### PR TITLE
test(e2e): make inference switch baselines sandbox-reachable

### DIFF
--- a/test/e2e/live/hermes-inference-switch.test.ts
+++ b/test/e2e/live/hermes-inference-switch.test.ts
@@ -120,10 +120,14 @@ test("Hermes inference set updates route/config and preserves live runtime", {
   });
   expect(docker.exitCode, resultText(docker)).toBe(0);
 
+  // OpenShell reaches this fixture from its gateway network namespace, where
+  // the runner's loopback address is not routable.
   const mockBaseline = mockAnthropicSwitchEnabled()
     ? await startFakeOpenAiCompatibleServer({
         apiKey: MOCK_BASELINE_API_KEY,
+        host: "0.0.0.0",
         model: MOCK_BASELINE_MODEL,
+        publicHost: "host.openshell.internal",
         requireAuth: true,
       })
     : undefined;

--- a/test/e2e/live/openclaw-inference-switch.test.ts
+++ b/test/e2e/live/openclaw-inference-switch.test.ts
@@ -934,10 +934,14 @@ test("openclaw-inference-switch: switches route and preserves live OpenClaw beha
 
   const useMockBaseline =
     SWITCH_PROVIDER === "compatible-anthropic-endpoint" && SWITCH_MOCK_ANTHROPIC === "1";
+  // OpenShell reaches this fixture from its gateway network namespace, where
+  // the runner's loopback address is not routable.
   const baselineProvider: FakeOpenAiCompatibleServer | undefined = useMockBaseline
     ? await startFakeOpenAiCompatibleServer({
         apiKey: MOCK_BASELINE_API_KEY,
+        host: "0.0.0.0",
         model: MOCK_BASELINE_MODEL,
+        publicHost: "host.openshell.internal",
         requireAuth: true,
       })
     : undefined;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make the mock OpenAI-compatible baselines in the OpenClaw and Hermes inference-switch live E2E targets reachable from the OpenShell gateway. Previously the runner-side smoke probe passed against loopback, but sandbox deployment verification returned HTTP 503 because the gateway could not reach the runner's loopback address.

## Changes

- Bind both mock baseline servers to `0.0.0.0` while advertising `host.openshell.internal` to OpenShell.
- Document the gateway network-namespace boundary at both fixture call sites.
- Keep the production compatible-endpoint rewrite and its policy-approved port allowlist unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This only corrects live E2E fixture reachability; CLI behavior, defaults, APIs, policies, supported integrations, and user workflows are unchanged. Existing docs already describe `host.openshell.internal` for sandbox-to-host inference routes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The change is confined to mock baseline setup in two live E2E tests. Production inference routing, network policies, credentials, and sandbox implementation are unchanged; both call sites now use the established host-bridge pattern already exercised by other live E2E targets.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-cleanup-resources.test.ts test/e2e/support/e2e-clients.test.ts` (2 files, 70 tests passed). The exact live targets require external state and are left to the E2E workflow.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused live E2E configuration change. A broader `e2e-support` run was attempted; the mapped tests passed, while 12 unrelated workflow-boundary subprocess timeout failures occurred across five unchanged files.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated live inference-switch test scenarios to use explicit network routing for baseline compatibility servers.
  * Improved test reliability when running with mocked Anthropic-compatible endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->