### PR TITLE
test(e2e): align Hermes GPU mode proof

### DIFF
--- a/test/e2e/live/hermes-gpu-startup-proof.ts
+++ b/test/e2e/live/hermes-gpu-startup-proof.ts
@@ -54,7 +54,7 @@ export async function assertHermesGpuStartupProof({
     expect(installText).toContain(
       "Recreating OpenShell Docker sandbox container with NVIDIA GPU access",
     );
-    expect(installText).toContain("Docker GPU mode selected:");
+    expect(installText).toContain("Docker container mode selected:");
     for (const fragment of HERMES_GPU_FALLBACK_DISCLOSURE_FRAGMENTS) {
       expect(installText).not.toContain(fragment);
     }
@@ -68,7 +68,7 @@ export async function assertHermesGpuStartupProof({
     expect(installText).toContain(
       "Recreating OpenShell Docker sandbox container with NVIDIA GPU access",
     );
-    expect(installText).toContain("Docker GPU mode selected:");
+    expect(installText).toContain("Docker container mode selected:");
   } else {
     expect(installText).toContain(
       "Direct sandbox GPU enabled; allowing OpenShell GPU policy enrichment.",
@@ -76,7 +76,7 @@ export async function assertHermesGpuStartupProof({
     expect(installText).not.toContain(
       "Recreating OpenShell Docker sandbox container with NVIDIA GPU access",
     );
-    expect(installText).not.toContain("Docker GPU mode selected:");
+    expect(installText).not.toContain("Docker container mode selected:");
     for (const fragment of HERMES_GPU_FALLBACK_DISCLOSURE_FRAGMENTS) {
       expect(installText).not.toContain(fragment);
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Updates the Hermes GPU live proof to assert the canonical `Docker container mode selected:` message introduced by #6333. The stale `Docker GPU mode selected:` expectation failed the exact-candidate fallback E2E after container recreation, Ready state, and CUDA verification had already succeeded.

## Changes

- Require the canonical container-mode selection message for fallback and compatibility-only routes.
- Verify that the native route does not emit the compatibility container-mode message.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only an internal live-test assertion; user-facing GPU routing, configuration, commands, and documented behavior are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/hermes-gpu-startup-fallback.test.ts test/e2e/support/hermes-gpu-startup-integrity.test.ts test/e2e/support/hermes-workflow-boundary.test.ts` (38 passed); live-test collection passed for native, fallback, and compatibility-only scenarios
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end validation to reflect revised Docker startup messaging.
  * Added coverage for container-mode logging in compatibility and fallback scenarios.
  * Confirmed container-mode messaging is absent for other GPU routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->