### PR TITLE
fix(ci): omit null conclusion from check update

### DIFF
--- a/test/pr-e2e-gate-fork-skip.test.ts
+++ b/test/pr-e2e-gate-fork-skip.test.ts
@@ -1240,12 +1240,12 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
       expect(restoredAuthorizations).toHaveLength(2);
       expect(restoredAuthorizations[0]?.body).toMatchObject({
         status: "in_progress",
-        conclusion: null,
         output: {
           title: "Maintainer authorization required to run E2E",
           summary: expect.stringContaining("launch a fresh first-attempt `run-control-plane`"),
         },
       });
+      expect(restoredAuthorizations[0]?.body).not.toHaveProperty("conclusion");
       expect(checkTitle).toBe("Maintainer authorization required to run E2E");
       expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
     } finally {

--- a/test/pr-e2e-gate-retry-history.test.ts
+++ b/test/pr-e2e-gate-retry-history.test.ts
@@ -246,7 +246,6 @@ describe("PR E2E controller retry history", () => {
         .at(-1);
       expect(completion?.body).toMatchObject({
         status: "in_progress",
-        conclusion: null,
         output: {
           title: "Maintainer authorization required to run E2E",
           summary: expect.stringContaining(
@@ -254,6 +253,7 @@ describe("PR E2E controller retry history", () => {
           ),
         },
       });
+      expect(completion?.body).not.toHaveProperty("conclusion");
       expect(checkRuns[0]).toEqual(completedCheck);
       expect(checkRuns[1]).toMatchObject({
         id: 18,

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -1057,7 +1057,7 @@ async function markCheckInProgress(
     token,
     {
       method: "PATCH",
-      body: { status: "in_progress", conclusion: null, output: { title, summary } },
+      body: { status: "in_progress", output: { title, summary } },
       userAgent: USER_AGENT,
     },
   );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Omit `conclusion` when moving the PR E2E coordination check back to `in_progress`. GitHub rejects an explicit `null` conclusion with HTTP 422, so the controller currently stops before it can authorize or launch E2E.

## Changes

- Send only `status: "in_progress"` and the updated output in the check-run PATCH.
- Continue requiring GitHub's returned in-progress check to have `conclusion: null`.
- Assert both retry-history and fork-approval recovery paths omit the request field.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This corrects an internal GitHub check-run request and does not change user-facing behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent controller review found no blocker and confirmed both `markCheckInProgress` call paths remain covered.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/pr-e2e-gate-retry-history.test.ts test/pr-e2e-gate-fork-skip.test.ts test/pr-e2e-gate-lifecycle.test.ts test/pr-e2e-gate.test.ts test/pr-e2e-required.test.ts` (108/108 passed); `npm run build:cli`; `npm run typecheck:cli`; Biome and `git diff --check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Targeted controller coverage is proportionate to this one-field request correction.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The failure is reproducible in [controller run 29548952081](https://github.com/NVIDIA/NemoClaw/actions/runs/29548952081) and independently in [controller run 29548924425](https://github.com/NVIDIA/NemoClaw/actions/runs/29548924425).

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved check status updates by preserving existing conclusions when a check is marked as in progress.
  * Updated end-to-end validation to confirm that in-progress check updates omit unnecessary conclusion data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->