### PR TITLE
ci(advisors): use GPT-5.6 Terra

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -59,9 +59,9 @@ jobs:
       fail-fast: false
       matrix:
         advisor:
-          - id: gpt-5.5
-            label: GPT-5.5
-            model: openai/openai/gpt-5.5
+          - id: gpt-5.6-terra
+            label: GPT-5.6 Terra
+            model: azure/openai/gpt-5.6-terra
             artifact_dir: pr-review-advisor
             artifact_name: pr-review-advisor
             publish_comment: true

--- a/test/advisor-session-runner.test.ts
+++ b/test/advisor-session-runner.test.ts
@@ -282,7 +282,7 @@ afterEach(() => {
 
 describe("advisor session runner", () => {
   it("uses one bounded provider-aware retry layer for transient failures", () => {
-    expect(advisorRetrySettings("openai/openai/gpt-5.5")).toEqual({
+    expect(advisorRetrySettings("azure/openai/gpt-5.6-terra")).toEqual({
       enabled: true,
       maxRetries: 4,
       baseDelayMs: 6_000,

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -349,7 +349,7 @@ fi
         "artifact_name: pr-review-advisor-nemotron-ultra",
         "artifact_name: pr-review-advisor",
       )
-      .replace("model: nvidia/nvidia/nemotron-3-ultra", "model: openai/openai/gpt-5.5")
+      .replace("model: nvidia/nvidia/nemotron-3-ultra", "model: azure/openai/gpt-5.6-terra")
       .replace('\n              --title "$PR_REVIEW_ADVISOR_COMMENT_TITLE" \\', "");
     fs.writeFileSync(workflowPath, workflow);
 
@@ -357,7 +357,7 @@ fi
       const errors = validatePrReviewAdvisorWorkflowBoundary(workflowPath);
       expect(errors).toEqual(
         expect.arrayContaining([
-          "advisor matrix field model must be unique: openai/openai/gpt-5.5",
+          "advisor matrix field model must be unique: azure/openai/gpt-5.6-terra",
           "advisor matrix field artifact_dir must be unique: pr-review-advisor",
           "advisor matrix field artifact_name must be unique: pr-review-advisor",
           "step 'Post PR review advisor comment' run script must include --title \"$PR_REVIEW_ADVISOR_COMMENT_TITLE\"",

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -170,7 +170,7 @@ describe("PR review advisor", () => {
     };
 
     expect(DEFAULT_ADVISOR_PROVIDER).toBe("openai");
-    expect(DEFAULT_ADVISOR_MODEL).toBe("openai/openai/gpt-5.5");
+    expect(DEFAULT_ADVISOR_MODEL).toBe("azure/openai/gpt-5.6-terra");
     expect(NEMOTRON_ULTRA_ADVISOR_MODEL).toBe("nvidia/nvidia/nemotron-3-ultra");
     expect(config.apiKey).toBe("PR_REVIEW_ADVISOR_API_KEY");
     expect(config.baseUrl).toBe(ADVISOR_OPENAI_COMPATIBLE_BASE_URL);

--- a/tools/advisors/session.mts
+++ b/tools/advisors/session.mts
@@ -47,7 +47,7 @@ export {
 } from "./turn-protocol.mts";
 
 export const DEFAULT_ADVISOR_PROVIDER = "openai";
-export const DEFAULT_ADVISOR_MODEL = "openai/openai/gpt-5.5";
+export const DEFAULT_ADVISOR_MODEL = "azure/openai/gpt-5.6-terra";
 export const NEMOTRON_ULTRA_ADVISOR_MODEL = "nvidia/nvidia/nemotron-3-ultra";
 export const ADVISOR_OPENAI_COMPATIBLE_BASE_URL = "https://inference-api.nvidia.com/v1";
 
@@ -175,14 +175,22 @@ export function openAiAdvisorProviderConfig(credentialEnv: string): AdvisorProvi
     api: "openai-completions",
     baseUrl: ADVISOR_OPENAI_COMPATIBLE_BASE_URL,
     models: [
-      advisorModel(DEFAULT_ADVISOR_MODEL, "GPT-5.5", 256000, 32768, false, ["text", "image"], {
-        supportsDeveloperRole: false,
-        supportsReasoningEffort: false,
-        supportsStore: false,
-        supportsStrictMode: false,
-        supportsUsageInStreaming: false,
-        maxTokensField: "max_tokens",
-      }),
+      advisorModel(
+        DEFAULT_ADVISOR_MODEL,
+        "GPT-5.6 Terra",
+        256000,
+        32768,
+        false,
+        ["text", "image"],
+        {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          supportsStore: false,
+          supportsStrictMode: false,
+          supportsUsageInStreaming: false,
+          maxTokensField: "max_tokens",
+        },
+      ),
       advisorModel(
         NEMOTRON_ULTRA_ADVISOR_MODEL,
         "Nemotron 3 Ultra",

--- a/tools/e2e-advisor/README.md
+++ b/tools/e2e-advisor/README.md
@@ -57,7 +57,7 @@ Configure this repository secret for E2E recommendations:
 
 - `PI_E2E_ADVISOR_API_KEY`
 
-The analyzer uses the fixed `openai/openai/gpt-5.5` advisor model through the
+The analyzer uses the fixed `azure/openai/gpt-5.6-terra` advisor model through the
 OpenAI-compatible `https://inference-api.nvidia.com/v1` service.
 
 If advisor credentials are unavailable, the advisor writes a low-confidence unavailable result instead of

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -34,7 +34,7 @@ It intentionally does not report GitHub mergeability, branch protection, CI stat
 4. Uses the trusted runner's ripgrep when present, otherwise installs an exact pinned package on a pinned Ubuntu runner, then installs a pinned Pi SDK package with lifecycle scripts disabled.
 5. Builds the same deterministic regression risk plan used by E2E Advisor and injects it into the scope/risk, security/trust, and tests/regressions contexts.
 6. Runs `tools/pr-review-advisor/analyze.mts` from the trusted checkout.
-7. Runs the same advisor conversation in parallel for the primary GPT-5.5 lane and an artifact-only Nemotron Ultra evaluation lane.
+7. Runs the same advisor conversation in parallel for the primary GPT-5.6 Terra lane and an artifact-only Nemotron Ultra evaluation lane.
 8. Opens one Pi session per model variant and reviews the PR in 13 bounded turns: six small analysis/commit pairs for scope/risk, correctness/state, security/trust, tests/regressions, CI/operations, and reconciliation, followed by final JSON synthesis. Each analysis turn exposes only that stage's deterministic context as real read-only tools and emits a concise visible receipt.
 9. Gives each commit turn one job: apply exactly one successful atomic ledger commit for the preceding analysis. The model-facing commit is one flat object with homogeneous additions, updates, resolutions, and supersessions arrays plus an explicit no-change reason; legacy nested operation unions and stringified arrays are rejected. Additions require a structured observed-versus-expected basis, a concrete file and line, and eligibility for the active stage. Positives, advisor/provider state, prior-review process state, open-PR overlap, merge coordination, and live CI/E2E status stay in prose receipts rather than becoming findings. The ledger mutation tool is the turn's only active tool, and the runner rejects prose, other tool calls, or activity after the successful commit. Rejected attempts do not mutate the ledger and may be corrected before one success. If a commit turn ends with no successful call and every attempt settled without mutating state, the runner permits one tool-only retry and then fails closed. Ledger findings receive stable `F-...` IDs, and conclusion changes require a reason plus new evidence; final synthesis can only read the ledger.
 10. Treats open ledger records as the canonical finding set. Final synthesis cannot silently add, drop, merge, reword, or reclassify those findings. Unresolved source-of-truth review entries must reference their covering open ledger ID structurally rather than relying on prose matching.
@@ -94,7 +94,7 @@ Configure this repository secret for review analysis:
 - `PR_REVIEW_ADVISOR_API_KEY`
 
 The analyzer uses the OpenAI-compatible `https://inference-api.nvidia.com/v1` service.
-The primary lane uses `openai/openai/gpt-5.5`; the parallel Nemotron lane sets
+The primary lane uses `azure/openai/gpt-5.6-terra`; the parallel Nemotron lane sets
 `PR_REVIEW_ADVISOR_MODEL=nvidia/nvidia/nemotron-3-ultra` and reuses the same analyzer,
 prompts, schema, safety boundary, and credential secret.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Updates the PR Review Advisor primary lane and the shared E2E Advisor default from `openai/openai/gpt-5.5` to `azure/openai/gpt-5.6-terra`. The artifact-only Nemotron lane and trusted-main rollout boundary remain unchanged.

## Changes

- Register GPT-5.6 Terra as the shared default advisor model while preserving the existing provider endpoint and compatibility settings.
- Update the PR Review Advisor primary workflow lane to select GPT-5.6 Terra while retaining the former default as the safe trusted-main bootstrap exemption.
- Update advisor documentation and exact model-selection, retry, and workflow-boundary regression assertions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Advisor model selection is internal CI tooling; the tool-specific advisor READMEs were updated, and no `docs/` page describes this configuration.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Model-only review confirmed the credential, provider endpoint, and trusted-main execution boundaries are unchanged; advisor workflow-boundary tests pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/pr-review-advisor.test.ts test/advisor-session-runner.test.ts test/pr-review-advisor-workflow-boundary.test.ts` passed 77/77; `npx vitest run --project integration test/e2e-advisor.test.ts test/e2e-advisor-targets.test.ts` passed 38/38.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The PR review advisor now uses the GPT-5.6 Terra model as its default.
  * Advisor workflow and retry settings have been aligned with the new model.
  * Documentation now reflects the updated model configuration.
* **Tests**
  * Updated validation and default-model checks to cover GPT-5.6 Terra.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->