### PR TITLE
fix(ci): keep E2E gate strip-types compatible

### DIFF
--- a/test/pr-e2e-gate-command.test.ts
+++ b/test/pr-e2e-gate-command.test.ts
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 import { parseControllerCommand } from "../tools/e2e/pr-e2e-gate.mts";
@@ -11,6 +13,7 @@ import { parseControllerCommand } from "../tools/e2e/pr-e2e-gate.mts";
 const HEAD_SHA = "a".repeat(40);
 const BASE_SHA = "b".repeat(40);
 const WORKFLOW_SHA = "d".repeat(40);
+const GATE_SCRIPT = fileURLToPath(new URL("../tools/e2e/pr-e2e-gate.mts", import.meta.url));
 
 function parseStartCommand(workDir: string, prNumber = "42") {
   return parseControllerCommand([
@@ -52,6 +55,18 @@ function withPrivateWorkDir(run: (workDir: string) => void) {
 }
 
 describe("PR E2E controller commands", () => {
+  it("loads under the workflow's Node strip-types runtime", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["--experimental-strip-types", GATE_SCRIPT, "--mode", "invalid"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("--mode must be seed, start, finish");
+    expect(result.stderr).not.toContain("ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX");
+  });
+
   it("parses a start command inside a private workspace", () => {
     withPrivateWorkDir((workDir) => {
       expect(parseStartCommand(workDir)).toMatchObject({

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -222,9 +222,12 @@ export type PrGateVerdict = {
 };
 
 class ObsoleteExactDiffError extends Error {
-  constructor(readonly verdict: PrGateVerdict) {
+  readonly verdict: PrGateVerdict;
+
+  constructor(verdict: PrGateVerdict) {
     super(`${verdict.title}: ${verdict.summary}`);
     this.name = "ObsoleteExactDiffError";
+    this.verdict = verdict;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the unsupported TypeScript constructor parameter property in the PR E2E gate
- add a regression that launches the controller with the exact `node --experimental-strip-types` runtime used by Actions

## Why
Current `main` crashes every PR E2E gate during initialization with `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`, before it can evaluate the PR. This is visible on #6770, #6711, and #6672.

## Validation
- `npx vitest run --project integration test/pr-e2e-gate-command.test.ts test/pr-e2e-gate-lifecycle.test.ts test/pr-e2e-gate-exceptions.test.ts test/pr-e2e-gate.test.ts test/pr-e2e-gate-workflow.test.ts` (108 passed)
- `npm run build:cli`
- pre-commit and pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for invalid end-to-end gate modes, including clearer error messaging and the correct failure status.
  * Prevented unsupported TypeScript syntax errors when running the gate command directly in Node’s experimental type-stripping mode.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->