### PR TITLE
fix(onboard): reject macOS Podman compat socket before gateway launch (#7320)

### DIFF
--- a/src/lib/onboard/fatal-runtime-preflight.test.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.test.ts
@@ -26,7 +26,7 @@ function hostWithRuntime(runtime: HostAssessment["runtime"]): HostAssessment {
     cdiNvidiaGpuSpecMissing: false,
     nvidiaContainerToolkitInstalled: false,
     notes: [],
-  } as HostAssessment;
+  };
 }
 
 describe("rejectUnsupportedContainerRuntime (#7320)", () => {

--- a/src/lib/onboard/fatal-runtime-preflight.test.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.test.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import { isLinuxDockerDriverGatewayEnabled } from "./docker-driver-platform";
+import { rejectUnsupportedContainerRuntime } from "./fatal-runtime-preflight";
+import type { HostAssessment } from "./preflight";
+
+function hostWithRuntime(runtime: HostAssessment["runtime"]): HostAssessment {
+  return {
+    platform: process.platform,
+    isWsl: false,
+    runtime,
+    dockerInstalled: true,
+    dockerRunning: true,
+    dockerReachable: true,
+    nodeInstalled: true,
+    openshellInstalled: true,
+    isContainerRuntimeUnderProvisioned: false,
+    hasNestedOverlayConflict: false,
+    requiresHostCgroupnsFix: false,
+    isUnsupportedRuntime: runtime === "podman",
+    isHeadlessLikely: false,
+    hasNvidiaGpu: false,
+    dockerCdiSpecDirs: [],
+    cdiNvidiaGpuSpecMissing: false,
+    nvidiaContainerToolkitInstalled: false,
+    notes: [],
+  } as HostAssessment;
+}
+
+describe("rejectUnsupportedContainerRuntime (#7320)", () => {
+  it("exits when Podman is detected on a Docker-driver gateway platform", () => {
+    // The Docker-driver gateway path is forced on Linux and Apple Silicon
+    // macOS; the CI runner satisfies isLinuxDockerDriverGatewayEnabled().
+    if (!isLinuxDockerDriverGatewayEnabled()) return;
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    });
+    expect(() =>
+      rejectUnsupportedContainerRuntime(hostWithRuntime("podman"), exit as never),
+    ).toThrow("exit");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not exit for a supported Docker runtime", () => {
+    const exit = vi.fn();
+    rejectUnsupportedContainerRuntime(hostWithRuntime("docker"), exit as never);
+    expect(exit).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/fatal-runtime-preflight.test.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.test.ts
@@ -32,8 +32,8 @@ function hostWithRuntime(runtime: HostAssessment["runtime"]): HostAssessment {
 describe("rejectUnsupportedContainerRuntime (#7320)", () => {
   // The Docker-driver gateway path is forced on Linux and Apple Silicon macOS;
   // the reject gate only fires there. Gate the test on the same predicate via
-  // it.runIf (not an in-body `if`) so it runs on the Linux CI runner.
-  it.runIf(isLinuxDockerDriverGatewayEnabled())(
+  // it.skipIf (not an in-body `if`) so it runs on the Linux CI runner.
+  it.skipIf(!isLinuxDockerDriverGatewayEnabled())(
     "exits when Podman is detected on a Docker-driver gateway platform",
     () => {
       const exit = vi.fn(() => {

--- a/src/lib/onboard/fatal-runtime-preflight.test.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.test.ts
@@ -30,18 +30,21 @@ function hostWithRuntime(runtime: HostAssessment["runtime"]): HostAssessment {
 }
 
 describe("rejectUnsupportedContainerRuntime (#7320)", () => {
-  it("exits when Podman is detected on a Docker-driver gateway platform", () => {
-    // The Docker-driver gateway path is forced on Linux and Apple Silicon
-    // macOS; the CI runner satisfies isLinuxDockerDriverGatewayEnabled().
-    if (!isLinuxDockerDriverGatewayEnabled()) return;
-    const exit = vi.fn(() => {
-      throw new Error("exit");
-    });
-    expect(() =>
-      rejectUnsupportedContainerRuntime(hostWithRuntime("podman"), exit as never),
-    ).toThrow("exit");
-    expect(exit).toHaveBeenCalledWith(1);
-  });
+  // The Docker-driver gateway path is forced on Linux and Apple Silicon macOS;
+  // the reject gate only fires there. Gate the test on the same predicate via
+  // it.runIf (not an in-body `if`) so it runs on the Linux CI runner.
+  it.runIf(isLinuxDockerDriverGatewayEnabled())(
+    "exits when Podman is detected on a Docker-driver gateway platform",
+    () => {
+      const exit = vi.fn(() => {
+        throw new Error("exit");
+      });
+      expect(() =>
+        rejectUnsupportedContainerRuntime(hostWithRuntime("podman"), exit as never),
+      ).toThrow("exit");
+      expect(exit).toHaveBeenCalledWith(1);
+    },
+  );
 
   it("does not exit for a supported Docker runtime", () => {
     const exit = vi.fn();

--- a/src/lib/onboard/preflight-messages.test.ts
+++ b/src/lib/onboard/preflight-messages.test.ts
@@ -72,6 +72,9 @@ describe("onboard preflight severity messages (#6004)", () => {
     expect(lines(err)[0]).toContain("✗");
     expect(lines(err)[0]).toContain("Docker driver");
     expect(lines(err).join("\n")).toContain("Switch to Docker Engine");
+    // macOS reporters use Docker Desktop or Colima, not native Docker Engine (#7320).
+    expect(lines(err).join("\n")).toContain("Docker Desktop");
+    expect(lines(err).join("\n")).toContain("Colima");
   });
 
   it("prints the under-provisioned warning to stderr with a ⚠ marker and colima resize", () => {

--- a/src/lib/onboard/preflight-messages.ts
+++ b/src/lib/onboard/preflight-messages.ts
@@ -24,7 +24,7 @@ export function printDockerNotReachableError(): void {
 export function printUnsupportedRuntimeError(): void {
   console.error(failLine(`${cliDisplayName()} onboarding now uses OpenShell's Docker driver.`));
   console.error(`    Podman is not supported for this ${cliDisplayName()} integration path.`);
-  console.error("    Switch to Docker Engine and rerun onboarding.");
+  console.error("    Switch to Docker Engine, Docker Desktop, or Colima, then rerun onboarding.");
 }
 
 export interface UnderProvisionedRuntimeWarning {

--- a/src/lib/onboard/preflight-podman-compat.test.ts
+++ b/src/lib/onboard/preflight-podman-compat.test.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+// Import source directly so tests cannot pass against a stale build.
+import { assessHost } from "./preflight";
+
+// Regression: NemoClaw #7320. On Apple Silicon macOS a Docker CLI routed to
+// Podman's docker-compat socket reaches the forced Docker-driver gateway and
+// exits EADDRNOTAVAIL binding Podman's VM-only bridge IP (10.89.1.1, from
+// Podman's DefaultAddressPools base 10.89.0.0/16). Podman's docker-compat
+// `/info` mimics Docker (no "podman" marker: ServerVersion "5.6.2",
+// OperatingSystem "fedora", plus "docker" strings like DockerRootDir), so
+// `docker info` alone misclassifies it as `docker`. `docker version` still
+// names the "Podman Engine" component, which reclassifies it as unsupported so
+// the preflight gate rejects it before any gateway launch.
+//
+// Fixtures below are trimmed from live captures on an Apple Silicon macOS host
+// running `podman machine` behind `/var/run/docker.sock`.
+const PODMAN_COMPAT_DOCKER_INFO = JSON.stringify({
+  ServerVersion: "5.6.2",
+  OperatingSystem: "fedora",
+  OSType: "linux",
+  Architecture: "arm64",
+  Name: "localhost.localdomain",
+  DefaultRuntime: "crun",
+  ProductLicense: "Apache-2.0",
+  DockerRootDir: "/var/lib/containers/storage",
+  DefaultAddressPools: [{ Base: "10.89.0.0/16", Size: 24 }],
+  ClientInfo: { Platform: { Name: "Docker Engine - Community" }, Context: "default" },
+});
+const PODMAN_COMPAT_DOCKER_VERSION = JSON.stringify({
+  Client: { Platform: { Name: "Docker Engine - Community" }, Version: "29.3.1" },
+  Server: {
+    Platform: { Name: "linux/arm64/fedora-42" },
+    Version: "5.6.2",
+    Components: [
+      { Name: "Podman Engine", Version: "5.6.2" },
+      { Name: "Conmon", Version: "conmon version 2.1.13" },
+      { Name: "OCI Runtime (crun)", Version: "crun version 1.23.1" },
+    ],
+  },
+});
+
+describe("assessHost Podman docker-compat detection (#7320)", () => {
+  it("reclassifies Podman behind the Docker compatibility socket as unsupported", () => {
+    const result = assessHost({
+      platform: "darwin",
+      env: {},
+      dockerInfoOutput: PODMAN_COMPAT_DOCKER_INFO,
+      dockerVersionOutput: PODMAN_COMPAT_DOCKER_VERSION,
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+
+    expect(result.dockerReachable).toBe(true);
+    expect(result.runtime).toBe("podman");
+    expect(result.isUnsupportedRuntime).toBe(true);
+  });
+
+  it("reclassifies Podman from docker info ProductLicense when the version probe is empty", () => {
+    const result = assessHost({
+      platform: "darwin",
+      env: {},
+      dockerInfoOutput: PODMAN_COMPAT_DOCKER_INFO,
+      dockerVersionOutput: "",
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+
+    expect(result.dockerReachable).toBe(true);
+    expect(result.runtime).toBe("podman");
+    expect(result.isUnsupportedRuntime).toBe(true);
+  });
+
+  it("keeps real Docker classified as supported (no Podman false positive)", () => {
+    const realDockerInfo = JSON.stringify({
+      ServerVersion: "29.6.2",
+      OperatingSystem: "Ubuntu 24.04.3 LTS",
+      OSType: "linux",
+      Architecture: "x86_64",
+      DefaultRuntime: "runc",
+      DockerRootDir: "/var/lib/docker",
+      DefaultAddressPools: [{ Base: "192.168.240.0/20", Size: 24 }],
+      ClientInfo: { Platform: { Name: "Docker Engine - Community" } },
+    });
+    const realDockerVersion = JSON.stringify({
+      Client: { Platform: { Name: "Docker Engine - Community" } },
+      Server: {
+        Platform: { Name: "Docker Engine - Community" },
+        Version: "29.6.2",
+        Components: [
+          { Name: "Engine", Version: "29.6.2" },
+          { Name: "containerd", Version: "v2.2.6" },
+          { Name: "runc", Version: "1.3.6" },
+          { Name: "docker-init", Version: "0.19.0" },
+        ],
+      },
+    });
+    const result = assessHost({
+      platform: "darwin",
+      env: {},
+      dockerInfoOutput: realDockerInfo,
+      dockerVersionOutput: realDockerVersion,
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+
+    expect(result.dockerReachable).toBe(true);
+    expect(result.runtime).toBe("docker");
+    expect(result.isUnsupportedRuntime).toBe(false);
+  });
+});

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -169,6 +169,7 @@ export interface AssessHostOpts {
   procVersion?: string;
   dockerInfoOutput?: string;
   dockerInfoError?: string;
+  dockerVersionOutput?: string;
   readFileImpl?: (filePath: string, encoding: BufferEncoding) => string;
   readdirImpl?: (dir: string) => string[];
   runCaptureImpl?: RunCaptureFn;
@@ -213,6 +214,83 @@ function inferContainerRuntime(info = ""): ContainerRuntime {
   if (normalized.includes("docker desktop")) return "docker-desktop";
   if (normalized.includes("docker")) return "docker";
   return "unknown";
+}
+
+/**
+ * Detect Podman fronting the Docker CLI compatibility socket from the explicit
+ * `docker version --format '{{json .}}'` engine banner.
+ *
+ * Podman's docker-compat `/info` endpoint mimics Docker so closely that
+ * `docker info` carries no "podman" marker (observed on Apple Silicon macOS:
+ * `ServerVersion: "5.6.2"`, `OperatingSystem: "fedora"`, no "podman"
+ * substring), so `inferContainerRuntime` misclassifies it as plain Docker.
+ * The docker-compat `/version` payload still names the engine: a
+ * `Server.Components[].Name` of "Podman Engine" and a `Server.Platform.Name`
+ * like "linux/arm64/fedora-42". Real Docker reports
+ * `Server.Platform.Name: "Docker Engine - Community"` and components
+ * `Engine`/`containerd`/`runc`, so this stays false on Docker Engine,
+ * Docker Desktop, and Colima (#7320).
+ */
+function dockerVersionReportsPodman(versionOutput = ""): boolean {
+  const text = String(versionOutput || "").trim();
+  if (!text) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Plain-text `docker version` still prints the "Podman Engine" server banner.
+    return /podman/i.test(text);
+  }
+  const server = (parsed as Record<string, unknown> | null)?.Server;
+  if (!server || typeof server !== "object") return false;
+  const s = server as Record<string, unknown>;
+  const platformName = (s.Platform as Record<string, unknown> | undefined)?.Name;
+  if (typeof platformName === "string" && /podman/i.test(platformName)) return true;
+  const components = s.Components;
+  return (
+    Array.isArray(components) &&
+    components.some((component) => {
+      const name =
+        component && typeof component === "object"
+          ? (component as Record<string, unknown>).Name
+          : undefined;
+      return typeof name === "string" && /podman/i.test(name);
+    })
+  );
+}
+
+/**
+ * Backstop Podman signal from `docker info --format '{{json .}}'` when the
+ * `docker version` probe is unavailable: Podman's docker-compat `/info` reports
+ * `ProductLicense: "Apache-2.0"` (Podman is Apache-2.0 licensed), whereas Docker
+ * Engine omits `ProductLicense` (Docker CE) or reports a Docker license string.
+ * Observed Apache-2.0 on the reporter-equivalent Podman machine (#7320).
+ */
+function dockerInfoReportsPodmanCompat(infoOutput = ""): boolean {
+  const text = String(infoOutput || "").trim();
+  if (!text) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return false;
+  }
+  if (!parsed || typeof parsed !== "object") return false;
+  const license = (parsed as Record<string, unknown>).ProductLicense;
+  return typeof license === "string" && license.trim().toLowerCase() === "apache-2.0";
+}
+
+/**
+ * Reclassify a Docker CLI routed to Podman's compatibility socket as `podman`
+ * so the unsupported-runtime gate fires before the forced macOS/Linux
+ * Docker-driver gateway binds Podman's VM-only bridge address and exits
+ * `EADDRNOTAVAIL` (#7320).
+ */
+function isDockerCompatPodman(dockerInfoOutput = "", dockerVersionOutput = ""): boolean {
+  return (
+    dockerVersionReportsPodman(dockerVersionOutput) ||
+    dockerInfoReportsPodmanCompat(dockerInfoOutput)
+  );
 }
 
 function parseDockerCgroupVersion(info = ""): "v1" | "v2" | "unknown" {
@@ -536,6 +614,16 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     dockerRunning = true;
   }
 
+  // Capture the docker-compat engine banner so Podman fronting the Docker CLI
+  // socket is reclassified below. Only probed when the daemon is reachable so a
+  // down/absent Docker never pays for the extra call (#7320).
+  let dockerVersionOutput = opts.dockerVersionOutput;
+  if (dockerReachable && dockerVersionOutput === undefined) {
+    dockerVersionOutput = runCaptureImpl(["docker", "version", "--format", "{{json .}}"], {
+      ignoreError: true,
+    });
+  }
+
   const release = opts.release ?? os.release();
   const procVersion =
     opts.procVersion ??
@@ -547,6 +635,18 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
       }
     })();
   let runtime = inferContainerRuntime(dockerInfoOutput);
+  // Podman fronting the Docker CLI compatibility socket mimics Docker in
+  // `docker info`, so the grep above misclassifies it as `docker`. Reclassify
+  // from the explicit docker-compat signals so the unsupported-runtime gate
+  // fires before the forced Docker-driver gateway binds Podman's VM-only
+  // bridge IP and exits EADDRNOTAVAIL (#7320).
+  if (
+    dockerReachable &&
+    runtime !== "podman" &&
+    isDockerCompatPodman(dockerInfoOutput, dockerVersionOutput)
+  ) {
+    runtime = "podman";
+  }
   if (dockerReachable && runtime === "unknown" && platform === "linux") {
     runtime = "docker";
   }


### PR DESCRIPTION
## Summary

On Apple Silicon macOS, onboarding forces the OpenShell Docker-driver gateway path. When the Docker CLI is routed to a Podman machine's Docker compatibility socket, preflight failed to recognize Podman and let onboarding start the Docker-driver gateway, which then bound Podman's VM-only bridge address (`10.89.1.1:8080`) and exited `EADDRNOTAVAIL`. This change detects Podman behind the compatibility socket in preflight and fails closed early with the existing unsupported-runtime guidance, before any gateway launch. Podman remains unsupported per `ci/platform-matrix.json`; no Podman support is added.

## Related Issue

Fixes #7320

## Changes

- `src/lib/onboard/preflight.ts`: `assessHost()` now reclassifies a Docker CLI fronting Podman's docker-compat socket as `runtime: "podman"`. Podman's `/info` mimics Docker and carries no `"podman"` marker (observed: `ServerVersion "5.6.2"`, `OperatingSystem "fedora"`), so detection uses two observed docker-compat signals: the explicit `docker version --format '{{json .}}'` `"Podman Engine"` server component (primary), and the `/info` `ProductLicense: "Apache-2.0"` (backstop when the version probe is unavailable). The `docker version` probe runs only when the daemon is reachable. No false positives on Docker Engine, Docker Desktop, or Colima.
- `src/lib/onboard/preflight-messages.ts`: the unsupported-runtime recovery message now names Docker Engine, Docker Desktop, and Colima (macOS reporters use Docker Desktop/Colima, not native Docker Engine).
- Regression tests: `preflight-podman-compat.test.ts` (real docker-compat `info`+`version` metadata drives `runtime: "podman"`; real Docker stays supported) and `fatal-runtime-preflight.test.ts` (the rejection path); message-guidance assertions in `preflight-messages.test.ts`.

The existing preflight gate (`rejectUnsupportedContainerRuntime`) already runs on both the fresh and resume paths before the gateway state; correcting runtime detection is what makes it fire. No new abstraction, config, or fallback path is introduced.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs not applicable — justification: `docs/reference/platform-support.mdx` and `troubleshooting.mdx` already document Podman as unsupported and direct users to Docker Engine/Docker Desktop/Colima; this fix makes that already-documented rejection actually fire for the macOS docker-compat case.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: preflight/onboarding path; local `code-review` (high) surfaced only two low-severity, non-blocking design notes (ProductLicense backstop scope; one extra `docker version` subprocess per reachable-Docker `assessHost`), both acceptable; awaiting maintainer sensitive-path review.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set — command/result: `npx vitest run src/lib/onboard/preflight-podman-compat.test.ts src/lib/onboard/fatal-runtime-preflight.test.ts src/lib/onboard/preflight-messages.test.ts src/lib/onboard/preflight.test.ts` → 143 passed; full `--project cli` → 9593 passed / 1 skipped.
- [x] No secrets, API keys, or credentials committed

### Real-CLI E2E (Apple Silicon macOS, Podman docker-compat socket)

Reproduced the exact reporter command `./bin/nemoclaw.js onboard --fresh` on an Apple Silicon macOS host (macOS 26.5.2, arm64) with a running `podman machine` whose Docker compatibility socket forwards to `/var/run/docker.sock`, Docker CLI 29.3.1 routed to it (`ServerVersion 5.6.2`, `ProductLicense Apache-2.0`, `DefaultRuntime crun`).

- **Pre-fix:** preflight misclassified the runtime (`✓ Container runtime: docker`) and advanced to `[2/8] Starting OpenShell gateway → Starting OpenShell Docker-driver gateway` — the forced Docker-driver path the reporter hits.
- **Post-fix:** onboarding fails closed at `[1/8] Preflight checks` with `✗ … Podman is not supported for this NemoClaw integration path. Switch to Docker Engine, Docker Desktop, or Colima, then rerun onboarding.` and exits non-zero (1), before any gateway launch. `assessHost()` against the live socket now reports `runtime: "podman"`, `isUnsupportedRuntime: true`.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host runtime detection to correctly identify Podman when it fronts Docker-compatible interfaces.
  * Unsupported Podman environments are now blocked earlier in onboarding, with clearer “switch to Docker Engine, Docker Desktop, or Colima” guidance.
* **Tests**
  * Added targeted test coverage for runtime rejection behavior and Podman/docker-compat detection scenarios.
  * Expanded assertions to validate macOS-oriented error message guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->