### PR TITLE
refactor(ci): move PR E2E gate polling and download into the controller

### DIFF
--- a/.github/workflows/pr-e2e-gate.yaml
+++ b/.github/workflows/pr-e2e-gate.yaml
@@ -259,76 +259,11 @@ jobs:
         if: ${{ steps.start.outputs.dispatched == 'true' }}
         continue-on-error: true
         env:
-          GATE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ steps.start.outputs.run_id }}
-        run: |
-          wait_status=0
-          timeout --signal=TERM --kill-after=30s 105m bash -s <<'WAIT' || wait_status=$?
-          set -euo pipefail
-
-          if [[ ! "$RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
-            printf '::error title=Invalid run ID::The controller did not provide a positive numeric run ID. %s\n' \
-              "$GATE_RUN_URL" >&2
-            exit 1
-          fi
-
-          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
-          last_state=""
-          while true; do
-            if ! state="$(
-              gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
-                --json status,conclusion \
-                --jq '.status + ":" + (if (.conclusion == null or .conclusion == "") then "none" else .conclusion end)'
-            )"; then
-              printf '::error title=Run status query failed::Unable to query run %s. %s\n' \
-                "$RUN_ID" "$run_url" >&2
-              exit 1
-            fi
-
-            if [[ "$state" != "$last_state" ]]; then
-              case "$state" in
-                queued:none | in_progress:none | requested:none | waiting:none | pending:none)
-                  printf 'Run %s status=%s url=%s\n' \
-                    "$RUN_ID" "${state%%:*}" "$run_url"
-                  ;;
-                completed:success)
-                  printf 'Run %s status=completed conclusion=success url=%s\n' \
-                    "$RUN_ID" "$run_url"
-                  ;;
-                completed:failure | completed:cancelled | completed:timed_out | completed:action_required | completed:neutral | completed:skipped | completed:stale | completed:startup_failure)
-                  printf 'Run %s status=completed conclusion=%s url=%s\n' \
-                    "$RUN_ID" "${state#*:}" "$run_url"
-                  ;;
-                *)
-                  printf '::error title=Unexpected run state::Run %s returned an unsupported status/conclusion pair. %s\n' \
-                    "$RUN_ID" "$run_url" >&2
-                  ;;
-              esac
-              last_state="$state"
-            fi
-
-            case "$state" in
-              queued:none | in_progress:none | requested:none | waiting:none | pending:none)
-                sleep 10
-                ;;
-              completed:success | completed:failure | completed:cancelled | completed:timed_out | completed:action_required | completed:neutral | completed:skipped | completed:stale | completed:startup_failure)
-                exit 0
-                ;;
-              *)
-                exit 1
-                ;;
-            esac
-          done
-          WAIT
-
-          if [ "$wait_status" -eq 124 ]; then
-            run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
-            printf 'Run %s did not complete within 105 minutes; finalization will cancel it and report the PR gate outcome. %s\n' \
-              "$RUN_ID" "$run_url"
-            wait_status=0
-          fi
-          exit "$wait_status"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
+          --mode wait
+          --run-id "${{ steps.start.outputs.run_id }}"
 
       - id: evidence
         name: Download evidence
@@ -336,22 +271,12 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ steps.start.outputs.run_id }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.start.outputs.run_id }}
-        run: |
-          set -euo pipefail
-          download_status=0
-          timeout --signal=TERM --kill-after=30s 10m \
-            gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
-              --dir "${{ steps.workspace.outputs.work_dir }}/evidence" || download_status=$?
-          if [ "$download_status" -eq 124 ]; then
-            printf '::error title=Evidence download timed out::Artifact download exceeded 10 minutes. %s\n' \
-              "$RUN_URL" >&2
-          elif [ "$download_status" -ne 0 ]; then
-            printf '::error title=Evidence download failed::Artifact download exited with status %s. %s\n' \
-              "$download_status" "$RUN_URL" >&2
-          fi
-          exit "$download_status"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
+          --mode download
+          --work-dir "${{ steps.workspace.outputs.work_dir }}"
+          --run-id "${{ steps.start.outputs.run_id }}"
 
       - id: finish
         name: Verify evidence

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -337,6 +337,11 @@
       "category": "security"
     },
     {
+      "file": "test/pr-e2e-gate-workflow.test.ts",
+      "test": "orders the coordinate steps and always finalizes through the controller",
+      "category": "security"
+    },
+    {
       "file": "test/pr-e2e-gate-shards.test.ts",
       "test": "rejects malformed configured matrix shard selectors",
       "category": "security"

--- a/test/pr-e2e-gate-command.test.ts
+++ b/test/pr-e2e-gate-command.test.ts
@@ -219,6 +219,42 @@ describe("PR E2E controller commands", () => {
     ).toEqual({ mode: "abandon", checkRunId: 17, childRunId: 23 });
   });
 
+  it("parses a wait command", () => {
+    expect(parseControllerCommand(["--mode", "wait", "--run-id", "23"])).toEqual({
+      mode: "wait",
+      childRunId: 23,
+    });
+  });
+
+  it("rejects a wait command without a positive run ID", () => {
+    expect(() => parseControllerCommand(["--mode", "wait", "--run-id", "0"])).toThrow(
+      /positive integer/u,
+    );
+  });
+
+  it("parses a download command into the private evidence workspace", () => {
+    withPrivateWorkDir((workDir) => {
+      expect(
+        parseControllerCommand(["--mode", "download", "--run-id", "23", "--work-dir", workDir]),
+      ).toEqual({
+        mode: "download",
+        childRunId: 23,
+        planPath: path.join(workDir, "risk-plan.json"),
+        statePath: path.join(workDir, "controller-state.json"),
+        evidencePath: path.join(workDir, "evidence"),
+      });
+    });
+  });
+
+  it("rejects a download workspace that is not private", () => {
+    withPrivateWorkDir((workDir) => {
+      fs.chmodSync(workDir, 0o755);
+      expect(() =>
+        parseControllerCommand(["--mode", "download", "--run-id", "23", "--work-dir", workDir]),
+      ).toThrow(/owned private absolute directory/u);
+    });
+  });
+
   it("rejects an unsafe pull request number", () => {
     expect(() => parseControllerCommand(["--mode", "cancel", "--pr", "9007199254740992"])).toThrow(
       /safe integer range/u,

--- a/test/pr-e2e-gate-run-wait.test.ts
+++ b/test/pr-e2e-gate-run-wait.test.ts
@@ -54,6 +54,7 @@ describe("PR E2E child run wait", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter([
         childRunRoute([
+          { status: "queued", conclusion: null },
           { status: "in_progress", conclusion: null },
           { status: "in_progress", conclusion: null },
           { status: "completed", conclusion: "success" },
@@ -63,9 +64,10 @@ describe("PR E2E child run wait", () => {
 
     await waitForChildRun(23, { sleep: async () => {} });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
     expect(logs).toEqual([
+      `Run 23 status=queued url=${CHILD_RUN_URL}`,
       `Run 23 status=in_progress url=${CHILD_RUN_URL}`,
       `Run 23 status=completed conclusion=success url=${CHILD_RUN_URL}`,
     ]);

--- a/test/pr-e2e-gate-run-wait.test.ts
+++ b/test/pr-e2e-gate-run-wait.test.ts
@@ -1,10 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { downloadChildRunEvidence, waitForChildRun } from "../tools/e2e/pr-e2e-gate.mts";
 import { createGitHubFetchRouter, githubFetchRoute } from "./support/github-fetch-router.ts";
+
+type DownloadEvidenceDeps = NonNullable<Parameters<typeof downloadChildRunEvidence>[2]>;
+type EvidenceSpawnFn = NonNullable<DownloadEvidenceDeps["spawn"]>;
+
+class FakeEvidenceChild extends EventEmitter {
+  kill = vi.fn((_signal?: NodeJS.Signals | number) => true);
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -56,6 +64,7 @@ describe("PR E2E child run wait", () => {
     await waitForChildRun(23, { sleep: async () => {} });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
     expect(logs).toEqual([
       `Run 23 status=in_progress url=${CHILD_RUN_URL}`,
       `Run 23 status=completed conclusion=success url=${CHILD_RUN_URL}`,
@@ -120,49 +129,102 @@ describe("PR E2E child run wait", () => {
       timeoutMs: 20_000,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(logs.some((line) => /did not complete within \d+ minutes/u.test(line))).toBe(true);
-    expect(logs.some((line) => line.includes(CHILD_RUN_URL))).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual([
+      `Run 23 status=in_progress url=${CHILD_RUN_URL}`,
+      `Run 23 did not complete within 0 minutes; finalization will cancel it and report the PR gate outcome. ${CHILD_RUN_URL}`,
+    ]);
   });
 });
 
 describe("PR E2E evidence download", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("downloads evidence into the private destination", async () => {
     vi.stubEnv("GITHUB_TOKEN", "token");
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
-    const calls: string[][] = [];
+    const child = new FakeEvidenceChild();
+    const spawnCalls: {
+      command: string;
+      args: readonly string[];
+      options: Record<string, unknown>;
+    }[] = [];
+    const spawnMock: EvidenceSpawnFn = (command, args, options) => {
+      spawnCalls.push({ command, args, options: options as Record<string, unknown> });
+      return child;
+    };
 
-    await downloadChildRunEvidence(23, "/private/work/evidence", {
-      run: async (args) => {
-        calls.push(args);
-        return { code: 0, timedOut: false };
+    const promise = downloadChildRunEvidence(23, "/private/work/evidence", { spawn: spawnMock });
+    child.emit("close", 0);
+    await promise;
+
+    expect(spawnCalls).toEqual([
+      {
+        command: "gh",
+        args: [
+          "run",
+          "download",
+          "23",
+          "--repo",
+          "NVIDIA/NemoClaw",
+          "--dir",
+          "/private/work/evidence",
+        ],
+        options: expect.objectContaining({ stdio: "inherit" }),
       },
-    });
-
-    expect(calls).toEqual([
-      ["run", "download", "23", "--repo", "NVIDIA/NemoClaw", "--dir", "/private/work/evidence"],
     ]);
   });
 
-  it("fails when the evidence download exceeds its bounded timeout", async () => {
+  it("sends SIGTERM then escalates to SIGKILL when the download exceeds its bounded timeout", async () => {
+    vi.useFakeTimers();
     vi.stubEnv("GITHUB_TOKEN", "token");
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    const child = new FakeEvidenceChild();
 
-    await expect(
-      downloadChildRunEvidence(23, "/private/work/evidence", {
-        run: async () => ({ code: null, timedOut: true }),
-      }),
+    const assertion = expect(
+      downloadChildRunEvidence(23, "/private/work/evidence", { spawn: () => child }),
     ).rejects.toThrow(/exceeded 10 minutes/u);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(child.kill).toHaveBeenCalledTimes(2);
+    expect(child.kill).toHaveBeenLastCalledWith("SIGKILL");
+
+    child.emit("close", null);
+    await assertion;
   });
 
-  it("fails when the evidence download exits non-zero", async () => {
+  it("fails when the evidence download exits non-zero, and clears the timeout timer on close", async () => {
+    vi.useFakeTimers();
     vi.stubEnv("GITHUB_TOKEN", "token");
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    const child = new FakeEvidenceChild();
 
-    await expect(
-      downloadChildRunEvidence(23, "/private/work/evidence", {
-        run: async () => ({ code: 2, timedOut: false }),
-      }),
+    const assertion = expect(
+      downloadChildRunEvidence(23, "/private/work/evidence", { spawn: () => child }),
     ).rejects.toThrow(/exited with status 2/u);
+    child.emit("close", 2);
+    await assertion;
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("propagates a spawn error", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    const child = new FakeEvidenceChild();
+    const spawnError = new Error("spawn gh ENOENT");
+
+    const assertion = expect(
+      downloadChildRunEvidence(23, "/private/work/evidence", { spawn: () => child }),
+    ).rejects.toThrow(spawnError);
+    child.emit("error", spawnError);
+    await assertion;
   });
 });

--- a/test/pr-e2e-gate-run-wait.test.ts
+++ b/test/pr-e2e-gate-run-wait.test.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { downloadChildRunEvidence, waitForChildRun } from "../tools/e2e/pr-e2e-gate.mts";
+import { createGitHubFetchRouter, githubFetchRoute } from "./support/github-fetch-router.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+function githubResponse(value?: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => value,
+    text: async () => (value === undefined ? "" : JSON.stringify(value)),
+  } as Response;
+}
+
+describe("PR E2E child run wait", () => {
+  const CHILD_RUN_URL = "https://github.com/NVIDIA/NemoClaw/actions/runs/23";
+
+  function childRunRoute(states: Array<{ status: string; conclusion: string | null }>) {
+    let index = 0;
+    return githubFetchRoute(
+      ({ url, method }) => method === "GET" && url.endsWith("/actions/runs/23"),
+      () => githubResponse(states[Math.min(index++, states.length - 1)]),
+    );
+  }
+
+  function captureLogs(): string[] {
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+      logs.push(String(message));
+    });
+    return logs;
+  }
+
+  it("logs each child state once and returns after a terminal conclusion", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    const logs = captureLogs();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter([
+        childRunRoute([
+          { status: "in_progress", conclusion: null },
+          { status: "in_progress", conclusion: null },
+          { status: "completed", conclusion: "success" },
+        ]),
+      ]),
+    );
+
+    await waitForChildRun(23, { sleep: async () => {} });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(logs).toEqual([
+      `Run 23 status=in_progress url=${CHILD_RUN_URL}`,
+      `Run 23 status=completed conclusion=success url=${CHILD_RUN_URL}`,
+    ]);
+  });
+
+  it("leaves a terminal child failure for finalization to report", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    const logs = captureLogs();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter([childRunRoute([{ status: "completed", conclusion: "failure" }])]),
+    );
+
+    await expect(waitForChildRun(23, { sleep: async () => {} })).resolves.toBeUndefined();
+    expect(logs).toEqual([`Run 23 status=completed conclusion=failure url=${CHILD_RUN_URL}`]);
+  });
+
+  it("fails and reports the child run URL when the status query fails", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter([
+        githubFetchRoute(
+          ({ url, method }) => method === "GET" && url.endsWith("/actions/runs/23"),
+          () => githubResponse("simulated GitHub query failure", 500),
+        ),
+      ]),
+    );
+
+    await expect(waitForChildRun(23, { sleep: async () => {} })).rejects.toThrow(
+      /Run status query failed:.*actions\/runs\/23/su,
+    );
+  });
+
+  it("fails closed on an unsupported child state", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter([childRunRoute([{ status: "completed", conclusion: "bewildered" }])]),
+    );
+
+    await expect(waitForChildRun(23, { sleep: async () => {} })).rejects.toThrow(
+      /unsupported status\/conclusion pair/u,
+    );
+  });
+
+  it("returns after the wait budget is exhausted so finalization can cancel", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    const logs = captureLogs();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(
+        createGitHubFetchRouter([childRunRoute([{ status: "in_progress", conclusion: null }])]),
+      );
+    let ticks = 0;
+
+    await waitForChildRun(23, {
+      sleep: async () => {},
+      now: () => ticks++ * 10_000,
+      timeoutMs: 20_000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(logs.some((line) => /did not complete within \d+ minutes/u.test(line))).toBe(true);
+    expect(logs.some((line) => line.includes(CHILD_RUN_URL))).toBe(true);
+  });
+});
+
+describe("PR E2E evidence download", () => {
+  it("downloads evidence into the private destination", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    const calls: string[][] = [];
+
+    await downloadChildRunEvidence(23, "/private/work/evidence", {
+      run: async (args) => {
+        calls.push(args);
+        return { code: 0, timedOut: false };
+      },
+    });
+
+    expect(calls).toEqual([
+      ["run", "download", "23", "--repo", "NVIDIA/NemoClaw", "--dir", "/private/work/evidence"],
+    ]);
+  });
+
+  it("fails when the evidence download exceeds its bounded timeout", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+
+    await expect(
+      downloadChildRunEvidence(23, "/private/work/evidence", {
+        run: async () => ({ code: null, timedOut: true }),
+      }),
+    ).rejects.toThrow(/exceeded 10 minutes/u);
+  });
+
+  it("fails when the evidence download exits non-zero", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+
+    await expect(
+      downloadChildRunEvidence(23, "/private/work/evidence", {
+        run: async () => ({ code: 2, timedOut: false }),
+      }),
+    ).rejects.toThrow(/exited with status 2/u);
+  });
+});

--- a/test/pr-e2e-gate-workflow.test.ts
+++ b/test/pr-e2e-gate-workflow.test.ts
@@ -60,111 +60,6 @@ function collectStrings(value: unknown): string[] {
         : [];
 }
 
-function runWaitStep(
-  scenario: "success" | "failure" | "query-failure" | "timeout" | "unsupported",
-  options: { runId?: string } = {},
-) {
-  const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
-  const wait = step(workflow.jobs.coordinate, "Wait for E2E run");
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-wait-"));
-  const binDir = path.join(tempDir, "bin");
-  const callCountPath = path.join(tempDir, "gh-call-count");
-  fs.mkdirSync(binDir);
-  fs.writeFileSync(callCountPath, "0\n");
-  fs.writeFileSync(
-    path.join(binDir, "gh"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-count="$(cat "$FAKE_GH_CALL_COUNT")"
-count=$((count + 1))
-printf '%s\n' "$count" > "$FAKE_GH_CALL_COUNT"
-case "$FAKE_GH_SCENARIO:$count" in
-  success:1 | success:2 | failure:1) printf 'in_progress:none\n' ;;
-  success:*) printf 'completed:success\n' ;;
-  failure:*) printf 'completed:failure\n' ;;
-  query-failure:*) printf 'simulated GitHub query failure\n' >&2; exit 1 ;;
-  unsupported:*) printf 'completed:unknown\n' ;;
-  *) exit 2 ;;
-esac
-`,
-    { mode: 0o755 },
-  );
-  fs.writeFileSync(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
-  fs.writeFileSync(
-    path.join(binDir, "timeout"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-if [ "$FAKE_GH_SCENARIO" = "timeout" ]; then
-  exit 124
-fi
-shift 3
-exec "$@"
-`,
-    { mode: 0o755 },
-  );
-
-  try {
-    const result = spawnSync("bash", ["-e", "-o", "pipefail", "-c", wait.run!], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_GH_CALL_COUNT: callCountPath,
-        FAKE_GH_SCENARIO: scenario,
-        GATE_RUN_URL: "https://github.com/NVIDIA/NemoClaw/actions/runs/17",
-        GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
-        RUN_ID: options.runId ?? "29110351531",
-      },
-      timeout: 5_000,
-    });
-    return {
-      ...result,
-      ghCallCount: Number(fs.readFileSync(callCountPath, "utf8").trim()),
-    };
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
-function runEvidenceStep(scenario: "success" | "failure" | "timeout") {
-  const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
-  const evidence = step(workflow.jobs.coordinate, "Download evidence");
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-evidence-"));
-  const binDir = path.join(tempDir, "bin");
-  fs.mkdirSync(binDir);
-  fs.writeFileSync(
-    path.join(binDir, "timeout"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-case "$FAKE_DOWNLOAD_SCENARIO" in
-  success) exit 0 ;;
-  failure) printf 'simulated artifact download failure\n' >&2; exit 2 ;;
-  timeout) exit 124 ;;
-  *) exit 64 ;;
-esac
-`,
-    { mode: 0o755 },
-  );
-
-  try {
-    const script = evidence.run!.replaceAll("${{ steps.workspace.outputs.work_dir }}", tempDir);
-    return spawnSync("bash", ["-e", "-o", "pipefail", "-c", script], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_DOWNLOAD_SCENARIO: scenario,
-        GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
-        RUN_ID: "29110351531",
-        RUN_URL: "https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531",
-      },
-      timeout: 5_000,
-    });
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
 function runStartStep(headBranch: string, prNumber = "42") {
   const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
   const start = step(workflow.jobs.coordinate, "Start evaluation");
@@ -576,14 +471,15 @@ describe("PR E2E gate workflow", () => {
     expect(start.run).toContain('--ci-display-title "$CI_DISPLAY_TITLE"');
     expect(start.run).toContain('--gate-run-id "$GATE_RUN_ID"');
     const wait = step(coordinate, "Wait for E2E run");
-    expect(wait.env?.GATE_RUN_URL).toBe(
-      "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-    );
+    expect(wait.env?.GITHUB_TOKEN).toBe("${{ github.token }}");
+    expect(wait.run).toContain("--mode wait");
+    expect(wait.run).toContain('--run-id "${{ steps.start.outputs.run_id }}"');
     const evidence = step(coordinate, "Download evidence");
-    expect(evidence.env?.RUN_URL).toBe(
-      "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.start.outputs.run_id }}",
-    );
-    expect(evidence.run).toContain('"$RUN_URL" >&2');
+    expect(evidence.env?.GH_TOKEN).toBe("${{ github.token }}");
+    expect(evidence.env?.GITHUB_TOKEN).toBe("${{ github.token }}");
+    expect(evidence.run).toContain("--mode download");
+    expect(evidence.run).toContain('--work-dir "${{ steps.workspace.outputs.work_dir }}"');
+    expect(evidence.run).toContain('--run-id "${{ steps.start.outputs.run_id }}"');
     const finish = step(coordinate, "Verify evidence");
     expect(finish.run).toContain('--evidence-outcome "${{ steps.evidence.outcome }}"');
     const approval = step(approveForkSkip, "Record approved credentialed E2E skip");
@@ -746,73 +642,34 @@ describe("PR E2E gate workflow", () => {
     expect(racedWorkflow.stdout).toContain("workflow_sha must match the trusted workflow commit");
   });
 
-  it("logs each child state once and exits after success", () => {
-    const result = runWaitStep("success");
+  // source-shape-contract: security -- Always-run finalization and private-workspace cleanup must survive every coordinate failure path
+  it("orders the coordinate steps and always finalizes through the controller", () => {
+    const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
+    const coordinate = workflow.jobs.coordinate;
 
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout.trim().split(/\r?\n/u)).toEqual([
-      expect.stringContaining("status=in_progress"),
-      expect.stringContaining("status=completed conclusion=success"),
+    expect((coordinate.steps ?? []).map((candidate) => candidate.name)).toEqual([
+      "Checkout controller",
+      "Setup Node",
+      "Install controller dependencies",
+      "Create private workspace",
+      "Start evaluation",
+      "Upload risk plan",
+      "Wait for E2E run",
+      "Download evidence",
+      "Verify evidence",
+      "Close incomplete check",
+      "Remove private workspace",
     ]);
-  });
 
-  it("leaves terminal child failures for finalization to report", () => {
-    const result = runWaitStep("failure");
-
-    expect(result.status).toBe(0);
-    expect(result.stdout.match(/status=in_progress/gu)).toHaveLength(1);
-    expect(result.stdout).toContain("status=completed conclusion=failure");
-    expect(result.stderr).toBe("");
-  });
-
-  it("preserves GitHub CLI errors when status queries fail", () => {
-    const result = runWaitStep("query-failure");
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("simulated GitHub query failure");
-    expect(result.stderr).toContain("::error title=Run status query failed::");
-    expect(result.stderr).toContain("https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531");
-  });
-
-  it("leaves bounded wait timeouts for finalization to cancel and report", () => {
-    const result = runWaitStep("timeout");
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("did not complete within 105 minutes");
-    expect(result.stdout).toContain("https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531");
-    expect(result.stderr).toBe("");
-  });
-
-  it("links timeout and generic evidence download failures to the child run", () => {
-    const timeout = runEvidenceStep("timeout");
-    const failure = runEvidenceStep("failure");
-    const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531";
-
-    expect(timeout.status).toBe(124);
-    expect(timeout.stderr).toContain("::error title=Evidence download timed out::");
-    expect(timeout.stderr).toContain(runUrl);
-    expect(failure.status).toBe(2);
-    expect(failure.stderr).toContain("simulated artifact download failure");
-    expect(failure.stderr).toContain("::error title=Evidence download failed::");
-    expect(failure.stderr).toContain(runUrl);
-  });
-
-  it("rejects an invalid child run ID before querying GitHub", () => {
-    const result = runWaitStep("success", { runId: "invalid" });
-
-    expect(result.status).toBe(1);
-    expect(result.ghCallCount).toBe(0);
-    expect(result.stderr).toContain("::error title=Invalid run ID::");
-    expect(result.stderr).toContain("https://github.com/NVIDIA/NemoClaw/actions/runs/17");
-  });
-
-  it("fails closed for an unsupported child state", () => {
-    const result = runWaitStep("unsupported");
-
-    expect(result.status).toBe(1);
-    expect(result.ghCallCount).toBe(1);
-    expect(result.stderr).toContain("::error title=Unexpected run state::");
-    expect(result.stderr).toContain("https://github.com/NVIDIA/NemoClaw/actions/runs/29110351531");
+    const evidence = step(coordinate, "Download evidence");
+    expect(evidence.if).toContain("always()");
+    const finish = step(coordinate, "Verify evidence");
+    expect(finish.if).toContain("always()");
+    const abandon = step(coordinate, "Close incomplete check");
+    expect(abandon.if).toContain("always()");
+    const cleanup = step(coordinate, "Remove private workspace");
+    expect(cleanup.if).toContain("always()");
+    expect(cleanup.if).toContain("steps.workspace.outputs.work_dir");
+    expect(cleanup.run).toBe('rm -rf -- "${{ steps.workspace.outputs.work_dir }}"');
   });
 });

--- a/tools/advisors/github.mts
+++ b/tools/advisors/github.mts
@@ -11,6 +11,7 @@ export type GitHubRequestOptions = {
   method?: string;
   body?: unknown;
   userAgent?: string;
+  signal?: AbortSignal;
 };
 
 export async function githubRest<T>(apiPath: string, token: string): Promise<T> {
@@ -94,6 +95,7 @@ export async function githubApi<T>(
       ...(options.userAgent ? { "User-Agent": options.userAgent } : {}),
     },
     body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    signal: options.signal,
   });
   const text = await response.text();
   if (!response.ok) {

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -68,6 +69,22 @@ const ACTIVE_WORKFLOW_RUN_STATUSES = [
   "in_progress",
 ] as const;
 const ACTIVE_WORKFLOW_RUN_STATUS_SET = new Set<string>(ACTIVE_WORKFLOW_RUN_STATUSES);
+const TERMINAL_WORKFLOW_RUN_CONCLUSIONS = [
+  "success",
+  "failure",
+  "cancelled",
+  "timed_out",
+  "action_required",
+  "neutral",
+  "skipped",
+  "stale",
+  "startup_failure",
+] as const;
+const TERMINAL_WORKFLOW_RUN_CONCLUSION_SET = new Set<string>(TERMINAL_WORKFLOW_RUN_CONCLUSIONS);
+const WAIT_POLL_INTERVAL_MS = 10_000;
+const WAIT_TIMEOUT_MS = 105 * 60_000;
+const EVIDENCE_DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
+const EVIDENCE_DOWNLOAD_KILL_GRACE_MS = 30_000;
 const EVIDENCE_LIMITS = {
   maxDepth: 8,
   maxEntries: 4096,
@@ -146,6 +163,8 @@ export type ControllerCommand =
     } & ControllerPaths)
   | { mode: "abandon"; checkRunId: number; childRunId?: number }
   | { mode: "cancel"; prNumber: number }
+  | { mode: "wait"; childRunId: number }
+  | ({ mode: "download"; childRunId: number } & ControllerPaths)
   | ControlPlaneDispatchCommand
   | ManualForkSkipCommand
   | ApprovedForkSkipCommand;
@@ -423,6 +442,19 @@ export function parseControllerCommand(argv: string[]): ControllerCommand {
       prNumber: parsePositiveId(requiredArgument(args.pr, "pr"), "--pr"),
     };
   }
+  if (args.mode === "wait") {
+    return {
+      mode: "wait",
+      childRunId: parsePositiveId(requiredArgument(args.runId, "run-id"), "--run-id"),
+    };
+  }
+  if (args.mode === "download") {
+    return {
+      mode: "download",
+      childRunId: parsePositiveId(requiredArgument(args.runId, "run-id"), "--run-id"),
+      ...privateControllerPaths(requiredArgument(args.workDir, "work-dir")),
+    };
+  }
   if (args.mode === "start-control-plane") {
     const maintainer = requiredArgument(args.maintainer, "maintainer");
     if (!MAINTAINER_PATTERN.test(maintainer)) throw new Error("--maintainer is invalid");
@@ -488,7 +520,7 @@ export function parseControllerCommand(argv: string[]): ControllerCommand {
     };
   }
   throw new Error(
-    "--mode must be seed, start, start-control-plane, finish, abandon, cancel, record-fork-e2e-skip, or record-approved-fork-e2e-skip",
+    "--mode must be seed, start, start-control-plane, finish, abandon, cancel, wait, download, record-fork-e2e-skip, or record-approved-fork-e2e-skip",
   );
 }
 
@@ -1696,6 +1728,136 @@ async function cancelChildRun(repository: string, token: string, runId: number):
   }
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function waitForChildRun(
+  childRunId: number,
+  deps: {
+    sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+  } = {},
+): Promise<void> {
+  const { token, repository } = tokenAndRepository();
+  const wait = deps.sleep ?? sleep;
+  const now = deps.now ?? Date.now;
+  const pollIntervalMs = deps.pollIntervalMs ?? WAIT_POLL_INTERVAL_MS;
+  const timeoutMs = deps.timeoutMs ?? WAIT_TIMEOUT_MS;
+  const runUrl = `https://github.com/${repository}/actions/runs/${childRunId}`;
+  const deadline = now() + timeoutMs;
+  let lastState = "";
+  while (true) {
+    let run: WorkflowRun;
+    try {
+      run = await githubApi<WorkflowRun>(`repos/${repository}/actions/runs/${childRunId}`, token, {
+        userAgent: USER_AGENT,
+      });
+    } catch (error) {
+      throw new Error(
+        `Run status query failed: unable to query run ${childRunId}. ${runUrl} (${controllerErrorMessage(error)})`,
+      );
+    }
+    const conclusion = run.conclusion && run.conclusion.length > 0 ? run.conclusion : "none";
+    const state = `${run.status}:${conclusion}`;
+    const active = ACTIVE_WORKFLOW_RUN_STATUS_SET.has(run.status) && conclusion === "none";
+    const completed =
+      run.status === "completed" && TERMINAL_WORKFLOW_RUN_CONCLUSION_SET.has(conclusion);
+    if (state !== lastState) {
+      if (active) {
+        console.log(`Run ${childRunId} status=${run.status} url=${runUrl}`);
+      } else if (completed) {
+        console.log(`Run ${childRunId} status=completed conclusion=${conclusion} url=${runUrl}`);
+      }
+      lastState = state;
+    }
+    if (completed) return;
+    if (!active) {
+      throw new Error(
+        `Unexpected run state: run ${childRunId} returned an unsupported status/conclusion pair (${state}). ${runUrl}`,
+      );
+    }
+    if (now() >= deadline) {
+      console.log(
+        `Run ${childRunId} did not complete within ${Math.round(timeoutMs / 60_000)} minutes; finalization will cancel it and report the PR gate outcome. ${runUrl}`,
+      );
+      return;
+    }
+    await wait(pollIntervalMs);
+  }
+}
+
+type EvidenceDownloadResult = { code: number | null; timedOut: boolean };
+
+function spawnEvidenceDownload(
+  args: string[],
+  timeoutMs: number,
+  killGraceMs: number,
+): Promise<EvidenceDownloadResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("gh", args, {
+      stdio: "inherit",
+      env: { ...process.env, GH_TOKEN: process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? "" },
+    });
+    let timedOut = false;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), killGraceMs);
+    }, timeoutMs);
+    child.on("error", (error) => {
+      clearTimeout(timeoutTimer);
+      if (killTimer) clearTimeout(killTimer);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeoutTimer);
+      if (killTimer) clearTimeout(killTimer);
+      resolve({ code, timedOut });
+    });
+  });
+}
+
+export async function downloadChildRunEvidence(
+  childRunId: number,
+  evidencePath: string,
+  deps: {
+    timeoutMs?: number;
+    killGraceMs?: number;
+    run?: (args: string[]) => Promise<EvidenceDownloadResult>;
+  } = {},
+): Promise<void> {
+  const { repository } = tokenAndRepository();
+  const timeoutMs = deps.timeoutMs ?? EVIDENCE_DOWNLOAD_TIMEOUT_MS;
+  const killGraceMs = deps.killGraceMs ?? EVIDENCE_DOWNLOAD_KILL_GRACE_MS;
+  const runUrl = `https://github.com/${repository}/actions/runs/${childRunId}`;
+  const run = deps.run ?? ((args) => spawnEvidenceDownload(args, timeoutMs, killGraceMs));
+  const result = await run([
+    "run",
+    "download",
+    String(childRunId),
+    "--repo",
+    repository,
+    "--dir",
+    evidencePath,
+  ]);
+  if (result.timedOut) {
+    throw new Error(
+      `Evidence download timed out: artifact download for run ${childRunId} exceeded ${Math.round(timeoutMs / 60_000)} minutes. ${runUrl}`,
+    );
+  }
+  if (result.code !== 0) {
+    throw new Error(
+      `Evidence download failed: artifact download for run ${childRunId} exited with status ${result.code}. ${runUrl}`,
+    );
+  }
+}
+
 async function dispatchSelectedPrGate(options: {
   repository: string;
   token: string;
@@ -2723,6 +2885,14 @@ async function main(): Promise<void> {
   }
   if (command.mode === "abandon") {
     await abandonPrGate(command.checkRunId, command.childRunId);
+    return;
+  }
+  if (command.mode === "wait") {
+    await waitForChildRun(command.childRunId);
+    return;
+  }
+  if (command.mode === "download") {
+    await downloadChildRunEvidence(command.childRunId, command.evidencePath);
     return;
   }
   if (command.mode === "record-fork-e2e-skip") {

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawn } from "node:child_process";
+import { spawn, type SpawnOptions } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -1756,6 +1756,7 @@ export async function waitForChildRun(
     try {
       run = await githubApi<WorkflowRun>(`repos/${repository}/actions/runs/${childRunId}`, token, {
         userAgent: USER_AGENT,
+        signal: AbortSignal.timeout(Math.max(1, deadline - now())),
       });
     } catch (error) {
       throw new Error(
@@ -1793,13 +1794,26 @@ export async function waitForChildRun(
 
 type EvidenceDownloadResult = { code: number | null; timedOut: boolean };
 
+interface SpawnedEvidenceProcess {
+  kill(signal?: NodeJS.Signals | number): boolean;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "close", listener: (code: number | null) => void): this;
+}
+
+type SpawnEvidenceImpl = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => SpawnedEvidenceProcess;
+
 function spawnEvidenceDownload(
   args: string[],
   timeoutMs: number,
   killGraceMs: number,
+  spawnImpl: SpawnEvidenceImpl = spawn,
 ): Promise<EvidenceDownloadResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn("gh", args, {
+    const child = spawnImpl("gh", args, {
       stdio: "inherit",
       env: { ...process.env, GH_TOKEN: process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? "" },
     });
@@ -1829,23 +1843,19 @@ export async function downloadChildRunEvidence(
   deps: {
     timeoutMs?: number;
     killGraceMs?: number;
-    run?: (args: string[]) => Promise<EvidenceDownloadResult>;
+    spawn?: SpawnEvidenceImpl;
   } = {},
 ): Promise<void> {
   const { repository } = tokenAndRepository();
   const timeoutMs = deps.timeoutMs ?? EVIDENCE_DOWNLOAD_TIMEOUT_MS;
   const killGraceMs = deps.killGraceMs ?? EVIDENCE_DOWNLOAD_KILL_GRACE_MS;
   const runUrl = `https://github.com/${repository}/actions/runs/${childRunId}`;
-  const run = deps.run ?? ((args) => spawnEvidenceDownload(args, timeoutMs, killGraceMs));
-  const result = await run([
-    "run",
-    "download",
-    String(childRunId),
-    "--repo",
-    repository,
-    "--dir",
-    evidencePath,
-  ]);
+  const result = await spawnEvidenceDownload(
+    ["run", "download", String(childRunId), "--repo", repository, "--dir", evidencePath],
+    timeoutMs,
+    killGraceMs,
+    deps.spawn,
+  );
   if (result.timedOut) {
     throw new Error(
       `Evidence download timed out: artifact download for run ${childRunId} exceeded ${Math.round(timeoutMs / 60_000)} minutes. ${runUrl}`,


### PR DESCRIPTION
## Summary

The PR E2E gate controller workflow still ran a run-state polling loop and an evidence download wrapper as inline shell in its `coordinate` job. Both move into the already-testable controller as `--mode wait` and `--mode download` entrypoints, following the `#6952` effort to keep executable logic out of Actions YAML. The workflow keeps triggers, permissions, concurrency, artifact upload, step conditions, and always-run finalization. Behaviour is preserved end to end.

## Related Issue

Resolves #6960
Part of #6952

## Changes

- `tools/e2e/pr-e2e-gate.mts`: add `--mode wait`, which polls the child run through the existing REST client, logs each state change once, reports the child-run URL, treats the nine terminal conclusions as completion, fails closed on an unknown state or query error, and returns after a 105-minute budget so finalization cancels and reports. Add `--mode download`, which runs `gh run download` into the private evidence workspace under a Node-enforced 10-minute timeout (SIGTERM then SIGKILL), failing when the download times out or exits non-zero. Both parse and dispatch through the existing command model; the timeout and destination are the current requirement carried over from the shell steps, covered by the direct controller tests below.
- `.github/workflows/pr-e2e-gate.yaml`: replace the inline polling loop and download wrapper with the two controller invocations. Workspace creation, risk-plan upload, evidence verification, incomplete-check finalization, and workspace removal stay in YAML.
- Tests: direct controller coverage for the poll state machine and bounded download in `pr-e2e-gate.test.ts`; wait/download parsing in `pr-e2e-gate-command.test.ts`; a step-ordering and always-run finalization contract in `pr-e2e-gate-workflow.test.ts` (registered in the source-shape budget).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal CI controller relocation with no user-facing behaviour or documented interface change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: the write-capable E2E gate controller is a trust boundary; this change relocates polling and download logic without altering permissions, run states, timeouts, evidence destination, or finalization, and every path is covered by the controller and workflow contract tests — awaiting maintainer sensitive-path review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run` on the pr-e2e-gate command/controller/workflow/lifecycle/shards and source-shape-scanner suites → 110 passed; `npm run typecheck:cli` → pass; `node find-source-shape-tests.mts --check` → pass; Biome check → clean (Node 22.22).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated controller coordination modes for waiting on child run completion and downloading child run evidence.
* **Bug Fixes**
  * Improved CI e2e gate robustness with stronger run-id validation, clearer terminal-state handling, and safer evidence workspace cleanup.
  * Enhanced timeout and process termination behavior during evidence download.
* **Tests**
  * Expanded command parsing and end-to-end coverage for wait/download flows, including timeout, error, and permission scenarios.
* **Chores**
  * Updated CI workflow to use shared coordination tooling for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Carlos Villela <cvillela@nvidia.com>