### PR TITLE
fix(onboard): preserve structured mounts during recreation

### DIFF
--- a/src/lib/onboard/__test-helpers__/docker-gpu-patch-fixtures.ts
+++ b/src/lib/onboard/__test-helpers__/docker-gpu-patch-fixtures.ts
@@ -43,6 +43,18 @@ export function createDockerGpuInspectFixture(): DockerContainerInspect {
     },
     HostConfig: {
       Binds: ["/host:/container:rw"],
+      Mounts: [
+        {
+          Type: "tmpfs",
+          Target: "/tmp/nemoclaw-exact-main-driver-config",
+          ReadOnly: false,
+          TmpfsOptions: {
+            Options: [["noexec"]],
+            SizeBytes: 16_777_216,
+            Mode: 0o1777,
+          },
+        },
+      ],
       NetworkMode: "openshell-docker",
       RestartPolicy: { Name: "unless-stopped" },
       CapAdd: ["SYS_ADMIN", "NET_ADMIN"],

--- a/src/lib/onboard/docker-gpu-patch-clone.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-clone.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./docker-gpu-patch";
 
 describe("Docker GPU clone envelope", () => {
-  it("builds clone args that preserve OpenShell labels and runtime settings", () => {
+  it("builds clone args that preserve OpenShell labels, mounts, and runtime settings", () => {
     const args = buildDockerGpuCloneRunArgs(inspectFixture(), buildDockerGpuMode("gpus"));
 
     expect(args).toEqual(
@@ -32,6 +32,8 @@ describe("Docker GPU clone envelope", () => {
         "openshell.ai/sandbox-name=alpha",
         "--volume",
         "/host:/container:rw",
+        "--tmpfs",
+        "/tmp/nemoclaw-exact-main-driver-config:noexec,size=16777216,mode=1777",
         "--network",
         "openshell-docker",
         "--network-alias",
@@ -54,6 +56,26 @@ describe("Docker GPU clone envelope", () => {
       ]),
     );
     expect(args).not.toEqual(expect.arrayContaining(["--env", "NVIDIA_VISIBLE_DEVICES=void"]));
+  });
+
+  it("preserves OpenShell structured volume options", () => {
+    const inspect = inspectFixture();
+    inspect.HostConfig!.Mounts!.push({
+      Type: "volume",
+      Source: "sandbox-cache",
+      Target: "/sandbox/cache",
+      ReadOnly: true,
+      VolumeOptions: { NoCopy: true, Subpath: "project" },
+    });
+
+    const args = buildDockerGpuCloneRunArgs(inspect, buildDockerGpuMode("startup-command"));
+
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--mount",
+        "type=volume,src=sandbox-cache,dst=/sandbox/cache,readonly,volume-nocopy,volume-subpath=project",
+      ]),
+    );
   });
 
   it("adds OpenShell's sandbox command env when the inspected container lacks one", () => {

--- a/src/lib/onboard/docker-gpu-patch-clone.ts
+++ b/src/lib/onboard/docker-gpu-patch-clone.ts
@@ -16,6 +16,9 @@ const GPU_ENV_KEYS = new Set([
   "NVIDIA_REQUIRE_CUDA",
   "NVIDIA_DISABLE_REQUIRE",
 ]);
+type DockerStructuredMount = NonNullable<
+  NonNullable<DockerContainerInspect["HostConfig"]>["Mounts"]
+>[number];
 
 export const DOCKER_GPU_PATCH_NETWORK_ENV = "NEMOCLAW_DOCKER_GPU_PATCH_NETWORK";
 
@@ -113,6 +116,117 @@ function dockerUlimits(
     merged.set(normalized.name, normalized);
   }
   return [...merged.values()];
+}
+
+function mountValue(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim()) {
+    throw new Error(`Docker structured mount ${label} must be a non-empty trimmed string.`);
+  }
+  if (/[\0,:]/u.test(value)) {
+    throw new Error(`Docker structured mount ${label} contains an unsupported delimiter.`);
+  }
+  return value;
+}
+
+function optionalMountBoolean(value: unknown, label: string): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value !== "boolean") {
+    throw new Error(`Docker structured mount ${label} must be a boolean.`);
+  }
+  return value;
+}
+
+function assertUnusedMountOption(value: unknown, label: string): void {
+  if (value !== undefined && value !== null) {
+    throw new Error(`Docker structured mount has unexpected ${label}.`);
+  }
+}
+
+function dockerTmpfsMountValue(mount: DockerStructuredMount): string {
+  if (String(mount.Source ?? "") !== "") {
+    throw new Error("Docker tmpfs mount must not include a source.");
+  }
+  if (String(mount.Consistency ?? "") !== "") {
+    throw new Error("Docker tmpfs mount consistency is not supported during recreation.");
+  }
+  assertUnusedMountOption(mount.BindOptions, "BindOptions for a tmpfs mount");
+  assertUnusedMountOption(mount.VolumeOptions, "VolumeOptions for a tmpfs mount");
+
+  const target = mountValue(mount.Target, "target");
+  if (!target.startsWith("/")) {
+    throw new Error("Docker structured mount target must be an absolute container path.");
+  }
+  const options: string[] = [];
+  if (optionalMountBoolean(mount.ReadOnly, "ReadOnly")) options.push("ro");
+  for (const parts of mount.TmpfsOptions?.Options ?? []) {
+    if (!Array.isArray(parts) || parts.length < 1 || parts.length > 2) {
+      throw new Error("Docker tmpfs mount options must contain one or two values.");
+    }
+    options.push(parts.map((part) => mountValue(part, "tmpfs option")).join("="));
+  }
+
+  const sizeBytes = mount.TmpfsOptions?.SizeBytes;
+  if (sizeBytes !== undefined && sizeBytes !== null) {
+    if (!Number.isSafeInteger(sizeBytes) || sizeBytes <= 0) {
+      throw new Error("Docker tmpfs mount size must be a positive safe integer.");
+    }
+    options.push(`size=${sizeBytes}`);
+  }
+  const mode = mount.TmpfsOptions?.Mode;
+  if (mode !== undefined && mode !== null) {
+    if (!Number.isSafeInteger(mode) || mode < 0 || mode > 0o7777) {
+      throw new Error("Docker tmpfs mount mode must be a valid non-negative file mode.");
+    }
+    options.push(`mode=${mode.toString(8)}`);
+  }
+  return options.length > 0 ? `${target}:${options.join(",")}` : target;
+}
+
+function dockerVolumeMountValue(mount: DockerStructuredMount): string {
+  if (String(mount.Consistency ?? "") !== "") {
+    throw new Error("Docker volume mount consistency is not supported during recreation.");
+  }
+  assertUnusedMountOption(mount.BindOptions, "BindOptions for a volume mount");
+  assertUnusedMountOption(mount.TmpfsOptions, "TmpfsOptions for a volume mount");
+
+  const source = mountValue(mount.Source, "volume source");
+  const target = mountValue(mount.Target, "target");
+  if (!target.startsWith("/")) {
+    throw new Error("Docker structured mount target must be an absolute container path.");
+  }
+  const values = [`type=volume`, `src=${source}`, `dst=${target}`];
+  if (optionalMountBoolean(mount.ReadOnly, "ReadOnly")) values.push("readonly");
+  const volumeOptions = mount.VolumeOptions;
+  if (optionalMountBoolean(volumeOptions?.NoCopy, "VolumeOptions.NoCopy")) {
+    values.push("volume-nocopy");
+  }
+  if (volumeOptions?.Subpath) {
+    values.push(`volume-subpath=${mountValue(volumeOptions.Subpath, "volume subpath")}`);
+  }
+  if (volumeOptions?.Labels && Object.keys(volumeOptions.Labels).length > 0) {
+    throw new Error("Docker volume mount labels are not supported during recreation.");
+  }
+  assertUnusedMountOption(volumeOptions?.DriverConfig, "VolumeOptions.DriverConfig");
+  return values.join(",");
+}
+
+function dockerStructuredMountArgs(inspect: DockerContainerInspect): string[] {
+  const args: string[] = [];
+  for (const mount of inspect.HostConfig?.Mounts ?? []) {
+    switch (mount.Type) {
+      case "tmpfs":
+        // The --tmpfs form preserves OpenShell's arbitrary TmpfsOptions.Options,
+        // such as noexec, in addition to the structured size and mode fields.
+        args.push("--tmpfs", dockerTmpfsMountValue(mount));
+        break;
+      case "volume":
+        args.push("--mount", dockerVolumeMountValue(mount));
+        break;
+      default:
+        throw new Error(`Unsupported Docker structured mount type '${String(mount.Type)}'.`);
+    }
+  }
+  return args;
 }
 
 function pushNumberFlag(args: string[], flag: string, value: unknown): void {
@@ -235,6 +349,7 @@ export function buildDockerGpuCloneRunArgs(
     if (value !== undefined && value !== null) args.push("--label", `${key}=${value}`);
   }
   for (const bind of stringArray(host.Binds)) args.push("--volume", bind);
+  args.push(...dockerStructuredMountArgs(inspect));
   const networkMode = options.networkMode ?? host.NetworkMode;
   pushStringFlag(args, "--network", networkMode);
   for (const alias of dockerNetworkAliases(inspect, networkMode))

--- a/src/lib/onboard/docker-gpu-patch-types.ts
+++ b/src/lib/onboard/docker-gpu-patch-types.ts
@@ -188,6 +188,25 @@ export type DockerContainerInspect = {
   } | null;
   HostConfig?: {
     Binds?: string[] | null;
+    Mounts?: Array<{
+      Type?: string;
+      Source?: string;
+      Target?: string;
+      ReadOnly?: boolean;
+      Consistency?: string;
+      BindOptions?: unknown;
+      VolumeOptions?: {
+        NoCopy?: boolean;
+        Labels?: Record<string, string> | null;
+        Subpath?: string;
+        DriverConfig?: unknown;
+      } | null;
+      TmpfsOptions?: {
+        SizeBytes?: number;
+        Mode?: number;
+        Options?: string[][] | null;
+      } | null;
+    }> | null;
     NetworkMode?: string;
     RestartPolicy?: { Name?: string; MaximumRetryCount?: number } | null;
     CapAdd?: string[] | null;

--- a/src/lib/onboard/docker-gpu-patch-validation.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-validation.test.ts
@@ -143,6 +143,44 @@ describe("Docker GPU startup command validation (#6110)", () => {
     expect(dockerRunDetached).not.toHaveBeenCalled();
   });
 
+  it("rejects unsupported structured mounts before touching the original container", () => {
+    const inspect = inspectFixture();
+    inspect.HostConfig!.Mounts = [{ Type: "bind", Source: "/host/path", Target: "/sandbox/path" }];
+    const dockerStop = vi.fn(() => ({ status: 0 }));
+    const dockerRename = vi.fn(() => ({ status: 0 }));
+    const dockerRunDetached = vi.fn(() => ({ status: 0, stdout: "new-container-id\n" }));
+
+    expect(() =>
+      recreateOpenShellDockerSandboxWithGpu(
+        {
+          sandboxName: "alpha",
+          timeoutSecs: 1,
+          openshellSandboxCommand: ["env", "nemoclaw-start"],
+        },
+        {
+          dockerCapture: vi.fn((args: readonly string[]) =>
+            args[0] === "ps"
+              ? "old-container-id\n"
+              : args[0] === "inspect"
+                ? JSON.stringify([inspect])
+                : "",
+          ),
+          detectSandboxFallbackDns: vi.fn(() => null),
+          dockerRun: vi.fn(() => ({ status: 0, stdout: "probe-id\n" })),
+          dockerRunDetached,
+          dockerRename,
+          dockerRm: vi.fn(() => ({ status: 0 })),
+          dockerStop,
+          readDir: vi.fn(() => null),
+          readFile: vi.fn(() => null),
+        },
+      ),
+    ).toThrow("Unsupported Docker structured mount type 'bind'");
+    expect(dockerStop).not.toHaveBeenCalled();
+    expect(dockerRename).not.toHaveBeenCalled();
+    expect(dockerRunDetached).not.toHaveBeenCalled();
+  });
+
   it.each([
     ";",
     "&&",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Deep Agents Code startup-command recreation preserved legacy Docker binds but silently dropped OpenShell structured mounts, causing the exact-main MCP bridge proof to lose its tmpfs immediately after onboarding. Preserve the structured mount contract across recreation and reject unsupported inspect shapes before mutating the original container.

## Changes

- Render OpenShell tmpfs mounts with their read-only flag, arbitrary options, byte size, and octal mode when recreating a Docker sandbox.
- Render supported named-volume mounts with their read-only, no-copy, and subpath options; fail closed on unsupported mount types and option shapes.
- Extend the clone inspect fixture with the exact `noexec`, 16 MiB, mode `1777` tmpfs that failed in live E2E, and prove unsupported mounts are rejected before stop, rename, or clone.
- Record the QA escape: the DCode recreation path added in #7128 exercised `HostConfig.Mounts`, while its source tests modeled only `HostConfig.Binds`; the corrected fixture now protects that boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the existing internal Docker-driver recreation contract without changing commands, configuration, defaults, schemas, migrations, or documented behavior; the required documentation review found no inaccurate user-facing guidance.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: fail-closed review confirmed that only the tmpfs and named-volume shapes emitted by supported OpenShell are reconstructed, delimiter-bearing or malformed values are rejected, and unsupported mount types fail before the original container is stopped or renamed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/docker-gpu-patch-clone.test.ts src/lib/onboard/docker-gpu-patch-validation.test.ts` (27 passed); `npx vitest run --project cli src/lib/onboard/docker-gpu-patch-recreate.test.ts` (2 passed); `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker GPU sandbox clones now preserve supported tmpfs and volume mount settings, including read-only, no-copy, subpath, size, and mode options.
  * Unsupported mount types are rejected before modifying the original container.
  * Improved validation prevents invalid structured mount configurations from being recreated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->