### PR TITLE
fix(installer): accept OTA-upgraded DGX OS on Station GB300 without image marker

### DIFF
--- a/scripts/prepare-dgx-station-host.sh
+++ b/scripts/prepare-dgx-station-host.sh
@@ -197,8 +197,23 @@ dgx_station_release_profile() {
   platform="$(dgx_station_release_value "$path" DGX_PLATFORM)" || return 1
   [[ "$platform" == "DGX Server for GALAXY-GB300" ]] || return 1
 
-  if ota_pretty="$(dgx_station_release_value "$path" DGX_OTA_PRETTY_NAME 2>/dev/null)"; then
-    [[ "$ota_pretty" == "DGX OS" ]] || return 1
+  # DGX OS keeps its upgrade history in the DGX_OTA_* fields, so a host that has
+  # an OTA history is classified by the most recent OTA version it applied.
+  #
+  # A host provisioned from a full DGX OS image also carries the identity field
+  # DGX_OTA_PRETTY_NAME="DGX OS"; when that field is present it must read exactly
+  # "DGX OS". It is absent on a host that was first installed from an older base
+  # image (for example 7.4.1-GB300ws) and later OTA-upgraded, because an OTA
+  # upgrade never adds that field. In that case, fall back to the hardware
+  # identity and require DGX_PRETTY_NAME="NVIDIA DGX GB300WS" so that other
+  # release lineages that also emit DGX_OTA_* fields stay fail-closed.
+  if dgx_station_release_value "$path" DGX_OTA_VERSION >/dev/null 2>&1; then
+    if ota_pretty="$(dgx_station_release_value "$path" DGX_OTA_PRETTY_NAME 2>/dev/null)"; then
+      [[ "$ota_pretty" == "DGX OS" ]] || return 1
+    else
+      pretty="$(dgx_station_release_value "$path" DGX_PRETTY_NAME)" || return 1
+      [[ "$pretty" == "NVIDIA DGX GB300WS" ]] || return 1
+    fi
     version="$(dgx_station_release_value "$path" DGX_OTA_VERSION)" || return 1
     case "$version" in
       7.2.0 | 7.4.0 | 7.5.0) printf '%s' supported-dgx-os ;;
@@ -210,7 +225,6 @@ dgx_station_release_profile() {
   # No-OTA factory images are separate, exact profiles. Do not infer support
   # merely from a missing OTA identity: internal BaseOS and customer images
   # use different software stacks and qualification evidence.
-  dgx_station_release_value "$path" DGX_OTA_VERSION >/dev/null 2>&1 && return 1
   dgx_station_release_value "$path" DGX_OTA_DATE >/dev/null 2>&1 && return 1
   pretty="$(dgx_station_release_value "$path" DGX_PRETTY_NAME)" || return 1
   version="$(dgx_station_release_value "$path" DGX_SWBUILD_VERSION)" || return 1

--- a/test/install-station-dgx-os.test.ts
+++ b/test/install-station-dgx-os.test.ts
@@ -116,6 +116,36 @@ function writeNoOtaFactoryRelease(
   return target;
 }
 
+function writeOtaUpgradedRelease(
+  overrides: Partial<{ pretty: string; otaVersion: string; swbuildVersion: string }> = {},
+) {
+  const fields = {
+    pretty: "NVIDIA DGX GB300WS",
+    otaVersion: "7.5.0",
+    swbuildVersion: "7.4.1-GB300ws",
+    ...overrides,
+  };
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-ota-upgraded-"));
+  const target = path.join(dir, "dgx-release");
+  fs.writeFileSync(
+    target,
+    [
+      'DGX_NAME="DGX GB300WS"',
+      `DGX_PRETTY_NAME="${fields.pretty}"`,
+      'DGX_SWBUILD_DATE="2026-02-20-05-22-42"',
+      `DGX_SWBUILD_VERSION="${fields.swbuildVersion}"`,
+      'DGX_COMMIT_ID="51c59a9"',
+      'DGX_PLATFORM="DGX Server for GALAXY-GB300"',
+      'DGX_SERIAL_NUMBER="Unknown"',
+      "",
+      `DGX_OTA_VERSION="${fields.otaVersion}"`,
+      'DGX_OTA_DATE="Sun Apr 12 16:25:30 PDT 2026"',
+      "",
+    ].join("\n"),
+  );
+  return target;
+}
+
 describe("DGX Station stock DGX OS classification", () => {
   it.each([
     "7.2.0",
@@ -347,6 +377,37 @@ dgx_station_release_state "$DGX_RELEASE"
 
     expect(result.status, output).toBe(0);
     expect(result.stdout).toBe(expected);
+  });
+
+  it("classifies an OTA-upgraded GB300 workstation without the fresh-install marker as supported-dgx-os (#7103)", () => {
+    const release = writeOtaUpgradedRelease();
+    const { result, output } = runSourced(
+      STATION_PREPARE,
+      `
+stat() { printf '0|0|644|256\n'; }
+dgx_station_release_state "$DGX_RELEASE"
+`,
+      { DGX_RELEASE: release },
+    );
+
+    expect(result.status, output).toBe(0);
+    expect(result.stdout).toBe("supported-dgx-os");
+  });
+
+  it.each([
+    [
+      "a non-workstation DGX Server identity",
+      writeOtaUpgradedRelease({ pretty: "NVIDIA DGX Server" }),
+    ],
+    ["an unreviewed latest OTA version", writeOtaUpgradedRelease({ otaVersion: "7.6.0" })],
+  ])("keeps a marker-less OTA host fail-closed with %s (#7103)", (_scenario, release) => {
+    const { result } = runSourced(
+      STATION_PREPARE,
+      `dgx_station_release_contents_are_supported "$DGX_RELEASE"`,
+      { DGX_RELEASE: release },
+    );
+
+    expect(result.status).not.toBe(0);
   });
 
   it("keeps the classifier self-contained when the helper is transported alone", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Use existing repository terms; do not invent a label for this PR. -->
The Station express installer classifies a GB300 DGX OS host from its `/etc/dgx-release` metadata, but it only recognized DGX OS when the full-image identity field `DGX_OTA_PRETTY_NAME="DGX OS"` was present. A Station GB300 that was first installed from an older base image (for example `7.4.1-GB300ws`) and later OTA-upgraded to `7.5.0` accrues `DGX_OTA_VERSION`/`DGX_OTA_DATE` but never gains that field, so it fell through to `unsupported-dgx-os` and hit the express boundary error even though it is a genuine, healthy DGX OS `7.5.0` GB300 host. This change classifies a host that carries an OTA history by its latest applied OTA version, so such a host is now recognized as `supported-dgx-os` and takes the existing stock-DGX-OS path that reuses the factory driver and container runtime without mutating host packages.

## Related Issue
Fixes #7224 

## Changes
- `scripts/prepare-dgx-station-host.sh`: in `dgx_station_release_profile`, gate the DGX OS branch on OTA-history presence and the latest `DGX_OTA_VERSION` (`7.2.0`/`7.4.0`/`7.5.0`) rather than on the `DGX_OTA_PRETTY_NAME` image marker. When that marker is present it must still read exactly `DGX OS`; when it is absent, the host must identify as the GB300 workstation via `DGX_PRETTY_NAME="NVIDIA DGX GB300WS"` so that other release lineages which also emit `DGX_OTA_*` fields stay fail-closed. The now-shadowed `DGX_OTA_VERSION` guard in the no-OTA branch is removed; the `DGX_OTA_DATE` guard is kept as defense-in-depth.
- No new classification string or downstream wiring: the host resolves to the existing `supported-dgx-os` → `stock-dgx-os` profile, which already reuses the factory driver and container runtime with no package, service, or runtime mutation.
- `test/install-station-dgx-os.test.ts`: add a positive case for a marker-less OTA-upgraded GB300 workstation (mirrors the reported `/etc/dgx-release`, classified as `supported-dgx-os`), plus fail-closed cases for a non-workstation `DGX Server` identity and for an unreviewed latest OTA version.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no user-facing docs change; the DGX Station support matrix and boundary wording are unchanged (still Deferred; still DGX OS 7.2.0/7.4.0/7.5.0). Only the release-metadata classifier is broadened to recognize an OTA-upgraded host.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [ ] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [ ] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Hung Le <hple@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DGX OS release detection for OTA-upgraded workstations.
  * Added validation for supported OTA versions and release identities.
  * Prevented unsupported DGX Server identities and unreviewed OTA versions from being accepted.
  * Correctly recognizes eligible OTA-upgraded GB300 workstations without a fresh-install marker.

* **Tests**
  * Added coverage for OTA-upgraded workstation release detection and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->