### PR TITLE
test(vitest): add owned resource fixtures

### DIFF
--- a/test/cli/debug-command.test.ts
+++ b/test/cli/debug-command.test.ts
@@ -25,7 +25,7 @@ describe("CLI debug command", () => {
   });
 
   it(
-    "debug --quick exits 0 and produces diagnostic output",
+    "exits with status 0 and produces diagnostic output for debug --quick",
     testTimeoutOptions(30_000),
     ({ resources }) => {
       const r = runWithEnv(

--- a/test/cli/debug-command.test.ts
+++ b/test/cli/debug-command.test.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+import { describe, expect, test as it } from "../helpers/owned-test-resources";
 
 import {
   createDebugCommandTestEnv,
@@ -23,24 +24,28 @@ describe("CLI debug command", () => {
     expect(r.out.includes("--output")).toBeTruthy();
   });
 
-  it("debug --quick exits 0 and produces diagnostic output", testTimeoutOptions(30_000), () => {
-    const r = runWithEnv(
-      "debug --quick",
-      createDebugCommandTestEnv("nemoclaw-cli-debug-quick-"),
-      30000,
-    );
-    expect(r.code).toBe(0);
-    expect(r.out.includes("Collecting diagnostics")).toBeTruthy();
-    expect(r.out.includes("System")).toBeTruthy();
-    expect(r.out.includes("Onboard Session")).toBeTruthy();
-    expect(r.out.includes("Done")).toBeTruthy();
-  });
+  it(
+    "debug --quick exits 0 and produces diagnostic output",
+    testTimeoutOptions(30_000),
+    ({ resources }) => {
+      const r = runWithEnv(
+        "debug --quick",
+        createDebugCommandTestEnv(resources, "nemoclaw-cli-debug-quick-"),
+        30000,
+      );
+      expect(r.code).toBe(0);
+      expect(r.out.includes("Collecting diagnostics")).toBeTruthy();
+      expect(r.out.includes("System")).toBeTruthy();
+      expect(r.out.includes("Onboard Session")).toBeTruthy();
+      expect(r.out.includes("Done")).toBeTruthy();
+    },
+  );
 
   it.skipIf(os.platform() !== "linux")(
     "debug --quick explains restricted dmesg instead of printing raw stderr on Linux",
     testTimeoutOptions(30_000),
-    () => {
-      const env = createDebugCommandTestEnv("nemoclaw-cli-debug-dmesg-");
+    ({ resources }) => {
+      const env = createDebugCommandTestEnv(resources, "nemoclaw-cli-debug-dmesg-");
       const localBin = env.PATH?.split(path.delimiter)[0];
       if (!localBin) throw new Error("Expected debug test PATH to include a fake bin dir");
       fs.writeFileSync(
@@ -82,15 +87,21 @@ describe("CLI debug command", () => {
     expect(r.out.includes("nemoclaw debug")).toBeTruthy();
   });
 
-  it("debug --sandbox NAME targets the specified sandbox", testTimeoutOptions(30_000), () => {
-    const r = runWithEnv(
-      "debug --quick --sandbox mybox",
-      createDebugCommandTestEnv("nemoclaw-cli-debug-sandbox-", { extraSandboxNames: ["mybox"] }),
-      30000,
-    );
-    expect(r.code).toBe(0);
-    expect(r.out).toContain("Collecting diagnostics for sandbox 'mybox'");
-  });
+  it(
+    "debug --sandbox NAME targets the specified sandbox",
+    testTimeoutOptions(30_000),
+    ({ resources }) => {
+      const r = runWithEnv(
+        "debug --quick --sandbox mybox",
+        createDebugCommandTestEnv(resources, "nemoclaw-cli-debug-sandbox-", {
+          extraSandboxNames: ["mybox"],
+        }),
+        30000,
+      );
+      expect(r.code).toBe(0);
+      expect(r.out).toContain("Collecting diagnostics for sandbox 'mybox'");
+    },
+  );
 
   it("debug --sandbox NAME rejects an unregistered name and exits non-zero", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-debug-unknown-"));

--- a/test/cli/doctor-gateway-token.test.ts
+++ b/test/cli/doctor-gateway-token.test.ts
@@ -3,9 +3,9 @@
 
 import { spawn } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+
+import { describe, expect, test as it } from "../helpers/owned-test-resources";
 
 import {
   createCloudflaredServiceDir,
@@ -89,8 +89,8 @@ function parseJsonPrefix<T>(output: string): T {
 }
 
 describe("CLI dispatch", () => {
-  it("gateway-token help uses native oclif usage", testTimeoutOptions(15_000), () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-token-help-"));
+  it("gateway-token help uses native oclif usage", testTimeoutOptions(15_000), ({ resources }) => {
+    const { home } = resources.home("nemoclaw-cli-token-help-");
     writeSandboxRegistry(home);
 
     const r = runWithEnv("alpha gateway-token --help", { HOME: home });
@@ -103,36 +103,40 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("Hermes' API_SERVER_KEY");
   });
 
-  it("doctor fails a present sandbox that is not Ready", testTimeoutOptions(15_000), () => {
-    const setup = createDoctorTestSetup("nemoclaw-cli-doctor-not-ready-", [
-      'case "$*" in',
-      '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
-      '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
-      '  "sandbox list") printf "NAME STATUS\\nalpha Creating\\n"; exit 0 ;;',
-      '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
-      "esac",
-    ]);
+  it(
+    "doctor fails a present sandbox that is not Ready",
+    testTimeoutOptions(15_000),
+    ({ resources }) => {
+      const setup = createDoctorTestSetup(resources, "nemoclaw-cli-doctor-not-ready-", [
+        'case "$*" in',
+        '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
+        '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+        '  "sandbox list") printf "NAME STATUS\\nalpha Creating\\n"; exit 0 ;;',
+        '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
+        "esac",
+      ]);
 
-    const r = setup.runDoctor();
+      const r = setup.runDoctor();
 
-    expect(r.code).toBe(1);
-    const report = JSON.parse(r.out) as {
-      checks: Array<{ label: string; status: string; detail: string }>;
-    };
-    const liveSandbox = report.checks.find((check) => check.label === "Live sandbox");
-    expect(liveSandbox).toEqual(
-      expect.objectContaining({
-        status: "fail",
-        detail: expect.stringContaining("Creating"),
-      }),
-    );
-  });
+      expect(r.code).toBe(1);
+      const report = JSON.parse(r.out) as {
+        checks: Array<{ label: string; status: string; detail: string }>;
+      };
+      const liveSandbox = report.checks.find((check) => check.label === "Live sandbox");
+      expect(liveSandbox).toEqual(
+        expect.objectContaining({
+          status: "fail",
+          detail: expect.stringContaining("Creating"),
+        }),
+      );
+    },
+  );
 
   it(
     "doctor does not inspect the legacy k3s gateway container in Docker-driver mode",
     testTimeoutOptions(15_000),
-    () => {
-      const setup = createDoctorTestSetup("nemoclaw-cli-doctor-docker-driver-", [
+    ({ resources }) => {
+      const setup = createDoctorTestSetup(resources, "nemoclaw-cli-doctor-docker-driver-", [
         'case "$*" in',
         '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
         '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
@@ -195,8 +199,8 @@ describe("CLI dispatch", () => {
     },
   );
 
-  it("doctor checks the sandbox persisted non-default gateway", () => {
-    const setup = createDoctorTestSetup("nemoclaw-cli-doctor-named-gateway-", [
+  it("doctor checks the sandbox persisted non-default gateway", ({ resources }) => {
+    const setup = createDoctorTestSetup(resources, "nemoclaw-cli-doctor-named-gateway-", [
       'case "$*" in',
       '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw-8090\\n  Status: Connected\\n"; exit 0 ;;',
       '  "gateway info -g nemoclaw-8090") printf "Gateway: nemoclaw-8090\\n"; exit 0 ;;',
@@ -232,8 +236,8 @@ describe("CLI dispatch", () => {
   it(
     "doctor still inspects the legacy k3s gateway container for the kubernetes driver",
     testTimeoutOptions(15_000),
-    () => {
-      const setup = createDoctorTestSetup("nemoclaw-cli-doctor-k8s-driver-", [
+    ({ resources }) => {
+      const setup = createDoctorTestSetup(resources, "nemoclaw-cli-doctor-k8s-driver-", [
         'case "$*" in',
         '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
         '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
@@ -262,8 +266,8 @@ describe("CLI dispatch", () => {
   it(
     "doctor accepts a local openshell-gateway process when legacy inspect fails",
     testTimeoutOptions(15_000),
-    () => {
-      const setup = createDoctorTestSetup("nemoclaw-cli-doctor-local-gateway-", [
+    ({ resources }) => {
+      const setup = createDoctorTestSetup(resources, "nemoclaw-cli-doctor-local-gateway-", [
         'case "$*" in',
         '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
         '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
@@ -310,16 +314,20 @@ describe("CLI dispatch", () => {
   it(
     "doctor treats local gateway process evidence as informational until OpenShell verifies the named gateway",
     testTimeoutOptions(15_000),
-    () => {
-      const setup = createDoctorTestSetup("nemoclaw-cli-doctor-unverified-local-gateway-", [
-        'case "$*" in',
-        '  "status") printf "Server Status\\n\\n  Gateway: other\\n  Status: Connected\\n"; exit 0 ;;',
-        '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
-        '  "gateway select nemoclaw") exit 1 ;;',
-        '  "gateway start --name nemoclaw --port 8080") exit 1 ;;',
-        '  "sandbox list") echo "should not query sandbox list" >> "$marker_file"; exit 0 ;;',
-        "esac",
-      ]);
+    ({ resources }) => {
+      const setup = createDoctorTestSetup(
+        resources,
+        "nemoclaw-cli-doctor-unverified-local-gateway-",
+        [
+          'case "$*" in',
+          '  "status") printf "Server Status\\n\\n  Gateway: other\\n  Status: Connected\\n"; exit 0 ;;',
+          '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+          '  "gateway select nemoclaw") exit 1 ;;',
+          '  "gateway start --name nemoclaw --port 8080") exit 1 ;;',
+          '  "sandbox list") echo "should not query sandbox list" >> "$marker_file"; exit 0 ;;',
+          "esac",
+        ],
+      );
       writeSandboxRegistry(setup.home, "alpha", { openshellDriver: "kubernetes" });
       const hostCalls = path.join(setup.home, "host-calls");
       writeDockerInspectFailureStub(setup, hostCalls);
@@ -348,15 +356,19 @@ describe("CLI dispatch", () => {
   it(
     "doctor reports unavailable local gateway probe tools while trusting a verified named gateway",
     testTimeoutOptions(15_000),
-    () => {
-      const setup = createDoctorTestSetup("nemoclaw-cli-doctor-missing-local-probe-tools-", [
-        'case "$*" in',
-        '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
-        '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
-        '  "sandbox list") printf "NAME STATUS\\nalpha Ready\\n"; exit 0 ;;',
-        '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
-        "esac",
-      ]);
+    ({ resources }) => {
+      const setup = createDoctorTestSetup(
+        resources,
+        "nemoclaw-cli-doctor-missing-local-probe-tools-",
+        [
+          'case "$*" in',
+          '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
+          '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+          '  "sandbox list") printf "NAME STATUS\\nalpha Ready\\n"; exit 0 ;;',
+          '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
+          "esac",
+        ],
+      );
       writeSandboxRegistry(setup.home, "alpha", { openshellDriver: "kubernetes" });
       const hostCalls = path.join(setup.home, "host-calls");
       writeDockerInspectFailureStub(setup, hostCalls);
@@ -389,8 +401,8 @@ describe("CLI dispatch", () => {
   it(
     "doctor reports fresh shields state as not configured instead of down",
     testTimeoutOptions(30_000),
-    () => {
-      const setup = createDoctorTestSetup("nemoclaw-cli-doctor-shields-default-", [
+    ({ resources }) => {
+      const setup = createDoctorTestSetup(resources, "nemoclaw-cli-doctor-shields-default-", [
         'case "$*" in',
         '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
         '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
@@ -418,8 +430,8 @@ describe("CLI dispatch", () => {
   it(
     "doctor does not query sandbox state from a different active gateway",
     testTimeoutOptions(15_000),
-    () => {
-      const setup = createDoctorTestSetup("nemoclaw-cli-doctor-wrong-gateway-", [
+    ({ resources }) => {
+      const setup = createDoctorTestSetup(resources, "nemoclaw-cli-doctor-wrong-gateway-", [
         'case "$*" in',
         '  "status") printf "Server Status\\n\\n  Gateway: other\\n  Status: Connected\\n"; exit 0 ;;',
         '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
@@ -438,29 +450,35 @@ describe("CLI dispatch", () => {
     },
   );
 
-  it("doctor treats a live non-cloudflared PID as stale", testTimeoutOptions(15_000), () => {
-    const { sandboxName, serviceDir } = createCloudflaredServiceDir("doctorpid-");
-    const setup = createDoctorTestSetup(
-      "nemoclaw-cli-doctor-wrong-cloudflared-pid-",
-      [
-        'case "$*" in',
-        '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
-        '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
-        `  "sandbox list") printf "NAME STATUS\\n${sandboxName} Ready\\n"; exit 0 ;;`,
-        '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
-        "esac",
-      ],
-      sandboxName,
-    );
-    const sleeper = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
-      stdio: "ignore",
-    });
-    const sleeperPid = sleeper.pid;
-    if (typeof sleeperPid !== "number") {
-      throw new Error("expected spawned helper process to have a PID");
-    }
+  it(
+    "doctor treats a live non-cloudflared PID as stale",
+    testTimeoutOptions(15_000),
+    ({ resources }) => {
+      const { sandboxName, serviceDir } = createCloudflaredServiceDir("doctorpid-");
+      resources.ownDirectory(serviceDir);
+      const setup = createDoctorTestSetup(
+        resources,
+        "nemoclaw-cli-doctor-wrong-cloudflared-pid-",
+        [
+          'case "$*" in',
+          '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
+          '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+          `  "sandbox list") printf "NAME STATUS\\n${sandboxName} Ready\\n"; exit 0 ;;`,
+          '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
+          "esac",
+        ],
+        sandboxName,
+      );
+      const sleeper = resources.ownChild(
+        spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+          stdio: "ignore",
+        }),
+      );
+      const sleeperPid = sleeper.pid;
+      if (typeof sleeperPid !== "number") {
+        throw new Error("expected spawned helper process to have a PID");
+      }
 
-    try {
       fs.writeFileSync(path.join(serviceDir, "cloudflared.pid"), String(sleeperPid));
       const r = setup.runDoctor(`${sandboxName} doctor --json`);
 
@@ -474,15 +492,14 @@ describe("CLI dispatch", () => {
           detail: `stale PID ${sleeperPid}`,
         }),
       );
-    } finally {
-      sleeper.kill();
-      fs.rmSync(serviceDir, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 
-  it("doctor accepts a live cloudflared PID", testTimeoutOptions(35_000), () => {
+  it("doctor accepts a live cloudflared PID", testTimeoutOptions(35_000), ({ resources }) => {
     const { sandboxName, serviceDir } = createCloudflaredServiceDir("doctorcloudflared-");
+    resources.ownDirectory(serviceDir);
     const setup = createDoctorTestSetup(
+      resources,
       "nemoclaw-cli-doctor-cloudflared-pid-",
       [
         'case "$*" in',
@@ -494,35 +511,31 @@ describe("CLI dispatch", () => {
       ],
       sandboxName,
     );
-    const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cloudflared-shim-"));
+    const shimDir = resources.temporaryDirectory("nemoclaw-cloudflared-shim-");
     const cloudflaredBin = path.join(shimDir, "cloudflared");
     fs.symlinkSync(process.execPath, cloudflaredBin);
-    const sleeper = spawn(cloudflaredBin, ["-e", "setTimeout(() => {}, 30000)"], {
-      stdio: "ignore",
-    });
+    const sleeper = resources.ownChild(
+      spawn(cloudflaredBin, ["-e", "setTimeout(() => {}, 30000)"], {
+        stdio: "ignore",
+      }),
+    );
     const sleeperPid = sleeper.pid;
     if (typeof sleeperPid !== "number") {
       throw new Error("expected spawned helper process to have a PID");
     }
 
-    try {
-      fs.writeFileSync(path.join(serviceDir, "cloudflared.pid"), String(sleeperPid));
-      const r = setup.runDoctor(`${sandboxName} doctor --json`);
+    fs.writeFileSync(path.join(serviceDir, "cloudflared.pid"), String(sleeperPid));
+    const r = setup.runDoctor(`${sandboxName} doctor --json`);
 
-      const report = JSON.parse(r.out) as {
-        checks: Array<{ label: string; status: string; detail: string }>;
-      };
-      const cloudflared = report.checks.find((check) => check.label === "cloudflared");
-      expect(cloudflared).toEqual(
-        expect.objectContaining({
-          status: "ok",
-          detail: `running (PID ${sleeperPid})`,
-        }),
-      );
-    } finally {
-      sleeper.kill();
-      fs.rmSync(serviceDir, { recursive: true, force: true });
-      fs.rmSync(shimDir, { recursive: true, force: true });
-    }
+    const report = JSON.parse(r.out) as {
+      checks: Array<{ label: string; status: string; detail: string }>;
+    };
+    const cloudflared = report.checks.find((check) => check.label === "cloudflared");
+    expect(cloudflared).toEqual(
+      expect.objectContaining({
+        status: "ok",
+        detail: `running (PID ${sleeperPid})`,
+      }),
+    );
   });
 });

--- a/test/cli/helpers.test.ts
+++ b/test/cli/helpers.test.ts
@@ -6,13 +6,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   nodeOptionsWithoutSourceLoader,
   SOURCE_REQUIRE_HOOK,
   sourceLoaderNodeOptions,
 } from "../helpers/source-loader-options";
+import { testTimeoutOptions } from "../helpers/timeouts";
 import { runWithEnv } from "./helpers";
 
 const tempDirs = new Set<string>();
@@ -149,6 +150,89 @@ describe("source-loader Node options", () => {
 
     expect(result.code).toBe(0);
     expect(JSON.parse(fs.readFileSync(marker, "utf8"))).toEqual({ hasTypeScriptHook: true });
+  });
+
+  it("removes the implicit CLI HOME after a synchronous invocation", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-owned-home-"));
+    tempDirs.add(directory);
+    const marker = path.join(directory, "home.txt");
+    const preload = path.join(directory, "record-home.cjs");
+    fs.writeFileSync(
+      preload,
+      `require("node:fs").writeFileSync(${JSON.stringify(marker)}, process.env.HOME ?? "");`,
+    );
+
+    const result = runWithEnv("--version", {
+      NODE_OPTIONS: `${sourceLoaderNodeOptions(undefined)} --require=${preload}`,
+    });
+    const implicitHome = fs.readFileSync(marker, "utf8");
+
+    expect(result.code).toBe(0);
+    expect(path.isAbsolute(implicitHome)).toBe(true);
+    expect(fs.existsSync(implicitHome)).toBe(false);
+  });
+
+  it("removes the implicit CLI HOME after a failed invocation", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-failed-home-"));
+    tempDirs.add(directory);
+    const marker = path.join(directory, "home.txt");
+    const preload = path.join(directory, "record-home.cjs");
+    fs.writeFileSync(
+      preload,
+      `require("node:fs").writeFileSync(${JSON.stringify(marker)}, process.env.HOME ?? "");`,
+    );
+
+    const result = runWithEnv("not-a-command", {
+      NODE_OPTIONS: `${sourceLoaderNodeOptions(undefined)} --require=${preload}`,
+    });
+    const implicitHome = fs.readFileSync(marker, "utf8");
+
+    expect(result.code).not.toBe(0);
+    expect(fs.existsSync(implicitHome)).toBe(false);
+  });
+
+  it(
+    "removes the implicit CLI HOME after a timed-out invocation",
+    testTimeoutOptions(10_000),
+    () => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-timeout-home-"));
+      tempDirs.add(directory);
+      const marker = path.join(directory, "home.txt");
+      const preload = path.join(directory, "record-home-and-wait.cjs");
+      fs.writeFileSync(
+        preload,
+        [
+          `require("node:fs").writeFileSync(${JSON.stringify(marker)}, process.env.HOME ?? "");`,
+          "setInterval(() => {}, 1000);",
+        ].join("\n"),
+      );
+
+      const result = runWithEnv(
+        "--version",
+        { NODE_OPTIONS: `${sourceLoaderNodeOptions(undefined)} --require=${preload}` },
+        2_000,
+      );
+      const implicitHome = fs.readFileSync(marker, "utf8");
+
+      expect(result.code).not.toBe(0);
+      expect(result.out).toContain("ETIMEDOUT");
+      expect(fs.existsSync(implicitHome)).toBe(false);
+    },
+  );
+
+  it("uses an explicit CLI HOME without allocating a hidden one", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-explicit-home-"));
+    tempDirs.add(directory);
+    const mkdtemp = vi.spyOn(fs, "mkdtempSync");
+    try {
+      const result = runWithEnv("--version", { HOME: directory });
+
+      expect(result.code).toBe(0);
+      expect(mkdtemp).not.toHaveBeenCalled();
+      expect(fs.existsSync(directory)).toBe(true);
+    } finally {
+      mkdtemp.mockRestore();
+    }
   });
 
   it("quotes preload paths that contain spaces for Node (#6245)", () => {

--- a/test/cli/helpers.ts
+++ b/test/cli/helpers.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
 
+import type { OwnedTestResources } from "../helpers/owned-test-resources";
 import { execTimeout, testTimeout, testTimeoutOptions } from "../helpers/timeouts";
 
 export { execTimeout, testTimeout, testTimeoutOptions };
@@ -180,32 +181,39 @@ function runWithEnvInternal(
   const parsedArgs = splitCliArgs(args);
   const mergeStderrOnSuccess = parsedArgs.includes("2>&1");
   const cliArgs = parsedArgs.filter((token) => token !== "2>&1");
-  const result = spawnSync(process.execPath, [CLI, ...cliArgs], {
-    encoding: "utf-8",
-    input,
-    stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
-    timeout,
-    env: {
-      ...process.env,
-      HOME: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-test-")),
-      NEMOCLAW_HEALTH_POLL_COUNT: "1",
-      NEMOCLAW_HEALTH_POLL_INTERVAL: "0",
-      // #4710: the post-recovery settle-confirm waits 25s by default; CLI
-      // tests disable it to stay fast. Settle behavior has dedicated
-      // coverage in process-recovery.test.ts and a targeted CLI test in
-      // connect-recovery-settle.test.ts that overrides this with a short window.
-      NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS: "0",
-      ...env,
-    },
-  });
-  const stdout = result.stdout || "";
-  const stderr = result.stderr || "";
-  const errorOutput = result.error ? String(result.error) : "";
-  const code = typeof result.status === "number" ? result.status : 1;
-  if (code === 0) {
-    return { code, out: mergeStderrOnSuccess ? `${stdout}${stderr}` : stdout };
+  const implicitHome = Object.hasOwn(env, "HOME")
+    ? null
+    : fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-test-"));
+  try {
+    const result = spawnSync(process.execPath, [CLI, ...cliArgs], {
+      encoding: "utf-8",
+      input,
+      stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+      timeout,
+      env: {
+        ...process.env,
+        ...(implicitHome ? { HOME: implicitHome } : {}),
+        NEMOCLAW_HEALTH_POLL_COUNT: "1",
+        NEMOCLAW_HEALTH_POLL_INTERVAL: "0",
+        // #4710: the post-recovery settle-confirm waits 25s by default; CLI
+        // tests disable it to stay fast. Settle behavior has dedicated
+        // coverage in process-recovery.test.ts and a targeted CLI test in
+        // connect-recovery-settle.test.ts that overrides this with a short window.
+        NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS: "0",
+        ...env,
+      },
+    });
+    const stdout = result.stdout || "";
+    const stderr = result.stderr || "";
+    const errorOutput = result.error ? String(result.error) : "";
+    const code = typeof result.status === "number" ? result.status : 1;
+    if (code === 0) {
+      return { code, out: mergeStderrOnSuccess ? `${stdout}${stderr}` : stdout };
+    }
+    return { code, out: `${stdout}${stderr}${errorOutput}` };
+  } finally {
+    if (implicitHome) fs.rmSync(implicitHome, { force: true, recursive: true });
   }
-  return { code, out: `${stdout}${stderr}${errorOutput}` };
 }
 
 export function readRecordedArgs(markerFile: string): string[] {
@@ -303,12 +311,12 @@ type LogsTestSetupOptions = {
 };
 
 export function createLogsTestSetup(
+  resources: OwnedTestResources,
   prefix: string,
   openshellLines: string[] = [],
   options: LogsTestSetupOptions = {},
 ) {
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  const localBin = path.join(home, "bin");
+  const { home, bin: localBin } = resources.home(prefix);
   const markerFile = path.join(home, "logs-calls");
   const gatewayStartedLines = options.gatewayStartedMarker
     ? [`  printf '%s\\n' ${JSON.stringify(options.gatewayStartedMarker)} >> "$marker_file"`]
@@ -357,12 +365,12 @@ export function createLogsTestSetup(
 }
 
 export function createDoctorTestSetup(
+  resources: OwnedTestResources,
   prefix: string,
   openshellLines: string[],
   sandboxName = "alpha",
 ) {
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  const localBin = path.join(home, "bin");
+  const { home, bin: localBin } = resources.home(prefix);
   const markerFile = path.join(home, "doctor-calls");
   fs.mkdirSync(localBin, { recursive: true });
   writeSandboxRegistry(home, sandboxName);
@@ -431,11 +439,11 @@ export function createCloudflaredServiceDir(prefix: string): {
 }
 
 export function createDebugCommandTestEnv(
+  resources: OwnedTestResources,
   prefix: string,
   options: { extraSandboxNames?: string[] } = {},
 ): Record<string, string> {
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  const localBin = path.join(home, "bin");
+  const { home, bin: localBin } = resources.home(prefix);
   const sandboxName = `${prefix}${process.pid.toString(36)}-${Date.now().toString(36)}`;
   fs.mkdirSync(localBin, { recursive: true });
   // Register the env-sourced sandbox plus any extra names supplied via the

--- a/test/cli/logs.test.ts
+++ b/test/cli/logs.test.ts
@@ -5,7 +5,8 @@ import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+
+import { describe, expect, test as it } from "../helpers/owned-test-resources";
 
 import {
   CLI,
@@ -22,8 +23,8 @@ import {
 } from "./helpers";
 
 describe("CLI dispatch", () => {
-  it("routes logs to OpenClaw and OpenShell log sources", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-routing-");
+  it("routes logs to OpenClaw and OpenShell log sources", ({ resources }) => {
+    const setup = createLogsTestSetup(resources, "nemoclaw-cli-logs-routing-");
     const r = setup.runLogs();
 
     const calls = setup.readCalls();
@@ -37,8 +38,8 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
   });
 
-  it("shows logs help without calling OpenShell", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-help-");
+  it("shows logs help without calling OpenShell", ({ resources }) => {
+    const setup = createLogsTestSetup(resources, "nemoclaw-cli-logs-help-");
     const r = setup.runLogs("alpha logs --help");
 
     expect(r.code).toBe(0);
@@ -49,8 +50,8 @@ describe("CLI dispatch", () => {
     expect(setup.readCalls()).toEqual([]);
   });
 
-  it("rejects unknown logs flags before calling OpenShell", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-unknown-");
+  it("rejects unknown logs flags before calling OpenShell", ({ resources }) => {
+    const setup = createLogsTestSetup(resources, "nemoclaw-cli-logs-unknown-");
     const r = setup.runLogs("alpha logs --bogus 2>&1");
 
     expect(r.code).not.toBe(0);
@@ -58,8 +59,10 @@ describe("CLI dispatch", () => {
     expect(setup.readCalls()).toEqual([]);
   });
 
-  it("continues to OpenShell logs when the OpenClaw gateway log probe times out", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-openclaw-timeout-", [
+  it("continues to OpenShell logs when the OpenClaw gateway log probe times out", ({
+    resources,
+  }) => {
+    const setup = createLogsTestSetup(resources, "nemoclaw-cli-logs-openclaw-timeout-", [
       'if [ "$1" = "sandbox" ]; then',
       "  while true; do :; done",
       "fi",
@@ -73,8 +76,8 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
   });
 
-  it("maps --follow to OpenShell live log streaming", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-follow-");
+  it("maps --follow to OpenShell live log streaming", ({ resources }) => {
+    const setup = createLogsTestSetup(resources, "nemoclaw-cli-logs-follow-");
     const r = setup.runLogs("alpha logs --follow");
 
     const calls = setup.readCalls();
@@ -86,10 +89,11 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
   });
 
-  it("starts OpenClaw logs before enabling audit logs for logs --follow", () => {
+  it("starts OpenClaw logs before enabling audit logs for logs --follow", ({ resources }) => {
     const gatewayStartedMarker = "gateway-started";
     const auditCompleteMarker = "audit-enabled";
     const setup = createLogsTestSetup(
+      resources,
       "nemoclaw-cli-logs-follow-audit-slow-",
       [
         'if [ "$1" = "settings" ]; then',
@@ -126,12 +130,10 @@ describe("CLI dispatch", () => {
   it(
     "keeps logs --follow running when one log source exits",
     testTimeoutOptions(10_000),
-    async () => {
-      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-source-exit-"));
-      const localBin = path.join(home, "bin");
+    async ({ resources }) => {
+      const { home, bin: localBin } = resources.home("nemoclaw-cli-logs-follow-source-exit-");
       const registryDir = path.join(home, ".nemoclaw");
       const markerFile = path.join(home, "logs-follow-source-exit-args");
-      fs.mkdirSync(localBin, { recursive: true });
       fs.mkdirSync(registryDir, { recursive: true });
       writeHealthyDockerStub(localBin);
       fs.writeFileSync(
@@ -171,11 +173,13 @@ describe("CLI dispatch", () => {
         { mode: 0o755 },
       );
 
-      const child = spawn(process.execPath, [CLI, "alpha", "logs", "--follow"], {
-        cwd: path.join(import.meta.dirname, ".."),
-        env: { ...process.env, HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` },
-        stdio: "ignore",
-      });
+      const child = resources.ownChild(
+        spawn(process.execPath, [CLI, "alpha", "logs", "--follow"], {
+          cwd: path.join(import.meta.dirname, ".."),
+          env: { ...process.env, HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` },
+          stdio: "ignore",
+        }),
+      );
       const exitPromise = waitForChildExit(child);
       const readCalls = () =>
         fs.existsSync(markerFile) ? fs.readFileSync(markerFile, "utf8").trim().split(/\n/) : [];
@@ -198,11 +202,13 @@ describe("CLI dispatch", () => {
         expect(isChildRunning(child)).toBe(true);
         expect(calls).toContain("logs alpha -n 200 --source all --tail");
         expect(calls).toContain("sandbox exec -n alpha -- tail -n 200 -f /tmp/gateway.log");
+        child.kill("SIGTERM");
+        expect(await exitPromise).toBe(143);
       } finally {
         if (isChildRunning(child)) {
-          child.kill("SIGTERM");
+          child.kill("SIGKILL");
         }
-        expect(await exitPromise).toBe(143);
+        await exitPromise;
       }
     },
   );
@@ -210,12 +216,10 @@ describe("CLI dispatch", () => {
   it(
     "waits for logs --follow children to stop after SIGTERM",
     testTimeoutOptions(10_000),
-    async () => {
-      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-sigterm-wait-"));
-      const localBin = path.join(home, "bin");
+    async ({ resources }) => {
+      const { home, bin: localBin } = resources.home("nemoclaw-cli-logs-follow-sigterm-wait-");
       const markerFile = path.join(home, "logs-follow-sigterm-wait-args");
       const releaseFile = path.join(home, "release-log-children");
-      fs.mkdirSync(localBin, { recursive: true });
       writeSandboxRegistry(home);
       writeHealthyDockerStub(localBin);
       fs.writeFileSync(
@@ -237,11 +241,13 @@ describe("CLI dispatch", () => {
         { mode: 0o755 },
       );
 
-      const child = spawn(process.execPath, [CLI, "alpha", "logs", "--follow"], {
-        cwd: path.join(import.meta.dirname, ".."),
-        env: { ...process.env, HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` },
-        stdio: "ignore",
-      });
+      const child = resources.ownChild(
+        spawn(process.execPath, [CLI, "alpha", "logs", "--follow"], {
+          cwd: path.join(import.meta.dirname, ".."),
+          env: { ...process.env, HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` },
+          stdio: "ignore",
+        }),
+      );
       let hasExited = false;
       const exitPromise = waitForChildExit(child).then((code) => {
         hasExited = true;
@@ -289,6 +295,7 @@ describe("CLI dispatch", () => {
         if (isChildRunning(child)) {
           child.kill("SIGKILL");
         }
+        await exitPromise;
       }
     },
   );

--- a/test/cli/sandbox-mutations.test.ts
+++ b/test/cli/sandbox-mutations.test.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+
+import { describe, expect, test as it } from "../helpers/owned-test-resources";
 
 import { runWithEnv, runWithInput, testTimeoutOptions, writeSandboxRegistry } from "./helpers";
 
@@ -50,11 +50,11 @@ function writePolicyMutationOpenshellStub(home: string): string {
 }
 
 describe("CLI dispatch", () => {
-  it("connect help uses native oclif usage through the public sandbox route", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-inspection-help-"));
+  it("connect help uses native oclif usage through the public sandbox route", ({ testHome }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
 
-    const connect = runWithEnv("alpha connect --help", { HOME: home });
+    const connect = runWithEnv("alpha connect --help", testHome.environment());
 
     expect(connect.code).toBe(0);
     expect(connect.out).toContain("Usage: nemoclaw alpha connect");
@@ -64,99 +64,112 @@ describe("CLI dispatch", () => {
   it(
     "keeps public compatibility help routes for sandbox command families",
     testTimeoutOptions(30_000),
-    () => {
-      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-family-help-"));
+    ({ testHome }) => {
+      const { home } = testHome;
       writeSandboxRegistry(home);
 
-      const logs = runWithEnv("alpha logs --help", { HOME: home });
+      const logs = runWithEnv("alpha logs --help", testHome.environment());
       expect(logs.code).toBe(0);
       expect(logs.out).toContain("$ nemoclaw sandbox logs <name>");
       expect(logs.out).toContain("--tail");
 
-      const policy = runWithEnv("alpha policy-add --help", { HOME: home });
+      const policy = runWithEnv("alpha policy-add --help", testHome.environment());
       expect(policy.code).toBe(0);
       expect(policy.out).toContain("$ nemoclaw sandbox policy add <name>");
 
-      const hosts = runWithEnv("alpha hosts-add --help", { HOME: home });
+      const hosts = runWithEnv("alpha hosts-add --help", testHome.environment());
       expect(hosts.code).toBe(0);
       expect(hosts.out).toContain("$ nemoclaw sandbox hosts add <name>");
 
-      const channels = runWithEnv("alpha channels add --help", { HOME: home });
+      const channels = runWithEnv("alpha channels add --help", testHome.environment());
       expect(channels.code).toBe(0);
       expect(channels.out).toContain("$ nemoclaw sandbox channels add <name>");
 
-      const config = runWithEnv("alpha config get --help", { HOME: home });
+      const config = runWithEnv("alpha config get --help", testHome.environment());
       expect(config.code).toBe(0);
       expect(config.out).toContain("$ nemoclaw sandbox config get <name>");
       expect(config.out).toContain("--format json|yaml");
     },
   );
 
-  it("keeps public mutation dry-runs and native sandbox command routes", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-route-smoke-"));
+  it("keeps public mutation dry-runs and native sandbox command routes", ({ testHome }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
 
-    const policy = runWithEnv("alpha policy-add github --dry-run", { HOME: home });
+    const policy = runWithEnv("alpha policy-add github --dry-run", testHome.environment());
     expect(policy.code).toBe(0);
     expect(policy.out).toContain("--dry-run: no changes applied.");
 
-    const channels = runWithEnv("alpha channels add telegram --dry-run", { HOME: home });
+    const channels = runWithEnv("alpha channels add telegram --dry-run", testHome.environment());
     expect(channels.code).toBe(0);
     expect(channels.out).toContain("--dry-run: would enable channel 'telegram' for 'alpha'.");
 
-    const snapshots = runWithEnv("sandbox snapshot list alpha", { HOME: home });
+    const snapshots = runWithEnv("sandbox snapshot list alpha", testHome.environment());
     expect(snapshots.code).toBe(0);
     expect(snapshots.out).toContain("No snapshots found for 'alpha'.");
   });
 
-  it("keeps public policy-add/remove built-in mutation routes", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-policy-mutation-"));
+  it("keeps public policy-add/remove built-in mutation routes", ({ testHome }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
     const openshell = writePolicyMutationOpenshellStub(home);
 
-    const add = runWithEnv("alpha policy-add github --yes", {
-      HOME: home,
-      NEMOCLAW_OPENSHELL_BIN: openshell,
-    });
+    const add = runWithEnv(
+      "alpha policy-add github --yes",
+      testHome.environment({
+        NEMOCLAW_OPENSHELL_BIN: openshell,
+      }),
+    );
     expect(add.code).toBe(0);
     expect(add.out).toContain("Applied preset: github");
     expect(readSandboxPolicies(home)).toContain("github");
 
-    const remove = runWithEnv("alpha policy-remove github -y", {
-      HOME: home,
-      NEMOCLAW_OPENSHELL_BIN: openshell,
-    });
+    const remove = runWithEnv(
+      "alpha policy-remove github -y",
+      testHome.environment({
+        NEMOCLAW_OPENSHELL_BIN: openshell,
+      }),
+    );
     expect(remove.code).toBe(0);
     expect(remove.out).toContain("Removed preset: github");
     expect(readSandboxPolicies(home)).not.toContain("github");
   });
 
-  it("keeps public policy-add non-interactive missing-preset failure before mutation", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-policy-noninteractive-"));
+  it("keeps public policy-add non-interactive missing-preset failure before mutation", ({
+    testHome,
+  }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
     const openshell = writePolicyMutationOpenshellStub(home);
 
-    const result = runWithEnv("alpha policy-add", {
-      HOME: home,
-      NEMOCLAW_NON_INTERACTIVE: "1",
-      NEMOCLAW_OPENSHELL_BIN: openshell,
-    });
+    const result = runWithEnv(
+      "alpha policy-add",
+      testHome.environment({
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_OPENSHELL_BIN: openshell,
+      }),
+    );
 
     expect(result.code).toBe(1);
     expect(result.out).toContain("Non-interactive mode requires a preset name.");
     expect(readSandboxPolicies(home)).toEqual([]);
   });
 
-  it("keeps public policy-add missing-preset failure when stdin contains probe output", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-policy-stdin-"));
+  it("keeps public policy-add missing-preset failure when stdin contains probe output", ({
+    testHome,
+  }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
     const openshell = writePolicyMutationOpenshellStub(home);
 
-    const result = runWithInput("alpha policy-add", "/usr/bin/dmesg\n3", {
-      HOME: home,
-      NEMOCLAW_NON_INTERACTIVE: "1",
-      NEMOCLAW_OPENSHELL_BIN: openshell,
-    });
+    const result = runWithInput(
+      "alpha policy-add",
+      "/usr/bin/dmesg\n3",
+      testHome.environment({
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_OPENSHELL_BIN: openshell,
+      }),
+    );
 
     expect(result.code).toBe(1);
     expect(result.out).toContain("Non-interactive mode requires a preset name.");
@@ -164,14 +177,20 @@ describe("CLI dispatch", () => {
     expect(readSandboxPolicies(home)).toEqual([]);
   });
 
-  it("sandbox channels start rejects a sandbox missing from the registry (#4584)", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-channels-missing-"));
+  it("sandbox channels start rejects a sandbox missing from the registry (#4584)", ({
+    testHome,
+  }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
 
-    const startMissing = runWithEnv("sandbox channels start does-not-exist telegram", {
-      HOME: home,
-    });
-    const stopMissing = runWithEnv("sandbox channels stop does-not-exist telegram", { HOME: home });
+    const startMissing = runWithEnv(
+      "sandbox channels start does-not-exist telegram",
+      testHome.environment(),
+    );
+    const stopMissing = runWithEnv(
+      "sandbox channels stop does-not-exist telegram",
+      testHome.environment(),
+    );
 
     expect(startMissing.code).toBe(1);
     expect(startMissing.out).toContain("Sandbox 'does-not-exist' not found in the registry.");

--- a/test/cli/snapshot-shields.test.ts
+++ b/test/cli/snapshot-shields.test.ts
@@ -1,70 +1,71 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, test as it } from "../helpers/owned-test-resources";
 
 import { runWithEnv, testTimeoutOptions, writeSandboxRegistry } from "./helpers";
 
 describe("CLI dispatch", () => {
-  it("shields help uses native oclif usage", testTimeoutOptions(30_000), () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-shields-help-"));
+  it("shields help uses native oclif usage", testTimeoutOptions(30_000), ({ testHome }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
 
-    const down = runWithEnv("alpha shields down --help", { HOME: home });
+    const down = runWithEnv("alpha shields down --help", testHome.environment());
     expect(down.code).toBe(0);
     expect(down.out).toContain("$ nemoclaw sandbox shields down <name>");
 
-    const up = runWithEnv("alpha shields up --help", { HOME: home });
+    const up = runWithEnv("alpha shields up --help", testHome.environment());
     expect(up.code).toBe(0);
     expect(up.out).toContain("$ nemoclaw sandbox shields up <name>");
 
-    const status = runWithEnv("alpha shields status --help", { HOME: home });
+    const status = runWithEnv("alpha shields status --help", testHome.environment());
     expect(status.code).toBe(0);
     expect(status.out).toContain("$ nemoclaw sandbox shields status <name>");
   });
 
-  it("snapshot subcommand help uses native oclif usage", testTimeoutOptions(30_000), () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-snapshot-help-"));
+  it(
+    "snapshot subcommand help uses native oclif usage",
+    testTimeoutOptions(30_000),
+    ({ testHome }) => {
+      const { home } = testHome;
+      writeSandboxRegistry(home);
+
+      const parent = runWithEnv("alpha snapshot --help", testHome.environment());
+      expect(parent.code).toBe(0);
+      expect(parent.out).toContain("$ nemoclaw sandbox snapshot <create|list|restore> <name>");
+      expect(parent.out).toContain("sandbox snapshot create");
+      expect(parent.out).toContain("sandbox snapshot list");
+
+      const list = runWithEnv("alpha snapshot list --help", testHome.environment());
+      expect(list.code).toBe(0);
+      expect(list.out).toContain("$ nemoclaw sandbox snapshot list <name>");
+
+      const create = runWithEnv("alpha snapshot create --help", testHome.environment());
+      expect(create.code).toBe(0);
+      expect(create.out).toContain("$ nemoclaw sandbox snapshot create <name> [--name <label>]");
+
+      const restore = runWithEnv("alpha snapshot restore --help", testHome.environment());
+      expect(restore.code).toBe(0);
+      expect(restore.out).toContain(
+        "$ nemoclaw sandbox snapshot restore <name> [selector] [--to <dst>]",
+      );
+    },
+  );
+
+  it("snapshot list dispatches through oclif", ({ testHome }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
 
-    const parent = runWithEnv("alpha snapshot --help", { HOME: home });
-    expect(parent.code).toBe(0);
-    expect(parent.out).toContain("$ nemoclaw sandbox snapshot <create|list|restore> <name>");
-    expect(parent.out).toContain("sandbox snapshot create");
-    expect(parent.out).toContain("sandbox snapshot list");
-
-    const list = runWithEnv("alpha snapshot list --help", { HOME: home });
-    expect(list.code).toBe(0);
-    expect(list.out).toContain("$ nemoclaw sandbox snapshot list <name>");
-
-    const create = runWithEnv("alpha snapshot create --help", { HOME: home });
-    expect(create.code).toBe(0);
-    expect(create.out).toContain("$ nemoclaw sandbox snapshot create <name> [--name <label>]");
-
-    const restore = runWithEnv("alpha snapshot restore --help", { HOME: home });
-    expect(restore.code).toBe(0);
-    expect(restore.out).toContain(
-      "$ nemoclaw sandbox snapshot restore <name> [selector] [--to <dst>]",
-    );
-  });
-
-  it("snapshot list dispatches through oclif", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-snapshot-list-"));
-    writeSandboxRegistry(home);
-
-    const r = runWithEnv("alpha snapshot list", { HOME: home });
+    const r = runWithEnv("alpha snapshot list", testHome.environment());
     expect(r.code).toBe(0);
     expect(r.out).toContain("No snapshots found for 'alpha'.");
   });
 
-  it("unknown snapshot subcommands fail before action dispatch", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-snapshot-unknown-"));
+  it("unknown snapshot subcommands fail before action dispatch", ({ testHome }) => {
+    const { home } = testHome;
     writeSandboxRegistry(home);
 
-    const r = runWithEnv("alpha snapshot bogus 2>&1", { HOME: home });
+    const r = runWithEnv("alpha snapshot bogus 2>&1", testHome.environment());
     expect(r.code).not.toBe(0);
     expect(r.out).toMatch(/Unexpected argument:|Command .*not found/);
   });

--- a/test/helpers/child-process-lifecycle.ts
+++ b/test/helpers/child-process-lifecycle.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChildProcess } from "node:child_process";
+
+export type ChildProcessOwnerOptions = {
+  forceTimeoutMs?: number;
+  gracefulTimeoutMs?: number;
+};
+
+export type ChildProcessOwner = {
+  child: ChildProcess;
+  closed: Promise<void>;
+  terminate: () => Promise<void>;
+};
+
+function childHasExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function childStdioClosed(child: ChildProcess): boolean {
+  return child.stdio.every((stream) => stream === null || stream === undefined || stream.destroyed);
+}
+
+function waitFor(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (completed: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(completed);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    timer.unref();
+    void promise.then(() => finish(true));
+  });
+}
+
+export function ownChildProcess(
+  child: ChildProcess,
+  options: ChildProcessOwnerOptions = {},
+): ChildProcessOwner {
+  const gracefulTimeoutMs = options.gracefulTimeoutMs ?? 1_000;
+  const forceTimeoutMs = options.forceTimeoutMs ?? 1_000;
+  let closed = childHasExited(child) && childStdioClosed(child);
+  const closedPromise = closed
+    ? Promise.resolve()
+    : new Promise<void>((resolve) => {
+        child.once("close", () => {
+          closed = true;
+          resolve();
+        });
+      });
+
+  return {
+    child,
+    closed: closedPromise,
+    terminate: async () => {
+      if (closed) return;
+      if (!childHasExited(child)) child.kill("SIGTERM");
+      if (await waitFor(closedPromise, gracefulTimeoutMs)) return;
+      if (!childHasExited(child)) child.kill("SIGKILL");
+      if (!(await waitFor(closedPromise, forceTimeoutMs))) {
+        throw new Error(`Child process ${child.pid ?? "<unknown>"} did not close after SIGKILL`);
+      }
+    },
+  };
+}

--- a/test/helpers/owned-test-resources.ts
+++ b/test/helpers/owned-test-resources.ts
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import type { Server } from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { test as base, describe, expect } from "vitest";
+
+import { ownChildProcess } from "./child-process-lifecycle";
+
+type Cleanup = {
+  label: string;
+  run: () => Promise<void> | void;
+};
+
+export type OwnedTestHome = {
+  home: string;
+  bin: string;
+  environment: (overrides?: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
+};
+
+function createServerCleanup(server: Server): () => Promise<void> {
+  let hasListened = server.listening;
+  let hasClosed = false;
+  let resolveClosed!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const onListening = (): void => {
+    hasListened = true;
+  };
+  const onClose = (): void => {
+    hasClosed = true;
+    server.off("listening", onListening);
+    resolveClosed();
+  };
+  server.on("listening", onListening);
+  server.once("close", onClose);
+
+  return async () => {
+    if (hasClosed) return;
+    if (!server.listening) {
+      if (hasListened) await closed;
+      else {
+        server.off("listening", onListening);
+        server.off("close", onClose);
+      }
+      return;
+    }
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING" || !hasListened)
+        throw error;
+      await closed;
+    }
+  };
+}
+
+export class OwnedTestResources {
+  readonly #cleanups: Cleanup[] = [];
+
+  ownDirectory(directory: string): string {
+    this.#cleanups.push({
+      label: `temporary directory ${directory}`,
+      run: () =>
+        fs.rmSync(directory, {
+          force: true,
+          maxRetries: 3,
+          recursive: true,
+          retryDelay: 50,
+        }),
+    });
+    return directory;
+  }
+
+  temporaryDirectory(prefix: string): string {
+    return this.ownDirectory(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+  }
+
+  home(prefix = "nemoclaw-test-home-"): OwnedTestHome {
+    const home = this.temporaryDirectory(prefix);
+    const bin = path.join(home, "bin");
+    fs.mkdirSync(bin, { recursive: true });
+    return {
+      home,
+      bin,
+      environment: (overrides = {}) => ({
+        ...process.env,
+        HOME: home,
+        PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+        ...overrides,
+      }),
+    };
+  }
+
+  ownServer<T extends Server>(server: T): T {
+    this.#cleanups.push({
+      label: "test server",
+      run: createServerCleanup(server),
+    });
+    return server;
+  }
+
+  ownChild<T extends ChildProcess>(child: T): T {
+    const owner = ownChildProcess(child);
+    this.#cleanups.push({
+      label: `child process ${child.pid ?? "<pending>"}`,
+      run: owner.terminate,
+    });
+    return child;
+  }
+
+  async cleanup(): Promise<void> {
+    const failures: Error[] = [];
+    for (const cleanup of this.#cleanups.splice(0).reverse()) {
+      try {
+        await cleanup.run();
+      } catch (error) {
+        failures.push(new Error(`Failed to clean up ${cleanup.label}: ${String(error)}`));
+      }
+    }
+    if (failures.length > 0)
+      throw new AggregateError(failures, "Owned test resource cleanup failed");
+  }
+}
+
+export type OwnedResourceFixtures = {
+  resources: OwnedTestResources;
+  testHome: OwnedTestHome;
+};
+
+export const test = base.extend<OwnedResourceFixtures>({
+  resources: async ({}, use) => {
+    const resources = new OwnedTestResources();
+    try {
+      await use(resources);
+    } finally {
+      await resources.cleanup();
+    }
+  },
+  testHome: async ({ resources }, use) => {
+    await use(resources.home());
+  },
+});
+
+export { describe, expect };

--- a/test/hermes-tool-gateway-broker.test.ts
+++ b/test/hermes-tool-gateway-broker.test.ts
@@ -8,11 +8,9 @@ import fs from "node:fs";
 import http from "node:http";
 import { createRequire } from "node:module";
 import net from "node:net";
-import os from "node:os";
 import path from "node:path";
 import zlib from "node:zlib";
-
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, test as it } from "./helpers/owned-test-resources";
 import { testTimeout } from "./helpers/timeouts";
 
 const SCRIPT = path.join(
@@ -32,7 +30,6 @@ const BROKER_WRAPPER = path.join(
   "hermes-tool-gateway-broker.ts",
 );
 
-let children: ChildProcess[] = [];
 const BROKER_READINESS_TIMEOUT_MS = 15_000;
 const BROKER_TEST_TIMEOUT_MS = testTimeout(45_000);
 
@@ -63,10 +60,6 @@ function listen(server: http.Server): Promise<number> {
       resolve(typeof address === "object" && address ? address.port : 0);
     });
   });
-}
-
-function close(server: http.Server): Promise<void> {
-  return new Promise((resolve) => server.close(() => resolve()));
 }
 
 function brokerDiagnostics(child: ChildProcess, output: () => string): string {
@@ -103,11 +96,6 @@ async function waitForBrokerCondition(
   );
 }
 
-afterEach(() => {
-  for (const child of children) child.kill("SIGTERM");
-  children = [];
-});
-
 describe("Hermes managed-tool gateway broker", () => {
   it("only auto-recovers for Hermes sandboxes with selected managed tools", () => {
     delete require.cache[require.resolve(BROKER_WRAPPER)];
@@ -141,8 +129,8 @@ describe("Hermes managed-tool gateway broker", () => {
 
   it("refreshes via header, replaces upstream auth, normalizes responses, and rotates OpenShell storage", {
     timeout: BROKER_TEST_TIMEOUT_MS,
-  }, async () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-tool-broker-"));
+  }, async ({ resources }) => {
+    const tmp = resources.temporaryDirectory("nemoclaw-hermes-tool-broker-");
     const stateDir = path.join(tmp, "state");
     const binDir = path.join(tmp, "bin");
     fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
@@ -183,40 +171,42 @@ describe("Hermes managed-tool gateway broker", () => {
 
     const tokenRequests: Array<{ body: string; refreshHeader?: string }> = [];
     const agentKeyRequests: Array<{ body: string; authorization?: string }> = [];
-    const portal = http.createServer((req, res) => {
-      const chunks: Buffer[] = [];
-      req.on("data", (chunk) => chunks.push(chunk));
-      req.on("end", () => {
-        const body = Buffer.concat(chunks).toString("utf8");
-        res.writeHead(200, { "Content-Type": "application/json" });
-        if (req.url === "/api/oauth/agent-key") {
-          agentKeyRequests.push({
+    const portal = resources.ownServer(
+      http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk) => chunks.push(chunk));
+        req.on("end", () => {
+          const body = Buffer.concat(chunks).toString("utf8");
+          res.writeHead(200, { "Content-Type": "application/json" });
+          if (req.url === "/api/oauth/agent-key") {
+            agentKeyRequests.push({
+              body,
+              authorization: req.headers.authorization,
+            });
+            res.end(
+              JSON.stringify({
+                api_key: "agent-key-2",
+                expires_in: 1800,
+                inference_base_url: "https://inference-api.nousresearch.com/v1",
+              }),
+            );
+            return;
+          }
+          tokenRequests.push({
             body,
-            authorization: req.headers.authorization,
+            refreshHeader: req.headers["x-nous-refresh-token"] as string | undefined,
           });
           res.end(
             JSON.stringify({
-              api_key: "agent-key-2",
-              expires_in: 1800,
-              inference_base_url: "https://inference-api.nousresearch.com/v1",
+              access_token: "access-2",
+              refresh_token: "refresh-2",
+              expires_in: 900,
+              token_type: "Bearer",
             }),
           );
-          return;
-        }
-        tokenRequests.push({
-          body,
-          refreshHeader: req.headers["x-nous-refresh-token"] as string | undefined,
         });
-        res.end(
-          JSON.stringify({
-            access_token: "access-2",
-            refresh_token: "refresh-2",
-            expires_in: 900,
-            token_type: "Bearer",
-          }),
-        );
-      });
-    });
+      }),
+    );
     const portalPort = await listen(portal);
 
     const upstreamRequests: Array<{
@@ -226,24 +216,26 @@ describe("Hermes managed-tool gateway broker", () => {
       apiKey?: string;
       acceptEncoding?: string;
     }> = [];
-    const upstream = http.createServer((req, res) => {
-      upstreamRequests.push({
-        url: req.url,
-        authorization: req.headers.authorization,
-        browserUseApiKey: req.headers["x-browser-use-api-key"] as string | undefined,
-        apiKey: req.headers["x-api-key"] as string | undefined,
-        acceptEncoding: req.headers["accept-encoding"] as string | undefined,
-      });
-      const body = zlib.gzipSync(JSON.stringify({ ok: true, path: req.url }));
-      res.writeHead(200, {
-        "Content-Type": "application/json",
-        "Content-Encoding": "gzip",
-        "Content-Length": String(body.length),
-        "Content-MD5": "not-a-real-digest",
-        "Set-Cookie": "fixture_session=1; HttpOnly; Secure; SameSite=Strict",
-      });
-      res.end(body);
-    });
+    const upstream = resources.ownServer(
+      http.createServer((req, res) => {
+        upstreamRequests.push({
+          url: req.url,
+          authorization: req.headers.authorization,
+          browserUseApiKey: req.headers["x-browser-use-api-key"] as string | undefined,
+          apiKey: req.headers["x-api-key"] as string | undefined,
+          acceptEncoding: req.headers["accept-encoding"] as string | undefined,
+        });
+        const body = zlib.gzipSync(JSON.stringify({ ok: true, path: req.url }));
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Content-Encoding": "gzip",
+          "Content-Length": String(body.length),
+          "Content-MD5": "not-a-real-digest",
+          "Set-Cookie": "fixture_session=1; HttpOnly; Secure; SameSite=Strict",
+        });
+        res.end(body);
+      }),
+    );
     const upstreamPort = await listen(upstream);
     const matrixPath = path.join(tmp, "matrix.json");
     const upstreamBase = `http://127.0.0.1:${upstreamPort}`;
@@ -259,19 +251,20 @@ describe("Hermes managed-tool gateway broker", () => {
     );
     const brokerPort = await freePort();
 
-    const child = spawn(process.execPath, ["--experimental-strip-types", SCRIPT], {
-      env: {
-        ...process.env,
-        HERMES_TOOL_GATEWAY_PORT: String(brokerPort),
-        HERMES_TOOL_GATEWAY_STATE_DIR: stateDir,
-        HERMES_TOOL_GATEWAY_MATRIX_PATH: matrixPath,
-        NOUS_PORTAL_BASE_URL: `http://127.0.0.1:${portalPort}`,
-        NEMOCLAW_OPENSHELL_BIN: openshellBin,
-        NEMOCLAW_HERMES_TOOL_GATEWAY_REFRESH_TOKEN: "refresh-1",
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    children.push(child);
+    const child = resources.ownChild(
+      spawn(process.execPath, ["--experimental-strip-types", SCRIPT], {
+        env: {
+          ...process.env,
+          HERMES_TOOL_GATEWAY_PORT: String(brokerPort),
+          HERMES_TOOL_GATEWAY_STATE_DIR: stateDir,
+          HERMES_TOOL_GATEWAY_MATRIX_PATH: matrixPath,
+          NOUS_PORTAL_BASE_URL: `http://127.0.0.1:${portalPort}`,
+          NEMOCLAW_OPENSHELL_BIN: openshellBin,
+          NEMOCLAW_HERMES_TOOL_GATEWAY_REFRESH_TOKEN: "refresh-1",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
 
     let output = "";
     child.stdout.on("data", (chunk) => {
@@ -281,129 +274,121 @@ describe("Hermes managed-tool gateway broker", () => {
       output += chunk.toString();
     });
 
-    try {
-      await waitForBrokerCondition(
-        "broker health",
-        child,
-        () => output,
-        async () => {
-          const response = await fetch(`http://127.0.0.1:${brokerPort}/health`, {
-            signal: AbortSignal.timeout(1_000),
-          });
-          return response.status === 200;
-        },
-      );
-      await waitForBrokerCondition(
-        "inference provider refresh",
-        child,
-        () => output,
-        () => {
-          try {
-            return fs
-              .readFileSync(openshellLog, "utf8")
-              .includes("provider update hermes-provider");
-          } catch {
-            return false;
-          }
-        },
-      );
-
-      const unknown = await fetch(`http://127.0.0.1:${brokerPort}/unknown`);
-      expect(unknown.status).toBe(404);
-
-      const denied = await fetch(`http://127.0.0.1:${brokerPort}/firecrawl/v1/scrape`, {
-        headers: { Authorization: "Bearer wrong-broker-token" },
-      });
-      expect(denied.status).toBe(401);
-
-      const firecrawl = await fetch(`http://127.0.0.1:${brokerPort}/firecrawl/v1/scrape?debug=1`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": "refresh-2",
-        },
-        body: JSON.stringify({ url: "https://example.com" }),
-      });
-      const firecrawlBody = await firecrawl.text();
-      expect(firecrawl.status, `${firecrawlBody}\n${output}`).toBe(200);
-      expect(firecrawl.headers.get("content-encoding")).toBeNull();
-      expect(firecrawl.headers.get("content-length")).toBeNull();
-      expect(firecrawl.headers.get("content-md5")).toBeNull();
-      expect(firecrawl.headers.get("set-cookie")).toBeNull();
-      expect(JSON.parse(firecrawlBody)).toEqual({ ok: true, path: "/v1/scrape?debug=1" });
-      expect(tokenRequests).toHaveLength(1);
-      expect(tokenRequests[0]?.refreshHeader).toBe("refresh-1");
-      expect(new URLSearchParams(tokenRequests[0]?.body).get("refresh_token")).toBeNull();
-      expect(new URLSearchParams(tokenRequests[0]?.body).get("grant_type")).toBe("refresh_token");
-      expect(agentKeyRequests).toHaveLength(1);
-      expect(agentKeyRequests[0]?.authorization).toBe("Bearer access-2");
-      expect(JSON.parse(agentKeyRequests[0]?.body || "{}")).toEqual({
-        min_ttl_seconds: 1800,
-      });
-      expect(upstreamRequests[0]).toMatchObject({
-        url: "/v1/scrape?debug=1",
-        authorization: "Bearer access-2",
-        acceptEncoding: "identity",
-      });
-      expect(upstreamRequests[0]?.apiKey).toBeUndefined();
-
-      const rotatedState = JSON.parse(fs.readFileSync(statePath, "utf8"));
-      expect(rotatedState.refresh_token_sha256).toBe(sha256("refresh-2"));
-      const openshellOutput = fs.readFileSync(openshellLog, "utf8");
-      expect(openshellOutput).toContain(
-        "provider update sandbox-hermes-tool-gateway --credential NEMOCLAW_HERMES_TOOL_GATEWAY_REFRESH_TOKEN",
-      );
-      expect(openshellOutput).toContain("refresh=refresh-2");
-      expect(openshellOutput).toContain(
-        "provider update hermes-provider --credential OPENAI_API_KEY --config OPENAI_BASE_URL=https://inference-api.nousresearch.com/v1",
-      );
-      expect(openshellOutput).toContain("openai=agent-key-2");
-      expect(rotatedState.inference_provider_name).toBe("hermes-provider");
-      expect(rotatedState.inference_credential_env).toBe("OPENAI_API_KEY");
-      expect(rotatedState.inference_agent_key_expires_at).toBeTruthy();
-
-      const checks = [
-        ["/browser-use/browsers", { "X-Browser-Use-API-Key": "broker-1" }, "browser"],
-        ["/fal-queue/fal-ai/test", { Authorization: "Key broker-1" }, "fal"],
-        ["/openai-audio/v1/audio/speech", { "openai-api-key": "broker-1" }, "audio"],
-        ["/modal/sandboxes", { Authorization: "Bearer broker-1" }, "modal"],
-      ] as const;
-      for (const [route, headers] of checks) {
-        const resp = await fetch(`http://127.0.0.1:${brokerPort}${route}`, {
-          method: "POST",
-          headers,
-          body: "{}",
+    await waitForBrokerCondition(
+      "broker health",
+      child,
+      () => output,
+      async () => {
+        const response = await fetch(`http://127.0.0.1:${brokerPort}/health`, {
+          signal: AbortSignal.timeout(1_000),
         });
-        expect(resp.status).toBe(200);
-      }
-      expect(upstreamRequests[1]).toMatchObject({
-        url: "/browsers",
-        browserUseApiKey: "access-2",
+        return response.status === 200;
+      },
+    );
+    await waitForBrokerCondition(
+      "inference provider refresh",
+      child,
+      () => output,
+      () => {
+        try {
+          return fs.readFileSync(openshellLog, "utf8").includes("provider update hermes-provider");
+        } catch {
+          return false;
+        }
+      },
+    );
+
+    const unknown = await fetch(`http://127.0.0.1:${brokerPort}/unknown`);
+    expect(unknown.status).toBe(404);
+
+    const denied = await fetch(`http://127.0.0.1:${brokerPort}/firecrawl/v1/scrape`, {
+      headers: { Authorization: "Bearer wrong-broker-token" },
+    });
+    expect(denied.status).toBe(401);
+
+    const firecrawl = await fetch(`http://127.0.0.1:${brokerPort}/firecrawl/v1/scrape?debug=1`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": "refresh-2",
+      },
+      body: JSON.stringify({ url: "https://example.com" }),
+    });
+    const firecrawlBody = await firecrawl.text();
+    expect(firecrawl.status, `${firecrawlBody}\n${output}`).toBe(200);
+    expect(firecrawl.headers.get("content-encoding")).toBeNull();
+    expect(firecrawl.headers.get("content-length")).toBeNull();
+    expect(firecrawl.headers.get("content-md5")).toBeNull();
+    expect(firecrawl.headers.get("set-cookie")).toBeNull();
+    expect(JSON.parse(firecrawlBody)).toEqual({ ok: true, path: "/v1/scrape?debug=1" });
+    expect(tokenRequests).toHaveLength(1);
+    expect(tokenRequests[0]?.refreshHeader).toBe("refresh-1");
+    expect(new URLSearchParams(tokenRequests[0]?.body).get("refresh_token")).toBeNull();
+    expect(new URLSearchParams(tokenRequests[0]?.body).get("grant_type")).toBe("refresh_token");
+    expect(agentKeyRequests).toHaveLength(1);
+    expect(agentKeyRequests[0]?.authorization).toBe("Bearer access-2");
+    expect(JSON.parse(agentKeyRequests[0]?.body || "{}")).toEqual({
+      min_ttl_seconds: 1800,
+    });
+    expect(upstreamRequests[0]).toMatchObject({
+      url: "/v1/scrape?debug=1",
+      authorization: "Bearer access-2",
+      acceptEncoding: "identity",
+    });
+    expect(upstreamRequests[0]?.apiKey).toBeUndefined();
+
+    const rotatedState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    expect(rotatedState.refresh_token_sha256).toBe(sha256("refresh-2"));
+    const openshellOutput = fs.readFileSync(openshellLog, "utf8");
+    expect(openshellOutput).toContain(
+      "provider update sandbox-hermes-tool-gateway --credential NEMOCLAW_HERMES_TOOL_GATEWAY_REFRESH_TOKEN",
+    );
+    expect(openshellOutput).toContain("refresh=refresh-2");
+    expect(openshellOutput).toContain(
+      "provider update hermes-provider --credential OPENAI_API_KEY --config OPENAI_BASE_URL=https://inference-api.nousresearch.com/v1",
+    );
+    expect(openshellOutput).toContain("openai=agent-key-2");
+    expect(rotatedState.inference_provider_name).toBe("hermes-provider");
+    expect(rotatedState.inference_credential_env).toBe("OPENAI_API_KEY");
+    expect(rotatedState.inference_agent_key_expires_at).toBeTruthy();
+
+    const checks = [
+      ["/browser-use/browsers", { "X-Browser-Use-API-Key": "broker-1" }, "browser"],
+      ["/fal-queue/fal-ai/test", { Authorization: "Key broker-1" }, "fal"],
+      ["/openai-audio/v1/audio/speech", { "openai-api-key": "broker-1" }, "audio"],
+      ["/modal/sandboxes", { Authorization: "Bearer broker-1" }, "modal"],
+    ] as const;
+    for (const [route, headers] of checks) {
+      const resp = await fetch(`http://127.0.0.1:${brokerPort}${route}`, {
+        method: "POST",
+        headers,
+        body: "{}",
       });
-      expect(upstreamRequests[1]?.authorization).toBeUndefined();
-      expect(upstreamRequests[2]).toMatchObject({
-        url: "/fal-ai/test",
-        authorization: "Key access-2",
-      });
-      expect(upstreamRequests[3]).toMatchObject({
-        url: "/v1/audio/speech",
-        authorization: "Bearer access-2",
-      });
-      expect(upstreamRequests[4]).toMatchObject({
-        url: "/sandboxes",
-        authorization: "Bearer access-2",
-      });
-      expect(tokenRequests).toHaveLength(1);
-      expect(agentKeyRequests).toHaveLength(1);
-      expect(output).not.toContain("refresh-1");
-      expect(output).not.toContain("refresh-2");
-      expect(output).not.toContain("access-2");
-      expect(output).not.toContain("sandbox-secret");
-      expect(output).not.toContain("agent-key-2");
-    } finally {
-      await close(portal);
-      await close(upstream);
-      fs.rmSync(tmp, { recursive: true, force: true });
+      expect(resp.status).toBe(200);
     }
+    expect(upstreamRequests[1]).toMatchObject({
+      url: "/browsers",
+      browserUseApiKey: "access-2",
+    });
+    expect(upstreamRequests[1]?.authorization).toBeUndefined();
+    expect(upstreamRequests[2]).toMatchObject({
+      url: "/fal-ai/test",
+      authorization: "Key access-2",
+    });
+    expect(upstreamRequests[3]).toMatchObject({
+      url: "/v1/audio/speech",
+      authorization: "Bearer access-2",
+    });
+    expect(upstreamRequests[4]).toMatchObject({
+      url: "/sandboxes",
+      authorization: "Bearer access-2",
+    });
+    expect(tokenRequests).toHaveLength(1);
+    expect(agentKeyRequests).toHaveLength(1);
+    expect(output).not.toContain("refresh-1");
+    expect(output).not.toContain("refresh-2");
+    expect(output).not.toContain("access-2");
+    expect(output).not.toContain("sandbox-secret");
+    expect(output).not.toContain("agent-key-2");
   });
 });

--- a/test/ollama-auth-proxy-handler-helpers.ts
+++ b/test/ollama-auth-proxy-handler-helpers.ts
@@ -172,8 +172,11 @@ export async function startProxy(
 export async function terminate(child: ChildProcess | undefined): Promise<void> {
   if (!child) return;
   const owner = proxyOwners.get(child) ?? ownChildProcess(child);
-  await owner.terminate();
-  proxyOwners.delete(child);
+  try {
+    await owner.terminate();
+  } finally {
+    proxyOwners.delete(child);
+  }
 }
 
 export async function forceKill(child: ChildProcess | undefined): Promise<void> {

--- a/test/ollama-auth-proxy-handler-helpers.ts
+++ b/test/ollama-auth-proxy-handler-helpers.ts
@@ -6,6 +6,7 @@
 // request driver all branch, so they live here to keep the test body linear.
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
@@ -143,6 +144,15 @@ export async function terminate(child: ChildProcess | undefined): Promise<void> 
   const owner = proxyOwners.get(child) ?? ownChildProcess(child);
   await owner.terminate();
   proxyOwners.delete(child);
+}
+
+export async function forceKill(child: ChildProcess | undefined): Promise<void> {
+  if (!child) return;
+  const hasExited = child.exitCode !== null || child.signalCode !== null;
+  if (hasExited && child.stdio.every((stream) => stream === null || stream?.destroyed)) return;
+  const closed = once(child, "close");
+  if (!hasExited) child.kill("SIGKILL");
+  await closed;
 }
 
 export interface ProxyResponse {

--- a/test/ollama-auth-proxy-handler-helpers.ts
+++ b/test/ollama-auth-proxy-handler-helpers.ts
@@ -10,18 +10,27 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 
+import { type ChildProcessOwner, ownChildProcess } from "./helpers/child-process-lifecycle.ts";
+
 export const PROXY_SCRIPT = path.resolve(
   import.meta.dirname,
   "..",
   "scripts",
   "ollama-auth-proxy.js",
 );
+const proxyOwners = new WeakMap<ChildProcess, ChildProcessOwner>();
 
 export interface BackendCapture {
   method: string;
   url: string;
   headers: http.IncomingHttpHeaders;
 }
+
+export type StartProxyOptions = {
+  onSpawn?: (child: ChildProcess) => void;
+  readinessPort?: number;
+  readinessTimeoutMs?: number;
+};
 
 /** Start a loopback stub backend that records the request it received. */
 export function startBackend(): Promise<{
@@ -67,6 +76,7 @@ export async function startProxy(
   proxyPort: number,
   backendPort: number,
   token: string,
+  options: StartProxyOptions = {},
 ): Promise<ChildProcess> {
   const child = spawn(process.execPath, [PROXY_SCRIPT], {
     env: {
@@ -77,51 +87,57 @@ export async function startProxy(
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-    const timer = setTimeout(() => {
-      settled = true;
-      reject(new Error("proxy did not start in time"));
-    }, 5_000);
-    const tryConnect = (): void => {
-      if (settled) return;
-      const req = http.request(
-        { host: "127.0.0.1", port: proxyPort, path: "/", method: "GET" },
-        (res) => {
-          res.resume();
-          settled = true;
-          clearTimeout(timer);
-          resolve();
-        },
-      );
-      req.on("error", () => {
-        if (!settled) setTimeout(tryConnect, 100);
+  const owner = ownChildProcess(child, { forceTimeoutMs: 2_000, gracefulTimeoutMs: 2_000 });
+  proxyOwners.set(child, owner);
+  try {
+    options.onSpawn?.(child);
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        settled = true;
+        reject(new Error("proxy did not start in time"));
+      }, options.readinessTimeoutMs ?? 5_000);
+      const tryConnect = (): void => {
+        if (settled) return;
+        const req = http.request(
+          {
+            host: "127.0.0.1",
+            port: options.readinessPort ?? proxyPort,
+            path: "/",
+            method: "GET",
+          },
+          (res) => {
+            res.resume();
+            settled = true;
+            clearTimeout(timer);
+            resolve();
+          },
+        );
+        req.on("error", () => {
+          if (!settled) setTimeout(tryConnect, 100);
+        });
+        req.end();
+      };
+      child.once("exit", (code) => {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`proxy exited early with code ${code}`));
       });
-      req.end();
-    };
-    child.once("exit", (code) => {
-      settled = true;
-      clearTimeout(timer);
-      reject(new Error(`proxy exited early with code ${code}`));
+      tryConnect();
     });
-    tryConnect();
-  });
-  return child;
+    return child;
+  } catch (error) {
+    await owner.terminate();
+    proxyOwners.delete(child);
+    throw error;
+  }
 }
 
 export async function terminate(child: ChildProcess | undefined): Promise<void> {
-  if (!child || child.killed || child.exitCode !== null) return;
-  child.kill("SIGTERM");
-  await new Promise<void>((resolve) => {
-    const timer = setTimeout(() => {
-      if (!child.killed && child.exitCode === null) child.kill("SIGKILL");
-      resolve();
-    }, 2_000);
-    child.once("exit", () => {
-      clearTimeout(timer);
-      resolve();
-    });
-  });
+  if (!child) return;
+  const owner = proxyOwners.get(child) ?? ownChildProcess(child);
+  await owner.terminate();
+  proxyOwners.delete(child);
 }
 
 export interface ProxyResponse {

--- a/test/ollama-auth-proxy-handler-helpers.ts
+++ b/test/ollama-auth-proxy-handler-helpers.ts
@@ -127,8 +127,13 @@ export async function startProxy(
     });
     return child;
   } catch (error) {
-    await owner.terminate();
-    proxyOwners.delete(child);
+    try {
+      await owner.terminate();
+    } catch {
+      // Cleanup failure must not replace the proxy startup failure.
+    } finally {
+      proxyOwners.delete(child);
+    }
     throw error;
   }
 }

--- a/test/ollama-auth-proxy-handler-helpers.ts
+++ b/test/ollama-auth-proxy-handler-helpers.ts
@@ -72,6 +72,69 @@ export function freePort(): Promise<number> {
   });
 }
 
+export function waitForProxyReadiness(
+  child: ChildProcess,
+  proxyPort: number,
+  options: Pick<StartProxyOptions, "readinessPort" | "readinessTimeoutMs"> = {},
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let activeRequest: http.ClientRequest | undefined;
+    let retryTimer: NodeJS.Timeout | undefined;
+
+    const finish = (complete: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (retryTimer) clearTimeout(retryTimer);
+      child.off("error", handleChildError);
+      child.off("exit", handleChildExit);
+      const request = activeRequest;
+      activeRequest = undefined;
+      request?.destroy();
+      complete();
+    };
+    const handleChildError = (error: Error): void => finish(() => reject(error));
+    const handleChildExit = (code: number | null): void =>
+      finish(() => reject(new Error(`proxy exited early with code ${code}`)));
+    const timeout = setTimeout(
+      () => finish(() => reject(new Error("proxy did not start in time"))),
+      options.readinessTimeoutMs ?? 5_000,
+    );
+    const tryConnect = (): void => {
+      if (settled) return;
+      const request = http.request(
+        {
+          host: "127.0.0.1",
+          port: options.readinessPort ?? proxyPort,
+          path: "/",
+          method: "GET",
+        },
+        (res) => {
+          activeRequest = undefined;
+          res.resume();
+          finish(resolve);
+        },
+      );
+      activeRequest = request;
+      request.once("error", () => {
+        if (activeRequest === request) activeRequest = undefined;
+        if (!settled) {
+          retryTimer = setTimeout(() => {
+            retryTimer = undefined;
+            tryConnect();
+          }, 100);
+        }
+      });
+      request.end();
+    };
+
+    child.once("error", handleChildError);
+    child.once("exit", handleChildExit);
+    tryConnect();
+  });
+}
+
 /** Spawn the real proxy script and wait until its listener accepts a connection. */
 export async function startProxy(
   proxyPort: number,
@@ -92,40 +155,7 @@ export async function startProxy(
   proxyOwners.set(child, owner);
   try {
     options.onSpawn?.(child);
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      const timer = setTimeout(() => {
-        settled = true;
-        reject(new Error("proxy did not start in time"));
-      }, options.readinessTimeoutMs ?? 5_000);
-      const tryConnect = (): void => {
-        if (settled) return;
-        const req = http.request(
-          {
-            host: "127.0.0.1",
-            port: options.readinessPort ?? proxyPort,
-            path: "/",
-            method: "GET",
-          },
-          (res) => {
-            res.resume();
-            settled = true;
-            clearTimeout(timer);
-            resolve();
-          },
-        );
-        req.on("error", () => {
-          if (!settled) setTimeout(tryConnect, 100);
-        });
-        req.end();
-      };
-      child.once("exit", (code) => {
-        settled = true;
-        clearTimeout(timer);
-        reject(new Error(`proxy exited early with code ${code}`));
-      });
-      tryConnect();
-    });
+    await waitForProxyReadiness(child, proxyPort, options);
     return child;
   } catch (error) {
     try {

--- a/test/ollama-auth-proxy-handler-startup-cleanup.test.ts
+++ b/test/ollama-auth-proxy-handler-startup-cleanup.test.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ChildProcess } from "node:child_process";
-import { once } from "node:events";
 import type { AddressInfo } from "node:net";
 import net from "node:net";
 
@@ -18,7 +17,7 @@ vi.mock("./helpers/child-process-lifecycle.ts", () => ({
   ownChildProcess: ownerMocks.ownChildProcess,
 }));
 
-import { freePort, startProxy, terminate } from "./ollama-auth-proxy-handler-helpers.ts";
+import { forceKill, freePort, startProxy, terminate } from "./ollama-auth-proxy-handler-helpers.ts";
 
 const TOKEN = "unit-test-secret-token";
 
@@ -48,12 +47,7 @@ it("preserves the readiness failure and allows cleanup to be retried", async ({
   const readinessPort = (readinessRejector.address() as AddressInfo).port;
   const proxyPort = await freePort();
   let spawned: ChildProcess | undefined;
-  onTestFinished(async () => {
-    if (!spawned || spawned.stdio.every((stream) => stream?.destroyed !== false)) return;
-    const closed = once(spawned, "close");
-    if (spawned.exitCode === null && spawned.signalCode === null) spawned.kill("SIGKILL");
-    await closed;
-  });
+  onTestFinished(() => forceKill(spawned));
 
   await expect(
     startProxy(proxyPort, 1, TOKEN, {

--- a/test/ollama-auth-proxy-handler-startup-cleanup.test.ts
+++ b/test/ollama-auth-proxy-handler-startup-cleanup.test.ts
@@ -62,5 +62,4 @@ it("preserves the readiness failure and allows cleanup to be retried", async ({
   await expect(terminate(spawned)).resolves.toBeUndefined();
   expect(failedTermination).toHaveBeenCalledOnce();
   expect(retryTermination).toHaveBeenCalledOnce();
-  expect(ownerMocks.ownChildProcess).toHaveBeenCalledTimes(2);
 });

--- a/test/ollama-auth-proxy-handler-startup-cleanup.test.ts
+++ b/test/ollama-auth-proxy-handler-startup-cleanup.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+
+import { expect, vi } from "vitest";
+
+import { test as it } from "./helpers/owned-test-resources";
+
+const ownerMocks = vi.hoisted(() => ({
+  ownChildProcess: vi.fn(),
+}));
+
+vi.mock("./helpers/child-process-lifecycle.ts", () => ({
+  ownChildProcess: ownerMocks.ownChildProcess,
+}));
+
+import { freePort, startProxy, terminate } from "./ollama-auth-proxy-handler-helpers.ts";
+
+const TOKEN = "unit-test-secret-token";
+
+it("preserves the readiness failure and allows cleanup to be retried", async ({
+  onTestFinished,
+  resources,
+}) => {
+  const failedTermination = vi.fn().mockRejectedValue(new Error("cleanup failed"));
+  const retryTermination = vi.fn().mockResolvedValue(undefined);
+  ownerMocks.ownChildProcess
+    .mockImplementationOnce((child: ChildProcess) => ({
+      child,
+      closed: Promise.resolve(),
+      terminate: failedTermination,
+    }))
+    .mockImplementationOnce((child: ChildProcess) => ({
+      child,
+      closed: Promise.resolve(),
+      terminate: retryTermination,
+    }));
+
+  const readinessRejector = resources.ownServer(net.createServer((socket) => socket.destroy()));
+  await new Promise<void>((resolve, reject) => {
+    readinessRejector.once("error", reject);
+    readinessRejector.listen(0, "127.0.0.1", resolve);
+  });
+  const readinessPort = (readinessRejector.address() as AddressInfo).port;
+  const proxyPort = await freePort();
+  let spawned: ChildProcess | undefined;
+  onTestFinished(async () => {
+    if (!spawned || spawned.stdio.every((stream) => stream?.destroyed !== false)) return;
+    const closed = once(spawned, "close");
+    if (spawned.exitCode === null && spawned.signalCode === null) spawned.kill("SIGKILL");
+    await closed;
+  });
+
+  await expect(
+    startProxy(proxyPort, 1, TOKEN, {
+      onSpawn: (child) => {
+        spawned = child;
+      },
+      readinessPort,
+      readinessTimeoutMs: 100,
+    }),
+  ).rejects.toThrow("proxy did not start in time");
+
+  await expect(terminate(spawned)).resolves.toBeUndefined();
+  expect(failedTermination).toHaveBeenCalledOnce();
+  expect(retryTermination).toHaveBeenCalledOnce();
+  expect(ownerMocks.ownChildProcess).toHaveBeenCalledTimes(2);
+});

--- a/test/ollama-auth-proxy-handler-startup-cleanup.test.ts
+++ b/test/ollama-auth-proxy-handler-startup-cleanup.test.ts
@@ -5,7 +5,7 @@ import type { ChildProcess } from "node:child_process";
 import type { AddressInfo } from "node:net";
 import net from "node:net";
 
-import { expect, vi } from "vitest";
+import { beforeEach, expect, vi } from "vitest";
 
 import { test as it } from "./helpers/owned-test-resources";
 
@@ -20,6 +20,10 @@ vi.mock("./helpers/child-process-lifecycle.ts", () => ({
 import { forceKill, freePort, startProxy, terminate } from "./ollama-auth-proxy-handler-helpers.ts";
 
 const TOKEN = "unit-test-secret-token";
+
+beforeEach(() => {
+  ownerMocks.ownChildProcess.mockReset();
+});
 
 it("preserves the readiness failure and allows cleanup to be retried", async ({
   onTestFinished,
@@ -60,6 +64,34 @@ it("preserves the readiness failure and allows cleanup to be retried", async ({
   ).rejects.toThrow("proxy did not start in time");
 
   await expect(terminate(spawned)).resolves.toBeUndefined();
+  expect(failedTermination).toHaveBeenCalledOnce();
+  expect(retryTermination).toHaveBeenCalledOnce();
+});
+
+it("removes a failed termination owner so cleanup can be retried", async ({ onTestFinished }) => {
+  const failedTermination = vi.fn().mockRejectedValue(new Error("cleanup failed"));
+  const retryTermination = vi.fn().mockResolvedValue(undefined);
+  ownerMocks.ownChildProcess
+    .mockImplementationOnce((child: ChildProcess) => ({
+      child,
+      closed: Promise.resolve(),
+      terminate: failedTermination,
+    }))
+    .mockImplementationOnce((child: ChildProcess) => ({
+      child,
+      closed: Promise.resolve(),
+      terminate: retryTermination,
+    }));
+  let spawned: ChildProcess | undefined;
+  onTestFinished(() => forceKill(spawned));
+  const proxy = await startProxy(await freePort(), 1, TOKEN, {
+    onSpawn: (child) => {
+      spawned = child;
+    },
+  });
+
+  await expect(terminate(proxy)).rejects.toThrow("cleanup failed");
+  await expect(terminate(proxy)).resolves.toBeUndefined();
   expect(failedTermination).toHaveBeenCalledOnce();
   expect(retryTermination).toHaveBeenCalledOnce();
 });

--- a/test/ollama-auth-proxy-handler.test.ts
+++ b/test/ollama-auth-proxy-handler.test.ts
@@ -11,10 +11,15 @@
 // cannot be required as a handler. Instead we spawn it as a real child process
 // (unmodified production code) on an ephemeral port, point it at a tiny
 // in-process stub HTTP backend, and drive real requests through it. No network
-// beyond loopback; both servers and the child are torn down in afterEach.
+// beyond loopback; every server and child process has an awaited cleanup owner.
 
-import type { ChildProcess } from "node:child_process";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type ChildProcess, spawn } from "node:child_process";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+import { afterEach, beforeEach, describe, expect } from "vitest";
+
+import { test as it } from "./helpers/owned-test-resources";
 
 import {
   freePort,
@@ -110,5 +115,54 @@ describe("ollama-auth-proxy request handler", () => {
     expect(res.status).toBe(502);
     expect(res.body).toMatch(/Ollama backend error/);
     expect(proxy?.exitCode).toBeNull();
+  });
+});
+
+describe("ollama-auth-proxy process ownership", () => {
+  it("reaps the proxy before reporting a readiness failure", async ({
+    onTestFinished,
+    resources,
+  }) => {
+    const readinessRejector = resources.ownServer(net.createServer((socket) => socket.destroy()));
+    await new Promise<void>((resolve, reject) => {
+      readinessRejector.once("error", reject);
+      readinessRejector.listen(0, "127.0.0.1", resolve);
+    });
+    const readinessPort = (readinessRejector.address() as AddressInfo).port;
+    const proxyPort = await freePort();
+    let spawned: ChildProcess | undefined;
+    onTestFinished(() => terminate(spawned));
+
+    await expect(
+      startProxy(proxyPort, 1, TOKEN, {
+        onSpawn: (child) => {
+          spawned = child;
+        },
+        readinessPort,
+        readinessTimeoutMs: 100,
+      }),
+    ).rejects.toThrow("proxy did not start in time");
+
+    expect(spawned).toBeDefined();
+    expect(spawned?.signalCode).toBe("SIGTERM");
+    expect(spawned?.stdout?.destroyed).toBe(true);
+  });
+
+  it("escalates a SIGTERM-ignoring child and awaits close", async ({ onTestFinished }) => {
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        "process.on('SIGTERM', () => {}); process.stdout.write('ready'); setInterval(() => {}, 1000);",
+      ],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+    onTestFinished(() => terminate(child));
+    await once(child.stdout!, "data");
+
+    await terminate(child);
+
+    expect(child.signalCode).toBe("SIGKILL");
+    expect(child.stdout?.destroyed).toBe(true);
   });
 });

--- a/test/ollama-auth-proxy-handler.test.ts
+++ b/test/ollama-auth-proxy-handler.test.ts
@@ -14,10 +14,11 @@
 // beyond loopback; every server and child process has an awaited cleanup owner.
 
 import { type ChildProcess, spawn } from "node:child_process";
-import { once } from "node:events";
+import { EventEmitter, once } from "node:events";
+import http from "node:http";
 import type { AddressInfo } from "node:net";
 import net from "node:net";
-import { afterEach, beforeEach, describe, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, vi } from "vitest";
 
 import { test as it } from "./helpers/owned-test-resources";
 
@@ -27,6 +28,7 @@ import {
   startBackend,
   startProxy,
   terminate,
+  waitForProxyReadiness,
 } from "./ollama-auth-proxy-handler-helpers.ts";
 
 const TOKEN = "unit-test-secret-token";
@@ -146,6 +148,41 @@ describe("ollama-auth-proxy process ownership", () => {
     expect(spawned).toBeDefined();
     expect(spawned?.signalCode).toBe("SIGTERM");
     expect(spawned?.stdout?.destroyed).toBe(true);
+  });
+
+  it("destroys a stalled readiness request and removes child listeners", async ({
+    onTestFinished,
+  }) => {
+    const child = new EventEmitter() as unknown as ChildProcess;
+    const destroy = vi.fn();
+    const end = vi.fn();
+    const request = Object.assign(new EventEmitter(), {
+      destroy,
+      end,
+    }) as unknown as http.ClientRequest;
+    const requestSpy = vi.spyOn(http, "request").mockReturnValue(request);
+    onTestFinished(() => requestSpy.mockRestore());
+
+    await expect(waitForProxyReadiness(child, 1, { readinessTimeoutMs: 10 })).rejects.toThrow(
+      "proxy did not start in time",
+    );
+
+    expect(end).toHaveBeenCalledOnce();
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.listenerCount("exit")).toBe(0);
+  });
+
+  it("rejects a child spawn error and removes readiness listeners", async () => {
+    const child = new EventEmitter() as unknown as ChildProcess;
+    const spawnError = Object.assign(new Error("spawn EACCES"), { code: "EACCES" });
+    const readiness = waitForProxyReadiness(child, 1, { readinessTimeoutMs: 1_000 });
+
+    child.emit("error", spawnError);
+
+    await expect(readiness).rejects.toBe(spawnError);
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.listenerCount("exit")).toBe(0);
   });
 
   it("escalates a SIGTERM-ignoring child and awaits close", async ({ onTestFinished }) => {

--- a/test/owned-test-resources.test.ts
+++ b/test/owned-test-resources.test.ts
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { OwnedTestResources } from "./helpers/owned-test-resources";
+
+function listen(server: net.Server, port = 0): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(port, "127.0.0.1", () => {
+      const address = server.address();
+      expect(address).not.toBeNull();
+      expect(typeof address).toBe("object");
+      resolve((address as net.AddressInfo).port);
+    });
+  });
+}
+
+function close(server: net.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("owned test resources", () => {
+  it("owns a temporary HOME, bin directory, and child environment", async ({ onTestFinished }) => {
+    const resources = new OwnedTestResources();
+    onTestFinished(() => resources.cleanup());
+    const testHome = resources.home("nemoclaw-owned-home-");
+    const environment = testHome.environment({ FIXTURE_VALUE: "owned" });
+
+    expect(fs.statSync(testHome.home).isDirectory()).toBe(true);
+    expect(fs.statSync(testHome.bin).isDirectory()).toBe(true);
+    expect(environment).toMatchObject({
+      FIXTURE_VALUE: "owned",
+      HOME: testHome.home,
+    });
+    expect(environment.PATH?.split(path.delimiter)[0]).toBe(testHome.bin);
+
+    await resources.cleanup();
+    expect(fs.existsSync(testHome.home)).toBe(false);
+    await expect(resources.cleanup()).resolves.toBeUndefined();
+  });
+
+  it("waits for owned servers and child processes to exit during cleanup", async ({
+    onTestFinished,
+  }) => {
+    const resources = new OwnedTestResources();
+    onTestFinished(() => resources.cleanup());
+    const server = resources.ownServer(net.createServer());
+    const port = await listen(server);
+    const child = resources.ownChild(
+      spawn(
+        process.execPath,
+        [
+          "-e",
+          "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 50)); process.stdout.write('ready'); setInterval(() => {}, 1000);",
+        ],
+        { stdio: ["ignore", "pipe", "ignore"] },
+      ),
+    );
+    await once(child.stdout!, "data");
+
+    await resources.cleanup();
+
+    expect(server.listening).toBe(false);
+    expect(child.exitCode).toBe(0);
+    const replacement = net.createServer();
+    await listen(replacement, port);
+    await close(replacement);
+  });
+
+  it("waits for an owned server whose shutdown is already in progress", async ({
+    onTestFinished,
+  }) => {
+    const resources = new OwnedTestResources();
+    onTestFinished(() => resources.cleanup());
+    let acceptConnection!: (socket: net.Socket) => void;
+    const accepted = new Promise<net.Socket>((resolve) => {
+      acceptConnection = resolve;
+    });
+    const server = resources.ownServer(net.createServer((socket) => acceptConnection(socket)));
+    const port = await listen(server);
+    const client = net.createConnection({ host: "127.0.0.1", port });
+    onTestFinished(() => {
+      client.destroy();
+    });
+    await once(client, "connect");
+    const serverSocket = await accepted;
+    onTestFinished(() => {
+      serverSocket.destroy();
+    });
+
+    let serverClosed = false;
+    server.close(() => {
+      serverClosed = true;
+    });
+    expect(server.listening).toBe(false);
+    let cleanupFinished = false;
+    const cleanup = resources.cleanup().then(() => {
+      cleanupFinished = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(cleanupFinished).toBe(false);
+    expect(serverClosed).toBe(false);
+    client.destroy();
+    await cleanup;
+    expect(serverClosed).toBe(true);
+  });
+
+  it("escalates a SIGTERM-ignoring child and waits for piped stdio to close", async ({
+    onTestFinished,
+  }) => {
+    const resources = new OwnedTestResources();
+    onTestFinished(() => resources.cleanup());
+    const child = resources.ownChild(
+      spawn(
+        process.execPath,
+        [
+          "-e",
+          "process.on('SIGTERM', () => {}); process.stdout.write('ready'); setInterval(() => {}, 1000);",
+        ],
+        { stdio: ["ignore", "pipe", "ignore"] },
+      ),
+    );
+    await once(child.stdout!, "data");
+
+    await resources.cleanup();
+
+    expect(child.signalCode).toBe("SIGKILL");
+    expect(child.stdout?.destroyed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Add per-test ownership for temporary HOME/bin directories, loopback servers, and child processes so cleanup is awaited even when setup or assertions fail. Migrate the current high-use CLI helpers and high-risk Hermes broker and Ollama proxy consumers, including cleanup of each implicit CLI HOME. This is PR4 in the #6692 stack; PRs #6696 and #6697 are already merged.

## Related Issue

Related to #6692

## Changes

- Add `OwnedTestResources` and focused `test.extend` fixtures for LIFO cleanup of temporary directories, HOME/bin environments, servers, and child processes.
- Add a shared child-process owner that waits for `close`, attempts graceful termination, escalates to `SIGKILL` when required, and confirms piped stdio is closed. The owned-resource fixture and Ollama proxy harness share this lifecycle because suite teardown did not consistently cover setup failures or await process closure.
- Track server lifetime from ownership registration so fixture cleanup waits for both fixture-initiated shutdown and shutdown already started by code under test.
- Remove the unowned per-invocation CLI HOME by deleting it when `runWithEnvInternal` completes, while preserving explicit caller-owned HOME directories.
- Migrate the current repeated CLI HOME/bin setup helpers and the high-risk logs, doctor, Hermes broker, and Ollama proxy process/server consumers.
- Add focused regressions for idempotent cleanup, server shutdown already in progress, graceful and forced child termination, proxy readiness failure cleanup, and CLI HOME cleanup after success, failure, and timeout.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes test-only resource ownership and cleanup. The required documentation-writer review confirmed there is no user-facing behavior, test command, lane, or contributor contract to document.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `npx vitest run --project integration test/owned-test-resources.test.ts test/cli/helpers.test.ts test/cli/logs.test.ts test/cli/debug-command.test.ts test/cli/doctor-gateway-token.test.ts test/cli/sandbox-mutations.test.ts test/cli/snapshot-shields.test.ts test/hermes-tool-gateway-broker.test.ts test/ollama-auth-proxy-handler.test.ts` — 9 files, 71/71 tests passed on the rebased branch.
  - `NEMOCLAW_TEST_TIMEOUT=60000 npx vitest run --project integration test/cli/helpers.test.ts` — 12/12 tests passed; the synchronous timeout regression remained fixed at 2 seconds.
  - `npx vitest run --project integration test/cli/logs.test.ts --detectAsyncLeaks` — 10/10 tests passed with no async leaks.
  - `npm run typecheck:cli`, Biome on all changed files, `npm run source-shape:check`, `npm run test-size:check`, `npm run test:projects:check`, `npm run test:imports:check`, and `npm run test:titles:check` passed.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm test` passed on the rebased branch (1,438 files and 16,457 tests passed; 3 files and 40 opt-in platform tests skipped).
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved CLI test hermeticity by standardizing on `owned-test-resources` with resource-scoped setup/teardown across logs, doctor, debug, sandbox mutations, snapshot shields, and sandbox/server-related suites.
  * Expanded HOME-related coverage, verifying no implicit HOME is left behind for successful, failed, and timed-out runs (while honoring explicit HOME).
  * Added dedicated child-process lifecycle ownership utilities and new verification tests for graceful shutdown, SIGTERM→SIGKILL escalation, and reliable stream closure/cleanup.
  * Strengthened ollama auth proxy startup/cleanup tests, including readiness timeout failures, listener removal, and retryable cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->