### PR TITLE
test(e2e): raise full-e2e onboard budget to 205s for cold-build variance (#6002)

### DIFF
--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -33,7 +33,15 @@ import { extractOpenClawAgentPayloadText } from "./agent-turn-latency-helpers.ts
 const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-full";
 const LIVE_TIMEOUT_MS = 50 * 60_000;
 const FIRST_TURN_TIMEOUT_MS = 240_000;
-const ONBOARD_BUDGET_SECS = 180;
+// Cold-path acceptance budget for install + BuildKit image build + gateway
+// health + first hosted agent turn (#6002, #6265). The dominant term is the
+// cold BuildKit image build, which swings run-to-run with Docker Hub pull
+// speed and hosted-runner I/O. Observed post-#6265 onboard phase alone ranged
+// 163s (pass) to 173s (fail) on identical `main` commits — a ~10s swing — so
+// the original 180s cap left only ~7s of headroom and tipped over on slow
+// builds. Raised to 205s to absorb build-phase variance while still catching
+// gross onboard regressions (first hosted turn itself is only ~5-8s).
+const ONBOARD_BUDGET_SECS = 205;
 const MAX_SILENCE_SECS = 60;
 const EXPECTED_FIRST_REPLY = "NEMOCLAW_E2E_READY_6002";
 const MEASURE_COLD_ONBOARD = process.env.E2E_TARGET_ID === "full-e2e";

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -3,6 +3,12 @@
   "version": 1,
   "entries": [
     {
+      "live": "test/e2e/live/full-e2e.test.ts",
+      "fast": [
+        "test/e2e/support/onboard-performance.test.ts"
+      ]
+    },
+    {
       "live": "test/e2e/live/onboard-repair.test.ts",
       "fast": [
         "src/lib/onboard/extra-provider-reconciliation-diagnostics.test.ts",


### PR DESCRIPTION
## Summary

Raise the `full-e2e` cold-onboard acceptance budget (`ONBOARD_BUDGET_SECS`) from **180s → 205s**. This is the umbrella PR for today's live-E2E failures on `main`; scope and evidence per job below.

## Failure triage (main, 2026-07-10)

A full `E2E` dispatch on `main` (run [29124128082](https://github.com/NVIDIA/NemoClaw/actions/runs/29124128082)) came back **78 passed / 5 skipped / 3 failed**. Each failure was root-caused, not retried blindly:

| Job | Verdict | Root cause |
|-----|---------|-----------|
| `agent-turn-latency` | ✅ flake, self-cleared | Passed on first retry — hosted-inference timing variance. |
| `full-e2e` | 🔧 **fixed here** | Consistent ~1s overshoot of a too-tight 180s onboard budget (see below). |
| `rebuild-hermes` | ⏳ **verification pending** | Both observed failures were infra (`operation was canceled`, `runner lost communication with the server`) — **not** a test assertion or image-build error. Retry on post-bump `main` in flight ([29129133666](https://github.com/NVIDIA/NemoClaw/actions/runs/29129133666)). See "Hermes v0.18" below. |

## `full-e2e` — full analysis (no gaps)

**Symptom.** The `[1/8]-to-first-response` gate (`full-e2e.test.ts:215`) failed **3 consecutive times**:

| Run | to-first-response | vs 180s budget |
|-----|-------------------|----------------|
| [29124128082](https://github.com/NVIDIA/NemoClaw/actions/runs/29124128082) | 180,829 ms | +0.8s |
| [29125880976](https://github.com/NVIDIA/NemoClaw/actions/runs/29125880976) | 181,550 ms | +1.5s |
| [29127670707](https://github.com/NVIDIA/NemoClaw/actions/runs/29127670707) | 180,602 ms | +0.6s |

**Not flake, not inference, not a code regression** — proven by the `onboard-progress-budget.json` artifact decomposition:

| | `onboardSecs` | `totalSecs` | headroom | notes |
|---|---|---|---|---|
| Passing run [29128496025](https://github.com/NVIDIA/NemoClaw/actions/runs/29128496025) (`f4cd7ea9`) | **163** | 168 | +12s | BuildKit prebuild ✓, 0 classic steps |
| Failing run [29127670707](https://github.com/NVIDIA/NemoClaw/actions/runs/29127670707) (`fcc121d5`) | **173** | 181 | −1s | BuildKit prebuild ✓, 0 classic steps |

- The entire delta is in the **cold onboard/BuildKit image-build phase** (163s → 173s, a ~10s run-to-run swing) on **identical, post-#6265 `main`** — both heads are after the Hermes v0.18 bump, so the bump is not the cause.
- The first hosted agent turn is only **~5–8s** (`totalSecs − onboardSecs`); inference is a rounding error.
- The 180s cap (introduced 4 days ago in #6265) left only ~7s of headroom against a phase that varies ~10s with Docker Hub pull speed and hosted-runner I/O — so slow-build runs tip over.

**Fix.** Raise to **205s**: covers the observed 173s worst case plus build-variance headroom, while still catching gross onboard regressions (a real regression blows well past 205s; `MAX_SILENCE_SECS` and BuildKit-fallback assertions are unchanged).

## Hermes v0.18 context

Today's `main` includes `feat(hermes): upgrade to v0.18 and enable Slack Block Kit` (#6507, 17:45Z), plus `#6624` (release-matched sandbox bases) and `#6623` (surface cluster image build failures). Because `rebuild-hermes` rebuilds the Hermes image, a v0.18-induced regression *could* in principle surface as runner resource-exhaustion. **This PR does not yet claim `rebuild-hermes` is a flake** — the in-flight retry on post-bump `main` is the deciding evidence:
- retry **passes** → confirmed infra flake, no code change needed, this PR ships as-is;
- retry **fails** (build error / OOM / repeat comms-loss) → v0.18 is implicated and a fix is added to this branch before merge.

## Test evidence

- `commitlint`, `gitleaks`, test-size/shape budgets: passed (pre-commit).
- No product-code change; single test-constant edit. Behavioral proof is the artifact decomposition above.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted end-to-end onboarding timing thresholds by increasing the “acceptance budget” to allow for typical variability in image build times.
  * Updated test parity mappings to ensure the added live coverage is correctly linked with the corresponding faster test set.
  * Added inline guidance for why timing can fluctuate between runs, and why the previous cap needed more headroom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->