### PR TITLE
fix(ci): report advisor health and close stale E2E checks

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -397,6 +397,7 @@ jobs:
       PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       ADVISOR_DIR: ${{ github.workspace }}/advisor
       PUBLISH_ARTIFACT_DIR: ${{ github.workspace }}/publish-artifacts/pr-review-advisor
+      SECONDARY_PUBLISH_ARTIFACT_DIR: ${{ github.workspace }}/publish-artifacts/pr-review-advisor-nemotron-ultra
       PR_REVIEW_ADVISOR_MAX_RESULT_BYTES: "2097152"
       PR_REVIEW_ADVISOR_MAX_SUMMARY_BYTES: "1048576"
     steps:
@@ -418,23 +419,49 @@ jobs:
           name: pr-review-advisor
           path: publish-artifacts/pr-review-advisor
 
-      - name: Validate primary advisor artifact
+      # A missing or invalid second opinion must not suppress a completed
+      # primary review. A present artifact must pass the same validation before
+      # the publisher includes its sanitized status.
+      - name: Download secondary advisor artifact
+        id: download-secondary-advisor-artifact
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-review-advisor-nemotron-ultra
+          path: publish-artifacts/pr-review-advisor-nemotron-ultra
+
+      - name: Validate advisor artifacts
+        id: validate-advisor-artifacts
         env:
           GH_TOKEN: ${{ github.token }}
+          SECONDARY_ARTIFACT_OUTCOME: ${{ steps.download-secondary-advisor-artifact.outcome }}
         run: |
           set -euo pipefail
           if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]] || [[ ! "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] || [[ ! "$TRUSTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]] || [[ ! "$PR_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::Invalid target-event publication identity"
             exit 1
           fi
+          if [ "$SECONDARY_ARTIFACT_OUTCOME" != "success" ] && [ "$SECONDARY_ARTIFACT_OUTCOME" != "failure" ]; then
+            echo "::error::Invalid secondary advisor artifact outcome"
+            exit 1
+          fi
 
+          export ANALYSIS_RESULT_PATH="$PUBLISH_ARTIFACT_DIR/pr-review-advisor-result.json"
           export RESULT_PATH="$PUBLISH_ARTIFACT_DIR/pr-review-advisor-final-result.json"
           export SUMMARY_PATH="$PUBLISH_ARTIFACT_DIR/pr-review-advisor-summary.md"
+          export SECONDARY_ANALYSIS_RESULT_PATH="$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-result.json"
+          export SECONDARY_RESULT_PATH="$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-final-result.json"
+          export SECONDARY_SUMMARY_PATH="$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-summary.md"
           node <<'NODE'
           const fs = require("node:fs");
           const path = require("node:path");
+          const { isDeepStrictEqual } = require("node:util");
 
-          function requireBoundedRegularFile(file, maxBytes, label) {
+          function requireBoundedRegularFile(rootDir, file, maxBytes, label) {
+            const rootStat = fs.lstatSync(rootDir);
+            if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+              throw new Error(`${label} artifact root must be a regular non-symlink directory`);
+            }
             const stat = fs.lstatSync(file);
             if (!stat.isFile() || stat.isSymbolicLink()) {
               throw new Error(`${label} must be a regular non-symlink file`);
@@ -442,44 +469,131 @@ jobs:
             if (stat.size <= 0 || stat.size > maxBytes) {
               throw new Error(`${label} size ${stat.size} is outside 1..${maxBytes} bytes`);
             }
-            const root = `${fs.realpathSync(process.env.PUBLISH_ARTIFACT_DIR)}${path.sep}`;
+            const root = `${fs.realpathSync(rootDir)}${path.sep}`;
             const real = fs.realpathSync(file);
             if (!real.startsWith(root)) throw new Error(`${label} escapes the artifact directory`);
           }
 
-          requireBoundedRegularFile(
+          function readJson(file, label) {
+            const value = JSON.parse(fs.readFileSync(file, "utf8"));
+            if (!value || typeof value !== "object" || Array.isArray(value)) {
+              throw new Error(`${label} must be a JSON object`);
+            }
+            return value;
+          }
+
+          function validateFinalResult(result, label) {
+            if (!result || typeof result !== "object" || Array.isArray(result)) {
+              throw new Error(`${label} must be a JSON object`);
+            }
+            if (result.version !== 1) throw new Error(`${label} version must be 1`);
+            if (result.headSha !== process.env.EXPECTED_HEAD_SHA) {
+              throw new Error(`${label} head SHA does not match the triggering PR head`);
+            }
+            if (!result.summary || typeof result.summary !== "object" || Array.isArray(result.summary)) {
+              throw new Error(`${label} summary must be an object`);
+            }
+            if (!["low", "medium", "high"].includes(result.summary.confidence)) {
+              throw new Error(`${label} summary confidence must be low, medium, or high`);
+          }
+            if (!Array.isArray(result.findings)) {
+              throw new Error(`${label} findings must be an array`);
+            }
+            for (const finding of result.findings) {
+              if (!finding || typeof finding !== "object" || Array.isArray(finding)) {
+                throw new Error(`${label} findings must contain JSON objects`);
+              }
+              if (!["blocker", "warning", "suggestion"].includes(finding.severity)) {
+                throw new Error(`${label} finding severity must be blocker, warning, or suggestion`);
+              }
+            }
+            if (!result.e2e || typeof result.e2e !== "object" || Array.isArray(result.e2e)) {
+              throw new Error(`${label} e2e must be an object`);
+            }
+            if (!result.e2e.coverage || typeof result.e2e.coverage !== "object" || Array.isArray(result.e2e.coverage)) {
+              throw new Error(`${label} e2e.coverage must be an object`);
+            }
+            if (!result.e2e.targets || typeof result.e2e.targets !== "object" || Array.isArray(result.e2e.targets)) {
+              throw new Error(`${label} e2e.targets must be an object`);
+            }
+          }
+
+          function validateAnalysisResult(analysisResult, finalResult, label) {
+            const statusCount = [
+              analysisResult.version === 1,
+              analysisResult.failed === true,
+              analysisResult.skipped === true,
+            ].filter(Boolean).length;
+            if (statusCount !== 1) {
+              throw new Error(`${label} must report exactly one analysis status`);
+            }
+            if (analysisResult.version === 1) {
+              if (!isDeepStrictEqual(analysisResult, finalResult)) {
+                throw new Error(`${label} completed analysis result must match its final result`);
+              }
+              return;
+            }
+            if (analysisResult.failed === true) {
+              if (typeof analysisResult.reason !== "string" || !analysisResult.reason.trim()) {
+                throw new Error(`${label} failed analysis must include a reason`);
+              }
+              if (analysisResult.partial === true) {
+                if (!Number.isInteger(analysisResult.findingCount) || analysisResult.findingCount !== finalResult.findings.length) {
+                  throw new Error(`${label} partial finding count must match its final result`);
+                }
+              } else if (finalResult.findings.length !== 0) {
+                throw new Error(`${label} failed analysis without a partial marker must not publish findings`);
+              }
+              return;
+            }
+            if (analysisResult.skipped === true) {
+              if (typeof analysisResult.reason !== "string" || !analysisResult.reason.trim()) {
+                throw new Error(`${label} skipped analysis must include a reason`);
+              }
+              if (finalResult.findings.length !== 0) {
+                throw new Error(`${label} skipped analysis must not publish findings`);
+              }
+              return;
+            }
+            throw new Error(`${label} must report completed, failed, or skipped analysis status`);
+          }
+
+          function validateLane(rootDir, analysisResultPath, resultPath, summaryPath, label) {
+            requireBoundedRegularFile(rootDir, analysisResultPath, Number(process.env.PR_REVIEW_ADVISOR_MAX_RESULT_BYTES), `${label} analysis result`);
+            requireBoundedRegularFile(rootDir, resultPath, Number(process.env.PR_REVIEW_ADVISOR_MAX_RESULT_BYTES), `${label} final result`);
+            requireBoundedRegularFile(rootDir, summaryPath, Number(process.env.PR_REVIEW_ADVISOR_MAX_SUMMARY_BYTES), `${label} summary`);
+            const analysisResult = readJson(analysisResultPath, `${label} analysis result`);
+            const finalResult = readJson(resultPath, `${label} final result`);
+            validateFinalResult(finalResult, `${label} final result`);
+            validateAnalysisResult(analysisResult, finalResult, label);
+          }
+
+          validateLane(
+            process.env.PUBLISH_ARTIFACT_DIR,
+            process.env.ANALYSIS_RESULT_PATH,
             process.env.RESULT_PATH,
-            Number(process.env.PR_REVIEW_ADVISOR_MAX_RESULT_BYTES),
-            "advisor result",
-          );
-          requireBoundedRegularFile(
             process.env.SUMMARY_PATH,
-            Number(process.env.PR_REVIEW_ADVISOR_MAX_SUMMARY_BYTES),
-            "advisor summary",
+            "primary advisor",
           );
-          const result = JSON.parse(fs.readFileSync(process.env.RESULT_PATH, "utf8"));
-          if (!result || typeof result !== "object" || Array.isArray(result)) {
-            throw new Error("advisor result must be a JSON object");
+          let secondaryArtifactValidated = false;
+          if (process.env.SECONDARY_ARTIFACT_OUTCOME === "success") {
+            try {
+              validateLane(
+                process.env.SECONDARY_PUBLISH_ARTIFACT_DIR,
+                process.env.SECONDARY_ANALYSIS_RESULT_PATH,
+                process.env.SECONDARY_RESULT_PATH,
+                process.env.SECONDARY_SUMMARY_PATH,
+                "secondary advisor",
+              );
+              secondaryArtifactValidated = true;
+            } catch {
+              console.error("::warning::Secondary advisor artifact failed validation; publishing the primary review without it");
+            }
           }
-          if (result.version !== 1) throw new Error("advisor result version must be 1");
-          if (result.headSha !== process.env.EXPECTED_HEAD_SHA) {
-            throw new Error("advisor result head SHA does not match the triggering PR head");
-          }
-          if (!result.summary || typeof result.summary !== "object" || Array.isArray(result.summary)) {
-            throw new Error("advisor result summary must be an object");
-          }
-          if (!Array.isArray(result.findings)) {
-            throw new Error("advisor result findings must be an array");
-          }
-          if (!result.e2e || typeof result.e2e !== "object" || Array.isArray(result.e2e)) {
-            throw new Error("advisor result e2e must be an object");
-          }
-          if (!result.e2e.coverage || typeof result.e2e.coverage !== "object" || Array.isArray(result.e2e.coverage)) {
-            throw new Error("advisor result e2e.coverage must be an object");
-          }
-          if (!result.e2e.targets || typeof result.e2e.targets !== "object" || Array.isArray(result.e2e.targets)) {
-            throw new Error("advisor result e2e.targets must be an object");
-          }
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `secondary_artifact_validated=${secondaryArtifactValidated}\n`,
+          );
           NODE
 
           LIVE_HEAD_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')"
@@ -496,12 +610,22 @@ jobs:
       - name: Post PR review advisor comment
         env:
           GH_TOKEN: ${{ github.token }}
+          SECONDARY_ARTIFACT_VALIDATED: ${{ steps.validate-advisor-artifacts.outputs.secondary_artifact_validated }}
         run: |
+          SECONDARY_ARGS=()
+          if [ "$SECONDARY_ARTIFACT_VALIDATED" = "true" ]; then
+            SECONDARY_ARGS=(
+              --second-opinion-analysis-result "$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-result.json"
+              --second-opinion-result "$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-final-result.json"
+            )
+          fi
           node --experimental-strip-types "$ADVISOR_DIR/tools/pr-review-advisor/comment.mts" \
             --repo "$GITHUB_REPOSITORY" \
             --pr "$PR_NUMBER" \
             --summary "$PUBLISH_ARTIFACT_DIR/pr-review-advisor-summary.md" \
+            --analysis-result "$PUBLISH_ARTIFACT_DIR/pr-review-advisor-result.json" \
             --result "$PUBLISH_ARTIFACT_DIR/pr-review-advisor-final-result.json" \
             --marker "$PR_REVIEW_ADVISOR_COMMENT_MARKER" \
             --title "$PR_REVIEW_ADVISOR_COMMENT_TITLE" \
-            --label "$PR_REVIEW_ADVISOR_COMMENT_LABEL"
+            --label "$PR_REVIEW_ADVISOR_COMMENT_LABEL" \
+            "${SECONDARY_ARGS[@]}"

--- a/test/e2e-recommendations.test.ts
+++ b/test/e2e-recommendations.test.ts
@@ -312,6 +312,26 @@ describe("E2E recommendation normalizer", () => {
     expect(normalized.confidence).toBe("medium");
   });
 
+  it("does not report an empty coverage decision when optional coverage was selected", () => {
+    const normalized = normalizeE2eCoverageResult(
+      {
+        requiredTests: [],
+        optionalTests: [
+          {
+            id: "docs-validation",
+            reason: "Documentation routing changed.",
+          },
+        ],
+        confidence: "high",
+      },
+      metadata({ changedFiles: [] }),
+    );
+
+    expect(normalized.requiredTests).toEqual([]);
+    expect(normalized.optionalTests.map((item) => item.id)).toEqual(["docs-validation"]);
+    expect(normalized.noE2eReason).toBeNull();
+  });
+
   it("does not let a model downgrade a deterministic risk-plan job", () => {
     const normalized = normalizeE2eTargetAdvisorResult(
       {

--- a/test/pr-e2e-gate.test.ts
+++ b/test/pr-e2e-gate.test.ts
@@ -970,6 +970,7 @@ describe("PR E2E controller", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
         [
+          emptyPrGateCheckRunsRoute(),
           pullRequestDetailRoute({
             ...pullRequest(),
             base: { ...pullRequest().base, sha: "c".repeat(40) },
@@ -983,8 +984,77 @@ describe("PR E2E controller", () => {
       await expect(
         startPrGate({ ...startCommand(workDir), ciConclusion: "failure" }),
       ).rejects.toThrow(/expected exact head and base/u);
-      expect(requests).toHaveLength(1);
-      expect(requests.some((request) => request.url.includes("/check-runs"))).toBe(false);
+      expect(requests).toHaveLength(2);
+      expect(requests.filter((request) => request.url.includes("/check-runs?"))).toHaveLength(1);
+      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
+      expect(fs.readFileSync(outputPath, "utf8")).toBe("");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers a superseded exact-diff check for the workflow cleanup step", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-superseded-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          existingPrGateCheckRunsRoute(),
+          pullRequestDetailRoute({
+            ...pullRequest(),
+            head: { ...pullRequest().head, sha: "c".repeat(40) },
+          }),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir))).rejects.toThrow(
+        /expected exact head and base/u,
+      );
+      expect(requests).toHaveLength(2);
+      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
+      expect(requests.some((request) => request.method === "PATCH")).toBe(false);
+      expect(fs.readFileSync(outputPath, "utf8")).toBe("check_id=17\n");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reopen a completed check when a superseded CI event arrives", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-completed-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          existingPrGateCheckRunsRoute({ status: "completed", conclusion: "success" }),
+          pullRequestDetailRoute({
+            ...pullRequest(),
+            head: { ...pullRequest().head, sha: "c".repeat(40) },
+          }),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir))).rejects.toThrow(
+        /expected exact head and base/u,
+      );
+      expect(requests).toHaveLength(2);
+      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
+      expect(requests.some((request) => request.method === "PATCH")).toBe(false);
       expect(fs.readFileSync(outputPath, "utf8")).toBe("");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
@@ -1211,7 +1281,7 @@ describe("PR E2E controller", () => {
               url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
             () => {
               checkListCalls += 1;
-              return checkListCalls === 1
+              return checkListCalls <= 2
                 ? githubResponse({ total_count: 0, check_runs: [] })
                 : githubResponse({ total_count: 1, check_runs: [exactPrGateCheck()] });
             },

--- a/test/pr-review-advisor-comment-cli.test.ts
+++ b/test/pr-review-advisor-comment-cli.test.ts
@@ -6,7 +6,10 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 import {
+  buildComment,
+  normalizeAdvisorLaneReport,
   normalizeCommentOptions,
+  readAdvisorLaneReports,
   readCommentArtifacts,
 } from "../tools/pr-review-advisor/comment.mts";
 
@@ -87,5 +90,233 @@ describe("PR review advisor comment CLI", () => {
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("normalizes completed, partial, failed, skipped, and unavailable lane states", () => {
+    const headSha = "a".repeat(40);
+    const finalResult = {
+      version: 1,
+      headSha,
+      summary: { confidence: "high" },
+      findings: [
+        { severity: "blocker", title: "one" },
+        { severity: "warning", title: "two" },
+        { severity: "suggestion", title: "three" },
+        { severity: "invalid", title: "ignored" },
+      ],
+      e2e: {
+        coverage: {
+          requiredTests: [{ id: "security-posture", reason: "not fingerprinted" }],
+          optionalTests: [],
+        },
+        targets: {
+          required: [
+            {
+              id: "security-posture",
+              workflow: "e2e.yaml",
+              selectorType: "job",
+              reason: "not fingerprinted",
+            },
+          ],
+          optional: [],
+        },
+      },
+    };
+
+    const completed = normalizeAdvisorLaneReport(finalResult, finalResult, headSha);
+    expect(completed).toMatchObject({
+      status: "completed",
+      partial: false,
+      confidence: "high",
+      counts: { blockers: 1, warnings: 1, suggestions: 1 },
+    });
+    expect(completed.fingerprints?.findings).toMatch(/^[0-9a-f]{64}$/u);
+    expect(completed.fingerprints?.e2e).toMatch(/^[0-9a-f]{64}$/u);
+    const reordered = normalizeAdvisorLaneReport(
+      { ...finalResult, findings: [...finalResult.findings].reverse() },
+      { ...finalResult, findings: [...finalResult.findings].reverse() },
+      headSha,
+    );
+    expect(reordered.fingerprints?.findings).toBe(completed.fingerprints?.findings);
+
+    expect(
+      normalizeAdvisorLaneReport(
+        { failed: true, partial: true, reason: "provider text must not render" },
+        { ...finalResult, summary: { confidence: "low" } },
+        headSha,
+      ),
+    ).toMatchObject({
+      status: "failed",
+      partial: true,
+      confidence: "low",
+      counts: { blockers: 1, warnings: 1, suggestions: 1 },
+    });
+    expect(normalizeAdvisorLaneReport({ failed: true }, finalResult, headSha)).toEqual({
+      status: "failed",
+      partial: false,
+    });
+    expect(normalizeAdvisorLaneReport({ skipped: true }, finalResult, headSha)).toEqual({
+      status: "skipped",
+      partial: false,
+    });
+    expect(normalizeAdvisorLaneReport(undefined, finalResult, headSha)).toEqual({
+      status: "unavailable",
+      partial: false,
+    });
+    expect(normalizeAdvisorLaneReport(finalResult, finalResult, "b".repeat(40))).toEqual({
+      status: "unavailable",
+      partial: false,
+    });
+  });
+
+  it("reads optional second-opinion artifacts without making them publication-critical", () => {
+    const tmp = fs.mkdtempSync(path.join(ROOT, ".tmp-pr-advisor-lanes-"));
+    const primaryAnalysis = path.join(tmp, "primary-analysis.json");
+    const secondaryAnalysis = path.join(tmp, "secondary-analysis.json");
+    const secondaryResult = path.join(tmp, "secondary-final.json");
+    const headSha = "a".repeat(40);
+    const primaryResult = {
+      version: 1,
+      headSha,
+      summary: { confidence: "medium" },
+      findings: [],
+    };
+    fs.writeFileSync(primaryAnalysis, `${JSON.stringify(primaryResult)}\n`);
+    fs.writeFileSync(
+      secondaryAnalysis,
+      `${JSON.stringify({ failed: true, partial: true, reason: "secret-like failure text" })}\n`,
+    );
+    fs.writeFileSync(
+      secondaryResult,
+      `${JSON.stringify({
+        version: 1,
+        headSha,
+        summary: { confidence: "low", oneLine: "untrusted secondary prose" },
+        findings: [{ severity: "warning", title: "secondary finding prose" }],
+      })}\n`,
+    );
+
+    try {
+      expect(
+        readAdvisorLaneReports({
+          primaryAnalysisResultPath: primaryAnalysis,
+          primaryResult,
+          secondOpinionAnalysisResultPath: secondaryAnalysis,
+          secondOpinionResultPath: secondaryResult,
+        }),
+      ).toMatchObject({
+        primary: { status: "completed", confidence: "medium" },
+        secondOpinion: {
+          status: "failed",
+          partial: true,
+          confidence: "low",
+          counts: { blockers: 0, warnings: 1, suggestions: 0 },
+        },
+      });
+      fs.writeFileSync(secondaryResult, "not json\n");
+      expect(
+        readAdvisorLaneReports({
+          primaryAnalysisResultPath: primaryAnalysis,
+          primaryResult,
+          secondOpinionAnalysisResultPath: secondaryAnalysis,
+          secondOpinionResultPath: secondaryResult,
+        }).secondOpinion,
+      ).toEqual({ status: "unavailable", partial: false });
+      expect(
+        readAdvisorLaneReports({
+          primaryAnalysisResultPath: primaryAnalysis,
+          primaryResult,
+        }).secondOpinion,
+      ).toEqual({ status: "unavailable", partial: false });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("renders sanitized model-lane status and structural disagreement only", () => {
+    const result = {
+      version: 1,
+      headSha: "a".repeat(40),
+      summary: {
+        recommendation: "info_only",
+        confidence: "high",
+        oneLine: "Primary review completed.",
+      },
+      findings: [{ severity: "warning", title: "Primary warning" }],
+      e2e: {
+        coverage: {
+          requiredTests: [],
+          optionalTests: [{ id: "docs-validation", reason: "primary optional coverage" }],
+        },
+        targets: {
+          required: [],
+          optional: [
+            {
+              id: "docs-validation",
+              workflow: "e2e.yaml",
+              selectorType: "job",
+              required: false,
+              reason: "primary optional selector",
+            },
+          ],
+        },
+      },
+    };
+    const primary = normalizeAdvisorLaneReport(result, result, result.headSha);
+    const secondOpinionResult = {
+      version: 1,
+      headSha: result.headSha,
+      summary: { confidence: "low", oneLine: "do not publish this summary" },
+      findings: [{ severity: "warning", title: "do not publish this finding" }],
+      e2e: {
+        coverage: { requiredTests: [{ id: "security-posture" }], optionalTests: [] },
+        targets: { required: [], optional: [] },
+      },
+    };
+    const secondOpinion = normalizeAdvisorLaneReport(
+      secondOpinionResult,
+      secondOpinionResult,
+      result.headSha,
+    );
+    const comment = buildComment({
+      summary: "# ignored\n",
+      result,
+      lanes: { primary, secondOpinion },
+    });
+
+    expect(comment).toContain("**Advisor assessment:** Informational / high confidence");
+    expect(comment).toContain(
+      "**GPT-5.6 Terra (primary):** Completed · high confidence · 0 blockers · 1 warning · 0 suggestions",
+    );
+    expect(comment).toContain(
+      "**Nemotron 3 Ultra (non-blocking second opinion):** Completed · low confidence · 0 blockers · 1 warning · 0 suggestions",
+    );
+    expect(comment).toContain("normalized findings differ");
+    expect(comment).toContain("normalized E2E selections differ");
+    expect(comment).toContain("severity counts match");
+    expect(comment).not.toContain("do not publish this summary");
+    expect(comment).not.toContain("do not publish this finding");
+    expect(comment).not.toContain("Why no E2E coverage is recommended");
+    expect(comment).not.toContain("Why no selector is recommended");
+
+    const partialComment = buildComment({
+      summary: "# ignored\n",
+      result,
+      lanes: {
+        primary,
+        secondOpinion: normalizeAdvisorLaneReport(
+          { failed: true, partial: true, reason: "do not publish this provider failure" },
+          secondOpinionResult,
+          result.headSha,
+        ),
+      },
+    });
+    expect(partialComment).toContain(
+      "**Nemotron 3 Ultra (non-blocking second opinion):** Failed after a partial review · low confidence · 0 blockers · 1 warning · 0 suggestions",
+    );
+    expect(partialComment).not.toContain("Model comparison");
+    expect(partialComment).not.toContain("do not publish this provider failure");
+    expect(partialComment).not.toContain("do not publish this summary");
+    expect(partialComment).not.toContain("do not publish this finding");
   });
 });

--- a/test/pr-review-advisor-security-boundaries.test.ts
+++ b/test/pr-review-advisor-security-boundaries.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { upsertStickyComment } from "../tools/advisors/github.mts";
+import { deleteBotOwnedStickyComments, upsertStickyComment } from "../tools/advisors/github.mts";
 import { buildRiskPlan } from "../tools/advisors/risk-plan.mts";
 import { runReadOnlyAdvisor } from "../tools/advisors/session.mts";
 import { normalizeReviewResult, renderSummary } from "../tools/pr-review-advisor/analyze.mts";
@@ -157,6 +157,76 @@ describe("PR review advisor security boundaries", () => {
         label: "test",
       }),
     ).rejects.toThrow(/403.*Resource not accessible/);
+  });
+
+  it("deletes only bot-owned comments with exact legacy advisor markers", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () =>
+          JSON.stringify([
+            {
+              id: 10,
+              body: "<!-- nemoclaw-e2e-advisor -->\nlegacy coverage",
+              user: { login: "github-actions[bot]" },
+            },
+            {
+              id: 11,
+              body: "<!-- nemoclaw-e2e-target-advisor -->\nlegacy targets",
+              user: { login: "github-actions[bot]" },
+            },
+            {
+              id: 12,
+              body: "<!-- nemoclaw-e2e-advisor -->\ncontributor text",
+              user: { login: "contributor" },
+            },
+            {
+              id: 13,
+              body: "prefix <!-- nemoclaw-e2e-advisor -->",
+              user: { login: "github-actions[bot]" },
+            },
+          ]),
+      } as Response)
+      .mockResolvedValue({ ok: true, text: async () => "" } as Response);
+
+    await expect(
+      deleteBotOwnedStickyComments({
+        repo: "NVIDIA/NemoClaw",
+        pr: "1",
+        token: "token",
+        markers: ["<!-- nemoclaw-e2e-advisor -->", "<!-- nemoclaw-e2e-target-advisor -->"],
+        label: "legacy E2E advisor",
+      }),
+    ).resolves.toBe(2);
+
+    const deletes = fetchMock.mock.calls.filter(
+      ([, options]) => (options as RequestInit | undefined)?.method === "DELETE",
+    );
+    expect(deletes.map(([input]) => String(input))).toEqual([
+      expect.stringContaining("issues/comments/10"),
+      expect.stringContaining("issues/comments/11"),
+    ]);
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes("comments/12"))).toBe(
+      false,
+    );
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes("comments/13"))).toBe(
+      false,
+    );
+  });
+
+  it("does not query comments when no retirement markers are provided", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await expect(
+      deleteBotOwnedStickyComments({
+        repo: "NVIDIA/NemoClaw",
+        pr: "1",
+        token: "token",
+        markers: [],
+        label: "legacy E2E advisor",
+      }),
+    ).resolves.toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("rejects command-shaped E2E guidance without weakening deterministic coverage", () => {

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -114,27 +114,76 @@ fi
 function runArtifactValidation(
   result: unknown,
   options: {
+    analysisResult?: unknown;
     summary?: string;
     liveHead?: string;
     liveBase?: string;
+    omitAnalysisResult?: boolean;
+    omitSummary?: boolean;
+    symlinkAnalysisResult?: boolean;
     symlinkResult?: boolean;
+    secondaryResult?: unknown;
+    secondaryAnalysisResult?: unknown;
+    secondarySummary?: string;
+    secondaryDownloadOutcome?: "success" | "failure" | "unexpected";
+    omitSecondaryArtifact?: boolean;
+    omitSecondarySummary?: boolean;
+    symlinkSecondaryResult?: boolean;
   } = {},
 ) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pr-review-advisor-publish-"));
   const artifactDir = path.join(tmp, "artifacts");
+  const secondaryArtifactDir = path.join(tmp, "secondary-artifacts");
   const binDir = path.join(tmp, "bin");
+  const githubOutputPath = path.join(tmp, "github-output");
+  const analysisResultPath = path.join(artifactDir, "pr-review-advisor-result.json");
+  const analysisResultFixturePath = path.join(tmp, "analysis-result-fixture.json");
   const resultPath = path.join(artifactDir, "pr-review-advisor-final-result.json");
   const resultFixturePath = path.join(tmp, "result-fixture.json");
+  const secondaryResult = options.secondaryResult ?? validPrimaryResult();
+  const secondaryResultPath = path.join(
+    secondaryArtifactDir,
+    "pr-review-advisor-final-result.json",
+  );
+  const secondaryResultFixturePath = path.join(tmp, "secondary-result-fixture.json");
   fs.mkdirSync(artifactDir);
   fs.mkdirSync(binDir);
   fs.writeFileSync(resultFixturePath, `${JSON.stringify(result)}\n`);
   options.symlinkResult
     ? fs.symlinkSync(resultFixturePath, resultPath)
     : fs.copyFileSync(resultFixturePath, resultPath);
-  fs.writeFileSync(
-    path.join(artifactDir, "pr-review-advisor-summary.md"),
-    options.summary ?? "# PR Review Advisor\n",
-  );
+  if (!options.omitAnalysisResult) {
+    fs.writeFileSync(
+      analysisResultFixturePath,
+      `${JSON.stringify(options.analysisResult ?? result)}\n`,
+    );
+    options.symlinkAnalysisResult
+      ? fs.symlinkSync(analysisResultFixturePath, analysisResultPath)
+      : fs.copyFileSync(analysisResultFixturePath, analysisResultPath);
+  }
+  if (!options.omitSummary) {
+    fs.writeFileSync(
+      path.join(artifactDir, "pr-review-advisor-summary.md"),
+      options.summary ?? "# PR Review Advisor\n",
+    );
+  }
+  if (!options.omitSecondaryArtifact) {
+    fs.mkdirSync(secondaryArtifactDir);
+    fs.writeFileSync(secondaryResultFixturePath, `${JSON.stringify(secondaryResult)}\n`);
+    options.symlinkSecondaryResult
+      ? fs.symlinkSync(secondaryResultFixturePath, secondaryResultPath)
+      : fs.copyFileSync(secondaryResultFixturePath, secondaryResultPath);
+    fs.writeFileSync(
+      path.join(secondaryArtifactDir, "pr-review-advisor-result.json"),
+      `${JSON.stringify(options.secondaryAnalysisResult ?? secondaryResult)}\n`,
+    );
+    if (!options.omitSecondarySummary) {
+      fs.writeFileSync(
+        path.join(secondaryArtifactDir, "pr-review-advisor-summary.md"),
+        options.secondarySummary ?? "# PR Review Advisor (second opinion)\n",
+      );
+    }
+  }
   fs.writeFileSync(
     path.join(binDir, "gh"),
     '#!/bin/bash\ncase "$*" in *".base.sha"*) printf \'%s\\n\' "$FAKE_LIVE_BASE" ;; *) printf \'%s\\n\' "$FAKE_LIVE_HEAD" ;; esac\n',
@@ -142,7 +191,7 @@ function runArtifactValidation(
   );
   const completed = spawnSync(
     "/bin/bash",
-    ["-c", workflowStepScript("publish", "Validate primary advisor artifact")],
+    ["-c", workflowStepScript("publish", "Validate advisor artifacts")],
     {
       cwd: ROOT,
       encoding: "utf8",
@@ -151,6 +200,7 @@ function runArtifactValidation(
         EXPECTED_HEAD_SHA: HEAD_SHA,
         FAKE_LIVE_BASE: options.liveBase ?? BASE_SHA,
         FAKE_LIVE_HEAD: options.liveHead ?? HEAD_SHA,
+        GITHUB_OUTPUT: githubOutputPath,
         GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
         PR_BASE_SHA: BASE_SHA,
@@ -158,6 +208,8 @@ function runArtifactValidation(
         PR_REVIEW_ADVISOR_MAX_RESULT_BYTES: "2097152",
         PR_REVIEW_ADVISOR_MAX_SUMMARY_BYTES: "1048576",
         PUBLISH_ARTIFACT_DIR: artifactDir,
+        SECONDARY_ARTIFACT_OUTCOME: options.secondaryDownloadOutcome ?? "success",
+        SECONDARY_PUBLISH_ARTIFACT_DIR: secondaryArtifactDir,
         TRUSTED_WORKFLOW_SHA: "c".repeat(40),
       },
     },
@@ -165,6 +217,7 @@ function runArtifactValidation(
   return {
     ...completed,
     cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }),
+    githubOutput: fs.existsSync(githubOutputPath) ? fs.readFileSync(githubOutputPath, "utf8") : "",
   };
 }
 
@@ -172,7 +225,7 @@ function validPrimaryResult(): Record<string, unknown> {
   return {
     version: 1,
     headSha: HEAD_SHA,
-    summary: { recommendation: "info_only" },
+    summary: { recommendation: "info_only", confidence: "high" },
     findings: [],
     e2e: { coverage: { requiredTests: [] }, targets: { required: [] } },
   };
@@ -564,27 +617,136 @@ process.exitCode = valid ? 0 : 1;`,
     }
   });
 
-  it("accepts a bounded same-head primary artifact for publication", () => {
+  it("accepts bounded same-head primary and secondary artifacts for publication", () => {
     const result = runArtifactValidation(validPrimaryResult());
     try {
       expect(result.status, result.stderr).toBe(0);
+      expect(result.githubOutput).toBe("secondary_artifact_validated=true\n");
     } finally {
       result.cleanup();
     }
   });
 
-  it("rejects malformed, wrong-head, stale, and symlinked publication artifacts", () => {
+  it("accepts a validated partial primary failure for publication", () => {
+    const partialPrimary = {
+      ...validPrimaryResult(),
+      summary: { recommendation: "info_only", confidence: "low" },
+      findings: [{ severity: "warning", title: "partial primary finding" }],
+    };
+    const result = runArtifactValidation(partialPrimary, {
+      analysisResult: {
+        failed: true,
+        partial: true,
+        reason: "provider stopped",
+        findingCount: 1,
+      },
+    });
+    try {
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.githubOutput).toBe("secondary_artifact_validated=true\n");
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it("accepts failed, partial, skipped, and unavailable second-opinion outcomes", () => {
+    const partialSecondary = {
+      ...validPrimaryResult(),
+      summary: { recommendation: "info_only", confidence: "low" },
+      findings: [{ severity: "warning", title: "partial second-opinion finding" }],
+    };
+    const cases = [
+      {
+        name: "failed partial",
+        options: {
+          secondaryResult: partialSecondary,
+          secondaryAnalysisResult: {
+            failed: true,
+            partial: true,
+            reason: "provider stopped",
+            findingCount: 1,
+          },
+        },
+        validated: true,
+      },
+      {
+        name: "failed before findings",
+        options: {
+          secondaryAnalysisResult: { failed: true, reason: "provider stopped" },
+        },
+        validated: true,
+      },
+      {
+        name: "skipped",
+        options: {
+          secondaryAnalysisResult: { skipped: true, reason: "model unavailable" },
+        },
+        validated: true,
+      },
+      {
+        name: "artifact unavailable",
+        options: {
+          secondaryDownloadOutcome: "failure" as const,
+          omitSecondaryArtifact: true,
+        },
+        validated: false,
+      },
+    ];
+    for (const { name, options, validated } of cases) {
+      const result = runArtifactValidation(validPrimaryResult(), options);
+      try {
+        expect(result.status, `${name}: ${result.stdout}${result.stderr}`).toBe(0);
+        expect(result.githubOutput, name).toBe(`secondary_artifact_validated=${validated}\n`);
+      } finally {
+        result.cleanup();
+      }
+    }
+  });
+
+  it("rejects malformed, wrong-head, stale, and symlinked primary artifacts", () => {
     const cases = [
       { name: "version", artifact: { ...validPrimaryResult(), version: 2 } },
       { name: "head", artifact: { ...validPrimaryResult(), headSha: "d".repeat(40) } },
       { name: "findings", artifact: { ...validPrimaryResult(), findings: null } },
       { name: "e2e", artifact: { ...validPrimaryResult(), e2e: {} } },
-      { name: "live head", artifact: validPrimaryResult(), liveHead: "e".repeat(40) },
-      { name: "live base", artifact: validPrimaryResult(), liveBase: "e".repeat(40) },
-      { name: "symlink", artifact: validPrimaryResult(), symlinkResult: true },
+      {
+        name: "unknown status",
+        artifact: validPrimaryResult(),
+        options: { analysisResult: { unexpected: true } },
+      },
+      {
+        name: "missing status",
+        artifact: validPrimaryResult(),
+        options: { omitAnalysisResult: true },
+      },
+      {
+        name: "missing summary",
+        artifact: validPrimaryResult(),
+        options: { omitSummary: true },
+      },
+      {
+        name: "symlinked status",
+        artifact: validPrimaryResult(),
+        options: { symlinkAnalysisResult: true },
+      },
+      {
+        name: "symlinked final result",
+        artifact: validPrimaryResult(),
+        options: { symlinkResult: true },
+      },
+      {
+        name: "live head",
+        artifact: validPrimaryResult(),
+        options: { liveHead: "e".repeat(40) },
+      },
+      {
+        name: "live base",
+        artifact: validPrimaryResult(),
+        options: { liveBase: "e".repeat(40) },
+      },
     ];
-    for (const { name, artifact, liveHead, liveBase, symlinkResult } of cases) {
-      const result = runArtifactValidation(artifact, { liveHead, liveBase, symlinkResult });
+    for (const { name, artifact, options } of cases) {
+      const result = runArtifactValidation(artifact, options);
       try {
         expect(result.status, `${name}: ${result.stdout}${result.stderr}`).toBe(1);
       } finally {
@@ -593,20 +755,110 @@ process.exitCode = valid ? 0 : 1;`,
     }
   });
 
+  it("withholds every invalid secondary artifact without suppressing the primary", () => {
+    const mismatchedAnalysisResult = {
+      ...validPrimaryResult(),
+      summary: { recommendation: "info_only", confidence: "medium" },
+    };
+    const cases = [
+      {
+        name: "wrong head",
+        options: {
+          secondaryResult: { ...validPrimaryResult(), headSha: "d".repeat(40) },
+        },
+      },
+      {
+        name: "unknown status",
+        options: { secondaryAnalysisResult: { unexpected: true } },
+      },
+      {
+        name: "conflicting status",
+        options: {
+          secondaryAnalysisResult: {
+            failed: true,
+            skipped: true,
+            reason: "ambiguous status",
+          },
+        },
+      },
+      {
+        name: "completed result mismatch",
+        options: { secondaryAnalysisResult: mismatchedAnalysisResult },
+      },
+      {
+        name: "partial count mismatch",
+        options: {
+          secondaryAnalysisResult: {
+            failed: true,
+            partial: true,
+            reason: "provider stopped",
+            findingCount: 1,
+          },
+        },
+      },
+      { name: "missing artifact", options: { omitSecondaryArtifact: true } },
+      { name: "missing summary", options: { omitSecondarySummary: true } },
+      { name: "symlinked final result", options: { symlinkSecondaryResult: true } },
+    ];
+    for (const { name, options } of cases) {
+      const result = runArtifactValidation(validPrimaryResult(), options);
+      try {
+        expect(result.status, `${name}: ${result.stdout}${result.stderr}`).toBe(0);
+        expect(result.githubOutput, name).toBe("secondary_artifact_validated=false\n");
+        expect(result.stderr, name).toContain("Secondary advisor artifact failed validation");
+      } finally {
+        result.cleanup();
+      }
+    }
+  });
+
+  it("rejects an unrecognized trusted secondary download outcome", () => {
+    const result = runArtifactValidation(validPrimaryResult(), {
+      secondaryDownloadOutcome: "unexpected",
+    });
+    try {
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain("Invalid secondary advisor artifact outcome");
+      expect(result.githubOutput).toBe("");
+    } finally {
+      result.cleanup();
+    }
+  });
+
   it("rejects cross-run artifact downloads and missing publication validation", () => {
-    const crossRun = validateMutation((source) =>
+    const primaryCrossRun = validateMutation((source) =>
       source.replace(
         "          name: pr-review-advisor\n          path: publish-artifacts/pr-review-advisor",
         "          name: pr-review-advisor\n          path: publish-artifacts/pr-review-advisor\n          run-id: ${{ github.event.workflow_run.id }}",
       ),
     );
-    expect(crossRun).toContain("Download primary advisor artifact must not set with.run-id");
+    expect(primaryCrossRun).toContain("Download primary advisor artifact must not set with.run-id");
+
+    const secondaryCrossRun = validateMutation((source) =>
+      source.replace(
+        "          name: pr-review-advisor-nemotron-ultra\n          path: publish-artifacts/pr-review-advisor-nemotron-ultra",
+        "          name: pr-review-advisor-nemotron-ultra\n          path: publish-artifacts/pr-review-advisor-nemotron-ultra\n          run-id: ${{ github.event.workflow_run.id }}",
+      ),
+    );
+    expect(secondaryCrossRun).toContain(
+      "Download secondary advisor artifact must not set with.run-id",
+    );
+
+    const blockingSecondary = validateMutation((source) =>
+      source.replace(
+        "        continue-on-error: true\n        uses: actions/download-artifact",
+        "        continue-on-error: false\n        uses: actions/download-artifact",
+      ),
+    );
+    expect(blockingSecondary).toContain(
+      "secondary advisor artifact download must remain non-blocking",
+    );
 
     const noVersionCheck = validateMutation((source) =>
       source.replace("if (result.version !== 1)", "if (false)"),
     );
     expect(noVersionCheck).toContain(
-      "step 'Validate primary advisor artifact' run script must include result.version !== 1",
+      "step 'Validate advisor artifacts' run script must include result.version !== 1",
     );
   });
 

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -51,6 +51,11 @@ function writeFakeCommand(binDir: string, name: string): void {
   );
 }
 
+function writeOptionalFixture(omitted: boolean | undefined, write: () => void): void {
+  const selectedWrite = omitted ? undefined : write;
+  selectedWrite?.();
+}
+
 function runPrepareWorkspace(
   env: Partial<{
     TARGET_REPO: string;
@@ -152,7 +157,7 @@ function runArtifactValidation(
   options.symlinkResult
     ? fs.symlinkSync(resultFixturePath, resultPath)
     : fs.copyFileSync(resultFixturePath, resultPath);
-  if (!options.omitAnalysisResult) {
+  writeOptionalFixture(options.omitAnalysisResult, () => {
     fs.writeFileSync(
       analysisResultFixturePath,
       `${JSON.stringify(options.analysisResult ?? result)}\n`,
@@ -160,14 +165,14 @@ function runArtifactValidation(
     options.symlinkAnalysisResult
       ? fs.symlinkSync(analysisResultFixturePath, analysisResultPath)
       : fs.copyFileSync(analysisResultFixturePath, analysisResultPath);
-  }
-  if (!options.omitSummary) {
+  });
+  writeOptionalFixture(options.omitSummary, () => {
     fs.writeFileSync(
       path.join(artifactDir, "pr-review-advisor-summary.md"),
       options.summary ?? "# PR Review Advisor\n",
     );
-  }
-  if (!options.omitSecondaryArtifact) {
+  });
+  writeOptionalFixture(options.omitSecondaryArtifact, () => {
     fs.mkdirSync(secondaryArtifactDir);
     fs.writeFileSync(secondaryResultFixturePath, `${JSON.stringify(secondaryResult)}\n`);
     options.symlinkSecondaryResult
@@ -177,13 +182,13 @@ function runArtifactValidation(
       path.join(secondaryArtifactDir, "pr-review-advisor-result.json"),
       `${JSON.stringify(options.secondaryAnalysisResult ?? secondaryResult)}\n`,
     );
-    if (!options.omitSecondarySummary) {
+    writeOptionalFixture(options.omitSecondarySummary, () => {
       fs.writeFileSync(
         path.join(secondaryArtifactDir, "pr-review-advisor-summary.md"),
         options.secondarySummary ?? "# PR Review Advisor (second opinion)\n",
       );
-    }
-  }
+    });
+  });
   fs.writeFileSync(
     path.join(binDir, "gh"),
     '#!/bin/bash\ncase "$*" in *".base.sha"*) printf \'%s\\n\' "$FAKE_LIVE_BASE" ;; *) printf \'%s\\n\' "$FAKE_LIVE_HEAD" ;; esac\n',

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -287,6 +287,41 @@ describe("PR review advisor", () => {
     expect(comment).not.toContain("rm -rf");
   });
 
+  it("reconciles trusted E2E coverage and selector tiers before publication", () => {
+    const normalize = (required: Array<Record<string, string>> = []) =>
+      normalizeReviewResult(
+        validResult({
+          e2e: {
+            coverage: {
+              requiredTests: [],
+              optionalTests: [{ id: "docs-validation", reason: "Documentation changed." }],
+              confidence: "low",
+            },
+            targets: { required, optional: [], confidence: "low" },
+          },
+        }),
+        metadata({ changedFiles: [] }),
+      ).e2e;
+    const optional = normalize();
+    expect(optional.coverage.optionalTests.map(({ id }) => id)).toEqual(["docs-validation"]);
+    expect(optional.targets.optional).toEqual([
+      expect.objectContaining({ id: "docs-validation", selectorType: "job", required: false }),
+    ]);
+    const required = normalize([
+      {
+        id: "docs-validation",
+        workflow: "e2e.yaml",
+        selectorType: "job",
+        reason: "The live documentation check is required.",
+      },
+    ]);
+    expect(required.coverage.requiredTests.map(({ id }) => id)).toEqual(["docs-validation"]);
+    expect(required.targets.required).toEqual([
+      expect.objectContaining({ id: "docs-validation", selectorType: "job", required: true }),
+    ]);
+    expect([required.coverage.optionalTests, required.targets.optional]).toEqual([[], []]);
+  });
+
   it("renders the reasons for recommended E2E coverage", () => {
     const result = normalizeReviewResult(
       validResult({
@@ -321,9 +356,8 @@ describe("PR review advisor", () => {
     expect(comment).toContain(
       "- <code>security-posture</code> — Selected from the trusted checked-in E2E coverage inventory.",
     );
-    expect(comment).toContain(
-      "**Why no selector is recommended:** No trusted E2E selector was selected.",
-    );
+    expect(comment).toContain("**Recommended selectors:** <code>security-posture</code>");
+    expect(comment).not.toContain("Why no selector is recommended");
 
     const noE2eResult = normalizeReviewResult(validResult(), metadata());
     const noE2eComment = buildComment({

--- a/tools/advisors/e2e-recommendations.mts
+++ b/tools/advisors/e2e-recommendations.mts
@@ -179,7 +179,7 @@ export function normalizeE2eCoverageResult(
     // authority boundary.
     newE2eRecommendations: [],
     noE2eReason:
-      requiredTests.length > 0
+      requiredTests.length > 0 || optionalTests.length > 0
         ? null
         : "No deterministic or trusted-inventory E2E coverage was selected.",
     confidence:

--- a/tools/advisors/github.mts
+++ b/tools/advisors/github.mts
@@ -146,6 +146,58 @@ export async function upsertStickyComment({
   }
 }
 
+export async function deleteBotOwnedStickyComments({
+  repo,
+  pr,
+  token,
+  markers,
+  label,
+  userAgent,
+}: {
+  repo: string;
+  pr: string;
+  token: string;
+  markers: readonly string[];
+  label: string;
+  userAgent?: string;
+}): Promise<number> {
+  if (markers.length === 0) return 0;
+  const comments: GitHubComment[] = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await githubApi<GitHubComment[]>(
+      `repos/${repo}/issues/${pr}/comments?per_page=100&page=${page}`,
+      token,
+      { userAgent },
+    );
+    comments.push(...batch);
+    if (batch.length < 100) break;
+  }
+  const matches = comments.filter((comment) => {
+    const body = comment.body;
+    return (
+      Number.isSafeInteger(comment.id) &&
+      comment.id > 0 &&
+      comment.user?.login === "github-actions[bot]" &&
+      typeof body === "string" &&
+      markers.some((marker) => firstCommentLine(body) === marker)
+    );
+  });
+  for (const comment of matches) {
+    await githubApi(`repos/${repo}/issues/comments/${comment.id}`, token, {
+      method: "DELETE",
+      userAgent,
+    });
+  }
+  if (matches.length > 0) {
+    console.log(`Deleted ${matches.length} ${label} comment(s) on ${repo}#${pr}`);
+  }
+  return matches.length;
+}
+
+function firstCommentLine(body: string): string {
+  return body.trimStart().split(/\r?\n/u, 1)[0]?.trim() ?? "";
+}
+
 async function findExistingComment(
   repo: string,
   pr: string,

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -1467,6 +1467,19 @@ export async function startPrGate(
   ) {
     throw new Error("CI run identity does not match the triggering workflow run");
   }
+  const existingChecks = await matchingPrGateChecks({
+    repository,
+    token,
+    headSha: command.headSha,
+    baseSha: ciIdentity.baseSha,
+    prNumber: ciIdentity.prNumber,
+  });
+  if (existingChecks.length > 1) {
+    throw new Error("Multiple exact-diff PR gate checks already exist");
+  }
+  const existingCheckRunId =
+    existingChecks[0]?.status === "in_progress" ? existingChecks[0].id : undefined;
+  if (existingCheckRunId) appendOutput("check_id", String(existingCheckRunId));
   const pull = await requireLiveExactDiff({
     repository,
     token,
@@ -1487,7 +1500,7 @@ export async function startPrGate(
     baseSha: ciIdentity.baseSha,
     prNumber: ciIdentity.prNumber,
   });
-  appendOutput("check_id", String(checkRunId));
+  if (checkRunId !== existingCheckRunId) appendOutput("check_id", String(checkRunId));
   await markCheckInProgress(
     { repository, checkRunId },
     token,

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -2300,12 +2300,46 @@ export function normalizeCombinedE2eResult(
     recommendationMetadata,
     metadata.deterministic.riskPlan,
   );
+  const inventory = trustedE2eRecommendationInventory();
+  const selectorTypes = new Map<string, "job" | "target">([
+    ...inventory.allowedJobIds.map((id) => [id, "job"] as const),
+    ...inventory.liveSupportedTargetIds.map((id) => [id, "target"] as const),
+  ]);
+  const targetInput = isObjectRecord(object.targets) ? object.targets : {};
+  const coverageTargets = (
+    tests: E2eCoverageResult["requiredTests"],
+    required: boolean,
+  ): Array<Record<string, unknown>> =>
+    tests.flatMap((test) => {
+      const selectorType = selectorTypes.get(test.id);
+      return selectorType
+        ? [
+            {
+              id: test.id,
+              workflow: inventory.workflow,
+              selectorType,
+              required,
+              reason: "Align this trusted selector with the normalized coverage decision.",
+            },
+          ]
+        : [];
+    });
   const normalizedTargets = normalizeE2eTargetAdvisorResult(
-    object.targets ?? {},
+    {
+      ...targetInput,
+      required: [
+        ...recordItems(targetInput.required),
+        ...coverageTargets(coverage.requiredTests, true),
+      ],
+      optional: [
+        ...recordItems(targetInput.optional),
+        ...coverageTargets(coverage.optionalTests, false),
+      ],
+    },
     recommendationMetadata,
     { riskPlan: metadata.deterministic.riskPlan },
   );
-  return {
+  return reconcileCombinedE2eResult({
     coverage,
     targets: {
       relevantChangedFiles: normalizedTargets.relevantChangedFiles,
@@ -2318,6 +2352,56 @@ export function normalizeCombinedE2eResult(
       noTargetE2eReason: normalizedTargets.noTargetE2eReason,
       confidence: normalizedTargets.confidence,
     },
+  });
+}
+
+function reconcileCombinedE2eResult(result: CombinedE2eResult): CombinedE2eResult {
+  const inventory = trustedE2eRecommendationInventory();
+  const regularIds = new Set([...inventory.allowedJobIds, ...inventory.liveSupportedTargetIds]);
+  const requiredIds = [
+    ...new Set([
+      ...result.coverage.requiredTests.map((item) => item.id),
+      ...result.targets.required.filter((item) => regularIds.has(item.id)).map((item) => item.id),
+    ]),
+  ];
+  const requiredIdSet = new Set(requiredIds);
+  const optionalIds = [
+    ...new Set([
+      ...result.coverage.optionalTests.map((item) => item.id),
+      ...result.targets.optional.filter((item) => regularIds.has(item.id)).map((item) => item.id),
+    ]),
+  ].filter((id) => !requiredIdSet.has(id));
+  const coverageById = new Map(
+    [...result.coverage.requiredTests, ...result.coverage.optionalTests].map((item) => [
+      item.id,
+      item,
+    ]),
+  );
+  const alignedCoverage = (ids: readonly string[]): E2eCoverageResult["requiredTests"] =>
+    ids.map(
+      (id) =>
+        coverageById.get(id) ?? {
+          id,
+          reason: `Selected from the trusted checked-in E2E coverage inventory.`,
+        },
+    );
+  const requiredCoverage = alignedCoverage(requiredIds);
+  const optionalCoverage = alignedCoverage(optionalIds);
+  return {
+    coverage: {
+      ...result.coverage,
+      requiredTests: requiredCoverage,
+      optionalTests: optionalCoverage,
+      noE2eReason:
+        requiredCoverage.length > 0 || optionalCoverage.length > 0
+          ? null
+          : "No deterministic or trusted-inventory E2E coverage was selected.",
+      confidence:
+        requiredCoverage.length > 0 && result.coverage.confidence === "low"
+          ? "medium"
+          : result.coverage.confidence,
+    },
+    targets: result.targets,
   };
 }
 

--- a/tools/pr-review-advisor/comment.mts
+++ b/tools/pr-review-advisor/comment.mts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -9,7 +10,7 @@ import {
   type TrustedE2eRecommendationInventory,
   trustedE2eRecommendationInventory,
 } from "../advisors/e2e-recommendations.mts";
-import { upsertStickyComment } from "../advisors/github.mts";
+import { deleteBotOwnedStickyComments, upsertStickyComment } from "../advisors/github.mts";
 import { parseArgs, readIfExists, readJsonIfExists } from "../advisors/io.mts";
 
 const MARKER = "<!-- nemoclaw-pr-review-advisor -->";
@@ -108,6 +109,30 @@ type FindingRecord = {
   finding: Finding;
 };
 
+type FindingCounts = {
+  blockers: number;
+  warnings: number;
+  suggestions: number;
+};
+
+type LaneFingerprints = {
+  findings: string;
+  e2e: string;
+};
+
+export type AdvisorLaneReport = {
+  status: "completed" | "failed" | "skipped" | "unavailable";
+  partial: boolean;
+  counts?: FindingCounts;
+  confidence?: "low" | "medium" | "high";
+  fingerprints?: LaneFingerprints;
+};
+
+export type AdvisorLaneReports = {
+  primary: AdvisorLaneReport;
+  secondOpinion: AdvisorLaneReport;
+};
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error: unknown) => {
     console.error(error instanceof Error ? error.message : String(error));
@@ -122,6 +147,14 @@ async function main(): Promise<void> {
   const summaryPath = args.summary || "artifacts/pr-review-advisor/pr-review-advisor-summary.md";
   const resultPath =
     args.result || "artifacts/pr-review-advisor/pr-review-advisor-final-result.json";
+  if (!args.analysisResult) {
+    throw new Error("--analysis-result is required");
+  }
+  if (Boolean(args.secondOpinionAnalysisResult) !== Boolean(args.secondOpinionResult)) {
+    throw new Error(
+      "--second-opinion-analysis-result and --second-opinion-result must be provided together",
+    );
+  }
   const { marker, title, label } = normalizeCommentOptions({
     marker: args.marker || process.env.PR_REVIEW_ADVISOR_COMMENT_MARKER || MARKER,
     title: args.title || process.env.PR_REVIEW_ADVISOR_COMMENT_TITLE || COMMENT_TITLE,
@@ -146,6 +179,12 @@ async function main(): Promise<void> {
     summaryExplicit: Boolean(args.summary),
     resultExplicit: Boolean(args.result),
   });
+  const lanes = readAdvisorLaneReports({
+    primaryAnalysisResultPath: args.analysisResult,
+    primaryResult: result,
+    secondOpinionAnalysisResultPath: args.secondOpinionAnalysisResult,
+    secondOpinionResultPath: args.secondOpinionResult,
+  });
   const baseMetadata = {
     runId: process.env.PR_REVIEW_ADVISOR_RUN_ID || process.env.GITHUB_RUN_ID,
     runAttempt: process.env.PR_REVIEW_ADVISOR_RUN_ATTEMPT || process.env.GITHUB_RUN_ATTEMPT,
@@ -162,6 +201,7 @@ async function main(): Promise<void> {
     marker,
     title,
     metadata: baseMetadata,
+    lanes,
   });
 
   await upsertStickyComment({
@@ -179,7 +219,15 @@ async function main(): Promise<void> {
         marker,
         title,
         metadata: { ...baseMetadata, commentId: String(comment.id) },
+        lanes,
       }),
+  });
+  await deleteBotOwnedStickyComments({
+    repo,
+    pr,
+    token,
+    markers: ["<!-- nemoclaw-e2e-advisor -->", "<!-- nemoclaw-e2e-target-advisor -->"],
+    label: "legacy E2E advisor",
   });
 }
 
@@ -234,6 +282,70 @@ export function readCommentArtifacts(
   return { summary, result };
 }
 
+export function readAdvisorLaneReports({
+  primaryAnalysisResultPath,
+  primaryResult,
+  secondOpinionAnalysisResultPath,
+  secondOpinionResultPath,
+}: {
+  primaryAnalysisResultPath: string;
+  primaryResult?: ReviewAdvisorResult;
+  secondOpinionAnalysisResultPath?: string;
+  secondOpinionResultPath?: string;
+}): AdvisorLaneReports {
+  const primaryAnalysisResult = readJsonIfExists<unknown>(primaryAnalysisResultPath);
+  if (!primaryAnalysisResult) {
+    throw new Error(`No primary advisor analysis result found at ${primaryAnalysisResultPath}`);
+  }
+  const primary = normalizeAdvisorLaneReport(primaryAnalysisResult, primaryResult);
+  if (!secondOpinionAnalysisResultPath || !secondOpinionResultPath) {
+    return { primary, secondOpinion: unavailableLaneReport() };
+  }
+
+  try {
+    const secondOpinionAnalysisResult = readJsonIfExists<unknown>(secondOpinionAnalysisResultPath);
+    const secondOpinionResult = readJsonIfExists<ReviewAdvisorResult>(secondOpinionResultPath);
+    return {
+      primary,
+      secondOpinion: normalizeAdvisorLaneReport(
+        secondOpinionAnalysisResult,
+        secondOpinionResult,
+        primaryResult?.headSha,
+      ),
+    };
+  } catch {
+    // The evaluation lane is deliberately non-blocking. A malformed or
+    // unreadable second-opinion artifact is reported as unavailable and can
+    // never suppress publication of the trusted primary result.
+    return { primary, secondOpinion: unavailableLaneReport() };
+  }
+}
+
+export function normalizeAdvisorLaneReport(
+  analysisResult: unknown,
+  finalResult: unknown,
+  expectedHeadSha?: string,
+): AdvisorLaneReport {
+  if (!isRecord(analysisResult)) return unavailableLaneReport();
+  const failed = analysisResult.failed === true;
+  const skipped = analysisResult.skipped === true;
+  if (failed && skipped) return unavailableLaneReport();
+  if (skipped) return { status: "skipped", partial: false };
+
+  const partial = failed && analysisResult.partial === true;
+  if (failed && !partial) return { status: "failed", partial: false };
+  const structure = trustedLaneStructure(finalResult, expectedHeadSha);
+  if (failed) {
+    return {
+      status: "failed",
+      partial: true,
+      ...(structure ?? {}),
+    };
+  }
+  if (analysisResult.version !== 1 || !structure) return unavailableLaneReport();
+  return { status: "completed", partial: false, ...structure };
+}
+
 export function buildComment({
   summary: _summary,
   result,
@@ -241,6 +353,7 @@ export function buildComment({
   marker,
   title,
   metadata,
+  lanes,
 }: {
   summary: string;
   result?: ReviewAdvisorResult;
@@ -248,6 +361,7 @@ export function buildComment({
   marker?: string;
   title?: string;
   metadata?: CommentMetadata;
+  lanes?: AdvisorLaneReports;
 }): string {
   const findingRecords = collectFindingRecords(result);
   const blockerCount = findingRecords.filter(
@@ -259,16 +373,21 @@ export function buildComment({
   const suggestionCount = findingRecords.filter(
     (record) => record.finding.severity === "suggestion",
   ).length;
-  const secondary = buildSecondarySummary(result);
+  const reviewHistory = buildSecondarySummary(result);
   const informational =
     result?.summary?.recommendation === "info_only" && result.summary.oneLine
       ? `**Status:** ${escapeCommentText(result.summary.oneLine)}\n`
       : "";
   const findingsDetails = renderFindingsDetails(findingRecords);
   const e2eDetails = renderE2eDetails(result);
+  const laneDetails = renderAdvisorLanes(lanes);
   const details = runUrl ? `\n[Workflow run details](${runUrl})` : "";
   const hiddenMetadata = renderHiddenMetadata(result, metadata);
-  const posture = reviewPosture(result?.summary?.recommendation, blockerCount);
+  const posture = reviewPosture(
+    result?.summary?.recommendation,
+    result?.summary?.confidence,
+    blockerCount,
+  );
   const headline = reviewHeadline(result?.summary?.recommendation, blockerCount);
   const heading = validateSingleLineCommentField(title || COMMENT_TITLE, "title");
   const renderedMarker = validateCommentMarker(marker || MARKER);
@@ -278,12 +397,88 @@ export function buildComment({
 **Advisor assessment:** ${posture}
 **Primary next action:** ${primaryNextAction(findingRecords)}
 **Findings:** ${compactCount(blockerCount, "blocker")} · ${compactCount(warningCount, "warning")} · ${compactCount(suggestionCount, "optional suggestion")}
-${informational}${secondary}${e2eDetails}${findingsDetails}${details}
+${informational}${laneDetails}${reviewHistory}${e2eDetails}${findingsDetails}${details}
 
 This is an automated, non-authoritative review. Findings are inputs to maintainer adjudication. Warnings and optional suggestions do not require a response or follow-up. A human maintainer makes the final merge decision.
 
 `;
   return boundedComment(prefix, content);
+}
+
+function renderAdvisorLanes(lanes?: AdvisorLaneReports): string {
+  if (!lanes) return "";
+  const lines = [
+    "",
+    "### Model lanes",
+    `- **GPT-5.6 Terra (primary):** ${renderLaneReport(lanes.primary)}`,
+    `- **Nemotron 3 Ultra (non-blocking second opinion):** ${renderLaneReport(lanes.secondOpinion)}`,
+  ];
+  const comparison = renderLaneComparison(lanes.primary, lanes.secondOpinion);
+  if (comparison) lines.push(`- **Model comparison:** ${comparison}`);
+  lines.push(
+    "",
+    "_Nemotron is a non-blocking second opinion. Its prose, findings, and E2E guidance do not change the primary assessment above and remain in workflow artifacts only._",
+    "",
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+function renderLaneReport(report: AdvisorLaneReport): string {
+  const status =
+    report.status === "completed"
+      ? "Completed"
+      : report.status === "failed"
+        ? report.partial
+          ? "Failed after a partial review"
+          : "Failed"
+        : report.status === "skipped"
+          ? "Skipped"
+          : "Unavailable";
+  if (!report.counts) return status;
+  const confidence = report.confidence ? ` · ${report.confidence} confidence` : "";
+  return `${status}${confidence} · ${compactCount(report.counts.blockers, "blocker")} · ${compactCount(report.counts.warnings, "warning")} · ${compactCount(report.counts.suggestions, "suggestion")}`;
+}
+
+function renderLaneComparison(
+  primary: AdvisorLaneReport,
+  secondOpinion: AdvisorLaneReport,
+): string | undefined {
+  if (
+    primary.status !== "completed" ||
+    secondOpinion.status !== "completed" ||
+    !primary.counts ||
+    !secondOpinion.counts ||
+    !primary.fingerprints ||
+    !secondOpinion.fingerprints
+  ) {
+    return undefined;
+  }
+  const differences = [
+    countDifference(secondOpinion.counts.blockers - primary.counts.blockers, "blocker"),
+    countDifference(secondOpinion.counts.warnings - primary.counts.warnings, "warning"),
+    countDifference(secondOpinion.counts.suggestions - primary.counts.suggestions, "suggestion"),
+  ];
+  const findingComparison =
+    primary.fingerprints.findings === secondOpinion.fingerprints.findings
+      ? "normalized findings match"
+      : "normalized findings differ";
+  const e2eComparison =
+    primary.fingerprints.e2e === secondOpinion.fingerprints.e2e
+      ? "normalized E2E selections match"
+      : "normalized E2E selections differ";
+  const countComparison = differences.every((difference) =>
+    difference.startsWith("the same number"),
+  )
+    ? "severity counts match"
+    : `Nemotron reported ${differences.join(", ")}`;
+  return `${findingComparison}; ${e2eComparison}; ${countComparison}.`;
+}
+
+function countDifference(difference: number, label: string): string {
+  if (difference === 0) return `the same number of ${label}s`;
+  const direction = difference > 0 ? "more" : "fewer";
+  const count = Math.abs(difference);
+  return `${count} ${direction} ${count === 1 ? label : `${label}s`}`;
 }
 
 function renderE2eDetails(result?: ReviewAdvisorResult): string {
@@ -366,10 +561,10 @@ function renderE2eDetails(result?: ReviewAdvisorResult): string {
     lines.push("", "</details>");
   }
 
-  if (requiredCoverage.length === 0 && requiredTargets.length === 0 && noE2eReason) {
+  if (requiredCoverage.length === 0 && optionalCoverage.length === 0 && noE2eReason) {
     lines.push("", `**Why no E2E coverage is recommended:** ${escapeCommentText(noE2eReason)}`);
   }
-  if (requiredTargets.length === 0 && noTargetE2eReason) {
+  if (requiredTargets.length === 0 && optionalTargets.length === 0 && noTargetE2eReason) {
     lines.push("", `**Why no selector is recommended:** ${escapeCommentText(noTargetE2eReason)}`);
   }
   lines.push("");
@@ -470,6 +665,111 @@ function collectFindingRecords(result?: ReviewAdvisorResult): FindingRecord[] {
   }));
 }
 
+function trustedLaneStructure(
+  value: unknown,
+  expectedHeadSha?: string,
+):
+  | {
+      counts: FindingCounts;
+      confidence?: "low" | "medium" | "high";
+      fingerprints: LaneFingerprints;
+    }
+  | undefined {
+  if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.findings)) return undefined;
+  if (expectedHeadSha && value.headSha !== expectedHeadSha) return undefined;
+  const counts: FindingCounts = { blockers: 0, warnings: 0, suggestions: 0 };
+  for (const finding of value.findings) {
+    if (!isRecord(finding)) continue;
+    if (finding.severity === "blocker") counts.blockers += 1;
+    else if (finding.severity === "warning") counts.warnings += 1;
+    else if (finding.severity === "suggestion") counts.suggestions += 1;
+  }
+  const summary = isRecord(value.summary) ? value.summary : undefined;
+  const confidence = trustedLaneConfidence(summary?.confidence);
+  return {
+    counts,
+    ...(confidence ? { confidence } : {}),
+    fingerprints: {
+      findings: opaqueFingerprint(normalizedFindingRecords(value.findings)),
+      e2e: opaqueFingerprint(e2eDecisionSets(value.e2e)),
+    },
+  };
+}
+
+function normalizedFindingRecords(value: unknown[]): unknown[] {
+  return value
+    .filter(isRecord)
+    .map((finding) => ({ ...finding }))
+    .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
+}
+
+function trustedLaneConfidence(value: unknown): "low" | "medium" | "high" | undefined {
+  return value === "low" || value === "medium" || value === "high" ? value : undefined;
+}
+
+function e2eDecisionSets(value: unknown): Record<string, string[]> {
+  const e2e = isRecord(value) ? value : {};
+  const coverage = isRecord(e2e.coverage) ? e2e.coverage : {};
+  const targets = isRecord(e2e.targets) ? e2e.targets : {};
+  return {
+    requiredCoverage: normalizedIds(coverage.requiredTests),
+    optionalCoverage: normalizedIds(coverage.optionalTests),
+    requiredSelectors: normalizedSelectors(targets.required),
+    optionalSelectors: normalizedSelectors(targets.optional),
+  };
+}
+
+function normalizedIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value.flatMap((item) => (isRecord(item) && typeof item.id === "string" ? [item.id] : [])),
+    ),
+  ].sort();
+}
+
+function normalizedSelectors(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value.flatMap((item) => {
+        if (
+          !isRecord(item) ||
+          typeof item.id !== "string" ||
+          typeof item.workflow !== "string" ||
+          typeof item.selectorType !== "string"
+        ) {
+          return [];
+        }
+        return [`${item.workflow}:${item.selectorType}:${item.id}`];
+      }),
+    ),
+  ].sort();
+}
+
+function opaqueFingerprint(value: unknown): string {
+  return createHash("sha256").update(stableJson(value)).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function unavailableLaneReport(): AdvisorLaneReport {
+  return { status: "unavailable", partial: false };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 function renderHiddenMetadata(result?: ReviewAdvisorResult, metadata?: CommentMetadata): string {
   const fields = [
     result?.headSha ? `head_sha: ${safeMetadataValue(result.headSha)}` : undefined,
@@ -527,11 +827,23 @@ function reviewHeadline(recommendation: string | undefined, blockerCount: number
   return "No blocking findings reported";
 }
 
-function reviewPosture(recommendation: string | undefined, blockerCount: number): string {
+function reviewPosture(
+  recommendation: string | undefined,
+  confidence: string | undefined,
+  blockerCount: number,
+): string {
   if (blockerCount > 0) return "Blocking findings require maintainer adjudication";
   if (recommendation === "superseded") return "Superseded by other work";
-  if (recommendation === "info_only") return "Informational / low confidence";
+  if (recommendation === "info_only") {
+    return `Informational / ${trustedConfidence(confidence)} confidence`;
+  }
   return "No blocking advisor findings reported";
+}
+
+function trustedConfidence(confidence: string | undefined): string {
+  return confidence === "low" || confidence === "medium" || confidence === "high"
+    ? confidence
+    : "unknown";
 }
 
 function primaryNextAction(records: FindingRecord[]): string {

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -11,6 +11,13 @@ const DEFAULT_WORKFLOW_PATH = join(REPO_ROOT, ".github", "workflows", "pr-review
 const DEFAULT_PACKAGE_LOCK_PATH = join(REPO_ROOT, "package-lock.json");
 const TRUSTED_WORKFLOW_REF = "${{ github.workflow_sha }}";
 const CANONICAL_ADVISOR_NPM_CI = "npm ci --ignore-scripts --no-audit --no-fund";
+const FORBIDDEN_ARTIFACT_DOWNLOAD_WITH_KEYS = [
+  "run-id",
+  "github-token",
+  "repository",
+  "pattern",
+  "merge-multiple",
+] as const;
 const ADVISOR_RUNTIME_PACKAGE_PINS = [
   { packageName: "@earendil-works/pi-coding-agent", envName: "PI_SDK_VERSION", version: "0.80.6" },
   { packageName: "typebox", envName: "TYPEBOX_VERSION", version: "1.1.38" },
@@ -528,7 +535,7 @@ function checkPublishJob(errors: string[], publishJob: WorkflowRecord): void {
   if (download && booleanValue(download["continue-on-error"]) === true) {
     errors.push("primary advisor artifact download must fail closed");
   }
-  for (const forbidden of ["run-id", "github-token", "repository", "pattern", "merge-multiple"]) {
+  for (const forbidden of FORBIDDEN_ARTIFACT_DOWNLOAD_WITH_KEYS) {
     if (Object.hasOwn(asRecord(download?.with), forbidden)) {
       errors.push(`Download primary advisor artifact must not set with.${forbidden}`);
     }
@@ -550,7 +557,7 @@ function checkPublishJob(errors: string[], publishJob: WorkflowRecord): void {
   if (secondaryDownload && booleanValue(secondaryDownload["continue-on-error"]) !== true) {
     errors.push("secondary advisor artifact download must remain non-blocking");
   }
-  for (const forbidden of ["run-id", "github-token", "repository", "pattern", "merge-multiple"]) {
+  for (const forbidden of FORBIDDEN_ARTIFACT_DOWNLOAD_WITH_KEYS) {
     if (Object.hasOwn(asRecord(secondaryDownload?.with), forbidden)) {
       errors.push(`Download secondary advisor artifact must not set with.${forbidden}`);
     }

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -501,6 +501,9 @@ function checkPublishJob(errors: string[], publishJob: WorkflowRecord): void {
     EXPECTED_HEAD_SHA: "${{ github.event.pull_request.head.sha }}",
     TRUSTED_WORKFLOW_SHA: "${{ github.workflow_sha }}",
     PR_BASE_SHA: "${{ github.event.pull_request.base.sha }}",
+    PUBLISH_ARTIFACT_DIR: "${{ github.workspace }}/publish-artifacts/pr-review-advisor",
+    SECONDARY_PUBLISH_ARTIFACT_DIR:
+      "${{ github.workspace }}/publish-artifacts/pr-review-advisor-nemotron-ultra",
   })) {
     requireEnv(errors, "publish job", publishJob, key, expected);
   }
@@ -522,33 +525,94 @@ function checkPublishJob(errors: string[], publishJob: WorkflowRecord): void {
   const download = requireStep(errors, steps, "Download primary advisor artifact");
   requireWith(errors, download, "name", "pr-review-advisor");
   requireWith(errors, download, "path", "publish-artifacts/pr-review-advisor");
+  if (download && booleanValue(download["continue-on-error"]) === true) {
+    errors.push("primary advisor artifact download must fail closed");
+  }
   for (const forbidden of ["run-id", "github-token", "repository", "pattern", "merge-multiple"]) {
     if (Object.hasOwn(asRecord(download?.with), forbidden)) {
       errors.push(`Download primary advisor artifact must not set with.${forbidden}`);
     }
   }
 
-  const validate = requireStep(errors, steps, "Validate primary advisor artifact");
+  const secondaryDownload = requireStep(errors, steps, "Download secondary advisor artifact");
+  requireWith(errors, secondaryDownload, "name", "pr-review-advisor-nemotron-ultra");
+  requireWith(
+    errors,
+    secondaryDownload,
+    "path",
+    "publish-artifacts/pr-review-advisor-nemotron-ultra",
+  );
+  if (stringValue(secondaryDownload?.id) !== "download-secondary-advisor-artifact") {
+    errors.push(
+      "Download secondary advisor artifact id must be download-secondary-advisor-artifact",
+    );
+  }
+  if (secondaryDownload && booleanValue(secondaryDownload["continue-on-error"]) !== true) {
+    errors.push("secondary advisor artifact download must remain non-blocking");
+  }
+  for (const forbidden of ["run-id", "github-token", "repository", "pattern", "merge-multiple"]) {
+    if (Object.hasOwn(asRecord(secondaryDownload?.with), forbidden)) {
+      errors.push(`Download secondary advisor artifact must not set with.${forbidden}`);
+    }
+  }
+
+  const validate = requireStep(errors, steps, "Validate advisor artifacts");
+  if (stringValue(validate?.id) !== "validate-advisor-artifacts") {
+    errors.push("Validate advisor artifacts id must be validate-advisor-artifacts");
+  }
+  if (
+    asRecord(validate?.env).SECONDARY_ARTIFACT_OUTCOME !==
+    "${{ steps.download-secondary-advisor-artifact.outcome }}"
+  ) {
+    errors.push("Validate advisor artifacts must use the trusted secondary download step outcome");
+  }
   for (const fragment of [
     "lstatSync",
     "isSymbolicLink",
     "realpathSync",
+    "isDeepStrictEqual",
     "PR_REVIEW_ADVISOR_MAX_RESULT_BYTES",
     "PR_REVIEW_ADVISOR_MAX_SUMMARY_BYTES",
     "JSON.parse",
+    'ANALYSIS_RESULT_PATH="$PUBLISH_ARTIFACT_DIR/pr-review-advisor-result.json"',
+    'RESULT_PATH="$PUBLISH_ARTIFACT_DIR/pr-review-advisor-final-result.json"',
+    'SUMMARY_PATH="$PUBLISH_ARTIFACT_DIR/pr-review-advisor-summary.md"',
+    'SECONDARY_ANALYSIS_RESULT_PATH="$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-result.json"',
+    'SECONDARY_RESULT_PATH="$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-final-result.json"',
+    'SECONDARY_SUMMARY_PATH="$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-summary.md"',
+    '"$SECONDARY_ARTIFACT_OUTCOME" != "success"',
+    '"$SECONDARY_ARTIFACT_OUTCOME" != "failure"',
     "result.version !== 1",
     "result.headSha !== process.env.EXPECTED_HEAD_SHA",
     "Array.isArray(result.findings)",
     "result.e2e.coverage",
     "result.e2e.targets",
+    "statusCount !== 1",
+    "validateAnalysisResult(analysisResult, finalResult, label)",
+    "let secondaryArtifactValidated = false",
+    'process.env.SECONDARY_ARTIFACT_OUTCOME === "success"',
+    "process.env.SECONDARY_PUBLISH_ARTIFACT_DIR",
+    "secondaryArtifactValidated = true",
+    "catch {",
+    "process.env.GITHUB_OUTPUT",
+    "secondary_artifact_validated=${secondaryArtifactValidated}",
     'gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"',
     '"$LIVE_HEAD_SHA" != "$EXPECTED_HEAD_SHA"',
     '"$LIVE_BASE_SHA" != "$PR_BASE_SHA"',
   ]) {
     requireRunContains(errors, validate, fragment);
   }
+  requireRunOrder(errors, validate, '"primary advisor",', "let secondaryArtifactValidated = false");
 
   const comment = requireStep(errors, steps, "Post PR review advisor comment");
+  if (
+    asRecord(comment?.env).SECONDARY_ARTIFACT_VALIDATED !==
+    "${{ steps.validate-advisor-artifacts.outputs.secondary_artifact_validated }}"
+  ) {
+    errors.push(
+      "Post PR review advisor comment must use the trusted secondary artifact validation output",
+    );
+  }
   requireRunContains(errors, comment, '"$ADVISOR_DIR/tools/pr-review-advisor/comment.mts"');
   requireRunContains(
     errors,
@@ -560,13 +624,42 @@ function checkPublishJob(errors: string[], publishJob: WorkflowRecord): void {
     comment,
     '--result "$PUBLISH_ARTIFACT_DIR/pr-review-advisor-final-result.json"',
   );
-  const validateIndex = steps.findIndex(
-    (step) => step.name === "Validate primary advisor artifact",
+  requireRunContains(
+    errors,
+    comment,
+    '--analysis-result "$PUBLISH_ARTIFACT_DIR/pr-review-advisor-result.json"',
   );
+  requireRunContains(errors, comment, 'if [ "$SECONDARY_ARTIFACT_VALIDATED" = "true" ]');
+  requireRunContains(
+    errors,
+    comment,
+    '--second-opinion-analysis-result "$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-result.json"',
+  );
+  requireRunContains(
+    errors,
+    comment,
+    '--second-opinion-result "$SECONDARY_PUBLISH_ARTIFACT_DIR/pr-review-advisor-final-result.json"',
+  );
+  requireRunContains(errors, comment, '"${SECONDARY_ARGS[@]}"');
+  const primaryDownloadIndex = steps.findIndex(
+    (step) => step.name === "Download primary advisor artifact",
+  );
+  const secondaryDownloadIndex = steps.findIndex(
+    (step) => step.name === "Download secondary advisor artifact",
+  );
+  const validateIndex = steps.findIndex((step) => step.name === "Validate advisor artifacts");
   const commentIndex = steps.findIndex((step) => step.name === "Post PR review advisor comment");
-  if (validateIndex < 0 || commentIndex < 0 || validateIndex > commentIndex) {
+  if (
+    primaryDownloadIndex < 0 ||
+    secondaryDownloadIndex < 0 ||
+    validateIndex < 0 ||
+    commentIndex < 0 ||
+    primaryDownloadIndex > validateIndex ||
+    secondaryDownloadIndex > validateIndex ||
+    validateIndex > commentIndex
+  ) {
     errors.push(
-      "primary artifact and live PR identity must be validated before the trusted comment script",
+      "same-run advisor artifacts and live PR identity must be validated before the trusted comment script",
     );
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Use existing repository terms; do not invent a label for this PR. -->

This follow-up to #6745 and #6788 makes the combined PR Review Advisor disclose both model lanes without giving Nemotron authority over GPT's assessment, fixes contradictory confidence and E2E guidance, and ensures stale CI events close only the seeded in-progress E2E check. Missing or malformed Nemotron artifacts now degrade to an unavailable second opinion while a valid GPT review still publishes.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- Download the exact same-run Nemotron artifact in the write-capable publisher, validate its raw status, final result, summary, size, path, and head SHA, and pass it to the comment renderer only through a trusted validation output. GPT remains fail-closed and authoritative; the nonblocking Nemotron lane reports only allowlisted status, confidence, severity counts, and opaque structural agreement or disagreement.
- Render the actual normalized confidence for informational reviews, reconcile trusted E2E coverage and selector tiers through the existing target normalizer, and avoid “Why no…” text when optional guidance exists.
- Delete only `github-actions[bot]` comments whose first line is one of the two retired E2E Advisor markers, after the combined sticky comment publishes. The bot-owner and exact-marker restrictions are covered by the security-boundary tests.
- Recover an existing exact-diff check ID before stale workflow-run validation only when the check is still `in_progress`, allowing the existing cleanup step to terminalize abandoned checks without rewriting completed historical results.
- Extend workflow-boundary, comment, normalization, GitHub API, and gate regression tests for complete, partial, failed, skipped, malformed, stale, and completed-check cases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal maintainer automation and GitHub workflow behavior only; the required documentation-writer pass found no user-facing CLI, configuration, API, policy, or product documentation change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent final reviews found no remaining findings after checking `pull_request_target` privilege separation, same-run artifact provenance, primary fail-closed behavior, nonblocking secondary validation, prose isolation, exact bot-owned legacy comment deletion, E2E selector trust, and stale/completed check races. The nine-category security checklist also found no secret, injection, authorization, dependency, logging, cryptography, configuration, test, or holistic posture regression.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect that behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — final advisor suites passed 120/120 tests, the compacted advisor regression passed 44/44, and all four PR E2E gate suites passed 69/69; CLI type-check passed in the normal pre-push hook.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR review comments now support an optional second-opinion analysis, including model-lane status and comparison details when compatible.
  * Comments show clearer confidence-aware model-lane information, with improved E2E “no coverage” messaging.
  * Legacy advisor sticky comments are cleaned up automatically during updates.
* **Bug Fixes**
  * E2E recommendations/coverage handling is corrected when only optional coverage is selected.
  * E2E coverage/target reconciliation is more accurately aligned with available trusted capabilities.
  * PR gate handling is improved for stale, duplicate, and superseded checks—avoiding unnecessary check reopens and recording recovered check IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->