### PR TITLE
fix(status): keep gateway selection out of JSON stdout

### DIFF
--- a/src/lib/actions/sandbox/gateway-select.test.ts
+++ b/src/lib/actions/sandbox/gateway-select.test.ts
@@ -20,8 +20,24 @@ describe("selectSandboxOwningGateway", () => {
     expect(selected).toEqual({ outcome: "selected", gatewayName: "nemoclaw-8091" });
     expect(run).toHaveBeenCalledWith(
       ["gateway", "select", "nemoclaw-8091"],
-      expect.objectContaining({ ignoreError: true }),
+      expect.objectContaining({
+        ignoreError: true,
+        stdio: ["inherit", "pipe", "inherit"],
+      }),
     );
+  });
+
+  it("replays selection output through the parent stdout writer", () => {
+    vi.spyOn(registry, "getSandbox").mockReturnValue({ gatewayPort: 8080 } as never);
+    const output = "\u001b[32m✓ Active gateway set to 'nemoclaw'\u001b[0m\n";
+    const run = vi.fn(() => ({ status: 0, stdout: output }) as never);
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    expect(selectSandboxOwningGateway("alpha", run)).toEqual({
+      outcome: "selected",
+      gatewayName: "nemoclaw",
+    });
+    expect(write).toHaveBeenCalledWith(output);
   });
 
   it("keeps the bare default gateway name for a default-port sandbox", () => {

--- a/src/lib/actions/sandbox/gateway-select.test.ts
+++ b/src/lib/actions/sandbox/gateway-select.test.ts
@@ -27,11 +27,11 @@ describe("selectSandboxOwningGateway", () => {
     );
   });
 
-  it("replays selection output through the parent stdout writer", () => {
+  it("replays selection output through stderr", () => {
     vi.spyOn(registry, "getSandbox").mockReturnValue({ gatewayPort: 8080 } as never);
     const output = "\u001b[32m✓ Active gateway set to 'nemoclaw'\u001b[0m\n";
     const run = vi.fn(() => ({ status: 0, stdout: output }) as never);
-    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     expect(selectSandboxOwningGateway("alpha", run)).toEqual({
       outcome: "selected",

--- a/src/lib/actions/sandbox/gateway-select.test.ts
+++ b/src/lib/actions/sandbox/gateway-select.test.ts
@@ -27,13 +27,13 @@ describe("selectSandboxOwningGateway", () => {
     );
   });
 
-  it("replays selection output through stderr", () => {
+  it("replays selection output through the stdio adapter", () => {
     vi.spyOn(registry, "getSandbox").mockReturnValue({ gatewayPort: 8080 } as never);
     const output = "\u001b[32m✓ Active gateway set to 'nemoclaw'\u001b[0m\n";
     const run = vi.fn(() => ({ status: 0, stdout: output }) as never);
-    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const write = vi.fn();
 
-    expect(selectSandboxOwningGateway("alpha", run)).toEqual({
+    expect(selectSandboxOwningGateway("alpha", run, write)).toEqual({
       outcome: "selected",
       gatewayName: "nemoclaw",
     });

--- a/src/lib/actions/sandbox/gateway-select.ts
+++ b/src/lib/actions/sandbox/gateway-select.ts
@@ -23,7 +23,7 @@ export function selectSandboxOwningGateway(
     stdio: ["inherit", "pipe", "inherit"],
     timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
   });
-  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stdout) process.stderr.write(result.stdout);
   if (result.error || result.status !== 0) {
     return { outcome: "failed", gatewayName: targetGatewayName };
   }

--- a/src/lib/actions/sandbox/gateway-select.ts
+++ b/src/lib/actions/sandbox/gateway-select.ts
@@ -20,8 +20,10 @@ export function selectSandboxOwningGateway(
   if (!targetGatewayName) return { outcome: "unregistered", gatewayName: null };
   const result = run(["gateway", "select", targetGatewayName], {
     ignoreError: true,
+    stdio: ["inherit", "pipe", "inherit"],
     timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
   });
+  if (result.stdout) process.stdout.write(result.stdout);
   if (result.error || result.status !== 0) {
     return { outcome: "failed", gatewayName: targetGatewayName };
   }

--- a/src/lib/actions/sandbox/gateway-select.ts
+++ b/src/lib/actions/sandbox/gateway-select.ts
@@ -3,9 +3,11 @@
 
 import { runOpenshell } from "../../adapters/openshell/runtime";
 import { OPENSHELL_OPERATION_TIMEOUT_MS } from "../../adapters/openshell/timeouts";
+import { writeStderr } from "../../adapters/stdio";
 import { getKnownSandboxTargetGatewayName } from "./gateway-target";
 
 export type GatewaySelectRunner = typeof runOpenshell;
+export type GatewaySelectOutputWriter = typeof writeStderr;
 
 export type GatewaySelectResult =
   | { outcome: "selected"; gatewayName: string }
@@ -15,6 +17,7 @@ export type GatewaySelectResult =
 export function selectSandboxOwningGateway(
   sandboxName: string,
   run: GatewaySelectRunner = runOpenshell,
+  writeOutput: GatewaySelectOutputWriter = writeStderr,
 ): GatewaySelectResult {
   const targetGatewayName = getKnownSandboxTargetGatewayName(sandboxName);
   if (!targetGatewayName) return { outcome: "unregistered", gatewayName: null };
@@ -23,7 +26,7 @@ export function selectSandboxOwningGateway(
     stdio: ["inherit", "pipe", "inherit"],
     timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
   });
-  if (result.stdout) process.stderr.write(result.stdout);
+  if (result.stdout) writeOutput(result.stdout);
   if (result.error || result.status !== 0) {
     return { outcome: "failed", gatewayName: targetGatewayName };
   }

--- a/src/lib/adapters/stdio.ts
+++ b/src/lib/adapters/stdio.ts
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function writeStderr(output: string): void {
+  process.stderr.write(output);
+}

--- a/test/cli/sandbox-status-json.test.ts
+++ b/test/cli/sandbox-status-json.test.ts
@@ -133,6 +133,10 @@ describe("CLI sandbox status JSON output", testTimeoutOptions(20_000), () => {
       path.join(localBin, "openshell"),
       [
         "#!/usr/bin/env bash",
+        'if [ "$1" = "gateway" ] && [ "$2" = "select" ]; then',
+        "  printf \"\\033[32m✓ Active gateway set to 'nemoclaw'\\033[0m\\n\"",
+        "  exit 0",
+        "fi",
         'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
         "  echo 'Gateway inference:'",
         "  echo",
@@ -168,6 +172,7 @@ describe("CLI sandbox status JSON output", testTimeoutOptions(20_000), () => {
     expect(r.out.trim().endsWith("}")).toBe(true);
     expect(r.out).not.toContain("Sandbox: ");
     expect(r.out).not.toContain("Nonexistent flag: --json");
+    expect(r.out).not.toContain("Active gateway set");
 
     const parsed = JSON.parse(r.out);
     expect(parsed).toMatchObject({

--- a/test/e2e/e2e-cloud-experimental/checks/04-deepagents-code-fresh-reonboard.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/04-deepagents-code-fresh-reonboard.sh
@@ -257,9 +257,9 @@ if (JSON.parse(process.env.CONFIG_MODEL_JSON) !== "openai:" + process.env.MODEL_
 ' || fail "keyed config get did not return model B after re-onboard"
 pass "keyed config get reports model B after re-onboard"
 
-status_output="$("$CLI" "$SANDBOX_NAME" status --json 2>&1)" || fail "nemoclaw status failed after re-onboard: $status_output"
-STATUS_OUTPUT="$status_output" SANDBOX_NAME="$SANDBOX_NAME" MODEL_B="$model_b" node -e '
-const status = JSON.parse(process.env.STATUS_OUTPUT);
+status_json="$("$CLI" "$SANDBOX_NAME" status --json)" || fail "nemoclaw status failed after re-onboard: ${status_json:-<no stdout>}"
+STATUS_JSON="$status_json" SANDBOX_NAME="$SANDBOX_NAME" MODEL_B="$model_b" node -e '
+const status = JSON.parse(process.env.STATUS_JSON);
 if (status.name !== process.env.SANDBOX_NAME ||
     status.model !== process.env.MODEL_B ||
     status.provider !== "compatible-endpoint") process.exit(1);

--- a/test/e2e/e2e-cloud-experimental/checks/04-deepagents-code-fresh-reonboard.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/04-deepagents-code-fresh-reonboard.sh
@@ -258,14 +258,8 @@ if (JSON.parse(process.env.CONFIG_MODEL_JSON) !== "openai:" + process.env.MODEL_
 pass "keyed config get reports model B after re-onboard"
 
 status_output="$("$CLI" "$SANDBOX_NAME" status --json 2>&1)" || fail "nemoclaw status failed after re-onboard: $status_output"
-# gateway-select.ts invokes OpenShell with inherited stdio. Remove this exception when owning-gateway
-# selection is quiet for machine-readable status output.
 STATUS_OUTPUT="$status_output" SANDBOX_NAME="$SANDBOX_NAME" MODEL_B="$model_b" node -e '
-const lines = process.env.STATUS_OUTPUT.split(/\r?\n/);
-const banner = "✓ Active gateway set to '\''nemoclaw'\''";
-const plainFirstLine = lines[0].replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");
-if (plainFirstLine === banner) lines.shift();
-const status = JSON.parse(lines.join("\n"));
+const status = JSON.parse(process.env.STATUS_OUTPUT);
 if (status.name !== process.env.SANDBOX_NAME ||
     status.model !== process.env.MODEL_B ||
     status.provider !== "compatible-endpoint") process.exit(1);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes the `status --json` regression introduced by #7113, where OpenShell's ANSI gateway-selection confirmation bypassed the CLI's stdout guard and made Deep Agents target discovery fail to parse the response. Human-readable status output remains unchanged while JSON stdout is again machine-parseable.

## Changes
<!-- Bullet list of key changes. -->

- Capture `openshell gateway select` stdout instead of letting the child process write directly to file descriptor 1.
- Replay captured output through an injected stdio adapter that writes to stderr, keeping the human confirmation visible without contaminating structured stdout or coupling the action to process streams.
- Add unit coverage for the subprocess stdio contract and integration coverage for the exact ANSI gateway-selection message.
- Remove the temporary #7233 consumer-side banner sanitizer so the Deep Agents fresh re-onboard check again parses the raw JSON document and detects any producer regression.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the existing documented structured `status --json` contract; stdout routing is an internal implementation detail.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending independent review; no waiver claimed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — gateway selection unit tests (6 passed); sandbox status JSON integration tests (18 passed); `npm run typecheck:cli`, `bash -n`, and `shellcheck` passed.
- [x] Exact-head GitHub CI and protected E2E evidence passed — [ordinary CI](https://github.com/NVIDIA/NemoClaw/actions/runs/29748711264), [controller](https://github.com/NVIDIA/NemoClaw/actions/runs/29749472530), and [child suite](https://github.com/NVIDIA/NemoClaw/actions/runs/29749508328).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this narrow stdout-routing regression; focused unit/integration tests, CLI typecheck, and normal hooks passed.
- [ ] Quality Gates section completed with required justifications or waivers — pending independent sensitive-path review.
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway selection output is now displayed correctly without contaminating structured JSON status responses.
  * `sandbox status --json` now consistently returns machine-readable output, even when gateway status messages are generated.

* **Tests**
  * Expanded coverage for gateway selection output handling and command execution behavior.
  * Updated end-to-end validation to parse status JSON reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
