### PR TITLE
fix(rebuild): keep the fresh agent model routing on config restore (#7011)

### DIFF
--- a/src/lib/state/openclaw-config-merge.test.ts
+++ b/src/lib/state/openclaw-config-merge.test.ts
@@ -243,6 +243,56 @@ describe("mergeOpenClawRestoredConfig", () => {
     ).toEqual({ command: "npx", args: ["-y", "fs-server", "/work"] });
   });
 
+  it("keeps the fresh agent model routing while restoring durable agent tuning (#7011)", () => {
+    // Reporter scenario: switch inference provider/model, then rebuild. The
+    // backup (pre-switch config) must not revert agents.defaults.model.primary
+    // or a per-agent model ref, or the agent keeps routing to the old model
+    // even though the host route was updated.
+    const merged = mergeOpenClawRestoredConfig(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "inference/nvidia/nemotron-3-super-120b-a12b" },
+            thinkingDefault: "off",
+            timeoutSeconds: 600,
+          },
+          list: [
+            { id: "main", default: true, model: "inference/nvidia/nemotron-3-super-120b-a12b" },
+          ],
+        },
+        mcp: { servers: { fs: { command: "npx" } } },
+      },
+      {
+        agents: {
+          defaults: {
+            model: { primary: "inference/nvidia/nemotron-3-ultra-550b-a55b" },
+            thinkingDefault: "on",
+          },
+          list: [{ id: "main", default: true }],
+        },
+      },
+    );
+
+    const agents = (merged as { agents: Record<string, unknown> }).agents;
+    const defaults = agents.defaults as Record<string, unknown>;
+    // Routing identity is owned by the fresh rebuild.
+    expect((defaults.model as Record<string, unknown>).primary).toBe(
+      "inference/nvidia/nemotron-3-ultra-550b-a55b",
+    );
+    // Durable user tuning is restored from the backup.
+    expect(defaults.thinkingDefault).toBe("off");
+    expect(defaults.timeoutSeconds).toBe(600);
+    // The fresh main agent routes via defaults (no per-agent model); the stale
+    // backup ref must not be resurrected.
+    const mainAgent = (agents.list as Record<string, unknown>[])[0];
+    expect("model" in mainAgent).toBe(false);
+    expect(mainAgent.default).toBe(true);
+    // Unrelated durable sections survive.
+    expect((merged as { mcp: { servers: Record<string, unknown> } }).mcp.servers.fs).toEqual({
+      command: "npx",
+    });
+  });
+
   it("keeps current provider and plugin entries for matching keys", () => {
     const merged = mergeOpenClawRestoredConfig(
       {

--- a/src/lib/state/openclaw-config-merge.ts
+++ b/src/lib/state/openclaw-config-merge.ts
@@ -33,7 +33,13 @@ export const OPENCLAW_CONFIG_RESTORE_OWNERSHIP = {
   providerRuntimeOwnedFields: ["baseUrl", "api", "apiKey"],
   /** A model entry's routing identity is owned by the fresh rebuild. */
   modelRuntimeOwnedFields: ["id", "name"],
-  /** Durable user-owned top-level sections are inherited from the backup. */
+  /**
+   * Durable user-owned top-level sections are inherited from the backup. Note
+   * `agents` is durable EXCEPT for its model routing identity
+   * (`agents.defaults.model` and per-agent `model` refs), which the fresh
+   * rebuild owns so a provider/model switch is not reverted (see
+   * mergeOpenClawAgents, issue #7011).
+   */
   backupDurableSections: ["mcp", "mcpServers", "customAgents", "agents"],
   /** NemoClaw's cross-agent disclosure selection owns this generated key. */
   currentGeneratedToolFields: ["toolSearch"],
@@ -368,6 +374,61 @@ function mergeOpenClawModels(backupModels: unknown, currentModels: unknown): unk
   return merged;
 }
 
+function agentEntryId(entry: unknown): string | null {
+  if (isPlainObject(entry) && typeof entry.id === "string" && entry.id) return entry.id;
+  return null;
+}
+
+/**
+ * Merge the `agents` section. The backup restores the user's durable agent
+ * config (per-agent customizations and non-routing defaults such as
+ * `thinkingDefault` / `timeoutSeconds` / `compaction`), but the model *routing*
+ * identity is owned by the fresh rebuild: `agents.defaults.model` (which holds
+ * `primary`) and each agent-list entry's `model` ref.
+ *
+ * Without this, a provider/model switch is silently reverted on rebuild: the
+ * backup (pre-switch config) wins the routing ref, so the sandbox keeps routing
+ * to the old model even though the host route and `inference get` show the new
+ * one (issue #7011). This mirrors how the `models` section already lets the
+ * fresh rebuild own the routing identity (id/name) while restoring user tuning.
+ */
+function mergeOpenClawAgents(backupAgents: unknown, currentAgents: unknown): unknown {
+  if (!isPlainObject(currentAgents)) return cloneJson(backupAgents ?? currentAgents);
+  const backup = isPlainObject(backupAgents) ? backupAgents : {};
+  const merged = mergeJsonObjects(currentAgents, backup);
+
+  // Fresh rebuild owns agents.defaults.model (the routing block).
+  if (isPlainObject(currentAgents.defaults) && "model" in currentAgents.defaults) {
+    const mergedDefaults = isPlainObject(merged.defaults)
+      ? merged.defaults
+      : ((merged.defaults = {}) as Record<string, unknown>);
+    mergedDefaults.model = cloneJson(currentAgents.defaults.model);
+  }
+
+  // Fresh rebuild owns each agent-list entry's `model` routing ref (by id). An
+  // agent that the fresh config routes via defaults (no `model` key) must not
+  // resurrect a stale per-agent ref from the backup.
+  if (Array.isArray(merged.list) && Array.isArray(currentAgents.list)) {
+    const freshById = new Map<string, Record<string, unknown>>();
+    for (const entry of currentAgents.list) {
+      const id = agentEntryId(entry);
+      if (id && isPlainObject(entry) && !freshById.has(id)) freshById.set(id, entry);
+    }
+    merged.list = merged.list.map((entry) => {
+      if (!isPlainObject(entry)) return entry;
+      const id = agentEntryId(entry);
+      const fresh = id ? freshById.get(id) : undefined;
+      if (!fresh) return entry;
+      const next: Record<string, unknown> = { ...entry };
+      if ("model" in fresh) next.model = cloneJson(fresh.model);
+      else delete next.model;
+      return next;
+    });
+  }
+
+  return merged;
+}
+
 function mergeOpenClawPlugins(
   backupPlugins: unknown,
   currentPlugins: unknown,
@@ -452,6 +513,9 @@ export function mergeOpenClawRestoredConfig(
     previousOwnership.ids,
   );
   merged.models = mergeOpenClawModels(backedUpConfig.models, currentConfig.models);
+  if ("agents" in backedUpConfig || "agents" in currentConfig) {
+    merged.agents = mergeOpenClawAgents(backedUpConfig.agents, currentConfig.agents);
+  }
   merged.plugins = mergeOpenClawPlugins(
     backedUpConfig.plugins,
     currentConfig.plugins,


### PR DESCRIPTION
## Summary

After switching the inference provider/model (e.g. `nemoclaw onboard` → NVIDIA Endpoints), the host route and `nemoclaw inference get` show the new model, but the OpenClaw agent inside the sandbox keeps routing to the **previous** model — and a `rebuild` does not fix it.

**Root cause:** the rebuild config-restore merge (`mergeOpenClawRestoredConfig`) treats the whole `agents` section as durable (restored from the pre-rebuild backup). So `agents.defaults.model.primary` — the ref the agent/TUI routes on — is reverted to the backed-up (pre-switch) model, overriding the fresh rebuild's new routing. This is inconsistent with the `models` section, where the fresh rebuild already owns the routing identity while the backup restores user tuning (#5202).

## Fix

Add `mergeOpenClawAgents`: the backup still restores durable agent config (per-agent settings, `thinkingDefault` / `timeoutSeconds` / `compaction`, …), but the **fresh rebuild owns the model routing** — `agents.defaults.model` and each agent-list entry's `model` ref.

## Reproduced and fixed end-to-end (DGX Spark, build provider, super→ultra)

The bug is **provider/model-agnostic** (any switch + rebuild reverts), so it does not require the reporter's DGX Station / DeepSeek setup.

| Stage | Host `inference get` | Sandbox `openclaw.json` primary |
|---|---|---|
| onboard-switch super→ultra | ultra | **super** (reverted) |
| `rebuild --yes` (before fix) | ultra | **super** (persists) |
| `rebuild --yes` (with this fix) | ultra | **ultra** ✓ |

Durable agent tuning (`thinkingDefault=off`) is preserved across the rebuild. Also verified at the merge level directly.

Unit test covers the fresh-routing / durable-tuning split; the existing #5202 restore tests still pass.

Fixes #7011.

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored configuration now preserves the current agent model and provider routing.
  * Durable agent settings, such as thinking defaults and timeouts, continue to be restored from backups.
  * Prevented stale per-agent model references from returning during configuration restore.
  * Preserved unrelated MCP server settings during restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->