### PR TITLE
fix(ci): install advisor vitest dependency

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -87,6 +87,8 @@ jobs:
       TYPEBOX_VERSION: "1.1.38"
       # Workflow-boundary modules parse YAML before the advisor session starts.
       YAML_VERSION: "2.8.3"
+      # Credential-free E2E discovery invokes the Vitest file-list command.
+      VITEST_VERSION: "4.1.9"
       FD_FIND_VERSION: "9.0.0-1"
       RIPGREP_VERSION: "14.1.0-1"
       PR_REVIEW_ADVISOR_TIMEOUT_MS: "900000"
@@ -248,7 +250,7 @@ jobs:
           fi
 
           PI_SDK_DIR="$RUNNER_TEMP/pi-sdk"
-          npm install --prefix "$PI_SDK_DIR" --ignore-scripts --no-save --package-lock=false --before=2026-07-11T00:00:00.000Z "@earendil-works/pi-coding-agent@${PI_SDK_VERSION}" "typebox@${TYPEBOX_VERSION}" "yaml@${YAML_VERSION}"
+          npm install --prefix "$PI_SDK_DIR" --ignore-scripts --no-save --package-lock=false --before=2026-07-11T00:00:00.000Z "@earendil-works/pi-coding-agent@${PI_SDK_VERSION}" "typebox@${TYPEBOX_VERSION}" "vitest@${VITEST_VERSION}" "yaml@${YAML_VERSION}"
           rm -rf "$ADVISOR_DIR/node_modules"
           ln -s "$PI_SDK_DIR/node_modules" "$ADVISOR_DIR/node_modules"
 

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -483,6 +483,7 @@ printf 'sudo %s\\n' "$*" >> "$CALL_LOG"
             RIPGREP_VERSION: "14.1.0-1",
             RUNNER_TEMP: path.join(tmp, "runner"),
             TYPEBOX_VERSION: "test-typebox-version",
+            VITEST_VERSION: "test-vitest-version",
             YAML_VERSION: "test-yaml-version",
           },
         },
@@ -497,6 +498,7 @@ printf 'sudo %s\\n' "$*" >> "$CALL_LOG"
       expect(fs.readFileSync(callLog, "utf8")).toContain("rg --version");
       expect(fs.readFileSync(callLog, "utf8")).toContain("--ignore-scripts");
       expect(fs.readFileSync(callLog, "utf8")).toContain("typebox@test-typebox-version");
+      expect(fs.readFileSync(callLog, "utf8")).toContain("vitest@test-vitest-version");
       expect(fs.readFileSync(callLog, "utf8")).toContain("yaml@test-yaml-version");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
@@ -642,6 +644,7 @@ process.exitCode = valid ? 0 : 1;`,
     const errors = validateMutation((source) =>
       source
         .replace('      FD_FIND_VERSION: "9.0.0-1"', '      FD_FIND_VERSION: "latest"')
+        .replace('      VITEST_VERSION: "4.1.9"', '      VITEST_VERSION: "latest"')
         .replace('      YAML_VERSION: "2.8.3"', '      YAML_VERSION: "latest"')
         .replace(
           '      PR_REVIEW_ADVISOR_LOAD_PREVIOUS_REVIEW: "false"',
@@ -652,6 +655,7 @@ process.exitCode = valid ? 0 : 1;`,
     expect(errors).toEqual(
       expect.arrayContaining([
         "review job env.FD_FIND_VERSION must be 9.0.0-1",
+        "review job env.VITEST_VERSION must be 4.1.9",
         "review job env.YAML_VERSION must be 2.8.3",
         "review job env.PR_REVIEW_ADVISOR_LOAD_PREVIOUS_REVIEW must be false",
       ]),

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -249,6 +249,7 @@ function checkAnalysisJob(errors: string[], reviewJob: WorkflowRecord): void {
   requireEnv(errors, "review job", reviewJob, "FD_FIND_VERSION", "9.0.0-1");
   requireEnv(errors, "review job", reviewJob, "RIPGREP_VERSION", "14.1.0-1");
   requireEnv(errors, "review job", reviewJob, "TYPEBOX_VERSION", "1.1.38");
+  requireEnv(errors, "review job", reviewJob, "VITEST_VERSION", "4.1.9");
   requireEnv(errors, "review job", reviewJob, "YAML_VERSION", "2.8.3");
   requireEnv(
     errors,
@@ -366,6 +367,7 @@ done < <(find "$ADVISOR_WORKDIR" -type l -print0)`;
   );
   requireRunContains(errors, install, "--ignore-scripts");
   requireRunContains(errors, install, '"typebox@${TYPEBOX_VERSION}"');
+  requireRunContains(errors, install, '"vitest@${VITEST_VERSION}"');
   requireRunContains(errors, install, '"yaml@${YAML_VERSION}"');
   requireRunContains(errors, install, '"$ADVISOR_DIR/node_modules"');
 


### PR DESCRIPTION
## Summary
- pin and install Vitest in the trusted PR advisor runtime
- enforce the dependency in the workflow boundary and executable fixture
- keep mutable runtime dependencies fail-closed

## Why
The advisor now reaches credential-free test discovery, but fails before model analysis because `node_modules/vitest/vitest.mjs` is absent. This is the final bootstrap dependency exposed by [run 29286578690](https://github.com/NVIDIA/NemoClaw/actions/runs/29286578690).

## Validation
- `npx vitest run --project integration test/pr-review-advisor-workflow-boundary.test.ts` (19/19)
- commit and push hooks

Signed-off-by: Prekshi Vyas <34834085+prekshivyas@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Vitest version used by the automated review environment for more consistent results.
  * Added validation to ensure the configured Vitest version cannot be replaced with an unpinned or changing version.

* **Tests**
  * Updated workflow checks to confirm Vitest is installed at the expected pinned version.
  * Expanded boundary validation coverage for the new runtime requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->