### PR TITLE
fix(onboard): remove experimental vLLM label on managed platforms

### DIFF
--- a/docs/inference/local-compatible-inference-setup.mdx
+++ b/docs/inference/local-compatible-inference-setup.mdx
@@ -220,7 +220,7 @@ On supported Linux hosts with NVIDIA GPUs, the onboard wizard can also install o
 
 ### Use an Existing vLLM Server
 
-For an already-running vLLM server, run `$$nemoclaw onboard` and select **Local vLLM [experimental]** from the provider list.
+For an already-running vLLM server, run `$$nemoclaw onboard` and select **Local vLLM** from the provider list. The entry retains an experimental label on generic hosts, but not on DGX Spark or DGX Station.
 If vLLM is already running, NemoClaw detects the running model and validates the endpoint.
 When vLLM exposes runtime metadata such as `max_model_len`, NemoClaw uses that value for the configured context window unless you set `NEMOCLAW_CONTEXT_WINDOW` yourself.
 

--- a/docs/inference/local-compatible-inference-setup.mdx
+++ b/docs/inference/local-compatible-inference-setup.mdx
@@ -220,7 +220,8 @@ On supported Linux hosts with NVIDIA GPUs, the onboard wizard can also install o
 
 ### Use an Existing vLLM Server
 
-For an already-running vLLM server, run `$$nemoclaw onboard` and select **Local vLLM** from the provider list. The entry retains an experimental label on generic hosts, but not on DGX Spark or DGX Station.
+For an already-running vLLM server, run `$$nemoclaw onboard` and select **Local vLLM** from the provider list.
+On generic hosts, you see an experimental label on the entry; on DGX Spark or DGX Station, you do not.
 If vLLM is already running, NemoClaw detects the running model and validates the endpoint.
 When vLLM exposes runtime metadata such as `max_model_len`, NemoClaw uses that value for the configured context window unless you set `NEMOCLAW_CONTEXT_WINDOW` yourself.
 

--- a/docs/inference/tool-calling-reliability.mdx
+++ b/docs/inference/tool-calling-reliability.mdx
@@ -104,7 +104,7 @@ These routes therefore keep direct structured tool calling until search, describ
 
 ## Recommended Fix
 
-For persistent NemoClaw use, start vLLM with auto tool choice and the parser that matches your model family, then rerun onboarding and select **Local vLLM [experimental]** or **Other OpenAI-compatible endpoint**.
+For persistent NemoClaw use, start vLLM with auto tool choice and the parser that matches your model family, then rerun onboarding and select **Local vLLM** or **Other OpenAI-compatible endpoint**. The Local vLLM entry retains an experimental label on generic hosts, but not on DGX Spark or DGX Station.
 
 ### Configure vLLM
 

--- a/docs/inference/tool-calling-reliability.mdx
+++ b/docs/inference/tool-calling-reliability.mdx
@@ -104,7 +104,8 @@ These routes therefore keep direct structured tool calling until search, describ
 
 ## Recommended Fix
 
-For persistent NemoClaw use, start vLLM with auto tool choice and the parser that matches your model family, then rerun onboarding and select **Local vLLM** or **Other OpenAI-compatible endpoint**. The Local vLLM entry retains an experimental label on generic hosts, but not on DGX Spark or DGX Station.
+For persistent NemoClaw use, start vLLM with auto tool choice and the parser that matches your model family, then rerun onboarding and select **Local vLLM** or **Other OpenAI-compatible endpoint**.
+On generic hosts, you see an experimental label on the Local vLLM entry; on DGX Spark or DGX Station, you do not.
 
 ### Configure vLLM
 

--- a/src/lib/onboard/vllm-menu.test.ts
+++ b/src/lib/onboard/vllm-menu.test.ts
@@ -20,7 +20,7 @@ describe("buildVllmMenuEntries", () => {
     assert.deepEqual(entries, []);
   });
 
-  it("returns the running entry when vLLM is reachable on localhost", () => {
+  it("marks the running entry experimental on generic hosts", () => {
     const entries = buildVllmMenuEntries({
       vllmRunning: true,
       vllmProfile: null,
@@ -34,6 +34,27 @@ describe("buildVllmMenuEntries", () => {
     assert.match(entries[0].label, /Local vLLM \[experimental\]/);
     assert.match(entries[0].label, /running/);
   });
+
+  for (const [platform, hostLabel] of [
+    ["spark", "Spark"],
+    ["station", "Station"],
+  ] as const) {
+    it(`does not mark the running entry experimental on DGX ${hostLabel}`, () => {
+      const entries = buildVllmMenuEntries({
+        vllmRunning: true,
+        vllmProfile: null,
+        experimental: false,
+        platform,
+        hasVllmImage: false,
+        log: () => {},
+        env: {},
+      });
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].key, "vllm");
+      assert.doesNotMatch(entries[0].label, /experimental/);
+      assert.match(entries[0].label, /running/);
+    });
+  }
 
   it("returns the install entry when a profile matches and EXPERIMENTAL is set", () => {
     const entries = buildVllmMenuEntries({

--- a/src/lib/onboard/vllm-menu.test.ts
+++ b/src/lib/onboard/vllm-menu.test.ts
@@ -25,6 +25,7 @@ describe("buildVllmMenuEntries", () => {
       vllmRunning: true,
       vllmProfile: null,
       experimental: false,
+      platform: "linux",
       hasVllmImage: false,
       log: () => {},
       env: {},

--- a/src/lib/onboard/vllm-menu.ts
+++ b/src/lib/onboard/vllm-menu.ts
@@ -62,10 +62,12 @@ export function buildVllmMenuEntries(opts: BuildVllmMenuOptions): VllmMenuEntry[
         `  Note: NEMOCLAW_PROVIDER=install-vllm requested, but vLLM is already running on localhost:${VLLM_PORT} — selecting the running instance.`,
       );
     }
+    const experimentalLabel =
+      opts.platform && MANAGED_VLLM_DEFAULT_PLATFORMS.has(opts.platform) ? "" : " [experimental]";
     return [
       {
         key: "vllm",
-        label: `Local vLLM [experimental] (localhost:${VLLM_PORT}) — running (suggested)`,
+        label: `Local vLLM${experimentalLabel} (localhost:${VLLM_PORT}) — running (suggested)`,
       },
     ];
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
Removes the experimental label from the running Local vLLM provider entry on managed vLLM platforms. DGX Spark and DGX Station now show Local vLLM as supported, while generic and unknown platforms retain the experimental label.


## Changes
<!-- Bullet list of key changes. -->
- Make the running Local vLLM label platform-aware.
- Remove `[experimental]` on DGX Spark and DGX Station.
- Retain `[experimental]` on generic and unknown hosts.
- Add unit coverage for managed and generic platform labels.
- Update Local vLLM documentation to describe the platform-specific label.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: This changes only the provider menu label based on the existing managed-platform set;  The onboarding flow is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local vLLM setup and tool-calling reliability guidance to clarify when the “experimental” label appears.
  * Clarified that generic hosts may show “Local vLLM [experimental]”, while DGX Spark and DGX Station do not.

* **Bug Fixes**
  * Adjusted the onboarding provider menu so “Local vLLM (running…)” is marked experimental only on generic hosts, not on managed DGX platforms.

* **Tests**
  * Updated and expanded menu-label coverage for generic vs DGX Spark/DGX Station scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->