### PR TITLE
fix(installer): accept current Station resume receipts

### DIFF
--- a/src/lib/onboard/station-express-resume.test.ts
+++ b/src/lib/onboard/station-express-resume.test.ts
@@ -52,6 +52,13 @@ function receiptText(generation = receiptGeneration, model = "nemotron-3-ultra-5
   return `revision=${receiptRevision}\nmodel=${model}\ngeneration=${generation}\n`;
 }
 
+function currentReceiptText(
+  overrides: Partial<{ agent: string; sandbox: string; policyTier: string }> = {},
+): string {
+  const { agent = "hermes", sandbox = "my-assistant", policyTier = "balanced" } = overrides;
+  return `${receiptText().trimEnd()}\nagent=${agent}\nsandbox=${sandbox}\npolicy_tier=${policyTier}\n`;
+}
+
 function retirementClaims(home: string): string[] {
   const stateDir = path.join(home, ".nemoclaw");
   return fs
@@ -615,6 +622,45 @@ describe("DGX Station Express resume (#7048)", () => {
 
       retireStationExpressInstallerResume(receiptGeneration, { env: { HOME: home } });
       expect(fs.existsSync(receipt)).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts and retires the current installer receipt with complete express intent", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-current-receipt-"));
+    const stateDir = path.join(home, ".nemoclaw");
+    const receipt = path.join(stateDir, "station-express-resume");
+    fs.mkdirSync(stateDir, { mode: 0o700 });
+    fs.writeFileSync(receipt, currentReceiptText(), { mode: 0o600 });
+
+    try {
+      expect(() =>
+        assertStationExpressInstallerResumeMatches(receiptGeneration, { HOME: home }),
+      ).not.toThrow();
+      retireStationExpressInstallerResume(receiptGeneration, { env: { HOME: home } });
+      expect(fs.existsSync(receipt)).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["agent", { agent: "unknown-agent" }],
+    ["sandbox", { sandbox: "Invalid Sandbox" }],
+    ["policy tier", { policyTier: "unrestricted" }],
+  ])("rejects a current installer receipt with an invalid %s", (_field, overrides) => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-current-invalid-"));
+    const stateDir = path.join(home, ".nemoclaw");
+    const receipt = path.join(stateDir, "station-express-resume");
+    fs.mkdirSync(stateDir, { mode: 0o700 });
+    fs.writeFileSync(receipt, currentReceiptText(overrides), { mode: 0o600 });
+
+    try {
+      expect(() =>
+        assertStationExpressInstallerResumeMatches(receiptGeneration, { HOME: home }),
+      ).toThrow("installer resume state is malformed");
+      expect(fs.readFileSync(receipt, "utf8")).toBe(currentReceiptText(overrides));
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/src/lib/onboard/station-express-resume.ts
+++ b/src/lib/onboard/station-express-resume.ts
@@ -82,6 +82,8 @@ const STATION_EXPRESS_RETIREMENT_CLAIM_ATTEMPTS = 3;
 const STATION_EXPRESS_RECEIPT_GENERATION_PATTERN = /^[0-9a-f]{32}$/;
 const STATION_EXPRESS_RECEIPT_REVISION_PATTERN = /^[0-9a-f]{40}$/;
 const STATION_EXPRESS_RETIREMENT_CLAIM_SUFFIX_PATTERN = /^[A-Za-z0-9]+$/;
+const STATION_EXPRESS_RECEIPT_AGENTS = new Set(["openclaw", "hermes", "langchain-deepagents-code"]);
+const STATION_EXPRESS_RECEIPT_POLICY_TIERS = new Set(["restricted", "balanced", "open"]);
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -243,7 +245,17 @@ export function assertStationExpressInstallerResumeSafe(
 
 function readStationExpressInstallerResumeGeneration(stateFile: string): string {
   const lines = fs.readFileSync(stateFile, "utf8").split("\n");
-  if (lines.length !== 4 || lines[3] !== "") {
+  const legacyFormat = lines.length === 4 && lines[3] === "";
+  const currentFormat =
+    lines.length === 7 &&
+    lines[6] === "" &&
+    lines[3]?.startsWith("agent=") &&
+    STATION_EXPRESS_RECEIPT_AGENTS.has(lines[3].slice("agent=".length)) &&
+    lines[4]?.startsWith("sandbox=") &&
+    validSandboxName(lines[4].slice("sandbox=".length)) &&
+    lines[5]?.startsWith("policy_tier=") &&
+    STATION_EXPRESS_RECEIPT_POLICY_TIERS.has(lines[5].slice("policy_tier=".length));
+  if (!legacyFormat && !currentFormat) {
     throw new Error("DGX Station Express installer resume state is malformed.");
   }
   const revision = lines[0]?.startsWith("revision=") ? lines[0].slice("revision=".length) : "";

--- a/test/install-station-host-preparation.test.ts
+++ b/test/install-station-host-preparation.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  assertStationExpressInstallerResumeMatches,
   clearStationExpressInstallerResume,
   withStationExpressResumeEnvironment,
 } from "../src/lib/onboard/station-express-resume";
@@ -1115,6 +1116,9 @@ ensure_station_express_host
         "agent=openclaw\nsandbox=my-assistant\npolicy_tier=balanced\n",
     );
     expect(fs.statSync(stateFile).mode & 0o777).toBe(0o600);
+    expect(() =>
+      assertStationExpressInstallerResumeMatches(STATION_GENERATION, { HOME: home }),
+    ).not.toThrow();
     expect(output).toContain(`NEMOCLAW_INSTALL_TAG=${STATION_REVISION}`);
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Station Express host preparation writes a six-field resume receipt, but onboarding accepted only the legacy three-field format. This caused a physical Station E2E on merged `main` to exit during final receipt retirement; the parser now accepts and validates both formats.

## Changes

- Accept the current installer receipt fields for agent, sandbox, and policy tier while preserving legacy receipt compatibility.
- Keep receipt parsing fail-closed by validating every current field and rejecting unknown agents, invalid sandbox names, invalid policy tiers, extra lines, and malformed core fields.
- Add a cross-contract regression that writes the receipt through the shell installer and validates it through the TypeScript retirement boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the documented Station resume flow and changes only validation of the private installer receipt; the documentation review found no inaccurate user-facing guidance.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: local fail-closed review confirmed that both accepted formats validate revision, model, and generation; the current format additionally validates agent, sandbox, and policy tier, with negative regression coverage.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/station-express-resume.test.ts` (43 passed); `npx vitest run --project installer-integration test/install-station-host-preparation.test.ts` (55 passed); `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for resuming Station Express installation from the current receipt format, including agent, sandbox, and policy tier details.
  - Continued support for legacy installer resume receipts.

- **Bug Fixes**
  - Improved validation of installer resume data, rejecting unsupported or malformed values while preserving the receipt for troubleshooting.

- **Tests**
  - Added coverage for accepting and retiring valid receipts, rejecting invalid receipts, and validating resume state after a required reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->