### PR TITLE
ci: fetch history for platform Vitest

### DIFF
--- a/.github/workflows/platform-vitest-main.yaml
+++ b/.github/workflows/platform-vitest-main.yaml
@@ -83,6 +83,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -155,6 +158,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve workspace paths for WSL
         shell: powershell

--- a/test/platform-vitest-main-workflow.test.ts
+++ b/test/platform-vitest-main-workflow.test.ts
@@ -31,11 +31,16 @@ describe("platform Vitest main workflow", () => {
   // source-shape-contract: compatibility -- macOS must use the same modern shell/tool semantics as the Linux sandbox fixtures
   it("provisions the pinned macOS test runtime before running the full suite", () => {
     const stepNames = job("macos-vitest").steps?.map((entry) => entry.name) ?? [];
+    const checkout = step("macos-vitest", "Checkout");
     const setupPython = step("macos-vitest", "Setup Python");
     const install = step("macos-vitest", "Install macOS test dependencies");
     const run = install.run ?? "";
 
     expect(job("macos-vitest")["timeout-minutes"]).toBe(60);
+    expect(checkout.with).toMatchObject({
+      "fetch-depth": 0,
+      "persist-credentials": false,
+    });
     expect(stepNames.indexOf("Setup Python")).toBeLessThan(
       stepNames.indexOf("Install macOS test dependencies"),
     );
@@ -72,11 +77,16 @@ describe("platform Vitest main workflow", () => {
   // source-shape-contract: security -- ordinary tests stay non-root while the five UID-0 contracts remain isolated
   it("keeps the WSL suite unprivileged with explicit root-only contracts", () => {
     const stepNames = job("wsl-vitest").steps?.map((entry) => entry.name) ?? [];
+    const checkout = step("wsl-vitest", "Checkout");
     const install = step("wsl-vitest", "Install Ubuntu dependencies").run ?? "";
     const fullSuite = step("wsl-vitest", "Run full Vitest suite in WSL").run ?? "";
     const rootSuite = step("wsl-vitest", "Run root-required Vitest contracts in WSL").run ?? "";
 
     expect(job("wsl-vitest")["timeout-minutes"]).toBe(60);
+    expect(checkout.with).toMatchObject({
+      "fetch-depth": 0,
+      "persist-credentials": false,
+    });
     expect(stepNames.indexOf("Install Ubuntu dependencies")).toBeLessThan(
       stepNames.indexOf("Run full Vitest suite in WSL"),
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Platform Vitest main workflow now checks out complete Git history before its macOS and WSL full-suite runs. This lets historical-schema contracts resolve their pinned evidence commits instead of failing on the default shallow checkout.

## Changes

- Fetch complete history in the macOS and WSL platform jobs.
- Keep checkout credentials out of both full-suite worktrees.
- Protect both checkout requirements in the existing platform workflow contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal CI checkout behavior only; the documentation writer confirmed there is no user-facing command, configuration, supported-platform, or troubleshooting change.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/platform-vitest-main-workflow.test.ts` (2 tests passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved source checkout configuration for macOS and Windows Subsystem for Linux validation workflows.

* **Tests**
  * Added coverage to verify complete repository history is available and checkout credentials are not persisted in these workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->