### PR TITLE
fix(install): name NEMOCLAW_FRESH=1 in failed-session remediation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2404,19 +2404,19 @@ run_onboard() {
         # Refuse in non-interactive mode (no safe default); prompt in
         # interactive mode so the user can pick resume vs. fresh.
         if [ "${NON_INTERACTIVE:-}" = "1" ]; then
-          error "Previous onboarding session failed. Re-run with --fresh to discard it, or run '${_CLI_BIN} onboard --resume' to retry the same session."
+          error "Previous onboarding session failed. Re-run with NEMOCLAW_FRESH=1 to discard it, or run '${_CLI_BIN} onboard --resume' to retry the same session."
         fi
         local _prompt_stdin="/dev/tty"
         if [ -t 0 ]; then _prompt_stdin="/dev/stdin"; fi
         if [ ! -r "$_prompt_stdin" ]; then
-          error "Previous onboarding session failed, and no TTY is available to prompt. Re-run with --fresh or run '${_CLI_BIN} onboard --resume'."
+          error "Previous onboarding session failed, and no TTY is available to prompt. Re-run with NEMOCLAW_FRESH=1 or run '${_CLI_BIN} onboard --resume'."
         fi
         info "Previous onboarding session failed."
         local _resume_answer=""
         while :; do
           printf "  Resume the failed session, or start fresh? [R/f]: " >&2
           if ! IFS= read -r _resume_answer <"$_prompt_stdin"; then
-            error "Could not read response from TTY. Re-run with --fresh or run '${_CLI_BIN} onboard --resume'."
+            error "Could not read response from TTY. Re-run with NEMOCLAW_FRESH=1 or run '${_CLI_BIN} onboard --resume'."
           fi
           # Use tr to lowercase the answer rather than the bash 4 case
           # expansion form (lowercase via the comma-comma operator), which

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -963,7 +963,7 @@ fi`,
 
     expect(result.status).not.toBe(0);
     expect(`${result.stdout}${result.stderr}`).toMatch(/Previous onboarding session failed/);
-    expect(`${result.stdout}${result.stderr}`).toMatch(/--fresh/);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/NEMOCLAW_FRESH=1/);
     // The installer must have bailed out before invoking nemoclaw onboard.
     expect(fs.existsSync(onboardLog)).toBe(false);
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The installer's failed onboarding-session error told users to `Re-run with --fresh`, but `--fresh` cannot be passed through a piped `curl … | bash` install — the only actionable lever there is the `NEMOCLAW_FRESH=1` environment variable, which the installer already documents and honours. The three `run_onboard` failed-session branches now name `NEMOCLAW_FRESH=1`, so the remediation is actionable for the non-interactive and no-TTY paths that emit it.

## Related Issue

Fixes #6912

## Changes

- `scripts/install.sh`: the non-interactive, no-TTY, and TTY-unreadable failed-session branches now advise `NEMOCLAW_FRESH=1` in place of the un-pipeable `--fresh` flag; the `onboard --resume` alternative is unchanged.
- `test/install-preflight.test.ts`: the non-interactive failed-session test now asserts the emitted error names `NEMOCLAW_FRESH=1`, guarding the corrected remediation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `NEMOCLAW_FRESH=1` is already documented in the installer help and environment list; only an existing error-message string changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: wording-only change to an existing onboarding error message; no change to control flow, onboarding logic, or security posture — deferring to maintainer review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: n/a — string-only installer change, no broad runtime/harness or coverage change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installer guidance for recovering from failed onboarding sessions.
  * Clarified how to start a fresh onboarding attempt or resume an existing session in interactive and non-interactive modes.
  * Corrected the fresh-start option to use the `NEMOCLAW_FRESH=1` environment setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->