### PR TITLE
feat(presets): add shrike-security preset for AI agent action governance

### DIFF
--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -63,6 +63,7 @@ Messaging channel presets are scoped to the sandbox's active agent; if an agent 
 | Public reference APIs | `public-reference` |
 | Python Package Index | `pypi` |
 | Slack messaging | `slack` |
+| Shrike Security AI action governance | `shrike-security` |
 | Tavily Search | `tavily` |
 | Telegram Bot API | `telegram` |
 | Weather and geocoding APIs | `weather` |
@@ -285,6 +286,21 @@ Configure `TAVILY_API_KEY` during that onboarding run.
 The `tavily` preset permits only `POST /search` and `POST /extract` to `api.tavily.com`.
 It enables request-body credential rewriting because Hermes sends its resolver placeholder in the JSON `api_key` field.
 OpenShell replaces that placeholder at egress, so the raw key is not written into the sandbox configuration.
+
+## AI Agent Action Governance With Shrike Security
+
+Use the `shrike-security` preset when the agent should consult [Shrike Security](https://shrikesecurity.com) before executing tool calls.
+The preset allows egress to `api.shrikesecurity.com` only, path-scoped to the `/agent/api/scan/enforce` decision endpoints, read-only session status, and health checks.
+The scan API returns one of `allow`, `warn`, `require_approval`, or `block` for each submitted action, and the calling SDK or MCP wrapper enforces that decision at the tool-call boundary.
+
+```bash
+$$nemoclaw my-assistant policy-add shrike-security --dry-run
+$$nemoclaw my-assistant policy-add shrike-security --yes
+```
+
+Scanning activates only after you configure a `SHRIKE_API_KEY` credential for the sandboxed agent.
+Without the key, the preset adds the network allowance but no scan traffic leaves the sandbox.
+Shrike documents API keys and the enforce contract in its [Quickstart](https://shrikesecurity.com/docs/quickstart).
 
 ## Weather and Public Reference Lookups
 

--- a/nemoclaw-blueprint/policies/presets/shrike-security.yaml
+++ b/nemoclaw-blueprint/policies/presets/shrike-security.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Data flow: When activated with a SHRIKE_API_KEY, scanned content is
+# transmitted to api.shrikesecurity.com over TLS for threat analysis and
+# an enforce/allow/warn/require_approval/block decision is returned to
+# the caller. No data leaves the device without an API key configured.
+# See https://shrikesecurity.com/privacy for retention, GDPR/CCPA, and
+# data-deletion posture.
+
+preset:
+  name: shrike-security
+  description: "Shrike Security — action governance for AI agents (canonical /api/scan/enforce endpoint returns allow / warn / require_approval / block; read-only session state observability)"
+
+network_policies:
+  shrike_security:
+    name: shrike_security
+    endpoints:
+      - host: api.shrikesecurity.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          # Canonical enforce endpoint — server-side action derivation
+          # returns "allow" | "warn" | "require_approval" | "block".
+          # The caller (SDK or MCP tool wrapper) honors action verbatim;
+          # no local reinterpretation. Contract pinned by the SDK
+          # contract-symmetry tests in shrike-guard{-js,-python}.
+          - allow: { method: POST, path: "/agent/api/scan/enforce" }
+          # Specialized enforce for action-plane content types
+          # (sql, command, file_write, web_search, a2a_message, agent_card).
+          - allow: { method: POST, path: "/agent/api/scan/enforce/specialized" }
+          # Read-only session state (session_status MCP tool + SDK). Callable
+          # while the session is quarantined — that is the point. Never
+          # exposes prompts, responses, tokens, or detector attribution.
+          - allow: { method: GET, path: "/agent/api/session/status" }
+          - allow: { method: GET, path: "/health" }
+    binaries:
+      # shrike-mcp is distributed as an npm CLI; OpenShell may observe
+      # the Node runtime instead of the shim that launched it (matches
+      # the claude-code preset precedent).
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+      - { path: /tmp/npm-global/bin/shrike-mcp }
+      - { path: /home/linuxbrew/.linuxbrew/bin/shrike-mcp }
+      # shrike-sh — optional Go shell proxy (single binary, ~5ms startup)
+      # that governs command execution via the SDK. Not required for
+      # baseline scanning; installed only when the operator opts in.
+      - { path: /usr/local/bin/shrike-sh }
+      - { path: /usr/bin/shrike-sh }


### PR DESCRIPTION
## History

This is a refresh of [#829](https://github.com/NVIDIA/NemoClaw/pull/829), which was closed on 2026-04-29 for inactivity (not on substance). @wscurran had left a positive comment; the review then stalled on our side. The four months since have shipped material changes on both sides, so a fresh PR with updated content is the cleanest way to pick this up again.

**What's different from #829:**
- Tightened endpoint list: enforce + read-only session status only. Threatsense, approvals, and session-reset are dropped from the baseline preset — they're optional add-ons for follow-up revs, not required for the core "safe by default" story.
- Updated to the current `preset.name` / `network_policies[].endpoints[].rules` schema (matches [`claude-code.yaml`](nemoclaw-blueprint/policies/presets/claude-code.yaml) + [`huggingface.yaml`](nemoclaw-blueprint/policies/presets/huggingface.yaml) precedents).
- Absolute binary paths instead of glob suffixes (matches current preset conventions).
- Pins Shrike's `/api/scan/enforce` endpoint (server-side action derivation shipped 2026-07-07) instead of the older `/scan` shape.

Tagging @wscurran, @cv, @prekshivyas — happy to address anything and will keep this active this time.

## Summary

Add a network policy preset for [Shrike Security](https://shrikesecurity.com), a runtime action-governance layer for AI agents. The preset lets sandboxed agents call Shrike's canonical `/api/scan/enforce` endpoint before executing tool calls; the server returns one of `allow` / `warn` / `require_approval` / `block` and the SDK/MCP wrapper honors it verbatim.

- Adds `shrike-security.yaml` to the presets directory (auto-discovered by `listPresets` — single-file change)
- Restricts egress to `api.shrikesecurity.com:443`, path-scoped to 4 endpoints
- Binary-restricted to `node` (for the shrike-mcp npm CLI) and `shrike-sh` (optional Go shell proxy)

## What Shrike does — one paragraph

Shrike is action governance for AI agents. When an agent is about to send a prompt, return a response, run a command, or issue a SQL query, the SDK calls `/api/scan/enforce` with the content and receives a canonical decision (`allow` / `warn` / `require_approval` / `block`) that the developer's code enforces at the tool-call boundary. Under the hood a 9-layer cascade evaluates prompt-injection, PII, SQL/command injection, path traversal, agent-delegation risk, session correlation, and the OWASP LLM Top 10. Server-side session state is available read-only via `/api/session/status` for observability + recovery guidance.

## Relationship to OpenShell / NemoClaw sandboxing

This preset is **complementary** to OpenShell's sandbox and network isolation:

- OpenShell restricts *where* the agent can reach → this preset says "and one of those places is Shrike's decision API"
- OpenShell decides *whether the packet leaves* → Shrike decides *whether the action should have been taken*
- OpenShell is baseline hygiene → Shrike is the specialist layer enterprise operators bring in for SOC2/HIPAA/audit-grade content governance

The two are designed to sit alongside each other. Neither replaces the other.

## Allowed endpoints (tightened from #829)

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/agent/api/scan/enforce` | Canonical scan with server-side `action` decision |
| POST | `/agent/api/scan/enforce/specialized` | Action-plane content types (sql, command, file_write, web_search, a2a_message, agent_card) |
| GET | `/agent/api/session/status` | Read-only session state (risk score, turn, patterns, locked?) — safe to call while quarantined |
| GET | `/health` | Health check |

**Dropped from #829** (out of scope for baseline preset; can be added by operators or in follow-up presets):
- `/agent/api/threatsense/**` — pattern reporting, requires customer_id write permissions
- `/agent/api/v1/approvals/**` — human-in-the-loop polling, requires operator-side approval routing setup
- `/agent/api/session/reset` — administrative endpoint, restricted at block threshold anyway

## Preset design decisions

- **Path-scoped rules (not `/**`):** Only enforce, session status, and health. Dashboard, admin, and reporting APIs are excluded — the sandboxed agent has no business reaching those. Same pattern used by [`huggingface.yaml`](nemoclaw-blueprint/policies/presets/huggingface.yaml)'s POST removal to prevent token-exfiltration by sandboxed agents.
- **`enforcement: enforce`:** Not observe. If Shrike is unreachable, the SDK's fail-closed default refuses the action. This is the behavior serious buyers want; the operator can override via config for observability-only rollouts.
- **Absolute binary paths:** `node`, `npx`-installed `shrike-mcp`, optional `shrike-sh`. Matches the `claude-code` preset precedent — no glob suffixes.

## Privacy & data flow

- Egress is opt-in — the operator must configure `SHRIKE_API_KEY` on the sandbox before scan traffic activates. Without the key, the preset adds the network allow-list entry but no data leaves the device.
- TLS-encrypted end-to-end. Retention + GDPR/CCPA + data deletion posture: [shrikesecurity.com/privacy](https://shrikesecurity.com/privacy).
- The preset YAML carries a `Data flow:` comment documenting this behavior in-source.

## Files changed

| File | Change |
|------|--------|
| `nemoclaw-blueprint/policies/presets/shrike-security.yaml` | New preset (4 path-scoped rules, 6 explicit binary paths, SPDX header, data-flow comment). Presets are auto-discovered from the directory — no registry or test changes needed. |
| `docs/network-policy/integration-policy-examples.mdx` | Supported-presets table row + short integration section (follows the `gmail` preset precedent) |

## Test plan

- [x] Preset YAML matches the shape of `claude-code.yaml` / `huggingface.yaml`
- [x] `npx vitest run test/policies.test.ts test/policy-preset-sync.test.ts test/presets-checkbox.test.ts test/rebuild-policy-presets.test.ts test/validate-blueprint.test.ts` — 122 passed with the preset present
- [x] docs suites (`check-docs-links`, `docs-copyable-command-blocks`, `test-title-style`, `network-policies-published-routes`, `check-docs-published-routes`, `agent-variant-docs`) — 55 passed with the docs section added
- [ ] `openshell policy set` applies without error (requires sandbox)
- [ ] Sandboxed agent can POST to `/agent/api/scan/enforce` and receives an `action` decision
- [ ] Non-listed binaries (e.g., `curl`) cannot use the policy endpoints

## Related

- [Shrike MCP Server on npm](https://www.npmjs.com/package/shrike-mcp) — Apache-2.0
- [shrike-guard-python](https://pypi.org/project/shrike-guard/) + [shrike-guard-js](https://www.npmjs.com/package/shrike-guard) — Apache-2.0
- [OWASP LLM Top 10 mapping](https://shrikesecurity.com/docs/owasp-llm-top-10) — public
- NVIDIA Inception member
- Previous submission: [#829](https://github.com/NVIDIA/NemoClaw/pull/829) (closed for inactivity 2026-04-29)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `shrike-security` network policy preset.
  - Supports secure action governance, specialized enforcement, session status, and health checks.
  - Added executable allowlisting for supported Shrike Security tools.
  - Added setup guidance, dry-run and apply commands, credential behavior, and scan enforcement details to the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->