### PR TITLE
fix(onboard): preserve tier-default brave/tavily on re-onboard reuse

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4597,7 +4597,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
         // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
         verifyCompatibleEndpointSandboxSmoke: (options) => verifyCompatibleEndpointSandboxSmoke({ ...options, runOpenshell: runCoreGatewayOpenshell, redact }),
         preparePolicyPresetResumeSelection: (name, options) =>
-          preparePolicyPresetResumeSelection({ policies }, name, options),
+          preparePolicyPresetResumeSelection({ policies, tiers }, name, options),
         arePolicyPresetsApplied,
         skippedStepMessage,
         recordStateSkipped,

--- a/src/lib/onboard/policy-preset-reconciliation.ts
+++ b/src/lib/onboard/policy-preset-reconciliation.ts
@@ -84,6 +84,7 @@ export function isStaleBuiltinBravePolicyPreset(
   options: {
     webSearchConfig?: WebSearchConfig | null;
     customPresetNames?: ReadonlySet<string> | null;
+    tierDefaultPresetNames?: ReadonlySet<string> | null;
   } = {},
 ): boolean {
   return isStaleBuiltinWebSearchPolicyPreset(name, options);
@@ -94,9 +95,17 @@ export function isStaleBuiltinWebSearchPolicyPreset(
   options: {
     webSearchConfig?: WebSearchConfig | null;
     customPresetNames?: ReadonlySet<string> | null;
+    tierDefaultPresetNames?: ReadonlySet<string> | null;
   } = {},
 ): boolean {
   if (options.customPresetNames?.has(name)) return false;
+  // brave/tavily double as a tier's default egress preset (e.g. Brave Search API
+  // host access on the Balanced/Open tiers) AND the built-in web-search provider
+  // preset. When the preset is a default of the tier being applied it is a tier
+  // egress default, not a stale web-search leftover — keep it regardless of the
+  // web-search provider choice. The Restricted tier lists no such default, so a
+  // genuinely stale brave/tavily there still prunes. (#6844)
+  if (options.tierDefaultPresetNames?.has(name)) return false;
   if (name === "nous-web") {
     return Boolean(
       options.webSearchConfig && webSearchProviderForConfig(options.webSearchConfig) === "tavily",
@@ -114,14 +123,23 @@ export function createUnavailablePolicyPresetPruner(options: {
   webSearchConfig?: WebSearchConfig | null;
   customPresetNames?: ReadonlySet<string> | null;
   customOwnsObservability?: boolean;
-}): (presetNames: string[], pruning?: { preserveExplicitWebSearch?: boolean }) => string[] {
+}): (
+  presetNames: string[],
+  pruning?: {
+    preserveExplicitWebSearch?: boolean;
+    tierDefaultPresetNames?: ReadonlySet<string> | null;
+  },
+) => string[] {
   // Custom and interactive selections may explicitly opt into a built-in web-search
   // preset without storing provider config. Inactive observability remains ineligible.
   return (presetNames, pruning = {}) =>
     pruneDisabledMessagingPolicyPresets(presetNames, options.disabledChannels).filter(
       (name) =>
         (pruning.preserveExplicitWebSearch ||
-          !isStaleBuiltinWebSearchPolicyPreset(name, options)) &&
+          !isStaleBuiltinWebSearchPolicyPreset(name, {
+            ...options,
+            tierDefaultPresetNames: pruning.tierDefaultPresetNames,
+          })) &&
         !isInactiveObservabilityPolicyPreset(name, options),
     );
 }

--- a/src/lib/onboard/policy-resume-selection.test.ts
+++ b/src/lib/onboard/policy-resume-selection.test.ts
@@ -87,6 +87,70 @@ describe("preparePolicyPresetResumeSelection web search reconciliation", () => {
   });
 });
 
+function tiers(defaults: Record<string, string[]>) {
+  return {
+    resolveTierPresets: (tierName: string) => (defaults[tierName] ?? []).map((name) => ({ name })),
+  };
+}
+
+describe("preparePolicyPresetResumeSelection tier-default preservation (#6844)", () => {
+  const BALANCED = { balanced: ["npm", "brave"], restricted: [] as string[] };
+
+  it("preserves brave on reuse when it is a Balanced-tier default and web search is off", () => {
+    const result = preparePolicyPresetResumeSelection(
+      { policies: policies(), tiers: tiers(BALANCED) },
+      "alpha",
+      {
+        recordedPolicyPresets: ["npm", "brave"],
+        agent: "openclaw",
+        webSearchConfig: null,
+        webSearchSupported: true,
+        tierName: "balanced",
+      },
+    );
+
+    // brave is a Balanced default (an egress preset), not a stale web-search
+    // leftover — it must survive reuse just like npm, and no reconcile is needed.
+    expect(result.policyPresets).toEqual(["npm", "brave"]);
+    expect(result.recordedPolicyPresetsNeedReconcile).toBe(false);
+  });
+
+  it("still prunes a stale brave on the Restricted tier (no brave default)", () => {
+    const result = preparePolicyPresetResumeSelection(
+      { policies: policies(), tiers: tiers(BALANCED) },
+      "alpha",
+      {
+        recordedPolicyPresets: ["npm", "brave"],
+        agent: "openclaw",
+        webSearchConfig: null,
+        webSearchSupported: true,
+        tierName: "restricted",
+      },
+    );
+
+    expect(result.policyPresets).toEqual(["npm"]);
+    expect(result.recordedPolicyPresetsNeedReconcile).toBe(true);
+  });
+
+  it("keeps brave on Balanced even when web search is set to a different provider", () => {
+    const result = preparePolicyPresetResumeSelection(
+      { policies: policies(), tiers: tiers(BALANCED) },
+      "alpha",
+      {
+        recordedPolicyPresets: ["npm", "brave"],
+        agent: "openclaw",
+        webSearchConfig: { fetchEnabled: true, provider: "tavily" },
+        webSearchConfigChanged: true,
+        webSearchSupported: true,
+        tierName: "balanced",
+      },
+    );
+
+    // brave stays as the tier egress default; tavily is added as the active provider.
+    expect(result.policyPresets).toEqual(["npm", "brave", "tavily"]);
+  });
+});
+
 describe("preparePolicyPresetResumeSelection observability reconciliation", () => {
   it("adds the local OTLP preset only while Deep Agents Code observability is enabled", () => {
     const enabled = preparePolicyPresetResumeSelection({ policies: policies() }, "alpha", {

--- a/src/lib/onboard/policy-resume-selection.ts
+++ b/src/lib/onboard/policy-resume-selection.ts
@@ -45,8 +45,12 @@ type PoliciesApi = {
   ): string[];
 };
 
+type TiersApi = {
+  resolveTierPresets(tierName: string): Preset[];
+};
+
 export function preparePolicyPresetResumeSelection(
-  deps: { policies: PoliciesApi },
+  deps: { policies: PoliciesApi; tiers?: TiersApi },
   sandboxName: string,
   options: {
     recordedPolicyPresets: string[] | null;
@@ -100,10 +104,18 @@ export function preparePolicyPresetResumeSelection(
     supportOptions,
     customPolicyPresetNames,
   );
+  // Defaults of the recorded/active tier (e.g. `brave` on Balanced) are tier
+  // egress presets, not stale web-search leftovers — exempt them from the
+  // web-search staleness prune so re-onboard reuse preserves them. (#6844)
+  const tierDefaultPresetNames =
+    options.tierName && deps.tiers
+      ? new Set(deps.tiers.resolveTierPresets(options.tierName).map((preset) => preset.name))
+      : null;
   const isStaleBuiltinWebSearch = (name: string) =>
     isStaleBuiltinWebSearchPolicyPreset(name, {
       webSearchConfig: options.webSearchConfig,
       customPresetNames: customPolicyPresetNames,
+      tierDefaultPresetNames,
     });
   const isInactiveObservability = (name: string) =>
     isInactiveObservabilityPolicyPreset(name, {

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -320,6 +320,12 @@ async function setupPoliciesWithSelectionInner(
   // branch before presets are recorded, so its persisted tier must also win
   // over a new prompt or non-interactive default.
   const recordedTierName = options.tierName ?? deps.getRecordedPolicyTier?.(sandboxName) ?? null;
+  // Defaults of the recorded tier (e.g. `brave` on Balanced) are tier egress
+  // presets, not stale web-search leftovers — exempt them from pruning so a
+  // reconcile-triggered reuse reapply preserves them. (#6844)
+  const recordedTierDefaultPresetNames = recordedTierName
+    ? new Set(deps.tiers.resolveTierPresets(recordedTierName).map((preset) => preset.name))
+    : null;
   if (chosen !== null) {
     const knownSelectablePresets = new Set(selectablePresets.map((preset) => preset.name));
     chosen = mergeRequiredSetupPolicyPresets(chosen, {
@@ -334,7 +340,9 @@ async function setupPoliciesWithSelectionInner(
       customPresetNames,
       customOwnsObservability,
     });
-    chosen = pruneUnavailablePresets(chosen);
+    chosen = pruneUnavailablePresets(chosen, {
+      tierDefaultPresetNames: recordedTierDefaultPresetNames,
+    });
   }
 
   if (selectedPresets !== null) {


### PR DESCRIPTION
## Summary

On the re-onboard **reuse** path, the Balanced-tier default preset `brave` (Brave Search API access) was silently dropped even when the policy tier (Balanced) and the web-search choice (No web search) were unchanged from the initial onboard. The other four Balanced defaults (`npm`, `pypi`, `huggingface`, `brew`) persisted — only `brave` was narrowed out of the reapplied set, removing its egress (`api.search.brave.com`).

Fixes #6844.

## Root cause

`isStaleBuiltinWebSearchPolicyPreset` treats `brave`/`tavily` as a stale web-search leftover whenever no matching web-search provider is configured. It did not account for the case where the same preset is *also* a default egress preset of the tier being applied. On reuse, `preparePolicyPresetResumeSelection` pruned `brave` under this rule, which flipped `recordedPolicyPresetsNeedReconcile` to true and drove a reapply whose set omitted `brave`.

## Fix

- Add a `tierDefaultPresetNames` exemption to `isStaleBuiltinWebSearchPolicyPreset`: a preset that is a default of the tier being applied is a tier egress default, not a stale web-search leftover, so it is kept regardless of the web-search provider choice.
- Thread the recorded tier's defaults through both prune sites on the reuse path: the resume-selection prune (`preparePolicyPresetResumeSelection`) and the reuse reapply prune (`createUnavailablePolicyPresetPruner` via the pruning options).

The change is scoped to the reuse/resume path; fresh-onboard suggestion behavior is unchanged.

### Behavior preserved
- **Restricted tier** lists no `brave`/`tavily` default, so a genuinely stale preset there still prunes.
- **Provider switch** (brave → tavily) still replaces the stale provider and adds the newly active one.

## Testing

- New unit tests in `policy-resume-selection.test.ts`: brave preserved on Balanced reuse with web search off (no reconcile); still pruned on Restricted; kept on Balanced alongside a switched-in `tavily`.
- Full `onboard` policy/tier/preset test suites pass (118 tests across 12 files); `build:cli` + `typecheck` green.
- End-to-end on our Ubuntu 24.04 x86_64 test host (no GPU): onboarded a Balanced sandbox with `brave` applied, then re-onboarded via the reuse path.
  - **Before the fix:** reapply set = `npm, pypi, huggingface, brew` → `Removed preset: brave` → brave inactive.
  - **After the fix:** reapply set = `npm, pypi, huggingface, brew, brave` → brave stays active (`[from balanced tier]`), no egress narrowing.

The reporter's environment is DGX Station (aarch64); the reapply logic is platform-independent (verified byte-identical on the paths exercised), but cross-arch confirmation on aarch64 was not separately run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved tier-default web-search presets during onboarding and re-onboarding.
  * Prevented default Brave or Tavily presets from being incorrectly removed when web-search settings differ.
  * Improved policy preset reconciliation for resumed tier selections.

* **Tests**
  * Added coverage for preserving or pruning presets across Balanced and Restricted tier scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->