### PR TITLE
fix(cli): explain shields on skill upload failures

### DIFF
--- a/src/lib/actions/sandbox/skill-install.test.ts
+++ b/src/lib/actions/sandbox/skill-install.test.ts
@@ -246,4 +246,33 @@ describe("sandbox skill action orchestration", () => {
     expectTempSshConfigCleanedUp(tempConfig);
     expect(process.exitCode).toBeUndefined();
   });
+
+  it("adds shields recovery guidance when skill upload fails (#6859)", async () => {
+    const skillDir = makeSkillDir();
+    skillInstall.uploadDirectory.mockReturnValue({
+      uploaded: 0,
+      failed: ["SKILL.md"],
+      skippedDotfiles: [],
+      unsafePaths: [],
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`process.exit ${code}`);
+    }) as typeof process.exit);
+
+    try {
+      await expect(
+        installSandboxSkill("alpha", { command: "install", path: skillDir }),
+      ).rejects.toThrow("process.exit 1");
+    } finally {
+      fs.rmSync(skillDir, { recursive: true, force: true });
+    }
+
+    const output = error.mock.calls.map((args) => args.join(" ")).join("\n");
+    expect(output).toContain("Failed to upload 1 file(s): SKILL.md");
+    expect(output).toContain("locked while shields are up");
+    expect(output).toContain("nemoclaw alpha shields down");
+    expect(skillInstall.postInstall).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/lib/actions/sandbox/skill-install.ts
+++ b/src/lib/actions/sandbox/skill-install.ts
@@ -80,6 +80,15 @@ export function printPluginInstallHint(): void {
   );
 }
 
+function printSkillUploadFailureHint(sandboxName: string): void {
+  console.error(
+    "  Skill uploads write to the agent skills directory, which is locked while shields are up.",
+  );
+  console.error(
+    `  If shields are up, run \`${CLI_NAME} ${sandboxName} shields down\` before installing skills.`,
+  );
+}
+
 /**
  * Remove an installed skill from a live sandbox by name.
  */
@@ -308,6 +317,7 @@ export async function installSandboxSkill(
     const { uploaded, failed } = skillInstall.uploadDirectory(ctx, skillDir, paths.uploadDir);
     if (failed.length > 0) {
       console.error(`  Failed to upload ${failed.length} file(s): ${failed.join(", ")}`);
+      printSkillUploadFailureHint(sandboxName);
       process.exit(1);
     }
     console.log(`  ${G}✓${R} Uploaded ${uploaded} file(s) to sandbox`);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Skill install upload failures now point users at the common shields-up cause instead of reporting only the failed filenames. The hint stays conditional, so unrelated upload failures are not reported as definitely caused by shields.

## Related Issue
Fixes #6859

## Changes
- Print a recovery hint after `skill install` upload failures explaining that skill uploads write to a directory locked while shields are up.
- Tell users to run `nemoclaw <sandbox> shields down` before installing skills when shields are up.
- Add action-level regression coverage for the upload failure message and post-install short-circuit.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is a narrow runtime error-message improvement for an existing command and does not change command usage, options, defaults, or documented workflows.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review of sandbox action behavior; the change only adds guidance after an upload failure and does not alter upload, shields, permission, or sandbox mutation logic.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: DGX Spark/Linux: `npx vitest run --project cli src/lib/actions/sandbox/skill-install.test.ts` passed; `npm run check:diff` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: HwangJohn <angelic805@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when skill uploads fail by providing guidance to lower shields before retrying.
  * Prevented post-install steps from running after an unsuccessful upload.

* **Tests**
  * Added coverage for failed skill uploads, including error details and recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->