### PR TITLE
fix(installer): restore Station package preparation

### DIFF
--- a/scripts/prepare-dgx-station-host.sh
+++ b/scripts/prepare-dgx-station-host.sh
@@ -1436,7 +1436,7 @@ create_apt_transaction_guard() {
   assert_root_directory_safe "$APT_TRANSACTION_GUARD_DIR" "APT transaction guard directory"
   assert_root_regular_file_safe "$hook_path" 0700 "APT transaction guard"
   assert_root_regular_file_safe "$targets_path" 0600 "APT transaction target manifest"
-  APT_TRANSACTION_HOOK=$hook_path
+  APT_TRANSACTION_HOOK="/bin/bash ${hook_path}"
 }
 
 validate_apt_simulation() {
@@ -1496,12 +1496,13 @@ validate_apt_simulation() {
 
 simulate_install() {
   local simulation
-  [[ "$APT_TRANSACTION_HOOK" =~ ^/run/nemoclaw-apt-transaction\.[A-Za-z0-9]+/verify-plan$ ]] \
+  [[ "$APT_TRANSACTION_GUARD_DIR" =~ ^/run/nemoclaw-apt-transaction\.[A-Za-z0-9]+$ &&
+    "$APT_TRANSACTION_HOOK" == "/bin/bash ${APT_TRANSACTION_GUARD_DIR}/verify-plan" ]] \
     || fatal "APT transaction guard is not ready"
   simulation="$(sudo env DEBIAN_FRONTEND=noninteractive LC_ALL=C \
     apt-get -s install --no-install-recommends --no-remove \
     -o "DPkg::Pre-Install-Pkgs::=${APT_TRANSACTION_HOOK}" \
-    -o "DPkg::Tools::options::${APT_TRANSACTION_HOOK}::Version=3" "$@")" \
+    -o "DPkg::Tools::options::/bin/bash::Version=3" "$@")" \
     || fatal "APT simulation failed"
   printf '%s\n' "$simulation"
   validate_apt_simulation "$simulation" "$@"
@@ -1516,13 +1517,12 @@ install_packages() {
   validate_package_availability "${PACKAGE_TRANSACTION_SPECS[@]}"
   create_apt_transaction_guard
   simulate_install "${PACKAGE_TRANSACTION_SPECS[@]}"
-  check_no_workloads
   require_docker_restart_quiescence "Station prerequisite package installation"
   info "Installing missing pinned Station prerequisites"
   sudo env DEBIAN_FRONTEND=noninteractive LC_ALL=C \
     apt-get install -y --no-install-recommends --no-remove \
     -o "DPkg::Pre-Install-Pkgs::=${APT_TRANSACTION_HOOK}" \
-    -o "DPkg::Tools::options::${APT_TRANSACTION_HOOK}::Version=3" \
+    -o "DPkg::Tools::options::/bin/bash::Version=3" \
     "${PACKAGE_TRANSACTION_SPECS[@]}"
   cleanup_apt_transaction_guard
 

--- a/test/install-station-host-preparation.test.ts
+++ b/test/install-station-host-preparation.test.ts
@@ -416,13 +416,12 @@ run_apply
 configure_repositories() { printf 'CONFIGURE_REPOSITORIES\n'; }
 validate_package_availability() { printf 'VALIDATE_PACKAGES\n'; }
 simulate_install() { printf 'SIMULATE_INSTALL\n'; }
-check_no_workloads() { printf 'RECHECK_ALL_WORKLOADS\n'; }
 require_docker_restart_quiescence() { printf 'RECHECK_RESTART_QUIESCENCE\n'; }
 package_state() { printf 'missing\n'; }
 package_is_exact() { return 0; }
 create_apt_transaction_guard() {
   APT_TRANSACTION_GUARD_DIR=/run/nemoclaw-apt-transaction.TEST
-  APT_TRANSACTION_HOOK="$APT_TRANSACTION_GUARD_DIR/verify-plan"
+  APT_TRANSACTION_HOOK="/bin/bash $APT_TRANSACTION_GUARD_DIR/verify-plan"
 }
 cleanup_apt_transaction_guard() { :; }
 sudo() { printf 'SUDO %s\n' "$*"; }

--- a/test/install-station-package-transaction.test.ts
+++ b/test/install-station-package-transaction.test.ts
@@ -89,7 +89,7 @@ apt-get() {
     done
   fi
 }
-require_docker_restart_quiescence() { printf 'RECHECK_DOCKER_RESTART\n'; }
+require_docker_restart_quiescence() { printf 'RECHECK_DOCKER_RESTART %s\n' "$1"; }
 package_state() { printf 'missing\n'; }
 package_is_exact() { return 0; }
 create_apt_transaction_guard() {
@@ -130,7 +130,10 @@ cat "$HOME/apt-cache-calls"
     expect(output).toContain(
       "SUDO env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get -s install --no-install-recommends --no-remove",
     );
-    expect(output).toContain("RECHECK_DOCKER_RESTART");
+    const quiescenceMarker = "RECHECK_DOCKER_RESTART Station prerequisite package installation";
+    const installMarker = "SUDO env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get install -y";
+    expect(output).toContain(quiescenceMarker);
+    expect(output.indexOf(installMarker)).toBeGreaterThan(output.indexOf(quiescenceMarker));
     expect(output).toContain("CLEANUP_GUARD");
     expect(output).toContain("pinned_packages=installed");
   });

--- a/test/install-station-package-transaction.test.ts
+++ b/test/install-station-package-transaction.test.ts
@@ -89,13 +89,12 @@ apt-get() {
     done
   fi
 }
-check_no_workloads() { printf 'RECHECK_ALL_WORKLOADS\n'; }
 require_docker_restart_quiescence() { printf 'RECHECK_DOCKER_RESTART\n'; }
 package_state() { printf 'missing\n'; }
 package_is_exact() { return 0; }
 create_apt_transaction_guard() {
   APT_TRANSACTION_GUARD_DIR=/run/nemoclaw-apt-transaction.TEST
-  APT_TRANSACTION_HOOK="$APT_TRANSACTION_GUARD_DIR/verify-plan"
+  APT_TRANSACTION_HOOK="/bin/bash $APT_TRANSACTION_GUARD_DIR/verify-plan"
 }
 cleanup_apt_transaction_guard() {
   printf 'CLEANUP_GUARD\n'
@@ -124,14 +123,14 @@ cat "$HOME/apt-cache-calls"
     expect(aptCommands).toEqual(
       [
         ...EXPECTED_PACKAGE_SPECS.map((spec) => `APT_CACHE show ${spec}`),
-        `APT_GET -s install --no-install-recommends --no-remove -o DPkg::Pre-Install-Pkgs::=/run/nemoclaw-apt-transaction.TEST/verify-plan -o DPkg::Tools::options::/run/nemoclaw-apt-transaction.TEST/verify-plan::Version=3 ${expectedTuple}`,
-        `SUDO env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get install -y --no-install-recommends --no-remove -o DPkg::Pre-Install-Pkgs::=/run/nemoclaw-apt-transaction.TEST/verify-plan -o DPkg::Tools::options::/run/nemoclaw-apt-transaction.TEST/verify-plan::Version=3 ${expectedTuple}`,
+        `APT_GET -s install --no-install-recommends --no-remove -o DPkg::Pre-Install-Pkgs::=/bin/bash /run/nemoclaw-apt-transaction.TEST/verify-plan -o DPkg::Tools::options::/bin/bash::Version=3 ${expectedTuple}`,
+        `SUDO env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get install -y --no-install-recommends --no-remove -o DPkg::Pre-Install-Pkgs::=/bin/bash /run/nemoclaw-apt-transaction.TEST/verify-plan -o DPkg::Tools::options::/bin/bash::Version=3 ${expectedTuple}`,
       ].sort(),
     );
     expect(output).toContain(
       "SUDO env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get -s install --no-install-recommends --no-remove",
     );
-    expect(output).toContain("RECHECK_ALL_WORKLOADS");
+    expect(output).toContain("RECHECK_DOCKER_RESTART");
     expect(output).toContain("CLEANUP_GUARD");
     expect(output).toContain("pinned_packages=installed");
   });
@@ -155,7 +154,6 @@ apt-get() {
     done
   fi
 }
-check_no_workloads() { :; }
 require_docker_restart_quiescence() { :; }
 package_state() {
   if [[ "$1" == '${retainedSpec}' ]]; then printf 'exact\n'; else printf 'missing\n'; fi
@@ -163,7 +161,7 @@ package_state() {
 package_is_exact() { return 0; }
 create_apt_transaction_guard() {
   APT_TRANSACTION_GUARD_DIR=/run/nemoclaw-apt-transaction.TEST
-  APT_TRANSACTION_HOOK="$APT_TRANSACTION_GUARD_DIR/verify-plan"
+  APT_TRANSACTION_HOOK="/bin/bash $APT_TRANSACTION_GUARD_DIR/verify-plan"
 }
 cleanup_apt_transaction_guard() {
   APT_TRANSACTION_GUARD_DIR=""
@@ -191,8 +189,8 @@ cat "$HOME/apt-cache-calls"
     expect(aptCommands).toEqual(
       [
         ...missingSpecs.map((spec) => `APT_CACHE show ${spec}`),
-        `APT_GET -s install --no-install-recommends --no-remove -o DPkg::Pre-Install-Pkgs::=/run/nemoclaw-apt-transaction.TEST/verify-plan -o DPkg::Tools::options::/run/nemoclaw-apt-transaction.TEST/verify-plan::Version=3 ${expectedTuple}`,
-        `SUDO env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get install -y --no-install-recommends --no-remove -o DPkg::Pre-Install-Pkgs::=/run/nemoclaw-apt-transaction.TEST/verify-plan -o DPkg::Tools::options::/run/nemoclaw-apt-transaction.TEST/verify-plan::Version=3 ${expectedTuple}`,
+        `APT_GET -s install --no-install-recommends --no-remove -o DPkg::Pre-Install-Pkgs::=/bin/bash /run/nemoclaw-apt-transaction.TEST/verify-plan -o DPkg::Tools::options::/bin/bash::Version=3 ${expectedTuple}`,
+        `SUDO env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get install -y --no-install-recommends --no-remove -o DPkg::Pre-Install-Pkgs::=/bin/bash /run/nemoclaw-apt-transaction.TEST/verify-plan -o DPkg::Tools::options::/bin/bash::Version=3 ${expectedTuple}`,
       ].sort(),
     );
     expect(aptCommands.join("\n")).not.toContain(retainedSpec);
@@ -216,7 +214,7 @@ installed_version() { if [[ "$1" == "libc6" ]]; then printf '2.39-0ubuntu8'; fi;
 package_is_exact() { return 0; }
 create_apt_transaction_guard() {
   APT_TRANSACTION_GUARD_DIR=/run/nemoclaw-apt-transaction.TEST
-  APT_TRANSACTION_HOOK="$APT_TRANSACTION_GUARD_DIR/verify-plan"
+  APT_TRANSACTION_HOOK="/bin/bash $APT_TRANSACTION_GUARD_DIR/verify-plan"
 }
 sudo() {
   printf 'SUDO %s\n' "$*"
@@ -358,7 +356,7 @@ install_packages
     }
   });
 
-  it("emits an executable root-hook payload bound to its target manifest", () => {
+  it("emits a noexec-safe root-hook command bound to its target manifest", () => {
     const { result, output } = runSourced(
       `
 PACKAGE_TRANSACTION_SPECS=('${DOCKER_CE_SPEC}')
@@ -378,12 +376,18 @@ sudo() {
       cat >"$HOME/generated-guard/\${2##*/}"
       ;;
     chmod)
-      command chmod "$2" "$HOME/generated-guard/\${3##*/}"
+      printf 'SUDO %s\n' "$*"
+      if [[ "$3" == /run/nemoclaw-apt-transaction.GENERATED ]]; then
+        command chmod "$2" "$HOME/generated-guard"
+      else
+        command chmod "$2" "$HOME/generated-guard/\${3##*/}"
+      fi
       ;;
   esac
 }
 create_apt_transaction_guard
-"$HOME/generated-guard/verify-plan" <<<"$APT_PLAN"
+/bin/bash "$HOME/generated-guard/verify-plan" <<<"$APT_PLAN"
+printf 'APT_HOOK=%s\n' "$APT_TRANSACTION_HOOK"
 printf 'GENERATED_HOOK_ACCEPTED\n'
 `,
       {
@@ -396,6 +400,11 @@ printf 'GENERATED_HOOK_ACCEPTED\n'
 
     expect(result.status, output).toBe(0);
     expect(output).toContain("GENERATED_HOOK_ACCEPTED");
+    expect(output).toContain(
+      "APT_HOOK=/bin/bash /run/nemoclaw-apt-transaction.GENERATED/verify-plan",
+    );
+    expect(output).toContain("SUDO chmod 0700 /run/nemoclaw-apt-transaction.GENERATED/verify-plan");
+    expect(output).toContain("SUDO chmod 0600 /run/nemoclaw-apt-transaction.GENERATED/targets");
   });
 
   it("cleans the root-owned transaction guard when the caller exits", () => {
@@ -404,7 +413,7 @@ sudo() { printf 'SUDO %s\n' "$*"; }
 setup_log() { :; }
 run_apply() {
   APT_TRANSACTION_GUARD_DIR=/run/nemoclaw-apt-transaction.EXITTEST
-  APT_TRANSACTION_HOOK="$APT_TRANSACTION_GUARD_DIR/verify-plan"
+  APT_TRANSACTION_HOOK="/bin/bash $APT_TRANSACTION_GUARD_DIR/verify-plan"
 }
 main --apply
 `);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fresh generic Ubuntu Station host preparation no longer exits after APT simulation. The installer now uses the existing Docker restart-quiescence gate and invokes its root-only APT pre-install guard through `/bin/bash`, which works when `/run` is mounted `noexec`.

## Related Issue

Fixes #7182

## Changes

- Remove the undefined `check_no_workloads` invocation added by #7090.
- Keep `require_docker_restart_quiescence` as the single fail-closed gate before the package transaction.
- Keep the root-owned APT guard and package manifest private (`0700`/`0600`), invoke the hook through `/bin/bash` for a `noexec` `/run` mount, and bind APT protocol Version 3 to that executable command token.
- Remove test-only `check_no_workloads` definitions that masked the production failure and assert the real restart-quiescence call instead.
- Assert the generated guard command and private hook/manifest modes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the documented Station preparation flow without changing commands, prompts, prerequisites, defaults, recovery, or the Docker quiescence contract; independent documentation review found no update necessary.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: maintainer review approved exact head `4ea0f4b59143000d69e6446d330f14d8c1981766` at https://github.com/NVIDIA/NemoClaw/pull/7183#pullrequestreview-4730271735; the APT Version=3 key, root-private `noexec`-safe hook command, fail-closed restart-quiescence gate, and pre-install ordering assertion were reviewed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project installer-integration test/install-station-package-transaction.test.ts test/install-station-host-preparation.test.ts --testTimeout=15000` (62 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable: three-line production correction with focused installer coverage; normal hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>\nSigned-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DGX Station host/package preparation by removing the workload recheck gate and enforcing Docker restart quiescence before installing pinned prerequisite packages.
  * Updated APT transaction guard behavior to consistently run plan verification via an explicit `/bin/bash` wrapper.
* **Tests**
  * Updated Station host/package transaction test scenarios and assertions to match the new `/bin/bash`-prefixed guard hook behavior and adjusted related permission/cleanup expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->