### PR TITLE
fix(ci): select migrated E2E parity entrypoint

### DIFF
--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -91,7 +91,15 @@ runs:
             exit 0
             ;;
         esac
-        npx tsx scripts/checks/e2e-mock-parity.ts --base "$base" --head "$head"
+        parity_check=scripts/checks/e2e-mock-parity.mts
+        if [ ! -f "$parity_check" ]; then
+          parity_check=scripts/checks/e2e-mock-parity.ts
+        fi
+        if [ ! -f "$parity_check" ]; then
+          echo "::error title=Missing E2E mock parity entrypoint::Expected scripts/checks/e2e-mock-parity.mts or scripts/checks/e2e-mock-parity.ts."
+          exit 1
+        fi
+        npx tsx "$parity_check" --base "$base" --head "$head"
 
     - name: Build TypeScript plugin
       shell: bash

--- a/test/e2e-mock-parity.test.ts
+++ b/test/e2e-mock-parity.test.ts
@@ -1,12 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   isMockParityRelevantSourceChange,
   type MockParityManifest,
   validateMockParity,
 } from "../scripts/checks/e2e-mock-parity";
+import { type CompositeAction, readYaml } from "./helpers/e2e-workflow-contract";
 
 const live = "test/e2e/live/example.test.ts";
 const fast = "test/e2e/support/example.test.ts";
@@ -106,5 +111,75 @@ describe("changed live E2E mock parity", () => {
         fileExists: exists,
       }),
     ).toEqual([`${live}: liveOnlyReason must be a string`]);
+  });
+});
+
+describe("trusted E2E parity entrypoint selection", () => {
+  const action = readYaml<CompositeAction>(".github/actions/ci-cli-coverage-shard/action.yaml");
+  const parityStep = action.runs.steps.find(
+    (step) => step.name === "Validate changed live E2E mock parity",
+  );
+  if (!parityStep) throw new Error("Missing E2E mock parity action step");
+
+  it("prefers .mts, falls back to .ts, and rejects a missing check (#6921)", () => {
+    const stem = "scripts/checks/e2e-mock-parity";
+    const variants = [
+      { extensions: ["mts", "ts"], expected: `${stem}.mts`, status: 0 },
+      { extensions: ["mts"], expected: `${stem}.mts`, status: 0 },
+      { extensions: ["ts"], expected: `${stem}.ts`, status: 0 },
+      { extensions: [], expected: null, status: 1 },
+    ] as const;
+
+    for (const variant of variants) {
+      const temp = mkdtempSync(join(tmpdir(), "nemoclaw-e2e-parity-entrypoint-"));
+      const fakeBin = join(temp, "bin");
+      const commandLog = join(temp, "command.json");
+      mkdirSync(fakeBin);
+      mkdirSync(join(temp, "scripts", "checks"), { recursive: true });
+      writeFileSync(
+        join(fakeBin, "npx"),
+        [
+          "#!/usr/bin/env node",
+          'const fs = require("node:fs");',
+          "fs.appendFileSync(process.env.COMMAND_LOG, `${JSON.stringify(process.argv.slice(2))}\\n`);",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+      for (const extension of variant.extensions) {
+        writeFileSync(join(temp, `${stem}.${extension}`), "// fixture\n");
+      }
+
+      try {
+        const result = spawnSync("bash", ["-c", parityStep.run ?? ""], {
+          cwd: temp,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            ...parityStep.env,
+            COMMAND_LOG: commandLog,
+            EVENT_NAME: "pull_request",
+            PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+            PUSH_BASE_SHA: "unused",
+          },
+          timeout: 5_000,
+        });
+
+        expect(result.status, String(result.stderr)).toBe(variant.status);
+        if (variant.expected) {
+          const commands = readFileSync(commandLog, "utf8")
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+          expect(commands).toEqual([
+            ["tsx", variant.expected, "--base", "HEAD^1", "--head", "HEAD^2"],
+          ]);
+        } else {
+          expect(existsSync(commandLog)).toBe(false);
+          expect(String(result.stdout)).toContain("Missing E2E mock parity entrypoint");
+        }
+      } finally {
+        rmSync(temp, { force: true, recursive: true });
+      }
+    }
   });
 });

--- a/test/e2e-mock-parity.test.ts
+++ b/test/e2e-mock-parity.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -119,67 +119,79 @@ describe("trusted E2E parity entrypoint selection", () => {
   const parityStep = action.runs.steps.find(
     (step) => step.name === "Validate changed live E2E mock parity",
   );
-  if (!parityStep) throw new Error("Missing E2E mock parity action step");
+  const parityRun = parityStep?.run ?? "";
+  const parityEnv = parityStep?.env ?? {};
+  const stem = "scripts/checks/e2e-mock-parity";
 
-  it("prefers .mts, falls back to .ts, and rejects a missing check (#6921)", () => {
-    const stem = "scripts/checks/e2e-mock-parity";
-    const variants = [
-      { extensions: ["mts", "ts"], expected: `${stem}.mts`, status: 0 },
-      { extensions: ["mts"], expected: `${stem}.mts`, status: 0 },
-      { extensions: ["ts"], expected: `${stem}.ts`, status: 0 },
-      { extensions: [], expected: null, status: 1 },
-    ] as const;
+  function withParityEntrypoints(
+    extensions: readonly string[],
+    verify: (result: SpawnSyncReturns<string>, commandLog: string) => void,
+  ): void {
+    const temp = mkdtempSync(join(tmpdir(), "nemoclaw-e2e-parity-entrypoint-"));
+    const fakeBin = join(temp, "bin");
+    const commandLog = join(temp, "command.json");
+    mkdirSync(fakeBin);
+    mkdirSync(join(temp, "scripts", "checks"), { recursive: true });
+    writeFileSync(
+      join(fakeBin, "npx"),
+      [
+        "#!/usr/bin/env node",
+        'const fs = require("node:fs");',
+        "fs.appendFileSync(process.env.COMMAND_LOG, `${JSON.stringify(process.argv.slice(2))}\\n`);",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    for (const extension of extensions) {
+      writeFileSync(join(temp, `${stem}.${extension}`), "// fixture\n");
+    }
 
-    for (const variant of variants) {
-      const temp = mkdtempSync(join(tmpdir(), "nemoclaw-e2e-parity-entrypoint-"));
-      const fakeBin = join(temp, "bin");
-      const commandLog = join(temp, "command.json");
-      mkdirSync(fakeBin);
-      mkdirSync(join(temp, "scripts", "checks"), { recursive: true });
-      writeFileSync(
-        join(fakeBin, "npx"),
-        [
-          "#!/usr/bin/env node",
-          'const fs = require("node:fs");',
-          "fs.appendFileSync(process.env.COMMAND_LOG, `${JSON.stringify(process.argv.slice(2))}\\n`);",
-        ].join("\n"),
-        { mode: 0o755 },
-      );
-      for (const extension of variant.extensions) {
-        writeFileSync(join(temp, `${stem}.${extension}`), "// fixture\n");
-      }
-
-      try {
-        const result = spawnSync("bash", ["-c", parityStep.run ?? ""], {
+    try {
+      verify(
+        spawnSync("bash", ["-c", parityRun], {
           cwd: temp,
           encoding: "utf8",
           env: {
             ...process.env,
-            ...parityStep.env,
+            ...parityEnv,
             COMMAND_LOG: commandLog,
             EVENT_NAME: "pull_request",
             PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
             PUSH_BASE_SHA: "unused",
           },
           timeout: 5_000,
-        });
-
-        expect(result.status, String(result.stderr)).toBe(variant.status);
-        if (variant.expected) {
-          const commands = readFileSync(commandLog, "utf8")
-            .trim()
-            .split("\n")
-            .map((line) => JSON.parse(line));
-          expect(commands).toEqual([
-            ["tsx", variant.expected, "--base", "HEAD^1", "--head", "HEAD^2"],
-          ]);
-        } else {
-          expect(existsSync(commandLog)).toBe(false);
-          expect(String(result.stdout)).toContain("Missing E2E mock parity entrypoint");
-        }
-      } finally {
-        rmSync(temp, { force: true, recursive: true });
-      }
+        }),
+        commandLog,
+      );
+    } finally {
+      rmSync(temp, { force: true, recursive: true });
     }
+  }
+
+  it.each([
+    {
+      extensions: ["mts", "ts"],
+      expected: `${stem}.mts`,
+      title: "prefers .mts when both entrypoints exist",
+    },
+    { extensions: ["mts"], expected: `${stem}.mts`, title: "runs the migrated .mts entrypoint" },
+    { extensions: ["ts"], expected: `${stem}.ts`, title: "falls back to the .ts entrypoint" },
+  ])("$title (#6921)", ({ extensions, expected }) => {
+    withParityEntrypoints(extensions, (result, commandLog) => {
+      expect(result.status, String(result.stderr)).toBe(0);
+      expect(
+        readFileSync(commandLog, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line)),
+      ).toEqual([["tsx", expected, "--base", "HEAD^1", "--head", "HEAD^2"]]);
+    });
+  });
+
+  it("rejects a missing parity entrypoint (#6921)", () => {
+    withParityEntrypoints([], (result, commandLog) => {
+      expect(result.status, String(result.stderr)).toBe(1);
+      expect(existsSync(commandLog)).toBe(false);
+      expect(String(result.stdout)).toContain("Missing E2E mock parity entrypoint");
+    });
   });
 });

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -975,9 +975,9 @@ describe("pull request and main workflow contracts", () => {
     expect(parityStep.run).toContain("base=HEAD^1");
     expect(parityStep.run).toContain("head=HEAD^2");
     expect(parityStep.run).toContain('base="$PUSH_BASE_SHA"');
-    expect(parityStep.run).toContain(
-      'npx tsx scripts/checks/e2e-mock-parity.ts --base "$base" --head "$head"',
-    );
+    expect(parityStep.run).toContain("parity_check=scripts/checks/e2e-mock-parity.mts");
+    expect(parityStep.run).toContain("parity_check=scripts/checks/e2e-mock-parity.ts");
+    expect(parityStep.run).toContain('npx tsx "$parity_check" --base "$base" --head "$head"');
 
     const trustedCapabilityProbe = requiredWorkflowStep(
       prWorkflow.jobs["cli-test-shards"],

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -975,9 +975,6 @@ describe("pull request and main workflow contracts", () => {
     expect(parityStep.run).toContain("base=HEAD^1");
     expect(parityStep.run).toContain("head=HEAD^2");
     expect(parityStep.run).toContain('base="$PUSH_BASE_SHA"');
-    expect(parityStep.run).toContain("parity_check=scripts/checks/e2e-mock-parity.mts");
-    expect(parityStep.run).toContain("parity_check=scripts/checks/e2e-mock-parity.ts");
-    expect(parityStep.run).toContain('npx tsx "$parity_check" --base "$base" --head "$head"');
 
     const trustedCapabilityProbe = requiredWorkflowStep(
       prWorkflow.jobs["cli-test-shards"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The base-trusted CLI coverage action currently hardcodes the TypeScript E2E parity entrypoint. Select the migrated `.mts` entrypoint when present, retain the `.ts` path for merge commits on the earlier layout, and fail clearly when neither trusted path exists.

## Related Issue

Unblocks #6940.

## Changes

- Prefer `scripts/checks/e2e-mock-parity.mts` and fall back to `scripts/checks/e2e-mock-parity.ts` in the trusted CLI coverage shard.
- Fail closed with an explicit workflow annotation when neither expected entrypoint exists.
- Exercise `.mts` preference, `.ts` compatibility, and missing-entrypoint rejection at the composite-action boundary, replacing the prior hardcoded command-text assertion.

The compatibility fallback is required because the base-trusted action validates merge commits on both sides of the `.ts` to `.mts` migration. `test/e2e-mock-parity.test.ts` protects that transition contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal trusted CI action and regression tests only; the documentation assessment found no user-facing behavior or workflow change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The action remains base-trusted, selects only two fixed repository paths, quotes the selected path, and fails closed if both are absent; the maintainer authorized publishing this prerequisite on 2026-07-16.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/e2e-mock-parity.test.ts test/pr-workflow-contract.test.ts` (30 passed); `npm run test-conditionals:scan -- --top 25` reports no `if` statements in the changed test; `npm run source-shape:check` passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the focused CI contract is covered by targeted tests and `npm run check:diff`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved E2E mock parity validation by automatically preferring the `.mts` entrypoint and falling back to `.ts`.
  * Added a clear error when no valid E2E mock parity entrypoint is available.
* **Tests**
  * Expanded CI workflow tests to verify correct entrypoint selection, command invocation, and the failure path when the entrypoint is missing.
  * Updated PR workflow contract checks to assert the computed `base`/`head` values rather than a single hard-coded command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->