### PR TITLE
fix(onboard): reserve skipped inference resume route

### DIFF
--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -528,6 +528,32 @@ describe("handleProviderInferenceState", () => {
     expect(result.sandboxName).toBe("tm");
   });
 
+  it("does not reserve a route when resume skips inference after sandbox completion (#6562)", async () => {
+    const session = createSession({
+      sandboxName: "completed-sandbox",
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-test",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+      preferredInferenceApi: "openai-responses",
+    });
+    session.steps.provider_selection.status = "complete";
+    session.steps.sandbox.status = "complete";
+    const { deps, calls } = createDeps({ isInferenceRouteReady: vi.fn(() => true) });
+
+    const result = await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: "completed-sandbox",
+    });
+
+    expect(calls.promptName).not.toHaveBeenCalled();
+    expect(calls.setupNim).not.toHaveBeenCalled();
+    expect(calls.setupInference).not.toHaveBeenCalled();
+    expect(calls.reserveRoute).not.toHaveBeenCalled();
+    expect(result.sandboxName).toBe("completed-sandbox");
+  });
+
   it("reserves the prompted sandbox route after redoing provider selection on resume (#6562)", async () => {
     const session = createSession();
     const completedSelection = createSession({ sessionId: "resume-selection-session" });

--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -495,6 +495,67 @@ describe("handleProviderInferenceState", () => {
     expect(result).toMatchObject({ provider: "ollama-local", model: "llama3.1" });
   });
 
+  it("reserves the prompted sandbox route when resume skips already-ready inference (#6562)", async () => {
+    const session = createSession({
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-test",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+      preferredInferenceApi: "openai-responses",
+    });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({ isInferenceRouteReady: vi.fn(() => true) });
+    calls.promptName.mockResolvedValueOnce("tm");
+
+    const result = await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: null,
+    });
+
+    expect(calls.promptName).toHaveBeenCalledWith(null);
+    expect(calls.setupNim).not.toHaveBeenCalled();
+    expect(calls.setupInference).not.toHaveBeenCalled();
+    expect(calls.reserveRoute).toHaveBeenCalledWith("tm", {
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-test",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+      preferredInferenceApi: "openai-responses",
+      gatewayName: "nemoclaw",
+      reservationSessionId: session.sessionId,
+    });
+    expect(result.sandboxName).toBe("tm");
+  });
+
+  it("reserves the prompted sandbox route after redoing provider selection on resume (#6562)", async () => {
+    const session = createSession();
+    const completedSelection = createSession({ sessionId: "resume-selection-session" });
+    const { deps, calls } = createDeps({ isInferenceRouteReady: vi.fn(() => true) });
+    calls.complete.mockResolvedValueOnce(completedSelection);
+    calls.promptName.mockResolvedValueOnce("tm");
+
+    const result = await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: null,
+    });
+
+    expect(calls.setupNim).toHaveBeenCalledOnce();
+    expect(calls.setupInference).not.toHaveBeenCalled();
+    expect(calls.promptName).toHaveBeenCalledWith(null);
+    expect(calls.reserveRoute).toHaveBeenCalledWith("tm", {
+      provider: "nvidia-prod",
+      model: "nvidia/test",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+      preferredInferenceApi: "openai-responses",
+      gatewayName: "nemoclaw",
+      reservationSessionId: "resume-selection-session",
+    });
+    expect(result.sandboxName).toBe("tm");
+  });
+
   it("coerces a resumed anthropic-messages seed for an OpenAI-only agent (#6294)", async () => {
     const session = createSession({
       provider: "compatible-anthropic-endpoint",
@@ -985,7 +1046,15 @@ describe("handleProviderInferenceState", () => {
     });
 
     expect(calls.reconcileRouter).toHaveBeenCalledOnce();
-    expect(calls.reserveRoute).not.toHaveBeenCalled();
+    expect(calls.reserveRoute).toHaveBeenCalledWith("router-sandbox", {
+      provider: "nvidia-router",
+      model: "router/model",
+      endpointUrl: "http://host.openshell.internal:4000/v1",
+      credentialEnv: null,
+      preferredInferenceApi: null,
+      gatewayName: "nemoclaw",
+      reservationSessionId: session.sessionId,
+    });
   });
 
   // #5974 instance 5: the Model Router Python preflight (`prepareModelRouterVenv`)

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -636,10 +636,12 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
         );
         break;
       }
-      const authoritativeReservationName = authoritativeResumeConfig
-        ? (sandboxName ?? (await deps.promptValidatedSandboxName(agent)))
-        : null;
-      if (authoritativeReservationName) sandboxName = authoritativeReservationName;
+      const sandboxStepComplete = session?.steps?.sandbox?.status === "complete";
+      const resumeReservationName =
+        authoritativeResumeConfig || !sandboxStepComplete
+          ? (sandboxName ?? (await deps.promptValidatedSandboxName(agent)))
+          : null;
+      if (resumeReservationName) sandboxName = resumeReservationName;
       const routedInferenceProvider = deps.isRoutedInferenceProvider(provider);
       if (routedInferenceProvider) {
         // #4564: re-upsert the gateway provider with the sandbox-facing
@@ -667,8 +669,8 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
             credentialEnv,
           );
           const reserved =
-            reupserted.ok && authoritativeReservationName
-              ? deps.reserveSandboxInferenceRoute(authoritativeReservationName, {
+            reupserted.ok && resumeReservationName
+              ? deps.reserveSandboxInferenceRoute(resumeReservationName, {
                   provider: selectedProvider,
                   model: selectedModel,
                   endpointUrl: reupserted.endpointUrl,
@@ -688,22 +690,20 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
           deps.exitProcess(reupserted.status ?? 1);
         }
         if (reserved === false) {
-          deps.error(
-            `  Failed to reserve inference route for sandbox '${authoritativeReservationName}'.`,
-          );
+          deps.error(`  Failed to reserve inference route for sandbox '${resumeReservationName}'.`);
           deps.exitProcess(1);
         }
         endpointUrl = reupserted.endpointUrl;
       }
-      if (authoritativeReservationName && !routedInferenceProvider) {
+      if (resumeReservationName && !routedInferenceProvider) {
         const reserved = await deps.withGatewayRouteMutationLock(gatewayName, () => {
-          assertProviderInferenceRouteCompatible(deps, gatewayName, authoritativeReservationName, {
+          assertProviderInferenceRouteCompatible(deps, gatewayName, resumeReservationName, {
             provider: selectedProvider,
             model: selectedModel,
             endpointUrl,
             preferredInferenceApi,
           });
-          return deps.reserveSandboxInferenceRoute(authoritativeReservationName, {
+          return deps.reserveSandboxInferenceRoute(resumeReservationName, {
             provider: selectedProvider,
             model: selectedModel,
             endpointUrl,
@@ -714,9 +714,7 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
           });
         });
         if (!reserved) {
-          deps.error(
-            `  Failed to reserve inference route for sandbox '${authoritativeReservationName}'.`,
-          );
+          deps.error(`  Failed to reserve inference route for sandbox '${resumeReservationName}'.`);
           deps.exitProcess(1);
         }
       }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Resume onboarding can skip provider setup after the provider/model are already recorded but before sandbox setup is complete. This change reserves or repairs the sandbox inference route during that resume path so the later sandbox profile step does not fail with `sandbox route reservation '<name>' disappeared while onboarding was in progress`.

## Related Issue
Fixes #6562

## Changes
- Reserve the sandbox inference route when `nemoclaw onboard --resume` skips already-ready inference while sandbox setup is still incomplete.
- Apply the repair to both routed and direct-compatible provider branches while preserving complete-sandbox resume behavior.
- Add regression coverage for the reported cancellation-after-sandbox-name resume path and the already-ready inference resume path.

What each PR/fix does:

- #6572: protects an existing `pendingRouteReservation` from being deleted by stale-entry cleanup when no live sandbox exists. It handles "reservation existed, cleanup would remove it."
- #6626: protects an existing session-owned pending reservation during a NotReady sandbox recreate. It handles "reservation existed, recreate would remove it."
- This fix: creates/repairs the reservation when resume skips inference before sandbox setup has a complete sandbox. It handles your repro: "reservation was missing because resume skipped the step that normally creates it."

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The public `--resume` contract is unchanged; this repairs internal route reservation state. A docs review found no documentation updates needed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
  - `git push -u origin HEAD` ran pre-push TypeScript checks and passed.
  - `npm run check:diff` passed in a temporary clean worktree after `npm run build:cli` generated the required `dist/` artifacts. The main checkout has ignored local `worktrees/` directories that otherwise make the source-shape scanner inspect unrelated files.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `npx vitest run --project cli src/lib/onboard/machine/handlers/provider-inference.test.ts` — passed (35 tests)
  - `npx vitest run --project cli src/lib/onboard/machine/handlers/provider-inference-recovery-gating.test.ts src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts src/lib/state/registry-route-reservation.test.ts src/lib/onboard/setup-inference-route-containment.test.ts src/lib/onboard/sandbox-lifecycle.test.ts` — passed (38 tests)
  - `npm run typecheck:cli` — passed
  - `npm run build:cli` — passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume reliability during provider inference by correcting which sandbox route is reserved, even when inference is already ready or provider reselection is required.
  * Ensured no sandbox route is reserved when resuming after the sandbox step is already completed.
  * Updated routed-inference reservation behavior to match the expected host-alias endpoint details.
* **Tests**
  * Added coverage to validate the resumed provider inference reservation flow and updated related router reconciliation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->