### PR TITLE
ci(platform): stabilize Vitest on WSL runners

### DIFF
--- a/.github/workflows/platform-vitest-main.yaml
+++ b/.github/workflows/platform-vitest-main.yaml
@@ -194,13 +194,10 @@ jobs:
             'Acquire::Retries "5";' \
             >/etc/apt/apt.conf.d/99github-actions-network
           apt-get update
-          apt-get install -y bash ca-certificates curl git jq lsb-release make python3 python3-pip python3-venv rsync sudo tar unzip xz-utils
+          apt-get install -y bash ca-certificates curl git jq lsb-release make python3 python3-pip python3-venv rsync tar unzip xz-utils
           if ! id -u "$test_user" >/dev/null 2>&1; then
             useradd --create-home --shell /bin/bash "$test_user"
           fi
-          printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$test_user" >"/etc/sudoers.d/$test_user"
-          chmod 0440 "/etc/sudoers.d/$test_user"
-          visudo -cf "/etc/sudoers.d/$test_user"
           '@
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
@@ -253,7 +250,6 @@ jobs:
           $script = @"
           set -euo pipefail
           id -un | grep -Fxq '$env:WSL_TEST_USER'
-          sudo -n true
           cd '$env:WSL_WORKDIR'
           npm ci --ignore-scripts
           npm run build:cli

--- a/.github/workflows/platform-vitest-main.yaml
+++ b/.github/workflows/platform-vitest-main.yaml
@@ -79,7 +79,7 @@ jobs:
 
   macos-vitest:
     runs-on: macos-26
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -116,9 +116,10 @@ jobs:
 
   wsl-vitest:
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       WSL_DISTRO: Ubuntu
+      WSL_TEST_USER: nemoclaw-ci
     steps:
       - name: Force LF line endings for checkout
         shell: powershell
@@ -186,18 +187,25 @@ jobs:
         run: |
           $script = @'
           set -euo pipefail
+          test_user="${1:?missing WSL test user}"
           export DEBIAN_FRONTEND=noninteractive
           printf '%s\n' \
             'Acquire::ForceIPv4 "true";' \
             'Acquire::Retries "5";' \
             >/etc/apt/apt.conf.d/99github-actions-network
           apt-get update
-          apt-get install -y bash ca-certificates curl git jq lsb-release make python3 python3-pip rsync tar unzip xz-utils
+          apt-get install -y bash ca-certificates curl git jq lsb-release make python3 python3-pip python3-venv rsync sudo tar unzip xz-utils
+          if ! id -u "$test_user" >/dev/null 2>&1; then
+            useradd --create-home --shell /bin/bash "$test_user"
+          fi
+          printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$test_user" >"/etc/sudoers.d/$test_user"
+          chmod 0440 "/etc/sudoers.d/$test_user"
+          visudo -cf "/etc/sudoers.d/$test_user"
           '@
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
-          wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
+          wsl -d $env:WSL_DISTRO --user root -- bash -l $wslTmp $env:WSL_TEST_USER
 
       - name: Install Node.js 22 in WSL
         shell: powershell
@@ -212,7 +220,7 @@ jobs:
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
-          wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
+          wsl -d $env:WSL_DISTRO --user root -- bash -l $wslTmp
 
       - name: Copy checkout into WSL ext4 workspace
         shell: powershell
@@ -232,17 +240,20 @@ jobs:
           git config --global --add safe.directory '$workdir'
           git -C '$workdir' reset --hard HEAD
           git -C '$workdir' clean -ffdx
+          chown -R '$($env:WSL_TEST_USER):$($env:WSL_TEST_USER)' '$workdir'
           "@
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
-          wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
+          wsl -d $env:WSL_DISTRO --user root -- bash -l $wslTmp
 
       - name: Install dependencies and build in WSL
         shell: powershell
         run: |
           $script = @"
           set -euo pipefail
+          id -un | grep -Fxq '$env:WSL_TEST_USER'
+          sudo -n true
           cd '$env:WSL_WORKDIR'
           npm ci --ignore-scripts
           npm run build:cli
@@ -253,13 +264,14 @@ jobs:
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
-          wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
+          wsl -d $env:WSL_DISTRO --user $env:WSL_TEST_USER -- bash -l $wslTmp
 
       - name: Run full Vitest suite in WSL
         shell: powershell
         run: |
           $script = @"
           set -euo pipefail
+          id -un | grep -Fxq '$env:WSL_TEST_USER'
           cd '$env:WSL_WORKDIR'
           export NEMOCLAW_EXEC_TIMEOUT=60000
           export NEMOCLAW_TEST_TIMEOUT=60000
@@ -268,4 +280,33 @@ jobs:
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
-          wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
+          wsl -d $env:WSL_DISTRO --user $env:WSL_TEST_USER -- bash -l $wslTmp
+
+      - name: Run root-required Vitest contracts in WSL
+        shell: powershell
+        run: |
+          $script = @"
+          set -euo pipefail
+          id -u | grep -Fxq '0'
+          cd '$env:WSL_WORKDIR'
+          if ! getent group sandbox >/dev/null; then
+            groupadd --system sandbox
+          fi
+          if ! id -u sandbox >/dev/null 2>&1; then
+            useradd --system --gid sandbox --home-dir /sandbox --shell /bin/bash sandbox
+          fi
+          install -d -o root -g root -m 0755 /usr/local/lib/nemoclaw
+          install -o root -g root -m 0644 \
+            scripts/lib/normalize_mutable_config_perms.py \
+            /usr/local/lib/nemoclaw/normalize_mutable_config_perms.py
+          npx vitest run --project integration \
+            test/hermes-restart-config-seal-recovery.test.ts \
+            -t 'keeps the locked Hermes entry sticky-protected|lets a sandbox-group peer create state'
+          npx vitest run --project integration \
+            test/nemoclaw-start-perms.test.ts \
+            -t 'requires both fixed files to match|reclaims a root-owned collapsed config|leaves a root-owned recovery baseline untouched'
+          "@
+          $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
+          [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
+          $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
+          wsl -d $env:WSL_DISTRO --user root -- bash -l $wslTmp

--- a/src/lib/actions/sandbox/forward-recovery.ts
+++ b/src/lib/actions/sandbox/forward-recovery.ts
@@ -35,6 +35,7 @@ type SandboxPortDeps = {
 type SandboxForwardRecoveryOptions = {
   afterSuccess?: () => boolean;
   beforeStart?: () => boolean;
+  isWsl?: boolean;
 };
 
 function isValidPort(value: unknown): value is number {
@@ -73,7 +74,7 @@ export function ensureSandboxPortForward(
 ): boolean {
   const port = resolveSandboxDashboardPort(sandboxName);
   const remoteBindRequested = isRemoteDashboardBindRequested(process.env.NEMOCLAW_DASHBOARD_BIND);
-  const allInterfaceBindRequired = remoteBindRequested || isWsl();
+  const allInterfaceBindRequired = remoteBindRequested || isWsl({ isWsl: options.isWsl });
   if (
     remoteBindRequested &&
     registry.getSandbox(sandboxName)?.dashboardRemoteBindPrepared !== true
@@ -109,9 +110,13 @@ export function ensureSandboxPortForward(
  * Local reachability is intentionally not sufficient: an unrelated listener
  * cannot prove that OpenShell assigned this sandbox the requested host port.
  */
-export function isSandboxForwardHealthy(sandboxName: string): SandboxForwardHealth {
+export function isSandboxForwardHealthy(
+  sandboxName: string,
+  options: { isWsl?: boolean } = {},
+): SandboxForwardHealth {
   const allInterfaceBindRequired =
-    isRemoteDashboardBindRequested(process.env.NEMOCLAW_DASHBOARD_BIND) || isWsl();
+    isRemoteDashboardBindRequested(process.env.NEMOCLAW_DASHBOARD_BIND) ||
+    isWsl({ isWsl: options.isWsl });
   return isSandboxPortForwardHealthy(
     sandboxName,
     resolveSandboxDashboardPort(sandboxName),

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -828,6 +828,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     relaunchManagedSupervisorSessionImpl = relaunchManagedSupervisorSession,
     isSandboxGatewayRunningImpl = isSandboxGatewayRunning,
     waitForRecreatedSandboxOpenShellReadyImpl = waitForRecreatedSandboxOpenShellReady,
+    isWsl: isWslOverride,
   }: {
     quiet?: boolean;
     requestGatewaySupervisorAction?: typeof executeGatewaySupervisorAction;
@@ -835,6 +836,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     relaunchManagedSupervisorSessionImpl?: typeof relaunchManagedSupervisorSession;
     isSandboxGatewayRunningImpl?: typeof isSandboxGatewayRunning;
     waitForRecreatedSandboxOpenShellReadyImpl?: typeof waitForRecreatedSandboxOpenShellReady;
+    isWsl?: boolean;
   } = {},
 ) {
   const recoveryAgent = agentRuntime.getSessionAgent(sandboxName);
@@ -876,14 +878,14 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     // Gateway is alive but the host-side forward can still be dead or
     // owned by another sandbox. Probe and re-establish only when
     // necessary so the live-and-healthy path stays a no-op.
-    const forwardHealthy = isSandboxForwardHealthy(sandboxName);
+    const forwardHealthy = isSandboxForwardHealthy(sandboxName, { isWsl: isWslOverride });
     if (forwardHealthy === false) {
       if (!quiet) {
         console.log("");
         console.log(`  Dashboard port forward to '${sandboxName}' is missing or dead.`);
         console.log("  Re-establishing...");
       }
-      const forwardRecovered = ensureSandboxPortForward(sandboxName);
+      const forwardRecovered = ensureSandboxPortForward(sandboxName, { isWsl: isWslOverride });
       const dashboardForwardRecovered = ensureHermesDashboardPortForwardIfEnabled(sandboxName);
       const messagingForwardRecovered = recoverMessagingHostForward(sandboxName, { quiet });
       const declaredForwardsRecovered = recoverDeclaredAgentForwardPorts(
@@ -1116,6 +1118,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     const forwardRecovered = ensureSandboxPortForward(sandboxName, {
       afterSuccess: confirmRelaunchedManagedHealth ?? undefined,
       beforeStart: confirmRelaunchedManagedHealth ?? undefined,
+      isWsl: isWslOverride,
     });
     if (!forwardRecovered && relaunchedIdentityRejected) {
       return {
@@ -1196,6 +1199,7 @@ export function checkAndRecoverSandboxProcesses(
     relaunchManagedSupervisorSessionImpl?: typeof relaunchManagedSupervisorSession;
     isSandboxGatewayRunningImpl?: typeof isSandboxGatewayRunning;
     waitForRecreatedSandboxOpenShellReadyImpl?: typeof waitForRecreatedSandboxOpenShellReady;
+    isWsl?: boolean;
   } = {},
 ) {
   return withTimerBoundShieldsMutationLock(sandboxName, "gateway process recovery", () =>

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -942,7 +942,7 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
       .map((failure) => `${failure.name}: ${failure.message}`)
       .join(" | ");
     const wslHint =
-      isWsl() && retriedAfterTimeout
+      isWsl({ isWsl: options.isWsl }) && retriedAfterTimeout
         ? " · WSL2 detected \u2014 network verification may be slower than expected. " +
           "Run `nemoclaw onboard` with the `--skip-verify` flag if this endpoint is known to be reachable."
         : "";

--- a/src/lib/onboard/dashboard-access.test.ts
+++ b/src/lib/onboard/dashboard-access.test.ts
@@ -95,16 +95,20 @@ describe("NEMOCLAW_DASHBOARD_BIND remote-bind opt-in gate (#3259)", () => {
   it("opens the remote bind when env NEMOCLAW_DASHBOARD_BIND=0.0.0.0", () => {
     const chain = buildDashboardChain(LOOPBACK_URL, {
       env: { NEMOCLAW_DASHBOARD_BIND: "0.0.0.0" },
+      isWsl: false,
     });
     expect(chain.bindAddress).toBe("0.0.0.0");
     expect(chain.forwardTarget).toBe("0.0.0.0:18789");
     expect(
-      getDashboardForwardTarget(LOOPBACK_URL, { env: { NEMOCLAW_DASHBOARD_BIND: "0.0.0.0" } }),
+      getDashboardForwardTarget(LOOPBACK_URL, {
+        env: { NEMOCLAW_DASHBOARD_BIND: "0.0.0.0" },
+        isWsl: false,
+      }),
     ).toBe("0.0.0.0:18789");
   });
 
   it("stays loopback when env NEMOCLAW_DASHBOARD_BIND is unset", () => {
-    const chain = buildDashboardChain(LOOPBACK_URL, { env: {} });
+    const chain = buildDashboardChain(LOOPBACK_URL, { env: {}, isWsl: false });
     expect(chain.bindAddress).toBe("127.0.0.1");
     expect(chain.forwardTarget).toBe("18789");
   });
@@ -112,6 +116,7 @@ describe("NEMOCLAW_DASHBOARD_BIND remote-bind opt-in gate (#3259)", () => {
   it("stays loopback when env NEMOCLAW_DASHBOARD_BIND is empty", () => {
     const chain = buildDashboardChain(LOOPBACK_URL, {
       env: { NEMOCLAW_DASHBOARD_BIND: "" },
+      isWsl: false,
     });
     expect(chain.bindAddress).toBe("127.0.0.1");
     expect(chain.forwardTarget).toBe("18789");
@@ -120,6 +125,7 @@ describe("NEMOCLAW_DASHBOARD_BIND remote-bind opt-in gate (#3259)", () => {
   it("stays loopback when env NEMOCLAW_DASHBOARD_BIND=127.0.0.1", () => {
     const chain = buildDashboardChain(LOOPBACK_URL, {
       env: { NEMOCLAW_DASHBOARD_BIND: "127.0.0.1" },
+      isWsl: false,
     });
     expect(chain.bindAddress).toBe("127.0.0.1");
     expect(chain.forwardTarget).toBe("18789");
@@ -135,6 +141,7 @@ describe("NEMOCLAW_DASHBOARD_BIND remote-bind opt-in gate (#3259)", () => {
   ])("does NOT open a remote bind for invalid env value %j", (value) => {
     const chain = buildDashboardChain(LOOPBACK_URL, {
       env: { NEMOCLAW_DASHBOARD_BIND: value },
+      isWsl: false,
     });
     expect(chain.bindAddress).toBe("127.0.0.1");
     expect(chain.forwardTarget).toBe("18789");
@@ -142,14 +149,14 @@ describe("NEMOCLAW_DASHBOARD_BIND remote-bind opt-in gate (#3259)", () => {
 
   it("falls back to process.env when no options.env override is provided", () => {
     vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", "0.0.0.0");
-    const chain = buildDashboardChain(LOOPBACK_URL);
+    const chain = buildDashboardChain(LOOPBACK_URL, { isWsl: false });
     expect(chain.bindAddress).toBe("0.0.0.0");
     expect(chain.forwardTarget).toBe("0.0.0.0:18789");
   });
 
   it("does NOT open a remote bind for invalid process.env value", () => {
     vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", "0.0.0.0; rm -rf");
-    const chain = buildDashboardChain(LOOPBACK_URL);
+    const chain = buildDashboardChain(LOOPBACK_URL, { isWsl: false });
     expect(chain.bindAddress).toBe("127.0.0.1");
     expect(chain.forwardTarget).toBe("18789");
   });

--- a/test/cli/connect-recovery.test.ts
+++ b/test/cli/connect-recovery.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { nonWslPlatformNodeOptions } from "../helpers/platform-override-node-options";
 import {
   runWithEnv,
   testTimeoutOptions,
@@ -206,6 +207,7 @@ describe("CLI connect recovery process contracts", () => {
       try {
         const result = runWithEnv("alpha connect --probe-only", {
           HOME: home,
+          NODE_OPTIONS: nonWslPlatformNodeOptions(home),
           PATH: `${localBin}:${process.env.PATH || ""}`,
         });
 
@@ -280,6 +282,7 @@ describe("CLI connect recovery process contracts", () => {
       try {
         const result = runWithEnv("alpha connect --probe-only", {
           HOME: home,
+          NODE_OPTIONS: nonWslPlatformNodeOptions(home),
           PATH: `${localBin}:${process.env.PATH || ""}`,
         });
 
@@ -348,6 +351,7 @@ describe("CLI connect recovery process contracts", () => {
     try {
       const result = runWithEnv("alpha connect --probe-only", {
         HOME: home,
+        NODE_OPTIONS: nonWslPlatformNodeOptions(home),
         PATH: `${localBin}:${process.env.PATH || ""}`,
       });
 
@@ -465,6 +469,7 @@ describe("CLI connect recovery process contracts", () => {
 
     const result = runWithEnv("alpha connect", {
       HOME: home,
+      NODE_OPTIONS: nonWslPlatformNodeOptions(home),
       PATH: `${localBin}:${process.env.PATH || ""}`,
     });
 

--- a/test/dashboard-remote-bind-lifecycle.test.ts
+++ b/test/dashboard-remote-bind-lifecycle.test.ts
@@ -682,9 +682,6 @@ describe("remote dashboard bind production lifecycle", () => {
     let started = false;
     vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", "");
     vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
-    vi.stubEnv("WSL_DISTRO_NAME", "");
-    vi.stubEnv("WSL_INTEROP", "");
-    vi.spyOn(os, "release").mockReturnValue("6.8.0-linux");
     vi.spyOn(registry, "getSandbox").mockReturnValue({
       name: "beta",
       dashboardPort: 18789,
@@ -705,7 +702,7 @@ describe("remote dashboard bind production lifecycle", () => {
         return { status: 0 } as never;
       });
 
-    expect(ensureSandboxPortForward("beta")).toBe(true);
+    expect(ensureSandboxPortForward("beta", { isWsl: false })).toBe(true);
     expect(runOpenshell).toHaveBeenCalledWith(
       ["forward", "stop", "18789", "beta"],
       expect.anything(),
@@ -723,7 +720,6 @@ describe("remote dashboard bind production lifecycle", () => {
     let started = false;
     vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", "");
     vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
-    vi.stubEnv("WSL_DISTRO_NAME", "Ubuntu");
     vi.spyOn(registry, "getSandbox").mockReturnValue({
       name: "beta",
       dashboardPort: 18789,
@@ -743,7 +739,7 @@ describe("remote dashboard bind production lifecycle", () => {
         return { status: 0 } as never;
       });
 
-    expect(ensureSandboxPortForward("beta")).toBe(true);
+    expect(ensureSandboxPortForward("beta", { isWsl: true })).toBe(true);
     expect(runOpenshell).toHaveBeenCalledWith(
       ["forward", "start", "--background", "0.0.0.0:18789", "beta"],
       { ignoreError: true, stdio: "ignore" },
@@ -757,9 +753,6 @@ describe("remote dashboard bind production lifecycle", () => {
     let started = false;
     vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", "");
     vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
-    vi.stubEnv("WSL_DISTRO_NAME", "");
-    vi.stubEnv("WSL_INTEROP", "");
-    vi.spyOn(os, "release").mockReturnValue("6.8.0-linux");
     vi.spyOn(registry, "getSandbox").mockReturnValue({
       name: "beta",
       dashboardPort: 18789,
@@ -780,7 +773,7 @@ describe("remote dashboard bind production lifecycle", () => {
         return { status: 0 } as never;
       });
 
-    expect(ensureSandboxPortForward("beta")).toBe(true);
+    expect(ensureSandboxPortForward("beta", { isWsl: false })).toBe(true);
     expect(runOpenshell).toHaveBeenCalledWith(
       ["forward", "start", "--background", "18789", "beta"],
       { ignoreError: true, stdio: "ignore" },

--- a/test/helpers/platform-override-node-options.ts
+++ b/test/helpers/platform-override-node-options.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+export function nonWslPlatformNodeOptions(
+  directory: string,
+  inheritedNodeOptions = process.env.NODE_OPTIONS,
+): string {
+  const preload = path.join(directory, "force-non-wsl-platform.cjs");
+  fs.writeFileSync(
+    preload,
+    [
+      "delete process.env.WSL_DISTRO_NAME;",
+      "delete process.env.WSL_INTEROP;",
+      'require("node:os").release = () => "6.8.0-linux";',
+      "",
+    ].join("\n"),
+    { mode: 0o600 },
+  );
+  return [inheritedNodeOptions, `--require=${JSON.stringify(preload)}`].filter(Boolean).join(" ");
+}

--- a/test/managed-gateway-control.test.ts
+++ b/test/managed-gateway-control.test.ts
@@ -260,6 +260,9 @@ with tempfile.TemporaryDirectory() as root:
         except control.ControlError as error:
             duplicate_supervisor = error.code
         remove_process(proc_root, 45)
+        # The preceding cases recreate fake PIDs 40 and 41, so refresh their
+        # inode-bound identities before testing stable reads and signals.
+        supervisor = control._discover_supervisor(reader)
 
         preflight_steps = []
         real_validator = control._run_fixed_validator
@@ -312,7 +315,7 @@ with tempfile.TemporaryDirectory() as root:
             duplicate = error.code
         remove_process(proc_root, 42)
 
-        expected_gateway = candidates[0]
+        expected_gateway = control._gateway_candidates(reader, supervisor, hermes)[0]
         sent = []
         real_pidfd_open = control._pidfd_open
         real_pidfd_exited = control._pidfd_exited

--- a/test/onboard-sandbox-build.test.ts
+++ b/test/onboard-sandbox-build.test.ts
@@ -441,6 +441,7 @@ const { createSandbox } = require(${onboardPath});
     const sandboxBaseImagePath = JSON.stringify(
       path.join(repoRoot, "src", "lib", "sandbox-base-image.ts"),
     );
+    const platformPath = JSON.stringify(path.join(repoRoot, "src", "lib", "platform.ts"));
 
     fs.mkdirSync(fakeBin, { recursive: true });
     writeOkOpenshell(fakeBin);
@@ -456,8 +457,11 @@ const preflight = require(${preflightPath});
 const credentials = require(${credentialsPath});
 const buildContext = require(${buildContextPath});
 const sandboxBaseImage = require(${sandboxBaseImagePath});
+const platform = require(${platformPath});
 const childProcess = require("node:child_process");
 const { EventEmitter } = require("node:events");
+
+platform.isWsl = () => false;
 
 const commands = [];
 const logs = [];

--- a/test/process-recovery-custom-agent.test.ts
+++ b/test/process-recovery-custom-agent.test.ts
@@ -9,9 +9,16 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSource = createRequire(import.meta.url);
-const { checkAndRecoverSandboxProcesses } = requireSource(
+const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } = requireSource(
   "../src/lib/actions/sandbox/process-recovery.ts",
 ) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
+
+function checkAndRecoverSandboxProcesses(
+  sandboxName: string,
+  options: Parameters<typeof checkAndRecoverSandboxProcessesImpl>[1] = {},
+) {
+  return checkAndRecoverSandboxProcessesImpl(sandboxName, { isWsl: false, ...options });
+}
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/test/process-recovery-forward-failure.test.ts
+++ b/test/process-recovery-forward-failure.test.ts
@@ -9,9 +9,16 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSource = createRequire(import.meta.url);
-const { checkAndRecoverSandboxProcesses } = requireSource(
+const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } = requireSource(
   "../src/lib/actions/sandbox/process-recovery.ts",
 ) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
+
+function checkAndRecoverSandboxProcesses(
+  sandboxName: string,
+  options: Parameters<typeof checkAndRecoverSandboxProcessesImpl>[1] = {},
+) {
+  return checkAndRecoverSandboxProcessesImpl(sandboxName, { isWsl: false, ...options });
+}
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/test/process-recovery-managed-controller.test.ts
+++ b/test/process-recovery-managed-controller.test.ts
@@ -10,9 +10,16 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSource = createRequire(import.meta.url);
-const { checkAndRecoverSandboxProcesses } = requireSource(
+const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } = requireSource(
   "../src/lib/actions/sandbox/process-recovery.ts",
 ) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
+
+function checkAndRecoverSandboxProcesses(
+  sandboxName: string,
+  options: Parameters<typeof checkAndRecoverSandboxProcessesImpl>[1] = {},
+) {
+  return checkAndRecoverSandboxProcessesImpl(sandboxName, { isWsl: false, ...options });
+}
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/test/process-recovery.test.ts
+++ b/test/process-recovery.test.ts
@@ -185,7 +185,13 @@ beta  127.0.0.1  18789  12345  running`;
     ).toBe(false);
   });
 
-  it("restarts a loopback forward when remote dashboard bind is requested (#6024)", () => {
+  it.each([
+    { dashboardBind: "0.0.0.0", isWsl: false, requirement: "remote bind" },
+    { dashboardBind: "", isWsl: true, requirement: "WSL" },
+  ])("restarts a loopback forward when $requirement requires all interfaces (#6024)", ({
+    dashboardBind,
+    isWsl,
+  }) => {
     const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
     const agentRuntime = requireSource("../src/lib/agent/runtime.js");
     const registry = requireSource("../src/lib/state/registry.js");
@@ -193,7 +199,7 @@ beta  127.0.0.1  18789  12345  running`;
     const childProcess = requireSource("node:child_process");
     let forwardStarted = false;
 
-    vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", "0.0.0.0");
+    vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", dashboardBind);
     vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
     vi.spyOn(childProcess, "spawnSync").mockReturnValue({
       status: 0,
@@ -223,7 +229,9 @@ beta  127.0.0.1  18789  12345  running`;
       });
 
     expect(
-      withFakeOpenshellBinary(() => checkAndRecoverSandboxProcesses("beta", { quiet: true })),
+      withFakeOpenshellBinary(() =>
+        checkAndRecoverSandboxProcesses("beta", { isWsl, quiet: true }),
+      ),
     ).toEqual({
       checked: true,
       wasRunning: true,

--- a/test/process-recovery.test.ts
+++ b/test/process-recovery.test.ts
@@ -10,12 +10,19 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSource = createRequire(import.meta.url);
-const { checkAndRecoverSandboxProcesses } = requireSource(
+const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } = requireSource(
   "../src/lib/actions/sandbox/process-recovery.ts",
 ) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
 const { ensureSandboxPortForwardForPort } = requireSource(
   "../src/lib/actions/sandbox/forward-recovery.ts",
 ) as typeof import("../src/lib/actions/sandbox/forward-recovery.js");
+
+function checkAndRecoverSandboxProcesses(
+  sandboxName: string,
+  options: Parameters<typeof checkAndRecoverSandboxProcessesImpl>[1] = {},
+) {
+  return checkAndRecoverSandboxProcessesImpl(sandboxName, { isWsl: false, ...options });
+}
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/test/recover-port-forward.test.ts
+++ b/test/recover-port-forward.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { nonWslPlatformNodeOptions } from "./helpers/platform-override-node-options";
 import { execTimeout, testTimeoutOptions } from "./helpers/timeouts";
 
 const tmpFixtures: string[] = [];
@@ -279,6 +280,7 @@ function runRecover(fixture: Fixture) {
       env: {
         ...process.env,
         HOME: fixture.tmpDir,
+        NODE_OPTIONS: nonWslPlatformNodeOptions(fixture.tmpDir),
         PATH: "/usr/bin:/bin",
         NEMOCLAW_NO_CONNECT_HINT: "1",
         NEMOCLAW_FORWARD_RECOVERY_WAIT_MS: fixture.recoveryWaitMs,

--- a/test/sandbox-connect-inference/helpers.ts
+++ b/test/sandbox-connect-inference/helpers.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, expect } from "vitest";
+import { nonWslPlatformNodeOptions } from "../helpers/platform-override-node-options";
 import { execTimeout } from "../helpers/timeouts";
 
 /**
@@ -571,6 +572,7 @@ export function runConnect(
       encoding: "utf-8",
       env: {
         HOME: tmpDir,
+        NODE_OPTIONS: nonWslPlatformNodeOptions(tmpDir, ""),
         PATH: `${path.join(tmpDir, ".local", "bin")}:/usr/bin:/bin`,
         NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT: "1",
         NEMOCLAW_NO_CONNECT_HINT: "1",

--- a/test/wsl2-probe-timeout.test.ts
+++ b/test/wsl2-probe-timeout.test.ts
@@ -61,17 +61,13 @@ describe("WSL2 inference verification timeouts (#987)", () => {
   });
 
   describe("retry logic in probeOpenAiLikeEndpoint", () => {
-    function runProbeWithCurlStatuses(statuses: number[]) {
+    function runProbeWithCurlStatuses(statuses: number[], isWsl = false) {
       const httpProbePath = require.resolve("../src/lib/adapters/http/probe.js");
-      const platformPath = require.resolve("../src/lib/platform.js");
       const probesPath = require.resolve("../src/lib/inference/onboard-probes.js");
       const httpProbe = require(httpProbePath);
-      const platform = require(platformPath);
       const originalRunCurlProbe = httpProbe.runCurlProbe;
-      const originalIsWsl = platform.isWsl;
       const calls: string[][] = [];
       let index = 0;
-      platform.isWsl = () => false;
       httpProbe.runCurlProbe = (args: string[]) => {
         calls.push(args);
         const status = statuses[index++] ?? 0;
@@ -105,12 +101,12 @@ describe("WSL2 inference verification timeouts (#987)", () => {
           ) => { ok: boolean };
         };
         const result = probeOpenAiLikeEndpoint("http://localhost:8000", "test-model", "key", {
+          isWsl,
           skipResponsesProbe: false,
         });
         return { result, calls };
       } finally {
         httpProbe.runCurlProbe = originalRunCurlProbe;
-        platform.isWsl = originalIsWsl;
         delete require.cache[probesPath];
       }
     }
@@ -150,12 +146,9 @@ describe("WSL2 inference verification timeouts (#987)", () => {
 
     function runProbeWithResults(results: ProbeResultFixture[], opts: { isWsl?: boolean } = {}) {
       const httpProbePath = require.resolve("../src/lib/adapters/http/probe.js");
-      const platformPath = require.resolve("../src/lib/platform.js");
       const probesPath = require.resolve("../src/lib/inference/onboard-probes.js");
       const httpProbe = require(httpProbePath);
-      const platform = require(platformPath);
       const originalRunCurlProbe = httpProbe.runCurlProbe;
-      const originalIsWsl = platform.isWsl;
       const atomics = globalThis as typeof globalThis & {
         Atomics: { wait: (...args: never[]) => "ok" | "not-equal" | "timed-out" };
       };
@@ -166,7 +159,6 @@ describe("WSL2 inference verification timeouts (#987)", () => {
         calls.push(args);
         return results[index++] ?? results[results.length - 1];
       };
-      platform.isWsl = () => opts.isWsl === true;
       atomics.Atomics.wait = () => "ok";
       delete require.cache[probesPath];
       try {
@@ -178,11 +170,12 @@ describe("WSL2 inference verification timeouts (#987)", () => {
             options?: Record<string, unknown>,
           ) => { ok: boolean; message?: string };
         };
-        const result = probeOpenAiLikeEndpoint("http://localhost:8000", "test-model", "key");
+        const result = probeOpenAiLikeEndpoint("http://localhost:8000", "test-model", "key", {
+          isWsl: opts.isWsl ?? false,
+        });
         return { result, calls };
       } finally {
         httpProbe.runCurlProbe = originalRunCurlProbe;
-        platform.isWsl = originalIsWsl;
         atomics.Atomics.wait = originalWait;
         delete require.cache[probesPath];
       }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fix the main-branch platform Vitest watch that produced 83 WSL failures and canceled macOS at its 20-minute ceiling. The WSL suite now exercises ordinary behavior as a non-root user while retaining focused root-only contracts, and host-dependent tests explicitly select the platform behavior they verify.

## Changes

- Provision a non-root WSL test user, install `python3-venv`, and run dependency installation, builds, and the full suite under that user.
- Preserve all five UID-0-only security contracts in a focused root step with their required sandbox identity and trusted normalizer fixture.
- Pass explicit WSL behavior through dashboard, forward-recovery, process-recovery, and inference probe tests so ordinary-Linux assertions do not inherit the host kernel. Child-process connect and recover tests use a preload because they execute the compiled CLI in a separate process; their tests protect that boundary.
- Refresh inode-bound fake process identities after recreating fake `/proc` entries.
- Raise the macOS and WSL full-suite ceilings to 60 minutes based on the observed 20-minute macOS cutoff and approximately 43-minute WSL runtime.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal CI execution and test determinism without changing supported user-facing behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent diff review covered WSL privilege separation, preservation of root-only contracts, PowerShell/Bash quoting, and explicit platform overrides; the identified root-coverage gap was corrected before commit.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 13 changed-behavior files, 137 tests passed together; the fake-process fixture also passed five consecutive focused runs. `npm run typecheck:cli`, project membership, source-shape checks, and all diff-scoped hooks passed.
- [ ] Applicable broad gate passed — the real branch platform workflow is running at https://github.com/NVIDIA/NemoClaw/actions/runs/29299731938. Local `npm test` under unsupported Node 26/macOS completed 16,851 tests and reported 66 unrelated environment/order failures in untouched files; changed-set tests pass in isolation.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox port-forward recovery/health checks to consistently respect explicit WSL mode overrides.
  * Refined WSL2 timeout/connection error messaging to reflect the intended execution environment.
* **Tests**
  * Updated dashboard and sandbox lifecycle tests to pass explicit WSL mode flags.
  * Added/expanded test helpers to force non-WSL behavior and stabilize platform-dependent assertions.
* **CI**
  * Increased CI timeouts for WSL and Ubuntu compatibility runs; adjusted WSL job execution user/permissions for reliable test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->