### PR TITLE
fix(images): refresh shared curl pin

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3=3.13.5-1 \
         python3-pip=25.1.1+dfsg-1 \
         python3-venv=3.13.5-1 \
-        curl=8.14.1-2+deb13u3 \
+        curl=8.14.1-2+deb13u4 \
         git=1:2.47.3-0+deb13u1 \
         gnupg=2.4.7-21+deb13u1 \
         ca-certificates=20250419 \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # NemoClaw sandbox base image — expensive, rarely-changing layers.
 #
 # Contains: node:22-trixie-slim, apt packages, gosu, user/group setup,

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3=3.13.5-1 \
         python3-pip=25.1.1+dfsg-1 \
         python3-venv=3.13.5-1 \
-        curl=8.14.1-2+deb13u3 \
+        curl=8.14.1-2+deb13u4 \
         git=1:2.47.3-0+deb13u1 \
         gnupg=2.4.7-21+deb13u1 \
         ca-certificates=20250419 \

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -63,7 +63,22 @@ const publishers = [
   },
 ] as const;
 
+function pinnedAptVersion(dockerfile: string, packageName: string): string {
+  const source = fs.readFileSync(path.join(repoRoot, dockerfile), "utf8");
+  const version = source.match(new RegExp(`^\\s*${packageName}=([^\\s\\\\]+)`, "m"))?.[1];
+  expect(version, `${dockerfile} must pin ${packageName}`).toBeDefined();
+  return version as string;
+}
+
 describe("Deep Agents Code base-image publication", () => {
+  it("keeps shared apt package pins aligned across all sandbox base images (#6679)", () => {
+    const dockerfiles = publishers.map(({ dockerfile }) => dockerfile);
+    const curlVersions = dockerfiles.map((dockerfile) => pinnedAptVersion(dockerfile, "curl"));
+
+    expect(curlVersions).toEqual(expect.arrayContaining(["8.14.1-2+deb13u4"]));
+    expect(new Set(curlVersions)).toEqual(new Set([curlVersions[0]]));
+  });
+
   it("triggers its publisher whenever the DCode base inputs change (#6456)", () => {
     expect(workflow.on?.push?.paths).toEqual(
       expect.arrayContaining([

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -93,7 +93,13 @@ export default defineConfig({
           // 7 GiB CI runner. The canonical local full suite instead runs this
           // project as a bounded four-worker phase after the other projects.
           ...integrationProjectScheduling,
-          env: { NODE_OPTIONS: sourceNodeOptions },
+          env: {
+            NODE_OPTIONS: sourceNodeOptions,
+            // Integration fixtures exercise onboarding against controlled fake
+            // Docker state. Keep a base-image Dockerfile change in the PR from
+            // redirecting those fixtures into the real local-build guard.
+            NEMOCLAW_SANDBOX_BASE_IMAGE_REF: "ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+          },
           include: ["test/**/*.test.{js,ts}"],
           exclude: [
             "**/node_modules/**",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Refresh the Debian Trixie curl package pin used by the standard and Hermes sandbox base images from the unavailable `8.14.1-2+deb13u3` build to `8.14.1-2+deb13u4`. Keep controlled integration fixtures isolated from production base-image change detection so the pin change exercises their intended fake-Docker paths.

## Related Issue

Fixes #6679
Refs #6686

## Changes

- Update the standard and Hermes sandbox base-image curl pins to the available Debian package revision.
- Add the required SPDX license header to the standard sandbox base Dockerfile.
- Add regression coverage that keeps the curl pin aligned across all published sandbox base Dockerfiles.
- Set the integration test project's base-image reference explicitly so controlled fake-Docker fixtures are not diverted by production input-change detection.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal package pin and test-fixture isolation without changing the documented user workflow or interface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The production change is limited to an exact curl package revision; the environment override is scoped to controlled integration fixtures and does not weaken production image selection or sandbox behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/dcode-base-image-workflow.test.ts test/onboard.test.ts test/onboard-custom-dockerfile.test.ts test/onboard-installer-restore-intent.test.ts test/onboard-reservation-recreate.test.ts test/gateway-state-reconcile-2276.test.ts test/onboard-messaging.test.ts` (7 files, 103 tests passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
