### PR TITLE
fix(inference): scope managed vLLM cache preflight to the target model

### DIFF
--- a/src/lib/inference/vllm-storage.test.ts
+++ b/src/lib/inference/vllm-storage.test.ts
@@ -211,6 +211,20 @@ describe("host cache-storage detection", () => {
     expect(walked).not.toContain(siblingLockDir);
   });
 
+  it("flags a root-owned locks parent before creating a new target's lock directory", () => {
+    const target = "/cache/hub/models--org--target";
+    const locksDir = "/cache/hub/.locks";
+    const present = new Set(["/cache", "/cache/hub", locksDir]);
+
+    expect(
+      findUnwritableModelCachePath("/cache", target, {
+        exists: (path) => present.has(path),
+        canWrite: (path) => path !== locksDir,
+        list: () => [],
+      }),
+    ).toBe(locksDir);
+  });
+
   it("skips the model subtree when the model cache path is unresolved", () => {
     const walked: string[] = [];
     expect(

--- a/src/lib/inference/vllm-storage.test.ts
+++ b/src/lib/inference/vllm-storage.test.ts
@@ -176,6 +176,41 @@ describe("host cache-storage detection", () => {
     ).toBeNull();
   });
 
+  it("catches a root-owned lock directory for the target model", () => {
+    const target = "/cache/hub/models--org--target";
+    const lockDir = "/cache/hub/.locks/models--org--target";
+    const blocked = `${lockDir}/abc123.lock`;
+    const present = new Set(["/cache", "/cache/hub", target, lockDir]);
+    const entries = new Map([[lockDir, [{ kind: "file" as const, name: "abc123.lock" }]]]);
+
+    expect(
+      findUnwritableModelCachePath("/cache", target, {
+        exists: (path) => present.has(path),
+        canWrite: (path) => path !== blocked,
+        list: (path) => entries.get(path) ?? [],
+      }),
+    ).toBe(blocked);
+  });
+
+  it("ignores a sibling model's root-owned lock directory", () => {
+    const target = "/cache/hub/models--org--target";
+    const siblingLockDir = "/cache/hub/.locks/models--org--other";
+    const present = new Set(["/cache", "/cache/hub", siblingLockDir]);
+    const walked: string[] = [];
+
+    expect(
+      findUnwritableModelCachePath("/cache", target, {
+        exists: (path) => present.has(path),
+        canWrite: (path) => {
+          walked.push(path);
+          return true;
+        },
+        list: () => [],
+      }),
+    ).toBeNull();
+    expect(walked).not.toContain(siblingLockDir);
+  });
+
   it("skips the model subtree when the model cache path is unresolved", () => {
     const walked: string[] = [];
     expect(

--- a/src/lib/inference/vllm-storage.test.ts
+++ b/src/lib/inference/vllm-storage.test.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  findUnwritableModelCachePath,
   findUnwritableTreePath,
   formatStorageBytes,
   imageStorageRequirementBytes,
@@ -101,6 +102,93 @@ describe("host cache-storage detection", () => {
         list: () => [],
       }),
     ).toBeNull();
+  });
+
+  it("ignores an unrelated model's root-owned artifacts when scoped to a target model", () => {
+    const target = "/cache/hub/models--org--target";
+    const sibling = "/cache/hub/models--org--other";
+    const rootOwned = new Set([
+      sibling,
+      `${sibling}/.no_exist`,
+      `${sibling}/.no_exist/config.json`,
+    ]);
+    const present = new Set(["/cache", "/cache/hub", target, sibling]);
+    const walked: string[] = [];
+
+    expect(
+      findUnwritableModelCachePath("/cache", target, {
+        exists: (path) => present.has(path),
+        canWrite: (path) => {
+          walked.push(path);
+          return !rootOwned.has(path);
+        },
+        list: () => [],
+      }),
+    ).toBeNull();
+    expect(walked).not.toContain(sibling);
+    expect(walked).not.toContain(`${sibling}/.no_exist`);
+  });
+
+  it("catches a root-owned artifact inside the target model tree", () => {
+    const target = "/cache/hub/models--org--target";
+    const blocked = `${target}/.no_exist/processor_config.json`;
+    const entries = new Map([
+      [target, [{ kind: "directory" as const, name: ".no_exist" }]],
+      [`${target}/.no_exist`, [{ kind: "file" as const, name: "processor_config.json" }]],
+    ]);
+
+    expect(
+      findUnwritableModelCachePath("/cache", target, {
+        exists: () => true,
+        canWrite: (path) => path !== blocked,
+        list: (path) => entries.get(path) ?? [],
+      }),
+    ).toBe(blocked);
+  });
+
+  it("flags an unwritable cache root before inspecting the hub", () => {
+    expect(
+      findUnwritableModelCachePath("/cache", "/cache/hub/models--org--target", {
+        exists: () => true,
+        canWrite: (path) => path !== "/cache",
+        list: () => [],
+      }),
+    ).toBe("/cache");
+  });
+
+  it("flags an unwritable hub directory", () => {
+    expect(
+      findUnwritableModelCachePath("/cache", "/cache/hub/models--org--target", {
+        exists: () => true,
+        canWrite: (path) => path !== "/cache/hub",
+        list: () => [],
+      }),
+    ).toBe("/cache/hub");
+  });
+
+  it("accepts a fresh cache with no hub directory yet", () => {
+    expect(
+      findUnwritableModelCachePath("/cache", "/cache/hub/models--org--target", {
+        exists: () => false,
+        canWrite: () => true,
+        list: () => [],
+      }),
+    ).toBeNull();
+  });
+
+  it("skips the model subtree when the model cache path is unresolved", () => {
+    const walked: string[] = [];
+    expect(
+      findUnwritableModelCachePath("/cache", null, {
+        exists: (path) => path === "/cache/hub",
+        canWrite: (path) => {
+          walked.push(path);
+          return true;
+        },
+        list: () => [],
+      }),
+    ).toBeNull();
+    expect(walked).toEqual(["/cache", "/cache/hub"]);
   });
 
   it("counts complete and partial snapshot files without following directory symlinks", () => {

--- a/src/lib/inference/vllm-storage.ts
+++ b/src/lib/inference/vllm-storage.ts
@@ -308,6 +308,7 @@ interface DirectorySizeEntry {
 interface WritableTreeDeps {
   canWrite: (target: string, directory: boolean) => boolean;
   list: (target: string) => DirectorySizeEntry[];
+  exists: (target: string) => boolean;
 }
 
 function defaultWritableTreeDeps(): WritableTreeDeps {
@@ -322,6 +323,7 @@ function defaultWritableTreeDeps(): WritableTreeDeps {
       }
     },
     list: defaultDirectorySizeDeps().list,
+    exists: fs.existsSync,
   };
 }
 
@@ -355,6 +357,29 @@ export function findUnwritableTreePath(
         return entryPath;
       }
     }
+  }
+  return null;
+}
+
+/**
+ * Return the first path that would block a managed onboard for one model,
+ * scoped to what onboard actually writes: the cache root, its `hub`
+ * directory, and the target model's own cache subtree. Unrelated sibling
+ * model directories are not walked, so a root-owned artifact left by a
+ * previous model's download cannot block onboarding a different model.
+ */
+export function findUnwritableModelCachePath(
+  cacheDir: string,
+  modelCacheDir: string | null,
+  overrides: Partial<WritableTreeDeps> = {},
+): string | null {
+  const deps = { ...defaultWritableTreeDeps(), ...overrides };
+  if (!deps.canWrite(cacheDir, true)) return cacheDir;
+  const hubDir = path.join(cacheDir, "hub");
+  if (!deps.exists(hubDir)) return null;
+  if (!deps.canWrite(hubDir, true)) return hubDir;
+  if (modelCacheDir !== null && deps.exists(modelCacheDir)) {
+    return findUnwritableTreePath(modelCacheDir, deps);
   }
   return null;
 }

--- a/src/lib/inference/vllm-storage.ts
+++ b/src/lib/inference/vllm-storage.ts
@@ -385,10 +385,12 @@ export function findUnwritableModelCachePath(
     const blockedPath = findUnwritableTreePath(modelCacheDir, deps);
     if (blockedPath) return blockedPath;
   }
-  const lockDir = path.join(hubDir, ".locks", path.basename(modelCacheDir));
+  const locksDir = path.join(hubDir, ".locks");
+  const lockDir = path.join(locksDir, path.basename(modelCacheDir));
   if (deps.exists(lockDir)) {
     return findUnwritableTreePath(lockDir, deps);
   }
+  if (deps.exists(locksDir) && !deps.canWrite(locksDir, true)) return locksDir;
   return null;
 }
 

--- a/src/lib/inference/vllm-storage.ts
+++ b/src/lib/inference/vllm-storage.ts
@@ -364,9 +364,11 @@ export function findUnwritableTreePath(
 /**
  * Return the first path that would block a managed onboard for one model,
  * scoped to what onboard actually writes: the cache root, its `hub`
- * directory, and the target model's own cache subtree. Unrelated sibling
- * model directories are not walked, so a root-owned artifact left by a
- * previous model's download cannot block onboarding a different model.
+ * directory, and the target model's own cache subtree (including the
+ * download lock directory `hub/.locks/<model>` the Hugging Face client
+ * creates alongside it). Unrelated sibling model directories and lock
+ * subtrees are not walked, so a root-owned artifact left by a previous
+ * model's download cannot block onboarding a different model.
  */
 export function findUnwritableModelCachePath(
   cacheDir: string,
@@ -378,8 +380,14 @@ export function findUnwritableModelCachePath(
   const hubDir = path.join(cacheDir, "hub");
   if (!deps.exists(hubDir)) return null;
   if (!deps.canWrite(hubDir, true)) return hubDir;
-  if (modelCacheDir !== null && deps.exists(modelCacheDir)) {
-    return findUnwritableTreePath(modelCacheDir, deps);
+  if (modelCacheDir === null) return null;
+  if (deps.exists(modelCacheDir)) {
+    const blockedPath = findUnwritableTreePath(modelCacheDir, deps);
+    if (blockedPath) return blockedPath;
+  }
+  const lockDir = path.join(hubDir, ".locks", path.basename(modelCacheDir));
+  if (deps.exists(lockDir)) {
+    return findUnwritableTreePath(lockDir, deps);
   }
   return null;
 }

--- a/src/lib/inference/vllm.test.ts
+++ b/src/lib/inference/vllm.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   dockerRunDetached: vi.fn(),
   dockerSpawn: vi.fn(),
   dockerStop: vi.fn(),
-  findUnwritableTreePath: vi.fn(),
+  findUnwritableModelCachePath: vi.fn(),
   getGpuIndicesByName: vi.fn<(_pattern: RegExp) => number[]>(() => []),
   measureDirectorySizeBytes: vi.fn(),
   probeDockerStorage: vi.fn(),
@@ -46,7 +46,7 @@ vi.mock("./vllm-storage", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./vllm-storage")>();
   return {
     ...actual,
-    findUnwritableTreePath: mocks.findUnwritableTreePath,
+    findUnwritableModelCachePath: mocks.findUnwritableModelCachePath,
     measureDirectorySizeBytes: mocks.measureDirectorySizeBytes,
     probeDockerStorage: mocks.probeDockerStorage,
     probeHostStorage: mocks.probeHostStorage,
@@ -70,7 +70,7 @@ import { buildVllmServeCommand, VLLM_MODELS } from "./vllm-models";
 
 beforeEach(() => {
   mocks.dockerImageInspectFormat.mockReturnValue("");
-  mocks.findUnwritableTreePath.mockReturnValue(null);
+  mocks.findUnwritableModelCachePath.mockReturnValue(null);
   mocks.measureDirectorySizeBytes.mockReturnValue(0n);
   mocks.probeDockerStorage.mockReturnValue({
     ok: true,
@@ -1294,8 +1294,14 @@ describe("installVllm model resolution", () => {
     mockSuccessfulVllmInstall(profile.containerName);
     mocks.dockerImageInspectFormat.mockReturnValue("sha256:cached-image");
     const cacheDir = path.join(os.homedir(), ".cache", "huggingface");
-    const rootOwnedPath = path.join(cacheDir, "hub", ".locks");
-    mocks.findUnwritableTreePath.mockReturnValue(rootOwnedPath);
+    const rootOwnedPath = path.join(
+      cacheDir,
+      "hub",
+      "models--nvidia--Qwen3.6-35B-A3B-NVFP4",
+      ".no_exist",
+      "processor_config.json",
+    );
+    mocks.findUnwritableModelCachePath.mockReturnValue(rootOwnedPath);
 
     const result = await installVllm(profile, {
       hasImage: true,
@@ -1304,7 +1310,11 @@ describe("installVllm model resolution", () => {
     });
 
     expect(result).toEqual({ ok: false });
-    expect(mocks.findUnwritableTreePath).toHaveBeenCalledWith(cacheDir);
+    const [scopedCacheDir, scopedModelDir] = mocks.findUnwritableModelCachePath.mock.calls[0];
+    expect(scopedCacheDir).toBe(cacheDir);
+    expect(scopedModelDir).toBe(
+      path.join(cacheDir, "hub", "models--nvidia--Qwen3.6-35B-A3B-NVFP4"),
+    );
     expect(mocks.dockerPullWithProgressWatchdog).not.toHaveBeenCalled();
     expect(mocks.dockerSpawn).not.toHaveBeenCalled();
     expect(mocks.dockerRunDetached).not.toHaveBeenCalled();
@@ -1313,7 +1323,7 @@ describe("installVllm model resolution", () => {
     expect(errors).toContain("not writable by host user");
     expect(errors).toContain("NemoClaw did not modify it");
     expect(errors).toContain("sudo chown -R");
-    expect(errors).toContain(`'${cacheDir}'`);
+    expect(errors).toContain(`'${rootOwnedPath}'`);
     expect(errors).toContain(currentHostIdentity() ?? "$(id -u):$(id -g)");
   });
 

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -36,7 +36,7 @@ import {
 } from "./vllm-models";
 import { resolveVllmInstallModel } from "./vllm-prompt";
 import {
-  findUnwritableTreePath,
+  findUnwritableModelCachePath,
   formatStorageBytes,
   imageStorageRequirementBytes,
   measureDirectorySizeBytes,
@@ -165,6 +165,14 @@ function hfModelSnapshotDir(model: VllmModelDef): string | null {
     "snapshots",
     revision,
   );
+}
+
+function hfModelCacheDir(model: VllmModelDef): string | null {
+  const modelParts = model.id.split("/");
+  if (modelParts.some((part) => !HF_CACHE_COMPONENT_PATTERN.test(part))) {
+    return null;
+  }
+  return path.join(hostHfCacheDir(), "hub", `models--${modelParts.join("--")}`);
 }
 
 function hostUserIdentity(): string | null {
@@ -902,7 +910,7 @@ async function modelStorageAccepted(
   );
 }
 
-function ensureHfCacheDir(): { ok: true } | { ok: false; reason: string } {
+function ensureHfCacheDir(model: VllmModelDef): { ok: true } | { ok: false; reason: string } {
   const cacheDir = hostHfCacheDir();
   try {
     fs.mkdirSync(cacheDir, { recursive: true });
@@ -912,7 +920,7 @@ function ensureHfCacheDir(): { ok: true } | { ok: false; reason: string } {
       reason: `could not create Hugging Face cache directory ${cacheDir}: ${(err as Error).message}`,
     };
   }
-  const unwritablePath = findUnwritableTreePath(cacheDir);
+  const unwritablePath = findUnwritableModelCachePath(cacheDir, hfModelCacheDir(model));
   if (unwritablePath) {
     const identity = hostUserIdentity() ?? "$(id -u):$(id -g)";
     return {
@@ -920,7 +928,7 @@ function ensureHfCacheDir(): { ok: true } | { ok: false; reason: string } {
       reason:
         `Hugging Face cache path ${unwritablePath} is not writable by host user ${identity}. ` +
         "It may have been created by an earlier root-run downloader; NemoClaw did not modify it. " +
-        `Repair ownership, then retry: sudo chown -R ${identity} ${shellQuote(cacheDir)}`,
+        `Repair ownership, then retry: sudo chown -R ${identity} ${shellQuote(unwritablePath)}`,
     };
   }
   return { ok: true };
@@ -1052,7 +1060,7 @@ export async function installVllm(
     return { ok: false };
   }
 
-  const cacheDir = ensureHfCacheDir();
+  const cacheDir = ensureHfCacheDir(model);
   if (!cacheDir.ok) {
     console.error(`  vLLM install failed: ${cacheDir.reason}`);
     return { ok: false };


### PR DESCRIPTION
## Summary

Switching a managed vLLM model aborted onboarding because the Hugging Face cache writability preflight walked the entire `~/.cache/huggingface` tree and tripped on root-owned `.no_exist` directories left by a previous model's root-run download. The preflight now checks only the paths onboarding writes for the target model, so an unrelated model's artifacts no longer block the switch and no manual `chown` is required to proceed.

## Related Issue

Fixes #7088

## Changes

- Add `findUnwritableModelCachePath` in `src/lib/inference/vllm-storage.ts`, which checks the cache root, its `hub` directory, and only the target model's `models--<id>` subtree, skipping unrelated sibling model directories.
- Extend `WritableTreeDeps` with an `exists` probe so hub and model-directory presence is tested directly instead of misreading an absent directory as unwritable.
- Thread the onboarding model through `ensureHfCacheDir` in `src/lib/inference/vllm.ts` via a new `hfModelCacheDir` helper, and point the repair hint at the exact blocking path rather than the whole cache.
- Update `vllm-storage.test.ts` and `vllm.test.ts` to cover the scoped preflight.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal preflight scoping; the only user-visible text is the existing repair hint, which keeps the same shape.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: clean maintainer security review — https://github.com/NVIDIA/NemoClaw/pull/7099#issuecomment-5004710827
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run src/lib/inference/vllm-storage.test.ts src/lib/inference/vllm.test.ts` → 112 passed; `npm run typecheck:cli` clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vLLM model downloads by checking writability for the selected model’s specific Hugging Face cache path instead of the cache root.
  * Updated safety-repair guidance to reference the exact unwritable directory/file that must be ownership-repaired, avoiding unnecessary full-cache fixes.
  * Reduced false blocks from root-owned or lock artifacts belonging to unrelated sibling models.
* **Tests**
  * Expanded automated coverage for model-scoped unwritable-path detection across missing directories, lock states, and root-owned scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->