### PR TITLE
fix(e2e): add retry to PR gate observer GitHub reads

### DIFF
--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -455,7 +455,7 @@ describe("native PR E2E required job", () => {
       expect(sleepCalls[0]).toBeLessThanOrEqual(100);
     });
 
-    it("exhausts retries and preserves the original error", async () => {
+    it("exhausts retries and preserves the first error as cause", async () => {
       let calls = 0;
       const error = await retryableGithubRead(
         "test-op",
@@ -474,7 +474,9 @@ describe("native PR E2E required job", () => {
       expect(calls).toBe(3);
       expect(error).toBeInstanceOf(TypeError);
       expect((error as TypeError).message).toBe("fetch failed attempt 3");
-      expect((error as Error & { cause?: unknown }).cause).toBeInstanceOf(TypeError);
+      const cause = (error as Error & { cause?: unknown }).cause;
+      expect(cause).toBeInstanceOf(TypeError);
+      expect((cause as TypeError).message).toBe("fetch failed attempt 1");
     });
 
     it("does not retry non-retryable HTTP responses", async () => {

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -11,8 +11,10 @@ import {
   coordinationExternalId,
   findCoordinationCheck,
   formatRequiredGateOutcome,
+  isRetryableError,
   type RequiredGateIdentity,
   type RequiredGateResult,
+  retryableGithubRead,
   waitForRequiredGate,
 } from "../tools/e2e/pr-e2e-required.mts";
 import { createGitHubFetchRouter, githubFetchRoute } from "./support/github-fetch-router.ts";
@@ -423,5 +425,103 @@ describe("native PR E2E required job", () => {
     await expect(
       waitForRequiredGate(identity, { timeoutMs: 100, pollIntervalMs: 10 }),
     ).rejects.toThrow("no longer matches the exact head and base revision");
+  });
+
+  describe("retryableGithubRead", () => {
+    it("retries a transient fetch failure and succeeds on the next attempt", async () => {
+      const responses = [
+        () => {
+          throw new TypeError("fetch failed");
+        },
+        () => "success",
+      ];
+      const sleepCalls: number[] = [];
+      const result = await retryableGithubRead(
+        "test-op",
+        async () => responses.shift()!() as string,
+        null,
+        {
+          baseDelayMs: 100,
+          sleep: async (ms) => {
+            sleepCalls.push(ms);
+          },
+        },
+      );
+
+      expect(result).toBe("success");
+      expect(responses).toHaveLength(0);
+      expect(sleepCalls).toHaveLength(1);
+      expect(sleepCalls[0]).toBeGreaterThan(0);
+      expect(sleepCalls[0]).toBeLessThanOrEqual(100);
+    });
+
+    it("exhausts retries and preserves the original error", async () => {
+      let calls = 0;
+      const error = await retryableGithubRead(
+        "test-op",
+        async () => {
+          calls += 1;
+          throw new TypeError(`fetch failed attempt ${calls}`);
+        },
+        null,
+        {
+          maxAttempts: 3,
+          baseDelayMs: 10,
+          sleep: async () => {},
+        },
+      ).catch((e: unknown) => e);
+
+      expect(calls).toBe(3);
+      expect(error).toBeInstanceOf(TypeError);
+      expect((error as TypeError).message).toBe("fetch failed attempt 3");
+      expect((error as Error & { cause?: unknown }).cause).toBeInstanceOf(TypeError);
+    });
+
+    it("does not retry non-retryable HTTP responses", async () => {
+      let calls = 0;
+      await expect(
+        retryableGithubRead(
+          "test-op",
+          async () => {
+            calls += 1;
+            throw new Error("GitHub API repos/x/pulls/1 failed: 404 Not Found");
+          },
+          null,
+          { sleep: async () => {} },
+        ),
+      ).rejects.toThrow("failed: 404 Not Found");
+
+      expect(calls).toBe(1);
+    });
+
+    it("fails closed when PR identity changes during retry", async () => {
+      let calls = 0;
+      vi.spyOn(globalThis, "fetch").mockImplementation(
+        createGitHubFetchRouter([
+          githubFetchRoute(
+            ({ url }) => url.includes("/pulls/42"),
+            () => githubResponse(pullRequest({ head: { sha: "c".repeat(40) } })),
+          ),
+          githubFetchRoute(
+            ({ url }) => !url.includes("/pulls/42"),
+            () => githubResponse({}),
+          ),
+        ]),
+      );
+
+      await expect(
+        retryableGithubRead(
+          "test-op",
+          async () => {
+            calls += 1;
+            throw new TypeError("fetch failed");
+          },
+          identity,
+          { sleep: async () => {} },
+        ),
+      ).rejects.toThrow("no longer matches the exact head and base revision");
+
+      expect(calls).toBe(1);
+    });
   });
 });

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -32,6 +32,20 @@ const MAX_LOG_URLS = 20;
 
 type CheckConclusion = "success" | "failure" | "cancelled";
 
+export type RetryableGithubReadOptions = {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+const RETRYABLE_HTTP_PATTERN = /failed: (5\d{2}|429)\b/;
+
+export function isRetryableError(error: unknown): boolean {
+  if (error instanceof TypeError) return true;
+  if (error instanceof Error && RETRYABLE_HTTP_PATTERN.test(error.message)) return true;
+  return false;
+}
+
 export type CoordinationCheckRun = {
   id: number;
   name: string;
@@ -162,6 +176,50 @@ async function requireExactPullRequest(identity: RequiredGateIdentity): Promise<
   );
 }
 
+export async function retryableGithubRead<T>(
+  operation: string,
+  fn: () => Promise<T>,
+  identity: RequiredGateIdentity | null,
+  options?: RetryableGithubReadOptions,
+): Promise<T> {
+  const maxAttempts = Math.max(1, options?.maxAttempts ?? 3);
+  const baseDelayMs = options?.baseDelayMs ?? 1000;
+  const sleep =
+    options?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error: unknown) {
+      if (!isRetryableError(error) || attempt === maxAttempts) {
+        if (attempt > 1 && error instanceof Error && lastError instanceof Error) {
+          (error as Error & { cause?: unknown }).cause = lastError;
+        }
+        throw error;
+      }
+      lastError = error;
+      const errorClass = error instanceof TypeError ? "network" : "http";
+      console.log(`E2E / PR Gate [${operation}] attempt ${attempt}/${maxAttempts}: ${errorClass}`);
+
+      if (identity) {
+        try {
+          await requireExactPullRequest(identity);
+        } catch (revalidationError: unknown) {
+          if (!isRetryableError(revalidationError)) {
+            throw revalidationError;
+          }
+        }
+      }
+
+      const jitter = 0.5 + Math.random() * 0.5;
+      const delay = Math.min(baseDelayMs * 2 ** (attempt - 1) * jitter, 4000);
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
 function hasRetryableFailureMarker(check: CoordinationCheckRun): boolean {
   if (check.status !== "completed" || check.conclusion !== "failure") return false;
   if (NEVER_RETRY_FAILURE_TITLES.has(check.output?.title ?? "")) return false;
@@ -207,10 +265,15 @@ async function matchingChecks(
   name: string,
 ): Promise<CoordinationCheckRun[]> {
   const response = validateCheckRunsResponse(
-    await githubApi<unknown>(
-      `repos/${identity.repository}/commits/${identity.headSha}/check-runs?check_name=${encodeURIComponent(name)}&filter=all&per_page=100`,
-      identity.token,
-      { userAgent: USER_AGENT },
+    await retryableGithubRead(
+      `matchingChecks(${name})`,
+      () =>
+        githubApi<unknown>(
+          `repos/${identity.repository}/commits/${identity.headSha}/check-runs?check_name=${encodeURIComponent(name)}&filter=all&per_page=100`,
+          identity.token,
+          { userAgent: USER_AGENT },
+        ),
+      identity,
     ),
   );
   const externalId = coordinationExternalId(identity.prNumber, identity.headSha, identity.baseSha);
@@ -362,14 +425,24 @@ export async function waitForRequiredGate(
   let lastDescription = "";
   let lastLogUrls: string[] | undefined;
 
-  await requireExactPullRequest(identity);
+  await retryableGithubRead(
+    "requireExactPullRequest",
+    () => requireExactPullRequest(identity),
+    null,
+    { sleep },
+  );
   while (now() < deadline) {
     const classified = classifyCoordinationCheck(
       await findCoordinationCheck(identity),
       identity.repository,
     );
     if (classified.state === "complete") {
-      await requireExactPullRequest(identity);
+      await retryableGithubRead(
+        "requireExactPullRequest",
+        () => requireExactPullRequest(identity),
+        null,
+        { sleep },
+      );
       return classified.result;
     }
     const message = `${classified.description}${logUrlSuffix(classified.logUrls)}`;

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -187,17 +187,19 @@ export async function retryableGithubRead<T>(
   const sleep =
     options?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
+  let firstError: unknown;
   let lastError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       return await fn();
     } catch (error: unknown) {
       if (!isRetryableError(error) || attempt === maxAttempts) {
-        if (attempt > 1 && error instanceof Error && lastError instanceof Error) {
-          (error as Error & { cause?: unknown }).cause = lastError;
+        if (attempt > 1 && error instanceof Error && firstError instanceof Error) {
+          (error as Error & { cause?: unknown }).cause = firstError;
         }
         throw error;
       }
+      firstError ??= error;
       lastError = error;
       const errorClass = error instanceof TypeError ? "network" : "http";
       console.log(`E2E / PR Gate [${operation}] attempt ${attempt}/${maxAttempts}: ${errorClass}`);


### PR DESCRIPTION
## Summary

The native E2E PR Gate required-check observer (`tools/e2e/pr-e2e-required.mts`) can terminate with a `fetch failed` error after a single transient GitHub API read failure. This adds bounded retry with identity safety for all GitHub API reads in the observer.

## Changes

**`tools/e2e/pr-e2e-required.mts`** — New `retryableGithubRead<T>()` helper:
- 3 max attempts with exponential backoff (1s base, 2× growth, jitter, capped at 4s)
- Error classification: `TypeError` (network) or `5xx`/`429` in error message → retryable; all else → immediate rethrow
- Identity re-validation between retries via `requireExactPullRequest` — fail-closed if PR head/base changed during retry window
- Best-effort re-validation: transient errors during re-validation don't abort the retry cycle
- Applied to `matchingChecks()` GitHub API calls (with identity re-validation) and `requireExactPullRequest()` calls in `waitForRequiredGate` (retry-only, no re-validation)
- Observer-local — no changes to shared `tools/advisors/github.mts`

**`test/pr-e2e-required.test.ts`** — 4 new deterministic tests:
- Retries a transient fetch failure and succeeds on the next attempt
- Exhausts retries and preserves the original error as `cause`
- Does not retry non-retryable HTTP responses (e.g. 404)
- Fails closed when PR identity changes during retry

## Testing

```
npx vitest run test/pr-e2e-required.test.ts  # 19 tests pass (15 existing + 4 new)
npx biome check tools/e2e/pr-e2e-required.mts test/pr-e2e-required.test.ts  # clean
```

Closes #7207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable retry helper for GitHub API reads with bounded exponential backoff and jitter.
  * Enhanced the required-gate E2E flow to retry transient failures and revalidate PR identity during retry windows.
  * Updated gate checks/wait logic to use the new retry behavior.
* **Bug Fixes**
  * Retries now skip non-retryable failures (e.g., 404).
  * Preserves the original error when retry attempts are exhausted.
  * “Fails closed” if PR head/base changes during retries.
* **Tests**
  * Added e2e coverage for retry success, exhaustion, non-retryable behavior, and identity-change failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->