### PR TITLE
docs(release): add v0.0.83 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,26 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.83
+
+NemoClaw v0.0.83 makes shared inference route changes explicit and safe, restores DGX Station GB300 express setup, warns on risky local vLLM configurations, and fixes several onboarding and platform edge cases.
+
+- Shared inference route changes are now explicit and fail-safe.
+  When multiple sandboxes share a gateway, onboarding warns immediately before re-pointing the live route and fails closed before replacing a provider-global identity used by another sandbox.
+  Status output shows each sandbox's recorded route, the live route, and whether `connect` can safely restore a drifted route.
+  For more information, refer to [View Active Inference Route](../inference/manage-inference/view-active-inference-route), [Switch Models](../inference/manage-inference/switch-models), and [Troubleshooting](../reference/troubleshooting).
+- DGX Station GB300 systems enter the express-install path, and managed vLLM storage preflight blocks only for a verified shortage rather than inconclusive capacity.
+  For more information, refer to [Set Up vLLM](../inference/local-inference/set-up-vllm) and [NemoClaw CLI Commands Reference](../reference/commands).
+- Onboarding warns when a bring-your-own vLLM server on DGX Spark appears to serve a large unquantized model that may exhaust GPU memory under agent tool-call load.
+  The warning is suppressed for the managed Spark vLLM recipe.
+  For more information, refer to [Set Up vLLM](../inference/local-inference/set-up-vllm) and [Troubleshooting](../reference/troubleshooting).
+- Re-onboarding with the reuse path preserves tier-default policy presets such as `brave` and `tavily` when the policy tier and web-search choice are unchanged.
+- Unreachable custom endpoints during onboarding now route through the transport-recovery path with DNS/VPN guidance and a retry/back/exit prompt instead of silently looping back to provider selection.
+- Rebuild preflight uses the model-aware token field for GPT-5 and o-series models, preventing spurious HTTP 400 failures before rebuild processing begins.
+- Corporate CA trust anchors are available throughout the sandbox image build, so `npm audit signatures` succeeds behind TLS-intercepting corporate proxies without manual workarounds.
+- SSH `ControlMaster`-delegated forwards are recognized by the untracked-forward fallback, preventing a healthy sandbox from being deleted after a forward-detection timeout.
+- Hermes light terminal skin writes correctly on macOS via stdin streaming.
+
 ## v0.0.82
 
 NemoClaw v0.0.82 adds non-destructive sandbox stop and start commands, protects managed vLLM downloads with storage checks, strengthens custom policy and dependency validation, and improves onboarding, backup, snapshot, and contributor guidance.


### PR DESCRIPTION
## Summary

Add v0.0.83 release notes to `docs/about/release-notes.mdx` for pre-tag release prep.

## Source Summary

- #6773 -> `docs/about/release-notes.mdx`: Shared inference route changes are explicit and fail-safe; status shows recorded route, live route, and drift.
- #6875 -> `docs/about/release-notes.mdx`: DGX Station GB300 express setup restored; vLLM storage preflight narrowed.
- #6770 -> `docs/about/release-notes.mdx`: Risky Spark vLLM server warning during onboarding.
- #6856 -> `docs/about/release-notes.mdx`: Re-onboard reuse preserves tier-default brave/tavily presets.
- #6867 -> `docs/about/release-notes.mdx`: Unreachable custom endpoint routed through transport-recovery path.
- #6860 -> `docs/about/release-notes.mdx`: Rebuild preflight uses model-aware token field for o-series/GPT-5.
- #6845 -> `docs/about/release-notes.mdx`: Corporate CA anchored for image build TLS.
- #6833 -> `docs/about/release-notes.mdx`: SSH ControlMaster-delegated forwards recognized in fallback.
- #6837 -> `docs/about/release-notes.mdx`: Hermes light skin writes via stdin on macOS.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: doc-only release notes
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed
- [ ] Non-success, skipped, or missing CI check accepted by maintainer

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed
- [x] `npm run docs` passes with 0 errors

Signed-off-by: Jessica Yaunches <jyaunches@nvidia.com>