### PR TITLE
fix(inference): use model-aware token field in rebuild preflight

### DIFF
--- a/src/lib/actions/sandbox/rebuild-inference-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-inference-preflight.test.ts
@@ -63,4 +63,19 @@ describe("atomic rebuild inference preflight", () => {
 
     expect(preflightRebuildInferenceRoute(input, { execute })).toEqual({ ok: true });
   });
+
+  it("sends max_completion_tokens for a GPT-5 model on the chat completions route (#6850)", () => {
+    const command = buildRebuildInferenceProbeCommand({ ...input, model: "gpt-5.4" });
+
+    expect(command).toContain("https://inference.local/v1/chat/completions");
+    expect(command).toContain('"max_completion_tokens":8');
+    expect(command).not.toContain('"max_tokens"');
+  });
+
+  it("keeps max_tokens for a non-GPT-5 model on the chat completions route (#6850)", () => {
+    const command = buildRebuildInferenceProbeCommand({ ...input, model: "nvidia/nemotron" });
+
+    expect(command).toContain('"max_tokens":8');
+    expect(command).not.toContain('"max_completion_tokens"');
+  });
 });

--- a/src/lib/actions/sandbox/rebuild-inference-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-inference-preflight.test.ts
@@ -64,7 +64,7 @@ describe("atomic rebuild inference preflight", () => {
     expect(preflightRebuildInferenceRoute(input, { execute })).toEqual({ ok: true });
   });
 
-  it("sends max_completion_tokens for a GPT-5 model on the chat completions route (#6850)", () => {
+  it("sends max_completion_tokens for a GPT-5 model on the chat completions route", () => {
     const command = buildRebuildInferenceProbeCommand({ ...input, model: "gpt-5.4" });
 
     expect(command).toContain("https://inference.local/v1/chat/completions");
@@ -72,7 +72,14 @@ describe("atomic rebuild inference preflight", () => {
     expect(command).not.toContain('"max_tokens"');
   });
 
-  it("keeps max_tokens for a non-GPT-5 model on the chat completions route (#6850)", () => {
+  it("sends max_completion_tokens for an o-series model on the chat completions route", () => {
+    const command = buildRebuildInferenceProbeCommand({ ...input, model: "o3-mini" });
+
+    expect(command).toContain('"max_completion_tokens":8');
+    expect(command).not.toContain('"max_tokens"');
+  });
+
+  it("keeps max_tokens for a model that supports the legacy chat completions field", () => {
     const command = buildRebuildInferenceProbeCommand({ ...input, model: "nvidia/nemotron" });
 
     expect(command).toContain('"max_tokens":8');

--- a/src/lib/actions/sandbox/rebuild-inference-preflight.ts
+++ b/src/lib/actions/sandbox/rebuild-inference-preflight.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getSandboxInferenceConfig } from "../../inference/config";
+import { resolveMaxTokensField } from "../../inference/max-tokens-field";
 import { shellQuote } from "../../runner";
 import { executeSandboxExecCommand, type SandboxCommandResult } from "./process-recovery";
 
@@ -51,7 +52,7 @@ function buildProbeRequest(input: RebuildInferencePreflightInput): {
     headers: [],
     payload: {
       model: input.model,
-      max_tokens: 8,
+      [resolveMaxTokensField(input.model)]: 8,
       messages: [{ role: "user", content: "Reply with OK" }],
       stream: false,
     },


### PR DESCRIPTION
## Summary

The atomic DCode rebuild gate probes the sandbox's recorded OpenAI-compatible route before making changes. Its Chat Completions payload hard-coded `max_tokens`, so rebuilds configured with GPT-5 or o-series models could fail with HTTP 400 before rebuild processing began.

This PR makes that rebuild-only probe use the shared model-aware token-field resolver. It does not change the managed gateway's ongoing route-health validation.

## Scope

`preflightRebuildInferenceRoute` is called only by the DCode rebuild preflight. This PR intentionally does not change the managed gateway's ongoing route-health validation or claim broader runtime behavior.

## Changes

- Resolve the Chat Completions reply-budget field with `resolveMaxTokensField(input.model)`.
- Send `max_completion_tokens` for GPT-5 and o1/o3/o4 model families.
- Preserve `max_tokens` for models that support the legacy field.
- Cover GPT-5, o-series, and legacy-model behavior at the rebuild-preflight command boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior - justification:
- [ ] Tests not applicable - justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable - justification: internal rebuild inference preflight behavior; no user-facing contract changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded - reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer - check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes `Signed-off-by:` lines and every commit is signed
- [x] `npm run check:diff`
- [x] `npm run build:cli`
- [x] `npm run typecheck:cli`
- [x] `npx vitest run --project cli src/lib/actions/sandbox/rebuild-inference-preflight.test.ts` - 7 passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed

Signed-off-by: Tinson Lai <tinsonl@nvidia.com>
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference preflight checks for newer GPT-5 and o-series models by using the correct completion token parameter.
  * Preserved compatibility with legacy models by continuing to use their supported token limit parameter.
  * Added coverage to verify request payloads use the appropriate field for each model type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->