### PR TITLE
fix(gateway): install/manage OpenShell gateway service for reboot persistence

### DIFF
--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -786,6 +786,25 @@ if [[ -n "$ACTIVE_OPENSHELL_BIN" && "$ACTIVE_OPENSHELL_BIN" = /* ]]; then
   fi
 fi
 
+stage_nemoclaw_gateway_service() {
+  local gateway_bin="$1"
+  if [ "$OS" != "Linux" ]; then return 0; fi
+  if ! command -v systemctl >/dev/null 2>&1; then return 0; fi
+  if systemctl --user list-unit-files openshell-gateway.service --no-legend 2>/dev/null | grep -q .; then
+    info "Upstream openshell-gateway.service already present; skipping NemoClaw-owned unit."
+    return 0
+  fi
+  local unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+  local env_dir="${XDG_STATE_HOME:-$HOME/.local/state}/nemoclaw/openshell-docker-gateway"
+  mkdir -p "$unit_dir" "$env_dir"
+  chmod 0700 "$env_dir"
+  sed "s|ExecStart=.*|ExecStart=$gateway_bin|" \
+    "$(dirname "$0")/nemoclaw-openshell-gateway.service" \
+    > "$unit_dir/nemoclaw-openshell-gateway.service"
+  systemctl --user daemon-reload 2>/dev/null || true
+  info "Staged NemoClaw-owned gateway service unit (not yet enabled). Onboarding will enable it."
+}
+
 install_bins() {
   local dir="$1"
   install -m 755 "$tmpdir/openshell" "$dir/openshell"
@@ -827,5 +846,7 @@ fi
 required_driver_bins_installed_in_dir "$target_dir" \
   || fail "OpenShell release '$RELEASE_TAG' did not install the required Docker-driver binaries."
 require_openshell_messaging_features "$target_dir/openshell"
+
+stage_nemoclaw_gateway_service "$target_dir/openshell-gateway"
 
 info "$("$target_dir/openshell" --version 2>&1 || echo openshell) installed"

--- a/scripts/nemoclaw-openshell-gateway.service
+++ b/scripts/nemoclaw-openshell-gateway.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenShell Docker-driver gateway (NemoClaw-managed)
+After=network.target
+
+[Service]
+EnvironmentFile=%h/.local/state/nemoclaw/openshell-docker-gateway/gateway.env
+ExecStart=/usr/local/bin/openshell-gateway
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -28,6 +28,7 @@ import { isModelRouterCommandLineForPort } from "../../onboard/model-router-proc
 import { stopStaleDashboardListeners } from "../../onboard/stale-gateway-cleanup";
 import { stopOpenRouterRuntimeAdapter } from "./openrouter-runtime-adapter-cleanup";
 import { classifyShimPath, type FileSystemDeps } from "./plan";
+import { uninstallNemoclawGatewayUserService } from "../../onboard/docker-driver-gateway-service";
 
 export interface RunResult {
   status: number | null;
@@ -939,10 +940,15 @@ function executePlan(
     } else if (step.name === "State and binaries") {
       removeManagedSwap(paths, runtime);
       for (const pattern of paths.runtimeTempGlobs) removeGlob(pattern, runtime);
-      if (options.keepOpenShell) runtime.log("Keeping OpenShell binaries as requested.");
-      else
-        for (const target of paths.openshellInstallPaths)
+      if (options.keepOpenShell) {
+        runtime.log("Keeping OpenShell binaries as requested.");
+        runtime.log("Keeping NemoClaw-managed gateway service as requested.");
+      } else {
+        uninstallNemoclawGatewayUserService({ env: runtime.env });
+        for (const target of paths.openshellInstallPaths) {
           removeFileWithOptionalSudo(target, runtime);
+        }
+      }
       if (!removePathExcept(paths.nemoclawStateDir, preserveUnderStateDir, runtime)) ok = false;
       removePath(paths.gatewayLocalStateDir, runtime);
       removePath(paths.openshellConfigDir, runtime);

--- a/src/lib/domain/uninstall/plan.ts
+++ b/src/lib/domain/uninstall/plan.ts
@@ -38,6 +38,8 @@ export type UninstallPlanAction =
   | { kind: "stop-ollama-auth-proxy" }
   | { kind: "stop-openshell-forward-processes" }
   | { kind: "stop-orphaned-openshell-processes" }
+  | { kind: "uninstall-nemoclaw-gateway-service" }
+  | { kind: "preserve-nemoclaw-gateway-service" }
   | { kind: "uninstall-npm-package"; name: "nemoclaw" };
 
 export interface UninstallPlanStep {
@@ -125,11 +127,19 @@ export function buildUninstallPlan(
                   kind: "preserve-openshell-install-paths" as const,
                   paths: paths.openshellInstallPaths,
                 },
+                {
+                  kind: "preserve-nemoclaw-gateway-service" as const,
+                },
               ]
-            : paths.openshellInstallPaths.map((path) => ({
-                kind: "delete-openshell-install-path" as const,
-                path,
-              }))),
+            : [
+                ...paths.openshellInstallPaths.map((path) => ({
+                  kind: "delete-openshell-install-path" as const,
+                  path,
+                })),
+                {
+                  kind: "uninstall-nemoclaw-gateway-service" as const,
+                },
+              ]),
           ...uninstallStatePaths(paths).map((path) => ({ kind: "delete-path" as const, path })),
         ],
       },

--- a/src/lib/onboard/docker-driver-gateway-env.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.ts
@@ -19,6 +19,8 @@ import {
 import { buildDockerDriverGatewayLocalTlsEnv } from "./docker-driver-gateway-local-tls";
 import {
   hasOpenShellGatewayUserService,
+  hasNemoclawGatewayUserService,
+  getNemoclawGatewayEnvFilePath,
   type PackageManagedDockerDriverGatewayOptions,
   startPackageManagedDockerDriverGateway,
 } from "./docker-driver-gateway-service";
@@ -272,6 +274,23 @@ function writeDockerGatewayDebEnvOverrideFile(getOverride: () => Record<string, 
   fs.chmodSync(envFile, 0o600);
 }
 
+export function writeNemoclawGatewayEnvFile(
+  getOverride: () => Record<string, string>,
+  opts: Parameters<typeof hasNemoclawGatewayUserService>[0] = {},
+): void {
+  const override = getOverride();
+  const envFile = getNemoclawGatewayEnvFilePath(opts);
+  const envDir = path.dirname(envFile);
+  fs.mkdirSync(envDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(envDir, 0o700);
+  const existing = readTextFileIfPresent(envFile);
+  fs.writeFileSync(envFile, buildDockerGatewayDebEnvFile(existing, override), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  fs.chmodSync(envFile, 0o600);
+}
+
 export function writeDockerGatewayDebEnvOverride(
   getOverride: () => Record<string, string>,
   opts: Parameters<typeof hasOpenShellGatewayUserService>[0] = {},
@@ -297,7 +316,12 @@ export function startPackageManagedDockerDriverGatewayWithEnvOverride({
   assertDockerDriverGatewayAuthConfigSafe(gatewayEnv);
   return startPackageManagedDockerDriverGateway({
     ...options,
-    prepareOpenShellGatewayUserServiceEnv: () =>
-      writeDockerGatewayDebEnvOverrideFile(() => gatewayEnv),
+    prepareOpenShellGatewayUserServiceEnv: () => {
+      if (hasOpenShellGatewayUserService()) {
+        writeDockerGatewayDebEnvOverrideFile(() => gatewayEnv);
+      } else if (hasNemoclawGatewayUserService()) {
+        writeNemoclawGatewayEnvFile(() => gatewayEnv);
+      }
+    },
   });
 }

--- a/src/lib/onboard/docker-driver-gateway-service.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.test.ts
@@ -8,6 +8,8 @@ import {
   getOpenShellGatewayUserServiceBinaryPaths,
   getOpenShellGatewayUserServicePaths,
   hasOpenShellGatewayUserService,
+  hasNemoclawGatewayUserService,
+  uninstallNemoclawGatewayUserService,
   type SpawnSyncLikeResult,
   startOpenShellGatewayUserService,
   startPackageManagedDockerDriverGateway,
@@ -75,6 +77,48 @@ describe("docker-driver-gateway-service", () => {
     expect(existsSync.mock.calls.flat()).not.toContain(
       "/home/nvidia/.config/systemd/user/openshell-gateway.service",
     );
+  });
+
+  describe("nemoclaw-managed gateway service", () => {
+    it("detects the NemoClaw-managed service correctly on Linux", () => {
+      const existsSync = vi.fn((candidate: string) => candidate.includes("nemoclaw-openshell-gateway.service"));
+      expect(hasNemoclawGatewayUserService({ existsSync, platform: "linux", env: {} })).toBe(true);
+      expect(hasNemoclawGatewayUserService({ existsSync, platform: "darwin", env: {} })).toBe(false);
+    });
+
+    it("uninstalls the NemoClaw-managed service correctly", () => {
+      const events: string[] = [];
+      const spawnSyncImpl = vi.fn((_command: string, args: string[]) => {
+        events.push(args[1] ?? args[0] ?? "");
+        return spawnResult();
+      });
+
+      uninstallNemoclawGatewayUserService({
+        env: {},
+        existsSync: () => true,
+        platform: "linux",
+        spawnSyncImpl,
+      });
+
+      expect(events).toEqual(["disable", "daemon-reload"]);
+    });
+
+    it("does not run systemctl commands if NemoClaw-managed service does not exist", () => {
+      const events: string[] = [];
+      const spawnSyncImpl = vi.fn((_command: string, args: string[]) => {
+        events.push(args[1] ?? args[0] ?? "");
+        return spawnResult();
+      });
+
+      uninstallNemoclawGatewayUserService({
+        env: {},
+        existsSync: () => false,
+        platform: "linux",
+        spawnSyncImpl,
+      });
+
+      expect(events).toEqual([]);
+    });
   });
 
   it("restarts the upstream user service with systemctl --user after validating identity", () => {

--- a/src/lib/onboard/docker-driver-gateway-service.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.ts
@@ -8,13 +8,12 @@ import path from "node:path";
 import { sleepSeconds, waitUntilAsync } from "../core/wait";
 import { isGatewayHealthy } from "../state/gateway";
 import { envInt } from "./env";
-import {
-  createGatewayHealthWaitOptions,
-  formatGatewayHealthWaitLimit,
-} from "./gateway-health-wait";
+import { createGatewayHealthWaitOptions, formatGatewayHealthWaitLimit } from "./gateway-health-wait";
 import { isDockerDriverGatewayHttpReady } from "./gateway-http-readiness";
+import os from "node:os";
 
 export const OPENSHELL_GATEWAY_USER_SERVICE = "openshell-gateway";
+export const NEMOCLAW_GATEWAY_USER_SERVICE = "nemoclaw-openshell-gateway";
 
 export interface OpenShellGatewayUserServiceOptions {
   commandExists?: (command: string) => boolean;
@@ -91,6 +90,44 @@ export function hasOpenShellGatewayUserService(
   if ((opts.platform ?? process.platform) !== "linux") return false;
   const existsSync = opts.existsSync ?? fs.existsSync;
   return getOpenShellGatewayUserServicePaths().some((candidate) => existsSync(candidate));
+}
+
+export function getNemoclawGatewayUserServicePath(opts: Pick<OpenShellGatewayUserServiceOptions, "env"> = {}): string {
+  const home = os.homedir();
+  const configHome = (opts.env ?? process.env).XDG_CONFIG_HOME ?? path.join(home, ".config");
+  return path.join(configHome, "systemd", "user", `${NEMOCLAW_GATEWAY_USER_SERVICE}.service`);
+}
+
+export function getNemoclawGatewayEnvFilePath(opts: Pick<OpenShellGatewayUserServiceOptions, "env"> = {}): string {
+  const home = os.homedir();
+  const stateHome = (opts.env ?? process.env).XDG_STATE_HOME ?? path.join(home, ".local", "state");
+  return path.join(stateHome, "nemoclaw", "openshell-docker-gateway", "gateway.env");
+}
+
+export function hasNemoclawGatewayUserService(
+  opts: Pick<OpenShellGatewayUserServiceOptions, "existsSync" | "platform" | "env"> = {},
+): boolean {
+  if ((opts.platform ?? process.platform) !== "linux") return false;
+  const existsSync = opts.existsSync ?? fs.existsSync;
+  return existsSync(getNemoclawGatewayUserServicePath(opts));
+}
+
+export function uninstallNemoclawGatewayUserService(
+  opts: Pick<OpenShellGatewayUserServiceOptions, "env" | "spawnSyncImpl" | "existsSync" | "platform"> = {},
+): void {
+  if (!hasNemoclawGatewayUserService(opts)) return;
+  const env = opts.env ?? process.env;
+  const spawnSyncImpl = opts.spawnSyncImpl ?? spawnSync;
+  
+  runSystemctlUser(["disable", "--now", NEMOCLAW_GATEWAY_USER_SERVICE], { env, spawnSyncImpl });
+  runSystemctlUser(["daemon-reload"], { env, spawnSyncImpl });
+  
+  try {
+    fs.rmSync(getNemoclawGatewayUserServicePath(opts), { force: true });
+  } catch {}
+  try {
+    fs.rmSync(getNemoclawGatewayEnvFilePath(opts), { force: true });
+  } catch {}
 }
 
 function defaultCommandExists(command: string, env: NodeJS.ProcessEnv): boolean {
@@ -287,6 +324,79 @@ export function startOpenShellGatewayUserService(
   return { attempted: true, fallbackAllowed: false, started: true };
 }
 
+export function startNemoclawGatewayUserService(
+  opts: OpenShellGatewayUserServiceOptions = {},
+): OpenShellGatewayUserServiceStartResult {
+  const platform = opts.platform ?? process.platform;
+  if (platform !== "linux") {
+    return { attempted: false, fallbackAllowed: true, started: false, reason: "not a Linux host" };
+  }
+  const existsSync = opts.existsSync ?? fs.existsSync;
+  if (!hasNemoclawGatewayUserService({ existsSync, platform, env: opts.env })) {
+    return {
+      attempted: false,
+      fallbackAllowed: true,
+      started: false,
+      reason: "NemoClaw-managed service unit not installed",
+    };
+  }
+
+  const env = opts.env ?? process.env;
+  const commandExists = opts.commandExists ?? ((command) => defaultCommandExists(command, env));
+  if (!commandExists("systemctl")) {
+    return {
+      attempted: true,
+      fallbackAllowed: true,
+      started: false,
+      reason: "systemctl is not available",
+    };
+  }
+
+  const spawnSyncImpl = opts.spawnSyncImpl ?? spawnSync;
+  for (const args of [["daemon-reload"]]) {
+    const result = runSystemctlUser(args, { env, spawnSyncImpl });
+    if (!result.ok) {
+      const reason = `systemctl --user ${args.join(" ")} failed: ${result.reason}`;
+      return {
+        attempted: true,
+        fallbackAllowed: userManagerLooksUnavailable(result.reason ?? ""),
+        reason,
+        started: false,
+      };
+    }
+  }
+
+  try {
+    opts.prepareServiceEnv?.();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      attempted: true,
+      fallbackAllowed: false,
+      reason: `failed to prepare NemoClaw OpenShell gateway service environment: ${detail}`,
+      started: false,
+    };
+  }
+
+  for (const args of [
+    ["enable", NEMOCLAW_GATEWAY_USER_SERVICE],
+    ["restart", NEMOCLAW_GATEWAY_USER_SERVICE],
+  ]) {
+    const result = runSystemctlUser(args, { env, spawnSyncImpl });
+    if (!result.ok) {
+      const reason = `systemctl --user ${args.join(" ")} failed: ${result.reason}`;
+      return {
+        attempted: true,
+        fallbackAllowed: userManagerLooksUnavailable(result.reason ?? ""),
+        reason,
+        started: false,
+      };
+    }
+  }
+
+  return { attempted: true, fallbackAllowed: false, started: true };
+}
+
 export async function startPackageManagedDockerDriverGateway({
   clearDockerDriverGatewayRuntimeFiles,
   exitOnFailure,
@@ -306,12 +416,25 @@ export async function startPackageManagedDockerDriverGateway({
     startOpenShellGatewayUserServiceImpl = startOpenShellGatewayUserService,
   verifySandboxBridgeGatewayReachableOrExit,
 }: PackageManagedDockerDriverGatewayOptions): Promise<boolean> {
-  if (!hasOpenShellGatewayUserServiceImpl()) return false;
+  const hasUpstream = hasOpenShellGatewayUserServiceImpl();
+  const hasNemoclaw = hasNemoclawGatewayUserService();
+  
+  if (!hasUpstream && !hasNemoclaw) return false;
 
-  console.log("  Starting OpenShell Docker-driver gateway via upstream user service...");
-  const serviceStart = startOpenShellGatewayUserServiceImpl({
-    prepareServiceEnv: prepareOpenShellGatewayUserServiceEnv,
-  });
+  console.log(
+    hasUpstream 
+      ? "  Starting OpenShell Docker-driver gateway via upstream user service..." 
+      : "  Starting OpenShell Docker-driver gateway via NemoClaw-managed user service..."
+  );
+
+  const serviceStart = hasUpstream
+    ? startOpenShellGatewayUserServiceImpl({
+        prepareServiceEnv: prepareOpenShellGatewayUserServiceEnv,
+      })
+    : startNemoclawGatewayUserService({
+        prepareServiceEnv: prepareOpenShellGatewayUserServiceEnv,
+      });
+
   if (!serviceStart.started) {
     const detail = serviceStart.reason ? ` (${serviceStart.reason})` : "";
     if (serviceStart.fallbackAllowed) {
@@ -322,7 +445,7 @@ export async function startPackageManagedDockerDriverGateway({
     }
     const message = `OpenShell gateway user service failed to start${detail}.`;
     console.error(`  ${message}`);
-    console.error("  Check: systemctl --user status openshell-gateway");
+    console.error(`  Check: systemctl --user status ${hasUpstream ? OPENSHELL_GATEWAY_USER_SERVICE : NEMOCLAW_GATEWAY_USER_SERVICE}`);
     if (exitOnFailure) process.exit(1);
     throw new Error(message);
   }
@@ -359,7 +482,7 @@ export async function startPackageManagedDockerDriverGateway({
     pollInterval,
   )}.`;
   console.error(`  ${message}`);
-  console.error("  Check: systemctl --user status openshell-gateway");
+  console.error(`  Check: systemctl --user status ${hasUpstream ? OPENSHELL_GATEWAY_USER_SERVICE : NEMOCLAW_GATEWAY_USER_SERVICE}`);
   if (exitOnFailure) process.exit(1);
   throw new Error(message);
 }


### PR DESCRIPTION
## Summary
Implemented reboot persistence for the OpenShell gateway by adding a NemoClaw-managed systemd user service, environment handling, and related tests.

## Related Issue
Fixes #6903

## Changes
- Added detection of existing OpenShell gateway service.
- Created `nemoclaw-openshell-gateway.service` unit in user systemd config.
- Implemented environment file creation for the gateway.
- Updated install script to stage and enable the service.
- Added uninstall logic to disable and remove the service and its env file.
- Added unit tests for detection and uninstall behavior.
- Updated documentation task tracking.

## DCO
Signed-off-by: Jibin7Jose <jibinjose884@gmail.com>
