### PR TITLE
fix(blueprint): fail apply when provider or inference setup fails (#6703)

### DIFF
--- a/nemoclaw/src/blueprint/runner-test-fixtures.ts
+++ b/nemoclaw/src/blueprint/runner-test-fixtures.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function minimalBlueprint(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    version: "1.0",
+    components: {
+      inference: {
+        profiles: {
+          default: {
+            provider_type: "openai",
+            provider_name: "my-provider",
+            endpoint: "https://api.example.com/v1",
+            model: "gpt-4",
+            credential_env: "MY_API_KEY",
+          },
+        },
+      },
+      sandbox: {
+        image: "openclaw",
+        name: "test-sandbox",
+        forward_ports: [18789],
+      },
+      policy: { additions: {} },
+    },
+    ...overrides,
+  };
+}
+
+export function routedBlueprint(): Record<string, unknown> {
+  return {
+    version: "1.0",
+    components: {
+      inference: {
+        profiles: {
+          routed: {
+            provider_type: "openai",
+            provider_name: "nvidia-router",
+            endpoint: "http://localhost:4000/v1",
+            model: "routed",
+            credential_env: "NVIDIA_INFERENCE_API_KEY",
+            credential_default: "router-local",
+            timeout_secs: 180,
+          },
+        },
+      },
+      sandbox: {
+        image: "openclaw",
+        name: "test-sandbox",
+        forward_ports: [18789],
+      },
+      router: {
+        enabled: true,
+        port: 4000,
+        pool_config_path: "router/pool-config.yaml",
+      },
+      policy: { additions: {} },
+    },
+  };
+}
+
+export function blueprintWithPolicyAdditions(
+  additions: Record<string, unknown>,
+): Record<string, unknown> {
+  const blueprint = minimalBlueprint();
+  const components = blueprint.components as Record<string, unknown>;
+  return {
+    ...blueprint,
+    components: {
+      ...components,
+      policy: { additions },
+    },
+  };
+}

--- a/nemoclaw/src/blueprint/runner-test-fixtures.ts
+++ b/nemoclaw/src/blueprint/runner-test-fixtures.ts
@@ -72,3 +72,13 @@ export function blueprintWithPolicyAdditions(
     },
   };
 }
+
+export function resultForCommandFailure(
+  args: readonly string[],
+  command: readonly [string, string],
+  stderr: string,
+): { exitCode: number; stdout: string; stderr: string } {
+  return args[0] === command[0] && args[1] === command[1]
+    ? { exitCode: 1, stdout: "", stderr }
+    : { exitCode: 0, stdout: "", stderr: "" };
+}

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
 
 // ── In-memory filesystem ────────────────────────────────────────
@@ -636,6 +636,64 @@ describe("runner", () => {
         ["sandbox", "create", "--from", "openclaw", "--name", "test-sandbox", "--forward", "18789"],
         expect.objectContaining({ reject: false }),
       );
+    });
+
+    const hasPlanJson = (): boolean => [...store.keys()].some((k) => k.endsWith("plan.json"));
+
+    it("rejects without persisting a plan when provider create fails (#6703)", async () => {
+      mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args[0] === "provider" && args[1] === "create") {
+          return { exitCode: 1, stdout: "", stderr: "provider setup failed" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      });
+
+      await expect(actionApply("default", minimalBlueprint())).rejects.toThrow(
+        /Failed to create inference provider 'my-provider'.*provider setup failed/i,
+      );
+
+      // A failed required mutation must not leave a successful persisted plan or
+      // emit ready/completion output.
+      expect(hasPlanJson()).toBe(false);
+      expect(stdoutText()).not.toContain("Apply complete");
+      expect(stdoutText()).not.toContain("PROGRESS:100");
+      // The inference route must not be attempted after provider creation fails.
+      const inferenceSetCalls = mockExeca.mock.calls.filter(
+        (c) => Array.isArray(c[1]) && c[1][0] === "inference" && c[1][1] === "set",
+      );
+      expect(inferenceSetCalls).toEqual([]);
+    });
+
+    it("reuses an already-existing provider instead of failing (#6703)", async () => {
+      mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args[0] === "provider" && args[1] === "create") {
+          return { exitCode: 1, stdout: "", stderr: "provider 'my-provider' already exists" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      });
+
+      // Matches the sandbox-create contract: already-existing is a reuse, so the
+      // apply proceeds and completes.
+      await actionApply("default", minimalBlueprint());
+      expect(hasPlanJson()).toBe(true);
+      expect(stdoutText()).toContain("Apply complete");
+    });
+
+    it("rejects without persisting a plan when inference set fails (#6703)", async () => {
+      mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args[0] === "inference" && args[1] === "set") {
+          return { exitCode: 1, stdout: "", stderr: "inference route rejected" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      });
+
+      await expect(actionApply("default", minimalBlueprint())).rejects.toThrow(
+        /Failed to set inference route .*model 'gpt-4'.*inference route rejected/i,
+      );
+
+      expect(hasPlanJson()).toBe(false);
+      expect(stdoutText()).not.toContain("Apply complete");
+      expect(stdoutText()).not.toContain("PROGRESS:100");
     });
 
     it("applies blueprint policy additions by merging into the base policy", async () => {

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -4,6 +4,11 @@
 import type fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
+import {
+  blueprintWithPolicyAdditions,
+  minimalBlueprint,
+  routedBlueprint,
+} from "./runner-test-fixtures.js";
 
 // ── In-memory filesystem ────────────────────────────────────────
 
@@ -114,78 +119,8 @@ function capturedJsonOutput<T = unknown>(): T {
   return JSON.parse(json) as T;
 }
 
-function minimalBlueprint(overrides?: Record<string, unknown>): Record<string, unknown> {
-  return {
-    version: "1.0",
-    components: {
-      inference: {
-        profiles: {
-          default: {
-            provider_type: "openai",
-            provider_name: "my-provider",
-            endpoint: "https://api.example.com/v1",
-            model: "gpt-4",
-            credential_env: "MY_API_KEY",
-          },
-        },
-      },
-      sandbox: {
-        image: "openclaw",
-        name: "test-sandbox",
-        forward_ports: [18789],
-      },
-      policy: { additions: {} },
-    },
-    ...overrides,
-  };
-}
-
-function routedBlueprint(): Record<string, unknown> {
-  return {
-    version: "1.0",
-    components: {
-      inference: {
-        profiles: {
-          routed: {
-            provider_type: "openai",
-            provider_name: "nvidia-router",
-            endpoint: "http://localhost:4000/v1",
-            model: "routed",
-            credential_env: "NVIDIA_INFERENCE_API_KEY",
-            credential_default: "router-local",
-            timeout_secs: 180,
-          },
-        },
-      },
-      sandbox: {
-        image: "openclaw",
-        name: "test-sandbox",
-        forward_ports: [18789],
-      },
-      router: {
-        enabled: true,
-        port: 4000,
-        pool_config_path: "router/pool-config.yaml",
-      },
-      policy: { additions: {} },
-    },
-  };
-}
-
 function seedBlueprintFile(bp?: Record<string, unknown>): void {
   addFile("blueprint.yaml", YAML.stringify(bp ?? minimalBlueprint()));
-}
-
-function blueprintWithPolicyAdditions(additions: Record<string, unknown>): Record<string, unknown> {
-  const bp = minimalBlueprint();
-  const components = bp.components as Record<string, unknown>;
-  return {
-    ...bp,
-    components: {
-      ...components,
-      policy: { additions },
-    },
-  };
 }
 
 function mockCurrentPolicy(stdout: string): void {
@@ -641,27 +576,39 @@ describe("runner", () => {
     const hasPlanJson = (): boolean => [...store.keys()].some((k) => k.endsWith("plan.json"));
 
     it("rejects without persisting a plan when provider create fails (#6703)", async () => {
+      const credential = "provider-secret-value";
+      process.env.MY_API_KEY = credential;
       mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args[0] === "provider" && args[1] === "create") {
-          return { exitCode: 1, stdout: "", stderr: "provider setup failed" };
+          return {
+            exitCode: 1,
+            stdout: "",
+            stderr: `provider setup failed\nOPENAI_API_KEY=${credential}\nAuthorization: Bearer opaque-bearer`,
+          };
         }
         return { exitCode: 0, stdout: "", stderr: "" };
       });
 
-      await expect(actionApply("default", minimalBlueprint())).rejects.toThrow(
-        /Failed to create inference provider 'my-provider'.*provider setup failed/i,
-      );
-
-      // A failed required mutation must not leave a successful persisted plan or
-      // emit ready/completion output.
-      expect(hasPlanJson()).toBe(false);
-      expect(stdoutText()).not.toContain("Apply complete");
-      expect(stdoutText()).not.toContain("PROGRESS:100");
-      // The inference route must not be attempted after provider creation fails.
-      const inferenceSetCalls = mockExeca.mock.calls.filter(
-        (c) => Array.isArray(c[1]) && c[1][0] === "inference" && c[1][1] === "set",
-      );
-      expect(inferenceSetCalls).toEqual([]);
+      try {
+        const error = await actionApply("default", minimalBlueprint()).then(
+          () => new Error("expected provider creation to fail"),
+          (cause: unknown) => cause,
+        );
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(
+          /Failed to create inference provider 'my-provider'.*provider setup failed/i,
+        );
+        expect((error as Error).message).toContain("OPENAI_API_KEY=<REDACTED>");
+        expect((error as Error).message).toContain("Authorization: Bearer <REDACTED>");
+        expect((error as Error).message).not.toContain(credential);
+        expect((error as Error).message).not.toContain("opaque-bearer");
+        expect(hasPlanJson()).toBe(false);
+        expect(stdoutText()).not.toContain("Apply complete");
+        expect(stdoutText()).not.toContain("PROGRESS:70");
+        expect(stdoutText()).not.toContain("PROGRESS:100");
+      } finally {
+        delete process.env.MY_API_KEY;
+      }
     });
 
     it("reuses an already-existing provider instead of failing (#6703)", async () => {

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -7,6 +7,7 @@ import YAML from "yaml";
 import {
   blueprintWithPolicyAdditions,
   minimalBlueprint,
+  resultForCommandFailure,
   routedBlueprint,
 } from "./runner-test-fixtures.js";
 
@@ -578,16 +579,13 @@ describe("runner", () => {
     it("rejects without persisting a plan when provider create fails (#6703)", async () => {
       const credential = "provider-secret-value";
       process.env.MY_API_KEY = credential;
-      mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
-        if (args[0] === "provider" && args[1] === "create") {
-          return {
-            exitCode: 1,
-            stdout: "",
-            stderr: `provider setup failed\nOPENAI_API_KEY=${credential}\nAuthorization: Bearer opaque-bearer`,
-          };
-        }
-        return { exitCode: 0, stdout: "", stderr: "" };
-      });
+      mockExeca.mockImplementation(async (_cmd: string, args: string[]) =>
+        resultForCommandFailure(
+          args,
+          ["provider", "create"],
+          `provider setup failed\nOPENAI_API_KEY=${credential}\nAuthorization: Bearer opaque-bearer`,
+        ),
+      );
 
       try {
         const error = await actionApply("default", minimalBlueprint()).then(
@@ -612,12 +610,13 @@ describe("runner", () => {
     });
 
     it("reuses an already-existing provider instead of failing (#6703)", async () => {
-      mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
-        if (args[0] === "provider" && args[1] === "create") {
-          return { exitCode: 1, stdout: "", stderr: "provider 'my-provider' already exists" };
-        }
-        return { exitCode: 0, stdout: "", stderr: "" };
-      });
+      mockExeca.mockImplementation(async (_cmd: string, args: string[]) =>
+        resultForCommandFailure(
+          args,
+          ["provider", "create"],
+          "provider 'my-provider' already exists",
+        ),
+      );
 
       // Matches the sandbox-create contract: already-existing is a reuse, so the
       // apply proceeds and completes.
@@ -627,12 +626,9 @@ describe("runner", () => {
     });
 
     it("rejects without persisting a plan when inference set fails (#6703)", async () => {
-      mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
-        if (args[0] === "inference" && args[1] === "set") {
-          return { exitCode: 1, stdout: "", stderr: "inference route rejected" };
-        }
-        return { exitCode: 0, stdout: "", stderr: "" };
-      });
+      mockExeca.mockImplementation(async (_cmd: string, args: string[]) =>
+        resultForCommandFailure(args, ["inference", "set"], "inference route rejected"),
+      );
 
       await expect(actionApply("default", minimalBlueprint())).rejects.toThrow(
         /Failed to set inference route .*model 'gpt-4'.*inference route rejected/i,

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -24,8 +24,8 @@ import { DASHBOARD_PORT } from "../lib/ports.js";
 import { buildSubprocessEnv } from "../lib/subprocess-env.js";
 import { isPlainObject, type UnknownRecord } from "../shared/object-record.js";
 import * as importedOpenShellPolicyBoundary from "../shared/openshell-policy-boundary.cjs";
-import { actionSnapshots } from "./snapshot-command.js";
 import type { SnapshotCommandOptions } from "./snapshot-command.js";
+import { actionSnapshots } from "./snapshot-command.js";
 import { safeEndpointUrlForDownstream, validateEndpointUrl } from "./ssrf.js";
 
 // The compiled plugin exposes named CommonJS exports. Source-mode tsx maps the
@@ -76,6 +76,19 @@ const ENDPOINT_TLS_MODES = new Set(["terminate", "passthrough", "skip"]);
 
 function isAction(value: string | undefined): value is Action {
   return value === "plan" || value === "apply" || value === "status" || value === "rollback";
+}
+
+// Bound OpenShell command stderr before surfacing it in an apply error so a
+// verbose or attacker-influenced failure stream stays a compact, single-line
+// diagnostic. Credentials are passed to these commands via the subprocess env
+// (never argv), so the stream itself does not carry the secret. (#6703)
+const MAX_COMMAND_ERROR_CHARS = 500;
+function boundedCommandError(stderr: string): string {
+  const collapsed = stderr.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) return "no error output";
+  return collapsed.length > MAX_COMMAND_ERROR_CHARS
+    ? `${collapsed.slice(0, MAX_COMMAND_ERROR_CHARS)}…`
+    : collapsed;
 }
 
 function isOptionalString(value: unknown): value is string | undefined {
@@ -749,12 +762,27 @@ export async function actionApply(
     providerArgs.push("--config", `OPENAI_BASE_URL=${endpoint}`);
   }
 
-  await execa(providerArgs[0], providerArgs.slice(1), {
+  const providerResult = await execa(providerArgs[0], providerArgs.slice(1), {
     reject: false,
     stdout: "pipe",
     stderr: "pipe",
     env: buildSubprocessEnv(credEnv),
   });
+  // A required mutation: a silently-ignored failure would persist plan.json and
+  // report a ready sandbox that cannot perform inference. Mirror the
+  // sandbox-create contract above — tolerate an already-existing provider as a
+  // reuse (keeps re-apply idempotent) and fail on any other non-zero result.
+  // The credential is passed via env (never argv), so stderr cannot echo it;
+  // still bound the surfaced detail. (#6703)
+  if (providerResult.exitCode !== 0) {
+    if (providerResult.stderr.includes("already exists")) {
+      log(`Provider '${providerName}' already exists, reusing.`);
+    } else {
+      throw new Error(
+        `Failed to create inference provider '${providerName}': ${boundedCommandError(providerResult.stderr)}`,
+      );
+    }
+  }
 
   progress(70, "Setting inference route");
   const inferenceArgs = [
@@ -769,7 +797,14 @@ export async function actionApply(
   if (inferenceCfg.timeout_secs !== undefined) {
     inferenceArgs.push("--timeout", String(inferenceCfg.timeout_secs));
   }
-  await runCmd(inferenceArgs, { reject: false });
+  const inferenceResult = await runCmd(inferenceArgs, { reject: false });
+  // Another required mutation: without a routed provider the sandbox cannot
+  // perform inference, so a non-zero result must abort the apply. (#6703)
+  if (inferenceResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to set inference route (provider '${providerName}', model '${model}'): ${boundedCommandError(inferenceResult.stderr)}`,
+    );
+  }
 
   if (Object.keys(policyAdditions).length > 0) {
     progress(78, "Applying policy additions");

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -78,13 +78,23 @@ function isAction(value: string | undefined): value is Action {
   return value === "plan" || value === "apply" || value === "status" || value === "rollback";
 }
 
-// Bound OpenShell command stderr before surfacing it in an apply error so a
-// verbose or attacker-influenced failure stream stays a compact, single-line
-// diagnostic. Credentials are passed to these commands via the subprocess env
-// (never argv), so the stream itself does not carry the secret. (#6703)
+// Redact credential-shaped output before bounding OpenShell stderr to a compact,
+// single-line diagnostic. (#6703)
 const MAX_COMMAND_ERROR_CHARS = 500;
-function boundedCommandError(stderr: string): string {
-  const collapsed = stderr.replace(/\s+/g, " ").trim();
+const SENSITIVE_ERROR_ASSIGNMENT =
+  /(\b[A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*)[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
+
+function boundedCommandError(stderr: string, secretValues: readonly string[] = []): string {
+  let redacted = stderr;
+  for (const secret of [...new Set(secretValues)]
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length)) {
+    redacted = redacted.split(secret).join("<REDACTED>");
+  }
+  redacted = redacted
+    .replace(SENSITIVE_ERROR_ASSIGNMENT, "$1=<REDACTED>")
+    .replace(/\b(Bearer)\s+\S+/gi, "$1 <REDACTED>");
+  const collapsed = redacted.replace(/\s+/g, " ").trim();
   if (collapsed.length === 0) return "no error output";
   return collapsed.length > MAX_COMMAND_ERROR_CHARS
     ? `${collapsed.slice(0, MAX_COMMAND_ERROR_CHARS)}…`
@@ -772,14 +782,14 @@ export async function actionApply(
   // report a ready sandbox that cannot perform inference. Mirror the
   // sandbox-create contract above — tolerate an already-existing provider as a
   // reuse (keeps re-apply idempotent) and fail on any other non-zero result.
-  // The credential is passed via env (never argv), so stderr cannot echo it;
-  // still bound the surfaced detail. (#6703)
+  // The credential is passed via env (never argv); redact it from stderr before
+  // surfacing bounded diagnostic context. (#6703)
   if (providerResult.exitCode !== 0) {
     if (providerResult.stderr.includes("already exists")) {
       log(`Provider '${providerName}' already exists, reusing.`);
     } else {
       throw new Error(
-        `Failed to create inference provider '${providerName}': ${boundedCommandError(providerResult.stderr)}`,
+        `Failed to create inference provider '${providerName}': ${boundedCommandError(providerResult.stderr, [credential])}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

The direct Blueprint runner's `actionApply` (`nemoclaw/src/blueprint/runner.ts`) ran two **required** OpenShell mutations with `reject: false` but never inspected their results:

- `openshell provider create`
- `openshell inference set`

A non-zero exit from either was silently ignored, so `actionApply` still persisted `plan.json`, emitted `PROGRESS:100` / `Apply complete`, and reported the sandbox ready — leaving automation with a **successful apply result and durable run state for a sandbox that cannot perform inference**.

Fixes #6703.

## Change (scoped to the runner + its co-located tests)

- **`provider create`** — inspect the result. Mirror the sandbox-create contract already in this function: tolerate an already-existing provider as a **reuse** (keeps re-apply idempotent), and fail on any other non-zero result.
- **`inference set`** — inspect the result; any non-zero result aborts the apply (no `already exists` nuance — a routed provider is mandatory).
- Surface **bounded, single-line** command detail via a new `boundedCommandError` helper. The credential is passed to these commands via the subprocess **env (never argv)**, so the stderr stream cannot carry the secret; the helper also caps length.

### The reporter's open question (provider "already exists")

The reporter asked what the contract should be when `provider create` reports the provider already exists (reuse / upsert / fail). This PR encodes **reuse**, because that's the **existing, in-file contract**: the sibling `sandbox create` call a few lines above already treats `"already exists"` as a reuse (`runner.ts`, the `createResult.stderr.includes("already exists")` branch). Following the same convention keeps apply idempotent and avoids a substring-accident. If maintainers want stricter semantics (e.g. verify the existing provider's config matches, or upsert), that's a separable follow-up — this PR does not regress the false-success bug in the meantime.

## Verification

- `npx vitest run nemoclaw/src/blueprint/runner.test.ts` → **95/95 pass** (locally and on the `ipp2-0085` verify host, Node 22.23.1), including 3 new regression tests:
  - provider-create failure → apply **rejects**, no `plan.json`, no `Apply complete` / `PROGRESS:100`, and inference-set is **not** attempted;
  - provider "already exists" → apply **completes** and persists (reuse path);
  - inference-set failure → apply **rejects**, no `plan.json`, no completion output.
- `npx biome check` clean; `npx tsx scripts/checks/run.ts` all structural checks pass; `test-conditionals:scan` exits 0 (the new mock-dispatch `if`s match the existing pattern in this test file).

Signed-off-by: Jason Ma <jama@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox setup so failed provider creation or inference route configuration stops execution and no longer reports success.
  - Prevents persisting incomplete plans (`plan.json`) after failures, avoiding misleading `PROGRESS:100` updates.
  - Reuses an existing provider when setup reports it already exists.
  - Makes command error output more concise by compacting and truncating verbose stderr.
- **Tests**
  - Added coverage for credential-redacted failure behavior and “already exists” reuse scenarios during apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->