### PR TITLE
fix(installer): constrain Station metadata override

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3088,13 +3088,19 @@ fail_force_station_terminal_required() {
 }
 
 validate_force_station_install_override() {
-  local platform="$1"
+  local platform="$1" release_state
   if [ "${FORCE_STATION_INSTALL:-}" != "1" ]; then
     return 0
   fi
   if [ "$platform" != "DGX Station" ]; then
     error "--force-station-install requires DGX Station GB300 hardware (detected: ${platform:-unsupported platform})."
   fi
+  release_state="$(classify_dgx_station_release)"
+  case "$release_state" in
+    generic-ubuntu | supported-dgx-os | supported-colossus-baseos | supported-ai-developer-tools)
+      error "--force-station-install is only for unrecognized DGX Station release metadata. This host is already supported (${release_state}); omit --force-station-install."
+      ;;
+  esac
   if [ "${NEMOCLAW_NO_EXPRESS:-}" = "1" ]; then
     error "--force-station-install cannot be combined with NEMOCLAW_NO_EXPRESS=1. Remove one override."
   fi
@@ -3689,7 +3695,9 @@ maybe_offer_express_install() {
     describe_express_install "$platform"
     printf "  Run express install with these settings? [Y/n]: "
     if ! IFS= read -r reply; then
-      if [ "${STATION_DEEPSEEK:-}" = "1" ]; then
+      if [ "${FORCE_STATION_INSTALL:-}" = "1" ]; then
+        fail_force_station_terminal_required
+      elif [ "${STATION_DEEPSEEK:-}" = "1" ]; then
         fail_station_deepseek_terminal_required
       fi
       info "Skipping express install (unable to read from TTY)."
@@ -3701,7 +3709,9 @@ maybe_offer_express_install() {
     printf "  Run express install with these settings? [Y/n]: "
     if ! IFS= read -r reply <&3; then
       exec 3<&-
-      if [ "${STATION_DEEPSEEK:-}" = "1" ]; then
+      if [ "${FORCE_STATION_INSTALL:-}" = "1" ]; then
+        fail_force_station_terminal_required
+      elif [ "${STATION_DEEPSEEK:-}" = "1" ]; then
         fail_station_deepseek_terminal_required
       fi
       info "Skipping express install (unable to read from TTY)."

--- a/scripts/prepare-dgx-station-host.sh
+++ b/scripts/prepare-dgx-station-host.sh
@@ -631,6 +631,13 @@ check_platform() {
   is_station_gb300_product "$product" || fatal "Expected DGX Station GB300 DMI, found ${product}"
   release_path="$(dgx_station_release_path)"
   release_state="$(dgx_station_release_state "$release_path")"
+  if ((FORCE_STATION_INSTALL == 1)); then
+    case "$release_state" in
+      generic-ubuntu | supported-dgx-os | supported-colossus-baseos | supported-ai-developer-tools)
+        fatal "--force-station-install is only for unrecognized DGX Station release metadata. This host is already supported (${release_state}); omit --force-station-install."
+        ;;
+    esac
+  fi
   case "$release_state" in
     generic-ubuntu)
       station_has_exact_gb300_pci_gpu "$(station_pci_devices_path)" \
@@ -642,6 +649,8 @@ check_platform() {
     supported-ai-developer-tools) STATION_HOST_PROFILE="ai-developer-tools" ;;
     *)
       if ((FORCE_STATION_INSTALL == 1)); then
+        station_has_exact_gb300_pci_gpu "$(station_pci_devices_path)" \
+          || fatal "Expected an NVIDIA GB300 PCI GPU (${GB300_PCI_VENDOR#0x}:${GB300_PCI_DEVICE#0x}) before forced factory-runtime validation"
         STATION_HOST_PROFILE="forced-factory-runtime"
         warn "DGX release metadata allowlist bypassed by explicit --force-station-install intent; all hardware and factory-runtime health checks remain required"
       else

--- a/test/install-express-prompt.test.ts
+++ b/test/install-express-prompt.test.ts
@@ -59,6 +59,7 @@ else:
     script = r'''
 source "$INSTALLER_UNDER_TEST" >/dev/null
 detect_express_platform() { printf "$EXPRESS_PLATFORM"; }
+classify_dgx_station_release() { printf "%s" "\${EXPRESS_RELEASE_STATE:-generic-ubuntu}"; }
 NON_INTERACTIVE="\${NON_INTERACTIVE:-}"
 NEMOCLAW_PROVIDER="\${NEMOCLAW_PROVIDER:-}"
 NEMOCLAW_NO_EXPRESS="\${NEMOCLAW_NO_EXPRESS:-}"
@@ -519,10 +520,24 @@ ensure_station_express_host`,
       name: "a forced Station install in non-interactive mode",
       args: ["--force-station-install", "--non-interactive"],
       platform: "DGX Station",
-      env: {},
+      env: { EXPRESS_RELEASE_STATE: "unsupported-dgx-os" },
       message:
         /--force-station-install selects the DGX Station express prompt and cannot be combined with non-interactive mode \(triggered by: the --non-interactive flag\)/,
     },
+    ...[
+      "generic-ubuntu",
+      "supported-dgx-os",
+      "supported-colossus-baseos",
+      "supported-ai-developer-tools",
+    ].map((releaseState) => ({
+      name: `an unnecessary forced Station install on ${releaseState}`,
+      args: ["--force-station-install"],
+      platform: "DGX Station",
+      env: { EXPRESS_RELEASE_STATE: releaseState },
+      message: new RegExp(
+        `This host is already supported \\(${releaseState}\\); omit --force-station-install`,
+      ),
+    })),
     {
       name: "a Station-only flag on DGX Spark",
       args: ["--station-deepseek"],
@@ -570,6 +585,7 @@ ensure_station_express_host`,
         `
 source "$INSTALLER_UNDER_TEST" >/dev/null
 detect_express_platform() { printf "%s" "$EXPRESS_PLATFORM"; }
+classify_dgx_station_release() { printf "%s" "\${EXPRESS_RELEASE_STATE:-generic-ubuntu}"; }
 ensure_docker() { printf "ensure_docker\\n" >>"$MUTATION_LOG"; }
 ensure_openshell_build_deps() { printf "ensure_openshell_build_deps\\n" >>"$MUTATION_LOG"; }
 main "$@"
@@ -759,6 +775,20 @@ sys.exit(result.returncode)
     expect(result.status, output).not.toBe(0);
     expect(output).toMatch(/--station-deepseek.*needs an interactive terminal/);
     expect(output).not.toMatch(/Using express install/);
+    expect(output).not.toMatch(/RESULT NON_INTERACTIVE=/);
+  });
+
+  it("fails closed if the forced Station prompt becomes unreadable after preflight (#7138)", () => {
+    const result = runExpressPromptWithTty("", "tty", "DGX Station", {
+      EXPRESS_RELEASE_STATE: "unsupported-dgx-os",
+      FORCE_EXPRESS_PROMPT_READ_FAILURE: "1",
+      FORCE_STATION_INSTALL: "1",
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/--force-station-install.*needs an interactive terminal/);
+    expect(output).not.toMatch(/Skipping express install/);
     expect(output).not.toMatch(/RESULT NON_INTERACTIVE=/);
   });
 

--- a/test/install-station-dgx-os.test.ts
+++ b/test/install-station-dgx-os.test.ts
@@ -403,6 +403,7 @@ station_os_release_path() { printf '%s' "$HOME/os-release"; }
 station_product_name_path() { printf '%s' "$HOME/product-name"; }
 dgx_station_release_path() { printf '%s' "$HOME/dgx-release"; }
 dgx_station_release_state() { printf 'unsupported-dgx-os'; }
+station_has_exact_gb300_pci_gpu() { return 0; }
 FORCE_STATION_INSTALL=1
 check_platform
 printf 'PROFILE=%s\n' "$STATION_HOST_PROFILE"
@@ -429,6 +430,57 @@ check_platform
 
     expect(unforced.result.status, unforced.output).not.toBe(0);
     expect(unforced.output).toContain("outside the validated boundary");
+  });
+
+  it.each([
+    "generic-ubuntu",
+    "supported-dgx-os",
+    "supported-colossus-baseos",
+    "supported-ai-developer-tools",
+  ])("rejects explicit metadata intent for recognized %s before preparation (#7138)", (releaseState) => {
+    const { result, output } = runSourced(
+      STATION_PREPARE,
+      `
+printf 'ID=ubuntu\nVERSION_ID="24.04"\nPRETTY_NAME="Ubuntu 24.04"\n' >"$HOME/os-release"
+printf 'NVIDIA DGX Station GB300\n' >"$HOME/product-name"
+uname() { printf 'aarch64\n'; }
+station_os_release_path() { printf '%s' "$HOME/os-release"; }
+station_product_name_path() { printf '%s' "$HOME/product-name"; }
+dgx_station_release_path() { printf '%s' "$HOME/dgx-release"; }
+dgx_station_release_state() { printf '%s' "$RELEASE_STATE"; }
+FORCE_STATION_INSTALL=1
+check_platform
+printf 'PREPARATION_REACHED\n'
+`,
+      { RELEASE_STATE: releaseState },
+    );
+
+    expect(result.status, output).not.toBe(0);
+    expect(output).toContain(
+      `This host is already supported (${releaseState}); omit --force-station-install`,
+    );
+    expect(output).not.toContain("PREPARATION_REACHED");
+  });
+
+  it("keeps generic Ubuntu preparation unchanged without explicit metadata intent (#7138)", () => {
+    const { result, output } = runSourced(
+      STATION_PREPARE,
+      `
+printf 'ID=ubuntu\nVERSION_ID="24.04"\nPRETTY_NAME="Ubuntu 24.04"\n' >"$HOME/os-release"
+printf 'NVIDIA DGX Station GB300\n' >"$HOME/product-name"
+uname() { printf 'aarch64\n'; }
+station_os_release_path() { printf '%s' "$HOME/os-release"; }
+station_product_name_path() { printf '%s' "$HOME/product-name"; }
+dgx_station_release_path() { printf '%s' "$HOME/dgx-release"; }
+dgx_station_release_state() { printf 'generic-ubuntu'; }
+station_has_exact_gb300_pci_gpu() { return 0; }
+check_platform
+printf 'PROFILE=%s\n' "$STATION_HOST_PROFILE"
+`,
+    );
+
+    expect(result.status, output).toBe(0);
+    expect(output).toContain("PROFILE=generic-ubuntu");
   });
 
   it("parses the metadata override only alongside a preparation mode", () => {

--- a/test/install-station-platform-identity.test.ts
+++ b/test/install-station-platform-identity.test.ts
@@ -135,4 +135,50 @@ run_apply
     expect(output).toContain("Expected an NVIDIA GB300 PCI GPU (10de:31c2)");
     expect(output).not.toContain("UNEXPECTED_MUTATION");
   });
+
+  it("rejects forced metadata intent without the exact GB300 PCI identity before mutation (#7138)", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-platform-"));
+    const osReleasePath = path.join(fixtureRoot, "os-release");
+    const productNamePath = path.join(fixtureRoot, "product_name");
+    const dgxReleasePath = path.join(fixtureRoot, "dgx-release");
+    const pciRoot = writePciIdentityFixture("0x1234");
+    fs.writeFileSync(
+      osReleasePath,
+      'ID=ubuntu\nVERSION_ID="24.04"\nPRETTY_NAME="Ubuntu 24.04.4 LTS"\n',
+    );
+    fs.writeFileSync(productNamePath, "DGX Station GB300\n");
+    fs.writeFileSync(dgxReleasePath, 'DGX_PRETTY_NAME="Unrecognized Station"\n');
+
+    const { result, output } = runStationPrepare(
+      `
+station_os_release_path() { printf '%s' "$OS_RELEASE_PATH"; }
+station_product_name_path() { printf '%s' "$PRODUCT_NAME_PATH"; }
+station_pci_devices_path() { printf '%s' "$PCI_ROOT"; }
+dgx_station_release_path() { printf '%s' "$DGX_RELEASE_PATH"; }
+dgx_station_release_state() { printf 'unsupported-dgx-os'; }
+uname() {
+  case "$*" in
+    -m) printf 'aarch64' ;;
+    -r) printf 'test-kernel' ;;
+    *) return 1 ;;
+  esac
+}
+require_command() { :; }
+acquire_sudo() { :; }
+install_packages() { printf 'UNEXPECTED_MUTATION\n'; }
+FORCE_STATION_INSTALL=1
+run_apply
+`,
+      {
+        OS_RELEASE_PATH: osReleasePath,
+        PRODUCT_NAME_PATH: productNamePath,
+        PCI_ROOT: pciRoot,
+        DGX_RELEASE_PATH: dgxReleasePath,
+      },
+    );
+
+    expect(result.status, output).not.toBe(0);
+    expect(output).toContain("Expected an NVIDIA GB300 PCI GPU (10de:31c2)");
+    expect(output).not.toContain("UNEXPECTED_MUTATION");
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restricts `--force-station-install` to DGX Station GB300 systems whose release metadata is actually unrecognized. Recognized profiles now fail before host mutation, while the remaining forced path also verifies the exact GB300 PCI identity and fails closed if its required prompt becomes unreadable.

## Related Issue

Fixes #7138

## Changes

- Reject the force flag during outer installer preflight when release classification is generic Ubuntu, stock DGX OS, Colossus BaseOS, or NVIDIA AI Developer Tools.
- Repeat the recognized-profile guard in the Station preparation helper so direct callers cannot enter package or runtime preparation.
- Require the exact NVIDIA GB300 PCI vendor, device, and display-class identity before selecting the forced factory-runtime profile.
- Fail closed when the forced interactive prompt becomes unreadable instead of silently continuing through another install path.
- Add regression coverage for all recognized release states, unchanged unforced generic Ubuntu behavior, mutation boundaries, exact PCI identity, and prompt-read failure.

The PCI and prompt-read changes close the two unaddressed force-path findings reported by the PR Review Advisor on #7132.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the Station preparation, quickstart, and platform-support pages already document the narrow metadata-only override and mandatory hardware/runtime checks; this fix makes implementation match that contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: accepted scope and fail-before-mutation criteria are recorded in #7138; the exact PCI and prompt-read gaps were independently reported in the final PR Review Advisor review on #7132.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, including shfmt, ShellCheck, repository checks, secret scanning, CLI type-checking, and commitlint
- [x] Targeted behavior tests pass for the current change set — `npx vitest run --project installer-integration test/install-express-prompt.test.ts test/install-station-dgx-os.test.ts` (128 passed, 1 skipped); `npx vitest run --project installer-integration test/install-station-host-preparation.test.ts` (55 passed); `npx vitest run --project integration test/install-station-platform-identity.test.ts` (20 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forced DGX Station installation validation for already-supported host configurations.
  * Added clearer errors when required GPU hardware is missing or does not match.
  * Improved non-interactive installation failures when an interactive terminal is required.
  * Prevented system changes when platform identity checks fail.
* **Tests**
  * Added coverage for supported release profiles, invalid GPU identities, and unreadable installation prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->