### PR TITLE
fix(inference): refresh agent primary model on rebuild after provider switch

### DIFF
--- a/src/lib/state/openclaw-config-merge.test.ts
+++ b/src/lib/state/openclaw-config-merge.test.ts
@@ -87,6 +87,79 @@ describe("mergeOpenClawRestoredConfig", () => {
     expect((merged as { channels: Record<string, unknown> }).channels.slack).toBeUndefined();
   });
 
+  it("refreshes the agent's primary model from the rebuild after a provider switch (#7011)", () => {
+    // Backup was captured on the old provider (vllm-local / DeepSeek); the fresh
+    // rebuild reflects the switched provider (NVIDIA Endpoints / Nemotron). The
+    // agent routes on agents.defaults.model.primary, so it must follow the fresh
+    // rebuild, not the stale backup — otherwise the sandbox agent keeps calling
+    // the old model even though models.providers routing is already refreshed.
+    const merged = mergeOpenClawRestoredConfig(
+      {
+        models: {
+          providers: {
+            inference: { models: [{ id: "deepseek-ai/DeepSeek-V4-Flash" }] },
+          },
+        },
+        agents: {
+          defaults: {
+            model: { primary: "inference/deepseek-ai/DeepSeek-V4-Flash" },
+            timeoutSeconds: 900,
+          },
+          list: [{ id: "main", model: "inference/deepseek-ai/DeepSeek-V4-Flash" }],
+        },
+      },
+      {
+        models: {
+          providers: {
+            inference: { models: [{ id: "nvidia/nemotron-3-ultra-550b-a55b" }] },
+          },
+        },
+        agents: {
+          defaults: {
+            model: { primary: "inference/nvidia/nemotron-3-ultra-550b-a55b" },
+          },
+        },
+      },
+    );
+
+    expect(merged).toMatchObject({
+      models: {
+        providers: {
+          inference: { models: [{ id: "nvidia/nemotron-3-ultra-550b-a55b" }] },
+        },
+      },
+      agents: {
+        defaults: {
+          // fresh rebuild owns the routing reference
+          model: { primary: "inference/nvidia/nemotron-3-ultra-550b-a55b" },
+          // backup-durable user tuning is still inherited
+          timeoutSeconds: 900,
+        },
+        // the main agent's routing model follows the fresh primary too
+        list: [{ id: "main", model: "inference/nvidia/nemotron-3-ultra-550b-a55b" }],
+      },
+    });
+  });
+
+  it("inherits backup agent config unchanged when the rebuild has no agent primary (#7011)", () => {
+    const merged = mergeOpenClawRestoredConfig(
+      {
+        agents: {
+          defaults: { model: { primary: "inference/deepseek-ai/DeepSeek-V4-Flash" } },
+          list: [{ id: "researcher", model: "inference/custom", default: true }],
+        },
+      },
+      { gateway: { auth: { token: "fresh" } } },
+    );
+
+    expect(merged).toMatchObject({
+      agents: {
+        defaults: { model: { primary: "inference/deepseek-ai/DeepSeek-V4-Flash" } },
+        list: [{ id: "researcher", model: "inference/custom", default: true }],
+      },
+    });
+  });
+
   it("keeps the rebuilt gateway section — including the reload pin — over the backup's (#4710)", () => {
     // gateway.reload.mode="hot" is what keeps the in-sandbox gateway from
     // SIGUSR1-restarting itself out from under the nemoclaw-start respawn

--- a/src/lib/state/openclaw-config-merge.test.ts
+++ b/src/lib/state/openclaw-config-merge.test.ts
@@ -160,6 +160,39 @@ describe("mergeOpenClawRestoredConfig", () => {
     });
   });
 
+  it("refreshes only the default agent's model when no main agent exists (#7011)", () => {
+    // Fallback branch: with no `main` agent, the fresh primary re-owns the first
+    // `default: true` agent's string model and leaves other durable agents alone.
+    const merged = mergeOpenClawRestoredConfig(
+      {
+        agents: {
+          defaults: { model: { primary: "inference/deepseek-ai/DeepSeek-V4-Flash" } },
+          list: [
+            { id: "researcher", default: true, model: "inference/deepseek-ai/DeepSeek-V4-Flash" },
+            { id: "planner", model: "inference/pinned-by-user" },
+          ],
+        },
+      },
+      {
+        agents: {
+          defaults: { model: { primary: "inference/nvidia/nemotron-3-ultra-550b-a55b" } },
+        },
+      },
+    );
+
+    expect(merged).toMatchObject({
+      agents: {
+        defaults: { model: { primary: "inference/nvidia/nemotron-3-ultra-550b-a55b" } },
+        list: [
+          // selected default agent follows the fresh primary
+          { id: "researcher", default: true, model: "inference/nvidia/nemotron-3-ultra-550b-a55b" },
+          // a non-default agent's pinned model is left untouched
+          { id: "planner", model: "inference/pinned-by-user" },
+        ],
+      },
+    });
+  });
+
   it("keeps the rebuilt gateway section — including the reload pin — over the backup's (#4710)", () => {
     // gateway.reload.mode="hot" is what keeps the in-sandbox gateway from
     // SIGUSR1-restarting itself out from under the nemoclaw-start respawn

--- a/src/lib/state/openclaw-config-merge.ts
+++ b/src/lib/state/openclaw-config-merge.ts
@@ -33,8 +33,15 @@ export const OPENCLAW_CONFIG_RESTORE_OWNERSHIP = {
   providerRuntimeOwnedFields: ["baseUrl", "api", "apiKey"],
   /** A model entry's routing identity is owned by the fresh rebuild. */
   modelRuntimeOwnedFields: ["id", "name"],
-  /** Durable user-owned top-level sections are inherited from the backup. */
+  /**
+   * Durable user-owned top-level sections are inherited from the backup.
+   * `agents` is durable except its primary model routing reference, which the
+   * fresh rebuild re-owns (see `agentPrimaryModelPath`) so a provider switch
+   * followed by rebuild does not leave the agent pinned to the old model.
+   */
   backupDurableSections: ["mcp", "mcpServers", "customAgents", "agents"],
+  /** Fresh rebuild owns the agent's primary model routing within `agents`. */
+  agentPrimaryModelPath: ["agents", "defaults", "model", "primary"],
   /** NemoClaw's cross-agent disclosure selection owns this generated key. */
   currentGeneratedToolFields: ["toolSearch"],
 } as const;
@@ -417,6 +424,71 @@ function mergeOpenClawPlugins(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+function ensureMergedObject(record: Record<string, unknown>, key: string): Record<string, unknown> {
+  const existing = record[key];
+  if (isPlainObject(existing)) return existing as Record<string, unknown>;
+  const created: Record<string, unknown> = {};
+  record[key] = created;
+  return created;
+}
+
+/** Read the fresh rebuild's `agents.defaults.model.primary`, or undefined. */
+function readAgentPrimaryModelRef(config: Record<string, unknown>): string | undefined {
+  const agents = config.agents;
+  if (!isPlainObject(agents)) return undefined;
+  const defaults = agents.defaults;
+  if (!isPlainObject(defaults)) return undefined;
+  const model = defaults.model;
+  if (!isPlainObject(model)) return undefined;
+  return typeof model.primary === "string" ? model.primary : undefined;
+}
+
+/**
+ * Point the merged main/default agent's list model at the fresh primary,
+ * mirroring `updatePrimaryAgentListModel` in the inference-set path: the agent
+ * with id `main` wins; otherwise the first `default: true` agent, and only when
+ * its `model` is a string routing reference.
+ */
+function updateMainAgentListModel(agents: Record<string, unknown>, primaryModelRef: string): void {
+  const list = agents.list;
+  if (!Array.isArray(list)) return;
+  let defaultAgent: Record<string, unknown> | undefined;
+  for (const entry of list) {
+    if (!isPlainObject(entry)) continue;
+    if (entry.id === "main") {
+      if (typeof entry.model === "string") entry.model = primaryModelRef;
+      return;
+    }
+    if (!defaultAgent && entry.default === true) defaultAgent = entry;
+  }
+  if (defaultAgent && typeof defaultAgent.model === "string") defaultAgent.model = primaryModelRef;
+}
+
+/**
+ * Re-own the agent's primary model routing from the fresh rebuild.
+ *
+ * `agents` is backup-durable, so the overlay inherits the user's agent config
+ * from the snapshot — including a stale `model.primary` captured before an
+ * inference provider switch. `models.providers` routing is already refreshed,
+ * but the agent routes on `agents.defaults.model.primary` (and the matching
+ * main/default `agents.list[].model`), so without this the rebuilt sandbox
+ * keeps calling the previous model (issue #7011). Only override when the fresh
+ * config carries a primary, so backups with no rebuild-owned routing are left
+ * untouched.
+ */
+function reconcileAgentPrimaryModel(
+  merged: Record<string, unknown>,
+  currentConfig: Record<string, unknown>,
+): void {
+  const freshPrimary = readAgentPrimaryModelRef(currentConfig);
+  if (freshPrimary === undefined) return;
+  const agents = ensureMergedObject(merged, "agents");
+  const defaults = ensureMergedObject(agents, "defaults");
+  const model = ensureMergedObject(defaults, "model");
+  model.primary = freshPrimary;
+  updateMainAgentListModel(agents, freshPrimary);
+}
+
 export interface OpenClawConfigMergeOptions {
   freshImagePluginInstalls?: readonly OpenClawImagePluginInstall[];
   previousImagePluginInstalls?: readonly OpenClawImagePluginInstall[];
@@ -459,6 +531,7 @@ export function mergeOpenClawRestoredConfig(
     freshOwnership,
   );
   merged.tools = mergeOpenClawTools(backedUpConfig.tools, currentConfig.tools);
+  reconcileAgentPrimaryModel(merged, currentConfig);
 
   return merged;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
On sandbox rebuild, the OpenClaw config restore merge overlays the durable snapshot backup over the freshly generated config. The `agents` section is backup-durable, so `agents.defaults.model.primary` (and the matching main/default `agents.list[].model`) was inherited from the snapshot, which still pointed at the model selected before an inference provider switch. `models.providers` routing was already re-owned from the fresh rebuild, so the routing table was correct while the agent kept calling the old model. After this change the merge re-owns the agent's primary model routing from the fresh rebuild, so a provider switch followed by rebuild routes the sandbox agent to the newly selected model.

## Related Issue
Closes #7011

## Changes
- `src/lib/state/openclaw-config-merge.ts`: after the backup overlay, `reconcileAgentPrimaryModel` re-owns `agents.defaults.model.primary` and the main/default `agents.list[].model` from the fresh rebuild config, mirroring `updateAgentPrimary`/`updatePrimaryAgentListModel` in the inference-set path. It only overrides when the fresh config carries a primary, so backups with no rebuild-owned routing are left untouched. `agents` remains backup-durable for all other (genuinely user-owned) fields; the primary model reference is the one carve-out and is documented in `OPENCLAW_CONFIG_RESTORE_OWNERSHIP.agentPrimaryModelPath`.
- `src/lib/state/openclaw-config-merge.test.ts`: regression coverage — the agent primary (and main-agent list model) follows the fresh rebuild after a provider switch, and backup agent config is left unchanged when the rebuild carries no agent primary. The merge unit previously had zero `agents` coverage, which let this stale-field bug escape.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal rebuild config-restore behavior; no user-facing surface or documented flag changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Requesting maintainer sensitive-path review — this touches inference model routing on sandbox rebuild and was prepared by an automated fix loop.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/state/openclaw-config-merge.test.ts` → 24 passed (incl. 2 new #7011 cases); confirmed red before the fix, green after.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated restored agent configuration to prevent stale primary model routing after switching providers or rebuilding.
  * When a new primary model isn’t available, preserved existing agent settings unchanged.
  * Kept the primary model synchronized between the defaults primary setting and the main (or first default) agent’s model routing.
* **Tests**
  * Added coverage for agent model reconciliation scenarios during restore merges, including missing primary model and absence of a main agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->