### PR TITLE
refactor(scripts): migrate the OpenClaw tool-catalog patch tool to .mts (#6929)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,13 +210,13 @@ RUN npm ci --prefix /usr/local/lib/nemoclaw/wechat-runtime \
         /usr/local/share/nemoclaw/wechat-npm-cache \
     && chmod -R a+rX,go-w /usr/local/lib/nemoclaw/wechat-runtime \
         /usr/local/share/nemoclaw/wechat-npm-cache
-COPY scripts/patch-openclaw-tool-catalog.js /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js
+COPY scripts/patch-openclaw-tool-catalog.mts /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.mts
 COPY scripts/patch-openclaw-chat-send.js /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js
 COPY scripts/patch-openclaw-mcp-npx.mts /usr/local/lib/nemoclaw/patch-openclaw-mcp-npx.mts
 COPY scripts/patch-openclaw-issue-4434-diagnostics.ts /usr/local/lib/nemoclaw/patch-openclaw-issue-4434-diagnostics.ts
 COPY scripts/patch-openclaw-device-self-approval.ts /usr/local/lib/nemoclaw/patch-openclaw-device-self-approval.ts
 COPY scripts/verify-wechat-runtime-lock.mts /usr/local/lib/nemoclaw/verify-wechat-runtime-lock.mts
-RUN chmod 755 /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js \
+RUN chmod 755 /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.mts \
         /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js \
         /usr/local/lib/nemoclaw/patch-openclaw-mcp-npx.mts \
         /usr/local/lib/nemoclaw/patch-openclaw-issue-4434-diagnostics.ts \
@@ -776,7 +776,7 @@ RUN node --experimental-strip-types /usr/local/lib/nemoclaw/patch-openclaw-mcp-n
 # need it. OpenClaw 2026.6.10 ships a built-in catalog surface, so the script
 # skips cleanly after classifying the compiled selection-*.js shape.
 # hadolint ignore=DL3059
-RUN node /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js \
+RUN node --experimental-strip-types /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.mts \
     /usr/local/lib/node_modules/openclaw/dist
 
 # Set up blueprint for local resolution.

--- a/nemoclaw-blueprint/scripts/nemotron-inference-fix.js
+++ b/nemoclaw-blueprint/scripts/nemotron-inference-fix.js
@@ -140,7 +140,7 @@
   // `nemoclaw/src/index.ts:WRITE_TOOL_NAMES` so this allowlist stays
   // aligned with the same write-capable surface OpenClaw scans for
   // secrets. `tool_call` is the OpenClaw compact-catalog wrapper from
-  // `scripts/patch-openclaw-tool-catalog.js` — when it's present we
+  // `scripts/patch-openclaw-tool-catalog.mts` — when it's present we
   // can't tell from the request alone which underlying tool will be
   // dispatched, so treat it as execution-capable and skip the nudge.
   var EXECUTION_TOOL_NAMES = new Set([

--- a/scripts/patch-openclaw-tool-catalog.mts
+++ b/scripts/patch-openclaw-tool-catalog.mts
@@ -1,13 +1,14 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --experimental-strip-types
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-"use strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const fs = require("node:fs");
-const path = require("node:path");
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
 
-const MARKER = "/* nemoclaw compact tool catalog (#2600) */";
+export const MARKER = "/* nemoclaw compact tool catalog (#2600) */";
 const ALL_CUSTOM_TOOLS_PATTERN =
   "\t\t\tconst allCustomTools = [...customTools, ...clientToolDefs];";
 const EFFECTIVE_TOOLS_PATTERN = "\t\tconst effectiveTools = [...tools, ...filteredBundledTools];";
@@ -177,11 +178,20 @@ const CATALOG_HELPER_AND_ASSIGNMENT = [
   "\t\t\tconst allCustomTools = nemoClawCreateToolCatalog(nemoClawCatalogSourceTools);",
 ].join("\n");
 
-function usage() {
-  return "Usage: patch-openclaw-tool-catalog.js <openclaw-dist-dir>";
+type PatchStatus = "patched" | "already-patched" | "native-tool-search" | "skipped-built-in";
+
+type PatchSelectionResult = {
+  patched: boolean;
+  text: string;
+  status?: PatchStatus;
+  skippedBuiltIn?: boolean;
+};
+
+function usage(): string {
+  return "Usage: patch-openclaw-tool-catalog.mts <openclaw-dist-dir>";
 }
 
-function countOccurrences(haystack, needle) {
+function countOccurrences(haystack: string, needle: string): number {
   let count = 0;
   let index = haystack.indexOf(needle);
   while (index !== -1) {
@@ -191,14 +201,16 @@ function countOccurrences(haystack, needle) {
   return count;
 }
 
-function readOpenClawVersion(distDir) {
+function readOpenClawVersion(distDir: string): string {
   const packageJsonPath = path.resolve(distDir, "..", "package.json");
-  let payload;
+  let payload: { version?: unknown };
   try {
     payload = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
   } catch (err) {
     throw new Error(
-      `Could not read OpenClaw package metadata at ${packageJsonPath}: ${err.message}`,
+      `Could not read OpenClaw package metadata at ${packageJsonPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
   }
   if (typeof payload.version !== "string") {
@@ -207,12 +219,16 @@ function readOpenClawVersion(distDir) {
   return payload.version;
 }
 
-function listSelectionFiles(distDir) {
-  let entries;
+function listSelectionFiles(distDir: string): string[] {
+  let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(distDir, { withFileTypes: true });
   } catch (err) {
-    throw new Error(`Could not read OpenClaw dist directory ${distDir}: ${err.message}`);
+    throw new Error(
+      `Could not read OpenClaw dist directory ${distDir}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
   return entries
     .filter((entry) => entry.isFile() && /^selection-.*\.js$/.test(entry.name))
@@ -220,15 +236,15 @@ function listSelectionFiles(distDir) {
     .sort();
 }
 
-function hasBuiltInToolCatalog(source) {
+function hasBuiltInToolCatalog(source: string): boolean {
   return source.includes("applyToolSearchCatalog({") && source.includes("buildToolSearchRunPlan({");
 }
 
-function hasNativeToolSearch(source) {
+function hasNativeToolSearch(source: string): boolean {
   return NATIVE_TOOL_SEARCH_PATTERNS.every((pattern) => source.includes(pattern));
 }
 
-function patchSelectionText(source, filePath) {
+export function patchSelectionText(source: string, filePath: string): PatchSelectionResult {
   if (source.includes(MARKER)) {
     if (ALREADY_PATCHED_FORBIDDEN_PATTERNS.some((pattern) => source.includes(pattern))) {
       throw new Error(`${filePath}: compact catalog marker is present but original targets remain`);
@@ -273,7 +289,11 @@ function patchSelectionText(source, filePath) {
   return { patched: true, text };
 }
 
-function patchOpenClawToolCatalog(distDir) {
+export function patchOpenClawToolCatalog(distDir: string): {
+  status: PatchStatus;
+  file: string;
+  version: string;
+} {
   const resolvedDist = path.resolve(distDir);
   const version = readOpenClawVersion(resolvedDist);
 
@@ -309,7 +329,7 @@ function patchOpenClawToolCatalog(distDir) {
   return { status: result.status ?? "already-patched", file: target, version };
 }
 
-function main(argv) {
+function main(argv: readonly string[]): number {
   const distDir = argv[2];
   if (!distDir || argv.length > 3) {
     console.error(usage());
@@ -327,12 +347,6 @@ function main(argv) {
   }
 }
 
-if (require.main === module) {
+if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
   process.exitCode = main(process.argv);
 }
-
-module.exports = {
-  MARKER,
-  patchOpenClawToolCatalog,
-  patchSelectionText,
-};

--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -231,8 +231,8 @@ function stageOptimizedSandboxBuildContext(
   );
   normalizeReadModesForDockerCopy(path.join(buildCtx, "src"));
   fs.copyFileSync(
-    path.join(rootDir, "scripts", "patch-openclaw-tool-catalog.js"),
-    path.join(stagedScriptsDir, "patch-openclaw-tool-catalog.js"),
+    path.join(rootDir, "scripts", "patch-openclaw-tool-catalog.mts"),
+    path.join(stagedScriptsDir, "patch-openclaw-tool-catalog.mts"),
   );
   fs.copyFileSync(
     path.join(rootDir, "scripts", "patch-openclaw-chat-send.js"),

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -657,7 +657,7 @@ startGateway(null).catch(() => {});
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw", "src"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw-blueprint", ".venv"))).toBe(false);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "nemoclaw-start.sh"))).toBe(true);
-      expect(fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-tool-catalog.js"))).toBe(
+      expect(fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-tool-catalog.mts"))).toBe(
         true,
       );
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);

--- a/test/openclaw-dependency-review.test.ts
+++ b/test/openclaw-dependency-review.test.ts
@@ -413,6 +413,9 @@ check_not_contains "$optional_plugin_block" 'pack_reviewed_npm_tarball' "optiona
 		grep -Fq 'nemoclaw: #4434 structured unreachable-inference diagnostic' "$issue_4434_patch"
 		grep -Fq 'COPY scripts/patch-openclaw-issue-4434-diagnostics.ts /usr/local/lib/nemoclaw/patch-openclaw-issue-4434-diagnostics.ts' Dockerfile
 		grep -Fq 'node --experimental-strip-types /usr/local/lib/nemoclaw/patch-openclaw-issue-4434-diagnostics.ts \\' Dockerfile
+		grep -Fq 'COPY scripts/patch-openclaw-tool-catalog.mts /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.mts' Dockerfile
+		grep -Fq 'node --experimental-strip-types /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.mts \\' Dockerfile
+		! grep -Fq 'patch-openclaw-tool-catalog.js' Dockerfile
 		device_self_approval_patch=${JSON.stringify(DEVICE_SELF_APPROVAL_PATCH)}
 		grep -Fq 'nemoclaw: reach gateway for bounded same-device scope approval' "$device_self_approval_patch"
 		grep -Fq 'nemoclaw: bounded same-device scope approval' "$device_self_approval_patch"

--- a/test/openclaw-tool-catalog-patch.test.ts
+++ b/test/openclaw-tool-catalog-patch.test.ts
@@ -2,21 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import { createRequire } from "node:module";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
+import { MARKER } from "../scripts/patch-openclaw-tool-catalog.mts";
 
-const require = createRequire(import.meta.url);
 const PATCH_SCRIPT = path.join(
   import.meta.dirname,
   "..",
   "scripts",
-  "patch-openclaw-tool-catalog.js",
+  "patch-openclaw-tool-catalog.mts",
 );
-const { MARKER } = require(PATCH_SCRIPT) as { MARKER: string };
 
 function writePackageJson(root: string, version = "2026.4.24") {
   fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ version }, null, 2));
@@ -160,7 +158,7 @@ function makeFixture(opts: { version?: string; allCustomToolsLine?: string } = {
 }
 
 function runPatch(dist: string) {
-  return spawnSync(process.execPath, [PATCH_SCRIPT, dist], {
+  return spawnSync(process.execPath, ["--experimental-strip-types", PATCH_SCRIPT, dist], {
     encoding: "utf-8",
     timeout: 10_000,
   });

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -107,7 +107,7 @@ describe("sandbox build context staging", () => {
       path.join("src", "lib", "messaging", "channels", "fixture", "hooks", "example.ts"),
     );
     writeFixture(path.join("src", "lib", "tool-disclosure.ts"));
-    writeFixture(path.join("scripts", "patch-openclaw-tool-catalog.js"));
+    writeFixture(path.join("scripts", "patch-openclaw-tool-catalog.mts"));
     writeFixture(path.join("scripts", "patch-openclaw-chat-send.js"));
     writeFixture(path.join("scripts", "patch-openclaw-mcp-npx.mts"));
     writeFixture(path.join("scripts", "patch-openclaw-issue-4434-diagnostics.ts"));
@@ -363,7 +363,7 @@ describe("sandbox build context staging", () => {
       expect(
         fs.existsSync(path.join(buildCtx, "scripts", "lib", "normalize_mutable_config_perms.py")),
       ).toBe(true);
-      expect(fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-tool-catalog.js"))).toBe(
+      expect(fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-tool-catalog.mts"))).toBe(
         true,
       );
       expect(fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-chat-send.js"))).toBe(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Migrates `scripts/patch-openclaw-tool-catalog.js` to `scripts/patch-openclaw-tool-catalog.mts`, following the `scripts/patch-openclaw-mcp-npx.mts` precedent already in the tree. This is a module-boundary migration only — no behavior, patch shape, or output contract changes.

## Related Issue

Fixes #6929
Parent: #6918

## Changes

- `scripts/patch-openclaw-tool-catalog.js` → `.mts` (git detects the rename at 89% similarity):
  - Shebang `#!/usr/bin/env node` → `#!/usr/bin/env -S node --experimental-strip-types`, matching the mcp-npx precedent.
  - `require("node:fs")` / `require("node:path")` → ESM imports; dropped `"use strict"` (implicit in ESM).
  - `module.exports` → named exports (`MARKER`, `patchOpenClawToolCatalog`, `patchSelectionText`) — the same three the CommonJS export block exposed.
  - `require.main === module` → `path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)`, the precedent's ESM main guard.
  - Added types at the existing seams. The two `catch (err)` blocks that interpolated `err.message` now narrow via `err instanceof Error ? err.message : String(err)`, since `err` is `unknown` in TypeScript — the message text is unchanged for `Error` instances, which is what both paths (`ENOENT` from `readFileSync`/`readdirSync`) actually throw.
- `Dockerfile`: `COPY` and `chmod` paths updated; the `RUN` invocation now passes `--experimental-strip-types`, matching how the adjacent `.mts` patch tools are already invoked (lines 204/221/772).
- `src/lib/sandbox/build-context.ts`: staged build-context copy path updated.
- `test/openclaw-tool-catalog-patch.test.ts`: replaced the `createRequire(import.meta.url)` bridge with a static ESM import (a `.mts` module cannot be `require()`d), and the direct-execution spawn now passes `--experimental-strip-types`. Mirrors `test/openclaw-mcp-npx-patch.test.ts`.
- `test/onboard.test.ts`, `test/sandbox-build-context.test.ts`: build-context fixture/assertion paths updated.
- `nemoclaw-blueprint/scripts/nemotron-inference-fix.js`: stale path in an explanatory comment.

No live reference to the old `.js` path remains (`git grep patch-openclaw-tool-catalog.js` → no matches).

## Preserved contracts

Per the epic's scope rules — shebang, executable mode (`755`, carried through `git mv`), SPDX header, exit codes, and the stdout/stderr contract are unchanged. Verified by direct execution:

```text
$ ./scripts/patch-openclaw-tool-catalog.mts
Usage: patch-openclaw-tool-catalog.mts <openclaw-dist-dir>       # exit 2

$ node --experimental-strip-types scripts/patch-openclaw-tool-catalog.mts /nonexistent
ERROR: Could not read OpenClaw package metadata at /package.json: ENOENT: ...   # exit 1
```

The usage string now names `.mts` — it is derived from the filename it prints for, so leaving it as `.js` would have misnamed the tool.

## Testing

- `npx vitest run test/openclaw-tool-catalog-patch.test.ts test/sandbox-build-context.test.ts` → **11 passed**
- `npx vitest run test/onboard.test.ts` → **33 passed**
- `npm run typecheck:cli` → clean
- Direct execution verified for both the usage (exit 2) and error (exit 1) paths, and via the shebang standalone — covering both the "direct execution" and "import/module use" halves the epic's shared acceptance criteria ask for.

## Docs

No change needed — this tool has no contributor-facing command examples in `docs/`; it is invoked only by the Dockerfile build.

## Note for reviewers

The Docker image build is the one contract I could not exercise locally. The `RUN` line depends on `--experimental-strip-types` being available in the image's Node, which the three adjacent `.mts`/`.ts` patch tools already rely on at lines 204/221/747/762/772 of the same Dockerfile, so the capability is established. Worth a CI image build to confirm.

## Checklist

- [x] Follows the repository code style and conventions
- [x] Tests updated for the changed module boundary
- [x] Docs reviewed (no change required — see above)
- [x] No secrets, API keys, or credentials committed

Signed-off-by: Atulya Singh <atulyarajsingh@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated the OpenClaw tool-catalog patch script from JavaScript to a TypeScript module.
  * Updated the Docker image build and sandbox staging to copy and run the new module format.
  * Improved robustness of patch-script error reporting.

* **Tests**
  * Updated sandbox and tool-catalog patch tests to validate the TypeScript-based workflow.
  * Expanded the dependency-review contract test to ensure the Dockerfile uses the new module and no longer references the old JavaScript script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->