### PR TITLE
test(e2e): accept idempotent Shields cleanup

### DIFF
--- a/test/e2e/live/shields-config.test.ts
+++ b/test/e2e/live/shields-config.test.ts
@@ -441,7 +441,7 @@ test("shields-config: live shields up/down locks config and detects drift", {
       artifactName: "cleanup-shields-up-before-destroy",
     });
     expect(restore.exitCode, resultText(restore)).toBe(0);
-    expect(resultText(restore)).toContain("Lockdown active");
+    expect(resultText(restore)).toMatch(/Lockdown (?:is already )?active/);
   });
 
   const configUp = await statPath(sandbox, CONFIG_PATH, "phase-3-config-perms-up");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Broaden the live Shields cleanup assertion to accept the existing idempotent `Lockdown is already active.` success response. The cleanup still requires exit code 0, so real restore failures remain failures while a valid no-op restore is no longer misclassified.

## Changes

- Accept both successful `shields up` responses in the `shields-config` cleanup callback.
- Keep the existing exit-code assertion as the authoritative success boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only a live E2E assertion for two existing success messages; the documentation-writer review found no user-facing contract change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The assertion remains gated by exit code 0 and accepts only the two success messages already emitted by `shields up`; no production Shields behavior changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by accepting both valid messages when restoring shield protection during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->