### PR TITLE
fix(ci): verify packaged fdfind identity

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -236,8 +236,8 @@ jobs:
           FD_BINARY_VERSION="$(fdfind --version)"
           RG_BINARY_VERSION="$(rg --version)"
           RG_BINARY_VERSION="${RG_BINARY_VERSION%%$'\n'*}"
-          if [ "$FD_BINARY_VERSION" != "fd $EXPECTED_FD_BINARY_VERSION" ]; then
-            echo "::error::fdfind binary version $FD_BINARY_VERSION does not match fd $EXPECTED_FD_BINARY_VERSION"
+          if [ "$FD_BINARY_VERSION" != "fdfind $EXPECTED_FD_BINARY_VERSION" ]; then
+            echo "::error::fdfind binary version $FD_BINARY_VERSION does not match fdfind $EXPECTED_FD_BINARY_VERSION"
             exit 1
           fi
           if [ "$RG_BINARY_VERSION" != "ripgrep $EXPECTED_RG_BINARY_VERSION" ]; then

--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -85,6 +85,8 @@ jobs:
       # The review ledger imports TypeBox directly. Pi 0.80.6 shrinkwraps its
       # own copy, so the advisor runtime must install this direct dependency.
       TYPEBOX_VERSION: "1.1.38"
+      # Workflow-boundary modules parse YAML before the advisor session starts.
+      YAML_VERSION: "2.8.3"
       FD_FIND_VERSION: "9.0.0-1"
       RIPGREP_VERSION: "14.1.0-1"
       PR_REVIEW_ADVISOR_TIMEOUT_MS: "900000"
@@ -246,7 +248,7 @@ jobs:
           fi
 
           PI_SDK_DIR="$RUNNER_TEMP/pi-sdk"
-          npm install --prefix "$PI_SDK_DIR" --ignore-scripts --no-save --package-lock=false --before=2026-07-11T00:00:00.000Z "@earendil-works/pi-coding-agent@${PI_SDK_VERSION}" "typebox@${TYPEBOX_VERSION}"
+          npm install --prefix "$PI_SDK_DIR" --ignore-scripts --no-save --package-lock=false --before=2026-07-11T00:00:00.000Z "@earendil-works/pi-coding-agent@${PI_SDK_VERSION}" "typebox@${TYPEBOX_VERSION}" "yaml@${YAML_VERSION}"
           rm -rf "$ADVISOR_DIR/node_modules"
           ln -s "$PI_SDK_DIR/node_modules" "$ADVISOR_DIR/node_modules"
 

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -451,7 +451,7 @@ esac
     );
     fs.writeFileSync(
       path.join(binDir, "fdfind"),
-      "#!/bin/bash\nprintf 'fdfind %s\\n' \"$*\" >> \"$CALL_LOG\"\nprintf 'fd 9.0.0\\n'\n",
+      "#!/bin/bash\nprintf 'fdfind %s\\n' \"$*\" >> \"$CALL_LOG\"\nprintf 'fdfind 9.0.0\\n'\n",
       { mode: 0o755 },
     );
     fs.writeFileSync(

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -483,6 +483,7 @@ printf 'sudo %s\\n' "$*" >> "$CALL_LOG"
             RIPGREP_VERSION: "14.1.0-1",
             RUNNER_TEMP: path.join(tmp, "runner"),
             TYPEBOX_VERSION: "test-typebox-version",
+            YAML_VERSION: "test-yaml-version",
           },
         },
       );
@@ -496,6 +497,7 @@ printf 'sudo %s\\n' "$*" >> "$CALL_LOG"
       expect(fs.readFileSync(callLog, "utf8")).toContain("rg --version");
       expect(fs.readFileSync(callLog, "utf8")).toContain("--ignore-scripts");
       expect(fs.readFileSync(callLog, "utf8")).toContain("typebox@test-typebox-version");
+      expect(fs.readFileSync(callLog, "utf8")).toContain("yaml@test-yaml-version");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -636,10 +638,11 @@ process.exitCode = valid ? 0 : 1;`,
     );
   });
 
-  it("keeps mutable review history disabled and the find dependency pinned", () => {
+  it("keeps mutable review history disabled and runtime dependencies pinned", () => {
     const errors = validateMutation((source) =>
       source
         .replace('      FD_FIND_VERSION: "9.0.0-1"', '      FD_FIND_VERSION: "latest"')
+        .replace('      YAML_VERSION: "2.8.3"', '      YAML_VERSION: "latest"')
         .replace(
           '      PR_REVIEW_ADVISOR_LOAD_PREVIOUS_REVIEW: "false"',
           "      PR_REVIEW_ADVISOR_LOAD_PREVIOUS_REVIEW: ${{ matrix.advisor.publish_comment }}",
@@ -649,6 +652,7 @@ process.exitCode = valid ? 0 : 1;`,
     expect(errors).toEqual(
       expect.arrayContaining([
         "review job env.FD_FIND_VERSION must be 9.0.0-1",
+        "review job env.YAML_VERSION must be 2.8.3",
         "review job env.PR_REVIEW_ADVISOR_LOAD_PREVIOUS_REVIEW must be false",
       ]),
     );

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -353,7 +353,11 @@ done < <(find "$ADVISOR_WORKDIR" -type l -print0)`;
   requireRunContains(errors, install, "command -v rg");
   requireRunContains(errors, install, 'FD_BINARY_VERSION="$(fdfind --version)"');
   requireRunContains(errors, install, 'RG_BINARY_VERSION="$(rg --version)"');
-  requireRunContains(errors, install, '"$FD_BINARY_VERSION" != "fd $EXPECTED_FD_BINARY_VERSION"');
+  requireRunContains(
+    errors,
+    install,
+    '"$FD_BINARY_VERSION" != "fdfind $EXPECTED_FD_BINARY_VERSION"',
+  );
   requireRunContains(
     errors,
     install,

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -249,6 +249,7 @@ function checkAnalysisJob(errors: string[], reviewJob: WorkflowRecord): void {
   requireEnv(errors, "review job", reviewJob, "FD_FIND_VERSION", "9.0.0-1");
   requireEnv(errors, "review job", reviewJob, "RIPGREP_VERSION", "14.1.0-1");
   requireEnv(errors, "review job", reviewJob, "TYPEBOX_VERSION", "1.1.38");
+  requireEnv(errors, "review job", reviewJob, "YAML_VERSION", "2.8.3");
   requireEnv(
     errors,
     "review job",
@@ -365,6 +366,7 @@ done < <(find "$ADVISOR_WORKDIR" -type l -print0)`;
   );
   requireRunContains(errors, install, "--ignore-scripts");
   requireRunContains(errors, install, '"typebox@${TYPEBOX_VERSION}"');
+  requireRunContains(errors, install, '"yaml@${YAML_VERSION}"');
   requireRunContains(errors, install, '"$ADVISOR_DIR/node_modules"');
 
   const analyze = requireStep(errors, steps, "Run PR review advisor");


### PR DESCRIPTION
## Summary

- validate the pinned Ubuntu `fd-find` binary using its actual `fdfind <version>` identity
- keep the trusted workflow-boundary validator aligned with the executable check
- make the workflow test fixture reproduce the package output seen on hosted runners

## Why

PR review advisors currently fail during SDK bootstrap before analysis. The pinned Ubuntu package reports `fdfind 9.0.0`, while the workflow expects `fd 9.0.0`. This was reproduced on both advisor lanes for #6711.

## Validation

- `npx vitest run --project integration test/pr-review-advisor-workflow-boundary.test.ts` (19 passed)
- `npm run checks`
- pre-commit and pre-push hooks, including CLI typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected verification of the `fdfind` search tool version during Pi SDK installation.
  * Improved workflow boundary validation to align with the tool’s actual version output and mismatch messaging.
  * Ensured YAML is explicitly pinned and validated during Pi SDK installation and related workflow jobs, improving consistency and reliability of the PR review automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->