### PR TITLE
fix(onboard): honor provider model env for Ollama

### DIFF
--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -172,7 +172,7 @@ The following settings control non-interactive selection:
 |---|---|
 | `NEMOCLAW_PROVIDER` | Set to `ollama`. |
 | `NEMOCLAW_MODEL` | Optional Ollama model tag. |
-| `NEMOCLAW_PROVIDER_MODEL` | Compatibility fallback for automation that cannot pass `NEMOCLAW_MODEL`. Ignored when `NEMOCLAW_MODEL` is set. |
+| `NEMOCLAW_PROVIDER_MODEL` | Compatibility fallback for the NVIDIA QA non-interactive Ollama invocation tracked in [#6869](https://github.com/NVIDIA/NemoClaw/issues/6869). Ignored when `NEMOCLAW_MODEL` is set; remove after that workflow migrates to `NEMOCLAW_MODEL`. |
 | `NEMOCLAW_YES` | Optional model download authorization when set to `1`. |
 
 Under `--non-interactive`, include `--yes` or set `NEMOCLAW_YES=1` to authorize a model download.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -172,6 +172,7 @@ The following settings control non-interactive selection:
 |---|---|
 | `NEMOCLAW_PROVIDER` | Set to `ollama`. |
 | `NEMOCLAW_MODEL` | Optional Ollama model tag. |
+| `NEMOCLAW_PROVIDER_MODEL` | Compatibility fallback for automation that cannot pass `NEMOCLAW_MODEL`. Ignored when `NEMOCLAW_MODEL` is set. |
 | `NEMOCLAW_YES` | Optional model download authorization when set to `1`. |
 
 Under `--non-interactive`, include `--yes` or set `NEMOCLAW_YES=1` to authorize a model download.
@@ -179,7 +180,9 @@ Onboarding exits when a download requires confirmation and the run cannot prompt
 
 ## Understand Model Selection
 
-When `NEMOCLAW_MODEL` is unset, NemoClaw selects a starter model based on currently available memory.
+When `NEMOCLAW_MODEL` and the `NEMOCLAW_PROVIDER_MODEL` compatibility fallback are unset, NemoClaw selects a starter model based on currently available memory.
+During interactive onboarding, if the requested model env contains a safe model tag that appears in the current Ollama menu, NemoClaw uses that menu entry as the default.
+If the tag is absent from the rendered installed or starter list, the normal memory-based default remains.
 If a known bootstrap model does not fit, NemoClaw warns and falls back to the largest known model that does fit.
 Unknown or custom tags pass through to the Ollama runner for validation.
 

--- a/src/lib/inference/ollama/proxy.test.ts
+++ b/src/lib/inference/ollama/proxy.test.ts
@@ -136,6 +136,42 @@ describe("promptOllamaModel installed-model fit filter", () => {
     expect(result).toBe("qwen3.5:9b");
   });
 
+  it("defaults to a requested model when it is shown in the installed model menu", async () => {
+    const setup = loadProxyWithMocks({
+      installed: ["qwen2.5:0.5b", "qwen3.6:35b"],
+      promptValues: [""],
+    });
+    active = setup;
+    const result = await setup.proxy.promptOllamaModel(
+      {
+        type: "nvidia",
+        totalMemoryMB: 131_072,
+        availableMemoryMB: 131_072,
+      },
+      { defaultModel: "qwen3.6:35b" },
+    );
+    expect(result).toBe("qwen3.6:35b");
+    expect(setup.promptArgs).toEqual(["  Choose model [2]: "]);
+  });
+
+  it("keeps the memory-based default when a requested model is not shown", async () => {
+    const setup = loadProxyWithMocks({
+      installed: ["qwen2.5:0.5b", "qwen3.5:9b"],
+      promptValues: [""],
+    });
+    active = setup;
+    const result = await setup.proxy.promptOllamaModel(
+      {
+        type: "nvidia",
+        totalMemoryMB: 131_072,
+        availableMemoryMB: 131_072,
+      },
+      { defaultModel: "qwen3.6:35b" },
+    );
+    expect(result).toBe("qwen2.5:0.5b");
+    expect(setup.promptArgs).toEqual(["  Choose model [1]: "]);
+  });
+
   it("respects unknown installed tags (not in the registry) even when nothing else fits", async () => {
     const setup = loadProxyWithMocks({
       installed: ["my-custom:model"],

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -16,6 +16,7 @@ const { isNonInteractiveEnv }: typeof import("../../core/non-interactive") =
 const { waitForPort } = require("../../core/wait");
 const { ensurePulledOllamaModel }: typeof import("./model-discovery") =
   require("./model-discovery");
+const { ollamaModelRefsMatch }: typeof import("./model-discovery") = require("./model-discovery");
 const {
   getDefaultOllamaModel,
   getBootstrapOllamaModelOptions,
@@ -491,7 +492,7 @@ function probeOllamaAuthProxyHealth(): { ok: boolean; endpoint: string; detail: 
 
 async function promptOllamaModel(
   gpu: GpuInfo | null = null,
-  promptOptions: { excludeModels?: ReadonlySet<string> } = {},
+  promptOptions: { defaultModel?: string | null; excludeModels?: ReadonlySet<string> } = {},
 ) {
   const excludeModels = promptOptions.excludeModels;
   const isExcluded = (tag: string): boolean =>
@@ -510,11 +511,21 @@ async function promptOllamaModel(
   const usingInstalled = installedFitting.length > 0;
   const bootstrap = getBootstrapOllamaModelOptions(gpu).filter((tag: string) => !isExcluded(tag));
   const options = usingInstalled ? installedFitting : bootstrap;
+  const requestedDefaultModel =
+    typeof promptOptions.defaultModel === "string" ? promptOptions.defaultModel.trim() : "";
+  const requestedDefaultOption = requestedDefaultModel
+    ? options.find((option: string) => ollamaModelRefsMatch(option, requestedDefaultModel))
+    : undefined;
   const defaultModelCandidate = getDefaultOllamaModel(gpu);
-  const defaultModel = isExcluded(defaultModelCandidate)
-    ? (options[0] ?? defaultModelCandidate)
-    : defaultModelCandidate;
-  const defaultIndex = Math.max(0, options.indexOf(defaultModel));
+  const defaultModel =
+    requestedDefaultOption ??
+    (isExcluded(defaultModelCandidate)
+      ? (options[0] ?? defaultModelCandidate)
+      : defaultModelCandidate);
+  const defaultIndex = Math.max(
+    0,
+    options.findIndex((option: string) => ollamaModelRefsMatch(option, defaultModel)),
+  );
 
   console.log("");
   console.log(usingInstalled ? "  Ollama models:" : "  Ollama starter models:");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2999,12 +2999,8 @@ type OllamaModelSelectionOutcome =
 async function selectAndValidateOllamaModel(
   gpu: ReturnType<typeof nim.detectGpu>,
   provider: string,
-  defaults: {
-    requestedModel: string | null;
-    recoveredModel: string | null;
-    lockedModel?: string | null;
-    promptDefaultModel?: string | null;
-  },
+  // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+  defaults: { requestedModel: string | null; recoveredModel: string | null; lockedModel?: string | null; promptDefaultModel?: string | null },
   onModelSelected?: (model: string) => void,
 ): Promise<OllamaModelSelectionOutcome> {
   const { requestedModel, recoveredModel, lockedModel, promptDefaultModel } = defaults;
@@ -3020,12 +3016,8 @@ async function selectAndValidateOllamaModel(
     } else if (isNonInteractive()) {
       model = localInference.resolveNonInteractiveOllamaModel(requestedModel, recoveredModel, gpu);
     } else {
-      const safePromptDefaultModel =
-        promptDefaultModel && isSafeModelId(promptDefaultModel) ? promptDefaultModel : null;
-      model = await promptOllamaModel(gpu, {
-        defaultModel: safePromptDefaultModel,
-        excludeModels: probeFailures.excludedModels(),
-      });
+      // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+      model = await promptOllamaModel(gpu, { defaultModel: promptDefaultModel && isSafeModelId(promptDefaultModel) ? promptDefaultModel : null, excludeModels: probeFailures.excludedModels() });
     }
     if (isBackToSelection(model)) {
       console.log("  Returning to provider selection.");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3003,10 +3003,11 @@ async function selectAndValidateOllamaModel(
     requestedModel: string | null;
     recoveredModel: string | null;
     lockedModel?: string | null;
+    promptDefaultModel?: string | null;
   },
   onModelSelected?: (model: string) => void,
 ): Promise<OllamaModelSelectionOutcome> {
-  const { requestedModel, recoveredModel, lockedModel } = defaults;
+  const { requestedModel, recoveredModel, lockedModel, promptDefaultModel } = defaults;
   const probeFailures = new OllamaProbeFailureTracker();
   const confirm = (question: string, defaultIsYes: boolean) =>
     promptYesNoOrDefault(question, null, defaultIsYes);
@@ -3019,7 +3020,12 @@ async function selectAndValidateOllamaModel(
     } else if (isNonInteractive()) {
       model = localInference.resolveNonInteractiveOllamaModel(requestedModel, recoveredModel, gpu);
     } else {
-      model = await promptOllamaModel(gpu, { excludeModels: probeFailures.excludedModels() });
+      const safePromptDefaultModel =
+        promptDefaultModel && isSafeModelId(promptDefaultModel) ? promptDefaultModel : null;
+      model = await promptOllamaModel(gpu, {
+        defaultModel: safePromptDefaultModel,
+        excludeModels: probeFailures.excludedModels(),
+      });
     }
     if (isBackToSelection(model)) {
       console.log("  Returning to provider selection.");

--- a/src/lib/onboard/providers.test.ts
+++ b/src/lib/onboard/providers.test.ts
@@ -392,7 +392,7 @@ describe("onboard provider helpers", () => {
     );
   });
 
-  it("uses NEMOCLAW_PROVIDER_MODEL as a non-interactive model fallback", () => {
+  it("supports the NVIDIA QA non-interactive provider-model contract (#6869)", () => {
     withProviderEnv(
       {
         NEMOCLAW_PROVIDER: "ollama",

--- a/src/lib/onboard/providers.test.ts
+++ b/src/lib/onboard/providers.test.ts
@@ -81,6 +81,7 @@ function withProviderEnv(next: Record<string, string | undefined>, testBody: () 
     "NEMOCLAW_PROVIDER",
     "NEMOCLAW_ENDPOINT_URL",
     "NEMOCLAW_MODEL",
+    "NEMOCLAW_PROVIDER_MODEL",
     "NEMOCLAW_COMPAT_MODEL",
     "NEMOCLAW_PREFERRED_API",
     "NEMOCLAW_CLOUD_EXPERIMENTAL_MODEL",
@@ -387,6 +388,31 @@ describe("onboard provider helpers", () => {
         expect(process.env.NEMOCLAW_PROVIDER).toBeUndefined();
         expect(process.env.NEMOCLAW_MODEL).toBeUndefined();
         expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
+      },
+    );
+  });
+
+  it("uses NEMOCLAW_PROVIDER_MODEL as a non-interactive model fallback", () => {
+    withProviderEnv(
+      {
+        NEMOCLAW_PROVIDER: "ollama",
+        NEMOCLAW_PROVIDER_MODEL: "qwen3.6:35b",
+      },
+      () => {
+        expect(getRequestedModelHint(true)).toBe("qwen3.6:35b");
+      },
+    );
+  });
+
+  it("keeps NEMOCLAW_MODEL ahead of NEMOCLAW_PROVIDER_MODEL", () => {
+    withProviderEnv(
+      {
+        NEMOCLAW_PROVIDER: "ollama",
+        NEMOCLAW_MODEL: "qwen2.5:0.5b",
+        NEMOCLAW_PROVIDER_MODEL: "qwen3.6:35b",
+      },
+      () => {
+        expect(getRequestedModelHint(true)).toBe("qwen2.5:0.5b");
       },
     );
   });

--- a/src/lib/onboard/providers.ts
+++ b/src/lib/onboard/providers.ts
@@ -309,6 +309,9 @@ function isHostedInferenceProviderKeyCredentialCandidate(value) {
 
 const isProviderKeyCredentialCandidate = isHostedInferenceProviderKeyCredentialCandidate;
 
+/**
+ * Resolve the requested model from the preferred env var or its compatibility fallback.
+ */
 function getRequestedModelEnv(env = process.env) {
   const model = (env[MODEL_ENV] || "").trim();
   if (model) return { value: model, source: MODEL_ENV };
@@ -317,6 +320,9 @@ function getRequestedModelEnv(env = process.env) {
   return { value: "", source: null };
 }
 
+/**
+ * Return the requested model value without exposing which env var supplied it.
+ */
 function getRequestedModelFromEnv(env = process.env) {
   return getRequestedModelEnv(env).value || null;
 }

--- a/src/lib/onboard/providers.ts
+++ b/src/lib/onboard/providers.ts
@@ -30,6 +30,8 @@ const HOSTED_INFERENCE_PROVIDER_KEY_ENV = "NEMOCLAW_PROVIDER_KEY";
 const HOSTED_INFERENCE_CREDENTIAL_ENV = "COMPATIBLE_API_KEY";
 const HOSTED_INFERENCE_ENDPOINT_URL = "https://inference-api.nvidia.com/v1";
 const MODEL_ENV = "NEMOCLAW_MODEL";
+// Compatibility for the NVIDIA QA non-interactive Ollama invocation tracked
+// in #6869. Remove after that workflow migrates to NEMOCLAW_MODEL.
 const PROVIDER_MODEL_ENV = "NEMOCLAW_PROVIDER_MODEL";
 // Private CI-compatible Inference Hub endpoint model IDs use the
 // provider/namespace/model convention. This endpoint is staged as a custom

--- a/src/lib/onboard/providers.ts
+++ b/src/lib/onboard/providers.ts
@@ -29,6 +29,8 @@ const HOSTED_INFERENCE_SOURCE_ENV = "NVIDIA_INFERENCE_API_KEY";
 const HOSTED_INFERENCE_PROVIDER_KEY_ENV = "NEMOCLAW_PROVIDER_KEY";
 const HOSTED_INFERENCE_CREDENTIAL_ENV = "COMPATIBLE_API_KEY";
 const HOSTED_INFERENCE_ENDPOINT_URL = "https://inference-api.nvidia.com/v1";
+const MODEL_ENV = "NEMOCLAW_MODEL";
+const PROVIDER_MODEL_ENV = "NEMOCLAW_PROVIDER_MODEL";
 // Private CI-compatible Inference Hub endpoint model IDs use the
 // provider/namespace/model convention. This endpoint is staged as a custom
 // OpenAI-compatible provider, not as the public build.nvidia.com provider.
@@ -288,11 +290,11 @@ function stageHostedInferenceSourceSecretEnv() {
   process.env.NEMOCLAW_ENDPOINT_URL =
     (process.env.NEMOCLAW_ENDPOINT_URL || "").trim() || HOSTED_INFERENCE_ENDPOINT_URL;
   const model =
-    (process.env.NEMOCLAW_MODEL || "").trim() ||
+    getRequestedModelFromEnv() ||
     (process.env.NEMOCLAW_COMPAT_MODEL || "").trim() ||
     (process.env.NEMOCLAW_CLOUD_EXPERIMENTAL_MODEL || "").trim() ||
     HOSTED_INFERENCE_MODEL;
-  process.env.NEMOCLAW_MODEL = model;
+  process.env[MODEL_ENV] = model;
   process.env.NEMOCLAW_COMPAT_MODEL = (process.env.NEMOCLAW_COMPAT_MODEL || "").trim() || model;
   process.env.NEMOCLAW_PREFERRED_API =
     (process.env.NEMOCLAW_PREFERRED_API || "").trim() || "openai-completions";
@@ -307,11 +309,23 @@ function isHostedInferenceProviderKeyCredentialCandidate(value) {
 
 const isProviderKeyCredentialCandidate = isHostedInferenceProviderKeyCredentialCandidate;
 
+function getRequestedModelEnv(env = process.env) {
+  const model = (env[MODEL_ENV] || "").trim();
+  if (model) return { value: model, source: MODEL_ENV };
+  const providerModel = (env[PROVIDER_MODEL_ENV] || "").trim();
+  if (providerModel) return { value: providerModel, source: PROVIDER_MODEL_ENV };
+  return { value: "", source: null };
+}
+
+function getRequestedModelFromEnv(env = process.env) {
+  return getRequestedModelEnv(env).value || null;
+}
+
 function getNonInteractiveModel(providerKey) {
-  const model = (process.env.NEMOCLAW_MODEL || "").trim();
+  const { value: model, source } = getRequestedModelEnv();
   if (!model) return null;
   if (!isSafeModelId(model)) {
-    console.error(`  Invalid NEMOCLAW_MODEL for provider '${providerKey}': ${model}`);
+    console.error(`  Invalid ${source || MODEL_ENV} for provider '${providerKey}': ${model}`);
     console.error("  Model values may only contain letters, numbers, '.', '_', ':', '/', and '-'.");
     process.exit(1);
   }
@@ -510,6 +524,7 @@ module.exports = {
   stageHostedInferenceSourceSecretEnv,
   getNonInteractiveProvider,
   getNonInteractiveModel,
+  getRequestedModelFromEnv,
   getRequestedProviderHint,
   getRequestedModelHint,
   isProviderKeyCredentialCandidate,

--- a/src/lib/onboard/setup-nim-ollama.test.ts
+++ b/src/lib/onboard/setup-nim-ollama.test.ts
@@ -136,7 +136,11 @@ describe("createSetupNimOllamaHandlers", () => {
         isNonInteractive: () => false,
         process: {
           ...process,
-          env: { ...process.env, NEMOCLAW_PROVIDER_MODEL: "qwen3.6:35b" },
+          env: {
+            ...process.env,
+            NEMOCLAW_MODEL: undefined,
+            NEMOCLAW_PROVIDER_MODEL: "qwen3.6:35b",
+          },
         } as NodeJS.Process,
         selectAndValidateOllamaModel: selectModel,
       }),

--- a/src/lib/onboard/setup-nim-ollama.test.ts
+++ b/src/lib/onboard/setup-nim-ollama.test.ts
@@ -80,6 +80,7 @@ describe("createSetupNimOllamaHandlers", () => {
         },
         selectAndValidateOllamaModel: async (_gpu, _provider, args, onModelSelected) => {
           expect(args.lockedModel).toBe("required/model");
+          expect(args.promptDefaultModel).toBeNull();
           events.push("prepare-model");
           onModelSelected?.("required/model");
           return { outcome: "selected", model: "required/model", allowToolsIncompatible: false };
@@ -95,6 +96,56 @@ describe("createSetupNimOllamaHandlers", () => {
       "prepare-model",
       "guard:required/model",
     ]);
+  });
+
+  it("passes NEMOCLAW_MODEL as the interactive Ollama prompt default", async () => {
+    const state = makeState();
+    const selectModel = vi.fn(async (_gpu, _provider, args) => {
+      expect(args.requestedModel).toBeNull();
+      expect(args.lockedModel).toBeNull();
+      expect(args.promptDefaultModel).toBe("qwen3.6:35b");
+      return { outcome: "selected" as const, model: "qwen3.6:35b", allowToolsIncompatible: false };
+    });
+    const { handleRunningOllamaSelection } = createSetupNimOllamaHandlers(
+      makeDeps({
+        isNonInteractive: () => false,
+        process: {
+          ...process,
+          env: { ...process.env, NEMOCLAW_MODEL: "qwen3.6:35b" },
+        } as NodeJS.Process,
+        selectAndValidateOllamaModel: selectModel,
+      }),
+    );
+
+    const result = await handleRunningOllamaSelection(null, null, null, true, state);
+
+    expect(result).toBe("selected");
+    expect(selectModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes NEMOCLAW_PROVIDER_MODEL as the interactive Ollama prompt default fallback", async () => {
+    const state = makeState();
+    const selectModel = vi.fn(async (_gpu, _provider, args) => {
+      expect(args.requestedModel).toBeNull();
+      expect(args.lockedModel).toBeNull();
+      expect(args.promptDefaultModel).toBe("qwen3.6:35b");
+      return { outcome: "selected" as const, model: "qwen3.6:35b", allowToolsIncompatible: false };
+    });
+    const { handleRunningOllamaSelection } = createSetupNimOllamaHandlers(
+      makeDeps({
+        isNonInteractive: () => false,
+        process: {
+          ...process,
+          env: { ...process.env, NEMOCLAW_PROVIDER_MODEL: "qwen3.6:35b" },
+        } as NodeJS.Process,
+        selectAndValidateOllamaModel: selectModel,
+      }),
+    );
+
+    const result = await handleRunningOllamaSelection(null, null, null, true, state);
+
+    expect(result).toBe("selected");
+    expect(selectModel).toHaveBeenCalledTimes(1);
   });
 
   it("does not install Ollama when shared-gateway preflight rejects", async () => {

--- a/src/lib/onboard/setup-nim-ollama.ts
+++ b/src/lib/onboard/setup-nim-ollama.ts
@@ -4,6 +4,12 @@
 import type { OllamaStartupOutcome } from "./ollama-startup";
 import type { SetupNimSelectionState } from "./setup-nim-selection";
 
+const {
+  getRequestedModelFromEnv,
+}: {
+  getRequestedModelFromEnv: (env?: NodeJS.ProcessEnv) => string | null;
+} = require("./providers");
+
 type SetupNimSelectionResult = "selected" | "retry-selection";
 
 type SetupNimOllamaDeps = {
@@ -30,6 +36,7 @@ type SetupNimOllamaDeps = {
       requestedModel: string | null;
       recoveredModel: string | null;
       lockedModel?: string | null;
+      promptDefaultModel?: string | null;
     },
     onModelSelected?: (model: string) => void,
   ) => Promise<
@@ -91,6 +98,8 @@ export function createSetupNimOllamaHandlers(deps: SetupNimOllamaDeps): {
     lockedModel: string | null,
   ): Promise<SetupNimSelectionResult> {
     const constrainedModel = typeof state.model === "string" ? state.model : requestedModel;
+    const promptDefaultModel =
+      !lockedModel && !deps.isNonInteractive() ? getRequestedModelFromEnv(deps.process.env) : null;
     const result = await deps.selectAndValidateOllamaModel(
       gpu,
       state.provider,
@@ -98,6 +107,7 @@ export function createSetupNimOllamaHandlers(deps: SetupNimOllamaDeps): {
         requestedModel: constrainedModel,
         recoveredModel,
         lockedModel,
+        promptDefaultModel,
       },
       (model) => {
         state.model = model;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Honor `NEMOCLAW_PROVIDER_MODEL` as a compatibility fallback for Ollama onboarding while keeping `NEMOCLAW_MODEL` as the preferred model env. Interactive Ollama selection now defaults to the requested model when that model appears in the rendered menu, instead of falling back to the memory-based or alphabetically-first default.

## Related Issue

Fixes #6869

## Changes

- Add a shared requested-model env reader that prefers `NEMOCLAW_MODEL` and falls back to `NEMOCLAW_PROVIDER_MODEL` for non-interactive provider selection.
- Pass the requested model env into interactive Ollama model prompting only when no route-compatibility lock already controls the model.
- Match the requested default against rendered Ollama menu entries with existing Ollama model-reference normalization, and keep the memory-based default when the requested model is not shown.
- Document the `NEMOCLAW_PROVIDER_MODEL` compatibility fallback for Ollama and add regression coverage for env precedence, interactive defaults, and hidden requested models.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Contributor self-review focused on onboarding/inference env precedence and validation; the change does not read credentials, alter policy, or expose new secret material. Maintainer review is still required before merge.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — `npm run check:diff` passed on DGX Spark Linux/aarch64 against the committed diff
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/inference/ollama/proxy.test.ts src/lib/onboard/setup-nim-ollama.test.ts src/lib/onboard/providers.test.ts` passed locally on Windows and on DGX Spark Linux/aarch64 (71 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable; this is a focused onboarding/inference env handling change covered by targeted tests, docs build, CLI build, and diff gate
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — `npm run docs` passed on DGX Spark Linux/aarch64 with 0 errors; Fern reported existing hidden warnings/upgrade notice, so this box is left unchecked
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: HwangJohn <angelic805@gmail.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compatibility support for configuring a provider model via `NEMOCLAW_PROVIDER_MODEL`.
  * Enhanced interactive Ollama onboarding: when a requested “safe” model tag exists in the current Ollama menu, it’s used as the default selection.
* **Bug Fixes**
  * Improved Ollama model selection to match models by reference and compute the default selection index correctly.
  * If the requested model isn’t available, the app now consistently falls back to the memory-based default.
* **Documentation**
  * Updated Ollama onboarding docs to describe `NEMOCLAW_PROVIDER_MODEL` and the interactive/non-interactive default-model fallback behavior.
* **Tests**
  * Added/expanded unit tests for provider-model selection and interactive default-model forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->