### PR TITLE
test(blueprint): cover router boolean validation

### DIFF
--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -394,6 +394,21 @@ describe("runner", () => {
       expect(() => loadBlueprint()).toThrow(/valid nested component shapes/);
     });
 
+    it("rejects a non-boolean router enabled flag (#6692)", () => {
+      addFile(
+        "blueprint.yaml",
+        YAML.stringify({
+          version: "2.0",
+          components: {
+            router: {
+              enabled: "yes",
+            },
+          },
+        }),
+      );
+      expect(() => loadBlueprint()).toThrow(/valid nested component shapes/);
+    });
+
     it("rejects non-plain policy additions values", () => {
       addFile(
         "blueprint.yaml",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds regression coverage for the existing `components.router.enabled` boolean validation. This restores plugin function coverage above the new 99% ratchet after #6704 added validator functions and #6705 landed the tighter floor.

## Related Issue

Part of #6692.

## Changes

- Add a public-parser regression test that rejects a string-valued router `enabled` field.
- Raise measured plugin function coverage from 98.66% to 99.10% without changing production behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this adds coverage for existing blueprint validation and changes no runtime or user-facing behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: maintainer-authored test-only change; no production runner code changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — full plugin coverage: 23 files and 557 tests passed; functions 99.10%; coverage ratchet passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blueprint validation to reject invalid non-boolean values for router component settings.
  * Clear schema validation errors are now surfaced for malformed blueprint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->