### PR TITLE
docs: fix API key casing in credential rotation heading

### DIFF
--- a/docs/security/credential-rotation.mdx
+++ b/docs/security/credential-rotation.mdx
@@ -34,7 +34,7 @@ Use `channels add`, `channels remove`, or `channels stop` for messaging integrat
 | Slack, Telegram, or Discord token | Re-add the channel, then rebuild | Rebuild required |
 | Brave or Tavily web search key | Rerun onboarding with the selected web search provider | Sandbox recreation required |
 
-## Rotate an Inference API Key
+## Rotate an Inference API key
 
 Supply the replacement key and rerun onboarding for the existing sandbox.
 Read replacement credentials silently on a trusted host so their values do not enter shell history or terminal scrollback.


### PR DESCRIPTION
## Summary
- Fixes an inconsistent heading in `docs/security/credential-rotation.mdx`: "Rotate an Inference API Key" used capital-K "Key" while the table above and the prose below both correctly use "API key" per the word list in `docs/CONTRIBUTING.md`.

## Test plan
- [x] Visual diff review (single-word heading change, no content/behavior impact)

Signed-off-by: Atharv Kumaria <kumariaaatharv@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected capitalization in the “Rotate an Inference API key” section heading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->