### PR TITLE
fix(cli): preserve rebuild endpoint provenance

### DIFF
--- a/src/lib/onboard/authoritative-rebuild-target.test.ts
+++ b/src/lib/onboard/authoritative-rebuild-target.test.ts
@@ -107,6 +107,7 @@ describe("prepared provider reconfiguration handoff", () => {
     onboardLockAlreadyHeld: true,
     targetGatewayName: "nemoclaw-8081",
     targetGatewayPort: 8081,
+    endpointSource: "onboard" as const,
     rebuildProviderReconfigure: providerTarget,
   };
 
@@ -148,6 +149,7 @@ describe("prepared provider reconfiguration handoff", () => {
         provider: "compatible-endpoint",
         model: "nvidia/model",
         endpointUrl: "https://inference.example.test/v1",
+        endpointSource: "onboard",
         preferredInferenceApi: "openai-completions",
         source: "registry",
       },
@@ -177,6 +179,17 @@ describe("prepared provider reconfiguration handoff", () => {
       { ...flowContext, sandboxName: "beta" },
     );
     expect(wrongSandbox.providerRecoveryReceipt).toBeNull();
+
+    const wrongEndpointSource = rebuildProviderFlowOptions(
+      {
+        ...authorizedOptions,
+        endpointSource: "inference-set" as const,
+        providerRecoveryReceipt: receipt,
+        rebuildProviderReconfigure: undefined,
+      },
+      flowContext,
+    );
+    expect(wrongEndpointSource.providerRecoveryReceipt).toBeNull();
   });
 
   it("rejects an unauthorized or mismatched handoff (#6114)", () => {

--- a/src/lib/onboard/authoritative-rebuild-target.ts
+++ b/src/lib/onboard/authoritative-rebuild-target.ts
@@ -156,6 +156,7 @@ export function rebuildProviderFlowOptions(
               provider: target.provider,
               model: target.model,
               endpointUrl: target.endpointUrl ?? null,
+              endpointSource: opts.endpointSource ?? null,
               preferredInferenceApi: target.preferredInferenceApi ?? "",
               source: "registry",
             },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preserve compatible-endpoint provenance when an authoritative rebuild activates its provider-recovery receipt. Previously, the activation target dropped `endpointSource`, so the exact route check rejected an onboard-provenance receipt and the rebuild fell back to the default provider instead of reusing the OpenShell-stored credential.

## Changes

- Pass the current endpoint provenance into the registry route used to activate a rebuild recovery receipt.
- Cover successful activation for matching `onboard` provenance and fail-closed rejection for mismatched `inference-set` provenance.
- Detection gap: the existing activation test omitted endpoint provenance, so both receipt and target normalized to `null` and did not exercise the live E2E route identity.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the documented rebuild credential-reuse contract without changing the CLI or configuration surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: exact route matching remains fail closed; the new negative test verifies that mismatched endpoint provenance cannot activate a recovery receipt.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/authoritative-rebuild-target.test.ts` (16 passed); `npx vitest run --project integration test/onboard-remote-recreate-credential-reuse.test.ts` (1 passed); `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider recovery rebuild handoffs by including the selected endpoint source in the ledger activation target route.
  - Recovery receipts now apply only when the receipt’s endpoint source matches the active session/flow context, avoiding stale or mismatched routing.

- **Tests**
  - Updated provider recovery handoff tests to require matching endpoint source for authorized handoff and receipt activation.
  - Added a negative assertion to confirm no recovery receipt is returned when the flow context endpoint source is overridden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->