### PR TITLE
fix(ci): describe prerequisite failures in PR E2E gate

### DIFF
--- a/.github/workflows/pr-e2e-gate.yaml
+++ b/.github/workflows/pr-e2e-gate.yaml
@@ -85,10 +85,13 @@ jobs:
         name: Start evaluation
         env:
           CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          CI_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
           GITHUB_TOKEN: ${{ github.token }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
           WORK_DIR: ${{ steps.workspace.outputs.work_dir }}
         run: >-
@@ -99,6 +102,9 @@ jobs:
           --head-branch "$HEAD_BRANCH"
           --workflow-sha "$WORKFLOW_SHA"
           --ci-conclusion "$CI_CONCLUSION"
+          --ci-run-attempt "$CI_RUN_ATTEMPT"
+          --ci-run-id "$CI_RUN_ID"
+          --pr "$PR_NUMBER"
           --work-dir "$WORK_DIR"
 
       - name: Upload risk plan

--- a/test/pr-e2e-gate-workflow.test.ts
+++ b/test/pr-e2e-gate-workflow.test.ts
@@ -121,7 +121,7 @@ exec "$@"
   }
 }
 
-function runStartStep(headBranch: string) {
+function runStartStep(headBranch: string, prNumber = "42") {
   const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
   const start = step(workflow.jobs.coordinate, "Start evaluation");
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-start-step-"));
@@ -140,12 +140,15 @@ function runStartStep(headBranch: string) {
       env: {
         ...process.env,
         CI_CONCLUSION: "success",
+        CI_RUN_ATTEMPT: "3",
+        CI_RUN_ID: "99",
         FAKE_NODE_ARGUMENTS: argumentsPath,
         GITHUB_TOKEN: "token",
         HEAD_BRANCH: headBranch,
         HEAD_REPOSITORY: "NVIDIA/NemoClaw",
         HEAD_SHA: "a".repeat(40),
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        PR_NUMBER: prNumber,
         WORKFLOW_SHA: "d".repeat(40),
         WORK_DIR: tempDir,
       },
@@ -311,6 +314,14 @@ describe("PR E2E gate workflow", () => {
     expect(execution.arguments[branchFlag + 1]).toBe(headBranch);
   });
 
+  it("passes an empty pull request association to the controller fallback", () => {
+    const execution = runStartStep("feature/pr-e2e-gate", "");
+    const prFlag = execution.arguments.indexOf("--pr");
+
+    expect(execution.result.status).toBe(0);
+    expect(execution.arguments[prFlag + 1]).toBe("");
+  });
+
   it("coordinates the check around one E2E run", () => {
     const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
     const job = workflow.jobs.coordinate;
@@ -337,13 +348,19 @@ describe("PR E2E gate workflow", () => {
     expect(start.run).toContain('--head-branch "$HEAD_BRANCH"');
     expect(start.run).toContain('--workflow-sha "$WORKFLOW_SHA"');
     expect(start.run).toContain('--ci-conclusion "$CI_CONCLUSION"');
+    expect(start.run).toContain('--ci-run-attempt "$CI_RUN_ATTEMPT"');
+    expect(start.run).toContain('--ci-run-id "$CI_RUN_ID"');
+    expect(start.run).toContain('--pr "$PR_NUMBER"');
     expect(start.run).toContain('--work-dir "$WORK_DIR"');
     expect(start.run).not.toContain("${{ github.event.");
     expect(start.env).toMatchObject({
       CI_CONCLUSION: "${{ github.event.workflow_run.conclusion }}",
+      CI_RUN_ATTEMPT: "${{ github.event.workflow_run.run_attempt }}",
+      CI_RUN_ID: "${{ github.event.workflow_run.id }}",
       HEAD_BRANCH: "${{ github.event.workflow_run.head_branch }}",
       HEAD_REPOSITORY: "${{ github.event.workflow_run.head_repository.full_name }}",
       HEAD_SHA: "${{ github.event.workflow_run.head_sha }}",
+      PR_NUMBER: "${{ github.event.workflow_run.pull_requests[0].number }}",
       WORKFLOW_SHA: "${{ github.workflow_sha }}",
       WORK_DIR: "${{ steps.workspace.outputs.work_dir }}",
     });

--- a/test/pr-e2e-gate.test.ts
+++ b/test/pr-e2e-gate.test.ts
@@ -484,6 +484,54 @@ describe("PR E2E controller", () => {
     }
   });
 
+  it("rejects a pull request that does not match the triggering workflow run", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-pr-identity-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs") && method === "POST",
+            () => githubResponse({ id: 17 }),
+          ),
+          githubFetchRoute(
+            ({ url }) => url.includes("/pulls?state=open&head="),
+            () => githubResponse([pullRequestListItem()]),
+          ),
+          githubFetchRoute(
+            ({ url }) => url.endsWith("/pulls/42"),
+            () => githubResponse(pullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            () => githubResponse({}),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir, "43"))).rejects.toThrow(
+        /PR identity does not match the triggering workflow run/u,
+      );
+      expect(requests.some((request) => request.url.includes("/files?"))).toBe(false);
+      expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
+      const finalUpdate = requests.find(
+        (request) => request.url.endsWith("/check-runs/17") && request.method === "PATCH",
+      );
+      expect(finalUpdate?.body).toMatchObject({ status: "completed", conclusion: "failure" });
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("links the pull request and failed CI jobs when prerequisite CI blocks E2E", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-ci-failure-"));
     const outputPath = path.join(workDir, "github-output");

--- a/test/pr-e2e-gate.test.ts
+++ b/test/pr-e2e-gate.test.ts
@@ -13,10 +13,12 @@ import {
   assertCorrelatedWorkflowRun,
   cancelPrGate,
   classifyPrGateEvidence,
+  controllerErrorAnnotationTitle,
   dispatchPrGate,
   expectedSignalShards,
   findSignalFiles,
   finishPrGate,
+  PrerequisiteCiError,
   type PrGateState,
   type PullRequest,
   parseControllerCommand,
@@ -37,6 +39,8 @@ import {
 const HEAD_SHA = "a".repeat(40);
 const BASE_SHA = "b".repeat(40);
 const WORKFLOW_SHA = "d".repeat(40);
+const CI_RUN_ID = 99;
+const CI_RUN_ATTEMPT = 3;
 const CORRELATION_ID = "12345678-1234-4123-8123-123456789abc";
 const BROAD_FILES = [
   "src/lib/onboard.ts",
@@ -120,7 +124,7 @@ function state(): PrGateState {
   };
 }
 
-function startCommand(workDir: string) {
+function startCommand(workDir: string, prNumber = "42") {
   const command = parseControllerCommand([
     "--mode",
     "start",
@@ -134,6 +138,12 @@ function startCommand(workDir: string) {
     WORKFLOW_SHA,
     "--ci-conclusion",
     "success",
+    "--ci-run-attempt",
+    String(CI_RUN_ATTEMPT),
+    "--ci-run-id",
+    String(CI_RUN_ID),
+    "--pr",
+    prNumber,
     "--work-dir",
     workDir,
   ]);
@@ -199,11 +209,20 @@ describe("PR E2E controller", () => {
           WORKFLOW_SHA,
           "--ci-conclusion",
           "success",
+          "--ci-run-attempt",
+          String(CI_RUN_ATTEMPT),
+          "--ci-run-id",
+          String(CI_RUN_ID),
+          "--pr",
+          "42",
           "--work-dir",
           workDir,
         ]),
       ).toMatchObject({
         mode: "start",
+        ciRunAttempt: CI_RUN_ATTEMPT,
+        ciRunId: CI_RUN_ID,
+        prNumber: 42,
         planPath: path.join(workDir, "risk-plan.json"),
         statePath: path.join(workDir, "controller-state.json"),
         evidencePath: path.join(workDir, "evidence"),
@@ -218,6 +237,7 @@ describe("PR E2E controller", () => {
       expect(() =>
         parseControllerCommand(["--mode", "cancel", "--pr", "9007199254740992"]),
       ).toThrow(/safe integer range/u);
+      expect(startCommand(workDir, "").prNumber).toBeUndefined();
 
       fs.chmodSync(workDir, 0o755);
       expect(() => parseControllerCommand(["--mode", "finish", "--work-dir", workDir])).toThrow(
@@ -227,6 +247,15 @@ describe("PR E2E controller", () => {
       fs.chmodSync(workDir, 0o700);
       fs.rmSync(workDir, { recursive: true, force: true });
     }
+  });
+
+  it("distinguishes prerequisite CI failures from controller failures in annotations", () => {
+    expect(controllerErrorAnnotationTitle(new PrerequisiteCiError("CI failed"))).toBe(
+      "PR CI did not pass",
+    );
+    expect(controllerErrorAnnotationTitle(new Error("controller failed"))).toBe(
+      "Controller failed",
+    );
   });
 
   it("validates the risk plan and bounded state", () => {
@@ -450,6 +479,196 @@ describe("PR E2E controller", () => {
         startPrGate({ ...startCommand(workDir), headRepository: "contributor/NemoClaw" }),
       ).rejects.toThrow(/PR branch must be in the base repository/u);
       expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("links the pull request and failed CI jobs when prerequisite CI blocks E2E", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-ci-failure-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs") && method === "POST",
+            () => githubResponse({ id: 17 }),
+          ),
+          githubFetchRoute(
+            ({ url }) =>
+              url.includes(`/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT}/jobs?`),
+            () =>
+              githubResponse({
+                total_count: 101,
+                jobs: [
+                  {
+                    id: 101,
+                    name: "cli-test-shards (6)",
+                    conclusion: "failure",
+                    steps: [{ name: "Run CLI coverage shard", conclusion: "failure" }],
+                  },
+                  {
+                    id: 102,
+                    name: "cli-tests",
+                    conclusion: "failure",
+                    steps: [{ name: "Verify CLI shards completed", conclusion: "failure" }],
+                  },
+                  {
+                    id: 103,
+                    name: "static-checks",
+                    conclusion: "success",
+                    steps: [{ name: "Run checks", conclusion: "success" }],
+                  },
+                  {
+                    id: 104,
+                    name: "unsafe]\n::error::<tag>&",
+                    conclusion: "failure",
+                    steps: [{ name: "bad` step\n::warning::", conclusion: "failure" }],
+                  },
+                  ...Array.from({ length: 96 }, (_, index) => ({
+                    id: 200 + index,
+                    name: `passing-job-${index}`,
+                    conclusion: "success",
+                    steps: [],
+                  })),
+                ],
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            () => githubResponse({}),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      let rejection: unknown;
+      try {
+        await startPrGate({ ...startCommand(workDir), ciConclusion: "failure" });
+      } catch (error) {
+        rejection = error;
+      }
+      expect(rejection).toBeInstanceOf(PrerequisiteCiError);
+      const rejectionMessage = (rejection as Error).message;
+      expect(rejectionMessage).toContain("PR #42: https://github.com/NVIDIA/NemoClaw/pull/42");
+      expect(rejectionMessage).toContain(
+        `CI run attempt ${CI_RUN_ATTEMPT}: https://github.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT}`,
+      );
+      expect(rejectionMessage).toContain("cli-test-shards (6) (Run CLI coverage shard)");
+      expect(rejectionMessage).toContain("job listing truncated");
+
+      expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
+      expect(requests.some((request) => request.url.includes("/pulls"))).toBe(false);
+      const finalUpdate = requests.find(
+        (request) => request.url.endsWith("/check-runs/17") && request.method === "PATCH",
+      );
+      expect(finalUpdate?.body).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        details_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT}`,
+        output: {
+          title: "PR #42 CI did not pass",
+        },
+      });
+      const summary = (finalUpdate?.body as { output?: { summary?: string } } | undefined)?.output
+        ?.summary;
+      expect(summary).toContain("[PR #42](https://github.com/NVIDIA/NemoClaw/pull/42)");
+      expect(summary).toContain(
+        `[CI / Pull Request attempt ${CI_RUN_ATTEMPT}](https://github.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT})`,
+      );
+      expect(summary).toContain(
+        `[cli-test-shards (6)](https://github.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/job/101)`,
+      );
+      expect(summary).toContain("failed step: `Run CLI coverage shard`");
+      expect(summary).toContain(
+        `[cli-tests](https://github.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/job/102)`,
+      );
+      expect(summary).toContain(
+        `[unsafe\\] ::error::&lt;tag&gt;&amp;](https://github.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/job/104)`,
+      );
+      expect(summary).toContain("failed step: `bad' step ::warning::`");
+      expect(summary).not.toContain("\n::error::");
+      expect(summary).not.toContain("\n::warning::");
+      expect(summary).not.toContain("static-checks");
+      expect(summary).toContain("The job listing was truncated");
+      const outputs = fs.readFileSync(outputPath, "utf8");
+      expect(outputs).toContain("dispatched=false");
+      expect(outputs).toContain("finalized=true");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the known CI failure when job details cannot be loaded", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-ci-fallback-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs") && method === "POST",
+            () => githubResponse({ id: 17 }),
+          ),
+          githubFetchRoute(
+            ({ url }) =>
+              url.includes(`/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT}/jobs?`),
+            () => githubResponse({ message: "temporary failure" }, 503),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            () => githubResponse({}),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(
+        startPrGate({
+          ...startCommand(workDir),
+          ciConclusion: "failure",
+          prNumber: undefined,
+        }),
+      ).rejects.toThrow(
+        new RegExp(
+          `CI run attempt ${CI_RUN_ATTEMPT}: https://github\\.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT}`,
+          "u",
+        ),
+      );
+
+      expect(requests.some((request) => request.url.includes("/pulls"))).toBe(false);
+      const finalUpdate = requests.find(
+        (request) => request.url.endsWith("/check-runs/17") && request.method === "PATCH",
+      );
+      expect(finalUpdate?.body).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        details_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT}`,
+        output: {
+          title: "PR CI did not pass",
+          summary: expect.stringContaining("Job details could not be loaded"),
+        },
+      });
+      const summary = (finalUpdate?.body as { output?: { summary?: string } } | undefined)?.output
+        ?.summary;
+      expect(summary).toContain("The triggering PR was not present in the workflow event");
+      expect(summary).not.toContain("/pull/");
+      const outputs = fs.readFileSync(outputPath, "utf8");
+      expect(outputs).toContain("dispatched=false");
+      expect(outputs).toContain("finalized=true");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -39,6 +39,7 @@ const MAX_PLAN_BYTES = 1024 * 1024;
 const MAX_CONTROLLER_ERROR_CHARS = 512;
 const MAX_PR_FILES = 3000;
 const MAX_ACTIVE_RUN_PAGES_PER_STATUS = 10;
+const MAX_REPORTED_CI_JOBS = 10;
 const ACTIVE_WORKFLOW_RUN_STATUSES = [
   "requested",
   "waiting",
@@ -66,6 +67,9 @@ export type ControllerCommand =
       headBranch: string;
       workflowSha: string;
       ciConclusion: string;
+      ciRunId: number;
+      ciRunAttempt: number;
+      prNumber?: number;
     } & ControllerPaths)
   | ({
       mode: "finish";
@@ -104,6 +108,13 @@ type WorkflowRun = {
 };
 
 type WorkflowRunsResponse = { workflow_runs: WorkflowRun[] };
+type WorkflowJob = {
+  id: number;
+  name: string;
+  conclusion: string | null;
+  steps: Array<{ name: string; conclusion: string | null }>;
+};
+type WorkflowJobsPage = { totalCount: number; jobs: WorkflowJob[] };
 type CheckRun = { id: number };
 type GitReference = { ref: string; object: { type: string; sha: string } };
 
@@ -137,6 +148,8 @@ export type PrGateVerdict = {
   title: string;
   summary: string;
 };
+
+export class PrerequisiteCiError extends Error {}
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -232,6 +245,12 @@ export function parseControllerCommand(argv: string[]): ControllerCommand {
       headBranch: requiredArgument(args.headBranch, "head-branch"),
       workflowSha: requiredArgument(args.workflowSha, "workflow-sha"),
       ciConclusion: requiredArgument(args.ciConclusion, "ci-conclusion"),
+      ciRunId: parsePositiveId(requiredArgument(args.ciRunId, "ci-run-id"), "--ci-run-id"),
+      ciRunAttempt: parsePositiveId(
+        requiredArgument(args.ciRunAttempt, "ci-run-attempt"),
+        "--ci-run-attempt",
+      ),
+      prNumber: args.pr ? parsePositiveId(args.pr, "--pr") : undefined,
       ...privateControllerPaths(requiredArgument(args.workDir, "work-dir")),
     };
   }
@@ -677,6 +696,176 @@ export async function resolvePullRequest(options: {
   return detail;
 }
 
+function validateWorkflowJob(value: unknown): WorkflowJob {
+  if (
+    !isObjectRecord(value) ||
+    !Number.isSafeInteger(value.id) ||
+    (value.id as number) < 1 ||
+    typeof value.name !== "string" ||
+    value.name.length === 0 ||
+    (value.conclusion !== null && typeof value.conclusion !== "string") ||
+    (value.steps !== undefined && !Array.isArray(value.steps))
+  ) {
+    throw new Error("GitHub returned an invalid workflow job");
+  }
+  const steps = (value.steps ?? []).map((step) => {
+    if (
+      !isObjectRecord(step) ||
+      typeof step.name !== "string" ||
+      step.name.length === 0 ||
+      (step.conclusion !== null && typeof step.conclusion !== "string")
+    ) {
+      throw new Error("GitHub returned an invalid workflow job step");
+    }
+    return { name: step.name, conclusion: step.conclusion };
+  });
+  return {
+    id: value.id as number,
+    name: value.name,
+    conclusion: value.conclusion,
+    steps,
+  };
+}
+
+function validateWorkflowJobsPage(value: unknown): WorkflowJobsPage {
+  if (
+    !isObjectRecord(value) ||
+    !Number.isSafeInteger(value.total_count) ||
+    (value.total_count as number) < 0 ||
+    !Array.isArray(value.jobs)
+  ) {
+    throw new Error("GitHub returned an invalid workflow job listing");
+  }
+  return {
+    totalCount: value.total_count as number,
+    jobs: value.jobs.map(validateWorkflowJob),
+  };
+}
+
+async function listNonPassingCiJobs(
+  repository: string,
+  token: string,
+  ciRunId: number,
+  ciRunAttempt: number,
+): Promise<{ jobs: WorkflowJob[]; complete: boolean }> {
+  const response = validateWorkflowJobsPage(
+    await githubApi<unknown>(
+      `repos/${repository}/actions/runs/${ciRunId}/attempts/${ciRunAttempt}/jobs?per_page=100`,
+      token,
+      { userAgent: USER_AGENT },
+    ),
+  );
+  if (response.jobs.length > response.totalCount) {
+    throw new Error("GitHub returned an invalid workflow job count");
+  }
+  return {
+    jobs: response.jobs.filter(
+      (job) => !["success", "skipped", "neutral"].includes(job.conclusion ?? ""),
+    ),
+    complete: response.jobs.length === response.totalCount,
+  };
+}
+
+function normalizedCiMetadata(value: string, fallback: string): string {
+  const normalized = value
+    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
+    .replace(/\s{2,}/gu, " ")
+    .trim();
+  if (!normalized) return fallback;
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function markdownLinkText(value: string): string {
+  return normalizedCiMetadata(value, "unnamed job")
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/\\/gu, "\\\\")
+    .replace(/\[/gu, "\\[")
+    .replace(/\]/gu, "\\]");
+}
+
+function markdownCode(value: string, fallback: string): string {
+  return `\`${normalizedCiMetadata(value, fallback).replace(/`/gu, "'")}\``;
+}
+
+function ciFailureReport(options: {
+  repository: string;
+  prNumber?: number;
+  ciRunId: number;
+  ciRunAttempt: number;
+  ciConclusion: string;
+  jobs: readonly WorkflowJob[];
+  jobDetailsAvailable: boolean;
+  jobDetailsComplete: boolean;
+}): { summary: string; errorMessage: string; ciRunUrl: string } {
+  const prUrl = options.prNumber
+    ? `https://github.com/${options.repository}/pull/${options.prNumber}`
+    : undefined;
+  const ciRunUrl = `https://github.com/${options.repository}/actions/runs/${options.ciRunId}/attempts/${options.ciRunAttempt}`;
+  const conclusion = normalizedCiMetadata(options.ciConclusion, "without a result");
+  const reportedJobs = options.jobs.slice(0, MAX_REPORTED_CI_JOBS);
+  const ciLink = `[CI / Pull Request attempt ${options.ciRunAttempt}](${ciRunUrl})`;
+  const summary = options.prNumber
+    ? [
+        `[PR #${options.prNumber}](${prUrl}) did not pass ${ciLink} (${markdownCode(conclusion, "without a result")}), so no E2E run was dispatched.`,
+      ]
+    : [
+        `${ciLink} concluded ${markdownCode(conclusion, "without a result")}, so no E2E run was dispatched. The triggering PR was not present in the workflow event.`,
+      ];
+  if (reportedJobs.length > 0) {
+    summary.push("", "Jobs that did not pass:");
+    for (const job of reportedJobs) {
+      const jobUrl = `https://github.com/${options.repository}/actions/runs/${options.ciRunId}/job/${job.id}`;
+      const failedSteps = job.steps.filter((step) => step.conclusion === "failure");
+      const detail =
+        failedSteps.length > 0
+          ? `${failedSteps.length === 1 ? "failed step" : "failed steps"}: ${failedSteps
+              .slice(0, 3)
+              .map((step) => markdownCode(step.name, "unnamed step"))
+              .join(", ")}${failedSteps.length > 3 ? ` and ${failedSteps.length - 3} more` : ""}`
+          : `concluded ${markdownCode(job.conclusion ?? "without a result", "without a result")}`;
+      summary.push(`- [${markdownLinkText(job.name)}](${jobUrl}) — ${detail}.`);
+    }
+    if (options.jobs.length > reportedJobs.length) {
+      summary.push(
+        `- ${options.jobs.length - reportedJobs.length} more; open the CI run for details.`,
+      );
+    }
+    if (!options.jobDetailsComplete) {
+      summary.push("- The job listing was truncated; open the CI run for the full result.");
+    }
+  } else if (options.jobDetailsAvailable) {
+    summary.push(
+      "",
+      options.jobDetailsComplete
+        ? "GitHub reported no non-passing job. Open the CI run for details."
+        : "The job listing was truncated before a non-passing job was found. Open the CI run for details.",
+    );
+  } else {
+    summary.push("", "Job details could not be loaded. Open the CI run for details.");
+  }
+
+  const conciseJobs = reportedJobs.slice(0, 3).map((job) => {
+    const failedSteps = job.steps
+      .filter((step) => step.conclusion === "failure")
+      .slice(0, 2)
+      .map((step) => normalizedCiMetadata(step.name, "unnamed step"));
+    const detail =
+      failedSteps.length > 0 ? failedSteps.join(", ") : (job.conclusion ?? "no result");
+    return `${normalizedCiMetadata(job.name, "unnamed job")} (${detail})`;
+  });
+  const jobMessage =
+    conciseJobs.length > 0 ? conciseJobs.join("; ") : "no non-passing job details were available";
+  const truncationMessage =
+    options.jobDetailsAvailable && !options.jobDetailsComplete ? "; job listing truncated" : "";
+  return {
+    summary: summary.join("\n"),
+    errorMessage: `${options.prNumber ? `PR #${options.prNumber}: ${prUrl}` : "Triggering PR unavailable"}; CI run attempt ${options.ciRunAttempt}: ${ciRunUrl}; CI / Pull Request concluded ${conclusion}; jobs that did not pass: ${jobMessage}${truncationMessage}`,
+    ciRunUrl,
+  };
+}
+
 export async function pullChangedFiles(
   repository: string,
   pull: PullRequest,
@@ -937,15 +1126,49 @@ export async function startPrGate(
   let childRunId: number | undefined;
   try {
     if (command.ciConclusion !== "success") {
-      await completeCheck({ repository, checkRunId }, token, {
-        conclusion: "failure",
-        title: "PR CI did not pass",
-        summary: `CI / Pull Request concluded ${command.ciConclusion || "without a result"}; no run was dispatched.`,
+      let jobs: WorkflowJob[] = [];
+      let jobDetailsAvailable = true;
+      let jobDetailsComplete = true;
+      try {
+        const details = await listNonPassingCiJobs(
+          repository,
+          token,
+          command.ciRunId,
+          command.ciRunAttempt,
+        );
+        jobs = details.jobs;
+        jobDetailsComplete = details.complete;
+      } catch (error) {
+        jobDetailsAvailable = false;
+        jobDetailsComplete = false;
+        console.warn(`Could not load CI job details: ${controllerErrorMessage(error)}`);
+      }
+      const report = ciFailureReport({
+        repository,
+        prNumber: command.prNumber,
+        ciRunId: command.ciRunId,
+        ciRunAttempt: command.ciRunAttempt,
+        ciConclusion: command.ciConclusion,
+        jobs,
+        jobDetailsAvailable,
+        jobDetailsComplete,
       });
+      await completeCheck(
+        { repository, checkRunId },
+        token,
+        {
+          conclusion: "failure",
+          title: command.prNumber
+            ? `PR #${command.prNumber} CI did not pass`
+            : "PR CI did not pass",
+          summary: report.summary,
+        },
+        report.ciRunUrl,
+      );
       appendOutput("dispatched", "false");
       appendOutput("finalized", "true");
       finalized = true;
-      throw new Error(`CI / Pull Request concluded ${command.ciConclusion || "without a result"}`);
+      throw new PrerequisiteCiError(report.errorMessage);
     }
 
     const pull = await resolvePullRequest({
@@ -955,8 +1178,12 @@ export async function startPrGate(
       headRepository: command.headRepository,
       headBranch: command.headBranch,
     });
-    if (command.headRepository !== repository || pull.head.repo?.full_name !== repository) {
-      throw new Error("PR branch must be in the base repository");
+    if (
+      command.headRepository !== repository ||
+      pull.head.repo?.full_name !== repository ||
+      (command.prNumber !== undefined && pull.number !== command.prNumber)
+    ) {
+      throw new Error("PR identity does not match the triggering workflow run");
     }
 
     const changedFiles = await pullChangedFiles(repository, pull, token);
@@ -1248,12 +1475,16 @@ export async function cancelPrGate(prNumber: number): Promise<number> {
   return active.size;
 }
 
+export function controllerErrorAnnotationTitle(error: unknown): string {
+  return error instanceof PrerequisiteCiError ? "PR CI did not pass" : "Controller failed";
+}
+
 function reportControllerError(error: unknown): void {
   const message = controllerErrorMessage(error);
   console.error(message);
   if (process.env.GITHUB_ACTIONS === "true") {
     const escaped = message.replace(/%/gu, "%25").replace(/\r/gu, "%0D").replace(/\n/gu, "%0A");
-    console.error(`::error title=Controller failed::${escaped}`);
+    console.error(`::error title=${controllerErrorAnnotationTitle(error)}::${escaped}`);
   }
 }
 

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -1128,7 +1128,7 @@ export async function startPrGate(
     if (command.ciConclusion !== "success") {
       let jobs: WorkflowJob[] = [];
       let jobDetailsAvailable = true;
-      let jobDetailsComplete = true;
+      let jobDetailsComplete: boolean;
       try {
         const details = await listNonPassingCiJobs(
           repository,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Replace the generic PR E2E prerequisite failure with actionable diagnostics. The gate now links the triggering PR and exact CI attempt when available, and identifies the jobs and steps that prevented E2E dispatch.

## Changes

- Pass the upstream CI run ID, attempt, and optional PR number from the `workflow_run` event to the controller.
- Link the PR, attempt-specific CI run, and non-passing jobs while reporting failed step names from GitHub's structured job metadata.
- Normalize and bound GitHub-provided names before rendering them across the privileged `workflow_run` boundary, and disclose when the single-page job listing is truncated.
- Preserve the known prerequisite failure when GitHub omits the PR association or job-detail enrichment fails; controller and workflow regression tests protect both fallbacks.
- Label expected prerequisite failures as `PR CI did not pass` instead of `Controller failed`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes internal GitHub Check diagnostics, not NemoClaw runtime, CLI, configuration, APIs, or the documented E2E lifecycle.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: two independent read-only reviews audited the privileged `workflow_run` boundary; hostile metadata, rerun attempts, missing PR association, API failure, and truncation are covered by regression tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/pr-e2e-gate.test.ts test/pr-e2e-gate-workflow.test.ts` (42 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced pull request gate reporting for prerequisite CI failures with richer diagnostics and clearer attribution using CI run/attempt metadata.
  * Added bounded reporting to limit how many non-passing CI jobs appear in failure summaries.
* **Bug Fixes**
  * Strengthened validation to ensure the gate run matches the correct pull request.
  * Improved fallback messaging when CI job details can’t be retrieved.
* **Tests**
  * Expanded unit and end-to-end coverage for CI metadata handling, PR matching rules, and error annotation behavior (including missing/empty PR association cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->