### PR TITLE
fix(install): name NEMOCLAW_FRESH=1 in failed-session remediation (#6912)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -176,6 +176,15 @@ Interactive third-party software acceptance requires a TTY.
 EOF
 }
 
+# Common remediation for the run_onboard failed-session branches. Names both
+# the --fresh flag and the NEMOCLAW_FRESH=1 env var the installer already
+# documents and honors, because a piped `curl … | bash` install takes flags
+# only via `bash -s --`, so the env var is the form that pipe can use
+# directly. Shared by all three branches so the hint stays in sync (#6912).
+onboard_failed_session_remediation() {
+  printf "Re-run with --fresh or set NEMOCLAW_FRESH=1 to discard it, or run '%s onboard --resume' to retry the same session." "$_CLI_BIN"
+}
+
 verify_downloaded_script() {
   local file="$1" label="${2:-script}" expected_hash="${3:-}"
   if [ ! -s "$file" ]; then
@@ -2025,19 +2034,19 @@ run_onboard() {
         # Refuse in non-interactive mode (no safe default); prompt in
         # interactive mode so the user can pick resume vs. fresh.
         if [ "${NON_INTERACTIVE:-}" = "1" ]; then
-          error "Previous onboarding session failed. Re-run with --fresh to discard it, or run '${_CLI_BIN} onboard --resume' to retry the same session."
+          error "Previous onboarding session failed. $(onboard_failed_session_remediation)"
         fi
         local _prompt_stdin="/dev/tty"
         if [ -t 0 ]; then _prompt_stdin="/dev/stdin"; fi
         if [ ! -r "$_prompt_stdin" ]; then
-          error "Previous onboarding session failed, and no TTY is available to prompt. Re-run with --fresh or run '${_CLI_BIN} onboard --resume'."
+          error "Previous onboarding session failed, and no TTY is available to prompt. $(onboard_failed_session_remediation)"
         fi
         info "Previous onboarding session failed."
         local _resume_answer=""
         while :; do
           printf "  Resume the failed session, or start fresh? [R/f]: " >&2
           if ! IFS= read -r _resume_answer <"$_prompt_stdin"; then
-            error "Could not read response from TTY. Re-run with --fresh or run '${_CLI_BIN} onboard --resume'."
+            error "Could not read response from TTY. $(onboard_failed_session_remediation)"
           fi
           # Use tr to lowercase the answer rather than the bash 4 case
           # expansion form (lowercase via the comma-comma operator), which

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -1013,6 +1013,10 @@ fi`,
     expect(result.status).not.toBe(0);
     expect(`${result.stdout}${result.stderr}`).toMatch(/Previous onboarding session failed/);
     expect(`${result.stdout}${result.stderr}`).toMatch(/--fresh/);
+    // The non-interactive branch is reachable through a piped curl|bash
+    // install, which passes flags only via `bash -s --`, so the refusal must
+    // also name the env var form the installer documents and honors (#6912).
+    expect(`${result.stdout}${result.stderr}`).toMatch(/NEMOCLAW_FRESH=1/);
     // The installer must have bailed out before invoking nemoclaw onboard.
     expect(fs.existsSync(onboardLog)).toBe(false);
   });
@@ -2654,6 +2658,25 @@ exit 1
     const r = callInstallerFn('NEMOCLAW_VERSION="0.0.21"; installer_version_for_display');
     expect(r.status).toBe(0);
     expect(r.stdout).toBe("  v0.0.21");
+  });
+
+  it("onboard_failed_session_remediation: names the env var alongside the flag (#6912)", () => {
+    const r = callInstallerFn("onboard_failed_session_remediation");
+    expect(r.status).toBe(0);
+    // A piped `curl … | bash` install takes flags only via `bash -s --`, so
+    // the env var is the form that pipe can apply directly. Naming only the
+    // flag left curl|bash users without an actionable remediation (#6912).
+    expect(r.stdout).toContain("NEMOCLAW_FRESH=1");
+    expect(r.stdout).toContain("--fresh");
+    expect(r.stdout).toContain("nemoclaw onboard --resume");
+  });
+
+  it("onboard_failed_session_remediation: uses the active CLI alias", () => {
+    const r = callInstallerFn("onboard_failed_session_remediation", {
+      NEMOCLAW_AGENT: "hermes",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("nemohermes onboard --resume");
   });
 
   it("agent_display_name: formats Hermes and NemoClaw names", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The installer's three failed-session refusal branches told users to "Re-run with `--fresh`" but never named `NEMOCLAW_FRESH=1`, the env-var form `scripts/install.sh` already documents (usage line `NEMOCLAW_FRESH=1  Same as --fresh`) and honors (`FRESH="${FRESH:-${NEMOCLAW_FRESH:-}}"`). A piped `curl … | bash` install applies a flag only through `bash -s --`, so for the documented one-liner the env var is the form the pipe can apply directly — and it was the one form the error never mentioned.

The three branches now share one remediation that names both forms, so the hint cannot drift from the documented behavior again.

## Related Issue

Fixes #6912

## Changes

- `scripts/install.sh`: added `onboard_failed_session_remediation()`, which names both `--fresh` and `NEMOCLAW_FRESH=1` plus the `onboard --resume` alternative, and called it from all three `run_onboard` failed-session branches (non-interactive refusal, no-TTY, TTY-unreadable).
- `test/install-preflight.test.ts`: added direct coverage of the helper and tightened the existing non-interactive refusal test.

### On the shared helper

This is not a new abstraction layer: `tty_required_error_message()` sits directly above it and exists for exactly this reason — its comment reads *"so the recovery hint stays in sync (#3058)."* Three copies of a remediation drifting from the documented env var is precisely what produced this bug, and the current consumers are the three branches named above, each covered by tests.

Wording follows the existing vocabulary already in this file:

```text
Re-run with --yes-i-accept-third-party-software or set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1.
```

so the installer phrases both refusals the same way.

### Before / after

```text
Before: Previous onboarding session failed. Re-run with --fresh to discard it, or run
        'nemoclaw onboard --resume' to retry the same session.

After:  Previous onboarding session failed. Re-run with --fresh or set NEMOCLAW_FRESH=1
        to discard it, or run 'nemoclaw onboard --resume' to retry the same session.
```

The helper interpolates `_CLI_BIN`, so the NemoHermes branding path (`nemohermes onboard --resume`) is preserved and now covered by a test the previous inline strings never had.

## One correction to the issue report

The issue states that `--fresh` "cannot be passed through a piped curl|bash install." That is not accurate — `install.sh` documents `curl -fsSL … | bash -s -- [options]` in its usage, and `docs/reference/troubleshooting.mdx` already gives `bash -s -- --fresh` as a working remediation.

The defect is real but narrower than described: the message named a bare flag without saying what to re-run it on, and omitted the simpler env-var form the docs recommend for the pipe. This PR fixes that actual defect. Flagging it so the issue's premise is not baked into the fix.

## Testing

- `NEMOCLAW_RUN_INSTALLER_TESTS=1 npx vitest run --project installer-integration` → **117 passed**, spawning real `install.sh` processes.
- **Regression coverage confirmed**: reverting the helper body to the pre-fix wording makes `onboard_failed_session_remediation: names the env var alongside the flag (#6912)` fail with `expected 'Re-run with --fresh to discard it, …' to contain 'NEMOCLAW_FRESH=1'`. The test was verified to fail against the unfixed message, not just pass against the fixed one.
- The existing non-interactive refusal test asserted only `/--fresh/`, which passes against the broken message; it now also asserts `/NEMOCLAW_FRESH=1/`.

### Hook note for reviewers

`pre-commit`/`pre-push` were run with `SKIP=test-cli`; every other hook ran normally and passed, including gitleaks, commitlint, and the source-shape test budget. The `test-cli` hook reports 21 failures on this machine that are **pre-existing on clean `origin/main`** with this change stashed (`src/lib/inference/local.test.ts`, `test/cli.test.ts`, `test/snapshot-*.test.ts`, and others) — they are macOS/Docker-environmental and untouched by this PR, which changes only `install.sh` and its own test. CI is the authoritative signal for that lane.

## Docs

No change needed. `docs/reference/troubleshooting.mdx` ("Previous onboarding session failed") already documents both `bash -s -- --fresh` and `NEMOCLAW_FRESH=1 bash` correctly. This PR brings the error message in line with docs that were already right.

## Checklist

- [x] Follows the repository code style and conventions
- [x] Tests added or updated for the changed behavior
- [x] Docs reviewed (no change required — see above)
- [x] No secrets, API keys, or credentials committed

Signed-off-by: Atulya Singh <atulyarajsingh@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer guidance when onboarding fails or cannot continue interactively.
  * Failure messages now consistently explain how to resume onboarding or start fresh using the appropriate environment variable and command options.
  * Remediation instructions now reflect the active CLI alias.

* **Tests**
  * Added coverage to verify onboarding failure messages include the correct fresh-start instructions and CLI alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->