### PR TITLE
docs: clarify policy preview and Station package state

### DIFF
--- a/docs/get-started/dgx-station-preparation.mdx
+++ b/docs/get-started/dgx-station-preparation.mdx
@@ -53,6 +53,14 @@ The installer records the override in the printed relogin command when Docker-gr
 
 On the generic Ubuntu path, accepting express install prepares the host with NVIDIA open driver `610.43.02`, Docker CE `29.6.1` with Buildx, and NVIDIA Container Toolkit `1.19.1`.
 Preparation probes package and runtime state first, reuses exact matches, and installs only missing pinned packages, including the NVIDIA Container Toolkit libraries and `nvidia-ctk` CLI.
+NemoClaw accepts an idle PackageKit daemon and quiesces it during repository and package changes.
+NemoClaw still stops before mutation when it finds any of these conditions:
+
+- An active or malformed PackageKit transaction.
+- An active APT or dpkg process or lock.
+- Unhealthy package state.
+- A failure in a required package or package-manager state query.
+
 It permits only the reviewed factory transition from `dkms` `3.0.11-1ubuntu13` to `1:3.4.0-1ubuntu1`.
 It also accepts an installed `dkms` `1:3.4.1-1ubuntu1` as a retained-compatible forward revision, warns that it differs from the validated `1:3.4.0-1ubuntu1` pin, excludes it from APT transactions, and continues runtime validation.
 Retention requires `dpkg` to report a fully installed package for `arm64` or architecture `all`; an unhealthy or malformed record, an unexpected architecture, or a package-query failure stops preparation before APT changes.

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -75,6 +75,9 @@ Preview the endpoints before applying:
 $$nemoclaw my-assistant policy-add outlook --dry-run
 ```
 
+NemoClaw generates the preview from the exact preset policy YAML that `policy-add` would apply.
+It lists hosts, ports, access, protocol, TLS, and enforcement settings, HTTP methods and paths, and the binary allowlist.
+
 Apply the preset:
 
 ```bash


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR documents the full YAML-derived `policy-add --dry-run` disclosure near the preset preview workflow.
It also defines the generic Ubuntu package-state boundary for DGX Station preparation.
This post-release documentation follow-up does not change a dated changelog entry.

## Changes

- [#7187](https://github.com/NVIDIA/NemoClaw/pull/7187) -> `docs/network-policy/integration-policy-examples.mdx`: Explain that the preview uses the exact preset YAML and discloses endpoint, HTTP rule, and binary scope.
- [#7241](https://github.com/NVIDIA/NemoClaw/pull/7241) -> `docs/get-started/dgx-station-preparation.mdx`: Document that NemoClaw accepts and quiesces an idle PackageKit daemon.
- [#7202](https://github.com/NVIDIA/NemoClaw/pull/7202) -> `docs/get-started/dgx-station-preparation.mdx`: Document the fail-closed package transaction, lock, package-state, and query boundary before mutation.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This PR changes prose only. Existing source tests own the documented behavior, and focused documentation guards pass.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Documentation only.
- Result: No host behavior changed.
- Supporting evidence: Source behavior verified against merged PRs #7241 and #7202 and their focused tests.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts test/station-doc-ownership.test.ts test/policy-roundtrip-docs.test.ts`: 3 files and 12 tests passed.
- [ ] Applicable broad gate passed — Not applicable to this doc-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — The build passed with 0 errors. Fern reported the existing light-mode accent contrast warning.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Ubuntu preparation behavior when PackageKit, APT, or dpkg activity is detected, including conditions that stop preparation before changes are made.
  - Expanded network policy preview guidance to explain that output reflects the maintained preset configuration and includes hosts, ports, access rules, protocols, TLS and enforcement settings, HTTP methods and paths, and binary allowlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->