### PR TITLE
fix(release): handle empty label search output

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-day/scripts/bump-stragglers.ts
+++ b/.agents/skills/nemoclaw-maintainer-day/scripts/bump-stragglers.ts
@@ -106,18 +106,10 @@ function main(): void {
 }
 
 function ensureReleaseLabel(repo: string, label: string): void {
-  const labels = ghJsonArray<{ name: string }>([
-    "label",
-    "list",
-    "--repo",
-    repo,
-    "--search",
-    label,
-    "--json",
-    "name",
-    "--limit",
-    "100",
-  ]);
+  const labels = ghJsonArray<{ name: string }>(
+    ["label", "list", "--repo", repo, "--search", label, "--json", "name", "--limit", "100"],
+    { emptyOutputIsEmptyArray: true },
+  );
   if (labels.some((entry) => entry.name === label)) return;
 
   gh([
@@ -133,8 +125,12 @@ function ensureReleaseLabel(repo: string, label: string): void {
   ]);
 }
 
-function ghJsonArray<T>(args: string[]): T[] {
+function ghJsonArray<T>(
+  args: string[],
+  { emptyOutputIsEmptyArray = false }: { emptyOutputIsEmptyArray?: boolean } = {},
+): T[] {
   const output = gh(args);
+  if (output === "" && emptyOutputIsEmptyArray) return [];
   try {
     const parsed = JSON.parse(output) as unknown;
     if (!Array.isArray(parsed)) {

--- a/test/bump-stragglers.test.ts
+++ b/test/bump-stragglers.test.ts
@@ -62,6 +62,22 @@ esac
     });
   });
 
+  it("creates the target label when a successful lookup returns no output", () => {
+    const result = runBumpStragglers(`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "label list"*) ;;
+  "label create v1.2.4"*) : > "$0.created" ;;
+  "pr list"*) test -f "$0.created"; printf '[]' ;;
+  "issue list"*) printf '[]' ;;
+  *) echo "unexpected gh args: $*" >&2; exit 9 ;;
+esac
+`);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ from: "v1.2.3", to: "v1.2.4", bumped: [] });
+  });
+
   it("fails visibly when gh label lookup fails", () => {
     const result = runBumpStragglers(`#!/usr/bin/env bash
 set -euo pipefail
@@ -118,6 +134,37 @@ esac
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("Failed to parse gh JSON output");
+    expect(result.stdout).toBe("");
+  });
+
+  it("fails visibly when a successful PR lookup returns no output", () => {
+    const result = runBumpStragglers(`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "label list"*) printf '[{"name":"v1.2.4"}]' ;;
+  "pr list"*) ;;
+  *) echo "unexpected gh args: $*" >&2; exit 9 ;;
+esac
+`);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Failed to parse gh JSON output for gh pr list");
+    expect(result.stdout).toBe("");
+  });
+
+  it("fails visibly when a successful issue lookup returns no output", () => {
+    const result = runBumpStragglers(`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "label list"*) printf '[{"name":"v1.2.4"}]' ;;
+  "pr list"*) printf '[]' ;;
+  "issue list"*) ;;
+  *) echo "unexpected gh args: $*" >&2; exit 9 ;;
+esac
+`);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Failed to parse gh JSON output for gh issue list");
     expect(result.stdout).toBe("");
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Post-tag carry-forward aborted before changing labels because `gh label list --search` exited successfully with no output and the release helper tried to parse that output as JSON. A successful empty label search now means no matching label, while PR and issue inventory remain fail-closed.

## Changes

- Accept successful empty output only for the target-label lookup so the helper can create a missing release label.
- Keep empty, malformed, non-array, and failed PR or issue inventory queries from reporting false housekeeping success.
- Add regression coverage that proves the empty label lookup reaches label creation and that empty PR or issue inventory still fails visibly.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal maintainer release-housekeeping helper and does not change user-facing commands, configuration, runtime behavior, or documentation.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/bump-stragglers.test.ts` passed 10/10 after the hook formatter update.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run for this focused maintainer-helper fix.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release housekeeping when label searches return no results, allowing missing labels to be created successfully.
  * Preserved clear error reporting when pull request or issue lookups return invalid or empty data.

* **Tests**
  * Added coverage for successful label creation and lookup failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->