### PR TITLE
feat(onboard): surface back-navigation hint on inference setup prompts

### DIFF
--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -158,6 +158,7 @@ Use these details when your first-run path needs more control.
     The wizard asks for an inference provider, model, required credential, and sandbox name before it prints the review summary.
     After confirmation, NemoClaw registers inference, prompts for optional Tavily Search and supported messaging channels, builds and starts the sandbox, sets up Hermes, and applies the selected network policy tier and presets.
     At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
+    At prompts that display the navigation hint, type `b` to return to provider selection.
 
     The default Hermes sandbox name is `hermes`.
     Use a distinct name, such as `my-hermes`, when you run Hermes and OpenClaw sandboxes side by side.

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -97,6 +97,7 @@ nemoclaw onboard --agent langchain
 
 The wizard asks for an inference provider, model, required credential, sandbox name, and policy tier before it prints the review summary.
 At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
+At prompts that display the navigation hint, type `b` to return to provider selection.
 The default Deep Agents sandbox name is `deepagents-code`.
 Use a distinct name, such as `my-deepagents`, when you run Deep Agents, Hermes, and OpenClaw sandboxes side by side.
 Refer to [Choose an Inference Provider](../inference/learn-and-choose/choose-inference-provider) for provider-specific prompts.

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -97,7 +97,7 @@ nemoclaw onboard --agent langchain
 
 The wizard asks for an inference provider, model, required credential, sandbox name, and policy tier before it prints the review summary.
 At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
-At prompts that display the navigation hint, type `b` to return to provider selection.
+At prompts that display the navigation hint, type `b` to return to the previous prompt.
 The default Deep Agents sandbox name is `deepagents-code`.
 Use a distinct name, such as `my-deepagents`, when you run Deep Agents, Hermes, and OpenClaw sandboxes side by side.
 Refer to [Choose an Inference Provider](../inference/learn-and-choose/choose-inference-provider) for provider-specific prompts.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -240,6 +240,7 @@ Use these details when your first-run path needs more control.
     It prints a review summary before it registers the provider with OpenShell.
     After confirmation, NemoClaw registers inference, prompts for optional web search and messaging channels, builds and starts the sandbox, sets up OpenClaw, and applies the selected network policy tier and presets.
     At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
+    At prompts that display the navigation hint, type `b` to return to provider selection.
 
     If registered sandboxes already exist, the installer prepares the current NemoClaw CLI without replacing OpenShell, requires a fresh backup of every registered sandbox before it changes the gateway, and runs `nemoclaw upgrade-sandboxes --auto` after the host upgrade.
     After backup, it retires the running gateway before replacing OpenShell only when the installed OpenShell version is outside the current release's supported range; an unknown installed version or an invalid or missing range stops the update without retiring the gateway, while any retirement failure stops the update with the sandbox backups preserved.

--- a/src/lib/credentials/store.ts
+++ b/src/lib/credentials/store.ts
@@ -155,7 +155,7 @@ export function normalizeCredentialValue(value: CredentialInput): string {
 export function getCredentialPromptIntent(value: CredentialInput): CredentialPromptIntent {
   const normalized = normalizeCredentialValue(value);
   const navigation = normalized.toLowerCase();
-  if (navigation === "back") return { kind: "back" };
+  if (navigation === "b" || navigation === "back") return { kind: "back" };
   if (navigation === "exit" || navigation === "quit") return { kind: "exit" };
   if (navigation === "?" || navigation === "help") return { kind: "help" };
   return { kind: "credential", value: normalized };

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -7,3 +7,9 @@ export type BackToSelection = typeof BACK_TO_SELECTION;
 export function isBackToSelection(value: unknown): value is BackToSelection {
   return value === BACK_TO_SELECTION;
 }
+
+export const NAVIGATION_HINT = "  Enter b to go back, or exit to quit.";
+
+export function printNavigationHint(log: (message?: string) => void = console.log): void {
+  log(NAVIGATION_HINT);
+}

--- a/src/lib/onboard/credential-navigation.test.ts
+++ b/src/lib/onboard/credential-navigation.test.ts
@@ -10,7 +10,7 @@ import {
   shouldReturnToProviderSelection,
 } from "./credential-navigation";
 
-describe("credential prompt navigation helpers", () => {
+describe("credential prompt navigation helpers (#6005)", () => {
   it("accepts the short b token as back so the advertised key works", () => {
     expect(getNavigationChoice("b")).toBe("back");
     expect(getNavigationChoice(" B ")).toBe("back");

--- a/src/lib/onboard/credential-navigation.test.ts
+++ b/src/lib/onboard/credential-navigation.test.ts
@@ -5,11 +5,20 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   BACK_TO_SELECTION,
+  getNavigationChoice,
   returningToProviderSelection,
   shouldReturnToProviderSelection,
 } from "./credential-navigation";
 
 describe("credential prompt navigation helpers", () => {
+  it("accepts the short b token as back so the advertised key works", () => {
+    expect(getNavigationChoice("b")).toBe("back");
+    expect(getNavigationChoice(" B ")).toBe("back");
+    expect(getNavigationChoice("back")).toBe("back");
+    expect(getNavigationChoice("exit")).toBe("exit");
+    expect(getNavigationChoice("nvapi-xxxx")).toBeNull();
+  });
+
   it("treats both the shared back sentinel and credential back intents as provider-selection navigation", () => {
     const exitOnboard = vi.fn(() => {
       throw new Error("unexpected exit");

--- a/src/lib/onboard/credential-navigation.test.ts
+++ b/src/lib/onboard/credential-navigation.test.ts
@@ -17,15 +17,12 @@ let navigationKeyBeforeTest: string | undefined;
 
 beforeEach(() => {
   navigationKeyBeforeTest = process.env.NEMOCLAW_TEST_NAVIGATION_KEY;
+  vi.stubEnv("NEMOCLAW_TEST_NAVIGATION_KEY", navigationKeyBeforeTest);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
-  if (navigationKeyBeforeTest === undefined) {
-    delete process.env.NEMOCLAW_TEST_NAVIGATION_KEY;
-  } else {
-    process.env.NEMOCLAW_TEST_NAVIGATION_KEY = navigationKeyBeforeTest;
-  }
+  vi.unstubAllEnvs();
 });
 
 describe("credential prompt navigation helpers (#6005)", () => {

--- a/src/lib/onboard/credential-navigation.test.ts
+++ b/src/lib/onboard/credential-navigation.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as credentials from "../credentials/store";
 
@@ -13,9 +13,19 @@ import {
   shouldReturnToProviderSelection,
 } from "./credential-navigation";
 
+let navigationKeyBeforeTest: string | undefined;
+
+beforeEach(() => {
+  navigationKeyBeforeTest = process.env.NEMOCLAW_TEST_NAVIGATION_KEY;
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
-  delete process.env.NEMOCLAW_TEST_NAVIGATION_KEY;
+  if (navigationKeyBeforeTest === undefined) {
+    delete process.env.NEMOCLAW_TEST_NAVIGATION_KEY;
+  } else {
+    process.env.NEMOCLAW_TEST_NAVIGATION_KEY = navigationKeyBeforeTest;
+  }
 });
 
 describe("credential prompt navigation helpers (#6005)", () => {
@@ -42,7 +52,7 @@ describe("credential prompt navigation helpers (#6005)", () => {
 
     expect(result).toBe(BACK_TO_SELECTION);
     expect(saveCredential).not.toHaveBeenCalled();
-    expect(process.env.NEMOCLAW_TEST_NAVIGATION_KEY).toBeUndefined();
+    expect(process.env.NEMOCLAW_TEST_NAVIGATION_KEY).toBe(navigationKeyBeforeTest);
   });
 
   it("treats both the shared back sentinel and credential back intents as provider-selection navigation", () => {

--- a/src/lib/onboard/credential-navigation.test.ts
+++ b/src/lib/onboard/credential-navigation.test.ts
@@ -1,14 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import * as credentials from "../credentials/store";
 
 import {
   BACK_TO_SELECTION,
   getNavigationChoice,
+  replaceNamedCredential,
   returningToProviderSelection,
   shouldReturnToProviderSelection,
 } from "./credential-navigation";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.NEMOCLAW_TEST_NAVIGATION_KEY;
+});
 
 describe("credential prompt navigation helpers (#6005)", () => {
   it("accepts the short b token as back so the advertised key works", () => {
@@ -17,6 +25,24 @@ describe("credential prompt navigation helpers (#6005)", () => {
     expect(getNavigationChoice("back")).toBe("back");
     expect(getNavigationChoice("exit")).toBe("exit");
     expect(getNavigationChoice("nvapi-xxxx")).toBeNull();
+  });
+
+  it("routes a trimmed short b token through the real secret prompt without staging it", async () => {
+    vi.spyOn(credentials, "prompt").mockResolvedValue(" B ");
+    const saveCredential = vi.spyOn(credentials, "saveCredential");
+    const exitOnboard = vi.fn(() => {
+      throw new Error("unexpected exit");
+    }) as unknown as () => never;
+
+    const result = await replaceNamedCredential({
+      envName: "NEMOCLAW_TEST_NAVIGATION_KEY",
+      label: "Test credential",
+      exitOnboardFromPrompt: exitOnboard,
+    });
+
+    expect(result).toBe(BACK_TO_SELECTION);
+    expect(saveCredential).not.toHaveBeenCalled();
+    expect(process.env.NEMOCLAW_TEST_NAVIGATION_KEY).toBeUndefined();
   });
 
   it("treats both the shared back sentinel and credential back intents as provider-selection navigation", () => {

--- a/src/lib/onboard/credential-navigation.ts
+++ b/src/lib/onboard/credential-navigation.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as credentials from "../credentials/store";
-import { BACK_TO_SELECTION, type BackToSelection, isBackToSelection } from "../navigation";
+import {
+  BACK_TO_SELECTION,
+  type BackToSelection,
+  isBackToSelection,
+  printNavigationHint,
+} from "../navigation";
 
 export type BackNavigationResult = BackToSelection | { kind: "back" };
 export type { BackToSelection };
@@ -12,7 +17,7 @@ export function getNavigationChoice(value = ""): "back" | "exit" | null {
   const normalized = String(value || "")
     .trim()
     .toLowerCase();
-  if (normalized === "back") return "back";
+  if (normalized === "back" || normalized === "b") return "back";
   if (normalized === "exit" || normalized === "quit") return "exit";
   return null;
 }
@@ -80,6 +85,8 @@ export async function replaceNamedCredential({
     console.log(`  Get your ${label} from: ${helpUrl}`);
     console.log("");
   }
+
+  printNavigationHint();
 
   while (true) {
     const key = await readCredentialValue(`  ${label}: `, exitOnboardFromPrompt);

--- a/src/lib/onboard/hermes-auth.test.ts
+++ b/src/lib/onboard/hermes-auth.test.ts
@@ -11,6 +11,7 @@ import {
   HERMES_NOUS_API_KEY_CREDENTIAL_ENV,
   type HermesAuthFlowDeps,
 } from "./hermes-auth";
+import { getNavigationChoice as getPromptNavigationChoice } from "./prompt-helpers";
 
 function clearHermesAuthEnvironment(): void {
   vi.stubEnv("NEMOCLAW_HERMES_AUTH_METHOD", undefined);
@@ -47,18 +48,24 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("Hermes auth back-navigation affordance", () => {
+describe("Hermes auth back-navigation affordance (#6005)", () => {
   it("prints the navigation hint before the interactive auth-method prompt", async () => {
     clearHermesAuthEnvironment();
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const events: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+      if (message === NAVIGATION_HINT) events.push("hint");
+    });
     const deps = createDeps({
       isNonInteractive: vi.fn(() => false),
-      prompt: vi.fn(async () => "1"),
+      prompt: vi.fn(async () => {
+        events.push("prompt");
+        return "1";
+      }),
     });
 
     await createHermesAuthHelpers(deps).promptHermesAuthMethod();
 
-    expect(logSpy.mock.calls.some((call) => call[0] === NAVIGATION_HINT)).toBe(true);
+    expect(events).toEqual(["hint", "prompt"]);
   });
 
   it("returns to provider selection when the auth-method prompt replies back", async () => {
@@ -67,7 +74,7 @@ describe("Hermes auth back-navigation affordance", () => {
     const deps = createDeps({
       isNonInteractive: vi.fn(() => false),
       prompt: vi.fn(async () => "b"),
-      getNavigationChoice: vi.fn((): "back" => "back"),
+      getNavigationChoice: getPromptNavigationChoice,
     });
 
     const result = await createHermesAuthHelpers(deps).promptHermesAuthMethod();

--- a/src/lib/onboard/hermes-auth.test.ts
+++ b/src/lib/onboard/hermes-auth.test.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { NAVIGATION_HINT } from "../navigation";
 import {
   createHermesAuthHelpers,
   HERMES_AUTH_METHOD_API_KEY,
@@ -44,6 +45,45 @@ function createDeps(overrides: Partial<HermesAuthFlowDeps> = {}): HermesAuthFlow
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
+});
+
+describe("Hermes auth back-navigation affordance", () => {
+  it("prints the navigation hint before the interactive auth-method prompt", async () => {
+    clearHermesAuthEnvironment();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const deps = createDeps({
+      isNonInteractive: vi.fn(() => false),
+      prompt: vi.fn(async () => "1"),
+    });
+
+    await createHermesAuthHelpers(deps).promptHermesAuthMethod();
+
+    expect(logSpy.mock.calls.some((call) => call[0] === NAVIGATION_HINT)).toBe(true);
+  });
+
+  it("returns to provider selection when the auth-method prompt replies back", async () => {
+    clearHermesAuthEnvironment();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const deps = createDeps({
+      isNonInteractive: vi.fn(() => false),
+      prompt: vi.fn(async () => "b"),
+      getNavigationChoice: vi.fn((): "back" => "back"),
+    });
+
+    const result = await createHermesAuthHelpers(deps).promptHermesAuthMethod();
+
+    expect(result).toBe(deps.backToSelection);
+  });
+
+  it("does not print the navigation hint in non-interactive mode", async () => {
+    clearHermesAuthEnvironment();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const deps = createDeps({ isNonInteractive: vi.fn(() => true) });
+
+    await createHermesAuthHelpers(deps).promptHermesAuthMethod();
+
+    expect(logSpy.mock.calls.some((call) => call[0] === NAVIGATION_HINT)).toBe(false);
+  });
 });
 
 describe("Hermes authentication exit boundaries", () => {

--- a/src/lib/onboard/hermes-auth.test.ts
+++ b/src/lib/onboard/hermes-auth.test.ts
@@ -53,7 +53,7 @@ describe("Hermes auth back-navigation affordance (#6005)", () => {
     clearHermesAuthEnvironment();
     const events: string[] = [];
     vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
-      if (message === NAVIGATION_HINT) events.push("hint");
+      events.push(String(message));
     });
     const deps = createDeps({
       isNonInteractive: vi.fn(() => false),
@@ -65,7 +65,11 @@ describe("Hermes auth back-navigation affordance (#6005)", () => {
 
     await createHermesAuthHelpers(deps).promptHermesAuthMethod();
 
-    expect(events).toEqual(["hint", "prompt"]);
+    const hintIndex = events.indexOf(NAVIGATION_HINT);
+    const promptIndex = events.indexOf("prompt");
+    expect(hintIndex).toBeGreaterThanOrEqual(0);
+    expect(promptIndex).toBeGreaterThanOrEqual(0);
+    expect(hintIndex).toBeLessThan(promptIndex);
   });
 
   it("returns to provider selection when the auth-method prompt replies back", async () => {

--- a/src/lib/onboard/hermes-auth.ts
+++ b/src/lib/onboard/hermes-auth.ts
@@ -4,6 +4,7 @@
 import { normalizeCredentialValue } from "../credentials/store";
 import type { HermesAuthMethod } from "../hermes-provider-auth";
 import * as hermesProviderAuth from "../hermes-provider-auth";
+import { printNavigationHint } from "../navigation";
 
 export type { HermesAuthMethod };
 
@@ -126,6 +127,7 @@ export function createHermesAuthHelpers(deps: HermesAuthFlowDeps): HermesAuthHel
 
     const defaultIdx =
       (requested ? methods.findIndex((method) => method.key === requested) : 0) + 1;
+    printNavigationHint();
     const choice = await deps.prompt(`  Choose [${defaultIdx}]: `);
     const navigation = deps.getNavigationChoice(choice);
     if (navigation === "back") return deps.backToSelection;
@@ -159,6 +161,7 @@ export function createHermesAuthHelpers(deps: HermesAuthFlowDeps): HermesAuthHel
     console.log("");
     console.log("  Hermes Provider Nous API Key");
     console.log(`  Create or copy a key from ${HERMES_NOUS_API_KEY_HELP_URL}`);
+    printNavigationHint();
     const rawKey = await deps.prompt("  Nous API Key: ", {
       secret: true,
     });

--- a/src/lib/onboard/prompt-helpers.test.ts
+++ b/src/lib/onboard/prompt-helpers.test.ts
@@ -17,7 +17,7 @@ function makeDeps(promptReply: string) {
   };
 }
 
-describe("getNavigationChoice back token", () => {
+describe("getNavigationChoice back token (#6005)", () => {
   it("treats the short b token as back so the advertised key works", () => {
     expect(getNavigationChoice("b")).toBe("back");
     expect(getNavigationChoice(" B ")).toBe("back");

--- a/src/lib/onboard/prompt-helpers.test.ts
+++ b/src/lib/onboard/prompt-helpers.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, expect, it, vi } from "vitest";
 // Import source directly so tests cannot pass against a stale build.
-import { promptOrDefault, selectFromNumberedMenuOrExit } from "./prompt-helpers";
+import {
+  getNavigationChoice,
+  promptOrDefault,
+  selectFromNumberedMenuOrExit,
+} from "./prompt-helpers";
 
 function makeDeps(promptReply: string) {
   return {
@@ -12,6 +16,28 @@ function makeDeps(promptReply: string) {
     prompt: vi.fn().mockResolvedValue(promptReply),
   };
 }
+
+describe("getNavigationChoice back token", () => {
+  it("treats the short b token as back so the advertised key works", () => {
+    expect(getNavigationChoice("b")).toBe("back");
+    expect(getNavigationChoice(" B ")).toBe("back");
+  });
+
+  it("still treats the full back word as back", () => {
+    expect(getNavigationChoice("back")).toBe("back");
+  });
+
+  it("keeps exit and quit mapped to exit", () => {
+    expect(getNavigationChoice("exit")).toBe("exit");
+    expect(getNavigationChoice("quit")).toBe("exit");
+  });
+
+  it("returns null for ordinary values", () => {
+    expect(getNavigationChoice("brave")).toBeNull();
+    expect(getNavigationChoice("2")).toBeNull();
+    expect(getNavigationChoice("")).toBeNull();
+  });
+});
 
 describe("promptOrDefault interactive default fallback (#4387)", () => {
   it("returns defaultValue when the user just presses Enter (empty reply)", async () => {

--- a/src/lib/onboard/prompt-helpers.ts
+++ b/src/lib/onboard/prompt-helpers.ts
@@ -11,7 +11,7 @@ export function getNavigationChoice(value = ""): "back" | "exit" | null {
   const normalized = String(value || "")
     .trim()
     .toLowerCase();
-  if (normalized === "back") return "back";
+  if (normalized === "back" || normalized === "b") return "back";
   if (normalized === "exit" || normalized === "quit") return "exit";
   return null;
 }


### PR DESCRIPTION
## Summary

The inference provider setup prompts already accepted a `back` reply to return to provider selection, but the option was never shown, so users could not discover it and pressed Ctrl+C instead. This surfaces a visible navigation hint before the credential and Hermes auth prompts and accepts the short `b` token as a `back` alias. Behaviour is interactive-only, so non-interactive runs are unchanged.

## Related Issue

Partial progress toward #6005

## Changes

- Add `NAVIGATION_HINT` and `printNavigationHint()` to `src/lib/navigation.ts` as the single source for the hint text.
- Accept the short `b` token as a `back` alias in both `getNavigationChoice` parsers (`prompt-helpers.ts`, `credential-navigation.ts`).
- Print the hint before the credential entry prompt and before the Hermes auth-method and Nous API key prompts.
- No control-flow change: the prompts already routed `back` to provider selection; this only makes the existing affordance visible and keyboard-friendly.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: interactive prompt hint only; no documented onboarding flow, command, or option surface changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: onboarding/credential prompt paths touched; requesting maintainer sensitive-path review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run src/lib/onboard/prompt-helpers.test.ts src/lib/onboard/credential-navigation.test.ts src/lib/onboard/hermes-auth.test.ts` → 32 passed; `npm run test:changed` → 14 files / 211 passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added centralized navigation-hint messaging for interactive onboarding prompts.
  - Enabled `b` as a shortcut to return to provider selection across prompts.
- **Bug Fixes**
  - Improved back-navigation parsing so `b` (whitespace/case variants) is treated as `back`.
  - Ensured the navigation hint is presented at the right time before credential entry.
- **Documentation**
  - Updated Quickstart guides to mention the `b` shortcut when hints are shown.
- **Tests**
  - Expanded coverage for navigation choice normalization and hint logging behavior in interactive vs non-interactive modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
