### PR TITLE
fix(onboard): pause phase heartbeats while a prompt owns the terminal

### DIFF
--- a/src/lib/core/prompt-activity.test.ts
+++ b/src/lib/core/prompt-activity.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { isAnyPromptActive, markPromptActive } from "./prompt-activity";
+import {
+  createPromptActivityCleanup,
+  isAnyPromptActive,
+  markPromptActive,
+} from "./prompt-activity";
 
 describe("prompt activity registry", () => {
   it("reports activity only between mark and release (#6651)", () => {
@@ -29,6 +33,19 @@ describe("prompt activity registry", () => {
     const releaseSecond = markPromptActive();
     expect(isAnyPromptActive()).toBe(true);
     releaseSecond();
+    expect(isAnyPromptActive()).toBe(false);
+  });
+
+  it("releases activity before delegated terminal cleanup", () => {
+    let activeDuringCleanup = true;
+    const cleanup = createPromptActivityCleanup(() => {
+      activeDuringCleanup = isAnyPromptActive();
+    });
+
+    expect(isAnyPromptActive()).toBe(true);
+    cleanup();
+
+    expect(activeDuringCleanup).toBe(false);
     expect(isAnyPromptActive()).toBe(false);
   });
 });

--- a/src/lib/core/prompt-activity.test.ts
+++ b/src/lib/core/prompt-activity.test.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { isAnyPromptActive, markPromptActive } from "./prompt-activity";
+
+describe("prompt activity registry", () => {
+  it("reports activity only between mark and release (#6651)", () => {
+    expect(isAnyPromptActive()).toBe(false);
+    const release = markPromptActive();
+    expect(isAnyPromptActive()).toBe(true);
+    release();
+    expect(isAnyPromptActive()).toBe(false);
+  });
+
+  it("stays active until every overlapping prompt releases", () => {
+    const releaseFirst = markPromptActive();
+    const releaseSecond = markPromptActive();
+    releaseFirst();
+    expect(isAnyPromptActive()).toBe(true);
+    releaseSecond();
+    expect(isAnyPromptActive()).toBe(false);
+  });
+
+  it("ignores duplicate releases from defensive error paths", () => {
+    const releaseFirst = markPromptActive();
+    releaseFirst();
+    releaseFirst();
+    const releaseSecond = markPromptActive();
+    expect(isAnyPromptActive()).toBe(true);
+    releaseSecond();
+    expect(isAnyPromptActive()).toBe(false);
+  });
+});

--- a/src/lib/core/prompt-activity.ts
+++ b/src/lib/core/prompt-activity.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Process-wide registry of in-flight asynchronous terminal prompts.
+ *
+ * Async prompts (readline-based) yield the event loop while waiting for the
+ * user, so unrelated timers — like the onboarding phase heartbeat — can write
+ * to the terminal mid-prompt and corrupt the menu the user is answering
+ * (#6651). Prompt implementations register here for the lifetime of each
+ * question so background writers can hold their output while a prompt owns
+ * the terminal.
+ *
+ * Synchronous prompts (`core/stdin.ts`) block the event loop outright and
+ * cannot be interrupted by timers, so they do not need to register.
+ */
+
+let activePromptCount = 0;
+
+/**
+ * Record that an async prompt now owns the terminal. Returns a release
+ * function that must be called exactly once when the prompt settles;
+ * duplicate releases are ignored so error paths can call it defensively.
+ */
+export function markPromptActive(): () => void {
+  activePromptCount += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    activePromptCount = Math.max(0, activePromptCount - 1);
+  };
+}
+
+/** True while any registered async prompt is awaiting user input. */
+export function isAnyPromptActive(): boolean {
+  return activePromptCount > 0;
+}

--- a/src/lib/core/prompt-activity.ts
+++ b/src/lib/core/prompt-activity.ts
@@ -32,6 +32,18 @@ export function markPromptActive(): () => void {
   };
 }
 
+/**
+ * Register prompt activity and release it before running terminal cleanup.
+ * Releasing first lets cleanup callbacks safely observe the settled state.
+ */
+export function createPromptActivityCleanup(cleanup: () => void): () => void {
+  const releasePromptActivity = markPromptActive();
+  return () => {
+    releasePromptActivity();
+    cleanup();
+  };
+}
+
 /** True while any registered async prompt is awaiting user input. */
 export function isAnyPromptActive(): boolean {
   return activePromptCount > 0;

--- a/src/lib/credentials/store.ts
+++ b/src/lib/credentials/store.ts
@@ -541,6 +541,8 @@ export function promptSecret(question: string): Promise<string> {
     function cleanup() {
       releasePromptActivity();
       input.removeListener("data", onData);
+      input.removeListener("end", onInputClosed);
+      input.removeListener("close", onInputClosed);
       if (rawModeEnabled && typeof input.setRawMode === "function") {
         input.setRawMode(false);
       }
@@ -569,6 +571,10 @@ export function promptSecret(question: string): Promise<string> {
       cleanup();
       output.write("\n");
       reject(error);
+    }
+
+    function onInputClosed() {
+      rejectPrompt(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }));
     }
 
     function onData(chunk: Buffer | string) {
@@ -610,16 +616,22 @@ export function promptSecret(question: string): Promise<string> {
       }
     }
 
-    output.write(question);
-    input.setEncoding("utf8");
-    if (typeof input.resume === "function") {
-      input.resume();
+    try {
+      output.write(question);
+      input.setEncoding("utf8");
+      if (typeof input.resume === "function") {
+        input.resume();
+      }
+      if (typeof input.setRawMode === "function") {
+        input.setRawMode(true);
+        rawModeEnabled = true;
+      }
+      input.on("data", onData);
+      input.on("end", onInputClosed);
+      input.on("close", onInputClosed);
+    } catch (error) {
+      rejectPrompt(error instanceof Error ? error : new Error(String(error)));
     }
-    if (typeof input.setRawMode === "function") {
-      input.setRawMode(true);
-      rawModeEnabled = true;
-    }
-    input.on("data", onData);
   });
 }
 
@@ -654,8 +666,8 @@ export function prompt(question: string, opts: { secret?: boolean } = {}): Promi
     }
     // The secret path above registers inside promptSecret(); this covers the
     // readline path. Released in cleanup() on every settle path. (#6651)
-    const releasePromptActivity = markPromptActive();
     const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+    const releasePromptActivity = markPromptActive();
     let finished = false;
 
     function cleanup() {
@@ -687,24 +699,28 @@ export function prompt(question: string, opts: { secret?: boolean } = {}): Promi
       reject(error);
     }
 
-    rl.on("SIGINT", () => {
-      const error = Object.assign(new Error("Prompt interrupted"), { code: "SIGINT" });
-      rejectPrompt(error);
-      process.kill(process.pid, "SIGINT");
-    });
-    // Treat readline closing before the question is answered as cancellation.
-    // When stdin reaches EOF (e.g. `nemoclaw onboard ... < /dev/null`), the
-    // `question` callback never fires; without this the prompt promise would
-    // hang or the process would exit 0 silently. resolvePrompt/rejectPrompt set
-    // `finished` before calling cleanup() (which itself closes rl), so the
-    // post-answer close is ignored and only a premature EOF rejects here.
-    rl.on("close", () => {
-      if (finished) return;
-      rejectPrompt(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }));
-    });
-    rl.question(question, (answer) => {
-      resolvePrompt(answer.trim());
-    });
+    try {
+      rl.on("SIGINT", () => {
+        const error = Object.assign(new Error("Prompt interrupted"), { code: "SIGINT" });
+        rejectPrompt(error);
+        process.kill(process.pid, "SIGINT");
+      });
+      // Treat readline closing before the question is answered as cancellation.
+      // When stdin reaches EOF (e.g. `nemoclaw onboard ... < /dev/null`), the
+      // `question` callback never fires; without this the prompt promise would
+      // hang or the process would exit 0 silently. resolvePrompt/rejectPrompt set
+      // `finished` before calling cleanup() (which itself closes rl), so the
+      // post-answer close is ignored and only a premature EOF rejects here.
+      rl.on("close", () => {
+        if (finished) return;
+        rejectPrompt(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }));
+      });
+      rl.question(question, (answer) => {
+        resolvePrompt(answer.trim());
+      });
+    } catch (error) {
+      rejectPrompt(error instanceof Error ? error : new Error(String(error)));
+    }
   });
 }
 

--- a/src/lib/credentials/store.ts
+++ b/src/lib/credentials/store.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 import readline from "node:readline";
 
 import { isErrnoException } from "../core/errno";
+import { markPromptActive } from "../core/prompt-activity";
 import { listMessagingCredentialMetadata } from "../messaging/channels";
 import { rejectSymlinksOnPath } from "../state/config-io";
 
@@ -520,6 +521,10 @@ export function removeLegacyCredentialsFileIfEmpty(): boolean {
  */
 export function promptSecret(question: string): Promise<string> {
   return new Promise((resolve, reject) => {
+    // Register with the prompt-activity registry so background timers
+    // (e.g. onboarding heartbeats) hold their output while this prompt
+    // owns the terminal. Released in cleanup() on every settle path. (#6651)
+    const releasePromptActivity = markPromptActive();
     const input = process.stdin;
     const output = process.stderr;
     // Re-attach stdin to the event loop. cleanup() below unrefs after the
@@ -534,6 +539,7 @@ export function promptSecret(question: string): Promise<string> {
     let finished = false;
 
     function cleanup() {
+      releasePromptActivity();
       input.removeListener("data", onData);
       if (rawModeEnabled && typeof input.setRawMode === "function") {
         input.setRawMode(false);
@@ -646,10 +652,14 @@ export function prompt(question: string, opts: { secret?: boolean } = {}): Promi
         });
       return;
     }
+    // The secret path above registers inside promptSecret(); this covers the
+    // readline path. Released in cleanup() on every settle path. (#6651)
+    const releasePromptActivity = markPromptActive();
     const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
     let finished = false;
 
     function cleanup() {
+      releasePromptActivity();
       rl.close();
       // pause+unref so the process exits naturally after the last prompt
       // resolves. The matching ref() above keeps subsequent prompts working;

--- a/src/lib/credentials/store.ts
+++ b/src/lib/credentials/store.ts
@@ -14,7 +14,7 @@ import path from "node:path";
 import readline from "node:readline";
 
 import { isErrnoException } from "../core/errno";
-import { markPromptActive } from "../core/prompt-activity";
+import { createPromptActivityCleanup } from "../core/prompt-activity";
 import { listMessagingCredentialMetadata } from "../messaging/channels";
 import { rejectSymlinksOnPath } from "../state/config-io";
 
@@ -521,10 +521,6 @@ export function removeLegacyCredentialsFileIfEmpty(): boolean {
  */
 export function promptSecret(question: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    // Register with the prompt-activity registry so background timers
-    // (e.g. onboarding heartbeats) hold their output while this prompt
-    // owns the terminal. Released in cleanup() on every settle path. (#6651)
-    const releasePromptActivity = markPromptActive();
     const input = process.stdin;
     const output = process.stderr;
     // Re-attach stdin to the event loop. cleanup() below unrefs after the
@@ -538,8 +534,7 @@ export function promptSecret(question: string): Promise<string> {
     let rawModeEnabled = false;
     let finished = false;
 
-    function cleanup() {
-      releasePromptActivity();
+    const cleanup = createPromptActivityCleanup(() => {
       input.removeListener("data", onData);
       input.removeListener("end", onInputClosed);
       input.removeListener("close", onInputClosed);
@@ -555,7 +550,7 @@ export function promptSecret(question: string): Promise<string> {
       if (typeof input.unref === "function") {
         input.unref();
       }
-    }
+    });
 
     function resolvePrompt(value: string) {
       if (finished) return;
@@ -664,14 +659,10 @@ export function prompt(question: string, opts: { secret?: boolean } = {}): Promi
         });
       return;
     }
-    // The secret path above registers inside promptSecret(); this covers the
-    // readline path. Released in cleanup() on every settle path. (#6651)
     const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
-    const releasePromptActivity = markPromptActive();
     let finished = false;
 
-    function cleanup() {
-      releasePromptActivity();
+    const cleanup = createPromptActivityCleanup(() => {
       rl.close();
       // pause+unref so the process exits naturally after the last prompt
       // resolves. The matching ref() above keeps subsequent prompts working;
@@ -683,7 +674,7 @@ export function prompt(question: string, opts: { secret?: boolean } = {}): Promi
       if (typeof process.stdin.unref === "function") {
         process.stdin.unref();
       }
-    }
+    });
 
     function resolvePrompt(value: string) {
       if (finished) return;

--- a/src/lib/onboard/machine/phase-progress.test.ts
+++ b/src/lib/onboard/machine/phase-progress.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
+import { markPromptActive } from "../../core/prompt-activity";
 import {
   createPhaseProgressReporter,
   ONBOARD_PHASE_LABELS,
@@ -118,6 +119,44 @@ describe("phase progress", () => {
       )
       .run("ctx");
     expect(state.timerCallback).not.toBeNull();
+  });
+
+  it("holds heartbeats while an interactive prompt owns the terminal (#6651)", async () => {
+    let promptActive = false;
+    const { reporter, state } = createHarness({ isPromptActive: () => promptActive });
+    const wrapped = reporter.wrap(
+      phase("sandbox", async (context) => {
+        state.clockMs = 30_000;
+        promptActive = true;
+        state.timerCallback?.();
+        promptActive = false;
+        state.clockMs = 60_000;
+        state.timerCallback?.();
+        return { context, result: advanceTo("agent_setup") };
+      }),
+    );
+
+    await wrapped.run("ctx");
+
+    expect(state.lines).toEqual(["  ⏳ Still working on Sandbox creation… (60s elapsed)"]);
+  });
+
+  it("pauses heartbeats through the shared prompt-activity registry by default (#6651)", async () => {
+    const { reporter, state } = createHarness();
+    const wrapped = reporter.wrap(
+      phase("sandbox", async (context) => {
+        state.clockMs = 30_000;
+        const releasePromptActivity = markPromptActive();
+        state.timerCallback?.();
+        releasePromptActivity();
+        state.timerCallback?.();
+        return { context, result: advanceTo("agent_setup") };
+      }),
+    );
+
+    await wrapped.run("ctx");
+
+    expect(state.lines).toEqual(["  ⏳ Still working on Sandbox creation… (30s elapsed)"]);
   });
 
   it("clears the timer and preserves the phase error", async () => {

--- a/src/lib/onboard/machine/phase-progress.ts
+++ b/src/lib/onboard/machine/phase-progress.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isAnyPromptActive } from "../../core/prompt-activity";
 import type { OnboardSequencePhase } from "./sequence-runner";
 import type { OnboardNonTerminalMachineState } from "./types";
 
@@ -41,6 +42,7 @@ export interface PhaseProgressOptions {
   enabled?: boolean;
   interactive?: boolean;
   heartbeatIntervalMs?: number;
+  isPromptActive?: () => boolean;
   logLine?: (line: string) => void;
   now?: () => number;
   setTimer?: (callback: () => void, intervalMs: number) => PhaseProgressTimer;
@@ -60,6 +62,7 @@ export function createPhaseProgressReporter(
     ? HEARTBEAT_PHASE_STATES
     : new Set([...HEARTBEAT_PHASE_STATES, ...INTERACTIVE_PHASE_STATES]);
   const heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const isPromptActive = options.isPromptActive ?? isAnyPromptActive;
   const logLine = options.logLine ?? console.log;
   const now = options.now ?? Date.now;
   const setTimer =
@@ -78,6 +81,12 @@ export function createPhaseProgressReporter(
           const label = ONBOARD_PHASE_LABELS[phase.state];
           const startedAt = now();
           const timer = setTimer(() => {
+            // Interactive prompts inside heartbeat phases (sandbox name
+            // confirmation, credential entry, …) yield the event loop, so
+            // this timer can fire mid-prompt and corrupt the menu the user
+            // is answering. Hold the beat; the next one reports cumulative
+            // elapsed time anyway. (#6651)
+            if (isPromptActive()) return;
             const elapsedSeconds = Math.max(0, Math.round((now() - startedAt) / 1000));
             try {
               logLine(`  ⏳ Still working on ${label}… (${elapsedSeconds}s elapsed)`);

--- a/src/lib/onboard/messaging-selector.test.ts
+++ b/src/lib/onboard/messaging-selector.test.ts
@@ -132,6 +132,56 @@ describe("messaging selector key handling", () => {
     expect(stdinUnref).toHaveBeenCalledOnce();
   });
 
+  it("releases raw-mode prompt activity when terminal setup throws (#6651)", async () => {
+    const input = createMockSelectorInput();
+    input.setRawMode.mockImplementation(() => {
+      throw new Error("raw mode unavailable");
+    });
+    const output = { write: vi.fn() };
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: input,
+    });
+    Object.defineProperty(process, "stderr", {
+      configurable: true,
+      value: output,
+    });
+
+    expect(isAnyPromptActive()).toBe(false);
+    const selection = readMessagingChannelSelection(channels, new Set<string>(), () => {});
+
+    await expect(selection).rejects.toThrow("raw mode unavailable");
+    expect(isAnyPromptActive()).toBe(false);
+    expect(input.pause).toHaveBeenCalledOnce();
+    expect(input.unref).toHaveBeenCalledOnce();
+    expect(input.listenerCount("data")).toBe(0);
+  });
+
+  it("releases raw-mode prompt activity when stdin closes before a selection (#6651)", async () => {
+    const input = createMockSelectorInput();
+    const output = { write: vi.fn() };
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: input,
+    });
+    Object.defineProperty(process, "stderr", {
+      configurable: true,
+      value: output,
+    });
+
+    expect(isAnyPromptActive()).toBe(false);
+    const selection = readMessagingChannelSelection(channels, new Set<string>(), () => {});
+    expect(isAnyPromptActive()).toBe(true);
+
+    input.emit("close");
+
+    await expect(selection).rejects.toMatchObject({ code: "EOF" });
+    expect(isAnyPromptActive()).toBe(false);
+    expect(input.listenerCount("data")).toBe(0);
+    expect(input.listenerCount("end")).toBe(0);
+    expect(input.listenerCount("close")).toBe(0);
+  });
+
   it("restores raw mode and removes listeners when SIGTERM interrupts", async () => {
     const input = createMockSelectorInput();
     const output = { write: vi.fn() };

--- a/src/lib/onboard/messaging-selector.test.ts
+++ b/src/lib/onboard/messaging-selector.test.ts
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { EventEmitter } from "node:events";
+import readline from "node:readline";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { isAnyPromptActive } from "../core/prompt-activity";
 import {
   applyMessagingSelectorKey,
   createMessagingSelectorNormalizerState,
   normalizeMessagingSelectorInput,
+  promptMessagingChannelLineSelection,
   readMessagingChannelSelection,
   resolveMessagingChannelSelectorEntry,
 } from "./messaging-selector";
@@ -100,6 +103,33 @@ describe("messaging selector key handling", () => {
     expect(resolveMessagingChannelSelectorEntry("2", channels)?.id).toBe("discord");
     expect(resolveMessagingChannelSelectorEntry("WeChat", channels)?.id).toBe("wechat");
     expect(resolveMessagingChannelSelectorEntry("mattermost", channels)).toBeNull();
+  });
+
+  it("releases line-mode prompt activity when stdin closes before an answer (#6651)", async () => {
+    const rl = new EventEmitter() as EventEmitter & {
+      close: ReturnType<typeof vi.fn>;
+      question: ReturnType<typeof vi.fn>;
+    };
+    rl.close = vi.fn();
+    rl.question = vi.fn();
+    vi.spyOn(readline, "createInterface").mockReturnValue(rl as unknown as readline.Interface);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdinRef = vi.spyOn(process.stdin, "ref").mockImplementation(() => process.stdin);
+    const stdinPause = vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+    const stdinUnref = vi.spyOn(process.stdin, "unref").mockImplementation(() => process.stdin);
+
+    expect(isAnyPromptActive()).toBe(false);
+    const selection = promptMessagingChannelLineSelection(channels, new Set<string>(), () => "");
+    expect(isAnyPromptActive()).toBe(true);
+
+    rl.emit("close");
+
+    await expect(selection).rejects.toMatchObject({ code: "EOF" });
+    expect(isAnyPromptActive()).toBe(false);
+    expect(rl.close).toHaveBeenCalledOnce();
+    expect(stdinRef).toHaveBeenCalledOnce();
+    expect(stdinPause).toHaveBeenCalledOnce();
+    expect(stdinUnref).toHaveBeenCalledOnce();
   });
 
   it("restores raw mode and removes listeners when SIGTERM interrupts", async () => {

--- a/src/lib/onboard/messaging-selector.ts
+++ b/src/lib/onboard/messaging-selector.ts
@@ -295,6 +295,10 @@ function promptMessagingSelectorLine(question: string): Promise<string> {
       rejectPrompt(Object.assign(new Error("Prompt interrupted"), { code: "SIGINT" }));
       process.kill(process.pid, "SIGINT");
     });
+    rl.on("close", () => {
+      if (finished) return;
+      rejectPrompt(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }));
+    });
     rl.question(question, resolvePrompt);
   });
 }

--- a/src/lib/onboard/messaging-selector.ts
+++ b/src/lib/onboard/messaging-selector.ts
@@ -3,6 +3,8 @@
 
 import readline from "node:readline";
 
+import { markPromptActive } from "../core/prompt-activity";
+
 export interface MessagingChannelSelectorEntry {
   readonly id: string;
   readonly displayName: string;
@@ -154,10 +156,14 @@ export function readMessagingChannelSelection<T extends MessagingChannelSelector
     const input = process.stdin as MessagingSelectorInput;
     const output = process.stderr;
     const normalizerState = createMessagingSelectorNormalizerState();
+    // Hold background heartbeat output while this raw-mode menu owns the
+    // terminal; released in cleanup() on every settle path. (#6651)
+    const releasePromptActivity = markPromptActive();
     let rawModeEnabled = false;
     let finished = false;
 
     function cleanup() {
+      releasePromptActivity();
       input.removeListener("data", onData);
       process.removeListener("SIGINT", sigintHandler);
       process.removeListener("SIGTERM", sigtermHandler);
@@ -254,10 +260,14 @@ function promptMessagingSelectorLine(question: string): Promise<string> {
       process.stdin.ref();
     }
 
+    // Hold background heartbeat output while this prompt owns the terminal;
+    // released in cleanup() on every settle path. (#6651)
+    const releasePromptActivity = markPromptActive();
     const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
     let finished = false;
 
     function cleanup() {
+      releasePromptActivity();
       rl.close();
       if (typeof process.stdin.pause === "function") {
         process.stdin.pause();

--- a/src/lib/onboard/messaging-selector.ts
+++ b/src/lib/onboard/messaging-selector.ts
@@ -165,6 +165,8 @@ export function readMessagingChannelSelection<T extends MessagingChannelSelector
     function cleanup() {
       releasePromptActivity();
       input.removeListener("data", onData);
+      input.removeListener("end", inputClosedHandler);
+      input.removeListener("close", inputClosedHandler);
       process.removeListener("SIGINT", sigintHandler);
       process.removeListener("SIGTERM", sigtermHandler);
       if (rawModeEnabled && typeof input.setRawMode === "function") {
@@ -194,12 +196,23 @@ export function readMessagingChannelSelection<T extends MessagingChannelSelector
       process.kill(process.pid, signal);
     }
 
+    function fail(error: unknown): void {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+
     function sigintHandler(): void {
       interrupt("SIGINT");
     }
 
     function sigtermHandler(): void {
       interrupt("SIGTERM");
+    }
+
+    function inputClosedHandler(): void {
+      fail(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }));
     }
 
     function onData(chunk: Buffer | string): void {
@@ -220,20 +233,26 @@ export function readMessagingChannelSelection<T extends MessagingChannelSelector
       }
     }
 
-    if (typeof input.ref === "function") {
-      input.ref();
+    try {
+      if (typeof input.ref === "function") {
+        input.ref();
+      }
+      input.setEncoding("utf8");
+      if (typeof input.resume === "function") {
+        input.resume();
+      }
+      if (typeof input.setRawMode === "function") {
+        input.setRawMode(true);
+        rawModeEnabled = true;
+      }
+      process.on("SIGINT", sigintHandler);
+      process.on("SIGTERM", sigtermHandler);
+      input.on("data", onData);
+      input.on("end", inputClosedHandler);
+      input.on("close", inputClosedHandler);
+    } catch (error) {
+      fail(error);
     }
-    input.setEncoding("utf8");
-    if (typeof input.resume === "function") {
-      input.resume();
-    }
-    if (typeof input.setRawMode === "function") {
-      input.setRawMode(true);
-      rawModeEnabled = true;
-    }
-    process.on("SIGINT", sigintHandler);
-    process.on("SIGTERM", sigtermHandler);
-    input.on("data", onData);
   });
 }
 
@@ -262,8 +281,8 @@ function promptMessagingSelectorLine(question: string): Promise<string> {
 
     // Hold background heartbeat output while this prompt owns the terminal;
     // released in cleanup() on every settle path. (#6651)
-    const releasePromptActivity = markPromptActive();
     const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+    const releasePromptActivity = markPromptActive();
     let finished = false;
 
     function cleanup() {
@@ -291,14 +310,18 @@ function promptMessagingSelectorLine(question: string): Promise<string> {
       reject(error);
     }
 
-    rl.on("SIGINT", () => {
-      rejectPrompt(Object.assign(new Error("Prompt interrupted"), { code: "SIGINT" }));
-      process.kill(process.pid, "SIGINT");
-    });
-    rl.on("close", () => {
-      if (finished) return;
-      rejectPrompt(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }));
-    });
-    rl.question(question, resolvePrompt);
+    try {
+      rl.on("SIGINT", () => {
+        rejectPrompt(Object.assign(new Error("Prompt interrupted"), { code: "SIGINT" }));
+        process.kill(process.pid, "SIGINT");
+      });
+      rl.on("close", () => {
+        if (finished) return;
+        rejectPrompt(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }));
+      });
+      rl.question(question, resolvePrompt);
+    } catch (error) {
+      rejectPrompt(error instanceof Error ? error : new Error(String(error)));
+    }
   });
 }

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -808,6 +808,50 @@ createCredentialPromptHelpers(() => { throw new Error("unexpected exit"); }).rea
     }
   });
 
+  it("registers prompt activity while a readline prompt awaits input so heartbeats hold (#6651)", async () => {
+    const readline = require("node:readline") as typeof import("node:readline");
+    const rl = new EventEmitter() as EventEmitter & {
+      close: ReturnType<typeof vi.fn>;
+      question: ReturnType<typeof vi.fn>;
+    };
+    rl.close = vi.fn();
+    const questionCallbacks: Array<(answer: string) => void> = [];
+    rl.question = vi.fn((_question: string, callback: (answer: string) => void) => {
+      questionCallbacks.push(callback);
+    });
+
+    const createInterfaceSpy = vi.spyOn(readline, "createInterface").mockReturnValue(rl as any);
+    const stdinRef = vi.spyOn(process.stdin, "ref").mockImplementation(() => process.stdin);
+    const stdinPause = vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+    const stdinUnref = vi.spyOn(process.stdin, "unref").mockImplementation(() => process.stdin);
+
+    try {
+      const credentials = await import("../src/lib/credentials/store.js");
+      const promptActivity = await import("../src/lib/core/prompt-activity.js");
+      expect(promptActivity.isAnyPromptActive()).toBe(false);
+
+      const pending = credentials.prompt("question: ");
+      expect(promptActivity.isAnyPromptActive()).toBe(true);
+
+      questionCallbacks[0]?.("answer");
+      await expect(pending).resolves.toBe("answer");
+      expect(promptActivity.isAnyPromptActive()).toBe(false);
+
+      // The cancellation path must release the registry too, or one aborted
+      // prompt would silence heartbeats for the rest of onboarding.
+      const cancelled = credentials.prompt("question: ");
+      expect(promptActivity.isAnyPromptActive()).toBe(true);
+      rl.emit("close");
+      await expect(cancelled).rejects.toMatchObject({ code: "EOF" });
+      expect(promptActivity.isAnyPromptActive()).toBe(false);
+    } finally {
+      createInterfaceSpy.mockRestore();
+      stdinRef.mockRestore();
+      stdinPause.mockRestore();
+      stdinUnref.mockRestore();
+    }
+  });
+
   it("normalizes credential values and keeps prompting on invalid NVIDIA API key prefixes", async () => {
     const credentials = await importCredentialsModule("/tmp");
     expect(credentials.normalizeCredentialValue("  nvapi-good-key\r\n")).toBe("nvapi-good-key");

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -673,6 +673,7 @@ describe("prompt machinery (unchanged)", () => {
   it("settles the outer prompt promise on secret prompt errors", () => {
     const script = `
 const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
+const { isAnyPromptActive } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "core", "prompt-activity.ts"))});
 process.stdin.isTTY = true;
 process.stderr.isTTY = true;
 process.stdin.ref = () => process.stdin;
@@ -681,7 +682,10 @@ process.stdin.unref = () => process.stdin;
 process.stdin.setRawMode = () => { throw new Error('raw mode unavailable'); };
 prompt('secret: ', { secret: true })
   .then(() => { console.error('unexpected resolve'); process.exit(1); })
-  .catch((err) => { console.log('REJECTED=' + err.message); });
+  .catch((err) => {
+    console.log('REJECTED=' + err.message);
+    console.log('PROMPT_ACTIVE=' + String(isAnyPromptActive()));
+  });
 `;
     const result = spawnSync(process.execPath, ["-e", script], {
       encoding: "utf-8",
@@ -689,6 +693,36 @@ prompt('secret: ', { secret: true })
     });
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("REJECTED=raw mode unavailable");
+    expect(result.stdout).toContain("PROMPT_ACTIVE=false");
+  });
+
+  it("releases secret prompt activity when stdin closes before an answer (#6651)", () => {
+    const script = `
+const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
+const { isAnyPromptActive } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "core", "prompt-activity.ts"))});
+process.stdin.isTTY = true;
+process.stderr.isTTY = true;
+process.stdin.ref = () => process.stdin;
+process.stdin.resume = () => process.stdin;
+process.stdin.pause = () => process.stdin;
+process.stdin.unref = () => process.stdin;
+process.stdin.setRawMode = () => process.stdin;
+const pending = prompt('secret: ', { secret: true });
+setImmediate(() => process.stdin.emit('close'));
+pending
+  .then(() => { console.error('unexpected resolve'); process.exit(1); })
+  .catch((err) => {
+    console.log('REJECTED_CODE=' + String(err.code));
+    console.log('PROMPT_ACTIVE=' + String(isAnyPromptActive()));
+  });
+`;
+    const result = spawnSync(process.execPath, ["-e", script], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("REJECTED_CODE=EOF");
+    expect(result.stdout).toContain("PROMPT_ACTIVE=false");
   });
 
   it("classifies secret credential prompts as navigation or credential intent", async () => {


### PR DESCRIPTION
## Summary

During onboarding, the 30-second phase-progress heartbeat (`⏳ Still working on Sandbox creation… (30s elapsed)`) could fire while an interactive prompt owned the terminal, disrupting menu layout and overwriting the current selection. This PR adds a process-wide prompt-activity registry so heartbeats hold while any async prompt is awaiting input and resume afterwards with cumulative elapsed time.

## Related Issue

Fixes #6651

## Changes

- Add `src/lib/core/prompt-activity.ts`: a small process-wide registry (`markPromptActive()` / `isAnyPromptActive()`) of in-flight async terminal prompts.
- `src/lib/onboard/machine/phase-progress.ts`: the heartbeat timer skips its beat while a prompt is active (new injectable `isPromptActive` option, defaulting to the shared registry). The next beat reports cumulative elapsed time, so no progress signal is lost.
- Register the async prompt implementations for the lifetime of each question: `credentials/store.ts` (`prompt()` readline path and `promptSecret()`), and `onboard/messaging-selector.ts` (line prompt and raw-mode channel menu). Release happens in `cleanup()` on every settle path (answer, SIGINT, EOF).
- Synchronous prompts (`core/stdin.ts`) block the event loop, so timers cannot fire mid-prompt; they intentionally do not register.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal terminal-output timing fix; no user-facing behavior, commands, or configuration changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending maintainer review on this PR (touches `credentials/store.ts` prompt plumbing and onboarding progress output; no credential handling logic changed).
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/core/prompt-activity.test.ts src/lib/onboard/machine/phase-progress.test.ts src/lib/onboard/messaging-selector.test.ts src/lib/onboard/messaging-channel-setup.test.ts` (all pass) and `npx vitest run --project integration test/credentials.test.ts` (43 pass). Additionally verified end-to-end against compiled `dist/`: a live `prompt()` held 4 pending heartbeat ticks and heartbeats resumed after the answer, with the typed answer intact.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)

---
Signed-off-by: Shawn Xie <shaxie@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paused background progress/heartbeat output while interactive terminal prompts await input.
  * Coordinated credential and messaging prompts to suppress background timers while the prompt owns the terminal.
  * Improved overlapping-prompt behavior and ensured prompt activity is released on all completion/error paths.
  * Added consistent early-close handling for readline prompts and stdin closure, rejecting with an EOF-style error when input ends before an answer.
* **Tests**
  * Expanded Vitest and spawned CLI coverage for prompt activity tracking, heartbeat suppression, overlap/release behavior, and early-close cancellation/error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->