### PR TITLE
fix(inference): serve managed Nemotron-3-Nano with its reasoning parser (#6915)

### DIFF
--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -223,7 +223,7 @@ describe("vllm model registry", () => {
     expect(cmd).not.toContain("--gpu-memory-utilization 0.7");
   });
 
-  it("builds the Nemotron-3-Nano-4B FP8 serve command with auto tool-choice enabled (#6314)", () => {
+  it("builds the Nemotron-3-Nano-4B FP8 serve command with auto tool-choice and reasoning parser (#6314, #6915)", () => {
     // #6314: the generic-Linux managed-vLLM default (`GENERIC_LINUX_PROFILE.defaultModel`)
     // used to omit `--enable-auto-tool-choice` and `--tool-call-parser`, so every agent
     // request with `tool_choice: "auto"` failed HTTP 400 out of the box on generic Linux.
@@ -239,11 +239,19 @@ describe("vllm model registry", () => {
     expect(cmd).toContain("--load-format fastsafetensors");
     expect(cmd).toContain("--enable-auto-tool-choice");
     expect(cmd).toContain("--tool-call-parser qwen3_coder");
-    // The tool-call flags must appear paired: the parser value comes as a single
-    // shell token immediately after `--tool-call-parser`, and each switch is listed
-    // only once.
+    // #6915: Nemotron-3-Nano is a reasoning model, so the serve command must
+    // also pin the reasoning parser from the model card. Without it, vLLM
+    // leaves the `<think>…</think>` trace (and the orphan `</think>` marker the
+    // chat template does not pair with an opening tag) inline in `content`,
+    // which the agent's streaming parser mishandles into an empty turn that
+    // wedges the session. The Ultra-550B managed profile already pins the same
+    // `nemotron_v3` parser; this asserts the generic-Linux Nano default matches.
+    expect(cmd).toContain("--reasoning-parser nemotron_v3");
+    // The parser flags must appear paired and exactly once each: the value is a
+    // single shell token immediately after its switch.
     expect(cmd.match(/--enable-auto-tool-choice/g)).toHaveLength(1);
     expect(cmd.match(/--tool-call-parser/g)).toHaveLength(1);
+    expect(cmd.match(/--reasoning-parser/g)).toHaveLength(1);
   });
 
   it("registers the Qwen3.6-35B NVFP4 checkpoint for DGX Spark", () => {

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -148,9 +148,22 @@ export const VLLM_MODELS: readonly VllmModelDef[] = [
     // --tool-call-parser to be set" (#6314) — which blocks every agent
     // tool-call flow on the generic-Linux managed vLLM default (Spark and
     // Station defaults already pin their own tool-call parser).
+    //
+    // `--reasoning-parser nemotron_v3` is likewise part of that same model
+    // card launch recipe: Nemotron-3-Nano is a reasoning model that emits a
+    // `<think>…</think>` trace. Without a reasoning parser vLLM leaves the
+    // trace — including the bare `</think>` marker the chat template does not
+    // pair with an opening `<think>` — inline in `content`, and the agent's
+    // streaming parser mishandles that orphan marker into an empty turn that
+    // wedges the session (#6915). `nemotron_v3` is a built-in parser in the
+    // pinned NGC vLLM image (it subclasses the DeepSeek-R1 parser) and moves
+    // the trace out of `content`, so no plugin file is required. The Spark and
+    // Station defaults already pin their own reasoning parser.
     modelArgs: [
       "--gpu-memory-utilization",
       "0.7",
+      "--reasoning-parser",
+      "nemotron_v3",
       "--load-format",
       "fastsafetensors",
       "--enable-auto-tool-choice",


### PR DESCRIPTION
## Summary

`nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8` — the generic-Linux managed-vLLM default — is a **reasoning model** (its model card describes it as "a unified model for both reasoning and non-reasoning tasks" that "generates a reasoning trace and then a final response"). Its profile in `vllm-models.ts` pinned the tool-call parser but **not a reasoning parser**.

Without a reasoning parser, vLLM leaves the `<think>…</think>` trace inline in `content`. Because the chat template consumes the opening `<think>` as the generation prompt prefix, the model output begins mid-trace and contains a **bare, orphan `</think>` marker**. OpenClaw's streaming parser mishandles that orphan marker into an empty assistant turn, and the session then wedges until reset (#6915).

## Fix

Add `--reasoning-parser nemotron_v3` to the Nano-4B profile — the same parser the model card's vLLM launch recipe pins, and the same one the **Ultra-550B managed profile already uses**. `nemotron_v3` is a **built-in** parser in the pinned NGC vLLM image (it subclasses the DeepSeek-R1 parser), so no plugin file is required; it moves the reasoning trace out of `content`.

## Verification (real hardware — DGX Spark GB10)

Served the checkpoint with the profile's exact generated serve command, sending an identical reasoning request to each:

| Serve args | `content` returned to the agent |
|---|---|
| current profile (no reasoning parser) | `"…Provide brief thought then answer.\n</think>\nThe train covers 60 km… **80 km/h**."` — reasoning trace **and orphan `</think>`** inline → wedge trigger |
| profile **+ `--reasoning-parser nemotron_v3`** | `"\nThe train covers 60 km… **80 km/h**."` — clean final answer, **no `</think>`** |

The reasoning parser is the only variable changed between the two runs. Unit test in `vllm-models.test.ts` asserts the generated Nano serve command now includes `--reasoning-parser nemotron_v3` (exactly once, paired with its value).

## Scope

Nano is the generic-Linux managed-vLLM default (`platforms: ["spark", "station", "linux"]`); the fix applies wherever that default resolves. The Spark and Station reasoning defaults already pin their own reasoning parser, so they are unaffected.

Fixes #6915.

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in reasoning support for the NVIDIA Nemotron 3 Nano 4B model.
  * Improved handling of reasoning traces when serving this model.

* **Tests**
  * Expanded coverage to verify the model’s reasoning and tool-calling configuration is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->