### PR TITLE
ci: link aggregate failures to job logs

### DIFF
--- a/.github/workflows/brev-nightly-e2e.yaml
+++ b/.github/workflows/brev-nightly-e2e.yaml
@@ -24,6 +24,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: read
   # GitHub validates a reusable workflow's complete permission ceiling before
   # evaluating skipped jobs. The called workflow explicitly downgrades its

--- a/.github/workflows/candidate-compatibility.yaml
+++ b/.github/workflows/candidate-compatibility.yaml
@@ -372,6 +372,9 @@ jobs:
       - live
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
     steps:
       - name: Check out trusted compatibility controller
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -394,11 +397,14 @@ jobs:
           path: candidate-results
           merge-multiple: true
 
-      - name: Finalize auditable evidence
+      - id: finalize
+        name: Finalize auditable evidence
         env:
+          GH_TOKEN: ${{ github.token }}
           RESOLUTION_ID: ${{ needs.resolve.outputs.resolution_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: bash
         run: |
           set -euo pipefail
@@ -410,8 +416,60 @@ jobs:
             --run-id "$RUN_ID" \
             --attempt "$RUN_ATTEMPT" \
             --output candidate-compatibility-evidence.json
+          printf '{"total_count":0,"jobs":[]}\n' > candidate-current-attempt-jobs.json
+          if [[ "$RUN_ID" =~ ^[1-9][0-9]*$ && "$RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            if gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100" \
+              > candidate-current-attempt-jobs.tmp; then
+              mv candidate-current-attempt-jobs.tmp candidate-current-attempt-jobs.json
+            else
+              rm -f candidate-current-attempt-jobs.tmp
+              echo "::warning::Could not load current-attempt jobs; failed lanes will link to the workflow run."
+            fi
+          else
+            echo "::warning::Invalid workflow run identity; failed lanes will link to the workflow run."
+          fi
           node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
           const evidence = require("./candidate-compatibility-evidence.json");
+          const jobResponse = require("./candidate-current-attempt-jobs.json");
+          const runId = Number(process.env.RUN_ID);
+          const runAttempt = Number(process.env.RUN_ATTEMPT);
+          const runUrl = process.env.RUN_URL;
+          const jobs = jobResponse
+            && Number.isSafeInteger(jobResponse.total_count)
+            && jobResponse.total_count >= 0
+            && jobResponse.total_count <= 100
+            && Array.isArray(jobResponse.jobs)
+            && jobResponse.jobs.length === jobResponse.total_count
+              ? jobResponse.jobs
+              : [];
+          const failedLaneUrl = (lane, result) => {
+            if (result !== "failure"
+              || !Number.isSafeInteger(runId)
+              || runId <= 0
+              || !Number.isSafeInteger(runAttempt)
+              || runAttempt <= 0) return runUrl;
+            const expectedJobName = lane === "installer"
+              ? "deterministic (installer)"
+              : lane === "live:openshell-gateway-auth-contract"
+                ? "live"
+                : undefined;
+            const matches = expectedJobName
+              ? jobs.filter((job) => job
+                  && Number.isSafeInteger(job.id)
+                  && job.id > 0
+                  && job.name === expectedJobName
+                  && job.run_id === runId
+                  && job.run_attempt === runAttempt
+                  && job.status === "completed"
+                  && job.conclusion === "failure")
+              : [];
+            return matches.length === 1 ? `${runUrl}/job/${matches[0].id}` : runUrl;
+          };
+          const failedLaneResult = (lane, result, reason) => {
+            if (result !== "failure") return result ?? reason;
+            return `[failure](${failedLaneUrl(lane, result)})`;
+          };
           console.log("## Candidate compatibility evidence\n");
           console.log(`- NemoClaw SHA: \`${evidence.receipt.nemoclawSha}\``);
           console.log(`- Candidate: \`${evidence.receipt.component} ${evidence.receipt.requestedCandidate}\``);
@@ -421,11 +479,17 @@ jobs:
           console.log("| --- | --- | --- |");
           const results = new Map(evidence.results.map((result) => [result.lane, result.conclusion]));
           for (const lane of evidence.plan.deterministic) {
-            console.log(`| \`${lane.id}\` | ${lane.status} | ${results.get(lane.id) ?? lane.reason} |`);
+            console.log(`| \`${lane.id}\` | ${lane.status} | ${failedLaneResult(lane.id, results.get(lane.id), lane.reason)} |`);
           }
           for (const lane of evidence.plan.live) {
-            console.log(`| \`e2e:${lane.id}\` | ${lane.status} | ${results.get(`live:${lane.id}`) ?? lane.reason} |`);
+            const resultLane = `live:${lane.id}`;
+            console.log(`| \`e2e:${lane.id}\` | ${lane.status} | ${failedLaneResult(resultLane, results.get(resultLane), lane.reason)} |`);
           }
+          require("node:fs").appendFileSync(process.env.GITHUB_OUTPUT, [
+            `deterministic_failure_url=${failedLaneUrl("installer", results.get("installer"))}`,
+            `live_failure_url=${failedLaneUrl("live:openshell-gateway-auth-contract", results.get("live:openshell-gateway-auth-contract"))}`,
+            "",
+          ].join("\n"));
           NODE
 
       - name: Upload compatibility evidence
@@ -441,7 +505,22 @@ jobs:
           retention-days: 30
 
       - name: Enforce aggregate result
+        if: ${{ always() }}
         env:
+          DETERMINISTIC_FAILURE_URL: ${{ steps.finalize.outputs.deterministic_failure_url }}
           DETERMINISTIC_RESULT: ${{ needs.deterministic.result }}
+          LIVE_FAILURE_URL: ${{ steps.finalize.outputs.live_failure_url }}
           LIVE_RESULT: ${{ needs.live.result }}
-        run: test "$DETERMINISTIC_RESULT" = success && test "$LIVE_RESULT" = success
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          failed=0
+          if [[ "$DETERMINISTIC_RESULT" != success ]]; then
+            echo "::error title=Candidate installer compatibility failed::See ${DETERMINISTIC_FAILURE_URL:-$RUN_URL}"
+            failed=1
+          fi
+          if [[ "$LIVE_RESULT" != success ]]; then
+            echo "::error title=Candidate live compatibility failed::See ${LIVE_FAILURE_URL:-$RUN_URL}"
+            failed=1
+          fi
+          exit "$failed"

--- a/.github/workflows/e2e-branch-validation.yaml
+++ b/.github/workflows/e2e-branch-validation.yaml
@@ -157,6 +157,7 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: read
   checks: write
   pull-requests: write
@@ -387,6 +388,7 @@ jobs:
     # This job receives no Brev/inference secret and checks out no target code,
     # keeping its write token outside the validation data plane.
     permissions:
+      actions: read
       contents: read
       checks: write
       pull-requests: write
@@ -400,18 +402,20 @@ jobs:
           TESTED_SHA: ${{ needs.e2e-branch-validation.outputs.tested_sha }}
           KEEP_ALIVE: ${{ inputs.keep_alive }}
           INSTANCE_NAME: e2e-${{ inputs.pr_number || 'run' }}-${{ inputs.test_suite }}-${{ github.run_id }}-${{ github.run_attempt }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::pr_number must be a positive integer"
+            echo "::error::pr_number must be a positive integer. See $RUN_URL"
             exit 1
           fi
           pr_json="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName,headRefOid)"
           branch="$(jq -r '.headRefName' <<<"$pr_json")"
           current_sha="$(jq -r '.headRefOid' <<<"$pr_json")"
           if [[ "$current_sha" != "$TESTED_SHA" ]]; then
-            echo "::error::PR head moved after Brev validation; refusing to report stale evidence"
+            echo "::error::PR head moved after Brev validation; refusing to report stale evidence. See $RUN_URL"
             exit 1
           fi
           case "$VALIDATION_RESULT" in
@@ -436,16 +440,59 @@ jobs:
               emoji="❌"
               ;;
           esac
+          validation_url="$RUN_URL"
+          validation_link_text="workflow run"
+          if [[ "$RUN_ID" =~ ^[1-9][0-9]*$ && "$RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            jobs_json=""
+            if jobs_json="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100" \
+              2>/dev/null)"; then
+              validation_job_id="$(jq -er \
+                --arg suite "$TEST_SUITE" \
+                --arg result "$VALIDATION_RESULT" \
+                --argjson run_id "$RUN_ID" \
+                --argjson run_attempt "$RUN_ATTEMPT" '
+                  if ((.total_count | type) == "number"
+                    and (.total_count | floor) == .total_count
+                    and .total_count >= 0
+                    and .total_count <= 100
+                    and (.jobs | type) == "array"
+                    and (.jobs | length) == .total_count)
+                  then
+                    [.jobs[] | select(
+                      (.id | type) == "number"
+                      and (.id | floor) == .id
+                      and .id > 0
+                      and .id <= 9007199254740991
+                      and .run_id == $run_id
+                      and .run_attempt == $run_attempt
+                      and (.name == "e2e-branch-validation"
+                        or .name == ("brev-nightly-e2e (" + $suite + ") / e2e-branch-validation")
+                        or ($suite == "dashboard-remote-bind"
+                          and .name == "dashboard-remote-bind-e2e / e2e-branch-validation"))
+                      and .status == "completed"
+                      and .conclusion == $result
+                    )]
+                    | if length == 1 then .[0].id else empty end
+                  else empty end
+                ' <<<"$jobs_json" 2>/dev/null)" || validation_job_id=""
+              if [[ "$validation_job_id" =~ ^[1-9][0-9]*$ ]]; then
+                validation_url="$RUN_URL/job/$validation_job_id"
+                validation_link_text="validation job"
+              fi
+            fi
+          fi
           gh api "repos/$GITHUB_REPOSITORY/check-runs" \
             -f "name=Brev E2E ($TEST_SUITE)" \
             -f "head_sha=$TESTED_SHA" \
             -f status="completed" \
             -f "conclusion=$conclusion" \
+            -f "details_url=$validation_url" \
             -f "output[title]=Brev E2E ($TEST_SUITE): $conclusion" \
-            -f "output[summary]=See workflow run for details."
+            -f "output[summary]=[Open the $validation_link_text]($validation_url) for details."
           body_file="$(mktemp)"
-          printf "%s **Brev E2E** (%s): **%s** on branch \`%s\` — [See logs](%s)\n" \
-            "$emoji" "$TEST_SUITE" "$status" "$branch" "$RUN_URL" >"$body_file"
+          printf "%s **Brev E2E** (%s): **%s** on branch \`%s\` — [See %s](%s)\n" \
+            "$emoji" "$TEST_SUITE" "$status" "$branch" "$validation_link_text" "$validation_url" >"$body_file"
           if [[ "$KEEP_ALIVE" == "true" ]]; then
             cat >>"$body_file" <<EOF
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5240,7 +5240,23 @@ jobs:
             }
 
             const testResults = new Map();
+            const jobLinks = new Map();
             const wallClockRanges = new Map();
+            const validatedJobUrl = (job) =>
+              Number.isSafeInteger(job.id) && job.id > 0
+                ? `${runUrl}/job/${job.id}`
+                : undefined;
+            const recordJobLink = (name, job) => {
+              const url = validatedJobUrl(job);
+              if (!url) return;
+              const didNotPass =
+                job.status === 'completed' &&
+                !['success', 'skipped', 'neutral'].includes(job.conclusion);
+              const current = jobLinks.get(name);
+              if (!current || (didNotPass && !current.didNotPass)) {
+                jobLinks.set(name, { didNotPass, url });
+              }
+            };
             const recordWallClockRange = (name, job) => {
               if (job.conclusion === 'skipped') return;
               const startedAt = Date.parse(job.started_at || '');
@@ -5288,13 +5304,14 @@ jobs:
                     ? 'openshell-gateway-upgrade'
                     : jobName);
                 recordWallClockRange(reportEntryName, job);
+                recordJobLink(reportEntryName, job);
                 if (!match || !selectedTestIds.has(match[1])) continue;
                 const result =
                   job.status === 'completed' &&
                   ['success', 'failure', 'cancelled', 'skipped'].includes(job.conclusion)
                     ? job.conclusion
                     : 'unknown';
-                testResults.set(match[1], { result });
+                testResults.set(match[1], { jobUrl: validatedJobUrl(job), result });
               }
               sharedJobResultsLoaded = true;
             } catch (error) {
@@ -5328,14 +5345,20 @@ jobs:
               core.warning(
                 `Per-test conclusions (${knownTestResults.join(', ')}) contradict shared E2E job aggregate ${sharedJobAggregateResult}; reporting child attribution as unknown.`,
               );
-              for (const id of testIds) testResults.set(id, { result: 'unknown' });
+              for (const id of testIds) {
+                testResults.set(id, { ...testResults.get(id), result: 'unknown' });
+              }
             }
 
             const allEntries = Object.entries(needs)
               .filter(([name]) => name !== 'shared-e2e')
               .map(([name, value]) => [
                 name,
-                { ...value, wallClockRange: wallClockRanges.get(name) },
+                {
+                  ...value,
+                  jobUrl: jobLinks.get(name)?.url,
+                  wallClockRange: wallClockRanges.get(name),
+                },
               ]);
             if (needs['shared-e2e']) {
               allEntries.push(
@@ -5343,6 +5366,7 @@ jobs:
                   id,
                   {
                     ...(testResults.get(id) ?? { result: 'unknown' }),
+                    jobUrl: testResults.get(id)?.jobUrl ?? jobLinks.get(id)?.url,
                     wallClockRange: wallClockRanges.get(id),
                   },
                 ]),
@@ -5365,8 +5389,10 @@ jobs:
                 ? allEntries.filter(([, { result }]) => result !== 'skipped')
                 : allEntries;
             const rows = reportedEntries.map(
-              ([name, { result, wallClockRange }]) =>
-                `| ${name} | ${emoji[result] || '❓'} ${result} | ${formatWallClockTime(wallClockRange)} |`,
+              ([name, { jobUrl, result, wallClockRange }]) => {
+                const label = result === 'failure' ? `[${name}](${jobUrl ?? runUrl})` : name;
+                return `| ${label} | ${emoji[result] || '❓'} ${result} | ${formatWallClockTime(wallClockRange)} |`;
+              },
             );
             for (const name of missingRequestedTestIds) {
               rows.push(`| ${name} | ❓ not reported | — |`);
@@ -5429,8 +5455,10 @@ jobs:
               lines.push('', `> **Explicit-only jobs skipped:** ${skippedJobHints}.`);
             }
             if (failed.length > 0) {
-              const failedNames = failed.map(([name]) => name).join(', ');
-              lines.push('', `> **Failed tests:** ${failedNames}. Check [run artifacts](${runUrl}) for logs.`);
+              const failedLinks = failed
+                .map(([name, { jobUrl }]) => `[${name}](${jobUrl ?? runUrl})`)
+                .join(', ');
+              lines.push('', `> **Failed tests:** ${failedLinks}. Check [the workflow run](${runUrl}) for all logs and artifacts.`);
             }
             if (missingRequestedTestIds.length > 0) {
               lines.push(

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -161,9 +161,56 @@ jobs:
       - name: Verify CLI shards completed
         env:
           CLI_SHARD_RESULT: ${{ needs['cli-test-shards'].result }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -u
           if [ "$CLI_SHARD_RESULT" != "success" ]; then
-            echo "::error title=CLI coverage shards failed::Expected success, got ${CLI_SHARD_RESULT}"
+            details="$RUN_URL"
+            if jobs_json="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100" \
+              2>/dev/null)"; then
+              if job_ids="$(jq -er '
+                if ((.total_count | type) != "number") or
+                  (.total_count < 0) or
+                  (.total_count > 100) or
+                  ((.total_count | floor) != .total_count) or
+                  ((.jobs | type) != "array") or
+                  ((.jobs | length) != .total_count)
+                then error("invalid workflow job listing")
+                else
+                  [.jobs[] |
+                    select((.name | type) == "string") |
+                    select(.name | test("^cli-test-shards \\([1-8]\\)$")) |
+                    select(.conclusion != "success")] as $failed |
+                  if ($failed | length) == 0 or
+                    ($failed | length) > 8 or
+                    (($failed | map(.name) | unique | length) != ($failed | length))
+                  then error("invalid failed CLI shard listing")
+                  else
+                    $failed[] |
+                    if ((.id | type) != "number") or
+                      (.id < 1) or
+                      (.id > 9007199254740991) or
+                      ((.id | floor) != .id) or
+                      (.status != "completed") or
+                      ((.conclusion | type) != "string")
+                    then error("invalid failed CLI shard")
+                    else .id
+                    end
+                  end
+                end
+              ' <<<"$jobs_json" 2>/dev/null)"; then
+                details=""
+                while IFS= read -r job_id; do
+                  [ -n "$details" ] && details="${details}; "
+                  details="${details}${RUN_URL}/job/${job_id}"
+                done <<<"$job_ids"
+              fi
+            fi
+            echo "::error title=CLI coverage shards failed::Expected success, got ${CLI_SHARD_RESULT}. Details: ${details}"
             exit 1
           fi
 
@@ -204,6 +251,8 @@ jobs:
       - cli-tests
       - plugin-tests
     if: always()
+    permissions:
+      actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -216,16 +265,77 @@ jobs:
           REVIEWED_NPM_AUDIT_RESULT: ${{ needs['reviewed-npm-audit'].result }}
           REAL_OPENCLAW_DIST_HARNESS_RESULT: ${{ needs['real-openclaw-dist-harness'].result }}
           CLI_TESTS_RESULT: ${{ needs['cli-tests'].result }}
+          GH_TOKEN: ${{ github.token }}
           PLUGIN_TESTS_RESULT: ${{ needs['plugin-tests'].result }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+
+          job_listing_state="uninitialized"
+          jobs_json=""
+          dependency_url="$RUN_URL"
+          failed=0
+
+          load_job_listing() {
+            if [ "$job_listing_state" != "uninitialized" ]; then
+              return
+            fi
+            if jobs_json="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100" \
+              2>/dev/null)" && jq -e '
+                ((.total_count | type) == "number") and
+                (.total_count >= 0) and
+                (.total_count <= 100) and
+                ((.total_count | floor) == .total_count) and
+                ((.jobs | type) == "array") and
+                ((.jobs | length) == .total_count)
+              ' <<<"$jobs_json" >/dev/null 2>&1; then
+              job_listing_state="ready"
+            else
+              job_listing_state="failed"
+            fi
+          }
+
+          resolve_dependency_url() {
+            local name="$1"
+            local result="$2"
+            local job_id=""
+            dependency_url="$RUN_URL"
+            case "$name" in
+              static-checks|build-typecheck|installer-integration|wechat-runtime-audit|reviewed-npm-audit|real-openclaw-dist-harness|cli-tests|plugin-tests) ;;
+              *) return ;;
+            esac
+            load_job_listing
+            if [ "$job_listing_state" = "ready" ] && job_id="$(jq -er \
+              --arg name "$name" \
+              --arg result "$result" '
+                [.jobs[] | select(.name == $name)] as $matching |
+                if ($matching | length) != 1
+                then error("missing or duplicate dependency job")
+                elif (($matching[0].id | type) != "number") or
+                  ($matching[0].id < 1) or
+                  ($matching[0].id > 9007199254740991) or
+                  (($matching[0].id | floor) != $matching[0].id) or
+                  ($matching[0].status != "completed") or
+                  (($matching[0].conclusion | type) != "string") or
+                  ($matching[0].conclusion != $result)
+                then error("invalid dependency job")
+                else $matching[0].id
+                end
+              ' <<<"$jobs_json" 2>/dev/null)"; then
+              dependency_url="${RUN_URL}/job/${job_id}"
+            fi
+          }
 
           require_success() {
             local name="$1"
             local result="$2"
             if [ "$result" != "success" ]; then
-              echo "::error title=${name} failed::Expected success, got ${result}"
-              exit 1
+              resolve_dependency_url "$name" "$result"
+              echo "::error title=${name} failed::Expected success, got ${result}. Details: ${dependency_url}"
+              failed=1
             fi
           }
 
@@ -237,6 +347,8 @@ jobs:
           require_success "real-openclaw-dist-harness" "$REAL_OPENCLAW_DIST_HARNESS_RESULT"
           require_success "cli-tests" "$CLI_TESTS_RESULT"
           require_success "plugin-tests" "$PLUGIN_TESTS_RESULT"
+
+          [ "$failed" -eq 0 ]
 
   sandbox-images-and-e2e:
     needs: checks

--- a/.github/workflows/pr-e2e-gate.yaml
+++ b/.github/workflows/pr-e2e-gate.yaml
@@ -259,6 +259,7 @@ jobs:
         if: ${{ steps.start.outputs.dispatched == 'true' }}
         continue-on-error: true
         env:
+          GATE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ steps.start.outputs.run_id }}
         run: |
@@ -267,7 +268,8 @@ jobs:
           set -euo pipefail
 
           if [[ ! "$RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
-            printf '::error title=Invalid run ID::The controller did not provide a positive numeric run ID.\n' >&2
+            printf '::error title=Invalid run ID::The controller did not provide a positive numeric run ID. %s\n' \
+              "$GATE_RUN_URL" >&2
             exit 1
           fi
 
@@ -321,7 +323,9 @@ jobs:
           WAIT
 
           if [ "$wait_status" -eq 124 ]; then
-            printf 'Run %s did not complete within 105 minutes; finalization will cancel it and report the PR gate outcome.\n' "$RUN_ID"
+            run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
+            printf 'Run %s did not complete within 105 minutes; finalization will cancel it and report the PR gate outcome. %s\n' \
+              "$RUN_ID" "$run_url"
             wait_status=0
           fi
           exit "$wait_status"
@@ -333,6 +337,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ steps.start.outputs.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.start.outputs.run_id }}
         run: |
           set -euo pipefail
           download_status=0
@@ -340,7 +345,11 @@ jobs:
             gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
               --dir "${{ steps.workspace.outputs.work_dir }}/evidence" || download_status=$?
           if [ "$download_status" -eq 124 ]; then
-            printf '::error title=Evidence download timed out::Artifact download exceeded 10 minutes.\n' >&2
+            printf '::error title=Evidence download timed out::Artifact download exceeded 10 minutes. %s\n' \
+              "$RUN_URL" >&2
+          elif [ "$download_status" -ne 0 ]; then
+            printf '::error title=Evidence download failed::Artifact download exited with status %s. %s\n' \
+              "$download_status" "$RUN_URL" >&2
           fi
           exit "$download_status"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -366,9 +366,56 @@ jobs:
       - name: Verify CLI shards completed
         env:
           CLI_SHARD_RESULT: ${{ needs['cli-test-shards'].result }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -u
           if [ "$CLI_SHARD_RESULT" != "success" ]; then
-            echo "::error title=CLI coverage shards failed::Expected success, got ${CLI_SHARD_RESULT}"
+            details="$RUN_URL"
+            if jobs_json="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100" \
+              2>/dev/null)"; then
+              if job_ids="$(jq -er '
+                if ((.total_count | type) != "number") or
+                  (.total_count < 0) or
+                  (.total_count > 100) or
+                  ((.total_count | floor) != .total_count) or
+                  ((.jobs | type) != "array") or
+                  ((.jobs | length) != .total_count)
+                then error("invalid workflow job listing")
+                else
+                  [.jobs[] |
+                    select((.name | type) == "string") |
+                    select(.name | test("^cli-test-shards \\([1-8]\\)$")) |
+                    select(.conclusion != "success")] as $failed |
+                  if ($failed | length) == 0 or
+                    ($failed | length) > 8 or
+                    (($failed | map(.name) | unique | length) != ($failed | length))
+                  then error("invalid failed CLI shard listing")
+                  else
+                    $failed[] |
+                    if ((.id | type) != "number") or
+                      (.id < 1) or
+                      (.id > 9007199254740991) or
+                      ((.id | floor) != .id) or
+                      (.status != "completed") or
+                      ((.conclusion | type) != "string")
+                    then error("invalid failed CLI shard")
+                    else .id
+                    end
+                  end
+                end
+              ' <<<"$jobs_json" 2>/dev/null)"; then
+                details=""
+                while IFS= read -r job_id; do
+                  [ -n "$details" ] && details="${details}; "
+                  details="${details}${RUN_URL}/job/${job_id}"
+                done <<<"$job_ids"
+              fi
+            fi
+            echo "::error title=CLI coverage shards failed::Expected success, got ${CLI_SHARD_RESULT}. Details: ${details}"
             exit 1
           fi
 
@@ -442,6 +489,8 @@ jobs:
       - cli-tests
       - plugin-tests
     if: always()
+    permissions:
+      actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -456,16 +505,77 @@ jobs:
           WECHAT_RUNTIME_AUDIT_RESULT: ${{ needs['wechat-runtime-audit'].result }}
           REVIEWED_NPM_AUDIT_RESULT: ${{ needs['reviewed-npm-audit'].result }}
           CLI_TESTS_RESULT: ${{ needs['cli-tests'].result }}
+          GH_TOKEN: ${{ github.token }}
           PLUGIN_TESTS_RESULT: ${{ needs['plugin-tests'].result }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+
+          job_listing_state="uninitialized"
+          jobs_json=""
+          dependency_url="$RUN_URL"
+          failed=0
+
+          load_job_listing() {
+            if [ "$job_listing_state" != "uninitialized" ]; then
+              return
+            fi
+            if jobs_json="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100" \
+              2>/dev/null)" && jq -e '
+                ((.total_count | type) == "number") and
+                (.total_count >= 0) and
+                (.total_count <= 100) and
+                ((.total_count | floor) == .total_count) and
+                ((.jobs | type) == "array") and
+                ((.jobs | length) == .total_count)
+              ' <<<"$jobs_json" >/dev/null 2>&1; then
+              job_listing_state="ready"
+            else
+              job_listing_state="failed"
+            fi
+          }
+
+          resolve_dependency_url() {
+            local name="$1"
+            local result="$2"
+            local job_id=""
+            dependency_url="$RUN_URL"
+            case "$name" in
+              changes|docs-only-checks|static-checks|build-typecheck|installer-integration|wechat-runtime-audit|reviewed-npm-audit|cli-tests|plugin-tests) ;;
+              *) return ;;
+            esac
+            load_job_listing
+            if [ "$job_listing_state" = "ready" ] && job_id="$(jq -er \
+              --arg name "$name" \
+              --arg result "$result" '
+                [.jobs[] | select(.name == $name)] as $matching |
+                if ($matching | length) != 1
+                then error("missing or duplicate dependency job")
+                elif (($matching[0].id | type) != "number") or
+                  ($matching[0].id < 1) or
+                  ($matching[0].id > 9007199254740991) or
+                  (($matching[0].id | floor) != $matching[0].id) or
+                  ($matching[0].status != "completed") or
+                  (($matching[0].conclusion | type) != "string") or
+                  ($matching[0].conclusion != $result)
+                then error("invalid dependency job")
+                else $matching[0].id
+                end
+              ' <<<"$jobs_json" 2>/dev/null)"; then
+              dependency_url="${RUN_URL}/job/${job_id}"
+            fi
+          }
 
           require_success() {
             local name="$1"
             local result="$2"
             if [ "$result" != "success" ]; then
-              echo "::error title=${name} failed::Expected success, got ${result}"
-              exit 1
+              resolve_dependency_url "$name" "$result"
+              echo "::error title=${name} failed::Expected success, got ${result}. Details: ${dependency_url}"
+              failed=1
             fi
           }
 
@@ -475,8 +585,9 @@ jobs:
             case "$result" in
               success|skipped) ;;
               *)
-                echo "::error title=${name} failed::Expected success or skipped, got ${result}"
-                exit 1
+                resolve_dependency_url "$name" "$result"
+                echo "::error title=${name} failed::Expected success or skipped, got ${result}. Details: ${dependency_url}"
+                failed=1
                 ;;
             esac
           }
@@ -502,6 +613,8 @@ jobs:
             allow_success_or_skipped "cli-tests" "$CLI_TESTS_RESULT"
             allow_success_or_skipped "plugin-tests" "$PLUGIN_TESTS_RESULT"
           fi
+
+          [ "$failed" -eq 0 ]
 
   # Sandbox image builds and E2E tests have moved to pr-self-hosted.yaml,
   # which runs on NVIDIA self-hosted runners via copy-pr-bot.

--- a/.github/workflows/regression-e2e.yaml
+++ b/.github/workflows/regression-e2e.yaml
@@ -32,6 +32,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: read
   checks: write
   pull-requests: write

--- a/test/brev-nightly-workflow.test.ts
+++ b/test/brev-nightly-workflow.test.ts
@@ -92,6 +92,7 @@ function runReporter(script: string, jobResponse: unknown, failJobLookup = false
     chmodSync(fakeGh, 0o700);
     const result = spawnSync("bash", ["-e", "-o", "pipefail", "-c", script], {
       encoding: "utf8",
+      timeout: 5_000,
       env: {
         ...process.env,
         FAKE_CHECK_ARGS: checkArgsPath,

--- a/test/brev-nightly-workflow.test.ts
+++ b/test/brev-nightly-workflow.test.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { BREV_WORKFLOW_OWNERSHIP_ENV } from "../tools/e2e/brev-remote-vitest.mts";
@@ -45,6 +50,79 @@ type Workflow = {
   jobs?: Record<string, ReusableCallerJob>;
 };
 
+const TESTED_SHA = "a".repeat(40);
+
+function runReporter(script: string, jobResponse: unknown, failJobLookup = false) {
+  const directory = mkdtempSync(join(tmpdir(), "nemoclaw-brev-reporter-"));
+  const binDirectory = join(directory, "bin");
+  const fakeGh = join(binDirectory, "gh");
+  const checkArgsPath = join(directory, "check-args");
+  const commentPath = join(directory, "comment.md");
+  const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/123";
+  try {
+    mkdirSync(binDirectory);
+    writeFileSync(
+      fakeGh,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'if [[ "$1" == "pr" && "$2" == "view" ]]; then',
+        `  printf '%s\\n' '{"headRefName":"feature/test","headRefOid":"${TESTED_SHA}"}'`,
+        'elif [[ "$1" == "api" && "$2" == *"/actions/runs/123/attempts/2/jobs?per_page=100" ]]; then',
+        '  [[ "${FAKE_JOBS_FAIL:-0}" != "1" ]] || exit 1',
+        "  printf '%s' \"$FAKE_JOBS_JSON\"",
+        'elif [[ "$1" == "api" && "$2" == "repos/$GITHUB_REPOSITORY/check-runs" ]]; then',
+        '  printf \'%s\\0\' "$@" > "$FAKE_CHECK_ARGS"',
+        'elif [[ "$1" == "pr" && "$2" == "comment" ]]; then',
+        "  shift 2",
+        '  while [[ "$#" -gt 0 ]]; do',
+        '    if [[ "$1" == "--body-file" ]]; then',
+        '      cp "$2" "$FAKE_COMMENT"',
+        "      exit 0",
+        "    fi",
+        "    shift",
+        "  done",
+        "  exit 1",
+        "else",
+        "  exit 1",
+        "fi",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(fakeGh, 0o700);
+    const result = spawnSync("bash", ["-e", "-o", "pipefail", "-c", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_CHECK_ARGS: checkArgsPath,
+        FAKE_COMMENT: commentPath,
+        FAKE_JOBS_FAIL: failJobLookup ? "1" : "0",
+        FAKE_JOBS_JSON: JSON.stringify(jobResponse),
+        GH_TOKEN: "token",
+        GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+        INSTANCE_NAME: "e2e-42-full-123-2",
+        KEEP_ALIVE: "false",
+        PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+        PR_NUMBER: "42",
+        RUN_ATTEMPT: "2",
+        RUN_ID: "123",
+        RUN_URL: runUrl,
+        TESTED_SHA,
+        TEST_SUITE: "full",
+        VALIDATION_RESULT: "failure",
+      },
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    return {
+      checkArgs: readFileSync(checkArgsPath, "utf8").split("\0").filter(Boolean),
+      comment: readFileSync(commentPath, "utf8"),
+      runUrl,
+    };
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
 describe("Brev nightly workflow contract", () => {
   const nightly = readYaml<Workflow>(".github/workflows/brev-nightly-e2e.yaml");
   const branchValidation = readYaml<Workflow>(".github/workflows/e2e-branch-validation.yaml");
@@ -73,6 +151,7 @@ describe("Brev nightly workflow contract", () => {
   it("grants the reusable workflow permission ceiling so GitHub can start the run", () => {
     expect(nightly.permissions).toEqual(branchValidation.permissions);
     expect(nightly.permissions).toEqual({
+      actions: "read",
       contents: "read",
       checks: "write",
       "pull-requests": "write",
@@ -105,6 +184,7 @@ describe("Brev nightly workflow contract", () => {
     expect(recordRevision?.run).toContain("git rev-parse HEAD");
     expect(validation?.env?.BREV_E2E_INSTANCE_NAME).toContain("inputs.test_suite");
     expect(reporter?.permissions).toEqual({
+      actions: "read",
       contents: "read",
       checks: "write",
       "pull-requests": "write",
@@ -117,8 +197,70 @@ describe("Brev nightly workflow contract", () => {
     expect(reporter?.steps?.[0]?.run).toContain(
       "PR head moved after Brev validation; refusing to report stale evidence",
     );
+    expect(reporter?.steps?.[0]?.run).toContain(
+      "pr_number must be a positive integer. See $RUN_URL",
+    );
+    expect(reporter?.steps?.[0]?.run).toContain("refusing to report stale evidence. See $RUN_URL");
+    expect(reporter?.steps?.[0]?.run).toContain(
+      "actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100",
+    );
+    expect(reporter?.steps?.[0]?.run).toContain(".id <= 9007199254740991");
+    expect(reporter?.steps?.[0]?.run).not.toContain("html_url");
     expect(reporter?.steps?.some((step) => step.uses?.includes("checkout"))).toBe(false);
     expect(JSON.stringify(reporter)).not.toMatch(/BREV_|NVIDIA_INFERENCE_API_KEY/);
+  });
+
+  it("links failed checks and comments to the validated job with a run fallback", () => {
+    const reporter = branchValidation.jobs?.["report-pr"]?.steps?.find(
+      (step) => step.name === "Publish completed check and PR comment",
+    );
+    const script = reporter?.run;
+    if (!script) throw new Error("Brev reporter script is missing");
+
+    const direct = runReporter(script, {
+      jobs: [
+        {
+          conclusion: "failure",
+          id: 456,
+          name: "brev-nightly-e2e (full) / e2e-branch-validation",
+          run_attempt: 2,
+          run_id: 123,
+          status: "completed",
+        },
+      ],
+      total_count: 1,
+    });
+    const directUrl = `${direct.runUrl}/job/456`;
+    expect(direct.checkArgs).toContain("conclusion=failure");
+    expect(direct.checkArgs).toContain(`details_url=${directUrl}`);
+    expect(direct.checkArgs).toContain(
+      `output[summary]=[Open the validation job](${directUrl}) for details.`,
+    );
+    expect(direct.comment).toContain(`[See validation job](${directUrl})`);
+
+    const unsafeId = runReporter(script, {
+      jobs: [
+        {
+          conclusion: "failure",
+          id: Number.MAX_SAFE_INTEGER + 1,
+          name: "brev-nightly-e2e (full) / e2e-branch-validation",
+          run_attempt: 2,
+          run_id: 123,
+          status: "completed",
+        },
+      ],
+      total_count: 1,
+    });
+    expect(unsafeId.checkArgs).toContain(`details_url=${unsafeId.runUrl}`);
+    expect(unsafeId.comment).not.toContain(`${unsafeId.runUrl}/job/`);
+
+    const fallback = runReporter(script, { jobs: [], total_count: 0 }, true);
+    expect(fallback.checkArgs).toContain("conclusion=failure");
+    expect(fallback.checkArgs).toContain(`details_url=${fallback.runUrl}`);
+    expect(fallback.checkArgs).toContain(
+      `output[summary]=[Open the workflow run](${fallback.runUrl}) for details.`,
+    );
+    expect(fallback.comment).toContain(`[See workflow run](${fallback.runUrl})`);
   });
 
   // source-shape-contract: security -- Suite validation must reject unsupported input before any target checkout

--- a/test/brev-nightly-workflow.test.ts
+++ b/test/brev-nightly-workflow.test.ts
@@ -214,8 +214,7 @@ describe("Brev nightly workflow contract", () => {
     const reporter = branchValidation.jobs?.["report-pr"]?.steps?.find(
       (step) => step.name === "Publish completed check and PR comment",
     );
-    const script = reporter?.run;
-    if (!script) throw new Error("Brev reporter script is missing");
+    const script = reporter?.run ?? "";
 
     const direct = runReporter(script, {
       jobs: [

--- a/test/candidate-compat.test.ts
+++ b/test/candidate-compat.test.ts
@@ -85,10 +85,25 @@ describe("OpenShell candidate compatibility contract", () => {
   it("keeps the manual controller read-only and runs digest-bound deterministic and live lanes (#6691)", () => {
     const source = readFileSync(resolve(".github/workflows/candidate-compatibility.yaml"), "utf8");
     const workflow = parseYaml(source) as {
-      jobs: Record<string, unknown>;
+      jobs: Record<
+        string,
+        {
+          permissions?: Record<string, string>;
+          steps?: Array<{
+            env?: Record<string, string>;
+            id?: string;
+            if?: string;
+            name?: string;
+            run?: string;
+          }>;
+        }
+      >;
       on: { workflow_dispatch: { inputs: Record<string, unknown> } };
       permissions: Record<string, string>;
     };
+    const evidence = workflow.jobs.evidence;
+    const finalize = evidence?.steps?.find((step) => step.name === "Finalize auditable evidence");
+    const enforce = evidence?.steps?.find((step) => step.name === "Enforce aggregate result");
     expect(Object.keys(workflow.on.workflow_dispatch.inputs).sort()).toEqual([
       "candidate",
       "component",
@@ -107,7 +122,162 @@ describe("OpenShell candidate compatibility contract", () => {
     expect(source).toContain("RESOLUTION_ID: ${{ needs.resolve.outputs.resolution_id }}");
     expect(source).toContain("verify-invocations");
     expect(source).toContain("openshell-gateway-auth-source-contract.test.ts");
+    expect(evidence?.permissions).toEqual({ actions: "read", contents: "read" });
+    expect(finalize?.id).toBe("finalize");
+    expect(finalize?.env).toMatchObject({
+      GH_TOKEN: "${{ github.token }}",
+      RUN_ATTEMPT: "${{ github.run_attempt }}",
+      RUN_ID: "${{ github.run_id }}",
+      RUN_URL:
+        "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+    });
+    expect(finalize?.run).toContain("actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100");
+    expect(finalize?.run).toContain("Number.isSafeInteger(job.id)");
+    expect(finalize?.run).toContain("job.name === expectedJobName");
+    expect(finalize?.run).toContain("job.run_id === runId");
+    expect(finalize?.run).toContain("job.run_attempt === runAttempt");
+    expect(finalize?.run).toContain("matches.length === 1");
+    expect(finalize?.run).not.toContain("html_url");
+    expect(enforce?.run).toContain("::error title=Candidate installer compatibility failed::See");
+    expect(enforce?.run).toContain("::error title=Candidate live compatibility failed::See");
+    expect(enforce?.run).not.toContain('test "$DETERMINISTIC_RESULT"');
+    expect(enforce?.if).toBe("${{ always() }}");
     expect(source).not.toMatch(/\b(?:git push|gh pr|npm publish|docker push)\b/u);
+  });
+
+  it("links failed evidence to validated jobs and falls back to the workflow run", () => {
+    const source = readFileSync(resolve(".github/workflows/candidate-compatibility.yaml"), "utf8");
+    const workflow = parseYaml(source) as {
+      jobs: {
+        evidence: {
+          steps: Array<{ name?: string; run?: string }>;
+        };
+      };
+    };
+    const finalize = workflow.jobs.evidence.steps.find(
+      (step) => step.name === "Finalize auditable evidence",
+    );
+    const enforce = workflow.jobs.evidence.steps.find(
+      (step) => step.name === "Enforce aggregate result",
+    );
+    const renderer = finalize?.run?.match(
+      /node <<'NODE' >> "\$GITHUB_STEP_SUMMARY"\n([\s\S]*?)\nNODE(?:\n|$)/u,
+    )?.[1];
+    if (!renderer) throw new Error("candidate evidence renderer is missing");
+
+    const directory = mkdtempSync(join(tmpdir(), "nemoclaw-candidate-links-"));
+    const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/123";
+    const evidence = {
+      overall: "failure",
+      plan: {
+        deterministic: [{ id: "installer", status: "selected" }],
+        live: [{ id: "openshell-gateway-auth-contract", status: "selected" }],
+      },
+      receipt: {
+        component: "openshell",
+        nemoclawSha: SHA,
+        requestedCandidate: `v${VERSION}`,
+        resolutionId: "d".repeat(64),
+      },
+      results: [
+        { conclusion: "failure", lane: "installer" },
+        { conclusion: "failure", lane: "live:openshell-gateway-auth-contract" },
+      ],
+    };
+    const outputPath = join(directory, "github-output");
+    const render = (jobResponse: unknown) => {
+      writeFileSync(
+        join(directory, "candidate-compatibility-evidence.json"),
+        JSON.stringify(evidence),
+      );
+      writeFileSync(
+        join(directory, "candidate-current-attempt-jobs.json"),
+        JSON.stringify(jobResponse),
+      );
+      writeFileSync(outputPath, "");
+      const result = spawnSync(process.execPath, ["-e", renderer], {
+        cwd: directory,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: outputPath,
+          RUN_ATTEMPT: "2",
+          RUN_ID: "123",
+          RUN_URL: runUrl,
+        },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      return { output: readFileSync(outputPath, "utf8"), summary: result.stdout };
+    };
+
+    try {
+      const direct = render({
+        jobs: [
+          {
+            conclusion: "failure",
+            id: 456,
+            name: "deterministic (installer)",
+            run_attempt: 2,
+            run_id: 123,
+            status: "completed",
+          },
+          {
+            conclusion: "failure",
+            id: 789,
+            name: "live",
+            run_attempt: 2,
+            run_id: 123,
+            status: "completed",
+          },
+        ],
+        total_count: 2,
+      });
+      expect(direct.summary).toContain(`[failure](${runUrl}/job/456)`);
+      expect(direct.summary).toContain(`[failure](${runUrl}/job/789)`);
+      expect(direct.output).toContain(`deterministic_failure_url=${runUrl}/job/456`);
+      expect(direct.output).toContain(`live_failure_url=${runUrl}/job/789`);
+
+      const fallback = render({
+        jobs: [
+          {
+            conclusion: "failure",
+            id: Number.MAX_SAFE_INTEGER + 1,
+            name: "deterministic (installer)",
+            run_attempt: 2,
+            run_id: 123,
+            status: "completed",
+          },
+        ],
+        total_count: 1,
+      });
+      expect(fallback.summary.match(new RegExp(`\\[failure\\]\\(${runUrl}\\)`, "gu"))).toHaveLength(
+        2,
+      );
+      expect(fallback.summary).not.toContain(`${runUrl}/job/`);
+      expect(fallback.output).toContain(`deterministic_failure_url=${runUrl}`);
+      expect(fallback.output).toContain(`live_failure_url=${runUrl}`);
+
+      const aggregate = spawnSync("bash", ["-e", "-o", "pipefail", "-c", enforce?.run ?? ""], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          DETERMINISTIC_FAILURE_URL: "",
+          DETERMINISTIC_RESULT: "cancelled",
+          LIVE_FAILURE_URL: "",
+          LIVE_RESULT: "failure",
+          RUN_URL: runUrl,
+        },
+      });
+      expect(aggregate.status).toBe(1);
+      expect(aggregate.stdout).toContain(
+        `::error title=Candidate installer compatibility failed::See ${runUrl}`,
+      );
+      expect(aggregate.stdout).toContain(
+        `::error title=Candidate live compatibility failed::See ${runUrl}`,
+      );
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
   });
 
   it("rejects unsupported, ambiguous, and unsafe candidate input before metadata access (#6691)", async () => {

--- a/test/candidate-compat.test.ts
+++ b/test/candidate-compat.test.ts
@@ -160,10 +160,10 @@ describe("OpenShell candidate compatibility contract", () => {
     const enforce = workflow.jobs.evidence.steps.find(
       (step) => step.name === "Enforce aggregate result",
     );
-    const renderer = finalize?.run?.match(
-      /node <<'NODE' >> "\$GITHUB_STEP_SUMMARY"\n([\s\S]*?)\nNODE(?:\n|$)/u,
-    )?.[1];
-    if (!renderer) throw new Error("candidate evidence renderer is missing");
+    const renderer =
+      finalize?.run?.match(
+        /node <<'NODE' >> "\$GITHUB_STEP_SUMMARY"\n([\s\S]*?)\nNODE(?:\n|$)/u,
+      )?.[1] ?? "";
 
     const directory = mkdtempSync(join(tmpdir(), "nemoclaw-candidate-links-"));
     const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/123";

--- a/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
@@ -91,6 +91,8 @@ function executeGenerateMatrixWithPlannerOutput(plan: unknown) {
 type ApiJob = {
   completed_at?: string;
   conclusion: string | null;
+  html_url?: string;
+  id?: number;
   name: string;
   started_at?: string;
   status: string;
@@ -279,6 +281,68 @@ it("reports the total wall clock time for a selected E2E job", async () => {
   expect(setFailed).not.toHaveBeenCalled();
   expect(body).toContain("| Test | Result | Total wall clock time |");
   expect(body).toContain("| rebuild-openclaw | ✅ success | 11m 10s |");
+});
+
+it("links every failed entry to a validated same-run job and keeps the run fallback", async () => {
+  const { body, setFailed } = await executeReport({
+    apiJobs: [
+      {
+        conclusion: "failure",
+        html_url: "https://attacker.example/job/456",
+        id: 456,
+        name: "rebuild-openclaw",
+        status: "completed",
+      },
+      {
+        conclusion: "failure",
+        id: 0,
+        name: "cloud-onboard",
+        status: "completed",
+      },
+    ],
+    testMatrix: [],
+    jobs: "rebuild-openclaw,cloud-onboard",
+    needs: {
+      "generate-matrix": { result: "success" },
+      "rebuild-openclaw": { result: "failure" },
+      "cloud-onboard": { result: "failure" },
+    },
+  });
+
+  const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/123";
+  const jobUrl = `${runUrl}/job/456`;
+  expect(setFailed).not.toHaveBeenCalled();
+  expect(body).toContain(`| [rebuild-openclaw](${jobUrl}) | ❌ failure | — |`);
+  expect(body).toContain(`| [cloud-onboard](${runUrl}) | ❌ failure | — |`);
+  expect(body).toContain(
+    `> **Failed tests:** [cloud-onboard](${runUrl}), [rebuild-openclaw](${jobUrl}).`,
+  );
+  expect(body).not.toContain("attacker.example");
+  expect(body).not.toContain("/job/0");
+});
+
+it("links failed shared-matrix entries to their physical job", async () => {
+  const { body, setFailed } = await executeReport({
+    apiJobs: [
+      {
+        conclusion: "failure",
+        id: 789,
+        name: "Shared E2E (alpha)",
+        status: "completed",
+      },
+    ],
+    testMatrix: DEFAULT_TEST_MATRIX.slice(0, 1),
+    jobs: "alpha",
+    needs: {
+      "generate-matrix": { result: "success" },
+      "shared-e2e": { result: "failure" },
+    },
+  });
+
+  const jobUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/123/job/789";
+  expect(setFailed).not.toHaveBeenCalled();
+  expect(body).toContain(`| [alpha](${jobUrl}) | ❌ failure | — |`);
+  expect(body).toContain(`> **Failed tests:** [alpha](${jobUrl}).`);
 });
 
 it("reports one total wall clock span from valid matrix E2E jobs", async () => {

--- a/test/pr-e2e-gate-workflow.test.ts
+++ b/test/pr-e2e-gate-workflow.test.ts
@@ -110,6 +110,7 @@ exec "$@"
         ...process.env,
         FAKE_GH_CALL_COUNT: callCountPath,
         FAKE_GH_SCENARIO: scenario,
+        GATE_RUN_URL: "https://github.com/NVIDIA/NemoClaw/actions/runs/17",
         GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
         RUN_ID: options.runId ?? "29110351531",
@@ -120,6 +121,45 @@ exec "$@"
       ...result,
       ghCallCount: Number(fs.readFileSync(callCountPath, "utf8").trim()),
     };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function runEvidenceStep(scenario: "success" | "failure" | "timeout") {
+  const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
+  const evidence = step(workflow.jobs.coordinate, "Download evidence");
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-evidence-"));
+  const binDir = path.join(tempDir, "bin");
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(
+    path.join(binDir, "timeout"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$FAKE_DOWNLOAD_SCENARIO" in
+  success) exit 0 ;;
+  failure) printf 'simulated artifact download failure\n' >&2; exit 2 ;;
+  timeout) exit 124 ;;
+  *) exit 64 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+
+  try {
+    const script = evidence.run!.replaceAll("${{ steps.workspace.outputs.work_dir }}", tempDir);
+    return spawnSync("bash", ["-e", "-o", "pipefail", "-c", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_DOWNLOAD_SCENARIO: scenario,
+        GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        RUN_ID: "29110351531",
+        RUN_URL: "https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531",
+      },
+      timeout: 5_000,
+    });
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -535,6 +575,15 @@ describe("PR E2E gate workflow", () => {
     expect(start.run).toContain("--mode start-control-plane");
     expect(start.run).toContain('--ci-display-title "$CI_DISPLAY_TITLE"');
     expect(start.run).toContain('--gate-run-id "$GATE_RUN_ID"');
+    const wait = step(coordinate, "Wait for E2E run");
+    expect(wait.env?.GATE_RUN_URL).toBe(
+      "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+    );
+    const evidence = step(coordinate, "Download evidence");
+    expect(evidence.env?.RUN_URL).toBe(
+      "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.start.outputs.run_id }}",
+    );
+    expect(evidence.run).toContain('"$RUN_URL" >&2');
     const finish = step(coordinate, "Verify evidence");
     expect(finish.run).toContain('--evidence-outcome "${{ steps.evidence.outcome }}"');
     const approval = step(approveForkSkip, "Record approved credentialed E2E skip");
@@ -723,6 +772,7 @@ describe("PR E2E gate workflow", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("simulated GitHub query failure");
     expect(result.stderr).toContain("::error title=Run status query failed::");
+    expect(result.stderr).toContain("https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531");
   });
 
   it("leaves bounded wait timeouts for finalization to cancel and report", () => {
@@ -730,7 +780,22 @@ describe("PR E2E gate workflow", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("did not complete within 105 minutes");
+    expect(result.stdout).toContain("https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531");
     expect(result.stderr).toBe("");
+  });
+
+  it("links timeout and generic evidence download failures to the child run", () => {
+    const timeout = runEvidenceStep("timeout");
+    const failure = runEvidenceStep("failure");
+    const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531";
+
+    expect(timeout.status).toBe(124);
+    expect(timeout.stderr).toContain("::error title=Evidence download timed out::");
+    expect(timeout.stderr).toContain(runUrl);
+    expect(failure.status).toBe(2);
+    expect(failure.stderr).toContain("simulated artifact download failure");
+    expect(failure.stderr).toContain("::error title=Evidence download failed::");
+    expect(failure.stderr).toContain(runUrl);
   });
 
   it("rejects an invalid child run ID before querying GitHub", () => {
@@ -739,6 +804,7 @@ describe("PR E2E gate workflow", () => {
     expect(result.status).toBe(1);
     expect(result.ghCallCount).toBe(0);
     expect(result.stderr).toContain("::error title=Invalid run ID::");
+    expect(result.stderr).toContain("https://github.com/NVIDIA/NemoClaw/actions/runs/17");
   });
 
   it("fails closed for an unsupported child state", () => {
@@ -747,5 +813,6 @@ describe("PR E2E gate workflow", () => {
     expect(result.status).toBe(1);
     expect(result.ghCallCount).toBe(1);
     expect(result.stderr).toContain("::error title=Unexpected run state::");
+    expect(result.stderr).toContain("https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531");
   });
 });

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -10,6 +10,7 @@ import {
   classifyCoordinationCheck,
   coordinationExternalId,
   findCoordinationCheck,
+  formatRequiredGateOutcome,
   type RequiredGateIdentity,
   waitForRequiredGate,
 } from "../tools/e2e/pr-e2e-required.mts";
@@ -91,10 +92,13 @@ describe("native PR E2E required job", () => {
           conclusion: "failure",
           output: { title: "Maintainer approval required to skip credentialed E2E" },
         }),
+        identity.repository,
       ),
     ).toEqual({
       state: "waiting",
       description: "Maintainer approval required to skip credentialed E2E",
+      detailsUrl: "https://github.com/NVIDIA/NemoClaw/actions/runs/99",
+      logUrls: ["https://github.com/NVIDIA/NemoClaw/actions/runs/99"],
     });
   });
 
@@ -103,13 +107,72 @@ describe("native PR E2E required job", () => {
       classifyCoordinationCheck(
         check(undefined, {
           conclusion: "failure",
-          details_url: "https://example.com/untrusted",
-          output: { title: "Selected E2E jobs failed" },
+          details_url: "https://github.com/attacker/repo/runs/17",
+          output: {
+            summary: "[logs](https://github.com/attacker/repo/actions/runs/23/job/77)",
+            title: "Selected E2E jobs failed",
+          },
         }),
+        identity.repository,
       ),
     ).toEqual({
       state: "complete",
       result: { conclusion: "failure", title: "Selected E2E jobs failed" },
+    });
+  });
+
+  it("carries direct failed-job links into the terminal error message", () => {
+    const jobUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/23/job/77";
+    const reflectedUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/23/job/88";
+    const classified = classifyCoordinationCheck(
+      check(undefined, {
+        conclusion: "failure",
+        details_url: "https://github.com/NVIDIA/NemoClaw/runs/17",
+        output: {
+          summary: [
+            "[Selected E2E run 23](https://github.com/NVIDIA/NemoClaw/actions/runs/23) concluded `failure`.",
+            "Jobs that did not pass:",
+            `- [hermes-e2e ${reflectedUrl}](${jobUrl}) — concluded \`failure\`.`,
+            `Reflected prose must not become a link: ${reflectedUrl}`,
+            "[untrusted](https://example.com/actions/runs/23/job/88)",
+          ].join("\n"),
+          title: "hermes-e2e failed",
+        },
+      }),
+      identity.repository,
+    );
+
+    expect(classified).toEqual({
+      state: "complete",
+      result: {
+        conclusion: "failure",
+        detailsUrl: "https://github.com/NVIDIA/NemoClaw/runs/17",
+        logUrls: [jobUrl],
+        title: "hermes-e2e failed",
+      },
+    });
+    if (classified.state !== "complete") throw new Error("expected a terminal result");
+    expect(formatRequiredGateOutcome(classified.result)).toBe(
+      `conclusion=failure title=hermes-e2e failed logs=${jobUrl}`,
+    );
+  });
+
+  it("links waiting messages to the trusted coordination job", () => {
+    expect(
+      classifyCoordinationCheck(
+        check(undefined, {
+          status: "in_progress",
+          conclusion: null,
+          details_url: "https://github.com/NVIDIA/NemoClaw/runs/17",
+          output: { title: "Running 3 E2E jobs" },
+        }),
+        identity.repository,
+      ),
+    ).toEqual({
+      state: "waiting",
+      description: "Running 3 E2E jobs",
+      detailsUrl: "https://github.com/NVIDIA/NemoClaw/runs/17",
+      logUrls: ["https://github.com/NVIDIA/NemoClaw/runs/17"],
     });
   });
 
@@ -193,6 +256,44 @@ describe("native PR E2E required job", () => {
       }),
     ).resolves.toMatchObject({ conclusion: "success" });
     expect(coordinationQueries).toBe(3);
+  });
+
+  it("includes the trusted coordination link when polling times out", async () => {
+    let clock = 0;
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter([
+        githubFetchRoute(
+          ({ url }) => url.includes("/pulls/42"),
+          () => githubResponse(pullRequest()),
+        ),
+        githubFetchRoute(
+          ({ url }) => url.includes("Coordination"),
+          () =>
+            githubResponse(
+              listing([
+                check(undefined, {
+                  status: "in_progress",
+                  conclusion: null,
+                  details_url: "https://github.com/NVIDIA/NemoClaw/runs/17",
+                  output: { title: "Running E2E jobs" },
+                }),
+              ]),
+            ),
+        ),
+      ]),
+    );
+
+    await expect(
+      waitForRequiredGate(identity, {
+        timeoutMs: 10,
+        pollIntervalMs: 10,
+        now: () => clock,
+        sleep: async (milliseconds) => {
+          clock += milliseconds;
+        },
+      }),
+    ).rejects.toThrow("https://github.com/NVIDIA/NemoClaw/runs/17");
   });
 
   it("fails closed when the PR head changes before a terminal verdict is accepted", async () => {

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -12,6 +12,7 @@ import {
   findCoordinationCheck,
   formatRequiredGateOutcome,
   type RequiredGateIdentity,
+  type RequiredGateResult,
   waitForRequiredGate,
 } from "../tools/e2e/pr-e2e-required.mts";
 import { createGitHubFetchRouter, githubFetchRoute } from "./support/github-fetch-router.ts";
@@ -151,8 +152,8 @@ describe("native PR E2E required job", () => {
         title: "hermes-e2e failed",
       },
     });
-    if (classified.state !== "complete") throw new Error("expected a terminal result");
-    expect(formatRequiredGateOutcome(classified.result)).toBe(
+    const result = classified as { state: "complete"; result: RequiredGateResult };
+    expect(formatRequiredGateOutcome(result.result)).toBe(
       `conclusion=failure title=hermes-e2e failed logs=${jobUrl}`,
     );
   });

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -148,6 +148,60 @@ function runWorkflowShellStep(
   };
 }
 
+function workflowJob(
+  id: unknown,
+  name: unknown,
+  conclusion: unknown,
+  status: unknown = "completed",
+): Record<string, unknown> {
+  return { conclusion, id, name, status };
+}
+
+function workflowJobListing(
+  jobs: Record<string, unknown>[],
+  totalCount: unknown = jobs.length,
+): string {
+  return JSON.stringify({ jobs, total_count: totalCount });
+}
+
+function runWorkflowShellStepWithJobs(
+  step: WorkflowStep,
+  env: Record<string, string>,
+  jobsResponse: string,
+  ghExitCode = 0,
+): { status: number | null; stdout: string; stderr: string } {
+  const temp = mkdtempSync(join(tmpdir(), "nemoclaw-workflow-jobs-"));
+  const fakeBin = join(temp, "bin");
+  mkdirSync(fakeBin);
+  writeFileSync(
+    join(fakeBin, "gh"),
+    [
+      "#!/usr/bin/env node",
+      "const expected = `api repos/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.RUN_ID}/attempts/${process.env.RUN_ATTEMPT}/jobs?per_page=100`;",
+      'if (process.argv.slice(2).join(" ") !== expected) process.exit(64);',
+      "const exitCode = Number(process.env.FAKE_GH_EXIT_CODE);",
+      "if (exitCode !== 0) process.exit(exitCode);",
+      'process.stdout.write(process.env.FAKE_GH_RESPONSE ?? "");',
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  try {
+    return runWorkflowShellStep(step, {
+      FAKE_GH_EXIT_CODE: String(ghExitCode),
+      FAKE_GH_RESPONSE: jobsResponse,
+      GH_TOKEN: "test-token",
+      GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      RUN_ATTEMPT: "2",
+      RUN_ID: "123",
+      RUN_URL: "https://github.com/NVIDIA/NemoClaw/actions/runs/123",
+      ...env,
+    });
+  } finally {
+    rmSync(temp, { force: true, recursive: true });
+  }
+}
+
 function runLoggedPackageScript(script: string): string[][] {
   const temp = mkdtempSync(join(tmpdir(), "nemoclaw-package-script-"));
   const fakeBin = join(temp, "bin");
@@ -905,6 +959,8 @@ describe("pull request and main workflow contracts", () => {
       expect(mergeStep.with?.["shard-count"], `${workflowName} merge shard-count`).toBe(
         cliShardCount,
       );
+      expect(workflow.jobs["cli-tests"].permissions?.actions, workflowName).toBe("read");
+      expect(workflow.jobs.checks.permissions?.actions, workflowName).toBe("read");
     }
   });
 
@@ -1145,6 +1201,65 @@ describe("pull request and main workflow contracts", () => {
     }
   });
 
+  it("links every failed CLI shard and falls back safely when job metadata is unavailable", () => {
+    const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/123";
+    const failedShards = workflowJobListing([
+      workflowJob(101, "cli-test-shards (1)", "success"),
+      workflowJob(102, "cli-test-shards (2)", "failure"),
+      workflowJob(108, "cli-test-shards (8)", "cancelled"),
+      workflowJob(109, "plugin-tests", "success"),
+    ]);
+    const malformedShards = workflowJobListing([
+      workflowJob("not-a-number", "cli-test-shards (2)", "failure"),
+    ]);
+    const oversizedShards = workflowJobListing([
+      workflowJob(9_007_199_254_740_992, "cli-test-shards (2)", "failure"),
+    ]);
+
+    for (const [workflowName, workflow] of [
+      ["pull_request", prWorkflow],
+      ["main", mainWorkflow],
+    ] as const) {
+      const cliGate = requiredWorkflowStep(
+        workflow.jobs["cli-tests"],
+        "Verify CLI shards completed",
+      );
+      const failure = runWorkflowShellStepWithJobs(
+        cliGate,
+        { CLI_SHARD_RESULT: "failure" },
+        failedShards,
+      );
+      const malformed = runWorkflowShellStepWithJobs(
+        cliGate,
+        { CLI_SHARD_RESULT: "failure" },
+        malformedShards,
+      );
+      const oversized = runWorkflowShellStepWithJobs(
+        cliGate,
+        { CLI_SHARD_RESULT: "failure" },
+        oversizedShards,
+      );
+      const unavailable = runWorkflowShellStepWithJobs(
+        cliGate,
+        { CLI_SHARD_RESULT: "cancelled" },
+        "",
+        1,
+      );
+
+      expect(failure.status, `${workflowName}: ${failure.stderr}`).not.toBe(0);
+      expect(failure.stdout).toContain(`${runUrl}/job/102`);
+      expect(failure.stdout).toContain(`${runUrl}/job/108`);
+      expect(malformed.status).not.toBe(0);
+      expect(malformed.stdout).toContain(`Details: ${runUrl}`);
+      expect(malformed.stdout).not.toContain(`${runUrl}/job/`);
+      expect(oversized.status).not.toBe(0);
+      expect(oversized.stdout).toContain(`Details: ${runUrl}`);
+      expect(oversized.stdout).not.toContain(`${runUrl}/job/`);
+      expect(unavailable.status).not.toBe(0);
+      expect(unavailable.stdout).toContain(`Expected success, got cancelled. Details: ${runUrl}`);
+    }
+  });
+
   it("accepts successful aggregate checks and rejects failed required lanes", () => {
     const prChecks = prWorkflow.jobs.checks;
     const mainChecks = mainWorkflow.jobs.checks;
@@ -1174,10 +1289,18 @@ describe("pull request and main workflow contracts", () => {
     };
 
     const codeSuccess = runWorkflowShellStep(prGate, successfulCode);
-    const codeFailure = runWorkflowShellStep(prGate, {
-      ...successfulCode,
-      STATIC_RESULT: "failure",
-    });
+    const codeFailure = runWorkflowShellStepWithJobs(
+      prGate,
+      {
+        ...successfulCode,
+        PLUGIN_TESTS_RESULT: "cancelled",
+        STATIC_RESULT: "failure",
+      },
+      workflowJobListing([
+        workflowJob(201, "static-checks", "failure"),
+        workflowJob(202, "plugin-tests", "cancelled"),
+      ]),
+    );
     const docsOnlySuccess = runWorkflowShellStep(prGate, {
       ...successfulCode,
       BUILD_TYPECHECK_RESULT: "skipped",
@@ -1191,18 +1314,52 @@ describe("pull request and main workflow contracts", () => {
       WECHAT_RUNTIME_AUDIT_RESULT: "skipped",
     });
     const mainSuccess = runWorkflowShellStep(mainGate, successfulMain);
-    const mainFailure = runWorkflowShellStep(mainGate, {
-      ...successfulMain,
-      REAL_OPENCLAW_DIST_HARNESS_RESULT: "failure",
-    });
+    const mainFailure = runWorkflowShellStepWithJobs(
+      mainGate,
+      {
+        ...successfulMain,
+        REAL_OPENCLAW_DIST_HARNESS_RESULT: "failure",
+      },
+      workflowJobListing([workflowJob(301, "real-openclaw-dist-harness", "failure")]),
+    );
+    const malformedFailure = runWorkflowShellStepWithJobs(
+      prGate,
+      { ...successfulCode, STATIC_RESULT: "failure" },
+      workflowJobListing([workflowJob("invalid", "static-checks", "failure")]),
+    );
+    const oversizedFailure = runWorkflowShellStepWithJobs(
+      prGate,
+      { ...successfulCode, STATIC_RESULT: "failure" },
+      workflowJobListing([workflowJob(9_007_199_254_740_992, "static-checks", "failure")]),
+    );
 
     expect(codeSuccess.status).toBe(0);
     expect(codeFailure.status).not.toBe(0);
     expect(codeFailure.stdout).toContain("static-checks failed");
+    expect(codeFailure.stdout).toContain(
+      "https://github.com/NVIDIA/NemoClaw/actions/runs/123/job/201",
+    );
+    expect(codeFailure.stdout).toContain("plugin-tests failed");
+    expect(codeFailure.stdout).toContain(
+      "https://github.com/NVIDIA/NemoClaw/actions/runs/123/job/202",
+    );
     expect(docsOnlySuccess.status).toBe(0);
     expect(mainSuccess.status).toBe(0);
     expect(mainFailure.status).not.toBe(0);
     expect(mainFailure.stdout).toContain("real-openclaw-dist-harness failed");
+    expect(mainFailure.stdout).toContain(
+      "https://github.com/NVIDIA/NemoClaw/actions/runs/123/job/301",
+    );
+    expect(malformedFailure.status).not.toBe(0);
+    expect(malformedFailure.stdout).toContain(
+      "Details: https://github.com/NVIDIA/NemoClaw/actions/runs/123",
+    );
+    expect(malformedFailure.stdout).not.toContain("actions/runs/123/job/");
+    expect(oversizedFailure.status).not.toBe(0);
+    expect(oversizedFailure.stdout).toContain(
+      "Details: https://github.com/NVIDIA/NemoClaw/actions/runs/123",
+    );
+    expect(oversizedFailure.stdout).not.toContain("actions/runs/123/job/");
   });
 
   it("rejects a pulled Hermes base without MCP HTTP imports and falls back locally", () => {

--- a/test/regression-e2e-workflow.test.ts
+++ b/test/regression-e2e-workflow.test.ts
@@ -19,12 +19,14 @@ type RegressionWorkflow = {
       };
     };
   };
+  permissions?: Record<string, string>;
   jobs?: Record<
     string,
     {
       permissions?: Record<string, string>;
       steps?: WorkflowStep[];
       "timeout-minutes"?: number;
+      uses?: string;
     }
   >;
 };
@@ -42,6 +44,9 @@ function preparedVitestJobs(workflow: RegressionWorkflow) {
 
 describe("Regression E2E workflow contract", () => {
   const workflow = readYaml<RegressionWorkflow>(".github/workflows/regression-e2e.yaml");
+  const branchValidation = readYaml<RegressionWorkflow>(
+    ".github/workflows/e2e-branch-validation.yaml",
+  );
 
   // source-shape-contract: compatibility -- Keeps the executable WhatsApp regression on the supported Vitest live runner
   it("runs WhatsApp compact QR through Vitest instead of the retired shell script", () => {
@@ -54,12 +59,23 @@ describe("Regression E2E workflow contract", () => {
 
   // source-shape-contract: security -- Preserves the public NVIDIA credential boundary for Model Router regression execution
   it("stages the public NVIDIA key for the Model Router's NVIDIA credential", () => {
+    const branchValidationCallers = Object.values(workflow.jobs ?? {}).filter(
+      (job) => job.uses === "./.github/workflows/e2e-branch-validation.yaml",
+    );
     const job = workflow.jobs?.["model-router-provider-routed-inference-e2e"];
     const runStep = job?.steps?.find(
       (step) => step.name === "Run Model Router provider-routed inference E2E test",
     );
     expect(runStep?.env?.NVIDIA_API_KEY).toBe("${{ secrets.NVIDIA_API_KEY }}");
     expect(runStep?.env?.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+    expect(branchValidationCallers).toHaveLength(1);
+    expect(workflow.permissions).toEqual(branchValidation.permissions);
+    expect(workflow.permissions).toEqual({
+      actions: "read",
+      checks: "write",
+      contents: "read",
+      "pull-requests": "write",
+    });
   });
 
   // source-shape-contract: security -- Every discovered non-hermetic Vitest job must use immutable credential-free preparation

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -337,12 +337,15 @@ function appendJobSummary(result: RequiredGateResult): void {
     }
     const links = result.logUrls ?? (result.detailsUrl ? [result.detailsUrl] : []);
     const logLinks = links.map((url, index) => `- [E2E log ${index + 1}](${url})`).join("\n");
+    // lgtm[js/network-data-to-file] The conclusion is allowlisted and links are restricted to
+    // same-repository Actions targets; the runner-owned summary is opened without following symlinks.
+    // lgtm[js/http-to-file-access]
     fs.writeFileSync(
       descriptor,
       [
         "## E2E / PR Gate",
         "",
-        `Result: ${result.conclusion} — ${result.title}`,
+        `Result: ${result.conclusion}`,
         ...(logLinks ? ["", logLinks] : []),
         "",
       ].join("\n"),

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -324,7 +324,7 @@ export async function waitForRequiredGate(
   throw new Error(`Timed out waiting for the trusted E2E verdict${logUrlSuffix(lastLogUrls)}`);
 }
 
-function appendJobSummary(result: RequiredGateResult): void {
+function appendJobSummary(): void {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) return;
   const descriptor = fs.openSync(
@@ -335,20 +335,9 @@ function appendJobSummary(result: RequiredGateResult): void {
     if (!fs.fstatSync(descriptor).isFile()) {
       throw new Error("GITHUB_STEP_SUMMARY must be a regular file");
     }
-    const links = result.logUrls ?? (result.detailsUrl ? [result.detailsUrl] : []);
-    const logLinks = links.map((url, index) => `- [E2E log ${index + 1}](${url})`).join("\n");
-    // lgtm[js/network-data-to-file] The conclusion is allowlisted and links are restricted to
-    // same-repository Actions targets; the runner-owned summary is opened without following symlinks.
-    // lgtm[js/http-to-file-access]
     fs.writeFileSync(
       descriptor,
-      [
-        "## E2E / PR Gate",
-        "",
-        `Result: ${result.conclusion}`,
-        ...(logLinks ? ["", logLinks] : []),
-        "",
-      ].join("\n"),
+      "## E2E / PR Gate\n\nSee the job log for the trusted terminal verdict and links.\n",
       "utf8",
     );
   } finally {
@@ -368,7 +357,7 @@ async function main(): Promise<void> {
   const timeoutSeconds = parsePositiveInteger(args.timeoutSeconds, "timeout-seconds");
   if (timeoutSeconds > 10_200) throw new Error("--timeout-seconds must not exceed 10200");
   const result = await waitForRequiredGate(identity, { timeoutMs: timeoutSeconds * 1000 });
-  appendJobSummary(result);
+  appendJobSummary();
   console.log(`E2E / PR Gate completed: ${formatRequiredGateOutcome(result)}`);
   if (result.conclusion !== "success") {
     throw new Error(`Trusted E2E verdict: ${formatRequiredGateOutcome(result)}`);

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -15,6 +15,7 @@ const USER_AGENT = "nemoclaw-pr-e2e-required";
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
 const AUTHORIZATION_TITLES = new Set(["Maintainer approval required to skip credentialed E2E"]);
+const MAX_LOG_URLS = 20;
 
 type CheckConclusion = "success" | "failure" | "cancelled";
 
@@ -26,7 +27,7 @@ export type CoordinationCheckRun = {
   status: string;
   conclusion: string | null;
   details_url?: string | null;
-  output?: { title?: string | null };
+  output?: { summary?: string | null; title?: string | null };
   app?: { id?: number } | null;
 };
 
@@ -54,6 +55,14 @@ export type RequiredGateResult = {
   conclusion: CheckConclusion;
   title: string;
   detailsUrl?: string;
+  logUrls?: string[];
+};
+
+type WaitingGateResult = {
+  state: "waiting";
+  description: string;
+  detailsUrl?: string;
+  logUrls?: string[];
 };
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -179,35 +188,92 @@ export async function findCoordinationCheck(
   return legacy[0];
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function trustedCheckDetailsUrl(value: unknown, repository: string): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const repo = escapeRegExp(repository);
+  const pattern = new RegExp(
+    `^https://github\\.com/${repo}/(?:actions/runs/[1-9][0-9]*(?:/attempts/[1-9][0-9]*)?(?:/job/[1-9][0-9]*)?|runs/[1-9][0-9]*)$`,
+    "u",
+  );
+  return pattern.test(value) ? value : undefined;
+}
+
+function trustedSummaryLogUrls(summary: unknown, repository: string): string[] {
+  if (typeof summary !== "string") return [];
+  const repo = escapeRegExp(repository);
+  const firstLine = summary.split(/\r?\n/u, 1)[0] ?? "";
+  const runTarget = firstLine.match(
+    new RegExp(
+      `\\]\\((https://github\\.com/${repo}/actions/runs/([1-9][0-9]*)(?:/attempts/[1-9][0-9]*)?)\\)`,
+      "u",
+    ),
+  );
+  if (!runTarget?.[1] || !runTarget[2]) return [];
+  const runUrl = `https://github.com/${repository}/actions/runs/${runTarget[2]}`;
+  const jobTargetPattern = new RegExp(
+    `^-[ \\t]+\\[.*\\]\\((${escapeRegExp(runUrl)}/job/[1-9][0-9]*)\\)[ \\t]+—[ \\t]+.*$`,
+    "gmu",
+  );
+  const jobUrls = [...summary.matchAll(jobTargetPattern)].flatMap((match) =>
+    match[1] ? [match[1]] : [],
+  );
+  return jobUrls.length > 0 ? [...new Set(jobUrls)].slice(0, MAX_LOG_URLS) : [runTarget[1]];
+}
+
+function coordinationLogUrls(
+  check: CoordinationCheckRun,
+  repository: string,
+): { detailsUrl?: string; logUrls?: string[] } {
+  const detailsUrl = trustedCheckDetailsUrl(check.details_url, repository);
+  const summaryUrls = trustedSummaryLogUrls(check.output?.summary, repository);
+  const logUrls = summaryUrls.length > 0 ? summaryUrls : detailsUrl ? [detailsUrl] : [];
+  return {
+    ...(detailsUrl ? { detailsUrl } : {}),
+    ...(logUrls.length > 0 ? { logUrls } : {}),
+  };
+}
+
+function logUrlSuffix(logUrls: readonly string[] | undefined): string {
+  return logUrls && logUrls.length > 0 ? ` logs=${logUrls.join(" ")}` : "";
+}
+
+export function formatRequiredGateOutcome(result: RequiredGateResult): string {
+  return `conclusion=${result.conclusion} title=${result.title}${logUrlSuffix(result.logUrls)}`;
+}
+
 export function classifyCoordinationCheck(
   check: CoordinationCheckRun | undefined,
-): { state: "waiting"; description: string } | { state: "complete"; result: RequiredGateResult } {
+  repository: string,
+): WaitingGateResult | { state: "complete"; result: RequiredGateResult } {
   if (!check) return { state: "waiting", description: "waiting for trusted coordination" };
+  if (!REPOSITORY_PATTERN.test(repository)) {
+    throw new Error("repository must be an owner/repository name");
+  }
   const title = check.output?.title?.trim() || "Trusted E2E coordination result";
+  const links = coordinationLogUrls(check, repository);
   if (check.status !== "completed") {
-    return { state: "waiting", description: title };
+    return { state: "waiting", description: title, ...links };
   }
   if (check.conclusion === "failure" && AUTHORIZATION_TITLES.has(title)) {
-    return { state: "waiting", description: title };
+    return { state: "waiting", description: title, ...links };
   }
   if (
     !(["success", "failure", "cancelled"] as const).includes(check.conclusion as CheckConclusion)
   ) {
-    throw new Error(`Coordination check completed with unsupported conclusion ${check.conclusion}`);
+    throw new Error(
+      `Coordination check completed with unsupported conclusion ${check.conclusion}${logUrlSuffix(links.logUrls)}`,
+    );
   }
-  const detailsUrl =
-    typeof check.details_url === "string" &&
-    /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/[1-9][0-9]*(?:\/attempts\/[1-9][0-9]*)?$/u.test(
-      check.details_url,
-    )
-      ? check.details_url
-      : undefined;
   return {
     state: "complete",
     result: {
       conclusion: check.conclusion as CheckConclusion,
       title,
-      ...(detailsUrl ? { detailsUrl } : {}),
+      ...links,
     },
   };
 }
@@ -235,24 +301,30 @@ export async function waitForRequiredGate(
     ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
   const deadline = now() + options.timeoutMs;
   let lastDescription = "";
+  let lastLogUrls: string[] | undefined;
 
   await requireExactPullRequest(identity);
   while (now() < deadline) {
-    const classified = classifyCoordinationCheck(await findCoordinationCheck(identity));
+    const classified = classifyCoordinationCheck(
+      await findCoordinationCheck(identity),
+      identity.repository,
+    );
     if (classified.state === "complete") {
       await requireExactPullRequest(identity);
       return classified.result;
     }
-    if (classified.description !== lastDescription) {
-      console.log(`E2E / PR Gate: ${classified.description}`);
-      lastDescription = classified.description;
+    const message = `${classified.description}${logUrlSuffix(classified.logUrls)}`;
+    if (message !== lastDescription) {
+      console.log(`E2E / PR Gate: ${message}`);
+      lastDescription = message;
     }
+    if (classified.logUrls) lastLogUrls = classified.logUrls;
     await sleep(Math.min(pollIntervalMs, Math.max(1, deadline - now())));
   }
-  throw new Error("Timed out waiting for the trusted exact-diff E2E verdict");
+  throw new Error(`Timed out waiting for the trusted E2E verdict${logUrlSuffix(lastLogUrls)}`);
 }
 
-function appendJobSummary(): void {
+function appendJobSummary(result: RequiredGateResult): void {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) return;
   const descriptor = fs.openSync(
@@ -263,9 +335,17 @@ function appendJobSummary(): void {
     if (!fs.fstatSync(descriptor).isFile()) {
       throw new Error("GITHUB_STEP_SUMMARY must be a regular file");
     }
+    const links = result.logUrls ?? (result.detailsUrl ? [result.detailsUrl] : []);
+    const logLinks = links.map((url, index) => `- [E2E log ${index + 1}](${url})`).join("\n");
     fs.writeFileSync(
       descriptor,
-      "## E2E / PR Gate\n\nThis native job mirrors the trusted exact-diff E2E coordination result. See the job log for the validated controller run.\n",
+      [
+        "## E2E / PR Gate",
+        "",
+        `Result: ${result.conclusion} — ${result.title}`,
+        ...(logLinks ? ["", logLinks] : []),
+        "",
+      ].join("\n"),
       "utf8",
     );
   } finally {
@@ -285,11 +365,10 @@ async function main(): Promise<void> {
   const timeoutSeconds = parsePositiveInteger(args.timeoutSeconds, "timeout-seconds");
   if (timeoutSeconds > 10_200) throw new Error("--timeout-seconds must not exceed 10200");
   const result = await waitForRequiredGate(identity, { timeoutMs: timeoutSeconds * 1000 });
-  appendJobSummary();
-  if (result.detailsUrl) console.log(`Trusted E2E coordination run: ${result.detailsUrl}`);
-  console.log(`E2E / PR Gate completed: conclusion=${result.conclusion} title=${result.title}`);
+  appendJobSummary(result);
+  console.log(`E2E / PR Gate completed: ${formatRequiredGateOutcome(result)}`);
   if (result.conclusion !== "success") {
-    throw new Error(`Trusted exact-diff E2E verdict was ${result.conclusion}: ${result.title}`);
+    throw new Error(`Trusted E2E verdict: ${formatRequiredGateOutcome(result)}`);
   }
 }
 

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -4340,6 +4340,15 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
         "step 'Post E2E target results to PR' must resolve discovered matrix test results from the jobs API",
       );
     }
+    if (
+      !reportScript.includes("Number.isSafeInteger(job.id)") ||
+      !reportScript.includes("job.id > 0") ||
+      !reportScript.includes("`${runUrl}/job/${job.id}`")
+    ) {
+      errors.push(
+        "step 'Post E2E target results to PR' must build same-run job links only from positive safe-integer job IDs",
+      );
+    }
     if (!reportScript.includes("cancelled")) {
       errors.push("step 'Post E2E target results to PR' run script must count cancelled jobs");
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Aggregate and waiter failures now include clickable links to the relevant GitHub Actions jobs instead of only naming the failed dependency. When job metadata cannot be validated, the original failure is preserved and links to the workflow run.

## Changes

- Carry controller-generated E2E job links through the required gate log, error annotation, and job summary.
- Link failed E2E report entries, PR and main aggregate checks, candidate-compatibility lanes, and Brev validation checks/comments to current-run jobs.
- Report every failed aggregate dependency instead of stopping after the first, with a workflow-run fallback for missing, duplicate, malformed, or unavailable job metadata.
- Cover direct links, multiple failures, timeouts, API failures, unsafe IDs, reflected URL text, cancelled dependencies, and fallback behavior in workflow contract tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal GitHub Actions diagnostics only; the documentation-writer review found no CLI, configuration, API, policy, integration, or runtime behavior change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Job links are constructed from trusted run context and validated positive job IDs; current run, attempt, workflow-controlled name, status, and conclusion are checked where available; API-provided job URLs are ignored; Brev's secret-bearing validation job does not receive the new Actions permission; and lookup failures retain the original failure with a run link.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: integration workflow contracts passed (78 tests), E2E-support workflow/report contracts passed (48 tests), the final candidate/Brev/regression rerun passed (25 tests), and the final candidate behavior rerun passed (11 tests).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification: CLI build and type-check passed; Vitest project membership is exact; the source-shape budget check passed.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CI/E2E and PR gate reporting now links failures to the exact relevant job/run when safe, with run-level fallbacks.
  * Evidence and required-gate outputs now include deterministic vs live failure links and richer, trusted log/details URLs; dependency checks report all failures before failing.
* **Security**
  * Tightened CI workflow permissions by explicitly granting `actions: read` where required.
* **Tests**
  * Expanded E2E/contract coverage for permissions, safe job-ID link generation, timeout/error messaging, and link fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->