### PR TITLE
fix(install): show full failed-session recovery command

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -761,26 +761,66 @@ Silent retry would loop on the same failure if your original choice, such as an 
 - In non-interactive mode (piped `curl | bash` with `NEMOCLAW_NON_INTERACTIVE=1`, CI, scripts), the installer refuses and exits with a non-zero status so a scripted re-run cannot loop.
   You must opt in to one of two paths explicitly:
 
-  Start over with new choices (discards the recorded session and provider/model selection):
+Start over with new choices to discard the recorded session and provider/model selection.
 
-  ```bash
-  curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh
-  ```
+<AgentOnly variant="openclaw">
 
-  Or equivalently, via env var.
-  The variable must be set on the `bash` side of the pipe, not on `curl`, since only the right-hand process inherits it:
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh
+```
 
-  ```bash
-  curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_FRESH=1 bash
-  ```
+</AgentOnly>
 
-  Retry the same session.
+<AgentOnly variant="hermes">
 
-  This is only useful if the original failure was transient, for example a network blip or a stopped Docker daemon, and not a wrong provider choice:
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=hermes bash -s -- --fresh
+```
 
-  ```bash
-  $$nemoclaw onboard --resume
-  ```
+</AgentOnly>
+
+<AgentOnly variant="deepagents">
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=langchain-deepagents-code bash -s -- --fresh
+```
+
+</AgentOnly>
+
+Or use environment variables instead.
+Set them on the `bash` side of the pipe because only the right-hand process inherits them.
+
+<AgentOnly variant="openclaw">
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_FRESH=1 bash
+```
+
+</AgentOnly>
+
+<AgentOnly variant="hermes">
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=hermes NEMOCLAW_FRESH=1 bash
+```
+
+</AgentOnly>
+
+<AgentOnly variant="deepagents">
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=langchain-deepagents-code NEMOCLAW_FRESH=1 bash
+```
+
+</AgentOnly>
+
+Retry the same session.
+
+This is only useful if the original failure was transient, for example a network blip or a stopped Docker daemon, and not a wrong provider choice:
+
+```bash
+$$nemoclaw onboard --resume
+```
 
 <AgentOnly variant="openclaw">
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2595,19 +2595,19 @@ run_onboard() {
         # Refuse in non-interactive mode (no safe default); prompt in
         # interactive mode so the user can pick resume vs. fresh.
         if [ "${NON_INTERACTIVE:-}" = "1" ]; then
-          error "Previous onboarding session failed. Re-run with NEMOCLAW_FRESH=1 to discard it, or run '${_CLI_BIN} onboard --resume' to retry the same session."
+          error "Previous onboarding session failed. To discard it and start over, run 'curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
         fi
         local _prompt_stdin="/dev/tty"
         if [ -t 0 ]; then _prompt_stdin="/dev/stdin"; fi
         if [ ! -r "$_prompt_stdin" ]; then
-          error "Previous onboarding session failed, and no TTY is available to prompt. Re-run with NEMOCLAW_FRESH=1 or run '${_CLI_BIN} onboard --resume'."
+          error "Previous onboarding session failed, and no TTY is available to prompt. To discard it and start over, run 'curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
         fi
         info "Previous onboarding session failed."
         local _resume_answer=""
         while :; do
           printf "  Resume the failed session, or start fresh? [R/f]: " >&2
           if ! IFS= read -r _resume_answer <"$_prompt_stdin"; then
-            error "Could not read response from TTY. Re-run with NEMOCLAW_FRESH=1 or run '${_CLI_BIN} onboard --resume'."
+            error "Could not read response from TTY. To discard the failed session and start over, run 'curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
           fi
           # Use tr to lowercase the answer rather than the bash 4 case
           # expansion form (lowercase via the comma-comma operator), which

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2594,20 +2594,32 @@ run_onboard() {
         # choice may be the cause, so auto-resuming would just loop.
         # Refuse in non-interactive mode (no safe default); prompt in
         # interactive mode so the user can pick resume vs. fresh.
+        local _fresh_install_cmd
+        case "${NEMOCLAW_AGENT:-openclaw}" in
+          hermes)
+            _fresh_install_cmd="curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=hermes bash -s -- --fresh"
+            ;;
+          langchain-deepagents-code)
+            _fresh_install_cmd="curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=langchain-deepagents-code bash -s -- --fresh"
+            ;;
+          *)
+            _fresh_install_cmd="curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh"
+            ;;
+        esac
         if [ "${NON_INTERACTIVE:-}" = "1" ]; then
-          error "Previous onboarding session failed. To discard it and start over, run 'curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
+          error "Previous onboarding session failed. To discard it and start over, run '${_fresh_install_cmd}'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
         fi
         local _prompt_stdin="/dev/tty"
         if [ -t 0 ]; then _prompt_stdin="/dev/stdin"; fi
         if [ ! -r "$_prompt_stdin" ]; then
-          error "Previous onboarding session failed, and no TTY is available to prompt. To discard it and start over, run 'curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
+          error "Previous onboarding session failed, and no TTY is available to prompt. To discard it and start over, run '${_fresh_install_cmd}'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
         fi
         info "Previous onboarding session failed."
         local _resume_answer=""
         while :; do
           printf "  Resume the failed session, or start fresh? [R/f]: " >&2
           if ! IFS= read -r _resume_answer <"$_prompt_stdin"; then
-            error "Could not read response from TTY. To discard the failed session and start over, run 'curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
+            error "Could not read response from TTY. To discard the failed session and start over, run '${_fresh_install_cmd}'. To retry the same session, run '${_CLI_BIN} onboard --resume'."
           fi
           # Use tr to lowercase the answer rather than the bash 4 case
           # expansion form (lowercase via the comma-comma operator), which

--- a/test/install-onboard-yes.test.ts
+++ b/test/install-onboard-yes.test.ts
@@ -134,14 +134,21 @@ function runOnboardWithSession(
   return captured.split("\n").filter((line) => line.length > 0);
 }
 
-type FailedPromptMode = "unreadable-tty" | "read-failure";
+type FailedPromptMode = "non-interactive" | "unreadable-tty" | "read-failure";
+type FailedSessionAgent = "" | "hermes" | "langchain-deepagents-code";
 
-function runFailedSessionRecovery(mode: FailedPromptMode) {
+function runFailedSessionRecovery(mode: FailedPromptMode, agent: FailedSessionAgent = "") {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-failed-recovery-"));
   const home = path.join(tmp, "home");
   const promptInput = path.join(tmp, "prompt-input.txt");
   const argvLog = path.join(tmp, "argv.txt");
-  const cliBin = path.join(tmp, "nemoclaw");
+  const cliName =
+    agent === "hermes"
+      ? "nemohermes"
+      : agent === "langchain-deepagents-code"
+        ? "nemo-deepagents"
+        : "nemoclaw";
+  const cliBin = path.join(tmp, cliName);
   fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
   fs.writeFileSync(
     path.join(home, ".nemoclaw", "onboard-session.json"),
@@ -155,7 +162,6 @@ function runFailedSessionRecovery(mode: FailedPromptMode) {
   const snippet = `
     set -e
     source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1 || true
-    _CLI_BIN="nemoclaw"
     _CLI_PATH=""
     show_usage_notice() { :; }
     info() { :; }
@@ -179,9 +185,10 @@ function runFailedSessionRecovery(mode: FailedPromptMode) {
       ...process.env,
       FRESH: "",
       HOME: home,
+      NEMOCLAW_AGENT: agent,
       NEMOCLAW_FRESH: "",
       NEMOCLAW_NON_INTERACTIVE: "",
-      NON_INTERACTIVE: "",
+      NON_INTERACTIVE: mode === "non-interactive" ? "1" : "",
       PATH: `${tmp}:${process.env.PATH ?? ""}`,
       PROMPT_INPUT_FILE: promptInput,
       PROMPT_MODE: mode,
@@ -275,6 +282,27 @@ describe("install.sh run_onboard — failed-session recovery", () => {
     expect(output).toContain(error);
     expect(output).toContain("curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh");
     expect(output).toContain("nemoclaw onboard --resume");
+    expect(fs.existsSync(argvLog)).toBe(false);
+  });
+
+  it.each([
+    {
+      agent: "hermes",
+      cliName: "nemohermes",
+      freshCommand:
+        "curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=hermes bash -s -- --fresh",
+    },
+    {
+      agent: "langchain-deepagents-code",
+      cliName: "nemo-deepagents",
+      freshCommand:
+        "curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=langchain-deepagents-code bash -s -- --fresh",
+    },
+  ] as const)("preserves $agent in the fresh and resume commands", (testCase) => {
+    const { argvLog, output, status } = runFailedSessionRecovery("non-interactive", testCase.agent);
+    expect(status).not.toBe(0);
+    expect(output).toContain(testCase.freshCommand);
+    expect(output).toContain(`${testCase.cliName} onboard --resume`);
     expect(fs.existsSync(argvLog)).toBe(false);
   });
 });

--- a/test/install-onboard-yes.test.ts
+++ b/test/install-onboard-yes.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
 
@@ -134,6 +134,62 @@ function runOnboardWithSession(
   return captured.split("\n").filter((line) => line.length > 0);
 }
 
+type FailedPromptMode = "unreadable-tty" | "read-failure";
+
+function runFailedSessionRecovery(mode: FailedPromptMode) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-failed-recovery-"));
+  const home = path.join(tmp, "home");
+  const promptInput = path.join(tmp, "prompt-input.txt");
+  const argvLog = path.join(tmp, "argv.txt");
+  const cliBin = path.join(tmp, "nemoclaw");
+  fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
+  fs.writeFileSync(
+    path.join(home, ".nemoclaw", "onboard-session.json"),
+    JSON.stringify({ status: "failed", resumable: true, failure: { step: "inference" } }),
+  );
+  fs.writeFileSync(promptInput, "");
+  fs.writeFileSync(cliBin, `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > "${argvLog}"\n`, {
+    mode: 0o755,
+  });
+
+  const snippet = `
+    set -e
+    source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1 || true
+    _CLI_BIN="nemoclaw"
+    _CLI_PATH=""
+    show_usage_notice() { :; }
+    info() { :; }
+    warn() { :; }
+    error() { printf 'ERROR: %s\\n' "$*" >&2; exit 1; }
+    function [ {
+      if [[ "$#" -eq 3 && "$1" = "-t" && "$2" = "0" && "$3" = "]" ]]; then
+        if [[ "$PROMPT_MODE" = "read-failure" ]]; then return 0; fi
+        return 1
+      fi
+      if [[ "$PROMPT_MODE" = "unreadable-tty" && "$#" -eq 4 && "$1" = "!" && "$2" = "-r" && "$3" = "/dev/tty" && "$4" = "]" ]]; then
+        return 0
+      fi
+      builtin [ "$@"
+    }
+    run_onboard < "$PROMPT_INPUT_FILE"
+  `;
+  const result = spawnSync("bash", ["-c", snippet], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      FRESH: "",
+      HOME: home,
+      NEMOCLAW_FRESH: "",
+      NEMOCLAW_NON_INTERACTIVE: "",
+      NON_INTERACTIVE: "",
+      PATH: `${tmp}:${process.env.PATH ?? ""}`,
+      PROMPT_INPUT_FILE: promptInput,
+      PROMPT_MODE: mode,
+    },
+  });
+  return { argvLog, output: `${result.stdout}${result.stderr}`, status: result.status };
+}
+
 describe("install.sh run_onboard — session classification (#5626)", () => {
   it("starts fresh (not --resume) when interrupted before sandbox creation", () => {
     // in_progress with no sandboxName and an incomplete sandbox step: nothing
@@ -206,6 +262,20 @@ describe("install.sh run_onboard — session classification (#5626)", () => {
     expect(argv).toContain("onboard");
     expect(argv).not.toContain("--resume");
     expect(argv).not.toContain("--fresh");
+  });
+});
+
+describe("install.sh run_onboard — failed-session recovery", () => {
+  it.each([
+    { mode: "unreadable-tty", name: "no prompt TTY is readable", error: "no TTY" },
+    { mode: "read-failure", name: "reading prompt input fails", error: "Could not read" },
+  ] as const)("shows both recovery commands when $name", ({ mode, error }) => {
+    const { argvLog, output, status } = runFailedSessionRecovery(mode);
+    expect(status).not.toBe(0);
+    expect(output).toContain(error);
+    expect(output).toContain("curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh");
+    expect(output).toContain("nemoclaw onboard --resume");
+    expect(fs.existsSync(argvLog)).toBe(false);
   });
 });
 

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -964,7 +964,7 @@ fi`,
     const freshCommand = "curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh";
     expect(result.status).not.toBe(0);
     expect(`${result.stdout}${result.stderr}`).toContain(freshCommand);
-    // The installer must have bailed out before invoking nemoclaw onboard.
+    expect(`${result.stdout}${result.stderr}`).toContain("nemoclaw onboard --resume");
     expect(fs.existsSync(onboardLog)).toBe(false);
   });
 

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -961,9 +961,9 @@ fi`,
       },
     });
 
+    const freshCommand = "curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --fresh";
     expect(result.status).not.toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toMatch(/Previous onboarding session failed/);
-    expect(`${result.stdout}${result.stderr}`).toMatch(/NEMOCLAW_FRESH=1/);
+    expect(`${result.stdout}${result.stderr}`).toContain(freshCommand);
     // The installer must have bailed out before invoking nemoclaw onboard.
     expect(fs.existsSync(onboardLog)).toBe(false);
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Failed onboarding-session exits currently name `NEMOCLAW_FRESH=1` without giving non-technical users a complete installer command. As a follow-up to #6916, this change prints a copy-pasteable `curl ... --fresh` command and the full agent-specific resume command while preserving the active supported agent.

## Changes

- Show the complete fresh-install and resume commands in all three failed-session error exits.
- Keep the default OpenClaw command concise and preserve Hermes or Deep Agents through fixed, whitelisted `NEMOCLAW_AGENT` selectors.
- Cover non-interactive, unreadable-terminal, prompt-read-failure, Hermes, and Deep Agents recovery output.
- Update the troubleshooting page so each generated agent variant shows its exact fresh and resume commands.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending maintainer re-review after addressing the requested agent-variant coverage and fixed-selector handling.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect that behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/install-onboard-yes.test.ts` — 13 passed; `npx vitest run --project installer-integration test/install-preflight.test.ts -t "refuses to auto-resume a failed onboarding session"` — 1 passed, 93 skipped; `npm run test-size:check`, `shellcheck scripts/install.sh`, `bash -n scripts/install.sh`, and `npx biome check test/install-onboard-yes.test.ts` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; focused installer recovery output, tests, and matching troubleshooting guidance.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — 0 errors and 2 existing warnings; `npm run docs:sync-agent-variants` passed.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer recovery messaging for a failed previous onboarding session, including cases with no readable terminal or failed input capture.
  * Recovery instructions now consistently provide agent-aware “start over” (`--fresh`) and “retry/resume” (`onboard --resume`) commands.
* **Documentation**
  * Updated troubleshooting guidance for “Previous onboarding session failed” with agent-specific fresh reinstall examples.
* **Tests**
  * Strengthened preflight and installer tests to verify the exact fresh one-liner, resume guidance, and correct agent context across failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->