### PR TITLE
fix(vllm): label storage advisory output

### DIFF
--- a/src/lib/cli/terminal-style.test.ts
+++ b/src/lib/cli/terminal-style.test.ts
@@ -3,7 +3,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { B, D, failLine, G, R, RD, warnLine, YW } from "./terminal-style";
+import { B, D, failLine, G, labeledWarnLine, R, RD, warnLine, YW } from "./terminal-style";
 
 describe("terminal-style", () => {
   it("exports terminal style strings", () => {
@@ -70,6 +70,7 @@ describe("preflight severity lines (#6004)", () => {
       stubStream(process.stderr, true, 24);
       stubStream(process.stdout, false, 1);
       expect(warnLine("disk low")).toBe(`  ${YELLOW("⚠ disk low")}`);
+      expect(labeledWarnLine("disk low")).toBe(`  ${YELLOW("[WARN] disk low")}`);
       expect(failLine("docker down")).toBe(`  ${RED("✗ docker down")}`);
     });
   });
@@ -82,6 +83,7 @@ describe("preflight severity lines (#6004)", () => {
       stubStream(process.stdout, true, 24);
       stubStream(process.stderr, false, 1);
       expect(warnLine("disk low")).toBe("  ⚠ disk low");
+      expect(labeledWarnLine("disk low")).toBe("  [WARN] disk low");
       expect(failLine("docker down")).toBe("  ✗ docker down");
     });
   });
@@ -93,6 +95,7 @@ describe("preflight severity lines (#6004)", () => {
       stubStream(process.stdout, true, 24);
       stubStream(process.stderr, true, 24);
       expect(warnLine("a")).toBe("  ⚠ a");
+      expect(labeledWarnLine("a")).toBe("  [WARN] a");
       expect(failLine("b")).toBe("  ✗ b");
     });
   });

--- a/src/lib/cli/terminal-style.ts
+++ b/src/lib/cli/terminal-style.ts
@@ -26,7 +26,7 @@ export const YW = useColor ? "\x1b[1;33m" : "";
 // FORCE_COLOR (#6004). The old output keyed color off stdout, which dropped
 // color on `onboard >log` and leaked ANSI into `onboard 2>log`.
 function stderrSeverityLine(
-  marker: "⚠ " | "✗ ",
+  marker: "⚠ " | "✗ " | "[WARN] ",
   format: "yellow" | "red",
   message: string,
 ): string {
@@ -35,4 +35,6 @@ function stderrSeverityLine(
 }
 
 export const warnLine = (message: string): string => stderrSeverityLine("⚠ ", "yellow", message);
+export const labeledWarnLine = (message: string): string =>
+  stderrSeverityLine("[WARN] ", "yellow", message);
 export const failLine = (message: string): string => stderrSeverityLine("✗ ", "red", message);

--- a/src/lib/inference/vllm.test.ts
+++ b/src/lib/inference/vllm.test.ts
@@ -877,11 +877,11 @@ describe("installVllm model resolution", () => {
     expect(mocks.dockerPullWithProgressWatchdog).toHaveBeenCalledTimes(1);
     expect(mocks.dockerSpawn).toHaveBeenCalledTimes(1);
     const errors = errSpy.mock.calls.map((call: unknown[]) => String(call[0])).join("\n");
-    expect(errors).toContain("Insufficient storage for the managed vLLM model cache");
+    expect(errors).toContain("[WARN] Insufficient storage for the managed vLLM model cache");
     expect(errors).toContain("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4");
     expect(errors).toContain("Hugging Face cache");
     expect(errors).toContain(
-      "Continuing because managed vLLM storage estimates are advisory in non-interactive setup",
+      "[INFO] Continuing because managed vLLM storage estimates are advisory in non-interactive setup",
     );
   });
 
@@ -1017,11 +1017,11 @@ describe("installVllm model resolution", () => {
     expect(mocks.dockerPullWithProgressWatchdog).toHaveBeenCalledTimes(1);
     expect(mocks.dockerSpawn).toHaveBeenCalledTimes(1);
     expect(errSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Insufficient storage for the managed vLLM model cache"),
+      expect.stringContaining("[WARN] Insufficient storage for the managed vLLM model cache"),
     );
     expect(errSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Continuing because managed vLLM storage estimates are advisory in non-interactive setup",
+        "[INFO] Continuing because managed vLLM storage estimates are advisory in non-interactive setup",
       ),
     );
   });
@@ -1154,9 +1154,10 @@ describe("installVllm model resolution", () => {
     expect(mocks.dockerPullWithProgressWatchdog).toHaveBeenCalledTimes(1);
     expect(mocks.dockerSpawn).toHaveBeenCalledTimes(1);
     expect(errSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "Continuing because managed vLLM storage estimates are advisory in non-interactive setup",
-      ),
+      "  [WARN] Insufficient Docker storage for the managed vLLM image.",
+    );
+    expect(errSpy).toHaveBeenCalledWith(
+      "  [INFO] Continuing because managed vLLM storage estimates are advisory in non-interactive setup.",
     );
   });
 

--- a/src/lib/inference/vllm.test.ts
+++ b/src/lib/inference/vllm.test.ts
@@ -574,6 +574,7 @@ describe("installVllm model resolution", () => {
     delete process.env.NEMOCLAW_VLLM_EXTRA_ARGS_JSON;
     delete process.env.HF_TOKEN;
     delete process.env.HUGGING_FACE_HUB_TOKEN;
+    process.env.NO_COLOR = "1";
     // Fail dockerPrereqsOk so the function returns before any docker work,
     // letting tests assert on the resolved model + summary line without
     // mocking the full install chain.

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -779,7 +779,7 @@ function printImageStorageWarning(
   const insufficient = probe.ok && probe.capacity.availableBytes < requiredBytes;
   console.error("");
   console.error(
-    `  ${insufficient ? "Insufficient" : "Unable to verify"} Docker storage for the managed vLLM image.`,
+    `  [WARN] ${insufficient ? "Insufficient" : "Unable to verify"} Docker storage for the managed vLLM image.`,
   );
   console.error("");
   console.error(`  Image:     ${profile.image}`);
@@ -813,7 +813,7 @@ function printModelStorageWarning(
   const insufficient = probe.ok && probe.capacity.availableBytes < requiredBytes;
   console.error("");
   console.error(
-    `  ${insufficient ? "Insufficient" : "Unable to verify"} storage for the managed vLLM model cache.`,
+    `  [WARN] ${insufficient ? "Insufficient" : "Unable to verify"} storage for the managed vLLM model cache.`,
   );
   console.error("");
   console.error(`  Model:     ${model.id}`);
@@ -860,7 +860,7 @@ async function imageStorageAccepted(
   }
   if (opts.nonInteractive) {
     console.error(
-      "  Continuing because managed vLLM storage estimates are advisory in non-interactive setup.",
+      "  [INFO] Continuing because managed vLLM storage estimates are advisory in non-interactive setup.",
     );
     return true;
   }
@@ -887,7 +887,7 @@ async function modelStorageAccepted(
   printModelStorageWarning(model, probe, requiredBytes, cachedBytes, snapshotBytes);
   if (probe.ok && opts.nonInteractive) {
     console.error(
-      "  Continuing because managed vLLM storage estimates are advisory in non-interactive setup.",
+      "  [INFO] Continuing because managed vLLM storage estimates are advisory in non-interactive setup.",
     );
     return true;
   }

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -18,6 +18,7 @@ import {
   dockerStop,
 } from "../adapters/docker";
 import { buildValidatedCurlCommandArgs } from "../adapters/http/curl-args";
+import { labeledWarnLine } from "../cli/terminal-style";
 import { VLLM_PORT } from "../core/ports";
 import { shellQuote } from "../core/shell-quote";
 import { isAffirmativeAnswer } from "../onboard/prompt-helpers";
@@ -779,7 +780,9 @@ function printImageStorageWarning(
   const insufficient = probe.ok && probe.capacity.availableBytes < requiredBytes;
   console.error("");
   console.error(
-    `  [WARN] ${insufficient ? "Insufficient" : "Unable to verify"} Docker storage for the managed vLLM image.`,
+    labeledWarnLine(
+      `${insufficient ? "Insufficient" : "Unable to verify"} Docker storage for the managed vLLM image.`,
+    ),
   );
   console.error("");
   console.error(`  Image:     ${profile.image}`);
@@ -813,7 +816,9 @@ function printModelStorageWarning(
   const insufficient = probe.ok && probe.capacity.availableBytes < requiredBytes;
   console.error("");
   console.error(
-    `  [WARN] ${insufficient ? "Insufficient" : "Unable to verify"} storage for the managed vLLM model cache.`,
+    labeledWarnLine(
+      `${insufficient ? "Insufficient" : "Unable to verify"} storage for the managed vLLM model cache.`,
+    ),
   );
   console.error("");
   console.error(`  Model:     ${model.id}`);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed vLLM storage notices currently render the low-storage warning and non-interactive continuation as unclassified text. As a focused follow-up to #6985, this prefixes the shortage headline with `[WARN]`, highlights the full warning sentence in yellow when stderr supports color, and prefixes the uncolored advisory continuation with `[INFO]` without changing storage-preflight behavior. This PR remains draft while the output is manually validated.

## Changes

- Prefix insufficient and inconclusive Docker image-storage and model-cache headlines with `[WARN]`.
- Render the complete `[WARN]` headline yellow using the shared stderr-aware terminal style, while keeping redirected output and `NO_COLOR` plain.
- Prefix verified-low non-interactive advisory continuation messages with an uncolored `[INFO]`.
- Tighten focused tests for the labels, stderr color capability, redirected output, and `NO_COLOR` behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This classifies and styles existing output without changing behavior; current docs describe the warning/continue flow and do not contract exact stderr formatting. A documentation-impact review found no source, changelog, command-reference, or user-guide routing update necessary.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent reviews confirmed the shared call-time stderr styling honors terminal capability and `NO_COLOR`, leaves all preflight decisions unchanged, and keeps `[INFO]` plain; focused tests cover Docker/model-cache text and color boundaries.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/inference/vllm.test.ts src/lib/cli/terminal-style.test.ts` (80 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this focused output-style change
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>
