### PR TITLE
fix(onboard): align policy defaults with web search

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3837,12 +3837,12 @@ async function selectPolicyTier(): Promise<string> {
 async function selectTierPresetsAndAccess(
   tierName: string,
   allPresets: Array<{ name: string; description?: string }>,
-  extraSelected: string[] = [],
+  initialSelected?: string[],
 ): Promise<Array<{ name: string; access: string }>> {
   return getPolicySelectionPromptHelpers().selectTierPresetsAndAccess(
     tierName,
     allPresets,
-    extraSelected,
+    initialSelected,
   );
 }
 

--- a/src/lib/onboard/policy-selection-prompts.test.ts
+++ b/src/lib/onboard/policy-selection-prompts.test.ts
@@ -180,6 +180,19 @@ describe("createPolicySelectionPromptHelpers", () => {
     expect(stdin.listenerCount("data")).toBe(0);
   });
 
+  it("selectTierPresetsAndAccess honors an exact initial selection", async () => {
+    const { helpers, stdin } = createHarness();
+    const result = helpers.selectTierPresetsAndAccess(
+      "balanced",
+      [{ name: "npm" }, { name: "pypi" }, { name: "github" }],
+      ["npm"],
+    );
+
+    stdin.emit("data", "\r");
+
+    await expect(result).resolves.toEqual([{ name: "npm", access: "read" }]);
+  });
+
   it("selectPolicyTier marks rollback and restores raw mode on SIGTERM", () => {
     const { helpers, markCancelled, processEvents, stdin } = createHarness();
 

--- a/src/lib/onboard/policy-selection-prompts.ts
+++ b/src/lib/onboard/policy-selection-prompts.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SandboxCancelRollback } from "./cancel-rollback";
 import type { TierDefinition } from "../policy/tiers";
+import type { SandboxCancelRollback } from "./cancel-rollback";
 
 type PresetWithDescription = { name: string; description?: string };
 type PresetWithAccess = { name: string; access: string };
@@ -54,7 +54,7 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
   selectTierPresetsAndAccess(
     tierName: string,
     allPresets: PresetWithDescription[],
-    extraSelected?: string[],
+    initialSelected?: string[],
   ): Promise<PresetWithAccess[]>;
   presetsCheckboxSelector(
     allPresets: Array<{ name: string; description: string }>,
@@ -207,12 +207,13 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
    * per-preset access (read vs read-write).
    *
    * Tier presets are listed first (in tier order), then remaining presets
-   * alphabetically. Tier presets are pre-checked; others start unchecked.
+   * alphabetically. Callers can supply the exact initial checked set after
+   * filtering tier defaults for the selected agent and integrations.
    */
   async function selectTierPresetsAndAccess(
     tierName: string,
     allPresets: PresetWithDescription[],
-    extraSelected: string[] = [],
+    initialSelected?: string[],
   ): Promise<PresetWithAccess[]> {
     const tierDef = tiers.getTier(tierName);
     const tierPresetMap: Record<string, string> = {};
@@ -232,11 +233,14 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
       ...allPresets.filter((preset) => !tierSet.has(preset.name)),
     ];
 
-    // Initial inclusion: tier presets + any already-applied extras.
-    const included = new Set([
-      ...tierNames,
-      ...extraSelected.filter((name) => ordered.find((preset) => preset.name === name)),
-    ]);
+    // When the caller has already reconciled tier defaults with the selected
+    // agent and integrations, preserve that exact initial choice. Direct
+    // callers that omit it retain the tier defaults.
+    const included = new Set(
+      (initialSelected ?? tierNames).filter((name) =>
+        ordered.some((preset) => preset.name === name),
+      ),
+    );
 
     // Access levels: tier defaults for tier presets, read-write default for others.
     const accessModes: Record<string, string> = {};

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -108,7 +108,7 @@ export type SetupPolicySelectionDeps = {
   selectTierPresetsAndAccess: (
     tierName: string,
     presets: Preset[],
-    extraSelected: string[],
+    initialSelected: string[],
   ) => Promise<Array<Preset & { access: string }>>;
   parsePolicyPresetEnv: (raw: string) => string[];
   env?: NodeJS.ProcessEnv;

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -460,14 +460,14 @@ async function setupPoliciesWithSelectionInner(
   }
 
   const knownNames = new Set(allPresets.map((preset) => preset.name));
-  const extraSelected = [
+  const initialSelected = [
     ...appliedForPreservation.filter((name) => knownNames.has(name)),
     ...suggestions.filter((name) => knownNames.has(name) && !applied.includes(name)),
   ];
   const resolvedPresets = await deps.selectTierPresetsAndAccess(
     tierName,
     allPresets,
-    extraSelected,
+    initialSelected,
   );
   const interactiveChoice = pruneUnavailablePresets(
     mergeRequiredSetupPolicyPresets(

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -163,9 +163,13 @@ function createSetupHarness({
       tierUpdates.push({ sandboxName, policyTier });
     },
     getRecordedPolicyTier: () => recordedPolicyTier,
-    selectTierPresetsAndAccess: async (selectedTier, presets, extraSelected) => {
+    selectTierPresetsAndAccess: async (selectedTier, presets, initialSelected) => {
       const promptHarness = createPromptHarness();
-      return promptHarness.helpers.selectTierPresetsAndAccess(selectedTier, presets, extraSelected);
+      return promptHarness.helpers.selectTierPresetsAndAccess(
+        selectedTier,
+        presets,
+        initialSelected,
+      );
     },
     parsePolicyPresetEnv,
     env: {

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -95,6 +95,7 @@ type SetupHarnessOptions = {
   customPresets?: TestPreset[];
   customOwnsObservability?: boolean;
   recordedPolicyTier?: string | null;
+  nonInteractive?: boolean;
   env?: NodeJS.ProcessEnv;
 };
 
@@ -106,6 +107,7 @@ function createSetupHarness({
   customPresets = [],
   customOwnsObservability = false,
   recordedPolicyTier = null,
+  nonInteractive = true,
   env = {},
 }: SetupHarnessOptions = {}) {
   const notes: string[] = [];
@@ -142,7 +144,7 @@ function createSetupHarness({
     localInferenceProviders: ["ollama-local", "vllm-local"],
     step: () => undefined,
     note: (message) => notes.push(message),
-    isNonInteractive: () => true,
+    isNonInteractive: () => nonInteractive,
     waitForSandboxReady: () => true,
     syncPresetSelection: (sandboxName, current, selected, accessByName) => {
       syncCalls.push({
@@ -467,6 +469,46 @@ describe("policy tier setup", () => {
     assert.ok(!result.applied.includes("brave"));
     assert.ok(result.removedCalls.includes("brave"));
     assert.ok(!result.appliedCalls.includes("brave"));
+  });
+
+  it.each([
+    ["OpenClaw", "openclaw", "no web search", null, []],
+    [
+      "OpenClaw",
+      "openclaw",
+      "Brave Search",
+      { fetchEnabled: true, provider: "brave" as const },
+      ["brave"],
+    ],
+    [
+      "OpenClaw",
+      "openclaw",
+      "Tavily Search",
+      { fetchEnabled: true, provider: "tavily" as const },
+      ["tavily"],
+    ],
+    ["Hermes", "hermes", "no web search", null, []],
+    [
+      "Hermes",
+      "hermes",
+      "Tavily Search",
+      { fetchEnabled: true, provider: "tavily" as const },
+      ["tavily"],
+    ],
+  ])("preselects only the matching web-search preset for fresh interactive %s onboarding with %s (#7125)", async (_agentLabel, agent, _searchLabel, webSearchConfig, expectedSearchPresets) => {
+    const result = await runPolicySetup(
+      { tierName: "balanced", nonInteractive: false },
+      {
+        agent,
+        webSearchConfig,
+        webSearchSupported: true,
+      },
+    );
+
+    assert.deepEqual(
+      result.applied.filter((name) => name === "brave" || name === "tavily"),
+      expectedSearchPresets,
+    );
   });
 
   it("keeps explicitly requested built-in Brave when web search is supported", async () => {
@@ -797,10 +839,10 @@ describe("policy tier setup", () => {
 describe("selectTierPresetsAndAccess", () => {
   async function resolve(
     tierName: string,
-    extraSelected: string[] = [],
+    initialSelected?: string[],
   ): Promise<Array<{ name: string; access: string }>> {
     const { helpers } = createPromptHarness();
-    return helpers.selectTierPresetsAndAccess(tierName, policy.listPresets(), extraSelected);
+    return helpers.selectTierPresetsAndAccess(tierName, policy.listPresets(), initialSelected);
   }
 
   it("returns tier presets with their default access levels", async () => {
@@ -819,20 +861,19 @@ describe("selectTierPresetsAndAccess", () => {
     assert.deepEqual(await resolve("restricted"), []);
   });
 
-  it("adds a non-tier preset to the initial checked set through extraSelected", async () => {
-    const names = (await resolve("balanced", ["slack"])).map((preset) => preset.name);
-    assert.ok(names.includes("slack"), "slack should be included via extraSelected");
-    assert.ok(names.includes("npm"), "npm (tier default) should still be included");
+  it("uses an explicit initial checked set when provided", async () => {
+    const names = (await resolve("balanced", ["npm", "slack"])).map((preset) => preset.name);
+    assert.deepEqual(names, ["npm", "slack"]);
   });
 
-  it("silently filters an invalid extraSelected preset name", async () => {
+  it("silently filters an invalid initial preset name", async () => {
     const names = (await resolve("balanced", ["nonexistent-preset"])).map((preset) => preset.name);
     assert.ok(!names.includes("nonexistent-preset"), "invalid preset should be dropped");
   });
 
   it("returns tier presets before non-tier presets", async () => {
-    const names = (await resolve("balanced", ["slack"])).map((preset) => preset.name);
     const tierNames = ["npm", "pypi", "huggingface", "brew", "brave"];
+    const names = (await resolve("balanced", [...tierNames, "slack"])).map((preset) => preset.name);
     const lastTierIdx = Math.max(...tierNames.map((name) => names.indexOf(name)));
     const slackIdx = names.indexOf("slack");
     assert.ok(slackIdx > lastTierIdx, "non-tier preset (slack) should appear after tier presets");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fresh interactive onboarding now initializes the policy preset screen from the agent- and web-search-aware suggestions instead of rechecking every policy-tier default. Selecting no web search no longer preselects Brave egress, while Brave and Tavily selections continue to check only their matching preset.

## Related Issue

Fixes #7125

## Changes

- Treat the policy prompt's supplied initial selection as the exact checked set while retaining tier ordering and access defaults.
- Preserve the existing agent support split: OpenClaw supports Brave and Tavily, while Hermes supports Tavily only.
- Add prompt-level and onboarding regression coverage for no-search, Brave, and Tavily selections across OpenClaw and Hermes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing OpenClaw, Hermes, and network-policy docs already describe the agent-specific provider choices and matching policy presets; the documentation review found no mismatch.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Focused nine-category review found no security issues. The change adds no inputs, credentials, dependencies, or policy rules; it narrows unintended default egress while preserving explicit operator selections, with agent/provider regression coverage.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run src/lib/onboard/policy-selection-prompts.test.ts test/policy-tiers-onboard.test.ts test/onboard-policy-suggestions.test.ts` — 3 files and 104 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Will Curran <wcurran@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive policy onboarding now preselects the correct web-search preset(s) based on the selected agent and search configuration.
  * Onboarding can now honor explicitly provided initial preset selections.

* **Bug Fixes**
  * Invalid initial preset names are now safely ignored.
  * Preset ordering and computed access remain consistent when starting from preselected options.

* **Tests**
  * Added coverage for agent-specific search defaults and explicit initial selection behavior (including filtering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->