### PR TITLE
test: clean up temporary files after runs

### DIFF
--- a/nemoclaw/vitest.config.ts
+++ b/nemoclaw/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       },
     ],
     environment: "node",
+    globalSetup: path.resolve(import.meta.dirname, "../test/helpers/vitest-temp-root.ts"),
     include: ["src/**/*.test.ts"],
   },
 });

--- a/src/lib/tunnel/services.test.ts
+++ b/src/lib/tunnel/services.test.ts
@@ -149,7 +149,12 @@ describe("sandbox name validation", () => {
   });
 
   it("accepts valid alphanumeric names", () => {
-    expect(() => getServiceStatuses({ sandboxName: "my-sandbox.1" })).not.toThrow();
+    const pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-svc-valid-name-test-"));
+    try {
+      expect(() => getServiceStatuses({ pidDir, sandboxName: "my-sandbox.1" })).not.toThrow();
+    } finally {
+      rmSync(pidDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/e2e-advisor.test.ts
+++ b/test/e2e-advisor.test.ts
@@ -18,6 +18,7 @@ import {
 import { validateE2eAdvisorEventBoundary } from "../tools/e2e-advisor/workflow-boundary.mts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const E2E_ADVISOR_TARGET_DIR = "/tmp/e2e-advisor-target";
 
 interface WorkflowStep {
   env?: Record<string, string>;
@@ -74,22 +75,30 @@ function runPrepareTargetCheckout(env: {
     '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$FAKE_GIT_LOG"\nif [[ "$*" == *"rev-parse HEAD" ]]; then\n  printf \'%s\\n\' "$FAKE_HEAD_SHA"\nfi\n',
     { mode: 0o755 },
   );
-  const result = spawnSync("bash", ["-c", prepareTargetCheckoutScript()], {
-    cwd: REPO_ROOT,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      ...env,
-      FAKE_GIT_LOG: gitLog,
-      GITHUB_ENV: githubEnv,
-      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+  const targetDir = path.join(tmp, "target");
+  const workflowScript = prepareTargetCheckoutScript();
+  expect(workflowScript).toContain(E2E_ADVISOR_TARGET_DIR);
+  const result = spawnSync(
+    "bash",
+    ["-c", workflowScript.replaceAll(E2E_ADVISOR_TARGET_DIR, targetDir)],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...env,
+        FAKE_GIT_LOG: gitLog,
+        GITHUB_ENV: githubEnv,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
     },
-  });
+  );
   return {
     ...result,
     cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }),
     gitCalls: fs.existsSync(gitLog) ? fs.readFileSync(gitLog, "utf8").trim().split(/\r?\n/u) : [],
     githubEnv: fs.existsSync(githubEnv) ? fs.readFileSync(githubEnv, "utf8") : "",
+    targetDir,
   };
 }
 
@@ -264,13 +273,13 @@ describe("E2E recommendation advisor prompt", () => {
     try {
       expect(valid.status).toBe(0);
       expect(valid.gitCalls).toEqual([
-        "-C /tmp/e2e-advisor-target init",
-        "-C /tmp/e2e-advisor-target remote add target https://github.com/NVIDIA/NemoClaw.git",
-        "-C /tmp/e2e-advisor-target fetch --no-tags target refs/heads/main:refs/remotes/target/main",
-        "-C /tmp/e2e-advisor-target fetch --no-tags target pull/5756/head:refs/remotes/target/pr-5756",
-        "-C /tmp/e2e-advisor-target checkout --detach refs/remotes/target/pr-5756",
+        `-C ${valid.targetDir} init`,
+        `-C ${valid.targetDir} remote add target https://github.com/NVIDIA/NemoClaw.git`,
+        `-C ${valid.targetDir} fetch --no-tags target refs/heads/main:refs/remotes/target/main`,
+        `-C ${valid.targetDir} fetch --no-tags target pull/5756/head:refs/remotes/target/pr-5756`,
+        `-C ${valid.targetDir} checkout --detach refs/remotes/target/pr-5756`,
       ]);
-      expect(valid.githubEnv).toBe("ADVISOR_WORKDIR=/tmp/e2e-advisor-target\nPR_NUMBER=5756\n");
+      expect(valid.githubEnv).toBe(`ADVISOR_WORKDIR=${valid.targetDir}\nPR_NUMBER=5756\n`);
     } finally {
       valid.cleanup();
     }
@@ -287,7 +296,7 @@ describe("E2E recommendation advisor prompt", () => {
       expect(mismatchedHead.stdout).toContain(
         "Fetched pull ref does not match the triggering PR head SHA",
       );
-      expect(mismatchedHead.gitCalls).toContain("-C /tmp/e2e-advisor-target rev-parse HEAD");
+      expect(mismatchedHead.gitCalls).toContain(`-C ${mismatchedHead.targetDir} rev-parse HEAD`);
       expect(mismatchedHead.githubEnv).toBe("");
     } finally {
       mismatchedHead.cleanup();

--- a/test/helpers/vitest-temp-root.ts
+++ b/test/helpers/vitest-temp-root.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const KEEP_TEMP_ENV = "NEMOCLAW_TEST_KEEP_TEMP";
+const TEMP_ENV_KEYS = ["TMPDIR", "TMP", "TEMP"] as const;
+
+type TempEnvKey = (typeof TEMP_ENV_KEYS)[number];
+
+function restoreTempEnv(previous: ReadonlyMap<TempEnvKey, string | undefined>): void {
+  for (const key of TEMP_ENV_KEYS) {
+    const value = previous.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+export function setupVitestTempRoot(): () => void {
+  const previous = new Map<TempEnvKey, string | undefined>(
+    TEMP_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-vitest-"));
+  const keepTemp = process.env[KEEP_TEMP_ENV] === "1";
+  let cleanupComplete = false;
+
+  for (const key of TEMP_ENV_KEYS) process.env[key] = root;
+
+  const cleanup = (): void => {
+    if (cleanupComplete) return;
+    if (keepTemp) {
+      process.stderr.write(`Kept Vitest temp files at ${root}\n`);
+    } else {
+      fs.rmSync(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 50,
+      });
+    }
+    cleanupComplete = true;
+  };
+
+  // Vitest's signal handler can call process.exit() without running global
+  // teardown. Keep a synchronous fallback for that path.
+  const cleanupOnExit = (): void => {
+    try {
+      cleanup();
+    } catch (error) {
+      process.stderr.write(`Failed to remove Vitest temp files at ${root}: ${String(error)}\n`);
+      if (!process.exitCode) process.exitCode = 1;
+    }
+  };
+
+  process.once("exit", cleanupOnExit);
+
+  return () => {
+    try {
+      cleanup();
+      // If removal throws, leave the exit fallback armed to retry after the
+      // worker pool closes.
+      process.off("exit", cleanupOnExit);
+    } finally {
+      restoreTempEnv(previous);
+    }
+  };
+}
+
+export default setupVitestTempRoot;

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -396,23 +396,23 @@ exit 98
   });
 
   it("scripts/install.sh --help works when run directly outside a repo checkout", () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-installer-payload-stdin-"));
     const scriptContents = fs.readFileSync(INSTALLER_PAYLOAD, "utf-8");
-    const result = spawnSync("bash", ["-s", "--", "--help"], {
-      cwd: tmp,
-      input: scriptContents,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmp,
-        PATH: TEST_SYSTEM_PATH,
-      },
-    });
-
-    const output = `${result.stdout}${result.stderr}`;
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-    expect(output).toMatch(/NemoClaw Installer/);
-    expect(output).not.toMatch(/deprecated compatibility wrapper/);
+    const tmp = fs.mkdtempSync("/tmp/nemoclaw-installer-test-");
+    try {
+      const stagedFixturePath = path.join(tmp, "payload.sh");
+      fs.writeFileSync(stagedFixturePath, scriptContents);
+      const result = spawnSync("bash", ["-s", "--", "--help"], {
+        cwd: tmp,
+        input: scriptContents,
+        encoding: "utf-8",
+        env: { ...process.env, NEMOCLAW_INSTALLER_STAGED: stagedFixturePath },
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toMatch(/NemoClaw Installer/);
+      expect(fs.existsSync(stagedFixturePath)).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("exits 0 and shows install usage for --help", () => {

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -397,10 +397,10 @@ exit 98
 
   it("scripts/install.sh --help works when run directly outside a repo checkout", () => {
     const scriptContents = fs.readFileSync(INSTALLER_PAYLOAD, "utf-8");
-    const tmp = fs.mkdtempSync("/tmp/nemoclaw-installer-test-");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-installer-payload-stdin-"));
+    const stagedFixturePath = `/tmp/nemoclaw-installer-${path.basename(tmp).slice(-6)}`;
     try {
-      const stagedFixturePath = path.join(tmp, "payload.sh");
-      fs.writeFileSync(stagedFixturePath, scriptContents);
+      fs.writeFileSync(stagedFixturePath, scriptContents, { flag: "wx", mode: 0o600 });
       const result = spawnSync("bash", ["-s", "--", "--help"], {
         cwd: tmp,
         input: scriptContents,
@@ -408,9 +408,9 @@ exit 98
         env: { ...process.env, NEMOCLAW_INSTALLER_STAGED: stagedFixturePath },
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      expect(`${result.stdout}${result.stderr}`).toMatch(/NemoClaw Installer/);
       expect(fs.existsSync(stagedFixturePath)).toBe(false);
     } finally {
+      fs.rmSync(stagedFixturePath, { force: true });
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/test/install-stage-from-stdin.test.ts
+++ b/test/install-stage-from-stdin.test.ts
@@ -127,6 +127,14 @@ function runEntryGuardInFixture(tmp: string, opts: EntryGuardOptions): StagingOu
   };
 }
 
+function ownedStagedFileOrPlaceholder(execLog: string, tmp: string): string {
+  const placeholder = path.join(tmp, "no-owned-staged-file");
+  const recordedPath = fs.existsSync(execLog)
+    ? fs.readFileSync(execLog, "utf-8").split("\n")[0]
+    : placeholder;
+  return /^\/tmp\/nemoclaw-installer-[A-Za-z0-9]+$/.test(recordedPath) ? recordedPath : placeholder;
+}
+
 function runEntryGuard(opts: EntryGuardOptions): StagingOutcome {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-stage-"));
   const execLog = path.join(tmp, "exec-intent.txt");
@@ -135,12 +143,7 @@ function runEntryGuard(opts: EntryGuardOptions): StagingOutcome {
     return runEntryGuardInFixture(tmp, opts);
   } finally {
     try {
-      if (fs.existsSync(execLog)) {
-        const [stagedPath] = fs.readFileSync(execLog, "utf-8").split("\n");
-        if (/^\/tmp\/nemoclaw-installer-[A-Za-z0-9]+$/.test(stagedPath)) {
-          fs.rmSync(stagedPath, { force: true });
-        }
-      }
+      fs.rmSync(ownedStagedFileOrPlaceholder(execLog, tmp), { force: true });
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/install-stage-from-stdin.test.ts
+++ b/test/install-stage-from-stdin.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
 
@@ -16,18 +16,19 @@ type StagingOutcome = {
   stagedFileContent: string | null;
 };
 
+type EntryGuardOptions = {
+  bashSourceOverride?: string; // simulate disk-file invocation
+  envOverrides?: Record<string, string>;
+  curlSucceeds?: boolean;
+  curlOutputContent?: string;
+};
+
 // Inlines the entry-guard staging block from install.sh into a bash
 // subshell, replacing `exec bash "$_staged" "$@"` with a capture step so
 // the test sees the intended argv without actually launching a new
 // installer process. Keep the inlined block in sync with
 // scripts/install.sh:2486-2505.
-function runEntryGuard(opts: {
-  bashSourceOverride?: string; // simulate disk-file invocation
-  envOverrides?: Record<string, string>;
-  curlSucceeds?: boolean;
-  curlOutputContent?: string;
-}): StagingOutcome {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-stage-"));
+function runEntryGuardInFixture(tmp: string, opts: EntryGuardOptions): StagingOutcome {
   const execLog = path.join(tmp, "exec-intent.txt");
   const fallthrough = path.join(tmp, "fallthrough.flag");
 
@@ -126,6 +127,26 @@ function runEntryGuard(opts: {
   };
 }
 
+function runEntryGuard(opts: EntryGuardOptions): StagingOutcome {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-stage-"));
+  const execLog = path.join(tmp, "exec-intent.txt");
+
+  try {
+    return runEntryGuardInFixture(tmp, opts);
+  } finally {
+    try {
+      if (fs.existsSync(execLog)) {
+        const [stagedPath] = fs.readFileSync(execLog, "utf-8").split("\n");
+        if (/^\/tmp\/nemoclaw-installer-[A-Za-z0-9]+$/.test(stagedPath)) {
+          fs.rmSync(stagedPath, { force: true });
+        }
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+}
+
 describe("install.sh entry-guard staging for curl|bash stdin self-stage (#4414)", () => {
   it("stages to /tmp and would exec bash on the staged file when invoked via curl|bash", () => {
     // Pipe-mode invocation: BASH_SOURCE[0] empty. Without staging,
@@ -136,6 +157,7 @@ describe("install.sh entry-guard staging for curl|bash stdin self-stage (#4414)"
     expect(outcome.execIntent.length).toBeGreaterThan(0);
     const stagedPath = outcome.execIntent[0];
     expect(stagedPath).toMatch(/^\/tmp\/nemoclaw-installer-[A-Za-z0-9]+$/);
+    expect(fs.existsSync(stagedPath)).toBe(false);
 
     // Original installer args are preserved across the would-be exec
     expect(outcome.execIntent).toContain("--non-interactive");

--- a/test/nemo-deepagents-alias.test.ts
+++ b/test/nemo-deepagents-alias.test.ts
@@ -29,7 +29,7 @@ function runDeepAgents(
       timeout: execTimeout(),
       env: {
         ...process.env,
-        HOME: "/tmp/nemo-deepagents-test-" + Date.now(),
+        HOME: fs.mkdtempSync(path.join(os.tmpdir(), "nemo-deepagents-test-")),
         // Clear inherited markers so the launcher under test sets them itself.
         NEMOCLAW_AGENT: undefined,
         NEMOCLAW_INVOKED_AS: undefined,
@@ -57,7 +57,7 @@ function runNemoClaw(
       timeout: execTimeout(),
       env: {
         ...process.env,
-        HOME: "/tmp/nemo-deepagents-test-" + Date.now(),
+        HOME: fs.mkdtempSync(path.join(os.tmpdir(), "nemo-deepagents-test-")),
         // Clear inherited markers so the base nemoclaw bin has a clean slate.
         NEMOCLAW_AGENT: undefined,
         NEMOCLAW_INVOKED_AS: undefined,

--- a/test/nemohermes-alias.test.ts
+++ b/test/nemohermes-alias.test.ts
@@ -3,6 +3,7 @@
 
 import { execSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -21,7 +22,7 @@ function runHermes(
       timeout: execTimeout(),
       env: {
         ...process.env,
-        HOME: "/tmp/nemohermes-test-" + Date.now(),
+        HOME: fs.mkdtempSync(path.join(os.tmpdir(), "nemohermes-test-")),
         // Clear inherited markers so the launcher under test sets them itself.
         NEMOCLAW_AGENT: undefined,
         NEMOCLAW_INVOKED_AS: undefined,
@@ -49,7 +50,7 @@ function runNemoClaw(
       timeout: execTimeout(),
       env: {
         ...process.env,
-        HOME: "/tmp/nemohermes-test-" + Date.now(),
+        HOME: fs.mkdtempSync(path.join(os.tmpdir(), "nemohermes-test-")),
         // Clear inherited markers so the base nemoclaw bin has a clean slate.
         // The base launcher does not set NEMOCLAW_INVOKED_AS, so leaving an
         // inherited value would silently re-brand the CLI as the alias.

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -10,6 +10,7 @@ import YAML from "yaml";
 import { validatePrReviewAdvisorWorkflowBoundary } from "../tools/pr-review-advisor/workflow-boundary.mts";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
+const PR_REVIEW_ADVISOR_TARGET_DIR = "/tmp/pr-review-advisor-target";
 
 function prepareTargetCheckoutScript(): string {
   return workflowStepScript("Prepare target PR checkout");
@@ -47,22 +48,30 @@ function runPrepareTargetCheckout(env: {
     '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$FAKE_GIT_LOG"\n',
     { mode: 0o755 },
   );
-  const result = spawnSync("bash", ["-c", prepareTargetCheckoutScript()], {
-    cwd: ROOT,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      ...env,
-      FAKE_GIT_LOG: gitLog,
-      GITHUB_ENV: githubEnv,
-      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+  const targetDir = path.join(tmp, "target");
+  const workflowScript = prepareTargetCheckoutScript();
+  expect(workflowScript).toContain(PR_REVIEW_ADVISOR_TARGET_DIR);
+  const result = spawnSync(
+    "bash",
+    ["-c", workflowScript.replaceAll(PR_REVIEW_ADVISOR_TARGET_DIR, targetDir)],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...env,
+        FAKE_GIT_LOG: gitLog,
+        GITHUB_ENV: githubEnv,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
     },
-  });
+  );
   return {
     ...result,
     cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }),
     gitCalls: fs.existsSync(gitLog) ? fs.readFileSync(gitLog, "utf8").trim().split(/\r?\n/u) : [],
     githubEnv: fs.existsSync(githubEnv) ? fs.readFileSync(githubEnv, "utf8") : "",
+    targetDir,
   };
 }
 
@@ -318,15 +327,13 @@ fi
     try {
       expect(valid.status).toBe(0);
       expect(valid.gitCalls).toEqual([
-        "-C /tmp/pr-review-advisor-target init",
-        "-C /tmp/pr-review-advisor-target remote add target https://github.com/NVIDIA/NemoClaw.git",
-        "-C /tmp/pr-review-advisor-target fetch --no-tags target main",
-        "-C /tmp/pr-review-advisor-target fetch --no-tags target pull/5756/head:refs/remotes/target/pr-5756",
-        "-C /tmp/pr-review-advisor-target checkout --detach refs/remotes/target/pr-5756",
+        `-C ${valid.targetDir} init`,
+        `-C ${valid.targetDir} remote add target https://github.com/NVIDIA/NemoClaw.git`,
+        `-C ${valid.targetDir} fetch --no-tags target main`,
+        `-C ${valid.targetDir} fetch --no-tags target pull/5756/head:refs/remotes/target/pr-5756`,
+        `-C ${valid.targetDir} checkout --detach refs/remotes/target/pr-5756`,
       ]);
-      expect(valid.githubEnv).toBe(
-        "ADVISOR_WORKDIR=/tmp/pr-review-advisor-target\nPR_NUMBER=5756\n",
-      );
+      expect(valid.githubEnv).toBe(`ADVISOR_WORKDIR=${valid.targetDir}\nPR_NUMBER=5756\n`);
     } finally {
       valid.cleanup();
     }

--- a/test/runtime-shell.test.ts
+++ b/test/runtime-shell.test.ts
@@ -244,8 +244,10 @@ describe("shell runtime helpers", () => {
     const result = runShell(
       `function colima() { cat > /dev/null || true; printf 'nameserver 100.100.100.100\\n'; }
        source "${RUNTIME_SH}"
+       nameserver_output="$(mktemp "\${TMPDIR:-/tmp}/nemoclaw-colima-ns.XXXXXX")"
+       trap 'rm -f "$nameserver_output"' EXIT
        printf 'sandbox-answer\\n' | {
-         get_colima_vm_nameserver > /tmp/nemoclaw-colima-ns.out
+         get_colima_vm_nameserver > "$nameserver_output"
          cat
        }`,
     );

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -131,17 +131,30 @@ describe("service environment", () => {
 
     it("starts without messaging-related warnings", { timeout: 30000 }, () => {
       const workspace = mkdtempSync(join(tmpdir(), "nemoclaw-services-no-key-"));
-      const result = execFileSync("bash", [scriptPath], {
-        encoding: "utf-8",
-        env: {
-          ...process.env,
-          SANDBOX_NAME: "test-box",
-          TMPDIR: workspace,
-        },
-      });
+      const sandboxName = `test-box-${String(process.pid)}-${String(Date.now())}`;
+      const pidDir = `/tmp/nemoclaw-services-${sandboxName}`;
+      const env = {
+        ...process.env,
+        SANDBOX_NAME: sandboxName,
+        TMPDIR: workspace,
+      };
+      try {
+        const result = execFileSync("bash", [scriptPath], {
+          encoding: "utf-8",
+          env,
+        });
 
-      // Messaging channels are now native to OpenClaw inside the sandbox
-      expect(result).toContain("Messaging:   via OpenClaw native channels");
+        // Messaging channels are now native to OpenClaw inside the sandbox
+        expect(result).toContain("Messaging:   via OpenClaw native channels");
+      } finally {
+        try {
+          execFileSync("bash", [scriptPath, "--stop"], { env, stdio: "ignore" });
+        } catch {
+          // Startup may fail before there is a service to stop.
+        }
+        rmSync(pidDir, { recursive: true, force: true });
+        rmSync(workspace, { recursive: true, force: true });
+      }
     });
   });
 
@@ -964,7 +977,26 @@ describe("service environment", () => {
       const proxyEnvPath = join(fakeDataDir, "proxy-env.sh");
       const rcPath = join(fakeHome, ".bashrc");
       const tmpFile = join(tmpdir(), `nemoclaw-rc-skip-composed-${process.pid}.sh`);
+      const isolatedSandboxInitPath = join(fakeDataDir, "sandbox-init.sh");
+      const isolatedSandboxEnv = {
+        ...process.env,
+        ISOLATED_SANDBOX_INIT: isolatedSandboxInitPath,
+        NEMOCLAW_TEST_AUTO_PAIR_LOG: join(fakeDataDir, "auto-pair.log"),
+        NEMOCLAW_TEST_GATEWAY_LOG: join(fakeDataDir, "gateway.log"),
+        PLUGIN_REFRESH_LOG: join(fakeDataDir, "nemoclaw-plugin-refresh.log"),
+      };
       try {
+        const sandboxLibDir = join(import.meta.dirname, "../scripts/lib");
+        const sandboxInitFixture = readFileSync(join(sandboxLibDir, "sandbox-init.sh"), "utf-8")
+          .replaceAll("/tmp/gateway.log", '"${NEMOCLAW_TEST_GATEWAY_LOG}"')
+          .replaceAll("/tmp/auto-pair.log", '"${NEMOCLAW_TEST_AUTO_PAIR_LOG}"');
+        writeFileSync(isolatedSandboxInitPath, sandboxInitFixture, { mode: 0o600 });
+        writeFileSync(
+          join(fakeDataDir, "sandbox-rlimits.sh"),
+          readFileSync(join(sandboxLibDir, "sandbox-rlimits.sh"), "utf-8"),
+          { mode: 0o600 },
+        );
+
         const shimLine = `[ -f ${proxyEnvPath} ] && . ${proxyEnvPath}`;
         const originalBashrc = [
           "# user-managed bashrc owned by a foreign uid (e.g. root)",
@@ -985,7 +1017,7 @@ describe("service environment", () => {
         const wrapper = [
           "#!/usr/bin/env bash",
           "set -euo pipefail",
-          sandboxInitSource,
+          'source "$ISOLATED_SANDBOX_INIT"',
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
@@ -1003,13 +1035,13 @@ describe("service environment", () => {
           "set +u",
           persistBlock,
           extractRuntimeShellEnvShimSnippet(),
-          // validate_tmp_permissions also inspects fixed runtime log paths; keep
-          // this fixture independent of ambient /tmp state left by other tests.
-          "install -m 600 /dev/null /tmp/gateway.log",
           "validate_tmp_permissions " + JSON.stringify(proxyEnvPath),
         ].join("\n");
         writeFileSync(tmpFile, wrapper, { mode: 0o700 });
-        const result = execFileSync("bash", [tmpFile], { encoding: "utf-8" });
+        const result = execFileSync("bash", [tmpFile], {
+          encoding: "utf-8",
+          env: isolatedSandboxEnv,
+        });
 
         expect(result).not.toContain("[SECURITY] " + proxyEnvPath + " has unsafe permissions");
 

--- a/test/vitest-temp-root.test.ts
+++ b/test/vitest-temp-root.test.ts
@@ -16,6 +16,11 @@ const ROOT_SETUP = "test/helpers/vitest-temp-root.ts";
 
 type TempEnv = Record<(typeof TEMP_ENV_KEYS)[number], string | undefined>;
 
+function restoreEnvValue(key: string, value: string | undefined): void {
+  Reflect.deleteProperty(process.env, key);
+  Object.assign(process.env, value === undefined ? {} : { [key]: value });
+}
+
 function readTempEnv(): TempEnv {
   return {
     TMPDIR: process.env.TMPDIR,
@@ -26,12 +31,7 @@ function readTempEnv(): TempEnv {
 
 function restoreTempEnv(previous: TempEnv): void {
   for (const key of TEMP_ENV_KEYS) {
-    const value = previous[key];
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
+    restoreEnvValue(key, previous[key]);
   }
 }
 
@@ -55,8 +55,8 @@ describe("Vitest temp root", () => {
     const outerEnv = readTempEnv();
     const previousKeep = process.env.NEMOCLAW_TEST_KEEP_TEMP;
     const parent = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-vitest-parent-"));
-    let nestedRoot: string | undefined;
-    let teardown: (() => void) | undefined;
+    let nestedRoot = path.join(parent, "no-nested-root");
+    let teardown = (): void => {};
 
     try {
       delete process.env.NEMOCLAW_TEST_KEEP_TEMP;
@@ -75,19 +75,18 @@ describe("Vitest temp root", () => {
       expect(os.tmpdir()).toBe(nestedRoot);
 
       teardown();
-      teardown = undefined;
+      teardown = (): void => {};
 
       expect(fs.existsSync(nestedRoot)).toBe(false);
       expect(readTempEnv()).toEqual(previous);
     } finally {
-      teardown?.();
-      if (nestedRoot) fs.rmSync(nestedRoot, { recursive: true, force: true });
-      fs.rmSync(parent, { recursive: true, force: true });
-      restoreTempEnv(outerEnv);
-      if (previousKeep === undefined) {
-        delete process.env.NEMOCLAW_TEST_KEEP_TEMP;
-      } else {
-        process.env.NEMOCLAW_TEST_KEEP_TEMP = previousKeep;
+      try {
+        teardown();
+      } finally {
+        fs.rmSync(nestedRoot, { recursive: true, force: true });
+        fs.rmSync(parent, { recursive: true, force: true });
+        restoreTempEnv(outerEnv);
+        restoreEnvValue("NEMOCLAW_TEST_KEEP_TEMP", previousKeep);
       }
     }
   });
@@ -96,8 +95,8 @@ describe("Vitest temp root", () => {
     const previousKeep = process.env.NEMOCLAW_TEST_KEEP_TEMP;
     const outerEnv = readTempEnv();
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    let keptRoot: string | undefined;
-    let teardown: (() => void) | undefined;
+    let keptRoot = path.join(os.tmpdir(), "no-kept-root");
+    let teardown = (): void => {};
 
     try {
       process.env.NEMOCLAW_TEST_KEEP_TEMP = "1";
@@ -106,20 +105,19 @@ describe("Vitest temp root", () => {
       fs.writeFileSync(path.join(keptRoot, "sentinel"), "test");
 
       teardown();
-      teardown = undefined;
+      teardown = (): void => {};
 
       expect(fs.readFileSync(path.join(keptRoot, "sentinel"), "utf8")).toBe("test");
       expect(readTempEnv()).toEqual(outerEnv);
       expect(stderr).toHaveBeenCalledWith(expect.stringContaining(keptRoot));
     } finally {
-      teardown?.();
-      if (keptRoot) fs.rmSync(keptRoot, { recursive: true, force: true });
-      if (previousKeep === undefined) {
-        delete process.env.NEMOCLAW_TEST_KEEP_TEMP;
-      } else {
-        process.env.NEMOCLAW_TEST_KEEP_TEMP = previousKeep;
+      try {
+        teardown();
+      } finally {
+        fs.rmSync(keptRoot, { recursive: true, force: true });
+        restoreEnvValue("NEMOCLAW_TEST_KEEP_TEMP", previousKeep);
+        restoreTempEnv(outerEnv);
       }
-      restoreTempEnv(outerEnv);
     }
   });
 

--- a/test/vitest-temp-root.test.ts
+++ b/test/vitest-temp-root.test.ts
@@ -121,6 +121,87 @@ describe("Vitest temp root", () => {
     }
   });
 
+  it("removes the run root through the process-exit fallback", () => {
+    const outerEnv = readTempEnv();
+    const previousKeep = process.env.NEMOCLAW_TEST_KEEP_TEMP;
+    const previousExitListeners = process.listenerCount("exit");
+    let exitHandler = (_code: number): void => {};
+    let root = path.join(os.tmpdir(), "no-exit-fallback-root");
+    let teardown = (): void => {};
+
+    try {
+      delete process.env.NEMOCLAW_TEST_KEEP_TEMP;
+      teardown = setupVitestTempRoot();
+      root = process.env.TMPDIR as string;
+      fs.writeFileSync(path.join(root, "sentinel"), "test");
+      exitHandler = process.listeners("exit").at(-1) as (code: number) => void;
+
+      expect(process.listenerCount("exit")).toBe(previousExitListeners + 1);
+      exitHandler(0);
+      expect(fs.existsSync(root)).toBe(false);
+
+      teardown();
+      teardown = (): void => {};
+      expect(readTempEnv()).toEqual(outerEnv);
+      expect(process.listenerCount("exit")).toBe(previousExitListeners);
+    } finally {
+      try {
+        teardown();
+      } finally {
+        process.off("exit", exitHandler);
+        fs.rmSync(root, { recursive: true, force: true });
+        restoreTempEnv(outerEnv);
+        restoreEnvValue("NEMOCLAW_TEST_KEEP_TEMP", previousKeep);
+      }
+    }
+  });
+
+  it("retries cleanup on exit after teardown removal fails", () => {
+    const outerEnv = readTempEnv();
+    const previousKeep = process.env.NEMOCLAW_TEST_KEEP_TEMP;
+    const previousExitListeners = process.listenerCount("exit");
+    const removeError = new Error("simulated removal failure");
+    const realRmSync = fs.rmSync;
+    const remove = vi
+      .spyOn(fs, "rmSync")
+      .mockImplementationOnce(() => {
+        throw removeError;
+      })
+      .mockImplementation(realRmSync);
+    let exitHandler = (_code: number): void => {};
+    let root = path.join(os.tmpdir(), "no-retry-root");
+    let teardown = (): void => {};
+
+    try {
+      delete process.env.NEMOCLAW_TEST_KEEP_TEMP;
+      teardown = setupVitestTempRoot();
+      root = process.env.TMPDIR as string;
+      fs.writeFileSync(path.join(root, "sentinel"), "test");
+      exitHandler = process.listeners("exit").at(-1) as (code: number) => void;
+
+      expect(teardown).toThrow(removeError);
+      expect(readTempEnv()).toEqual(outerEnv);
+      expect(process.listenerCount("exit")).toBe(previousExitListeners + 1);
+
+      exitHandler(0);
+      expect(fs.existsSync(root)).toBe(false);
+      expect(remove).toHaveBeenCalledTimes(2);
+
+      teardown();
+      teardown = (): void => {};
+      expect(process.listenerCount("exit")).toBe(previousExitListeners);
+    } finally {
+      try {
+        teardown();
+      } finally {
+        process.off("exit", exitHandler);
+        realRmSync(root, { recursive: true, force: true });
+        restoreTempEnv(outerEnv);
+        restoreEnvValue("NEMOCLAW_TEST_KEEP_TEMP", previousKeep);
+      }
+    }
+  });
+
   it("wires cleanup into root and standalone plugin test runs", () => {
     expect(rootVitestConfig.test?.globalSetup).toBe(ROOT_SETUP);
     expect(pluginVitestConfig.test?.globalSetup).toBe(

--- a/test/vitest-temp-root.test.ts
+++ b/test/vitest-temp-root.test.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import pluginVitestConfig from "../nemoclaw/vitest.config";
+import rootVitestConfig from "../vitest.config";
+import { setupVitestTempRoot } from "./helpers/vitest-temp-root";
+
+const TEMP_ENV_KEYS = ["TMPDIR", "TMP", "TEMP"] as const;
+const ROOT_SETUP = "test/helpers/vitest-temp-root.ts";
+
+type TempEnv = Record<(typeof TEMP_ENV_KEYS)[number], string | undefined>;
+
+function readTempEnv(): TempEnv {
+  return {
+    TMPDIR: process.env.TMPDIR,
+    TMP: process.env.TMP,
+    TEMP: process.env.TEMP,
+  };
+}
+
+function restoreTempEnv(previous: TempEnv): void {
+  for (const key of TEMP_ENV_KEYS) {
+    const value = previous[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Vitest temp root", () => {
+  it("redirects the selected project into one private temp root", () => {
+    const root = process.env.TMPDIR as string;
+
+    expect(process.env.TMP).toBe(root);
+    expect(process.env.TEMP).toBe(root);
+    expect(os.tmpdir()).toBe(root);
+    expect(path.isAbsolute(root)).toBe(true);
+    expect(path.basename(root)).toMatch(/^nemoclaw-vitest-/);
+    expect(fs.statSync(root).isDirectory()).toBe(true);
+  });
+
+  it("removes run artifacts and restores the caller temp environment", () => {
+    const outerEnv = readTempEnv();
+    const previousKeep = process.env.NEMOCLAW_TEST_KEEP_TEMP;
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-vitest-parent-"));
+    let nestedRoot: string | undefined;
+    let teardown: (() => void) | undefined;
+
+    try {
+      delete process.env.NEMOCLAW_TEST_KEEP_TEMP;
+      process.env.TMPDIR = parent;
+      process.env.TMP = parent;
+      delete process.env.TEMP;
+      const previous = readTempEnv();
+
+      teardown = setupVitestTempRoot();
+      nestedRoot = process.env.TMPDIR as string;
+      fs.mkdirSync(path.join(nestedRoot, "nested"));
+      fs.writeFileSync(path.join(nestedRoot, "nested", "sentinel"), "test");
+
+      expect(process.env.TMP).toBe(nestedRoot);
+      expect(process.env.TEMP).toBe(nestedRoot);
+      expect(os.tmpdir()).toBe(nestedRoot);
+
+      teardown();
+      teardown = undefined;
+
+      expect(fs.existsSync(nestedRoot)).toBe(false);
+      expect(readTempEnv()).toEqual(previous);
+    } finally {
+      teardown?.();
+      if (nestedRoot) fs.rmSync(nestedRoot, { recursive: true, force: true });
+      fs.rmSync(parent, { recursive: true, force: true });
+      restoreTempEnv(outerEnv);
+      if (previousKeep === undefined) {
+        delete process.env.NEMOCLAW_TEST_KEEP_TEMP;
+      } else {
+        process.env.NEMOCLAW_TEST_KEEP_TEMP = previousKeep;
+      }
+    }
+  });
+
+  it("keeps run artifacts only when explicitly requested", () => {
+    const previousKeep = process.env.NEMOCLAW_TEST_KEEP_TEMP;
+    const outerEnv = readTempEnv();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let keptRoot: string | undefined;
+    let teardown: (() => void) | undefined;
+
+    try {
+      process.env.NEMOCLAW_TEST_KEEP_TEMP = "1";
+      teardown = setupVitestTempRoot();
+      keptRoot = process.env.TMPDIR as string;
+      fs.writeFileSync(path.join(keptRoot, "sentinel"), "test");
+
+      teardown();
+      teardown = undefined;
+
+      expect(fs.readFileSync(path.join(keptRoot, "sentinel"), "utf8")).toBe("test");
+      expect(readTempEnv()).toEqual(outerEnv);
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining(keptRoot));
+    } finally {
+      teardown?.();
+      if (keptRoot) fs.rmSync(keptRoot, { recursive: true, force: true });
+      if (previousKeep === undefined) {
+        delete process.env.NEMOCLAW_TEST_KEEP_TEMP;
+      } else {
+        process.env.NEMOCLAW_TEST_KEEP_TEMP = previousKeep;
+      }
+      restoreTempEnv(outerEnv);
+    }
+  });
+
+  it("wires cleanup into root and standalone plugin test runs", () => {
+    expect(rootVitestConfig.test?.globalSetup).toBe(ROOT_SETUP);
+    expect(pluginVitestConfig.test?.globalSetup).toBe(
+      path.resolve(import.meta.dirname, "..", ROOT_SETUP),
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ const integrationProjectScheduling = resolveIntegrationProjectScheduling({
 
 export default defineConfig({
   test: {
+    globalSetup: "test/helpers/vitest-temp-root.ts",
     tags: [
       {
         name: "e2e/credential-free",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Vitest runs now use one private, run-scoped temp root that is removed automatically after the run, including the process-exit fallback path. Test fixtures that previously bypassed the configured temp directory now use owned, unique paths and explicit cleanup. Set `NEMOCLAW_TEST_KEEP_TEMP=1` to retain the run root for debugging.

## Changes

- Add shared Vitest global setup for the root projects and standalone plugin suite.
- Redirect `TMPDIR`, `TMP`, and `TEMP` into the run root, then restore the caller environment during teardown.
- Clean installer, service, alias, advisor, and runtime-shell fixtures that previously escaped or outlived their tests.
- Add regression coverage for recursive cleanup, caller-environment restoration, keep-temp behavior, and config wiring.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test infrastructure and fixtures only; no user-facing CLI, configuration, API, policy, or sandbox behavior changed
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 124 integration tests, 35 CLI tests, 1 focused installer test, and 9 standalone plugin tests passed; keep-temp mode passed 4/4; `npm run test:projects:check` passed for 1,483 files
- [ ] Applicable broad gate passed — `npm test` exercised 1,406 files; two aggregate-only failures passed in exact CI-mode isolation (10/10 and 64/64), so PR CI is the authoritative broad gate
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved isolation by using dynamically created, OS-appropriate temp directories/files instead of fixed `/tmp` paths.
  * Added a shared temp-root initializer for tests, with robust teardown, environment restoration, and optional temp retention.
  * Updated e2e/installer/checkout/service/runtime tests to use dynamic target and sandbox directories and to ensure staged files and temp artifacts are cleaned up.
* **Tooling**
  * Configured the test runner to perform global temp initialization before executing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->