### PR TITLE
fix(sandbox): harden managed gateway restart proof

### DIFF
--- a/scripts/managed-gateway-control.py
+++ b/scripts/managed-gateway-control.py
@@ -57,6 +57,8 @@ import stat
 import subprocess
 import sys
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 
@@ -78,8 +80,8 @@ KILL_GRACE_SECONDS = 5.0
 RECOVERY_TIMEOUT_SECONDS = 150.0
 RECOVER_EXISTING_GRACE_SECONDS = 10.0
 POLL_SECONDS = 0.2
-SUPERVISOR_DISCOVERY_ATTEMPTS = 3
-SUPERVISOR_DISCOVERY_RETRY_SECONDS = 0.02
+PROCESS_PROOF_GRACE_SECONDS = 1.0
+PROCESS_PROOF_RETRY_SECONDS = 0.05
 NEMOCLAW_RUNTIME_DIR = "/run/nemoclaw"
 NEMOCLAW_RUNTIME_DIR_MODE = 0o711
 EXPECTED_EXIT_MARKER_NAME = "managed-gateway-expected-exit"
@@ -87,14 +89,42 @@ EXPECTED_EXIT_LOCK_NAME = "managed-gateway-expected-exit.lock"
 NONCE_RE = re.compile(r"[0-9a-f]{64}\Z")
 ENV_KEY_RE = re.compile(rb"[A-Za-z_][A-Za-z0-9_]*\Z")
 SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+CONTROL_STAGES = frozenset(
+    {
+        "detect-agent",
+        "discover-supervisor",
+        "initial-gateway-proof",
+        "preflight",
+        "await-existing-gateway",
+        "publish-expected-exit",
+        "terminate-gateway",
+        "await-replacement",
+        "cleanup-expected-exit",
+    }
+)
 
 
 class ControlError(RuntimeError):
     """A failure whose code is part of the existing host marker contract."""
 
-    def __init__(self, code: str):
+    def __init__(self, code: str, *, stage: str | None = None):
         super().__init__(code)
         self.code = code
+        self.stage = stage
+
+
+@contextmanager
+def _control_stage(stage: str) -> Iterator[None]:
+    """Attach one fixed, non-sensitive lifecycle stage to generic failures."""
+
+    if stage not in CONTROL_STAGES:
+        raise AssertionError(f"unknown managed-control stage: {stage}")
+    try:
+        yield
+    except ControlError as error:
+        if error.code == "SUPERVISOR_UNAVAILABLE" and error.stage is None:
+            raise ControlError(error.code, stage=stage) from error
+        raise
 
 
 @dataclass(frozen=True)
@@ -732,6 +762,39 @@ class ProcReader:
             os.close(pid_fd)
 
 
+def _recapture_exact_identity(
+    reader: ProcReader,
+    expected: ProcessIdentity,
+    *,
+    deadline: float | None = None,
+) -> ProcessIdentity:
+    """Retry only an internally inconsistent read of one already-pinned process."""
+
+    proof_deadline = (
+        time.monotonic() + PROCESS_PROOF_GRACE_SECONDS
+        if deadline is None
+        else deadline
+    )
+    while True:
+        try:
+            current = reader.capture(expected.pid)
+        except (FileNotFoundError, ProcessLookupError, PermissionError) as exc:
+            # A missing or unreadable pinned process is a conclusive loss of the
+            # proof. Only ProcReader's double-read inconsistency is retryable.
+            raise ControlError("SUPERVISOR_UNAVAILABLE") from exc
+        except ControlError as error:
+            if error.code != "SUPERVISOR_UNAVAILABLE":
+                raise
+            remaining = proof_deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(PROCESS_PROOF_RETRY_SECONDS, remaining))
+            continue
+        if current.stable_key() != expected.stable_key():
+            raise ControlError("SUPERVISOR_UNAVAILABLE")
+        return current
+
+
 def _basename(value: bytes) -> bytes:
     return value.rsplit(b"/", 1)[-1]
 
@@ -813,17 +876,16 @@ def _discover_supervisor(reader: ProcReader) -> ProcessIdentity:
         if len(matches) != 1:
             raise ControlError("SUPERVISOR_UNAVAILABLE")
         expected = matches[0].stable_key()
-        for _attempt in range(1, SUPERVISOR_DISCOVERY_ATTEMPTS):
-            time.sleep(SUPERVISOR_DISCOVERY_RETRY_SECONDS)
-            if reader.capture(1).stable_key() != pid1.stable_key():
+        deadline = time.monotonic() + PROCESS_PROOF_GRACE_SECONDS
+        while inconclusive:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
                 raise ControlError("SUPERVISOR_UNAVAILABLE")
+            time.sleep(min(PROCESS_PROOF_RETRY_SECONDS, remaining))
+            _recapture_exact_identity(reader, pid1, deadline=deadline)
             matches, inconclusive = _supervisor_candidates(reader, pid1, sandbox_uid)
             if len(matches) != 1 or matches[0].stable_key() != expected:
                 raise ControlError("SUPERVISOR_UNAVAILABLE")
-            if not inconclusive:
-                break
-        if inconclusive:
-            raise ControlError("SUPERVISOR_UNAVAILABLE")
     if len(matches) == 0:
         # A zero-match scan is the only absence signal that may authorize the
         # host to recreate a legacy Docker container with its managed startup
@@ -846,14 +908,9 @@ def _discover_supervisor(reader: ProcReader) -> ProcessIdentity:
         raise ControlError("SUPERVISOR_UNAVAILABLE")
     if len(matches) != 1:
         raise ControlError("SUPERVISOR_UNAVAILABLE")
-    current_pid1 = reader.capture(1)
-    current_supervisor = reader.capture(matches[0].pid)
-    if (
-        current_pid1.stable_key() != pid1.stable_key()
-        or current_supervisor.stable_key() != matches[0].stable_key()
-    ):
-        raise ControlError("SUPERVISOR_UNAVAILABLE")
-    return current_supervisor
+    deadline = time.monotonic() + PROCESS_PROOF_GRACE_SECONDS
+    _recapture_exact_identity(reader, pid1, deadline=deadline)
+    return _recapture_exact_identity(reader, matches[0], deadline=deadline)
 
 
 def _is_hermes_gateway(identity: ProcessIdentity) -> bool:
@@ -970,9 +1027,7 @@ def _gateway_candidates(
             matches.append(identity)
             if len(matches) > 1:
                 break
-    current_supervisor = reader.capture(supervisor.pid)
-    if current_supervisor.stable_key() != supervisor.stable_key():
-        raise ControlError("SUPERVISOR_UNAVAILABLE")
+    _recapture_exact_identity(reader, supervisor)
     if len(matches) > 1:
         raise ControlError("SUPERVISOR_UNAVAILABLE")
     return matches
@@ -1294,7 +1349,7 @@ def _preflight(
         _openclaw_preflight()
 
 
-def _pidfd_open(pid: int) -> int:
+def _pidfd_open(pid: int) -> int | None:
     opener = getattr(os, "pidfd_open", None)
     sender = getattr(signal, "pidfd_send_signal", None)
     if opener is None or sender is None:
@@ -1302,6 +1357,8 @@ def _pidfd_open(pid: int) -> int:
     try:
         return opener(pid, 0)
     except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return None
         raise ControlError("SUPERVISOR_UNAVAILABLE") from exc
 
 
@@ -1311,29 +1368,41 @@ def _pidfd_exited(pidfd: int, timeout_seconds: float) -> bool:
     return bool(poller.poll(max(0, int(timeout_seconds * 1000))))
 
 
-def _send_pidfd(pidfd: int, signum: signal.Signals) -> None:
+def _send_pidfd(pidfd: int, signum: signal.Signals) -> bool:
     sender = getattr(signal, "pidfd_send_signal", None)
     if sender is None:
         raise ControlError("PRIVILEGED_CONTROL_UNAVAILABLE")
     try:
         sender(pidfd, signum, None, 0)
     except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return False
         raise ControlError("GATEWAY_FAILED") from exc
+    return True
 
 
 def _terminate_gateway(reader: ProcReader, identity: ProcessIdentity) -> None:
     pidfd = _pidfd_open(identity.pid)
+    if pidfd is None:
+        return
     try:
-        current = reader.capture(identity.pid)
-        if current.stable_key() != identity.stable_key():
-            raise ControlError("SUPERVISOR_UNAVAILABLE")
-        _send_pidfd(pidfd, signal.SIGTERM)
+        try:
+            _recapture_exact_identity(reader, identity)
+        except ControlError:
+            # The pidfd is readable only when the exact process opened above has
+            # exited. Accept that race without ever falling back to a PID signal.
+            if _pidfd_exited(pidfd, 0):
+                return
+            raise
+        if not _send_pidfd(pidfd, signal.SIGTERM):
+            return
         if _pidfd_exited(pidfd, STOP_GRACE_SECONDS):
             return
-        current = reader.capture(identity.pid)
-        if current.stable_key() != identity.stable_key():
-            raise ControlError("SUPERVISOR_UNAVAILABLE")
-        _send_pidfd(pidfd, signal.SIGKILL)
+        # The pidfd already pins the proven gateway across exit and PID reuse.
+        # Re-reading /proc here races with the normal live-to-zombie transition
+        # and adds no signal-target safety.
+        if not _send_pidfd(pidfd, signal.SIGKILL):
+            return
         if not _pidfd_exited(pidfd, KILL_GRACE_SECONDS):
             raise ControlError("GATEWAY_FAILED")
     finally:
@@ -1410,14 +1479,18 @@ def _wait_for_recovery_candidate(
 
 
 def _control(action: str, nonce: str) -> tuple[str, int, int]:
-    agent = _detect_agent()
+    with _control_stage("detect-agent"):
+        agent = _detect_agent()
     with ProcReader() as reader:
-        supervisor = _discover_supervisor(reader)
-        spec = _agent_spec(agent, reader, supervisor)
-        candidates = _gateway_candidates(reader, supervisor, spec)
-        old_identity = candidates[0] if candidates else None
+        with _control_stage("discover-supervisor"):
+            supervisor = _discover_supervisor(reader)
+        with _control_stage("initial-gateway-proof"):
+            spec = _agent_spec(agent, reader, supervisor)
+            candidates = _gateway_candidates(reader, supervisor, spec)
+            old_identity = candidates[0] if candidates else None
 
-        _preflight(spec, reader, supervisor)
+        with _control_stage("preflight"):
+            _preflight(spec, reader, supervisor)
 
         if action == "probe":
             if old_identity is None:
@@ -1439,21 +1512,23 @@ def _control(action: str, nonce: str) -> tuple[str, int, int]:
             # grace, give the one successor its own bounded grace before any
             # signal so recovery cannot churn a newly launched replacement.
             original_identity = old_identity
-            existing, old_identity = _wait_for_recovery_candidate(
-                reader,
-                supervisor,
-                spec,
-                original_identity,
-            )
-            if existing is not None:
-                completed = _wait_for_healthy_gateway(
+            with _control_stage("await-existing-gateway"):
+                existing, old_identity = _wait_for_recovery_candidate(
                     reader,
                     supervisor,
                     spec,
-                    None,
-                    RECOVERY_TIMEOUT_SECONDS,
-                    True,
+                    original_identity,
                 )
+            if existing is not None:
+                with _control_stage("await-existing-gateway"):
+                    completed = _wait_for_healthy_gateway(
+                        reader,
+                        supervisor,
+                        spec,
+                        None,
+                        RECOVERY_TIMEOUT_SECONDS,
+                        True,
+                    )
                 return "already-running", original_identity.pid, completed.pid
 
         expected_exit_lease = None
@@ -1464,26 +1539,30 @@ def _control(action: str, nonce: str) -> tuple[str, int, int]:
                 # signal. The marker names this live root controller so a
                 # delayed reap remains authorized without trusting wall time,
                 # while an orphaned marker fails closed as an ordinary crash.
-                controller_identity = _controller_process_identity(reader)
-                expected_exit_lease = _publish_expected_exit_lease(
-                    old_identity,
-                    controller_identity,
-                )
+                with _control_stage("publish-expected-exit"):
+                    controller_identity = _controller_process_identity(reader)
+                    expected_exit_lease = _publish_expected_exit_lease(
+                        old_identity,
+                        controller_identity,
+                    )
             if old_identity is not None:
-                _terminate_gateway(reader, old_identity)
+                with _control_stage("terminate-gateway"):
+                    _terminate_gateway(reader, old_identity)
 
-            replacement = _wait_for_healthy_gateway(
-                reader,
-                supervisor,
-                spec,
-                old_identity,
-                RECOVERY_TIMEOUT_SECONDS,
-                True,
-            )
+            with _control_stage("await-replacement"):
+                replacement = _wait_for_healthy_gateway(
+                    reader,
+                    supervisor,
+                    spec,
+                    old_identity,
+                    RECOVERY_TIMEOUT_SECONDS,
+                    True,
+                )
             return "ok", old_identity.pid if old_identity else 0, replacement.pid
         finally:
             if expected_exit_lease is not None:
-                _clear_expected_exit_lease(expected_exit_lease)
+                with _control_stage("cleanup-expected-exit"):
+                    _clear_expected_exit_lease(expected_exit_lease)
 
 
 def _validate_request(argv: list[str]) -> tuple[str, str]:
@@ -1508,6 +1587,8 @@ def main(argv: list[str]) -> int:
         return 0
     except ControlError as error:
         print(error.code, file=sys.stderr)
+        if error.code == "SUPERVISOR_UNAVAILABLE" and error.stage is not None:
+            print(f"NEMOCLAW_CONTROL_STAGE={error.stage}", file=sys.stderr)
         return 1
     except (OSError, subprocess.SubprocessError):
         print("GATEWAY_FAILED", file=sys.stderr)

--- a/src/lib/actions/sandbox/gateway-restart.test.ts
+++ b/src/lib/actions/sandbox/gateway-restart.test.ts
@@ -19,6 +19,10 @@ describe("gateway restart failure markers", () => {
     > = [
       ["PRIVILEGED_CONTROL_UNAVAILABLE", "privileged control unavailable"],
       ["SUPERVISOR_UNAVAILABLE", "privileged control unavailable"],
+      [
+        "SUPERVISOR_UNAVAILABLE\nNEMOCLAW_CONTROL_STAGE=await-replacement",
+        "privileged control unavailable",
+      ],
       ["SUPERVISOR_NOT_RUNNING", "supervisor not running"],
       ["SUPERVISOR_REBUILD_REQUIRED", "privileged control unavailable"],
       ["SUPERVISOR_BUSY", "privileged control unavailable"],

--- a/test/managed-gateway-control.test.ts
+++ b/test/managed-gateway-control.test.ts
@@ -508,22 +508,24 @@ with tempfile.TemporaryDirectory() as root:
                 raise OSError(control.errno.EPERM, "denied")
             control.os.pidfd_open = pidfd_open_esrch
             control.signal.pidfd_send_signal = pidfd_send_esrch
-            helper_pidfd_open_esrch = real_pidfd_open(expected_gateway.pid)
-            helper_pidfd_send_esrch = real_send(read_fd, control.signal.SIGTERM)
-            control.signal.pidfd_send_signal = pidfd_send_eperm
             try:
-                real_send(read_fd, control.signal.SIGTERM)
-                helper_pidfd_send_eperm = "accepted"
-            except control.ControlError as error:
-                helper_pidfd_send_eperm = error.code
-            if real_os_pidfd_open is None:
-                del control.os.pidfd_open
-            else:
-                control.os.pidfd_open = real_os_pidfd_open
-            if real_signal_pidfd_send is None:
-                del control.signal.pidfd_send_signal
-            else:
-                control.signal.pidfd_send_signal = real_signal_pidfd_send
+                helper_pidfd_open_esrch = real_pidfd_open(expected_gateway.pid)
+                helper_pidfd_send_esrch = real_send(read_fd, control.signal.SIGTERM)
+                control.signal.pidfd_send_signal = pidfd_send_eperm
+                try:
+                    real_send(read_fd, control.signal.SIGTERM)
+                    helper_pidfd_send_eperm = "accepted"
+                except control.ControlError as error:
+                    helper_pidfd_send_eperm = error.code
+            finally:
+                if real_os_pidfd_open is None:
+                    del control.os.pidfd_open
+                else:
+                    control.os.pidfd_open = real_os_pidfd_open
+                if real_signal_pidfd_send is None:
+                    del control.signal.pidfd_send_signal
+                else:
+                    control.signal.pidfd_send_signal = real_signal_pidfd_send
         finally:
             reader.capture = real_capture
             control._pidfd_open = real_pidfd_open

--- a/test/managed-gateway-control.test.ts
+++ b/test/managed-gateway-control.test.ts
@@ -17,6 +17,8 @@ const NONCE = "a".repeat(64);
 
 const PROCESS_HARNESS = String.raw`
 import importlib.util
+import contextlib
+import io
 import json
 import os
 import shutil
@@ -199,7 +201,7 @@ with tempfile.TemporaryDirectory() as root:
         def transient_unrelated_process_churn(reader, pid1, sandbox_uid):
             matches, inconclusive = real_supervisor_candidates(reader, pid1, sandbox_uid)
             transient_scan_calls.append(len(matches))
-            return matches, len(transient_scan_calls) == 1 or inconclusive
+            return matches, len(transient_scan_calls) <= 5 or inconclusive
         control._supervisor_candidates = transient_unrelated_process_churn
         try:
             transient_supervisor = control._discover_supervisor(reader)
@@ -209,6 +211,48 @@ with tempfile.TemporaryDirectory() as root:
             ]
         finally:
             control._supervisor_candidates = real_supervisor_candidates
+
+        persistent_scan_calls = []
+        fake_clock = [0.0]
+        real_monotonic = control.time.monotonic
+        real_sleep = control.time.sleep
+        def persistent_unrelated_process_churn(reader, pid1, sandbox_uid):
+            matches, _inconclusive = real_supervisor_candidates(reader, pid1, sandbox_uid)
+            persistent_scan_calls.append(len(matches))
+            return matches, True
+        control._supervisor_candidates = persistent_unrelated_process_churn
+        control.time.monotonic = lambda: fake_clock[0]
+        control.time.sleep = lambda seconds: fake_clock.__setitem__(0, fake_clock[0] + seconds)
+        try:
+            control._discover_supervisor(reader)
+            persistent_supervisor_churn = ["accepted", len(persistent_scan_calls), fake_clock[0]]
+        except control.ControlError as error:
+            persistent_supervisor_churn = [
+                error.code,
+                len(persistent_scan_calls),
+                round(fake_clock[0], 3),
+            ]
+        finally:
+            control._supervisor_candidates = real_supervisor_candidates
+            control.time.monotonic = real_monotonic
+            control.time.sleep = real_sleep
+
+        transient_recapture_calls = []
+        real_capture = reader.capture
+        def capture_with_transient_supervisor_read(pid):
+            if pid == supervisor.pid:
+                transient_recapture_calls.append(pid)
+                if len(transient_recapture_calls) <= 4:
+                    raise control.ControlError("SUPERVISOR_UNAVAILABLE")
+            return real_capture(pid)
+        reader.capture = capture_with_transient_supervisor_read
+        try:
+            transient_gateway_candidates = [
+                control._gateway_candidates(reader, supervisor, hermes)[0].pid,
+                len(transient_recapture_calls),
+            ]
+        finally:
+            reader.capture = real_capture
 
         real_namespace_inode = control._namespace_inode
         control._namespace_inode = lambda _pid_fd: None
@@ -389,10 +433,24 @@ with tempfile.TemporaryDirectory() as root:
         read_fd, write_fd = os.pipe()
         try:
             control._pidfd_open = lambda _pid: os.dup(read_fd)
-            exit_checks = iter((False, True))
-            control._pidfd_exited = lambda _pidfd, _timeout: next(exit_checks)
-            control._send_pidfd = lambda _pidfd, signum: sent.append(int(signum))
+            exit_checks = [False, True, False]
+            control._pidfd_exited = lambda _pidfd, _timeout: exit_checks.pop(0)
+            def record_signal(_pidfd, signum):
+                sent.append(int(signum))
+                return True
+            control._send_pidfd = record_signal
+            real_capture = reader.capture
+            termination_capture_calls = []
+            def reject_post_signal_recapture(pid):
+                if pid == expected_gateway.pid:
+                    termination_capture_calls.append(pid)
+                    if len(termination_capture_calls) > 1:
+                        raise control.ControlError("SUPERVISOR_UNAVAILABLE")
+                return real_capture(pid)
+            reader.capture = reject_post_signal_recapture
             control._terminate_gateway(reader, expected_gateway)
+            reader.capture = real_capture
+            termination_proof_reads = len(termination_capture_calls)
 
             with open(os.path.join(proc_root, "41", "stat"), "w", encoding="ascii") as stream:
                 fields = ["S", "40"] + (["0"] * 15) + ["1", "0", "999"]
@@ -402,7 +460,72 @@ with tempfile.TemporaryDirectory() as root:
                 reused = "signalled"
             except control.ControlError as error:
                 reused = error.code
+
+            with open(os.path.join(proc_root, "41", "stat"), "w", encoding="ascii") as stream:
+                fields = ["S", "40"] + (["0"] * 15) + ["1", "0", "333"]
+                stream.write(f"41 (managed) {' '.join(fields)}\n")
+
+            control._pidfd_open = lambda _pid: os.dup(read_fd)
+            control._pidfd_exited = lambda _pidfd, _timeout: True
+            def reject_recapture_after_pidfd_open(pid):
+                if pid == expected_gateway.pid:
+                    raise control.ControlError("SUPERVISOR_UNAVAILABLE")
+                return real_capture(pid)
+            reader.capture = reject_recapture_after_pidfd_open
+            try:
+                control._terminate_gateway(reader, expected_gateway)
+                pidfd_recapture_exit = "accepted"
+            finally:
+                reader.capture = real_capture
+
+            control._pidfd_open = lambda _pid: None
+            control._terminate_gateway(reader, expected_gateway)
+            pidfd_open_exit = "accepted"
+
+            control._pidfd_open = lambda _pid: os.dup(read_fd)
+            control._send_pidfd = lambda _pidfd, _signum: False
+            control._terminate_gateway(reader, expected_gateway)
+            pidfd_signal_exit = "accepted"
+
+            timeout_signals = []
+            control._send_pidfd = lambda _pidfd, signum: (
+                timeout_signals.append(int(signum)) or True
+            )
+            control._pidfd_exited = lambda _pidfd, _timeout: False
+            try:
+                control._terminate_gateway(reader, expected_gateway)
+                kill_timeout = "accepted"
+            except control.ControlError as error:
+                kill_timeout = [error.code, timeout_signals]
+
+            real_os_pidfd_open = getattr(control.os, "pidfd_open", None)
+            real_signal_pidfd_send = getattr(control.signal, "pidfd_send_signal", None)
+            def pidfd_open_esrch(_pid, _flags):
+                raise OSError(control.errno.ESRCH, "gone")
+            def pidfd_send_esrch(_pidfd, _signum, _siginfo, _flags):
+                raise OSError(control.errno.ESRCH, "gone")
+            def pidfd_send_eperm(_pidfd, _signum, _siginfo, _flags):
+                raise OSError(control.errno.EPERM, "denied")
+            control.os.pidfd_open = pidfd_open_esrch
+            control.signal.pidfd_send_signal = pidfd_send_esrch
+            helper_pidfd_open_esrch = real_pidfd_open(expected_gateway.pid)
+            helper_pidfd_send_esrch = real_send(read_fd, control.signal.SIGTERM)
+            control.signal.pidfd_send_signal = pidfd_send_eperm
+            try:
+                real_send(read_fd, control.signal.SIGTERM)
+                helper_pidfd_send_eperm = "accepted"
+            except control.ControlError as error:
+                helper_pidfd_send_eperm = error.code
+            if real_os_pidfd_open is None:
+                del control.os.pidfd_open
+            else:
+                control.os.pidfd_open = real_os_pidfd_open
+            if real_signal_pidfd_send is None:
+                del control.signal.pidfd_send_signal
+            else:
+                control.signal.pidfd_send_signal = real_signal_pidfd_send
         finally:
+            reader.capture = real_capture
             control._pidfd_open = real_pidfd_open
             control._pidfd_exited = real_pidfd_exited
             control._send_pidfd = real_send
@@ -752,12 +875,28 @@ with tempfile.TemporaryDirectory() as root:
     installed_proc = control._proc_root()
     installed_system = control._system_root()
 
+    control.__file__ = sys.argv[1]
+    os.environ["NEMOCLAW_MANAGED_CONTROL_ALLOW_NONROOT_TEST"] = "1"
+    real_control = control._control
+    control._control = lambda *_args: (_ for _ in ()).throw(
+        control.ControlError("SUPERVISOR_UNAVAILABLE", stage="await-replacement")
+    )
+    staged_stderr = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(staged_stderr):
+            staged_status = control.main(["restart", "f" * 64])
+    finally:
+        control._control = real_control
+    staged_diagnostic = [staged_status, staged_stderr.getvalue().splitlines()]
+
     print(json.dumps({
         "initial": initial_proof,
         "zombie_leader_with_live_sibling": zombie_leader_with_live_sibling,
         "state_key_behavior": state_key_behavior,
         "mixed_namespace_rejected": mixed_namespace_rejected,
         "transient_supervisor_retry": transient_supervisor_retry,
+        "persistent_supervisor_churn": persistent_supervisor_churn,
+        "transient_gateway_candidates": transient_gateway_candidates,
         "namespace_denied": namespace_denied,
         "preflight": preflight_steps,
         "runtime_validation": runtime_validation,
@@ -768,6 +907,18 @@ with tempfile.TemporaryDirectory() as root:
         "duplicate_supervisor": duplicate_supervisor,
         "duplicate": duplicate,
         "signals": sent,
+        "termination_proof_reads": termination_proof_reads,
+        "pidfd_exit_races": [
+            pidfd_recapture_exit,
+            pidfd_open_exit,
+            pidfd_signal_exit,
+        ],
+        "pidfd_helper_errors": [
+            helper_pidfd_open_esrch,
+            helper_pidfd_send_esrch,
+            helper_pidfd_send_eperm,
+            kill_timeout,
+        ],
         "reused": reused,
         "restarted": restarted,
         "recovered": recovered,
@@ -796,6 +947,7 @@ with tempfile.TemporaryDirectory() as root:
         "source_seams": [source_proc, source_system],
         "disabled_source_seams": [disabled_source_proc, disabled_source_system],
         "installed_seams": [installed_proc, installed_system],
+        "staged_diagnostic": staged_diagnostic,
     }))
 `;
 
@@ -817,7 +969,9 @@ describe("managed gateway root control", () => {
       zombie_leader_with_live_sibling: "SUPERVISOR_UNAVAILABLE",
       state_key_behavior: [true, false],
       mixed_namespace_rejected: true,
-      transient_supervisor_retry: [40, 2],
+      transient_supervisor_retry: [40, 6],
+      persistent_supervisor_churn: ["SUPERVISOR_UNAVAILABLE", expect.any(Number), 1],
+      transient_gateway_candidates: [41, 5],
       namespace_denied: true,
       preflight: [
         {
@@ -843,6 +997,9 @@ describe("managed gateway root control", () => {
       duplicate_supervisor: "SUPERVISOR_UNAVAILABLE",
       duplicate: "SUPERVISOR_UNAVAILABLE",
       signals: [15, 9],
+      termination_proof_reads: 1,
+      pidfd_exit_races: ["accepted", "accepted", "accepted"],
+      pidfd_helper_errors: [null, false, "GATEWAY_FAILED", ["GATEWAY_FAILED", [15, 9]]],
       reused: "SUPERVISOR_UNAVAILABLE",
       restarted: ["ok", 41, 43],
       recovered: ["already-running", 43, 43],
@@ -881,6 +1038,10 @@ describe("managed gateway root control", () => {
       source_seams: ["/attacker/proc", "/attacker/root"],
       disabled_source_seams: ["/proc", "/"],
       installed_seams: ["/proc", "/"],
+      staged_diagnostic: [
+        1,
+        ["SUPERVISOR_UNAVAILABLE", "NEMOCLAW_CONTROL_STAGE=await-replacement"],
+      ],
     });
   });
 

--- a/test/process-recovery.test.ts
+++ b/test/process-recovery.test.ts
@@ -510,6 +510,11 @@ hermes-box  127.0.0.1  18789  12345  running`;
   it.each([
     ["a recovery marker from a failed action", "GATEWAY_PID=4242\n", "dashboard recovery failed"],
     ["an unavailable managed supervisor", "", "SUPERVISOR_UNAVAILABLE"],
+    [
+      "a staged unavailable managed supervisor",
+      "",
+      "SUPERVISOR_UNAVAILABLE\nNEMOCLAW_CONTROL_STAGE=await-replacement",
+    ],
     ["a non-exact self-recovery marker", "", "prefix SUPERVISOR_UNAVAILABLE suffix"],
     ["an extra self-recovery error", "", "SUPERVISOR_UNAVAILABLE\nGATEWAY_FAILED"],
     ["a self-recovery marker on stdout", "SUPERVISOR_UNAVAILABLE", ""],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hardens managed Hermes gateway restarts against short Linux process-lifecycle races observed in E2E. Inconsistent `/proc` reads for an already-proven exact process now receive a bounded grace period, while a pinned pidfd remains the sole signal target across exit and zombie transitions; identity changes and ambiguous process state still fail closed.

## Changes

- Retry only internally inconsistent captures of an already-proven exact PID/start-time/process identity, bounded to one second.
- Keep each retry pinned to the same PID 1 and supervisor identities, rejecting missing, duplicate, unreadable, or changed supervisors immediately.
- Treat pidfd `ESRCH` as an already-exited target and avoid a redundant post-signal `/proc` recapture without ever falling back to PID-based signaling.
- Preserve the existing first-line failure marker and add a fixed, allowlisted lifecycle-stage diagnostic for exact failure localization.
- Add regression coverage for transient and persistent process-table churn, pidfd exit races, PID reuse, signal errors, stage classification, and recovery behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: independent docs-impact review confirmed that the documented gateway-restart contract, security boundary, failure layer, and remediation remain unchanged; this is internal reliability and sanitized diagnostic hardening.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: an independent exact-diff security and correctness review found no blocker across stable process identity, pidfd-only signaling, fail-closed behavior, and diagnostic compatibility. A suggested exit-between-open-and-recapture regression case was added and passes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 115 expanded integration and CLI tests passed, plus the direct exit-between-pidfd-open-and-recapture regression after review.
- [ ] Applicable broad gate passed — focused lifecycle change is covered by the expanded targeted suites; `npm run typecheck:cli` and changed-file repository, format, lint, secret, source-shape, and test-size hooks passed. The optional full local suite was stopped after unrelated sandboxed macOS parallel-test failures across untouched areas; clean-environment PR CI is running.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed gateway recovery when supervisor processes restart, change, or become temporarily unavailable.
  * Strengthened termination checks to avoid acting on stale process identities and better handle process-exit races.
  * Added clearer diagnostics identifying the recovery stage when supervisor control is unavailable.

* **Tests**
  * Expanded coverage for supervisor churn, termination races, recovery failures, and staged diagnostics.
  * Updated failure classification and boundary checks for staged supervisor-unavailable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->