### PR TITLE
fix(rebuild): fall back to host-side MCP recovery when --force and exec relay unavailable

### DIFF
--- a/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
@@ -7,6 +7,11 @@ const mocks = vi.hoisted(() => ({
   prepareMcpForRebuild: vi.fn(),
   reattachMcpAfterDeleteFailure: vi.fn(),
   warnUnpreservedUserManagedFiles: vi.fn(),
+  runOpenshell: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
+  getSandboxDeleteOutcome: vi.fn(() => ({ alreadyGone: false })),
+  getSandbox: vi.fn(() => null),
+  listSandboxes: vi.fn(() => ({ sandboxes: [] })),
+  removeSandboxRegistryEntryWithReceipt: vi.fn(() => null),
 }));
 
 vi.mock("./rebuild-flow-helpers", async (importOriginal) => ({
@@ -18,6 +23,24 @@ vi.mock("./rebuild-mcp-phase", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./rebuild-mcp-phase")>()),
   prepareMcpForRebuild: mocks.prepareMcpForRebuild,
   reattachMcpAfterDeleteFailure: mocks.reattachMcpAfterDeleteFailure,
+}));
+
+vi.mock("../../adapters/openshell/runtime", () => ({
+  runOpenshell: mocks.runOpenshell,
+}));
+
+vi.mock("../../domain/sandbox/destroy", () => ({
+  getSandboxDeleteOutcome: mocks.getSandboxDeleteOutcome,
+}));
+
+vi.mock("../../state/registry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../state/registry")>()),
+  getSandbox: mocks.getSandbox,
+  listSandboxes: mocks.listSandboxes,
+}));
+
+vi.mock("./destroy", () => ({
+  removeSandboxRegistryEntryWithReceipt: mocks.removeSandboxRegistryEntryWithReceipt,
 }));
 
 import { runRebuildDestroyPhase } from "./rebuild-destroy-phase";
@@ -69,5 +92,32 @@ describe("rebuild destroy validation diagnostics", () => {
     expect(diagnostics).not.toContain(secret);
     expect(mocks.reattachMcpAfterDeleteFailure).toHaveBeenCalledOnce();
     expect(relockShieldsIfNeeded).toHaveBeenCalledWith(true);
+  });
+
+  it("passes force=true to prepareMcpForRebuild when input.force is set (#7062)", async () => {
+    const log = vi.fn();
+    const bail = vi.fn((message: string): never => {
+      throw new Error(message);
+    });
+
+    await runRebuildDestroyPhase({
+      sandboxName: "alpha",
+      sandboxEntry: { name: "alpha", agent: "openclaw" },
+      staleRecovery: false,
+      backupManifest: null,
+      force: true,
+      log,
+      bail,
+      relockShieldsIfNeeded: vi.fn(() => true),
+      onDeleted: vi.fn(),
+    });
+
+    expect(mocks.prepareMcpForRebuild).toHaveBeenCalledWith(
+      "alpha",
+      false,
+      true,
+      expect.any(Function),
+      expect.any(Function),
+    );
   });
 });

--- a/src/lib/actions/sandbox/rebuild-destroy-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.ts
@@ -30,6 +30,7 @@ export interface RebuildDestroyPhaseInput {
   log: RebuildLog;
   bail: RebuildBail;
   relockShieldsIfNeeded: (sandboxStillExists: boolean) => boolean;
+  force?: boolean;
   validateAfterMcpPreparation?: () => Promise<RebuildDeleteValidationResult>;
   onDeleted: () => void;
 }
@@ -66,7 +67,8 @@ export async function runRebuildDestroyPhase(
     `Registry entry: agent=${sbMeta?.agent}, agentVersion=${sbMeta?.agentVersion}, nimContainer=${sbMeta?.nimContainer}`,
   );
   const mcpPreparation = await prepareMcpBeforeBestEffortNimStop({
-    prepareMcp: () => prepareMcpForRebuild(sandboxName, staleRecovery, relockShieldsIfNeeded, bail),
+    prepareMcp: () =>
+      prepareMcpForRebuild(sandboxName, staleRecovery, input.force === true, relockShieldsIfNeeded, bail),
     afterPrepare: async (preparation) => {
       // MCP preparation removes only adapter entries whose exact ownership
       // fingerprints match the registry. Probe afterward so a Deep Agents

--- a/src/lib/actions/sandbox/rebuild-mcp-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-mcp-phase.ts
@@ -21,6 +21,7 @@ export type McpRebuildPreparation = Awaited<ReturnType<typeof prepareMcpBridgesF
 export async function prepareMcpForRebuild(
   sandboxName: string,
   staleRecovery: boolean,
+  force: boolean,
   relockShieldsIfNeeded: (sandboxStillExists: boolean) => boolean,
   bail: (message: string, code?: number) => never,
 ): Promise<McpRebuildPreparation | null> {
@@ -29,6 +30,20 @@ export async function prepareMcpForRebuild(
       ? prepareMcpBridgesForAbsentSandboxRebuild(sandboxName)
       : prepareMcpBridgesForRebuild(sandboxName));
   } catch (error) {
+    if (force && !staleRecovery) {
+      console.error(
+        `  ${YW}⚠${R} Live MCP bridge preparation failed; --force falling back to host-side recovery`,
+      );
+      try {
+        return await prepareMcpBridgesForAbsentSandboxRebuild(sandboxName);
+      } catch (fallbackError) {
+        relockShieldsIfNeeded(!staleRecovery);
+        bail(
+          `Failed to preserve MCP bridges before rebuild (--force fallback): ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`,
+        );
+        return null;
+      }
+    }
     relockShieldsIfNeeded(!staleRecovery);
     bail(
       `Failed to preserve MCP bridges before rebuild: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/lib/actions/sandbox/rebuild-pipeline.ts
+++ b/src/lib/actions/sandbox/rebuild-pipeline.ts
@@ -203,6 +203,7 @@ async function rebuildSandboxUnlocked(
         sandboxEntry,
         staleRecovery,
         backupManifest: backup.backupManifest,
+        force: normalized.force,
         log,
         bail,
         relockShieldsIfNeeded,


### PR DESCRIPTION
## Problem

When a registered sandbox with managed MCP state has its exec relay permanently unavailable (sandbox reports `Ready` but `openshell sandbox exec` fails), `rebuild --force` cannot recover because `prepareMcpForRebuild` still requires the live exec relay to scrub the MCP adapter before deletion.

This leaves all supported recovery paths blocked:
- `rebuild --yes` — cannot back up through the failed relay
- `rebuild --force` — cannot scrub the managed MCP adapter through the failed relay
- `onboard --recreate-sandbox` — refuses a sandbox that owns managed MCP servers
- `mcp remove --force` — cannot prove complete cleanup

Closes #7062

## Solution

Thread the `force` flag from the rebuild pipeline into `prepareMcpForRebuild`. When `--force` is set and the live MCP bridge preparation fails (because the exec relay is unavailable), fall back to `prepareMcpBridgesForAbsentSandboxRebuild` — the host-side-only recovery path that doesn't require sandbox exec.

This follows the existing pattern where `--force` already skips backup failures, extending it to also recover from exec relay failures during MCP preparation.

## Changes

| File | Change |
|------|--------|
| `rebuild-mcp-phase.ts` | Add `force: boolean` param; catch live-path failure and fall back to absent-sandbox path when `force=true` |
| `rebuild-destroy-phase.ts` | Add `force?: boolean` to `RebuildDestroyPhaseInput`; thread to `prepareMcpForRebuild` |
| `rebuild-pipeline.ts` | Pass `normalized.force` into `runRebuildDestroyPhase` |
| `rebuild-destroy-phase.test.ts` | Verify `force=true` is threaded to `prepareMcpForRebuild` |

## Testing

- `npx vitest run src/lib/actions/sandbox/rebuild-destroy-phase.test.ts` — 2/2 pass
- `npx tsc --noEmit` — clean (no new errors)
- 4-file diff, 69 insertions, 1 deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added force-mode support to the sandbox rebuild workflow.
  * Force mode now enables fallback recovery when MCP preparation encounters errors.
  * Improved failure handling with clear warnings and fallback error reporting.

* **Tests**
  * Added coverage confirming that force mode is correctly passed through the rebuild and destroy phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->