### PR TITLE
docs: add v0.0.88 release changelog

### DIFF
--- a/docs/changelog/2026-07-18.mdx
+++ b/docs/changelog/2026-07-18.mdx
@@ -1,0 +1,24 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.88
+
+NemoClaw v0.0.88 strengthens DGX Station host preparation, makes inference health claims more precise, fixes multi-gateway sandbox operations and recovery, aligns onboarding policy defaults with web search, and restores credential-aware rebuilds.
+
+- DGX Station preparation preserves stopped containers whose restart policy is `no` and stops if the container inventory changes or a workload becomes active.
+  It provides RDMA-aware remediation when `openibd.service` fails and can restore the packaged CDI refresh lifecycle on the exact June 2026 NVIDIA AI Developer Tools factory image without generating CDI directly or restarting Docker or containerd.
+  For more information, refer to [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/prerequisites/dgx-station-preparation), [Platform Support and Launch Claims](/user-guide/openclaw/reference/platform-support), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- Sandbox `status` and `doctor` now distinguish an inference route that is `reachable` from an upstream model that is `healthy` by using bounded authenticated model-invocation probes for supported remote providers.
+  Gateway-based agents also report `Serving process: not checked` so a fresh sandbox exec is not presented as proof that the long-running gateway process has equivalent inference access.
+  For more information, refer to [Verify the Sandbox Inference Route](/user-guide/openclaw/inference/validate-inference/verify-inference-route) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Sandbox-scoped status and exec operations select the sandbox's owning OpenShell gateway before querying or dispatching, which prevents another active gateway on the host from producing stale state or receiving the command.
+  Recovery also accepts an already-active port forward as success only after the live forward inventory confirms that the target sandbox owns the reachable listener.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes).
+- Fresh interactive onboarding now checks only the policy presets implied by the selected agent and web-search provider.
+  Disabling web search no longer preselects Brave egress, while Brave and Tavily selections continue to preselect only their matching maintained preset.
+  For more information, refer to [Common NemoClaw Integration Policy Examples](/user-guide/openclaw/network-policy/integration-policy-examples).
+- OpenClaw rebuild preflight now reuses the sandbox's exact gateway-registered Brave or Tavily credential binding when no host key is staged.
+  Rebuilds therefore no longer require you to export a web-search key again when the durable gateway provider already matches the sandbox configuration, while missing or mismatched bindings still fail closed.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the canonical `docs/changelog/2026-07-18.mdx` release-prep entry with the exact `## v0.0.88` heading.
The entry summarizes every user-visible change on `main` since v0.0.87 and links each release theme to the focused user documentation.

## Changes

- Add one parser-safe dated changelog entry for v0.0.88 covering DGX Station preparation, inference health, multi-gateway sandbox operations and recovery, onboarding policy defaults, and rebuild credential reuse.
- Reconcile the changelog against the merged v0.0.88-labeled PRs and the complete `v0.0.87..origin/main` commit range.
- Source mapping:
  - [#7152](https://github.com/NVIDIA/NemoClaw/pull/7152) -> `docs/changelog/2026-07-18.mdx`: Document RDMA-aware OpenIB service remediation during DGX Station preparation.
  - [#7155](https://github.com/NVIDIA/NemoClaw/pull/7155) -> `docs/changelog/2026-07-18.mdx`: Document stopped-container preservation and fail-closed restart-policy boundaries.
  - [#7158](https://github.com/NVIDIA/NemoClaw/pull/7158) -> `docs/changelog/2026-07-18.mdx`: Document bounded packaged CDI refresh for the exact AI Developer Tools Station profile.
  - [#7074](https://github.com/NVIDIA/NemoClaw/pull/7074) -> `docs/changelog/2026-07-18.mdx`: Document authenticated upstream model probes and precise route-reachability claims.
  - [#7007](https://github.com/NVIDIA/NemoClaw/pull/7007) -> `docs/changelog/2026-07-18.mdx`: Document the explicit serving-process health gap in `status` and `doctor`.
  - [#7113](https://github.com/NVIDIA/NemoClaw/pull/7113) -> `docs/changelog/2026-07-18.mdx`: Document owning-gateway selection for sandbox-scoped status and exec operations.
  - [#7092](https://github.com/NVIDIA/NemoClaw/pull/7092) -> `docs/changelog/2026-07-18.mdx`: Document idempotent recovery for target-owned active port forwards.
  - [#7133](https://github.com/NVIDIA/NemoClaw/pull/7133) -> `docs/changelog/2026-07-18.mdx`: Document web-search-aware policy preset defaults during onboarding.
  - [#7129](https://github.com/NVIDIA/NemoClaw/pull/7129) -> `docs/changelog/2026-07-18.mdx`: Document gateway-registered web-search credential reuse during rebuild preflight.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates the dated changelog contract, exact release heading, and parser-safe MDX structure.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed successfully with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — not applicable because native changelog entries use the required parser-safe MDX SPDX comment without frontmatter.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved DGX Station preparation workflows.
  * Enhanced sandbox status and diagnostic reporting for inference health.
  * Improved state selection and recovery across multiple gateways.
  * Added safer onboarding defaults for web search policies.
  * Improved rebuild preflight handling for credential reuse and fail-closed behavior.

* **Documentation**
  * Added release notes for version 0.0.88.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->