### PR TITLE
fix(cli): route sandbox exec exit codes through oclif (#6458)

### DIFF
--- a/src/commands/sandbox/exec.test.ts
+++ b/src/commands/sandbox/exec.test.ts
@@ -3,7 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const execSandboxMock = vi.hoisted(() => vi.fn(async () => {}));
+const execSandboxMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
 vi.mock("../../lib/actions/sandbox/exec", () => ({
   execSandbox: execSandboxMock,
 }));
@@ -39,7 +39,8 @@ describe("SandboxExecCommand oclif parse path", () => {
   it("routes completion codes through oclif exit-code handling", async () => {
     const previousExitCode = process.exitCode;
     process.exitCode = undefined;
-    execSandboxMock.mockImplementationOnce(async (_name, _cmd, _options, deps) => {
+    execSandboxMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const deps = args[3] as { exit?: (code: number) => void } | undefined;
       deps?.exit?.(42);
     });
 

--- a/src/commands/sandbox/exec.test.ts
+++ b/src/commands/sandbox/exec.test.ts
@@ -12,6 +12,7 @@ import { log } from "../../lib/cli/logger";
 import SandboxExecCommand from "./exec";
 
 const rootDir = process.cwd();
+const execExitDeps = { exit: expect.any(Function) };
 
 describe("SandboxExecCommand oclif parse path", () => {
   beforeEach(() => {
@@ -31,7 +32,23 @@ describe("SandboxExecCommand oclif parse path", () => {
       "alpha",
       ["openclaw", "agent", "--agent", "main", "-m", "hi"],
       { workdir: undefined, tty: null, timeoutSeconds: undefined, stdin: undefined },
+      execExitDeps,
     );
+  });
+
+  it("routes completion codes through oclif exit-code handling", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    execSandboxMock.mockImplementationOnce(async (_name, _cmd, _options, deps) => {
+      deps?.exit?.(42);
+    });
+
+    try {
+      await SandboxExecCommand.run(["alpha", "--", "sh", "-c", "exit 42"], rootDir);
+      expect(process.exitCode).toBe(42);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 
   it("does not assign host meaning to logging flags after --", async () => {
@@ -39,11 +56,16 @@ describe("SandboxExecCommand oclif parse path", () => {
 
     await SandboxExecCommand.run(["alpha", "--", "agent-cli", "--debug", "--quiet"], rootDir);
 
-    expect(execSandboxMock).toHaveBeenCalledWith("alpha", ["agent-cli", "--debug", "--quiet"], {
-      workdir: undefined,
-      tty: null,
-      timeoutSeconds: undefined,
-    });
+    expect(execSandboxMock).toHaveBeenCalledWith(
+      "alpha",
+      ["agent-cli", "--debug", "--quiet"],
+      {
+        workdir: undefined,
+        tty: null,
+        timeoutSeconds: undefined,
+      },
+      execExitDeps,
+    );
     expect(configure).toHaveBeenCalledWith({ debug: false, quiet: false });
     expect(configure).not.toHaveBeenCalledWith({ debug: true, quiet: false });
     expect(configure).not.toHaveBeenCalledWith({ debug: false, quiet: true });
@@ -96,6 +118,7 @@ describe("SandboxExecCommand oclif parse path", () => {
         "pass",
       ],
       { workdir: undefined, tty: null, timeoutSeconds: undefined, stdin: undefined },
+      execExitDeps,
     );
   });
 
@@ -104,12 +127,17 @@ describe("SandboxExecCommand oclif parse path", () => {
       ["alpha", "--workdir", "/sandbox/workspace", "--", "ls", "-la"],
       rootDir,
     );
-    expect(execSandboxMock).toHaveBeenCalledWith("alpha", ["ls", "-la"], {
-      workdir: "/sandbox/workspace",
-      tty: null,
-      timeoutSeconds: undefined,
-      stdin: undefined,
-    });
+    expect(execSandboxMock).toHaveBeenCalledWith(
+      "alpha",
+      ["ls", "-la"],
+      {
+        workdir: "/sandbox/workspace",
+        tty: null,
+        timeoutSeconds: undefined,
+        stdin: undefined,
+      },
+      execExitDeps,
+    );
   });
 
   it("forwards a multi-line heredoc command verbatim to the action guard (#5980)", async () => {
@@ -118,12 +146,17 @@ describe("SandboxExecCommand oclif parse path", () => {
     // action test. Here we pin that the heredoc reaches the action intact.
     const heredoc = "cat <<EOF\nline1\nline2\nEOF";
     await SandboxExecCommand.run(["alpha", "--", "bash", "-lc", heredoc], rootDir);
-    expect(execSandboxMock).toHaveBeenCalledWith("alpha", ["bash", "-lc", heredoc], {
-      workdir: undefined,
-      tty: null,
-      timeoutSeconds: undefined,
-      stdin: undefined,
-    });
+    expect(execSandboxMock).toHaveBeenCalledWith(
+      "alpha",
+      ["bash", "-lc", heredoc],
+      {
+        workdir: undefined,
+        tty: null,
+        timeoutSeconds: undefined,
+        stdin: undefined,
+      },
+      execExitDeps,
+    );
   });
 
   it("forwards the semicolon workaround to dispatch (#5980)", async () => {
@@ -135,6 +168,7 @@ describe("SandboxExecCommand oclif parse path", () => {
       "alpha",
       ["bash", "-lc", "echo line1; echo line2"],
       { workdir: undefined, tty: null, timeoutSeconds: undefined, stdin: undefined },
+      execExitDeps,
     );
   });
 
@@ -147,55 +181,81 @@ describe("SandboxExecCommand oclif parse path", () => {
       "alpha",
       ["bash", "-lc", "echo line1; echo line2"],
       { workdir: "/sandbox", tty: null, timeoutSeconds: undefined, stdin: undefined },
+      execExitDeps,
     );
   });
 
   it("parses --tty / --no-tty and --timeout into typed options", async () => {
     await SandboxExecCommand.run(["alpha", "--tty", "--timeout", "30", "--", "hostname"], rootDir);
-    expect(execSandboxMock).toHaveBeenCalledWith("alpha", ["hostname"], {
-      workdir: undefined,
-      tty: true,
-      timeoutSeconds: 30,
-      stdin: undefined,
-    });
+    expect(execSandboxMock).toHaveBeenCalledWith(
+      "alpha",
+      ["hostname"],
+      {
+        workdir: undefined,
+        tty: true,
+        timeoutSeconds: 30,
+        stdin: undefined,
+      },
+      execExitDeps,
+    );
     execSandboxMock.mockReset();
 
     await SandboxExecCommand.run(["alpha", "--no-tty", "--", "hostname"], rootDir);
-    expect(execSandboxMock).toHaveBeenCalledWith("alpha", ["hostname"], {
-      workdir: undefined,
-      tty: false,
-      timeoutSeconds: undefined,
-      stdin: undefined,
-    });
+    expect(execSandboxMock).toHaveBeenCalledWith(
+      "alpha",
+      ["hostname"],
+      {
+        workdir: undefined,
+        tty: false,
+        timeoutSeconds: undefined,
+        stdin: undefined,
+      },
+      execExitDeps,
+    );
   });
 
   it("parses --stdin as explicit stdin forwarding", async () => {
     await SandboxExecCommand.run(["alpha", "--stdin", "--", "cat"], rootDir);
-    expect(execSandboxMock).toHaveBeenCalledWith("alpha", ["cat"], {
-      workdir: undefined,
-      tty: null,
-      timeoutSeconds: undefined,
-      stdin: true,
-    });
+    expect(execSandboxMock).toHaveBeenCalledWith(
+      "alpha",
+      ["cat"],
+      {
+        workdir: undefined,
+        tty: null,
+        timeoutSeconds: undefined,
+        stdin: true,
+      },
+      execExitDeps,
+    );
   });
 
   it("parses --no-stdin as explicit stdin closure", async () => {
     await SandboxExecCommand.run(["alpha", "--no-stdin", "--", "pwd"], rootDir);
-    expect(execSandboxMock).toHaveBeenCalledWith("alpha", ["pwd"], {
-      workdir: undefined,
-      tty: null,
-      timeoutSeconds: undefined,
-      stdin: false,
-    });
+    expect(execSandboxMock).toHaveBeenCalledWith(
+      "alpha",
+      ["pwd"],
+      {
+        workdir: undefined,
+        tty: null,
+        timeoutSeconds: undefined,
+        stdin: false,
+      },
+      execExitDeps,
+    );
   });
 
   it("leaves stdin mode unset for the production spawner to auto-detect", async () => {
     await SandboxExecCommand.run(["alpha", "--", "bash"], rootDir);
-    expect(execSandboxMock).toHaveBeenCalledWith("alpha", ["bash"], {
-      workdir: undefined,
-      tty: null,
-      timeoutSeconds: undefined,
-      stdin: undefined,
-    });
+    expect(execSandboxMock).toHaveBeenCalledWith(
+      "alpha",
+      ["bash"],
+      {
+        workdir: undefined,
+        tty: null,
+        timeoutSeconds: undefined,
+        stdin: undefined,
+      },
+      execExitDeps,
+    );
   });
 });

--- a/src/commands/sandbox/exec.test.ts
+++ b/src/commands/sandbox/exec.test.ts
@@ -52,6 +52,22 @@ describe("SandboxExecCommand oclif parse path", () => {
     }
   });
 
+  it("routes multiline usage errors through oclif exit-code handling", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    execSandboxMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const deps = args[3] as { exit?: (code: number) => void } | undefined;
+      deps?.exit?.(2);
+    });
+
+    try {
+      await SandboxExecCommand.run(["alpha", "--", "bash", "-lc", "printf 'a\nb'"], rootDir);
+      expect(process.exitCode).toBe(2);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
   it("does not assign host meaning to logging flags after --", async () => {
     const configure = vi.spyOn(log, "configure").mockImplementation(() => undefined);
 

--- a/src/commands/sandbox/exec.ts
+++ b/src/commands/sandbox/exec.ts
@@ -51,11 +51,22 @@ export default class SandboxExecCommand extends NemoClawCommand {
     const cmd = (
       separatorIndex === -1 ? argv.slice(1) : originalArgv.slice(separatorIndex + 1)
     ) as string[];
-    await execSandbox(args.sandboxName, cmd, {
-      workdir: flags.workdir,
-      tty: typeof flags.tty === "boolean" ? flags.tty : null,
-      timeoutSeconds: flags.timeout,
-      stdin: flags.stdin,
-    });
+    await execSandbox(
+      args.sandboxName,
+      cmd,
+      {
+        workdir: flags.workdir,
+        tty: typeof flags.tty === "boolean" ? flags.tty : null,
+        timeoutSeconds: flags.timeout,
+        stdin: flags.stdin,
+      },
+      {
+        // Route through oclif's exit-code contract so host `$?` stays scriptable
+        // when dispatch completes normally instead of terminating via process.exit.
+        exit: (code) => {
+          this.setExitCode(code);
+        },
+      },
+    );
   }
 }

--- a/src/lib/actions/sandbox/exec.multiline-guard.test.ts
+++ b/src/lib/actions/sandbox/exec.multiline-guard.test.ts
@@ -342,4 +342,56 @@ describe("execSandbox multi-line guard (#5980)", () => {
       "echo line1; echo line2",
     ]);
   });
+
+  it("routes usage-error exits through the injected exit seam without terminating the process", async () => {
+    let exitCode = Number.NaN;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const run = vi.fn(() => ({ status: 0 }));
+
+    await execSandbox(
+      "alpha",
+      ["bash", "-lc", "printf 'a\nb'"],
+      {},
+      {
+        run,
+        resolveBinary: () => "openshell",
+        exit: (code) => {
+          exitCode = code;
+        },
+      },
+    );
+
+    expect(exitCode).toBe(2);
+    expect(run).not.toHaveBeenCalled();
+    expect(errSpy.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "contains a newline or carriage return",
+    );
+  });
+
+  it("routes missing --workdir exits through the injected exit seam", async () => {
+    let exitCode = Number.NaN;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const run = vi.fn(() => ({ status: 0 }));
+    const probeWorkdir = vi.fn(() => ({ status: 1 }));
+
+    await execSandbox(
+      "alpha",
+      ["bash", "-lc", "echo ok"],
+      { workdir: "/no/such/dir" },
+      {
+        run,
+        resolveBinary: () => "openshell",
+        probeWorkdir,
+        exit: (code) => {
+          exitCode = code;
+        },
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(run).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(
+      "error: --workdir: /no/such/dir does not exist inside the sandbox",
+    );
+  });
 });

--- a/src/lib/actions/sandbox/exec.ts
+++ b/src/lib/actions/sandbox/exec.ts
@@ -392,6 +392,8 @@ export type ExecSandboxDeps = {
   run?: SandboxExecRunner;
   policyHint?: ExecPolicyHintDeps;
   cleanupDeps?: SandboxExecCleanupDeps;
+  /** Exit seam; defaults to process.exit for passthrough and action callers. */
+  exit?: (code: number) => void;
 };
 
 export async function execSandbox(
@@ -442,5 +444,6 @@ export async function execSandbox(
     console.error(cleanupFailureMessage(completion.commandCode, completion.cleanupError));
   }
   await emitPolicyDenialHint(completion);
-  process.exit(completion.code);
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
+  exit(completion.code);
 }

--- a/src/lib/actions/sandbox/exec.ts
+++ b/src/lib/actions/sandbox/exec.ts
@@ -368,12 +368,15 @@ export function validateWorkdirOrFail(
   sandboxName: string,
   workdir: string,
   run: WorkdirProbeRunner = defaultWorkdirProbeRunner,
-): void {
+  exit: (code: number) => void = (code) => process.exit(code),
+): boolean {
   const outcome = evaluateWorkdirProbe(run(binary, buildWorkdirProbeArgs(sandboxName, workdir)));
   if (outcome === "missing") {
     console.error(workdirMissingMessage(workdir));
-    process.exit(1);
+    exit(1);
+    return false;
   }
+  return true;
 }
 
 function defaultResolveBinary(): string {
@@ -403,20 +406,26 @@ export async function execSandbox(
   deps: ExecSandboxDeps = {},
 ): Promise<void> {
   const { CLI_NAME } = require("../../cli/branding");
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
   if (command.length === 0) {
     console.error(
       `  Usage: ${CLI_NAME} ${sandboxName} exec [--workdir <dir>] [--tty|--no-tty] [--timeout <s>] [--stdin|--no-stdin] -- <cmd> [args...]`,
     );
-    process.exit(2);
+    exit(2);
+    return;
   }
   const multilineIndex = findMultilineExecArg(command);
   if (multilineIndex !== -1) {
     console.error(multilineExecMessage(CLI_NAME, sandboxName, command, multilineIndex));
-    process.exit(2);
+    exit(2);
+    return;
   }
   const binary = (deps.resolveBinary ?? defaultResolveBinary)();
-  if (options.workdir) {
-    validateWorkdirOrFail(binary, sandboxName, options.workdir, deps.probeWorkdir);
+  if (
+    options.workdir &&
+    !validateWorkdirOrFail(binary, sandboxName, options.workdir, deps.probeWorkdir, exit)
+  ) {
+    return;
   }
   const emitPolicyDenialHint = preparePolicyHint(CLI_NAME, sandboxName, deps.policyHint);
   const completion = await runSandboxExecCommand(
@@ -444,6 +453,5 @@ export async function execSandbox(
     console.error(cleanupFailureMessage(completion.commandCode, completion.cleanupError));
   }
   await emitPolicyDenialHint(completion);
-  const exit = deps.exit ?? ((code: number) => process.exit(code));
   exit(completion.code);
 }

--- a/test/sandbox-exec-cli.test.ts
+++ b/test/sandbox-exec-cli.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { runWithEnv, writeSandboxRegistry } from "./cli/helpers";
+
+function buildExecExitStubOpenshell(home: string, remoteExitCode: number): string {
+  const localBin = path.join(home, "bin");
+  fs.mkdirSync(localBin, { recursive: true });
+  fs.writeFileSync(
+    path.join(localBin, "openshell"),
+    [
+      "#!/usr/bin/env bash",
+      'case "$*" in',
+      '  *"sandbox exec"*)',
+      `    exit ${remoteExitCode} ;;`,
+      "  *) exit 0 ;;",
+      "esac",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return localBin;
+}
+
+function execCliEnv(home: string, localBin: string): Record<string, string> {
+  return {
+    HOME: home,
+    PATH: `${localBin}:${process.env.PATH || ""}`,
+  };
+}
+
+describe("sandbox exec CLI exit propagation (#6458)", () => {
+  it("forwards a non-zero remote exit code through the public route", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-exec-exit-public-"));
+    try {
+      writeSandboxRegistry(home, { agent: "hermes" });
+      const localBin = buildExecExitStubOpenshell(home, 42);
+
+      const result = runWithEnv("alpha exec -- sh -c 'exit 42' 2>&1", execCliEnv(home, localBin));
+      expect(result.code).toBe(42);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards exit 1 through the public route", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-exec-exit-one-"));
+    try {
+      writeSandboxRegistry(home, { agent: "hermes" });
+      const localBin = buildExecExitStubOpenshell(home, 1);
+
+      const result = runWithEnv("alpha exec -- sh -c 'exit 1' 2>&1", execCliEnv(home, localBin));
+      expect(result.code).toBe(1);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 0 when the remote command succeeds", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-exec-exit-zero-"));
+    try {
+      writeSandboxRegistry(home, { agent: "hermes" });
+      const localBin = buildExecExitStubOpenshell(home, 0);
+
+      const result = runWithEnv("alpha exec -- echo hello 2>&1", execCliEnv(home, localBin));
+      expect(result.code).toBe(0);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards a non-zero remote exit code through the native sandbox exec route", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-exec-exit-native-"));
+    try {
+      writeSandboxRegistry(home, { agent: "hermes" });
+      const localBin = buildExecExitStubOpenshell(home, 7);
+
+      const result = runWithEnv(
+        "sandbox exec alpha -- sh -c 'exit 7' 2>&1",
+        execCliEnv(home, localBin),
+      );
+      expect(result.code).toBe(7);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Hardens `nemoclaw exec` so remote command exit codes propagate through the oclif command layer via `setExitCode`, and adds CLI integration tests that lock end-to-end forwarding for both public (`<sandbox> exec`) and native (`sandbox exec`) routes.

## Related Issue

Fixes #6458

## Changes

- Route `sandbox:exec` completion through `this.setExitCode()` instead of terminating only via `process.exit()` inside the action.
- Add an optional `exit` seam to `execSandbox()` so passthrough callers keep the existing `process.exit()` default.
- Add `test/sandbox-exec-cli.test.ts` covering host exits 42, 1, and 0 through stub OpenShell.
- Extend `src/commands/sandbox/exec.test.ts` to assert oclif exit-code handling.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: behavior matches existing documented contract; this adds regression coverage and oclif exit-code hardening only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/sandbox-exec-cli.test.ts src/lib/actions/sandbox/exec.test.ts src/commands/sandbox/exec.test.ts` (43 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Thabhelo <50872400+Thabhelo@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `sandbox exec` exit-code propagation so remote command results correctly set the local CLI exit code (including non-zero failures).
  * Improved oclif-style exit handling to avoid premature process termination while preserving `$?` behavior.
  * Updated multiline and invalid/missing `--workdir` error paths to return the intended exit codes.

* **Tests**
  * Added/expanded CLI and action tests to verify exit-code forwarding for both `alpha exec` and `sandbox exec` routes, plus multiline and `--workdir` validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->