### PR TITLE
ci(e2e): report wall clock time in PR results

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5301,6 +5301,30 @@ jobs:
             }
 
             const testResults = new Map();
+            const wallClockRanges = new Map();
+            const recordWallClockRange = (name, job) => {
+              if (job.conclusion === 'skipped') return;
+              const startedAt = Date.parse(job.started_at || '');
+              const completedAt = Date.parse(job.completed_at || '');
+              if (!Number.isFinite(startedAt) || !Number.isFinite(completedAt) || completedAt < startedAt) {
+                return;
+              }
+              const current = wallClockRanges.get(name);
+              wallClockRanges.set(name, {
+                startedAt: current ? Math.min(current.startedAt, startedAt) : startedAt,
+                completedAt: current ? Math.max(current.completedAt, completedAt) : completedAt,
+              });
+            };
+            const formatWallClockTime = (range) => {
+              if (!range) return '—';
+              const totalSeconds = Math.round((range.completedAt - range.startedAt) / 1000);
+              const hours = Math.floor(totalSeconds / 3600);
+              const minutes = Math.floor((totalSeconds % 3600) / 60);
+              const seconds = totalSeconds % 60;
+              return [hours ? `${hours}h` : '', minutes ? `${minutes}m` : '', `${seconds}s`]
+                .filter(Boolean)
+                .join(' ');
+            };
             let sharedJobResultsLoaded = false;
             try {
               const apiJobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
@@ -5313,6 +5337,12 @@ jobs:
               const selectedTestIds = new Set(testIds);
               for (const job of apiJobs) {
                 const match = /^Shared E2E \(([A-Za-z0-9_-]+)\)$/.exec(job.name || '');
+                const reportEntryName = match
+                  ? match[1]
+                  : /^OpenShell gateway upgrade \(.+\)$/.test(job.name || '')
+                    ? 'openshell-gateway-upgrade'
+                    : job.name;
+                recordWallClockRange(reportEntryName, job);
                 if (!match || !selectedTestIds.has(match[1])) continue;
                 const result =
                   job.status === 'completed' &&
@@ -5356,10 +5386,21 @@ jobs:
               for (const id of testIds) testResults.set(id, { result: 'unknown' });
             }
 
-            const allEntries = Object.entries(needs).filter(([name]) => name !== 'shared-e2e');
+            const allEntries = Object.entries(needs)
+              .filter(([name]) => name !== 'shared-e2e')
+              .map(([name, value]) => [
+                name,
+                { ...value, wallClockRange: wallClockRanges.get(name) },
+              ]);
             if (needs['shared-e2e']) {
               allEntries.push(
-                ...testIds.map((id) => [id, testResults.get(id) ?? { result: 'unknown' }]),
+                ...testIds.map((id) => [
+                  id,
+                  {
+                    ...(testResults.get(id) ?? { result: 'unknown' }),
+                    wallClockRange: wallClockRanges.get(id),
+                  },
+                ]),
               );
             }
             allEntries.sort(([a], [b]) => a.localeCompare(b));
@@ -5379,10 +5420,11 @@ jobs:
                 ? allEntries.filter(([, { result }]) => result !== 'skipped')
                 : allEntries;
             const rows = reportedEntries.map(
-              ([name, { result }]) => `| ${name} | ${emoji[result] || '❓'} ${result} |`,
+              ([name, { result, wallClockRange }]) =>
+                `| ${name} | ${emoji[result] || '❓'} ${result} | ${formatWallClockTime(wallClockRange)} |`,
             );
             for (const name of missingRequestedTestIds) {
-              rows.push(`| ${name} | ❓ not reported |`);
+              rows.push(`| ${name} | ❓ not reported | — |`);
             }
 
             const ran = reportedEntries.filter(([, v]) => v.result !== 'skipped');
@@ -5428,8 +5470,8 @@ jobs:
                   : '**Requested test IDs:** _(default — all default-enabled tests; explicit-only tests `openshell-gateway-auth-contract`, `mcp-bridge-dev`, `hermes-gpu-startup`, `sandbox-rlimits-connect`, and `jetson-nvmap-gpu` are skipped unless selected)_',
               `**Summary:** ${passed.length} passed, ${failed.length} failed, ${cancelled.length} cancelled, ${skipped.length} skipped, ${unknown.length} unknown`,
               '',
-              '| Test | Result |',
-              '|-----|--------|',
+              '| Test | Result | Total wall clock time |',
+              '|-----|--------|-----------------------|',
               ...rows,
             ];
             if (!selectiveDispatch) {

--- a/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
@@ -88,8 +88,10 @@ function executeGenerateMatrixWithPlannerOutput(plan: unknown) {
 }
 
 type ApiJob = {
+  completed_at?: string;
   conclusion: string | null;
   name: string;
+  started_at?: string;
   status: string;
 };
 
@@ -248,10 +250,34 @@ it("reports matrix children by test ID without fabricating a missing child resul
   expect(warning).toHaveBeenCalledWith(
     "Missing per-test results for beta; reporting them as unknown.",
   );
-  expect(body).toContain("| alpha | ✅ success |");
-  expect(body).toContain("| beta | ❓ unknown |");
+  expect(body).toContain("| alpha | ✅ success | — |");
+  expect(body).toContain("| beta | ❓ unknown | — |");
   expect(body).toContain("Some tests failed");
   expect(body).toContain("Shared E2E job aggregate: failure");
+});
+
+it("reports the total wall clock time for a selected E2E job", async () => {
+  const { body, setFailed } = await executeReport({
+    apiJobs: [
+      {
+        completed_at: "2026-07-15T00:27:58Z",
+        conclusion: "success",
+        name: "rebuild-openclaw",
+        started_at: "2026-07-15T00:16:48Z",
+        status: "completed",
+      },
+    ],
+    testMatrix: [],
+    jobs: "rebuild-openclaw",
+    needs: {
+      "generate-matrix": { result: "success" },
+      "rebuild-openclaw": { result: "success" },
+    },
+  });
+
+  expect(setFailed).not.toHaveBeenCalled();
+  expect(body).toContain("| Test | Result | Total wall clock time |");
+  expect(body).toContain("| rebuild-openclaw | ✅ success | 11m 10s |");
 });
 
 it("reports API lookup failures as unknown rather than copying the aggregate result", async () => {

--- a/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
@@ -280,7 +280,7 @@ it("reports the total wall clock time for a selected E2E job", async () => {
   expect(body).toContain("| rebuild-openclaw | ✅ success | 11m 10s |");
 });
 
-it("reports one total wall clock span for a matrix E2E job", async () => {
+it("reports one total wall clock span from valid matrix E2E jobs", async () => {
   const { body, setFailed } = await executeReport({
     apiJobs: [
       {
@@ -295,6 +295,27 @@ it("reports one total wall clock span for a matrix E2E job", async () => {
         conclusion: "success",
         name: "OpenShell gateway upgrade (v0.2.0)",
         started_at: "2026-07-15T00:02:00Z",
+        status: "completed",
+      },
+      {
+        completed_at: "2026-07-14T23:40:00Z",
+        conclusion: "success",
+        name: "OpenShell gateway upgrade (reversed-timestamps)",
+        started_at: "2026-07-14T23:50:00Z",
+        status: "completed",
+      },
+      {
+        completed_at: "not-a-timestamp",
+        conclusion: "success",
+        name: "OpenShell gateway upgrade (invalid-timestamp)",
+        started_at: "2026-07-14T23:30:00Z",
+        status: "completed",
+      },
+      {
+        completed_at: "2026-07-15T01:00:00Z",
+        conclusion: "skipped",
+        name: "OpenShell gateway upgrade (skipped)",
+        started_at: "2026-07-14T23:00:00Z",
         status: "completed",
       },
     ],

--- a/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
@@ -280,6 +280,38 @@ it("reports the total wall clock time for a selected E2E job", async () => {
   expect(body).toContain("| rebuild-openclaw | ✅ success | 11m 10s |");
 });
 
+it("reports one total wall clock span for a matrix E2E job", async () => {
+  const { body, setFailed } = await executeReport({
+    apiJobs: [
+      {
+        completed_at: "2026-07-15T00:05:00Z",
+        conclusion: "success",
+        name: "OpenShell gateway upgrade (v0.1.0)",
+        started_at: "2026-07-15T00:00:00Z",
+        status: "completed",
+      },
+      {
+        completed_at: "2026-07-15T00:11:00Z",
+        conclusion: "success",
+        name: "OpenShell gateway upgrade (v0.2.0)",
+        started_at: "2026-07-15T00:02:00Z",
+        status: "completed",
+      },
+    ],
+    testMatrix: [],
+    jobs: "openshell-gateway-upgrade",
+    needs: {
+      "generate-matrix": { result: "success" },
+      "openshell-gateway-upgrade": { result: "success" },
+    },
+  });
+
+  expect(setFailed).not.toHaveBeenCalled();
+  expect(body).toContain("| openshell-gateway-upgrade | ✅ success | 11m 0s |");
+  expect(body).not.toContain("OpenShell gateway upgrade (v0.1.0)");
+  expect(body).not.toContain("OpenShell gateway upgrade (v0.2.0)");
+});
+
 it("reports API lookup failures as unknown rather than copying the aggregate result", async () => {
   const { body, setFailed, warning } = await executeReport({
     testMatrix: DEFAULT_TEST_MATRIX.slice(0, 1),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add total wall clock time to each E2E target result row posted on pull requests. The report now derives elapsed time from GitHub Actions job timestamps and shows an unavailable marker when a job has no valid timing data.

## Changes

- Record the earliest start and latest completion timestamps for each reported E2E entry, including current matrix job name mappings.
- Render a `Total wall clock time` column with compact hour, minute, and second values, or `—` for skipped and unavailable timings.
- Extend the report workflow boundary test with unavailable timing coverage, the referenced `rebuild-openclaw` job's `11m 10s` elapsed time, and multi-job matrix aggregation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal GitHub Actions PR-comment table that is not described in the public documentation.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts` (9 tests passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Total wall clock time” to pull request end-to-end test reports, including per-test elapsed duration.
  * Wall-clock durations are shown in hours/minutes/seconds, with an em dash (“—”) when timing isn’t available.
  * Improved handling and aggregation of matrix-based job timing so totals display correctly without duplicating entries.

* **Tests**
  * Updated and added end-to-end coverage to validate the new column and correct duration calculations (including the matrix aggregation behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->