### PR TITLE
fix(e2e): load shared exit helper under tsx

### DIFF
--- a/test/e2e/support/live-vitest-invocation.test.ts
+++ b/test/e2e/support/live-vitest-invocation.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -15,6 +16,9 @@ import {
   validateLiveSelector,
   validateLiveTestPath,
 } from "../../../tools/e2e/live-vitest-invocation.mts";
+
+const LIVE_VITEST_TOOL = path.resolve("tools/e2e/live-vitest-invocation.mts");
+const TSX = path.resolve("node_modules", ".bin", "tsx");
 
 describe("validateLiveProject (#6961)", () => {
   it("accepts the live project and defaults to it", () => {
@@ -234,12 +238,8 @@ describe("runLiveVitestCommand (#6961)", () => {
   it.each([
     ["missing", []],
     ["unsupported", ["runx"]],
-  ])("fails the direct CLI for a %s subcommand", (_label, args) => {
-    const result = spawnSync(
-      process.execPath,
-      ["--experimental-strip-types", "tools/e2e/live-vitest-invocation.mts", ...args],
-      { encoding: "utf8" },
-    );
+  ])("fails the workflow CLI for a %s subcommand", (_label, args) => {
+    const result = spawnSync(TSX, [LIVE_VITEST_TOOL, ...args], { encoding: "utf8" });
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('expected "run"');

--- a/tools/e2e/live-vitest-invocation.mts
+++ b/tools/e2e/live-vitest-invocation.mts
@@ -4,7 +4,18 @@
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
-import { spawnExitCode } from "../../src/lib/core/process-exit.ts";
+import * as importedProcessExit from "../../src/lib/core/process-exit.ts";
+
+// The root TypeScript package is exposed as CJS under the exact `npx tsx`
+// workflow execution mode, but as an ESM namespace under Vitest. Normalize
+// both representations so the executable and tests share exit handling.
+const processExit = (
+  "default" in importedProcessExit && importedProcessExit.default
+    ? importedProcessExit.default
+    : importedProcessExit
+) as typeof import("../../src/lib/core/process-exit.ts");
+
+const { spawnExitCode } = processExit;
 
 export const LIVE_VITEST_PROJECT = "e2e-live";
 export const LIVE_TEST_ROOT = "test/e2e/live/";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restore live E2E execution through the workflow's `npx tsx` command. The shared helper now loads the root CommonJS exit utility correctly instead of failing every converted live job during module initialization.

## Changes

- Normalize the CommonJS and ESM representations of `src/lib/core/process-exit.ts` in `tools/e2e/live-vitest-invocation.mts`. The current consumer is the live E2E workflow introduced by #6996; `tsx` and Vitest expose the root module differently, so the existing repository interop pattern is required to keep one shared exit-code implementation.
- Run the helper's subprocess regression coverage through the local `tsx` executable that `npx tsx` resolves, protecting the production loader boundary that the previous native Node test did not exercise.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is an internal CI loader fix; the workflow command and all user-facing behavior remain unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/live-vitest-invocation.test.ts` passed 24 tests; `npm run typecheck:cli` and Biome also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this focused CI helper fix. The full E2E-support attempt reached five unrelated failures in an unchanged platform-parity shell script under macOS Bash 3.2; the other 41 tests in the diagnostic subset passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of exit codes when running live Vitest commands across different module export formats.
  * Updated end-to-end workflow checks to invoke the CLI consistently, preserving expected failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->