### PR TITLE
ci(guardrails): batch conditional source reads

### DIFF
--- a/.github/workflows/codebase-growth-guardrails.yaml
+++ b/.github/workflows/codebase-growth-guardrails.yaml
@@ -394,13 +394,67 @@ jobs:
 
           node <<'NODE'
           const TEST_FILE_RE = /^(test|src|nemoclaw\/src)\/.*\.(test|spec)\.(?:[cm]?[jt]s)$/;
+          const GRAPHQL_URL = "https://api.github.com/graphql";
+          const GRAPHQL_BATCH_SIZE = 25;
+          const RETRY_ATTEMPTS = 4;
+          const RETRY_BASE_MS = 250;
+          const RETRY_MAX_MS = 4000;
           const { BASE_SHA, GH_TOKEN, HEAD_REPO, HEAD_SHA, PR_NUMBER, REPO } = process.env;
           const headers = { Authorization: `Bearer ${GH_TOKEN}`, "X-GitHub-Api-Version": "2022-11-28" };
 
-          async function getJson(url) {
-            const response = await fetch(url, { headers });
+          async function withRetry(label, fn) {
+            let lastError;
+            for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt += 1) {
+              try {
+                return await fn();
+              } catch (error) {
+                lastError = error;
+                const retriable = error && (error.transient === true || /HTTP (408|425|429|5\d{2})/.test(String(error.message ?? "")));
+                if (!retriable || attempt === RETRY_ATTEMPTS) throw error;
+                const jitter = Math.random() * RETRY_BASE_MS;
+                const delay = Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** (attempt - 1)) + jitter;
+                console.error(`retry: ${label} attempt ${attempt} failed (${error.message}); sleeping ${Math.round(delay)}ms`);
+                await new Promise((resolve) => setTimeout(resolve, delay));
+              }
+            }
+            throw lastError;
+          }
+
+          async function requestJson(url, init) {
+            let response;
+            try {
+              response = await fetch(url, init);
+            } catch (error) {
+              const wrapped = new Error(`${url}: network error ${error?.message ?? error}`);
+              wrapped.transient = true;
+              throw wrapped;
+            }
             if (!response.ok) throw new Error(`${url}: HTTP ${response.status}`);
             return response.json();
+          }
+
+          async function getJson(url) {
+            return withRetry(url, () => requestJson(url, { headers }));
+          }
+
+          async function graphql(query, variables) {
+            const body = JSON.stringify({ query, variables });
+            const label = `graphql ${variables.owner}/${variables.name}@${variables.oid}`;
+            return withRetry(label, async () => {
+              const payload = await requestJson(GRAPHQL_URL, {
+                method: "POST",
+                headers: { ...headers, "Content-Type": "application/json" },
+                body,
+              });
+              if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+                const messages = payload.errors.map((entry) => entry.message).join("; ");
+                const transient = payload.errors.some((entry) => entry.type === "RATE_LIMITED" || /timed? *out|unavailable|internal/i.test(entry.message ?? ""));
+                const error = new Error(`${label}: GraphQL errors: ${messages}`);
+                if (transient) error.transient = true;
+                throw error;
+              }
+              return payload.data;
+            });
           }
 
           async function getPullFiles() {
@@ -412,18 +466,67 @@ jobs:
             }
           }
 
-          async function getContent(repo, ref, file) {
+          async function getContentViaRest(repo, ref, file) {
             if (!file) return null;
             const encodedPath = file.split("/").map(encodeURIComponent).join("/");
             const url = `https://api.github.com/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`;
-            const response = await fetch(url, { headers });
-            if (response.status === 404) return null;
-            if (!response.ok) throw new Error(`${url}: HTTP ${response.status}`);
-            const body = await response.json();
-            if (body.type !== "file" || body.encoding !== "base64" || typeof body.content !== "string") {
-              throw new Error(`Could not decode file contents for ${file}`);
+            return withRetry(url, async () => {
+              let response;
+              try {
+                response = await fetch(url, { headers });
+              } catch (error) {
+                const wrapped = new Error(`${url}: network error ${error?.message ?? error}`);
+                wrapped.transient = true;
+                throw wrapped;
+              }
+              if (response.status === 404) return null;
+              if (!response.ok) throw new Error(`${url}: HTTP ${response.status}`);
+              const body = await response.json();
+              if (body.type !== "file" || body.encoding !== "base64" || typeof body.content !== "string") {
+                throw new Error(`Could not decode file contents for ${file}`);
+              }
+              return Buffer.from(body.content.replace(/\s/g, ""), "base64").toString("utf8");
+            });
+          }
+
+          function splitRepoName(fullName) {
+            const [owner, name] = fullName.split("/");
+            if (!owner || !name) throw new Error(`Unexpected repository full name: ${fullName}`);
+            return { owner, name };
+          }
+
+          function buildBlobQuery(paths) {
+            const aliases = paths.map((_, index) => `      f${index}: object(expression: $e${index}) { __typename ... on Blob { text isBinary isTruncated byteSize } }`).join("\n");
+            const params = paths.map((_, index) => `$e${index}: String!`).join(", ");
+            return `query($owner: String!, $name: String!, ${params}) {\n  repository(owner: $owner, name: $name) {\n${aliases}\n  }\n}`;
+          }
+
+          async function fetchBlobs(repoFullName, oid, paths) {
+            const results = new Map();
+            if (paths.length === 0) return results;
+            const { owner, name } = splitRepoName(repoFullName);
+            const rest = [];
+            for (let start = 0; start < paths.length; start += GRAPHQL_BATCH_SIZE) {
+              const chunk = paths.slice(start, start + GRAPHQL_BATCH_SIZE);
+              const query = buildBlobQuery(chunk);
+              const variables = { owner, name, oid };
+              chunk.forEach((path, index) => { variables[`e${index}`] = `${oid}:${path}`; });
+              const data = await graphql(query, variables);
+              const repository = data?.repository;
+              if (!repository) throw new Error(`GraphQL repository not found: ${repoFullName}`);
+              chunk.forEach((path, index) => {
+                const node = repository[`f${index}`];
+                if (!node) { results.set(path, null); return; }
+                if (node.__typename !== "Blob") { results.set(path, null); return; }
+                if (node.isBinary) throw new Error(`${path} is binary; refusing to count if statements`);
+                if (node.text === null || node.isTruncated) { rest.push(path); return; }
+                results.set(path, node.text);
+              });
             }
-            return Buffer.from(body.content.replace(/\s/g, ""), "base64").toString("utf8");
+            for (const path of rest) {
+              results.set(path, await getContentViaRest(repoFullName, oid, path));
+            }
+            return results;
           }
 
           function assertRepositoryName(repo, label) {
@@ -596,8 +699,7 @@ jobs:
             return stripTriviaAndLiterals(text).match(/\bif\s*\(/g)?.length ?? 0;
           }
 
-          async function countAt(repo, ref, file) {
-            const text = await getContent(repo, ref, file);
+          function countText(text) {
             return text === null ? 0 : countIfStatements(text);
           }
 
@@ -609,6 +711,17 @@ jobs:
             assertRepositoryName(REPO, "REPO");
             assertRepositoryName(HEAD_REPO, "HEAD_REPO");
 
+            const basePaths = [...new Set(changedTests.map((file) => (
+              TEST_FILE_RE.test(file.previous_filename ?? "") ? file.previous_filename : file.filename
+            )))];
+            const headPaths = [...new Set(changedTests
+              .filter((file) => file.status !== "removed" && TEST_FILE_RE.test(file.filename))
+              .map((file) => file.filename))];
+            const [baseBlobs, headBlobs] = await Promise.all([
+              fetchBlobs(REPO, BASE_SHA, basePaths),
+              fetchBlobs(HEAD_REPO, HEAD_SHA, headPaths),
+            ]);
+
             const details = [];
             let baseTotal = 0;
             let headTotal = 0;
@@ -616,8 +729,8 @@ jobs:
             for (const file of changedTests) {
               const basePath = TEST_FILE_RE.test(file.previous_filename ?? "") ? file.previous_filename : file.filename;
               const headPath = file.status === "removed" || !TEST_FILE_RE.test(file.filename) ? null : file.filename;
-              const baseCount = await countAt(REPO, BASE_SHA, basePath);
-              const headCount = await countAt(HEAD_REPO, HEAD_SHA, headPath);
+              const baseCount = countText(baseBlobs.get(basePath) ?? null);
+              const headCount = countText(headPath === null ? null : (headBlobs.get(headPath) ?? null));
               baseTotal += baseCount;
               headTotal += headCount;
               if (headCount > baseCount) {

--- a/test/codebase-growth-guardrails-conditionals.test.ts
+++ b/test/codebase-growth-guardrails-conditionals.test.ts
@@ -34,6 +34,8 @@ type MockContent = {
   readonly ref: string;
   readonly file: string;
   readonly text: string;
+  readonly graphqlText?: string | null;
+  readonly graphqlTruncated?: boolean;
 };
 
 function extractConditionalsNodeScript(): string {
@@ -54,6 +56,16 @@ function extractWorkflowCounterScript(): string {
 
 function pullFilesUrl(): string {
   return `https://api.github.com/repos/${ENV.REPO}/pulls/${ENV.PR_NUMBER}/files?per_page=100&page=1`;
+}
+
+function contentsUrl(content: MockContent): string {
+  const repo = content.repo ?? ENV.REPO;
+  const encodedPath = content.file.split("/").map(encodeURIComponent).join("/");
+  return `https://api.github.com/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(content.ref)}`;
+}
+
+function encodeContent(text: string): { type: "file"; encoding: "base64"; content: string } {
+  return { type: "file", encoding: "base64", content: Buffer.from(text).toString("base64") };
 }
 
 function astIfCount(sourceText: string): number {
@@ -77,11 +89,24 @@ function runWorkflowConditionalsGuard(input: {
 }): ReturnType<typeof spawnSync> {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-growth-conditionals-"));
   const scriptPath = path.join(tmpDir, "guardrail.cjs");
-  const responses = new Map<string, unknown>([[pullFilesUrl(), input.files]]);
+  const responses = new Map<string, unknown>([
+    [pullFilesUrl(), input.files],
+    ...input.contents.map(
+      (content) => [contentsUrl(content), encodeContent(content.text)] as const,
+    ),
+  ]);
   const blobs = new Map(
     input.contents.map(
       (content) =>
-        [`${content.repo ?? ENV.REPO}@${content.ref}:${content.file}`, content.text] as const,
+        [
+          `${content.repo ?? ENV.REPO}@${content.ref}:${content.file}`,
+          {
+            text: Object.prototype.hasOwnProperty.call(content, "graphqlText")
+              ? content.graphqlText
+              : content.text,
+            isTruncated: content.graphqlTruncated ?? false,
+          },
+        ] as const,
     ),
   );
   const wrapper = [
@@ -102,8 +127,8 @@ function runWorkflowConditionalsGuard(input: {
     "    .filter(([key]) => /^e\\d+$/.test(key))",
     "    .map(([key, expression]) => {",
     "      const index = Number(key.slice(1));",
-    "      const text = blobs.get(`${repo}@${expression}`);",
-    "      return [`f${index}`, text === undefined ? null : { __typename: 'Blob', text, isBinary: false, isTruncated: false, byteSize: Buffer.byteLength(text) }];",
+    "      const blob = blobs.get(`${repo}@${expression}`);",
+    "      return [`f${index}`, blob === undefined ? null : { __typename: 'Blob', text: blob.text, isBinary: false, isTruncated: blob.isTruncated, byteSize: Buffer.byteLength(blob.text ?? '') }];",
     "    });",
     "  const graphqlBody = { data: { repository: Object.fromEntries(aliases) } };",
     "  const body = responses.get(String(url));",
@@ -231,6 +256,26 @@ describe("codebase growth guardrail test conditionals step", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toMatch(/retry: graphql \S+ attempt 1 failed/);
     expect(result.stdout).toContain("MOCK_GRAPHQL_REQUESTS=3");
+  });
+
+  it("uses REST contents when GraphQL returns a truncated blob", () => {
+    const result = runWorkflowConditionalsGuard({
+      files: [{ filename: "test/truncated.test.ts" }],
+      contents: [
+        { file: "test/truncated.test.ts", ref: ENV.BASE_SHA, text: "" },
+        {
+          file: "test/truncated.test.ts",
+          repo: ENV.HEAD_REPO,
+          ref: ENV.HEAD_SHA,
+          text: "if (flag) expect(flag).toBe(true);",
+          graphqlText: "",
+          graphqlTruncated: true,
+        },
+      ],
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("test/truncated.test.ts");
   });
 
   it("does not count non-statement if property tokens", () => {

--- a/test/codebase-growth-guardrails-conditionals.test.ts
+++ b/test/codebase-growth-guardrails-conditionals.test.ts
@@ -229,7 +229,7 @@ describe("codebase growth guardrail test conditionals step", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stderr).toContain("retry: graphql NVIDIA/NemoClaw@base-sha attempt 1 failed");
+    expect(result.stderr).toMatch(/retry: graphql \S+ attempt 1 failed/);
     expect(result.stdout).toContain("MOCK_GRAPHQL_REQUESTS=3");
   });
 

--- a/test/codebase-growth-guardrails-conditionals.test.ts
+++ b/test/codebase-growth-guardrails-conditionals.test.ts
@@ -48,18 +48,8 @@ function extractConditionalsNodeScript(): string {
 function extractWorkflowCounterScript(): string {
   const script = extractConditionalsNodeScript();
   const counterStart = script.indexOf("function stripTriviaAndLiterals(text)");
-  const counterEnd = script.indexOf("async function countAt", counterStart);
+  const counterEnd = script.indexOf("function countText", counterStart);
   return script.slice(counterStart, counterEnd);
-}
-
-function encodeContent(text: string): string {
-  return Buffer.from(text, "utf8").toString("base64");
-}
-
-function contentsUrl(content: MockContent): string {
-  const repo = content.repo ?? ENV.REPO;
-  const encodedPath = content.file.split("/").map(encodeURIComponent).join("/");
-  return `https://api.github.com/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(content.ref)}`;
 }
 
 function pullFilesUrl(): string {
@@ -83,31 +73,45 @@ function workflowIfCount(sourceText: string): number {
 function runWorkflowConditionalsGuard(input: {
   readonly files: readonly MockFile[];
   readonly contents: readonly MockContent[];
+  readonly transientGraphqlFailures?: number;
 }): ReturnType<typeof spawnSync> {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-growth-conditionals-"));
   const scriptPath = path.join(tmpDir, "guardrail.cjs");
-  const responses = new Map<string, unknown>([
-    [pullFilesUrl(), input.files],
-    ...input.contents.map(
+  const responses = new Map<string, unknown>([[pullFilesUrl(), input.files]]);
+  const blobs = new Map(
+    input.contents.map(
       (content) =>
-        [
-          contentsUrl(content),
-          {
-            content: encodeContent(content.text),
-            encoding: "base64",
-            type: "file",
-          },
-        ] as const,
+        [`${content.repo ?? ENV.REPO}@${content.ref}:${content.file}`, content.text] as const,
     ),
-  ]);
+  );
   const wrapper = [
     `const responses = new Map(${JSON.stringify([...responses])});`,
-    "global.fetch = async (url) => {",
+    `const blobs = new Map(${JSON.stringify([...blobs])});`,
+    `let graphqlFailuresRemaining = ${input.transientGraphqlFailures ?? 0};`,
+    "let graphqlRequests = 0;",
+    "process.on('exit', () => console.log(`MOCK_GRAPHQL_REQUESTS=${graphqlRequests}`));",
+    "global.fetch = async (url, init = {}) => {",
+    "  const isGraphql = String(url) === 'https://api.github.com/graphql';",
+    "  graphqlRequests += Number(isGraphql);",
+    "  const shouldFail = isGraphql && graphqlFailuresRemaining > 0;",
+    "  graphqlFailuresRemaining -= Number(shouldFail);",
+    "  const request = isGraphql && !shouldFail ? JSON.parse(String(init.body)) : {};",
+    "  const variables = request.variables ?? {};",
+    "  const repo = `${variables.owner}/${variables.name}`;",
+    "  const aliases = Object.entries(variables)",
+    "    .filter(([key]) => /^e\\d+$/.test(key))",
+    "    .map(([key, expression]) => {",
+    "      const index = Number(key.slice(1));",
+    "      const text = blobs.get(`${repo}@${expression}`);",
+    "      return [`f${index}`, text === undefined ? null : { __typename: 'Blob', text, isBinary: false, isTruncated: false, byteSize: Buffer.byteLength(text) }];",
+    "    });",
+    "  const graphqlBody = { data: { repository: Object.fromEntries(aliases) } };",
     "  const body = responses.get(String(url));",
+    "  const responseBody = isGraphql ? graphqlBody : body;",
     "  return {",
-    "    ok: body !== undefined,",
-    "    status: body === undefined ? 404 : 200,",
-    "    json: async () => body ?? {},",
+    "    ok: shouldFail ? false : responseBody !== undefined,",
+    "    status: shouldFail ? 502 : responseBody === undefined ? 404 : 200,",
+    "    json: async () => responseBody ?? {},",
     "  };",
     "};",
     extractConditionalsNodeScript(),
@@ -182,6 +186,51 @@ describe("codebase growth guardrail test conditionals step", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("test/add.test.ts");
+  });
+
+  it("batches base and head blobs into one GraphQL request each", () => {
+    const result = runWorkflowConditionalsGuard({
+      files: [{ filename: "test/first.test.ts" }, { filename: "test/second.test.ts" }],
+      contents: [
+        { file: "test/first.test.ts", ref: ENV.BASE_SHA, text: "expect(true).toBe(true);" },
+        { file: "test/second.test.ts", ref: ENV.BASE_SHA, text: "expect(true).toBe(true);" },
+        {
+          file: "test/first.test.ts",
+          repo: ENV.HEAD_REPO,
+          ref: ENV.HEAD_SHA,
+          text: "expect(true).toBe(true);",
+        },
+        {
+          file: "test/second.test.ts",
+          repo: ENV.HEAD_REPO,
+          ref: ENV.HEAD_SHA,
+          text: "expect(true).toBe(true);",
+        },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("MOCK_GRAPHQL_REQUESTS=2");
+  });
+
+  it("retries a transient GraphQL failure", () => {
+    const result = runWorkflowConditionalsGuard({
+      files: [{ filename: "test/retry.test.ts" }],
+      contents: [
+        { file: "test/retry.test.ts", ref: ENV.BASE_SHA, text: "expect(true).toBe(true);" },
+        {
+          file: "test/retry.test.ts",
+          repo: ENV.HEAD_REPO,
+          ref: ENV.HEAD_SHA,
+          text: "expect(true).toBe(true);",
+        },
+      ],
+      transientGraphqlFailures: 1,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("retry: graphql NVIDIA/NemoClaw@base-sha attempt 1 failed");
+    expect(result.stdout).toContain("MOCK_GRAPHQL_REQUESTS=3");
   });
 
   it("does not count non-statement if property tokens", () => {


### PR DESCRIPTION
## Summary
The changed-test conditional guard previously fetched base and head contents one file at a time and failed the whole check on a single transient GitHub API error. This change batches trusted blob reads through GraphQL and retries transient failures while preserving the existing counting policy and REST fallback.

For a PR with 11 changed test files, the normal request shape drops from 23 GitHub API calls (one file-list request plus 22 content requests) to 3 (one file-list request plus two blob batches), an approximately 87% reduction.

## Changes
- Batch up to 25 base or head blobs per GraphQL request, with fork head reads kept repository-scoped and passed as GraphQL variables.
- Retry network failures, HTTP 408/425/429/5xx responses, and transient GraphQL errors up to four times with exponential backoff and jitter.
- Fall back to the retried REST content endpoint only for truncated GraphQL blobs.
- Add workflow-level regression coverage for batching and a transient HTTP 502 recovery while retaining all existing conditional-counting cases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal CI guardrail implementation without changing its policy or user-facing interface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Author review confirmed the `pull_request_target` job still executes only trusted base-branch code, validates repository names, sends PR-controlled paths as GraphQL variables, and performs read-only GitHub API operations.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/codebase-growth-guardrails-conditionals.test.ts` (11 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and accuracy of codebase growth guardrails by preloading changed-file contents in batches before counting.
  * Added retry handling for transient API/GraphQL failures to reduce incorrect failures.
  * Added a safe fallback to alternate content retrieval when GraphQL content is missing or truncated.
* **Tests**
  * Added coverage for batched content fetching behavior.
  * Added coverage verifying transient GraphQL failures are retried and that fallback is used when GraphQL indicates truncated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->