### PR TITLE
docs: add DeepAgents variant blocks to Windows Prerequisites (#7307)

### DIFF
--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -16,6 +16,9 @@ Complete these steps before following the [Quickstart](../quickstart).
 <AgentOnly variant="hermes">
 Complete these steps before following [Quickstart with Hermes](../quickstart).
 </AgentOnly>
+<AgentOnly variant="deepagents">
+Complete these steps before following [Quickstart with Deep Agents](../quickstart).
+</AgentOnly>
 Linux and macOS users do not need this page and can go directly to the Quickstart.
 
 <Note>
@@ -35,6 +38,11 @@ Verify the following before you begin:
 <AgentOnly variant="hermes">
 
 - Hardware requirements are the same as [Quickstart with Hermes](../quickstart).
+
+</AgentOnly>
+<AgentOnly variant="deepagents">
+
+- Hardware requirements are the same as [Quickstart with Deep Agents](../quickstart).
 
 </AgentOnly>
 
@@ -188,6 +196,11 @@ Then continue with the [Quickstart](../quickstart) to install NemoClaw and launc
 If you prepared Windows manually, open a WSL terminal.
 Type `wsl` in PowerShell, or open Ubuntu from Windows Terminal.
 Then continue with [Quickstart with Hermes](../quickstart) to install NemoClaw and launch your first Hermes sandbox.
+</AgentOnly>
+<AgentOnly variant="deepagents">
+If you prepared Windows manually, open a WSL terminal.
+Type `wsl` in PowerShell, or open Ubuntu from Windows Terminal.
+Then continue with [Quickstart with Deep Agents](../quickstart) to install NemoClaw and launch your first sandbox.
 </AgentOnly>
 
 All NemoClaw commands run inside WSL, not in PowerShell.


### PR DESCRIPTION
## Summary

The Windows Prerequisites page (`windows-preparation.mdx`) carried `AgentOnly`
blocks for `openclaw` and `hermes` in the intro, hardware-requirements, and Next
Step sections but none for `deepagents`, so DeepAgents readers saw generic or
OpenClaw-specific content without their variant's quickstart link or hardware
guidance. This adds the three missing DeepAgents variant blocks.

## Related Issue

Fixes #7307

## Changes

- Added three `AgentOnly variant="deepagents"` blocks to
  `docs/get-started/windows-preparation.mdx`, mirroring the existing
  `openclaw`/`hermes` blocks:
  - Page intro: quickstart pointer.
  - Prerequisites → hardware requirements: DeepAgents hardware line.
  - Next Step: manual-WSL navigation paragraph to the quickstart.
- Uses the established "Quickstart with Deep Agents" label (as in `docs/index.mdx`
  and the local-inference pages) and the same `../quickstart` route the
  openclaw/hermes blocks use. No new canonical content — this fills documented
  coverage gaps for an existing, supported variant.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (prose changes, no code sample modifications)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: documentation content parity; no code behavior changes.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: n/a (docs-only); coverage verified via the docs build below.
- [ ] Applicable broad gate passed — justification: docs-only content parity change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — result: `npm run docs` → 0 errors, exit 0, `check-docs-published-routes: OK`, locally and on a fresh clone + `npm ci` on an Ubuntu x86_64 host. (The 2 fern warnings are pre-existing and repo-wide: FERN_TOKEN-gated redirect check and a global light-mode accent contrast ratio; neither references this page.)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows preparation guidance for Deep Agents.
  * Included Deep Agents hardware requirements and instructions to continue with the quickstart.
  * Added next steps for installing NemoClaw and launching the first sandbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->