### PR TITLE
test(e2e): avoid repeated Jetson workflow validation

### DIFF
--- a/test/e2e/support/jetson-workflow-boundary.test.ts
+++ b/test/e2e/support/jetson-workflow-boundary.test.ts
@@ -1,13 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
 import { describe, expect, it } from "vitest";
-import YAML from "yaml";
-import { validateE2eWorkflowBoundary } from "../../../tools/e2e/workflow-boundary.mts";
+import {
+  validateE2eWorkflowBoundary,
+  validateJetsonRunnerDispatchBoundary,
+} from "../../../tools/e2e/workflow-boundary.mts";
 import { readWorkflow } from "../../helpers/e2e-workflow-contract.ts";
 
 function validateWorkflowMutation(
@@ -15,14 +13,7 @@ function validateWorkflowMutation(
 ): string[] {
   const workflow = readWorkflow();
   mutate(workflow);
-  const directory = mkdtempSync(join(tmpdir(), "nemoclaw-jetson-guard-"));
-  const workflowPath = join(directory, "workflow.yaml");
-  try {
-    writeFileSync(workflowPath, YAML.stringify(workflow));
-    return validateE2eWorkflowBoundary(workflowPath);
-  } finally {
-    rmSync(directory, { force: true, recursive: true });
-  }
+  return validateJetsonRunnerDispatchBoundary(workflow);
 }
 
 describe("Jetson nvmap GPU E2E workflow boundary", () => {
@@ -58,16 +49,12 @@ describe("Jetson nvmap GPU E2E workflow boundary", () => {
       guard!.if = "always()";
       const authIndex = steps.findIndex((step) => step.name === "Authenticate to Docker Hub");
       steps.splice(authIndex + 1, 0, guard!);
-      steps.find((step) => step.name === "Upload Jetson nvmap GPU artifacts")!.if = "success()";
-      steps.find((step) => step.name === "Clean up Docker auth")!.if = "success()";
     });
     expect(guardErrors).toEqual(
       expect.arrayContaining([
         "jetson-nvmap-gpu job must use ubuntu-latest unless allow_jetson_runner_queue is true",
         "jetson-nvmap-gpu dispatch guard must run before Docker Hub auth",
         "jetson-nvmap-gpu dispatch guard must run unless allow_jetson_runner_queue is true",
-        "jetson-nvmap-gpu upload-e2e-artifacts invocation must run with always()",
-        "jetson-nvmap-gpu Docker Hub cleanup step must always run",
       ]),
     );
   });

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -3556,6 +3556,17 @@ function validateJetsonRunnerDispatchGuard(errors: string[], jobs: WorkflowRecor
   requireRunDoesNotContain(errors, guard, "linux-arm64-gpu-jetson-orin-latest-1");
 }
 
+export function validateJetsonRunnerDispatchBoundary(workflow: unknown): string[] {
+  const workflowRecord = asRecord(workflow);
+  const triggers = asRecord(workflowRecord.on ?? workflowRecord[true as unknown as string]);
+  const workflowDispatch = asRecord(triggers.workflow_dispatch);
+  const errors: string[] = [];
+
+  validateAllowJetsonRunnerQueueInput(errors, asRecord(workflowDispatch.inputs));
+  validateJetsonRunnerDispatchGuard(errors, asRecord(workflowRecord.jobs));
+  return errors;
+}
+
 function validateSandboxRlimitConnectJob(errors: string[], jobs: WorkflowRecord): void {
   const jobName = "sandbox-rlimits-connect";
   const job = asRecord(jobs[jobName]);
@@ -3624,7 +3635,6 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
 
   const dispatchInputs = asRecord(workflowDispatch.inputs);
   requireInput(errors, dispatchInputs, "targets");
-  validateAllowJetsonRunnerQueueInput(errors, dispatchInputs);
   const jobsInput = requireInput(errors, dispatchInputs, "jobs");
   const jobsDescription = stringValue(jobsInput.description);
   if (!jobsDescription.includes("default-enabled tests")) {
@@ -3645,6 +3655,7 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
   if (permissions.contents !== "read") errors.push("workflow permissions.contents must be read");
 
   const jobs = asRecord(workflow.jobs);
+  errors.push(...validateJetsonRunnerDispatchBoundary(workflow));
   const { errors: inventoryErrors, inventory: freeStandingInventory } =
     deriveFreeStandingJobsInventoryFromJobs(jobs);
   errors.push(...inventoryErrors);
@@ -4087,7 +4098,6 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
 
   validateFreeStandingJobSelector(errors, jobs, "gateway-health-honest", "gateway-health-honest");
 
-  validateJetsonRunnerDispatchGuard(errors, jobs);
   validateSandboxRlimitConnectJob(errors, jobs);
 
   validateFreeStandingJobSelector(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Jetson workflow mutation tests now validate the runner-dispatch boundary in memory instead of serializing a 249 KB workflow and running the full aggregate validator for every mutation. This keeps `e2e-support` in the combined CLI coverage shards while removing the operation that exceeded the five-second test budget under CI contention.

## Changes

- Add `validateJetsonRunnerDispatchBoundary` as the shared consumer of the existing Jetson workflow input, selector, routing, and guard checks; the aggregate E2E workflow validator continues to invoke it.
- Route focused Jetson mutations through that in-memory boundary instead of temporary YAML files and repeated whole-workflow validation. The current requirement is the combined coverage shard introduced in #6857, and `jetson-workflow-boundary.test.ts` protects the direct and aggregate validator paths.
- Leave artifact-upload and Docker-auth cleanup contracts with their dedicated validators and tests rather than duplicating those cross-cutting assertions in the Jetson dispatch test.
- Reduce the previously failing coverage-mode mutation from 1.35 seconds to 118 milliseconds locally.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal test-harness optimization; no CLI behavior, workflow behavior, contributor command, or user-facing contract changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: No runtime runner path changed. The aggregate validator still invokes the same Jetson input, selector, routing, and dispatch-guard checks, and the complete E2E support suite passes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support`: 116 files and 1,000 tests passed; focused CI-style V8 coverage run: 3 tests passed and the mutation completed in 118 ms.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end workflow validation to check Jetson GPU dispatch boundaries directly and consistently.
  * Refined expected validation results to focus on runner queue settings and dispatch guard ordering.

* **Refactor**
  * Consolidated workflow boundary checks, reducing duplicate validation paths and improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->