### PR TITLE
test(e2e): make release fixtures sandbox-reachable

### DIFF
--- a/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
+++ b/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
@@ -22,6 +22,7 @@ import {
   validateSandboxName,
 } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
 import { CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/paths.ts";
 import { parseJsonFromText } from "./json-envelope.ts";
 
@@ -1015,9 +1016,24 @@ test("a custom OpenClaw plugin survives restart, recreation, and rebuild without
   const taggedOpenShellWrapper = createOpenShellTmpfsWrapper(taggedPinnedOpenshell.cli);
   cleanup.add("remove v0.0.71 EXDEV OpenShell PATH wrapper", taggedOpenShellWrapper.remove);
 
+  // The OpenShell gateway reaches the fixture from its network namespace, so
+  // runner loopback is not routable from the readiness probe.
+  const fake = await startFakeOpenAiCompatibleServer({
+    apiKey: "nemoclaw-exdev-dummy-key",
+    host: "0.0.0.0",
+    model: "nemoclaw-exdev-probe",
+    publicHost: "host.openshell.internal",
+    responseText: "ok",
+  });
+  await artifacts.writeJson("fake-openai-compatible.json", { baseUrl: fake.baseUrl });
+  cleanup.add("close EXDEV compatible endpoint mock", async () => {
+    await artifacts.writeJson("fake-openai-compatible-requests.json", fake.requests());
+    await fake.close();
+  });
+
   const deploymentEnv = liveEnv({
     COMPATIBLE_API_KEY: "nemoclaw-exdev-dummy-key",
-    NEMOCLAW_ENDPOINT_URL: "http://host.openshell.internal:65535/v1",
+    NEMOCLAW_ENDPOINT_URL: fake.baseUrl,
     NEMOCLAW_MODEL: "nemoclaw-exdev-probe",
     NEMOCLAW_PROVIDER_KEY: "nemoclaw-exdev-dummy-key",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -770,7 +770,9 @@ runLinuxOpenShellGatewayUpgrade(
 
     const fake = await startFakeOpenAiCompatibleServer({
       apiKey: "dummy",
+      host: "0.0.0.0",
       model: "test-model",
+      publicHost: "host.openshell.internal",
       responseText: "ok",
     });
     cleanup.add("close compatible endpoint mock", async () => {


### PR DESCRIPTION
## Summary

Release-candidate E2E exposed two fixture endpoints that the OpenShell gateway could not reach, producing deterministic inference readiness HTTP 503 failures. This change gives the EXDEV fixture a real authenticated compatible endpoint and advertises both affected mocks through `host.openshell.internal`.

## Changes

- Start a real authenticated fake OpenAI-compatible server for `openclaw-plugin-runtime-exdev` instead of pointing onboarding at an intentionally dead port.
- Bind the EXDEV and historical gateway-upgrade mocks on all runner interfaces and advertise their sandbox-reachable host address.
- Preserve mock request logs as E2E artifacts for failure diagnosis.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: These changes only repair live E2E fixture reachability; production behavior, commands, configuration, and supported contracts are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/device-auth-health-helpers.test.ts test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts test/e2e/support/openclaw-plugin-runtime-exdev-workflow-boundary.test.ts` (3 files, 8 tests passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved live deployment and upgrade test reliability by using a locally hosted, OpenAI-compatible mock service.
  * Updated test networking so the mock service is reachable through the expected environment endpoint.
  * Added artifact capture for mock service URLs and requests to support troubleshooting failed test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->