### PR TITLE
fix(upgrade): warn that non-.openclaw sandbox data is not preserved on recreate (#7073)

### DIFF
--- a/src/lib/actions/upgrade-sandboxes-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-recovery.test.ts
@@ -227,6 +227,7 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
     expectedSequence,
   }) => {
     const sequence: string[] = [];
+    const warningMessages: string[] = [];
     const statePaths = ["/sandbox/.openclaw", "/sandbox/.hermes"];
     const harness = createRecoveryHarness(["openclaw-box", "hermes-box"], {
       manifestAgentTypes: { "openclaw-box": "openclaw", "hermes-box": "hermes" },
@@ -237,6 +238,7 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
     });
     vi.mocked(console.log).mockImplementation((...args) => {
       const message = String(args[0]);
+      warningMessages.push(...[message].filter((entry) => entry.includes("⚠ Recovery restores")));
       sequence.push(
         ...statePaths
           .filter((candidate) =>
@@ -251,6 +253,14 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
 
     await expect(harness.upgradeSandboxes(options)).resolves.toBeUndefined();
 
+    expect(warningMessages).toHaveLength(statePaths.length);
+    expect(
+      warningMessages.map((message) =>
+        statePaths.filter((statePath) =>
+          message.includes(`Recovery restores ${JSON.stringify(statePath)} state only`),
+        ),
+      ),
+    ).toEqual(statePaths.map((statePath) => [statePath]));
     for (const statePath of statePaths) {
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining(

--- a/src/lib/actions/upgrade-sandboxes-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-recovery.test.ts
@@ -190,16 +190,36 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
     }
   });
 
-  it("warns that non-.openclaw sandbox data is not preserved before recreating (#7073)", async () => {
-    const harness = createRecoveryHarness(["alpha"]);
+  it.each([
+    { mode: "automatic", options: { auto: true }, expectedRebuilds: 2 },
+    { mode: "check-only", options: { check: true }, expectedRebuilds: 0 },
+  ] as const)("warns before every $mode prepared recovery path (#7073)", async ({
+    options,
+    expectedRebuilds,
+  }) => {
+    const sequence: string[] = [];
+    const harness = createRecoveryHarness(["alpha", "beta"]);
+    vi.mocked(console.log).mockImplementation((...args) => {
+      if (String(args[0]).includes("Recovery restores /sandbox/.openclaw state only")) {
+        sequence.push("warning");
+      }
+    });
+    harness.rebuildSpy.mockImplementation(async (name: string) => {
+      sequence.push(`rebuild:${name}`);
+    });
 
-    await expect(harness.upgradeSandboxes({ auto: true })).resolves.toBeUndefined();
+    await expect(harness.upgradeSandboxes(options)).resolves.toBeUndefined();
 
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining("Recovery restores /sandbox/.openclaw state only"),
     );
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining("NOT preserved by the recreate"),
+    );
+    expect(harness.rebuildSpy).toHaveBeenCalledTimes(expectedRebuilds);
+    expect(sequence[0]).toBe("warning");
+    expect(sequence.slice(1)).toEqual(
+      expectedRebuilds === 0 ? [] : ["rebuild:alpha", "rebuild:beta"],
     );
   });
 

--- a/src/lib/actions/upgrade-sandboxes-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-recovery.test.ts
@@ -12,19 +12,26 @@ import { upgradeSandboxes, upgradeSandboxesDependencies } from "./upgrade-sandbo
 
 type UpgradeSandboxes = typeof upgradeSandboxes;
 
-function makeManifest(sandboxName: string) {
+type ManifestAgentType = "openclaw" | "hermes";
+
+const MANIFEST_DIR_BY_AGENT: Record<ManifestAgentType, string> = {
+  openclaw: "/sandbox/.openclaw",
+  hermes: "/sandbox/.hermes",
+};
+
+function makeManifest(sandboxName: string, agentType: ManifestAgentType = "openclaw") {
   const timestamp = `2026-07-01T06-50-4${sandboxName.length}-044Z`;
   return {
     version: 1,
     sandboxName,
     timestamp,
-    agentType: "openclaw",
+    agentType,
     agentVersion: "2026.5.27",
     expectedVersion: "2026.5.27",
     stateDirs: ["workspace"],
     backedUpDirs: ["workspace"],
     stateFiles: [],
-    dir: "/sandbox/.openclaw",
+    dir: MANIFEST_DIR_BY_AGENT[agentType],
     backupPath: `/tmp/rebuild-backups/${sandboxName}/${timestamp}`,
     blueprintDigest: null,
     policyPresets: [],
@@ -40,16 +47,19 @@ function createRecoveryHarness(
     gatewayPort?: number;
     liveOutput?: string;
     latestBackup?: ReturnType<typeof makeManifest> | null;
-    registryOverrides?: Record<
-      string,
-      Partial<{
-        agent: "openclaw" | "hermes" | "langchain-deepagents-code" | null;
-        agentVersion: string | null;
-        createdAt: string;
-        nemoclawVersion: string | null;
-        fromDockerfile: string | null;
-        pendingRouteReservation: true;
-      }>
+    manifestAgentTypes?: Partial<Record<string, ManifestAgentType>>;
+    registryOverrides?: Partial<
+      Record<
+        string,
+        Partial<{
+          agent: "openclaw" | "hermes" | "langchain-deepagents-code" | null;
+          agentVersion: string | null;
+          createdAt: string;
+          nemoclawVersion: string | null;
+          fromDockerfile: string | null;
+          pendingRouteReservation: true;
+        }>
+      >
     >;
     confirmedLegacyManagedNames?: string[] | string;
     staleNames?: string[];
@@ -107,9 +117,12 @@ function createRecoveryHarness(
   });
   const latestBackupSpy = vi
     .spyOn(sandboxState, "getLatestBackup")
-    .mockImplementation((...args: unknown[]) =>
-      options.latestBackup === undefined ? makeManifest(String(args[0])) : options.latestBackup,
-    );
+    .mockImplementation((...args: unknown[]) => {
+      const sandboxName = String(args[0]);
+      return options.latestBackup === undefined
+        ? makeManifest(sandboxName, options.manifestAgentTypes?.[sandboxName])
+        : options.latestBackup;
+    });
   vi.spyOn(sandboxState, "validateRebuildRecoveryManifest").mockImplementation(
     (...args: unknown[]) => ({
       ok: true as const,
@@ -191,18 +204,46 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
   });
 
   it.each([
-    { mode: "automatic", options: { auto: true }, expectedRebuilds: 2 },
-    { mode: "check-only", options: { check: true }, expectedRebuilds: 0 },
-  ] as const)("warns before every $mode prepared recovery path (#7073)", async ({
+    {
+      mode: "automatic",
+      options: { auto: true },
+      expectedRebuilds: 2,
+      expectedSequence: [
+        "warning:/sandbox/.openclaw",
+        "warning:/sandbox/.hermes",
+        "rebuild:openclaw-box",
+        "rebuild:hermes-box",
+      ],
+    },
+    {
+      mode: "check-only",
+      options: { check: true },
+      expectedRebuilds: 0,
+      expectedSequence: ["warning:/sandbox/.openclaw", "warning:/sandbox/.hermes"],
+    },
+  ] as const)("warns with each agent's restore path before $mode mixed recovery (#7073)", async ({
     options,
     expectedRebuilds,
+    expectedSequence,
   }) => {
     const sequence: string[] = [];
-    const harness = createRecoveryHarness(["alpha", "beta"]);
+    const statePaths = ["/sandbox/.openclaw", "/sandbox/.hermes"];
+    const harness = createRecoveryHarness(["openclaw-box", "hermes-box"], {
+      manifestAgentTypes: { "openclaw-box": "openclaw", "hermes-box": "hermes" },
+      registryOverrides: {
+        "openclaw-box": { agent: "openclaw" },
+        "hermes-box": { agent: "hermes" },
+      },
+    });
     vi.mocked(console.log).mockImplementation((...args) => {
-      if (String(args[0]).includes("Recovery restores /sandbox/.openclaw state only")) {
-        sequence.push("warning");
-      }
+      const message = String(args[0]);
+      sequence.push(
+        ...statePaths
+          .filter((candidate) =>
+            message.includes(`Recovery restores ${JSON.stringify(candidate)} state only`),
+          )
+          .map((statePath) => `warning:${statePath}`),
+      );
     });
     harness.rebuildSpy.mockImplementation(async (name: string) => {
       sequence.push(`rebuild:${name}`);
@@ -210,17 +251,22 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
 
     await expect(harness.upgradeSandboxes(options)).resolves.toBeUndefined();
 
+    for (const statePath of statePaths) {
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Recovery restores ${JSON.stringify(statePath)} state only for this sandbox`,
+        ),
+      );
+    }
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining("Recovery restores /sandbox/.openclaw state only"),
+      expect.stringContaining("Files outside this recorded managed state path"),
     );
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("/sandbox/user-data"));
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining("NOT preserved by the recreate"),
     );
     expect(harness.rebuildSpy).toHaveBeenCalledTimes(expectedRebuilds);
-    expect(sequence[0]).toBe("warning");
-    expect(sequence.slice(1)).toEqual(
-      expectedRebuilds === 0 ? [] : ["rebuild:alpha", "rebuild:beta"],
-    );
+    expect(sequence).toEqual(expectedSequence);
   });
 
   it("continues through all eligible sandboxes before reporting a recovery failure", async () => {

--- a/src/lib/actions/upgrade-sandboxes-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-recovery.test.ts
@@ -190,6 +190,19 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
     }
   });
 
+  it("warns that non-.openclaw sandbox data is not preserved before recreating (#7073)", async () => {
+    const harness = createRecoveryHarness(["alpha"]);
+
+    await expect(harness.upgradeSandboxes({ auto: true })).resolves.toBeUndefined();
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("Recovery restores /sandbox/.openclaw state only"),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("NOT preserved by the recreate"),
+    );
+  });
+
   it("continues through all eligible sandboxes before reporting a recovery failure", async () => {
     const harness = createRecoveryHarness(["alpha", "beta"]);
     harness.rebuildSpy.mockRejectedValueOnce(new Error("alpha failed"));

--- a/src/lib/actions/upgrade-sandboxes.ts
+++ b/src/lib/actions/upgrade-sandboxes.ts
@@ -365,6 +365,13 @@ export async function upgradeSandboxes(
         `    ${recovery.sandbox.name}  ${D}${recovery.manifest.timestamp}${R}  (non-Ready)`,
       );
     }
+    // #7073: the pre-upgrade backup scopes to /sandbox/.openclaw only, so the
+    // recreate does not preserve files kept elsewhere in the sandbox. Warn
+    // before the destructive recreate so users can back those paths up first
+    // rather than silently losing them.
+    console.log(
+      `    ${YW}⚠ Recovery restores /sandbox/.openclaw state only. Files outside .openclaw (e.g. /sandbox/user-data) are NOT preserved by the recreate — back them up before upgrading.${R}`,
+    );
   }
   if (rejectedRecoveries.length > 0) {
     console.log(`\n  ${YW}Backup recovery blocked:${R}`);

--- a/src/lib/actions/upgrade-sandboxes.ts
+++ b/src/lib/actions/upgrade-sandboxes.ts
@@ -364,14 +364,14 @@ export async function upgradeSandboxes(
       console.log(
         `    ${recovery.sandbox.name}  ${D}${recovery.manifest.timestamp}${R}  (non-Ready)`,
       );
+      // #7073: the validated manifest records the agent-specific managed state
+      // root restored for this sandbox. Warn before the destructive recreate so
+      // users can back up paths outside that exact root rather than silently
+      // losing them.
+      console.log(
+        `    ${YW}⚠ Recovery restores ${JSON.stringify(recovery.manifest.dir)} state only for this sandbox. Files outside this recorded managed state path (e.g. /sandbox/user-data) are NOT preserved by the recreate — back them up before upgrading.${R}`,
+      );
     }
-    // #7073: the pre-upgrade backup scopes to /sandbox/.openclaw only, so the
-    // recreate does not preserve files kept elsewhere in the sandbox. Warn
-    // before the destructive recreate so users can back those paths up first
-    // rather than silently losing them.
-    console.log(
-      `    ${YW}⚠ Recovery restores /sandbox/.openclaw state only. Files outside .openclaw (e.g. /sandbox/user-data) are NOT preserved by the recreate — back them up before upgrading.${R}`,
-    );
   }
   if (rejectedRecoveries.length > 0) {
     console.log(`\n  ${YW}Backup recovery blocked:${R}`);


### PR DESCRIPTION
## Context

Part of #7073. A legacy `v0.0.55 → current` upgrade recreates the managed sandbox and restores it from a pre-upgrade backup. That backup scopes to `/sandbox/.openclaw` only (see `rebuild-backup-phase.ts` manifest `dir: "/sandbox/.openclaw"`), so any files the user keeps elsewhere in the sandbox (e.g. `/sandbox/user-data`) are dropped by the recreate with no prior notice.

I reproduced the loss on real hardware: after a legacy-recreate, non-`.openclaw` paths are absent from the recreated sandbox while `.openclaw` state is restored intact.

> Note: the **messaging-channel** loss facet of #7073 is being addressed separately via the maintainer's recommended `v0.0.63` migration bridge (which writes the plan-based `messaging` registry entry that #5123 made authoritative). I validated that bridge on a fresh `v0.0.63` install and reported the migrated-sandbox residual behavior in the issue thread. This PR does **not** claim to close that facet, so it does not `Fixes #7073`.

## Change

Print a warning in the prepared-backup-recovery summary. It shows in both `upgrade-sandboxes --check` (dry run) and the real recreate, immediately after the list of sandboxes that will be recovered — i.e. before the destructive step — so users can back up non-`.openclaw` paths externally first.

```
  Prepared backup recovery:
    my-assistant  2026-07-17T08-27-20-142Z  (non-Ready)
    ⚠ Recovery restores /sandbox/.openclaw state only. Files outside .openclaw
      (e.g. /sandbox/user-data) are NOT preserved by the recreate — back them up
      before upgrading.
```

## Verification

- New unit test drives the real `upgradeSandboxes` through the prepared-recovery branch and asserts the warning is emitted.
- Verified end-to-end on an x86_64 Ubuntu 24.04 host: forced a registered sandbox non-Ready with a validated backup and confirmed the live binary prints the warning in the `--check` output.
- `typecheck:cli` and the full `upgrade-sandboxes-recovery` suite (35 tests) pass.

## Independent validation

The reporter independently ran the full `v0.0.55 → v0.0.63 → v0.0.81` bridge on their own hardware and confirmed: the messaging bridge preserves the Slack channel (schema-v1 `messaging.plan` written on the v0.0.63 re-apply, survives to v0.0.81), while `/sandbox/user-data` seeded before the final upgrade is still lost afterward — i.e. the non-`.openclaw` data loss this PR warns about is the tracked concern of the issue, and an external backup remains required.

## Scope

Deliberately narrow: a warning only. It does not change backup scope or restore behavior (widening the backup to cover arbitrary sandbox paths is a larger design decision about what the managed lifecycle owns). This just closes the silent-data-loss gap by making the boundary explicit before the irreversible recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox upgrade/recovery messaging by adding a warning that recreate restores only the validated managed-state directory recorded in the recovery manifest, not other directories such as `/sandbox/user-data`, and reminding users to back up those paths beforehand.

* **Tests**
  * Enhanced the recovery test harness to support per-agent restore manifest directories and added a parameterized test (issue `#7073`) verifying upgrade warning order and that `rebuildSandbox` runs only in `{ auto: true }` mode (none in `{ check: true }`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>
