### PR TITLE
chore(openshell): trust v0.0.82 release manifests

### DIFF
--- a/scripts/check-installer-hash.sh
+++ b/scripts/check-installer-hash.sh
@@ -33,6 +33,9 @@ readonly -a OPENSHELL_RELEASE_MANIFEST_ALLOWLIST=(
   "0.0.72|openshell-checksums-sha256.txt|0049181983eaf925ef9510382f75348229a9511d02e27196107782e7c3259ae1"
   "0.0.72|openshell-gateway-checksums-sha256.txt|3c454dc15154b8c700ec820628559ea8964c6e552d9c5f8af78b6ee19cf34547"
   "0.0.72|openshell-sandbox-checksums-sha256.txt|d38507501338576437cf3e554df71fefe927dc0d72758f88e260069527ed9ccc"
+  "0.0.82|openshell-checksums-sha256.txt|74ba77d368744f412b2dd246099b63b38937962807333ded2b6284580a2d014e"
+  "0.0.82|openshell-gateway-checksums-sha256.txt|c0a369ba2c66bcde3c18ce2753b04ff942d1fe1b5f3e4656de520f6d4b175477"
+  "0.0.82|openshell-sandbox-checksums-sha256.txt|3300b9856cdbe8e3f9b0f8068bbad93673739c4cfd3212c80dc0675168ee2b8d"
 )
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary

Trust the three immutable OpenShell v0.0.82 release checksum manifests in the base-owned installer verifier. This is the base-branch prerequisite for #6726; it does not change NemoClaw's active OpenShell selector or consumed asset hashes.

## Changes

- Add the v0.0.82 CLI manifest digest `74ba77d368744f412b2dd246099b63b38937962807333ded2b6284580a2d014e`.
- Add the v0.0.82 gateway manifest digest `c0a369ba2c66bcde3c18ce2753b04ff942d1fe1b5f3e4656de520f6d4b175477`.
- Add the v0.0.82 sandbox manifest digest `3300b9856cdbe8e3f9b0f8068bbad93673739c4cfd3212c80dc0675168ee2b8d`.
- Keep the production selectors on v0.0.72 until the separately reviewed upgrade PR lands.

The manifests were produced by the successful NVIDIA/OpenShell `Release Tag` workflow run 29260186856 at verified tag commit `94cdd697c55aedb571f177ec13cfa54a8e213919`. This must land separately because the installer-hash workflow evaluates proposed selectors with verifier code from the PR base; an upgrade PR cannot authorize its own new manifest.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/installer-hash-check.test.ts` covers the manifest allowlist, exact digest matching, and base-trusted verification boundary; 61/61 focused tests pass.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this authorizes immutable release manifests without changing user-visible behavior or the active OpenShell version.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/installer-hash-check.test.ts --project integration` (61/61) and `bash scripts/check-installer-hash.sh`
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release verification records to support OpenShell v0.0.82 manifests.
  * Added integrity checks for the standard, gateway, and sandbox release checksum files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->