### PR TITLE
ci(release): dispatch Brev image on lkg promotion

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -13,6 +13,16 @@ Use the release scripts for normal release operations. Do not run raw `git tag`,
 
 The release is one annotated semver tag on an already-merged `origin/main` commit. The GitHub workflow moves `latest`; release admins promote `lkg` manually after validation. After the tag and `latest` are verified, automatically move remaining open issues/PRs from the released version label to the next patch label, draft release notes, then verify the maintainer-published Announcement before final handoff.
 
+## LKG Production Image Dispatch
+
+When a release admin creates or moves `lkg` to a commit carrying an exact `vX.Y.Z` tag, the `Release / LKG Brev Image` workflow dispatches the `Release Production Image` workflow in `brevdev/nemoclaw-image` on its `main` branch.
+The dispatch passes the immutable semver tag instead of the mutable `lkg` tag.
+The source workflow requires the `NEMOCLAW_IMAGE_DISPATCH_TOKEN` Actions secret with Actions read/write access to `brevdev/nemoclaw-image`; a missing secret fails before the API request, and the workflow summary never includes its value.
+The trigger summary records the selected release tag, full commit SHA, target workflow, and dispatch result.
+A rejected dispatch fails the trigger run but does not move or roll back `lkg`.
+Deleting `lkg` does not dispatch an image build.
+The downstream scheduled reconciliation remains available if the event-driven dispatch fails or is delayed.
+
 ## Hard Rules
 
 - Tag only the commit captured in a generated release plan.

--- a/.github/workflows/release-lkg-brev-image.yaml
+++ b/.github/workflows/release-lkg-brev-image.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release / LKG Brev Image
+
+on:
+  push:
+    tags:
+      - lkg
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-lkg-brev-image
+  cancel-in-progress: false
+
+jobs:
+  dispatch-production-image:
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.event.deleted == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out LKG target
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Dispatch production image build
+        env:
+          LKG_SHA: ${{ github.sha }}
+          NEMOCLAW_IMAGE_DISPATCH_TOKEN: ${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}
+        run: scripts/release-lkg-brev-image.sh

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -367,6 +367,11 @@
       "category": "compatibility"
     },
     {
+      "file": "test/release-lkg-brev-image.test.ts",
+      "test": "keeps LKG dispatch inside the trusted secret boundary (#6772)",
+      "category": "security"
+    },
+    {
       "file": "test/regression-e2e-workflow.test.ts",
       "test": "collects the gateway drift regression from its integration project (#6692)",
       "category": "compatibility"

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -367,11 +367,6 @@
       "category": "compatibility"
     },
     {
-      "file": "test/release-lkg-brev-image.test.ts",
-      "test": "keeps LKG dispatch inside the trusted secret boundary (#6772)",
-      "category": "security"
-    },
-    {
       "file": "test/regression-e2e-workflow.test.ts",
       "test": "collects the gateway drift regression from its integration project (#6692)",
       "category": "compatibility"
@@ -394,6 +389,11 @@
     {
       "file": "test/regression-e2e-workflow.test.ts",
       "test": "stages the public NVIDIA key for the Model Router's NVIDIA credential",
+      "category": "security"
+    },
+    {
+      "file": "test/release-lkg-brev-image.test.ts",
+      "test": "keeps LKG dispatch inside the trusted secret boundary (#6772)",
       "category": "security"
     },
     {

--- a/scripts/release-lkg-brev-image.sh
+++ b/scripts/release-lkg-brev-image.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+TARGET_REPOSITORY="brevdev/nemoclaw-image"
+TARGET_WORKFLOW="build-scheduled.yml"
+TARGET_REF="main"
+SUMMARY_PATH="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+lkg_commit="unresolved"
+release_tag="none"
+dispatch_result="not attempted"
+
+write_summary() {
+  {
+    echo "## LKG production image dispatch"
+    echo
+    echo "- LKG commit: \`$lkg_commit\`"
+    echo "- Release tag: \`$release_tag\`"
+    echo "- Target: \`$TARGET_REPOSITORY/.github/workflows/$TARGET_WORKFLOW@$TARGET_REF\`"
+    echo "- Dispatch result: \`$dispatch_result\`"
+  } >>"$SUMMARY_PATH"
+}
+
+fail() {
+  echo "release-lkg-brev-image: $*" >&2
+  exit 1
+}
+
+trap write_summary EXIT
+
+if [[ "${LKG_DELETED:-false}" == "true" ]]; then
+  dispatch_result="skipped (lkg deleted)"
+  echo "release-lkg-brev-image: skipping deleted lkg tag"
+  exit 0
+fi
+
+LKG_SHA="${LKG_SHA:?LKG_SHA is required}"
+if [[ ! "$LKG_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  fail "LKG_SHA must be a full commit or tag-object SHA"
+fi
+
+lkg_commit="$(git rev-parse --verify "${LKG_SHA}^{commit}" 2>/dev/null)" \
+  || fail "Unable to peel LKG target $LKG_SHA to a commit"
+
+release_tag="$({
+  git tag --points-at "$lkg_commit" --list 'v*' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -V \
+    | tail -1
+} || true)"
+
+if [[ -z "$release_tag" ]]; then
+  release_tag="none"
+  fail "LKG target $lkg_commit has no exact vX.Y.Z release tag"
+fi
+
+release_commit="$(git rev-parse --verify "refs/tags/${release_tag}^{commit}")"
+if [[ "$release_commit" != "$lkg_commit" ]]; then
+  fail "Release tag $release_tag does not peel to LKG target $lkg_commit"
+fi
+
+if [[ -z "${NEMOCLAW_IMAGE_DISPATCH_TOKEN:-}" ]]; then
+  fail "NEMOCLAW_IMAGE_DISPATCH_TOKEN is required to dispatch $TARGET_REPOSITORY"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  fail "GitHub CLI is required to dispatch $TARGET_REPOSITORY"
+fi
+
+payload="$(printf '{"ref":"%s","inputs":{"nemoclaw_ref":"%s"}}' "$TARGET_REF" "$release_tag")"
+endpoint="repos/$TARGET_REPOSITORY/actions/workflows/$TARGET_WORKFLOW/dispatches"
+
+if ! printf '%s\n' "$payload" \
+  | env -u GH_DEBUG GH_TOKEN="$NEMOCLAW_IMAGE_DISPATCH_TOKEN" gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$endpoint" \
+    --input - \
+    >/dev/null; then
+  dispatch_result="rejected"
+  fail "GitHub rejected the production image dispatch to $TARGET_REPOSITORY/$TARGET_WORKFLOW"
+fi
+
+dispatch_result="accepted (HTTP 204)"
+printf 'release-lkg-brev-image: dispatched %s for %s (%s)\n' \
+  "$TARGET_WORKFLOW" "$release_tag" "$lkg_commit"

--- a/test/release-lkg-brev-image.test.ts
+++ b/test/release-lkg-brev-image.test.ts
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readYaml } from "./helpers/e2e-workflow-contract";
+
+const repoRoot = path.join(import.meta.dirname, "..");
+const scriptPath = path.join(repoRoot, "scripts", "release-lkg-brev-image.sh");
+const tempRoots: string[] = [];
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  jobs: Record<
+    string,
+    {
+      if?: string;
+      steps?: WorkflowStep[];
+    }
+  >;
+  on?: {
+    push?: {
+      tags?: string[];
+    };
+  };
+  permissions?: Record<string, string>;
+};
+
+type Fixture = {
+  argsPath: string;
+  binDir: string;
+  commit: string;
+  inputPath: string;
+  root: string;
+  summaryPath: string;
+  work: string;
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "LKG Dispatch Test",
+      GIT_AUTHOR_EMAIL: "lkg-dispatch@example.com",
+      GIT_COMMITTER_NAME: "LKG Dispatch Test",
+      GIT_COMMITTER_EMAIL: "lkg-dispatch@example.com",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "tag.gpgSign",
+      GIT_CONFIG_VALUE_0: "false",
+    },
+  }).trim();
+}
+
+function createFixture(): Fixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-release-lkg-brev-image-"));
+  tempRoots.push(root);
+  const work = path.join(root, "work");
+  const binDir = path.join(root, "bin");
+  const argsPath = path.join(root, "gh-args.txt");
+  const inputPath = path.join(root, "gh-input.json");
+  const summaryPath = path.join(root, "summary.md");
+  fs.mkdirSync(work);
+  fs.mkdirSync(binDir);
+  git(work, ["init"]);
+  fs.writeFileSync(path.join(work, "file.txt"), "initial\n");
+  git(work, ["add", "file.txt"]);
+  git(work, ["commit", "-m", "initial"]);
+  const commit = git(work, ["rev-parse", "HEAD"]);
+
+  const fakeGh = path.join(binDir, "gh");
+  fs.writeFileSync(
+    fakeGh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${GH_TOKEN:-}" != "\${EXPECTED_GH_TOKEN:-}" ]]; then
+  echo "unexpected GH_TOKEN" >&2
+  exit 2
+fi
+printf '%s\n' "$@" >"$GH_ARGS_PATH"
+cat >"$GH_INPUT_PATH"
+if [[ "\${GH_EXIT_CODE:-0}" != "0" ]]; then
+  echo "HTTP 403: dispatch denied" >&2
+  exit "$GH_EXIT_CODE"
+fi
+`,
+    "utf8",
+  );
+  fs.chmodSync(fakeGh, 0o755);
+
+  return { argsPath, binDir, commit, inputPath, root, summaryPath, work };
+}
+
+function tag(fixture: Fixture, name: string, annotated = true): void {
+  const args = annotated
+    ? ["tag", "-a", name, fixture.commit, "-m", name]
+    : ["tag", name, fixture.commit];
+  git(fixture.work, args);
+}
+
+function runDispatch(
+  fixture: Fixture,
+  extraEnv: NodeJS.ProcessEnv = {},
+): ReturnType<typeof spawnSync> {
+  return spawnSync("bash", [scriptPath], {
+    cwd: fixture.work,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EXPECTED_GH_TOKEN: "test-dispatch-token",
+      GH_ARGS_PATH: fixture.argsPath,
+      GH_INPUT_PATH: fixture.inputPath,
+      GITHUB_STEP_SUMMARY: fixture.summaryPath,
+      LKG_SHA: fixture.commit,
+      NEMOCLAW_IMAGE_DISPATCH_TOKEN: "test-dispatch-token",
+      PATH: `${fixture.binDir}:${process.env.PATH ?? ""}`,
+      ...extraEnv,
+    },
+  });
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("LKG production image dispatch", () => {
+  it("dispatches the highest exact release tag to the production workflow (#6772)", () => {
+    const fixture = createFixture();
+    tag(fixture, "lkg");
+    tag(fixture, "v0.0.9");
+    tag(fixture, "v0.0.10");
+    tag(fixture, "v0.0.11-rc.1");
+    const lkgObject = git(fixture.work, ["rev-parse", "refs/tags/lkg"]);
+
+    const result = runDispatch(fixture, { LKG_SHA: lkgObject });
+
+    expect(result.status).toBe(0);
+    expect(fs.readFileSync(fixture.argsPath, "utf8").trim().split("\n")).toEqual([
+      "api",
+      "--method",
+      "POST",
+      "-H",
+      "Accept: application/vnd.github+json",
+      "-H",
+      "X-GitHub-Api-Version: 2022-11-28",
+      "repos/brevdev/nemoclaw-image/actions/workflows/build-scheduled.yml/dispatches",
+      "--input",
+      "-",
+    ]);
+    expect(JSON.parse(fs.readFileSync(fixture.inputPath, "utf8"))).toEqual({
+      ref: "main",
+      inputs: { nemoclaw_ref: "v0.0.10" },
+    });
+    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
+    expect(summary).toContain(`LKG commit: \`${fixture.commit}\``);
+    expect(summary).toContain("Release tag: `v0.0.10`");
+    expect(summary).toContain(
+      "Target: `brevdev/nemoclaw-image/.github/workflows/build-scheduled.yml@main`",
+    );
+    expect(summary).toContain("Dispatch result: `accepted (HTTP 204)`");
+    expect(`${result.stdout}${result.stderr}${summary}`).not.toContain("test-dispatch-token");
+  });
+
+  it("fails before dispatch when LKG has no exact release tag (#6772)", () => {
+    const fixture = createFixture();
+    tag(fixture, "latest", false);
+    tag(fixture, "v0.0.1-rc.1");
+
+    const result = runDispatch(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(`LKG target ${fixture.commit} has no exact vX.Y.Z release tag`);
+    expect(fs.existsSync(fixture.argsPath)).toBe(false);
+    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
+    expect(summary).toContain(`LKG commit: \`${fixture.commit}\``);
+    expect(summary).toContain("Release tag: `none`");
+    expect(summary).toContain("Dispatch result: `not attempted`");
+  });
+
+  it("skips dispatch when the LKG tag is deleted (#6772)", () => {
+    const fixture = createFixture();
+
+    const result = runDispatch(fixture, {
+      LKG_DELETED: "true",
+      LKG_SHA: "",
+      NEMOCLAW_IMAGE_DISPATCH_TOKEN: "",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("skipping deleted lkg tag");
+    expect(fs.existsSync(fixture.argsPath)).toBe(false);
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain(
+      "Dispatch result: `skipped (lkg deleted)`",
+    );
+  });
+
+  it("reports a missing dispatch token without invoking GitHub (#6772)", () => {
+    const fixture = createFixture();
+    tag(fixture, "v0.0.1");
+
+    const result = runDispatch(fixture, { NEMOCLAW_IMAGE_DISPATCH_TOKEN: "" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("NEMOCLAW_IMAGE_DISPATCH_TOKEN is required");
+    expect(fs.existsSync(fixture.argsPath)).toBe(false);
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain("Release tag: `v0.0.1`");
+  });
+
+  it("fails without changing LKG when GitHub rejects the dispatch (#6772)", () => {
+    const fixture = createFixture();
+    tag(fixture, "v0.0.1");
+
+    const result = runDispatch(fixture, { GH_EXIT_CODE: "1" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("HTTP 403: dispatch denied");
+    expect(result.stderr).toContain("GitHub rejected the production image dispatch");
+    expect(git(fixture.work, ["rev-parse", "HEAD"])).toBe(fixture.commit);
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain("Dispatch result: `rejected`");
+  });
+
+  // source-shape-contract: security -- The secret-bearing LKG trigger must stay canonical, deletion-safe, read-only, and immutable
+  it("keeps LKG dispatch inside the trusted secret boundary (#6772)", () => {
+    const workflow = readYaml<Workflow>(".github/workflows/release-lkg-brev-image.yaml");
+    const job = workflow.jobs["dispatch-production-image"];
+    const checkout = job.steps?.find((step) => step.name === "Check out LKG target");
+    const dispatch = job.steps?.find((step) => step.name === "Dispatch production image build");
+
+    expect(workflow.on?.push?.tags).toEqual(["lkg"]);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(job.if).toBe(
+      "${{ github.repository == 'NVIDIA/NemoClaw' && github.event.deleted == false }}",
+    );
+    expect(checkout?.uses).toMatch(/^actions\/checkout@[0-9a-f]{40}$/u);
+    expect(checkout?.with).toEqual({
+      ref: "${{ github.sha }}",
+      "fetch-depth": 0,
+      "persist-credentials": false,
+    });
+    expect(dispatch?.env).toEqual({
+      LKG_SHA: "${{ github.sha }}",
+      NEMOCLAW_IMAGE_DISPATCH_TOKEN: "${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}",
+    });
+    expect(dispatch?.run).toBe("scripts/release-lkg-brev-image.sh");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Promoting `lkg` now dispatches the downstream Brev production-image workflow with the immutable NemoClaw release tag. The source workflow validates the tag target, records non-secret correlation details, and leaves downstream image validation and promotion unchanged.

## Related Issue

Fixes #6772

## Changes

- Add a trusted `lkg` tag workflow with read-only repository permissions and an immutable checkout action pin.
- Resolve the promoted tag to its commit and highest exact `vX.Y.Z` tag before calling `brevdev/nemoclaw-image` on `main`.
- Fail before dispatch for invalid targets or missing credentials, fail without rolling back `lkg` for rejected requests, and skip tag deletions.
- Record the selected release, commit, target workflow, and dispatch result without exposing the cross-repository token.
- Protect the behavior and secret boundary with focused script and workflow contract tests.
- Document the downstream image-build side effect, token scope, and scheduled reconciliation fallback in the maintainer release skill.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is internal maintainer release automation; the maintainer-facing side effect and secret requirements are documented in the release skill, with no end-user behavior or Fern docs impact.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Focused local review verified read-only built-in permissions, disabled persisted checkout credentials, secret-free request and summary data, debug suppression, and negative tests for missing and rejected credentials.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/release-lkg-brev-image.test.ts` (1 file, 6 tests), `bash -n scripts/release-lkg-brev-image.sh`, and `npm run source-shape:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused workflow change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an event-driven production image dispatch for the LKG flow when an `lkg` tag targets a commit with an exact immutable `vX.Y.Z` release tag.
  * Dispatches builds using the immutable `vX.Y.Z` tag to improve release reliability.
  * Skips dispatch for deleted `lkg` tags and reports clear accepted/rejected outcomes.
* **Documentation**
  * Documented the LKG production image dispatch behavior, expected failure modes, and required permissions.
* **Tests**
  * Added end-to-end script tests covering success, missing/invalid tags, deletion handling, missing credentials, and dispatch rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->