### PR TITLE
fix(onboard): bound gateway preflight probes

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -596,6 +596,7 @@ import { createPolicySelectionPromptHelpers } from "./onboard/policy-selection-p
 import {
   printLowMemoryWarning,
   printMessagingProviderMissing,
+  printPortUnavailableError,
   printSwapCreationFailed,
 } from "./onboard/preflight-messages";
 import { shouldSkipPreRecreateBackup } from "./onboard/sandbox-backup-on-recreate";
@@ -1649,7 +1650,7 @@ async function preflight(
         else if (outcome.kind !== "not-openshell") continue;
       }
       console.error("");
-      console.error(`  !! Port ${port} is not available.`);
+      printPortUnavailableError(port);
       console.error(`     ${label} needs this port.`);
       console.error("");
       if (portCheck.process && portCheck.process !== "unknown") {

--- a/src/lib/onboard/gateway-reuse.test.ts
+++ b/src/lib/onboard/gateway-reuse.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createGatewayReuseHelpers } from "./gateway-reuse";
+
+describe("gateway reuse inspection", () => {
+  it("bounds every OpenShell metadata probe so a foreign listener cannot stall preflight (#6752)", () => {
+    const runCaptureOpenshell = vi.fn((_args: string[], _options?: Record<string, unknown>) => "");
+    const helpers = createGatewayReuseHelpers({
+      gatewayName: "nemoclaw",
+      runCaptureOpenshell,
+      runOpenshell: vi.fn(() => ({ status: 0 })),
+      cliDisplayName: () => "NemoClaw",
+    });
+
+    helpers.getGatewayReuseSnapshot();
+
+    expect(runCaptureOpenshell).toHaveBeenCalledTimes(3);
+    for (const [, options] of runCaptureOpenshell.mock.calls) {
+      expect(options).toMatchObject({ ignoreError: true, timeout: 5_000 });
+    }
+  });
+});

--- a/src/lib/onboard/gateway-reuse.ts
+++ b/src/lib/onboard/gateway-reuse.ts
@@ -3,6 +3,8 @@
 
 import { getGatewayReuseState, shouldSelectNamedGatewayForReuse } from "../state/gateway";
 
+const GATEWAY_INSPECTION_TIMEOUT_MS = 5_000;
+
 export type GatewayReuseSnapshot = {
   gatewayStatus: string;
   gwInfo: string;
@@ -28,11 +30,18 @@ export function createGatewayReuseHelpers(deps: GatewayReuseDeps): GatewayReuseH
 
   function getGatewayReuseSnapshot(): GatewayReuseSnapshot {
     const gatewayName = currentGatewayName();
-    const gatewayStatus = deps.runCaptureOpenshell(["status"], { ignoreError: true });
+    const gatewayStatus = deps.runCaptureOpenshell(["status"], {
+      ignoreError: true,
+      timeout: GATEWAY_INSPECTION_TIMEOUT_MS,
+    });
     const gwInfo = deps.runCaptureOpenshell(["gateway", "info", "-g", gatewayName], {
       ignoreError: true,
+      timeout: GATEWAY_INSPECTION_TIMEOUT_MS,
     });
-    const activeGatewayInfo = deps.runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
+    const activeGatewayInfo = deps.runCaptureOpenshell(["gateway", "info"], {
+      ignoreError: true,
+      timeout: GATEWAY_INSPECTION_TIMEOUT_MS,
+    });
     return {
       gatewayStatus,
       gwInfo,

--- a/src/lib/onboard/preflight-messages.test.ts
+++ b/src/lib/onboard/preflight-messages.test.ts
@@ -7,6 +7,7 @@ import {
   printDockerNotReachableError,
   printLowMemoryWarning,
   printMessagingProviderMissing,
+  printPortUnavailableError,
   printSwapCreationFailed,
   printUnderProvisionedRuntimeWarning,
   printUnsupportedRuntimeError,
@@ -62,6 +63,14 @@ describe("onboard preflight severity messages (#6004)", () => {
         "  ⚠ Low memory detected (4000 MB RAM + 0 MB swap = 4000 MB total)",
       );
       expect([...lines(err), ...lines(warn)].join("\n")).not.toContain("\x1b[");
+    });
+  });
+
+  it("renders port conflicts as failures without ANSI on plain stderr (#6752)", () => {
+    withStderrColorDepth(1, () => {
+      const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      printPortUnavailableError(8080);
+      expect(lines(err)).toEqual(["  ✗ Port 8080 is not available."]);
     });
   });
 

--- a/src/lib/onboard/preflight-messages.ts
+++ b/src/lib/onboard/preflight-messages.ts
@@ -20,6 +20,11 @@ export function printDockerNotReachableError(): void {
   console.error(failLine("Docker is not reachable. Please fix Docker and try again."));
 }
 
+/** A required onboarding port is already occupied. */
+export function printPortUnavailableError(port: number): void {
+  console.error(failLine(`Port ${port} is not available.`));
+}
+
 /** Podman under the Linux Docker-driver path is unsupported. */
 export function printUnsupportedRuntimeError(): void {
   console.error(failLine(`${cliDisplayName()} onboarding now uses OpenShell's Docker driver.`));


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Onboarding now bounds OpenShell gateway metadata probes so an unrelated listener cannot stall preflight indefinitely. Port-conflict failures also use the shared stderr-aware failure style.

## Related Issue

Fixes #6752

## Changes

- Apply a five-second timeout to each OpenShell status and gateway-info probe used for gateway reuse detection.
- Render the required-port conflict heading through the shared `failLine` helper.
- Add regression coverage for the probe timeout and plain-stderr failure output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the required documentation review confirmed that existing gateway-reuse and port-conflict recovery guidance remains accurate; the timeout is an internal safety bound.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending maintainer review; no waiver requested.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/gateway-reuse.test.ts src/lib/onboard/preflight-messages.test.ts` (9 passed); `npm run test:changed` (1,057 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused onboarding change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: ogarciarevett <ogarciarevett@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding messages for unavailable ports with consistent formatting.
  * Prevented gateway inspection checks from hanging by applying a five-second timeout.

* **Tests**
  * Added coverage for gateway inspection timeouts and port-conflict message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->