### PR TITLE
docs(release): add v0.0.84 changelog

### DIFF
--- a/docs/changelog/2026-07-15.mdx
+++ b/docs/changelog/2026-07-15.mdx
@@ -1,0 +1,42 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.84
+
+NemoClaw v0.0.84 adds DGX Station Nemotron Ultra express setup, trusted private inference endpoints, model-aware readiness checks, per-gateway host state, and safer recovery for snapshots, onboarding, configuration, messaging, and Hermes runtime changes.
+
+- DGX Station now offers a one-confirmation express path that selects the pinned NVIDIA Nemotron 3 Ultra 550B managed-vLLM recipe, while `--station-deepseek` selects the existing DeepSeek V4 Flash recipe.
+  Verified low Docker or model-cache capacity is advisory during express and other non-interactive setup while the storage checks mature, interactive setup still requires explicit confirmation, and an inconclusive model-cache check still stops non-interactive setup.
+  For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm) and the [NemoClaw Quickstart](/user-guide/openclaw/get-started/quickstart).
+- Custom endpoint onboarding can admit an exact trusted private hostname or IP literal from `NEMOCLAW_TRUSTED_PRIVATE_INFERENCE_HOSTS` when it resolves only to RFC1918, CGNAT, or IPv6 ULA destinations.
+  DNS resolution, connection-address pinning, exact-match semantics, and fail-closed blocking for metadata, link-local, multicast, translation, documentation, and other reserved ranges remain enforced.
+  For more information, refer to [Meet Custom Endpoint Security Requirements](/user-guide/openclaw/inference/custom-endpoints/custom-endpoint-security) and [Set Up an OpenAI-Compatible Endpoint](/user-guide/openclaw/inference/custom-endpoints/set-up-openai-compatible-endpoint).
+- Ollama onboarding prefers `NEMOCLAW_MODEL`, accepts `NEMOCLAW_PROVIDER_MODEL` as a compatibility fallback, and uses a requested model as the interactive default when it appears in the rendered model list.
+  Hermes setup now carries its `64000`-token Ollama context floor through daemon configuration, model validation, and generated config, while OpenClaw keeps its existing `16384`-token floor.
+  For more information, refer to [Use Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama) and [Configure Model Limits](/user-guide/openclaw/inference/manage-inference/configure-model-limits).
+- Sandbox status and doctor checks compare the configured Ollama or vLLM model with the provider inventory without issuing a completion or consuming tokens.
+  Onboarding finalization also treats an unreachable or HTTP 5xx inference route as not ready, preserves the session at retryable final verification, and lets `onboard --resume` complete after you repair the same route.
+  For more information, refer to [View Sandbox Status](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/view-sandbox-status) and [Verify the Sandbox Inference Route](/user-guide/openclaw/inference/validate-inference/verify-inference-route).
+- OpenClaw resume checkpoints completed sandbox name, web search, messaging, and resource choices, then reuses validated OpenShell credential registrations when their live bindings still match.
+  Installer failures and rebuild retry output now print complete fresh-install and resume commands that retain the selected agent and sandbox name.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands), [Troubleshooting](/user-guide/openclaw/reference/troubleshooting), and [Credential Storage](/user-guide/openclaw/security/credential-storage).
+- A non-default `NEMOCLAW_GATEWAY_PORT` now owns a separate `~/.nemoclaw/gateways/<port>/` host state root for its registry, onboarding state, snapshots, migration files, and local inference adapter state.
+  The default port keeps `~/.nemoclaw/`, and uninstall preserves other port-scoped environments.
+  For more information, refer to [Architecture Details](/user-guide/openclaw/reference/architecture) and [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw).
+- OpenClaw snapshots no longer capture machine-local device identity or pairing-token directories, and restore ignores those directories even in older snapshots.
+  OpenClaw regenerates device identity as needed and NemoClaw pairs clients again on connect instead of replacing live pairing state with sanitized snapshot data.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots).
+- `nemoclaw <name> channels status --channel telegram` now combines non-secret config comparison with a live OpenClaw log-based health probe and reports `healthy`, `idle`, `unreachable`, `token_rejected`, or `not_started`.
+  An unhealthy Telegram channel exits non-zero, and the default summary says when runtime health was not checked instead of presenting an all-green result.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- `nemohermes inference set` re-seeds the isolated Hermes dashboard config after an in-place route change and withholds the synced success message when the dashboard does not converge.
+  Hermes MCP reload also recognizes when the gateway already committed the intended config and integrity state during a concurrent apply-state update, so it returns success instead of starting a destructive rollback.
+  For more information, refer to [Switch Models](/user-guide/hermes/inference/manage-inference/switch-models) and [Manage MCP Servers](/user-guide/hermes/manage-sandboxes/mcp-servers/manage-mcp-servers).
+- Host-side OpenClaw `config set` validates the complete candidate with the installed OpenClaw runtime before replacing live config.
+  Schema failures, validator failures, timeouts, size-limit failures, and concurrent changes leave the existing config in place and do not reach the destructive gateway restart path.
+  For more information, refer to [Understand Runtime Changes](/user-guide/openclaw/manage-sandboxes/configure-sandboxes/understand-runtime-changes).
+- `shields up` and `shields down` can quarantine and recover a transition-lock record only when its recorded process is definitively dead or its process ID was reused.
+  Live, malformed, ambiguous, identity-unavailable, or concurrently replaced lock owners still fail closed with manual recovery guidance.
+  For more information, refer to [Trusted Computing Base](/user-guide/openclaw/security/trusted-computing-base).

--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -54,6 +54,9 @@ For messaging agents, the command also reports messaging-channel overlap warning
 $$nemoclaw my-assistant status
 ```
 
+For local Ollama and vLLM routes, sandbox status and doctor compare the selected model with the provider inventory without issuing a completion or consuming tokens.
+An invalid or empty inventory, or an inventory that does not contain the configured model, reports unhealthy provider status.
+
 Use the host-level status command when you want the sandbox inventory plus host auxiliary service state, such as cloudflared:
 
 ```bash

--- a/docs/manage-sandboxes/runtime-controls.mdx
+++ b/docs/manage-sandboxes/runtime-controls.mdx
@@ -50,6 +50,8 @@ OpenClaw config and inference changes are refused while shields are up.
 Run `$$nemoclaw <name> shields down` before the change, then restore lockdown with `$$nemoclaw <name> shields up`.
 
 Host-side OpenClaw config writes run under the per-sandbox transition lock and bind the replacement to the SHA-256 digest of the matching read.
+Before `config set` replaces the live file, NemoClaw validates the complete candidate with the installed OpenClaw runtime.
+If candidate validation fails, the command preserves the existing config and does not reach the gateway restart path.
 The root-only config guard validates bounded JSON input, transactionally publishes fresh config and hash inodes, and restores the prior mutable posture without adopting concurrent path changes.
 
 In the direct root-entrypoint topology, gateway restart performs a read-only config and hash preflight, temporarily seals fresh inodes while the root PID 1 supervisor replaces the gateway child, and then restores the prior shields posture.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the canonical `docs/changelog/2026-07-15.mdx` entry with the exact `## v0.0.84` heading for the release candidate range from `v0.0.83` through `710d2b36b9eebcb6bca3c2b2f796a1bdb69c3a31`.
Fills two owner-page gaps for model-aware local inference health and pre-write OpenClaw candidate validation.

## Changes

- Add the complete shared Fern changelog entry for `v0.0.84`, with literal CLI names and root-absolute OpenClaw and Hermes routes.
- Document that sandbox status and doctor compare the configured Ollama or vLLM model with provider inventory without issuing a completion.
- Document that host-side OpenClaw `config set` validates the complete candidate before replacing live config or reaching gateway restart.
- Reconcile the `v0.0.84` release label with the commit range. PR #6773 is already contained in `v0.0.83` and remains documented there; CI, test-harness, docs-infrastructure, and `.js` to `.mts` migration-only changes require no additional user guidance.

### Source summary

- [#6882](https://github.com/NVIDIA/NemoClaw/pull/6882) -> `docs/manage-sandboxes/backup-restore.mdx`, `docs/changelog/2026-07-15.mdx`: Explain that OpenClaw runtime identity and pairing state are excluded from snapshots and ignored during restore.
- [#6873](https://github.com/NVIDIA/NemoClaw/pull/6873) -> `docs/inference/set-up-ollama.mdx`, `docs/changelog/2026-07-15.mdx`: Record the Ollama requested-model environment fallback and interactive default.
- [#6835](https://github.com/NVIDIA/NemoClaw/pull/6835) -> `docs/changelog/2026-07-15.mdx`: Include the sandbox name in the documented rebuild resume-recovery behavior.
- [#6886](https://github.com/NVIDIA/NemoClaw/pull/6886) -> `docs/inference/custom-endpoint-security.mdx`, `docs/inference/set-up-openai-compatible-endpoint.mdx`, `docs/changelog/2026-07-15.mdx`: Explain the exact-host trusted-private endpoint opt-in and retained SSRF boundaries.
- [#6887](https://github.com/NVIDIA/NemoClaw/pull/6887) -> `docs/reference/commands.mdx`, `docs/changelog/2026-07-15.mdx`: Document Telegram channel health verdicts, summary behavior, and exit status.
- [#6863](https://github.com/NVIDIA/NemoClaw/pull/6863) -> `docs/manage-sandboxes/lifecycle.mdx`, `docs/changelog/2026-07-15.mdx`: Add the missing model-inventory behavior for local status and doctor checks.
- [#6902](https://github.com/NVIDIA/NemoClaw/pull/6902) -> `docs/manage-sandboxes/runtime-controls.mdx`, `docs/changelog/2026-07-15.mdx`: Add the missing pre-write OpenClaw candidate-validation contract.
- [#6916](https://github.com/NVIDIA/NemoClaw/pull/6916) -> `docs/changelog/2026-07-15.mdx`: Preserve the failed-session fresh-install recovery correction in the release entry.
- [#6934](https://github.com/NVIDIA/NemoClaw/pull/6934) -> `docs/reference/commands.mdx`, `docs/reference/troubleshooting.mdx`, `docs/security/credential-storage.mdx`, `docs/changelog/2026-07-15.mdx`: Summarize completed-prompt checkpointing and validated credential reuse during OpenClaw resume.
- [#6898](https://github.com/NVIDIA/NemoClaw/pull/6898) -> `docs/inference/switch-models.mdx`, `docs/inference/switch-providers.mdx`, `docs/reference/troubleshooting.mdx`, `docs/changelog/2026-07-15.mdx`: Explain Hermes dashboard convergence after in-place inference changes.
- [#6711](https://github.com/NVIDIA/NemoClaw/pull/6711) -> `docs/manage-sandboxes/run-sandboxes.mdx`, `docs/manage-sandboxes/uninstall-nemoclaw.mdx`, `docs/reference/architecture.mdx`, `docs/reference/commands.mdx`, `docs/changelog/2026-07-15.mdx`: Summarize port-scoped host state and uninstall preservation.
- [#6767](https://github.com/NVIDIA/NemoClaw/pull/6767) -> `docs/inference/configure-model-limits.mdx`, `docs/inference/set-up-ollama.mdx`, `docs/reference/troubleshooting.mdx`, `docs/changelog/2026-07-15.mdx`: Record the Hermes `64000`-token Ollama floor and unchanged OpenClaw floor.
- [#6862](https://github.com/NVIDIA/NemoClaw/pull/6862) -> `docs/get-started/quickstart.mdx`, `docs/inference/verify-inference-route.mdx`, `docs/changelog/2026-07-15.mdx`: Explain retryable not-ready finalization for unhealthy inference routes.
- [#6766](https://github.com/NVIDIA/NemoClaw/pull/6766) -> `docs/security/tcb-boundary.mdx`, `docs/changelog/2026-07-15.mdx`: Document definitive stale transition-lock recovery and fail-closed ambiguous cases.
- [#6948](https://github.com/NVIDIA/NemoClaw/pull/6948) -> `docs/manage-sandboxes/manage-mcp-servers.mdx`, `docs/changelog/2026-07-15.mdx`: Include Hermes MCP apply-state race recovery in the release entry without changing the established user workflow.
- [#6964](https://github.com/NVIDIA/NemoClaw/pull/6964) -> `docs/reference/troubleshooting.mdx`, `docs/changelog/2026-07-15.mdx`: Record complete agent-specific fresh-install and resume recovery commands.
- [#6883](https://github.com/NVIDIA/NemoClaw/pull/6883) -> `docs/get-started/quickstart.mdx`, `docs/inference/set-up-vllm.mdx`, `docs/reference/platform-support.mdx`, `docs/changelog/2026-07-15.mdx`: Summarize the DGX Station Nemotron Ultra express path and pinned managed-vLLM recipe.
- [#6985](https://github.com/NVIDIA/NemoClaw/pull/6985) -> `docs/inference/set-up-vllm.mdx`, `docs/reference/commands.mdx`, `docs/changelog/2026-07-15.mdx`: Capture the final automated and interactive storage-warning behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — `test/changelog-docs.test.ts` validates the dated-entry structure, exact version heading, and preserved history.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts` (6 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not run for this doc-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors; Fern reported the unchanged unauthenticated redirect-check and light-theme contrast warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — the native changelog entry uses the required parser-safe MDX SPDX comment and intentionally has no frontmatter.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the v0.0.84 changelog entry covering setup, endpoint onboarding, model handling, sandbox readiness, recovery, channel status, and configuration safeguards.
  * Clarified that sandbox health checks validate configured models against local Ollama and vLLM provider inventories without generating completions or consuming tokens.
  * Documented that invalid runtime configuration changes are rejected while preserving the existing working configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->