### PR TITLE
fix(checks): run Windows command shims through cmd

### DIFF
--- a/scripts/checks/run.ts
+++ b/scripts/checks/run.ts
@@ -15,6 +15,7 @@ type CheckCommand = {
 
 type CheckSpawnResult = {
   status: number | null;
+  error?: Error;
 };
 
 type CheckSpawn = (command: string, args: string[], options: SpawnSyncOptions) => CheckSpawnResult;
@@ -135,6 +136,9 @@ export function runChecks(options: RunChecksOptions = {}): void {
     });
     if (result.status !== 0) {
       console.error(`Check failed: ${check.name}`);
+      if (result.status === null && result.error?.message) {
+        console.error(result.error.message);
+      }
       exit(result.status ?? 1);
     }
   }

--- a/scripts/checks/run.ts
+++ b/scripts/checks/run.ts
@@ -3,7 +3,7 @@
 
 /** Runs local repository checks that are not first-class Biome rules. */
 
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,9 +13,20 @@ type CheckCommand = {
   args: string[];
 };
 
+type CheckSpawnResult = {
+  status: number | null;
+};
+
+type CheckSpawn = (command: string, args: string[], options: SpawnSyncOptions) => CheckSpawnResult;
+
+type SpawnInvocation = {
+  command: string;
+  args: string[];
+};
+
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const TSX = process.platform === "win32" ? "tsx.cmd" : "tsx";
-const CHECKS: readonly CheckCommand[] = [
+export const CHECKS: readonly CheckCommand[] = [
   {
     name: "direct-credential-env",
     command: TSX,
@@ -83,18 +94,53 @@ const CHECKS: readonly CheckCommand[] = [
   },
 ];
 
-function main(): void {
-  for (const check of CHECKS) {
-    const result = spawnSync(check.command, check.args, {
+type RunChecksOptions = {
+  checks?: readonly CheckCommand[];
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  spawn?: CheckSpawn;
+  exit?: (code?: number) => never;
+};
+
+export function buildCheckSpawnInvocation(
+  check: CheckCommand,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): SpawnInvocation {
+  if (platform === "win32") {
+    return {
+      command: env.ComSpec || "cmd.exe",
+      args: ["/d", "/s", "/c", check.command, ...check.args],
+    };
+  }
+  return {
+    command: check.command,
+    args: check.args,
+  };
+}
+
+export function runChecks(options: RunChecksOptions = {}): void {
+  const checks = options.checks ?? CHECKS;
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const spawn: CheckSpawn =
+    options.spawn ?? ((command, args, spawnOptions) => spawnSync(command, args, spawnOptions));
+  const exit = options.exit ?? process.exit;
+  for (const check of checks) {
+    const invocation = buildCheckSpawnInvocation(check, platform, env);
+    const result = spawn(invocation.command, invocation.args, {
       cwd: REPO_ROOT,
       encoding: "utf-8",
       stdio: "inherit",
     });
     if (result.status !== 0) {
       console.error(`Check failed: ${check.name}`);
-      process.exit(result.status ?? 1);
+      exit(result.status ?? 1);
     }
   }
 }
 
-main();
+const currentModule = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentModule) {
+  runChecks();
+}

--- a/test/checks-runner.test.ts
+++ b/test/checks-runner.test.ts
@@ -80,14 +80,37 @@ describe("checks runner", () => {
   it("exits with one when a check has no status", () => {
     const spawn = vi.fn((_command: string, _args: string[], _options: SpawnSyncOptions) => ({
       status: null,
+      error: new Error("spawn failed"),
     }));
     const exit = vi.fn((code?: number): never => {
       throw new Error(`exit ${code}`);
     });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     expect(() => runChecks({ checks: [sampleCheck], platform: "linux", spawn, exit })).toThrow(
       "exit 1",
     );
     expect(exit).toHaveBeenCalledWith(1);
+    expect(error).toHaveBeenCalledWith("Check failed: sample");
+    expect(error).toHaveBeenCalledWith("spawn failed");
+    error.mockRestore();
+  });
+
+  it("exits with the check status code on failure", () => {
+    const spawn = vi.fn((_command: string, _args: string[], _options: SpawnSyncOptions) => ({
+      status: 2,
+    }));
+    const exit = vi.fn((code?: number): never => {
+      throw new Error(`exit ${code}`);
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(() => runChecks({ checks: [sampleCheck], platform: "linux", spawn, exit })).toThrow(
+      "exit 2",
+    );
+    expect(exit).toHaveBeenCalledWith(2);
+    expect(error).toHaveBeenCalledWith("Check failed: sample");
+    expect(error).not.toHaveBeenCalledWith("spawn failed");
+    error.mockRestore();
   });
 });

--- a/test/checks-runner.test.ts
+++ b/test/checks-runner.test.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SpawnSyncOptions } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+
+import { buildCheckSpawnInvocation, runChecks } from "../scripts/checks/run";
+
+const sampleCheck = {
+  name: "sample",
+  command: "tsx.cmd",
+  args: ["scripts/checks/sample.ts"],
+};
+
+function successfulSpawn(): { status: number | null } {
+  return { status: 0 };
+}
+
+describe("checks runner", () => {
+  it("runs Windows command shims through cmd.exe", () => {
+    expect(
+      buildCheckSpawnInvocation(sampleCheck, "win32", {
+        ComSpec: "C:\\Windows\\System32\\cmd.exe",
+      }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", "tsx.cmd", "scripts/checks/sample.ts"],
+    });
+  });
+
+  it("uses cmd.exe when ComSpec is unavailable on Windows", () => {
+    expect(buildCheckSpawnInvocation(sampleCheck, "win32", {})).toMatchObject({
+      command: "cmd.exe",
+    });
+  });
+
+  it("keeps POSIX runner execution direct", () => {
+    expect(buildCheckSpawnInvocation(sampleCheck, "linux")).toEqual({
+      command: "tsx.cmd",
+      args: ["scripts/checks/sample.ts"],
+    });
+  });
+
+  it("uses the Windows shim invocation when running checks", () => {
+    const calls: SpawnSyncOptions[] = [];
+    const spawn = vi.fn((_command: string, _args: string[], options: SpawnSyncOptions) => {
+      calls.push(options);
+      return successfulSpawn();
+    });
+
+    runChecks({
+      checks: [sampleCheck],
+      platform: "win32",
+      env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+      spawn,
+    });
+
+    expect(spawn).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\cmd.exe",
+      ["/d", "/s", "/c", "tsx.cmd", "scripts/checks/sample.ts"],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+    expect(calls[0]?.shell).toBeUndefined();
+  });
+
+  it("uses direct execution when running checks on POSIX", () => {
+    const spawn = vi.fn((_command: string, _args: string[], _options: SpawnSyncOptions) =>
+      successfulSpawn(),
+    );
+
+    runChecks({ checks: [sampleCheck], platform: "linux", spawn });
+
+    expect(spawn).toHaveBeenCalledWith(
+      "tsx.cmd",
+      ["scripts/checks/sample.ts"],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+  });
+
+  it("exits with one when a check has no status", () => {
+    const spawn = vi.fn((_command: string, _args: string[], _options: SpawnSyncOptions) => ({
+      status: null,
+    }));
+    const exit = vi.fn((code?: number): never => {
+      throw new Error(`exit ${code}`);
+    });
+
+    expect(() => runChecks({ checks: [sampleCheck], platform: "linux", spawn, exit })).toThrow(
+      "exit 1",
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Repository checks now invoke Windows `.cmd` shims through `cmd.exe` instead of spawning the shim directly. This keeps `npm run checks` usable on Windows where direct `spawnSync('*.cmd')` returns `EINVAL`, while leaving POSIX execution direct.

## Changes
- Split `scripts/checks/run.ts` into testable invocation helpers while preserving the existing check list and script entry point.
- Route Windows check commands as `cmd.exe /d /s /c <shim> ...args` so `tsx.cmd` can run under Node on Windows.
- Add integration coverage for Windows shim invocation, POSIX direct invocation, and null-status failure handling.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: contributor validation tooling behavior changed, but no command syntax, documented workflow, or user-facing CLI behavior changed.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: DGX Spark/Linux: `npx vitest run --project integration test/checks-runner.test.ts` passed; Windows local mechanism check showed direct `spawnSync('npm.cmd')` returns `EINVAL` while `cmd.exe /d /s /c npm.cmd --version` exits 0.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: DGX Spark/Linux `npm run checks`, `npm run typecheck:cli`, and `npm run check:diff` passed. `npm run check` was attempted but the host lacks `hadolint`, and the separate all-files manual coverage stage exceeded the 10-minute local timeout; no broad-gate success is claimed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: HwangJohn <angelic805@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform execution of project checks, including reliable Windows command handling via `ComSpec`/cmd.exe routing.
  * Ensured failed or incomplete checks correctly trigger error exit codes.

* **Refactor**
  * Check execution was reworked into reusable, exported runner utilities with injectable spawn/exit behavior while preserving CLI behavior.

* **Tests**
  * Added coverage for Windows and POSIX invocation building, environment handling, output forwarding, and failure-path exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->