### PR TITLE
fix(vllm): accept /run/docker.sock as a default socket for disk-space check

### DIFF
--- a/src/lib/inference/vllm-storage.test.ts
+++ b/src/lib/inference/vllm-storage.test.ts
@@ -298,6 +298,24 @@ describe("Docker image-storage detection", () => {
     });
   });
 
+  it("accepts /run/docker.sock as a default socket (systemd /var/run -> /run symlink) (#6858)", () => {
+    // Regression: DOCKER_HOST=unix:///run/docker.sock is the same daemon socket
+    // as /var/run/docker.sock on systemd Linux, but was read as "non-default" and
+    // aborted express managed-vLLM disk-space verification.
+    vi.stubEnv("DOCKER_HOST", "unix:///run/docker.sock");
+    vi.stubEnv("DOCKER_CONTEXT", "default");
+
+    expect(
+      probeDockerHostLocality({
+        clientContainerized: false,
+        dockerInfo: () => nativeDockerInfo(),
+        osRelease: nativeHost.osRelease,
+        platform: nativeHost.platform,
+        dockerSocketPeerSharesMountNamespace: () => true,
+      }),
+    ).toEqual({ ok: true });
+  });
+
   it("fails closed when the default Docker socket is mounted into a client container (#6757)", () => {
     vi.stubEnv("DOCKER_HOST", "unix:///var/run/docker.sock");
     vi.stubEnv("DOCKER_CONTEXT", "default");

--- a/src/lib/inference/vllm-storage.ts
+++ b/src/lib/inference/vllm-storage.ts
@@ -18,6 +18,18 @@ const MODEL_MINIMUM_HEADROOM_BYTES = 2n * GIB_BYTES;
 const DEFAULT_CONTAINERD_ROOT = "/var/lib/containerd";
 const DEFAULT_CONTAINERD_CONFIG = "/etc/containerd/config.toml";
 const DEFAULT_DOCKER_SOCKET = "/var/run/docker.sock";
+// `/var/run` is a symlink to `/run` on modern systemd Linux, so the Docker
+// daemon socket is canonically `/run/docker.sock` and `/var/run/docker.sock`
+// addresses the same file. Accept both (and their `unix://` forms) as the
+// default local socket, mirroring the socket candidates probed in platform.ts,
+// so a `DOCKER_HOST` pointing at either does not read as a non-default socket
+// and abort managed-vLLM disk-space verification. (#6858)
+const DEFAULT_DOCKER_SOCKET_PATHS = ["/var/run/docker.sock", "/run/docker.sock"];
+
+function isDefaultDockerSocket(endpoint: string): boolean {
+  const socketPath = endpoint.startsWith("unix://") ? endpoint.slice("unix://".length) : endpoint;
+  return DEFAULT_DOCKER_SOCKET_PATHS.includes(socketPath);
+}
 const DOCKER_SOCKET_PEER_PROBE_TIMEOUT_MS = 5_000;
 // SO_PEERCRED translates the daemon PID into the caller's PID namespace. A
 // hidden peer therefore exposes the namespace-local PID 1 topology directly,
@@ -314,7 +326,7 @@ function nativeDockerHostProblem(info: DockerInfoShape, deps: StorageProbeDeps):
   if (endpoint) {
     const localSocket = endpoint.startsWith("unix://") || path.isAbsolute(endpoint);
     if (!localSocket) return `Docker uses a remote endpoint (${endpoint})`;
-    if (endpoint !== DEFAULT_DOCKER_SOCKET && endpoint !== `unix://${DEFAULT_DOCKER_SOCKET}`) {
+    if (!isDefaultDockerSocket(endpoint)) {
       return `Docker uses a non-default socket (${endpoint}) whose daemon host filesystem cannot be verified`;
     }
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
On v0.0.82 the managed-vLLM disk-space guard reads `DOCKER_HOST=unix:///run/docker.sock` as a "non-default socket" and, in non-interactive express mode, aborts onboarding at step `[3/8]` before verifying free space — even with ~1.5 TB free. `/run/docker.sock` and `/var/run/docker.sock` are the same daemon socket on systemd Linux (`/var/run` → `/run`). This PR accepts both spellings.

Closes #6858.

## Reproduction
Real compiled guard exercised on our DGX Spark aarch64 test host (GB10 GPU) against the real Docker daemon, with the reporter's `DOCKER_HOST`.

**Environment**
- Test machine: our DGX Spark aarch64 test host (GB10 GPU), Ubuntu 24.04 — matching the reporter's DGX Station aarch64
- NemoClaw `main` (v0.0.82)

**Observed on `main` (before fix)**
```
$ DOCKER_HOST=unix:///run/docker.sock node -e '...probeDockerHostLocality()'
{"ok":false,"reason":"Docker uses a non-default socket (unix:///run/docker.sock) whose daemon host filesystem cannot be verified"}
# and a real `install-vllm` onboard aborts at [3/8] (exit 1) with the same reason
```

**Observed on `fix/...` (after fix)**
```
$ DOCKER_HOST=unix:///run/docker.sock node -e '...probeDockerHostLocality()'
{"ok":true}
# a real `install-vllm` onboard now clears [3/8] and proceeds to pull the managed vLLM image
```
A genuinely non-default socket (e.g. `unix:///tmp/forwarded-remote.sock`) still fails closed.

## Analysis
`nativeDockerHostProblem` in `src/lib/inference/vllm-storage.ts` compared the `DOCKER_HOST` endpoint only against `/var/run/docker.sock` (and its `unix://` form). On modern systemd Linux `/var/run` is a symlink to `/run`, so a `DOCKER_HOST` of `unix:///run/docker.sock` addresses the identical socket but failed the equality check, returning "non-default socket". Both the image check (`probeDockerStorage` → `resolveDockerStorageLocations`) and the model-cache check (`probeDockerHostLocality`) route through `nativeDockerHostProblem`, so the failure blocks the whole disk-space verification; in non-interactive express mode `storageWarningAccepted` then returns false and onboarding exits before the pull. `src/lib/platform.ts` already treats both socket paths as valid daemon-socket candidates, so this check was the inconsistent outlier. Regression: this guard was added in v0.0.82 (v0.0.81 had no such check).

## Fix
Add an `isDefaultDockerSocket` helper that normalizes the optional `unix://` prefix and accepts both `/var/run/docker.sock` and `/run/docker.sock`, and use it in `nativeDockerHostProblem`. A remote (`ssh://…`) or genuinely non-default socket is still rejected. A regression test locks in that `/run/docker.sock` is accepted while `/tmp/forwarded-remote.sock` still fails closed.

## Changes
- `src/lib/inference/vllm-storage.ts`: accept `/run/docker.sock` as a default socket via `isDefaultDockerSocket`.
- `src/lib/inference/vllm-storage.test.ts`: regression test for `/run/docker.sock`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)

## Verification
- [x] `npm test` passes (touched files)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker connection detection for local daemon sockets.
  * Recognizes both `/var/run/docker.sock` and `/run/docker.sock`, including `unix://` formats, as valid default local endpoints.
  * Prevents valid local configurations from being incorrectly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->