### PR TITLE
fix(onboard): treat an unreachable custom endpoint as a transport failure

### DIFF
--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -160,6 +160,40 @@ describe("inference selection validation", () => {
     }
   });
 
+  it("routes an unreachable custom endpoint through transport recovery, not a silent loop (#6854)", async () => {
+    const probeOpenAiLikeEndpoint = vi.fn(() => ({ ok: true, api: "openai-completions" }));
+    const promptValidationRecovery = vi.fn(async () => "retry" as const);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const helpers = createInferenceSelectionValidationHelpers({
+      isNonInteractive: () => false,
+      agentProductName: () => "OpenClaw",
+      getCredential: () => "test-key",
+      probeOpenAiLikeEndpoint,
+      promptValidationRecovery,
+      resolveEndpointHost: async () => {
+        throw new Error("getaddrinfo ENOTFOUND example.invalid");
+      },
+    });
+
+    try {
+      await helpers.validateCustomOpenAiLikeSelection(
+        "Custom endpoint",
+        "https://example.invalid/v1",
+        "model-a",
+        "COMPATIBLE_API_KEY",
+      );
+      // A DNS-unreachable endpoint is a transport failure: the recovery prompt
+      // receives a transport classification (DNS/VPN/URL hint + retry/back/exit),
+      // not the silent selection loop the private-IP path takes.
+      expect(promptValidationRecovery).toHaveBeenCalled();
+      const recovery = promptValidationRecovery.mock.calls[0]?.[1] as { kind?: string };
+      expect(recovery.kind).toBe("transport");
+      expect(probeOpenAiLikeEndpoint).not.toHaveBeenCalled();
+    } finally {
+      error.mockRestore();
+    }
+  });
+
   it.each([
     "http://127.0.0.1:8000/v1",
     "https://inference.local/v1",

--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -162,7 +162,11 @@ describe("inference selection validation", () => {
 
   it("routes an unreachable custom endpoint through transport recovery, not a silent loop (#6854)", async () => {
     const probeOpenAiLikeEndpoint = vi.fn(() => ({ ok: true, api: "openai-completions" }));
-    const promptValidationRecovery = vi.fn(async () => "retry" as const);
+    let capturedRecovery: { kind?: string } | undefined;
+    const promptValidationRecovery = vi.fn(async (_label: string, recovery: { kind?: string }) => {
+      capturedRecovery = recovery;
+      return "retry" as const;
+    });
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     const helpers = createInferenceSelectionValidationHelpers({
       isNonInteractive: () => false,
@@ -186,8 +190,7 @@ describe("inference selection validation", () => {
       // receives a transport classification (DNS/VPN/URL hint + retry/back/exit),
       // not the silent selection loop the private-IP path takes.
       expect(promptValidationRecovery).toHaveBeenCalled();
-      const recovery = promptValidationRecovery.mock.calls[0]?.[1] as { kind?: string };
-      expect(recovery.kind).toBe("transport");
+      expect(capturedRecovery?.kind).toBe("transport");
       expect(probeOpenAiLikeEndpoint).not.toHaveBeenCalled();
     } finally {
       error.mockRestore();

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -162,15 +162,26 @@ export function createInferenceSelectionValidationHelpers(
     // the probe could otherwise rebind to a private/internal address after this
     // public preflight (TOCTOU — cv review, #6293).
     if (preflight.ok) return { pinnedAddresses: preflight.addresses };
+    const reason = preflight.reason ?? "endpoint resolves to a private/internal address";
+    // A preflight failure because the host does not resolve (an unreachable /
+    // non-existent endpoint) is a transport failure, not an endpoint-policy
+    // rejection. Mark it with curl's "could not resolve host" status (6) so it
+    // routes through the transport recovery path — a DNS/VPN/endpoint-URL hint
+    // plus a retry/back/exit prompt — instead of silently looping back to
+    // provider selection. A private-IP SSRF block keeps status 0: it resolved
+    // fine, the address is just refused. (#6854)
+    const unresolvedHost = /cannot resolve endpoint host|did not resolve to any address/i.test(
+      reason,
+    );
     const syntheticProbe = {
       ok: false as const,
-      message: preflight.reason,
+      message: reason,
       failures: [
         {
           name: "SSRF preflight",
           httpStatus: 0,
-          curlStatus: 0,
-          message: preflight.reason ?? "endpoint resolves to a private/internal address",
+          curlStatus: unresolvedHost ? 6 : 0,
+          message: reason,
           body: "",
         },
       ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
During `nemoclaw onboard`, choosing "Other OpenAI-compatible endpoint" and entering a DNS-unreachable base URL (`https://example.invalid/v1`) failed the SSRF preflight and **silently looped back to provider selection** — no probe guidance, no retry/back/exit prompt, no clean exit. This PR routes an unreachable endpoint through the existing transport-recovery path (DNS/VPN/URL hint + retry/back/exit + exit), matching the credential-failure path. The safety property is unchanged: no sandbox is created.

Closes #6854.

## Reproduction
Exercised the real compiled recovery path on our DGX Spark aarch64 test host (matching the reporter's DGX Spark aarch64), driving `validateCustomOpenAiLikeSelection` against a host that does not resolve and capturing the recovery classification handed to the prompt.

**Environment**
- Test machine: our DGX Spark aarch64 test host (GB10 GPU), Ubuntu 24.04
- NemoClaw `main` (v0.0.82)

**Observed on `main` (before fix)**
```
recovery.kind = unknown     # -> promptValidationRecovery falls through to the
                            #    silent "Please choose a provider/model again"
                            #    branch and loops back to provider selection
```

**Observed on `fix/...` (after fix)**
```
recovery.kind = transport   # -> "Validation could not resolve the provider
                            #    hostname. Check DNS, VPN, or the endpoint URL."
                            #    + "Type 'retry', 'back', or 'exit'"
```

## Analysis
`preflightCustomEndpointOrFail` (`src/lib/onboard/inference-selection-validation.ts`) builds a synthetic probe failure for an SSRF-preflight failure with `curlStatus: 0` and `httpStatus: 0`. `classifyValidationFailure` has no status to key on, so it returns `kind: "unknown"` (retry: "selection"), and `promptValidationRecovery` takes its final else-branch — printing "Please choose a provider/model again" and returning to the menu with no guidance and no exit option. The credential path and every real transport failure (curl exit 6/7/28, HTTP 429/5xx) instead get `getTransportRecoveryMessage` + a retry/back/exit prompt. A DNS-unreachable endpoint is genuinely a transport failure, but the synthetic failure never carried that signal.

## Fix
When the preflight reason is a host-resolution failure (`cannot resolve endpoint host …` / `did not resolve to any address`), mark the synthetic failure with curl's "could not resolve host" status (6). It then classifies as `transport` and routes through the existing transport recovery — which already emits the "Check DNS, VPN, or the endpoint URL" hint (curl 6 branch) and the retry/back/exit prompt with a clean exit. A private-IP SSRF block keeps status 0 (it resolved fine; the address is just refused), so that path is unchanged. No new recovery UI is added — the fix reuses the existing transport contract.

## Changes
- `src/lib/onboard/inference-selection-validation.ts`: classify an unresolved-host SSRF-preflight failure as a transport failure.
- `src/lib/onboard/inference-selection-validation.test.ts`: regression test that an unreachable endpoint yields a transport recovery.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)

## Verification
- [x] `npm test` passes (touched files)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for custom OpenAI-compatible endpoints when DNS/host resolution fails.
  * Unreachable endpoints are now classified as transport failures, triggering the appropriate recovery flow instead of being treated as blocked/unsafe.
  * Continued to keep separate handling for endpoints that resolve to private or internal network addresses.
* **Tests**
  * Added coverage to confirm DNS-style failures are detected as transport issues and follow the expected recovery path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->