### PR TITLE
chore(openshell): trust v0.0.85 release manifests

### DIFF
--- a/scripts/check-installer-hash.sh
+++ b/scripts/check-installer-hash.sh
@@ -36,6 +36,9 @@ readonly -a OPENSHELL_RELEASE_MANIFEST_ALLOWLIST=(
   "0.0.82|openshell-checksums-sha256.txt|74ba77d368744f412b2dd246099b63b38937962807333ded2b6284580a2d014e"
   "0.0.82|openshell-gateway-checksums-sha256.txt|c0a369ba2c66bcde3c18ce2753b04ff942d1fe1b5f3e4656de520f6d4b175477"
   "0.0.82|openshell-sandbox-checksums-sha256.txt|3300b9856cdbe8e3f9b0f8068bbad93673739c4cfd3212c80dc0675168ee2b8d"
+  "0.0.85|openshell-checksums-sha256.txt|6554b3f96c04006d661519786d40d17e34c7860b7aac8fd35259ef2aea01567f"
+  "0.0.85|openshell-gateway-checksums-sha256.txt|cc4f32afed376ebe9b43cccdb4d2a77b2524b57132a6b56bb88d705e02420f86"
+  "0.0.85|openshell-sandbox-checksums-sha256.txt|b6ac353c933fa4cf9a3ef11d66cce6635f39ecc2e928d9c8ff1783ca797308b3"
 )
 
 case "${1:-}" in


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR extends the base-owned OpenShell release-manifest trust anchor to stable `v0.0.85`. It is the narrow prerequisite that allows PR #6726 to verify the `v0.0.85` checksums, gateway, and sandbox manifests before proposed branch code executes.

## Changes

- Retain the existing `v0.0.72` and `v0.0.82` trusted manifest identities.
- Add the three published `v0.0.85` manifest SHA-256 identities independently verified against the stable release.
- Keep the candidate version selectors and consumed artifact pins out of this base-owned trust change; those remain in PR #6726.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/installer-hash-check.test.ts` enforces the manifest allowlist contract, and the base-owned checker passed all three manifests plus all ten consumed `v0.0.85` artifact references from PR #6726.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is an internal release-manifest trust prerequisite; the OpenShell version migration and user-facing documentation remain in PR #6726.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending maintainer review
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/installer-hash-check.test.ts` (69 passed); `NEMOCLAW_INSTALLER_HASH_REPO_ROOT=/private/tmp/nemoclaw-pr6726-v85.cJMI5J/wt scripts/check-installer-hash.sh` (3 manifests and 10 consumed references passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated trusted release verification data for OpenShell version 0.0.85.
  * Installer integrity checks now recognize the official checksum manifests for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->