### PR TITLE
fix(sandbox): bump root Dockerfile.base curl pin to deb13u4 (#6686)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3=3.13.5-1 \
         python3-pip=25.1.1+dfsg-1 \
         python3-venv=3.13.5-1 \
-        curl=8.14.1-2+deb13u3 \
+        curl=8.14.1-2+deb13u4 \
         git=1:2.47.3-0+deb13u1 \
         gnupg=2.4.7-21+deb13u1 \
         ca-certificates=20250419 \


### PR DESCRIPTION
## Summary

Debian Trixie's repositories no longer provide `curl=8.14.1-2+deb13u3` — a security update superseded it with `8.14.1-2+deb13u4`. Untagged/QA builds of the **root** sandbox base image (`Dockerfile.base`) therefore fail at `apt-get install`:

```
E: Version '8.14.1-2+deb13u3' for 'curl' was not found
ERROR: failed to build: ... exit code: 100
```

The dcode base (`agents/langchain-deepagents-code/Dockerfile.base`) already bumped this pin to `deb13u4` and builds in CI, so the value is confirmed available; the **independent pin in the repository-root `Dockerfile.base` was left stale**. This bumps it to match.

Fixes #6686.

## Change

- `Dockerfile.base` — `curl=8.14.1-2+deb13u3` → `curl=8.14.1-2+deb13u4` (one line).

**Scope:** The Hermes base (`agents/hermes/Dockerfile.base`) carries the identical stale pin; that's tracked and **already assigned** in #6679, so it's intentionally out of scope here.

**Acceptance criterion "other pins checked for the same rollover":** diffing the root base's apt pins against the already-fixed dcode base, `curl` is the **only** shared pin that drifted (the other differences — `gnupg`, `tmux` vs `ripgrep` — are legitimate per-agent package selections). The full-list apt simulate below independently confirms every other root pin still resolves.

## Verification

Because the fix is an apt version-availability change, verification is an `apt` simulate against the exact pinned base image (`node:22-trixie-slim@sha256:2d9f…`), not a unit test.

Run on **two hosts** (local x86_64 + the `ipp2-0085` verify host), identical results:

- `apt-cache madison curl` → only `8.14.1-2+deb13u4` is available (deb13u3 superseded).
- `apt-get install -s` of the **full root pinned package list with `curl=deb13u4`** → **resolves OK** (proves the fix *and* that every other root pin is still available — AC "other pins checked").
- `apt-get install -s curl=8.14.1-2+deb13u3` → `Version '8.14.1-2+deb13u3' for 'curl' was not found` — reproduces the exact reported failure.

**arm64/GB10:** Debian security updates publish `+deb13u4` for all release arches simultaneously, and the dcode base (which builds on the aarch64 GB10 CI) already uses `deb13u4` — so arm64 availability is confirmed by that building precedent.

Full base-image build (`docker build -f Dockerfile.base`) is the remaining end-to-end check; it needs the full base build + network apt and is covered transitively by the QA/Brev image pipeline that reported this. The targeted apt-simulate above deterministically proves the pin resolves.

Signed-off-by: Jason Ma <jama@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base image’s curl package to a newer security and maintenance release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->