### PR TITLE
fix(docs): preserve Fern preview paths during cleanup

### DIFF
--- a/.github/workflows/docs-publish-staging.yaml
+++ b/.github/workflows/docs-publish-staging.yaml
@@ -116,11 +116,19 @@ jobs:
         run: |
           set -euo pipefail
           FERN_VERSION=$(node -p "require('./fern/fern.config.json').version")
+          FERN_ORG=$(node -p "require('./fern/fern.config.json').organization")
+          INSTANCE_PATH="${FERN_STAGING_INSTANCE#*/}"
+          if [[ "$INSTANCE_PATH" == "$FERN_STAGING_INSTANCE" ]]; then
+            INSTANCE_PATH=""
+          else
+            INSTANCE_PATH="/${INSTANCE_PATH}"
+          fi
           cd fern
           while IFS= read -r preview_id; do
             if [ -z "$preview_id" ]; then
               continue
             fi
-            npx --yes "fern-api@${FERN_VERSION}" docs preview delete --id "$preview_id"
+            preview_url="https://${FERN_ORG}-preview-${preview_id}.docs.buildwithfern.com${INSTANCE_PATH}"
+            npx --yes "fern-api@${FERN_VERSION}" docs preview delete "$preview_url"
             echo "Deleted Fern preview ${preview_id}."
           done <<< "$PREVIEW_IDS"

--- a/test/docs-publish-staging-workflow.test.ts
+++ b/test/docs-publish-staging-workflow.test.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readYaml, type Workflow, type WorkflowStep } from "./helpers/e2e-workflow-contract";
+
+type DocsPublishStagingWorkflow = Workflow & {
+  env: Record<string, string>;
+};
+
+function requiredStep(steps: WorkflowStep[] | undefined, name: string): WorkflowStep {
+  const step = steps?.find((candidate) => candidate.name === name);
+  if (!step) {
+    throw new Error(`Missing workflow step: ${name}`);
+  }
+  return step;
+}
+
+describe("staging docs preview cleanup", () => {
+  const workflow = readYaml<DocsPublishStagingWorkflow>(
+    ".github/workflows/docs-publish-staging.yaml",
+  );
+
+  it("preserves the configured Fern instance path in every preview deletion URL", () => {
+    const deleteStep = requiredStep(workflow.jobs["delete-preview"]?.steps, "Delete Fern previews");
+    const temp = mkdtempSync(join(tmpdir(), "nemoclaw-fern-preview-cleanup-"));
+    const fakeBin = join(temp, "bin");
+    const commandLog = join(temp, "commands.jsonl");
+    mkdirSync(fakeBin);
+    writeFileSync(
+      join(fakeBin, "npx"),
+      [
+        "#!/usr/bin/env node",
+        'const fs = require("node:fs");',
+        'fs.appendFileSync(process.env.COMMAND_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");',
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    try {
+      const result = spawnSync("bash", ["-c", deleteStep.run ?? ""], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          COMMAND_LOG: commandLog,
+          FERN_STAGING_INSTANCE: workflow.env.FERN_STAGING_INSTANCE,
+          FERN_TOKEN: "test-token",
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          PREVIEW_IDS: "pr-6654\npr-6507",
+        },
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      const commands = readFileSync(commandLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      expect(commands).toEqual([
+        [
+          "--yes",
+          "fern-api@5.65.2",
+          "docs",
+          "preview",
+          "delete",
+          "https://nvidia-preview-pr-6654.docs.buildwithfern.com/nemoclaw",
+        ],
+        [
+          "--yes",
+          "fern-api@5.65.2",
+          "docs",
+          "preview",
+          "delete",
+          "https://nvidia-preview-pr-6507.docs.buildwithfern.com/nemoclaw",
+        ],
+      ]);
+    } finally {
+      rmSync(temp, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fix post-merge Fern preview cleanup for NemoClaw's path-based documentation site by deleting the complete preview URL, including `/nemoclaw`. This works around Fern's `--id` resolution dropping the configured instance path and returning `Domain not registered`.

## Changes

- Derive the preview hostname from the Fern organization in `fern.config.json`.
- Preserve the path from `FERN_STAGING_INSTANCE` when constructing the deletion URL.
- Pass the complete preview URL to `fern docs preview delete` instead of using `--id`.
- Add a workflow-level regression test covering cleanup of multiple preview IDs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal CI cleanup restores the preview-deletion behavior already documented in `docs/CONTRIBUTING.md`; it does not change a user-facing command or configuration.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/docs-publish-staging-workflow.test.ts` (1 test passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>
