### PR TITLE
ci: reduce CLI coverage critical path with eight shards

### DIFF
--- a/.github/actions/ci-cli-coverage-merge/action.yaml
+++ b/.github/actions/ci-cli-coverage-merge/action.yaml
@@ -7,7 +7,7 @@ description: Merge shared CLI coverage shard blob reports and run the coverage r
 inputs:
   shard-count:
     description: Total number of CLI coverage shards to merge.
-    default: "5"
+    default: "8"
 
 runs:
   using: composite

--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -10,7 +10,7 @@ inputs:
     required: true
   shard-count:
     description: Total number of CLI coverage shards.
-    default: "5"
+    default: "8"
 
 runs:
   using: composite

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -103,7 +103,7 @@ jobs:
         uses: ./.github/actions/ci-cli-coverage-shard
         with:
           shard: ${{ matrix.shard }}
-          shard-count: "5"
+          shard-count: "8"
 
   cli-tests:
     needs: cli-test-shards
@@ -133,7 +133,7 @@ jobs:
       - name: Merge CLI coverage
         uses: ./.github/actions/ci-cli-coverage-merge
         with:
-          shard-count: "5"
+          shard-count: "8"
 
   plugin-tests:
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -200,7 +200,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -226,7 +226,7 @@ jobs:
         uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-shard
         with:
           shard: ${{ matrix.shard }}
-          shard-count: "5"
+          shard-count: "8"
 
   cli-tests:
     needs:
@@ -273,7 +273,7 @@ jobs:
       - name: Merge CLI coverage
         uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-merge
         with:
-          shard-count: "5"
+          shard-count: "8"
 
   plugin-tests:
     needs: changes

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -83,7 +83,7 @@ const trustedActionDirs = [
   ".github/actions/ci-installer-integration",
 ] as const;
 
-const cliShardMatrix = [1, 2, 3, 4, 5] as const;
+const cliShardMatrix = [1, 2, 3, 4, 5, 6, 7, 8] as const;
 const cliShardCount = String(cliShardMatrix.length);
 
 function stepRuns(jobOrAction: WorkflowJob | CompositeAction): string[] {
@@ -1193,7 +1193,7 @@ npx tsx scripts/checks/e2e-mock-parity.ts --base "$BASE_SHA" --head HEAD
   });
 
   it("selects an available shard to publish the compiled CLI artifact", () => {
-    for (const shardCount of [1, 2, 3, 5]) {
+    for (const shardCount of [1, 2, 3, cliShardMatrix.length]) {
       const expectedProducer = Math.min(4, shardCount);
       const producers = Array.from({ length: shardCount }, (_, index) => index + 1).filter(
         (shard) => uploadsCompiledCliArtifact(sharedActions.cliCoverageShard, shard, shardCount),


### PR DESCRIPTION
## Summary
Reduces the required PR and main CI critical path by increasing CLI coverage parallelism from five shards to eight. Profiling 32 successful PR runs found a 10m04s median and 15m27s p90; replaying a successful timing artifact predicts a 34% reduction in the slowest shard workload (371s to 246s).

## Changes
- Run CLI and integration coverage across eight shards in PR and main workflows.
- Keep shared shard and merge action defaults aligned at eight.
- Update workflow contracts to validate the eight-shard matrix and compiled-artifact producer.

## Observed CI Result
- The first eight-shard run completed the required workflow in **7m06s**, down **2m58s (29%)** from the 32-run **10m04s** baseline median.
- All eight blob reports and the compiled CLI artifact were produced and consumed successfully.
- The slowest shard completed in **6m06s** and coverage merge/ratchet completed in **41s**, both within their 10-minute timeouts.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: CI-only scheduling change with no user-facing behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/pr-workflow-contract.test.ts --project integration -t "...shard/workflow contract tests..."` (7 passed)
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — authoritative eight-shard coverage/merge validation passed in [run 29135065089](https://github.com/NVIDIA/NemoClaw/actions/runs/29135065089)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Increased CLI test coverage parallelization from 5 to 8 shards.
  - Updated coverage collection and merging to support the expanded shard configuration.
  - Aligned pull request and main build workflows with the new shard count.

- **Tests**
  - Updated workflow validation to reflect the 8-shard configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->