### PR TITLE
fix(e2e): separate PR verdict from controller status

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -102,10 +102,12 @@ Runtime families and changes to workflow-wired live tests select
 canonical selectors from the trusted `e2e.yaml` inventory independently of
 advisor output. Ordinary internal changes execute those focused selections.
 Gate initialization and CI coordination share one non-cancelling concurrency
-group for the head repository and branch. Before either path creates, fails, or
-updates a check, it reads the live PR and requires the event's exact head and
-base, including when PR CI failed. This keeps a stale seed or completed CI run
-from being applied to a newer exact diff.
+group for the head repository and branch. Gate initialization requires the
+live PR to match the event's exact head and base before reserving a check. CI
+coordination reads the live PR before updating a check. If completed CI belongs
+to a closed PR or an obsolete head or base, it does not dispatch E2E and closes
+any existing exact-diff gate for that event as failed. This keeps a stale seed
+or completed CI run from being applied to a newer exact diff.
 Control-plane selections remain hash-bound in the recorded plan, but their
 credentialed execution is waived only through the exact-diff approval below.
 Shared sandbox-boundary changes have a floor of `full-e2e`, `hermes-e2e`, and
@@ -200,7 +202,14 @@ before downloaded evidence is classified.
 
 When the plan selects jobs, the check passes only when the E2E run succeeds and
 every expected job shard uploads one complete passing signal with no skips or
-pending tests. Every other dispatched outcome fails.
+pending tests. Every other dispatched outcome fails the exact-diff check.
+Expected negative PR outcomes, including failed prerequisite CI, failed or
+incomplete E2E evidence, and a revision that closes or changes during
+coordination, fail the exact-diff check while the trusted `workflow_run`
+controller job succeeds. GitHub attaches that controller run to the
+default-branch workflow SHA, so malformed state, provenance mismatches, and API
+or check-publication failures remain controller errors that fail the controller
+job.
 The coordinator has a 180-minute job budget and gives evidence download its
 own 10-minute limit, so a stalled download fails instead of consuming the
 remaining coordination time.

--- a/test/pr-e2e-gate-lifecycle.test.ts
+++ b/test/pr-e2e-gate-lifecycle.test.ts
@@ -96,6 +96,13 @@ function pullRequest(changedFiles = 1): PullRequest {
   };
 }
 
+function pullRequestDetailRoute(pull = pullRequest()) {
+  return githubFetchRoute(
+    ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+    () => githubResponse(pull),
+  );
+}
+
 function pullRequestListItem(pull = pullRequest()): Omit<PullRequest, "changed_files"> {
   const { changed_files: _changedFiles, ...item } = pull;
   return item;
@@ -276,6 +283,153 @@ describe("PR E2E controller lifecycle", () => {
     }
   });
 
+  it("ignores a superseded failed-CI event before mutating the live base check", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-stale-ci-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          emptyPrGateCheckRunsRoute(),
+          pullRequestDetailRoute({
+            ...pullRequest(),
+            base: { ...pullRequest().base, sha: "c".repeat(40) },
+          }),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(
+        startPrGate({ ...startCommand(workDir), ciConclusion: "failure" }),
+      ).resolves.toBeUndefined();
+      expect(requests).toHaveLength(2);
+      expect(requests.filter((request) => request.url.includes("/check-runs?"))).toHaveLength(1);
+      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
+      expect(requests.some((request) => request.method === "PATCH")).toBe(false);
+      expect(fs.readFileSync(outputPath, "utf8")).toBe("dispatched=false\n");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("closes an in-progress exact-diff check when its CI event is superseded", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-superseded-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          existingPrGateCheckRunsRoute(),
+          pullRequestDetailRoute({
+            ...pullRequest(),
+            head: { ...pullRequest().head, sha: "c".repeat(40) },
+          }),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            () => githubResponse({}),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir))).resolves.toBeUndefined();
+      expect(requests).toHaveLength(3);
+      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
+      const completion = requests.find((request) => request.method === "PATCH");
+      expect(completion?.body).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        output: { title: "PR revision changed" },
+      });
+      expect(fs.readFileSync(outputPath, "utf8")).toBe(
+        "check_id=17\nfinalized=true\ndispatched=false\n",
+      );
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces a completed success when a superseded CI event arrives", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-completed-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          existingPrGateCheckRunsRoute({ status: "completed", conclusion: "success" }),
+          pullRequestDetailRoute({
+            ...pullRequest(),
+            head: { ...pullRequest().head, sha: "c".repeat(40) },
+          }),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            () => githubResponse({}),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir))).resolves.toBeUndefined();
+      expect(requests).toHaveLength(3);
+      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
+      const completion = requests.find((request) => request.method === "PATCH");
+      expect(completion?.body).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        output: { title: "PR revision changed" },
+      });
+      expect(fs.readFileSync(outputPath, "utf8")).toBe(
+        "check_id=17\nfinalized=true\ndispatched=false\n",
+      );
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a malformed exact-diff check state", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-check-state-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [existingPrGateCheckRunsRoute({ status: "completed", conclusion: null })],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir))).rejects.toThrow(
+        "GitHub returned an invalid exact-diff check state",
+      );
+      expect(requests).toHaveLength(1);
+      expect(fs.readFileSync(outputPath, "utf8")).toBe("");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     {
       label: "the pull request base changes after dispatch",
@@ -283,14 +437,20 @@ describe("PR E2E controller lifecycle", () => {
         ...pullRequest(),
         base: { ...pullRequest().base, sha: "c".repeat(40) },
       },
-      expectedError: /expected exact head and base/u,
+      expectedTitle: "PR revision changed during E2E",
+      checkOverrides: { status: "completed", conclusion: "success" },
     },
     {
       label: "the pull request closes after dispatch",
       currentPull: { ...pullRequest(), state: "closed" },
-      expectedError: /invalid pull request state/u,
+      expectedTitle: "PR closed during E2E",
+      checkOverrides: {},
     },
-  ])("fails finalization when $label", async ({ currentPull, expectedError }) => {
+  ])("fails the exact check without failing the controller when $label", async ({
+    currentPull,
+    expectedTitle,
+    checkOverrides,
+  }) => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-retarget-"));
     const outputPath = path.join(workDir, "github-output");
     const statePath = path.join(workDir, "controller-state.json");
@@ -325,6 +485,7 @@ describe("PR E2E controller lifecycle", () => {
             ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
             () => githubResponse(currentPull),
           ),
+          existingPrGateCheckRunsRoute(checkOverrides),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
             () => githubResponse({}),
@@ -343,19 +504,14 @@ describe("PR E2E controller lifecycle", () => {
           checkRunId: 17,
           childRunId: 23,
         }),
-      ).rejects.toThrow(expectedError);
-      expect(
-        requests.some(
-          (request) => request.url.includes("/commits/") && request.url.includes("/check-runs?"),
-        ),
-      ).toBe(false);
+      ).resolves.toBeUndefined();
       const completion = requests.find(
         (request) => request.url.endsWith("/check-runs/17") && request.method === "PATCH",
       );
       expect(completion?.body).toMatchObject({
         status: "completed",
         conclusion: "failure",
-        output: { title: "Evidence could not be verified" },
+        output: { title: expectedTitle },
       });
       expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
     } finally {
@@ -367,22 +523,38 @@ describe("PR E2E controller lifecycle", () => {
     {
       label: "missing evidence",
       status: "completed",
+      conclusion: "success",
       expectCancellation: false,
       expectedTitle: "Evidence is missing",
-      expectedError: /Missing signals: onboard-repair:default, onboard-resume:default/u,
     },
     {
       label: "an unfinished child",
       status: "in_progress",
+      conclusion: null,
       expectCancellation: true,
       expectedTitle: "E2E run did not succeed",
-      expectedError: /The run concluded unfinished \(in_progress\)/u,
+    },
+    {
+      label: "a failed child",
+      status: "completed",
+      conclusion: "failure",
+      expectCancellation: false,
+      expectedTitle: "E2E run did not succeed",
+    },
+    {
+      label: "an invalid child result",
+      status: "unknown",
+      conclusion: null,
+      expectCancellation: false,
+      expectedTitle: "Evidence could not be verified",
+      expectedControllerError: "E2E workflow status and conclusion are invalid",
     },
   ])("closes the check as failure for $label", async ({
     status,
+    conclusion,
     expectCancellation,
     expectedTitle,
-    expectedError,
+    expectedControllerError,
   }) => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-finish-"));
     const outputPath = path.join(workDir, "github-output");
@@ -402,7 +574,7 @@ describe("PR E2E controller lifecycle", () => {
         [
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/actions/runs/23") && method === "GET",
-            () => githubResponse(workflowRun(gate, { status, conclusion: "success" })),
+            () => githubResponse(workflowRun(gate, { status, conclusion })),
           ),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/actions/runs/23/cancel") && method === "POST",
@@ -423,15 +595,18 @@ describe("PR E2E controller lifecycle", () => {
     );
 
     try {
-      await expect(
-        finishPrGate({
-          statePath,
-          stateHash: sha256(serializedState),
-          evidencePath,
-          checkRunId: 17,
-          childRunId: 23,
-        }),
-      ).rejects.toThrow(expectedError);
+      const finalization = finishPrGate({
+        statePath,
+        stateHash: sha256(serializedState),
+        evidencePath,
+        checkRunId: 17,
+        childRunId: 23,
+      });
+      if (expectedControllerError) {
+        await expect(finalization).rejects.toThrow(expectedControllerError);
+      } else {
+        await expect(finalization).resolves.toBeUndefined();
+      }
       expect(requests.some((request) => request.url.endsWith("/actions/runs/23/cancel"))).toBe(
         expectCancellation,
       );

--- a/test/pr-e2e-gate-lifecycle.test.ts
+++ b/test/pr-e2e-gate-lifecycle.test.ts
@@ -541,20 +541,11 @@ describe("PR E2E controller lifecycle", () => {
       expectCancellation: false,
       expectedTitle: "E2E run did not succeed",
     },
-    {
-      label: "an invalid child result",
-      status: "unknown",
-      conclusion: null,
-      expectCancellation: false,
-      expectedTitle: "Evidence could not be verified",
-      expectedControllerError: "E2E workflow status and conclusion are invalid",
-    },
   ])("closes the check as failure for $label", async ({
     status,
     conclusion,
     expectCancellation,
     expectedTitle,
-    expectedControllerError,
   }) => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-finish-"));
     const outputPath = path.join(workDir, "github-output");
@@ -595,18 +586,15 @@ describe("PR E2E controller lifecycle", () => {
     );
 
     try {
-      const finalization = finishPrGate({
-        statePath,
-        stateHash: sha256(serializedState),
-        evidencePath,
-        checkRunId: 17,
-        childRunId: 23,
-      });
-      if (expectedControllerError) {
-        await expect(finalization).rejects.toThrow(expectedControllerError);
-      } else {
-        await expect(finalization).resolves.toBeUndefined();
-      }
+      await expect(
+        finishPrGate({
+          statePath,
+          stateHash: sha256(serializedState),
+          evidencePath,
+          checkRunId: 17,
+          childRunId: 23,
+        }),
+      ).resolves.toBeUndefined();
       expect(requests.some((request) => request.url.endsWith("/actions/runs/23/cancel"))).toBe(
         expectCancellation,
       );
@@ -615,6 +603,61 @@ describe("PR E2E controller lifecycle", () => {
         status: "completed",
         conclusion: "failure",
         output: { title: expectedTitle },
+      });
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails the controller for an invalid child workflow result", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-invalid-child-"));
+    const outputPath = path.join(workDir, "github-output");
+    const statePath = path.join(workDir, "controller-state.json");
+    const evidencePath = path.join(workDir, "evidence");
+    const gate = state();
+    const serializedState = `${JSON.stringify(gate, null, 2)}\n`;
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    fs.writeFileSync(statePath, serializedState, { mode: 0o600 });
+    fs.mkdirSync(evidencePath);
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/actions/runs/23") && method === "GET",
+            () => githubResponse(workflowRun(gate, { status: "unknown", conclusion: null })),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            () => githubResponse({}),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(
+        finishPrGate({
+          statePath,
+          stateHash: sha256(serializedState),
+          evidencePath,
+          checkRunId: 17,
+          childRunId: 23,
+        }),
+      ).rejects.toThrow("E2E workflow status and conclusion are invalid");
+      expect(requests.some((request) => request.url.endsWith("/actions/runs/23/cancel"))).toBe(
+        false,
+      );
+      const completion = requests.find((request) => request.url.endsWith("/check-runs/17"));
+      expect(completion?.body).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        output: { title: "Evidence could not be verified" },
       });
       expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
     } finally {

--- a/test/pr-e2e-gate.test.ts
+++ b/test/pr-e2e-gate.test.ts
@@ -11,11 +11,9 @@ import { buildRiskPlan, riskPlanRequiredJobIds } from "../tools/advisors/risk-pl
 import {
   assertCorrelatedWorkflowRun,
   classifyPrGateEvidence,
-  controllerErrorAnnotationTitle,
   dispatchPrGate,
   expectedSignalShards,
   finishPrGate,
-  PrerequisiteCiError,
   type PrGateState,
   type PullRequest,
   parseControllerCommand,
@@ -365,15 +363,6 @@ describe("PR E2E controller", () => {
       fs.chmodSync(workDir, 0o700);
       fs.rmSync(workDir, { recursive: true, force: true });
     }
-  });
-
-  it("distinguishes prerequisite CI failures from controller failures in annotations", () => {
-    expect(controllerErrorAnnotationTitle(new PrerequisiteCiError("CI failed"))).toBe(
-      "PR CI did not pass",
-    );
-    expect(controllerErrorAnnotationTitle(new Error("controller failed"))).toBe(
-      "Controller failed",
-    );
   });
 
   it("validates the risk plan and bounded state", () => {
@@ -965,8 +954,53 @@ describe("PR E2E controller", () => {
     }
   });
 
-  it("rejects stale failed-CI evidence before mutating the live base check", async () => {
-    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-stale-ci-"));
+  it("closes the exact check when CI completes after the pull request closes", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-closed-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          existingPrGateCheckRunsRoute(),
+          pullRequestDetailRoute({ ...pullRequest(), state: "closed" }),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            () => githubResponse({}),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(
+        startPrGate({
+          ...startCommand(workDir, ""),
+          ciConclusion: "failure",
+        }),
+      ).resolves.toBeUndefined();
+      expect(requests.some((request) => request.url.includes("/jobs?"))).toBe(false);
+      expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
+      const completion = requests.find((request) => request.method === "PATCH");
+      expect(completion?.body).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        output: { title: "PR is no longer open" },
+      });
+      expect(fs.readFileSync(outputPath, "utf8")).toBe(
+        "check_id=17\nfinalized=true\ndispatched=false\n",
+      );
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a closed pull request that does not match the triggering branch", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-closed-ref-"));
     const outputPath = path.join(workDir, "github-output");
     fs.writeFileSync(outputPath, "", { mode: 0o600 });
     vi.stubEnv("GITHUB_TOKEN", "token");
@@ -979,7 +1013,8 @@ describe("PR E2E controller", () => {
           emptyPrGateCheckRunsRoute(),
           pullRequestDetailRoute({
             ...pullRequest(),
-            base: { ...pullRequest().base, sha: "c".repeat(40) },
+            state: "closed",
+            head: { ...pullRequest().head, ref: "feature/other" },
           }),
         ],
         requests,
@@ -987,80 +1022,30 @@ describe("PR E2E controller", () => {
     );
 
     try {
-      await expect(
-        startPrGate({ ...startCommand(workDir), ciConclusion: "failure" }),
-      ).rejects.toThrow(/expected exact head and base/u);
-      expect(requests).toHaveLength(2);
-      expect(requests.filter((request) => request.url.includes("/check-runs?"))).toHaveLength(1);
-      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
+      await expect(startPrGate(startCommand(workDir, ""))).rejects.toThrow(
+        "PR repository or branch does not match the triggering CI run",
+      );
+      expect(requests.some((request) => request.method !== "GET")).toBe(false);
       expect(fs.readFileSync(outputPath, "utf8")).toBe("");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
   });
 
-  it("recovers a superseded exact-diff check for the workflow cleanup step", async () => {
-    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-superseded-"));
+  it("rejects an unknown prerequisite CI conclusion before mutating checks", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-conclusion-"));
     const outputPath = path.join(workDir, "github-output");
     fs.writeFileSync(outputPath, "", { mode: 0o600 });
     vi.stubEnv("GITHUB_TOKEN", "token");
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
     vi.stubEnv("GITHUB_OUTPUT", outputPath);
-    const requests: RecordedGitHubRequest[] = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      createGitHubFetchRouter(
-        [
-          existingPrGateCheckRunsRoute(),
-          pullRequestDetailRoute({
-            ...pullRequest(),
-            head: { ...pullRequest().head, sha: "c".repeat(40) },
-          }),
-        ],
-        requests,
-      ),
-    );
+    const fetchMock = vi.spyOn(globalThis, "fetch");
 
     try {
-      await expect(startPrGate(startCommand(workDir))).rejects.toThrow(
-        /expected exact head and base/u,
-      );
-      expect(requests).toHaveLength(2);
-      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
-      expect(requests.some((request) => request.method === "PATCH")).toBe(false);
-      expect(fs.readFileSync(outputPath, "utf8")).toBe("check_id=17\n");
-    } finally {
-      fs.rmSync(workDir, { recursive: true, force: true });
-    }
-  });
-
-  it("does not reopen a completed check when a superseded CI event arrives", async () => {
-    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-completed-"));
-    const outputPath = path.join(workDir, "github-output");
-    fs.writeFileSync(outputPath, "", { mode: 0o600 });
-    vi.stubEnv("GITHUB_TOKEN", "token");
-    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
-    vi.stubEnv("GITHUB_OUTPUT", outputPath);
-    const requests: RecordedGitHubRequest[] = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      createGitHubFetchRouter(
-        [
-          existingPrGateCheckRunsRoute({ status: "completed", conclusion: "success" }),
-          pullRequestDetailRoute({
-            ...pullRequest(),
-            head: { ...pullRequest().head, sha: "c".repeat(40) },
-          }),
-        ],
-        requests,
-      ),
-    );
-
-    try {
-      await expect(startPrGate(startCommand(workDir))).rejects.toThrow(
-        /expected exact head and base/u,
-      );
-      expect(requests).toHaveLength(2);
-      expect(requests.some((request) => request.url.endsWith("/check-runs"))).toBe(false);
-      expect(requests.some((request) => request.method === "PATCH")).toBe(false);
+      await expect(
+        startPrGate({ ...startCommand(workDir), ciConclusion: "unknown" }),
+      ).rejects.toThrow("PR CI conclusion is invalid");
+      expect(fetchMock).not.toHaveBeenCalled();
       expect(fs.readFileSync(outputPath, "utf8")).toBe("");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
@@ -1134,20 +1119,9 @@ describe("PR E2E controller", () => {
     );
 
     try {
-      let rejection: unknown;
-      try {
-        await startPrGate({ ...startCommand(workDir), ciConclusion: "failure" });
-      } catch (error) {
-        rejection = error;
-      }
-      expect(rejection).toBeInstanceOf(PrerequisiteCiError);
-      const rejectionMessage = (rejection as Error).message;
-      expect(rejectionMessage).toContain("PR #42: https://github.com/NVIDIA/NemoClaw/pull/42");
-      expect(rejectionMessage).toContain(
-        `CI run attempt ${CI_RUN_ATTEMPT}: https://github.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT}`,
-      );
-      expect(rejectionMessage).toContain("cli-test-shards (6) (Run CLI coverage shard)");
-      expect(rejectionMessage).toContain("job listing truncated");
+      await expect(
+        startPrGate({ ...startCommand(workDir), ciConclusion: "failure" }),
+      ).resolves.toBeUndefined();
 
       expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
       expect(requests.filter((request) => request.url.endsWith("/pulls/42"))).toHaveLength(1);
@@ -1237,12 +1211,7 @@ describe("PR E2E controller", () => {
           ciConclusion: "failure",
           prNumber: undefined,
         }),
-      ).rejects.toThrow(
-        new RegExp(
-          `CI run attempt ${CI_RUN_ATTEMPT}: https://github\\.com/NVIDIA/NemoClaw/actions/runs/${CI_RUN_ID}/attempts/${CI_RUN_ATTEMPT}`,
-          "u",
-        ),
-      );
+      ).resolves.toBeUndefined();
 
       expect(requests.filter((request) => request.url.endsWith("/pulls/42"))).toHaveLength(1);
       expect(requests.some((request) => request.url.includes("/pulls?"))).toBe(false);

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -64,6 +64,17 @@ const ACTIVE_WORKFLOW_RUN_STATUSES = [
   "in_progress",
 ] as const;
 const ACTIVE_WORKFLOW_RUN_STATUS_SET = new Set<string>(ACTIVE_WORKFLOW_RUN_STATUSES);
+const WORKFLOW_RUN_CONCLUSIONS = new Set([
+  "action_required",
+  "cancelled",
+  "failure",
+  "neutral",
+  "skipped",
+  "stale",
+  "startup_failure",
+  "success",
+  "timed_out",
+]);
 const EVIDENCE_LIMITS = {
   maxDepth: 8,
   maxEntries: 4096,
@@ -136,7 +147,7 @@ type CheckConclusion = "success" | "failure";
 
 export type PullRequest = {
   number: number;
-  state: string;
+  state: "open" | "closed";
   changed_files: number;
   head: { ref: string; sha: string; repo: { full_name: string } | null };
   base: { sha: string; repo: { full_name: string } };
@@ -215,8 +226,6 @@ export type PrGateVerdict = {
   title: string;
   summary: string;
 };
-
-export class PrerequisiteCiError extends Error {}
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -745,6 +754,17 @@ async function matchingPrGateChecks(options: {
   return sameIdentity.filter((check) => check.app?.id === GITHUB_ACTIONS_APP_ID);
 }
 
+function validatePrGateCheckState(check: CheckRun): "in_progress" | "success" | "failure" {
+  if (check.status === "in_progress" && check.conclusion === null) return "in_progress";
+  if (
+    check.status === "completed" &&
+    (check.conclusion === "success" || check.conclusion === "failure")
+  ) {
+    return check.conclusion;
+  }
+  throw new Error("GitHub returned an invalid exact-diff check state");
+}
+
 async function ensurePrGateCheck(options: {
   repository: string;
   token: string;
@@ -911,7 +931,9 @@ function validatePullRequestIdentity(value: unknown): PullRequestListItem {
   ) {
     throw new Error("GitHub returned an invalid pull request number");
   }
-  if (value.state !== "open") throw new Error("GitHub returned invalid pull request state");
+  if (value.state !== "open" && value.state !== "closed") {
+    throw new Error("GitHub returned invalid pull request state");
+  }
   if (!isObjectRecord(value.head) || !isObjectRecord(value.base)) {
     throw new Error("GitHub returned invalid pull request refs");
   }
@@ -935,12 +957,32 @@ function validatePullRequestIdentity(value: unknown): PullRequestListItem {
   return value as PullRequestListItem;
 }
 
-function validatePullRequest(value: unknown): PullRequest {
+function validatePullRequestSnapshot(value: unknown): PullRequest {
   const identity = validatePullRequestIdentity(value);
   if (!isObjectRecord(value) || !Number.isSafeInteger(value.changed_files)) {
     throw new Error("GitHub returned an invalid pull request changed-file count");
   }
   return { ...identity, changed_files: value.changed_files as number };
+}
+
+function validatePullRequest(value: unknown): PullRequest {
+  const pull = validatePullRequestSnapshot(value);
+  if (pull.state !== "open") throw new Error("GitHub returned invalid pull request state");
+  return pull;
+}
+
+async function pullRequestSnapshot(options: {
+  repository: string;
+  token: string;
+  prNumber: number;
+}): Promise<PullRequest> {
+  return validatePullRequestSnapshot(
+    await githubApi<unknown>(
+      `repos/${options.repository}/pulls/${options.prNumber}`,
+      options.token,
+      { userAgent: USER_AGENT },
+    ),
+  );
 }
 
 async function requireLiveExactDiff(options: {
@@ -950,15 +992,7 @@ async function requireLiveExactDiff(options: {
   headSha: string;
   baseSha: string;
 }): Promise<PullRequest> {
-  const pull = validatePullRequest(
-    await githubApi<unknown>(
-      `repos/${options.repository}/pulls/${options.prNumber}`,
-      options.token,
-      {
-        userAgent: USER_AGENT,
-      },
-    ),
-  );
+  const pull = await pullRequestSnapshot(options);
   if (
     pull.number !== options.prNumber ||
     pull.state !== "open" ||
@@ -1008,6 +1042,7 @@ export async function resolvePullRequest(options: {
     .map(validatePullRequestIdentity)
     .filter(
       (pull) =>
+        pull.state === "open" &&
         pull.head.sha === options.headSha &&
         pull.head.ref === options.headBranch &&
         pull.head.repo?.full_name === options.headRepository &&
@@ -1418,6 +1453,22 @@ function diagnosticValue(value: unknown): string {
   return serialized.length > 256 ? `${serialized.slice(0, 253)}...` : serialized;
 }
 
+function assertWorkflowRunConclusion(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !WORKFLOW_RUN_CONCLUSIONS.has(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+}
+
+function assertWorkflowRunResult(run: WorkflowRun): void {
+  if (run.status === "completed") {
+    assertWorkflowRunConclusion(run.conclusion, "E2E workflow conclusion");
+    return;
+  }
+  if (!ACTIVE_WORKFLOW_RUN_STATUS_SET.has(run.status) || run.conclusion !== null) {
+    throw new Error("E2E workflow status and conclusion are invalid");
+  }
+}
+
 export function assertCorrelatedWorkflowRun(
   child: WorkflowRun,
   identity: WorkflowRunIdentity,
@@ -1533,6 +1584,7 @@ export async function startPrGate(
   }
   assertRepository(command.headRepository, "PR head repository");
   assertBranch(command.headBranch);
+  assertWorkflowRunConclusion(command.ciConclusion, "PR CI conclusion");
   const ciIdentity = parseCiRunIdentity(command.ciDisplayTitle);
   if (
     ciIdentity.headSha !== command.headSha ||
@@ -1550,21 +1602,47 @@ export async function startPrGate(
   if (existingChecks.length > 1) {
     throw new Error("Multiple exact-diff PR gate checks already exist");
   }
+  const existingCheckState = existingChecks[0]
+    ? validatePrGateCheckState(existingChecks[0])
+    : undefined;
   const existingCheckRunId =
-    existingChecks[0]?.status === "in_progress" ? existingChecks[0].id : undefined;
+    existingCheckState === "in_progress" ? existingChecks[0]!.id : undefined;
   if (existingCheckRunId) appendOutput("check_id", String(existingCheckRunId));
-  const pull = await requireLiveExactDiff({
+  const pull = await pullRequestSnapshot({
     repository,
     token,
     prNumber: ciIdentity.prNumber,
-    headSha: ciIdentity.headSha,
-    baseSha: ciIdentity.baseSha,
   });
   if (
+    pull.number !== ciIdentity.prNumber ||
+    pull.base.repo.full_name !== repository ||
     pull.head.repo?.full_name !== command.headRepository ||
     pull.head.ref !== command.headBranch
   ) {
     throw new Error("PR repository or branch does not match the triggering CI run");
+  }
+  const obsoleteTitle =
+    pull.state === "closed"
+      ? "PR is no longer open"
+      : pull.head.sha !== ciIdentity.headSha || pull.base.sha !== ciIdentity.baseSha
+        ? "PR revision changed"
+        : undefined;
+  if (obsoleteTitle) {
+    const obsoleteCheckRunId = existingChecks[0]?.id;
+    if (obsoleteCheckRunId && existingCheckState !== "failure") {
+      if (!existingCheckRunId) appendOutput("check_id", String(obsoleteCheckRunId));
+      await completeCheck({ repository, checkRunId: obsoleteCheckRunId }, token, {
+        conclusion: "failure",
+        title: obsoleteTitle,
+        summary: `CI completed for head ${ciIdentity.headSha} and base ${ciIdentity.baseSha}, but that is no longer the active PR revision. No E2E run was dispatched.`,
+      });
+      appendOutput("finalized", "true");
+    }
+    appendOutput("dispatched", "false");
+    console.log(
+      `Obsolete CI result ignored: pr=${ciIdentity.prNumber} head=${ciIdentity.headSha} base=${ciIdentity.baseSha} state=${pull.state}`,
+    );
+    return;
   }
   const checkRunId = await ensurePrGateCheck({
     repository,
@@ -1625,7 +1703,8 @@ export async function startPrGate(
       appendOutput("dispatched", "false");
       appendOutput("finalized", "true");
       finalized = true;
-      throw new PrerequisiteCiError(report.errorMessage);
+      console.log(report.errorMessage);
+      return;
     }
 
     const changedFiles = await pullChangedFiles(repository, pull, token);
@@ -1867,6 +1946,7 @@ export async function finishPrGate(options: {
       repository,
       workflowSha: state.workflowSha,
     });
+    assertWorkflowRunResult(child);
     if (child.status !== "completed") {
       await cancelChildRun(repository, token, options.childRunId);
       console.log(
@@ -1892,13 +1972,14 @@ export async function finishPrGate(options: {
       expectedShards: state.expectedShards,
       signals,
     });
-    await requireLiveExactDiff({
+    const pull = await pullRequestSnapshot({
       repository,
       token,
       prNumber: state.prNumber,
-      headSha: state.commitSha,
-      baseSha: state.baseSha,
     });
+    if (pull.number !== state.prNumber || pull.base.repo.full_name !== repository) {
+      throw new Error("pull request no longer matches the controller state");
+    }
     const matchingChecks = await matchingPrGateChecks({
       repository,
       token,
@@ -1909,15 +1990,40 @@ export async function finishPrGate(options: {
     if (matchingChecks.length !== 1 || matchingChecks[0]!.id !== options.checkRunId) {
       throw new Error("controller state does not match the exact PR gate check");
     }
+    const checkState = validatePrGateCheckState(matchingChecks[0]!);
+    const obsoleteTitle =
+      pull.state === "closed"
+        ? "PR closed during E2E"
+        : pull.head.sha !== state.commitSha || pull.base.sha !== state.baseSha
+          ? "PR revision changed during E2E"
+          : undefined;
+    if (obsoleteTitle) {
+      if (checkState !== "failure") {
+        await completeCheck(
+          context,
+          token,
+          {
+            conclusion: "failure",
+            title: obsoleteTitle,
+            summary:
+              "The dispatched run can no longer authorize this PR because its active revision changed before E2E finalization.",
+          },
+          childRunUrl,
+        );
+      }
+      appendOutput("finalized", "true");
+      finalized = true;
+      console.log(
+        `Obsolete E2E result ignored: pr=${state.prNumber} run=${options.childRunId} title=${obsoleteTitle} url=${childRunUrl}`,
+      );
+      return;
+    }
     await completeCheck(context, token, verdict, childRunUrl);
     appendOutput("finalized", "true");
     finalized = true;
     console.log(
       `Run completed: run=${options.childRunId} conclusion=${verdict.conclusion} title=${verdict.title} url=${childRunUrl}`,
     );
-    if (verdict.conclusion === "failure") {
-      throw new Error(`${verdict.title}: ${verdict.summary}`);
-    }
   } catch (error) {
     if (!finalized) {
       const closed = await completeFailureAfterControllerError(
@@ -2297,16 +2403,12 @@ export async function cancelPrGate(prNumber: number): Promise<number> {
   return active.size;
 }
 
-export function controllerErrorAnnotationTitle(error: unknown): string {
-  return error instanceof PrerequisiteCiError ? "PR CI did not pass" : "Controller failed";
-}
-
 function reportControllerError(error: unknown): void {
   const message = controllerErrorMessage(error);
   console.error(message);
   if (process.env.GITHUB_ACTIONS === "true") {
     const escaped = message.replace(/%/gu, "%25").replace(/\r/gu, "%0D").replace(/\n/gu, "%0A");
-    console.error(`::error title=${controllerErrorAnnotationTitle(error)}::${escaped}`);
+    console.error(`::error title=Controller failed::${escaped}`);
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

GitHub attaches the trusted `workflow_run` controller to the default-branch workflow SHA. Previously, expected negative PR outcomes updated the exact-diff `E2E PR Gate` check to failure and then threw, so the controller job on `main` also went red. This change lets the controller succeed after it reliably publishes a failed PR-scoped verdict, while malformed state, provenance mismatches, and API or check-publication failures still fail the controller.

## Related Issue

Part of #6145

## Changes

- Treat failed prerequisite CI and failed or incomplete E2E evidence as completed PR-gate verdicts instead of controller exceptions.
- Fail obsolete exact-diff checks without dispatching when a PR closes or its head or base changes, including replacing an obsolete completed success.
- Validate workflow conclusions and exact-diff check states before using GitHub data, preserving fail-closed behavior for malformed or untrusted controller state.
- Cover failed CI, failed and unfinished children, stale revisions, closed PRs, malformed states, and controller-error boundaries in the gate tests and maintainer E2E documentation.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Focused security review covered exact-diff identity and state validation, stale completed-success replacement, child-run provenance, and fail-closed API/publication errors; no findings remain.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/pr-e2e-gate.test.ts test/pr-e2e-gate-lifecycle.test.ts test/pr-e2e-gate-exceptions.test.ts test/pr-e2e-gate-workflow.test.ts` (96 passed)
- [ ] Applicable broad gate passed — not applicable; the change is isolated to the PR E2E controller and all four controller suites passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
* Improved E2E gate handling when pull requests are closed, retargeted, or updated during validation.
* Prevented stale CI/E2E results from mutating newer revisions, and ensured obsolete gates are closed as failure with clearer details.
* Added stricter validation for workflow status/conclusion combinations and base matches.
* **Tests**
* Expanded lifecycle tests for superseded, malformed, and invalid workflow evidence scenarios, updating expectations for error/patch behavior.
* **Documentation**
* Clarified PR gate initialization and the expected pass/fail contract for pending or unsuccessful validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->