### PR TITLE
docs: add v0.0.89 release changelog

### DIFF
--- a/docs/changelog/2026-07-20.mdx
+++ b/docs/changelog/2026-07-20.mdx
@@ -1,0 +1,24 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.89
+
+NemoClaw v0.0.89 broadens qualified DGX Station installation paths, preserves inference choices through onboarding and rebuilds, strengthens sandbox recovery, discloses messaging policy scope before mutation, and keeps CLI output and background processes contained.
+
+- DGX Station preparation now recognizes qualified OTA-upgraded GB300 workstations, both reviewed GB300 PCI device variants, and compatible installed package revisions without weakening the fail-closed boundary for unknown host drift.
+  The Station Express flow preserves its accepted recipe across reboot or login handoff, validates package state before mutation, retains the qualified forward DKMS revision, and allows an idle PackageKit daemon while continuing to reject active package transactions.
+  For more information, refer to [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/prerequisites/dgx-station-preparation) and the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart).
+- Onboarding now attaches the selected inference provider when it creates a sandbox and preserves the original endpoint provenance so later model switches retain the intended custom endpoint security boundary.
+  Managed vLLM cleanup reaps processes left behind by failed or interrupted startup, onboarding heartbeats identify the active vLLM installation, and Ollama model selection guidance distinguishes explicit model names from discovery.
+  For more information, refer to [Meet Custom Endpoint Security Requirements](/user-guide/openclaw/inference/custom-endpoints/custom-endpoint-security), [Switch Inference Models](/user-guide/openclaw/inference/manage-inference/switch-models), and [Set Up Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama).
+- Sandbox recovery and rebuild now wait for the target sandbox before probe-only inspection without restarting the shared host gateway, verify recovered sandbox stability, and recommend `start` when a sandbox container has crashed.
+  Rebuilds refresh the agent's primary model from the newly generated configuration, preserve durable agent tuning and intentional non-default model pins, preserve the Hermes default kanban database, and respawn the OpenClaw gateway after a managed restart.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Channel onboarding, channel lifecycle commands, rebuild reconciliation, and policy dry runs now print the complete effective messaging-preset egress before applying any policy mutation.
+  The disclosure comes from the exact policy YAML and includes hosts, ports, transport and access details, HTTP methods and paths, and the binary allowlist.
+  For more information, refer to [Common NemoClaw Integration Policy Examples](/user-guide/openclaw/network-policy/integration-policy-examples) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Sandbox status keeps human-readable gateway selection diagnostics out of JSON standard output, and inference route displays sanitize terminal control characters before printing provider, endpoint, or model values.
+  Hermes uninstall also stops its detached dashboard forward watcher so the background process does not survive sandbox removal.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the canonical dated changelog entry for NemoClaw `v0.0.89` before the release plan captures the tag commit.
The entry summarizes the user-visible Station preparation, inference, recovery, policy-disclosure, and CLI-containment changes merged since `v0.0.88`.

## Changes

- Add `docs/changelog/2026-07-20.mdx` with the exact `## v0.0.89` release heading, parser-safe SPDX comment, summary, and detailed bullets.
- Link each shipped theme to the most specific published OpenClaw documentation routes.
- Keep internal E2E, advisory-registry, and review-workflow refactors out of the user-facing release summary.

Source summary:

- #7214, #7241, #7237, #7223, #7204, #7202, #7183, and #7090 -> `docs/changelog/2026-07-20.mdx`: Summarize qualified DGX Station identity, package-state, PackageKit, DKMS, and reboot-handoff fixes.
- #7242, #7221, #7186, #7164, and #6874 -> `docs/changelog/2026-07-20.mdx`: Summarize inference endpoint provenance, provider attachment, managed vLLM cleanup and progress, and Ollama selection guidance.
- #7225, #7216, #7192, #7136, #7096, and #6910 -> `docs/changelog/2026-07-20.mdx`: Summarize sandbox readiness, recovery guidance, rebuilt model routing, durable Hermes state, and gateway restart behavior.
- #7187 -> `docs/changelog/2026-07-20.mdx`: Summarize complete effective messaging-preset egress disclosure before policy mutation.
- #7218, #7165, and #7184 -> `docs/changelog/2026-07-20.mdx`: Summarize structured output containment, terminal-safe route display, and Hermes forward cleanup.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This PR adds release-history prose only; the focused changelog contract test validates its required structure and routes.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `mise exec node@22.23.1 -- npx vitest run test/changelog-docs.test.ts` (6 passed).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this doc-only release entry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — `mise exec node@22.23.1 -- npm run docs` completed with 0 errors and 2 existing site-wide warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — the native changelog entry uses the required parser-safe MDX SPDX comment and does not use frontmatter.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded DGX Station installation support for qualified GB300 and OTA-upgraded environments.
  * Preserved selected inference providers, endpoints, model pins, and tuning settings during sandbox creation and rebuilds.
  * Improved sandbox recovery by validating availability and stability before restarting services.
  * Added clearer policy output showing the complete effective messaging egress configuration.

* **Bug Fixes**
  * Hardened status and inference route displays by sanitizing terminal control characters.
  * Improved Hermes uninstall behavior by stopping detached dashboard forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->