### PR TITLE
docs(release): add v0.0.81 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,37 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.81
+
+NemoClaw v0.0.81 strengthens rebuild and snapshot state preservation, repairs local compatible inference and WhatsApp setup, improves Docker restart recovery, and makes onboarding, backup, and security diagnostics easier to act on.
+
+- Rebuild and restore preserve more user-owned state without letting old backups replace current managed configuration.
+  Agent manifests can declare key-level restore ownership, managed Deep Agents restores keep only allowlisted UI and thread preferences, and Hermes rebuilds retain the Web Dashboard profile under `/sandbox/.hermes/dashboard-home/`, including its `MEMORY.md` and `USER.md` files.
+  Deep Agents snapshot creation also falls back to `/proc` when `ps` is unavailable while continuing to fail closed when it cannot prove the runtime is idle.
+  For more information, refer to [Backup and Restore](../manage-sandboxes/backup-restore) and [Workspace and State Files](../manage-sandboxes/workspace-files).
+- Compatible inference setup handles more endpoint and model contracts automatically.
+  Eligible loopback endpoints on ports `8000`, `11434`, and `11435` are validated on the host and registered through `host.openshell.internal`, GPT-5 and the `o1`, `o3`, and `o4` model families use `max_completion_tokens`, and related provider validation probes can reuse bounded HTTPS connections with established fallbacks.
+  Direct blueprint apply now aborts without persisting an incomplete plan or reporting false completion when provider creation or inference configuration fails.
+  For more information, refer to [Set Up an OpenAI-Compatible Endpoint](../inference/custom-endpoints/set-up-openai-compatible-endpoint) and [Choose a Compatible Inference API](../inference/custom-endpoints/choose-compatible-inference-api).
+- Sandbox lifecycle recovery covers more host restart and teardown cases.
+  On supported local Docker deployments, `recover` can transactionally replace a legacy keepalive container whose managed supervisor disappeared after a restart, and it commits only after health and settle checks pass.
+  Hermes persists its managed startup command across direct Docker restarts, while unattended destruction of the final sandbox releases the shared gateway by default on macOS.
+  For more information, refer to [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle), [NemoClaw CLI Commands Reference](../reference/commands), and [Troubleshooting](../reference/troubleshooting).
+- Managed Deep Agents sessions skip optional first-run setup and clean up their own process trees on disconnect.
+  The image includes `ripgrep`, pre-completes optional upstream onboarding, suppresses the optional Tavily warning unless web search is configured or used, and refuses a managed fetch CA bundle with unsafe ownership, permissions, links, or content.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](/user-guide/deepagents/get-started/quickstart) and [Security Best Practices](../security/best-practices).
+- WhatsApp pairing now uses the OpenClaw loopback gateway so a successful QR login can start the channel without moving a gateway token or requiring `operator.admin`.
+  Externally installed channel plugins now retain verified npm provenance, which enables the trusted persistent-state features expected by current OpenClaw releases.
+  For more information, refer to [Messaging Channels](/user-guide/openclaw/manage-sandboxes/messaging-channels).
+- Backup and onboarding failures provide more specific recovery evidence.
+  `backup-all` tells you to start a stopped sandbox or container and rerun the backup or installer, and backup failures identify these causes when available: `permission denied`, `tar read error`, or `absent after extraction`.
+  A created-but-not-ready sandbox prints a lifecycle receipt with its readiness gate, timeout, and cleanup result, onboarding progress waits while an interactive prompt owns the terminal, and resumed onboarding does not advance durable state from stale replay results.
+  For more information, refer to [Backup and Restore](../manage-sandboxes/backup-restore), [NemoClaw Quickstart](../get-started/quickstart), [NemoClaw CLI Commands Reference](../reference/commands), and [Troubleshooting](../reference/troubleshooting).
+- Security and policy diagnostics preserve more context without hiding risk.
+  OpenClaw security audits keep NemoClaw-managed dashboard compatibility findings visible with their severity, remediation, and recorded reason, while token-shaped URL query values are redacted even when their parameter names look benign.
+  The custom Streamable HTTP MCP policy recipe also scopes `DELETE` to the exact MCP endpoint used for session termination.
+  For more information, refer to [Security Best Practices](../security/best-practices) and [Customize the Network Policy](../network-policy/customize-network-policy).
+
 ## v0.0.80
 
 NemoClaw v0.0.80 upgrades Hermes to the v0.18 line with richer Slack rendering, routes OpenRouter runtime traffic through a host-local attribution adapter, imports host corporate proxy CAs into sandbox trust, hardens sandbox base-image selection and route probing, and preserves intent across more interrupted onboarding and recovery flows.

--- a/docs/manage-sandboxes/backup-restore.mdx
+++ b/docs/manage-sandboxes/backup-restore.mdx
@@ -48,7 +48,8 @@ Use the built-in snapshot commands for the fastest backup and restore path.
 Snapshots capture all workspace state directories defined in the agent manifest and store them in `~/.nemoclaw/rebuild-backups/<name>/`.
 Agent manifests can also declare durable top-level state files.
 <AgentOnly variant="hermes">
-For Hermes, snapshots include `SOUL.md` and the SQLite database behind `.hermes/state.db` using SQLite's online backup API, then restore that database through SQLite instead of copying a live raw database file.
+For Hermes, snapshots include `SOUL.md`, the Web Dashboard profile under `.hermes/dashboard-home/`, and the SQLite database behind `.hermes/state.db` using SQLite's online backup API, then restore that database through SQLite instead of copying a live raw database file.
+The dashboard profile includes `MEMORY.md` and `USER.md`, and the automatic rebuild snapshot preserves both files.
 </AgentOnly>
 <AgentOnly variant="deepagents">
 For Deep Agents, snapshots include manifest-declared state under `/sandbox/.deepagents`, including skills and runtime state, while omitting credential-bearing user files.
@@ -174,12 +175,17 @@ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/memory/ "$BAC
 ```bash
 SANDBOX=my-hermes
 BACKUP_DIR=~/.nemoclaw/backups/$(date +%Y%m%d-%H%M%S)
-mkdir -p "$BACKUP_DIR"
+mkdir -p "$BACKUP_DIR/dashboard-home"
 
 openshell sandbox download "$SANDBOX" /sandbox/SOUL.md "$BACKUP_DIR/"
 openshell sandbox download "$SANDBOX" /sandbox/.hermes/state.db "$BACKUP_DIR/"
+openshell sandbox download "$SANDBOX" /sandbox/.hermes/dashboard-home/MEMORY.md "$BACKUP_DIR/dashboard-home/MEMORY.md"
+openshell sandbox download "$SANDBOX" /sandbox/.hermes/dashboard-home/USER.md "$BACKUP_DIR/dashboard-home/USER.md"
 openshell sandbox download "$SANDBOX" /sandbox/.hermes/platforms/ "$BACKUP_DIR/platforms/"
 ```
+
+Copy only the dashboard profile's `MEMORY.md` and `USER.md` files.
+Do not copy `.hermes/dashboard-home/.env` or `.hermes/dashboard-home/config.yaml`; NemoClaw regenerates both files, and `.env` contains dashboard authentication material.
 
 </AgentOnly>
 <AgentOnly variant="deepagents">
@@ -229,6 +235,8 @@ BACKUP_DIR=~/.nemoclaw/backups/20260320-120000  # pick a timestamp
 
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/SOUL.md" /sandbox/
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/state.db" /sandbox/.hermes/
+openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/dashboard-home/MEMORY.md" /sandbox/.hermes/dashboard-home/MEMORY.md
+openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/dashboard-home/USER.md" /sandbox/.hermes/dashboard-home/USER.md
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/platforms/" /sandbox/.hermes/platforms/
 ```
 
@@ -261,6 +269,7 @@ $$nemoclaw backup-all
 
 `backup-all` walks the sandboxes registered on the host, creates a snapshot for each running sandbox, and stores the snapshot bundles under `~/.nemoclaw/rebuild-backups/<name>/`.
 If a registered sandbox is stopped, start the sandbox or its container and rerun `$$nemoclaw backup-all` so NemoClaw can capture a fresh snapshot before maintenance.
+When a backup fails, NemoClaw identifies the affected state item and reports one of these causes when available: `permission denied`, `tar read error`, or `absent after extraction`.
 Use `$$nemoclaw <name> snapshot list` and `$$nemoclaw <name> snapshot restore` to inspect or restore one sandbox's bundles later.
 
 ## Using the Backup Script

--- a/docs/manage-sandboxes/workspace-files.mdx
+++ b/docs/manage-sandboxes/workspace-files.mdx
@@ -124,6 +124,7 @@ Runtime state, such as logs, memory, platform sessions, and the SQLite state dat
 | `/sandbox/.hermes/config.yaml` | NemoClaw-generated Hermes runtime configuration. |
 | `/sandbox/.hermes/.env` | NemoClaw-generated environment and messaging placeholders. |
 | `/sandbox/.hermes/state.db` | Hermes SQLite state database. |
+| `/sandbox/.hermes/dashboard-home/` | Hermes Web Dashboard profile, including `MEMORY.md` and `USER.md`. |
 | `/sandbox/.hermes/platforms/` | Messaging platform state, including QR-paired sessions such as WhatsApp. |
 | `/sandbox/.hermes/logs/` | Hermes runtime logs. |
 | `/sandbox/SOUL.md` | Durable top-level Hermes persona file preserved by NemoClaw snapshots. |
@@ -132,7 +133,7 @@ Runtime state, such as logs, memory, platform sessions, and the SQLite state dat
 
 Hermes state lives in the sandbox's persistent state volume, not in the container image alone.
 Normal restarts preserve that state.
-Rebuilds and upgrades use NemoClaw's snapshot flow to preserve manifest-defined Hermes state, including `SOUL.md` and the SQLite database behind `.hermes/state.db`.
+Rebuilds and upgrades use NemoClaw's snapshot flow to preserve manifest-defined Hermes state, including `SOUL.md`, the Web Dashboard profile under `.hermes/dashboard-home/`, and the SQLite database behind `.hermes/state.db`.
 
 Running `$$nemoclaw <name> destroy` deletes the sandbox and its persistent state volume.
 Back up important state before destroying a Hermes sandbox.

--- a/docs/reference/host-files-and-state.mdx
+++ b/docs/reference/host-files-and-state.mdx
@@ -43,7 +43,7 @@ If you see `registry.json` in older tests, notes, or discussions, treat it as le
 | Path | Purpose | Safe to delete |
 |---|---|---|
 | `~/.nemoclaw/state/` | Operational coordination and history for lifecycle locks, shields transitions, timers, and audit events, local routing, and port-forward helpers. | No. Deleting it can disrupt an active operation and discard security or recovery context. |
-| `~/.nemoclaw/snapshots/` | Full copies of host `~/.openclaw` state created by blueprint migration and rollback flows. | Only after you no longer need the corresponding rollback or restore point. Use the blueprint runner retention commands instead of deleting entries manually. |
+| `~/.nemoclaw/snapshots/` | Full copies of host `~/.openclaw` state created by blueprint migration and rollback flows. | Only after you no longer need the corresponding rollback or restore point. The host CLI does not expose the direct runner's retention actions. |
 | `~/.nemoclaw/rebuild-backups/` | Host-side snapshots written by `backup-all`, `snapshot create`, and rebuild flows. | Only after you no longer need rollback or restore points. |
 | `~/.nemoclaw/backups/` | Workspace backups written by legacy backup helpers and some recovery flows. | Only after confirming you no longer need those workspace archives. |
 | `~/.nemoclaw/mounts/` | Default local mount points created by share or mount commands. | Unmount first, then remove unused directories. |
@@ -51,7 +51,7 @@ If you see `registry.json` in older tests, notes, or discussions, treat it as le
 
 ## Migration Snapshot Retention
 
-The blueprint runner accepts these commands for migration snapshots:
+The direct blueprint runner accepts these action arguments for migration snapshots:
 
 ```text
 snapshots list
@@ -59,7 +59,8 @@ snapshots prune --keep 3
 snapshots delete --path ~/.nemoclaw/snapshots/20260101T000000Z
 ```
 
-Run `snapshots list` first to inspect the available timestamped copies.
+These fragments are not standalone shell commands, and the host `nemoclaw` CLI does not expose them.
+An integration that invokes the direct runner can use `snapshots list` first to inspect the available timestamped copies.
 `snapshots prune` keeps the requested number of newest snapshots; `--keep 0` removes all of them.
 `snapshots delete` accepts only one timestamped directory directly under `~/.nemoclaw/snapshots/`.
 Both deletion commands are irreversible: they do not modify a running sandbox, but they remove host state that could otherwise be used for rollback or restore.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Release-prep documentation for v0.0.81 now summarizes user-facing changes merged since v0.0.80.
It also closes the Hermes dashboard-profile backup gap and distinguishes direct blueprint-runner actions from public host CLI commands.

## Changes

- Add the `v0.0.81` section to `docs/about/release-notes.mdx` with links to the detailed user guides.
- Document that Hermes rebuilds preserve `.hermes/dashboard-home/`, including Dashboard `MEMORY.md` and `USER.md`.
- Update Hermes manual backup and restore examples to transfer those two profile files without copying generated configuration or the secret-bearing dashboard `.env`.
- Explain the new per-item backup failure causes.
- Clarify that migration snapshot retention fragments are direct-runner arguments and are not exposed by the host `nemoclaw` CLI.

### Source summary

- #6445 -> `docs/about/release-notes.mdx`, `docs/manage-sandboxes/backup-restore.mdx`, and `docs/manage-sandboxes/workspace-files.mdx`: Summarize manifest-owned key-level restore and current-config authority.
- #6617 -> `docs/about/release-notes.mdx` and `docs/manage-sandboxes/backup-restore.mdx`: Record the fail-closed `/proc` fallback used to verify an idle Deep Agents runtime before snapshot creation.
- #6685 -> `docs/about/release-notes.mdx`, `docs/manage-sandboxes/backup-restore.mdx`, and `docs/manage-sandboxes/workspace-files.mdx`: Document Hermes Web Dashboard profile persistence and safe manual transfer.
- #6649 -> `docs/about/release-notes.mdx`: Summarize host-validated loopback compatible-endpoint routing through the sandbox gateway.
- #6643 -> `docs/about/release-notes.mdx`: Summarize automatic `max_completion_tokens` handling for GPT-5 and o-series models.
- #6661 -> `docs/about/release-notes.mdx`: Summarize bounded connection reuse for eligible provider-validation probes.
- #6704 -> `docs/about/release-notes.mdx`: Record that direct blueprint apply stops instead of persisting incomplete state after provider or inference setup fails.
- #6677 -> `docs/about/release-notes.mdx`: Summarize transactional recovery for legacy Docker containers whose managed supervisor disappeared after restart.
- #6625 -> `docs/about/release-notes.mdx`: Record Hermes managed-startup persistence across direct Docker restarts.
- #6597 -> `docs/about/release-notes.mdx`: Record final-sandbox gateway cleanup on macOS.
- #6680 -> `docs/about/release-notes.mdx`: Summarize managed Deep Agents first-run and process-tree cleanup improvements.
- #6647 -> `docs/about/release-notes.mdx`: Record fail-closed validation for the managed Deep Agents fetch CA bundle.
- #6645 -> `docs/about/release-notes.mdx`: Summarize WhatsApp loopback pairing and trusted npm plugin provenance.
- #6673 -> `docs/about/release-notes.mdx` and `docs/manage-sandboxes/backup-restore.mdx`: Document stopped-sandbox backup remediation.
- #6631 -> `docs/about/release-notes.mdx` and `docs/manage-sandboxes/backup-restore.mdx`: Document per-item backup failure causes.
- #6620 -> `docs/about/release-notes.mdx`: Record the created-but-not-ready sandbox lifecycle receipt.
- #6664 -> `docs/about/release-notes.mdx`: Record prompt-aware onboarding progress output.
- #6598 -> `docs/about/release-notes.mdx`: Summarize stale replay-result invalidation during resumed onboarding.
- #6593 -> `docs/about/release-notes.mdx`: Summarize contextual OpenClaw audit findings for managed dashboard compatibility settings.
- #6650 -> `docs/about/release-notes.mdx`: Record redaction of token-shaped URL query values.
- #6638 -> `docs/about/release-notes.mdx`: Record the exact-path MCP `DELETE` policy recipe for session termination.
- #5453 -> `docs/reference/host-files-and-state.mdx`: Clarify that snapshot retention actions belong to direct runner integrations and are not standalone host CLI commands.

### Skipped from docs-skip

- #6633 matched the `openclaw-sandbox-permissive.yaml` path in `docs/.docs-skip` and produced no documentation in this update.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This is a documentation-only release-prep update; behavior is protected by the merged source PRs, and the documentation build validates the changed examples and routes.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — tests are not applicable for this documentation-only change; `npm run docs` completed successfully.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run for this documentation-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — 0 errors; two existing Fern warnings remain.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new pages.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for v0.0.81 covering state preservation, inference setup, sandbox recovery, session setup, pairing, diagnostics, and security policy updates.
  - Expanded backup and restore guidance to include dashboard profile files and clarify files that must not be copied.
  - Added dashboard profile persistence details to workspace and rebuild documentation.
  - Clarified snapshot retention guidance and the distinction between host CLI capabilities and direct runner actions.
  - Added more detailed backup failure reporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->