### PR TITLE
fix(cli): stop overstating workspace durability on sandbox stop

### DIFF
--- a/src/lib/actions/sandbox/stop.test.ts
+++ b/src/lib/actions/sandbox/stop.test.ts
@@ -92,7 +92,8 @@ describe("stopSandbox", () => {
 
     expect(result.exitCode).toBe(0);
     const output = h.log.mock.calls.map(([line]) => line).join("\n");
-    expect(output).toContain("Workspace state is preserved");
+    expect(output).toContain("The sandbox stays registered for restart");
+    expect(output).not.toContain("Workspace state is preserved");
     expect(output).toContain("nemoclaw my-sandbox start");
   });
 

--- a/src/lib/actions/sandbox/stop.ts
+++ b/src/lib/actions/sandbox/stop.ts
@@ -181,7 +181,12 @@ export function stopSandbox(
     };
   }
 
-  log(`  Sandbox '${sandboxName}' stopped. Workspace state is preserved.`);
+  // Do not promise workspace-data durability here: `start` is a direct
+  // `docker start` of the same container, and the sandbox's /sandbox workspace
+  // lives on an OpenShell-owned PVC whose re-attachment on restart NemoClaw does
+  // not control (#7199). State only what stop guarantees — the sandbox stays
+  // registered so a later `start` can bring it back.
+  log(`  Sandbox '${sandboxName}' stopped. The sandbox stays registered for restart.`);
   log(`  Start it again with '${CLI_NAME} ${sandboxName} start'.`);
   return { exitCode: 0 };
 }


### PR DESCRIPTION
## Summary

`nemoclaw <sandbox> stop` printed `Workspace state is preserved.` unconditionally whenever `docker stop` returned 0, promising a workspace-durability guarantee it cannot make: `start` is a direct `docker start` of the same container, and the sandbox `/sandbox` workspace lives on an OpenShell-owned PVC whose re-attachment on restart NemoClaw does not control (#7199). After the change, `stop` states only what it guarantees — the sandbox stays registered for a later `start` — and no longer promises workspace-data preservation.

## Related Issue

Refs #7199 — this is the message-honesty slice only. Per the issue's triage, the actual workspace data-loss root cause is upstream OpenShell PVC re-attachment on a direct docker start and is being escalated there; this PR intentionally does **not** claim to fix that, so it uses `Refs` rather than `Fixes`/`Closes`.

## Changes

- `src/lib/actions/sandbox/stop.ts`: reword the post-stop message from `Workspace state is preserved.` to `The sandbox stays registered for restart.`, with a comment explaining why no workspace-durability promise is made here.
- `src/lib/actions/sandbox/stop.test.ts`: the #6026 test now asserts the honest message and adds a guard that the old absolute claim never regresses. No new abstraction, config, or fallback introduced.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no user-facing doc references this CLI string; only `stop.ts` and its test mention it (verified repo-wide).
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: diff is a user-facing CLI string plus its test only; no sandbox lifecycle, policy, credential, or control-flow logic changed — pending maintainer review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/actions/sandbox/stop.test.ts` → 18/18 passed; `npm run test:changed` → 40/40 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable (single user-facing string + its test; no runtime/harness or repo-wide validation change)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated sandbox stop messaging to clarify that the sandbox remains registered for restart.
  - Removed the misleading claim that workspace state is preserved, reflecting the actual behavior of the stop action.
- **Tests**
  - Updated coverage to verify the revised stop confirmation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->