### PR TITLE
fix(inference): converge Hermes Dashboard profile on inference set

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2598,6 +2598,23 @@ The Hermes entrypoint supervisor remains responsible for the gateway, dashboard,
 In the OpenShell-managed topology, that nonroot supervisor repairs failed auxiliaries continuously, recovers a gateway after four consecutive failed listener or HTTP health checks, and quarantines relaunch after five exits within 60 seconds until the sandbox is recreated.
 The host only repairs the host-side OpenShell forwards after the supervised processes pass health checks.
 
+### Dashboard Chat keeps serving the previous model after a model switch
+
+The Hermes Web Dashboard runs from an isolated profile under `/sandbox/.hermes/dashboard-home/`, seeded at container startup and kept separate from the main Hermes config.
+`nemohermes inference set` converges this Dashboard profile onto the new model along with the main config, so Dashboard Chat and its `/api/model/info` endpoint report the switched model.
+If the Dashboard profile is absent because the Dashboard is disabled, the convergence is a no-op.
+
+When convergence fails, `inference set` prints a warning, withholds the `Inference route synced` success line, and Dashboard Chat may keep using the previous model.
+Re-run the switch or restart the gateway to converge the Dashboard profile:
+
+```bash
+nemohermes inference set --provider <provider> --model <model> --sandbox <name>
+```
+
+```bash
+nemohermes <name> hermes gateway restart
+```
+
 ### Port 8642 in a browser shows a blank page or `Cannot GET /`
 
 `nemohermes onboard` forwards port `8642`, but Hermes serves an OpenAI-compatible API at that port, not a chat dashboard.

--- a/src/lib/actions/inference-set-gateway-restart.ts
+++ b/src/lib/actions/inference-set-gateway-restart.ts
@@ -20,6 +20,13 @@ interface InferenceResultForGateway {
   model: string;
   primaryModelRef: string;
   inSandboxConfigSynced: boolean;
+  /**
+   * Hermes only: whether the isolated Web Dashboard profile converged onto the
+   * switched model (#6893). Undefined for agents without a Dashboard profile,
+   * treated as converged. When explicitly false the success line is withheld so
+   * `inference set` does not claim a route it did not fully apply.
+   */
+  dashboardConverged?: boolean;
 }
 
 export interface InferenceMutation<T extends InferenceResultForGateway> {
@@ -101,7 +108,10 @@ export function finalizeInferenceMutation<T extends InferenceResultForGateway>(
     deps.appendAuditEntry(auditEntry);
   }
 
-  if (result.inSandboxConfigSynced && !openClawGatewayRestartRequired) {
+  // A Hermes switch whose Web Dashboard profile did not converge is not fully
+  // applied, so withhold the success line (the caller already warned) (#6893).
+  const hermesDashboardStale = agentName === "hermes" && result.dashboardConverged === false;
+  if (result.inSandboxConfigSynced && !openClawGatewayRestartRequired && !hermesDashboardStale) {
     deps.log(
       agentName === "hermes"
         ? `  Inference route synced for '${result.sandboxName}': ${result.model}`

--- a/src/lib/actions/inference-set-hermes-run.test.ts
+++ b/src/lib/actions/inference-set-hermes-run.test.ts
@@ -380,3 +380,88 @@ describe("runInferenceSet Hermes routing", () => {
     expect(deps.calls.writeSandboxConfig).not.toHaveBeenCalled();
   });
 });
+
+describe("runInferenceSet Hermes Web Dashboard convergence (#6893)", () => {
+  function hermesDeps(
+    overrides: Partial<Parameters<typeof createDeps>[0]> = {},
+  ): ReturnType<typeof createDeps> {
+    return createDeps({
+      config: {
+        model: { default: "old-model", provider: "custom", base_url: "https://inference.local/v1" },
+      },
+      entry: { name: "hermes", agent: "hermes", provider: "vllm-local", model: "old-model" },
+      defaultSandbox: "hermes",
+      target: HERMES_TARGET,
+      session: baseSession({ agent: "hermes", sandboxName: "hermes" }),
+      ...overrides,
+    });
+  }
+
+  const syncedLine = (deps: ReturnType<typeof createDeps>): boolean =>
+    deps.calls.log.mock.calls.some((c) => String(c[0]).includes("Inference route synced"));
+
+  it("converges the isolated Dashboard profile after a successful switch", async () => {
+    const deps = hermesDeps();
+
+    const result = await runInferenceSet(
+      { provider: "vllm-local", model: "nemotron-ultra", sandboxName: "hermes", noVerify: true },
+      deps,
+    );
+
+    // The regression on main: this call never happens, so Dashboard Chat stays
+    // on the previous model while every other surface reports the new one.
+    expect(deps.calls.convergeHermesDashboardModel).toHaveBeenCalledWith(
+      "hermes",
+      "/sandbox/.hermes",
+      "vllm-local",
+      "nemotron-ultra",
+    );
+    expect(result.dashboardConverged).toBe(true);
+    expect(syncedLine(deps)).toBe(true);
+  });
+
+  it("still reports synced when no Dashboard profile is present", async () => {
+    const deps = hermesDeps({ dashboardConverge: { status: "absent" } });
+
+    const result = await runInferenceSet(
+      { provider: "vllm-local", model: "nemotron-ultra", sandboxName: "hermes", noVerify: true },
+      deps,
+    );
+
+    expect(deps.calls.convergeHermesDashboardModel).toHaveBeenCalledTimes(1);
+    expect(result.dashboardConverged).toBe(true);
+    expect(syncedLine(deps)).toBe(true);
+  });
+
+  it("withholds the success line and warns when Dashboard convergence fails", async () => {
+    const deps = hermesDeps({
+      dashboardConverge: { status: "failed", detail: "exec exited 1" },
+    });
+
+    const result = await runInferenceSet(
+      { provider: "vllm-local", model: "nemotron-ultra", sandboxName: "hermes", noVerify: true },
+      deps,
+    );
+
+    expect(result.dashboardConverged).toBe(false);
+    expect(syncedLine(deps)).toBe(false);
+    expect(
+      deps.calls.log.mock.calls.some((c) => String(c[0]).includes("did not converge onto")),
+    ).toBe(true);
+  });
+
+  it("does not touch the Dashboard path for OpenClaw switches", async () => {
+    const deps = createDeps({
+      config: { models: { mode: "merge", providers: {} } },
+      entry: { name: "alpha", agent: "openclaw", provider: "nvidia-prod", model: "old" },
+      defaultSandbox: "alpha",
+    });
+
+    await runInferenceSet(
+      { provider: "nvidia-prod", model: "nvidia/nemotron-3-super-v3", sandboxName: "alpha" },
+      deps,
+    );
+
+    expect(deps.calls.convergeHermesDashboardModel).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/inference-set.test-support.ts
+++ b/src/lib/actions/inference-set.test-support.ts
@@ -83,6 +83,7 @@ export function createDeps(options: {
   localReachable?: boolean;
   contextWindow?: number | null;
   shieldsMutable?: boolean;
+  dashboardConverge?: ReturnType<InferenceSetDeps["convergeHermesDashboardModel"]>;
   prepareRunOpenshell?: () => void;
   rewriteConfigUrlsWithDnsPinning?: (value: ConfigValue) => Promise<ConfigValue>;
   restartSandboxGateway?: InferenceSetDeps["restartSandboxGateway"];
@@ -92,6 +93,7 @@ export function createDeps(options: {
     captureOpenshell: ReturnType<typeof vi.fn>;
     writeSandboxConfig: ReturnType<typeof vi.fn>;
     recomputeSandboxConfigHash: ReturnType<typeof vi.fn>;
+    convergeHermesDashboardModel: ReturnType<typeof vi.fn>;
     updateSandbox: ReturnType<typeof vi.fn>;
     readSandboxConfig: ReturnType<typeof vi.fn>;
     updateSession: ReturnType<typeof vi.fn>;
@@ -124,6 +126,9 @@ export function createDeps(options: {
     })),
     writeSandboxConfig: vi.fn(),
     recomputeSandboxConfigHash: vi.fn(),
+    convergeHermesDashboardModel: vi.fn(
+      () => options.dashboardConverge ?? { status: "converged" as const },
+    ),
     updateSandbox: vi.fn(() => true),
     readSandboxConfig: vi.fn(() => options.config),
     updateSession: vi.fn((mutator: (value: Session) => Session | void) => {
@@ -169,6 +174,7 @@ export function createDeps(options: {
     readSandboxConfig: calls.readSandboxConfig,
     writeSandboxConfig: calls.writeSandboxConfig,
     recomputeSandboxConfigHash: calls.recomputeSandboxConfigHash,
+    convergeHermesDashboardModel: calls.convergeHermesDashboardModel,
     prepareRunOpenshell: calls.prepareRunOpenshell,
     captureOpenshell: calls.captureOpenshell,
     appendAuditEntry: calls.appendAuditEntry,

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -29,6 +29,8 @@ import {
 } from "../openshell-gateway-endpoint-guard";
 import {
   type AgentConfigTarget,
+  convergeHermesDashboardModel,
+  type HermesDashboardConvergeResult,
   readSandboxConfig,
   recomputeSandboxConfigHash,
   resolveAgentConfig,
@@ -90,6 +92,7 @@ export interface InferenceSetResult {
   configChanged: boolean;
   sessionUpdated: boolean;
   inSandboxConfigSynced: boolean;
+  dashboardConverged: boolean;
 }
 
 export interface InferenceSetDeps extends InferenceGatewayRestartDeps {
@@ -110,6 +113,12 @@ export interface InferenceSetDeps extends InferenceGatewayRestartDeps {
     config: ConfigObject,
   ) => void;
   recomputeSandboxConfigHash: (sandboxName: string, target: AgentConfigTarget) => void;
+  convergeHermesDashboardModel: (
+    sandboxName: string,
+    configDir: string,
+    provider: string,
+    model: string,
+  ) => HermesDashboardConvergeResult;
   prepareRunOpenshell: () => void;
   captureOpenshell: (
     args: string[],
@@ -212,6 +221,7 @@ function defaultDeps(): InferenceSetDeps {
     readSandboxConfig,
     writeSandboxConfig,
     recomputeSandboxConfigHash,
+    convergeHermesDashboardModel,
     prepareRunOpenshell: () => {
       getOpenshellBinary();
     },
@@ -866,6 +876,35 @@ async function runInferenceSetWithoutHostLock(
       `  Run '${CLI_NAME} ${sandboxName} rebuild' to finish applying the model inside the sandbox.`,
     );
   }
+
+  // #6893: the Hermes Web Dashboard runs from an isolated HERMES_HOME and does
+  // not pick up an in-place model switch, so Dashboard Chat keeps serving the
+  // previous model even though every other status surface reports the new one.
+  // Converge that profile too before claiming success. Best-effort and gated on
+  // the main config having synced first: a Dashboard that was never enabled
+  // resolves to "absent" (no-op), and only a real convergence failure downgrades
+  // the success message.
+  let dashboardConverged = true;
+  if (agentName === "hermes" && inSandboxConfigSynced) {
+    const dashboardResult = deps.convergeHermesDashboardModel(
+      sandboxName,
+      target.configDir,
+      provider,
+      model,
+    );
+    if (dashboardResult.status === "failed") {
+      dashboardConverged = false;
+      deps.log(
+        `  Warning: updated the Hermes config for '${sandboxName}', but the Web Dashboard ` +
+          `profile did not converge onto '${model}': ${dashboardResult.detail}`,
+      );
+      deps.log(
+        `  Dashboard Chat may keep using the previous model. Re-run '${CLI_NAME} inference set' ` +
+          `or run '${CLI_NAME} ${sandboxName} hermes gateway restart'.`,
+      );
+    }
+  }
+
   const sessionUpdated = updateMatchingOnboardSession(
     sandboxName,
     provider,
@@ -890,6 +929,7 @@ async function runInferenceSetWithoutHostLock(
         configChanged: patched.changed,
         sessionUpdated,
         inSandboxConfigSynced,
+        dashboardConverged,
       },
     },
     deps,

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -92,7 +92,12 @@ export interface InferenceSetResult {
   configChanged: boolean;
   sessionUpdated: boolean;
   inSandboxConfigSynced: boolean;
-  dashboardConverged: boolean;
+  /**
+   * Hermes only: whether the isolated Web Dashboard profile converged onto the
+   * switched model (#6893). Undefined when convergence was not attempted — a
+   * non-Hermes agent, or a Hermes switch whose main config never synced.
+   */
+  dashboardConverged?: boolean;
 }
 
 export interface InferenceSetDeps extends InferenceGatewayRestartDeps {
@@ -884,7 +889,11 @@ async function runInferenceSetWithoutHostLock(
   // the main config having synced first: a Dashboard that was never enabled
   // resolves to "absent" (no-op), and only a real convergence failure downgrades
   // the success message.
-  let dashboardConverged = true;
+  // Undefined when convergence was not attempted (non-Hermes agent, or the main
+  // config never synced), true when the Dashboard converged or was absent, and
+  // false only on a real convergence failure — so the result never claims a
+  // Dashboard state it did not establish.
+  let dashboardConverged: boolean | undefined;
   if (agentName === "hermes" && inSandboxConfigSynced) {
     const dashboardResult = deps.convergeHermesDashboardModel(
       sandboxName,
@@ -892,8 +901,8 @@ async function runInferenceSetWithoutHostLock(
       provider,
       model,
     );
+    dashboardConverged = dashboardResult.status !== "failed";
     if (dashboardResult.status === "failed") {
-      dashboardConverged = false;
       deps.log(
         `  Warning: updated the Hermes config for '${sandboxName}', but the Web Dashboard ` +
           `profile did not converge onto '${model}': ${dashboardResult.detail}`,

--- a/src/lib/sandbox/config.ts
+++ b/src/lib/sandbox/config.ts
@@ -608,21 +608,22 @@ function convergeHermesDashboardModel(
   model: string,
 ): HermesDashboardConvergeResult {
   const dashboardHome = `${configDir.replace(/\/+$/, "")}/${HERMES_DASHBOARD_HOME_SUBDIR}`;
+  // Presence probe as a pure argv `test -d` (this security-boundary file prefers
+  // argv over shell construction). `dockerSpawnSync` returns the exit status
+  // rather than throwing, so an absent profile (`test` exits 1) is a clean skip
+  // and only a genuine exec error (spawn failure, signal, or a non-0/1 status
+  // such as Docker's 125 for a missing container) is a convergence failure.
+  const probe = dockerSpawnSync(
+    privilegedSandboxExecArgv(sandboxName, ["test", "-d", dashboardHome], false, true),
+    { encoding: "utf-8", timeout: HERMES_DASHBOARD_CONVERGE_TIMEOUT_MS },
+  );
+  if (probe.error) return { status: "failed", detail: probe.error.message };
+  if (probe.signal) return { status: "failed", detail: `probe terminated by ${probe.signal}` };
+  if (probe.status === 1) return { status: "absent" };
+  if (probe.status !== 0) {
+    return { status: "failed", detail: `dashboard probe exited ${String(probe.status)}` };
+  }
   try {
-    // Probe via an always-exit-0 shell so an absent profile is a clean "skip"
-    // rather than an exec that throws and reads as a failure.
-    const probe = privilegedSandboxExec(
-      sandboxName,
-      [
-        "sh",
-        "-c",
-        `if [ -d ${shellQuote(dashboardHome)} ]; then echo present; else echo absent; fi`,
-      ],
-      { timeout: HERMES_DASHBOARD_CONVERGE_TIMEOUT_MS },
-    );
-    if (!probe.trim().endsWith("present")) {
-      return { status: "absent" };
-    }
     for (const key of ["model.default", `providers.${provider}.default_model`]) {
       privilegedSandboxExec(
         sandboxName,

--- a/src/lib/sandbox/config.ts
+++ b/src/lib/sandbox/config.ts
@@ -163,6 +163,12 @@ const HERMES_STRICT_HASH_FILE = "/etc/nemoclaw/hermes.config-hash";
 const HERMES_RUNTIME_CONFIG_GUARD = "/usr/local/lib/nemoclaw/hermes-runtime-config-guard.py";
 const HERMES_PYTHON = "/opt/hermes/.venv/bin/python";
 const HERMES_RESTART_SEAL_STATE = "/run/nemoclaw/hermes-restart-seal.json";
+// The Hermes Web Dashboard runs from an isolated HERMES_HOME under this subdir of
+// the main config dir, seeded at container startup. An in-place `inference set`
+// updates only the main config, so the Dashboard profile must be converged
+// separately (#6893).
+const HERMES_DASHBOARD_HOME_SUBDIR = "dashboard-home";
+const HERMES_DASHBOARD_CONVERGE_TIMEOUT_MS = 30_000;
 const MAX_OPENCLAW_CONFIG_BYTES = 16 * 1024 * 1024;
 const CONFIG_CAPTURE_MAX_BUFFER = MAX_OPENCLAW_CONFIG_BYTES + 1024 * 1024;
 const OPENCLAW_CONFIG_GUARD_TIMEOUT_MS = 6 * 60 * 1000;
@@ -571,6 +577,65 @@ function writeSandboxConfig(
     } catch {
       // Best effort.
     }
+  }
+}
+
+export type HermesDashboardConvergeResult =
+  | { status: "converged" }
+  | { status: "absent" }
+  | { status: "failed"; detail: string };
+
+/**
+ * Converge the isolated Hermes Web Dashboard profile onto a switched model.
+ *
+ * `nemoclaw inference set` writes only the main Hermes config; the Dashboard runs
+ * from a separate HERMES_HOME under `<configDir>/dashboard-home`, seeded at
+ * container startup. An in-place switch therefore leaves Dashboard Chat and its
+ * `/api/model/info` endpoint on the previous model (#6893). This mirrors the
+ * reporter-verified recovery — `hermes config set model.default` and
+ * `providers.<provider>.default_model` under the Dashboard HERMES_HOME — and
+ * no-ops when the Dashboard profile is absent (Dashboard disabled).
+ *
+ * `provider` and `model` are pre-validated by the `inference set` caller
+ * (`assertSupportedProvider` allowlist + `isSafeModelId`), so they are safe as a
+ * config dotpath segment and value; they are still passed as distinct argv
+ * elements, never interpolated into a shell string.
+ */
+function convergeHermesDashboardModel(
+  sandboxName: string,
+  configDir: string,
+  provider: string,
+  model: string,
+): HermesDashboardConvergeResult {
+  const dashboardHome = `${configDir.replace(/\/+$/, "")}/${HERMES_DASHBOARD_HOME_SUBDIR}`;
+  try {
+    // Probe via an always-exit-0 shell so an absent profile is a clean "skip"
+    // rather than an exec that throws and reads as a failure.
+    const probe = privilegedSandboxExec(
+      sandboxName,
+      [
+        "sh",
+        "-c",
+        `if [ -d ${shellQuote(dashboardHome)} ]; then echo present; else echo absent; fi`,
+      ],
+      { timeout: HERMES_DASHBOARD_CONVERGE_TIMEOUT_MS },
+    );
+    if (!probe.trim().endsWith("present")) {
+      return { status: "absent" };
+    }
+    for (const key of ["model.default", `providers.${provider}.default_model`]) {
+      privilegedSandboxExec(
+        sandboxName,
+        ["env", `HERMES_HOME=${dashboardHome}`, "hermes", "config", "set", key, model],
+        { timeout: HERMES_DASHBOARD_CONVERGE_TIMEOUT_MS },
+      );
+    }
+    return { status: "converged" };
+  } catch (error) {
+    return {
+      status: "failed",
+      detail: error instanceof Error && error.message ? error.message : String(error),
+    };
   }
 }
 
@@ -1212,6 +1277,7 @@ export {
   configGet,
   configRotateToken,
   configSet,
+  convergeHermesDashboardModel,
   DEFAULT_AGENT_CONFIG,
   extractDotpath,
   findClobberingAncestor,

--- a/src/lib/sandbox/hermes-dashboard-converge.test.ts
+++ b/src/lib/sandbox/hermes-dashboard-converge.test.ts
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Direct coverage for convergeHermesDashboardModel (#6893). This exercises the
+// helper's own probe parsing, argv construction, and error classification —
+// the security-boundary logic that the inference-set tests only reach through a
+// mocked dependency. Both the presence probe and the model writes run through
+// the real code path with only the docker-exec adapter and the argv builder
+// replaced, so the assertions pin the exact argv (no shell interpolation of
+// provider/model) and prove failures are classified without leaking anything
+// beyond the underlying error message.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dockerExecPath = require.resolve("../adapters/docker/exec");
+const privilegedExecPath = require.resolve("./privileged-exec");
+const configModulePath = require.resolve("./config");
+
+type SpawnResult = { status: number | null; signal: string | null; error?: Error };
+
+const dockerExec = require(dockerExecPath) as {
+  dockerSpawnSync: (...args: unknown[]) => SpawnResult;
+  dockerExecFileSync: (...args: unknown[]) => string;
+};
+const privilegedExec = require(privilegedExecPath) as {
+  privilegedSandboxExecArgv: (...args: unknown[]) => string[];
+};
+
+const realSpawn = dockerExec.dockerSpawnSync;
+const realExecFile = dockerExec.dockerExecFileSync;
+const realArgv = privilegedExec.privilegedSandboxExecArgv;
+
+type ConvergeFn = (
+  sandboxName: string,
+  configDir: string,
+  provider: string,
+  model: string,
+) => { status: "converged" | "absent" | "failed"; detail?: string };
+
+function loadConverge(): ConvergeFn {
+  delete require.cache[configModulePath];
+  return (require(configModulePath) as { convergeHermesDashboardModel: ConvergeFn })
+    .convergeHermesDashboardModel;
+}
+
+beforeEach(() => {
+  // Pass the command through as the "argv" so the docker-exec spies receive the
+  // exact command array the helper built, without a live registry/container.
+  privilegedExec.privilegedSandboxExecArgv = (...args: unknown[]) => args[1] as string[];
+});
+
+afterEach(() => {
+  dockerExec.dockerSpawnSync = realSpawn;
+  dockerExec.dockerExecFileSync = realExecFile;
+  privilegedExec.privilegedSandboxExecArgv = realArgv;
+  vi.restoreAllMocks();
+});
+
+const DASHBOARD_HOME = "/sandbox/.hermes/dashboard-home";
+
+describe("convergeHermesDashboardModel (#6893)", () => {
+  it("probes with a pure argv `test -d` and skips a switch when the profile is absent", () => {
+    const spawn = vi.fn((..._args: unknown[]) => ({ status: 1, signal: null }));
+    const execFile = vi.fn((..._args: unknown[]) => "");
+    dockerExec.dockerSpawnSync = spawn;
+    dockerExec.dockerExecFileSync = execFile;
+
+    const result = loadConverge()("hermes", "/sandbox/.hermes", "vllm-local", "nemotron-ultra");
+
+    expect(result).toEqual({ status: "absent" });
+    expect(spawn.mock.calls[0][0]).toEqual(["test", "-d", DASHBOARD_HOME]);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("converges by writing model.default and providers.<provider>.default_model as argv", () => {
+    dockerExec.dockerSpawnSync = vi.fn((..._args: unknown[]) => ({ status: 0, signal: null }));
+    const execFile = vi.fn((..._args: unknown[]) => "");
+    dockerExec.dockerExecFileSync = execFile;
+
+    const result = loadConverge()("hermes", "/sandbox/.hermes/", "vllm-local", "nemotron-ultra");
+
+    expect(result).toEqual({ status: "converged" });
+    // Provider and model are discrete argv elements under the Dashboard
+    // HERMES_HOME — never interpolated into a shell string.
+    expect(execFile.mock.calls[0][0]).toEqual([
+      "env",
+      `HERMES_HOME=${DASHBOARD_HOME}`,
+      "hermes",
+      "config",
+      "set",
+      "model.default",
+      "nemotron-ultra",
+    ]);
+    expect(execFile.mock.calls[1][0]).toEqual([
+      "env",
+      `HERMES_HOME=${DASHBOARD_HOME}`,
+      "hermes",
+      "config",
+      "set",
+      "providers.vllm-local.default_model",
+      "nemotron-ultra",
+    ]);
+  });
+
+  it("classifies a non-0/1 probe status (e.g. Docker 125) as a failure without a switch", () => {
+    const execFile = vi.fn((..._args: unknown[]) => "");
+    dockerExec.dockerSpawnSync = vi.fn((..._args: unknown[]) => ({ status: 125, signal: null }));
+    dockerExec.dockerExecFileSync = execFile;
+
+    const result = loadConverge()("hermes", "/sandbox/.hermes", "vllm-local", "nemotron-ultra");
+
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("125");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("classifies a spawn error as a failure and surfaces only the error message", () => {
+    dockerExec.dockerSpawnSync = vi.fn(() => ({
+      status: null,
+      signal: null,
+      error: new Error("docker not found"),
+    }));
+    dockerExec.dockerExecFileSync = vi.fn((..._args: unknown[]) => "");
+
+    const result = loadConverge()("hermes", "/sandbox/.hermes", "vllm-local", "nemotron-ultra");
+
+    expect(result).toEqual({ status: "failed", detail: "docker not found" });
+  });
+
+  it("classifies a failed model write as a failure carrying the underlying message", () => {
+    dockerExec.dockerSpawnSync = vi.fn((..._args: unknown[]) => ({ status: 0, signal: null }));
+    dockerExec.dockerExecFileSync = vi.fn(() => {
+      throw new Error("hermes config set exited 1");
+    });
+
+    const result = loadConverge()("hermes", "/sandbox/.hermes", "vllm-local", "nemotron-ultra");
+
+    expect(result).toEqual({ status: "failed", detail: "hermes config set exited 1" });
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw inference set` for a Hermes sandbox updated the main config and printed `Inference route synced`, but the Hermes Web Dashboard runs from an isolated `HERMES_HOME` under `/sandbox/.hermes/dashboard-home/` that is only seeded at container startup. An in-place model switch therefore left Dashboard Chat and its `/api/model/info` endpoint on the previous model while `inference get`, `hermes config get`, and `hermes status` all reported the new one. After this change, `inference set` converges the Dashboard profile onto the switched model as part of the same command, so every managed Hermes model consumer agrees — or the command withholds its success line and warns.

## Related Issue

Fixes #6893

## Changes

- `src/lib/sandbox/config.ts`: add `convergeHermesDashboardModel`, which probes for the isolated Dashboard profile at `<configDir>/dashboard-home` and, when present, mirrors the reporter-verified recovery — `hermes config set model.default <model>` and `providers.<provider>.default_model <model>` run under the Dashboard `HERMES_HOME`. Returns `converged` / `absent` / `failed`. `provider` and `model` are already validated by the `inference set` caller (`assertSupportedProvider` allowlist + `isSafeModelId`) and are passed as distinct argv elements, never interpolated into a shell string.
- `src/lib/actions/inference-set.ts`: after the main in-sandbox config sync succeeds, call the convergence for Hermes sandboxes. It is best-effort and gated: an absent Dashboard profile (Dashboard disabled) is a no-op; a convergence failure logs a warning naming the recovery commands and marks the result not converged.
- `src/lib/actions/inference-set-gateway-restart.ts`: withhold the `Inference route synced` line for a Hermes switch whose Dashboard profile did not converge, so the command does not claim a route it did not fully apply.
- `docs/reference/troubleshooting.mdx`: add a Hermes troubleshooting entry for the "Dashboard Chat keeps serving the previous model" symptom and the now-current auto-convergence behavior.

Scope note: this fixes the in-place `inference set` path only. The issue also mentions rebuild restore reintroducing a stale Dashboard routing block (adjacent to merged #6685, which added `dashboard-home` to Hermes durable backup/restore); that is left as a separate follow-up to keep this diff surgical.

<sub>AI-assisted contribution.</sub>

## Type of Change

- [x] Code change with doc updates
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: change adds a sandbox exec (`hermes config set` under the Dashboard HERMES_HOME) on the inference path; inputs are pre-validated (`assertSupportedProvider` allowlist + `isSafeModelId`) and passed as argv, never shell-interpolated. Requesting maintainer sensitive-path review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run src/lib/actions/inference-set-hermes-run.test.ts` → 11 passed; the 3 new convergence tests fail on unpatched `main` (convergence never invoked), pass on this branch.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

<sub>Note: live end-to-end verification (a running Hermes sandbox + Web Dashboard + local vLLM) was not exercised. The fix mirrors the reporter's own verified recovery commands and is covered by a red-green unit test at the sandbox-exec dependency boundary. `npm run docs` reports 0 errors (2 pre-existing unrelated Fern warnings).</sub>

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the Hermes Web Dashboard could keep showing the previous model after a model switch.
  * The Dashboard profile now attempts to converge to the new model when available, and surfaces warnings when convergence fails (including preventing misleading “sync success” messaging when not converged).

* **Documentation**
  * Updated troubleshooting guidance with details on dashboard convergence behavior and remediation steps (re-run the inference set command or restart the Hermes gateway).

* **Tests**
  * Added end-to-end coverage for Dashboard convergence success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->