### PR TITLE
fix(e2e): aggregate matrix wall clock time

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5247,13 +5247,19 @@ jobs:
                 per_page: 100,
               });
               const selectedTestIds = new Set(testIds);
+              const aggregateJobNames = Object.keys(needs);
               for (const job of apiJobs) {
-                const match = /^Shared E2E \(([A-Za-z0-9_-]+)\)$/.exec(job.name || '');
-                const reportEntryName = match
-                  ? match[1]
-                  : /^OpenShell gateway upgrade \(.+\)$/.test(job.name || '')
+                const jobName = job.name || '';
+                const match = /^Shared E2E \(([A-Za-z0-9_-]+)\)$/.exec(jobName);
+                const aggregateJobName = aggregateJobNames.find((name) =>
+                  jobName.startsWith(`${name} (`),
+                );
+                const reportEntryName =
+                  match?.[1] ??
+                  aggregateJobName ??
+                  (/^OpenShell gateway upgrade \(.+\)$/.test(jobName)
                     ? 'openshell-gateway-upgrade'
-                    : job.name;
+                    : jobName);
                 recordWallClockRange(reportEntryName, job);
                 if (!match || !selectedTestIds.has(match[1])) continue;
                 const result =

--- a/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
@@ -333,6 +333,38 @@ it("reports one total wall clock span from valid matrix E2E jobs", async () => {
   expect(body).not.toContain("OpenShell gateway upgrade (v0.2.0)");
 });
 
+it("reports one total wall clock span when matrix job names start with their job ID", async () => {
+  const { body, setFailed } = await executeReport({
+    apiJobs: [
+      {
+        completed_at: "2026-07-15T04:56:38Z",
+        conclusion: "success",
+        name: "hermes-inference-switch (anthropic, e2e-hermes-anthropic-inference-switch, compatible-anthropic-e...",
+        started_at: "2026-07-15T04:49:26Z",
+        status: "completed",
+      },
+      {
+        completed_at: "2026-07-15T05:06:51Z",
+        conclusion: "success",
+        name: "hermes-inference-switch (hosted, e2e-hermes-inference-switch, nvidia-prod, nvidia/nemotron-3-supe...",
+        started_at: "2026-07-15T04:49:26Z",
+        status: "completed",
+      },
+    ],
+    testMatrix: [],
+    jobs: "hermes-inference-switch",
+    needs: {
+      "generate-matrix": { result: "success" },
+      "hermes-inference-switch": { result: "success" },
+    },
+  });
+
+  expect(setFailed).not.toHaveBeenCalled();
+  expect(body).toContain("| hermes-inference-switch | ✅ success | 17m 25s |");
+  expect(body).not.toContain("hermes-inference-switch (anthropic");
+  expect(body).not.toContain("hermes-inference-switch (hosted");
+});
+
 it("reports API lookup failures as unknown rather than copying the aggregate result", async () => {
   const { body, setFailed, warning } = await executeReport({
     testMatrix: DEFAULT_TEST_MATRIX.slice(0, 1),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Matrix E2E jobs now contribute their earliest start and latest completion timestamps to the canonical PR result row. Before this change, `hermes-inference-switch` completed two successful shards over 17m 25s but its wall-clock cell rendered as unavailable.

## Changes

- Map ordinary Actions matrix job names shaped `<job-id> (...)` back to the matching `needs` entry before recording wall-clock ranges.
- Preserve the existing `Shared E2E` child attribution and custom `OpenShell gateway upgrade` matrix mapping.
- Add boundary coverage using the live `hermes-inference-switch` shard timestamps and assert the canonical row reports `17m 25s` without emitting shard rows.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The required documentation review confirmed this only corrects internal GitHub Actions PR-comment attribution and does not change user-facing behavior, supported interfaces, E2E authorization, or contributor commands.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts` (10 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reporting so matrix job results are grouped under consistent test names.
  * Prevented duplicate or overly detailed job-name entries from appearing in pull request reports.
  * Ensured gateway upgrade results use a stable report label.

* **Tests**
  * Added coverage verifying accurate duration totals and clean report entries for grouped API test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->