### PR TITLE
fix(e2e): stabilize release fixture lifecycle

### DIFF
--- a/test/e2e/fixtures/phases/lifecycle.ts
+++ b/test/e2e/fixtures/phases/lifecycle.ts
@@ -327,11 +327,15 @@ export class LifecyclePhaseFixture {
     );
     assertExitZero(pidFileStop, "stop Docker-driver gateway PID");
 
+    // Docker's name filter is a regular-expression substring match unless it
+    // is explicitly anchored. The unanchored form can select a sandbox whose
+    // name contains the gateway prefix; stopping that container remounts its
+    // tmpfs and turns a gateway-restart probe into a sandbox-restart probe.
     const containerStop = await this.host.command(
       "sh",
       [
         "-lc",
-        `cid="$(docker ps -qf 'name=openshell-cluster-nemoclaw' 2>/dev/null | head -1)"; ` +
+        `cid="$(docker ps --filter 'name=^/openshell-cluster-nemoclaw$' --format '{{.ID}}' 2>/dev/null)"; ` +
           `if [ -n "$cid" ]; then docker stop "$cid" >/dev/null; fi`,
       ],
       {

--- a/test/e2e/live/issue-6194-tui-expect.ts
+++ b/test/e2e/live/issue-6194-tui-expect.ts
@@ -177,10 +177,11 @@ send -i $termSpawn -- "\\t"
 after 200
 expect_exact_or_exit $termSpawn $sandbox openshell_sandbox_listed 66 67
 send -i $termSpawn -- "\\r"
-# Ratatui may update the "Name:" label as separate terminal diffs. Wait for a
-# stable detail-panel heading, then still bind the view to the exact sandbox.
-expect_exact_or_exit $termSpawn {Filesystem Access} openshell_sandbox_detail 68 69
+# Ratatui renders the sandbox identity before the policy panel. Assert the
+# exact sandbox first so waiting for the later heading cannot consume its
+# earlier terminal diff and leave the identity check waiting forever.
 expect_exact_or_exit $termSpawn $sandbox openshell_sandbox_detail_name 70 71
+expect_exact_or_exit $termSpawn {Filesystem Access} openshell_sandbox_detail 68 69
 # OpenShell documents 'r' as the Network Rules focus key in sandbox detail.
 send -i $termSpawn -- "r"
 expect_exact_or_exit $termSpawn {Network Rules} network_rules_focused 72 73

--- a/test/e2e/support/e2e-phase-lifecycle.test.ts
+++ b/test/e2e/support/e2e-phase-lifecycle.test.ts
@@ -285,7 +285,9 @@ describe("LifecyclePhaseFixture gateway runtime restart helpers", () => {
       "sh -lc command -v openshell >/dev/null 2>&1 && openshell forward stop 18789 || true",
       "sh -lc command -v openshell >/dev/null 2>&1 && openshell gateway stop -g nemoclaw || true",
       expect.stringContaining("sh -lc pid_file="),
-      expect.stringContaining("sh -lc cid="),
+      expect.stringContaining(
+        "docker ps --filter 'name=^/openshell-cluster-nemoclaw$' --format '{{.ID}}'",
+      ),
       expect.stringContaining("sh -lc pid_file="),
       "docker ps -qf name=openshell-cluster-nemoclaw",
       "true ",

--- a/test/e2e/support/e2e-phase-lifecycle.test.ts
+++ b/test/e2e/support/e2e-phase-lifecycle.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -294,6 +295,55 @@ describe("LifecyclePhaseFixture gateway runtime restart helpers", () => {
       "nemoclaw status",
       "openshell status",
     ]);
+  });
+
+  it("stops only the exact gateway container when a sandbox has the gateway-name prefix", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue(shellResult(0, "12345\n")); // resolveHostRuntime pid probe
+    runner.enqueue(shellResult(0)); // forward stop
+    runner.enqueue(shellResult(0)); // gateway stop
+    runner.enqueue(shellResult(0)); // pid stop
+    runner.enqueue(shellResult(0)); // container stop
+
+    await fixture(runner, new FakeCleanup()).stopGatewayRuntime();
+
+    const containerStop = runner.calls.find(
+      (call) => call.options?.artifactName === "lifecycle-gateway-container-stop",
+    );
+    expect(containerStop?.command).toBe("sh");
+    expect(containerStop?.args.slice(0, 1)).toEqual(["-lc"]);
+
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-docker-"));
+    const stopLog = path.join(fakeBin, "stopped.txt");
+    const docker = path.join(fakeBin, "docker");
+    fs.writeFileSync(
+      docker,
+      `#!/bin/sh
+if [ "$1" = "ps" ]; then
+  shift
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--filter" ]; then filter="$2"; shift 2; else shift; fi
+  done
+  [ "$filter" = 'name=^/openshell-cluster-nemoclaw$' ] && printf '%s\\n' gateway-id
+elif [ "$1" = "stop" ]; then
+  printf '%s\\n' "$2" >>"$DOCKER_STOP_LOG"
+fi
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      execFileSync("sh", containerStop?.args ?? [], {
+        env: {
+          ...process.env,
+          DOCKER_STOP_LOG: stopLog,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+        },
+      });
+      expect(fs.readFileSync(stopLog, "utf8")).toBe("gateway-id\n");
+    } finally {
+      fs.rmSync(fakeBin, { force: true, recursive: true });
+    }
   });
 
   it("can recover a PID runtime through sandbox-specific status", async () => {

--- a/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
+++ b/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
@@ -174,6 +174,14 @@ describe("live TUI post-idle coverage contract (#6194)", () => {
     expect(script).toContain(
       "expect_exact_or_exit $termSpawn {Filesystem Access} openshell_sandbox_detail 68 69",
     );
+    const sandboxIdentity = script.indexOf(
+      "expect_exact_or_exit $termSpawn $sandbox openshell_sandbox_detail_name 70 71",
+    );
+    const policyPanel = script.indexOf(
+      "expect_exact_or_exit $termSpawn {Filesystem Access} openshell_sandbox_detail 68 69",
+    );
+    expect(sandboxIdentity).toBeGreaterThanOrEqual(0);
+    expect(policyPanel).toBeGreaterThan(sandboxIdentity);
     expect(script).not.toContain("expect_exact_or_exit $termSpawn {Name:}");
     expect(script).not.toContain("(Dashboard-)?Sandbox:");
     expect(script).toContain('send -i $termSpawn -- "r"');


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fix two deterministic release E2E fixture failures. Gateway restart probes now select only the exact gateway container, and the OpenClaw TUI correlation probe asserts the sandbox identity in the order Ratatui renders it.

## Changes

- Anchor the Docker gateway container name selector so the lifecycle fixture cannot restart a sandbox and erase its tmpfs marker.
- Check the TUI sandbox identity before the later policy-panel heading consumes the earlier terminal diff.
- Add E2E-support regression assertions for both contracts, including a fake-Docker boundary test that proves only the exact gateway ID is stopped.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: E2E fixture correctness only; no product or user-facing behavior changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-phase-lifecycle.test.ts test/e2e/support/issue-6194-tui-post-idle-contract.test.ts` (29 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway runtime shutdown to reliably target only the exact gateway container, reducing the risk of stopping similarly named containers.
  * Strengthened approval UI validation by confirming sandbox identity before checking filesystem access details.

* **Tests**
  * Updated lifecycle and TUI regression tests to match the improved container selection behavior and enforce the expected interaction order.  
  * Added coverage to verify only the exact gateway container is stopped when a sandbox name shares the gateway prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->