### PR TITLE
fix(ci): omit null conclusion from running checks

### DIFF
--- a/test/pr-e2e-gate-fork-skip.test.ts
+++ b/test/pr-e2e-gate-fork-skip.test.ts
@@ -887,6 +887,7 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
         status: "in_progress",
         output: { title: "E2E execution authorized by @maintainer" },
       });
+      expect(checkUpdates[0]?.body).not.toHaveProperty("conclusion");
       expect(checkUpdates[1]?.body).toMatchObject({
         status: "in_progress",
         output: { title: "Running 3 E2E jobs" },
@@ -1240,12 +1241,12 @@ describe("PR E2E controller fork credentialed E2E skip approval safety", () => {
       expect(restoredAuthorizations).toHaveLength(2);
       expect(restoredAuthorizations[0]?.body).toMatchObject({
         status: "in_progress",
-        conclusion: null,
         output: {
           title: "Maintainer authorization required to run E2E",
           summary: expect.stringContaining("launch a fresh first-attempt `run-control-plane`"),
         },
       });
+      expect(restoredAuthorizations[0]?.body).not.toHaveProperty("conclusion");
       expect(checkTitle).toBe("Maintainer authorization required to run E2E");
       expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
     } finally {

--- a/test/pr-e2e-gate-retry-history.test.ts
+++ b/test/pr-e2e-gate-retry-history.test.ts
@@ -246,7 +246,6 @@ describe("PR E2E controller retry history", () => {
         .at(-1);
       expect(completion?.body).toMatchObject({
         status: "in_progress",
-        conclusion: null,
         output: {
           title: "Maintainer authorization required to run E2E",
           summary: expect.stringContaining(
@@ -254,6 +253,7 @@ describe("PR E2E controller retry history", () => {
           ),
         },
       });
+      expect(completion?.body).not.toHaveProperty("conclusion");
       expect(checkRuns[0]).toEqual(completedCheck);
       expect(checkRuns[1]).toMatchObject({
         id: 18,

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -1057,7 +1057,7 @@ async function markCheckInProgress(
     token,
     {
       method: "PATCH",
-      body: { status: "in_progress", conclusion: null, output: { title, summary } },
+      body: { status: "in_progress", output: { title, summary } },
       userAgent: USER_AGENT,
     },
   );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restore the trusted PR E2E controller after #7054 by omitting the invalid `conclusion: null` field when updating an active GitHub check. GitHub currently rejects that request with HTTP 422 before control-plane authorization or E2E dispatch can occur.

## Changes

- Omit `conclusion` from in-progress check-run PATCH requests while retaining strict validation that GitHub returns `conclusion === null` for the persisted active check.
- Assert the outbound field is absent across initial authorization, restored authorization, and authorized dispatch transitions.
- Preserve exact PR/head/base identity, trusted-app validation, maintainer authorization, immutable history, and final stale-revision checks unchanged.

The escaped defect was caused by treating GitHub's response representation as a valid request representation. Existing mocks spread the request into a successful response, `toMatchObject` allowed the extra request key, and one test explicitly required the invalid null field. Live controller run https://github.com/NVIDIA/NemoClaw/actions/runs/29549179465 reproduced the API rejection after all ordinary CI passed.

This prerequisite cannot satisfy its own required `E2E / PR Gate Coordination` check: trusted workflow-run evaluation checks out the current `main` controller, which contains the defect being repaired. After ordinary CI and automated review pass, an independent maintainer must review this exact commit and explicitly accept that one check as a manual merge exception. Subsequent release PRs will then refresh on the repaired base and produce normal exact-head E2E evidence.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This only corrects an internal GitHub check-run request body; observable maintainer guidance, CLI/configuration, product behavior, and release notes do not change. Independent docs-writer review found no update necessary.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review of exact commit `a76af0b9c2d15486c0f5b6f869a802e3bb9ed631` returned PASS/GO with no findings; outbound null removal does not alter strict inbound identity, authorization, TOCTOU, or fail-closed validation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: Pending independent maintainer review of the expected `E2E / PR Gate Coordination` self-bootstrap failure described above. Do not merge before ordinary CI and automated review are otherwise green.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/pr-e2e-gate*.test.ts test/pr-e2e-required.test.ts` passed 149/149 tests across 9 files; the focused regression failed before the fix with received `conclusion: null` and passed afterward. Source-shape, test-size, Biome, CLI build, and CLI typecheck also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; the focused controller suite and normal hooks cover this three-file request-shape fix.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated E2E check-run progress updates to omit an unnecessary conclusion value while checks are in progress.
  * Improved handling of retryable authorization states after incompatible changes.

* **Tests**
  * Expanded coverage to verify check-run updates use the correct in-progress payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->