### PR TITLE
fix(install): trust OpenShell v0.0.85 manifests

### DIFF
--- a/scripts/check-installer-hash.sh
+++ b/scripts/check-installer-hash.sh
@@ -36,6 +36,9 @@ readonly -a OPENSHELL_RELEASE_MANIFEST_ALLOWLIST=(
   "0.0.82|openshell-checksums-sha256.txt|74ba77d368744f412b2dd246099b63b38937962807333ded2b6284580a2d014e"
   "0.0.82|openshell-gateway-checksums-sha256.txt|c0a369ba2c66bcde3c18ce2753b04ff942d1fe1b5f3e4656de520f6d4b175477"
   "0.0.82|openshell-sandbox-checksums-sha256.txt|3300b9856cdbe8e3f9b0f8068bbad93673739c4cfd3212c80dc0675168ee2b8d"
+  "0.0.85|openshell-checksums-sha256.txt|6554b3f96c04006d661519786d40d17e34c7860b7aac8fd35259ef2aea01567f"
+  "0.0.85|openshell-gateway-checksums-sha256.txt|cc4f32afed376ebe9b43cccdb4d2a77b2524b57132a6b56bb88d705e02420f86"
+  "0.0.85|openshell-sandbox-checksums-sha256.txt|b6ac353c933fa4cf9a3ef11d66cce6635f39ecc2e928d9c8ff1783ca797308b3"
 )
 
 case "${1:-}" in


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Trust the three reviewed immutable OpenShell v0.0.85 release-manifest digests before the separate version-pin update in #6726. Runtime selectors remain unchanged, preserving the base-trusted two-step rollout.

## Related Issue

Prerequisite for #6726.

## Changes

- Add the OpenShell v0.0.85 CLI, gateway, and sandbox release-manifest digests to the trusted allowlist.
- Keep every installer and blueprint version selector unchanged so #6726 cannot authorize its own release digests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/installer-hash-check.test.ts` covers complete alternate allowlist releases and the required two-step trust-anchor prerequisite; `test/dependency-pins-check.test.ts` validates the dependency-pin contract.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only the internal trusted release-manifest allowlist and does not alter user-facing behavior or selectors.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending independent review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/installer-hash-check.test.ts test/dependency-pins-check.test.ts` (78 passed); `bash scripts/check-installer-hash.sh` (all current OpenShell v0.0.72 assets verified).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to a three-entry trusted-data addition.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for verifying OpenShell v0.0.85 release manifests during installer integrity checks.
  * Installer validation now accepts and confirms the latest checksum files for the core, gateway, and sandbox components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->