### PR TITLE
fix(hermes): preserve dashboard profile on rebuild

### DIFF
--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -71,6 +71,10 @@ state_dirs:
   - profiles
   - cache
   - pairing
+  # Hermes' Web dashboard uses a separate profile home for its config,
+  # memories, and user identity. Preserve it so rebuilds do not reset the
+  # dashboard profile independently of the main Hermes runtime.
+  - dashboard-home
   # Hermes' WhatsApp bridge stores QR-paired session credentials under
   # ~/.hermes/platforms/whatsapp/session. Preserve the parent so rebuilds
   # keep the in-sandbox pairing state without re-scanning.

--- a/src/lib/agent/defs.test.ts
+++ b/src/lib/agent/defs.test.ts
@@ -86,6 +86,7 @@ describe("agent definitions", () => {
       auth: "session",
     });
     expect(hermes.dashboardUi).toBeNull();
+    expect(hermes.stateDirs).toContain("dashboard-home");
     // Hermes' OpenAI-compatible API uses a bearer token read from API_SERVER_KEY.
     expect(hermes.webAuth).toEqual({ method: "bearer_token", env: "API_SERVER_KEY" });
     expect(hermes.userManagedFiles).toEqual([".hermes/.env"]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preserve Hermes' Web Dashboard profile during sandbox rebuilds. Previously, `.hermes/dashboard-home` was omitted from the manifest-driven backup, causing Dashboard `MEMORY.md` and `USER.md` data to disappear after a successful rebuild.

## Related Issue

Fixes #6681

## Changes

- Add `dashboard-home` to the Hermes durable state directories used by backup and restore.
- Add a manifest regression assertion so the Dashboard profile cannot be silently removed from the durable-state contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the existing rebuild persistence contract without adding commands, configuration, or user workflows.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/agent/defs.test.ts` (31 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Live E2E

- NemoClaw v0.0.80 + OpenShell 0.0.72 + Hermes 0.18.0: real `rebuild --verbose` omitted `dashboard-home`; Dashboard remained healthy but `MEMORY.md` and `USER.md` were missing afterward.
- This change under the same OpenShell/Hermes setup: backup and restore both included `dashboard-home`; Dashboard remained healthy and both sentinel files retained identical SHA-256 hashes.

---
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the Hermes Web dashboard profile and settings across rebuilds, preventing them from being reset.

* **Tests**
  * Added coverage to verify that the dashboard profile storage is retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->