### PR TITLE
docs(release): add v0.0.82 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,48 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.82
+
+NemoClaw v0.0.82 adds non-destructive sandbox stop and start commands, protects managed vLLM downloads with storage checks, strengthens custom policy and dependency validation, and improves onboarding, backup, snapshot, and contributor guidance.
+
+- Sandbox lifecycle controls can now free host resources without deleting a workspace.
+  `$$nemoclaw <name> stop` stops managed channels and the sandbox's Docker containers while leaving the workspace, registry entry, OpenShell record, credentials, shared gateway, and inference services intact.
+  `$$nemoclaw <name> start` starts or unpauses the container, then checks runtime health and repairs the gateway and host forwards where applicable.
+  For more information, refer to [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle) and [NemoClaw CLI Commands Reference](../reference/commands).
+- Backup and snapshot recovery handle stopped and cloned sandboxes more safely.
+  `backup-all` can temporarily start an eligible stopped Docker sandbox, capture its backup, and return it to the stopped state, while strict mode still fails when identity, startup, backup, or cleanup cannot be proven.
+  Snapshot clones receive a destination-owned dashboard port so their dashboard URL and later rebuilds do not conflict with the source sandbox.
+  Installer upgrades also ignore route-only placeholders left by interrupted onboarding instead of treating them as backupable sandboxes.
+  For more information, refer to [Backup and Restore](../manage-sandboxes/backup-restore) and [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle).
+- Managed vLLM setup checks storage before large downloads begin.
+  NemoClaw verifies Docker image storage and the Hugging Face model cache before an uncached image pull or model download, rechecks model capacity after the image pull, and stops when capacity or filesystem identity cannot be established unless the operator explicitly accepts the warning.
+  Managed profiles use immutable platform digests, and the model download and serving containers use `--pull=never` so an implicit pull cannot bypass the storage gate.
+  For more information, refer to [Set Up vLLM](../inference/local-inference/set-up-vllm) and [Choose an Inference Provider](../inference/learn-and-choose/choose-inference-provider).
+- Onboarding reports local inference and gateway conflicts more accurately.
+  An identifiable foreign listener on the OpenShell gateway port now fails fast with process details and recovery guidance, interactive setup continues to detect running Ollama and vLLM services when another registry route exists, and an installed but stopped Ollama daemon appears as a start action instead of a running status.
+  Loopback readiness checks bypass host proxies, compatible endpoint validation recommends an OpenAI-compatible endpoint or switching to OpenClaw when a Chat-Completions-only agent selects an Anthropic-compatible endpoint that does not serve `/v1/chat/completions`, and an eligible matching successful check can satisfy the immediately following smoke probe without a duplicate request.
+  For more information, refer to [Troubleshooting](../reference/troubleshooting), [Choose a Local Inference Server](../inference/local-inference/choose-local-inference-server), and [Understand Provider Validation](../inference/validate-inference/understand-provider-validation).
+- Interrupted onboarding preserves more of the selected route and sandbox intent.
+  Resume repairs a missing pending route reservation when inference setup is already complete, and sandbox creation resolves its secret-free policy, messaging, provider, resource, and cleanup intent before destructive state changes begin.
+  These protections keep resumed setup and stale-provider cleanup aligned with the choices made before the interruption.
+  For more information, refer to [NemoClaw Quickstart](../get-started/quickstart) and [NemoClaw CLI Commands Reference](../reference/commands).
+- Managed Deep Agents headless sessions now use the bounded session supervisor, so completed sessions reap their DCode and LangGraph descendants without affecting other sessions or leaving the sandbox unusable.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](/user-guide/deepagents/get-started/quickstart).
+- Custom policy application rejects catch-all destinations before widening sandbox egress.
+  Runtime custom presets now reject `*`, `0.0.0.0`, `0.0.0.0/0`, `::`, and `::/0` while continuing to allow scoped subdomain wildcards such as `*.example.com`.
+  The same semantic check protects repository validation, `policy-add --from-file`, and in-memory custom preset application.
+  For more information, refer to [Customize the Network Policy](../network-policy/customize-network-policy).
+- NemoClaw now requires Node.js 22.19 or later for host installs and contributor tooling, matching current OpenClaw runtime and advisor SDK requirements.
+  Ubuntu 26.04 has a digest-pinned userspace contract lane for CLI, preflight, installer, and platform checks, while Docker-host, AppArmor, Landlock, and live onboarding validation remain pending.
+  For more information, refer to [Prerequisites](../get-started/prerequisites) and [Platform Support and Launch Claims](../reference/platform-support).
+- Contributor guidance now routes independent integrations, custom images, recipes, and complete workflows through Community Solutions while reserving canonical NemoClaw documentation for approved, maintained product surfaces.
+  The contributor skill catalog also adds evidence-driven workflows for semantic dependency upgrades and route-safe documentation refactors.
+  For more information, refer to [Community Solutions](../resources/community-contributions) and the [Documentation Contributor Guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md).
+- Build and dependency trust boundaries cover more of the sandbox image path.
+  Reviewed npm archives now share one production dependency audit, OpenClaw's managed WeChat runtime installs from a NemoClaw-owned offline lock, and the messaging build plan no longer persists in final OpenClaw or Hermes image environments.
+  Source and blueprint rebuilds also reuse cached plugin dependency layers.
+  For more information, refer to the [OpenClaw 2026.6.10 Dependency Review](https://github.com/NVIDIA/NemoClaw/blob/main/docs/security/openclaw-2026.6.10-dependency-review.md).
+
 ## v0.0.81
 
 NemoClaw v0.0.81 strengthens rebuild and snapshot state preservation, repairs local compatible inference and WhatsApp setup, improves Docker restart recovery, and makes onboarding, backup, and security diagnostics easier to act on.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -70,7 +70,8 @@ Run the onboard wizard.
 $$nemoclaw onboard
 ```
 
-Select **Local Ollama**.
+Select the Ollama entry for your host.
+The menu identifies a reachable daemon as running and labels an installed but stopped daemon **Start local Ollama**.
 NemoClaw lists installed models or offers starter models when none are installed.
 
 The starter list includes `qwen3.6:35b` and selects it by default when current GPU memory can accommodate it.

--- a/docs/manage-sandboxes/backup-restore.mdx
+++ b/docs/manage-sandboxes/backup-restore.mdx
@@ -102,6 +102,9 @@ $$nemoclaw my-assistant snapshot restore before-upgrade --to my-assistant-clone
 $$nemoclaw my-assistant snapshot restore before-upgrade --to my-assistant-clone --force --yes
 ```
 
+For dashboard-enabled agents, NemoClaw allocates the destination sandbox its own dashboard port instead of reusing the source port.
+If no port is available, restore stops before deleting an existing `--force` destination.
+
 The force-overwrite path restores and verifies lockdown on a destination with an active shields timer, then revokes that timer before it deletes the destination.
 It clears the remaining local shields state only after deletion succeeds, before a same-name replacement is created.
 
@@ -267,7 +270,7 @@ Use this host-installed command before broad maintenance such as `$$nemoclaw upd
 $$nemoclaw backup-all
 ```
 
-`backup-all` walks the sandboxes registered on the host, creates a snapshot for each running sandbox, and stores the snapshot bundles under `~/.nemoclaw/rebuild-backups/<name>/`.
+`backup-all` walks the sandboxes registered on the host, creates a snapshot for each eligible running or temporarily started sandbox, and stores the snapshot bundles under `~/.nemoclaw/rebuild-backups/<name>/`.
 If a registered docker-driver sandbox's container is stopped, `backup-all` starts the container for the duration of the backup and returns it to its stopped state afterward.
 If the container cannot be returned to the stopped state, the backup run fails and reports that the container was left running.
 If a sandbox is not running and its container cannot be started this way, start the sandbox or its container and rerun `$$nemoclaw backup-all` so NemoClaw can capture a fresh snapshot before maintenance.

--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -356,6 +356,8 @@ network_policies:
 
 The top-level `preset.name` must be a lowercase RFC 1123 label (letters, digits, hyphens) and must not collide with a built-in preset name such as `slack` or `pypi`.
 Rename `preset.name` if NemoClaw refuses to apply the file because of a collision.
+Each endpoint must name a specific host or a scoped subdomain wildcard such as `*.example.com`.
+NemoClaw rejects catch-all destinations including `*`, `0.0.0.0`, `0.0.0.0/0`, `::`, and `::/0` before it applies a custom preset.
 Rule matchers must match the endpoint protocol.
 REST and WebSocket rules require `method` and `path`; REST accepts standard HTTP methods or `*`, while WebSocket accepts `GET`, `WEBSOCKET_TEXT`, or `*`.
 JSON-RPC rules accept only `method`, and MCP rules accept `method` plus optional `tool` or `params.name` matchers.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2533,7 +2533,7 @@ A custom OpenClaw sandbox is recoverable only when the selected backup independe
 
 ### `$$nemoclaw backup-all`
 
-Back up all registered running sandboxes to `~/.nemoclaw/rebuild-backups/`.
+Back up registered sandboxes that are running or have an eligible stopped Docker-driver container to `~/.nemoclaw/rebuild-backups/`.
 A registered docker-driver sandbox whose container is stopped is started for the duration of the backup and returned to its stopped state afterward.
 If the container cannot be returned to the stopped state, the command fails and reports that the container was left running.
 Sandboxes that are not running and cannot be started this way are skipped with remediation guidance.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Release-prep documentation for v0.0.82 now summarizes user-facing changes merged since v0.0.81.
It also closes stale wording in the stopped-sandbox backup, snapshot-clone, Ollama selection, and custom-policy authoring guidance.

## Changes

- Add the `v0.0.82` section to `docs/about/release-notes.mdx` with links to the focused user guides.
- Document that snapshot clones receive a destination-owned dashboard port before destructive replacement begins.
- Align `backup-all` guidance with eligible stopped Docker-driver sandboxes that NemoClaw starts temporarily.
- Describe the running and stopped Ollama menu states without claiming one fixed label.
- Document runtime rejection of catch-all hosts in custom policy files.

### Source summary

- [#6748](https://github.com/NVIDIA/NemoClaw/pull/6748) -> `docs/about/release-notes.mdx`, `docs/manage-sandboxes/lifecycle.mdx`, and `docs/reference/commands.mdx`: Summarize non-destructive sandbox `stop` and `start` commands.
- [#6723](https://github.com/NVIDIA/NemoClaw/pull/6723) -> `docs/about/release-notes.mdx`, `docs/manage-sandboxes/backup-restore.mdx`, and `docs/reference/commands.mdx`: Record temporary startup and cleanup for eligible stopped-sandbox backups.
- [#6749](https://github.com/NVIDIA/NemoClaw/pull/6749) -> `docs/about/release-notes.mdx` and `docs/manage-sandboxes/backup-restore.mdx`: Document destination-owned dashboard ports for snapshot clones.
- [#6764](https://github.com/NVIDIA/NemoClaw/pull/6764) -> `docs/about/release-notes.mdx`: Summarize installer handling of route-only onboarding placeholders.
- [#6771](https://github.com/NVIDIA/NemoClaw/pull/6771) -> `docs/about/release-notes.mdx`, `docs/inference/set-up-vllm.mdx`, `docs/inference/choose-inference-provider.mdx`, `docs/reference/commands.mdx`, and `docs/reference/platform-support.mdx`: Summarize managed-vLLM storage gates, immutable image digests, and the explicit override boundary.
- [#6759](https://github.com/NVIDIA/NemoClaw/pull/6759) -> `docs/about/release-notes.mdx`: Record early, actionable OpenShell gateway-port conflict diagnostics.
- [#6753](https://github.com/NVIDIA/NemoClaw/pull/6753) -> `docs/about/release-notes.mdx` and `docs/inference/set-up-ollama.mdx`: Document truthful running and stopped Ollama menu states.
- [#6776](https://github.com/NVIDIA/NemoClaw/pull/6776) -> `docs/about/release-notes.mdx`: Summarize proxy-independent loopback readiness checks.
- [#6769](https://github.com/NVIDIA/NemoClaw/pull/6769) -> `docs/about/release-notes.mdx`: Record compatible endpoint and agent guidance when Chat Completions is unavailable.
- [#6730](https://github.com/NVIDIA/NemoClaw/pull/6730) -> `docs/about/release-notes.mdx`: Summarize bounded reuse of an eligible successful Chat Completions check.
- [#6768](https://github.com/NVIDIA/NemoClaw/pull/6768) -> `docs/about/release-notes.mdx`: Record route-reservation repair during resumed onboarding.
- [#6742](https://github.com/NVIDIA/NemoClaw/pull/6742) -> `docs/about/release-notes.mdx`: Summarize pre-mutation resolution of secret-free sandbox create intent.
- [#6721](https://github.com/NVIDIA/NemoClaw/pull/6721) -> `docs/about/release-notes.mdx` and `docs/get-started/quickstart-langchain-deepagents-code.mdx`: Record bounded cleanup of completed managed Deep Agents headless sessions.
- [#6731](https://github.com/NVIDIA/NemoClaw/pull/6731) -> `docs/about/release-notes.mdx` and `docs/network-policy/customize-network-policy.mdx`: Document runtime rejection of catch-all custom-policy destinations.
- [#6729](https://github.com/NVIDIA/NemoClaw/pull/6729) -> `docs/about/release-notes.mdx` and `docs/get-started/prerequisites.mdx`: Record the Node.js 22.19 minimum.
- [#6735](https://github.com/NVIDIA/NemoClaw/pull/6735) -> `docs/about/release-notes.mdx` and `docs/reference/platform-support.mdx`: Summarize the Ubuntu 26.04 userspace contract without claiming pending host or live validation.
- [#6775](https://github.com/NVIDIA/NemoClaw/pull/6775) -> `docs/about/release-notes.mdx` and `docs/resources/community-contributions.mdx`: Route independent solutions outside canonical supported-product documentation.
- [#6740](https://github.com/NVIDIA/NemoClaw/pull/6740) -> `docs/about/release-notes.mdx`: Summarize the semantic dependency-upgrade contributor workflow.
- [#6777](https://github.com/NVIDIA/NemoClaw/pull/6777) -> `docs/about/release-notes.mdx` and `docs/CONTRIBUTING.md`: Summarize the route-safe documentation-refactor workflow.
- [#6741](https://github.com/NVIDIA/NemoClaw/pull/6741) -> `docs/about/release-notes.mdx` and `docs/security/openclaw-2026.6.10-dependency-review.md`: Summarize reviewed npm archive verification and audit enforcement.
- [#6739](https://github.com/NVIDIA/NemoClaw/pull/6739) -> `docs/about/release-notes.mdx` and `docs/security/openclaw-2026.6.10-dependency-review.md`: Record the locked offline dependency graph for the managed OpenClaw WeChat runtime.
- [#6737](https://github.com/NVIDIA/NemoClaw/pull/6737) -> `docs/about/release-notes.mdx`: Record removal of the messaging build plan from final OpenClaw and Hermes image environments.
- [#6733](https://github.com/NVIDIA/NemoClaw/pull/6733) -> `docs/about/release-notes.mdx`: Summarize cached plugin dependency layers for source and blueprint rebuilds.

### Skipped from docs-skip

- None. No commit or changed path in `v0.0.81..origin/main` matched `openclaw-sandbox-permissive.yaml` or `config-show`, and the drafted content contains none of the configured skip terms.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This is a documentation-only release-prep update; behavior is protected by the merged source PRs, and the documentation build validates the changed routes and agent variants.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — tests are not applicable for this documentation-only change.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run for this documentation-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — 0 errors; two pre-existing Fern warnings remain.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new pages.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes with improvements to sandbox recovery, onboarding, session management, policy validation, storage checks, and system requirements.
  * Clarified Ollama setup instructions and status labels.
  * Documented safer snapshot restoration, including dedicated ports and protection against destructive failures.
  * Expanded `backup-all` coverage to include eligible stopped sandboxes.
  * Added guidance rejecting broad or catch-all network destinations in custom policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->