### PR TITLE
fix(install): notice acceptance must not imply non-interactive for --station-deepseek (#7008)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3135,7 +3135,15 @@ main() {
   # (run_onboard has the same gate). Without this, ACCEPT_THIRD_PARTY_SOFTWARE=1
   # alone clears the preflight below but the install can still partial-fail at
   # run_onboard with the same TTY error, leaving phases 1/2 on disk anyway.
-  if [ "${ACCEPT_THIRD_PARTY_SOFTWARE:-}" = "1" ] && [ "${NON_INTERACTIVE:-}" != "1" ]; then
+  #
+  # #7008: `--station-deepseek` is the exception — it explicitly selects the
+  # interactive DGX Station express prompt, so accepting the notice must NOT
+  # imply non-interactive there. The two signals are orthogonal: one accepts a
+  # licence, the other opts into an interactive express flow. Inferring
+  # non-interactive from the notice would make the express flow reject its own
+  # required flag (validate_station_deepseek_override).
+  if [ "${ACCEPT_THIRD_PARTY_SOFTWARE:-}" = "1" ] && [ "${NON_INTERACTIVE:-}" != "1" ] \
+    && [ "${STATION_DEEPSEEK:-}" != "1" ]; then
     NON_INTERACTIVE=1
   fi
 

--- a/test/install-express-prompt.test.ts
+++ b/test/install-express-prompt.test.ts
@@ -356,6 +356,50 @@ main "$@"
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
+  it("proceeds past the express preflight for --station-deepseek with NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 (#7008)", () => {
+    // #7008: accepting the third-party-software notice must NOT imply
+    // --non-interactive when --station-deepseek explicitly selects the
+    // interactive DGX Station express prompt. The two signals are orthogonal.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-accept3p-"));
+    const result = spawnSync(
+      "bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        `
+source "$INSTALLER_UNDER_TEST" >/dev/null
+detect_express_platform() { printf "%s" "$EXPRESS_PLATFORM"; }
+print_banner() { :; }
+# Stop main cleanly right after preflight_explicit_express_flags passes, echoing
+# NON_INTERACTIVE so the test can confirm the notice env var did not infer it.
+preflight_usage_notice_prompt() { printf "PROCEEDED NON_INTERACTIVE=%s\\n" "\${NON_INTERACTIVE:-}"; exit 0; }
+main "$@"
+`,
+        "_",
+        "--station-deepseek",
+      ],
+      {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: {
+          HOME: tmp,
+          PATH: TEST_SYSTEM_PATH,
+          INSTALLER_UNDER_TEST: INSTALLER_PAYLOAD,
+          EXPRESS_PLATFORM: "DGX Station",
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        },
+      },
+    );
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.status, output).toBe(0);
+    expect(output).toMatch(/PROCEEDED NON_INTERACTIVE=/);
+    // The notice acceptance must not have flipped the run non-interactive.
+    expect(output).not.toMatch(/PROCEEDED NON_INTERACTIVE=1/);
+    expect(output).not.toMatch(/cannot be combined with/);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
   it.each([
     ["NEMOCLAW_NO_EXPRESS", "1", /cannot be combined with NEMOCLAW_NO_EXPRESS=1/],
     ["NON_INTERACTIVE", "1", /cannot be combined with --non-interactive/],


### PR DESCRIPTION
## Summary

The documented DGX Station curl-pipe install aborted immediately:

```bash
curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=v0.0.84 NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash -s -- --station-deepseek
```

```
[ERROR] --station-deepseek selects the DGX Station express prompt and cannot be combined with --non-interactive.
```

`NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` (and `--yes-i-accept-third-party-software`) inferred `NON_INTERACTIVE=1`, which then made `validate_station_deepseek_override` reject `--station-deepseek` — a flag that explicitly selects the **interactive** DGX Station express prompt. The two signals are orthogonal: one accepts a licence, the other opts into an interactive flow.

## Fix

Skip the notice→non-interactive inference when `--station-deepseek` is set. The inference (and its #4414/#2671 partial-install protection) is preserved for every other install.

## Verification (DGX-Station-mocked aarch64)

Drove `main` with the platform mocked to `DGX Station`, stopping right after the express preflight:

- `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` + `--station-deepseek` → **proceeds** past the preflight, `NON_INTERACTIVE` stays unset (was: aborted).
- notice acceptance **without** `--station-deepseek` → still implies non-interactive (regression preserved by the existing tests).

New test case in `test/install-express-prompt.test.ts`.

Companion to #7009 (which improves the conflict error message); kept as a separate PR per issue. This PR does not change the error message.

Fixes #7008.

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
