### PR TITLE
fix(hermes): initialize shields metadata explicitly

### DIFF
--- a/agents/hermes/runtime-config-guard.py
+++ b/agents/hermes/runtime-config-guard.py
@@ -3641,23 +3641,24 @@ def _configure_shields_target_metadata(
             )
 
     sandbox_uid, sandbox_gid = _sandbox_identity()
-    if mode == "locked":
-        desired_uid = os.geteuid()
-        desired_gid = os.getegid()
-        desired_dir_mode = 0o755
-        desired_file_mode = 0o444
-        # `/sandbox` must remain a usable home, but its sticky root-owned entry
-        # prevents the sandbox identity from renaming the root-owned `.hermes`
-        # lock root out from under the protected files.
-        parent_meta.update({"uid": os.geteuid(), "gid": sandbox_gid, "mode": 0o1775})
-    elif mode == "mutable":
-        desired_uid = sandbox_uid
-        desired_gid = sandbox_gid
-        desired_dir_mode = 0o3770
-        desired_file_mode = 0o640
-        parent_meta.update({"uid": sandbox_uid, "gid": sandbox_gid, "mode": 0o755})
-    else:
+    if mode not in ("locked", "mutable"):
         raise UnsafePathError(f"refusing unsupported Hermes shields target: {mode}")
+
+    locked = mode == "locked"
+    desired_uid = os.geteuid() if locked else sandbox_uid
+    desired_gid = os.getegid() if locked else sandbox_gid
+    desired_dir_mode = 0o755 if locked else 0o3770
+    desired_file_mode = 0o444 if locked else 0o640
+    # `/sandbox` must remain a usable home, but its sticky root-owned entry
+    # prevents the sandbox identity from renaming the root-owned `.hermes`
+    # lock root out from under the protected files.
+    parent_meta.update(
+        {
+            "uid": desired_uid,
+            "gid": sandbox_gid,
+            "mode": 0o1775 if locked else 0o755,
+        }
+    )
 
     state_data["parent"] = parent_meta
     state_data["parent_flags"] = int(state_data.get("parent_flags", 0)) & ~(


### PR DESCRIPTION
## Summary
Make the Hermes shields metadata target values visibly total after validating the transition mode. This preserves the existing locked and mutable ownership/mode behavior while giving Python CodeQL an explicit initialization proof for alerts 1218–1219 tracked in #6263.

## Related Issue
Refs #6263

## Changes
- Reject unsupported shields target modes before deriving target metadata.
- Initialize the desired UID, GID, directory mode, and file mode with total expressions instead of branch-local assignments.
- Preserve the locked parent posture (`01775`), mutable parent posture (`0755`), Hermes directory modes (`0755`/`03770`), and sealed file modes (`0444`/`0640`).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The runtime guard, shields transition, and recovery suites exercise both locked and mutable metadata application, including ownership and directory/file mode assertions (38 passed, 2 platform-conditional skips).
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is a control-flow refactor with no user-facing behavior or configuration change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Author review confirmed that every target value remains identical for locked and mutable modes and unsupported modes still fail closed before metadata writes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/hermes-runtime-config-guard.test.ts test/hermes-restart-config-seal-transition.test.ts test/hermes-restart-config-seal-recovery.test.ts` (38 passed, 2 skipped)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of locked and mutable runtime configuration modes.
  * Preserved existing permissions, ownership, and sandbox behavior for configured shield targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->