### PR TITLE
fix(onboard): remove doubled "and" in license acceptance prompt (#7301)

### DIFF
--- a/bin/lib/usage-notice.json
+++ b/bin/lib/usage-notice.json
@@ -28,5 +28,5 @@
     "https://docs.openclaw.ai/gateway/security"
   ],
   "links": [],
-  "interactivePrompt": "Type 'yes' to accept the NemoClaw license and and third-party software notice and continue [no]: "
+  "interactivePrompt": "Type 'yes' to accept the NemoClaw license and third-party software notice and continue [no]: "
 }

--- a/src/lib/onboard/usage-notice.test.ts
+++ b/src/lib/onboard/usage-notice.test.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The interactive acceptance prompt is served from bin/lib/usage-notice.json to
+// both the installer and `nemoclaw onboard`. Guard the shipped copy against the
+// doubled-conjunction defect reported in #7301.
+
+import { describe, expect, it } from "vitest";
+
+import { loadUsageNoticeConfig } from "./usage-notice";
+
+describe("usage notice acceptance prompt (#7301)", () => {
+  it("reads the shipped interactive prompt without a doubled word", () => {
+    const { interactivePrompt } = loadUsageNoticeConfig();
+
+    // The exact grammatical form the prompt must present to the user.
+    expect(interactivePrompt).toBe(
+      "Type 'yes' to accept the NemoClaw license and third-party software notice and continue [no]: ",
+    );
+    // Guard against any adjacent duplicated word ("and and", "the the", ...),
+    // not just the specific occurrence that regressed.
+    expect(interactivePrompt).not.toMatch(/\b(\w+)\s+\1\b/i);
+  });
+});


### PR DESCRIPTION
## Summary

The license / third-party software acceptance prompt read "the NemoClaw license
and and third-party software notice", repeating "and". The text is served from a
single shared data field, so the doubled conjunction appeared in both the
curl|bash installer and `nemoclaw onboard` on every platform. This removes the
duplicate word.

## Related Issue

Fixes #7301

## Changes

- Fixed `interactivePrompt` in `bin/lib/usage-notice.json`: "license and and
  third-party" → "license and third-party". This one field is consumed by
  `scripts/install.sh` (installer) and `src/lib/onboard/usage-notice.ts`
  (`loadUsageNoticeConfig` → the `nemoclaw onboard` prompt), so a single edit
  corrects every surface.
- Added `src/lib/onboard/usage-notice.test.ts`, which reads the shipped prompt
  through `loadUsageNoticeConfig()` and asserts the exact grammatical form and
  the absence of any adjacent duplicated word.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: fixes a typo in a runtime prompt string; no documentation quotes this line.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Onboarding-adjacent, but the change is a single grammatical fix to prompt display text; acceptance logic, versioning, and gating are unchanged. Flagging for maintainer confirmation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/onboard/usage-notice.test.ts` → 1/1 passed locally and on a fresh clone + `npm ci` on an Ubuntu x86_64 host (exit 0).
- [ ] Applicable broad gate passed — justification: single-string data fix with a focused source-lane test; not a broad runtime/test-harness change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the license and third-party software acceptance prompt by removing duplicated wording.

* **Tests**
  * Added coverage to verify the prompt’s grammar and prevent repeated adjacent words.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->