### PR TITLE
docs: add v0.0.90 release changelog

### DIFF
--- a/docs/changelog/2026-07-20.mdx
+++ b/docs/changelog/2026-07-20.mdx
@@ -3,6 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */}
 
+## v0.0.90
+
+NemoClaw v0.0.90 keeps managed-image routing identifiers out of secret-shaped build arguments, restores provider-reset recovery, corrects WhatsApp health reporting, and aligns DGX Station guidance with the versioned installer.
+
+- Managed OpenClaw, Hermes, and Deep Agents images now use `NEMOCLAW_INFERENCE_PROVIDER_ID` for the non-secret inference route selector, while provider credentials stay in OpenShell storage and the host-side credential alias remains unchanged.
+  Existing custom images can use the legacy selector through v0.0.90 and should migrate before the fallback is removed in v0.0.91.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- `credentials reset` now recognizes sandbox attachments from wrapped OpenShell diagnostics, validates each sandbox name, detaches affected sandboxes, and retries provider deletion without exposing credential values.
+  For more information, refer to [Credential Rotation](/user-guide/openclaw/security/credential-rotation).
+- OpenClaw WhatsApp status now recognizes the current paired-session path and derives in-process bridge activity from redacted gateway-log evidence.
+  This prevents a working paired channel from being reported as unpaired or inactive while keeping phone numbers and raw log lines out of host output.
+  For more information, refer to [Set Up WhatsApp](/user-guide/openclaw/manage-sandboxes/messaging-channels/set-up-whatsapp) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- DGX Station coding-agent guidance now delegates qualification, preparation, consent, and resume behavior to the selected versioned installer.
+  Station Express keeps Nemotron 3 Ultra 550B as the default, while `--station-deepseek` selects DeepSeek V4 Flash.
+  Related guidance adds bounded OpenIB repair or disable steps, clarifies legacy recovery state limits, and gives platform-specific setup its own navigation group.
+  For more information, refer to [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation), the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart), and [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes).
+
 ## v0.0.89
 
 NemoClaw v0.0.89 broadens qualified DGX Station installation paths, preserves inference choices through onboarding and rebuilds, strengthens sandbox recovery, discloses messaging policy scope before mutation, and keeps CLI output and background processes contained.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -690,9 +690,9 @@ All NemoClaw build arguments (`NEMOCLAW_MODEL`, `NEMOCLAW_INFERENCE_PROVIDER_ID`
 `NEMOCLAW_INFERENCE_PROVIDER_ID` is a non-secret inference route identifier (for example `inference` for proxied providers, or a provider family such as `openai`), never a credential; provider credentials stay in OpenShell provider storage.
 It replaces the former `NEMOCLAW_PROVIDER_KEY` image argument, whose secret-shaped name triggered a BuildKit `SecretsUsedInArgOrEnv` warning.
 The host-side `NEMOCLAW_PROVIDER_KEY` credential alias is unchanged; this migration only renames the managed image route selector.
-Custom Dockerfiles that declare either `ARG NEMOCLAW_INFERENCE_PROVIDER_ID` or the legacy `ARG NEMOCLAW_PROVIDER_KEY` keep working through v0.0.89.
+Custom Dockerfiles that declare either `ARG NEMOCLAW_INFERENCE_PROVIDER_ID` or the legacy `ARG NEMOCLAW_PROVIDER_KEY` keep working through v0.0.90.
 NemoClaw updates whichever supported declaration is present, and runtime consumers read the legacy name as a fallback.
-Rename the legacy `ARG`/`ENV` declaration to `NEMOCLAW_INFERENCE_PROVIDER_ID` before legacy support is removed in v0.0.90.
+Rename the legacy `ARG`/`ENV` declaration to `NEMOCLAW_INFERENCE_PROVIDER_ID` before legacy support is removed in v0.0.91.
 
 Custom Dockerfiles must declare `ARG NEMOCLAW_TOOL_DISCLOSURE=progressive` exactly once in the final build stage and promote it into that stage's runtime environment.
 The usual runtime contract is:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the canonical `## v0.0.90` entry to `docs/changelog/2026-07-20.mdx` before the release tag is planned.
The update also corrects the documented custom-image migration window so the compatibility fallback that first ships in v0.0.90 remains available until v0.0.91.

## Changes

- Add the v0.0.90 summary and detailed release bullets for managed-image routing, provider-reset recovery, WhatsApp health reporting, and DGX Station guidance.
- Keep the newest release first in the shared dated changelog and use root-absolute links to the canonical OpenClaw routes.
- Correct `docs/reference/commands.mdx` to state that the legacy image route selector remains supported through v0.0.90 and is removed in v0.0.91.
- Release source summary:
  - [#7264](https://github.com/NVIDIA/NemoClaw/pull/7264) -> `docs/resources/prompt-assets/dgx-station.md`, `docs/changelog/2026-07-20.mdx`: Record the versioned Station installer path, Nemotron 3 Ultra 550B default, and explicit DeepSeek override.
  - [#7261](https://github.com/NVIDIA/NemoClaw/pull/7261) -> `docs/get-started/dgx-station-preparation.mdx`, `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx`, `docs/changelog/2026-07-20.mdx`: Include the OpenIB, legacy recovery, and Additional Setup documentation follow-ups.
  - [#7232](https://github.com/NVIDIA/NemoClaw/pull/7232) -> `docs/changelog/2026-07-20.mdx`: Document provider-reset recovery for wrapped OpenShell attachment diagnostics.
  - [#7189](https://github.com/NVIDIA/NemoClaw/pull/7189) -> `docs/reference/commands.mdx`, `docs/changelog/2026-07-20.mdx`: Document the managed-image route-selector rename and correct its one-release migration window.
  - [#7015](https://github.com/NVIDIA/NemoClaw/pull/7015) -> `docs/changelog/2026-07-20.mdx`: Document corrected OpenClaw WhatsApp health reporting.
- No additional user-facing page update is needed for [#7193](https://github.com/NVIDIA/NemoClaw/pull/7193), [#7110](https://github.com/NVIDIA/NemoClaw/pull/7110), [#6783](https://github.com/NVIDIA/NemoClaw/pull/6783), or [#7263](https://github.com/NVIDIA/NemoClaw/pull/7263) because they change contributor governance, internal CI or release automation, or editorial style without changing supported user behavior.
- [#7242](https://github.com/NVIDIA/NemoClaw/pull/7242) and [#7225](https://github.com/NVIDIA/NemoClaw/pull/7225) are already ancestors of and documented in v0.0.89, so this entry does not duplicate them despite their stale v0.0.90 labels.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates the dated changelog heading, SPDX form, version order, and published links.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh` or runtime behavior.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts` (6 passed).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this is a focused documentation-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and two unrelated baseline warnings for unauthenticated redirect checks and the existing light-mode contrast ratio.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for v0.0.90 covering inference routing, credential reset behavior, WhatsApp status detection, and DGX Station coding-agent guidance.
  - Updated custom Dockerfile guidance to document continued support for the legacy provider argument through v0.0.90.
  - Clarified that legacy declarations must be renamed to `NEMOCLAW_INFERENCE_PROVIDER_ID` before v0.0.91.
  - Added and refreshed related documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->