### PR TITLE
fix(onboard): bypass proxies for loopback readiness

### DIFF
--- a/src/lib/core/wait.test.ts
+++ b/src/lib/core/wait.test.ts
@@ -242,13 +242,63 @@ describe("waitForPort", () => {
 });
 
 describe("waitForHttp", () => {
-  it("returns true when curl reaches the endpoint", () => {
+  it("reaches a loopback server directly when an HTTP proxy is configured", async () => {
+    const server = childProcess.spawn(
+      process.execPath,
+      [
+        "-e",
+        "const h=require('node:http');" +
+          "const s=h.createServer((_,r)=>{r.writeHead(204);r.end();});" +
+          "s.listen(0,'127.0.0.1',()=>console.log(s.address().port));",
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const port = await new Promise<number>((resolve, reject) => {
+      server.once("error", reject);
+      server.stdout.once("data", (chunk) => resolve(Number(String(chunk).trim())));
+      server.once("exit", (code) => reject(new Error(`loopback test server exited ${code}`)));
+    });
+    const previousProxy = process.env.http_proxy;
+    process.env.http_proxy = "http://127.0.0.1:1";
+
+    try {
+      expect(waitForHttp(`http://127.0.0.1:${port}/health`, 2)).toBe(true);
+    } finally {
+      Reflect.deleteProperty(process.env, "http_proxy");
+      Object.assign(process.env, previousProxy === undefined ? {} : { http_proxy: previousProxy });
+      await new Promise<void>((resolve) => {
+        server.once("exit", () => resolve());
+        server.kill("SIGTERM");
+      });
+    }
+  });
+
+  it("uses a direct Node probe for loopback endpoints", () => {
     const buildValidatedCurlCommandArgs = curlArgs.buildValidatedCurlCommandArgs;
     const buildArgs = vi
       .spyOn(curlArgs, "buildValidatedCurlCommandArgs")
       .mockImplementation(buildValidatedCurlCommandArgs);
     const spawnSync = vi.spyOn(childProcess, "spawnSync").mockReturnValue(spawnResult(0));
     const url = "http://127.0.0.1:8080/health";
+
+    expect(waitForHttp(url, 1)).toBe(true);
+    expect(buildArgs).not.toHaveBeenCalled();
+    expect(spawnSync.mock.calls[0]?.[0]).toBe(process.execPath);
+    const probeArgs = spawnSync.mock.calls[0]?.[1];
+    expect(probeArgs?.[0]).toBe("-e");
+    expect(probeArgs?.[1]).toContain("require('node:http')");
+    expect(probeArgs?.[1]).not.toContain(url);
+    expect(probeArgs?.at(-1)).toBe(url);
+    expect(spawnSync.mock.calls[0]?.[2]).toMatchObject({ timeout: 2_000 });
+  });
+
+  it("keeps the validated curl path for non-loopback endpoints", () => {
+    const buildValidatedCurlCommandArgs = curlArgs.buildValidatedCurlCommandArgs;
+    const buildArgs = vi
+      .spyOn(curlArgs, "buildValidatedCurlCommandArgs")
+      .mockImplementation(buildValidatedCurlCommandArgs);
+    const spawnSync = vi.spyOn(childProcess, "spawnSync").mockReturnValue(spawnResult(0));
+    const url = "https://example.com/health";
     const rawArgs = ["-sf", "--connect-timeout", "1", "--max-time", "1", url];
 
     expect(waitForHttp(url, 1)).toBe(true);

--- a/src/lib/core/wait.ts
+++ b/src/lib/core/wait.ts
@@ -279,6 +279,33 @@ const TCP_PROBE_SCRIPT =
   "s.on('error',()=>process.exit(1));" +
   "s.setTimeout(1000,()=>{s.destroy();process.exit(1);});";
 
+// Native Node HTTP clients do not consult HTTP_PROXY. Prefer this direct path
+// for loopback readiness probes so user proxy settings and curl configuration
+// cannot route a localhost request away from the service being checked.
+const LOOPBACK_HTTP_PROBE_SCRIPT =
+  "const u=new URL(process.argv[1]);" +
+  "const m=u.protocol==='https:'?require('node:https'):require('node:http');" +
+  "const r=m.get(u,{timeout:1000},res=>{" +
+  "res.resume();process.exit(res.statusCode>=200&&res.statusCode<400?0:1);});" +
+  "r.on('timeout',()=>{r.destroy();process.exit(1);});" +
+  "r.on('error',()=>process.exit(1));";
+
+function isLoopbackHttpUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    const hostname = url.hostname
+      .replace(/^\[(.*)\]$/u, "$1")
+      .replace(/\.$/u, "")
+      .toLowerCase();
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1")
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Synchronously wait for a TCP port to become reachable on localhost.
  *
@@ -323,6 +350,14 @@ export function waitForHttp(url: string, timeoutSeconds = 5): boolean {
   return waitUntil(
     () => {
       try {
+        if (isLoopbackHttpUrl(url)) {
+          const probe = spawnSync(process.execPath, ["-e", LOOPBACK_HTTP_PROBE_SCRIPT, url], {
+            stdio: "ignore",
+            timeout: 2000,
+            env,
+          });
+          return probe.status === 0;
+        }
         const result = spawnSync(
           "curl",
           buildValidatedCurlCommandArgs(["-sf", "--connect-timeout", "1", "--max-time", "1", url]),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Loopback HTTP readiness checks could still be routed through a host proxy despite the existing NO_PROXY augmentation, causing a running Ollama service to be reported unavailable. Loopback URLs now use a bounded native Node probe that does not consult proxy settings, while non-loopback URLs retain the validated curl path.

## Related Issue

Fixes #6763

## Changes

- Probe exact loopback hosts (localhost, 127.0.0.1, and ::1) through a short-lived Node HTTP or HTTPS client with a one-second request timeout.
- Keep non-loopback readiness probes on the existing validated curl path.
- Add a process-level regression test with a live loopback server and a failing http_proxy, plus routing-contract tests for both probe paths.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the documented loopback proxy-bypass contract without changing commands or output
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: author review confirmed the direct path is restricted to exact loopback hostnames, the URL is passed as argv rather than interpolated into code, and non-loopback requests retain curl validation
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/core/wait.test.ts src/lib/onboard/install-ollama-macos.test.ts src/lib/onboard/ollama-startup.test.ts` (33 tests passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this focused readiness probe change; `npm run typecheck:cli`, Biome, test-conditional scan, and `npm run check:diff` passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Ho Lim <subhoya@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks for local HTTP and HTTPS endpoints.
  * Localhost checks now bypass configured HTTP proxies for more reliable results.
  * Non-local endpoints continue using the existing network validation behavior.
  * Added handling for common loopback address formats, including IPv6 localhost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->