### PR TITLE
ci(images): unify base image publisher caching

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -50,16 +50,31 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: nvidia/nemoclaw/sandbox-base
 
 jobs:
-  # Keep one job per package so build failures, reruns, and published tags stay
-  # independently observable. Consolidating the existing publishers into a
-  # matrix is a separate release-workflow refactor, not part of #6456.
+  # Keep one declarative publisher configuration while giving each base image
+  # an independently observable matrix job and registry cache namespace.
   build-and-push:
+    name: Build and push ${{ matrix.display_name }} base image
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - agent: openclaw
+            display_name: OpenClaw
+            dockerfile: Dockerfile.base
+            image: nvidia/nemoclaw/sandbox-base
+          - agent: hermes
+            display_name: Hermes
+            dockerfile: agents/hermes/Dockerfile.base
+            image: nvidia/nemoclaw/hermes-sandbox-base
+          - agent: langchain-deepagents-code
+            display_name: Deep Agents Code
+            dockerfile: agents/langchain-deepagents-code/Dockerfile.base
+            image: nvidia/nemoclaw/langchain-deepagents-code-sandbox-base
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -83,7 +98,7 @@ jobs:
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 8
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ matrix.image }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=tag
@@ -92,12 +107,13 @@ jobs:
       - name: Validate production Docker build args
         id: production-build-args
         env:
+          AGENT: ${{ matrix.agent }}
           OPENCLAW_VERSION_INPUT: ${{ inputs.openclaw_version }}
         run: |
           set -euo pipefail
           build_args=()
           openclaw_build_arg=""
-          if [ -n "${OPENCLAW_VERSION_INPUT}" ]; then
+          if [ "$AGENT" = "openclaw" ] && [ -n "${OPENCLAW_VERSION_INPUT}" ]; then
             openclaw_build_arg="OPENCLAW_VERSION=${OPENCLAW_VERSION_INPUT}"
             build_args+=(--build-arg "$openclaw_build_arg")
           fi
@@ -106,7 +122,7 @@ jobs:
           else
             scripts/check-production-build-args.sh
           fi
-          if [ -n "${OPENCLAW_VERSION_INPUT}" ]; then
+          if [ "$AGENT" = "openclaw" ] && [ -n "${OPENCLAW_VERSION_INPUT}" ]; then
             if [[ "$OPENCLAW_VERSION_INPUT" == *$'\r'* || "$OPENCLAW_VERSION_INPUT" == *$'\n'* ]]; then
               echo "ERROR: OpenClaw version must not contain CR or LF characters." >&2
               exit 1
@@ -122,107 +138,11 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          file: Dockerfile.base
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache,mode=max
           build-args: ${{ steps.production-build-args.outputs.openclaw_build_arg }}
-
-  build-and-push-hermes:
-    if: github.repository == 'NVIDIA/NemoClaw'
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        env:
-          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
-        with:
-          images: ${{ env.REGISTRY }}/nvidia/nemoclaw/hermes-sandbox-base
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=tag
-            type=sha,prefix=,format=short
-
-      - name: Validate Hermes production Docker build args
-        run: scripts/check-production-build-args.sh
-
-      - name: Build and push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: agents/hermes/Dockerfile.base
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/nvidia/nemoclaw/hermes-sandbox-base:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/nvidia/nemoclaw/hermes-sandbox-base:buildcache,mode=max
-
-  build-and-push-langchain-deepagents-code:
-    if: github.repository == 'NVIDIA/NemoClaw'
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        env:
-          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
-        with:
-          images: ${{ env.REGISTRY }}/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=tag
-            type=sha,prefix=,format=short
-
-      - name: Validate Deep Agents Code production Docker build args
-        run: scripts/check-production-build-args.sh
-
-      - name: Build and push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: agents/langchain-deepagents-code/Dockerfile.base
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base:buildcache,mode=max

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -15,6 +15,7 @@ type WorkflowStep = {
   id?: string;
   uses?: string;
   run?: string;
+  env?: Record<string, unknown>;
   with?: Record<string, unknown>;
 };
 
@@ -57,6 +58,8 @@ const workflow = YAML.parse(
   fs.readFileSync(path.join(repoRoot, ".github", "workflows", "base-image.yaml"), "utf8"),
 ) as Workflow;
 const FULL_SHA_ACTION = /^[^@]+@[0-9a-f]{40}$/i;
+const OPENCLAW_AGENT_GATE =
+  'if [ "$AGENT" = "openclaw" ] && [ -n "${OPENCLAW_VERSION_INPUT}" ]; then';
 
 function renderMatrixValue(value: unknown, matrix: PublisherMatrixEntry): string {
   return String(value ?? "").replace(
@@ -115,6 +118,17 @@ function registryCacheEntries(value: unknown): RegistryCacheEntry[] {
     );
 }
 
+function hasAgentScopedOpenClawVersion(step: WorkflowStep | undefined): boolean {
+  const segments = (step?.run ?? "").split(OPENCLAW_AGENT_GATE);
+  return (
+    step?.env?.AGENT === "${{ matrix.agent }}" &&
+    segments.length === 3 &&
+    segments[0].includes('openclaw_build_arg=""') &&
+    segments[1].includes('openclaw_build_arg="OPENCLAW_VERSION=${OPENCLAW_VERSION_INPUT}"') &&
+    segments[2].includes('if [[ "$OPENCLAW_VERSION_INPUT"')
+  );
+}
+
 function validatePublishers(candidate: Workflow): string[] {
   const triggerPaths = candidate.on?.push?.paths ?? [];
   const publishers = publisherJobs(candidate);
@@ -131,6 +145,7 @@ function validatePublishers(candidate: Workflow): string[] {
     const guardIndex = steps.findIndex((step) =>
       (step.run ?? "").includes("scripts/check-production-build-args.sh"),
     );
+    const guard = steps[guardIndex];
     const dockerfileExists =
       dockerfile.length > 0 && fs.existsSync(path.join(repoRoot, dockerfile));
     const copiedInputPaths = dockerfileExists ? copiedInputs(dockerfile) : [];
@@ -153,6 +168,9 @@ function validatePublishers(candidate: Workflow): string[] {
         .map((input) => `${jobName} copied input must trigger the publisher workflow: ${input}`),
       ...(guardIndex < 0 || guardIndex >= buildIndex
         ? [`${jobName} must validate production build args before publishing`]
+        : []),
+      ...(!hasAgentScopedOpenClawVersion(guard)
+        ? [`${jobName} must scope OpenClaw version handling to the OpenClaw matrix entry`]
         : []),
       ...(!metadata?.uses?.startsWith("docker/metadata-action@")
         ? [`${jobName} must derive publication metadata with docker/metadata-action`]
@@ -269,6 +287,20 @@ describe("base-image publication behavior", () => {
         `${mutatedPublisher.jobName} registry cache must use its publication image buildcache tag`,
         `${mutatedPublisher.jobName} must use a publisher-unique registry cache ref`,
       ]),
+    );
+
+    const invertedGate = structuredClone(workflow);
+    const invertedPublisher = publisherJobs(invertedGate)[0];
+    const invertedGuard = (invertedPublisher.job.steps ?? []).find((step) =>
+      (step.run ?? "").includes("scripts/check-production-build-args.sh"),
+    );
+    invertedGuard!.run = invertedGuard!.run!.replaceAll(
+      OPENCLAW_AGENT_GATE,
+      OPENCLAW_AGENT_GATE.replace("openclaw", "hermes"),
+    );
+
+    expect(validatePublishers(invertedGate)).toContain(
+      `${invertedPublisher.jobName} must scope OpenClaw version handling to the OpenClaw matrix entry`,
     );
   });
 

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -18,7 +18,18 @@ type WorkflowStep = {
   with?: Record<string, unknown>;
 };
 
+type PublisherMatrixEntry = {
+  agent?: string;
+  display_name?: string;
+  dockerfile?: string;
+  image?: string;
+};
+
 type WorkflowJob = {
+  strategy?: {
+    "fail-fast"?: boolean;
+    matrix?: { include?: PublisherMatrixEntry[] };
+  };
   steps?: WorkflowStep[];
 };
 
@@ -33,6 +44,7 @@ type Publisher = {
   build: WorkflowStep;
   buildIndex: number;
   dockerfile: string;
+  matrix: PublisherMatrixEntry;
 };
 
 type RegistryCacheEntry = {
@@ -46,20 +58,34 @@ const workflow = YAML.parse(
 ) as Workflow;
 const FULL_SHA_ACTION = /^[^@]+@[0-9a-f]{40}$/i;
 
-function publisherJobs(candidate: Workflow): Publisher[] {
+function renderMatrixValue(value: unknown, matrix: PublisherMatrixEntry): string {
+  return String(value ?? "").replace(
+    /\$\{\{\s*matrix\.([a-z_]+)\s*\}\}/gu,
+    (_match, key: keyof PublisherMatrixEntry) => String(matrix[key] ?? ""),
+  );
+}
+
+function publisherBuildSteps(candidate: Workflow): Omit<Publisher, "dockerfile" | "matrix">[] {
   return Object.entries(candidate.jobs ?? {}).flatMap(([jobName, job]) => {
     const steps = job.steps ?? [];
     return steps
       .map((build, buildIndex) => ({ build, buildIndex }))
       .filter(({ build }) => build.uses?.startsWith("docker/build-push-action@"))
-      .map(({ build, buildIndex }) => ({
-        jobName,
-        job,
-        build,
-        buildIndex,
-        dockerfile: String(build.with?.file ?? ""),
-      }));
+      .map(({ build, buildIndex }) => ({ jobName, job, build, buildIndex }));
   });
+}
+
+function publisherJobs(candidate: Workflow): Publisher[] {
+  return publisherBuildSteps(candidate).flatMap(({ jobName, job, build, buildIndex }) =>
+    (job.strategy?.matrix?.include ?? []).map((matrix) => ({
+      jobName: `${jobName} (${matrix.display_name ?? matrix.agent ?? "unnamed"})`,
+      job,
+      build,
+      buildIndex,
+      dockerfile: renderMatrixValue(build.with?.file, matrix),
+      matrix,
+    })),
+  );
 }
 
 function copiedInputs(dockerfile: string): string[] {
@@ -93,12 +119,13 @@ function validatePublishers(candidate: Workflow): string[] {
   const triggerPaths = candidate.on?.push?.paths ?? [];
   const publishers = publisherJobs(candidate);
   const exportedCacheRefCounts = new Map<string, number>();
-  for (const { build } of publishers) {
-    const cacheRef = registryCacheEntries(build.with?.["cache-to"])[0]?.ref ?? "";
+  for (const { build, matrix } of publishers) {
+    const cacheRef =
+      registryCacheEntries(renderMatrixValue(build.with?.["cache-to"], matrix))[0]?.ref ?? "";
     exportedCacheRefCounts.set(cacheRef, (exportedCacheRefCounts.get(cacheRef) ?? 0) + 1);
   }
 
-  return publishers.flatMap(({ jobName, job, build, buildIndex, dockerfile }) => {
+  return publishers.flatMap(({ jobName, job, build, buildIndex, dockerfile, matrix }) => {
     const steps = job.steps ?? [];
     const metadata = steps.find((step) => step.id === "meta");
     const guardIndex = steps.findIndex((step) =>
@@ -109,10 +136,10 @@ function validatePublishers(candidate: Workflow): string[] {
     const copiedInputPaths = dockerfileExists ? copiedInputs(dockerfile) : [];
     const dockerActions = steps.filter((step) => step.uses?.startsWith("docker/"));
     const tags = String(metadata?.with?.tags ?? "");
-    const metadataImage = String(metadata?.with?.images ?? "");
+    const metadataImage = renderMatrixValue(metadata?.with?.images, matrix);
     const expectedCacheRef = `${metadataImage}:buildcache`;
-    const cacheFrom = registryCacheEntries(build.with?.["cache-from"]);
-    const cacheTo = registryCacheEntries(build.with?.["cache-to"]);
+    const cacheFrom = registryCacheEntries(renderMatrixValue(build.with?.["cache-from"], matrix));
+    const cacheTo = registryCacheEntries(renderMatrixValue(build.with?.["cache-to"], matrix));
     const importedCacheRef = cacheFrom[0]?.ref;
     const exportedCacheRef = cacheTo[0]?.ref;
 
@@ -184,14 +211,40 @@ describe("base-image publication behavior", () => {
   // source-shape-contract: security -- Publisher mutations must preserve immutable actions, guarded arguments, and trusted registry cache ownership
   it("accepts every discovered publisher and rejects supply-chain mutations", () => {
     const publishers = publisherJobs(workflow);
-    expect(publishers.length).toBeGreaterThan(0);
+    expect(publisherBuildSteps(workflow)).toHaveLength(1);
+    expect(
+      publishers.map(({ dockerfile, matrix }) => ({
+        agent: matrix.agent,
+        dockerfile,
+        image: matrix.image,
+      })),
+    ).toEqual([
+      {
+        agent: "openclaw",
+        dockerfile: "Dockerfile.base",
+        image: "nvidia/nemoclaw/sandbox-base",
+      },
+      {
+        agent: "hermes",
+        dockerfile: "agents/hermes/Dockerfile.base",
+        image: "nvidia/nemoclaw/hermes-sandbox-base",
+      },
+      {
+        agent: "langchain-deepagents-code",
+        dockerfile: "agents/langchain-deepagents-code/Dockerfile.base",
+        image: "nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
+      },
+    ]);
+    expect(publishers[0].job.strategy?.["fail-fast"]).toBe(false);
     expect(validatePublishers(workflow)).toEqual([]);
 
     const mutated = structuredClone(workflow);
     const mutatedPublisher = publisherJobs(mutated)[0];
     const mutatedSteps = mutatedPublisher.job.steps ?? [];
     const otherPublisher = publisherJobs(mutated)[1];
-    const otherCacheRef = registryCacheEntries(otherPublisher.build.with?.["cache-to"])[0]?.ref;
+    const otherCacheRef = registryCacheEntries(
+      renderMatrixValue(otherPublisher.build.with?.["cache-to"], otherPublisher.matrix),
+    )[0]?.ref;
     const mutatedGuard = mutatedSteps.find((step) =>
       (step.run ?? "").includes("scripts/check-production-build-args.sh"),
     );

--- a/test/openclaw-dependency-review.test.ts
+++ b/test/openclaw-dependency-review.test.ts
@@ -100,6 +100,7 @@ function workflowContracts(): Array<{ name: string; workflow: Workflow }> {
 function runBaseImageBuildArgGuard(
   step: WorkflowStep,
   openclawVersion: string,
+  agent = "openclaw",
 ): { output: string; result: ReturnType<typeof spawnSync> } {
   const tmp = mkdtempSync(path.join(tmpdir(), "nemoclaw-base-image-build-args-"));
   const githubOutput = path.join(tmp, "github-output");
@@ -109,6 +110,7 @@ function runBaseImageBuildArgGuard(
       encoding: "utf-8",
       env: {
         ...process.env,
+        AGENT: agent,
         GITHUB_OUTPUT: githubOutput,
         OPENCLAW_VERSION_INPUT: openclawVersion,
       },
@@ -491,6 +493,12 @@ grep -Fq -- '--phase post-agent-install' Dockerfile
       const { output, result } = runBaseImageBuildArgGuard(guard, input);
       expect(result.status, `${JSON.stringify(input)}: ${result.stderr}`).toBe(0);
       expect(output).toBe(expectedOutput);
+    }
+
+    for (const agent of ["hermes", "langchain-deepagents-code"]) {
+      const { output, result } = runBaseImageBuildArgGuard(guard, "2026.6.10", agent);
+      expect(result.status, `${agent}: ${result.stderr}`).toBe(0);
+      expect(output).toBe("openclaw_build_arg=\n");
     }
 
     for (const input of ["v2026.6.10", "2026.6.10-beta.1", "2026.6.10 trailing", "2026.4.24"]) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Unifies the OpenClaw, Hermes, and Deep Agents Code base-image publishers behind one matrix-driven Buildx configuration. Each matrix child remains independently observable and keeps a distinct registry cache ref derived from its publication image, preventing concurrent cache exports from overwriting one another.

## Changes

- Replace three duplicated publisher jobs with one `fail-fast: false` matrix covering the three existing base images.
- Derive Dockerfile, image metadata, and `function () { [native code] }:buildcache` settings from each matrix entry while preserving the OpenClaw-only version override.
- Extend the base-image workflow contract to require exactly one build-push configuration, the reviewed three-entry mapping, and publisher-unique registry cache refs.
- The current requirement is to keep all three existing publishers aligned in the `Images / Base Images` workflow. Keeping three direct jobs would preserve the duplication that allowed their cache settings to drift; `test/dcode-base-image-workflow.test.ts` protects the shared matrix contract and per-image cache ownership.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal CI refactor; published images, tags, platforms, Dockerfiles, triggers, and cache refs are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/dcode-base-image-workflow.test.ts` (3 passed)
- [ ] Applicable broad gate passed — Not applicable: this is a focused CI workflow refactor covered by the targeted contract and normal hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded automated container publishing to build and push three base image variants via a single matrix-driven workflow.
  * Improved per-variant Dockerfile selection, image tagging, and registry cache keying for more reliable builds.
  * Added matrix-scoped build-argument validation so OpenClaw-specific version checks apply only to its variant.
* **Tests**
  * Updated workflow tests to validate matrix-expanded publishing, including Dockerfile resolution, cache-from/cache-to, and metadata-derived publication image handling.
  * Added coverage for OpenClaw scoping validation across multiple agent variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->