### PR TITLE
docs(e2e): sync full-e2e budget note

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -153,7 +153,7 @@ The `full-e2e` target enforces a separate hard acceptance contract for the
 first fresh onboarding path in that job. It measures from the onboard root span
 (a conservative anchor before wizard step `[1/8]`) through the first non-empty
 agent response, requires the local BuildKit prebuild for the NemoClaw-generated
-context without a gateway-builder fallback, limits the total to 180 seconds,
+context without a gateway-builder fallback, limits the total to 205 seconds,
 and limits the longest onboard output gap to 60 seconds. A violation fails
 `full-e2e`, and the target writes its evidence to `onboard-progress-budget.json`.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Sync the `full-e2e` README budget prose with the current hard total budget. The live full-E2E test uses a 205-second total budget, but the README still described the old 180-second limit.

## Related Issue
Refs #6660.

## Changes
- Update the `test/e2e/README.md` onboard performance budget section from `180 seconds` to `205 seconds`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: prose-only README sync; no runtime behavior changes.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this PR updates test-harness documentation only and does not change user-facing docs under `docs/`.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hook-equivalent checks passed
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: tests not applicable; `rg -n "ONBOARD_BUDGET_SECS|180 seconds|205 seconds" test/e2e/README.md test/e2e/live/full-e2e.test.ts` confirms the README now matches the 205-second budget source.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: HwangJohn <angelic805@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the end-to-end onboarding performance budget to allow up to 205 seconds for the full cold-path flow.
  * Retained the existing measurement process and output-gap requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->