### PR TITLE
fix(inference): sanitize route display output

### DIFF
--- a/src/lib/actions/inference-get.test.ts
+++ b/src/lib/actions/inference-get.test.ts
@@ -59,6 +59,22 @@ describe("runInferenceGet", () => {
     });
   });
 
+  it("sanitizes route values only for human-readable output", async () => {
+    const deps = createDeps(
+      "Gateway inference:\n  Provider: openai\u001b[2J\n  Model: gpt\u0007-5.4\r\n",
+    );
+
+    await expect(runInferenceGet({}, deps)).resolves.toEqual({
+      provider: "openai\u001b[2J",
+      model: "gpt\u0007-5.4",
+    });
+
+    expect(deps.log.mock.calls.map(([line]) => line)).toEqual([
+      "Provider: openai[2J",
+      "Model:    gpt-5.4",
+    ]);
+  });
+
   it("can return the route without rendering output for oclif JSON handling", async () => {
     const deps = createDeps("Gateway inference:\n  Provider: openai-api\n  Model: gpt-5.4\n");
 

--- a/src/lib/actions/inference-get.ts
+++ b/src/lib/actions/inference-get.ts
@@ -3,6 +3,7 @@
 
 import { captureOpenshell } from "../adapters/openshell/runtime";
 import { OPENSHELL_PROBE_TIMEOUT_MS } from "../adapters/openshell/timeouts";
+import { sanitizeRouteValueForDisplay } from "../inference/config";
 import { getLiveGatewayInference } from "../inference/live";
 
 export interface InferenceGetOptions {
@@ -59,10 +60,14 @@ export async function runInferenceGet(
     if (options.json) {
       deps.log(JSON.stringify(payload, null, 2));
     } else {
-      deps.log(`Provider: ${payload.provider ?? "unknown"}`);
-      deps.log(`Model:    ${payload.model ?? "unknown"}`);
+      deps.log(`Provider: ${formatRouteValueForDisplay(payload.provider)}`);
+      deps.log(`Model:    ${formatRouteValueForDisplay(payload.model)}`);
     }
   }
 
   return payload;
+}
+
+function formatRouteValueForDisplay(value: string | null): string {
+  return sanitizeRouteValueForDisplay(value) || "unknown";
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Sanitizes control characters in human-readable inference route output while preserving raw provider and model values for JSON output and programmatic callers. This is the upstream replacement for #7165 so required trusted CI and credentialed E2E can execute; the implementation remains credited to original author HwangJohn.

## Changes

- Sanitize provider and model fields only at the human-readable display boundary.
- Preserve raw route values in returned objects and JSON output.
- Add regression coverage for control characters and raw-value preservation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the command shape and documented behavior are unchanged; this hardens terminal rendering only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: the change is confined to the display boundary, and tests verify raw values remain intact for JSON and programmatic callers.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior — 5/5 inference-get tests
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference output readability by sanitizing control and escape characters in displayed provider and model values.
  * Preserved raw provider and model values for programmatic responses.
  * Continued displaying “unknown” when no usable provider or model value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->