### PR TITLE
fix(ci): clarify post-merge risk gate failures

### DIFF
--- a/.github/workflows/post-merge-e2e-risk-gate-shadow.yaml
+++ b/.github/workflows/post-merge-e2e-risk-gate-shadow.yaml
@@ -50,7 +50,6 @@ jobs:
 
       - id: start
         name: Build plan and dispatch exact-commit E2E
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
@@ -78,11 +77,8 @@ jobs:
           --mode abandon
           --check-id "${{ steps.start.outputs.check_id }}"
 
-      - name: Propagate controller startup failure
-        if: ${{ steps.start.outcome == 'failure' }}
-        run: exit 1
-
-      - name: Wait for correlated E2E run
+      - id: wait
+        name: Wait for correlated E2E run
         if: ${{ steps.start.outputs.dispatched == 'true' }}
         continue-on-error: true
         env:
@@ -90,9 +86,11 @@ jobs:
           RUN_ID: ${{ steps.start.outputs.run_id }}
         run: >-
           timeout --signal=TERM --kill-after=30s 105m
-          gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY" --exit-status
+          gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY"
+          --compact --interval 10 --exit-status
 
-      - name: Download correlated E2E evidence
+      - id: evidence
+        name: Download correlated E2E evidence
         if: ${{ always() && steps.start.outputs.dispatched == 'true' }}
         continue-on-error: true
         env:
@@ -105,7 +103,6 @@ jobs:
       - id: finish
         name: Complete exact-commit shadow check
         if: ${{ always() && steps.start.outputs.dispatched == 'true' }}
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
@@ -117,7 +114,7 @@ jobs:
           --run-id "${{ steps.start.outputs.run_id }}"
 
       - name: Close shadow check after completion failure
-        if: ${{ always() && steps.start.outputs.check_id != '' && steps.start.outputs.dispatched == 'true' && steps.finish.outcome == 'failure' }}
+        if: ${{ always() && steps.start.outputs.check_id != '' && steps.start.outputs.dispatched == 'true' && steps.finish.outcome == 'failure' && steps.finish.outputs.finalized != 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
@@ -125,9 +122,67 @@ jobs:
           --mode abandon
           --check-id "${{ steps.start.outputs.check_id }}"
 
-      - name: Propagate shadow completion failure
-        if: ${{ steps.finish.outcome == 'failure' }}
-        run: exit 1
+      - name: Summarize shadow controller
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ github.event.after }}
+          CHILD_RUN_ID: ${{ steps.start.outputs.run_id }}
+          WORK_DIR: ${{ steps.workspace.outputs.work_dir }}
+          START_OUTCOME: ${{ steps.start.outcome }}
+          WAIT_OUTCOME: ${{ steps.wait.outcome }}
+          EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
+          FINISH_OUTCOME: ${{ steps.finish.outcome }}
+        run: |
+          set -euo pipefail
+
+          selected_jobs="unavailable"
+          plan_path="${WORK_DIR}/post-merge-risk-plan.json"
+          if [ -n "$WORK_DIR" ] && [ -f "$plan_path" ]; then
+            selected_jobs="$(node -e '
+              const fs = require("node:fs");
+              const plan = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              process.stdout.write(plan.automaticJobs.join(",") || "none");
+            ' "$plan_path" 2>/dev/null || printf unavailable)"
+          fi
+
+          child_conclusion="not-dispatched"
+          if [ -n "$CHILD_RUN_ID" ]; then
+            child_conclusion="$(
+              gh run view "$CHILD_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+                --json conclusion --jq '.conclusion // "none"' 2>/dev/null || printf unavailable
+            )"
+          fi
+
+          failure_phase="none"
+          if [ "$START_OUTCOME" = "failure" ]; then
+            failure_phase="plan-and-dispatch"
+          elif [ "$FINISH_OUTCOME" = "failure" ]; then
+            failure_phase="evidence-verification"
+          elif [ "$WAIT_OUTCOME" = "failure" ]; then
+            failure_phase="child-run-or-wait"
+          elif [ "$EVIDENCE_OUTCOME" = "failure" ]; then
+            failure_phase="evidence-download"
+          fi
+
+          {
+            echo "## Post-merge E2E risk gate shadow"
+            echo
+            printf -- '- Controller run: [run `%s`](https://github.com/%s/actions/runs/%s)\n' \
+              "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
+            printf -- '- Controller commit: `%s`\n' "$COMMIT_SHA"
+            printf -- '- Selected jobs: `%s`\n' "$selected_jobs"
+            printf -- '- Plan and dispatch: `%s`\n' "$START_OUTCOME"
+            if [ -n "$CHILD_RUN_ID" ]; then
+              printf -- '- Correlated E2E: [run `%s`](https://github.com/%s/actions/runs/%s)\n' \
+                "$CHILD_RUN_ID" "$GITHUB_REPOSITORY" "$CHILD_RUN_ID"
+            fi
+            printf -- '- Child conclusion: `%s`\n' "$child_conclusion"
+            printf -- '- Child wait: `%s`\n' "$WAIT_OUTCOME"
+            printf -- '- Evidence download: `%s`\n' "$EVIDENCE_OUTCOME"
+            printf -- '- Evidence verification: `%s`\n' "$FINISH_OUTCOME"
+            printf -- '- Failure phase: `%s`\n' "$failure_phase"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove private controller workspace
         if: ${{ always() && steps.workspace.outputs.work_dir != '' }}

--- a/test/post-merge-e2e-risk-gate-workflow.test.ts
+++ b/test/post-merge-e2e-risk-gate-workflow.test.ts
@@ -63,7 +63,7 @@ describe("post-merge E2E risk gate shadow workflow", () => {
     const download = step(job, "Download correlated E2E evidence");
     const finish = step(job, "Complete exact-commit shadow check");
     const completionFallback = step(job, "Close shadow check after completion failure");
-    const propagateFailure = step(job, "Propagate shadow completion failure");
+    const summary = step(job, "Summarize shadow controller");
     const cleanup = step(job, "Remove private controller workspace");
 
     expect(checkout.with).toMatchObject({
@@ -77,21 +77,34 @@ describe("post-merge E2E risk gate shadow workflow", () => {
     expect(start.run).toContain('--base "${{ github.event.before }}"');
     expect(start.run).toContain('--commit "${{ github.event.after }}"');
     expect(start.run).toContain('--work-dir "${{ steps.workspace.outputs.work_dir }}"');
+    expect(start["continue-on-error"]).not.toBe(true);
     expect(wait.run).toContain("timeout --signal=TERM --kill-after=30s 105m");
+    expect(wait.run).toContain("--compact --interval 10 --exit-status");
+    expect(wait["continue-on-error"]).toBe(true);
     expect(wait.env?.RUN_ID).toBe("${{ steps.start.outputs.run_id }}");
     expect(download.run).toContain('--dir "${{ steps.workspace.outputs.work_dir }}/evidence"');
+    expect(download["continue-on-error"]).toBe(true);
     expect(download.env?.RUN_ID).toBe("${{ steps.start.outputs.run_id }}");
     expect(finish.id).toBe("finish");
     expect(finish.if).toContain("always()");
-    expect(finish["continue-on-error"]).toBe(true);
+    expect(finish["continue-on-error"]).not.toBe(true);
     expect(finish.run).toContain("post-merge-risk-gate.mts --mode finish");
     expect(finish.run).toContain('--work-dir "${{ steps.workspace.outputs.work_dir }}"');
     expect(finish.run).toContain('--state-hash "${{ steps.start.outputs.state_hash }}"');
     expect(finish.run).toContain('--check-id "${{ steps.start.outputs.check_id }}"');
     expect(finish.run).toContain('--run-id "${{ steps.start.outputs.run_id }}"');
+    expect(completionFallback.if).toContain("always()");
     expect(completionFallback.if).toContain("steps.finish.outcome == 'failure'");
+    expect(completionFallback.if).toContain("steps.finish.outputs.finalized != 'true'");
     expect(completionFallback.run).toContain("post-merge-risk-gate.mts --mode abandon");
-    expect(propagateFailure.if).toContain("steps.finish.outcome == 'failure'");
+    expect(job.steps?.some((candidate) => candidate.name?.startsWith("Propagate "))).toBe(false);
+    expect(summary.if).toContain("always()");
+    expect(summary.run).toContain("GITHUB_STEP_SUMMARY");
+    expect(summary.run).toContain("Controller run");
+    expect(summary.run).toContain("Selected jobs");
+    expect(summary.run).toContain("Correlated E2E");
+    expect(summary.run).toContain("Child conclusion");
+    expect(summary.run).toContain("Failure phase");
     expect(cleanup.if).toContain("always() && steps.workspace.outputs.work_dir != ''");
     expect(cleanup.run).toContain('rm -rf -- "${{ steps.workspace.outputs.work_dir }}"');
     expect(collectStrings(workflow).some((value) => value.includes("/tmp/"))).toBe(false);

--- a/test/post-merge-e2e-risk-gate-workflow.test.ts
+++ b/test/post-merge-e2e-risk-gate-workflow.test.ts
@@ -59,6 +59,7 @@ describe("post-merge E2E risk gate shadow workflow", () => {
     const checkout = step(job, "Checkout trusted controller");
     const workspace = step(job, "Create private controller workspace");
     const start = step(job, "Build plan and dispatch exact-commit E2E");
+    const startupFallback = step(job, "Close shadow check after controller startup failure");
     const wait = step(job, "Wait for correlated E2E run");
     const download = step(job, "Download correlated E2E evidence");
     const finish = step(job, "Complete exact-commit shadow check");
@@ -78,6 +79,11 @@ describe("post-merge E2E risk gate shadow workflow", () => {
     expect(start.run).toContain('--commit "${{ github.event.after }}"');
     expect(start.run).toContain('--work-dir "${{ steps.workspace.outputs.work_dir }}"');
     expect(start["continue-on-error"]).not.toBe(true);
+    expect(startupFallback.if).toContain("always()");
+    expect(startupFallback.if).toContain("steps.start.outputs.check_id != ''");
+    expect(startupFallback.if).toContain("steps.start.outputs.dispatched != 'true'");
+    expect(startupFallback.if).toContain("steps.start.outputs.finalized != 'true'");
+    expect(startupFallback.run).toContain("post-merge-risk-gate.mts --mode abandon");
     expect(wait.run).toContain("timeout --signal=TERM --kill-after=30s 105m");
     expect(wait.run).toContain("--compact --interval 10 --exit-status");
     expect(wait["continue-on-error"]).toBe(true);

--- a/test/post-merge-e2e-risk-gate.test.ts
+++ b/test/post-merge-e2e-risk-gate.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -165,6 +165,36 @@ describe("post-merge E2E risk gate", () => {
       fs.chmodSync(workDir, 0o700);
       fs.rmSync(workDir, { recursive: true, force: true });
     }
+  });
+
+  it("emits a single-line escaped Actions annotation for controller errors", () => {
+    const missingWorkDir = path.join(os.tmpdir(), "nemoclaw-risk-missing%\nworkspace");
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--experimental-strip-types",
+        "tools/e2e-advisor/post-merge-risk-gate.mts",
+        "--mode",
+        "finish",
+        "--work-dir",
+        missingWorkDir,
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_ACTIONS: "true" },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const annotations = result.stderr
+      .split(/\r?\n/gu)
+      .filter((line) =>
+        line.startsWith("::error title=Post-merge E2E risk gate controller failed::"),
+      );
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0]).toContain("nemoclaw-risk-missing%25 workspace");
+    expect(annotations[0]).not.toMatch(/[\r\t]/u);
   });
 
   it("derives changed files from an exact checked-out commit range", () => {

--- a/test/post-merge-e2e-risk-gate.test.ts
+++ b/test/post-merge-e2e-risk-gate.test.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildRiskPlan, RISK_RULES } from "../tools/advisors/risk-plan.mts";
 import {
+  assertCorrelatedWorkflowRun,
   assertTrustedMainPush,
   changedFilesBetween,
   classifyRiskEvidence,
@@ -269,6 +270,51 @@ describe("post-merge E2E risk gate", () => {
     ).toThrow(/mismatched workflow dispatch URLs/u);
   });
 
+  it("reports the exact mismatched correlated workflow identity fields", () => {
+    const gate = state();
+    const childRunId = 23;
+    const child = {
+      id: childRunId,
+      name: `E2E risk ${gate.correlationId}`,
+      path: ".github/workflows/e2e.yaml",
+      workflow_id: 304268429,
+      event: "workflow_dispatch",
+      head_sha: gate.commitSha,
+      status: "completed",
+      conclusion: "success",
+      created_at: "2026-07-08T00:00:00.000Z",
+      display_title: `E2E risk ${gate.correlationId}`,
+      html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${childRunId}`,
+    };
+    const identity = {
+      childRunId,
+      correlationId: gate.correlationId,
+      repository: "NVIDIA/NemoClaw",
+    };
+    const cases = [
+      { override: { id: 24 }, expected: "id expected=23 actual=24" },
+      {
+        override: { path: ".github/workflows/other.yaml" },
+        expected:
+          'path expected=".github/workflows/e2e.yaml" actual=".github/workflows/other.yaml"',
+      },
+      {
+        override: { display_title: "E2E risk wrong" },
+        expected: `display_title expected="E2E risk ${gate.correlationId}" actual="E2E risk wrong"`,
+      },
+      {
+        override: { workflow_id: 0 },
+        expected: 'workflow_id expected="positive safe integer" actual=0',
+      },
+    ];
+
+    for (const { override, expected } of cases) {
+      expect(() => assertCorrelatedWorkflowRun({ ...child, ...override }, identity)).toThrow(
+        expected,
+      );
+    }
+  });
+
   it("finish reports the directly dispatched child failure when main advances", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-finish-"));
     const statePath = path.join(workDir, "e2e-risk-gate-state.json");
@@ -285,13 +331,15 @@ describe("post-merge E2E risk gate", () => {
         text: async () =>
           JSON.stringify({
             id: childRunId,
-            name: "E2E",
+            name: `E2E risk ${gate.correlationId}`,
             event: "workflow_dispatch",
             head_sha: "b".repeat(40),
             status: "completed",
             conclusion: "failure",
             created_at: "2026-07-08T00:00:00.000Z",
             display_title: `E2E risk ${gate.correlationId}`,
+            path: ".github/workflows/e2e.yaml",
+            workflow_id: 304268429,
             html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${childRunId}`,
           }),
       } as Response)
@@ -321,11 +369,14 @@ describe("post-merge E2E risk gate", () => {
   it("rejects changed controller state before classifying downloaded evidence", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-state-"));
     const statePath = path.join(workDir, "e2e-risk-gate-state.json");
+    const outputPath = path.join(workDir, "github-output");
     const originalState = `${JSON.stringify(state())}\n`;
     const changedState = `${JSON.stringify({ ...state(), requiresManualExpansion: true })}\n`;
     vi.stubEnv("GITHUB_TOKEN", "token");
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
     fs.writeFileSync(statePath, changedState, { mode: 0o600 });
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue({ ok: true, text: async () => "{}" } as Response);
@@ -348,6 +399,10 @@ describe("post-merge E2E risk gate", () => {
         conclusion: "neutral",
         output: { title: "Risk-selected E2E evidence could not be verified" },
       });
+      expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)).output.summary).toContain(
+        "controller state changed after E2E dispatch",
+      );
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true\n");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tools/e2e-advisor/post-merge-risk-gate.mts
+++ b/tools/e2e-advisor/post-merge-risk-gate.mts
@@ -19,6 +19,7 @@ import { readPrivateRegularFile, writePrivateRegularFile } from "./private-file.
 import type { E2eRiskSignal } from "./risk-signal.ts";
 
 const E2E_WORKFLOW = "e2e.yaml";
+const E2E_WORKFLOW_PATH = `.github/workflows/${E2E_WORKFLOW}`;
 const CHECK_NAME = "E2E / Post-merge Risk Gate (shadow)";
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const HASH_PATTERN = /^[a-f0-9]{64}$/u;
@@ -27,6 +28,7 @@ const SHARD_PATTERN = /^(?:default|[A-Za-z0-9][A-Za-z0-9_-]*)$/u;
 const CORRELATION_PATTERN =
   /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/u;
 const MAX_PLAN_BYTES = 1024 * 1024;
+const MAX_CONTROLLER_ERROR_CHARS = 512;
 const DEFAULT_EVIDENCE_LIMITS = {
   maxDepth: 8,
   maxEntries: 4096,
@@ -54,6 +56,8 @@ type CheckConclusion = "success" | "failure" | "neutral";
 type WorkflowRun = {
   id: number;
   name: string;
+  path: string;
+  workflow_id: number;
   event: string;
   head_sha: string;
   status: string;
@@ -69,6 +73,12 @@ type WorkflowDispatchDetails = {
   workflow_run_id: number;
   run_url: string;
   html_url: string;
+};
+
+type WorkflowRunIdentity = {
+  childRunId: number;
+  correlationId: string;
+  repository: string;
 };
 
 export type RiskGateState = {
@@ -456,12 +466,24 @@ async function completeCheck(
   });
 }
 
+function controllerErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const singleLine = message
+    .replace(/[\r\n\t]+/gu, " ")
+    .replace(/\s{2,}/gu, " ")
+    .trim();
+  return singleLine.length > MAX_CONTROLLER_ERROR_CHARS
+    ? `${singleLine.slice(0, MAX_CONTROLLER_ERROR_CHARS - 3)}...`
+    : singleLine;
+}
+
 async function completeNeutralAfterControllerError(
   context: { repository: string; checkRunId: number },
   token: string,
   title: string,
-  detailsUrl?: string,
+  options: { error: unknown; detailsUrl?: string },
 ): Promise<boolean> {
+  const reason = controllerErrorMessage(options.error).replace(/`/gu, "'");
   try {
     await completeCheck(
       context,
@@ -470,9 +492,10 @@ async function completeNeutralAfterControllerError(
         conclusion: "neutral",
         title,
         summary:
-          "The shadow controller could not produce complete, trustworthy evidence. Inspect the controller workflow for details.",
+          "The shadow controller could not produce complete, trustworthy evidence." +
+          `\n\nController error: \`${reason}\``,
       },
-      detailsUrl,
+      options.detailsUrl,
     );
     return true;
   } catch (error) {
@@ -576,6 +599,47 @@ export function validateWorkflowDispatchDetails(
   return value as WorkflowDispatchDetails;
 }
 
+function diagnosticValue(value: unknown): string {
+  const serialized = JSON.stringify(value) ?? String(value);
+  return serialized.length > 256 ? `${serialized.slice(0, 253)}...` : serialized;
+}
+
+export function assertCorrelatedWorkflowRun(
+  child: WorkflowRun,
+  identity: WorkflowRunIdentity,
+): void {
+  const childRunUrl = `https://github.com/${identity.repository}/actions/runs/${identity.childRunId}`;
+  const mismatches: string[] = [];
+  const requireEqual = (field: string, expected: unknown, actual: unknown): void => {
+    if (actual !== expected) {
+      mismatches.push(
+        `${field} expected=${diagnosticValue(expected)} actual=${diagnosticValue(actual)}`,
+      );
+    }
+  };
+
+  requireEqual("id", identity.childRunId, child.id);
+  requireEqual("path", E2E_WORKFLOW_PATH, child.path);
+  requireEqual("event", "workflow_dispatch", child.event);
+  requireEqual("html_url", childRunUrl, child.html_url);
+  requireEqual("display_title", `E2E risk ${identity.correlationId}`, child.display_title);
+  if (!SHA_PATTERN.test(child.head_sha)) {
+    mismatches.push(
+      `head_sha expected="40 lowercase hexadecimal characters" actual=${diagnosticValue(child.head_sha)}`,
+    );
+  }
+  if (!Number.isSafeInteger(child.workflow_id) || child.workflow_id < 1) {
+    mismatches.push(
+      `workflow_id expected="positive safe integer" actual=${diagnosticValue(child.workflow_id)}`,
+    );
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      `correlated E2E workflow identity mismatch: ${mismatches.join("; ")}; observed run_name=${diagnosticValue(child.name)} workflow_id=${diagnosticValue(child.workflow_id)}`,
+    );
+  }
+}
+
 export async function dispatchRiskWorkflow(options: {
   repository: string;
   token: string;
@@ -669,6 +733,9 @@ async function start(options: {
       });
       appendOutput("dispatched", "false");
       appendOutput("finalized", "true");
+      console.log(
+        `Completed shadow check without dispatch: plan=${plan.planHash.slice(0, 12)} selected_jobs=none`,
+      );
       return;
     }
 
@@ -698,11 +765,15 @@ async function start(options: {
     appendOutput("state_hash", sha256(serializedState));
     appendOutput("run_id", String(childRunId));
     appendOutput("dispatched", "true");
+    console.log(
+      `Dispatched risk-selected E2E run ${childRunId}: plan=${plan.planHash.slice(0, 12)} selected_jobs=${plan.automaticJobs.join(",")} url=https://github.com/${repository}/actions/runs/${childRunId}`,
+    );
   } catch (error) {
     const finalized = await completeNeutralAfterControllerError(
       { repository, checkRunId },
       token,
       "Risk-selected E2E could not be dispatched",
+      { error },
     );
     if (finalized) appendOutput("finalized", "true");
     throw error;
@@ -793,16 +864,14 @@ export async function finishRiskGate(options: {
       token,
       { userAgent: "nemoclaw-e2e-risk-gate" },
     );
-    if (
-      child.id !== childRunId ||
-      child.name !== "E2E" ||
-      child.event !== "workflow_dispatch" ||
-      !SHA_PATTERN.test(child.head_sha) ||
-      child.html_url !== childRunUrl ||
-      child.display_title !== `E2E risk ${state.correlationId}`
-    ) {
-      throw new Error("correlated E2E workflow identity changed");
-    }
+    assertCorrelatedWorkflowRun(child, {
+      childRunId,
+      correlationId: state.correlationId,
+      repository,
+    });
+    console.log(
+      `Verified correlated E2E run ${childRunId}: conclusion=${child.conclusion ?? "none"} url=${childRunUrl}`,
+    );
     const signals =
       child.conclusion === "success"
         ? findSignalFiles(options.evidencePath).map((file) =>
@@ -817,13 +886,15 @@ export async function finishRiskGate(options: {
       requiresManualExpansion: state.requiresManualExpansion,
     });
     await completeCheck(context, token, verdict, childRunUrl);
+    console.log(`Completed shadow check: conclusion=${verdict.conclusion} title=${verdict.title}`);
   } catch (error) {
-    await completeNeutralAfterControllerError(
+    const finalized = await completeNeutralAfterControllerError(
       context,
       token,
       "Risk-selected E2E evidence could not be verified",
-      childRunUrl,
+      { error, detailsUrl: childRunUrl },
     );
+    if (finalized) appendOutput("finalized", "true");
     throw error;
   }
 }
@@ -840,6 +911,15 @@ async function abandon(checkRunId: number): Promise<void> {
     summary:
       "The shadow controller stopped before it could produce complete evidence. Inspect the controller workflow for details.",
   });
+}
+
+function reportControllerError(error: unknown): void {
+  const message = controllerErrorMessage(error);
+  console.error(message);
+  if (process.env.GITHUB_ACTIONS === "true") {
+    const escaped = message.replace(/%/gu, "%25").replace(/\r/gu, "%0D").replace(/\n/gu, "%0A");
+    console.error(`::error title=Post-merge E2E risk gate controller failed::${escaped}`);
+  }
 }
 
 async function main(): Promise<void> {
@@ -871,7 +951,7 @@ async function main(): Promise<void> {
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error));
+    reportControllerError(error);
     process.exit(1);
   });
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fix the post-merge E2E shadow controller's false workflow-identity rejection when GitHub returns a dynamic `run-name`. The change also keeps the causal controller step visibly failed and surfaces bounded, actionable diagnostics instead of a generic downstream `exit 1`.

## Changes
- Validate the dispatch-returned child run using its exact run ID, repository URL, workflow path, event, correlation title, and bounded response metadata without conflating workflow `name` with `run-name`.
- Report field-level identity mismatches, preserve the detailed neutral check after controller errors, emit an Actions error annotation, and add a linked job summary.
- Keep start and finish failures on their causal steps, retain always-run fallback/cleanup behavior, and reduce `gh run watch` noise with compact ten-second refreshes.
- Add production-shaped regression coverage for dynamic run names, advanced-main child failures, check finalization, failure visibility, watcher flags, and summary content.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only internal post-merge CI controller identity validation and diagnostics; no user command, configuration, API, policy, or runtime behavior changes
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: read-only trust-boundary review confirmed the exact dispatch-returned run ID remains the primary identity anchor, workflow path/correlation checks remain fail-closed, and documented main-advance child failures remain classifiable
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/post-merge-e2e-risk-gate.test.ts test/post-merge-e2e-risk-gate-workflow.test.ts` — 26 tests passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-merge E2E risk-gate failure handling and completion reporting.
  * Added stronger validation to ensure correlated E2E runs match the expected workflow and commit.
  * Enhanced error messages with clearer, concise diagnostics and GitHub Actions annotations.
  * Added detailed summaries showing selected checks, E2E results, evidence status, and failure phases.

* **Tests**
  * Expanded coverage for controller failures, workflow mismatches, and changed controller state.
  * Updated workflow tests for waiting, evidence collection, completion handling, and summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->