### PR TITLE
fix(ci): bound shadow E2E wait logs

### DIFF
--- a/.github/workflows/post-merge-e2e-risk-gate-shadow.yaml
+++ b/.github/workflows/post-merge-e2e-risk-gate-shadow.yaml
@@ -84,10 +84,70 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ steps.start.outputs.run_id }}
-        run: >-
-          timeout --signal=TERM --kill-after=30s 105m
-          gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY"
-          --compact --interval 10 --exit-status
+        run: |
+          wait_status=0
+          timeout --signal=TERM --kill-after=30s 105m bash -s <<'WAIT' || wait_status=$?
+          set -euo pipefail
+
+          if [[ ! "$RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            printf '::error title=Invalid correlated E2E run ID::The controller did not provide a positive numeric run ID.\n' >&2
+            exit 1
+          fi
+
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
+
+          last_state=""
+          while true; do
+            if ! state="$(
+              gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
+                --json status,conclusion \
+                --jq '.status + ":" + (if (.conclusion == null or .conclusion == "") then "none" else .conclusion end)'
+            )"; then
+              printf '::error title=Correlated E2E status query failed::Unable to query child run %s. %s\n' \
+                "$RUN_ID" "$run_url" >&2
+              exit 1
+            fi
+
+            if [[ "$state" != "$last_state" ]]; then
+              case "$state" in
+                queued:none | in_progress:none | requested:none | waiting:none | pending:none)
+                  printf 'Correlated E2E run %s status=%s url=%s\n' \
+                    "$RUN_ID" "${state%%:*}" "$run_url"
+                  ;;
+                completed:success)
+                  printf 'Correlated E2E run %s status=completed conclusion=success url=%s\n' \
+                    "$RUN_ID" "$run_url"
+                  ;;
+                completed:failure | completed:cancelled | completed:timed_out | completed:action_required | completed:neutral | completed:skipped | completed:stale | completed:startup_failure)
+                  printf '::error title=Correlated E2E run did not succeed::Run %s completed with conclusion %s. %s\n' \
+                    "$RUN_ID" "${state#*:}" "$run_url" >&2
+                  ;;
+                *)
+                  printf '::error title=Unexpected correlated E2E state::Run %s returned an unsupported status/conclusion pair. %s\n' \
+                    "$RUN_ID" "$run_url" >&2
+                  ;;
+              esac
+              last_state="$state"
+            fi
+
+            case "$state" in
+              queued:none | in_progress:none | requested:none | waiting:none | pending:none)
+                sleep 10
+                ;;
+              completed:success)
+                exit 0
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+          done
+          WAIT
+
+          if [ "$wait_status" -eq 124 ]; then
+            printf '::error title=Correlated E2E wait timed out::The child run did not complete within 105 minutes.\n' >&2
+          fi
+          exit "$wait_status"
 
       - id: evidence
         name: Download correlated E2E evidence

--- a/test/post-merge-e2e-risk-gate-workflow.test.ts
+++ b/test/post-merge-e2e-risk-gate-workflow.test.ts
@@ -40,7 +40,10 @@ function collectStrings(value: unknown): string[] {
         : [];
 }
 
-function runWaitStep(scenario: "success" | "failure" | "query-failure" | "timeout") {
+function runWaitStep(
+  scenario: "success" | "failure" | "query-failure" | "timeout" | "unsupported",
+  options: { runId?: string } = {},
+) {
   const workflow = readYaml<TriggeredWorkflow>(SHADOW_PATH);
   const wait = step(workflow.jobs.shadow, "Wait for correlated E2E run");
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-shadow-wait-"));
@@ -60,6 +63,7 @@ case "$FAKE_GH_SCENARIO:$count" in
   success:*) printf 'completed:success\n' ;;
   failure:*) printf 'completed:failure\n' ;;
   query-failure:*) printf 'simulated GitHub query failure\n' >&2; exit 1 ;;
+  unsupported:*) printf 'completed:unknown\n' ;;
   *) exit 2 ;;
 esac
 `,
@@ -80,7 +84,7 @@ exec "$@"
   );
 
   try {
-    return spawnSync("bash", ["-e", "-o", "pipefail", "-c", wait.run!], {
+    const result = spawnSync("bash", ["-e", "-o", "pipefail", "-c", wait.run!], {
       encoding: "utf8",
       env: {
         ...process.env,
@@ -88,10 +92,14 @@ exec "$@"
         FAKE_GH_SCENARIO: scenario,
         GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
-        RUN_ID: "29110351531",
+        RUN_ID: options.runId ?? "29110351531",
       },
       timeout: 5_000,
     });
+    return {
+      ...result,
+      ghCallCount: Number(fs.readFileSync(callCountPath, "utf8").trim()),
+    };
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -224,6 +232,22 @@ describe("post-merge E2E risk gate shadow workflow", () => {
     expect(result.status).toBe(124);
     expect(result.stderr).toContain("::error title=Correlated E2E wait timed out::");
     expect(result.stderr).toContain("did not complete within 105 minutes");
+  });
+
+  it("rejects an invalid child-run ID before querying GitHub", () => {
+    const result = runWaitStep("success", { runId: "invalid" });
+
+    expect(result.status).toBe(1);
+    expect(result.ghCallCount).toBe(0);
+    expect(result.stderr).toContain("::error title=Invalid correlated E2E run ID::");
+  });
+
+  it("fails closed for an unsupported child-run state", () => {
+    const result = runWaitStep("unsupported");
+
+    expect(result.status).toBe(1);
+    expect(result.ghCallCount).toBe(1);
+    expect(result.stderr).toContain("::error title=Unexpected correlated E2E state::");
   });
 
   it("binds every E2E checkout and test signal to the merged commit", () => {

--- a/test/post-merge-e2e-risk-gate-workflow.test.ts
+++ b/test/post-merge-e2e-risk-gate-workflow.test.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 import { RISK_RULES } from "../tools/advisors/risk-plan.mts";
 import {
@@ -33,6 +38,63 @@ function collectStrings(value: unknown): string[] {
       : value && typeof value === "object"
         ? Object.values(value).flatMap(collectStrings)
         : [];
+}
+
+function runWaitStep(scenario: "success" | "failure" | "query-failure" | "timeout") {
+  const workflow = readYaml<TriggeredWorkflow>(SHADOW_PATH);
+  const wait = step(workflow.jobs.shadow, "Wait for correlated E2E run");
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-shadow-wait-"));
+  const binDir = path.join(tempDir, "bin");
+  const callCountPath = path.join(tempDir, "gh-call-count");
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(callCountPath, "0\n");
+  fs.writeFileSync(
+    path.join(binDir, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+count="$(cat "$FAKE_GH_CALL_COUNT")"
+count=$((count + 1))
+printf '%s\n' "$count" > "$FAKE_GH_CALL_COUNT"
+case "$FAKE_GH_SCENARIO:$count" in
+  success:1 | success:2 | failure:1) printf 'in_progress:none\n' ;;
+  success:*) printf 'completed:success\n' ;;
+  failure:*) printf 'completed:failure\n' ;;
+  query-failure:*) printf 'simulated GitHub query failure\n' >&2; exit 1 ;;
+  *) exit 2 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+  fs.writeFileSync(
+    path.join(binDir, "timeout"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$FAKE_GH_SCENARIO" = "timeout" ]; then
+  exit 124
+fi
+shift 3
+exec "$@"
+`,
+    { mode: 0o755 },
+  );
+
+  try {
+    return spawnSync("bash", ["-e", "-o", "pipefail", "-c", wait.run!], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_GH_CALL_COUNT: callCountPath,
+        FAKE_GH_SCENARIO: scenario,
+        GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        RUN_ID: "29110351531",
+      },
+      timeout: 5_000,
+    });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 }
 
 describe("post-merge E2E risk gate shadow workflow", () => {
@@ -85,7 +147,18 @@ describe("post-merge E2E risk gate shadow workflow", () => {
     expect(startupFallback.if).toContain("steps.start.outputs.finalized != 'true'");
     expect(startupFallback.run).toContain("post-merge-risk-gate.mts --mode abandon");
     expect(wait.run).toContain("timeout --signal=TERM --kill-after=30s 105m");
-    expect(wait.run).toContain("--compact --interval 10 --exit-status");
+    expect(wait.run).toContain('gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY"');
+    expect(wait.run).toContain("--json status,conclusion");
+    expect(wait.run).toContain('if [[ "$state" != "$last_state" ]]');
+    expect(wait.run).toContain('case "$state" in');
+    expect(wait.run).toContain("completed:success");
+    expect(wait.run).toContain("completed:failure");
+    expect(wait.run).toContain("sleep 10");
+    expect(wait.run).toContain('if [ "$wait_status" -eq 124 ]');
+    expect(wait.run).toContain('exit "$wait_status"');
+    expect(wait.run).not.toContain("gh run watch");
+    expect(wait.run).not.toContain("--json jobs");
+    expect(wait.run).not.toContain("2>/dev/null");
     expect(wait["continue-on-error"]).toBe(true);
     expect(wait.env?.RUN_ID).toBe("${{ steps.start.outputs.run_id }}");
     expect(download.run).toContain('--dir "${{ steps.workspace.outputs.work_dir }}/evidence"');
@@ -114,6 +187,43 @@ describe("post-merge E2E risk gate shadow workflow", () => {
     expect(cleanup.if).toContain("always() && steps.workspace.outputs.work_dir != ''");
     expect(cleanup.run).toContain('rm -rf -- "${{ steps.workspace.outputs.work_dir }}"');
     expect(collectStrings(workflow).some((value) => value.includes("/tmp/"))).toBe(false);
+  });
+
+  it("logs each child-run state once and exits after success", () => {
+    const result = runWaitStep("success");
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout.trim().split(/\r?\n/u)).toEqual([
+      expect.stringContaining("status=in_progress"),
+      expect.stringContaining("status=completed conclusion=success"),
+    ]);
+    expect(result.stdout).not.toContain("JOBS");
+  });
+
+  it("surfaces a terminal child-run failure", () => {
+    const result = runWaitStep("failure");
+
+    expect(result.status).toBe(1);
+    expect(result.stdout.match(/status=in_progress/gu)).toHaveLength(1);
+    expect(result.stderr).toContain("::error title=Correlated E2E run did not succeed::");
+    expect(result.stderr).toContain("completed with conclusion failure");
+  });
+
+  it("preserves GitHub CLI errors when status queries fail", () => {
+    const result = runWaitStep("query-failure");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("simulated GitHub query failure");
+    expect(result.stderr).toContain("::error title=Correlated E2E status query failed::");
+  });
+
+  it("labels only the bounded wait exit as a timeout", () => {
+    const result = runWaitStep("timeout");
+
+    expect(result.status).toBe(124);
+    expect(result.stderr).toContain("::error title=Correlated E2E wait timed out::");
+    expect(result.stderr).toContain("did not complete within 105 minutes");
   });
 
   it("binds every E2E checkout and test signal to the merged commit", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Replace the post-merge shadow controller's repeated child-job rendering with bounded status polling. The wait step now logs only child-run state transitions while preserving failure propagation, evidence collection, and the 105-minute hard bound.

## Changes
- Poll only the correlated child's `status` and `conclusion` instead of repeatedly rendering its full job matrix.
- Emit concise transition, query-failure, terminal-failure, unsupported-state, and timeout diagnostics.
- Add executable workflow tests for duplicate-state suppression, success, terminal failure, GitHub query failure, and timeout handling.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only internal post-merge GitHub Actions polling and diagnostics; no user command, configuration, API, policy, or runtime behavior changes
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent shell and trust-boundary review confirmed positive numeric run-ID validation, fixed GitHub status fields, controlled annotation values, timeout/cancellation separation, and preserved always-run evidence/finalization behavior
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/post-merge-e2e-risk-gate-workflow.test.ts` — 11 tests passed; the exact embedded wait script also returned success for live run `29110351531` and a concise failure annotation for live run `29110867027`
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated end-to-end validation monitoring, with deterministic polling of correlated run status/conclusion.
  * Added robust handling for invalid run identifiers, query failures, non-success completions, and explicit timeout reporting.

* **Tests**
  * Expanded end-to-end risk gate workflow tests with a local harness that simulates CLI behavior across success, failure, query-failure, and timeout scenarios.
  * Added assertions to ensure the wait logic avoids unintended commands and handles timeout exit codes correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->