### PR TITLE
fix(e2e): parse swap rows from GitHub runners

### DIFF
--- a/test/e2e/fixtures/hermes-rebuild-swap.ts
+++ b/test/e2e/fixtures/hermes-rebuild-swap.ts
@@ -10,7 +10,13 @@ export function parseActiveSwapBytes(output: string): number {
     .filter(Boolean)
     .reduce((total, line) => {
       const fields = line.split(/\s+/u);
-      const size = fields.length === 1 ? fields[0] : fields.length === 5 ? fields[2] : undefined;
+      const isSwapRow =
+        fields.length === 5 &&
+        (fields[1] === "file" || fields[1] === "partition") &&
+        /^\d+$/u.test(fields[2] ?? "") &&
+        /^\d+$/u.test(fields[3] ?? "") &&
+        /^-?\d+$/u.test(fields[4] ?? "");
+      const size = fields.length === 1 ? fields[0] : isSwapRow ? fields[2] : undefined;
       if (!size || !/^\d+$/u.test(size)) return total;
       return total + Number.parseInt(size, 10);
     }, 0);

--- a/test/e2e/fixtures/hermes-rebuild-swap.ts
+++ b/test/e2e/fixtures/hermes-rebuild-swap.ts
@@ -9,8 +9,10 @@ export function parseActiveSwapBytes(output: string): number {
     .map((line) => line.trim())
     .filter(Boolean)
     .reduce((total, line) => {
-      if (!/^\d+$/u.test(line)) return total;
-      return total + Number.parseInt(line, 10);
+      const fields = line.split(/\s+/u);
+      const size = fields.length === 1 ? fields[0] : fields.length === 5 ? fields[2] : undefined;
+      if (!size || !/^\d+$/u.test(size)) return total;
+      return total + Number.parseInt(size, 10);
     }, 0);
 }
 

--- a/test/e2e/support/hermes-rebuild-swap.test.ts
+++ b/test/e2e/support/hermes-rebuild-swap.test.ts
@@ -15,6 +15,15 @@ describe("Hermes rebuild swap", () => {
     expect(parseActiveSwapBytes("17179869184\n17179869184\n")).toBe(HERMES_REBUILD_SWAP_BYTES);
   });
 
+  it("adds active swap sizes from GitHub Actions runner rows", () => {
+    const output = [
+      "/swapfile file 3221221376 0 -2",
+      "/mnt/nemoclaw-hermes-rebuild.swap file 34359734272 0 -3",
+    ].join("\n");
+
+    expect(parseActiveSwapBytes(output)).toBe(37_580_955_648);
+  });
+
   it("provisions swap only on GitHub Actions runners below the rebuild floor", () => {
     expect(needsHermesRebuildSwap({ activeSwapBytes: 0, githubActions: true })).toBe(true);
     expect(

--- a/test/e2e/support/hermes-rebuild-swap.test.ts
+++ b/test/e2e/support/hermes-rebuild-swap.test.ts
@@ -24,6 +24,13 @@ describe("Hermes rebuild swap", () => {
     expect(parseActiveSwapBytes(output)).toBe(37_580_955_648);
   });
 
+  it("ignores unrelated five-field output", () => {
+    const activeSwapBytes = parseActiveSwapBytes("notice ignored 34359738368 text text");
+
+    expect(activeSwapBytes).toBe(0);
+    expect(needsHermesRebuildSwap({ activeSwapBytes, githubActions: true })).toBe(true);
+  });
+
   it("provisions swap only on GitHub Actions runners below the rebuild floor", () => {
     expect(needsHermesRebuildSwap({ activeSwapBytes: 0, githubActions: true })).toBe(true);
     expect(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fix the Hermes rebuild swap probes so they accept the five-column `swapon` rows returned by GitHub Actions runners. Before this change, both probes reported healthy swap as zero; now they read the `SIZE` field while preserving digit-only output support.

## Changes

- Parse digit-only `SIZE` output and validated `NAME TYPE SIZE USED PRIO` runner rows.
- Add a regression test with the exact pre-provision and post-provision row shapes from the failed release gate.
- Reject unrelated five-field output so diagnostics cannot bypass swap provisioning.
- Record the escaped-defect cause: the parser assumed `--output SIZE` always produced one column, and the test covered only that assumed output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change only affects internal E2E release-validation infrastructure.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/hermes-rebuild-swap.test.ts` (5 passed)
- [ ] Applicable broad gate passed — not applicable to this focused helper change. A complete E2E-support run passed 1,273 tests; six unrelated macOS time-out or fixture failures remain outside the changed files.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of active swap information from multi-line runner-style output, including handling file/partition rows and descriptive columns.
  * More reliably totals swap sizes and safely ignores unrelated rows, improving swap-related decision behavior.

* **Tests**
  * Added end-to-end test cases covering varied swap row formats and validation of the summed total.
  * Added coverage for ignoring irrelevant output and ensuring the rebuild condition triggers appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->