### PR TITLE
feat(sandbox): add stop and start container lifecycle commands

### DIFF
--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -193,6 +193,26 @@ For full details on port conflicts and overrides, refer to [Port already in use]
 
 </AgentOnly>
 
+## Stop and Start a Sandbox
+
+Stop a sandbox's container to free CPU, memory, and GPU resources without losing anything:
+
+```bash
+$$nemoclaw <sandbox-name> stop
+```
+
+Workspace files, credentials, network policies, and the registry entry are preserved; only the container stops running.
+The shared host gateway and tunnel services keep serving other sandboxes.
+
+Start it again later; NemoClaw restarts the container and repairs the in-sandbox gateway and host forwards:
+
+```bash
+$$nemoclaw <sandbox-name> start
+```
+
+Refer to [`$$nemoclaw <name> stop`](../reference/commands#$$nemoclaw-name-stop) and [`$$nemoclaw <name> start`](../reference/commands#$$nemoclaw-name-start) for details.
+Use [`$$nemoclaw <name> destroy`](../reference/commands#$$nemoclaw-name-destroy) when you want to delete the sandbox instead.
+
 ## Reconfigure or Recover
 
 Recover from a misconfigured sandbox without re-running the full onboard wizard or destroying workspace state.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1125,6 +1125,34 @@ Terminal agents do not have a gateway runtime and fail as unsupported.
 
 </AgentOnly>
 
+### `$$nemoclaw <name> stop`
+
+Stop the sandbox's Docker container while preserving all of its state.
+Workspace files, credentials, network policies, the registry entry, and the OpenShell sandbox record stay in place; only the container stops running.
+Use this to free CPU, memory, and GPU resources without destroying the sandbox; use [`$$nemoclaw <name> destroy`](#$$nemoclaw-name-destroy) when you want to delete it instead.
+
+```bash
+$$nemoclaw my-assistant stop
+```
+
+For OpenClaw-managed gateways, the command first asks the in-sandbox gateway to shut down its channels gracefully; agent-managed gateways (for example Hermes) are supervised inside the sandbox and shut down with the container's stop signal.
+Then the container stops; a container stuck in a crash loop is stopped the same way, which also disarms its restart policy.
+The shared host gateway, tunnel services, and any local NIM inference container serve other sandboxes and keep running.
+Stopping an already-stopped sandbox succeeds without changes.
+The command controls the local Docker container directly, so it requires a Docker-driver sandbox on this host; if the Docker daemon itself is unreachable, the command reports the outage instead of guessing at container state.
+
+### `$$nemoclaw <name> start`
+
+Restart a sandbox container that was stopped with [`$$nemoclaw <name> stop`](#$$nemoclaw-name-stop) or by a host reboot, then repair the in-sandbox gateway and host-side forwards the same way [`$$nemoclaw <name> recover`](#$$nemoclaw-name-recover) does.
+
+```bash
+$$nemoclaw my-assistant start
+```
+
+Starting an already-running sandbox skips the container start and still runs the gateway and forward health checks.
+A paused container is unpaused.
+If the container was removed entirely, `start` fails and points you to `$$nemoclaw <name> rebuild`.
+
 ### `$$nemoclaw <name> status`
 
 Show sandbox-scoped status, health, and inference configuration for one registered sandbox.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1139,7 +1139,7 @@ For OpenClaw-managed gateways, the command first asks the in-sandbox gateway to 
 Then the container stops; a container stuck in a crash loop is stopped the same way, which also disarms its restart policy.
 The shared host gateway, tunnel services, and any local NIM inference container serve other sandboxes and keep running.
 Stopping an already-stopped sandbox succeeds without changes.
-The command controls the local Docker container directly, so it requires a Docker-driver sandbox on this host; if the Docker daemon itself is unreachable, the command reports the outage instead of guessing at container state.
+The command controls the local container directly, so it is available for local-container drivers (the default Docker driver and the vm driver) and unavailable for remote drivers such as kubernetes; if the Docker daemon itself is unreachable, the command reports the outage instead of guessing at container state.
 
 ### `$$nemoclaw <name> start`
 

--- a/src/commands/sandbox/start.test.ts
+++ b/src/commands/sandbox/start.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const startSandbox = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/actions/sandbox/start", () => ({ startSandbox }));
+
+import SandboxStartCommand from "./start";
+
+const rootDir = process.cwd();
+
+describe("SandboxStartCommand", () => {
+  beforeEach(() => {
+    startSandbox.mockClear();
+    startSandbox.mockResolvedValue({ exitCode: 0 });
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  it("starts the named sandbox (#6026)", async () => {
+    await SandboxStartCommand.run(["alpha"], rootDir);
+
+    expect(startSandbox).toHaveBeenCalledWith("alpha");
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("propagates the action's failure exit code (#6026)", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    startSandbox.mockResolvedValue({ exitCode: 1, message: "  boom" });
+
+    await SandboxStartCommand.run(["alpha"], rootDir);
+
+    expect(process.exitCode).toBe(1);
+    expect(error).toHaveBeenCalledWith("  boom");
+    error.mockRestore();
+  });
+
+  it("requires a sandbox name (#6026)", async () => {
+    await expect(SandboxStartCommand.run([], rootDir)).rejects.toThrow(/sandbox/i);
+
+    expect(startSandbox).not.toHaveBeenCalled();
+  });
+
+  it("rejects extra positional arguments (#6026)", async () => {
+    await expect(SandboxStartCommand.run(["alpha", "extra"], rootDir)).rejects.toThrow();
+
+    expect(startSandbox).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/sandbox/start.ts
+++ b/src/commands/sandbox/start.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Args } from "@oclif/core";
+
+import { startSandbox } from "../../lib/actions/sandbox/start";
+import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
+
+export default class SandboxStartCommand extends NemoClawCommand {
+  static id = "sandbox:start";
+  static strict = true;
+  static summary = "Restart a stopped sandbox container";
+  static description =
+    "Start a sandbox container that was stopped with 'stop' (or by a host reboot), then repair the in-sandbox gateway and host forwards the same way 'recover' does.";
+  static usage = ["<name>"];
+  static examples = ["<%= config.bin %> sandbox start alpha"];
+  static args = {
+    sandboxName: Args.string({ name: "sandbox", description: "Sandbox name", required: true }),
+  };
+  static flags = {};
+
+  public async run(): Promise<void> {
+    const { args } = await this.parse(SandboxStartCommand);
+    this.applyExitResult(await startSandbox(args.sandboxName));
+  }
+}

--- a/src/commands/sandbox/stop.test.ts
+++ b/src/commands/sandbox/stop.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const stopSandbox = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/actions/sandbox/stop", () => ({ stopSandbox }));
+
+import SandboxStopCommand from "./stop";
+
+const rootDir = process.cwd();
+
+describe("SandboxStopCommand", () => {
+  beforeEach(() => {
+    stopSandbox.mockClear();
+    stopSandbox.mockReturnValue({ exitCode: 0 });
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  it("stops the named sandbox (#6026)", async () => {
+    await SandboxStopCommand.run(["alpha"], rootDir);
+
+    expect(stopSandbox).toHaveBeenCalledWith("alpha");
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("propagates the action's failure exit code (#6026)", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    stopSandbox.mockReturnValue({ exitCode: 1, message: "  boom" });
+
+    await SandboxStopCommand.run(["alpha"], rootDir);
+
+    expect(process.exitCode).toBe(1);
+    expect(error).toHaveBeenCalledWith("  boom");
+    error.mockRestore();
+  });
+
+  it("requires a sandbox name (#6026)", async () => {
+    await expect(SandboxStopCommand.run([], rootDir)).rejects.toThrow(/sandbox/i);
+
+    expect(stopSandbox).not.toHaveBeenCalled();
+  });
+
+  it("rejects extra positional arguments (#6026)", async () => {
+    await expect(SandboxStopCommand.run(["alpha", "extra"], rootDir)).rejects.toThrow();
+
+    expect(stopSandbox).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/sandbox/stop.ts
+++ b/src/commands/sandbox/stop.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Args } from "@oclif/core";
+
+import { stopSandbox } from "../../lib/actions/sandbox/stop";
+import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
+
+export default class SandboxStopCommand extends NemoClawCommand {
+  static id = "sandbox:stop";
+  static strict = true;
+  static summary = "Stop the sandbox container, preserving workspace state";
+  static description =
+    "Stop a sandbox's Docker container without deleting anything. Workspace files, credentials, and the registry entry are preserved; restart later with 'start'. Use 'destroy' to delete the sandbox instead.";
+  static usage = ["<name>"];
+  static examples = ["<%= config.bin %> sandbox stop alpha"];
+  static args = {
+    sandboxName: Args.string({ name: "sandbox", description: "Sandbox name", required: true }),
+  };
+  static flags = {};
+
+  public async run(): Promise<void> {
+    const { args } = await this.parse(SandboxStopCommand);
+    this.applyExitResult(stopSandbox(args.sandboxName));
+  }
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NemoClawCommand } from "../lib/cli/nemoclaw-oclif-command";
-
-import { startAll } from "../lib/tunnel/services";
-import { runStartCommand } from "../lib/tunnel/service-command";
 import { serviceDeps } from "../lib/tunnel/command-support";
+import { runStartCommand } from "../lib/tunnel/service-command";
+import { startAll } from "../lib/tunnel/services";
 
 export default class DeprecatedStartCommand extends NemoClawCommand {
   static id = "start";
@@ -16,7 +15,8 @@ export default class DeprecatedStartCommand extends NemoClawCommand {
   static examples = ["<%= config.bin %> start"];
   static state = "deprecated" as const;
   static deprecationOptions = {
-    message: "Deprecated: 'nemoclaw start' is now 'nemoclaw tunnel start'. See 'nemoclaw help'.",
+    message:
+      "Deprecated: 'nemoclaw start' is now 'nemoclaw tunnel start'. To start a stopped sandbox container instead, use 'nemoclaw <name> start'. See 'nemoclaw help'.",
   };
   static flags = {};
 

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -17,7 +17,7 @@ export default class DeprecatedStopCommand extends NemoClawCommand {
   static state = "deprecated" as const;
   static deprecationOptions = {
     message:
-      "Deprecated: use 'nemoclaw tunnel stop' for tunnel-only shutdown. This legacy command also releases the managed host gateway port.",
+      "Deprecated: use 'nemoclaw tunnel stop' for tunnel-only shutdown. This legacy command also releases the managed host gateway port. To stop a sandbox container instead, use 'nemoclaw <name> stop'.",
   };
   static flags = {};
 

--- a/src/lib/actions/sandbox/start.test.ts
+++ b/src/lib/actions/sandbox/start.test.ts
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { SandboxEntry } from "../../state/registry";
+import { type SandboxStartDeps, startSandbox } from "./start";
+
+function sandbox(values: Partial<SandboxEntry> = {}): SandboxEntry {
+  return { name: "my-sandbox", ...values };
+}
+
+function harness(overrides: Partial<SandboxStartDeps> = {}) {
+  const getSandbox = vi.fn<NonNullable<SandboxStartDeps["getSandbox"]>>(() => sandbox());
+  const isDockerRuntimeDown = vi.fn<NonNullable<SandboxStartDeps["isDockerRuntimeDown"]>>(
+    () => false,
+  );
+  const printDockerRuntimeDownGuidance =
+    vi.fn<NonNullable<SandboxStartDeps["printDockerRuntimeDownGuidance"]>>();
+  const findLabeledSandboxContainers = vi.fn<
+    NonNullable<SandboxStartDeps["findLabeledSandboxContainers"]>
+  >(() => [{ name: "openshell-my-sandbox", status: "Exited (0) 2 hours ago", running: false }]);
+  const recoverDockerDriverSandbox = vi.fn<
+    NonNullable<SandboxStartDeps["recoverDockerDriverSandbox"]>
+  >(() => ({
+    recovered: true,
+    via: "started-stopped-original",
+    containerName: "openshell-my-sandbox",
+  }));
+  const dockerUnpause = vi.fn<NonNullable<SandboxStartDeps["dockerUnpause"]>>(() => ({
+    status: 0,
+  }));
+  const probeSandbox = vi.fn<NonNullable<SandboxStartDeps["probeSandbox"]>>(() =>
+    Promise.resolve(),
+  );
+  const log = vi.fn<(message: string) => void>();
+  const deps: SandboxStartDeps = {
+    getSandbox,
+    isDockerRuntimeDown,
+    printDockerRuntimeDownGuidance,
+    findLabeledSandboxContainers,
+    recoverDockerDriverSandbox,
+    dockerUnpause,
+    probeSandbox,
+    log,
+    ...overrides,
+  };
+  return {
+    deps,
+    dockerUnpause,
+    findLabeledSandboxContainers,
+    getSandbox,
+    isDockerRuntimeDown,
+    log,
+    printDockerRuntimeDownGuidance,
+    probeSandbox,
+    recoverDockerDriverSandbox,
+  };
+}
+
+describe("startSandbox", () => {
+  it("starts the stopped container and then probes gateway health (#6026)", async () => {
+    const h = harness();
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.recoverDockerDriverSandbox).toHaveBeenCalledWith("my-sandbox");
+    expect(h.probeSandbox).toHaveBeenCalledWith("my-sandbox");
+    expect(h.recoverDockerDriverSandbox.mock.invocationCallOrder[0]).toBeLessThan(
+      h.probeSandbox.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("reports the started container by name (#6026)", async () => {
+    const h = harness();
+
+    await startSandbox("my-sandbox", h.deps);
+
+    const output = h.log.mock.calls.map(([line]) => line).join("\n");
+    expect(output).toContain("openshell-my-sandbox");
+  });
+
+  it("still probes when the container was already running (#6026)", async () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([
+      { name: "openshell-my-sandbox", status: "Up 5 minutes", running: true },
+    ]);
+    h.recoverDockerDriverSandbox.mockReturnValue({
+      recovered: true,
+      via: "started-running-original",
+      containerName: "openshell-my-sandbox",
+    });
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.probeSandbox).toHaveBeenCalledWith("my-sandbox");
+    const output = h.log.mock.calls.map(([line]) => line).join("\n");
+    expect(output).toContain("already running");
+  });
+
+  it("unpauses a paused container instead of calling it already running (#6026)", async () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([
+      { name: "openshell-my-sandbox", status: "Up 3 minutes (Paused)", running: true },
+    ]);
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.dockerUnpause).toHaveBeenCalledWith("openshell-my-sandbox", {
+      ignoreError: true,
+      timeout: 30_000,
+    });
+    expect(h.recoverDockerDriverSandbox).not.toHaveBeenCalled();
+    expect(h.probeSandbox).toHaveBeenCalledWith("my-sandbox");
+    const output = h.log.mock.calls.map(([line]) => line).join("\n");
+    expect(output).toContain("unpaused");
+  });
+
+  it("surfaces a docker unpause failure with the container name (#6026)", async () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([
+      { name: "openshell-my-sandbox", status: "Up 3 minutes (Paused)", running: true },
+    ]);
+    h.dockerUnpause.mockReturnValue({ status: 125 });
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("openshell-my-sandbox");
+    expect(result.message).toContain("125");
+    expect(h.probeSandbox).not.toHaveBeenCalled();
+  });
+
+  it("restores a gpu-backup sibling through the recovery rename path (#6026)", async () => {
+    const h = harness();
+    h.recoverDockerDriverSandbox.mockReturnValue({
+      recovered: true,
+      via: "renamed-and-started-backup",
+      containerName: "openshell-my-sandbox",
+    });
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.probeSandbox).toHaveBeenCalledWith("my-sandbox");
+  });
+
+  it("names the Docker daemon outage instead of claiming the container was removed (#6026)", async () => {
+    const h = harness();
+    h.isDockerRuntimeDown.mockReturnValue(true);
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toBeUndefined();
+    expect(h.printDockerRuntimeDownGuidance).toHaveBeenCalledWith("my-sandbox", {
+      retryCommand: "start",
+    });
+    expect(h.recoverDockerDriverSandbox).not.toHaveBeenCalled();
+    expect(h.probeSandbox).not.toHaveBeenCalled();
+  });
+
+  it("fails with the recovery detail and a rebuild hint when no container exists (#6026)", async () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([]);
+    h.recoverDockerDriverSandbox.mockReturnValue({
+      recovered: false,
+      via: null,
+      detail: "no Docker container labeled 'openshell.ai/sandbox-name=my-sandbox'",
+    });
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("no Docker container labeled");
+    expect(result.message).toContain("rebuild");
+    expect(h.probeSandbox).not.toHaveBeenCalled();
+  });
+
+  it("refuses an unregistered sandbox (#6026)", async () => {
+    const h = harness();
+    h.getSandbox.mockReturnValue(null);
+
+    const result = await startSandbox("ghost", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("not registered");
+    expect(h.recoverDockerDriverSandbox).not.toHaveBeenCalled();
+  });
+
+  it("refuses non-direct drivers instead of guessing at container control (#6026)", async () => {
+    const h = harness();
+    h.getSandbox.mockReturnValue(sandbox({ openshellDriver: "kubernetes" }));
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("kubernetes");
+    expect(h.recoverDockerDriverSandbox).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["null driver", sandbox({ openshellDriver: null })],
+    ["docker driver", sandbox({ openshellDriver: "docker" })],
+    ["vm driver", sandbox({ openshellDriver: "vm" })],
+  ])("allows the %s like privileged exec does (#6026)", async (_label, entry) => {
+    const h = harness();
+    h.getSandbox.mockReturnValue(entry);
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("propagates a probe rejection instead of reporting success (#6026)", async () => {
+    const h = harness();
+    h.probeSandbox.mockRejectedValue(new Error("probe exploded"));
+
+    await expect(startSandbox("my-sandbox", h.deps)).rejects.toThrow("probe exploded");
+  });
+});

--- a/src/lib/actions/sandbox/start.ts
+++ b/src/lib/actions/sandbox/start.ts
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CLI_NAME } from "../../cli/branding";
+import {
+  findLabeledSandboxContainers,
+  recoverDockerDriverSandbox,
+} from "../../onboard/docker-driver-sandbox-recovery";
+import * as registry from "../../state/registry";
+import {
+  gateDirectDriverLifecycle,
+  gateDockerRuntimeUp,
+  type SandboxLifecycleResult,
+  type SandboxStopDeps,
+} from "./stop";
+
+// Lazy requires keep the heavy connect module (and the docker adapter's
+// transitive imports) out of this module's load path; tests inject
+// `deps.probeSandbox` / `deps.dockerUnpause`.
+function loadConnectProbe(): (sandboxName: string) => Promise<void> {
+  const { connectSandbox } = require("./connect") as {
+    connectSandbox: (sandboxName: string, options?: { probeOnly?: boolean }) => Promise<void>;
+  };
+  return (sandboxName) => connectSandbox(sandboxName, { probeOnly: true });
+}
+
+type DockerOpResult = { status?: number | null };
+type DockerUnpauseFn = (name: string, opts?: Record<string, unknown>) => DockerOpResult;
+
+function loadDockerUnpause(): DockerUnpauseFn {
+  return (require("../../adapters/docker") as { dockerUnpause: DockerUnpauseFn }).dockerUnpause;
+}
+
+const DOCKER_UNPAUSE_TIMEOUT_MS = 30_000;
+
+// Paused containers report `Up N minutes (Paused)` from `docker ps`, so the
+// recovery classifier counts them as running and would no-op — while
+// `docker start` on them fails outright. `docker unpause` is the only verb
+// that resumes them (#6026).
+function isPausedStatus(status: string): boolean {
+  return status.startsWith("Up") && status.endsWith("(Paused)");
+}
+
+export interface SandboxStartDeps
+  extends Pick<SandboxStopDeps, "isDockerRuntimeDown" | "printDockerRuntimeDownGuidance"> {
+  getSandbox?: typeof registry.getSandbox;
+  findLabeledSandboxContainers?: typeof findLabeledSandboxContainers;
+  recoverDockerDriverSandbox?: typeof recoverDockerDriverSandbox;
+  dockerUnpause?: DockerUnpauseFn;
+  /** Gateway/forward health probe; defaults to the `recover` action body. */
+  probeSandbox?: (sandboxName: string) => Promise<void>;
+  log?: (message: string) => void;
+}
+
+/**
+ * Restart a stopped sandbox container and bring its gateway and host
+ * forwards back up (#6026). Counterpart to `stopSandbox`.
+ *
+ * Container restart reuses the #4423 recovery module (handles the stopped
+ * original and the gpu-backup-sibling rename) plus a paused-container
+ * unpause branch; the health probe reuses the `recover` action body so
+ * forwards and the in-sandbox gateway come back exactly as they would after
+ * `nemoclaw <name> recover`.
+ */
+export async function startSandbox(
+  sandboxName: string,
+  deps: SandboxStartDeps = {},
+): Promise<SandboxLifecycleResult> {
+  const log = deps.log ?? console.log;
+
+  const gate = gateDirectDriverLifecycle(
+    sandboxName,
+    "start",
+    deps.getSandbox ?? registry.getSandbox,
+  );
+  if (gate) return gate;
+
+  const runtimeGate = gateDockerRuntimeUp(sandboxName, "start", deps);
+  if (runtimeGate) return runtimeGate;
+
+  const containers = (deps.findLabeledSandboxContainers ?? findLabeledSandboxContainers)(
+    sandboxName,
+  );
+  const paused = containers.find((container) => isPausedStatus(container.status));
+  if (paused) {
+    const dockerUnpause = deps.dockerUnpause ?? ((name, opts) => loadDockerUnpause()(name, opts));
+    const result = dockerUnpause(paused.name, {
+      ignoreError: true,
+      timeout: DOCKER_UNPAUSE_TIMEOUT_MS,
+    });
+    if (result.status !== 0) {
+      return {
+        exitCode: 1,
+        message: `  docker unpause ${paused.name} failed (exit ${result.status ?? "unknown"}).`,
+      };
+    }
+    log(`  Container '${paused.name}' unpaused.`);
+  } else {
+    const recovery = (deps.recoverDockerDriverSandbox ?? recoverDockerDriverSandbox)(sandboxName);
+    if (!recovery.recovered) {
+      return {
+        exitCode: 1,
+        message:
+          `  Could not start sandbox '${sandboxName}': ${recovery.detail ?? "unknown failure"}. ` +
+          `If the container was removed, run '${CLI_NAME} ${sandboxName} rebuild' to recreate it.`,
+      };
+    }
+
+    if (recovery.via === "started-running-original") {
+      log(`  Sandbox '${sandboxName}' is already running.`);
+    } else {
+      log(`  Container '${recovery.containerName ?? sandboxName}' started.`);
+    }
+  }
+
+  log("  Checking gateway health and host forwards…");
+  await (deps.probeSandbox ?? loadConnectProbe())(sandboxName);
+  return { exitCode: 0 };
+}

--- a/src/lib/actions/sandbox/stop.test.ts
+++ b/src/lib/actions/sandbox/stop.test.ts
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { SandboxEntry } from "../../state/registry";
+import { type SandboxStopDeps, stopSandbox } from "./stop";
+
+function sandbox(values: Partial<SandboxEntry> = {}): SandboxEntry {
+  return { name: "my-sandbox", ...values };
+}
+
+function container(name: string, running: boolean) {
+  return { name, status: running ? "Up 5 minutes" : "Exited (0) 2 hours ago", running };
+}
+
+function harness(overrides: Partial<SandboxStopDeps> = {}) {
+  const getSandbox = vi.fn<NonNullable<SandboxStopDeps["getSandbox"]>>(() => sandbox());
+  const isDockerRuntimeDown = vi.fn<NonNullable<SandboxStopDeps["isDockerRuntimeDown"]>>(
+    () => false,
+  );
+  const printDockerRuntimeDownGuidance =
+    vi.fn<NonNullable<SandboxStopDeps["printDockerRuntimeDownGuidance"]>>();
+  const findLabeledSandboxContainers = vi.fn<
+    NonNullable<SandboxStopDeps["findLabeledSandboxContainers"]>
+  >(() => [container("openshell-my-sandbox", true)]);
+  const stopSandboxChannels = vi.fn<NonNullable<SandboxStopDeps["stopSandboxChannels"]>>();
+  const dockerStop = vi.fn<NonNullable<SandboxStopDeps["dockerStop"]>>(() => ({ status: 0 }));
+  const log = vi.fn<(message: string) => void>();
+  const warn = vi.fn<(message: string) => void>();
+  const deps: SandboxStopDeps = {
+    getSandbox,
+    isDockerRuntimeDown,
+    printDockerRuntimeDownGuidance,
+    findLabeledSandboxContainers,
+    stopSandboxChannels,
+    dockerStop,
+    log,
+    warn,
+    ...overrides,
+  };
+  return {
+    deps,
+    dockerStop,
+    findLabeledSandboxContainers,
+    getSandbox,
+    isDockerRuntimeDown,
+    log,
+    printDockerRuntimeDownGuidance,
+    stopSandboxChannels,
+    warn,
+  };
+}
+
+describe("stopSandbox", () => {
+  it("gracefully stops in-sandbox channels before stopping the container (#6026)", () => {
+    const h = harness();
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.stopSandboxChannels).toHaveBeenCalledWith(
+      "my-sandbox",
+      expect.objectContaining({ info: expect.any(Function), warn: expect.any(Function) }),
+    );
+    expect(h.dockerStop).toHaveBeenCalledWith("openshell-my-sandbox", {
+      ignoreError: true,
+      timeout: 30_000,
+    });
+    expect(h.stopSandboxChannels.mock.invocationCallOrder[0]).toBeLessThan(
+      h.dockerStop.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("routes channel-stop reporter lines through the action's log and warn (#6026)", () => {
+    const h = harness();
+    h.stopSandboxChannels.mockImplementation((_name, channelDeps) => {
+      channelDeps?.info?.("gateway stopped inside sandbox.");
+      channelDeps?.warn?.("could not reach gateway.");
+    });
+
+    stopSandbox("my-sandbox", h.deps);
+
+    expect(h.log).toHaveBeenCalledWith("  gateway stopped inside sandbox.");
+    expect(h.warn).toHaveBeenCalledWith("  could not reach gateway.");
+  });
+
+  it("preserves the registry entry and tells the user how to start again (#6026)", () => {
+    const h = harness();
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    const output = h.log.mock.calls.map(([line]) => line).join("\n");
+    expect(output).toContain("Workspace state is preserved");
+    expect(output).toContain("nemoclaw my-sandbox start");
+  });
+
+  it("succeeds idempotently when the container is already stopped (#6026)", () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([container("openshell-my-sandbox", false)]);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.dockerStop).not.toHaveBeenCalled();
+    const output = h.log.mock.calls.map(([line]) => line).join("\n");
+    expect(output).toContain("already stopped");
+  });
+
+  it("stops a crash-looping container instead of calling it stopped (#6026)", () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([
+      { name: "openshell-my-sandbox", status: "Restarting (137) 2 seconds ago", running: false },
+    ]);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.dockerStop).toHaveBeenCalledWith("openshell-my-sandbox", {
+      ignoreError: true,
+      timeout: 30_000,
+    });
+  });
+
+  it("stops a paused container (#6026)", () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([
+      { name: "openshell-my-sandbox", status: "Up 5 minutes (Paused)", running: true },
+    ]);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.dockerStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops every running labeled container, including backup siblings (#6026)", () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([
+      container("openshell-my-sandbox", true),
+      container("openshell-my-sandbox-nemoclaw-gpu-backup-1700000000000", true),
+    ]);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.dockerStop).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues to docker stop when the graceful channel stop throws (#6026)", () => {
+    const h = harness();
+    h.stopSandboxChannels.mockImplementation(() => {
+      throw new Error("gateway unreachable");
+    });
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.dockerStop).toHaveBeenCalledTimes(1);
+    const warned = h.warn.mock.calls.map(([line]) => line).join("\n");
+    expect(warned).toContain("gateway unreachable");
+  });
+
+  it("names the Docker daemon outage instead of claiming the container was removed (#6026)", () => {
+    const h = harness();
+    h.isDockerRuntimeDown.mockReturnValue(true);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toBeUndefined();
+    expect(h.printDockerRuntimeDownGuidance).toHaveBeenCalledWith("my-sandbox", {
+      retryCommand: "stop",
+    });
+    expect(h.findLabeledSandboxContainers).not.toHaveBeenCalled();
+    expect(h.dockerStop).not.toHaveBeenCalled();
+  });
+
+  it("fails with a rebuild hint when no labeled container exists (#6026)", () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([]);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("No Docker container");
+    expect(result.message).toContain("rebuild");
+    expect(h.dockerStop).not.toHaveBeenCalled();
+  });
+
+  it("refuses an unregistered sandbox (#6026)", () => {
+    const h = harness();
+    h.getSandbox.mockReturnValue(null);
+
+    const result = stopSandbox("ghost", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("not registered");
+    expect(h.findLabeledSandboxContainers).not.toHaveBeenCalled();
+  });
+
+  it("refuses non-direct drivers instead of guessing at container control (#6026)", () => {
+    const h = harness();
+    h.getSandbox.mockReturnValue(sandbox({ openshellDriver: "kubernetes" }));
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("kubernetes");
+    expect(h.dockerStop).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["null driver", sandbox({ openshellDriver: null })],
+    ["docker driver", sandbox({ openshellDriver: "docker" })],
+    ["vm driver", sandbox({ openshellDriver: "vm" })],
+  ])("allows the %s like privileged exec does (#6026)", (_label, entry) => {
+    const h = harness();
+    h.getSandbox.mockReturnValue(entry);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("surfaces a docker stop failure with the container name (#6026)", () => {
+    const h = harness();
+    h.dockerStop.mockReturnValue({ status: 125 });
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("openshell-my-sandbox");
+    expect(result.message).toContain("125");
+  });
+
+  it("never removes containers or touches the registry entry (#6026)", () => {
+    const h = harness();
+
+    stopSandbox("my-sandbox", h.deps);
+
+    // The deps surface has no removal lever at all; assert the only docker
+    // mutation issued is the stop of the labeled container.
+    expect(h.dockerStop.mock.calls).toEqual([
+      ["openshell-my-sandbox", { ignoreError: true, timeout: 30_000 }],
+    ]);
+  });
+});

--- a/src/lib/actions/sandbox/stop.test.ts
+++ b/src/lib/actions/sandbox/stop.test.ts
@@ -235,6 +235,32 @@ describe("stopSandbox", () => {
     expect(result.message).toContain("125");
   });
 
+  it("attempts every container and aggregates failures when one stop fails (#6026)", () => {
+    const h = harness();
+    h.findLabeledSandboxContainers.mockReturnValue([
+      container("openshell-my-sandbox", true),
+      container("openshell-my-sandbox-nemoclaw-gpu-backup-1700000000000", true),
+    ]);
+    // First container fails to stop; the sibling still must be attempted.
+    h.dockerStop.mockReturnValueOnce({ status: 137 }).mockReturnValueOnce({ status: 0 });
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(h.dockerStop).toHaveBeenCalledTimes(2);
+    expect(h.dockerStop).toHaveBeenNthCalledWith(
+      2,
+      "openshell-my-sandbox-nemoclaw-gpu-backup-1700000000000",
+      {
+        ignoreError: true,
+        timeout: 30_000,
+      },
+    );
+    expect(result.message).toContain("openshell-my-sandbox");
+    expect(result.message).toContain("137");
+    expect(result.message).not.toContain("gpu-backup");
+  });
+
   it("never removes containers or touches the registry entry (#6026)", () => {
     const h = harness();
 

--- a/src/lib/actions/sandbox/stop.ts
+++ b/src/lib/actions/sandbox/stop.ts
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CLI_NAME } from "../../cli/branding";
+import { findLabeledSandboxContainers } from "../../onboard/docker-driver-sandbox-recovery";
+import * as registry from "../../state/registry";
+import { stopSandboxChannels } from "../../tunnel/sandbox-gateway-stop";
+import { isDockerRuntimeDown, printDockerRuntimeDownGuidance } from "./gateway-failure-classifier";
+
+// Lazy adapter accessor, same pattern as docker-driver-sandbox-recovery.ts:
+// tests inject `deps.dockerStop` so the lazy require never fires.
+type DockerOpResult = { status?: number | null };
+type DockerStopFn = (name: string, opts?: Record<string, unknown>) => DockerOpResult;
+
+function loadDockerStop(): DockerStopFn {
+  return (require("../../adapters/docker") as { dockerStop: DockerStopFn }).dockerStop;
+}
+
+const DOCKER_STOP_TIMEOUT_MS = 30_000;
+
+// Docker `Status` strings for containers that hold no resources: nothing to
+// stop. Everything else — `Up`, `Up … (Paused)`, and crash-looping
+// `Restarting (N) …` — is stoppable; `docker stop` also disarms an armed
+// restart policy, which is exactly how a crash loop is silenced (#6026).
+const AT_REST_STATUS_PREFIXES = ["Exited", "Created", "Dead"] as const;
+
+function isAtRest(status: string): boolean {
+  return AT_REST_STATUS_PREFIXES.some((prefix) => status.startsWith(prefix));
+}
+
+export type SandboxLifecycleResult = {
+  exitCode: number;
+  message?: string;
+};
+
+export interface SandboxStopDeps {
+  getSandbox?: typeof registry.getSandbox;
+  isDockerRuntimeDown?: typeof isDockerRuntimeDown;
+  printDockerRuntimeDownGuidance?: typeof printDockerRuntimeDownGuidance;
+  findLabeledSandboxContainers?: typeof findLabeledSandboxContainers;
+  stopSandboxChannels?: typeof stopSandboxChannels;
+  dockerStop?: DockerStopFn;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+function normalizeDriver(driver: unknown): string | null {
+  return typeof driver === "string" && driver.trim() ? driver.trim().toLowerCase() : null;
+}
+
+/**
+ * Refuse lifecycle control for sandboxes we cannot reach through the local
+ * Docker daemon. Mirrors the gate `privilegedSandboxExecArgv` applies before
+ * direct-container mutation (src/lib/sandbox/privileged-exec.ts).
+ */
+export function gateDirectDriverLifecycle(
+  sandboxName: string,
+  action: "stop" | "start",
+  getSandbox: typeof registry.getSandbox,
+): SandboxLifecycleResult | null {
+  const entry = getSandbox(sandboxName);
+  if (!entry) {
+    return {
+      exitCode: 1,
+      message:
+        `  Sandbox '${sandboxName}' is not registered. ` +
+        `Run '${CLI_NAME} list' to see registered sandboxes.`,
+    };
+  }
+  const driver = normalizeDriver(entry.openshellDriver);
+  if (driver !== null && driver !== "docker" && driver !== "vm") {
+    return {
+      exitCode: 1,
+      message:
+        `  '${CLI_NAME} ${sandboxName} ${action}' controls the local Docker container ` +
+        `directly and is unavailable for driver '${driver}'.`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Fail fast with the shared #4428 outage guidance when the Docker daemon is
+ * unreachable. Without this preflight an empty `docker ps` result is
+ * indistinguishable from "no containers", and stop/start would misreport a
+ * daemon outage as a removed container and steer the user toward `rebuild` —
+ * exactly the guidance printDockerRuntimeDownGuidance exists to prevent.
+ */
+export function gateDockerRuntimeUp(
+  sandboxName: string,
+  retryCommand: "stop" | "start",
+  deps: Pick<SandboxStopDeps, "isDockerRuntimeDown" | "printDockerRuntimeDownGuidance">,
+): SandboxLifecycleResult | null {
+  if (!(deps.isDockerRuntimeDown ?? isDockerRuntimeDown)(sandboxName)) return null;
+  (deps.printDockerRuntimeDownGuidance ?? printDockerRuntimeDownGuidance)(sandboxName, {
+    retryCommand,
+  });
+  return { exitCode: 1 };
+}
+
+/**
+ * Stop a sandbox's Docker container while preserving every piece of state
+ * destroy would remove: the workspace volume, registry entry, OpenShell
+ * sandbox record, credentials, and images all stay in place (#6026).
+ *
+ * The shared host gateway, tunnel, and any NIM inference container are
+ * gateway-scoped and serve other sandboxes — deliberately untouched.
+ */
+export function stopSandbox(
+  sandboxName: string,
+  deps: SandboxStopDeps = {},
+): SandboxLifecycleResult {
+  const log = deps.log ?? console.log;
+  const warn = deps.warn ?? console.warn;
+
+  const gate = gateDirectDriverLifecycle(
+    sandboxName,
+    "stop",
+    deps.getSandbox ?? registry.getSandbox,
+  );
+  if (gate) return gate;
+
+  const runtimeGate = gateDockerRuntimeUp(sandboxName, "stop", deps);
+  if (runtimeGate) return runtimeGate;
+
+  const containers = (deps.findLabeledSandboxContainers ?? findLabeledSandboxContainers)(
+    sandboxName,
+  );
+  if (containers.length === 0) {
+    return {
+      exitCode: 1,
+      message:
+        `  No Docker container found for sandbox '${sandboxName}'. ` +
+        `If the container was removed, run '${CLI_NAME} ${sandboxName} rebuild' to recreate it.`,
+    };
+  }
+
+  const stoppable = containers.filter((container) => !isAtRest(container.status));
+  if (stoppable.length === 0) {
+    log(`  Sandbox '${sandboxName}' is already stopped.`);
+    log(`  Start it again with '${CLI_NAME} ${sandboxName} start'.`);
+    return { exitCode: 0 };
+  }
+
+  // Graceful in-sandbox gateway shutdown first, so channels disconnect
+  // cleanly instead of dying with the container's SIGTERM. Best-effort:
+  // a stop must still free resources when the gateway is unreachable.
+  // Agent-managed gateways (e.g. Hermes) are supervised inside the sandbox
+  // and shut down with the container's stop signal instead.
+  try {
+    (deps.stopSandboxChannels ?? stopSandboxChannels)(sandboxName, {
+      info: (message) => log(`  ${message}`),
+      warn: (message) => warn(`  ${message}`),
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    warn(`  Warning: could not stop in-sandbox channels gracefully: ${detail}`);
+  }
+
+  const dockerStop = deps.dockerStop ?? ((name, opts) => loadDockerStop()(name, opts));
+  for (const container of stoppable) {
+    log(`  Stopping container '${container.name}'…`);
+    const result = dockerStop(container.name, {
+      ignoreError: true,
+      timeout: DOCKER_STOP_TIMEOUT_MS,
+    });
+    if (result.status !== 0) {
+      return {
+        exitCode: 1,
+        message: `  docker stop ${container.name} failed (exit ${result.status ?? "unknown"}).`,
+      };
+    }
+  }
+
+  log(`  Sandbox '${sandboxName}' stopped. Workspace state is preserved.`);
+  log(`  Start it again with '${CLI_NAME} ${sandboxName} start'.`);
+  return { exitCode: 0 };
+}

--- a/src/lib/actions/sandbox/stop.ts
+++ b/src/lib/actions/sandbox/stop.ts
@@ -157,7 +157,12 @@ export function stopSandbox(
     warn(`  Warning: could not stop in-sandbox channels gracefully: ${detail}`);
   }
 
+  // Attempt every stoppable container even if one fails: a sandbox can have
+  // more than one labeled container (e.g. a gpu-backup sibling), and aborting
+  // on the first failure would leave the rest running — the opposite of what
+  // stop is for. Collect failures and report them together.
   const dockerStop = deps.dockerStop ?? ((name, opts) => loadDockerStop()(name, opts));
+  const failures: string[] = [];
   for (const container of stoppable) {
     log(`  Stopping container '${container.name}'…`);
     const result = dockerStop(container.name, {
@@ -165,11 +170,15 @@ export function stopSandbox(
       timeout: DOCKER_STOP_TIMEOUT_MS,
     });
     if (result.status !== 0) {
-      return {
-        exitCode: 1,
-        message: `  docker stop ${container.name} failed (exit ${result.status ?? "unknown"}).`,
-      };
+      failures.push(`${container.name} (exit ${result.status ?? "unknown"})`);
     }
+  }
+
+  if (failures.length > 0) {
+    return {
+      exitCode: 1,
+      message: `  docker stop failed for: ${failures.join(", ")}.`,
+    };
   }
 
   log(`  Sandbox '${sandboxName}' stopped. Workspace state is preserved.`);

--- a/src/lib/adapters/docker/container.ts
+++ b/src/lib/adapters/docker/container.ts
@@ -17,6 +17,10 @@ export function dockerStart(containerName: string, opts: DockerRunOptions = {}):
   return dockerRun(["start", containerName], opts);
 }
 
+export function dockerUnpause(containerName: string, opts: DockerRunOptions = {}): DockerRunResult {
+  return dockerRun(["unpause", containerName], opts);
+}
+
 // NIM (and most Python services) write errors to stderr, so a stdout-only
 // capture would silently lose the auth-error tail. Use dockerRun so we can
 // read both streams from the SpawnResult and concatenate them. Bounded by a

--- a/src/lib/cli/public-display-defaults.ts
+++ b/src/lib/cli/public-display-defaults.ts
@@ -399,6 +399,18 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
       order: 3.5,
     },
   ],
+  "sandbox:stop": [
+    {
+      group: "Sandbox Management",
+      order: 3.6,
+    },
+  ],
+  "sandbox:start": [
+    {
+      group: "Sandbox Management",
+      order: 3.7,
+    },
+  ],
   "sandbox:share:mount": [
     {
       group: "Sandbox Management",

--- a/test/package-contract/cli/command-registry.test.ts
+++ b/test/package-contract/cli/command-registry.test.ts
@@ -56,16 +56,17 @@ describe("command-registry", () => {
   });
 
   describe("sandboxCommands()", () => {
-    it("should return exactly 58 entries", () => {
-      // 50 visible + 8 hidden (shields×3 + config get/set/rotate-token +
+    it("should return exactly 60 entries", () => {
+      // 52 visible + 8 hidden (shields×3 + config get/set/rotate-token +
       // inference get/set).
-      // 50 visible includes the sessions group (root + list + reset + delete +
+      // 52 visible includes the sessions group (root + list + reset + delete +
       // export), the agents quartet (add + apply + delete + list), the
-      // singular `agent` passthrough that forwards to `openclaw agent`, and
-      // the download + upload host-side openshell wrappers, plus five MCP
-      // bridge display entries under the `mcp` parent and the gateway restart
-      // command under the `gateway` parent.
-      expect(sandboxCommands()).toHaveLength(58);
+      // singular `agent` passthrough that forwards to `openclaw agent`, the
+      // download + upload host-side openshell wrappers, the stop + start
+      // container lifecycle pair (#6026), plus five MCP bridge display entries
+      // under the `mcp` parent and the gateway restart command under the
+      // `gateway` parent.
+      expect(sandboxCommands()).toHaveLength(60);
     });
 
     it("every entry has scope sandbox", () => {
@@ -224,9 +225,9 @@ describe("command-registry", () => {
   });
 
   describe("sandboxActionTokens()", () => {
-    it("returns exactly 33 unique action tokens including empty string", () => {
+    it("returns exactly 35 unique action tokens including empty string", () => {
       const tokens = sandboxActionTokens();
-      expect(tokens).toHaveLength(33);
+      expect(tokens).toHaveLength(35);
       // Must contain every first-level sandbox action plus the empty default action.
       const expected = new Set([
         "agent",
@@ -236,6 +237,8 @@ describe("command-registry", () => {
         "download",
         "exec",
         "status",
+        "stop",
+        "start",
         "doctor",
         "inference",
         "logs",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

NemoClaw sandboxes could only be destroyed, never temporarily stopped: the action surface offered `connect`/`exec`/`rebuild`/`destroy`/`recover`, and the deprecated global `nemoclaw stop` controls the tunnel, not the sandbox container. This PR adds `nemoclaw <name> stop` and `nemoclaw <name> start`, which stop and restart the sandbox's Docker container while preserving the workspace volume, registry entry, OpenShell sandbox record, and credentials — so users can free CPU/memory/GPU without losing their workspace.

## Related Issue

Fixes #6026

## Changes

- New `sandbox:stop` action (`src/lib/actions/sandbox/stop.ts`): gracefully stops OpenClaw-managed in-sandbox channels via the existing `stopSandboxChannels`, then `docker stop`s every labeled container that is not at rest. Crash-looping `Restarting (N)` containers are stopped too (docker stop is what disarms an armed restart policy) instead of being misreported as already stopped. Idempotent on already-stopped sandboxes. The shared host gateway, tunnel, and NIM container are gateway-scoped and deliberately untouched.
- New `sandbox:start` action (`src/lib/actions/sandbox/start.ts`): reuses the #4423 docker-driver recovery module (stopped original, gpu-backup-sibling rename), adds a `docker unpause` branch for paused containers (`docker ps` reports them as `Up … (Paused)`, so the recovery classifier alone would no-op while `docker start` fails), then delegates to the `recover` body (`connectSandbox` probe) so the gateway and host forwards return exactly as `recover` restores them.
- Both actions preflight with the existing `isDockerRuntimeDown`/`printDockerRuntimeDownGuidance` (#4428) so a Docker daemon outage is reported as a host runtime problem instead of "no container found — run rebuild". Both gate on the direct-container drivers the privileged-exec path already allows (null/docker/vm) and refuse others.
- New `dockerUnpause` primitive in `src/lib/adapters/docker/container.ts`, mirroring `dockerStop`/`dockerStart` (consumer: the paused-container branch in `startSandbox`; protected by `src/lib/actions/sandbox/start.test.ts`).
- Thin oclif adapters `src/commands/sandbox/stop.ts` / `start.ts` (recover.ts pattern); routing, `Valid actions:` text, and shell completion derive automatically from the registered command IDs.
- Display entries in `public-display-defaults.ts` next to `recover`; package-contract counts updated (58→60 commands, 33→35 action tokens).
- Deprecated global `stop`/`start` deprecation messages now point at the sandbox-scoped commands (the issue's Actual Result shows this exact confusion).
- Docs: `docs/reference/commands.mdx` sections for both commands (dump-commands parity gate), and a "Stop and Start a Sandbox" section in `docs/manage-sandboxes/lifecycle.mdx`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/actions/sandbox/stop.test.ts src/lib/actions/sandbox/start.test.ts src/commands/sandbox/stop.test.ts src/commands/sandbox/start.test.ts src/lib/adapters/docker/index.test.ts` → 52 passed; `npm run build:cli && npx vitest run --project package-contract` → 302 passed; `npm run typecheck:cli` clean
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced sandbox commands: `nemoclaw <sandbox-name> stop` and `nemoclaw <sandbox-name> start`.
  * Start/stop now preserve workspace data/config and verify gateway/host forwarding health; handles paused and already-running containers.
  * Updated CLI command display to include the new sandbox actions.

* **Documentation**
  * Added a “Stop and Start a Sandbox” lifecycle section and expanded the CLI command reference.
  * Enhanced deprecation messaging for legacy start/stop guidance.

* **Bug Fixes**
  * Improved behavior and messaging around Docker/runtime outages and missing containers (with rebuild guidance).

* **Tests**
  * Added command and action test coverage for stop/start flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->