### PR TITLE
test(vitest): strengthen security coverage floors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,6 +265,10 @@ assignments, so reset mock implementations and restore raw mutations in the test
 Live E2E projects do not enable this automatic cleanup because their stateful targets require
 explicit, validated teardown.
 
+Plugin tests also require each test to execute at least one Vitest `expect` assertion. This check
+is scoped to the plugin project; root projects may continue using Node `assert` where that is the
+existing contract.
+
 ### Test Titles as Behavioral Documentation
 
 Write `describe` and `it` titles so the Vitest tree reads as behavioral documentation. Start test
@@ -299,6 +303,10 @@ If you still have `core.hooksPath` set from an old Husky setup, Git will ignore 
 
 `npm run check` is the whole-repository pre-commit and full CLI/plugin coverage baseline for broad changes to hooks, formatters, generated checks, or shared validation behavior.
 It is not part of routine PR preparation for a focused change.
+Full coverage enforces the aggregate ratchets in `ci/coverage-threshold-*.json` and per-file floors
+for security-sensitive SSRF, credential filtering and redaction, policy mutation, and state-lock
+modules. CLI coverage shards defer the per-file checks until their reports are merged. Pull requests
+also upload CLI and plugin Cobertura reports for advisory changed-file coverage feedback.
 
 For doc-only changes, you do not need to run the full test suite by default.
 Commit and push normally so the hooks run, then run the docs build:

--- a/ci/coverage-threshold-cli.json
+++ b/ci/coverage-threshold-cli.json
@@ -1,6 +1,6 @@
 {
-  "lines": 74.3,
-  "functions": 76.2,
-  "branches": 67.4,
-  "statements": 73.3
+  "lines": 73.9,
+  "functions": 75.2,
+  "branches": 66.7,
+  "statements": 72.9
 }

--- a/ci/coverage-threshold-cli.json
+++ b/ci/coverage-threshold-cli.json
@@ -1,6 +1,6 @@
 {
-  "lines": 70.9,
-  "functions": 71.5,
-  "branches": 62.9,
-  "statements": 70.5
+  "lines": 74.3,
+  "functions": 76.2,
+  "branches": 67.4,
+  "statements": 73.3
 }

--- a/ci/coverage-threshold-plugin.json
+++ b/ci/coverage-threshold-plugin.json
@@ -1,6 +1,6 @@
 {
-  "lines": 95,
-  "functions": 98,
-  "branches": 86,
-  "statements": 95
+  "lines": 95.8,
+  "functions": 99.0,
+  "branches": 87.8,
+  "statements": 95.4
 }

--- a/nemoclaw/vitest.project.ts
+++ b/nemoclaw/vitest.project.ts
@@ -17,6 +17,7 @@ type PluginVitestProjectOptions = {
     alias: Array<{ find: RegExp; replacement: string }>;
     env: Record<string, string>;
     environment: "node";
+    expect: { requireAssertions: true };
     clearMocks: true;
     restoreMocks: true;
     unstubEnvs: true;
@@ -43,6 +44,9 @@ const pluginVitestProjectOptions = {
       NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT: "1",
     },
     environment: "node",
+    // Plugin tests use Vitest expect throughout. Keep assertion presence scoped
+    // here so root projects that intentionally use Node assert remain valid.
+    expect: { requireAssertions: true },
     clearMocks: true,
     restoreMocks: true,
     unstubEnvs: true,

--- a/scripts/check-coverage-ratchet.ts
+++ b/scripts/check-coverage-ratchet.ts
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Compares a Vitest coverage summary against a threshold file.
-// Exits non-zero if any metric drops more than 1% below its threshold.
+// Exits non-zero if any metric drops more than 0.1 percentage point below its threshold.
 
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 type MetricName = "lines" | "functions" | "branches" | "statements";
@@ -15,9 +15,10 @@ const METRICS: readonly MetricName[] = ["lines", "functions", "branches", "state
 
 type Thresholds = Record<MetricName, number>;
 type CoverageSummary = { total: Record<MetricName, { pct: number }> };
+type CoverageFailure = { metric: MetricName; actual: number; threshold: number };
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
-const TOLERANCE = 1;
+const TOLERANCE = 0.1;
 
 /** Read and JSON-parse a repo-relative file. */
 function loadJSON<T>(repoRelative: string): T {
@@ -50,6 +51,20 @@ function isThresholds(value: Partial<Thresholds> | null | undefined): value is T
   return METRICS.every((metric) => typeof value[metric] === "number");
 }
 
+export function findCoverageFailures(
+  summary: CoverageSummary,
+  thresholds: Thresholds,
+): CoverageFailure[] {
+  return METRICS.map((metric) => ({
+    metric,
+    actual: summary.total[metric].pct,
+    threshold: thresholds[metric],
+  })).filter(({ actual, threshold }) => {
+    const roundingTolerance = Number.EPSILON * Math.max(Math.abs(actual), Math.abs(threshold), 1);
+    return threshold - actual - TOLERANCE > roundingTolerance;
+  });
+}
+
 function main(): void {
   const [summaryPath, thresholdPath, label = "coverage"] = process.argv.slice(2);
   if (!summaryPath || !thresholdPath) {
@@ -68,20 +83,20 @@ function main(): void {
     throw new Error(`Invalid coverage threshold: ${thresholdPath}`);
   }
 
-  const failures = METRICS.map((metric) => ({
-    metric,
-    actual: summaryValue.total[metric].pct,
-    threshold: thresholdValue[metric],
-  })).filter((r) => r.actual < r.threshold - TOLERANCE);
+  const failures = findCoverageFailures(summaryValue, thresholdValue);
 
   if (failures.length === 0) return;
 
   console.error(`${label} ratchet failed:\n`);
   for (const { metric, actual, threshold } of failures) {
-    console.error(`  ${metric}: ${actual}% < ${threshold}% (tolerance ±${TOLERANCE}%)`);
+    console.error(
+      `  ${metric}: ${actual}% < ${threshold}% (allowed drop: ${TOLERANCE} percentage point)`,
+    );
   }
   console.error("\nAdd tests to bring coverage back above the threshold.");
   process.exitCode = 1;
 }
 
-main();
+if (fileURLToPath(import.meta.url) === resolve(process.argv[1] ?? "")) {
+  main();
+}

--- a/test/coverage-ratchet.test.ts
+++ b/test/coverage-ratchet.test.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { findCoverageFailures } from "../scripts/check-coverage-ratchet";
+
+const thresholds = {
+  lines: 71.2,
+  functions: 80.1,
+  branches: 78.8,
+  statements: 77.9,
+};
+
+function coverageSummary(lines: number) {
+  return {
+    total: {
+      lines: { pct: lines },
+      functions: { pct: thresholds.functions },
+      branches: { pct: thresholds.branches },
+      statements: { pct: thresholds.statements },
+    },
+  };
+}
+
+describe("coverage ratchet", () => {
+  it("allows a drop of exactly 0.1 percentage point (#6692)", () => {
+    expect(findCoverageFailures(coverageSummary(71.1), thresholds)).toEqual([]);
+  });
+
+  it("fails a drop of 0.11 percentage point (#6692)", () => {
+    expect(findCoverageFailures(coverageSummary(71.09), thresholds)).toEqual([
+      { metric: "lines", actual: 71.09, threshold: 71.2 },
+    ]);
+  });
+
+  it("reports the one-sided allowed drop when the CLI fails (#6692)", () => {
+    const directory = mkdtempSync(join(tmpdir(), "nemoclaw-coverage-ratchet-"));
+    const summaryPath = join(directory, "coverage-summary.json");
+    const thresholdPath = join(directory, "coverage-threshold.json");
+    writeFileSync(summaryPath, JSON.stringify(coverageSummary(71.09)));
+    writeFileSync(thresholdPath, JSON.stringify(thresholds));
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "scripts/check-coverage-ratchet.ts",
+          relative(process.cwd(), summaryPath),
+          relative(process.cwd(), thresholdPath),
+          "Test coverage",
+        ],
+        { cwd: process.cwd(), encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("lines: 71.09% < 71.2% (allowed drop: 0.1 percentage point)");
+      expect(result.stderr).not.toContain("±");
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/test/helpers/vitest-coverage-thresholds.ts
+++ b/test/helpers/vitest-coverage-thresholds.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const securityCoverageThresholds = {
+  perFile: true,
+  "nemoclaw/src/blueprint/ssrf.ts": {
+    lines: 95,
+    functions: 100,
+    branches: 95,
+    statements: 95,
+  },
+  "src/lib/inference/endpoint-ssrf-preflight.ts": {
+    lines: 85,
+    functions: 80,
+    branches: 75,
+    statements: 85,
+  },
+  "src/lib/security/{credential-filter,redact,redact-url}.ts": {
+    lines: 80,
+    functions: 70,
+    branches: 65,
+    statements: 80,
+  },
+  "src/commands/sandbox/policy/{add,remove}.ts": {
+    lines: 100,
+    functions: 100,
+    branches: 100,
+    statements: 100,
+  },
+  "src/lib/policy/{commands,merge}.ts": {
+    lines: 100,
+    functions: 100,
+    branches: 100,
+    statements: 100,
+  },
+  "src/lib/inference/gateway-route-mutation-lock.ts": {
+    lines: 100,
+    functions: 100,
+    branches: 65,
+    statements: 80,
+  },
+  "src/lib/shields/transition-lock.ts": {
+    lines: 70,
+    functions: 60,
+    branches: 60,
+    statements: 65,
+  },
+  "src/lib/state/mcp-lifecycle-lock-{acquisition,identity,storage}.ts": {
+    lines: 60,
+    functions: 75,
+    branches: 60,
+    statements: 60,
+  },
+} as const;
+
+export function resolveVitestCoverageThresholds(argv: readonly string[]) {
+  const usesShard = argv.some(
+    (argument, index) =>
+      argument.startsWith("--shard=") || (argument === "--shard" && argv[index + 1] !== undefined),
+  );
+  return usesShard ? undefined : securityCoverageThresholds;
+}

--- a/test/helpers/vitest-coverage-thresholds.ts
+++ b/test/helpers/vitest-coverage-thresholds.ts
@@ -10,10 +10,10 @@ export const securityCoverageThresholds = {
     statements: 95,
   },
   "src/lib/inference/endpoint-ssrf-preflight.ts": {
-    lines: 85,
+    lines: 76,
     functions: 80,
-    branches: 75,
-    statements: 85,
+    branches: 69,
+    statements: 75,
   },
   "src/lib/security/{credential-filter,redact,redact-url}.ts": {
     lines: 80,

--- a/test/plugin-vitest-project.test.ts
+++ b/test/plugin-vitest-project.test.ts
@@ -72,6 +72,21 @@ describe("plugin Vitest project contract", () => {
     });
   });
 
+  it("pilots assertion presence only in expect-based plugin tests (#6692)", () => {
+    const rootTest = rootVitestConfig.test as {
+      expect?: { requireAssertions?: boolean };
+      projects?: Array<{ test?: { expect?: { requireAssertions?: boolean }; name?: string } }>;
+    };
+
+    expect(pluginVitestProjectOptions.test.expect).toEqual({ requireAssertions: true });
+    expect(rootTest.expect?.requireAssertions).not.toBe(true);
+    for (const project of rootTest.projects ?? []) {
+      if (project.test?.name !== "plugin") {
+        expect(project.test?.expect?.requireAssertions, project.test?.name).not.toBe(true);
+      }
+    }
+  });
+
   it("keeps standalone plugin dependencies on the root Vitest toolchain", () => {
     for (const packageName of ["vitest", "vite"] as const) {
       expect(installedVersion(pluginRequire, packageName), packageName).toBe(

--- a/test/plugin-vitest-project.test.ts
+++ b/test/plugin-vitest-project.test.ts
@@ -80,10 +80,11 @@ describe("plugin Vitest project contract", () => {
 
     expect(pluginVitestProjectOptions.test.expect).toEqual({ requireAssertions: true });
     expect(rootTest.expect?.requireAssertions).not.toBe(true);
-    for (const project of rootTest.projects ?? []) {
-      if (project.test?.name !== "plugin") {
-        expect(project.test?.expect?.requireAssertions, project.test?.name).not.toBe(true);
-      }
+    const nonPluginProjects = (rootTest.projects ?? []).filter(
+      (project) => project.test?.name !== "plugin",
+    );
+    for (const project of nonPluginProjects) {
+      expect(project.test?.expect?.requireAssertions, project.test?.name).not.toBe(true);
     }
   });
 

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -1142,6 +1142,43 @@ npx tsx scripts/checks/e2e-mock-parity.ts --base "$BASE_SHA" --head HEAD
     expect(uploadStep.with?.["retention-days"]).toBe(14);
   });
 
+  it("uploads same-repository CLI and plugin Cobertura reports (#6692)", () => {
+    const sameRepositoryGuard =
+      "${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}";
+    const uploadAction = "actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3";
+    const reports = [
+      {
+        action: sharedActions.cliCoverageMerge,
+        coverageStep: "Merge CLI coverage",
+        uploadStep: "Upload CLI coverage report",
+        file: "coverage/cli/cobertura-coverage.xml",
+        label: "code-coverage/cli",
+      },
+      {
+        action: sharedActions.pluginCoverage,
+        coverageStep: "Run plugin coverage",
+        uploadStep: "Upload plugin coverage report",
+        file: "coverage/plugin/cobertura-coverage.xml",
+        label: "code-coverage/plugin",
+      },
+    ] as const;
+
+    for (const report of reports) {
+      expect(requiredStep(report.action, report.coverageStep).run).toContain(
+        "--coverage.reporter=cobertura",
+      );
+
+      const uploadStep = requiredStep(report.action, report.uploadStep);
+      expect(uploadStep.if).toBe(sameRepositoryGuard);
+      expect(uploadStep.uses).toBe(uploadAction);
+      expect(uploadStep.with).toEqual({
+        file: report.file,
+        language: "TypeScript",
+        label: report.label,
+      });
+    }
+  });
+
   it("runs CLI coverage in shards and merges coverage before ratcheting", () => {
     expect(sharedActions.cliCoverageShard.inputs?.["shard-count"]?.default).toBe(cliShardCount);
     expect(sharedActions.cliCoverageMerge.inputs?.["shard-count"]?.default).toBe(cliShardCount);

--- a/test/vitest-coverage-thresholds.test.ts
+++ b/test/vitest-coverage-thresholds.test.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import rootVitestConfig from "../vitest.config";
+import {
+  resolveVitestCoverageThresholds,
+  securityCoverageThresholds,
+} from "./helpers/vitest-coverage-thresholds";
+
+type RootTestOptions = {
+  coverage?: {
+    thresholds?: unknown;
+  };
+};
+
+describe("Vitest security coverage thresholds", () => {
+  it("enforces the exact per-file security floors for full and merged coverage (#6692)", () => {
+    expect(resolveVitestCoverageThresholds([])).toEqual({
+      perFile: true,
+      "nemoclaw/src/blueprint/ssrf.ts": {
+        lines: 95,
+        functions: 100,
+        branches: 95,
+        statements: 95,
+      },
+      "src/lib/inference/endpoint-ssrf-preflight.ts": {
+        lines: 85,
+        functions: 80,
+        branches: 75,
+        statements: 85,
+      },
+      "src/lib/security/{credential-filter,redact,redact-url}.ts": {
+        lines: 80,
+        functions: 70,
+        branches: 65,
+        statements: 80,
+      },
+      "src/commands/sandbox/policy/{add,remove}.ts": {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100,
+      },
+      "src/lib/policy/{commands,merge}.ts": {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100,
+      },
+      "src/lib/inference/gateway-route-mutation-lock.ts": {
+        lines: 100,
+        functions: 100,
+        branches: 65,
+        statements: 80,
+      },
+      "src/lib/shields/transition-lock.ts": {
+        lines: 70,
+        functions: 60,
+        branches: 60,
+        statements: 65,
+      },
+      "src/lib/state/mcp-lifecycle-lock-{acquisition,identity,storage}.ts": {
+        lines: 60,
+        functions: 75,
+        branches: 60,
+        statements: 60,
+      },
+    });
+    expect(resolveVitestCoverageThresholds(["--mergeReports", ".vitest-reports"])).toBe(
+      securityCoverageThresholds,
+    );
+    expect((rootVitestConfig.test as RootTestOptions).coverage?.thresholds).toBe(
+      securityCoverageThresholds,
+    );
+  });
+
+  it.each([
+    ["inline", ["--coverage", "--shard=1/8"]],
+    ["separate", ["--coverage", "--shard", "1/8"]],
+  ])("defers security floors until %s shard reports are merged (#6692)", (_syntax, argv) => {
+    expect(resolveVitestCoverageThresholds(argv)).toBeUndefined();
+  });
+});

--- a/test/vitest-coverage-thresholds.test.ts
+++ b/test/vitest-coverage-thresholds.test.ts
@@ -26,10 +26,10 @@ describe("Vitest security coverage thresholds", () => {
         statements: 95,
       },
       "src/lib/inference/endpoint-ssrf-preflight.ts": {
-        lines: 85,
+        lines: 76,
         functions: 80,
-        branches: 75,
-        statements: 85,
+        branches: 69,
+        statements: 75,
       },
       "src/lib/security/{credential-filter,redact,redact-url}.ts": {
         lines: 80,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ import { CliCoverageSequencer } from "./test/helpers/cli-coverage-sequencer";
 import { resolveIntegrationProjectScheduling } from "./test/helpers/integration-project-scheduling";
 import { sourceLoaderNodeOptions } from "./test/helpers/source-loader-options";
 import { testTimeout } from "./test/helpers/timeouts";
+import { resolveVitestCoverageThresholds } from "./test/helpers/vitest-coverage-thresholds";
 import { resolveVitestFeedback } from "./test/helpers/vitest-feedback";
 import { vitestStateIsolation } from "./test/helpers/vitest-state-isolation";
 import { vitestWatchTriggerPatterns } from "./test/helpers/vitest-watch-triggers";
@@ -231,6 +232,7 @@ export default defineConfig({
       include: ["src/**/*.ts", "bin/**/*.js", "nemoclaw/src/**/*.ts", "nemoclaw/src/**/*.cts"],
       exclude: ["**/*.test.ts", "dist/**"],
       reporter: ["text-summary", "json-summary"],
+      thresholds: resolveVitestCoverageThresholds(process.argv.slice(2)),
     },
   },
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Vitest now enforces per-file coverage floors for security-sensitive modules, while the aggregate ratchet permits at most a 0.1 percentage-point drop instead of a full point. Plugin tests pilot assertion-presence enforcement without invalidating root tests that use Node `assert`, and the existing Cobertura changed-file advisory is protected by workflow contracts. This is PR 8 in the #6692 stack; PRs 1-7 are merged.

## Related Issue
Part of #6692

## Changes
- Add Vitest-native per-file floors for 14 SSRF, credential filtering/redaction, policy mutation, gateway/state-lock, and shield-transition modules across eight exact path patterns.
- Disable whole-suite security floors on partial `--shard` runs and re-enable them for full runs and `--mergeReports`.
- Narrow the aggregate ratchet tolerance from 1.0 to 0.1 percentage point and test the exact 0.10-pass/0.11-fail boundary with one-sided diagnostics.
- Raise the shared CLI aggregate floors to 73.9% lines, 75.2% functions, 66.7% branches, and 72.9% statements, based on the lowest authoritative manual-hook run; raise plugin floors to 95.8%/99.0%/87.8%/95.4%.
- Require every plugin test to execute a Vitest `expect` assertion while leaving root Node `assert` suites unchanged.
- Contract-test the existing CLI and plugin Cobertura reporters, pinned uploader, report paths, labels, and same-repository guard as advisory changed-file feedback.
- Document the assertion and coverage-gate behavior in the contributor guide.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: product behavior is unchanged; contributor guidance was updated for the new test and coverage contracts.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 33 focused integration contracts passed; both root and standalone plugin runs passed 553 tests; project-membership, title-style, CLI/plugin type checks, and focused post-base-sync threshold tests passed.
- [x] Applicable broad gate passed — `npm test`: 1,454 files passed and 3 expected files skipped; 16,481 tests passed and 40 expected tests skipped. `npm run check`: all all-files hooks plus full CLI/plugin coverage passed; final CLI coverage was 74.50%/76.43%/67.48%/73.49% and plugin coverage was 95.81%/99.08%/87.82%/95.49% (lines/functions/branches/statements).
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with zero errors; Fern reported two unrelated baseline warnings.
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified contributor guidance for plugin-focused tests (assertions required) and expanded coverage guidance for security-sensitive modules, sharded runs, and changed-file advisory feedback.
- **Quality Improvements**
  - Raised coverage thresholds for supported suites.
  - Tightened coverage regression “ratchet” behavior to allow only a 0.1 percentage-point drop and improved failure messaging.
  - Enforced assertion requirements for plugin tests without affecting root test behavior.
- **Testing**
  - Added/updated coverage ratchet, threshold-resolution, assertion-scoping, and Cobertura publishing contract tests.
  - Updated test coverage thresholds to resolve dynamically from CLI arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->