### PR TITLE
fix(onboard): preserve tier-default brave/tavily on re-onboard reuse

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4597,7 +4597,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
         // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
         verifyCompatibleEndpointSandboxSmoke: (options) => verifyCompatibleEndpointSandboxSmoke({ ...options, runOpenshell: runCoreGatewayOpenshell, redact }),
         preparePolicyPresetResumeSelection: (name, options) =>
-          preparePolicyPresetResumeSelection({ policies }, name, options),
+          preparePolicyPresetResumeSelection({ policies, tiers }, name, options),
         arePolicyPresetsApplied,
         skippedStepMessage,
         recordStateSkipped,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4597,7 +4597,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
         // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
         verifyCompatibleEndpointSandboxSmoke: (options) => verifyCompatibleEndpointSandboxSmoke({ ...options, runOpenshell: runCoreGatewayOpenshell, redact }),
         preparePolicyPresetResumeSelection: (name, options) =>
-          preparePolicyPresetResumeSelection({ policies, tiers }, name, options),
+          preparePolicyPresetResumeSelection({ policies }, name, options),
         arePolicyPresetsApplied,
         skippedStepMessage,
         recordStateSkipped,

--- a/src/lib/onboard/policy-preset-reconciliation.ts
+++ b/src/lib/onboard/policy-preset-reconciliation.ts
@@ -13,6 +13,7 @@ import {
   mergeRequiredObservabilityPolicyPresets,
 } from "./observability-policy-presets";
 import { mergeRequiredOpenclawOtelPolicyPresets } from "./openclaw-otel-policy-presets";
+import { classifyPresetProvenance } from "../policy/preset-provenance";
 import { filterSuppressedAgentRequiredPresets } from "./policy-tier-suppression";
 
 export type RequiredSetupPolicyPresetOptions = {
@@ -84,7 +85,8 @@ export function isStaleBuiltinBravePolicyPreset(
   options: {
     webSearchConfig?: WebSearchConfig | null;
     customPresetNames?: ReadonlySet<string> | null;
-    tierDefaultPresetNames?: ReadonlySet<string> | null;
+    tierName?: string | null;
+    agentName?: string | null;
   } = {},
 ): boolean {
   return isStaleBuiltinWebSearchPolicyPreset(name, options);
@@ -95,17 +97,28 @@ export function isStaleBuiltinWebSearchPolicyPreset(
   options: {
     webSearchConfig?: WebSearchConfig | null;
     customPresetNames?: ReadonlySet<string> | null;
-    tierDefaultPresetNames?: ReadonlySet<string> | null;
+    tierName?: string | null;
+    agentName?: string | null;
   } = {},
 ): boolean {
   if (options.customPresetNames?.has(name)) return false;
   // brave/tavily double as a tier's default egress preset (e.g. Brave Search API
   // host access on the Balanced/Open tiers) AND the built-in web-search provider
-  // preset. When the preset is a default of the tier being applied it is a tier
-  // egress default, not a stale web-search leftover — keep it regardless of the
-  // web-search provider choice. The Restricted tier lists no such default, so a
-  // genuinely stale brave/tavily there still prunes. (#6844)
-  if (options.tierDefaultPresetNames?.has(name)) return false;
+  // preset. When the preset is a default of the applied tier it is a tier egress
+  // default, not a stale web-search leftover — keep it regardless of the web-search
+  // provider choice. Reuse the single provenance classifier so pruning and the
+  // policy-list display agree on WHY a preset is present, and so the exemption is
+  // scoped exactly to the applied tier (Restricted lists no such default → still
+  // pruned). classifyPresetProvenance's getTier() returns null for an unknown /
+  // non-canonical tier, so this fails safe (unknown → not "tier" → not exempt). (#6844)
+  if (
+    classifyPresetProvenance(name, {
+      tierName: options.tierName,
+      agentName: options.agentName,
+    }).source === "tier"
+  ) {
+    return false;
+  }
   if (name === "nous-web") {
     return Boolean(
       options.webSearchConfig && webSearchProviderForConfig(options.webSearchConfig) === "tavily",
@@ -127,7 +140,7 @@ export function createUnavailablePolicyPresetPruner(options: {
   presetNames: string[],
   pruning?: {
     preserveExplicitWebSearch?: boolean;
-    tierDefaultPresetNames?: ReadonlySet<string> | null;
+    tierName?: string | null;
   },
 ) => string[] {
   // Custom and interactive selections may explicitly opt into a built-in web-search
@@ -137,8 +150,10 @@ export function createUnavailablePolicyPresetPruner(options: {
       (name) =>
         (pruning.preserveExplicitWebSearch ||
           !isStaleBuiltinWebSearchPolicyPreset(name, {
-            ...options,
-            tierDefaultPresetNames: pruning.tierDefaultPresetNames,
+            webSearchConfig: options.webSearchConfig,
+            customPresetNames: options.customPresetNames,
+            tierName: pruning.tierName,
+            agentName: options.agent,
           })) &&
         !isInactiveObservabilityPolicyPreset(name, options),
     );

--- a/src/lib/onboard/policy-preset-reconciliation.ts
+++ b/src/lib/onboard/policy-preset-reconciliation.ts
@@ -84,6 +84,7 @@ export function isStaleBuiltinBravePolicyPreset(
   options: {
     webSearchConfig?: WebSearchConfig | null;
     customPresetNames?: ReadonlySet<string> | null;
+    tierDefaultPresetNames?: ReadonlySet<string> | null;
   } = {},
 ): boolean {
   return isStaleBuiltinWebSearchPolicyPreset(name, options);
@@ -94,9 +95,17 @@ export function isStaleBuiltinWebSearchPolicyPreset(
   options: {
     webSearchConfig?: WebSearchConfig | null;
     customPresetNames?: ReadonlySet<string> | null;
+    tierDefaultPresetNames?: ReadonlySet<string> | null;
   } = {},
 ): boolean {
   if (options.customPresetNames?.has(name)) return false;
+  // brave/tavily double as a tier's default egress preset (e.g. Brave Search API
+  // host access on the Balanced/Open tiers) AND the built-in web-search provider
+  // preset. When the preset is a default of the tier being applied it is a tier
+  // egress default, not a stale web-search leftover — keep it regardless of the
+  // web-search provider choice. The Restricted tier lists no such default, so a
+  // genuinely stale brave/tavily there still prunes. (#6844)
+  if (options.tierDefaultPresetNames?.has(name)) return false;
   if (name === "nous-web") {
     return Boolean(
       options.webSearchConfig && webSearchProviderForConfig(options.webSearchConfig) === "tavily",
@@ -114,14 +123,23 @@ export function createUnavailablePolicyPresetPruner(options: {
   webSearchConfig?: WebSearchConfig | null;
   customPresetNames?: ReadonlySet<string> | null;
   customOwnsObservability?: boolean;
-}): (presetNames: string[], pruning?: { preserveExplicitWebSearch?: boolean }) => string[] {
+}): (
+  presetNames: string[],
+  pruning?: {
+    preserveExplicitWebSearch?: boolean;
+    tierDefaultPresetNames?: ReadonlySet<string> | null;
+  },
+) => string[] {
   // Custom and interactive selections may explicitly opt into a built-in web-search
   // preset without storing provider config. Inactive observability remains ineligible.
   return (presetNames, pruning = {}) =>
     pruneDisabledMessagingPolicyPresets(presetNames, options.disabledChannels).filter(
       (name) =>
         (pruning.preserveExplicitWebSearch ||
-          !isStaleBuiltinWebSearchPolicyPreset(name, options)) &&
+          !isStaleBuiltinWebSearchPolicyPreset(name, {
+            ...options,
+            tierDefaultPresetNames: pruning.tierDefaultPresetNames,
+          })) &&
         !isInactiveObservabilityPolicyPreset(name, options),
     );
 }

--- a/src/lib/onboard/policy-resume-selection.test.ts
+++ b/src/lib/onboard/policy-resume-selection.test.ts
@@ -87,6 +87,70 @@ describe("preparePolicyPresetResumeSelection web search reconciliation", () => {
   });
 });
 
+function tiers(defaults: Record<string, string[]>) {
+  return {
+    resolveTierPresets: (tierName: string) => (defaults[tierName] ?? []).map((name) => ({ name })),
+  };
+}
+
+describe("preparePolicyPresetResumeSelection tier-default preservation (#6844)", () => {
+  const BALANCED = { balanced: ["npm", "brave"], restricted: [] as string[] };
+
+  it("preserves brave on reuse when it is a Balanced-tier default and web search is off", () => {
+    const result = preparePolicyPresetResumeSelection(
+      { policies: policies(), tiers: tiers(BALANCED) },
+      "alpha",
+      {
+        recordedPolicyPresets: ["npm", "brave"],
+        agent: "openclaw",
+        webSearchConfig: null,
+        webSearchSupported: true,
+        tierName: "balanced",
+      },
+    );
+
+    // brave is a Balanced default (an egress preset), not a stale web-search
+    // leftover — it must survive reuse just like npm, and no reconcile is needed.
+    expect(result.policyPresets).toEqual(["npm", "brave"]);
+    expect(result.recordedPolicyPresetsNeedReconcile).toBe(false);
+  });
+
+  it("still prunes a stale brave on the Restricted tier (no brave default)", () => {
+    const result = preparePolicyPresetResumeSelection(
+      { policies: policies(), tiers: tiers(BALANCED) },
+      "alpha",
+      {
+        recordedPolicyPresets: ["npm", "brave"],
+        agent: "openclaw",
+        webSearchConfig: null,
+        webSearchSupported: true,
+        tierName: "restricted",
+      },
+    );
+
+    expect(result.policyPresets).toEqual(["npm"]);
+    expect(result.recordedPolicyPresetsNeedReconcile).toBe(true);
+  });
+
+  it("keeps brave on Balanced even when web search is set to a different provider", () => {
+    const result = preparePolicyPresetResumeSelection(
+      { policies: policies(), tiers: tiers(BALANCED) },
+      "alpha",
+      {
+        recordedPolicyPresets: ["npm", "brave"],
+        agent: "openclaw",
+        webSearchConfig: { fetchEnabled: true, provider: "tavily" },
+        webSearchConfigChanged: true,
+        webSearchSupported: true,
+        tierName: "balanced",
+      },
+    );
+
+    // brave stays as the tier egress default; tavily is added as the active provider.
+    expect(result.policyPresets).toEqual(["npm", "brave", "tavily"]);
+  });
+});
+
 describe("preparePolicyPresetResumeSelection observability reconciliation", () => {
   it("adds the local OTLP preset only while Deep Agents Code observability is enabled", () => {
     const enabled = preparePolicyPresetResumeSelection({ policies: policies() }, "alpha", {

--- a/src/lib/onboard/policy-resume-selection.test.ts
+++ b/src/lib/onboard/policy-resume-selection.test.ts
@@ -87,28 +87,18 @@ describe("preparePolicyPresetResumeSelection web search reconciliation", () => {
   });
 });
 
-function tiers(defaults: Record<string, string[]>) {
-  return {
-    getTier: (tierName: string) => (tierName in defaults ? { name: tierName } : null),
-    resolveTierPresets: (tierName: string) => (defaults[tierName] ?? []).map((name) => ({ name })),
-  };
-}
-
 describe("preparePolicyPresetResumeSelection tier-default preservation (#6844)", () => {
-  const BALANCED = { balanced: ["npm", "brave"], restricted: [] as string[] };
+  // These exercise the real tiers.yaml through classifyPresetProvenance (no tier
+  // stub): `brave` is a Balanced default, and Restricted lists no such default.
 
   it("preserves brave on reuse when it is a Balanced-tier default and web search is off", () => {
-    const result = preparePolicyPresetResumeSelection(
-      { policies: policies(), tiers: tiers(BALANCED) },
-      "alpha",
-      {
-        recordedPolicyPresets: ["npm", "brave"],
-        agent: "openclaw",
-        webSearchConfig: null,
-        webSearchSupported: true,
-        tierName: "balanced",
-      },
-    );
+    const result = preparePolicyPresetResumeSelection({ policies: policies() }, "alpha", {
+      recordedPolicyPresets: ["npm", "brave"],
+      agent: "openclaw",
+      webSearchConfig: null,
+      webSearchSupported: true,
+      tierName: "balanced",
+    });
 
     // brave is a Balanced default (an egress preset), not a stale web-search
     // leftover — it must survive reuse just like npm, and no reconcile is needed.
@@ -117,38 +107,46 @@ describe("preparePolicyPresetResumeSelection tier-default preservation (#6844)",
   });
 
   it("still prunes a stale brave on the Restricted tier (no brave default)", () => {
-    const result = preparePolicyPresetResumeSelection(
-      { policies: policies(), tiers: tiers(BALANCED) },
-      "alpha",
-      {
-        recordedPolicyPresets: ["npm", "brave"],
-        agent: "openclaw",
-        webSearchConfig: null,
-        webSearchSupported: true,
-        tierName: "restricted",
-      },
-    );
+    const result = preparePolicyPresetResumeSelection({ policies: policies() }, "alpha", {
+      recordedPolicyPresets: ["npm", "brave"],
+      agent: "openclaw",
+      webSearchConfig: null,
+      webSearchSupported: true,
+      tierName: "restricted",
+    });
 
     expect(result.policyPresets).toEqual(["npm"]);
     expect(result.recordedPolicyPresetsNeedReconcile).toBe(true);
   });
 
   it("keeps brave on Balanced even when web search is set to a different provider", () => {
-    const result = preparePolicyPresetResumeSelection(
-      { policies: policies(), tiers: tiers(BALANCED) },
-      "alpha",
-      {
-        recordedPolicyPresets: ["npm", "brave"],
-        agent: "openclaw",
-        webSearchConfig: { fetchEnabled: true, provider: "tavily" },
-        webSearchConfigChanged: true,
-        webSearchSupported: true,
-        tierName: "balanced",
-      },
-    );
+    const result = preparePolicyPresetResumeSelection({ policies: policies() }, "alpha", {
+      recordedPolicyPresets: ["npm", "brave"],
+      agent: "openclaw",
+      webSearchConfig: { fetchEnabled: true, provider: "tavily" },
+      webSearchConfigChanged: true,
+      webSearchSupported: true,
+      tierName: "balanced",
+    });
 
     // brave stays as the tier egress default; tavily is added as the active provider.
     expect(result.policyPresets).toEqual(["npm", "brave", "tavily"]);
+  });
+
+  it("still prunes tavily on Balanced when it is not a tier default and web search is off", () => {
+    // Boundary: the exemption is scoped to real tier defaults. tavily is NOT a
+    // Balanced default (brave is), so a leftover tavily with no matching provider
+    // is still a stale web-search preset and must be pruned.
+    const result = preparePolicyPresetResumeSelection({ policies: policies() }, "alpha", {
+      recordedPolicyPresets: ["npm", "tavily"],
+      agent: "openclaw",
+      webSearchConfig: null,
+      webSearchSupported: true,
+      tierName: "balanced",
+    });
+
+    expect(result.policyPresets).toEqual(["npm"]);
+    expect(result.recordedPolicyPresetsNeedReconcile).toBe(true);
   });
 });
 

--- a/src/lib/onboard/policy-resume-selection.test.ts
+++ b/src/lib/onboard/policy-resume-selection.test.ts
@@ -89,6 +89,7 @@ describe("preparePolicyPresetResumeSelection web search reconciliation", () => {
 
 function tiers(defaults: Record<string, string[]>) {
   return {
+    getTier: (tierName: string) => (tierName in defaults ? { name: tierName } : null),
     resolveTierPresets: (tierName: string) => (defaults[tierName] ?? []).map((name) => ({ name })),
   };
 }

--- a/src/lib/onboard/policy-resume-selection.ts
+++ b/src/lib/onboard/policy-resume-selection.ts
@@ -45,8 +45,12 @@ type PoliciesApi = {
   ): string[];
 };
 
+type TiersApi = {
+  resolveTierPresets(tierName: string): Preset[];
+};
+
 export function preparePolicyPresetResumeSelection(
-  deps: { policies: PoliciesApi },
+  deps: { policies: PoliciesApi; tiers?: TiersApi },
   sandboxName: string,
   options: {
     recordedPolicyPresets: string[] | null;
@@ -100,10 +104,18 @@ export function preparePolicyPresetResumeSelection(
     supportOptions,
     customPolicyPresetNames,
   );
+  // Defaults of the recorded/active tier (e.g. `brave` on Balanced) are tier
+  // egress presets, not stale web-search leftovers — exempt them from the
+  // web-search staleness prune so re-onboard reuse preserves them. (#6844)
+  const tierDefaultPresetNames =
+    options.tierName && deps.tiers
+      ? new Set(deps.tiers.resolveTierPresets(options.tierName).map((preset) => preset.name))
+      : null;
   const isStaleBuiltinWebSearch = (name: string) =>
     isStaleBuiltinWebSearchPolicyPreset(name, {
       webSearchConfig: options.webSearchConfig,
       customPresetNames: customPolicyPresetNames,
+      tierDefaultPresetNames,
     });
   const isInactiveObservability = (name: string) =>
     isInactiveObservabilityPolicyPreset(name, {

--- a/src/lib/onboard/policy-resume-selection.ts
+++ b/src/lib/onboard/policy-resume-selection.ts
@@ -45,13 +45,8 @@ type PoliciesApi = {
   ): string[];
 };
 
-type TiersApi = {
-  getTier(tierName: string): unknown;
-  resolveTierPresets(tierName: string): Preset[];
-};
-
 export function preparePolicyPresetResumeSelection(
-  deps: { policies: PoliciesApi; tiers?: TiersApi },
+  deps: { policies: PoliciesApi },
   sandboxName: string,
   options: {
     recordedPolicyPresets: string[] | null;
@@ -106,17 +101,15 @@ export function preparePolicyPresetResumeSelection(
     customPolicyPresetNames,
   );
   // Defaults of the recorded/active tier (e.g. `brave` on Balanced) are tier
-  // egress presets, not stale web-search leftovers — exempt them from the
-  // web-search staleness prune so re-onboard reuse preserves them. (#6844)
-  const tierDefaultPresetNames =
-    options.tierName && deps.tiers?.getTier(options.tierName)
-      ? new Set(deps.tiers.resolveTierPresets(options.tierName).map((preset) => preset.name))
-      : null;
+  // egress presets, not stale web-search leftovers — pass the recorded tier +
+  // agent so the shared predicate exempts them via provenance and re-onboard
+  // reuse preserves them. (#6844)
   const isStaleBuiltinWebSearch = (name: string) =>
     isStaleBuiltinWebSearchPolicyPreset(name, {
       webSearchConfig: options.webSearchConfig,
       customPresetNames: customPolicyPresetNames,
-      tierDefaultPresetNames,
+      tierName: options.tierName,
+      agentName: options.agent,
     });
   const isInactiveObservability = (name: string) =>
     isInactiveObservabilityPolicyPreset(name, {

--- a/src/lib/onboard/policy-resume-selection.ts
+++ b/src/lib/onboard/policy-resume-selection.ts
@@ -46,6 +46,7 @@ type PoliciesApi = {
 };
 
 type TiersApi = {
+  getTier(tierName: string): unknown;
   resolveTierPresets(tierName: string): Preset[];
 };
 
@@ -108,7 +109,7 @@ export function preparePolicyPresetResumeSelection(
   // egress presets, not stale web-search leftovers — exempt them from the
   // web-search staleness prune so re-onboard reuse preserves them. (#6844)
   const tierDefaultPresetNames =
-    options.tierName && deps.tiers
+    options.tierName && deps.tiers?.getTier(options.tierName)
       ? new Set(deps.tiers.resolveTierPresets(options.tierName).map((preset) => preset.name))
       : null;
   const isStaleBuiltinWebSearch = (name: string) =>

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -320,6 +320,12 @@ async function setupPoliciesWithSelectionInner(
   // branch before presets are recorded, so its persisted tier must also win
   // over a new prompt or non-interactive default.
   const recordedTierName = options.tierName ?? deps.getRecordedPolicyTier?.(sandboxName) ?? null;
+  // Defaults of the recorded tier (e.g. `brave` on Balanced) are tier egress
+  // presets, not stale web-search leftovers — exempt them from pruning so a
+  // reconcile-triggered reuse reapply preserves them. (#6844)
+  const recordedTierDefaultPresetNames = recordedTierName
+    ? new Set(deps.tiers.resolveTierPresets(recordedTierName).map((preset) => preset.name))
+    : null;
   if (chosen !== null) {
     const knownSelectablePresets = new Set(selectablePresets.map((preset) => preset.name));
     chosen = mergeRequiredSetupPolicyPresets(chosen, {
@@ -334,7 +340,9 @@ async function setupPoliciesWithSelectionInner(
       customPresetNames,
       customOwnsObservability,
     });
-    chosen = pruneUnavailablePresets(chosen);
+    chosen = pruneUnavailablePresets(chosen, {
+      tierDefaultPresetNames: recordedTierDefaultPresetNames,
+    });
   }
 
   if (selectedPresets !== null) {

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -323,9 +323,13 @@ async function setupPoliciesWithSelectionInner(
   // Defaults of the recorded tier (e.g. `brave` on Balanced) are tier egress
   // presets, not stale web-search leftovers — exempt them from pruning so a
   // reconcile-triggered reuse reapply preserves them. (#6844)
-  const recordedTierDefaultPresetNames = recordedTierName
-    ? new Set(deps.tiers.resolveTierPresets(recordedTierName).map((preset) => preset.name))
-    : null;
+  // getTier returns null for an unknown/non-canonical recorded tier; guard on it
+  // so resolveTierPresets (which throws on unknown tiers) is only called for a
+  // real tier, leaving non-tier reuse paths on their prior behavior.
+  const recordedTierDefaultPresetNames =
+    recordedTierName && deps.tiers.getTier(recordedTierName)
+      ? new Set(deps.tiers.resolveTierPresets(recordedTierName).map((preset) => preset.name))
+      : null;
   if (chosen !== null) {
     const knownSelectablePresets = new Set(selectablePresets.map((preset) => preset.name));
     chosen = mergeRequiredSetupPolicyPresets(chosen, {

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -320,16 +320,6 @@ async function setupPoliciesWithSelectionInner(
   // branch before presets are recorded, so its persisted tier must also win
   // over a new prompt or non-interactive default.
   const recordedTierName = options.tierName ?? deps.getRecordedPolicyTier?.(sandboxName) ?? null;
-  // Defaults of the recorded tier (e.g. `brave` on Balanced) are tier egress
-  // presets, not stale web-search leftovers — exempt them from pruning so a
-  // reconcile-triggered reuse reapply preserves them. (#6844)
-  // getTier returns null for an unknown/non-canonical recorded tier; guard on it
-  // so resolveTierPresets (which throws on unknown tiers) is only called for a
-  // real tier, leaving non-tier reuse paths on their prior behavior.
-  const recordedTierDefaultPresetNames =
-    recordedTierName && deps.tiers.getTier(recordedTierName)
-      ? new Set(deps.tiers.resolveTierPresets(recordedTierName).map((preset) => preset.name))
-      : null;
   if (chosen !== null) {
     const knownSelectablePresets = new Set(selectablePresets.map((preset) => preset.name));
     chosen = mergeRequiredSetupPolicyPresets(chosen, {
@@ -344,9 +334,10 @@ async function setupPoliciesWithSelectionInner(
       customPresetNames,
       customOwnsObservability,
     });
-    chosen = pruneUnavailablePresets(chosen, {
-      tierDefaultPresetNames: recordedTierDefaultPresetNames,
-    });
+    // Pass the recorded tier so the pruner exempts that tier's egress defaults
+    // (e.g. `brave` on Balanced) via provenance — a reconcile-triggered reuse
+    // reapply must not narrow an applied tier default. (#6844)
+    chosen = pruneUnavailablePresets(chosen, { tierName: recordedTierName });
   }
 
   if (selectedPresets !== null) {

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -486,6 +486,7 @@ describe("policy tier setup", () => {
   it("preserves a recorded Balanced tier default during resumed reapply (#6844)", async () => {
     const result = await runPolicySetup(
       {
+        tierName: "restricted",
         currentApplied: ["npm", "brave"],
         recordedPolicyTier: "balanced",
       },

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -483,6 +483,30 @@ describe("policy tier setup", () => {
     assert.deepEqual(result.appliedCalls, ["brave", "npm"]);
   });
 
+  it("preserves a recorded Balanced tier default during resumed reapply (#6844)", async () => {
+    const result = await runPolicySetup(
+      {
+        currentApplied: ["npm", "brave"],
+        recordedPolicyTier: "balanced",
+      },
+      {
+        selectedPresets: ["npm", "brave"],
+        webSearchConfig: null,
+        webSearchSupported: true,
+      },
+    );
+
+    assert.deepEqual(result.applied, ["npm", "brave"]);
+    assert.deepEqual(result.syncCalls, [
+      {
+        sandboxName: "test-sb",
+        current: ["npm", "brave"],
+        selected: ["npm", "brave"],
+      },
+    ]);
+    assert.deepEqual(result.removedCalls, []);
+  });
+
   it("clamps resumed policy presets to web-search-supported presets", async () => {
     const result = await runPolicySetup(
       {


### PR DESCRIPTION
## Summary

On the re-onboard **reuse** path, the Balanced-tier default preset `brave` (Brave Search API access) was silently dropped even when the policy tier (Balanced) and the web-search choice (No web search) were unchanged. The other four Balanced defaults (`npm`, `pypi`, `huggingface`, `brew`) persisted — only `brave` was narrowed out of the reapplied set, removing its egress (`api.search.brave.com`).

Fixes #6844.

## Root cause

`isStaleBuiltinWebSearchPolicyPreset` treats `brave`/`tavily` as a stale web-search leftover whenever no matching web-search provider is configured. It did not account for the fact that the same preset is *also* a default egress preset of the tier being applied. On reuse, `preparePolicyPresetResumeSelection` pruned `brave` under this rule, flipping `recordedPolicyPresetsNeedReconcile` and driving a reapply whose set omitted `brave`.

## Fix

A preset that is a default of the **applied tier** is a tier egress default, not a stale web-search leftover. The exemption is expressed through the existing `classifyPresetProvenance` classifier (`source: "tier"`), so pruning and the `policy-list` display share a single notion of *why* a preset is present rather than a second, parallel one. It is threaded through both reuse/resume prune sites (`preparePolicyPresetResumeSelection` and `createUnavailablePolicyPresetPruner`).

Scoped to the reuse/resume path. **Fresh-onboard suggestion behaviour is intentionally unchanged**: a fresh *suggested* onboard omits `brave` egress unless web-search is chosen (conservative egress by design — see `onboard-policy-suggestions.test.ts`), which is not part of this reuse regression.

### Design annotation
- **invalidState**: on reuse, an already-applied tier-default egress preset (`brave`/`tavily` on Balanced/Open) is pruned as a stale web-search leftover and its egress narrowed, on an unchanged tier.
- **sourceBoundary**: `isStaleBuiltinWebSearchPolicyPreset` — the single predicate all reuse/resume prune sites share.
- **whyNotSourceFix**: preset provenance is intentionally *not* persisted (`preset-provenance.ts` is display-only by design); we reuse its classifier rather than reverse that decision with a persisted-state refactor.
- **regressionTest**: `policy-resume-selection.test.ts` — preserve on Balanced, still-prune on Restricted, keep-with-switched-provider, prune-non-tier-default.
- **removalCondition**: if preset provenance ever becomes persisted per-preset, replace the current-tier inference with the stored source.

### Behaviour preserved (boundaries)
- **Restricted tier** lists no `brave`/`tavily` default → a genuinely stale preset there is still pruned.
- A **non-tier-default** web-search preset (e.g. `tavily` on Balanced with no matching provider) is still pruned — the exemption is scoped to real tier defaults, not "any `brave`/`tavily`".
- **Provider switch** (brave → tavily) still replaces the stale provider and adds the newly active one.
- **Unknown / non-canonical recorded tier** fails safe (`getTier` → null → not `"tier"` → not exempt → prior behaviour), so the authoritative-rebuild-tier-pending case does not throw.

## Testing

- `policy-resume-selection.test.ts` covers the full contract above; the broader onboard policy/tier/preset suites pass (213 tests across 15 files); `build:cli` + `typecheck` green.
- **End-to-end on both arches**, on `main`, onboarding a local Ollama sandbox (loopback route, so onboarding is not blocked by the endpoint SSRF preflight):
  - **x86_64** (our Ubuntu 24.04 no-GPU test host) and **aarch64** (our DGX Spark GB10 GPU test host — matching the reporter's DGX Station architecture).
  - **Before the fix:** reuse reapply = `npm, pypi, huggingface, brew` → `Removed preset: brave` → brave inactive.
  - **After the fix:** reuse reapply = `npm, pypi, huggingface, brew, brave` → brave stays active (`[from balanced tier]`), no egress narrowing.

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved built-in web-search and egress presets based on the recorded tier during policy resume and reconciliation.
  * Prevented tier-default presets from being incorrectly pruned when resuming, including when web search is disabled or uses a different provider.
  * Ensured reconciliation still removes unavailable, non-default presets that don’t match the active tier’s defaults.
* **Tests**
  * Added coverage for tier-default preservation across resume selection and reapply behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->