### PR TITLE
test(inference): cover private Anthropic onboarding surfaces

### DIFF
--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -202,6 +202,77 @@ describe("inference selection validation", () => {
     }
   });
 
+  it.each([
+    {
+      runtimeSurface: "native Anthropic Messages",
+      intendedApi: "anthropic-messages" as const,
+      expectedEndpointUrl: "https://anthropic.corp.example",
+      expectedProbeOptions: { probeStreaming: true },
+    },
+    {
+      runtimeSurface: "managed Chat Completions (Hermes/DCode)",
+      intendedApi: "openai-completions" as const,
+      expectedEndpointUrl: "https://anthropic.corp.example/v1",
+      expectedProbeOptions: { calibrateTimeouts: true, skipResponsesProbe: true },
+    },
+  ])("probes an exactly allowlisted private Anthropic endpoint on its $runtimeSurface surface (#7037)", async ({
+    intendedApi,
+    expectedEndpointUrl,
+    expectedProbeOptions,
+  }) => {
+    vi.stubEnv("NEMOCLAW_TRUSTED_PRIVATE_INFERENCE_HOSTS", "anthropic.corp.example");
+    const probeEndpoint = vi.fn(() => ({
+      ok: true,
+      api: intendedApi,
+      label: "Compatible API",
+    }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const helpers = createInferenceSelectionValidationHelpers({
+      isNonInteractive: () => false,
+      agentProductName: () => "NemoClaw agent",
+      getCredential: () => "test-key",
+      probeAnthropicEndpoint: probeEndpoint,
+      probeOpenAiLikeEndpoint: probeEndpoint,
+      promptValidationRecovery: vi.fn(async () => "selection" as const),
+      resolveEndpointHost: async () => [{ address: "10.0.0.8", family: 4 }],
+    });
+
+    try {
+      const result = await helpers.validateCustomAnthropicSelection(
+        "Custom Anthropic endpoint",
+        "https://anthropic.corp.example",
+        "model-a",
+        "COMPATIBLE_ANTHROPIC_API_KEY",
+        null,
+        { intendedApi },
+      );
+
+      expect(result).toMatchObject({
+        ok: true,
+        api: intendedApi,
+        pinnedAddresses: ["10.0.0.8"],
+        trustedPrivateCapability: { addresses: ["10.0.0.8"] },
+      });
+      expect(probeEndpoint).toHaveBeenCalledOnce();
+      expect(probeEndpoint).toHaveBeenCalledWith(
+        expectedEndpointUrl,
+        "model-a",
+        "test-key",
+        expect.objectContaining({
+          ...expectedProbeOptions,
+          pinnedAddresses: ["10.0.0.8"],
+          trustedPrivateCapability: expect.objectContaining({ addresses: ["10.0.0.8"] }),
+        }),
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("operator-trusted private"));
+    } finally {
+      log.mockRestore();
+      warn.mockRestore();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("honors an exactly allowlisted private endpoint during non-interactive validation (#6861)", async () => {
     vi.stubEnv("NEMOCLAW_TRUSTED_PRIVATE_INFERENCE_HOSTS", "llm.corp.example");
     const probeOpenAiLikeEndpoint = vi.fn(() => ({ ok: true, api: "openai-completions" }));

--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -221,6 +221,7 @@ describe("inference selection validation", () => {
     expectedProbeOptions,
   }) => {
     vi.stubEnv("NEMOCLAW_TRUSTED_PRIVATE_INFERENCE_HOSTS", "anthropic.corp.example");
+    vi.stubEnv("NEMOCLAW_REASONING", "false");
     const probeEndpoint = vi.fn(() => ({
       ok: true,
       api: intendedApi,


### PR DESCRIPTION
## Summary

Add positive selection-level regression coverage for trusted-private Anthropic-compatible endpoints across both supported agent surfaces. The tests prove exact-host authorization, DNS pinning, capability propagation, and the operator warning without changing the secure default or production behavior.

## Related Issue

Closes #7037

## Changes

- Cover the native Anthropic Messages probe against an explicitly trusted private hostname.
- Cover the managed Hermes/DCode Chat Completions surface derived from the same endpoint.
- Assert each probe uses the pinned private address and issued endpoint capability.
- Assert the trusted-private operator warning remains visible.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this test-only change covers already-supported and already-documented trusted-private endpoint behavior; it changes no command, configuration, default, or user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: maintainer review confirmed that the diff is test-only, preserves exact-host authorization and DNS pinning, and does not broaden private-address policy.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused inference-selection validation passed 23/23; test-title validation passed; `npm run check:diff` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added parameterized coverage for validating exactly allowlisted operator-trusted private Anthropic inference endpoint selection across supported runtime surfaces.
  * Verifies correct `api` selection, pinned address/trusted-private capability derivation, and that probing occurs exactly once with the expected endpoint, model/credentials, and runtime-specific probe options.
  * Confirms expected console warning content and ensures environment/console spies are properly restored after the test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->