### PR TITLE
docs: complete coding-agent starter prompt guidance

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -92,6 +92,7 @@ Use these details when your first-run path needs more control.
     curl -fsSL https://www.nvidia.com/nemoclaw.sh | \
       NEMOCLAW_NON_INTERACTIVE=1 \
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
+      NEMOCLAW_AGENT=openclaw \
       NEMOCLAW_PROVIDER=build \
       NVIDIA_INFERENCE_API_KEY=<your-key> \
       NEMOCLAW_SANDBOX_NAME=my-gpt-claw \
@@ -99,7 +100,15 @@ Use these details when your first-run path needs more control.
     ```
 
     The example uses NVIDIA Endpoints.
+    Set `NEMOCLAW_AGENT` to `hermes` or `langchain-deepagents-code` to install another agent.
     Set `NEMOCLAW_PROVIDER` and the matching credential variable for another provider, then use a sandbox name that does not depend on a previous onboarding session.
+    To select a specific NemoClaw release, replace `vX.Y.Z` with its versioned release tag.
+
+    ```bash
+    curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=vX.Y.Z bash
+    ```
+
+    Keep `NEMOCLAW_INSTALL_TAG` on the `bash` side of the pipeline so the installer can read it.
     Do not place `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` before `curl`, because the installer process cannot read it there.
     Refer to the [Commands reference](../reference/commands#nemoclaw-onboard) for the full non-interactive configuration.
   </Accordion>
@@ -118,6 +127,11 @@ Use these details when your first-run path needs more control.
     On Linux, the installer checks Docker and can install it when it is missing.
     If the installer adds you to the `docker` group, run the printed `newgrp docker` command before you rerun it.
     On macOS, start Docker Desktop or Colima first.
+
+    When Codex reports that its execution sandbox blocked Docker, keep **Ask for approval** enabled.
+    Approve only the exact Docker-dependent command that Codex requests to rerun outside the sandbox.
+    Do not change Docker socket permissions or select **Full access** only to bypass the restriction.
+    If your organization blocks the approval, stop the coding-agent setup and contact the administrator who manages Codex permissions.
 
     DGX Spark, qualifying Station GB300 hosts, and Windows WSL offer an interactive express-install path that chooses a managed local inference option for the platform.
     Station accepts the generic Ubuntu 24.04 ARM64 image and stock DGX OS `7.2.0`, `7.4.0`, or `7.5.0` when a safe, root-owned `/etc/dgx-release` marker identifies `DGX Server for GALAXY-GB300`.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -128,10 +128,10 @@ Use these details when your first-run path needs more control.
     If the installer adds you to the `docker` group, run the printed `newgrp docker` command before you rerun it.
     On macOS, start Docker Desktop or Colima first.
 
-    When Codex reports that its execution sandbox blocked Docker, keep **Ask for approval** enabled.
-    Approve only the exact Docker-dependent command that Codex requests to rerun outside the sandbox.
-    Do not change Docker socket permissions or select **Full access** only to bypass the restriction.
-    If your organization blocks the approval, stop the coding-agent setup and contact the administrator who manages Codex permissions.
+    When a coding agent reports that its execution sandbox blocked Docker, use its command-scoped approval flow, if available.
+    Approve only the exact Docker-dependent command that the coding agent requests to rerun outside the sandbox.
+    Do not change Docker socket permissions or grant broad host access only to bypass the restriction.
+    If your organization blocks command-scoped approval, stop the coding-agent setup and contact the administrator who manages coding-agent permissions.
 
     DGX Spark, qualifying Station GB300 hosts, and Windows WSL offer an interactive express-install path that chooses a managed local inference option for the platform.
     Station accepts the generic Ubuntu 24.04 ARM64 image and stock DGX OS `7.2.0`, `7.4.0`, or `7.5.0` when a safe, root-owned `/etc/dgx-release` marker identifies `DGX Server for GALAXY-GB300`.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -103,12 +103,13 @@ Use these details when your first-run path needs more control.
     Set `NEMOCLAW_AGENT` to `hermes` or `langchain-deepagents-code` to install another agent.
     Set `NEMOCLAW_PROVIDER` and the matching credential variable for another provider, then use a sandbox name that does not depend on a previous onboarding session.
     To select a specific NemoClaw release, replace `vX.Y.Z` with its versioned release tag.
+    `NEMOCLAW_INSTALL_REF` is a higher-priority development override, so clear it when pinning a release tag.
 
     ```bash
-    curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=vX.Y.Z bash
+    curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_REF= NEMOCLAW_INSTALL_TAG=vX.Y.Z bash
     ```
 
-    Keep `NEMOCLAW_INSTALL_TAG` on the `bash` side of the pipeline so the installer can read it.
+    Keep both install variables on the `bash` side of the pipeline so the installer can read them.
     Do not place `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` before `curl`, because the installer process cannot read it there.
     Refer to the [Commands reference](../reference/commands#nemoclaw-onboard) for the full non-interactive configuration.
   </Accordion>

--- a/docs/manage-sandboxes/update-sandboxes.mdx
+++ b/docs/manage-sandboxes/update-sandboxes.mdx
@@ -43,10 +43,10 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 $$nemoclaw upgrade-sandboxes --check
 ```
 
-If a support workflow asks you to pass the maintained tag explicitly, set `NEMOCLAW_INSTALL_TAG` on the `bash` side of the install pipeline.
+If a support workflow asks you to pass the maintained tag explicitly, clear any inherited `NEMOCLAW_INSTALL_REF` and set `NEMOCLAW_INSTALL_TAG` on the `bash` side of the install pipeline.
 
 ```bash
-curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=lkg bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_REF= NEMOCLAW_INSTALL_TAG=lkg bash
 ```
 
 Before upgrade work, the installer prepares the current NemoClaw CLI without replacing OpenShell and requires a fresh backup of every registered sandbox.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3338,8 +3338,8 @@ Set them before running `$$nemoclaw onboard`.
 | `NEMOCLAW_SANDBOX_NAME` | sandbox name | Preferred environment override for the default sandbox. Used by onboarding defaults and host-level commands such as `list`, `status`, `tunnel`, `services`, and `debug`. |
 | `NEMOCLAW_SANDBOX` | sandbox name | Alternate spelling of `NEMOCLAW_SANDBOX_NAME`; used when neither a flag nor `NEMOCLAW_SANDBOX_NAME` is set. |
 | `SANDBOX_NAME` | sandbox name | Compatibility spelling used after `NEMOCLAW_SANDBOX_NAME` and `NEMOCLAW_SANDBOX`. |
-| `NEMOCLAW_INSTALL_REF` | git ref | For internal installer commands: the git ref to install from. Overridden by the `--install-ref` flag. |
-| `NEMOCLAW_INSTALL_TAG` | release tag | For internal installer commands: the release tag to install. Defaults to the admin-promoted `lkg` tag when unset. Overridden by the `--install-tag` flag. |
+| `NEMOCLAW_INSTALL_REF` | git ref | For internal installer commands: the git ref to install from. A nonempty value takes precedence over `NEMOCLAW_INSTALL_TAG`. Overridden by the `--install-ref` flag. |
+| `NEMOCLAW_INSTALL_TAG` | release tag | For internal installer commands: the release tag to install when `NEMOCLAW_INSTALL_REF` is unset or empty. Defaults to the admin-promoted `lkg` tag when unset. Overridden by the `--install-tag` flag. |
 | `NEMOCLAW_VLLM_MODEL` | registry slug or Hugging Face model id | Selects the model the managed-vLLM install path serves. Recognised slugs: `qwen3.6-27b`, `qwen3.6-35b-a3b-nvfp4`, `nemotron-3-nano-4b`, `deepseek-v4-flash`, `nemotron-3-ultra-550b-a55b`, `deepseek-r1-distill-70b`. Unset uses the per-platform profile default. The DGX Station express installer sets `nemotron-3-ultra-550b-a55b` explicitly. Gated models (e.g. `deepseek-r1-distill-70b`) require `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN`. |
 | `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` | JSON array of non-blank strings | Appends advanced operator-owned tokens to the managed `vllm serve` command after NemoClaw's registry defaults. Example: `["--max-num-seqs","2"]`. Malformed JSON, non-string tokens, or blank tokens fail before Docker work starts. |
 <AgentOnly variant="openclaw">

--- a/docs/resources/starter-prompt.md
+++ b/docs/resources/starter-prompt.md
@@ -40,8 +40,9 @@ Choices:
 2. Hermes.
 3. LangChain Deep Agents Code.
 
-Use `NEMOCLAW_AGENT=hermes` or `nemohermes onboard` for Hermes.
-Use `NEMOCLAW_AGENT=langchain-deepagents-code` or `nemo-deepagents onboard` for Deep Agents.
+Set `NEMOCLAW_AGENT=openclaw` for OpenClaw.
+Set `NEMOCLAW_AGENT=hermes` for Hermes, or use `nemohermes onboard`.
+Set `NEMOCLAW_AGENT=langchain-deepagents-code` for Deep Agents, or use `nemo-deepagents onboard`.
 
 ## Hardware and Readiness
 
@@ -63,6 +64,16 @@ Use `NEMOCLAW_AGENT=langchain-deepagents-code` or `nemo-deepagents onboard` for 
 - Never pipe a password, store it in a file, generate a password helper, or put it in command arguments.
 - Offer a user-local alternative only when official documentation supports it for that exact operation.
 - Do not silently use user-local Ollama for a system Ollama upgrade when the old system service would remain active.
+
+## Codex Execution Sandbox
+
+- If this coding agent is Codex, keep **Ask for approval** enabled.
+- If the Codex execution sandbox blocks a Docker command, ask permission to rerun only that exact command outside the sandbox.
+- Before requesting approval, explain that Docker daemon access can modify containers, images, and host files.
+- Do not change Docker socket permissions or request full access only to bypass the Codex sandbox.
+- If the user or managed policy denies approval, stop before the command.
+- Explain that `NEMOCLAW_NON_INTERACTIVE=1` removes NemoClaw prompts.
+- Explain that it does not bypass Codex permissions.
 
 ## Platform-Specific Instructions
 
@@ -121,6 +132,9 @@ Ask required model, endpoint, credential, and download questions one at a time.
 - Collect every choice before running the installer.
 - Ask one question at a time for model, endpoint, sandbox name, web search, messaging when the selected agent supports it, policy when no platform-asset install path is selected, credentials, administrator access, and downloads.
 - Use non-interactive environment variables whenever supported.
+- For installation outside an accepted platform-asset path, set `NEMOCLAW_AGENT` and `NEMOCLAW_PROVIDER` from my selections.
+- Use the maintained release unless I request a specific version.
+- For a specific version, set `NEMOCLAW_INSTALL_TAG=vX.Y.Z` to its versioned release tag.
 - Never leave a command waiting at `Choose [1]:`.
 - If a choice cannot be supplied non-interactively, stop before starting and explain the supported alternative.
 - The DGX Station asset is the exception for the official third-party-software notice and Express confirmation. Keep those installer prompts visible, wait for the user's response, and do not pre-answer them.

--- a/docs/resources/starter-prompt.md
+++ b/docs/resources/starter-prompt.md
@@ -65,15 +65,15 @@ Set `NEMOCLAW_AGENT=langchain-deepagents-code` for Deep Agents, or use `nemo-dee
 - Offer a user-local alternative only when official documentation supports it for that exact operation.
 - Do not silently use user-local Ollama for a system Ollama upgrade when the old system service would remain active.
 
-## Codex Execution Sandbox
+## Execution Sandbox
 
-- If this coding agent is Codex, keep **Ask for approval** enabled.
-- If the Codex execution sandbox blocks a Docker command, ask permission to rerun only that exact command outside the sandbox.
+- If the coding agent's execution sandbox blocks a Docker command, use its command-scoped approval flow, if available.
+- Request permission to rerun only that exact command outside the sandbox.
 - Before requesting approval, explain that Docker daemon access can modify containers, images, and host files.
-- Do not change Docker socket permissions or request full access only to bypass the Codex sandbox.
+- Do not change Docker socket permissions or request broad host access only to bypass the execution sandbox.
 - If the user or managed policy denies approval, stop before the command.
 - Explain that `NEMOCLAW_NON_INTERACTIVE=1` removes NemoClaw prompts.
-- Explain that it does not bypass Codex permissions.
+- Explain that `NEMOCLAW_NON_INTERACTIVE=1` does not bypass execution-sandbox permissions.
 
 ## Platform-Specific Instructions
 

--- a/docs/resources/starter-prompt.md
+++ b/docs/resources/starter-prompt.md
@@ -134,7 +134,7 @@ Ask required model, endpoint, credential, and download questions one at a time.
 - Use non-interactive environment variables whenever supported.
 - For installation outside an accepted platform-asset path, set `NEMOCLAW_AGENT` and `NEMOCLAW_PROVIDER` from my selections.
 - Use the maintained release unless I request a specific version.
-- For a specific version, set `NEMOCLAW_INSTALL_TAG=vX.Y.Z` to its versioned release tag.
+- For a specific version, clear any inherited `NEMOCLAW_INSTALL_REF`, then set `NEMOCLAW_INSTALL_TAG=vX.Y.Z` to its versioned release tag.
 - Never leave a command waiting at `Choose [1]:`.
 - If a choice cannot be supplied non-interactively, stop before starting and explain the supported alternative.
 - The DGX Station asset is the exception for the official third-party-software notice and Express confirmation. Keep those installer prompts visible, wait for the user's response, and do not pre-answer them.

--- a/test/starter-prompt-docs.test.ts
+++ b/test/starter-prompt-docs.test.ts
@@ -486,7 +486,7 @@ describe("starter prompt docs CTA", () => {
     ).toThrow("use LF line endings");
   });
 
-  it("names non-interactive install controls and scopes Codex Docker approval (#7311)", () => {
+  it("names non-interactive install controls and scopes sandboxed Docker approval (#7311)", () => {
     const promptSource = readStarterPrompt();
     const quickstartSource = read("docs/get-started/quickstart.mdx");
 
@@ -498,21 +498,27 @@ describe("starter prompt docs CTA", () => {
     expect(promptSource).toContain("NEMOCLAW_AGENT=openclaw");
     expect(promptSource).toContain("NEMOCLAW_INSTALL_TAG=vX.Y.Z");
     expect(promptSource).toContain(
-      "ask permission to rerun only that exact command outside the sandbox",
+      "Request permission to rerun only that exact command outside the sandbox",
     );
     expect(promptSource).toContain("`NEMOCLAW_NON_INTERACTIVE=1` removes NemoClaw prompts");
-    expect(promptSource).toContain("it does not bypass Codex permissions");
     expect(promptSource).toContain(
-      "Do not change Docker socket permissions or request full access only to bypass the Codex sandbox.",
+      "`NEMOCLAW_NON_INTERACTIVE=1` does not bypass execution-sandbox permissions",
+    );
+    expect(promptSource).toContain(
+      "Do not change Docker socket permissions or request broad host access only to bypass the execution sandbox.",
     );
     expect(promptSource).not.toContain("or another approved host command");
     expect(quickstartSource).toContain(
       "curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=vX.Y.Z bash",
     );
-    expect(quickstartSource).toContain("Approve only the exact Docker-dependent command");
     expect(quickstartSource).toContain(
-      "Do not change Docker socket permissions or select **Full access** only to bypass the restriction.",
+      "Approve only the exact Docker-dependent command that the coding agent requests",
     );
+    expect(quickstartSource).toContain(
+      "Do not change Docker socket permissions or grant broad host access only to bypass the restriction.",
+    );
+    expect(promptSource).not.toContain("## Codex Execution Sandbox");
+    expect(quickstartSource).not.toContain("When Codex reports");
     expect(quickstartSource).not.toContain("NEMOCLAW_INSTALL_TAG=vX.Y.Z curl");
     expect(promptSource).not.toContain("NEMOCLAW_INSTALL_TAG=<git-ref>");
     expect(quickstartSource).not.toContain("NEMOCLAW_INSTALL_TAG=<git-ref>");

--- a/test/starter-prompt-docs.test.ts
+++ b/test/starter-prompt-docs.test.ts
@@ -498,6 +498,12 @@ describe("starter prompt docs CTA", () => {
     }
 
     expect(promptSource).toContain("NEMOCLAW_AGENT=openclaw");
+    expect(promptSource).toContain("NEMOCLAW_AGENT=hermes");
+    expect(promptSource).toContain("NEMOCLAW_AGENT=langchain-deepagents-code");
+    expect(promptSource).toContain(
+      "set `NEMOCLAW_AGENT` and `NEMOCLAW_PROVIDER` from my selections",
+    );
+    expect(quickstartSource).toMatch(/NEMOCLAW_AGENT=openclaw\s*\\\s*NEMOCLAW_PROVIDER=build/);
     expect(promptSource).toContain("NEMOCLAW_INSTALL_TAG=vX.Y.Z");
     expect(promptSource).toContain("clear any inherited `NEMOCLAW_INSTALL_REF`");
     expect(promptSource).toContain(
@@ -529,6 +535,9 @@ describe("starter prompt docs CTA", () => {
     expect(commandsSource).toContain(
       "A nonempty value takes precedence over `NEMOCLAW_INSTALL_TAG`.",
     );
+    expect(commandsSource).toContain("Overridden by the `--install-ref` flag.");
+    expect(commandsSource).toContain("Overridden by the `--install-tag` flag.");
+    expect(commandsSource).toContain("Defaults to the admin-promoted `lkg` tag when unset.");
     expect(updateSource).toContain(
       "curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_REF= NEMOCLAW_INSTALL_TAG=lkg bash",
     );

--- a/test/starter-prompt-docs.test.ts
+++ b/test/starter-prompt-docs.test.ts
@@ -489,6 +489,8 @@ describe("starter prompt docs CTA", () => {
   it("names non-interactive install controls and scopes sandboxed Docker approval (#7311)", () => {
     const promptSource = readStarterPrompt();
     const quickstartSource = read("docs/get-started/quickstart.mdx");
+    const commandsSource = read("docs/reference/commands.mdx");
+    const updateSource = read("docs/manage-sandboxes/update-sandboxes.mdx");
 
     for (const variable of ["NEMOCLAW_AGENT", "NEMOCLAW_PROVIDER", "NEMOCLAW_INSTALL_TAG"]) {
       expect(promptSource, `starter prompt names ${variable}`).toContain(variable);
@@ -497,6 +499,7 @@ describe("starter prompt docs CTA", () => {
 
     expect(promptSource).toContain("NEMOCLAW_AGENT=openclaw");
     expect(promptSource).toContain("NEMOCLAW_INSTALL_TAG=vX.Y.Z");
+    expect(promptSource).toContain("clear any inherited `NEMOCLAW_INSTALL_REF`");
     expect(promptSource).toContain(
       "Request permission to rerun only that exact command outside the sandbox",
     );
@@ -509,7 +512,7 @@ describe("starter prompt docs CTA", () => {
     );
     expect(promptSource).not.toContain("or another approved host command");
     expect(quickstartSource).toContain(
-      "curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=vX.Y.Z bash",
+      "curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_REF= NEMOCLAW_INSTALL_TAG=vX.Y.Z bash",
     );
     expect(quickstartSource).toContain(
       "Approve only the exact Docker-dependent command that the coding agent requests",
@@ -520,6 +523,18 @@ describe("starter prompt docs CTA", () => {
     expect(promptSource).not.toContain("## Codex Execution Sandbox");
     expect(quickstartSource).not.toContain("When Codex reports");
     expect(quickstartSource).not.toContain("NEMOCLAW_INSTALL_TAG=vX.Y.Z curl");
+    expect(quickstartSource).not.toContain(
+      "https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=vX.Y.Z bash",
+    );
+    expect(commandsSource).toContain(
+      "A nonempty value takes precedence over `NEMOCLAW_INSTALL_TAG`.",
+    );
+    expect(updateSource).toContain(
+      "curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_REF= NEMOCLAW_INSTALL_TAG=lkg bash",
+    );
+    expect(updateSource).not.toContain(
+      "https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=lkg bash",
+    );
     expect(promptSource).not.toContain("NEMOCLAW_INSTALL_TAG=<git-ref>");
     expect(quickstartSource).not.toContain("NEMOCLAW_INSTALL_TAG=<git-ref>");
   });

--- a/test/starter-prompt-docs.test.ts
+++ b/test/starter-prompt-docs.test.ts
@@ -486,6 +486,38 @@ describe("starter prompt docs CTA", () => {
     ).toThrow("use LF line endings");
   });
 
+  it("names non-interactive install controls and scopes Codex Docker approval (#7311)", () => {
+    const promptSource = readStarterPrompt();
+    const quickstartSource = read("docs/get-started/quickstart.mdx");
+
+    for (const variable of ["NEMOCLAW_AGENT", "NEMOCLAW_PROVIDER", "NEMOCLAW_INSTALL_TAG"]) {
+      expect(promptSource, `starter prompt names ${variable}`).toContain(variable);
+      expect(quickstartSource, `quickstart names ${variable}`).toContain(variable);
+    }
+
+    expect(promptSource).toContain("NEMOCLAW_AGENT=openclaw");
+    expect(promptSource).toContain("NEMOCLAW_INSTALL_TAG=vX.Y.Z");
+    expect(promptSource).toContain(
+      "ask permission to rerun only that exact command outside the sandbox",
+    );
+    expect(promptSource).toContain("`NEMOCLAW_NON_INTERACTIVE=1` removes NemoClaw prompts");
+    expect(promptSource).toContain("it does not bypass Codex permissions");
+    expect(promptSource).toContain(
+      "Do not change Docker socket permissions or request full access only to bypass the Codex sandbox.",
+    );
+    expect(promptSource).not.toContain("or another approved host command");
+    expect(quickstartSource).toContain(
+      "curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=vX.Y.Z bash",
+    );
+    expect(quickstartSource).toContain("Approve only the exact Docker-dependent command");
+    expect(quickstartSource).toContain(
+      "Do not change Docker socket permissions or select **Full access** only to bypass the restriction.",
+    );
+    expect(quickstartSource).not.toContain("NEMOCLAW_INSTALL_TAG=vX.Y.Z curl");
+    expect(promptSource).not.toContain("NEMOCLAW_INSTALL_TAG=<git-ref>");
+    expect(quickstartSource).not.toContain("NEMOCLAW_INSTALL_TAG=<git-ref>");
+  });
+
   it("rejects missing or stale generated snippets and accepts the current output (#5048)", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-starter-prompt-"));
     const generatedPath = path.join(tempDir, "StarterPrompt.generated.mdx");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make the coding-agent starter prompt construct non-interactive installs with explicit agent, provider, and release-tag variables.
Add tool-neutral Docker approval guidance that keeps escalation command-scoped and preserves the execution-sandbox boundary.

## Related Issue

Fixes #7311

## Changes

- Name `NEMOCLAW_AGENT` for every supported agent and pair it with `NEMOCLAW_PROVIDER` during non-interactive command construction.
- Document `NEMOCLAW_INSTALL_TAG=vX.Y.Z` on the `bash` side of the installer pipeline and clear any inherited higher-priority `NEMOCLAW_INSTALL_REF`.
- Align the environment-variable reference and explicit `lkg` upgrade example with the same install-ref precedence.
- Tell a coding agent to use its command-scoped approval flow only for the exact Docker command blocked by its execution sandbox.
- Prohibit Docker socket permission changes and broad host access as sandbox workarounds.
- Add a regression contract for all three requested variables, release-tag precedence and placement, and the coding-agent Docker approval boundary.
- Record the QA detection gap: existing tests protected prompt generation and Deep Agents selection but did not assert the complete install-variable or execution-sandbox contract.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent documentation review confirmed the guidance is coding-agent-neutral, narrowed escalation to Docker commands, required explicit denial behavior, and prohibited socket-permission and broad-host-access workarounds.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `vitest run --project integration test/starter-prompt-docs.test.ts` passed 18 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — the command passed with 0 errors and one existing Fern light-mode accent contrast warning outside this diff.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded non-interactive onboarding with explicit agent/provider environment variables and clearer installation version pinning guidance.
  * Updated precedence rules for install reference vs install tag, including how CLI flags override each.
  * Added execution-sandbox guidance for when Docker commands are blocked, including narrowly scoped re-approval and what to avoid.

* **Tests**
  * Added a starter-prompt documentation test to verify required environment variables, sandbox approval language, and correct precedence/tag formatting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->