### PR TITLE
test(e2e): verify GPU recovery by execution trace

### DIFF
--- a/test/e2e/live/gpu-e2e-helpers.ts
+++ b/test/e2e/live/gpu-e2e-helpers.ts
@@ -123,6 +123,10 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+/**
+ * Assert that an agent command completed through the expected inference route.
+ * Visible assistant text is intentionally not part of this recovery proof.
+ */
 export function assertAgentExecutionSucceeded(
   raw: string,
   expectedProvider: string,

--- a/test/e2e/live/gpu-e2e-helpers.ts
+++ b/test/e2e/live/gpu-e2e-helpers.ts
@@ -117,6 +117,48 @@ export function chatContent(raw: string): string {
   );
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function assertAgentExecutionSucceeded(
+  raw: string,
+  expectedProvider: string,
+  expectedModel: string,
+): void {
+  const envelope = asRecord(JSON.parse(raw));
+  const result = asRecord(envelope?.result);
+  const meta = asRecord(result?.meta);
+  const agentMeta = asRecord(meta?.agentMeta);
+  const trace = asRecord(meta?.executionTrace);
+  const attempts = Array.isArray(trace?.attempts)
+    ? trace.attempts.flatMap((attempt) => {
+        const record = asRecord(attempt);
+        return record ? [record] : [];
+      })
+    : [];
+
+  expect(envelope?.status, "agent command must report success").toBe("ok");
+  expect(envelope?.summary, "agent command must complete").toBe("completed");
+  expect(meta?.aborted, "agent command must not abort").toBe(false);
+  expect(agentMeta?.provider, "agent must use the expected provider").toBe(expectedProvider);
+  expect(agentMeta?.model, "agent must use the expected model").toBe(expectedModel);
+  expect(trace?.winnerProvider, "execution trace must select the expected provider").toBe(
+    expectedProvider,
+  );
+  expect(trace?.winnerModel, "execution trace must select the expected model").toBe(expectedModel);
+  expect(attempts, "execution trace must contain a successful assistant attempt").toContainEqual(
+    expect.objectContaining({
+      provider: expectedProvider,
+      model: expectedModel,
+      result: "success",
+      stage: "assistant",
+    }),
+  );
+}
+
 export async function cleanupGpu(host: HostCliClient, sandbox: SandboxClient): Promise<void> {
   await preCleanBestEffort("destroy GPU sandbox", () =>
     host.command("node", [CLI, SANDBOX_NAME, "destroy", "--yes"], {

--- a/test/e2e/live/gpu-e2e-helpers.ts
+++ b/test/e2e/live/gpu-e2e-helpers.ts
@@ -124,8 +124,11 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 }
 
 /**
- * Assert that an agent command completed through the expected inference route.
- * Visible assistant text is intentionally not part of this recovery proof.
+ * Assert that upstream `openclaw agent --json` completed through the expected inference route.
+ * NemoClaw preserves that upstream stdout without owning its schema, so the live invocation is the
+ * producer-facing contract check. Visible assistant text is intentionally excluded because OpenClaw
+ * can suppress a successful turn as `NO_REPLY`. Replace this assertion when the pinned OpenClaw
+ * runtime exposes a dedicated stable completion signal.
  */
 export function assertAgentExecutionSucceeded(
   raw: string,

--- a/test/e2e/live/gpu-e2e.test.ts
+++ b/test/e2e/live/gpu-e2e.test.ts
@@ -5,8 +5,8 @@ import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { resultText } from "../fixtures/clients/index.ts";
 import { trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
-import { parseOpenClawAgentText } from "./common-egress-agent-helpers.ts";
 import {
+  assertAgentExecutionSucceeded,
   assertGpuInstallProofs,
   assertNvidiaAvailable,
   CLI,
@@ -311,7 +311,7 @@ exit 1`,
   expect(recovered.exitCode, resultText(recovered)).toBe(0);
   expect(resultText(recovered)).toContain("Checking Ollama model readiness after daemon restart");
   expect(resultText(recovered)).toContain(`Ollama model '${model}' is loaded and ready.`);
-  expect(parseOpenClawAgentText(recovered.stdout)).toMatch(/pong/i);
+  assertAgentExecutionSucceeded(recovered.stdout, "inference", model);
 
   const loaded = await host.command("curl", ["-fsS", "http://127.0.0.1:11434/api/ps"], {
     artifactName: "ollama-model-loaded-after-recovery",

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -8,7 +8,40 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { env, openClawModelConfigProjectionScript } from "../live/gpu-e2e-helpers.ts";
+import {
+  assertAgentExecutionSucceeded,
+  env,
+  openClawModelConfigProjectionScript,
+} from "../live/gpu-e2e-helpers.ts";
+
+const GPU_MODEL = "qwen3.5:9b";
+
+function agentOutput(attemptResult: "success" | "error"): string {
+  return JSON.stringify({
+    status: "ok",
+    summary: "completed",
+    result: {
+      payloads: [],
+      meta: {
+        aborted: false,
+        agentMeta: { provider: "inference", model: GPU_MODEL },
+        finalAssistantVisibleText: "NO_REPLY",
+        executionTrace: {
+          winnerProvider: "inference",
+          winnerModel: GPU_MODEL,
+          attempts: [
+            {
+              provider: "inference",
+              model: GPU_MODEL,
+              result: attemptResult,
+              stage: "assistant",
+            },
+          ],
+        },
+      },
+    },
+  });
+}
 
 describe("GPU E2E helpers", () => {
   it("forwards the workflow-owned Ollama model pull timeout", () => {
@@ -33,6 +66,18 @@ describe("GPU E2E helpers", () => {
     expect(env({}, { NEMOCLAW_TRACE_DIR: "/tmp/nemoclaw-traces" }).NEMOCLAW_TRACE_DIR).toBe(
       "/tmp/nemoclaw-traces",
     );
+  });
+
+  it("accepts successful execution proof when the model suppresses visible text", () => {
+    expect(() =>
+      assertAgentExecutionSucceeded(agentOutput("success"), "inference", GPU_MODEL),
+    ).not.toThrow();
+  });
+
+  it("rejects a recovery trace without a successful assistant attempt", () => {
+    expect(() =>
+      assertAgentExecutionSucceeded(agentOutput("error"), "inference", GPU_MODEL),
+    ).toThrow("execution trace must contain a successful assistant attempt");
   });
 
   it("projects only model evidence before OpenClaw config crosses the artifact boundary", () => {

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -16,23 +16,43 @@ import {
 
 const GPU_MODEL = "qwen3.5:9b";
 
-function agentOutput(attemptResult: "success" | "error"): string {
+interface AgentOutputOverrides {
+  status?: string;
+  summary?: string;
+  aborted?: boolean;
+  provider?: string;
+  model?: string;
+  winnerProvider?: string;
+  winnerModel?: string;
+  attemptResult?: "success" | "error";
+}
+
+function agentOutput({
+  status = "ok",
+  summary = "completed",
+  aborted = false,
+  provider = "inference",
+  model = GPU_MODEL,
+  winnerProvider = "inference",
+  winnerModel = GPU_MODEL,
+  attemptResult = "success",
+}: AgentOutputOverrides = {}): string {
   return JSON.stringify({
-    status: "ok",
-    summary: "completed",
+    status,
+    summary,
     result: {
       payloads: [],
       meta: {
-        aborted: false,
-        agentMeta: { provider: "inference", model: GPU_MODEL },
+        aborted,
+        agentMeta: { provider, model },
         finalAssistantVisibleText: "NO_REPLY",
         executionTrace: {
-          winnerProvider: "inference",
-          winnerModel: GPU_MODEL,
+          winnerProvider,
+          winnerModel,
           attempts: [
             {
-              provider: "inference",
-              model: GPU_MODEL,
+              provider,
+              model,
               result: attemptResult,
               stage: "assistant",
             },
@@ -42,6 +62,36 @@ function agentOutput(attemptResult: "success" | "error"): string {
     },
   });
 }
+
+const invalidExecutionProofs: Array<{
+  name: string;
+  overrides: AgentOutputOverrides;
+  message: string;
+}> = [
+  { name: "status", overrides: { status: "error" }, message: "agent command must report success" },
+  { name: "summary", overrides: { summary: "failed" }, message: "agent command must complete" },
+  { name: "abort state", overrides: { aborted: true }, message: "agent command must not abort" },
+  {
+    name: "provider",
+    overrides: { provider: "unexpected" },
+    message: "agent must use the expected provider",
+  },
+  {
+    name: "model",
+    overrides: { model: "unexpected" },
+    message: "agent must use the expected model",
+  },
+  {
+    name: "winner provider",
+    overrides: { winnerProvider: "unexpected" },
+    message: "execution trace must select the expected provider",
+  },
+  {
+    name: "winner model",
+    overrides: { winnerModel: "unexpected" },
+    message: "execution trace must select the expected model",
+  },
+];
 
 describe("GPU E2E helpers", () => {
   it("forwards the workflow-owned Ollama model pull timeout", () => {
@@ -70,14 +120,27 @@ describe("GPU E2E helpers", () => {
 
   it("accepts successful execution proof when the model suppresses visible text", () => {
     expect(() =>
-      assertAgentExecutionSucceeded(agentOutput("success"), "inference", GPU_MODEL),
+      assertAgentExecutionSucceeded(agentOutput(), "inference", GPU_MODEL),
     ).not.toThrow();
   });
 
   it("rejects a recovery trace without a successful assistant attempt", () => {
     expect(() =>
-      assertAgentExecutionSucceeded(agentOutput("error"), "inference", GPU_MODEL),
+      assertAgentExecutionSucceeded(
+        agentOutput({ attemptResult: "error" }),
+        "inference",
+        GPU_MODEL,
+      ),
     ).toThrow("execution trace must contain a successful assistant attempt");
+  });
+
+  it.each(invalidExecutionProofs)("rejects invalid $name execution proof", ({
+    overrides,
+    message,
+  }) => {
+    expect(() =>
+      assertAgentExecutionSucceeded(agentOutput(overrides), "inference", GPU_MODEL),
+    ).toThrow(message);
   });
 
   it("projects only model evidence before OpenClaw config crosses the artifact boundary", () => {

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -24,6 +24,9 @@ interface AgentOutputOverrides {
   model?: string;
   winnerProvider?: string;
   winnerModel?: string;
+  attemptProvider?: string;
+  attemptModel?: string;
+  attemptStage?: string;
   attemptResult?: "success" | "error";
 }
 
@@ -35,6 +38,9 @@ function agentOutput({
   model = GPU_MODEL,
   winnerProvider = "inference",
   winnerModel = GPU_MODEL,
+  attemptProvider = provider,
+  attemptModel = model,
+  attemptStage = "assistant",
   attemptResult = "success",
 }: AgentOutputOverrides = {}): string {
   return JSON.stringify({
@@ -51,10 +57,10 @@ function agentOutput({
           winnerModel,
           attempts: [
             {
-              provider,
-              model,
+              provider: attemptProvider,
+              model: attemptModel,
               result: attemptResult,
-              stage: "assistant",
+              stage: attemptStage,
             },
           ],
         },
@@ -90,6 +96,21 @@ const invalidExecutionProofs: Array<{
     name: "winner model",
     overrides: { winnerModel: "unexpected" },
     message: "execution trace must select the expected model",
+  },
+  {
+    name: "attempt provider",
+    overrides: { attemptProvider: "unexpected" },
+    message: "execution trace must contain a successful assistant attempt",
+  },
+  {
+    name: "attempt model",
+    overrides: { attemptModel: "unexpected" },
+    message: "execution trace must contain a successful assistant attempt",
+  },
+  {
+    name: "attempt stage",
+    overrides: { attemptStage: "tool" },
+    message: "execution trace must contain a successful assistant attempt",
   },
 ];
 


### PR DESCRIPTION
## Summary

The GPU recovery lane previously required Qwen to render the literal word PONG after Ollama restarted. It now verifies OpenClaw structured execution proof, so a successful inference that intentionally emits NO_REPLY does not fail the E2E while real execution failures still do.

## Changes

- Add a focused assertion for successful, non-aborted agent execution by the expected provider and model.
- Require the execution trace to select that route and contain a successful assistant attempt.
- Keep the earlier raw `inference.local` probe requiring PONG, so routed model output remains covered independently.
- Add fast E2E-support regressions for both NO_REPLY success and an unsuccessful assistant attempt.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the live E2E success oracle; product recovery behavior, commands, and diagnostics are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Test-only inference change. The raw route still must return PONG; the restart check now requires successful structured proof from the expected provider and model and rejects unsuccessful attempts.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/gpu-e2e-helpers.test.ts` (18 passed); `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved GPU end-to-end validation of agent recovery runs by switching to a dedicated execution-success assertion helper.
  * Strengthened post-run checks for successful completion, non-aborted status, and expected provider/model matching.
  * Enhanced execution-trace verification to require a successful assistant attempt (even when visible assistant text is suppressed).
  * Added comprehensive negative test coverage for invalid execution-trace cases, with specific expected error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->