### PR TITLE
fix(e2e): repair release gate regressions

### DIFF
--- a/src/lib/onboard/docker-gpu-patch.ts
+++ b/src/lib/onboard/docker-gpu-patch.ts
@@ -257,6 +257,10 @@ export type DockerContainerInspect = {
     GroupAdd?: string[] | null;
     Dns?: string[] | null;
     DnsSearch?: string[] | null;
+    DeviceRequests?: Array<{
+      Driver?: string;
+      DeviceIDs?: string[] | null;
+    }> | null;
     ShmSize?: number;
     ReadonlyPaths?: string[] | null;
     MaskedPaths?: string[] | null;
@@ -675,6 +679,21 @@ export function buildDockerGpuCloneRunArgs(
 
   const args: string[] = ["--name", dockerContainerName(inspect), ...mode.args];
   const gpuAugment = mode.kind !== "startup-command";
+
+  // Hermes restart persistence recreates the OpenShell-managed container
+  // without selecting NemoClaw's compatibility GPU mode. Preserve Docker's
+  // native CDI requests from the inspected container so that recreation does
+  // not silently drop OpenShell's GPU attachment (and the injected libcuda).
+  if (!gpuAugment) {
+    const cdiDeviceIds = new Set(
+      (host.DeviceRequests ?? [])
+        .filter((request) => request.Driver === "cdi")
+        .flatMap((request) => stringArray(request.DeviceIDs))
+        .map((deviceId) => deviceId.trim())
+        .filter(Boolean),
+    );
+    for (const deviceId of cdiDeviceIds) args.push("--device", deviceId);
+  }
 
   pushStringFlag(args, "--hostname", config.Hostname);
   pushStringFlag(args, "--user", config.User);

--- a/src/lib/onboard/docker-startup-command-patch.test.ts
+++ b/src/lib/onboard/docker-startup-command-patch.test.ts
@@ -72,6 +72,7 @@ describe("Docker startup-command patch", () => {
       ]),
     );
     expect(cloneArgs).not.toContain("--gpus");
+    expect(cloneArgs).not.toContain("--device");
     expect(cloneArgs).toEqual(expect.arrayContaining(["--env", "NVIDIA_VISIBLE_DEVICES=void"]));
     expect(cloneArgs).not.toEqual(expect.arrayContaining(["--cap-add", "SYS_PTRACE"]));
     expect(cloneArgs).not.toEqual(
@@ -82,6 +83,47 @@ describe("Docker startup-command patch", () => {
     expect(dockerCapture).toHaveBeenCalledWith(
       expect.arrayContaining(["ps", "-a", "--no-trunc"]),
       expect.objectContaining({ ignoreError: true }),
+    );
+  });
+
+  it("preserves OpenShell's native CDI GPU request during restart-persistence recreation", () => {
+    const inspect = inspectFixture();
+    inspect.HostConfig!.DeviceRequests = [
+      {
+        Driver: "cdi",
+        DeviceIDs: ["nvidia.com/gpu=all"],
+      },
+    ];
+    const dockerRunDetached = vi.fn((_args: readonly string[]) => ({
+      status: 0,
+      stdout: "new-container-id\n",
+    }));
+
+    recreateOpenShellDockerSandboxWithStartupCommand(
+      {
+        sandboxName: "alpha",
+        timeoutSecs: 1,
+        waitForSupervisor: false,
+        openshellSandboxCommand: ["env", "nemoclaw-start"],
+      },
+      {
+        dockerCapture: vi.fn((args: readonly string[]) =>
+          args[0] === "ps" ? "old-container-id\n" : JSON.stringify([inspect]),
+        ),
+        dockerRunDetached,
+        dockerRename: vi.fn(() => ({ status: 0 })),
+        dockerStop: vi.fn(() => ({ status: 0 })),
+        sleep: vi.fn(),
+        now: () => new Date("2026-07-10T00:00:00Z"),
+      },
+    );
+
+    const cloneArgs = dockerRunDetached.mock.calls[0]?.[0] ?? [];
+    expect(cloneArgs).toEqual(expect.arrayContaining(["--device", "nvidia.com/gpu=all"]));
+    expect(cloneArgs).not.toContain("--gpus");
+    expect(cloneArgs).not.toEqual(expect.arrayContaining(["--cap-add", "SYS_PTRACE"]));
+    expect(cloneArgs).not.toEqual(
+      expect.arrayContaining(["--security-opt", "apparmor=unconfined"]),
     );
   });
 

--- a/test/e2e/live/messaging-providers-slack-runtime-proof.ts
+++ b/test/e2e/live/messaging-providers-slack-runtime-proof.ts
@@ -20,6 +20,33 @@ export type InstalledSlackRuntimeProof = {
   channelId: string;
 };
 
+export const SLACK_MANAGED_NPM_PROJECT_DISCOVERY_SOURCE = String.raw`
+function addManagedNpmProjectSlackCandidates(projectsDir, addExternalCandidate) {
+  let entries;
+  try {
+    entries = fs.readdirSync(projectsDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory()) continue;
+    const projectRoot = path.join(projectsDir, entry.name);
+    let dependencies;
+    try {
+      dependencies = JSON.parse(
+        fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"),
+      ).dependencies;
+    } catch {
+      continue;
+    }
+    if (!dependencies || !Object.hasOwn(dependencies, "@openclaw/slack")) continue;
+    addExternalCandidate(
+      path.join(projectRoot, "node_modules", "@openclaw", "slack"),
+    );
+  }
+}
+`;
+
 export const SLACK_INSTALLED_RUNTIME_PROOF_SOURCE = String.raw`
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
@@ -29,6 +56,8 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 const allowLegacyTestApi = process.env.NEMOCLAW_E2E_ALLOW_LEGACY_SLACK_TEST_API === "1";
+
+${SLACK_MANAGED_NPM_PROJECT_DISCOVERY_SOURCE}
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
@@ -78,8 +107,11 @@ function resolveOpenClawSlackApiLocation() {
     }
   };
 
-  addExternalCandidate(
-    path.join(process.env.OPENCLAW_STATE_DIR || "/sandbox/.openclaw", "extensions", "slack"),
+  const openclawStateDir = process.env.OPENCLAW_STATE_DIR || "/sandbox/.openclaw";
+  addExternalCandidate(path.join(openclawStateDir, "extensions", "slack"));
+  addManagedNpmProjectSlackCandidates(
+    path.join(openclawStateDir, "npm", "projects"),
+    addExternalCandidate,
   );
   addExternalCandidate(process.env.OPENCLAW_SLACK_PACKAGE_ROOT);
   addCoreCandidate(process.env.OPENCLAW_PACKAGE_ROOT);

--- a/test/e2e/live/openshell-gateway-auth-source-contract.test.ts
+++ b/test/e2e/live/openshell-gateway-auth-source-contract.test.ts
@@ -12,9 +12,12 @@ const OPENSHELL_GATEWAY_AUTH_CONTRACT_VERSION = "0.0.72";
 test(
   `OpenShell ${OPENSHELL_GATEWAY_AUTH_CONTRACT_VERSION} Docker-driver gateway auth uses NemoClaw mTLS plus sandbox JWT`,
   { timeout: LIVE_TIMEOUT_MS },
-  (fixtures) =>
-    runOpenShellGatewayAuthSourceContractScenario(fixtures, {
-      buildDockerDriverGatewayLaunch,
-      ensureDockerDriverGatewayLocalTlsBundle,
-    }),
+  ({ artifacts, cleanup, host, skip }) =>
+    runOpenShellGatewayAuthSourceContractScenario(
+      { artifacts, cleanup, host, skip },
+      {
+        buildDockerDriverGatewayLaunch,
+        ensureDockerDriverGatewayLocalTlsBundle,
+      },
+    ),
 );

--- a/test/e2e/support/messaging-providers-runtime-proofs.test.ts
+++ b/test/e2e/support/messaging-providers-runtime-proofs.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   parseInstalledSlackProof,
   SLACK_INSTALLED_RUNTIME_PROOF_SOURCE,
+  SLACK_MANAGED_NPM_PROJECT_DISCOVERY_SOURCE,
 } from "../live/messaging-providers-slack-runtime-proof.ts";
 import { TELEGRAM_INSTALLED_RUNTIME_PROOF_SOURCE } from "../live/messaging-providers-telegram-runtime-proof.ts";
 
@@ -153,6 +154,54 @@ describe("messaging provider installed-runtime proofs", () => {
     );
     expect(SLACK_INSTALLED_RUNTIME_PROOF_SOURCE.match(/allowLegacyTestApi &&/gu)).toHaveLength(2);
     expect(SLACK_INSTALLED_RUNTIME_PROOF_SOURCE).toContain("/api/chat.postMessage");
+  });
+
+  it("finds Slack only in its canonical managed npm project", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-slack-managed-project-"));
+    const projectsDir = path.join(dir, "npm", "projects");
+    const slackProject = path.join(projectsDir, "openclaw-slack-reviewed");
+    const unrelatedProject = path.join(projectsDir, "unrelated-plugin");
+    const malformedProject = path.join(projectsDir, "malformed-plugin");
+    const slackPackageRoot = path.join(slackProject, "node_modules", "@openclaw", "slack");
+
+    try {
+      fs.mkdirSync(slackPackageRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(slackProject, "package.json"),
+        JSON.stringify({ dependencies: { "@openclaw/slack": "2026.6.10" } }),
+      );
+      fs.mkdirSync(path.join(unrelatedProject, "node_modules", "@openclaw", "slack"), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(unrelatedProject, "package.json"),
+        JSON.stringify({ dependencies: { "@openclaw/discord": "2026.6.10" } }),
+      );
+      fs.mkdirSync(malformedProject, { recursive: true });
+      fs.writeFileSync(path.join(malformedProject, "package.json"), "not json");
+
+      const source = [
+        'import fs from "node:fs";',
+        'import path from "node:path";',
+        SLACK_MANAGED_NPM_PROJECT_DISCOVERY_SOURCE,
+        "const candidates = [];",
+        "addManagedNpmProjectSlackCandidates(",
+        "  process.env.NEMOCLAW_TEST_PROJECTS_DIR,",
+        "  (candidate) => candidates.push(path.resolve(candidate)),",
+        ");",
+        "process.stdout.write(JSON.stringify(candidates));",
+      ].join("\n");
+      const result = spawnSync(process.execPath, ["--input-type=module", "-"], {
+        encoding: "utf8",
+        env: { ...process.env, NEMOCLAW_TEST_PROJECTS_DIR: projectsDir },
+        input: source,
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual([path.resolve(slackPackageRoot)]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("reports loader stderr without accepting stderr as a Slack proof (#6467)", () => {


### PR DESCRIPTION
## Summary
Repairs three deterministic failures found during v0.0.81 release validation. Hermes restart-safe recreation now preserves OpenShell's native CDI GPU attachment, the Slack proof finds the reviewed package in canonical managed npm projects, and the OpenShell auth contract collects under Vitest's fixture parser.

## Changes
- Preserve inspected `Driver: cdi` device IDs as Docker `--device` arguments during startup-command recreation, without selecting compatibility GPU mode or adding broader privileges.
- Discover `@openclaw/slack` one level below OpenClaw's managed npm projects only when the project manifest declares that dependency.
- Destructure the live auth-contract fixtures so Vitest 4.1.9 can collect the test while passing the same scenario inputs.
- Add regression coverage for the CDI clone arguments and managed Slack project discovery.
- Note for #6333: that PR moves the Docker clone code into split files but does not yet preserve CDI device requests; whichever PR rebases second must retain this contract.

The two `rebuild-hermes-stale-base` attempts ended with GitHub's hosted runner losing communication before Vitest exited or uploaded artifacts; the unchanged ordinary rebuild also lost a runner once and passed on retry. Jetson had no runner. Neither result has an evidence-backed repository change in this PR.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores existing GPU passthrough and release-proof contracts without changing commands, flags, configuration, defaults, or required user actions.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent diff review confirmed CDI propagation is startup-command-only, adds no broader GPU privileges, and Slack discovery is bounded to one manifest-gated directory level.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 67 Docker clone tests, 24 messaging-proof tests, live auth-contract collection to its intended availability skip, and 653 changed-scope tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved native CDI GPU device attachments when recreating Docker containers, preventing GPU access from being lost during startup-command persistence.
  - Improved Slack integration discovery for installations managed through project-specific npm environments.

- **Tests**
  - Added coverage for CDI GPU preservation and Slack package discovery across valid, unrelated, and malformed project directories.
  - Updated gateway authentication scenarios for more reliable end-to-end validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->