### PR TITLE
fix(ci): keep PR E2E authorization pending

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -196,17 +196,13 @@ or dispatch fails before a terminal E2E result, the controller restores the
 authorization title and leaves a current coordination check in progress so a
 maintainer can correct the problem and launch a fresh first-attempt
 authorization. The native required job treats these authorization and running
-titles as intermediate waiting states. The normal wait, evidence download, and
-finish path is the only path that can record success; the authorization itself
-cannot make the gate green. A changed head or base requires a new
-authorization.
-
-During rollout, manual authorization also accepts the older exact-diff state
-that already completed as failed with the authorization title. GitHub cannot
-reopen a completed check, so the native observer also treats a legacy completed
-failure titled `Running <count> E2E job(s)` as transitional. Only the
-authorization titles and this bounded legacy running-title shape receive that
-treatment; other completed failures fail the native required job.
+titles as intermediate waiting states only while coordination remains in
+progress. A completed failure is terminal; neither manual authorization nor the
+native observer reinterprets it. Older builds whose authorization check already
+completed as failed require a fresh exact-diff revision and PR CI run before a
+maintainer can authorize them. The normal wait, evidence download, and finish
+path is the only path that can record success; the authorization itself cannot
+make the gate green. A changed head or base requires a new authorization.
 
 A fork revision that selects jobs completes coordination as failed while the
 native required job waits for the skip-approval flow. The controller does not

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -192,17 +192,23 @@ permission, internal repository origin, open PR, exact head and base, risk
 plan, matching pending coordination state, compatible trusted controller
 commit, and final live revision. It then updates coordination to
 `Running <count> E2E job(s)` and dispatches the selected jobs. If authorization
-or dispatch fails before a terminal E2E result, the controller restores the
-authorization title and leaves a current coordination check in progress so a
-maintainer can correct the problem and launch a fresh first-attempt
-authorization. The native required job treats these authorization and running
-titles as intermediate waiting states only while coordination remains in
-progress. A completed failure is terminal; neither manual authorization nor the
-native observer reinterprets it. Older builds whose authorization check already
-completed as failed require a fresh exact-diff revision and PR CI run before a
-maintainer can authorize them. The normal wait, evidence download, and finish
-path is the only path that can record success; the authorization itself cannot
-make the gate green. A changed head or base requires a new authorization.
+fails before a child run is dispatched, the controller restores the
+authorization title and leaves coordination in progress so a maintainer can
+correct the problem and launch a fresh first-attempt authorization. After a
+child is dispatched, a startup failure requests cancellation. Whether or not
+cancellation is confirmed, the controller completes coordination as
+`Authorized E2E run requires reconciliation`; that exact-diff authorization
+cannot be retried because the child may still execute and a retry could start
+duplicate credential-bearing work. Inspect the linked run, then update the PR
+and run fresh CI before authorizing again.
+The native required job treats authorization and running titles as intermediate
+waiting states only while coordination remains in progress. A completed failure
+is terminal; neither manual authorization nor the native observer reinterprets
+it. Older builds whose authorization check already completed as failed also
+require a fresh exact-diff revision and PR CI run before a maintainer can
+authorize them. The normal wait, evidence download, and finish path is the only
+path that can record success; the authorization itself cannot make the gate
+green. A changed head or base requires a new authorization.
 
 A fork revision that selects jobs completes coordination as failed while the
 native required job waits for the skip-approval flow. The controller does not

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -179,23 +179,34 @@ recording a final result. The native observer revalidates the live revision
 before mirroring that terminal result.
 
 An internal revision whose control-plane matches include a file outside the
-trusted controller and observer boundaries completes coordination as failed
+trusted controller and observer boundaries leaves coordination in progress
 with `Maintainer authorization required to run E2E`. The native required job
-keeps waiting for the authorization flow. No selected job runs and no repository
-secret is exposed. After reviewing the exact revision, a repository
+keeps waiting for the authorization flow. No selected job runs and no
+repository secret is exposed. After reviewing the exact revision, a repository
 maintainer or administrator chooses **Run workflow** on `main`, selects
 `run-control-plane`, and supplies the PR number, current 40-character head SHA
 as `expected_head_sha`, current 40-character base SHA as `expected_base_sha`,
 and a specific 10–500-character `review_reason`. The authorization requires the
 first workflow attempt and revalidates the actor's `maintain` or `admin`
 permission, internal repository origin, open PR, exact head and base, risk
-plan, matching failed coordination check, compatible trusted controller commit,
-and final live revision. It then returns coordination to in progress and
-dispatches the selected jobs. The native required job treats this authorization
-title as an intermediate waiting state instead of mirroring the temporary
-failure. The normal wait, evidence download, and finish path is the only path
-that can record success; the authorization itself cannot make the gate green.
-A changed head or base requires a new authorization.
+plan, matching pending coordination state, compatible trusted controller
+commit, and final live revision. It then updates coordination to
+`Running <count> E2E job(s)` and dispatches the selected jobs. If authorization
+or dispatch fails before a terminal E2E result, the controller restores the
+authorization title and leaves a current coordination check in progress so a
+maintainer can correct the problem and launch a fresh first-attempt
+authorization. The native required job treats these authorization and running
+titles as intermediate waiting states. The normal wait, evidence download, and
+finish path is the only path that can record success; the authorization itself
+cannot make the gate green. A changed head or base requires a new
+authorization.
+
+During rollout, manual authorization also accepts the older exact-diff state
+that already completed as failed with the authorization title. GitHub cannot
+reopen a completed check, so the native observer also treats a legacy completed
+failure titled `Running <count> E2E job(s)` as transitional. Only the
+authorization titles and this bounded legacy running-title shape receive that
+treatment; other completed failures fail the native required job.
 
 A fork revision that selects jobs completes coordination as failed while the
 native required job waits for the skip-approval flow. The controller does not

--- a/test/pr-e2e-gate-fork-skip.test.ts
+++ b/test/pr-e2e-gate-fork-skip.test.ts
@@ -814,6 +814,94 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
     }
   });
 
+  it("fails authorization closed when child cancellation cannot be confirmed", async () => {
+    const workDirs = [
+      fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-cancel-failed-")),
+      fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-cancel-retry-")),
+    ];
+    const outputPath = path.join(workDirs[0]!, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    let check = exactPrGateCheck({
+      output: { title: "Maintainer authorization required to run E2E" },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url }) => url.endsWith("/collaborators/maintainer/permission"),
+            () => githubResponse({ role_name: "maintain", user: { login: "maintainer" } }),
+          ),
+          githubFetchRoute(
+            ({ url }) => url.endsWith("/pulls/42"),
+            () => githubResponse(pullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url }) => url.includes("/pulls/42/files?"),
+            () => githubResponse([{ filename: "test/e2e/risk-signal-reporter.ts" }]),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [check] }),
+          ),
+          mainWorkflowRefRoute(),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            (request) => {
+              const body = request.body as Record<string, unknown>;
+              const title = (body.output as { title?: string } | undefined)?.title;
+              if (title === "Running 3 E2E jobs") {
+                return githubResponse({ message: "simulated update failure" }, 500);
+              }
+              check = { ...check, ...body };
+              return githubResponse({});
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () =>
+              githubResponse({
+                workflow_run_id: 23,
+                run_url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/23",
+                html_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/actions/runs/23/cancel") && method === "POST",
+            () => githubResponse({ message: "simulated cancellation failure" }, 500),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startControlPlanePrGate(startControlPlaneCommand(workDirs[0]!))).rejects.toThrow(
+        /child cancellation failed/u,
+      );
+      expect(check).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        output: {
+          title: "Authorized E2E run requires reconciliation",
+          summary: expect.stringContaining("this exact-diff authorization cannot be retried"),
+        },
+      });
+      await expect(startControlPlanePrGate(startControlPlaneCommand(workDirs[1]!))).rejects.toThrow(
+        /matching pending control-plane authorization state/u,
+      );
+      expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(1);
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
+    } finally {
+      for (const workDir of workDirs) fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a credentialed E2E skip from a collaborator below maintainer role", async () => {
     vi.stubEnv("GITHUB_TOKEN", "token");
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");

--- a/test/pr-e2e-gate-fork-skip.test.ts
+++ b/test/pr-e2e-gate-fork-skip.test.ts
@@ -400,9 +400,7 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
         .filter((request) => request.url.endsWith("/check-runs/17"))
         .at(-1);
       expect(completion?.body).toMatchObject({
-        status: "completed",
-        conclusion: "failure",
-        details_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${GATE_RUN_ID}`,
+        status: "in_progress",
         output: {
           title: "Maintainer authorization required to run E2E",
           summary: expect.stringContaining(
@@ -410,6 +408,7 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
           ),
         },
       });
+      expect(JSON.stringify(completion?.body)).not.toContain("conclusion");
       expect(JSON.stringify(completion?.body)).toContain(
         "run `run-control-plane` with the PR number, exact head and base SHAs",
       );
@@ -728,8 +727,8 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
             () => githubResponse([{ filename: "test/e2e/risk-signal-reporter.ts" }]),
           ),
           existingPrGateCheckRunsRoute({
-            status: "completed",
-            conclusion: "failure",
+            status: "in_progress",
+            conclusion: null,
             output: { title: "Maintainer authorization required to run E2E" },
           }),
           mainWorkflowRefRoute(),
@@ -984,7 +983,7 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
 
     try {
       await expect(startControlPlanePrGate(startControlPlaneCommand(workDir))).rejects.toThrow(
-        /matching control-plane authorization failure/u,
+        /matching pending control-plane authorization state/u,
       );
       expect(requests.some((request) => request.method === "PATCH")).toBe(false);
     } finally {
@@ -1024,8 +1023,8 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
                 total_count: 1,
                 check_runs: [
                   exactPrGateCheck({
-                    status: "completed",
-                    conclusion: "failure",
+                    status: "in_progress",
+                    conclusion: null,
                     output: { title: checkTitle },
                   }),
                 ],
@@ -1052,20 +1051,22 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
           /main advanced through trusted E2E control-plane changes/u,
         );
       }
-      const completions = requests.filter(
+      const restoredAuthorizations = requests.filter(
         (request) =>
           request.url.endsWith("/check-runs/17") &&
           request.method === "PATCH" &&
-          (request.body as { status?: string } | undefined)?.status === "completed",
+          (request.body as { output?: { title?: string } } | undefined)?.output?.title ===
+            "Maintainer authorization required to run E2E",
       );
-      expect(completions).toHaveLength(2);
-      expect(completions[0]?.body).toMatchObject({
-        conclusion: "failure",
+      expect(restoredAuthorizations).toHaveLength(2);
+      expect(restoredAuthorizations[0]?.body).toMatchObject({
+        status: "in_progress",
         output: {
           title: "Maintainer authorization required to run E2E",
           summary: expect.stringContaining("launch a fresh first-attempt `run-control-plane`"),
         },
       });
+      expect(JSON.stringify(restoredAuthorizations[0]?.body)).not.toContain("conclusion");
       expect(checkTitle).toBe("Maintainer authorization required to run E2E");
       expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
     } finally {
@@ -1227,8 +1228,8 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
             () => githubResponse([{ filename: "test/e2e/risk-signal-reporter.ts" }]),
           ),
           existingPrGateCheckRunsRoute({
-            status: "completed",
-            conclusion: "failure",
+            status: "in_progress",
+            conclusion: null,
             output: { title: "Maintainer authorization required to run E2E" },
           }),
           mainWorkflowRefRoute(),

--- a/test/pr-e2e-gate-fork-skip.test.ts
+++ b/test/pr-e2e-gate-fork-skip.test.ts
@@ -951,7 +951,7 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
     expect(requests.some((request) => request.method === "PATCH")).toBe(false);
   });
 
-  it("rejects control-plane authorization when the failed gate title does not match", async () => {
+  it("rejects control-plane authorization when the gate is already completed", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-title-"));
     vi.stubEnv("GITHUB_TOKEN", "token");
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
@@ -974,7 +974,7 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
           existingPrGateCheckRunsRoute({
             status: "completed",
             conclusion: "failure",
-            output: { title: "Maintainer approval required to skip credentialed E2E" },
+            output: { title: "Maintainer authorization required to run E2E" },
           }),
         ],
         requests,

--- a/test/pr-e2e-gate-fork-skip.test.ts
+++ b/test/pr-e2e-gate-fork-skip.test.ts
@@ -854,11 +854,11 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
             (request) => {
               const body = request.body as Record<string, unknown>;
               const title = (body.output as { title?: string } | undefined)?.title;
-              if (title === "Running 3 E2E jobs") {
-                return githubResponse({ message: "simulated update failure" }, 500);
-              }
-              check = { ...check, ...body };
-              return githubResponse({});
+              const updateFails = title === "Running 3 E2E jobs";
+              check = updateFails ? check : { ...check, ...body };
+              return updateFails
+                ? githubResponse({ message: "simulated update failure" }, 500)
+                : githubResponse({});
             },
           ),
           githubFetchRoute(

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -147,7 +147,7 @@ describe("native PR E2E required job", () => {
     await expect(findCoordinationCheck(identity)).rejects.toThrow("unexpected GitHub App");
   });
 
-  it("waits through authorization and revalidates the exact PR before passing", async () => {
+  it("waits through legacy authorization and running states before passing", async () => {
     let legacyQueries = 0;
     let clock = 0;
     vi.spyOn(globalThis, "fetch").mockImplementation(
@@ -171,7 +171,12 @@ describe("native PR E2E required job", () => {
                       conclusion: "failure",
                       output: { title: "Maintainer authorization required to run E2E" },
                     })
-                  : check("E2E / PR Gate"),
+                  : legacyQueries === 2
+                    ? check("E2E / PR Gate", {
+                        conclusion: "failure",
+                        output: { title: "Running 3 E2E jobs" },
+                      })
+                    : check("E2E / PR Gate"),
               ]),
             );
           },
@@ -189,7 +194,7 @@ describe("native PR E2E required job", () => {
         },
       }),
     ).resolves.toMatchObject({ conclusion: "success" });
-    expect(legacyQueries).toBe(2);
+    expect(legacyQueries).toBe(3);
   });
 
   it("fails closed when the PR head changes before a terminal verdict is accepted", async () => {

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -84,17 +84,17 @@ describe("native PR E2E required job", () => {
     expect(result.stderr).not.toContain("ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX");
   });
 
-  it("classifies authorization-required failures as pending", () => {
+  it("classifies fork-skip approval failures as pending", () => {
     expect(
       classifyCoordinationCheck(
         check("E2E / PR Gate", {
           conclusion: "failure",
-          output: { title: "Maintainer authorization required to run E2E" },
+          output: { title: "Maintainer approval required to skip credentialed E2E" },
         }),
       ),
     ).toEqual({
       state: "waiting",
-      description: "Maintainer authorization required to run E2E",
+      description: "Maintainer approval required to skip credentialed E2E",
     });
   });
 
@@ -147,8 +147,8 @@ describe("native PR E2E required job", () => {
     await expect(findCoordinationCheck(identity)).rejects.toThrow("unexpected GitHub App");
   });
 
-  it("waits through legacy authorization and running states before passing", async () => {
-    let legacyQueries = 0;
+  it("waits through pending authorization and running states before passing", async () => {
+    let coordinationQueries = 0;
     let clock = 0;
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter([
@@ -158,25 +158,23 @@ describe("native PR E2E required job", () => {
         ),
         githubFetchRoute(
           ({ url }) => url.includes("Coordination"),
-          () => githubResponse(listing([])),
-        ),
-        githubFetchRoute(
-          ({ url }) => url.includes("/check-runs") && !url.includes("Coordination"),
           () => {
-            legacyQueries += 1;
+            coordinationQueries += 1;
             return githubResponse(
               listing([
-                legacyQueries === 1
-                  ? check("E2E / PR Gate", {
-                      conclusion: "failure",
+                coordinationQueries === 1
+                  ? check(undefined, {
+                      status: "in_progress",
+                      conclusion: null,
                       output: { title: "Maintainer authorization required to run E2E" },
                     })
-                  : legacyQueries === 2
-                    ? check("E2E / PR Gate", {
-                        conclusion: "failure",
+                  : coordinationQueries === 2
+                    ? check(undefined, {
+                        status: "in_progress",
+                        conclusion: null,
                         output: { title: "Running 3 E2E jobs" },
                       })
-                    : check("E2E / PR Gate"),
+                    : check(),
               ]),
             );
           },
@@ -194,7 +192,7 @@ describe("native PR E2E required job", () => {
         },
       }),
     ).resolves.toMatchObject({ conclusion: "success" });
-    expect(legacyQueries).toBe(3);
+    expect(coordinationQueries).toBe(3);
   });
 
   it("fails closed when the PR head changes before a terminal verdict is accepted", async () => {

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -244,6 +244,16 @@ class ObsoleteExactDiffError extends Error {
   }
 }
 
+class DispatchedChildRunError extends Error {
+  readonly childRunId: number;
+
+  constructor(message: string, childRunId: number) {
+    super(message);
+    this.name = "DispatchedChildRunError";
+    this.childRunId = childRunId;
+  }
+}
+
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -1730,11 +1740,15 @@ async function dispatchSelectedPrGate(options: {
     try {
       await cancelChildRun(options.repository, options.token, childRunId);
     } catch (cancelError) {
-      throw new Error(
+      throw new DispatchedChildRunError(
         `${controllerErrorMessage(error)}; child cancellation failed: ${controllerErrorMessage(cancelError)}`,
+        childRunId,
       );
     }
-    throw error;
+    throw new DispatchedChildRunError(
+      `${controllerErrorMessage(error)}; child cancellation requested`,
+      childRunId,
+    );
   }
 }
 
@@ -2068,22 +2082,37 @@ export async function startControlPlanePrGate(command: ControlPlaneDispatchComma
     });
   } catch (error) {
     if (checkRunId) {
-      const reason = controllerErrorMessage(error).replace(/`/gu, "'");
-      try {
-        await markCheckInProgress(
+      if (error instanceof DispatchedChildRunError) {
+        const closed = await completeFailureAfterControllerError(
           { repository, checkRunId },
           token,
-          CONTROL_PLANE_AUTHORIZATION_TITLE,
-          [
-            `The authorized E2E attempt did not produce an accepted result: \`${reason}\`.`,
-            "Review the controller error and any linked child run, then launch a fresh first-attempt `run-control-plane` workflow for this exact revision.",
-          ].join("\n\n"),
+          "Authorized E2E run requires reconciliation",
+          {
+            error,
+            detailsUrl: `https://github.com/${repository}/actions/runs/${error.childRunId}`,
+            recovery:
+              "A credential-bearing child run was dispatched, so this exact-diff authorization cannot be retried. Inspect the linked run, then update the PR and run fresh CI before authorizing again.",
+          },
         );
-        appendOutput("finalized", "true");
-      } catch (restoreError) {
-        console.error(
-          `Failed to restore control-plane authorization after controller error: ${controllerErrorMessage(restoreError)}`,
-        );
+        if (closed) appendOutput("finalized", "true");
+      } else {
+        const reason = controllerErrorMessage(error).replace(/`/gu, "'");
+        try {
+          await markCheckInProgress(
+            { repository, checkRunId },
+            token,
+            CONTROL_PLANE_AUTHORIZATION_TITLE,
+            [
+              `The authorized E2E attempt did not produce an accepted result: \`${reason}\`.`,
+              "Review the controller error and any linked child run, then launch a fresh first-attempt `run-control-plane` workflow for this exact revision.",
+            ].join("\n\n"),
+          );
+          appendOutput("finalized", "true");
+        } catch (restoreError) {
+          console.error(
+            `Failed to restore control-plane authorization after controller error: ${controllerErrorMessage(restoreError)}`,
+          );
+        }
       }
     }
     throw error;

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -33,6 +33,7 @@ const PR_GATE_WORKFLOW_PATH = ".github/workflows/pr-e2e-gate.yaml";
 const PR_GATE_APPROVAL_ENVIRONMENT = "approve-credentialed-e2e-skip-for-fork-pr";
 const CHECK_NAME = "E2E / PR Gate Coordination";
 const WORKFLOW_NAME = "E2E / PR Gate Controller";
+const CONTROL_PLANE_AUTHORIZATION_TITLE = "Maintainer authorization required to run E2E";
 const CHECK_EXTERNAL_ID_PREFIX = "nemoclaw-pr-e2e:v2";
 const LEGACY_CHECK_EXTERNAL_ID_PREFIX = "nemoclaw-pr-e2e:v1";
 const GITHUB_ACTIONS_APP_ID = 15368;
@@ -1906,22 +1907,17 @@ export async function startPrGate(
     }
     const controlPlaneFamily = plan.families.find((family) => family.id === "e2e-control-plane");
     if (controlPlaneFamily && requiresCredentialedE2eAuthorization(plan)) {
-      const gateRunUrl = `https://github.com/${repository}/actions/runs/${command.gateRunId}`;
       const workflowUrl = `https://github.com/${repository}/actions/workflows/${PR_GATE_WORKFLOW_PATH}`;
-      await completeCheck(
+      await markCheckInProgress(
         { repository, checkRunId },
         token,
-        {
-          conclusion: "failure",
-          title: "Maintainer authorization required to run E2E",
-          summary: [
-            `This exact internal diff (head \`${command.headSha}\`, base \`${ciIdentity.baseSha}\`) changes code that the selected credential-bearing E2E jobs execute or trust: ${jobs.join(", ")}.`,
-            "No selected E2E job ran and no repository secret was exposed.",
-            `A repository maintainer or administrator must review this exact revision, then open the [${WORKFLOW_NAME}](${workflowUrl}) workflow and run \`run-control-plane\` with the PR number, exact head and base SHAs, and a review reason. That authorized run dispatches the selected jobs and this gate passes only if their exact-SHA evidence verifies successfully.`,
-            `Deterministic plan: \`${plan.planHash}\`.`,
-          ].join("\n\n"),
-        },
-        gateRunUrl,
+        CONTROL_PLANE_AUTHORIZATION_TITLE,
+        [
+          `This exact internal diff (head \`${command.headSha}\`, base \`${ciIdentity.baseSha}\`) changes code that the selected credential-bearing E2E jobs execute or trust: ${jobs.join(", ")}.`,
+          "No selected E2E job ran and no repository secret was exposed.",
+          `A repository maintainer or administrator must review this exact revision, then open the [${WORKFLOW_NAME}](${workflowUrl}) workflow and run \`run-control-plane\` with the PR number, exact head and base SHAs, and a review reason. That authorized run dispatches the selected jobs and this gate passes only if their exact-SHA evidence verifies successfully.`,
+          `Deterministic plan: \`${plan.planHash}\`.`,
+        ].join("\n\n"),
       );
       appendOutput("dispatched", "false");
       appendOutput("finalized", "true");
@@ -2038,14 +2034,15 @@ export async function startControlPlanePrGate(command: ControlPlaneDispatchComma
       throw new Error(`Expected one exact-diff PR gate check; found ${matchingChecks.length}`);
     }
     const check = matchingChecks[0]!;
+    const pendingAuthorization = check.status === "in_progress" && check.conclusion === null;
+    // Migration bridge for PRs whose authorization check completed before this
+    // fix. GitHub lets later updates change its output but cannot reopen it.
+    const legacyAuthorization = check.status === "completed" && check.conclusion === "failure";
     if (
-      check.status !== "completed" ||
-      check.conclusion !== "failure" ||
-      check.output?.title !== "Maintainer authorization required to run E2E"
+      (!pendingAuthorization && !legacyAuthorization) ||
+      check.output?.title !== CONTROL_PLANE_AUTHORIZATION_TITLE
     ) {
-      throw new Error(
-        "PR gate must first complete with the matching control-plane authorization failure",
-      );
+      throw new Error("PR gate must have the matching pending control-plane authorization state");
     }
     checkRunId = check.id;
     appendOutput("check_id", String(checkRunId));
@@ -2077,18 +2074,23 @@ export async function startControlPlanePrGate(command: ControlPlaneDispatchComma
     });
   } catch (error) {
     if (checkRunId) {
-      const closed = await completeFailureAfterControllerError(
-        { repository, checkRunId },
-        token,
-        "Maintainer authorization required to run E2E",
-        {
-          error,
-          detailsUrl: `https://github.com/${repository}/actions/runs/${command.gateRunId}`,
-          recovery:
-            "The authorized E2E attempt did not produce an accepted result. Review the controller error and any linked child run, then launch a fresh first-attempt `run-control-plane` workflow for this exact revision.",
-        },
-      );
-      if (closed) appendOutput("finalized", "true");
+      const reason = controllerErrorMessage(error).replace(/`/gu, "'");
+      try {
+        await markCheckInProgress(
+          { repository, checkRunId },
+          token,
+          CONTROL_PLANE_AUTHORIZATION_TITLE,
+          [
+            `The authorized E2E attempt did not produce an accepted result: \`${reason}\`.`,
+            "Review the controller error and any linked child run, then launch a fresh first-attempt `run-control-plane` workflow for this exact revision.",
+          ].join("\n\n"),
+        );
+        appendOutput("finalized", "true");
+      } catch (restoreError) {
+        console.error(
+          `Failed to restore control-plane authorization after controller error: ${controllerErrorMessage(restoreError)}`,
+        );
+      }
     }
     throw error;
   }

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -2035,13 +2035,7 @@ export async function startControlPlanePrGate(command: ControlPlaneDispatchComma
     }
     const check = matchingChecks[0]!;
     const pendingAuthorization = check.status === "in_progress" && check.conclusion === null;
-    // Migration bridge for PRs whose authorization check completed before this
-    // fix. GitHub lets later updates change its output but cannot reopen it.
-    const legacyAuthorization = check.status === "completed" && check.conclusion === "failure";
-    if (
-      (!pendingAuthorization && !legacyAuthorization) ||
-      check.output?.title !== CONTROL_PLANE_AUTHORIZATION_TITLE
-    ) {
+    if (!pendingAuthorization || check.output?.title !== CONTROL_PLANE_AUTHORIZATION_TITLE) {
       throw new Error("PR gate must have the matching pending control-plane authorization state");
     }
     checkRunId = check.id;

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -14,11 +14,7 @@ const GITHUB_ACTIONS_APP_ID = 15368;
 const USER_AGENT = "nemoclaw-pr-e2e-required";
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
-const AUTHORIZATION_TITLES = new Set([
-  "Maintainer approval required to skip credentialed E2E",
-  "Maintainer authorization required to run E2E",
-]);
-const LEGACY_RUNNING_TITLE_PATTERN = /^Running [1-9][0-9]* E2E jobs?$/u;
+const AUTHORIZATION_TITLES = new Set(["Maintainer approval required to skip credentialed E2E"]);
 
 type CheckConclusion = "success" | "failure" | "cancelled";
 
@@ -191,12 +187,7 @@ export function classifyCoordinationCheck(
   if (check.status !== "completed") {
     return { state: "waiting", description: title };
   }
-  // Migration bridge for authorization checks completed before the controller
-  // kept them pending. GitHub can update their title but cannot reopen them.
-  if (
-    check.conclusion === "failure" &&
-    (AUTHORIZATION_TITLES.has(title) || LEGACY_RUNNING_TITLE_PATTERN.test(title))
-  ) {
+  if (check.conclusion === "failure" && AUTHORIZATION_TITLES.has(title)) {
     return { state: "waiting", description: title };
   }
   if (

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -18,6 +18,7 @@ const AUTHORIZATION_TITLES = new Set([
   "Maintainer approval required to skip credentialed E2E",
   "Maintainer authorization required to run E2E",
 ]);
+const LEGACY_RUNNING_TITLE_PATTERN = /^Running [1-9][0-9]* E2E jobs?$/u;
 
 type CheckConclusion = "success" | "failure" | "cancelled";
 
@@ -190,7 +191,12 @@ export function classifyCoordinationCheck(
   if (check.status !== "completed") {
     return { state: "waiting", description: title };
   }
-  if (check.conclusion === "failure" && AUTHORIZATION_TITLES.has(title)) {
+  // Migration bridge for authorization checks completed before the controller
+  // kept them pending. GitHub can update their title but cannot reopen them.
+  if (
+    check.conclusion === "failure" &&
+    (AUTHORIZATION_TITLES.has(title) || LEGACY_RUNNING_TITLE_PATTERN.test(title))
+  ) {
     return { state: "waiting", description: title };
   }
   if (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Keep control-plane E2E authorization in progress so GitHub can advance the same coordination check from authorization to running and then to its terminal verdict. This fixes the lifecycle observed on #6904, where GitHub preserved the completed failure conclusion even after the controller changed the check title to `Running 9 E2E jobs`, causing the native required job to fail while E2E was still running.

## Changes

- Leave an internal control-plane authorization checkpoint `in_progress`, validate that pending state during manual authorization, and restore it after a retryable controller failure.
- Reject completed authorization checks instead of reinterpreting them; older builds require a fresh exact-diff revision and PR-CI run before authorization.
- Fail closed after any child dispatch: request cancellation, publish a terminal reconciliation result, and require a fresh exact diff rather than risk duplicate credential-bearing execution.
- Update controller and native-observer lifecycle coverage for the pending authorization-to-running-to-success sequence, plus the E2E operator guide for pending authorization and retry restoration.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Required before merge; this changes the trusted controller state machine around credential-bearing E2E authorization while preserving exact head/base, maintainer-role, and risk-plan validation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/pr-e2e-gate-fork-skip.test.ts test/pr-e2e-required.test.ts test/pr-e2e-gate-workflow.test.ts test/pr-e2e-gate-lifecycle.test.ts test/pr-e2e-gate.test.ts` (5 files, 108 tests passed); `npm run typecheck:cli`; `npm run source-shape:check`; `npm run test:projects:check`; `npm run test-size:check`
- [ ] Applicable broad gate passed — not applicable; this is a focused controller/observer lifecycle correction covered by the targeted controller, native-observer, workflow, and lifecycle suites above
- [ ] Quality Gates section completed with required justifications or waivers — pending sensitive-path review above
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — build passed with the same two hidden Fern warnings
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only) — not applicable; only the E2E operator README changed
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated pending authorization check state for credentialed E2E runs, including clearer workflow instructions and required validation inputs.
  * Added reconciliation behavior when dispatched E2E jobs can’t be cancelled or completed reliably.

* **Bug Fixes**
  * Prevented authorization checks from being misinterpreted as retryable waiting states after failures.
  * Required fresh authorization when base/head revisions change.
  * Improved restoration and strict handling of intermediate authorization/observer states.

* **Documentation**
  * Updated E2E gate guidance to reflect the in-progress authorization and reconciliation flows.

* **Tests**
  * Expanded E2E coverage for fork-skip approval and authorization-close scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->