### PR TITLE
fix(ci): support mode-sharded E2E evidence

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1175,6 +1175,7 @@ jobs:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_AGENT: "hermes"
+      NEMOCLAW_E2E_SHARD: ${{ matrix.mode }}
       NEMOCLAW_SANDBOX_NAME: ${{ matrix.sandbox_name }}
       NEMOCLAW_SWITCH_PROVIDER: ${{ matrix.switch_provider }}
       NEMOCLAW_SWITCH_MODEL: ${{ matrix.switch_model }}
@@ -4262,6 +4263,7 @@ jobs:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_AGENT: "openclaw"
+      NEMOCLAW_E2E_SHARD: ${{ matrix.mode }}
       NEMOCLAW_SANDBOX_NAME: ${{ matrix.sandbox_name }}
       NEMOCLAW_SWITCH_PROVIDER: ${{ matrix.switch_provider }}
       NEMOCLAW_SWITCH_MODEL: ${{ matrix.switch_model }}

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -327,6 +327,11 @@
       "category": "security"
     },
     {
+      "file": "test/pr-e2e-gate-shards.test.ts",
+      "test": "rejects malformed configured matrix shard selectors",
+      "category": "security"
+    },
+    {
       "file": "test/pr-review-advisor-workflow-boundary.test.ts",
       "test": "rejects deleting or weakening analysis-workspace symlink removal",
       "category": "security"

--- a/test/e2e/support/inference-switch-workflow-boundary.test.ts
+++ b/test/e2e/support/inference-switch-workflow-boundary.test.ts
@@ -57,6 +57,20 @@ describe("inference switch workflow boundary", () => {
     );
   });
 
+  it("rejects missing or misconfigured E2E shard mappings", () => {
+    const missingShard = readInferenceSwitchWorkflow();
+    delete missingShard.jobs["hermes-inference-switch"].env!.NEMOCLAW_E2E_SHARD;
+    expect(validateInferenceSwitchWorkflow(missingShard)).toContain(
+      "hermes-inference-switch must map NEMOCLAW_E2E_SHARD from its mode matrix",
+    );
+
+    const hardcodedShard = readInferenceSwitchWorkflow();
+    hardcodedShard.jobs["openclaw-inference-switch"].env!.NEMOCLAW_E2E_SHARD = "hosted";
+    expect(validateInferenceSwitchWorkflow(hardcodedShard)).toContain(
+      "openclaw-inference-switch must map NEMOCLAW_E2E_SHARD from its mode matrix",
+    );
+  });
+
   it("uses a healthy hosted switch target and scopes its credentials to hosted mode", () => {
     const wrongTarget = readInferenceSwitchWorkflow();
     const hosted = wrongTarget.jobs["hermes-inference-switch"].strategy?.matrix?.include?.find(

--- a/test/pr-e2e-gate-shards.test.ts
+++ b/test/pr-e2e-gate-shards.test.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { expectedSignalShards } from "../tools/e2e/pr-e2e-gate.mts";
+
+const temporaryWorkflowDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryWorkflowDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function temporaryE2eWorkflow(source: string): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-shards-"));
+  temporaryWorkflowDirectories.push(directory);
+  const workflowPath = path.join(directory, "e2e.yaml");
+  fs.writeFileSync(workflowPath, source, "utf8");
+  return workflowPath;
+}
+
+describe("PR E2E shard policy", () => {
+  // source-shape-contract: security -- Malformed matrix shard selectors must fail closed before exact-SHA evidence dispatch
+  it("rejects malformed configured matrix shard selectors", () => {
+    const workflow = fs.readFileSync(".github/workflows/e2e.yaml", "utf8");
+    const shardExpression = "NEMOCLAW_E2E_SHARD: ${{ matrix.mode }}";
+
+    const invalidExpression = temporaryE2eWorkflow(
+      workflow.replace(shardExpression, "NEMOCLAW_E2E_SHARD: mode"),
+    );
+    expect(() => expectedSignalShards(["hermes-inference-switch"], invalidExpression)).toThrow(
+      /must name one matrix include field/u,
+    );
+
+    const missingField = temporaryE2eWorkflow(
+      workflow.replace(shardExpression, "NEMOCLAW_E2E_SHARD: ${{ matrix.missing }}"),
+    );
+    expect(() => expectedSignalShards(["hermes-inference-switch"], missingField)).toThrow(
+      /must name a missing shard/u,
+    );
+
+    const nonStringField = temporaryE2eWorkflow(
+      workflow.replace(
+        "          - mode: hosted\n            sandbox_name: e2e-hermes-inference-switch",
+        "          - mode: 1\n            sandbox_name: e2e-hermes-inference-switch",
+      ),
+    );
+    expect(() => expectedSignalShards(["hermes-inference-switch"], nonStringField)).toThrow(
+      /must name a mode shard/u,
+    );
+  });
+});

--- a/test/pr-e2e-gate.test.ts
+++ b/test/pr-e2e-gate.test.ts
@@ -372,6 +372,10 @@ describe("PR E2E controller", () => {
     expect(expectedSignalShards(["docs-validation"])).toEqual({
       "docs-validation": ["default"],
     });
+    expect(expectedSignalShards(["hermes-inference-switch", "openclaw-inference-switch"])).toEqual({
+      "hermes-inference-switch": ["hosted", "anthropic"],
+      "openclaw-inference-switch": ["hosted", "anthropic"],
+    });
     const broadPlan = buildRiskPlan({ headSha: HEAD_SHA, changedFiles: BROAD_FILES });
     const broadShards = expectedSignalShards(riskPlanRequiredJobIds(broadPlan));
     expect(Object.keys(broadShards)).toHaveLength(13);

--- a/tools/e2e/inference-switch-workflow-boundary.mts
+++ b/tools/e2e/inference-switch-workflow-boundary.mts
@@ -93,6 +93,7 @@ function validateJob(errors: string[], spec: JobSpec, job: WorkflowJob): void {
   const requiredEnv: Record<string, unknown> = {
     E2E_ARTIFACT_DIR: `\${{ github.workspace }}/e2e-artifacts/live/${spec.scenario}/\${{ matrix.mode }}`,
     NEMOCLAW_AGENT: spec.agent,
+    NEMOCLAW_E2E_SHARD: "${{ matrix.mode }}",
     NEMOCLAW_SANDBOX_NAME: "${{ matrix.sandbox_name }}",
     NEMOCLAW_SWITCH_PROVIDER: "${{ matrix.switch_provider }}",
     NEMOCLAW_SWITCH_MODEL: "${{ matrix.switch_model }}",

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -1433,11 +1433,28 @@ export function expectedSignalShards(
             throw new Error(`${jobId} matrix agent values must be strings`);
           }
         } else if (keys.length === 1 && Array.isArray(matrix.include)) {
-          shards = matrix.include.map((entry) => {
-            if (!isObjectRecord(entry) || typeof entry.agent !== "string") {
-              throw new Error(`${jobId} matrix include entries must name an agent`);
+          const env = isObjectRecord(job.env) ? job.env : {};
+          const configuredShard = env.NEMOCLAW_E2E_SHARD;
+          let shardKey = "agent";
+          if (configuredShard !== undefined) {
+            const match =
+              typeof configuredShard === "string"
+                ? /^\$\{\{\s*matrix\.([A-Za-z][A-Za-z0-9_]*)\s*\}\}$/u.exec(configuredShard)
+                : null;
+            if (!match) {
+              throw new Error(`${jobId} NEMOCLAW_E2E_SHARD must name one matrix include field`);
             }
-            return entry.agent;
+            shardKey = match[1]!;
+          }
+          shards = matrix.include.map((entry) => {
+            if (!isObjectRecord(entry) || !Object.hasOwn(entry, shardKey)) {
+              throw new Error(`${jobId} matrix include entries must name a ${shardKey} shard`);
+            }
+            const shard = entry[shardKey];
+            if (typeof shard !== "string") {
+              throw new Error(`${jobId} matrix include entries must name a ${shardKey} shard`);
+            }
+            return shard;
           });
         } else {
           throw new Error(`${jobId} uses an unsupported evidence matrix`);


### PR DESCRIPTION
## Summary

The trusted PR E2E controller rejects inference-switch jobs because their fixed include matrix shards by mode rather than agent. This change binds matrix-include evidence to the explicit `NEMOCLAW_E2E_SHARD` field and makes the Hermes and OpenClaw inference-switch jobs emit distinct `hosted` and `anthropic` evidence. It unblocks the credential-bearing E2E gate for PR 6898.

## Changes

- Derive a fixed include matrix's shard key from a strict `${{ matrix.<field> }}` expression, retaining the existing agent fallback and all safe-identifier/uniqueness checks.
- Set `NEMOCLAW_E2E_SHARD` from `matrix.mode` for both inference-switch jobs.
- Extend the controller test and inference-switch workflow boundary to pin the two expected mode shards.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal CI evidence plumbing only; no user-facing or contributor-facing behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: PR advisor, CodeRabbit, and maintainer review requested on this exact head.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `test/pr-e2e-gate.test.ts`: 27 passed; complete `e2e-support` project: 1,022 passed and 2 skipped
- [ ] Applicable broad gate passed — repository-sharded PR CI is the authoritative broad gate; local all-project execution was not used as passing evidence
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end validation for inference-switch workflows by wiring shard selection from the workflow matrix mode.
  * Strengthened PR shard-policy parsing to derive shard IDs from configurable environment-to-matrix selectors with stricter failure-closed validation.
* **Tests**
  * Expanded PR E2E shard policy coverage to include both inference-switch job variants.
  * Added security-focused E2E tests covering malformed shard selectors and invalid matrix values, plus boundary validation for missing/misconfigured shard mappings.
* **Chores**
  * Updated CI source-shape test budget to categorize the new security test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->