### PR TITLE
docs(policy): include MCP DELETE in custom recipe

### DIFF
--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -159,7 +159,8 @@ CONNECT tunnel failed, response 403
 This recipe applies only when URL-based MCP traffic uses the sandbox proxy and fails with that CONNECT 403 response.
 An OAuth MCP login failure such as `getaddrinfo EAI_AGAIN`, or any direct-DNS path that bypasses the proxy, is a separate transport problem and is not fixed by widening this allowlist.
 
-Add a preset with the MCP host, the exact Streamable HTTP MCP route, the HTTP methods that route uses (`GET` and `POST`), and only the process binary that opens the connection:
+Add a preset with the MCP host, the exact Streamable HTTP MCP route, the HTTP methods that route uses (`GET`, `POST`, and `DELETE`), and only the process binary that opens the connection.
+Streamable HTTP MCP clients can use `DELETE` on the same endpoint to terminate a session, so keep that method scoped to the exact MCP route instead of widening the path:
 
 ```yaml
 preset:
@@ -176,6 +177,7 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/mcp" }
           - allow: { method: POST, path: "/mcp" }
+          - allow: { method: DELETE, path: "/mcp" }
     binaries:
       - { path: /usr/local/bin/node }
 ```

--- a/test/policy-roundtrip-docs.test.ts
+++ b/test/policy-roundtrip-docs.test.ts
@@ -27,9 +27,11 @@ describe("policy round-trip documentation examples", () => {
     expect(section).toBeDefined();
     expect(section).toContain('- allow: { method: GET, path: "/mcp" }');
     expect(section).toContain('- allow: { method: POST, path: "/mcp" }');
+    expect(section).toContain('- allow: { method: DELETE, path: "/mcp" }');
     expect(section).not.toContain('path: "/**"');
     expect(section?.match(/- \{ path: \/usr\/local\/bin\//g)).toHaveLength(1);
     expect(section).toContain("only the process that opens the connection");
+    expect(section).toContain("terminate a session");
     expect(section).toContain("do not replace it with `/**`");
     expect(section).toContain("does not disable OpenShell's SSRF protection");
     expect(section).toContain("getaddrinfo EAI_AGAIN");


### PR DESCRIPTION
﻿<!-- markdownlint-disable MD041 -->
## Summary
Update the custom Streamable HTTP MCP network-policy recipe to include the `DELETE` method on the exact MCP endpoint. Some Streamable HTTP MCP clients use `DELETE` to terminate sessions, and the example should keep that method narrowly scoped instead of encouraging a wildcard path.

## Related Issue
Refs #6329

## Changes
- Document `GET`, `POST`, and `DELETE` for the URL-based MCP custom policy recipe.
- Add `DELETE /mcp` to the sample YAML while preserving the exact-path guidance.
- Extend the policy round-trip docs regression test to require the scoped `DELETE` rule and session-termination wording.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review confirmed this is a doc/test-only policy recipe update that adds `DELETE` only for the exact `/mcp` endpoint and preserves the warning against `/**` wildcard paths.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — `npm run check:diff` passed on DGX Spark/Linux.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/policy-roundtrip-docs.test.ts` passed on DGX Spark/Linux (3 tests).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — `npm run docs` passed on DGX Spark/Linux with 0 errors; Fern reported only the existing upgrade warning.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: HwangJohn <angelic805@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the URL-Based MCP Server network policy example to allow `DELETE` requests on the `/mcp` endpoint.
  * Clarified that the endpoint supports `GET`, `POST`, and `DELETE`, including session termination.

* **Tests**
  * Added coverage to verify the updated policy example and session-termination guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->