### PR TITLE
docs(release): add v0.0.80 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,35 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.80
+
+NemoClaw v0.0.80 upgrades Hermes to the v0.18 line with richer Slack rendering, routes OpenRouter runtime traffic through a host-local attribution adapter, imports host corporate proxy CAs into sandbox trust, hardens sandbox base-image selection and route probing, and preserves intent across more interrupted onboarding and recovery flows.
+
+- Hermes upgrades to the v0.18 release line and enables Slack Block Kit rendering.
+  Final Hermes Slack responses can use Block Kit, including native table blocks for Markdown tables, without new scopes or reinstalling the Slack app, and NemoClaw pins the resulting multi-architecture sandbox base image by immutable digest.
+  For more information, refer to [Messaging Channels](/user-guide/hermes/manage-sandboxes/messaging-channels).
+- OpenRouter runtime traffic now flows through a host-local NemoClaw adapter that injects the OpenRouter attribution headers `HTTP-Referer` and `X-OpenRouter-Title`.
+  The adapter binds to the OpenShell-held `OPENROUTER_API_KEY` by SHA-256 hash, never stores the key, and listens on port `11437` by default; set `NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_PORT` to use a different host port.
+  OpenRouter-backed LangChain Deep Agents Code sandboxes now use Deep Agents' native `openrouter` provider instead of OpenAI request shaping.
+  For more information, refer to [NemoClaw Inference Options](../inference/inference-options), [NemoClaw CLI Commands Reference](../reference/commands), and [Platform Support and Launch Claims](../reference/platform-support).
+- NemoClaw can import a host corporate proxy root CA into the sandbox trust bundle so external channel endpoints such as `api.telegram.org` verify TLS behind a corporate MITM proxy.
+  Set `NEMOCLAW_CORPORATE_CA_BUNDLE` before onboarding, or rely on detection of the conventional CA variables and host administrator anchor directories.
+  NemoClaw appends the validated CA and never replaces the OpenShell root, and you can opt out with `NEMOCLAW_CORPORATE_CA_IMPORT=0`.
+  For more information, refer to [Troubleshooting](../reference/troubleshooting).
+- Sandbox base-image resolution now prefers release-matched image tags before mutable `:latest` for release installs and stale source checkouts, validates explicit base-image overrides exactly, and fails closed when a requested image cannot be pulled or fails compatibility checks.
+  Failed cluster-image builds now surface captured, redacted Docker diagnostics instead of an opaque exit code, and the LangChain Deep Agents Code image build preserves the native OpenRouter Nemotron profile registration.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands) and [Troubleshooting](../reference/troubleshooting).
+- Bare `$$nemoclaw connect` with no sandbox name now connects to the registry default and falls back to the first non-pending registration, with clear guidance when only pending or no registrations remain.
+  Sandbox route probing rejects untrusted probe results and reports actionable rebuild guidance when the trusted Deep Agents route-probe helper is missing.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands) and [Troubleshooting](../reference/troubleshooting).
+- Onboarding and recovery preserve intent across more interrupted flows.
+  Live inference recovery is scoped to the sandbox, pending route reservations survive a not-ready recreate, re-onboarding probes registered extra providers exactly, and compatible provider recovery is preserved through the rebuild handoff.
+  Docker health checks no longer trust a stale gateway PID after the start supervisor exits, the installer's pre-upgrade backup abort message now names skipped sandboxes as well as failures, and the running Local vLLM provider entry drops the experimental label on DGX Spark and DGX Station.
+  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart), [NemoClaw CLI Commands Reference](../reference/commands), [Set Up Self-Hosted Inference Servers](../inference/local-compatible-inference-setup), and [Architecture Details](../reference/architecture).
+- Terminal and MCP startup behavior is more robust.
+  Hermes sandbox connections automatically apply a light-compatible terminal skin when the host terminal reports a light background, unless you set a Hermes theme override, and MCP stdio servers launched through `npx` now start non-interactively so a first-use install prompt no longer blocks the MCP `initialize` handshake.
+  For more information, refer to [Set Up MCP Servers](/user-guide/openclaw/manage-sandboxes/set-up-mcp-servers) and [NemoClaw Quickstart with Hermes](/user-guide/hermes/get-started/quickstart).
+
 ## v0.0.79
 
 NemoClaw v0.0.79 expands hosted and local inference options, improves operator diagnostics and shell integration, and hardens sandbox recovery, Deep Agents runtime limits, policy boundaries, and release validation.

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -26,7 +26,7 @@ NemoClaw v0.0.80 upgrades Hermes to the v0.18 line with richer Slack rendering, 
 - OpenRouter runtime traffic now flows through a host-local NemoClaw adapter that injects the OpenRouter attribution headers `HTTP-Referer` and `X-OpenRouter-Title`.
   The adapter binds to the OpenShell-held `OPENROUTER_API_KEY` by SHA-256 hash, never stores the key, and listens on port `11437` by default; set `NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_PORT` to use a different host port.
   OpenRouter-backed LangChain Deep Agents Code sandboxes now use Deep Agents' native `openrouter` provider instead of OpenAI request shaping.
-  For more information, refer to [NemoClaw Inference Options](../inference/inference-options), [NemoClaw CLI Commands Reference](../reference/commands), and [Platform Support and Launch Claims](../reference/platform-support).
+  For more information, refer to [Use OpenRouter](../inference/hosted-inference/use-openrouter), [NemoClaw CLI Commands Reference](../reference/commands), and [Platform Support and Launch Claims](../reference/platform-support).
 - NemoClaw can import a host corporate proxy root CA into the sandbox trust bundle so external channel endpoints such as `api.telegram.org` verify TLS behind a corporate MITM proxy.
   Set `NEMOCLAW_CORPORATE_CA_BUNDLE` before onboarding, or rely on detection of the conventional CA variables and host administrator anchor directories.
   NemoClaw appends the validated CA and never replaces the OpenShell root, and you can opt out with `NEMOCLAW_CORPORATE_CA_IMPORT=0`.
@@ -40,7 +40,7 @@ NemoClaw v0.0.80 upgrades Hermes to the v0.18 line with richer Slack rendering, 
 - Onboarding and recovery preserve intent across more interrupted flows.
   Live inference recovery is scoped to the sandbox, pending route reservations survive a not-ready recreate, re-onboarding probes registered extra providers exactly, and compatible provider recovery is preserved through the rebuild handoff.
   Docker health checks no longer trust a stale gateway PID after the start supervisor exits, the installer's pre-upgrade backup abort message now names skipped sandboxes as well as failures, and the running Local vLLM provider entry drops the experimental label on DGX Spark and DGX Station.
-  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart), [NemoClaw CLI Commands Reference](../reference/commands), [Set Up Self-Hosted Inference Servers](../inference/local-compatible-inference-setup), and [Architecture Details](../reference/architecture).
+  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart), [NemoClaw CLI Commands Reference](../reference/commands), [Choose a Local Inference Server](../inference/local-inference/choose-local-inference-server), and [Architecture Details](../reference/architecture).
 - Terminal and MCP startup behavior is more robust.
   Hermes sandbox connections automatically apply a light-compatible terminal skin when the host terminal reports a light background, unless you set a Hermes theme override, and MCP stdio servers launched through `npx` now start non-interactively so a first-use install prompt no longer blocks the MCP `initialize` handshake.
   For more information, refer to [Set Up MCP Servers](/user-guide/openclaw/manage-sandboxes/set-up-mcp-servers) and [NemoClaw Quickstart with Hermes](/user-guide/hermes/get-started/quickstart).


### PR DESCRIPTION
## Summary

Release-prep documentation for **v0.0.80**. Adds the `## v0.0.80` section to `docs/about/release-notes.mdx` summarizing user-facing changes since v0.0.79, each bullet linking to the relevant deeper page.

Produced via `nemoclaw-contributor-update-docs` (pre-tag path): scanned `v0.0.79..HEAD`, applied the docs skip list (no violations), and confirmed the 8 commits that already shipped in-PR docs are complete. No new pages needed.

## Source summary

- #6507 -> `docs/about/release-notes.mdx`: Hermes v0.18 + Slack Block Kit (rich rendering, digest-pinned base image).
- #6584 / #6616 -> `docs/about/release-notes.mdx`: host-local OpenRouter runtime attribution adapter (port `11437`, `NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_PORT`) and native Deep Agents `openrouter` provider.
- #6210 / #6292 -> `docs/about/release-notes.mdx`: host corporate proxy CA import into sandbox trust (`NEMOCLAW_CORPORATE_CA_BUNDLE`, `NEMOCLAW_CORPORATE_CA_IMPORT`).
- #6624 / #6623 / #6656 -> `docs/about/release-notes.mdx`: release-matched base-image selection, surfaced cluster-image build diagnostics, preserved Nemotron profile registration.
- #6629 / #6637 -> `docs/about/release-notes.mdx`: bare `connect` default-sandbox behavior and route-probe hardening.
- #6634 / #6626 / #6596 / #5569 / #6610 / #6655 -> `docs/about/release-notes.mdx`: onboarding/recovery preservation, stale-gateway-PID fix, installer backup message, vLLM label on managed platforms.
- #6578 / #5670 -> `docs/about/release-notes.mdx`: automatic Hermes light terminal skin and non-interactive `npx` MCP server startup.

## Verification

`npm run docs`: 0 errors, all internal links resolve (2 pre-existing hidden-page warnings). `_build/` variants for OpenClaw, Hermes, and Deep Agents all regenerate with the v0.0.80 section.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.80.
  * Documented Hermes upgrades, including Slack Block Kit rendering.
  * Added details on OpenRouter traffic routing and attribution headers.
  * Documented improved proxy certificate handling and sandbox reliability.
  * Highlighted enhanced connection defaults, route-probing safeguards, onboarding recovery, and terminal/MCP startup behavior.
  * Added references to relevant user-guide documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->