### PR TITLE
test(vitest): enforce exact discovery and credential-free tags

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -481,6 +481,7 @@ jobs:
         run: |
           set -euo pipefail
           npx vitest run --project "${TEST_PROJECT}" "${TEST_FILE}" \
+            --tags-filter=e2e/credential-free \
             --silent=false --reporter=default --reporter=test/e2e/risk-signal-reporter.ts
 
       - name: Upload test artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ When writing tests:
 - Root-level tests (`test/`) use ESM imports
 - Plugin tests use TypeScript and are co-located with their source files
 - Import CLI source from ordinary tests. Put genuine compiled-artifact assertions under `test/package-contract/`.
-- Keep project globs disjoint; `npm run test:projects:check` derives membership from Vitest and rejects overlap.
+- Keep project globs disjoint and exhaustive; `npm run test:projects:check` compares filesystem candidates with Vitest and rejects missing, overlapping, or unexpected membership.
 - Deterministic projects clear mock calls, restore `vi.spyOn`, and undo `vi.stubEnv` and `vi.stubGlobal` before each test. Create those spies and stubs in `beforeEach` or the test body unless a documented import-time stub must run before module evaluation. Restore direct environment or global mutations yourself, and reset mock implementations explicitly when needed. Live E2E and automatic `mockReset` are intentionally excluded.
 - Use `npm run test:changed` or `npm run test:watch` for focused CLI, plugin, and E2E-support feedback. Add only concrete opaque-input mappings to `test/helpers/vitest-watch-triggers.ts` when the import graph cannot see a YAML, Python, shell, generated, or workflow dependency.
 - Use `npm run test:shuffle -- --sequence.seed=<seed>` to replay a printed test-order seed. Use `npm run test:diagnose:leaks` for async-resource or shutdown-hang diagnostics; both commands keep coverage disabled, and leak diagnostics can accompany exit code 0 when assertions pass.

--- a/scripts/checks/vitest-project-overlap.ts
+++ b/scripts/checks/vitest-project-overlap.ts
@@ -2,48 +2,214 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+export const EXPECTED_VITEST_PROJECTS = [
+  "cli",
+  "integration",
+  "installer-integration",
+  "package-contract",
+  "plugin",
+  "e2e-support",
+  "e2e-live",
+  "e2e-branch-validation",
+] as const;
+
+type ExpectedVitestProject = (typeof EXPECTED_VITEST_PROJECTS)[number];
+
 export type ProjectListing = {
-  projects: Set<string>;
   projectsByFile: Map<string, Set<string>>;
 };
 
+export type ProjectMembershipMismatch = {
+  file: string;
+  expected: ReadonlySet<string>;
+  actual: ReadonlySet<string>;
+  reason:
+    | "overlap"
+    | "unsupported-candidate"
+    | "unexpected-listing"
+    | "wrong-project"
+    | "zero-membership";
+};
+
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const VITEST = path.join(
-  REPO_ROOT,
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "vitest.cmd" : "vitest",
-);
+const TEST_CANDIDATE_ROOTS = ["src", "test", "nemoclaw/src"] as const;
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/;
+const SKIP_DIRECTORIES = new Set([".git", "node_modules"]);
+const INSTALLER_INTEGRATION_TESTS = new Set([
+  "test/install-build-dependency-preflight.test.ts",
+  "test/install-express-prompt.test.ts",
+  "test/install-openshell-version-check.test.ts",
+  "test/install-preflight-docker-bootstrap.test.ts",
+  "test/install-preflight.test.ts",
+]);
+
+function normalizeRepoPath(file: string): string {
+  return file.replaceAll("\\", "/").replace(/^\.\/+/, "");
+}
+
+export function discoverVitestCandidates(repoRoot: string = REPO_ROOT): Set<string> {
+  const candidates: string[] = [];
+
+  const walk = (directory: string): void => {
+    if (!existsSync(directory)) return;
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isSymbolicLink() || SKIP_DIRECTORIES.has(entry.name)) continue;
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolutePath);
+      } else if (entry.isFile() && TEST_FILE_PATTERN.test(entry.name)) {
+        candidates.push(normalizeRepoPath(path.relative(repoRoot, absolutePath)));
+      }
+    }
+  };
+
+  for (const root of TEST_CANDIDATE_ROOTS) walk(path.join(repoRoot, root));
+  return new Set(candidates.sort((left, right) => left.localeCompare(right)));
+}
+
+export function expectedProjectForTestPath(file: string): ExpectedVitestProject | undefined {
+  const normalized = normalizeRepoPath(file);
+  if (normalized.startsWith("src/")) return "cli";
+  if (normalized.startsWith("nemoclaw/src/")) return "plugin";
+  if (INSTALLER_INTEGRATION_TESTS.has(normalized)) return "installer-integration";
+  if (normalized.startsWith("test/package-contract/")) return "package-contract";
+  if (normalized.startsWith("test/e2e/support/")) return "e2e-support";
+  if (normalized.startsWith("test/e2e/live/")) return "e2e-live";
+  if (normalized === "test/e2e/brev-e2e.test.ts") return "e2e-branch-validation";
+  if (normalized.startsWith("test/e2e/")) return undefined;
+  if (normalized.startsWith("test/")) return "integration";
+  return undefined;
+}
+
+export function resolveVitestInvocation(
+  args: readonly string[],
+  repoRoot: string = REPO_ROOT,
+): { command: string; args: string[] } {
+  return {
+    command: process.execPath,
+    args: [path.join(repoRoot, "node_modules", "vitest", "vitest.mjs"), ...args],
+  };
+}
 
 export function parseProjectListing(output: string): ProjectListing {
   const projectsByFile = new Map<string, Set<string>>();
-  const projects = new Set<string>();
   for (const line of output.split(/\r?\n/)) {
     if (!line.trim()) continue;
     const match = line.match(/^\[([^\]]+)\]\s+(.+)$/);
     if (!match) throw new Error(`Could not parse Vitest project listing line: ${line}`);
-    const [, project, file] = match;
-    projects.add(project);
+    const [, project, listedFile] = match;
+    const file = normalizeRepoPath(listedFile);
     const memberships = projectsByFile.get(file) ?? new Set<string>();
     memberships.add(project);
     projectsByFile.set(file, memberships);
   }
-  return { projects, projectsByFile };
+  return { projectsByFile };
 }
 
-export function findProjectOverlaps(
+export function parseProjectRoster(output: string): Set<string> {
+  let value: unknown;
+  try {
+    value = JSON.parse(output);
+  } catch (cause) {
+    throw new Error("Could not parse Vitest project roster JSON", { cause });
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("projects" in value) ||
+    !Array.isArray(value.projects)
+  ) {
+    throw new Error("Vitest project roster JSON must contain a projects array");
+  }
+
+  const projects = new Set<string>();
+  for (const project of value.projects) {
+    if (
+      typeof project !== "object" ||
+      project === null ||
+      !("name" in project) ||
+      typeof project.name !== "string" ||
+      project.name.length === 0
+    ) {
+      throw new Error("Every Vitest project roster entry must have a non-empty name");
+    }
+    projects.add(project.name);
+  }
+  return projects;
+}
+
+export function findProjectMembershipMismatches(
+  candidateFiles: ReadonlySet<string>,
   projectsByFile: ReadonlyMap<string, ReadonlySet<string>>,
-): Array<[string, ReadonlySet<string>]> {
-  return [...projectsByFile]
-    .filter(([, memberships]) => memberships.size > 1)
-    .sort(([left], [right]) => left.localeCompare(right));
+): ProjectMembershipMismatch[] {
+  const candidates = new Set([...candidateFiles].map(normalizeRepoPath));
+  const actualByFile = new Map<string, Set<string>>();
+  for (const [file, memberships] of projectsByFile) {
+    const normalized = normalizeRepoPath(file);
+    const actual = actualByFile.get(normalized) ?? new Set<string>();
+    for (const project of memberships) actual.add(project);
+    actualByFile.set(normalized, actual);
+  }
+
+  const files = new Set([...candidates, ...actualByFile.keys()]);
+  const mismatches: ProjectMembershipMismatch[] = [];
+  for (const file of [...files].sort((left, right) => left.localeCompare(right))) {
+    const actual = new Set([...(actualByFile.get(file) ?? [])].sort());
+    if (!candidates.has(file)) {
+      mismatches.push({
+        file,
+        expected: new Set(),
+        actual,
+        reason: "unexpected-listing",
+      });
+      continue;
+    }
+
+    const expectedProject = expectedProjectForTestPath(file);
+    if (!expectedProject) {
+      mismatches.push({
+        file,
+        expected: new Set(),
+        actual,
+        reason: "unsupported-candidate",
+      });
+      continue;
+    }
+
+    const expected = new Set([expectedProject]);
+    if (actual.size === 0) {
+      mismatches.push({ file, expected, actual, reason: "zero-membership" });
+    } else if (actual.size > 1) {
+      mismatches.push({ file, expected, actual, reason: "overlap" });
+    } else if (!actual.has(expectedProject)) {
+      mismatches.push({ file, expected, actual, reason: "wrong-project" });
+    }
+  }
+  return mismatches;
 }
 
-function main(): void {
-  const result = spawnSync(VITEST, ["list", "--filesOnly"], {
+export function findProjectRosterMismatches(projects: ReadonlySet<string>): {
+  missing: string[];
+  unexpected: string[];
+} {
+  const expected = new Set<string>(EXPECTED_VITEST_PROJECTS);
+  return {
+    missing: [...expected].filter((project) => !projects.has(project)).sort(),
+    unexpected: [...projects].filter((project) => !expected.has(project)).sort(),
+  };
+}
+
+function formatProjects(projects: ReadonlySet<string>): string {
+  return projects.size > 0 ? [...projects].sort().join(", ") : "<none>";
+}
+
+function runVitest(args: readonly string[]): string {
+  const invocation = resolveVitestInvocation(args);
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: REPO_ROOT,
     encoding: "utf8",
     env: {
@@ -51,6 +217,8 @@ function main(): void {
       NEMOCLAW_RUN_BRANCH_VALIDATION_E2E: "1",
       NEMOCLAW_RUN_LIVE_E2E: "1",
     },
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: 30_000,
   });
 
   if (result.error) throw result.error;
@@ -58,20 +226,34 @@ function main(): void {
     process.stderr.write(result.stderr);
     process.exit(result.status ?? 1);
   }
+  return result.stdout;
+}
 
-  const { projects, projectsByFile } = parseProjectListing(result.stdout);
-  const overlaps = findProjectOverlaps(projectsByFile);
+function main(): void {
+  const { projectsByFile } = parseProjectListing(runVitest(["list", "--filesOnly"]));
+  const projects = parseProjectRoster(runVitest(["--list-tags=json"]));
+  const candidates = discoverVitestCandidates();
+  const mismatches = findProjectMembershipMismatches(candidates, projectsByFile);
+  const roster = findProjectRosterMismatches(projects);
 
-  if (overlaps.length > 0) {
-    console.error("Vitest files must belong to exactly one project:");
-    for (const [file, memberships] of overlaps) {
-      console.error(`  ${file}: ${[...memberships].sort().join(", ")}`);
+  if (roster.missing.length > 0 || roster.unexpected.length > 0 || mismatches.length > 0) {
+    console.error("Vitest project discovery does not match the repository test contract:");
+    if (roster.missing.length > 0) {
+      console.error(`  missing projects: ${roster.missing.join(", ")}`);
+    }
+    if (roster.unexpected.length > 0) {
+      console.error(`  unexpected projects: ${roster.unexpected.join(", ")}`);
+    }
+    for (const { file, expected, actual, reason } of mismatches) {
+      console.error(
+        `  ${file}: ${reason}; expected ${formatProjects(expected)}; found ${formatProjects(actual)}`,
+      );
     }
     process.exit(1);
   }
 
   console.log(
-    `Vitest project membership is disjoint (${projectsByFile.size} files across ${projects.size} projects).`,
+    `Vitest project membership is exact (${candidates.size} candidate files across ${projects.size} projects).`,
   );
 }
 

--- a/test/e2e/support/shared-e2e-workflow-boundary.test.ts
+++ b/test/e2e/support/shared-e2e-workflow-boundary.test.ts
@@ -92,6 +92,7 @@ describe("shared E2E workflow boundary", () => {
       expect.arrayContaining([
         "shared E2E job must set CHECK_DOC_LINKS_REMOTE to 0",
         'step \'Run tagged credential-free test\' run script must include npx vitest run --project "${TEST_PROJECT}" "${TEST_FILE}"',
+        "step 'Run tagged credential-free test' run script must include --tags-filter=e2e/credential-free",
         "report-to-pr job must wait for shared-e2e",
       ]),
     );

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -50,6 +50,7 @@
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -252,23 +253,25 @@ describe("onboard dashboard-port exhaustion exits non-zero (#5974)", () => {
     binDir = path.join(home, "bin");
     fs.mkdirSync(binDir, { recursive: true });
 
-    // Fake openshell: report a supported version and embed the capability
-    // markers the installer greps for with `strings`, so onboard's preflight
-    // neither attempts a network reinstall nor fails the credential-rewrite
-    // capability gate before it reaches the dashboard-port check.
-    fs.writeFileSync(
-      path.join(binDir, "openshell"),
-      [
-        "#!/usr/bin/env bash",
-        "# openshell capabilities: request-body-credential-rewrite websocket-credential-rewrite",
-        'case "$1" in',
-        '  --version) echo "openshell 0.0.44"; exit 0;;',
-        "esac",
-        "echo '' >&2",
-        "exit 1",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
+    // Fake one coherent OpenShell release: onboard probes the CLI with `-V`,
+    // validates the sibling gateway/sandbox versions with `--version`, and
+    // scans the component set for all required capability markers. Keeping
+    // those contracts current prevents this fixture from reaching the network
+    // installer before it reaches the dashboard-port check.
+    for (const component of ["openshell", "openshell-gateway", "openshell-sandbox"]) {
+      fs.writeFileSync(
+        path.join(binDir, component),
+        [
+          "#!/usr/bin/env bash",
+          "# openshell capabilities: request-body-credential-rewrite websocket-credential-rewrite allow_all_known_mcp_methods",
+          'case "${1:-}" in',
+          '  -V|--version) printf "%s 0.0.72\\n" "${0##*/}"; exit 0;;',
+          "esac",
+          "exit 1",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+    }
     fs.writeFileSync(
       path.join(binDir, "docker"),
       [
@@ -303,7 +306,17 @@ describe("onboard dashboard-port exhaustion exits non-zero (#5974)", () => {
     fs.rmSync(home, { recursive: true, force: true });
   });
 
-  it("prints the canonical message and exits non-zero", testTimeoutOptions(60_000), () => {
+  it("prints the canonical message and exits non-zero", testTimeoutOptions(60_000), async () => {
+    // Ask the OS for an unused port instead of probing the host-global default
+    // 8080, which may legitimately belong to another local test or service.
+    const listener = createServer();
+    await new Promise<void>((resolve, reject) => {
+      listener.once("error", reject);
+      listener.listen(0, "127.0.0.1", resolve);
+    });
+    const gatewayPort = (listener.address() as { port: number }).port;
+    await new Promise<void>((resolve) => listener.close(() => resolve()));
+
     const result = spawnSync(
       process.execPath,
       [CLI, "onboard", "--name", "port-test", "--no-gpu", "--non-interactive"],
@@ -317,6 +330,11 @@ describe("onboard dashboard-port exhaustion exits non-zero (#5974)", () => {
           NEMOCLAW_TEST_NO_SLEEP: "1",
           NEMOCLAW_STATUS_PROBE_TIMEOUT_MS: "2000",
           NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+          NEMOCLAW_GATEWAY_PORT: String(gatewayPort),
+          NEMOCLAW_OPENSHELL_BIN: path.join(binDir, "openshell"),
+          NEMOCLAW_OPENSHELL_CHANNEL: "stable",
+          NEMOCLAW_OPENSHELL_GATEWAY_BIN: path.join(binDir, "openshell-gateway"),
+          NEMOCLAW_OPENSHELL_SANDBOX_BIN: path.join(binDir, "openshell-sandbox"),
         },
       },
     );
@@ -326,6 +344,7 @@ describe("onboard dashboard-port exhaustion exits non-zero (#5974)", () => {
     expect(combined).toContain(
       `All dashboard ports in range ${PORT_RANGE_START}-${PORT_RANGE_END} are occupied`,
     );
+    expect(combined).not.toMatch(/Installing OpenShell|Reinstalling|Upgrading/);
     expect(result.status).toBeGreaterThan(0);
   });
 });

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -344,7 +344,7 @@ describe("onboard dashboard-port exhaustion exits non-zero (#5974)", () => {
     expect(combined).toContain(
       `All dashboard ports in range ${PORT_RANGE_START}-${PORT_RANGE_END} are occupied`,
     );
-    expect(combined).not.toMatch(/Installing OpenShell|Reinstalling|Upgrading/);
+    expect(combined).not.toMatch(/\b(?:installing|reinstalling|upgrading)\b/i);
     expect(result.status).toBeGreaterThan(0);
   });
 });

--- a/test/test-boundary-guards.test.ts
+++ b/test/test-boundary-guards.test.ts
@@ -13,7 +13,16 @@ import {
   isFastProjectTestPath,
   isScannedTestPath,
 } from "../scripts/checks/no-test-dist-imports";
-import { findProjectOverlaps, parseProjectListing } from "../scripts/checks/vitest-project-overlap";
+import {
+  discoverVitestCandidates,
+  EXPECTED_VITEST_PROJECTS,
+  expectedProjectForTestPath,
+  findProjectMembershipMismatches,
+  findProjectRosterMismatches,
+  parseProjectListing,
+  parseProjectRoster,
+  resolveVitestInvocation,
+} from "../scripts/checks/vitest-project-overlap";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const SOURCE_RUNTIME = path.join(REPO_ROOT, "test", "helpers", "onboard-script-mocks.cjs");
@@ -645,21 +654,155 @@ describe("fast-project transitive import boundary", () => {
 });
 
 describe("Vitest project membership boundary", () => {
-  it("accepts disjoint listings and reports duplicate membership", () => {
-    const disjoint = parseProjectListing("[cli] src/a.test.ts\n[integration] test/b.test.ts\n");
-    expect(findProjectOverlaps(disjoint.projectsByFile)).toEqual([]);
+  it("discovers broad test candidates while ignoring dependencies and helpers (#6692)", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-vitest-candidates-"));
+    const included = [
+      "src/unit.test.ts",
+      "src/parser.spec.mts",
+      "src/dist/generated.test.ts",
+      "test/integration.test.js",
+      "test/component.test.tsx",
+      "test/.venv/environment.test.ts",
+      "nemoclaw/src/plugin.spec.cts",
+      "nemoclaw/src/coverage/generated.spec.ts",
+    ];
+    const excluded = ["src/helper.ts", "test/node_modules/dependency.spec.ts"];
 
-    const overlapping = parseProjectListing(
-      "[cli] src/a.test.ts\n[integration] test/b.test.ts\n[package-contract] src/a.test.ts\n",
-    );
-    expect(findProjectOverlaps(overlapping.projectsByFile)).toEqual([
-      ["src/a.test.ts", new Set(["cli", "package-contract"])],
+    try {
+      for (const file of [...included, ...excluded]) {
+        const absolutePath = path.join(fixtureRoot, file);
+        fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+        fs.writeFileSync(absolutePath, "");
+      }
+
+      expect([...discoverVitestCandidates(fixtureRoot)]).toEqual(
+        included.sort((left, right) => left.localeCompare(right)),
+      );
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("maps candidate paths to their exact project contract (#6692)", () => {
+    const expectedProjects = new Map<string, string | undefined>([
+      ["src/example.spec.ts", "cli"],
+      ["nemoclaw/src/example.test.js", "plugin"],
+      ["test/coverage-ratchet.test.ts", "integration"],
+      ["test/vitest-coverage-thresholds.test.ts", "integration"],
+      ["test/example.test.js", "integration"],
+      ["test/install-build-dependency-preflight.test.ts", "installer-integration"],
+      ["test/install-express-prompt.test.ts", "installer-integration"],
+      ["test/install-openshell-version-check.test.ts", "installer-integration"],
+      ["test/install-preflight-docker-bootstrap.test.ts", "installer-integration"],
+      ["test/install-preflight.test.ts", "installer-integration"],
+      ["test/package-contract/example.test.js", "package-contract"],
+      ["test/e2e/support/example.test.js", "e2e-support"],
+      ["test/e2e/live/example.spec.ts", "e2e-live"],
+      ["test/e2e/brev-e2e.test.ts", "e2e-branch-validation"],
+      ["test/e2e/other.test.ts", undefined],
     ]);
+
+    for (const [file, project] of expectedProjects) {
+      expect(expectedProjectForTestPath(file), file).toBe(project);
+    }
+  });
+
+  it("invokes Vitest through Node on every platform (#6692)", () => {
+    expect(resolveVitestInvocation(["list", "--filesOnly"], REPO_ROOT)).toEqual({
+      command: process.execPath,
+      args: [path.join(REPO_ROOT, "node_modules", "vitest", "vitest.mjs"), "list", "--filesOnly"],
+    });
+  });
+
+  it("reports zero, overlap, wrong, unsupported, and unexpected memberships (#6692)", () => {
+    const candidates = new Set([
+      "src/missing.test.ts",
+      "test/overlap.test.ts",
+      "nemoclaw/src/wrong.test.ts",
+      "test/e2e/unsupported.test.ts",
+      "test\\good.test.ts",
+    ]);
+    const listing = parseProjectListing(
+      [
+        "[integration] test/good.test.ts",
+        "[integration] test\\good.test.ts",
+        "[integration] test/overlap.test.ts",
+        "[cli] test/overlap.test.ts",
+        "[cli] nemoclaw/src/wrong.test.ts",
+        "[integration] src/helper.ts",
+      ].join("\n"),
+    );
+
+    expect(findProjectMembershipMismatches(candidates, listing.projectsByFile)).toEqual([
+      {
+        file: "nemoclaw/src/wrong.test.ts",
+        expected: new Set(["plugin"]),
+        actual: new Set(["cli"]),
+        reason: "wrong-project",
+      },
+      {
+        file: "src/helper.ts",
+        expected: new Set(),
+        actual: new Set(["integration"]),
+        reason: "unexpected-listing",
+      },
+      {
+        file: "src/missing.test.ts",
+        expected: new Set(["cli"]),
+        actual: new Set(),
+        reason: "zero-membership",
+      },
+      {
+        file: "test/e2e/unsupported.test.ts",
+        expected: new Set(),
+        actual: new Set(),
+        reason: "unsupported-candidate",
+      },
+      {
+        file: "test/overlap.test.ts",
+        expected: new Set(["integration"]),
+        actual: new Set(["cli", "integration"]),
+        reason: "overlap",
+      },
+    ]);
+  });
+
+  it("accepts the exact project roster and reports a renamed project (#6692)", () => {
+    const exactRoster = parseProjectRoster(
+      JSON.stringify({
+        projects: EXPECTED_VITEST_PROJECTS.map((name) => ({ name, tags: [] })),
+        tags: [],
+      }),
+    );
+    expect(findProjectRosterMismatches(exactRoster)).toEqual({
+      missing: [],
+      unexpected: [],
+    });
+
+    const renamed = parseProjectRoster(
+      JSON.stringify({
+        projects: [
+          ...EXPECTED_VITEST_PROJECTS.filter((name) => name !== "e2e-branch-validation").map(
+            (name) => ({ name, tags: [] }),
+          ),
+          { name: "e2e-branch", tags: [] },
+          { name: "empty-project", tags: [] },
+        ],
+        tags: [],
+      }),
+    );
+    expect(findProjectRosterMismatches(renamed)).toEqual({
+      missing: ["e2e-branch-validation"],
+      unexpected: ["e2e-branch", "empty-project"],
+    });
   });
 
   it("fails closed when Vitest listing output changes shape", () => {
     expect(() => parseProjectListing("unexpected output")).toThrow(
       "Could not parse Vitest project listing line",
+    );
+    expect(() => parseProjectRoster('{"projects": [{"tags": []}]}')).toThrow(
+      "Every Vitest project roster entry must have a non-empty name",
     );
   });
 });

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -5,7 +5,11 @@ import { readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
-import { discoverCredentialFreeTests, SHARED_E2E_JOB_ID } from "./credential-free-tests.mts";
+import {
+  CREDENTIAL_FREE_TEST_TAG,
+  discoverCredentialFreeTests,
+  SHARED_E2E_JOB_ID,
+} from "./credential-free-tests.mts";
 import { validateHermesDashboardWorkflowBoundary } from "./hermes-dashboard-workflow-boundary.mts";
 import { validateHermesGpuStartupWorkflowBoundary } from "./hermes-gpu-startup-workflow-boundary.mts";
 import { validateInferenceSwitchWorkflowBoundary } from "./inference-switch-workflow-boundary.mts";
@@ -746,6 +750,7 @@ function validateSharedE2eJob(errors: string[], jobs: WorkflowRecord): void {
     runVitest,
     'npx vitest run --project "${TEST_PROJECT}" "${TEST_FILE}"',
   );
+  requireRunContains(errors, runVitest, `--tags-filter=${CREDENTIAL_FREE_TEST_TAG}`);
   requireRunContains(errors, runVitest, "--reporter=test/e2e/risk-signal-reporter.ts");
 }
 


### PR DESCRIPTION
## Summary
Vitest project validation now compares every filesystem test candidate with Vitest's complete eight-project roster, rejecting omissions, overlaps, wrong routing, unexpected files, and unexpected project names. The shared credential-free E2E workflow now applies Vitest's native e2e/credential-free tag filter in addition to the existing safe matrix scanner. The dashboard-port regression fixture also uses a coherent fake OpenShell 0.0.72 component set and an OS-assigned gateway port so the repo-wide gate stays hermetic.

This is the final entry in the ordered #6692 stack after #6693, #6696, #6697, #6699, #6700, #6701, #6702, and #6705 landed.

## Related Issue
Closes #6692

## Changes
- Discover broad test/spec JavaScript and TypeScript candidates under src, test, and nemoclaw/src, including nested dist, coverage, and .venv paths that Vitest would see.
- Compare candidate routing with Vitest file listings and the complete roster from list-tags JSON, including empty and opt-in projects.
- Produce sorted diagnostics for zero membership, overlap, wrong project, unsupported candidates, unexpected listed files, and missing or extra projects.
- Invoke Vitest portably through process.execPath and node_modules/vitest/vitest.mjs.
- Require the exact native credential-free tag filter in the shared E2E workflow contract while retaining the TypeScript scanner's path, project, ID, and declaration checks.
- Keep the dashboard-port exhaustion regression independent of port 8080, developer OpenShell overrides, channel selection, and network installation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: these are contributor/test-harness safeguards; AGENTS.md now states the exhaustive project-membership contract, the E2E README already documents the native module tag, and the required documentation-writer review found no user-facing change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent review covered the shared credential-free workflow and onboarding regression fixture; it confirmed the filter preserves the existing scanner and the fixture's child-only environment cannot reach a real OpenShell install.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed, or npm run check:diff passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 46 integration tests passed across the boundary and dashboard-port files; 4 E2E-support workflow tests passed; project membership is exact for 1,537 candidates across 8 projects; CLI type-check, title style, Biome, and diff checks passed. The fixture also passed with hostile inherited OpenShell paths and dev-channel selection.
- [x] Applicable broad gate passed — npm test passed 1,456 files / 16,515 tests before the final focused hardening; npm run check passed the repo-wide structural, CLI coverage, and plugin coverage gates, followed by focused reruns and normal hooks after the final child-environment pin.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Credential-free end-to-end test runs now execute only tests matching the credential-free tag.
  - Vitest project validation now checks for missing, overlapping, unsupported, wrong, zero-membership, and unexpected test-to-project assignments, plus roster mismatches.
  - Expanded boundary tests cover test candidate discovery, expected project mapping, Vitest invocation resolution, and listing/roster parsing.
  - Improved onboarding “dashboard port exhaustion” assertions for more hermetic, reliable verification.
- **Documentation**
  - Updated testing guidance to require Vitest project globs be disjoint and exhaustive, enforced by the projects check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->