### PR TITLE
docs(changelog): add v0.0.85 release entry

### DIFF
--- a/docs/changelog/2026-07-16.mdx
+++ b/docs/changelog/2026-07-16.mdx
@@ -1,0 +1,28 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.85
+
+NemoClaw v0.0.85 upgrades the supported OpenShell release, prepares qualified DGX Station hosts for express setup, strengthens inference identity and route changes, and improves recovery across onboarding, MCP, rebuild, and managed gateway operations.
+
+- NemoClaw now uses OpenShell v0.0.85 and pins its consumed release archives, manifests, binaries, and supervisor image to reviewed immutable identities.
+  The integration preserves multiline command arguments byte-for-byte, rejects supervisor TLS credentials that reach child processes, validates release archives before extraction, and reports unavailable credential rewriting with specific recovery guidance.
+  For more information, refer to [Platform Support and Launch Claims](/user-guide/openclaw/reference/platform-support), [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands), and [Security Best Practices](/user-guide/openclaw/security/best-practices).
+- Authenticated MCP setup now rejects OpenShell's reserved revisioned credential names before provider mutation and keeps child-visible compatibility checks aligned with OpenShell v0.0.85.
+  MCP bridge validation also preserves fail-closed address pinning and reports credential-rewrite failures separately from generic transport errors.
+  For more information, refer to [About Managed MCP Servers](/user-guide/openclaw/manage-sandboxes/mcp-servers/about-managed-mcp-servers), [Add an MCP Server](/user-guide/openclaw/manage-sandboxes/mcp-servers/add-an-mcp-server), and [Troubleshoot MCP Servers](/user-guide/openclaw/reference/troubleshoot-mcp-servers).
+- DGX Station GB300 express setup can prepare a qualified generic Ubuntu 24.04 ARM64 host with reviewed NVIDIA driver, Docker, Buildx, and NVIDIA Container Toolkit versions.
+  Preparation reuses exact matches, stops on unsupported version drift, validates CDI and GPU container access, restores Docker configuration after a failed runtime change, and resumes the accepted recipe after a required reboot.
+  DGX Station remains Deferred pending physical end-to-end validation, and the `--station-deepseek` express flag now requires an interactive terminal instead of silently continuing headlessly.
+  For more information, refer to [Prerequisites](/user-guide/openclaw/get-started/prerequisites), [NemoClaw Quickstart](/user-guide/openclaw/get-started/quickstart), and [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm).
+- Managed and existing vLLM routes now distinguish a safe served-model alias from a model mismatch by requiring `/v1/models` to report the exact registered model as its root.
+  Managed Nemotron 3 Nano uses its reasoning parser, the Nemotron Ultra Build route removes an unsupported top-level thinking field, and inference switching verifies sandbox access before changing the live route.
+  For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm), [Understand Provider Validation](/user-guide/openclaw/inference/validate-inference/understand-provider-validation), and [Switch Models](/user-guide/openclaw/inference/manage-inference/switch-models).
+- Onboarding routes custom endpoint DNS failures through the transport recovery flow, with retry, back, and exit choices instead of returning silently to provider selection.
+  Installer upgrades also recover a user-local OpenShell installation, while interactive and non-interactive DGX Station notice handling remains explicit.
+  For more information, refer to [NemoClaw Quickstart](/user-guide/openclaw/get-started/quickstart), [Meet Custom Endpoint Security Requirements](/user-guide/openclaw/inference/custom-endpoints/custom-endpoint-security), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- Rebuild now treats a backup as unsuccessful when every state directory fails, even if it captured loose files, and stops before deleting the original sandbox unless you explicitly accept the `--force` recovery path.
+  Managed gateway discovery ignores only descriptor-pinned, single-thread zombies while failing closed on ambiguous empty command lines, and Hermes shields transitions attest the private mutable runtime topology before acting.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and [Trusted Computing Base](/user-guide/openclaw/security/trusted-computing-base).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the canonical dated changelog entry required before the v0.0.85 release plan can be generated.
The entry summarizes the user-visible OpenShell, DGX Station, inference, MCP, onboarding, and recovery changes merged since v0.0.84 and links to their owning guides.

## Changes

- Add `docs/changelog/2026-07-16.mdx` with the exact `## v0.0.85` heading, parser-safe SPDX comment, release summary, and detailed bullets.
- Link every documented theme to its most specific published OpenClaw guide routes.
- Reconcile the release entry with these merged source PRs:
  - #6726 -> `docs/changelog/2026-07-16.mdx`: Document the supported OpenShell v0.0.85 upgrade, immutable consumed artifacts, multiline exec, credential rewrite diagnostics, and child-process TLS boundary.
  - #6986 -> `docs/changelog/2026-07-16.mdx`: Document managed MCP behavior shared across supported agents.
  - #6991 and #7045 -> `docs/changelog/2026-07-16.mdx`: Document qualified DGX Station host preparation and the interactive-terminal boundary for `--station-deepseek`.
  - #6992, #7001, #7006, and #7044 -> `docs/changelog/2026-07-16.mdx`: Document managed-model reasoning behavior, safe inference route mutation, and verified vLLM served aliases.
  - #6865, #7010, and #7028 -> `docs/changelog/2026-07-16.mdx`: Document onboarding DNS recovery, explicit notice acceptance, and upgrades with user-local OpenShell.
  - #7005, #7021, #7029, and #7049 -> `docs/changelog/2026-07-16.mdx`: Document rebuild backup safety, no-dashboard state, managed gateway discovery, and Hermes shields topology checks.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates the canonical heading, parser-safe SPDX comment, and detailed entry structure; the docs build validates published routes.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts` passed 6/6.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this doc-only entry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 pre-existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [x] New doc pages include SPDX header and frontmatter (new pages only) — native changelog entries use the required parser-safe MDX SPDX comment instead of frontmatter.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for NemoClaw v0.0.85.
  * Documented improvements to compatibility, credential handling, setup validation, recovery workflows, endpoint configuration, gateway discovery, and runtime validation.
  * Added links to relevant user-guide sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->