### PR TITLE
fix(onboard): render truthful Ollama status in the inference menu

### DIFF
--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -162,6 +162,7 @@ You can also start it yourself beforehand with `ollama serve`.
 
 You can also use Ollama for Windows.
 During onboarding, NemoClaw can use an already-running Windows-host daemon, start or restart an installed daemon, or install Ollama on the Windows host.
+The Windows-host Ollama path requires Docker Desktop WSL integration; with native Docker Engine inside WSL, the onboarding menu labels the Windows-host actions accordingly, so use the WSL Ollama instance instead.
 If the installer offers express install on WSL, accepting it selects this Windows-host Ollama path automatically.
 When Ollama runs on the Windows host, NemoClaw detects it from WSL through `host.docker.internal` and pulls missing models through the Ollama HTTP API.
 Do not run both the Windows and WSL Ollama instances on port `11434` at the same time.

--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -162,8 +162,9 @@ You can also start it yourself beforehand with `ollama serve`.
 
 You can also use Ollama for Windows.
 During onboarding, NemoClaw can use an already-running Windows-host daemon, start or restart an installed daemon, or install Ollama on the Windows host.
-The Windows-host Ollama path requires Docker Desktop WSL integration; with native Docker Engine inside WSL, the onboarding menu labels the Windows-host actions accordingly, so use the WSL Ollama instance instead.
 If the installer offers express install on WSL, accepting it selects this Windows-host Ollama path automatically.
+The Windows-host Ollama path requires Docker Desktop WSL integration, and the express prompt appears on WSL regardless of the container runtime.
+With native Docker Engine inside WSL, decline the express prompt (or set `NEMOCLAW_NO_EXPRESS=1`) and select the WSL Ollama instance during onboarding; the menu labels the Windows-host actions as requiring Docker Desktop integration.
 When Ollama runs on the Windows host, NemoClaw detects it from WSL through `host.docker.internal` and pulls missing models through the Ollama HTTP API.
 Do not run both the Windows and WSL Ollama instances on port `11434` at the same time.
 Use one instance, or move one of them to a different port before running `$$nemoclaw onboard`.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -108,7 +108,7 @@ When the daemon does not become reachable, onboarding prints PowerShell commands
 Run only one Ollama instance on port `11434` at a time.
 
 Windows-host Ollama requires Docker Desktop WSL integration.
-When NemoClaw detects native Docker Engine inside WSL, it labels the Windows-host actions as requiring Docker Desktop integration and exits with remediation guidance if you select one.
+When NemoClaw detects native Docker Engine inside WSL, it labels the Windows-host actions as requiring Docker Desktop integration; selecting one prints remediation guidance and returns to the menu, or exits when onboarding runs non-interactively.
 
 WSL Ollama paths do not use the authenticated reverse proxy described below.
 

--- a/src/lib/onboard/ollama-install-menu.test.ts
+++ b/src/lib/onboard/ollama-install-menu.test.ts
@@ -28,6 +28,30 @@ describe("resolveRunningOllamaMenuEntry", () => {
         "Local Ollama (Windows host:11434) — running (requires Docker Desktop WSL integration)",
     });
   });
+
+  it("renders a start action for installed-but-stopped Ollama on WSL (#6750)", () => {
+    const entry = resolveRunningOllamaMenuEntry({
+      hasOllama: true,
+      ollamaRunning: false,
+      ollamaHost: null,
+      isWsl: true,
+      ollamaPort: 11434,
+    });
+
+    expect(entry).toEqual({ key: "ollama", label: "Start local Ollama (WSL:11434)" });
+  });
+
+  it("renders a start action for installed-but-stopped Ollama on non-WSL hosts (#6750)", () => {
+    const entry = resolveRunningOllamaMenuEntry({
+      hasOllama: true,
+      ollamaRunning: false,
+      ollamaHost: null,
+      isWsl: false,
+      ollamaPort: 11434,
+    });
+
+    expect(entry).toEqual({ key: "ollama", label: "Start local Ollama (localhost:11434)" });
+  });
 });
 
 describe("resolveOllamaInstallMenuEntry", () => {

--- a/src/lib/onboard/ollama-install-menu.ts
+++ b/src/lib/onboard/ollama-install-menu.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { OLLAMA_HOST_DOCKER_INTERNAL, validateOllamaPortConfiguration } from "../inference/local";
 import { OLLAMA_PORT } from "../core/ports";
+import { OLLAMA_HOST_DOCKER_INTERNAL, validateOllamaPortConfiguration } from "../inference/local";
 import {
   getInstalledOllamaVersion,
   getRunningOllamaDaemonVersion,
@@ -80,9 +80,13 @@ export function resolveRunningOllamaMenuEntry(
     (input.ollamaHost === OLLAMA_HOST_DOCKER_INTERNAL ? !windowsHostSuffix : !input.isWsl);
   const runningSuffix = input.ollamaRunning ? " — running" : "";
   const suggestionSuffix = suggested ? " (suggested)" : "";
+  // A stopped daemon renders as an action, not a status: selecting the entry
+  // starts Ollama, and a bare "Local Ollama (WSL:11434)" reads as a
+  // reachability claim when the daemon is down (#6750).
+  const labelPrefix = input.ollamaRunning ? "Local Ollama" : "Start local Ollama";
   return {
     key: "ollama",
-    label: `Local Ollama (${hostDisplay})${runningSuffix}${windowsHostSuffix}${suggestionSuffix}`,
+    label: `${labelPrefix} (${hostDisplay})${runningSuffix}${windowsHostSuffix}${suggestionSuffix}`,
   };
 }
 

--- a/src/lib/onboard/setup-nim-flow.test.ts
+++ b/src/lib/onboard/setup-nim-flow.test.ts
@@ -355,7 +355,7 @@ describe("createSetupNim", () => {
     expect(canProbeRoute).not.toHaveBeenCalled();
   });
 
-  it("checks shared-gateway compatibility before interactive local discovery probes (#6315)", async () => {
+  it("keeps interactive local discovery probes on when the route preflight reports a conflict (#6750)", async () => {
     const events: string[] = [];
     const canProbeRoute = vi.fn((provider: string) => {
       events.push(`preflight:${provider}`);
@@ -380,11 +380,10 @@ describe("createSetupNim", () => {
 
     await setupNim(null, null, null, true, null, "nemoclaw", undefined, canProbeRoute);
 
-    expect(events).toEqual([
-      "preflight:ollama-local",
-      "preflight:vllm-local",
-      "detect:false:false",
-    ]);
+    // Route conflicts are enforced at selection time; the interactive menu
+    // still probes so a running daemon renders its status truthfully.
+    expect(canProbeRoute).not.toHaveBeenCalled();
+    expect(events).toEqual(["detect:true:true"]);
   });
 
   it("rejects a known local route before host detection when its model conflicts (#6315)", async () => {

--- a/src/lib/onboard/setup-nim-provider-discovery.test.ts
+++ b/src/lib/onboard/setup-nim-provider-discovery.test.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { prepareProviderDiscovery } from "./setup-nim-provider-discovery";
+
+const interactiveDeps = {
+  remoteProviderConfig: {},
+  isNonInteractive: () => false,
+  getNonInteractiveProvider: () => null,
+  getNonInteractiveModel: () => null,
+  readRecordedProvider: () => null,
+  readRecordedNimContainer: () => null,
+  readRecordedModel: () => null,
+};
+
+describe("prepareProviderDiscovery", () => {
+  it("keeps local daemon probes on for the interactive menu when the route preflight reports a conflict (#6750)", () => {
+    const result = prepareProviderDiscovery({
+      deps: interactiveDeps,
+      sandboxName: null,
+      recoverProvider: false,
+      rebuildRegistryInferenceRoute: null,
+      canProbeRoute: () => false,
+      recoverySessionId: null,
+    });
+    expect(result.probeOllama).toBe(true);
+    expect(result.probeVllm).toBe(true);
+  });
+
+  it("keeps the route-conflict probe gate for non-interactive runs targeting a local provider", () => {
+    const result = prepareProviderDiscovery({
+      deps: {
+        ...interactiveDeps,
+        isNonInteractive: () => true,
+        getNonInteractiveProvider: () => "ollama",
+      },
+      sandboxName: null,
+      recoverProvider: false,
+      rebuildRegistryInferenceRoute: null,
+      canProbeRoute: () => false,
+      recoverySessionId: null,
+    });
+    expect(result.probeOllama).toBe(false);
+  });
+
+  it("probes local daemons non-interactively when the route preflight allows them", () => {
+    const result = prepareProviderDiscovery({
+      deps: {
+        ...interactiveDeps,
+        isNonInteractive: () => true,
+        getNonInteractiveProvider: () => "ollama",
+      },
+      sandboxName: null,
+      recoverProvider: false,
+      rebuildRegistryInferenceRoute: null,
+      canProbeRoute: () => true,
+      recoverySessionId: null,
+    });
+    expect(result.probeOllama).toBe(true);
+  });
+});

--- a/src/lib/onboard/setup-nim-provider-discovery.ts
+++ b/src/lib/onboard/setup-nim-provider-discovery.ts
@@ -157,8 +157,16 @@ export function prepareProviderDiscovery(options: {
     requestedModel,
     recoveredRegistryRoute,
     recordedProviderReaders,
+    // Interactive menus always probe: the probe only drives status display
+    // (" — running" suffix, detection banner), and route conflicts are still
+    // enforced at selection time via assertRouteCompatible. Gating the probe
+    // on the route preflight hid a running daemon from the menu whenever the
+    // registry held an unrelated same-gateway route (#6750).
     probeOllama:
-      intent.ollama && (ollamaPreflightPassed || (canProbeRoute?.("ollama-local") ?? true)),
-    probeVllm: intent.vllm && (vllmPreflightPassed || (canProbeRoute?.("vllm-local") ?? true)),
+      intent.ollama &&
+      (!nonInteractive || ollamaPreflightPassed || (canProbeRoute?.("ollama-local") ?? true)),
+    probeVllm:
+      intent.vllm &&
+      (!nonInteractive || vllmPreflightPassed || (canProbeRoute?.("vllm-local") ?? true)),
   };
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Interactive onboarding gated the local daemon probes on the shared-gateway route preflight, so any unrelated registry route on the same gateway silently hid a running Ollama or vLLM daemon from the step [3/8] inference menu (no `— running` suffix, no detection banner). Interactive runs now always probe — route conflicts stay enforced at selection time via `assertRouteCompatible` — and an installed-but-stopped daemon renders the action label `Start local Ollama (WSL:11434)` instead of a status-style label that reads as a reachability claim.

## Related Issue

Refs #6750

## Changes

- `src/lib/onboard/setup-nim-provider-discovery.ts`: stop ANDing `canProbeRoute` into `probeOllama`/`probeVllm` on the interactive path; non-interactive runs keep the preflight gate. Selection-time containment (`assertRouteCompatible` in `guardProviderInferenceRouteSelection`) is unchanged and remains the enforcement point for shared-gateway route conflicts.
- `src/lib/onboard/ollama-install-menu.ts`: render `Start local Ollama (<host>)` when the daemon is installed but not running; the running label (`Local Ollama (<host>) — running (suggested)`) is unchanged. The entry stays because selecting it is the deliberate auto-start path — suppressing it would leave WSL users on native Docker with no in-wizard path to a local Ollama.
- `src/lib/onboard/setup-nim-flow.test.ts`: update the probe-gating contract test to the new interactive behavior.
- `src/lib/onboard/setup-nim-provider-discovery.test.ts` (new) and `src/lib/onboard/ollama-install-menu.test.ts`: regression tests that fail without the fix, plus guards pinning the retained non-interactive gate.
- `docs/get-started/windows-preparation.mdx`, `docs/inference/set-up-ollama.mdx`: state the Docker Desktop WSL integration requirement for the Windows-host Ollama path and describe the interactive re-prompt accurately (the third symptom in #6750 — the `(requires Docker Desktop WSL integration)` suffix — is working as designed; the expected `(loopback only — switch to 0.0.0.0)` wording never existed in the codebase).

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/` — 294/295 files pass (2905 tests); new regression tests confirmed red before the fix and green after; the one failing file (`created-sandbox-finalization.test.ts`, 2 tests, #6311) fails identically on pristine `upstream/main` and is unrelated
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — 0 errors; the 2 reported warnings are pre-existing (identical count on a build without this change)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Interactive onboarding now continues local provider discovery even when route conflicts are detected.

- **Bug Fixes**
  - Improved provider detection and probing logic for interactive vs non-interactive onboarding scenarios.
  - Updated the Ollama menu label to clearly show “Start local Ollama” (with the correct host) when Ollama isn’t running.

- **Documentation**
  - Refined Windows/WSL Ollama setup guidance, including Docker Desktop WSL integration requirements and handling the express prompt (including `NEMOCLAW_NO_EXPRESS=1`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->