### PR TITLE
docs(openshell): document direct session transport

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2195,7 +2195,11 @@ Pass `-f` / `--file <agents.yaml>` to point at the manifest; `--yes` confirms th
 
 List OpenClaw conversation sessions in the sandbox.
 With no subcommand the in-sandbox CLI lists stored sessions for the configured default agent.
-NemoClaw invokes `openclaw sessions` via `openshell sandbox exec` and forwards OpenClaw flags verbatim, but filters default list output so internal `nemoclaw-onboard-warmup-*` sessions created during onboarding are hidden from user-facing output.
+NemoClaw invokes the read-only `openclaw sessions` command through the sandbox's named OpenShell gateway and forwards OpenClaw flags verbatim.
+It prefers the direct gRPC sandbox execution API.
+If gateway configuration or the gRPC transport fails before NemoClaw receives a command result, it retries this read-only list operation through the OpenShell CLI.
+A completed command, including a nonzero result, is never replayed during fallback.
+NemoClaw filters default list output so internal `nemoclaw-onboard-warmup-*` sessions created during onboarding are hidden from user-facing output.
 
 ```bash
 $$nemoclaw my-assistant sessions

--- a/src/lib/actions/sandbox/sessions/passthrough.test.ts
+++ b/src/lib/actions/sandbox/sessions/passthrough.test.ts
@@ -3,13 +3,22 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const captureMock = vi.hoisted(() => vi.fn());
+const readOnlyExecMock = vi.hoisted(() => vi.fn());
 const execMock = vi.hoisted(() => vi.fn(async () => {}));
 const ensureLiveMock = vi.hoisted(() => vi.fn(async () => ({})));
-const getSandboxMock = vi.hoisted(() => vi.fn(() => null as { agent?: string } | null));
+const getSandboxMock = vi.hoisted(() =>
+  vi.fn(
+    () =>
+      null as {
+        agent?: string;
+        gatewayName?: string;
+        gatewayPort?: number;
+      } | null,
+  ),
+);
 
-vi.mock("../../../adapters/openshell/runtime", () => ({
-  captureOpenshell: captureMock,
+vi.mock("../../../adapters/openshell/sandbox-control-routing", () => ({
+  execSandboxReadOnlyWithGrpcFallback: readOnlyExecMock,
 }));
 vi.mock("../exec", async () => {
   const actual = await vi.importActual<typeof import("../exec")>("../exec");
@@ -217,7 +226,7 @@ describe("runSessionsPassthrough", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    captureMock.mockReset();
+    readOnlyExecMock.mockReset();
     execMock.mockClear();
     ensureLiveMock.mockClear();
     getSandboxMock.mockReset();
@@ -234,13 +243,14 @@ describe("runSessionsPassthrough", () => {
   });
 
   it("captures and filters `sessions list --json` instead of streaming warm-up entries", async () => {
-    captureMock.mockReturnValueOnce({
+    readOnlyExecMock.mockResolvedValueOnce({
       status: 0,
-      output: JSON.stringify({
+      stdout: JSON.stringify({
         count: 1,
         totalCount: 1,
         sessions: [{ key: "agent:main:explicit:warm", sessionId: `${WARMUP_SESSION_ID_PREFIX}1` }],
       }),
+      stderr: "",
     });
 
     await runSessionsPassthrough("alpha", {
@@ -250,22 +260,11 @@ describe("runSessionsPassthrough", () => {
 
     expect(ensureLiveMock).toHaveBeenCalledWith("alpha", { allowNonReadyPhase: true });
     expect(execMock).not.toHaveBeenCalled();
-    expect(captureMock).toHaveBeenCalledWith(
-      [
-        "sandbox",
-        "exec",
-        "--name",
-        "alpha",
-        "--",
-        "openclaw",
-        "sessions",
-        "list",
-        "--agent",
-        "main",
-        "--json",
-      ],
-      { ignoreError: true, includeStreams: true, maxBuffer: 64 * 1024 * 1024 },
-    );
+    expect(readOnlyExecMock).toHaveBeenCalledWith("nemoclaw", {
+      sandboxName: "alpha",
+      command: ["openclaw", "sessions", "list", "--agent", "main", "--json"],
+      maxOutputBytes: 64 * 1024 * 1024,
+    });
     expect(JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]))).toEqual({
       count: 0,
       totalCount: 0,
@@ -274,40 +273,38 @@ describe("runSessionsPassthrough", () => {
   });
 
   it("captures and filters text `sessions list` output", async () => {
-    captureMock.mockReturnValueOnce({
+    readOnlyExecMock.mockResolvedValueOnce({
       status: 0,
       stdout: [
         "Sessions listed: 1",
         `direct  agent:main:expli...  1m ago  model  id:${WARMUP_SESSION_ID_PREFIX}1`,
       ].join("\n"),
       stderr: "warning: noisy but non-fatal\n",
-      output: [
-        "Sessions listed: 1",
-        `direct  agent:main:expli...  1m ago  model  id:${WARMUP_SESSION_ID_PREFIX}1`,
-      ].join("\n"),
     });
 
     await runSessionsPassthrough("alpha", { verb: "list", extraArgs: ["--agent", "main"] });
 
     expect(execMock).not.toHaveBeenCalled();
-    expect(captureMock).toHaveBeenCalled();
+    expect(readOnlyExecMock).toHaveBeenCalled();
     expect(String(stdoutSpy.mock.calls[0]?.[0])).toBe("Sessions listed: 0\n");
     expect(String(stderrSpy.mock.calls[0]?.[0])).toBe("warning: noisy but non-fatal\n");
   });
 
   it("also filters the parent `sessions` list shorthand", async () => {
-    captureMock.mockReturnValueOnce({
+    readOnlyExecMock.mockResolvedValueOnce({
       status: 0,
-      output: `Sessions listed: 1\nid:${WARMUP_SESSION_ID_PREFIX}1`,
+      stdout: `Sessions listed: 1\nid:${WARMUP_SESSION_ID_PREFIX}1`,
+      stderr: "",
     });
 
     await runSessionsPassthrough("alpha", { extraArgs: [] });
 
     expect(execMock).not.toHaveBeenCalled();
-    expect(captureMock).toHaveBeenCalledWith(
-      ["sandbox", "exec", "--name", "alpha", "--", "openclaw", "sessions"],
-      { ignoreError: true, includeStreams: true, maxBuffer: 64 * 1024 * 1024 },
-    );
+    expect(readOnlyExecMock).toHaveBeenCalledWith("nemoclaw", {
+      sandboxName: "alpha",
+      command: ["openclaw", "sessions"],
+      maxOutputBytes: 64 * 1024 * 1024,
+    });
     expect(String(stdoutSpy.mock.calls[0]?.[0])).toBe("Sessions listed: 0\n");
   });
 
@@ -317,11 +314,12 @@ describe("runSessionsPassthrough", () => {
     ) => {
       throw new Error(`process.exit:${code}`);
     }) as never);
-    captureMock.mockReturnValueOnce({
+    readOnlyExecMock.mockResolvedValueOnce({
       status: 0,
-      output: JSON.stringify({
+      stdout: JSON.stringify({
         records: [{ sid: `${WARMUP_SESSION_ID_PREFIX}1` }],
       }),
+      stderr: "",
     });
 
     try {
@@ -338,9 +336,10 @@ describe("runSessionsPassthrough", () => {
 
   it("passes through unrecognised JSON when it cannot leak a warm-up session", async () => {
     const raw = JSON.stringify({ records: [{ key: "agent:main:main", sessionId: "sid-real" }] });
-    captureMock.mockReturnValueOnce({
+    readOnlyExecMock.mockResolvedValueOnce({
       status: 0,
-      output: raw,
+      stdout: raw,
+      stderr: "",
     });
 
     await runSessionsPassthrough("alpha", { verb: "list", extraArgs: ["--json"] });
@@ -355,9 +354,8 @@ describe("runSessionsPassthrough", () => {
     ) => {
       throw new Error(`process.exit:${code}`);
     }) as never);
-    captureMock.mockReturnValueOnce({
+    readOnlyExecMock.mockResolvedValueOnce({
       status: null,
-      output: "",
       stdout: "",
       stderr: "",
       error: Object.assign(new Error("spawnSync openshell ENOBUFS"), { code: "ENOBUFS" }),
@@ -371,10 +369,10 @@ describe("runSessionsPassthrough", () => {
       exitSpy.mockRestore();
     }
 
-    expect(captureMock).toHaveBeenCalledWith(expect.any(Array), {
-      ignoreError: true,
-      includeStreams: true,
-      maxBuffer: 64 * 1024 * 1024,
+    expect(readOnlyExecMock).toHaveBeenCalledWith("nemoclaw", {
+      sandboxName: "alpha",
+      command: ["openclaw", "sessions", "list", "--all-agents", "--json"],
+      maxOutputBytes: 64 * 1024 * 1024,
     });
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("output exceeded NemoClaw's 64 MiB filtering buffer"),
@@ -388,21 +386,30 @@ describe("runSessionsPassthrough", () => {
 
     await runSessionsPassthrough("hermes", { extraArgs: [] });
 
-    expect(captureMock).not.toHaveBeenCalled();
+    expect(readOnlyExecMock).not.toHaveBeenCalled();
     expect(execMock).toHaveBeenCalledWith("hermes", ["hermes", "sessions", "list"]);
   });
 
   it("uses openclaw binary for openclaw-agent sandboxes (#6247)", async () => {
-    getSandboxMock.mockReturnValue({ agent: "openclaw" });
-    captureMock.mockReturnValueOnce({ status: 0, output: "Sessions listed: 0\n" });
+    getSandboxMock.mockReturnValue({
+      agent: "openclaw",
+      gatewayName: "nemoclaw-9090",
+      gatewayPort: 9090,
+    });
+    readOnlyExecMock.mockResolvedValueOnce({
+      status: 0,
+      stdout: "Sessions listed: 0\n",
+      stderr: "",
+    });
 
     await runSessionsPassthrough("alpha", { extraArgs: [] });
 
     expect(execMock).not.toHaveBeenCalled();
-    expect(captureMock).toHaveBeenCalledWith(
-      ["sandbox", "exec", "--name", "alpha", "--", "openclaw", "sessions"],
-      { ignoreError: true, includeStreams: true, maxBuffer: 64 * 1024 * 1024 },
-    );
+    expect(readOnlyExecMock).toHaveBeenCalledWith("nemoclaw-9090", {
+      sandboxName: "alpha",
+      command: ["openclaw", "sessions"],
+      maxOutputBytes: 64 * 1024 * 1024,
+    });
   });
 
   it("routes hermes `sessions list` with forwarded flags via execSandbox (#6247)", async () => {
@@ -413,34 +420,44 @@ describe("runSessionsPassthrough", () => {
       extraArgs: ["--limit", "5"],
     });
 
-    expect(captureMock).not.toHaveBeenCalled();
+    expect(readOnlyExecMock).not.toHaveBeenCalled();
     expect(execMock).toHaveBeenCalledWith("hermes", ["hermes", "sessions", "list", "--limit", "5"]);
   });
 
   it("defaults to the openclaw binary + filter path when the registry has no entry (#6247)", async () => {
     getSandboxMock.mockReturnValue(null);
-    captureMock.mockReturnValueOnce({ status: 0, output: "Sessions listed: 0\n" });
+    readOnlyExecMock.mockResolvedValueOnce({
+      status: 0,
+      stdout: "Sessions listed: 0\n",
+      stderr: "",
+    });
 
     await runSessionsPassthrough("alpha", { extraArgs: [] });
 
     expect(execMock).not.toHaveBeenCalled();
-    expect(captureMock).toHaveBeenCalledWith(
-      ["sandbox", "exec", "--name", "alpha", "--", "openclaw", "sessions"],
-      { ignoreError: true, includeStreams: true, maxBuffer: 64 * 1024 * 1024 },
-    );
+    expect(readOnlyExecMock).toHaveBeenCalledWith("nemoclaw", {
+      sandboxName: "alpha",
+      command: ["openclaw", "sessions"],
+      maxOutputBytes: 64 * 1024 * 1024,
+    });
   });
 
   it("defaults to the openclaw binary for an unknown agent value (#6247)", async () => {
     getSandboxMock.mockReturnValue({ agent: "custom-future-agent" });
-    captureMock.mockReturnValueOnce({ status: 0, output: "Sessions listed: 0\n" });
+    readOnlyExecMock.mockResolvedValueOnce({
+      status: 0,
+      stdout: "Sessions listed: 0\n",
+      stderr: "",
+    });
 
     await runSessionsPassthrough("alpha", { extraArgs: [] });
 
     expect(execMock).not.toHaveBeenCalled();
-    expect(captureMock).toHaveBeenCalledWith(
-      ["sandbox", "exec", "--name", "alpha", "--", "openclaw", "sessions"],
-      { ignoreError: true, includeStreams: true, maxBuffer: 64 * 1024 * 1024 },
-    );
+    expect(readOnlyExecMock).toHaveBeenCalledWith("nemoclaw", {
+      sandboxName: "alpha",
+      command: ["openclaw", "sessions"],
+      maxOutputBytes: 64 * 1024 * 1024,
+    });
   });
 
   it("prints captured output when OpenClaw exits non-zero", async () => {
@@ -449,9 +466,8 @@ describe("runSessionsPassthrough", () => {
     ) => {
       throw new Error(`process.exit:${code}`);
     }) as never);
-    captureMock.mockReturnValueOnce({
+    readOnlyExecMock.mockResolvedValueOnce({
       status: 2,
-      output: "",
       stdout: "",
       stderr: "unknown flag: --bad\n",
     });

--- a/src/lib/actions/sandbox/sessions/passthrough.ts
+++ b/src/lib/actions/sandbox/sessions/passthrough.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { openShellSandboxControl } from "../../../adapters/openshell/sandbox-control";
+import { execSandboxReadOnlyWithGrpcFallback } from "../../../adapters/openshell/sandbox-control-routing";
 import { CLI_NAME } from "../../../cli/branding";
+import { resolveSandboxGatewayName } from "../../../onboard/gateway-binding";
 import * as registry from "../../../state/registry";
 import { computeExitCode, execSandbox } from "../exec";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
@@ -36,11 +37,11 @@ export function printSessionsPassthroughHelp(verb?: SessionsPassthroughVerb): vo
   console.log(
     `  Pass-through to the sandbox agent's \`sessions${usageSuffix} ...\` command inside the sandbox`,
   );
-  console.log("  via `openshell sandbox exec` — `openclaw sessions ...` for OpenClaw sandboxes,");
+  console.log("  via OpenShell's supported sandbox execution API — `openclaw sessions ...` for");
   console.log(
-    `  \`hermes sessions${hermesUsageSuffix} ...\` for Hermes sandboxes; the in-sandbox binary is picked`,
+    `  OpenClaw sandboxes, \`hermes sessions${hermesUsageSuffix} ...\` for Hermes sandboxes; the`,
   );
-  console.log("  from the sandbox's agent.");
+  console.log("  in-sandbox binary is picked from the sandbox's agent.");
   console.log(
     "  On OpenClaw sandboxes, internal NemoClaw onboard warm-up sessions are hidden from default",
   );
@@ -223,14 +224,15 @@ export async function runSessionsPassthrough(
   // `~/.nemoclaw/sandboxes.json` registry (`REGISTRY_FILE`). Sandbox processes
   // cannot access the host filesystem to change this agent selection; unknown
   // or missing values deliberately default to `openclaw` below.
-  const sandboxAgent = registry.getSandbox(sandboxName)?.agent;
+  const sandbox = registry.getSandbox(sandboxName);
+  const sandboxAgent = sandbox?.agent;
   const inSandboxBinary = sandboxAgent === "hermes" ? "hermes" : "openclaw";
   const command = [inSandboxBinary, "sessions"];
   if (verb) command.push(verb);
   else if (inSandboxBinary === "hermes") command.push("list");
   for (const arg of extraArgs) command.push(arg);
   if (isFilterableListPassthrough(verb) && inSandboxBinary === "openclaw") {
-    const result = await openShellSandboxControl.exec({
+    const result = await execSandboxReadOnlyWithGrpcFallback(resolveSandboxGatewayName(sandbox), {
       sandboxName,
       command,
       maxOutputBytes: SESSIONS_LIST_CAPTURE_MAX_BUFFER_BYTES,

--- a/src/lib/adapters/openshell/grpc-sandbox-control.test.ts
+++ b/src/lib/adapters/openshell/grpc-sandbox-control.test.ts
@@ -22,6 +22,7 @@ import {
   createGrpcOpenShellSandboxControl,
   createOpenShellGrpcApi,
   OpenShellGrpcOutputLimitError,
+  OpenShellGrpcPreDispatchError,
   type OpenShellGrpcApi,
 } from "./grpc-sandbox-control";
 
@@ -221,7 +222,10 @@ describe("gRPC OpenShell sandbox control", () => {
       status: null,
       stdout: "",
       stderr: "",
-      error,
+      error: expect.objectContaining({
+        cause: error,
+        name: OpenShellGrpcPreDispatchError.name,
+      }),
     });
     expect(fake.execMetadata).toEqual([]);
   });

--- a/src/lib/adapters/openshell/grpc-sandbox-control.ts
+++ b/src/lib/adapters/openshell/grpc-sandbox-control.ts
@@ -72,6 +72,13 @@ export class OpenShellGrpcOutputLimitError extends Error {
   }
 }
 
+export class OpenShellGrpcPreDispatchError extends Error {
+  constructor(readonly cause: Error) {
+    super(cause.message, { cause });
+    this.name = "OpenShellGrpcPreDispatchError";
+  }
+}
+
 function isLoopback(hostname: string): boolean {
   const normalized = hostname.replace(/^\[|\]$/g, "").toLowerCase();
   return (
@@ -309,7 +316,13 @@ export function createGrpcOpenShellSandboxControl(
       try {
         id = await sandboxId(client, request.sandboxName, metadata, options);
       } catch (error) {
-        return { status: null, stdout: "", stderr: "", error: error as Error };
+        const cause = error instanceof Error ? error : new Error(String(error));
+        return {
+          status: null,
+          stdout: "",
+          stderr: "",
+          error: new OpenShellGrpcPreDispatchError(cause),
+        };
       }
       return execute(client, id, request, metadata, options);
     },

--- a/src/lib/adapters/openshell/sandbox-control-routing.test.ts
+++ b/src/lib/adapters/openshell/sandbox-control-routing.test.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { GrpcOpenShellSandboxControl } from "./grpc-sandbox-control";
+import type { OpenShellSandboxControl, SandboxExecResult } from "./sandbox-control";
+import { execSandboxReadOnlyWithGrpcFallback } from "./sandbox-control-routing";
+import { OPENSHELL_OPERATION_TIMEOUT_MS } from "./timeouts";
+
+function dependencies(grpcResult: SandboxExecResult | Error, cliResult?: SandboxExecResult) {
+  const close = vi.fn();
+  const grpcExec = vi.fn(async () => {
+    if (grpcResult instanceof Error) throw grpcResult;
+    return grpcResult;
+  });
+  const grpc: GrpcOpenShellSandboxControl = { close, exec: grpcExec };
+  const cliExec = vi.fn(async () => cliResult ?? { status: 0, stdout: "cli", stderr: "" });
+  const cli: OpenShellSandboxControl = { exec: cliExec };
+  const createGrpc = vi.fn(() => grpc);
+  const debug = vi.fn();
+  return { close, grpcExec, cliExec, createGrpc, debug, deps: { cli, createGrpc, debug } };
+}
+
+const request = {
+  sandboxName: "alpha",
+  command: ["openclaw", "sessions", "list"] as const,
+  maxOutputBytes: 4096,
+};
+
+describe("read-only OpenShell sandbox control routing", () => {
+  it("uses direct gRPC with a bounded deadline", async () => {
+    const test = dependencies({ status: 0, stdout: "grpc", stderr: "" });
+
+    await expect(
+      execSandboxReadOnlyWithGrpcFallback("nemoclaw-9090", request, test.deps),
+    ).resolves.toEqual({ status: 0, stdout: "grpc", stderr: "" });
+
+    expect(test.createGrpc).toHaveBeenCalledWith("nemoclaw-9090");
+    expect(test.grpcExec).toHaveBeenCalledWith({
+      ...request,
+      timeoutMs: OPENSHELL_OPERATION_TIMEOUT_MS,
+    });
+    expect(test.cliExec).not.toHaveBeenCalled();
+    expect(test.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not replay a completed non-zero command through the CLI", async () => {
+    const result = { status: 2, stdout: "", stderr: "unknown flag" };
+    const test = dependencies(result);
+
+    await expect(
+      execSandboxReadOnlyWithGrpcFallback("nemoclaw", request, test.deps),
+    ).resolves.toEqual(result);
+
+    expect(test.cliExec).not.toHaveBeenCalled();
+  });
+
+  it("retries a gRPC transport failure through the CLI without forwarding its deadline", async () => {
+    const grpcError = new Error("UNAVAILABLE");
+    const cliResult = { status: 0, stdout: "cli", stderr: "" };
+    const test = dependencies(
+      { status: null, stdout: "partial", stderr: "", error: grpcError },
+      cliResult,
+    );
+
+    await expect(
+      execSandboxReadOnlyWithGrpcFallback("nemoclaw", request, test.deps),
+    ).resolves.toEqual(cliResult);
+
+    expect(test.cliExec).toHaveBeenCalledWith(request);
+    expect(test.debug).toHaveBeenCalledWith(expect.stringContaining("gRPC read failed"), grpcError);
+    expect(test.close).toHaveBeenCalledOnce();
+  });
+
+  it("uses the CLI when gateway configuration cannot create a gRPC client", async () => {
+    const test = dependencies({ status: 0, stdout: "unused", stderr: "" });
+    const error = new Error("edge tunnel required");
+    test.createGrpc.mockImplementation(() => {
+      throw error;
+    });
+
+    await expect(execSandboxReadOnlyWithGrpcFallback("edge", request, test.deps)).resolves.toEqual({
+      status: 0,
+      stdout: "cli",
+      stderr: "",
+    });
+
+    expect(test.grpcExec).not.toHaveBeenCalled();
+    expect(test.cliExec).toHaveBeenCalledWith(request);
+    expect(test.debug).toHaveBeenCalledWith(expect.stringContaining("configuration failed"), error);
+  });
+
+  it("does not let close failures replace a successful result", async () => {
+    const test = dependencies({ status: 0, stdout: "grpc", stderr: "" });
+    const closeError = new Error("close failed");
+    test.close.mockImplementation(() => {
+      throw closeError;
+    });
+
+    await expect(
+      execSandboxReadOnlyWithGrpcFallback("nemoclaw", { ...request, timeoutMs: 0 }, test.deps),
+    ).resolves.toEqual({ status: 0, stdout: "grpc", stderr: "" });
+
+    expect(test.grpcExec).toHaveBeenCalledWith({ ...request, timeoutMs: 0 });
+    expect(test.debug).toHaveBeenCalledWith(
+      "OpenShell direct gRPC client close failed",
+      closeError,
+    );
+  });
+});

--- a/src/lib/adapters/openshell/sandbox-control-routing.test.ts
+++ b/src/lib/adapters/openshell/sandbox-control-routing.test.ts
@@ -10,10 +10,9 @@ import { OPENSHELL_OPERATION_TIMEOUT_MS } from "./timeouts";
 
 function dependencies(grpcResult: SandboxExecResult | Error, cliResult?: SandboxExecResult) {
   const close = vi.fn();
-  const grpcExec = vi.fn(async () => {
-    if (grpcResult instanceof Error) throw grpcResult;
-    return grpcResult;
-  });
+  const grpcExec = vi.fn(() =>
+    grpcResult instanceof Error ? Promise.reject(grpcResult) : Promise.resolve(grpcResult),
+  );
   const grpc: GrpcOpenShellSandboxControl = { close, exec: grpcExec };
   const cliExec = vi.fn(async () => cliResult ?? { status: 0, stdout: "cli", stderr: "" });
   const cli: OpenShellSandboxControl = { exec: cliExec };

--- a/src/lib/adapters/openshell/sandbox-control-routing.test.ts
+++ b/src/lib/adapters/openshell/sandbox-control-routing.test.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import type { GrpcOpenShellSandboxControl } from "./grpc-sandbox-control";
+import {
+  type GrpcOpenShellSandboxControl,
+  OpenShellGrpcPreDispatchError,
+} from "./grpc-sandbox-control";
 import type { OpenShellSandboxControl, SandboxExecResult } from "./sandbox-control";
 import { execSandboxReadOnlyWithGrpcFallback } from "./sandbox-control-routing";
 import { OPENSHELL_OPERATION_TIMEOUT_MS } from "./timeouts";
@@ -55,11 +58,16 @@ describe("read-only OpenShell sandbox control routing", () => {
     expect(test.cliExec).not.toHaveBeenCalled();
   });
 
-  it("retries a gRPC transport failure through the CLI without forwarding its deadline", async () => {
+  it("retries a pre-dispatch gRPC lookup failure without forwarding its deadline", async () => {
     const grpcError = new Error("UNAVAILABLE");
     const cliResult = { status: 0, stdout: "cli", stderr: "" };
     const test = dependencies(
-      { status: null, stdout: "partial", stderr: "", error: grpcError },
+      {
+        status: null,
+        stdout: "",
+        stderr: "",
+        error: new OpenShellGrpcPreDispatchError(grpcError),
+      },
       cliResult,
     );
 
@@ -68,8 +76,20 @@ describe("read-only OpenShell sandbox control routing", () => {
     ).resolves.toEqual(cliResult);
 
     expect(test.cliExec).toHaveBeenCalledWith(request);
-    expect(test.debug).toHaveBeenCalledWith(expect.stringContaining("gRPC read failed"), grpcError);
+    expect(test.debug).toHaveBeenCalledWith(expect.stringContaining("before dispatch"), grpcError);
     expect(test.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not replay a post-dispatch gRPC stream failure", async () => {
+    const grpcError = new Error("stream reset");
+    const result = { status: null, stdout: "partial", stderr: "", error: grpcError };
+    const test = dependencies(result);
+
+    await expect(
+      execSandboxReadOnlyWithGrpcFallback("nemoclaw", request, test.deps),
+    ).resolves.toEqual(result);
+
+    expect(test.cliExec).not.toHaveBeenCalled();
   });
 
   it("uses the CLI when gateway configuration cannot create a gRPC client", async () => {

--- a/src/lib/adapters/openshell/sandbox-control-routing.ts
+++ b/src/lib/adapters/openshell/sandbox-control-routing.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { log } from "../../cli/logger";
+import { OPENSHELL_OPERATION_TIMEOUT_MS } from "./timeouts";
+import { createGrpcOpenShellSandboxControlForGateway } from "./grpc-gateway-config";
+import {
+  createCliOpenShellSandboxControl,
+  type OpenShellSandboxControl,
+  type SandboxExecRequest,
+  type SandboxExecResult,
+} from "./sandbox-control";
+import type { GrpcOpenShellSandboxControl } from "./grpc-sandbox-control";
+
+export interface ReadOnlyRoutingDependencies {
+  cli: OpenShellSandboxControl;
+  createGrpc: (gatewayName: string) => GrpcOpenShellSandboxControl;
+  debug: (message: string, context: unknown) => void;
+}
+
+const defaultDependencies: ReadOnlyRoutingDependencies = {
+  cli: createCliOpenShellSandboxControl(),
+  createGrpc: createGrpcOpenShellSandboxControlForGateway,
+  debug: (message, context) => log.debug(message, context),
+};
+
+/**
+ * Prefer direct gRPC for a read-only sandbox exec and retry through the
+ * OpenShell CLI when gateway resolution or transport fails. This retry policy
+ * is intentionally restricted to read-only commands: a failed mutation may
+ * have committed remotely and must never be replayed automatically.
+ */
+export async function execSandboxReadOnlyWithGrpcFallback(
+  gatewayName: string,
+  request: SandboxExecRequest,
+  dependencies: ReadOnlyRoutingDependencies = defaultDependencies,
+): Promise<SandboxExecResult> {
+  let grpc: GrpcOpenShellSandboxControl | undefined;
+  try {
+    grpc = dependencies.createGrpc(gatewayName);
+    const result = await grpc.exec({
+      ...request,
+      timeoutMs: request.timeoutMs ?? OPENSHELL_OPERATION_TIMEOUT_MS,
+    });
+    if (!result.error) return result;
+    dependencies.debug("OpenShell direct gRPC read failed; retrying through the CLI", result.error);
+  } catch (error) {
+    dependencies.debug(
+      "OpenShell direct gRPC configuration failed; retrying through the CLI",
+      error,
+    );
+  } finally {
+    try {
+      grpc?.close();
+    } catch (error) {
+      dependencies.debug("OpenShell direct gRPC client close failed", error);
+    }
+  }
+  return dependencies.cli.exec(request);
+}

--- a/src/lib/adapters/openshell/sandbox-control-routing.ts
+++ b/src/lib/adapters/openshell/sandbox-control-routing.ts
@@ -10,7 +10,10 @@ import {
   type SandboxExecRequest,
   type SandboxExecResult,
 } from "./sandbox-control";
-import type { GrpcOpenShellSandboxControl } from "./grpc-sandbox-control";
+import {
+  type GrpcOpenShellSandboxControl,
+  OpenShellGrpcPreDispatchError,
+} from "./grpc-sandbox-control";
 
 export interface ReadOnlyRoutingDependencies {
   cli: OpenShellSandboxControl;
@@ -42,8 +45,11 @@ export async function execSandboxReadOnlyWithGrpcFallback(
       ...request,
       timeoutMs: request.timeoutMs ?? OPENSHELL_OPERATION_TIMEOUT_MS,
     });
-    if (!result.error) return result;
-    dependencies.debug("OpenShell direct gRPC read failed; retrying through the CLI", result.error);
+    if (!(result.error instanceof OpenShellGrpcPreDispatchError)) return result;
+    dependencies.debug(
+      "OpenShell direct gRPC lookup failed before dispatch; retrying through the CLI",
+      result.error.cause,
+    );
   } catch (error) {
     dependencies.debug(
       "OpenShell direct gRPC configuration failed; retrying through the CLI",


### PR DESCRIPTION
## Summary

Documents that OpenClaw session listing prefers direct gRPC through the sandbox's named OpenShell gateway, with OpenShell CLI retry only when a failure occurs before command dispatch. Clarifies that completed commands, including nonzero results, are never replayed.

This is PR 5 of 26 in the OpenShell gRPC migration stack.

## Changes

- Update the existing `nemoclaw <name> sessions` command reference to describe the direct gRPC execution path.
- Explain the read-only, pre-dispatch-only CLI compatibility retry and the no-replay boundary.
- Preserve the existing examples and warm-up-session filtering documentation; this slice changes prose only.

## Stack

- Stack index: https://github.com/NVIDIA/NemoClaw/pull/6790
- Depends on: https://github.com/NVIDIA/NemoClaw/pull/6793
- Review this PR against base branch `feat/openshell-grpc-gateway-auth/ae` to see only this slice.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: this is a prose-only update to an existing command-reference page; it changes no code samples or runtime behavior.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — tests are not applicable as noted above; `npm run docs` passed with 0 errors
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to a prose-only documentation change
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — the strict docs build passed with 0 errors and no unsuppressed warnings; Fern reported 2 configured suppressed warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
