### PR TITLE
test(e2e): align release fixtures with readiness checks

### DIFF
--- a/test/e2e/live/concurrent-gateway-ports.test.ts
+++ b/test/e2e/live/concurrent-gateway-ports.test.ts
@@ -329,8 +329,12 @@ test("concurrent gateway ports: onboards two sandboxes on isolated gateways and 
 
   const gatewayA = gatewayNameForPort(GATEWAY_PORT_A);
   const gatewayB = gatewayNameForPort(GATEWAY_PORT_B);
+  // OpenShell reaches this fixture from its gateway network namespace, where
+  // the runner's loopback address is not routable.
   const fake = await startFakeOpenAiCompatibleServer({
+    host: "0.0.0.0",
     port: Number(process.env.NEMOCLAW_E2E_FAKE_PORT ?? 0),
+    publicHost: "host.openshell.internal",
   });
   await artifacts.target.declare({
     id: "concurrent-gateway-ports",

--- a/test/e2e/live/double-onboard.test.ts
+++ b/test/e2e/live/double-onboard.test.ts
@@ -458,8 +458,12 @@ test("double-onboard: reuses gateway, preserves sibling sandbox, and recovers st
     "prereq-nemoclaw",
   );
 
+  // OpenShell reaches this fixture from its gateway network namespace, where
+  // the runner's loopback address is not routable.
   const fake = await startFakeOpenAiCompatibleServer({
+    host: "0.0.0.0",
     port: Number(process.env.NEMOCLAW_FAKE_PORT ?? 0),
+    publicHost: "host.openshell.internal",
   });
   await artifacts.writeJson("fake-openai.json", { baseUrl: fake.baseUrl });
   cleanup.trackDisposable("close fake OpenAI-compatible endpoint", async () => {

--- a/test/e2e/live/hermes-e2e.test.ts
+++ b/test/e2e/live/hermes-e2e.test.ts
@@ -380,7 +380,7 @@ test("hermes-e2e: install.sh onboards Hermes and proves health plus live inferen
 
   if (hermesDashboardE2eEnabled()) {
     expect(resultText(install)).toContain(
-      "Deployment verified — gateway and dashboard are healthy.",
+      "Deployment verified — gateway, dashboard, and inference route are healthy.",
     );
     expect(resultText(install)).toContain("Hermes Agent Dashboard");
     expect(resultText(install)).toContain(`http://127.0.0.1:${HERMES_DASHBOARD_PORT}/`);

--- a/test/e2e/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e/live/hermes-inference-switch-helpers.ts
@@ -84,16 +84,15 @@ export function mockAnthropicSwitchEnabled(runtimeEnv: NodeJS.ProcessEnv = proce
   );
 }
 
-export function expectAuthenticatedBaselineRequest(
+export function expectAuthenticatedBaselineInventoryRequest(
   baseline: Pick<FakeOpenAiCompatibleServer, "requests"> | undefined,
-  model: string,
 ): void {
   if (!baseline) return;
   expect(baseline.requests()).toContainEqual(
     expect.objectContaining({
       auth: "ok",
-      model,
-      path: "/v1/chat/completions",
+      authorizationSent: true,
+      path: "/v1/models",
     }),
   );
 }

--- a/test/e2e/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e/live/hermes-inference-switch-helpers.ts
@@ -92,6 +92,7 @@ export function expectAuthenticatedBaselineInventoryRequest(
     expect.objectContaining({
       auth: "ok",
       authorizationSent: true,
+      method: "GET",
       path: "/v1/models",
     }),
   );

--- a/test/e2e/live/hermes-inference-switch.test.ts
+++ b/test/e2e/live/hermes-inference-switch.test.ts
@@ -16,7 +16,7 @@ import {
   ensureCompatibleAnthropicSwitchProvider,
   env,
   envHash,
-  expectAuthenticatedBaselineRequest,
+  expectAuthenticatedBaselineInventoryRequest,
   expectedApiMode,
   expectedBaseUrl,
   hashCheck,
@@ -165,7 +165,7 @@ test("Hermes inference set updates route/config and preserves live runtime", {
 
   const install = await installHermes(host, apiKey, installEnv);
   expect(install.exitCode, resultText(install)).toBe(0);
-  expectAuthenticatedBaselineRequest(mockBaseline, MOCK_BASELINE_MODEL);
+  expectAuthenticatedBaselineInventoryRequest(mockBaseline);
   const baselineRoute = await sandbox.openshell(["inference", "get", "-g", "nemoclaw"], {
     artifactName: "openshell-inference-route-before-switch",
     env: env(),

--- a/test/e2e/support/hermes-inference-switch-command-shape.test.ts
+++ b/test/e2e/support/hermes-inference-switch-command-shape.test.ts
@@ -15,6 +15,7 @@ import {
   apiKeyShapeCommand,
   cleanupHermesSwitch,
   compatibleAnthropicMetadataArgs,
+  expectAuthenticatedBaselineInventoryRequest,
   hostedInstallModel,
   inferenceLocalMaxTokens,
   installHermes,
@@ -112,6 +113,37 @@ describe("Hermes inference switch command shape", () => {
         NEMOCLAW_SWITCH_MOCK_HOST: "host.openshell.internal",
       }),
     ).toBe("http://host.openshell.internal:18766");
+  });
+
+  it("uses authenticated model inventory as baseline readiness evidence", () => {
+    expect(() =>
+      expectAuthenticatedBaselineInventoryRequest({
+        requests: () => [
+          {
+            auth: "ok",
+            authorizationSent: true,
+            bodyBytes: 0,
+            method: "GET",
+            path: "/v1/models",
+          },
+        ],
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      expectAuthenticatedBaselineInventoryRequest({
+        requests: () => [
+          {
+            auth: "ok",
+            authorizationSent: true,
+            bodyBytes: 42,
+            method: "POST",
+            model: "legacy-chat-probe",
+            path: "/v1/chat/completions",
+          },
+        ],
+      }),
+    ).toThrow();
   });
 
   it("enables local baseline inference only for the mock Anthropic lane", () => {

--- a/test/e2e/support/hermes-inference-switch-command-shape.test.ts
+++ b/test/e2e/support/hermes-inference-switch-command-shape.test.ts
@@ -136,10 +136,9 @@ describe("Hermes inference switch command shape", () => {
           {
             auth: "ok",
             authorizationSent: true,
-            bodyBytes: 42,
+            bodyBytes: 0,
             method: "POST",
-            model: "legacy-chat-probe",
-            path: "/v1/chat/completions",
+            path: "/v1/models",
           },
         ],
       }),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Align the v0.0.84 live E2E fixtures with gateway-network reachability and inventory-only readiness checks. The affected tests previously used runner loopback addresses or asserted superseded completion and deployment text, producing deterministic release-gate failures despite the intended runtime behavior.

## Changes

- Advertise the double-onboard and concurrent-gateway mock inference endpoints through `host.openshell.internal` while binding their authenticated fixture servers for gateway access.
- Assert the new Hermes deployment verification text that includes inference-route health.
- Treat an authenticated `/v1/models` inventory request as Hermes baseline readiness evidence instead of requiring a token-consuming chat completion.
- Add focused support coverage that rejects the superseded chat-completion assertion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Fixture and assertion corrections only; supported user behavior and configuration are unchanged, and the canonical v0.0.84 changelog already documents inventory-only readiness.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending PR review; the diff changes live E2E fixtures only and does not alter production paths.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/hermes-inference-switch-command-shape.test.ts` (19 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live E2E connectivity by explicitly configuring the fake OpenAI-compatible server to be reachable from the gateway network namespace.
  * Strengthened Hermes deployment verification to require healthy gateway, dashboard, and inference route status.
* **Tests**
  * Updated Hermes inference baseline checks to use authenticated model-inventory (`/v1/models`) requests instead of chat-completions readiness.
  * Added assertions covering “baseline readiness evidence” behavior for accepted GET vs rejected authenticated POST request shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->