### PR TITLE
fix(inference): pre-flight sandbox read before mutating the inference route

### DIFF
--- a/src/lib/actions/inference-set-degraded-state.test.ts
+++ b/src/lib/actions/inference-set-degraded-state.test.ts
@@ -2,35 +2,50 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
+import { SandboxConfigError } from "../sandbox/config";
 import type { ConfigObject } from "../security/credential-filter";
-import { runInferenceSet } from "./inference-set";
+import { InferenceSetError, runInferenceSet } from "./inference-set";
 import { baseSession, createDeps } from "./inference-set.test-support";
 
 describe("runInferenceSet degraded state handling", () => {
-  it("keeps gateway and registry consistent when the sandbox config read fails", async () => {
+  it("aborts before mutating any layer when the sandbox config read fails (#6997)", async () => {
     const deps = createDeps({ config: {}, session: baseSession() });
+    // A stopped sandbox surfaces SandboxConfigError from the in-sandbox read —
+    // the exact path from the issue.
     deps.calls.readSandboxConfig.mockImplementation(() => {
-      throw new Error("sandbox config unreadable");
+      throw new SandboxConfigError([
+        "  Cannot read openclaw config (/sandbox/.openclaw/openclaw.json).",
+        "  Is the sandbox running?",
+      ]);
     });
 
-    await expect(
-      runInferenceSet(
-        { provider: "nvidia-prod", model: "nvidia/nemotron-3-super-120b-a12b", noVerify: true },
-        deps,
-      ),
-    ).rejects.toThrow("sandbox config unreadable");
-
-    expect(deps.calls.updateSandbox).toHaveBeenCalledWith(
-      "alpha",
-      expect.objectContaining({
-        provider: "nvidia-prod",
-        model: "nvidia/nemotron-3-super-120b-a12b",
-        endpointUrl: null,
-        credentialEnv: null,
-        preferredInferenceApi: null,
-        nimContainer: null,
-      }),
+    const error = await runInferenceSet(
+      { provider: "nvidia-prod", model: "nvidia/nemotron-3-super-120b-a12b", noVerify: true },
+      deps,
+    ).then(
+      () => {
+        throw new Error("expected runInferenceSet to reject");
+      },
+      (rejection: unknown) => rejection,
     );
+
+    // Converted to the command-layer error type with an actionable message, so
+    // the CLI reports cleanly instead of dumping a raw SandboxConfigError stack.
+    expect(error).toBeInstanceOf(InferenceSetError);
+    expect((error as Error).message).toMatch(/Is the sandbox running/);
+    expect((error as Error).message).toMatch(/Start the sandbox and retry/);
+
+    // #6997 core guarantee: the read is a pre-flight gate, so a stopped sandbox
+    // leaves EVERY mutable layer untouched. Previously the read ran after the
+    // gateway route and registry were committed, leaving a half-applied switch.
+    // Assert zero mutation so re-ordering the read back after the mutations
+    // regresses this test. (The read-only `openshell provider get` probe that
+    // runs earlier is not a mutation, so filter to the route-SET call.)
+    const routeSetCalls = deps.calls.captureOpenshell.mock.calls.filter(
+      (args) => Array.isArray(args[0]) && args[0][0] === "inference" && args[0][1] === "set",
+    );
+    expect(routeSetCalls).toHaveLength(0);
+    expect(deps.calls.updateSandbox).not.toHaveBeenCalled();
     expect(deps.calls.writeSandboxConfig).not.toHaveBeenCalled();
     expect(deps.calls.restartSandboxGateway).not.toHaveBeenCalled();
   });

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -34,6 +34,7 @@ import {
   recomputeSandboxConfigHash,
   resolveAgentConfig,
   rewriteConfigUrlsWithDnsPinning,
+  SandboxConfigError,
   seedHermesDashboardConfig,
   writeSandboxConfig,
 } from "../sandbox/config";
@@ -573,6 +574,36 @@ function assertHermesCompatibleAnthropicOpenAiProvider(
   );
 }
 
+/**
+ * Read the in-sandbox agent config, converting a `SandboxConfigError` (the
+ * in-sandbox config could not be read or parsed — most commonly because the
+ * sandbox container is stopped) into a clean `InferenceSetError`. Callers use
+ * this as a pre-flight gate before the gateway route and registry are mutated,
+ * so an unreadable config aborts the command cleanly instead of crashing with a
+ * raw stack after a half-applied switch (#6997).
+ */
+export function readInSandboxConfigOrFail(
+  deps: Pick<InferenceSetDeps, "readSandboxConfig">,
+  sandboxName: string,
+  target: AgentConfigTarget,
+): ConfigObject {
+  try {
+    return deps.readSandboxConfig(sandboxName, target);
+  } catch (error) {
+    if (error instanceof SandboxConfigError) {
+      const lines = [...error.lines];
+      // `readSandboxConfig` also raises this for a corrupt/unparseable config,
+      // which starting the sandbox would NOT fix — only add the start hint for
+      // the stopped-sandbox case (the one that asks "Is the sandbox running?").
+      if (lines.some((line) => /is the sandbox running/i.test(line))) {
+        lines.push("  Start the sandbox and retry.");
+      }
+      throw new InferenceSetError(lines.join("\n"), error.exitCode);
+    }
+    throw error;
+  }
+}
+
 async function runInferenceSetWithoutHostLock(
   options: InferenceSetOptions,
   deps: InferenceSetDeps,
@@ -750,6 +781,13 @@ async function runInferenceSetWithoutHostLock(
     deps,
   );
 
+  // Read the in-sandbox config *before* mutating the gateway route or registry.
+  // If it is unreadable (e.g. a stopped sandbox), the mutations below would have
+  // committed the gateway route and registry first (only the in-sandbox layer is
+  // `rebuild`-recoverable), so gate on the read here to abort cleanly instead of
+  // leaving a half-applied switch across the three config layers (#6997).
+  const config = readInSandboxConfigOrFail(deps, sandboxName, target);
+
   deps.log(`  Setting OpenShell inference route: ${provider} / ${model}`);
   const setResult = deps.captureOpenshell(
     openshellInferenceSetArgs({
@@ -795,7 +833,6 @@ async function runInferenceSetWithoutHostLock(
     throw new InferenceSetError(`Failed to update NemoClaw registry for sandbox '${sandboxName}'.`);
   }
 
-  const config = deps.readSandboxConfig(sandboxName, target);
   const previousOpenClawInferenceApi = readPreviousOpenClawInferenceApi(agentName, config);
   const preferredInferenceApi =
     explicitPreferredInferenceApi ??

--- a/test/inference-set-preflight.test.ts
+++ b/test/inference-set-preflight.test.ts
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { InferenceSetError, readInSandboxConfigOrFail } from "../src/lib/actions/inference-set";
+import type { AgentConfigTarget } from "../src/lib/sandbox/config";
+import { SandboxConfigError } from "../src/lib/sandbox/config";
+import type { ConfigObject } from "../src/lib/security/credential-filter";
+
+const TARGET = {
+  agentName: "openclaw",
+  configPath: "/sandbox/.openclaw/openclaw.json",
+} as unknown as AgentConfigTarget;
+
+describe("readInSandboxConfigOrFail (#6997 pre-flight gate)", () => {
+  it("returns the config when the sandbox is readable", () => {
+    const config = { model: "old" } as unknown as ConfigObject;
+    const readSandboxConfig = vi.fn(() => config);
+
+    const result = readInSandboxConfigOrFail({ readSandboxConfig }, "box", TARGET);
+
+    expect(result).toBe(config);
+    expect(readSandboxConfig).toHaveBeenCalledWith("box", TARGET);
+  });
+
+  it("converts a stopped-sandbox SandboxConfigError into an actionable InferenceSetError", () => {
+    const readSandboxConfig = vi.fn(() => {
+      throw new SandboxConfigError(
+        [
+          "  Cannot read openclaw config (/sandbox/.openclaw/openclaw.json).",
+          "  Is the sandbox running?",
+        ],
+        3,
+      );
+    });
+
+    let thrown: unknown;
+    try {
+      readInSandboxConfigOrFail({ readSandboxConfig }, "box", TARGET);
+    } catch (error) {
+      thrown = error;
+    }
+
+    // Must be the command-layer error type so it is handled cleanly (no raw stack).
+    expect(thrown).toBeInstanceOf(InferenceSetError);
+    const err = thrown as InferenceSetError;
+    // Preserves the original diagnostic lines and the recorded exit code...
+    expect(err.message).toContain("Is the sandbox running?");
+    expect(err.exitCode).toBe(3);
+    // ...and adds the actionable next step.
+    expect(err.message).toContain("Start the sandbox and retry");
+  });
+
+  it("omits the start-sandbox hint for a non-stopped config error (e.g. parse failure)", () => {
+    // A corrupt/unparseable config raises SandboxConfigError too, but starting
+    // the sandbox would not fix it — the start hint must not be appended.
+    const readSandboxConfig = vi.fn(() => {
+      throw new SandboxConfigError(["  Failed to parse openclaw config: unexpected token."], 1);
+    });
+
+    let thrown: unknown;
+    try {
+      readInSandboxConfigOrFail({ readSandboxConfig }, "box", TARGET);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(InferenceSetError);
+    const err = thrown as InferenceSetError;
+    expect(err.message).toContain("Failed to parse");
+    expect(err.message).not.toContain("Start the sandbox and retry");
+  });
+
+  it("does not swallow unrelated errors", () => {
+    const boom = new TypeError("unexpected");
+    const readSandboxConfig = vi.fn(() => {
+      throw boom;
+    });
+
+    expect(() => readInSandboxConfigOrFail({ readSandboxConfig }, "box", TARGET)).toThrow(boom);
+  });
+});

--- a/test/inference-set-preflight.test.ts
+++ b/test/inference-set-preflight.test.ts
@@ -13,7 +13,7 @@ const TARGET = {
   configPath: "/sandbox/.openclaw/openclaw.json",
 } as unknown as AgentConfigTarget;
 
-describe("readInSandboxConfigOrFail (#6997 pre-flight gate)", () => {
+describe("readInSandboxConfigOrFail pre-flight gate (#6997)", () => {
   it("returns the config when the sandbox is readable", () => {
     const config = { model: "old" } as unknown as ConfigObject;
     const readSandboxConfig = vi.fn(() => config);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Use existing repository terms; do not invent a label for this PR. -->
`nemoclaw inference set --no-verify --sandbox <name>` against a sandbox whose container is stopped crashed with an uncaught `SandboxConfigError` (raw Node stack, exit 1) and left a half-applied switch: the gateway route and registry were already mutated to the new model while the in-sandbox `openclaw.json` still pointed at the old one. The in-sandbox config is now read as a pre-flight gate before any mutation, so an unreadable config aborts cleanly and atomically (nothing mutated) with a clear message instead of a stack trace.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Closes #6997

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->
- `src/lib/actions/inference-set.ts`: add `readInSandboxConfigOrFail()`, which reads the in-sandbox config and converts a `SandboxConfigError` (the config could not be read or parsed — most commonly a stopped sandbox) into a clean `InferenceSetError`, preserving the original diagnostic lines and exit code. It appends a `Start the sandbox and retry.` hint **only** for the stopped-sandbox case (the one that reports `Is the sandbox running?`) — not for a corrupt/unparseable config, which starting the sandbox would not fix. Call it **before** the gateway-route mutation (`captureOpenshell inference set`) and the registry writes, replacing the former crash-prone read that ran *after* those mutations. Protected by the tests below.
- `src/lib/actions/inference-set-degraded-state.test.ts`: rewrite the read-failure case to exercise the real `SandboxConfigError` path and assert **zero mutation** (route-set, `updateSandbox`, `writeSandboxConfig`, `restartSandboxGateway` all uncalled) — locking the ordering so moving the read back after the mutations fails the test. The prior assertion asserted the buggy half-applied state.
- `test/inference-set-preflight.test.ts`: unit tests for the helper — readable path, stopped-sandbox conversion (error type, message, exit code), parse-failure conversion (no start hint), and pass-through of unrelated errors.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: behavior/error-message change on an existing command; no documented behavior contract changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Rui Luo <ruluo@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a pre-flight validation step for sandbox configuration before any gateway or sandbox updates.
  * Improved error handling when sandbox config reads fail, including a “Start the sandbox and retry” hint for stopped sandboxes.
  * Prevented partial/incomplete updates by aborting early when pre-flight config checks fail.

* **Tests**
  * Updated degraded-state coverage to ensure no gateway route updates or sandbox updates occur when config pre-flight fails.
  * Added new tests for the pre-flight config helper, covering success, stopped-sandbox errors, parse failures, and unexpected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->