### PR TITLE
docs: align Station coding-agent path with installer

### DIFF
--- a/docs/resources/prompt-assets/dgx-station.md
+++ b/docs/resources/prompt-assets/dgx-station.md
@@ -3,52 +3,47 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
-# DGX Station DeepSeek Instructions
+# DGX Station Express Instructions
 
 Use these instructions only after hardware detection confirms DGX Station.
 
-The provider-preseeded DeepSeek path below is not the installer Express path and is allowed only on an already-prepared DGX Station.
+Use the selected maintained release's official installer as the authority for Station qualification, host preparation, model selection, consent, and reboot or login resume.
+Do not run the Station preparation helper separately or reproduce Express by pre-setting provider and model environment variables.
+
+The installer provides these Station Express model choices:
+
+1. The ordinary installer defaults to `nemotron-3-ultra-550b-a55b`, served as `nvidia/nemotron-3-ultra-550b-a55b`.
+2. The explicit `--station-deepseek` flag selects `deepseek-v4-flash`, served as `deepseek-ai/DeepSeek-V4-Flash`.
+
+Both choices use the same Station detection, host-preparation, consent, suggested-policy, default-sandbox, and exact-revision resume flow.
 
 Before asking for consent, explain all of these boundaries:
 
-- The official `--station-deepseek` installer flow may install or change NVIDIA open driver `610.43.02`, Docker CE `29.6.1` with Buildx, NVIDIA Container Toolkit `1.19.1`, and the reviewed factory `dkms` transition from `3.0.11-1ubuntu13` to `1:3.4.0-1ubuntu1`.
+- On generic Ubuntu, Station Express may install or change the pinned NVIDIA open driver, Docker with Buildx, NVIDIA Container Toolkit, and the reviewed factory `dkms` transition. On qualified factory images, the installer follows its bounded validation and repair path instead of replacing the factory stack.
 - Official Station preparation may add the trusted local account to the `docker` group, which grants root-equivalent control and is suitable only for a trusted single-user development host.
 - Official Station preparation may require an operator-controlled reboot and resumes only with the exact accepted NemoClaw revision.
-- Both Station paths may install Node.js and the NemoClaw CLI, download a pinned vLLM container and DeepSeek V4 Flash model data, require enough space on the model-cache filesystem and Docker storage, and create a sandbox with suggested policy defaults.
+- Nemotron Ultra Express discloses an approximately `352 GB` model download. DeepSeek Express downloads its pinned vLLM container and model data. Both require enough space on the model-cache filesystem and Docker storage.
 - DGX Station remains an evaluation path with deferred end-to-end validation on physical hardware, so startup may still fail after readiness checks.
 
-Both `--check` and `--verify` are non-repairing readiness modes, and neither applies host repairs.
-`--verify` requires the pinned acceptance image to already be present locally and fails if the image is missing; it does not pull the image.
-`--verify` is not read-only: it starts short-lived GPU test containers through both CDI (`nvidia.com/gpu=all`) and Docker `--gpus all`, consumes GPU and temporary Docker storage, and may create Docker state and logs.
-
-Ask permission to run the selected maintained release's `scripts/prepare-dgx-station-host.sh --check` and `scripts/prepare-dgx-station-host.sh --verify` readiness modes.
-Treat the host as prepared only when both modes succeed and confirm the exact Station GB300 platform, generic Ubuntu 24.04 ARM64 image, pinned driver and package versions, packaged CDI lifecycle, `nvidia.com/gpu=all`, and real CDI and `--gpus all` container access.
-
-If either readiness mode fails, reports a mismatch, is unavailable, or has an inconclusive outcome:
-
-- Do not set `NEMOCLAW_PROVIDER`, `NEMOCLAW_VLLM_MODEL`, `NEMOCLAW_MODEL`, `NEMOCLAW_NON_INTERACTIVE`, `NEMOCLAW_YES`, or `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE`.
-- Explain that the only supported next step is the official installer with `--station-deepseek`, which owns pinned Station preparation and exact-revision reboot resume, then ask permission to start it.
-- Let the official installer present its third-party-software notice and complete confirmation summary.
-- Keep the official confirmation visible as the single active question, wait for the user's response, and do not pre-answer or suppress it.
-- If a secure interactive terminal is unavailable, stop instead of falling back to the provider-preseeded path.
-
-If and only if both readiness modes succeed, explain that the prepared-host path skips Station host preparation, uses DeepSeek V4 Flash in vLLM, and downloads the pinned vLLM container and model data.
-Include the third-party-software notice, then ask: "Run the prepared-host DeepSeek install with these settings?"
+Ask: "Which DGX Station Express model would you like?"
 Choices:
 
-1. Yes, use the prepared-host DeepSeek defaults.
-2. No, let me choose the runtime and model.
+1. Nemotron 3 Ultra 550B, the ordinary installer default.
+2. DeepSeek V4 Flash, the explicit `--station-deepseek` override.
+3. Neither, let me choose the runtime and model normally.
 
-If the prepared-host DeepSeek path is selected:
+If a Station Express model is selected:
 
-- Set `NEMOCLAW_PROVIDER=install-vllm`.
-- Set `NEMOCLAW_VLLM_MODEL=deepseek-v4-flash` and `NEMOCLAW_MODEL=deepseek-ai/DeepSeek-V4-Flash`.
 - Set `NEMOCLAW_AGENT` to the agent already selected in the starter prompt.
-- Set `NEMOCLAW_NON_INTERACTIVE=1`, `NEMOCLAW_NON_INTERACTIVE_SUDO_MODE=prompt`, `NEMOCLAW_YES=1`, and `NEMOCLAW_POLICY_MODE=suggested`.
-- Set `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` when the prepared-host DeepSeek path is accepted.
-- Leave `NEMOCLAW_SANDBOX_NAME`, `NEMOCLAW_POLICY_TIER`, web-search settings, and messaging settings unset so the installer applies the remaining maintained defaults.
-- Treat the prepared-host confirmation as approval for the disclosed downloads, sandbox creation, and installation, and skip the later final-permission prompt.
-- Do not ask again for the agent or ask separate questions for model, sandbox name, web search, messaging, policy, download approval, or final installation approval.
+- For Nemotron Ultra, run the ordinary installer without `--station-deepseek`.
+- For DeepSeek, pass `--station-deepseek` and no other model-selection override.
+- Do not set `NEMOCLAW_PROVIDER`, `NEMOCLAW_VLLM_MODEL`, `NEMOCLAW_MODEL`, `NEMOCLAW_NON_INTERACTIVE`, `NEMOCLAW_YES`, `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE`, or `NEMOCLAW_NO_EXPRESS`.
+- Leave `NEMOCLAW_SANDBOX_NAME`, `NEMOCLAW_POLICY_TIER`, web-search settings, and messaging settings unset so the installer applies its Express defaults.
+- Do not run `scripts/prepare-dgx-station-host.sh --check`, `--verify`, or `--apply` separately. The installer owns Station qualification and preparation.
+- Run the installer only in a secure interactive terminal. If the coding-agent UI cannot keep the installer prompts visible and accept the user's response, stop before installation.
+- Let the installer present its third-party-software notice and complete Express summary. Keep each official confirmation visible, wait for the user's response, and do not pre-answer or suppress it.
+- Do not pass `--force-station-install` unless the installer rejects release metadata on genuine Station GB300 hardware and the user separately chooses the documented temporary override.
+- Follow the installer's printed exact-revision command after a required reboot or login transition.
 
-If the prepared-host DeepSeek path is declined, continue with the normal provider selection.
+If Station Express is declined, continue with the normal provider selection.
 Offer existing vLLM when a ready server is detected, managed vLLM, supported local Ollama, and every hosted or compatible provider supported by the selected agent.

--- a/docs/resources/starter-prompt.md
+++ b/docs/resources/starter-prompt.md
@@ -123,6 +123,7 @@ Ask required model, endpoint, credential, and download questions one at a time.
 - Use non-interactive environment variables whenever supported.
 - Never leave a command waiting at `Choose [1]:`.
 - If a choice cannot be supplied non-interactively, stop before starting and explain the supported alternative.
+- The DGX Station asset is the exception for the official third-party-software notice and Express confirmation. Keep those installer prompts visible, wait for the user's response, and do not pre-answer them.
 
 ## Handle Tokens Securely and Visually
 
@@ -220,7 +221,8 @@ Use `channels add` and rebuild only for channels omitted from initial onboarding
 - Explain that messaging and web-search selections add required endpoints.
 - Before installation outside an accepted platform-asset path, summarize platform, administrator access, agent, provider, exact model, validation warning, downloads, storage, sandbox, web search, messaging, policy, credential names without their values, and system changes.
 - Ask for final permission before installation outside an accepted platform-asset path.
-- For an accepted platform-asset install path, treat the asset's confirmation as final permission and do not ask again.
+- When a platform asset delegates consent to the official installer, let the installer present its notice and final Express confirmation instead of pre-accepting them.
+- For other accepted platform-asset install paths, treat the asset's confirmation as final permission and do not ask again.
 - Set `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` and `NEMOCLAW_YES=1` only after their approvals.
 - Keep credentials in the approved environment and never display them.
 - Verify the command and version, sandbox status, provider, model, `inference.local`, GPU access when applicable, messaging bridges when configured, and dashboard route when available.

--- a/docs/resources/starter-prompt.md
+++ b/docs/resources/starter-prompt.md
@@ -68,9 +68,9 @@ Use `NEMOCLAW_AGENT=langchain-deepagents-code` or `nemo-deepagents onboard` for 
 
 After the readiness check, load exactly one matching instruction asset before provider selection:
 
-- Confirmed DGX Spark: [DGX Spark Express instructions](https://raw.githubusercontent.com/NVIDIA/NemoClaw/f3682a5be7069e58303d3345e682424d5c2453b2/docs/resources/prompt-assets/dgx-spark.md).
-- Confirmed DGX Station: [DGX Station installation instructions](https://raw.githubusercontent.com/NVIDIA/NemoClaw/f3682a5be7069e58303d3345e682424d5c2453b2/docs/resources/prompt-assets/dgx-station.md).
-- Officially detected Windows WSL: [Windows WSL Express instructions](https://raw.githubusercontent.com/NVIDIA/NemoClaw/f3682a5be7069e58303d3345e682424d5c2453b2/docs/resources/prompt-assets/windows-wsl.md).
+- Confirmed DGX Spark: [DGX Spark Express instructions](https://raw.githubusercontent.com/NVIDIA/NemoClaw/f814db4f7708ecf9ab054fcee449f11c95076dfd/docs/resources/prompt-assets/dgx-spark.md).
+- Confirmed DGX Station: [DGX Station installation instructions](https://raw.githubusercontent.com/NVIDIA/NemoClaw/f814db4f7708ecf9ab054fcee449f11c95076dfd/docs/resources/prompt-assets/dgx-station.md).
+- Officially detected Windows WSL: [Windows WSL Express instructions](https://raw.githubusercontent.com/NVIDIA/NemoClaw/f814db4f7708ecf9ab054fcee449f11c95076dfd/docs/resources/prompt-assets/windows-wsl.md).
 
 Read the matching raw Markdown file completely and follow it before continuing.
 Do not load a platform asset for any other computer.

--- a/test/starter-prompt-docs.test.ts
+++ b/test/starter-prompt-docs.test.ts
@@ -754,56 +754,22 @@ describe("starter prompt docs CTA", () => {
 
     expect(sparkSource).toContain("nvidia/Qwen3.6-35B-A3B-NVFP4");
     expect(sparkSource).toContain("Leave `NEMOCLAW_VLLM_MODEL` and `NEMOCLAW_MODEL` unset");
-    expect(stationSource).toContain("NEMOCLAW_VLLM_MODEL=deepseek-v4-flash");
-    expect(stationSource).toContain("NEMOCLAW_MODEL=deepseek-ai/DeepSeek-V4-Flash");
+    expect(stationSource).toContain("`nemotron-3-ultra-550b-a55b`");
+    expect(stationSource).toContain("`nvidia/nemotron-3-ultra-550b-a55b`");
+    expect(stationSource).toContain("`deepseek-v4-flash`");
+    expect(stationSource).toContain("`deepseek-ai/DeepSeek-V4-Flash`");
+    expect(stationSource).toContain("Nemotron 3 Ultra 550B, the ordinary installer default");
     expect(stationSource).toContain(
-      "provider-preseeded DeepSeek path below is not the installer Express path",
+      "DeepSeek V4 Flash, the explicit `--station-deepseek` override",
     );
-    expect(stationSource).toContain("downloads the pinned vLLM container and model data");
-    expect(stationSource).not.toContain("nemotron-3-ultra");
+    expect(stationSource).not.toContain("provider-preseeded DeepSeek path");
+    expect(stationSource).not.toContain("only supported next step");
     expect(stationSource).toContain("model-cache filesystem and Docker storage");
-    expect(stationSource).toContain("scripts/prepare-dgx-station-host.sh --check");
-    expect(stationSource).toContain("scripts/prepare-dgx-station-host.sh --verify");
-    const stationPermissionIndex = stationSource.indexOf(
-      "Ask permission to run the selected maintained release's",
+    expect(stationSource).toContain(
+      "Do not run `scripts/prepare-dgx-station-host.sh --check`, `--verify`, or `--apply` separately",
     );
-    const stationNonRepairingDisclosureIndex = stationSource.indexOf(
-      "Both `--check` and `--verify` are non-repairing readiness modes, and neither applies host repairs.",
-    );
-    const stationImageDisclosureIndex = stationSource.indexOf(
-      "`--verify` requires the pinned acceptance image to already be present locally",
-    );
-    const stationContainerDisclosureIndex = stationSource.indexOf(
-      "`--verify` is not read-only: it starts short-lived GPU test containers through both CDI",
-    );
-    expect(stationSource).toContain("consumes GPU and temporary Docker storage");
-    expect(stationSource).toContain("may create Docker state and logs");
-    expect(stationSource).not.toContain(
-      "Both `--check` and `--verify` are read-only readiness modes",
-    );
-    expect(stationPermissionIndex).toBeGreaterThan(-1);
-    for (const disclosureIndex of [
-      stationNonRepairingDisclosureIndex,
-      stationImageDisclosureIndex,
-      stationContainerDisclosureIndex,
-    ]) {
-      expect(disclosureIndex).toBeGreaterThan(-1);
-      expect(disclosureIndex).toBeLessThan(stationPermissionIndex);
-    }
-    expect(stationSource).not.toMatch(/--verify[^.\n]*\b(?:may|can|will)\s+pull\b/i);
-    expect(stationSource).toContain("If either readiness mode fails");
-    const stationFailureIndex = stationSource.indexOf("If either readiness mode fails");
-    const stationFallbackIndex = stationSource.indexOf(
-      "only supported next step is the official installer with `--station-deepseek`",
-      stationFailureIndex,
-    );
-    expect(stationFailureIndex).toBeGreaterThan(-1);
-    expect(stationFallbackIndex).toBeGreaterThan(stationFailureIndex);
-    const stationFailureInstructions = stationSource.slice(
-      stationFailureIndex,
-      stationFallbackIndex,
-    );
-    expect(stationFailureInstructions).toContain("- Do not set ");
+    expect(stationSource).toContain("For Nemotron Ultra, run the ordinary installer without");
+    expect(stationSource).toContain("For DeepSeek, pass `--station-deepseek`");
     for (const environmentName of [
       "NEMOCLAW_PROVIDER",
       "NEMOCLAW_VLLM_MODEL",
@@ -811,14 +777,15 @@ describe("starter prompt docs CTA", () => {
       "NEMOCLAW_NON_INTERACTIVE",
       "NEMOCLAW_YES",
       "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE",
+      "NEMOCLAW_NO_EXPRESS",
     ]) {
-      expect(stationFailureInstructions).toContain(`\`${environmentName}\``);
+      expect(stationSource).toContain(`\`${environmentName}\``);
     }
     expect(stationSource).toContain(
-      "Let the official installer present its third-party-software notice and complete confirmation summary.",
+      "Let the installer present its third-party-software notice and complete Express summary.",
     );
-    expect(stationSource).toContain("If a secure interactive terminal is unavailable, stop");
-    expect(stationSource).toContain("Keep the official confirmation visible");
+    expect(stationSource).toContain("Run the installer only in a secure interactive terminal");
+    expect(stationSource).toContain("Keep each official confirmation visible");
     expect(stationSource).toContain("evaluation path with deferred end-to-end validation");
     expect(stationSource).toContain("startup may still fail after readiness checks");
     expect(stationSource).toContain("third-party-software notice");
@@ -843,7 +810,6 @@ describe("starter prompt docs CTA", () => {
     const promptSource = readStarterPrompt();
     const platformAssets = [
       readPromptAsset(promptAssets.dgxSpark),
-      readPromptAsset(promptAssets.dgxStation),
       readPromptAsset(promptAssets.windowsWsl),
     ];
     const expressAssets = [
@@ -863,7 +829,7 @@ describe("starter prompt docs CTA", () => {
       "For installation outside an accepted platform-asset path, ask for Balanced, Restricted, or Open policy.",
     );
     expect(promptSource).toContain(
-      "For an accepted platform-asset install path, treat the asset's confirmation as final permission and do not ask again.",
+      "When a platform asset delegates consent to the official installer, let the installer present its notice and final Express confirmation instead of pre-accepting them.",
     );
     expect(promptSource).toContain(
       "Ask for final permission before installation outside an accepted platform-asset path.",
@@ -900,39 +866,35 @@ describe("starter prompt docs CTA", () => {
     }
 
     expect(stationSource).toContain(
-      "Set `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` when the prepared-host DeepSeek path is accepted.",
+      "Use the selected maintained release's official installer as the authority",
     );
-    expect(stationSource).toContain("Treat the prepared-host confirmation as approval");
+    expect(stationSource).toContain(
+      "Set `NEMOCLAW_AGENT` to the agent already selected in the starter prompt.",
+    );
+    expect(stationSource).not.toContain("`NEMOCLAW_NON_INTERACTIVE=1`");
+    expect(stationSource).not.toContain("Set `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1`");
+    expect(stationSource).not.toContain("Set `NEMOCLAW_PROVIDER=install-vllm`");
 
-    const stationDisclosureIndex = stationSource.indexOf(
-      "official `--station-deepseek` installer flow may install or change",
-    );
+    const stationDisclosureIndex = stationSource.indexOf("On generic Ubuntu, Station Express");
     const stationDockerGroupIndex = stationSource.indexOf(
       "`docker` group, which grants root-equivalent control",
     );
     const stationRebootIndex = stationSource.indexOf("operator-controlled reboot");
-    const stationNoticeIndex = stationSource.indexOf("Include the third-party-software notice");
+    const stationNoticeIndex = stationSource.indexOf(
+      "Let the installer present its third-party-software notice",
+    );
     const stationConfirmationIndex = stationSource.indexOf("Choices:");
-    const stationFailClosedIndex = stationSource.indexOf("If either readiness mode fails");
-    const stationPreparedGateIndex = stationSource.indexOf(
-      "If and only if both readiness modes succeed",
+    const stationDefaultIndex = stationSource.indexOf(
+      "For Nemotron Ultra, run the ordinary installer without",
     );
-    const stationProviderSetIndex = stationSource.indexOf("- Set `NEMOCLAW_PROVIDER=install-vllm`");
-    const stationAcceptanceIndex = stationSource.indexOf(
-      "Set `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1`",
-    );
+    const stationOverrideIndex = stationSource.indexOf("For DeepSeek, pass `--station-deepseek`");
     expect(stationDisclosureIndex).toBeGreaterThan(-1);
     expect(stationDockerGroupIndex).toBeGreaterThan(stationDisclosureIndex);
     expect(stationRebootIndex).toBeGreaterThan(stationDockerGroupIndex);
-    expect(stationNoticeIndex).toBeGreaterThan(stationRebootIndex);
-    expect(stationConfirmationIndex).toBeGreaterThan(stationNoticeIndex);
-    expect(stationPreparedGateIndex).toBeGreaterThan(stationFailClosedIndex);
-    expect(stationProviderSetIndex).toBeGreaterThan(stationPreparedGateIndex);
-    expect(stationAcceptanceIndex).toBeGreaterThan(stationConfirmationIndex);
-    expect(stationSource).toContain("NVIDIA open driver `610.43.02`");
-    expect(stationSource).toContain("Docker CE `29.6.1` with Buildx");
-    expect(stationSource).toContain("NVIDIA Container Toolkit `1.19.1`");
-    expect(stationSource).toContain("from `3.0.11-1ubuntu13` to `1:3.4.0-1ubuntu1`");
+    expect(stationConfirmationIndex).toBeGreaterThan(stationRebootIndex);
+    expect(stationDefaultIndex).toBeGreaterThan(stationConfirmationIndex);
+    expect(stationOverrideIndex).toBeGreaterThan(stationDefaultIndex);
+    expect(stationNoticeIndex).toBeGreaterThan(stationOverrideIndex);
   });
 
   it("rejects missing, ambiguous, and unsafe credential schemas (#5048)", async () => {

--- a/test/starter-prompt-docs.test.ts
+++ b/test/starter-prompt-docs.test.ts
@@ -30,7 +30,7 @@ const repoRoot = path.resolve(__dirname, "..");
 const starterPromptMarkdownSource = path.join(repoRoot, "docs", "resources", "starter-prompt.md");
 // CI resolves this exact Git commit and byte-compares its prompt-asset blobs with
 // the local files. The digests independently assert those same immutable bytes.
-const promptAssetRevision = "f3682a5be7069e58303d3345e682424d5c2453b2";
+const promptAssetRevision = "f814db4f7708ecf9ab054fcee449f11c95076dfd";
 
 type PromptAsset = {
   path: string;
@@ -53,7 +53,7 @@ const promptAssets = {
   ),
   dgxStation: definePromptAsset(
     "docs/resources/prompt-assets/dgx-station.md",
-    "82a47519f415c0c3ad1d6c5cb30dcb33de846026661d8da88054385b9789f3b5", // gitleaks:allow -- pinned prompt-asset SHA-256
+    "783a3f5973e1471178c78ead1952b904f3888dc603f5e079ad31d82cd2037f9a", // gitleaks:allow -- pinned prompt-asset SHA-256
   ),
   windowsWsl: definePromptAsset(
     "docs/resources/prompt-assets/windows-wsl.md",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Align the DGX Station coding-agent instructions with the versioned installer. The ordinary Station Express path now remains authoritative for its Nemotron Ultra default, while DeepSeek remains available only through the installer’s explicit `--station-deepseek` override.

## Changes

- [#7061](https://github.com/NVIDIA/NemoClaw/pull/7061) -> `docs/resources/prompt-assets/dgx-station.md`: Replace the DeepSeek-only provider-preseeded path with the installer’s Ultra-default and DeepSeek-override contract.
- Delegate Station qualification, host preparation, third-party notice, Express summary, and reboot or login resume to the selected maintained release’s installer.
- Stop the coding-agent path from pre-setting provider, model, non-interactive, approval, or Express-skip variables, and stop it from running the Station preparation helper separately.
- Preserve Ultra’s approximately 352 GB disclosure, shared Station host-safety boundaries, the temporary metadata override guard, and Deferred support status.
- Pin every starter-prompt platform asset URL to the immutable asset commit and update its SHA-256 contract.
- Update focused tests to require both installer-supported Station model outcomes and reject the former DeepSeek-only path.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh` or runtime behavior.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Installer behavior is covered by the focused automated Express tests below.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/starter-prompt-docs.test.ts test/install-express-prompt.test.ts` (88 passed, 1 skipped)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this is a focused documentation contract change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 1 Fern warning
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated DGX Station guidance to use the official Station Express installer after hardware detection.
  * Added support for Nemotron Ultra by default and DeepSeek V4 Flash as an explicit option.
  * Clarified installer consent, interactive prompts, reboot/resume behavior, and fallback provider selection.
  * Refreshed platform instruction links and clarified installer-specific prompt handling.

* **Tests**
  * Updated validation for revised Station Express instructions, consent messaging, and asset revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->