### PR TITLE
docs: simplify page frontmatter

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -211,9 +211,8 @@ Reserve `npm run check` for repo-wide validation or coverage-baseline changes.
 
 ### Format
 
-- Fern pages use MDX with YAML frontmatter. Use a flat `title`, `description`, optional `sidebar-title`, `description-agent`, `keywords`, and `position`.
+- Fern pages use MDX with YAML frontmatter. Include only a flat `title` and `description`.
 - Do not duplicate the page title as a body H1 in MDX pages because Fern renders the title from frontmatter.
-- Use `description-agent` as a concise routing summary for AI documentation clients and search indexes.
 - Include the SPDX license header in MDX frontmatter as comments:
 
   ```yaml
@@ -222,7 +221,6 @@ Reserve `npm run check` for repo-wide validation or coverage-baseline changes.
   # SPDX-License-Identifier: Apache-2.0
   title: "NemoClaw Page Title"
   description: "One-sentence summary for readers, SEO, and doc search snippets."
-  description-agent: "Third-person verb summary for agent routing. Add 'Use when...' with trigger phrases."
   ---
   ```
 
@@ -232,12 +230,8 @@ Reserve `npm run check` for repo-wide validation or coverage-baseline changes.
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: "NemoClaw Page Title: Subtitle with Context"
-sidebar-title: "Short Nav Title"
+title: "NemoClaw Page Title with Context"
 description: "One-sentence summary for readers, SEO, and doc search snippets."
-description-agent: "Third-person verb summary for agent routing. Add 'Use when...' with trigger phrases."
-keywords: "primary keyword, secondary keyword phrase"
-position: 1
 ---
 ```
 

--- a/docs/about/ecosystem-deepagents.mdx
+++ b/docs/about/ecosystem-deepagents.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Ecosystem"
-sidebar-title: "Ecosystem"
 description: "How LangChain Deep Agents Code, OpenShell, and NemoClaw form one managed terminal-agent stack."
-description-agent: "Explains how LangChain Deep Agents Code, OpenShell, and NemoClaw fit together, what NemoClaw adds for the managed dcode path, and when to use NemoClaw versus custom OpenShell integration. Use when users ask how Deep Agents relates to NemoClaw and OpenShell."
-keywords: ["nemoclaw deep agents ecosystem", "dcode openshell sandbox", "nemo-deepagents", "langchain deep agents code"]
-content:
-  type: "concept"
 ---
 NemoClaw provides onboarding, lifecycle management, policy, and inference routing for LangChain Deep Agents Code in OpenShell containers.
 Use the `nemo-deepagents` CLI alias when you work from the Deep Agents guide; it is equivalent to `nemoclaw` with `langchain-deepagents-code` pre-selected.

--- a/docs/about/ecosystem-hermes.mdx
+++ b/docs/about/ecosystem-hermes.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Ecosystem"
-sidebar-title: "Ecosystem"
 description: "How Hermes, OpenShell, and NemoClaw form one stack, where NemoClaw sits, what it adds beyond a custom OpenShell deployment, and when to use the reference integration versus OpenShell alone."
-description-agent: "Explains how Hermes, OpenShell, and NemoClaw form the ecosystem, NemoClaw's position in the stack, what NemoClaw adds beyond integrating OpenShell yourself, and when to prefer NemoHermes versus OpenShell. Use when users ask about Hermes, OpenShell, and NemoClaw together, or when to use NemoClaw versus OpenShell for Hermes."
-keywords: ["nemoclaw ecosystem", "hermes agent", "nemohermes", "nemoclaw vs openshell", "run hermes openshell sandbox"]
-content:
-  type: "concept"
 ---
 NemoClaw provides onboarding, lifecycle management, and Hermes operations in OpenShell containers.
 Use the `nemohermes` CLI alias when you work from the Hermes agent guide; it is equivalent to `nemoclaw` with the Hermes agent pre-selected.

--- a/docs/about/ecosystem.mdx
+++ b/docs/about/ecosystem.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Ecosystem"
-sidebar-title: "Ecosystem"
 description: "How the OpenClaw, OpenShell, and NemoClaw projects form one stack, where NemoClaw sits, what it adds beyond the OpenShell community sandbox, and when to use the reference integration versus OpenShell alone."
-description-agent: "Explains how OpenClaw, OpenShell, and NemoClaw form the ecosystem, NemoClaw's position in the stack, what NemoClaw adds beyond the community sandbox, and when to prefer NemoClaw versus integrating OpenShell and OpenClaw directly. Use when users ask about the relationship between OpenClaw, OpenShell, and NemoClaw, or when to use NemoClaw versus OpenShell."
-keywords: ["nemoclaw ecosystem", "openclaw openshell", "nemoclaw vs openshell", "sandboxed openclaw"]
-content:
-  type: "concept"
 ---
 NemoClaw provides onboarding, lifecycle management, and OpenClaw operations in OpenShell containers.
 

--- a/docs/about/how-it-works.mdx
+++ b/docs/about/how-it-works.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "NemoClaw Architecture Overview"
-sidebar-title: "Architecture Overview"
 description: "Learn how NemoClaw combines a host CLI, sandbox plugin, and versioned blueprint to run supported agents in a controlled sandbox."
-description-agent: "Describes how NemoClaw works internally: CLI, plugin, blueprint runner, OpenShell orchestration, inference routing, and protection layers. Use for sandbox lifecycle and architecture mechanics; not for product definition (Overview) or multi-project placement (Ecosystem)."
-keywords: ["how nemoclaw works", "nemoclaw sandbox lifecycle blueprint"]
-content:
-  type: "concept"
 ---
 import { AgentCli, AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/about/overview.mdx
+++ b/docs/about/overview.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Overview of NVIDIA NemoClaw"
-sidebar-title: "Overview"
 description: "NemoClaw is an open-source reference stack for running sandboxed AI agents more safely inside OpenShell."
-description-agent: "Explains what NemoClaw covers: onboarding, lifecycle management, and agent operations within OpenShell containers, plus capabilities and why it exists. Use when users ask what NemoClaw is or what the project provides. For ecosystem placement or OpenShell-only paths, use the Ecosystem page; for internal mechanics, use How It Works."
-keywords: ["nemoclaw overview", "openclaw always-on assistants", "hermes agent", "langchain deep agents code", "dcode sandbox", "nvidia openshell", "nvidia nemotron"]
-content:
-  type: "concept"
-skill:
-  priority: 10
 ---
 import { AgentCli, AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/configure-agents/configure-agent-heartbeats.mdx
+++ b/docs/configure-agents/configure-agent-heartbeats.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Configure OpenClaw Agent Heartbeats"
-sidebar-title: "Configure Agent Heartbeats"
 description: "Configure or disable periodic OpenClaw main-session agent turns in a NemoClaw sandbox."
-description-agent: "Configures OpenClaw heartbeat cadence through NemoClaw onboarding. Use when changing periodic agent wake-ups or disabling heartbeat instructions."
-keywords: ["nemoclaw heartbeat", "openclaw heartbeat", "HEARTBEAT.md"]
-content:
-  type: "how_to"
 ---
 
 OpenClaw heartbeats run periodic main-session agent turns.

--- a/docs/configure-agents/progressive-tool-disclosure.mdx
+++ b/docs/configure-agents/progressive-tool-disclosure.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Configure Progressive Tool Disclosure"
-sidebar-title: "Progressive Tool Disclosure"
 description: "Understand and configure how NemoClaw agents discover tools without loading every schema into model context."
-description-agent: "Explains progressive tool disclosure for OpenClaw, Hermes, and Deep Agents Code. Use when configuring Tool Search, search_tools, result limits, or direct disclosure."
-keywords: ["nemoclaw tool disclosure", "progressive tool disclosure", "search_tools", "Tool Search"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/configure-agents/understand-context-compaction.mdx
+++ b/docs/configure-agents/understand-context-compaction.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Understand OpenClaw Context Compaction"
-sidebar-title: "Understand Context Compaction"
 description: "How NemoClaw bounds OpenClaw context compaction for managed inference routes."
-description-agent: "Explains OpenClaw context compaction behavior in NemoClaw-managed sandboxes. Use when diagnosing long compaction attempts or understanding transcript rotation."
-keywords: ["nemoclaw context compaction", "openclaw transcript compaction", "openclaw context management"]
-content:
-  type: "concept"
 ---
 
 NemoClaw configures safeguard compaction for OpenClaw sandboxes that use its managed `inference.local` route, except for Local Ollama routes.

--- a/docs/deployment/brev-web-ui.mdx
+++ b/docs/deployment/brev-web-ui.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Launch NemoClaw with the Brev Web UI"
-sidebar-title: "Brev Web UI"
 description: "Launch a hosted NemoClaw sandbox from the Brev web interface without installing the CLI or using a local GPU."
-description-agent: "Guides users through deploying NemoClaw with the Brev web UI. Use when a user wants to try NemoClaw without installing the CLI, or asks how to get started on Brev."
-keywords: ["nemoclaw brev web ui", "nemoclaw getting started", "brev quickstart", "nvidia nemotron agent"]
-content:
-  type: "get_started"
 ---
 Use the Brev web UI to launch a hosted NemoClaw sandbox from your browser.
 Brev provisions a remote VM, configures inference, starts OpenClaw inside an OpenShell sandbox, and opens the OpenClaw dashboard.

--- a/docs/deployment/deploy-to-remote-gpu.mdx
+++ b/docs/deployment/deploy-to-remote-gpu.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Deploy NemoClaw to a Remote GPU Instance"
-sidebar-title: "Deploy to Remote GPU Instances"
 description: "Run NemoClaw on a remote GPU instance and understand the legacy Brev compatibility flow."
-description-agent: "Explains how to run NemoClaw on a remote GPU instance, including the deprecated Brev compatibility path and the preferred installer plus onboard flow. Use when deploying NemoClaw to a remote VM, onboarding a Brev instance, or migrating away from the legacy `nemoclaw deploy` wrapper."
-keywords: ["deploy nemoclaw remote gpu", "nemoclaw brev cloud deployment"]
-content:
-  type: "how_to"
-skill:
-  priority: 10
 ---
 Run NemoClaw on a remote GPU instance through [Brev](https://brev.nvidia.com).
 Prefer provisioning the VM first, running the standard NemoClaw installer on that host, and then running `nemoclaw onboard`.

--- a/docs/deployment/install-openclaw-plugins.mdx
+++ b/docs/deployment/install-openclaw-plugins.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Install OpenClaw Plugins"
-sidebar-title: "Install OpenClaw Plugins"
 description: "How to install an OpenClaw plugin from a version-matched full NemoClaw runtime source context."
-description-agent: "Explains the difference between OpenClaw plugins and agent skills, the complete-image contract of `nemoclaw onboard --from`, and the source-based workflow for adding a plugin without removing the managed runtime. Use when users ask how to install, build, or configure OpenClaw plugins under NemoClaw."
-keywords: ["nemoclaw plugins", "openclaw plugins", "install openclaw plugin", "nemoclaw onboard from dockerfile", "nemoclaw dockerignore"]
-content:
-  type: "how_to"
-skill:
-  priority: 20
 ---
 
 <Warning>

--- a/docs/deployment/sandbox-hardening.mdx
+++ b/docs/deployment/sandbox-hardening.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Review Sandbox Hardening"
-sidebar-title: "Review Sandbox Hardening"
 description: "Security hardening measures applied to the NemoClaw sandbox container image."
-description-agent: "Includes the sandbox container image hardening reference, covering Docker capabilities and process limits. Use when reviewing sandbox image security controls, auditing capability drops, or looking up the runtime resource limits."
-keywords: ["nemoclaw sandbox hardening", "container security", "docker capabilities", "process limits"]
-content:
-  type: "reference"
 ---
 The NemoClaw sandbox image applies several security measures to reduce the attack surface and limit damage from untrusted workloads.
 

--- a/docs/deployment/set-up-mcp-bridge.mdx
+++ b/docs/deployment/set-up-mcp-bridge.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "About Managed MCP Servers"
-sidebar-title: "About Managed MCP Servers"
 description: "Understand how NemoClaw connects sandboxed agents to authenticated Streamable HTTP MCP servers."
-description-agent: "Explains the accepted native OpenShell MCP design, credential and policy boundary, stable-release limitations, and agent adapters. Use when evaluating NemoClaw-managed MCP architecture and security."
-keywords: ["nemoclaw mcp", "authenticated mcp", "openshell credential replacement", "streamable http mcp"]
-content:
-  type: "concept"
-skill:
-  priority: 30
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/get-started/prerequisites.mdx
+++ b/docs/get-started/prerequisites.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Prerequisites"
-sidebar-title: "Prerequisites"
 description: "Hardware, software, and supported platforms for running NemoClaw."
-description-agent: "Lists the hardware, software, and container runtime requirements for running NemoClaw. Use when verifying prerequisites before installation."
-keywords: ["nemoclaw prerequisites", "nemoclaw supported platforms", "nemoclaw hardware software"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "NemoClaw Quickstart with Hermes"
-sidebar-title: "Quickstart with Hermes"
 description: "Install NemoClaw, launch a Hermes sandbox, and run your first Hermes prompt."
-description-agent: "Installs NemoClaw, selects Hermes, launches a sandbox, and runs the first prompt. Use when setting up NemoHermes or running Hermes inside OpenShell."
-keywords: ["nemohermes quickstart", "hermes agent nemoclaw", "run hermes openshell sandbox"]
-content:
-  type: "get_started"
-skill:
-  priority: 20
 ---
 Create a sandboxed Hermes agent, then chat with it from the dashboard or terminal.
 The `nemohermes` command is the NemoClaw CLI with Hermes pre-selected.

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -2,17 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Quickstart with LangChain Deep Agents Code"
-sidebar-title: "Quickstart with Deep Agents"
 description: "Install NemoClaw, launch a LangChain Deep Agents Code sandbox, and run your first prompt."
-description-agent: "Installs NemoClaw, launches a LangChain Deep Agents Code sandbox, and runs the first prompt. Use when installing or testing dcode for the first time."
-keywords: ["langchain deep agents code nemoclaw", "dcode openshell sandbox", "langchain coding agent", "dcode otlp tracing"]
-topics: ["get-started", "terminal-runtime", "langchain-deepagents-code", "observability"]
-tags: ["deep-agents-code", "dcode", "managed-inference", "otlp"]
-difficulty: "intermediate"
-audience: "operators"
-status: published
-content:
-  type: "get_started"
 ---
 Create a sandboxed LangChain Deep Agents Code agent, then run your first prompt.
 The `nemo-deepagents` command is an alias for `nemoclaw` with the `langchain-deepagents-code` agent pre-selected.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "NemoClaw Quickstart with OpenClaw"
-sidebar-title: "Quickstart with OpenClaw"
 description: "Install NemoClaw, launch a sandbox, and run your first OpenClaw prompt."
-description-agent: "Installs NemoClaw, launches an OpenClaw sandbox, and runs the first prompt. Use when onboarding, installing, or launching an OpenClaw sandbox for the first time."
-keywords: ["nemoclaw quickstart", "install nemoclaw openclaw sandbox"]
-content:
-  type: "get_started"
-skill:
-  priority: 10
 ---
 Create a sandboxed OpenClaw agent, then send it a first prompt.
 

--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Prepare Windows for NemoClaw"
-sidebar-title: "(Windows Only) Windows Prerequisites"
 description: "Prepare a Windows machine for NemoClaw before running the Quickstart: enable WSL 2, install Ubuntu, and configure Docker Desktop."
-description-agent: "Covers Windows-only preparation steps required before the Quickstart. Use when preparing a Windows machine for NemoClaw, enabling WSL 2, configuring Docker Desktop for Windows, or troubleshooting a Windows-specific install error."
-keywords: ["nemoclaw windows wsl2 setup", "nemoclaw install windows docker desktop"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -2,11 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "NVIDIA NemoClaw"
-sidebar-title: "Home"
 description: "NemoClaw is an open-source reference stack for running sandboxed AI agents more safely, with a single command and Markdown docs for AI assistants."
-keywords: "NemoClaw, OpenClaw, Hermes, LangChain Deep Agents Code, dcode, OpenShell, AI agents, Markdown docs, sandboxing, inference routing"
-layout: overview
-position: 1
 ---
 
 import { BadgeLinks } from "./_components/BadgeLinks";

--- a/docs/inference/choose-compatible-inference-api.mdx
+++ b/docs/inference/choose-compatible-inference-api.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Choose a Compatible Inference API"
-sidebar-title: "Choose a Compatible API"
 description: "Choose the Chat Completions or Responses API for a custom OpenAI-compatible endpoint."
-description-agent: "Explains how NemoClaw probes and selects the runtime API for OpenAI-compatible endpoints. Use when choosing between Chat Completions and Responses."
-keywords: ["nemoclaw preferred api", "openai responses api", "chat completions endpoint"]
-content:
-  type: "concept"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/choose-inference-provider.mdx
+++ b/docs/inference/choose-inference-provider.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Choose an Inference Provider"
-sidebar-title: "Choose a Provider"
 description: "Compare hosted, local, routed, and compatible inference providers available during NemoClaw onboarding."
-description-agent: "Compares NemoClaw inference provider options. Use when deciding which hosted provider, local server, model router, or compatible endpoint to select."
-keywords: ["choose inference provider", "nemoclaw providers", "hosted local inference"]
-content:
-  type: "concept"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/choose-local-inference-server.mdx
+++ b/docs/inference/choose-local-inference-server.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Choose a Local Inference Server"
-sidebar-title: "Choose a Local Server"
 description: "Compare Ollama, vLLM, and NVIDIA NIM before choosing a local inference server for NemoClaw."
-description-agent: "Compares NemoClaw local inference server options. Use when choosing between Ollama, vLLM, and NVIDIA NIM."
-keywords: ["nemoclaw local inference", "ollama vllm nim", "local inference server"]
-content:
-  type: "concept"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/choose-model.mdx
+++ b/docs/inference/choose-model.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Choose a Model"
-sidebar-title: "Choose a Model"
 description: "Compare curated cloud models by task fit, latency, tool use, context, and relative cost."
-description-agent: "Provides task-fit guidance for curated NemoClaw cloud models. Use when selecting a model during onboarding."
-keywords: ["choose inference model", "nemoclaw model guide", "model task fit"]
-content:
-  type: "concept"
 ---
 Use the curated model choices as starter guidance when selecting a cloud model during onboarding.
 The provider catalog remains authoritative for exact context-window limits and current pricing.

--- a/docs/inference/configure-inference-timeouts.mdx
+++ b/docs/inference/configure-inference-timeouts.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Configure Inference Timeouts"
-sidebar-title: "Configure Timeouts"
 description: "Configure NemoClaw inference request, provider-validation, and sandbox-readiness timeouts."
-description-agent: "Configures inference-related time budgets. Use when local validation, agent requests, or sandbox readiness exceeds the default timeout."
-keywords: ["nemoclaw inference timeout", "local inference timeout", "sandbox ready timeout"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/configure-model-capabilities.mdx
+++ b/docs/inference/configure-model-capabilities.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Configure OpenClaw Model Capabilities"
-sidebar-title: "Configure Model Capabilities"
 description: "Declare reasoning mode and input modalities for an OpenClaw model in a NemoClaw sandbox."
-description-agent: "Configures OpenClaw reasoning mode and text or image input support. Use when onboarding a reasoning or vision-capable model."
-keywords: ["nemoclaw reasoning model", "nemoclaw vision model", "NEMOCLAW_INFERENCE_INPUTS"]
-content:
-  type: "how_to"
 ---
 
 Declare model capabilities before onboarding so NemoClaw can bake them into the OpenClaw configuration.

--- a/docs/inference/configure-model-limits.mdx
+++ b/docs/inference/configure-model-limits.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Configure Model Limits"
-sidebar-title: "Configure Model Limits"
 description: "Set the context-window and output-token limits baked into a NemoClaw-managed sandbox."
-description-agent: "Configures model context and output limits. Use when changing the context window or maximum output tokens."
-keywords: ["nemoclaw context window", "nemoclaw max tokens", "model limits"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/custom-endpoint-security.mdx
+++ b/docs/inference/custom-endpoint-security.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Meet Custom Endpoint Security Requirements"
-sidebar-title: "Endpoint Security"
 description: "Understand credential isolation and URL validation requirements for custom NemoClaw inference endpoints."
-description-agent: "Explains custom endpoint credential isolation, SSRF validation, address restrictions, and the host service exception."
-keywords: ["nemoclaw endpoint security", "inference endpoint ssrf", "custom endpoint validation"]
-content:
-  type: "concept"
 ---
 
 NemoClaw keeps provider credentials on the host and validates explicit custom endpoint URLs before saving them through security-sensitive configuration paths.

--- a/docs/inference/declarative-agents-manifest.mdx
+++ b/docs/inference/declarative-agents-manifest.mdx
@@ -2,25 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Declarative Multi-Agent Manifest"
-sidebar-title: "Declarative Multi-Agent Manifest"
 description: "Bake secondary OpenClaw agents into a NemoClaw sandbox image from a checked-in agents.yaml manifest, including per-agent models and OpenClaw-native sub-agent delegation."
-description-agent: "Documents the `nemoclaw onboard --agents <agents.yaml>` flag and the YAML schema it consumes. Use when users ask how to declare a manager-worker layout, how to give a secondary agent its own model, or how to express OpenClaw's `subagents.allowAgents` from NemoClaw."
-keywords:
-  - "nemoclaw agents.yaml"
-  - "declarative agents"
-  - "agents.list bake"
-  - "manager worker agents"
-  - "subagents allowAgents"
-  - "per-agent model"
-topics: ["generative_ai", "ai_agents"]
-tags: ["nemoclaw", "openclaw", "openshell", "agents.yaml", "subagents"]
-content:
-  type: "how_to"
-  difficulty: technical_intermediate
-  audience: ["developer", "engineer"]
-skill:
-  priority: 30
-status: published
 ---
 
 NemoClaw can bake a multi-agent OpenClaw layout into a sandbox image from a single checked-in manifest.

--- a/docs/inference/how-inference-routing-works.mdx
+++ b/docs/inference/how-inference-routing-works.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "About Inference Routing"
-sidebar-title: "About Inference Routing"
 description: "Understand how NemoClaw routes sandbox inference through OpenShell without exposing provider credentials."
-description-agent: "Explains the NemoClaw inference route and credential boundary. Use when tracing inference traffic or determining where provider credentials reside."
-keywords: ["nemoclaw inference routing", "inference.local", "openshell inference proxy"]
-content:
-  type: "concept"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/model-capability-audit.mdx
+++ b/docs/inference/model-capability-audit.mdx
@@ -2,18 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Model Capability Audit Matrix"
-sidebar-title: "Model Capability Audit"
 description: "Maintained matrix template for auditing NemoClaw model and provider behavior across supported agent surfaces."
-description-agent: "Defines the maintained model capability audit matrix schema, states, evidence requirements, and seed rows. Use when adding or reviewing model/provider compatibility audit evidence."
-keywords: ["nemoclaw model audit", "model capability matrix", "provider compatibility audit", "agent model validation"]
-topics: ["inference", "model validation", "provider compatibility"]
-tags: ["model audit", "agent validation", "inference providers"]
-content:
-  type: "reference"
-difficulty: "intermediate"
-audience: ["maintainers", "contributors"]
-status: "maintained"
-exclude-from-skills-gen: true
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 Use this matrix to maintain model and provider audit evidence for NemoClaw agent behavior.

--- a/docs/inference/set-up-anthropic-compatible-endpoint.mdx
+++ b/docs/inference/set-up-anthropic-compatible-endpoint.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up an Anthropic-Compatible Endpoint"
-sidebar-title: "Anthropic-Compatible Endpoint"
 description: "Connect NemoClaw to a custom Anthropic-compatible inference endpoint."
-description-agent: "Shows how to configure an Anthropic-compatible endpoint for NemoClaw and explains the OpenClaw, Hermes, and Deep Agents runtime differences."
-keywords: ["nemoclaw anthropic compatible", "custom anthropic endpoint", "anthropic messages endpoint"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/set-up-model-router.mdx
+++ b/docs/inference/set-up-model-router.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up Model Router"
-sidebar-title: "Set Up Model Router"
 description: "Configure the NemoClaw host-side model router and its model pool."
-description-agent: "Sets up the NemoClaw Model Router. Use when routing requests across a configured model pool or tuning the router tolerance."
-keywords: ["NemoClaw Model Router", "model routing", "router pool"]
-content:
-  type: "how_to"
 ---
 Model Router runs on the host and selects a model from a configured pool for each request.
 OpenShell registers it as an OpenAI-compatible provider while the sandbox remains on `inference.local`.

--- a/docs/inference/set-up-nvidia-nim.mdx
+++ b/docs/inference/set-up-nvidia-nim.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up NVIDIA NIM"
-sidebar-title: "Set Up NVIDIA NIM"
 description: "Pull, start, and configure a local NVIDIA NIM container for NemoClaw inference."
-description-agent: "Shows how to set up experimental local NVIDIA NIM inference, including NGC authentication, architecture caveats, and non-interactive onboarding."
-keywords: ["nemoclaw nvidia nim", "local nim inference", "nim container onboarding"]
-content:
-  type: "how_to"
 ---
 
 NemoClaw can pull, start, and manage a local NVIDIA NIM container on hosts with a NIM-capable NVIDIA GPU.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up Ollama"
-sidebar-title: "Set Up Ollama"
 description: "Install, connect, and configure Ollama as NemoClaw's local inference server."
-description-agent: "Shows how to set up Ollama for NemoClaw, including installation, model selection, WSL routing, proxy security, and non-interactive onboarding."
-keywords: ["nemoclaw ollama", "ollama local inference", "ollama onboarding"]
-content:
-  type: "how_to"
-skill:
-  priority: 10
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/set-up-openai-compatible-endpoint.mdx
+++ b/docs/inference/set-up-openai-compatible-endpoint.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up an OpenAI-Compatible Endpoint"
-sidebar-title: "OpenAI-Compatible Endpoint"
 description: "Connect NemoClaw to a self-hosted or custom OpenAI-compatible inference endpoint."
-description-agent: "Shows how to configure an OpenAI-compatible endpoint for NemoClaw, including raw model files and non-interactive onboarding."
-keywords: ["nemoclaw openai compatible endpoint", "custom inference endpoint", "self-hosted inference"]
-content:
-  type: "how_to"
 ---
 
 Use the custom OpenAI-compatible provider for servers that implement `/v1/chat/completions` or a compatible `/v1/responses` API.

--- a/docs/inference/set-up-sub-agent.mdx
+++ b/docs/inference/set-up-sub-agent.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up Task-Specific Sub-Agents"
-sidebar-title: "Set Up Task-Specific Sub-Agents"
 description: "Where NemoClaw stores OpenClaw sub-agent model configuration, credentials, and workspace files inside the sandbox."
-description-agent: "Shows the NemoClaw-specific file paths and update flow for adding an auxiliary OpenClaw sub-agent model. Use when users ask how to add a second model, configure a sub-agent model, use Omni for vision tasks, configure agents.list, or use sessions_spawn in NemoClaw."
-keywords: ["nemoclaw additional model", "nemoclaw sub-agent model", "openclaw sub-agent", "agents.list", "sessions_spawn", "vlm-demo"]
-content:
-  type: "how_to"
-skill:
-  priority: 30
 ---
 OpenClaw documents the sub-agent behavior, `sessions_spawn` tool, `agents.list` configuration, tool policy, nesting, and auth model in [Sub-Agents](https://docs.openclaw.ai/tools/subagents).
 Use that page as the source of truth for how OpenClaw sub-agents work.

--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up vLLM"
-sidebar-title: "Set Up vLLM"
 description: "Connect NemoClaw to an existing vLLM server or start a managed vLLM container."
-description-agent: "Shows how to configure existing and managed vLLM servers for NemoClaw, including model overrides and non-interactive setup."
-keywords: ["nemoclaw vllm", "managed vllm", "local vllm inference"]
-content:
-  type: "how_to"
 ---
 
 NemoClaw can connect to an existing vLLM server or install and start a managed vLLM container on supported NVIDIA GPU hosts.

--- a/docs/inference/switch-models.mdx
+++ b/docs/inference/switch-models.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Switch Inference Models"
-sidebar-title: "Switch Models"
 description: "Change the model on a NemoClaw-managed inference route."
-description-agent: "Changes the active inference model. Use when selecting another model on an existing provider route."
-keywords: ["switch nemoclaw model", "change inference model", "nemoclaw inference set"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/switch-providers.mdx
+++ b/docs/inference/switch-providers.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Switch Inference Providers"
-sidebar-title: "Switch Providers"
 description: "Move a NemoClaw-managed sandbox to another registered inference provider."
-description-agent: "Switches inference provider families. Use when moving a sandbox between hosted, local, or compatible provider routes."
-keywords: ["switch nemoclaw provider", "change inference provider", "nemoclaw inference set provider"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/understand-provider-validation.mdx
+++ b/docs/inference/understand-provider-validation.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Understand Provider Validation"
-sidebar-title: "Provider Validation"
 description: "Understand how NemoClaw validates inference credentials, models, APIs, and streaming behavior during onboarding."
-description-agent: "Explains provider-specific inference validation. Use when an onboarding credential, model, API, tool-calling, or streaming probe fails."
-keywords: ["nemoclaw provider validation", "inference validation", "compatible endpoint probe"]
-content:
-  type: "concept"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/use-anthropic.mdx
+++ b/docs/inference/use-anthropic.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Use Anthropic"
-sidebar-title: "Use Anthropic"
 description: "Configure NemoClaw to use the Anthropic Messages API for hosted inference."
-description-agent: "Sets up Anthropic as the NemoClaw inference provider. Use when onboarding with an Anthropic API key or selecting a curated Claude model."
-keywords: ["NemoClaw Anthropic", "Anthropic Messages", "ANTHROPIC_API_KEY"]
-content:
-  type: "how_to"
 ---
 The Anthropic provider routes supported agents to the native Anthropic Messages API through OpenShell.
 The provider uses the `anthropic-messages` protocol.

--- a/docs/inference/use-google-gemini.mdx
+++ b/docs/inference/use-google-gemini.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Use Google Gemini"
-sidebar-title: "Use Google Gemini"
 description: "Configure NemoClaw to use Google Gemini through its OpenAI-compatible endpoint."
-description-agent: "Sets up Google Gemini as the NemoClaw inference provider. Use when onboarding with a Gemini API key or selecting a curated Gemini model."
-keywords: ["NemoClaw Gemini", "Google Gemini inference", "GEMINI_API_KEY"]
-content:
-  type: "how_to"
 ---
 The Google Gemini provider routes NemoClaw to Google's OpenAI-compatible Chat Completions endpoint.
 The sandbox continues to use the managed `inference.local` route.

--- a/docs/inference/use-hermes-provider.mdx
+++ b/docs/inference/use-hermes-provider.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Use Hermes Provider"
-sidebar-title: "Use Hermes Provider"
 description: "Configure Hermes Agent to use the host OpenShell provider registered by NemoClaw."
-description-agent: "Sets up Hermes Provider for Hermes Agent. Use when choosing the Hermes-specific hosted provider or one of its curated models."
-keywords: ["Hermes Provider", "NemoClaw Hermes inference", "Hermes models"]
-content:
-  type: "how_to"
 ---
 Hermes Provider routes Hermes Agent through the host OpenShell provider that NemoClaw registers during Hermes onboarding.
 This option is available only for Hermes Agent.

--- a/docs/inference/use-nvidia-endpoints.mdx
+++ b/docs/inference/use-nvidia-endpoints.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Use NVIDIA Endpoints"
-sidebar-title: "Use NVIDIA Endpoints"
 description: "Configure NemoClaw to use models hosted on NVIDIA Endpoints."
-description-agent: "Sets up NVIDIA Endpoints as the NemoClaw inference provider. Use when onboarding with an NVIDIA API key or selecting a hosted NVIDIA model."
-keywords: ["NVIDIA Endpoints", "NVIDIA inference API", "NemoClaw hosted inference"]
-content:
-  type: "how_to"
 ---
 NVIDIA Endpoints routes NemoClaw to models hosted on [build.nvidia.com](https://build.nvidia.com) through an OpenAI-compatible API.
 The sandbox keeps using `inference.local` while OpenShell forwards requests to the NVIDIA endpoint.

--- a/docs/inference/use-openai.mdx
+++ b/docs/inference/use-openai.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Use OpenAI"
-sidebar-title: "Use OpenAI"
 description: "Configure NemoClaw to use the OpenAI API for hosted inference."
-description-agent: "Sets up OpenAI as the NemoClaw inference provider. Use when onboarding with an OpenAI API key or selecting a curated OpenAI model."
-keywords: ["NemoClaw OpenAI", "OpenAI inference provider", "OPENAI_API_KEY"]
-content:
-  type: "how_to"
 ---
 The OpenAI provider routes NemoClaw inference to the OpenAI API through OpenShell.
 The sandbox uses the managed `inference.local` route and does not receive the raw OpenAI API key.

--- a/docs/inference/use-openrouter.mdx
+++ b/docs/inference/use-openrouter.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Use OpenRouter"
-sidebar-title: "Use OpenRouter"
 description: "Configure NemoClaw to route hosted inference through OpenRouter."
-description-agent: "Sets up OpenRouter as the NemoClaw inference provider. Use when onboarding with an OpenRouter API key or tracing the OpenRouter host adapter."
-keywords: ["NemoClaw OpenRouter", "OpenRouter API key", "OpenRouter adapter"]
-content:
-  type: "how_to"
 ---
 OpenRouter provides an OpenAI-compatible Chat Completions route for OpenClaw, Hermes, and LangChain Deep Agents Code.
 NemoClaw keeps the sandbox on `https://inference.local/v1` and sends upstream traffic through a host adapter.

--- a/docs/inference/use-shared-gateway-routes.mdx
+++ b/docs/inference/use-shared-gateway-routes.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Use Shared Gateway Routes"
-sidebar-title: "Use Shared Gateway Routes"
 description: "Understand how multiple NemoClaw sandboxes safely share one live OpenShell inference route."
-description-agent: "Explains shared gateway inference routes, recorded route drift, safe route changes, and provider-global compatibility. Use when multiple sandboxes use one OpenShell gateway."
-keywords: ["nemoclaw shared gateway", "shared inference route", "route drift"]
-content:
-  type: "how_to"
 ---
 
 OpenShell exposes one live inference route per gateway.

--- a/docs/inference/verify-inference-route.mdx
+++ b/docs/inference/verify-inference-route.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Verify the Sandbox Inference Route"
-sidebar-title: "Verify the Inference Route"
 description: "Verify that a NemoClaw sandbox can reach its configured model through the OpenShell inference route."
-description-agent: "Verifies the in-sandbox inference path. Use when checking that inference.local, proxy authentication, and the selected backend work together."
-keywords: ["verify inference.local", "nemoclaw inference route", "sandbox inference health"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/inference/view-active-inference-route.mdx
+++ b/docs/inference/view-active-inference-route.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "View the Active Inference Route"
-sidebar-title: "View the Active Route"
 description: "Inspect the provider and model on the live NemoClaw-managed OpenShell inference route."
-description-agent: "Shows the live inference provider and model. Use when checking the active route before or after an inference change."
-keywords: ["nemoclaw inference get", "active inference provider", "active inference model"]
-content:
-  type: "how_to"
 ---
 
 Use the NemoClaw CLI to read the provider and model on the live OpenShell inference route.

--- a/docs/manage-sandboxes/add-channels-after-onboarding.mdx
+++ b/docs/manage-sandboxes/add-channels-after-onboarding.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Add Channels After Onboarding"
-sidebar-title: "Add Channels After Onboarding"
 description: "Add a messaging channel to an existing NemoClaw sandbox and rebuild the runtime safely."
-description-agent: "Explains channels list and channels add behavior, policy application, rollback, non-interactive inputs, provider-specific examples, and post-rebuild verification. Use when adding a channel to an existing sandbox."
-keywords: ["nemoclaw channels add", "add messaging channel", "channels list"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/add-mcp-server.mdx
+++ b/docs/manage-sandboxes/add-mcp-server.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Add an MCP Server"
-sidebar-title: "Add an MCP Server"
 description: "Register an authenticated Streamable HTTP MCP server with a NemoClaw sandbox."
-description-agent: "Explains mcp add inputs, credential-name restrictions, URL and DNS validation, policy pinning, and agent capability checks. Use when adding a managed MCP server."
-keywords: ["nemoclaw mcp add", "streamable http mcp", "mcp bearer credential"]
-content:
-  type: "how_to"
-skill:
-  priority: 40
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/backup-restore.mdx
+++ b/docs/manage-sandboxes/backup-restore.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Create and Restore Snapshots"
-sidebar-title: "Create and Restore Snapshots"
 description: "Create, list, restore, clone, and bulk-create NemoClaw snapshots for sandbox state."
-description-agent: "Explains when to back up sandbox state and how to use snapshot create, list, restore, clone, and backup-all workflows. Use before rebuilds, upgrades, destroys, or state recovery."
-keywords: ["nemoclaw snapshot", "nemoclaw backup-all", "nemoclaw restore", "sandbox backup"]
-content:
-  type: "how_to"
-skill:
-  priority: 20
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/enable-channels-during-onboarding.mdx
+++ b/docs/manage-sandboxes/enable-channels-during-onboarding.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Enable Channels During Onboarding"
-sidebar-title: "Enable Channels During Onboarding"
 description: "Select messaging channels and supply their credentials or pairing inputs during NemoClaw onboarding."
-description-agent: "Explains the interactive and scripted onboarding flows for selecting messaging channels and creating OpenShell bridge providers. Use when enabling channels on a new sandbox."
-keywords: ["nemoclaw onboard messaging", "messaging channel picker", "channel environment variables"]
-content:
-  type: "how_to"
 ---
 Enable channels during onboarding when you are creating or recreating a sandbox.
 

--- a/docs/manage-sandboxes/gateway-lifecycle-control.mdx
+++ b/docs/manage-sandboxes/gateway-lifecycle-control.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Understand Gateway Lifecycle Control"
-sidebar-title: "Understand Gateway Lifecycle Control"
 description: "Understand how NemoClaw authenticates, executes, and verifies gateway recovery and restart operations."
-description-agent: "Explains the direct root-entrypoint and OpenShell-managed gateway lifecycle topologies, controller trust boundaries, health proofs, and fail-closed behavior. Use when reviewing recover or gateway restart security."
-keywords: ["gateway lifecycle control", "nemoclaw recover", "gateway restart", "privileged control"]
-content:
-  type: "concept"
-skill:
-  priority: 20
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/install-plugins-hermes.mdx
+++ b/docs/manage-sandboxes/install-plugins-hermes.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Install Hermes Plugins"
-sidebar-title: "Install Hermes Plugins"
 description: "Install Hermes plugins for NemoClaw-managed sandboxes."
-description-agent: "Explains how to install Hermes plugins in NemoClaw-managed sandboxes, including custom Dockerfile build-directory layout and `.dockerignore` handling. Use when users ask how to install, build, or configure Hermes plugins under NemoClaw."
-keywords: ["install hermes plugins", "hermes plugins nemoclaw", "nemoclaw hermes plugins", "nemohermes dockerignore"]
-content:
-  type: "how_to"
-skill:
-  priority: 40
 ---
 Hermes plugins extend the Hermes runtime inside a NemoClaw-managed sandbox.
 They are different from NemoClaw skills and from OpenClaw plugins, so install them through the Hermes plugin path instead of `skill install`.

--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "View Sandbox Status"
-sidebar-title: "View Sandbox Status"
 description: "List NemoClaw sandboxes, check their health, inspect logs, and collect diagnostics."
-description-agent: "Explains how to list registered sandboxes, inspect sandbox and host status, read logs, and collect diagnostics. Use when checking sandbox health or preparing a support handoff."
-keywords: ["nemoclaw status", "nemoclaw list", "nemoclaw logs", "nemoclaw debug"]
-content:
-  type: "how_to"
-skill:
-  priority: 10
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/manage-mcp-servers.mdx
+++ b/docs/manage-sandboxes/manage-mcp-servers.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Manage MCP Servers"
-sidebar-title: "Manage MCP Servers"
 description: "Inspect, probe, rotate, restart, remove, rebuild, and destroy NemoClaw-managed MCP servers."
-description-agent: "Explains managed MCP status and credential-resolution probes, credential rotation, restart, removal, rebuild restoration, destroy recovery, and lifecycle locking. Use after an MCP server is registered."
-keywords: ["nemoclaw mcp status", "nemoclaw mcp restart", "nemoclaw mcp remove", "mcp credential rotation"]
-content:
-  type: "how_to"
-skill:
-  priority: 50
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/manage-messaging-channels.mdx
+++ b/docs/manage-sandboxes/manage-messaging-channels.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Manage Messaging Channels"
-sidebar-title: "Manage Messaging Channels"
 description: "Rotate, pause, resume, remove, and conflict-check messaging channels on an existing sandbox."
-description-agent: "Explains channel credential rotation, destructive removal, pause and resume behavior, duplicate credential and port conflicts, and full messaging stop behavior. Use after a channel is configured."
-keywords: ["nemoclaw channels remove", "nemoclaw channels stop", "messaging credential rotation", "channel conflicts"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Choose Messaging Channels"
-sidebar-title: "Choose Messaging Channels"
 description: "Compare the supported Telegram, Discord, Slack, WeChat, WhatsApp, and Microsoft Teams messaging paths."
-description-agent: "Compares supported and experimental messaging channels, their credential or pairing requirements, and their NemoClaw runtime boundaries. Use when choosing a channel for OpenClaw or Hermes."
-keywords: ["nemoclaw messaging channels", "telegram", "discord", "slack", "wechat", "whatsapp", "microsoft teams"]
-content:
-  type: "concept"
-skill:
-  priority: 30
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Recover and Rebuild Sandboxes"
-sidebar-title: "Recover and Rebuild Sandboxes"
 description: "Recover a stopped agent runtime or rebuild a sandbox while preserving supported state."
-description-agent: "Explains the supported recovery and rebuild paths for OpenClaw, Hermes, and Deep Agents sandboxes. Use when a gateway or terminal runtime is degraded or when a sandbox image must be recreated."
-keywords: ["nemoclaw recover", "nemoclaw rebuild", "gateway restart", "sandbox recovery"]
-content:
-  type: "how_to"
-skill:
-  priority: 30
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/run-sandboxes.mdx
+++ b/docs/manage-sandboxes/run-sandboxes.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Run Sandboxes"
-sidebar-title: "Run Sandboxes"
 description: "Run multiple sandboxes and stop or start containers, with dashboard and tunnel guidance where supported."
-description-agent: "Explains multiple-sandbox naming and stop or start operations, plus dashboard and Cloudflare tunnel controls where the selected agent supports them. Use when operating one or more existing sandboxes."
-keywords: ["nemoclaw multiple sandboxes", "nemoclaw stop", "nemoclaw start", "sandbox operation"]
-content:
-  type: "how_to"
-skill:
-  priority: 20
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/runtime-controls.mdx
+++ b/docs/manage-sandboxes/runtime-controls.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Understand Runtime Changes"
-sidebar-title: "Understand Runtime Changes"
 description: "Determine which NemoClaw sandbox changes apply at runtime and which require a rebuild or re-onboard."
-description-agent: "Maps common OpenClaw and Hermes configuration changes to runtime updates, gateway restarts, rebuilds, or re-onboarding. Use when deciding how a sandbox change takes effect."
-keywords: ["sandbox mutability", "sandbox runtime configuration", "sandbox rebuild"]
-content:
-  type: "concept"
-skill:
-  priority: 10
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/set-up-discord.mdx
+++ b/docs/manage-sandboxes/set-up-discord.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up Discord"
-sidebar-title: "Set Up Discord"
 description: "Prepare a Discord bot token, server access, user restriction, and mention behavior for NemoClaw."
-description-agent: "Explains Discord bot credentials and NemoClaw server, user, and mention-mode settings. Use before enabling Discord during onboarding or adding it later."
-keywords: ["nemoclaw discord", "discord bot token", "discord server id"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/set-up-microsoft-teams.mdx
+++ b/docs/manage-sandboxes/set-up-microsoft-teams.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up Microsoft Teams"
-sidebar-title: "Set Up Microsoft Teams"
 description: "Configure experimental Microsoft Teams Bot Framework credentials, allowlists, mention mode, and webhook forwarding."
-description-agent: "Explains the experimental Microsoft Teams Bot Framework webhook path, app credentials, user access, mention mode, and port isolation. Use before enabling Teams."
-keywords: ["nemoclaw teams", "microsoft teams bot framework", "teams webhook"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/set-up-slack.mdx
+++ b/docs/manage-sandboxes/set-up-slack.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up Slack"
-sidebar-title: "Set Up Slack"
 description: "Prepare Slack Socket Mode credentials and user or channel allowlists for NemoClaw."
-description-agent: "Explains Slack bot and app token validation, allowlists, mention behavior, rich Hermes rendering, and duplicate Socket Mode detection. Use before enabling Slack."
-keywords: ["nemoclaw slack", "slack socket mode", "slack app token", "slack allowlist"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/set-up-telegram.mdx
+++ b/docs/manage-sandboxes/set-up-telegram.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up Telegram"
-sidebar-title: "Set Up Telegram"
 description: "Prepare a Telegram bot token, direct-message allowlist, group policy, and mention behavior for NemoClaw."
-description-agent: "Explains Telegram bot creation and NemoClaw allowlist, group-access, and mention-mode settings. Use before enabling Telegram during onboarding or adding it later."
-keywords: ["nemoclaw telegram", "telegram bot token", "telegram allowed ids"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/set-up-wechat.mdx
+++ b/docs/manage-sandboxes/set-up-wechat.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up WeChat"
-sidebar-title: "Set Up WeChat"
 description: "Pair experimental personal WeChat through the host-side iLink QR flow."
-description-agent: "Explains the experimental personal WeChat iLink QR flow, provider credential boundary, per-account metadata, and DM allowlist. Use before enabling WeChat."
-keywords: ["nemoclaw wechat", "wechat qr", "wechat ilink"]
-content:
-  type: "how_to"
 ---
 WeChat support is experimental and uses Tencent's iLink gateway.
 The supported mode in this release is personal WeChat with `bot_type=3`.

--- a/docs/manage-sandboxes/set-up-whatsapp.mdx
+++ b/docs/manage-sandboxes/set-up-whatsapp.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Set Up WhatsApp"
-sidebar-title: "Set Up WhatsApp"
 description: "Pair experimental WhatsApp inside an OpenClaw or Hermes sandbox and understand its durable session state."
-description-agent: "Explains the experimental in-sandbox WhatsApp QR pairing flow, durable session credentials, sender allowlist, and cross-sandbox limitations. Use before enabling WhatsApp."
-keywords: ["nemoclaw whatsapp", "whatsapp qr pairing", "whatsapp session"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/transfer-state-manually.mdx
+++ b/docs/manage-sandboxes/transfer-state-manually.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Transfer State Manually"
-sidebar-title: "Transfer State Manually"
 description: "Download and upload selected sandbox state files when a managed snapshot is not the right transfer path."
-description-agent: "Explains safe manual download and upload paths for OpenClaw workspace files, Hermes state, and Deep Agents state. Use when inspecting or transferring specific files."
-keywords: ["openshell sandbox download", "openshell sandbox upload", "manual sandbox backup", "workspace transfer"]
-content:
-  type: "how_to"
-skill:
-  priority: 30
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/uninstall-nemoclaw.mdx
+++ b/docs/manage-sandboxes/uninstall-nemoclaw.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Uninstall NemoClaw"
-sidebar-title: "Uninstall NemoClaw"
 description: "Remove NemoClaw while choosing whether to preserve host-side backups, registry state, OpenShell, and models."
-description-agent: "Explains the built-in and hosted uninstall workflows and the user data they preserve or remove. Use when uninstalling NemoClaw or cleaning host-side state."
-keywords: ["nemoclaw uninstall", "remove nemoclaw", "destroy user data"]
-content:
-  type: "how_to"
-skill:
-  priority: 50
 ---
 Use the built-in uninstall command when the installed CLI is available.
 

--- a/docs/manage-sandboxes/update-sandboxes.mdx
+++ b/docs/manage-sandboxes/update-sandboxes.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Update Sandboxes"
-sidebar-title: "Update Sandboxes"
 description: "Update the NemoClaw host CLI and reconcile existing sandboxes with the maintained release."
-description-agent: "Explains the maintained-release update workflow, backup requirements, and sandbox reconciliation behavior. Use when upgrading NemoClaw and existing sandboxes."
-keywords: ["nemoclaw update", "nemoclaw upgrade-sandboxes", "maintained release"]
-content:
-  type: "how_to"
-skill:
-  priority: 40
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/manage-sandboxes/workspace-files.mdx
+++ b/docs/manage-sandboxes/workspace-files.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Understand Sandbox State"
-sidebar-title: "Understand Sandbox State"
 description: "What agent workspace and state files are, where they live, and how they persist across sandbox restarts."
-description-agent: "Explains what OpenClaw workspace files, Hermes state, and Deep Agents state are, where they live, and how they persist. Use when preparing to edit, snapshot, or transfer sandbox state."
-keywords: ["nemoclaw workspace files", "deepagents state", "soul.md", "agents.md", "sandbox persistence"]
-content:
-  type: "concept"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/monitoring/monitor-sandbox-activity.mdx
+++ b/docs/monitoring/monitor-sandbox-activity.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Monitor Sandbox Activity and Debug Issues"
-sidebar-title: "Monitor Sandbox Activity"
 description: "Inspect sandbox health, trace agent behavior, and diagnose problems."
-description-agent: "Inspects sandbox health, traces agent behavior, and diagnoses problems. Use when monitoring a running sandbox, debugging agent issues, or checking sandbox logs."
-keywords: ["monitor nemoclaw sandbox", "debug nemoclaw agent issues"]
-content:
-  type: "how_to"
-skill:
-  priority: 10
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Approve or Deny Agent Network Requests"
-sidebar-title: "Approve or Deny Network Requests"
 description: "Review and approve blocked agent network requests in the TUI."
-description-agent: "Reviews and approves blocked agent network requests in the TUI. Use when approving or denying sandbox egress requests, managing blocked network calls, or using the approval TUI."
-keywords: ["nemoclaw approve network requests", "sandbox egress approval tui"]
-content:
-  type: "how_to"
-skill:
-  priority: 20
 ---
 Review network requests that the agent makes to endpoints that are not listed in the sandbox policy.
 OpenShell intercepts those requests and presents them in the TUI for operator approval.

--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Customize the Sandbox Network Policy"
-sidebar-title: "Customize the Network Policy"
 description: "Add, remove, or modify allowed endpoints in the sandbox policy."
-description-agent: "Adds, removes, or modifies allowed endpoints in the sandbox policy. Use when customizing network policy, changing egress rules, or configuring sandbox endpoint access."
-keywords: ["customize nemoclaw network policy", "sandbox egress policy configuration"]
-content:
-  type: "how_to"
-skill:
-  priority: 10
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Common NemoClaw Integration Policy Examples"
-sidebar-title: "Integration Policy Examples"
 description: "Guided examples for adding post-install integration policy access to a NemoClaw sandbox."
-description-agent: "Guides users through common post-install integration policy setup for maintained NemoClaw policy presets, including Outlook, messaging channels, GitHub, Gmail, Jira, Brave and Tavily web search, package managers, Hugging Face, local inference, and OpenShell approval workflows."
-keywords: ["nemoclaw integration policy examples", "post-install policy setup", "openshell approval workflow", "policy preset"]
-content:
-  type: "how_to"
-skill:
-  priority: 15
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Architecture Details"
-sidebar-title: "Architecture Details"
 description: "Learn how NemoClaw combines a host CLI, sandbox integration layer, and versioned blueprint to run compatible agents in controlled OpenShell sandboxes."
-description-agent: "Describes the NemoClaw integration layer and blueprint architecture and how they orchestrate compatible agent sandboxes. Use when looking up architecture, agent integration, plugin structure, or blueprint design."
-keywords: ["nemoclaw architecture", "nemoclaw agent architecture", "nemoclaw plugin blueprint structure"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/reference/cli-selection-guide.mdx
+++ b/docs/reference/cli-selection-guide.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Choose Between NemoClaw and OpenShell CLIs"
-sidebar-title: "Which CLI to Use"
 description: "Choose between the NemoClaw CLI and the OpenShell CLI for common sandbox operations."
-description-agent: "Explains when to use `$$nemoclaw` versus `openshell` for NemoClaw-managed sandboxes, including lifecycle, inference, policy, monitoring, file transfer, and gateway operations. Use when user asks to decide whether to use `$$nemoclaw` or `openshell`."
-keywords: ["nemoclaw vs openshell", "which cli", "nemoclaw cli", "openshell cli", "sandbox commands"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "NemoClaw CLI Commands Reference"
-sidebar-title: "Commands"
 description: "Full CLI reference for standalone NemoClaw commands and agent-specific in-sandbox commands."
-description-agent: "Includes the full CLI reference for standalone NemoClaw commands and agent-specific in-sandbox commands. Use when looking up a specific `$$nemoclaw`, `nemohermes`, `nemo-deepagents`, `dcode`, or `/nemoclaw` subcommand, flag, argument, or exit code."
-keywords: ["nemoclaw cli commands", "nemoclaw command reference", "nemo-deepagents commands", "dcode commands"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/reference/enterprise-readiness.mdx
+++ b/docs/reference/enterprise-readiness.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "NemoClaw Enterprise Readiness and Admin Capability Guidance"
-sidebar-title: "Enterprise Readiness"
 description: "A reviewed reference for what NemoClaw supports today, what requires manual or admin handling, what is platform-owned, and what is roadmap-only."
-description-agent: "Classifies NemoClaw enterprise readiness and admin/control-plane capabilities by current support state, with workarounds and tracked issues. Use when answering enterprise evaluation, support-boundary, or admin-capability questions, or when preparing field and customer conversations about what NemoClaw supports today."
-keywords: ["nemoclaw enterprise readiness", "nemoclaw support boundaries", "nemoclaw admin capabilities", "nemoclaw control plane"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/reference/extension-taxonomy-sdk-readiness.mdx
+++ b/docs/reference/extension-taxonomy-sdk-readiness.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Extension Taxonomy and SDK Readiness"
-sidebar-title: "Extension Taxonomy and SDK Readiness"
 description: "Defines NemoClaw extension terminology, stability levels, security boundaries, and measurable readiness gates for any future public SDK."
-description-agent: "Defines lifecycle contribution, managed agent package, and agent-native plugin terminology and the gates for any future NemoClaw extension SDK. Use when classifying extension proposals, choosing CLI or documentation wording, or evaluating SDK readiness."
-keywords: ["nemoclaw extensibility taxonomy", "nemoclaw plugin sdk", "lifecycle contribution", "managed agent package", "agent-native plugin", "sdk readiness"]
-content:
-  type: "reference"
 ---
 
 This decision record defines the terms and readiness bar for NemoClaw extension discussions.

--- a/docs/reference/host-files-and-state.mdx
+++ b/docs/reference/host-files-and-state.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Host Files and State"
-sidebar-title: "Host Files and State"
 description: "Reference for NemoClaw host-side files and directories under ~/.nemoclaw."
-description-agent: "Lists host-side NemoClaw config and state files under ~/.nemoclaw. Use when identifying config.json, sandboxes.json, usage-notice.json, legacy credentials.json, operational state, backup directories, mounts, or local inference adapter files."
-keywords: ["nemoclaw host files", "nemoclaw state directory", "nemoclaw sandboxes json", "nemoclaw usage notice"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Network Policies"
-sidebar-title: "Network Policies"
 description: "Baseline network policy, filesystem rules, and operator approval flow."
-description-agent: "Covers the baseline network policy, filesystem rules, and operator approval flow. Use when looking up a specific default endpoint, filesystem path, or the runtime approval sequence NemoClaw applies on blocked requests."
-keywords: ["nemoclaw network policy", "sandbox egress control operator approval"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/reference/platform-support.mdx
+++ b/docs/reference/platform-support.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Platform Support and Launch Claims"
-sidebar-title: "Platform Support"
 description: "Canonical matrix of supported platforms, inference providers, agents, integrations, and deployment paths for NemoClaw, with explicit status for each row."
-description-agent: "Single source of truth for what NemoClaw supports today. Use when verifying whether a platform, inference provider, agent, messaging integration, or deployment path is validated, partially validated, experimental, or out of scope before relying on it in docs, demos, sales material, or support conversations."
-keywords: ["nemoclaw platform support", "nemoclaw launch claims", "nemoclaw support matrix", "nemoclaw what is supported", "nemoclaw status"]
-content:
-  type: "reference"
 ---
 This page is the canonical reference for what NemoClaw supports today.
 Any documentation, demo, blog post, sales conversation, or support reply that describes a NemoClaw capability should match the entries below.

--- a/docs/reference/troubleshoot-mcp-servers.mdx
+++ b/docs/reference/troubleshoot-mcp-servers.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Troubleshoot MCP Servers"
-sidebar-title: "Troubleshoot MCP Servers"
 description: "Diagnose managed MCP credential resolution, incomplete transactions, capability gaps, policy drift, and lifecycle-lock failures."
-description-agent: "Provides symptom-based remediation for NemoClaw-managed MCP servers. Use when mcp add, status, restart, remove, rebuild, or destroy does not converge."
-keywords: ["troubleshoot nemoclaw mcp", "mcp credential resolution", "mcp policy drift", "mcp transaction"]
-content:
-  type: "troubleshooting"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Troubleshooting"
-sidebar-title: "Troubleshooting"
 description: "Diagnose and resolve common NemoClaw installation, onboarding, and runtime issues."
-description-agent: "Lists fixes for common installation, onboarding, and runtime issues. Use when diagnosing a reported NemoClaw error, a failed onboard, or unexpected sandbox behavior."
-keywords: ["nemoclaw troubleshooting", "nemoclaw debug sandbox issues", "openclaw tool calling", "raw tool call json"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/resources/agent-skills.mdx
+++ b/docs/resources/agent-skills.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Use NemoClaw Docs with Your Coding Agents"
-sidebar-title: "Use Docs with Agents"
 description: "NemoClaw exposes an MCP docs server and Markdown documentation that AI coding agents can use when they help you install, configure, or operate a sandbox."
-description-agent: "Guides users and their AI coding agents to the NemoClaw docs MCP server, canonical Markdown documentation, llms.txt index, and optional docs-routing skill. Use when users ask about AI agent support, Markdown docs, MCP docs server, agent skills, Cursor, Claude Code, Codex, or Copilot."
-keywords: ["nemoclaw ai agent docs", "nemoclaw mcp docs", "nemoclaw markdown docs", "llms.txt", "cursor", "claude code", "copilot"]
-content:
-  type: "how_to"
 ---
 NemoClaw publishes an MCP docs server and Markdown versions of its Fern documentation for AI coding agents.
 Your agent can search or fetch the same canonical pages that appear on the docs site and apply that guidance to your local setup.

--- a/docs/resources/community-contributions.mdx
+++ b/docs/resources/community-contributions.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Contribute Community Solutions"
-sidebar-title: "Community Solutions"
 description: "Choose whether a solution belongs in the canonical NemoClaw repository or the NVIDIA NemoClaw Community repository."
-description-agent: "Routes third-party solutions, custom integrations, recipes, custom images, and end-to-end examples to NemoClaw Community unless maintainers approved them as a supported NemoClaw product surface. Use when submitting or reviewing a contribution that may create product scope."
-keywords: ["nemoclaw community contributions", "nemoclaw third-party integrations", "nemoclaw examples", "nemoclaw product scope"]
-content:
-  type: "concept"
 ---
 
 NemoClaw's canonical documentation describes behavior that the project has chosen to support and maintain.

--- a/docs/resources/license.mdx
+++ b/docs/resources/license.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "License"
-sidebar-title: "License"
 description: "Apache 2.0 license for the NemoClaw project."
-description-agent: "Includes the Apache 2.0 license that covers the NemoClaw project."
-keywords: ["nemoclaw license", "nemoclaw apache 2.0"]
-content:
-  type: "reference"
 ---
 NemoClaw is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "NemoClaw Security Controls, Risks, and Posture Profiles"
-sidebar-title: "Security Best Practices"
 description: "A risk framework for every configurable security control in NemoClaw: defaults, what you can change, and what happens if you do."
-description-agent: "Presents a risk framework for every configurable security control in NemoClaw. Use when evaluating security posture, reviewing sandbox security defaults, or assessing control trade-offs."
-keywords: ["nemoclaw security best practices", "sandbox security controls risk framework"]
-content:
-  type: "concept"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/security/configure-corporate-ca-trust.mdx
+++ b/docs/security/configure-corporate-ca-trust.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Configure Corporate Certificate Authority Trust"
-sidebar-title: "Configure Corporate CA Trust"
 description: "Import a bounded corporate proxy CA chain into NemoClaw sandbox runtime trust and supported build-time flows."
-description-agent: "Configures corporate proxy CA trust for runtime TLS and supported build-time operations. Use when a corporate MITM proxy re-signs external TLS or certificate verification fails behind an enterprise proxy."
-keywords: ["nemoclaw corporate ca", "corporate proxy tls", "certificate verification"]
-content:
-  type: "how_to"
 ---
 
 Configure a corporate Certificate Authority (CA) before onboarding when an enterprise proxy re-signs external TLS with a root that OpenShell does not provide.

--- a/docs/security/credential-rotation.mdx
+++ b/docs/security/credential-rotation.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Credential Rotation"
-sidebar-title: "Credential Rotation"
 description: "Rotate inference, messaging, and web search credentials through the supported NemoClaw workflows."
-description-agent: "Step-by-step guide for rotating inference API keys, messaging tokens, and web search credentials in NemoClaw. Use when a key expires, is compromised, or must be replaced."
-keywords: ["nemoclaw credential rotation", "rotate api key", "update inference key", "messaging token", "nemoclaw credentials reset"]
-content:
-  type: "how_to"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/security/credential-storage.mdx
+++ b/docs/security/credential-storage.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Credential Storage"
-sidebar-title: "Credential Storage"
 description: "Learn where NemoClaw stores credentials, what protections it applies, and how to inspect or rotate stored secrets."
-description-agent: "Covers where NemoClaw stores provider credentials, why nothing is persisted to host disk, and how the OpenShell gateway acts as the single system of record. Use when reviewing how credentials are handled, locating a stored credential, or assessing the storage threat model."
-keywords: ["nemoclaw credential storage", "openshell provider", "api key security"]
-content:
-  type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/docs/security/openclaw-controls.mdx
+++ b/docs/security/openclaw-controls.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "OpenClaw Security Controls Beyond NemoClaw's Scope"
-sidebar-title: "OpenClaw Controls"
 description: "Documents application-layer security controls that OpenClaw provides independently, where NemoClaw adds no additional protection."
-description-agent: "Lists OpenClaw security controls that operate independently of NemoClaw, including prompt injection detection, tool access control, rate limiting, environment variable policy, audit framework, supply chain scanning, messaging access policy, context visibility, and safe regex. Use when reviewing the security boundary between NemoClaw and OpenClaw or assessing what NemoClaw does not cover."
-keywords: ["openclaw security controls", "nemoclaw security boundary", "prompt injection", "tool access control"]
-content:
-  type: "concept"
 ---
 NemoClaw provides infrastructure-layer security through sandbox isolation, network policy, filesystem restrictions, SSRF validation, and credential handling.
 It delegates all application-layer security to OpenClaw.

--- a/docs/security/openshell-0.0.71-gateway-auth-review.mdx
+++ b/docs/security/openshell-0.0.71-gateway-auth-review.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "OpenShell 0.0.71 Gateway Authentication Review"
-sidebar-title: "OpenShell 0.0.71 Review"
 description: "Reviews the OpenShell 0.0.71 gateway authentication boundary, compatibility behavior, and supporting validation in NemoClaw."
-description-agent: >-
-  Reviews the OpenShell 0.0.71 gateway authentication boundary and evidence.
-  Use when evaluating gateway mTLS, sandbox JWTs, compatibility behavior, or recovery controls.
-keywords: ["OpenShell 0.0.71", "gateway authentication", "mTLS", "sandbox JWT"]
-content:
-  type: "reference"
 ---
 
 Review date: 2026-06-26

--- a/docs/security/openshell-0.0.72-compatibility-review.mdx
+++ b/docs/security/openshell-0.0.72-compatibility-review.mdx
@@ -2,12 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "OpenShell 0.0.72 Compatibility Review"
-sidebar-title: "OpenShell 0.0.72 Review"
 description: "Review the OpenShell 0.0.72 release identity, gateway authentication boundary, policy round-trip behavior, and MCP and JSON-RPC compatibility."
-description-agent: "Documents NemoClaw's OpenShell 0.0.72 compatibility boundary, including gateway authentication, provider-composed policy handling, and MCP and JSON-RPC enforcement. Use when validating the OpenShell 0.0.72 dependency pin, reviewing `policy get --base` behavior, or assessing the gateway and network-policy security contract."
-keywords: ["openshell 0.0.72 compatibility", "nemoclaw policy round trip", "mcp json-rpc policy", "openshell gateway authentication"]
-content:
-  type: "reference"
 ---
 
 This review covers NemoClaw's stable OpenShell `0.0.72` pin, Docker-driver gateway authentication, policy mutation, and MCP and JSON-RPC policy compatibility.

--- a/docs/security/tcb-boundary.mdx
+++ b/docs/security/tcb-boundary.mdx
@@ -2,14 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Trusted Computing Base for Gateway Lifecycle Control"
-sidebar-title: "Trusted Computing Base"
 description: "Defines the trusted computing base, privilege boundaries, and review invariants for NemoClaw gateway lifecycle and shields operations."
-description-agent: >-
-  Maps NemoClaw gateway lifecycle and shields components to their trust boundaries, threats, privilege levels, and verification requirements.
-  Use when reviewing privileged gateway restart, config mutation, or shields changes.
-keywords: ["nemoclaw trusted computing base", "gateway lifecycle security", "shields trust boundary"]
-content:
-  type: "reference"
 ---
 
 NemoClaw uses a small set of host and sandbox components to restart built-in gateways and change shields posture without granting lifecycle authority to the sandbox agent.

--- a/scripts/sync-agent-variant-docs.mts
+++ b/scripts/sync-agent-variant-docs.mts
@@ -76,14 +76,6 @@ function replaceFrontmatterLine(frontmatter: string, key: string, value: string)
   return frontmatter.replace(pattern, `${key}: ${value}`);
 }
 
-function upsertFrontmatterLine(frontmatter: string, key: string, value: string): string {
-  const pattern = new RegExp(`^${escapeRegExp(key)}:.*$`, "m");
-  if (pattern.test(frontmatter)) {
-    return frontmatter.replace(pattern, `${key}: ${value}`);
-  }
-  return frontmatter.replace(/\n---\n$/, `\n${key}: ${value}\n---\n`);
-}
-
 function stripAgentOnlyBlocksForVariant(body: string, activeVariant: AgentVariant): string {
   type OpenBlock = {
     include: boolean;
@@ -189,16 +181,6 @@ function updateCommandsFrontmatter(frontmatter: string, variant: AgentVariant): 
       "description",
       '"Full CLI reference for standalone NemoHermes commands and Hermes-specific in-sandbox commands."',
     );
-    next = replaceFrontmatterLine(
-      next,
-      "description-agent",
-      '"Includes the full CLI reference for standalone NemoHermes commands and Hermes-specific in-sandbox commands. Use when looking up a specific `nemohermes` subcommand, flag, argument, or exit code."',
-    );
-    next = replaceFrontmatterLine(
-      next,
-      "keywords",
-      '["nemohermes cli commands", "hermes command reference", "nemohermes command reference"]',
-    );
   } else {
     next = replaceFrontmatterLine(next, "title", '"NemoDeepAgents CLI Commands Reference"');
     next = replaceFrontmatterLine(
@@ -206,19 +188,7 @@ function updateCommandsFrontmatter(frontmatter: string, variant: AgentVariant): 
       "description",
       '"Full CLI reference for standalone NemoDeepAgents commands and Deep Agents-specific in-sandbox commands."',
     );
-    next = replaceFrontmatterLine(
-      next,
-      "description-agent",
-      '"Includes the full CLI reference for standalone NemoDeepAgents commands and Deep Agents-specific in-sandbox commands. Use when looking up a specific `nemo-deepagents` subcommand, flag, argument, or exit code."',
-    );
-    next = replaceFrontmatterLine(
-      next,
-      "keywords",
-      '["nemo-deepagents cli commands", "deep agents command reference", "nemo-deepagents command reference"]',
-    );
   }
-  next = replaceFrontmatterLine(next, "sidebar-title", '"Commands"');
-  next = upsertFrontmatterLine(next, "exclude-from-skills-gen", "true");
   return next.replaceAll("`nemoclaw`", `\`${cli}\``);
 }
 

--- a/test/agent-variant-docs.test.ts
+++ b/test/agent-variant-docs.test.ts
@@ -9,7 +9,7 @@ import { renderAgentVariantPage } from "../scripts/sync-agent-variant-docs.mts";
 
 const source = `---
 title: "Example"
-description-agent: "Use when looking up $$nemoclaw commands."
+description: "Use when looking up $$nemoclaw commands."
 ---
 import { AgentCli, AgentOnly } from "../_components/AgentGuide";
 
@@ -39,7 +39,7 @@ describe("agent variant docs", () => {
 
     expect(rendered).toContain("OpenClaw only.");
     expect(rendered).toContain("Gateway agents only.");
-    expect(rendered).toContain('description-agent: "Use when looking up nemoclaw commands."');
+    expect(rendered).toContain('description: "Use when looking up nemoclaw commands."');
     expect(rendered).not.toContain("Hermes only.");
     expect(rendered).not.toContain("Deep Agents only.");
     expect(rendered).toContain("nemoclaw list");
@@ -54,7 +54,7 @@ describe("agent variant docs", () => {
     expect(rendered).toContain("Hermes only.");
     expect(rendered).toContain("Gateway agents only.");
     expect(rendered).not.toContain("Deep Agents only.");
-    expect(rendered).toContain('description-agent: "Use when looking up nemohermes commands."');
+    expect(rendered).toContain('description: "Use when looking up nemohermes commands."');
     expect(rendered).toContain("nemohermes list");
     expect(rendered).not.toContain("$$nemoclaw");
     expect(rendered).not.toContain("<AgentOnly");
@@ -67,9 +67,7 @@ describe("agent variant docs", () => {
     expect(rendered).not.toContain("Hermes only.");
     expect(rendered).toContain("Deep Agents only.");
     expect(rendered).not.toContain("Gateway agents only.");
-    expect(rendered).toContain(
-      'description-agent: "Use when looking up nemo-deepagents commands."',
-    );
+    expect(rendered).toContain('description: "Use when looking up nemo-deepagents commands."');
     expect(rendered).toContain("nemo-deepagents list");
     expect(rendered).not.toContain("$$nemoclaw");
     expect(rendered).not.toContain("<AgentOnly");

--- a/test/check-docs-published-routes.test.ts
+++ b/test/check-docs-published-routes.test.ts
@@ -85,10 +85,7 @@ function withChangelogSource(source: string, run: (docsDir: string) => void): vo
 function commandsSource(body: string): string {
   return `---
 title: "Commands"
-sidebar-title: "Commands"
 description: "Commands."
-description-agent: "Commands."
-keywords: ["commands"]
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 

--- a/test/sync-agent-variant-docs.test.ts
+++ b/test/sync-agent-variant-docs.test.ts
@@ -10,12 +10,7 @@ const FRONTMATTER = `---
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "NemoClaw CLI Commands Reference"
-sidebar-title: "Commands"
 description: "Full CLI reference for standalone NemoClaw commands and agent-specific in-sandbox commands."
-description-agent: "Includes the full CLI reference for standalone NemoClaw commands and agent-specific in-sandbox commands. Use when looking up a specific \`nemoclaw\`, \`nemohermes\`, \`nemo-deepagents\`, \`dcode\`, or \`/nemoclaw\` subcommand, flag, argument, or exit code."
-keywords: ["nemoclaw cli commands", "nemoclaw command reference", "nemo-deepagents commands", "dcode commands"]
-content:
-  type: "reference"
 ---
 `;
 
@@ -51,7 +46,10 @@ The gateway state path is \`~/.local/state/nemoclaw\`.
 `);
 
     expect(rendered).toContain("### `nemohermes list`");
-    expect(rendered).toContain("exclude-from-skills-gen: true");
+    expect(rendered).toContain('title: "NemoHermes CLI Commands Reference"');
+    expect(rendered).toContain(
+      'description: "Full CLI reference for standalone NemoHermes commands and Hermes-specific in-sandbox commands."',
+    );
     expect(rendered).toContain("nemohermes list");
     expect(rendered).toContain("NEMOCLAW_PROVIDER=routed nemohermes onboard --non-interactive");
     expect(rendered).toContain("URL=$(nemohermes my-assistant dashboard-url --quiet)");
@@ -83,7 +81,10 @@ The gateway state path is \`~/.local/state/nemoclaw\`.
 `);
 
     expect(rendered).toContain("### `nemo-deepagents list`");
-    expect(rendered).toContain("exclude-from-skills-gen: true");
+    expect(rendered).toContain('title: "NemoDeepAgents CLI Commands Reference"');
+    expect(rendered).toContain(
+      'description: "Full CLI reference for standalone NemoDeepAgents commands and Deep Agents-specific in-sandbox commands."',
+    );
     expect(rendered).toContain("nemo-deepagents list");
     expect(rendered).toContain(
       "NEMOCLAW_AGENT=langchain-deepagents-code nemo-deepagents onboard --non-interactive",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Simplify NemoClaw documentation frontmatter so tracked and generated pages retain only `title` and `description`. This removes unused metadata while preserving every existing title, description, and page body.

## Changes

- Remove `description-agent`, `sidebar-title`, `keywords`, `content`, `skill`, and other unused frontmatter fields from 97 MDX pages.
- Update the documentation authoring guidance and frontmatter template to require only `title` and `description`.
- Stop the agent-variant generator from injecting removed metadata and update its focused tests.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/agent-variant-docs.test.ts test/sync-agent-variant-docs.test.ts test/check-docs-published-routes.test.ts` (3 files, 33 tests passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this focused docs generator change
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — build passed with 0 errors; Fern reports the existing light-mode accent contrast warning
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>
