### PR TITLE
fix(e2e): repair historical gateway upgrades

### DIFF
--- a/docs/security/openclaw-2026.6.10-dependency-review.md
+++ b/docs/security/openclaw-2026.6.10-dependency-review.md
@@ -264,7 +264,8 @@ It installs the archive with lifecycle scripts disabled and invokes `postinstall
 The `v0.0.74` fixture retains npm registry signature verification for its historical mcporter lock.
 The reviewed `v0.0.36` and `v0.0.55` profiles require no advisory audit statement.
 The reviewed `v0.0.74` profile requires exactly one advisory audit statement, which the adapter replaces with a test-only skip.
-The adapter rejects an unknown profile or an advisory audit count that does not match its reviewed profile.
+Each audit policy is bound to one exact reviewed NemoClaw tag, full commit SHA, and OpenClaw version tuple before the installer is patched.
+The adapter rejects an unknown or mixed tuple and any advisory audit count that does not match its reviewed profile.
 `test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts` verifies these constraints.
 
 Invalid state: a production image build overriding `OPENCLAW_VERSION` to an old fixture pin or replacing any repository-reviewed integrity/tarball value while still passing the workflow boundary. Source boundary: Dockerfile and Dockerfile.base install blocks plus the guard that precedes every production image build. Source-fix constraint: keep stale-upgrade E2Es able to build old images without normalizing those pins or accepting caller-controlled production package identity. Regression tests: the integrity-pin contract suite rejects the flag, both legacy versions, all declared integrity/tarball ARG overrides through direct, `--build-arg`, and environment paths, and a future-shaped positional pin name; `test/openclaw-dependency-review.test.ts` proves all seven production image builds are guard-protected and carry no literal fixture selectors. Removal condition: issue #5896 section 9 retires the old-base fixture strategy and fixture flag; the general repository-owned production pin guard remains until production builds no longer expose package identity as Docker ARGs.

--- a/docs/security/openclaw-2026.6.10-dependency-review.md
+++ b/docs/security/openclaw-2026.6.10-dependency-review.md
@@ -259,10 +259,12 @@ The legacy `2026.3.11` and `2026.4.24` OpenClaw pins are retained only for stale
 
 Frozen OpenShell gateway-upgrade fixtures select only the SRI-pinned OpenClaw `2026.4.24`, `2026.5.22`, or `2026.5.27` archive.
 The live test uses `packReviewedNpmArchive` to verify exact registry metadata, the reviewed tarball URL, and the downloaded SRI.
-The adapter copies only that verified local archive into the historical build context.
+The adapter stores only that verified local archive at `nemoclaw/src/.nemoclaw-e2e-old-openclaw.tgz`, which the frozen optimized build-context staging preserves.
 It installs the archive with lifecycle scripts disabled and invokes `postinstall-bundled-plugins.mjs` directly.
-The fixtures retain npm registry signature verification for the historical mcporter lock.
-The adapter requires exactly one advisory audit statement before it replaces that statement with a test-only skip.
+The `v0.0.74` fixture retains npm registry signature verification for its historical mcporter lock.
+The reviewed `v0.0.36` and `v0.0.55` profiles require no advisory audit statement.
+The reviewed `v0.0.74` profile requires exactly one advisory audit statement, which the adapter replaces with a test-only skip.
+The adapter rejects an unknown profile or an advisory audit count that does not match its reviewed profile.
 `test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts` verifies these constraints.
 
 Invalid state: a production image build overriding `OPENCLAW_VERSION` to an old fixture pin or replacing any repository-reviewed integrity/tarball value while still passing the workflow boundary. Source boundary: Dockerfile and Dockerfile.base install blocks plus the guard that precedes every production image build. Source-fix constraint: keep stale-upgrade E2Es able to build old images without normalizing those pins or accepting caller-controlled production package identity. Regression tests: the integrity-pin contract suite rejects the flag, both legacy versions, all declared integrity/tarball ARG overrides through direct, `--build-arg`, and environment paths, and a future-shaped positional pin name; `test/openclaw-dependency-review.test.ts` proves all seven production image builds are guard-protected and carry no literal fixture selectors. Removal condition: issue #5896 section 9 retires the old-base fixture strategy and fixture flag; the general repository-owned production pin guard remains until production builds no longer expose package identity as Docker ARGs.

--- a/test/e2e/live/openshell-gateway-upgrade-helpers.ts
+++ b/test/e2e/live/openshell-gateway-upgrade-helpers.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { shellQuote } from "../fixtures/clients/command.ts";
+import { reviewedOldInstallerProfile } from "./openshell-gateway-upgrade-old-installer.ts";
 
 const NON_INTERACTIVE_INSTALLER_ARGS = ["--non-interactive", "--yes-i-accept-third-party-software"];
 const GATEWAY_VOLUME_PREFIX = "openshell-cluster-nemoclaw";
@@ -35,6 +36,7 @@ export function validateLegacyGatewayUpgradeFixture(fixture: LegacyGatewayUpgrad
       `NEMOCLAW_OLD_OPENCLAW_VERSION must use the YYYY.M.D release format; got ${fixture.openclawVersion}`,
     );
   }
+  reviewedOldInstallerProfile(fixture);
   const sandboxBaseDigest = fixture.sandboxBaseImageRef.match(
     /^[^@\s]+@sha256:([0-9a-f]{64})$/,
   )?.[1];

--- a/test/e2e/live/openshell-gateway-upgrade-old-installer.ts
+++ b/test/e2e/live/openshell-gateway-upgrade-old-installer.ts
@@ -10,6 +10,17 @@ export type ReviewedOldOpenClawArchive = Readonly<{
   tarballUrl: string;
 }>;
 
+export type OldInstallerFixtureIdentity = Readonly<{
+  nemoclawCommit: string;
+  nemoclawRef: string;
+  openclawVersion: string;
+}>;
+
+type ReviewedOldInstallerProfile = OldInstallerFixtureIdentity &
+  Readonly<{
+    expectedAdvisoryAuditCount: 0 | 1;
+  }>;
+
 const REVIEWED_OLD_OPENCLAW_ARCHIVES: Readonly<Record<string, ReviewedOldOpenClawArchive>> =
   Object.freeze({
     "2026.4.24": {
@@ -42,11 +53,27 @@ export const OLD_INSTALLER_ADVISORY_AUDIT =
   "    npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime audit --omit=dev --audit-level=low; \\\n";
 export const OLD_INSTALLER_ARCHIVE_CONTEXT_PATH = "nemoclaw/src/.nemoclaw-e2e-old-openclaw.tgz";
 
-const OLD_INSTALLER_ADVISORY_AUDIT_COUNTS: Readonly<Record<string, 0 | 1>> = Object.freeze({
-  "v0.0.36": 0,
-  "v0.0.55": 0,
-  "v0.0.74": 1,
-});
+const REVIEWED_OLD_INSTALLER_PROFILES: Readonly<Record<string, ReviewedOldInstallerProfile>> =
+  Object.freeze({
+    "v0.0.36": Object.freeze({
+      expectedAdvisoryAuditCount: 0,
+      nemoclawCommit: "3351fbdd4eb7d9b80ec471545083956327da2b10",
+      nemoclawRef: "v0.0.36",
+      openclawVersion: "2026.4.24",
+    }),
+    "v0.0.55": Object.freeze({
+      expectedAdvisoryAuditCount: 0,
+      nemoclawCommit: "95d483fe2b6569d68e59493c60f19df09a068e8f",
+      nemoclawRef: "v0.0.55",
+      openclawVersion: "2026.5.22",
+    }),
+    "v0.0.74": Object.freeze({
+      expectedAdvisoryAuditCount: 1,
+      nemoclawCommit: "3a05b54e8ec3e1d5550ec5c728de54af872bffe3",
+      nemoclawRef: "v0.0.74",
+      openclawVersion: "2026.5.27",
+    }),
+  });
 
 export function reviewedOldOpenClawArchive(version: string): ReviewedOldOpenClawArchive {
   const reviewedArchive = REVIEWED_OLD_OPENCLAW_ARCHIVES[version];
@@ -56,15 +83,32 @@ export function reviewedOldOpenClawArchive(version: string): ReviewedOldOpenClaw
   return reviewedArchive;
 }
 
+export function reviewedOldInstallerProfile(
+  identity: OldInstallerFixtureIdentity,
+): ReviewedOldInstallerProfile {
+  const profile = REVIEWED_OLD_INSTALLER_PROFILES[identity.nemoclawRef];
+  if (
+    !profile ||
+    profile.nemoclawCommit !== identity.nemoclawCommit ||
+    profile.openclawVersion !== identity.openclawVersion
+  ) {
+    throw new Error(
+      `Historical gateway upgrade fixture must match an exact reviewed ref/commit/OpenClaw profile; got ${identity.nemoclawRef}/${identity.nemoclawCommit}/${identity.openclawVersion}`,
+    );
+  }
+  return profile;
+}
+
 // The frozen release installers are the source of truth, but their embedded
 // Dockerfiles predate the fixture pins needed for a deterministic upgrade test.
 // Keep this adapter scoped to the frozen historical lanes and retire it with
 // them; changing the tagged release payloads is not viable.
-export function patchOldInstallerFixture(installer: string, nemoclawRef: string): void {
-  const expectedAdvisoryAuditCount = OLD_INSTALLER_ADVISORY_AUDIT_COUNTS[nemoclawRef];
-  if (expectedAdvisoryAuditCount === undefined) {
-    throw new Error(`Historical gateway upgrade ${nemoclawRef} has no reviewed installer profile`);
-  }
+export function patchOldInstallerFixture(
+  installer: string,
+  identity: OldInstallerFixtureIdentity,
+): void {
+  const profile = reviewedOldInstallerProfile(identity);
+  const expectedAdvisoryAuditCount = profile.expectedAdvisoryAuditCount;
 
   const hook =
     String.raw`  if [[ -n "\${NEMOCLAW_OLD_OPENCLAW_VERSION:-}" && -f "$payload_script" ]]; then

--- a/test/e2e/live/openshell-gateway-upgrade-old-installer.ts
+++ b/test/e2e/live/openshell-gateway-upgrade-old-installer.ts
@@ -40,6 +40,13 @@ export const OLD_INSTALLER_CLONE_NEEDLE =
   '    spin "Cloning ${_CLI_DISPLAY} source" clone_nemoclaw_ref "$release_ref" "$nemoclaw_src"\n';
 export const OLD_INSTALLER_ADVISORY_AUDIT =
   "    npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime audit --omit=dev --audit-level=low; \\\n";
+export const OLD_INSTALLER_ARCHIVE_CONTEXT_PATH = "nemoclaw/src/.nemoclaw-e2e-old-openclaw.tgz";
+
+const OLD_INSTALLER_ADVISORY_AUDIT_COUNTS: Readonly<Record<string, 0 | 1>> = Object.freeze({
+  "v0.0.36": 0,
+  "v0.0.55": 0,
+  "v0.0.74": 1,
+});
 
 export function reviewedOldOpenClawArchive(version: string): ReviewedOldOpenClawArchive {
   const reviewedArchive = REVIEWED_OLD_OPENCLAW_ARCHIVES[version];
@@ -53,7 +60,12 @@ export function reviewedOldOpenClawArchive(version: string): ReviewedOldOpenClaw
 // Dockerfiles predate the fixture pins needed for a deterministic upgrade test.
 // Keep this adapter scoped to the frozen historical lanes and retire it with
 // them; changing the tagged release payloads is not viable.
-export function patchOldInstallerFixture(installer: string): void {
+export function patchOldInstallerFixture(installer: string, nemoclawRef: string): void {
+  const expectedAdvisoryAuditCount = OLD_INSTALLER_ADVISORY_AUDIT_COUNTS[nemoclawRef];
+  if (expectedAdvisoryAuditCount === undefined) {
+    throw new Error(`Historical gateway upgrade ${nemoclawRef} has no reviewed installer profile`);
+  }
+
   const hook =
     String.raw`  if [[ -n "\${NEMOCLAW_OLD_OPENCLAW_VERSION:-}" && -f "$payload_script" ]]; then
     python3 - "$payload_script" <<'NEMOCLAW_OLD_PAYLOAD_PIN_PY'
@@ -68,7 +80,12 @@ hook = r'''    if [[ -n "\${NEMOCLAW_OLD_OPENCLAW_VERSION:-}" ]]; then
         echo "ERROR: reviewed historical OpenClaw archive is missing" >&2
         exit 1
       fi
-      cp -- "$NEMOCLAW_OLD_OPENCLAW_ARCHIVE" "$nemoclaw_src/.nemoclaw-e2e-old-openclaw.tgz"
+      archive_context_path="$nemoclaw_src/${OLD_INSTALLER_ARCHIVE_CONTEXT_PATH}"
+      if [[ ! -d "$(dirname "$archive_context_path")" ]]; then
+        echo "ERROR: historical OpenClaw archive context directory is missing" >&2
+        exit 1
+      fi
+      cp -- "$NEMOCLAW_OLD_OPENCLAW_ARCHIVE" "$archive_context_path"
       python3 - "$nemoclaw_src/Dockerfile" "$NEMOCLAW_OLD_OPENCLAW_VERSION" <<'NEMOCLAW_OLD_DOCKERFILE_PIN_PY'
 from pathlib import Path
 import sys
@@ -78,7 +95,7 @@ version = sys.argv[2]
 text = path.read_text(encoding="utf-8")
 injection = (
     "# E2E old-upgrade fixture: force the historical OpenClaw before the old Dockerfile's version gate.\n"
-    "COPY .nemoclaw-e2e-old-openclaw.tgz /tmp/nemoclaw-e2e-old-openclaw.tgz\n"
+    "COPY ${OLD_INSTALLER_ARCHIVE_CONTEXT_PATH} /tmp/nemoclaw-e2e-old-openclaw.tgz\n"
     "RUN rm -rf /usr/local/lib/node_modules/openclaw /usr/local/bin/openclaw \\\n"
     "    && npm install -g --ignore-scripts --no-audit --no-fund --no-progress /tmp/nemoclaw-e2e-old-openclaw.tgz \\\n"
     "    && node /usr/local/lib/node_modules/openclaw/scripts/postinstall-bundled-plugins.mjs \\\n"
@@ -105,14 +122,17 @@ if injection not in text:
 
 advisory_audit = ${JSON.stringify(OLD_INSTALLER_ADVISORY_AUDIT)}
 advisory_audit_count = text.count(advisory_audit)
-if advisory_audit_count != 1:
+expected_advisory_audit_count = ${expectedAdvisoryAuditCount}
+if advisory_audit_count != expected_advisory_audit_count:
     raise SystemExit(
-        f"{path}: found {advisory_audit_count} historical mcporter advisory audits; expected exactly one"
+        f"{path}: found {advisory_audit_count} historical mcporter advisory audits; "
+        f"expected {expected_advisory_audit_count}"
     )
-audit_fixture_note = (
-    '    echo "INFO: Skipping current advisory audit for the immutable historical mcporter lock"; \\\n'
-)
-text = text.replace(advisory_audit, audit_fixture_note, 1)
+if expected_advisory_audit_count == 1:
+    audit_fixture_note = (
+        '    echo "INFO: Skipping current advisory audit for the immutable historical mcporter lock"; \\\n'
+    )
+    text = text.replace(advisory_audit, audit_fixture_note, 1)
 
 path.write_text(text, encoding="utf-8")
 print(f"INFO: Forced OpenClaw {version} in old upgrade fixture Dockerfile", flush=True)

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -403,7 +403,7 @@ async function installOldNemoclawAndClaw(
     `downloaded ${OLD_NEMOCLAW_REF} installer must match its pinned SHA-256`,
   ).toBe(OLD_INSTALLER_SHA256);
   fs.chmodSync(oldInstaller, 0o755);
-  patchOldInstallerFixture(oldInstaller);
+  patchOldInstallerFixture(oldInstaller, OLD_NEMOCLAW_REF);
 
   const reviewedOpenClaw = packReviewedNpmArchive(reviewedOldOpenClawArchive(OLD_OPENCLAW_VERSION));
 

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -70,11 +70,14 @@ const OLD_SANDBOX_BASE_IMAGE_REF =
   process.env.NEMOCLAW_OLD_SANDBOX_BASE_IMAGE_REF ??
   "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:104151ffadc2ff0b6c815e3c95c2783ced61aee0d0f83fc327cc02be9b7e14e6";
 const OLD_OPENCLAW_VERSION = process.env.NEMOCLAW_OLD_OPENCLAW_VERSION ?? "2026.4.24";
-const { sandboxBaseDigest: OLD_SANDBOX_BASE_DIGEST } = validateLegacyGatewayUpgradeFixture({
-  nemoclawRef: OLD_NEMOCLAW_REF,
+const OLD_INSTALLER_FIXTURE_IDENTITY = Object.freeze({
   nemoclawCommit: OLD_NEMOCLAW_COMMIT,
-  installerSha256: OLD_INSTALLER_SHA256,
+  nemoclawRef: OLD_NEMOCLAW_REF,
   openclawVersion: OLD_OPENCLAW_VERSION,
+});
+const { sandboxBaseDigest: OLD_SANDBOX_BASE_DIGEST } = validateLegacyGatewayUpgradeFixture({
+  ...OLD_INSTALLER_FIXTURE_IDENTITY,
+  installerSha256: OLD_INSTALLER_SHA256,
   sandboxBaseImageRef: OLD_SANDBOX_BASE_IMAGE_REF,
 });
 const SURVIVOR_SANDBOX =
@@ -403,7 +406,7 @@ async function installOldNemoclawAndClaw(
     `downloaded ${OLD_NEMOCLAW_REF} installer must match its pinned SHA-256`,
   ).toBe(OLD_INSTALLER_SHA256);
   fs.chmodSync(oldInstaller, 0o755);
-  patchOldInstallerFixture(oldInstaller, OLD_NEMOCLAW_REF);
+  patchOldInstallerFixture(oldInstaller, OLD_INSTALLER_FIXTURE_IDENTITY);
 
   const reviewedOpenClaw = packReviewedNpmArchive(reviewedOldOpenClawArchive(OLD_OPENCLAW_VERSION));
 

--- a/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
@@ -27,8 +27,25 @@ const HISTORICAL_OPENCLAW_VERSIONS = Object.freeze({
   "v0.0.55": "2026.5.22",
   "v0.0.74": "2026.5.27",
 });
+const HISTORICAL_NEMOCLAW_COMMITS = Object.freeze({
+  "v0.0.36": "3351fbdd4eb7d9b80ec471545083956327da2b10",
+  "v0.0.55": "95d483fe2b6569d68e59493c60f19df09a068e8f",
+  "v0.0.74": "3a05b54e8ec3e1d5550ec5c728de54af872bffe3",
+});
 
 type ReviewedHistoricalRef = keyof typeof HISTORICAL_BUILD_CONTEXT_MODULES;
+
+function historicalFixtureIdentity(nemoclawRef: ReviewedHistoricalRef): {
+  nemoclawCommit: string;
+  nemoclawRef: ReviewedHistoricalRef;
+  openclawVersion: string;
+} {
+  return {
+    nemoclawCommit: HISTORICAL_NEMOCLAW_COMMITS[nemoclawRef],
+    nemoclawRef,
+    openclawVersion: HISTORICAL_OPENCLAW_VERSIONS[nemoclawRef],
+  };
+}
 
 function writeInstallerHarness(sourceRoot: string): {
   archive: string;
@@ -152,7 +169,7 @@ process.stdout.write(staged.buildCtx);
 
 function runReviewedHistoricalFixture(nemoclawRef: ReviewedHistoricalRef): string {
   const fixture = writeInstallerHarness(extractReviewedHistoricalSource(nemoclawRef));
-  patchOldInstallerFixture(fixture.installer, nemoclawRef);
+  patchOldInstallerFixture(fixture.installer, historicalFixtureIdentity(nemoclawRef));
 
   const result = spawnSync("bash", [fixture.installer], {
     encoding: "utf8",
@@ -213,7 +230,7 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
 
   it("rejects an ambiguous historical advisory boundary", () => {
     const fixture = writeHistoricalFixture(2);
-    patchOldInstallerFixture(fixture.installer, "v0.0.74");
+    patchOldInstallerFixture(fixture.installer, historicalFixtureIdentity("v0.0.74"));
     const originalDockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
 
     const result = spawnSync("bash", [fixture.installer], {
@@ -231,7 +248,7 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
 
   it("rejects a missing historical advisory boundary", () => {
     const fixture = writeHistoricalFixture(0);
-    patchOldInstallerFixture(fixture.installer, "v0.0.74");
+    patchOldInstallerFixture(fixture.installer, historicalFixtureIdentity("v0.0.74"));
     const originalDockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
 
     const result = spawnSync("bash", [fixture.installer], {
@@ -249,7 +266,7 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
 
   it("rejects an advisory audit in a profile that predates the audit", () => {
     const fixture = writeHistoricalFixture(1);
-    patchOldInstallerFixture(fixture.installer, "v0.0.36");
+    patchOldInstallerFixture(fixture.installer, historicalFixtureIdentity("v0.0.36"));
     const originalDockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
 
     const result = spawnSync("bash", [fixture.installer], {
@@ -269,9 +286,26 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
     const fixture = writeHistoricalFixture();
     const originalInstaller = fs.readFileSync(fixture.installer, "utf8");
 
-    expect(() => patchOldInstallerFixture(fixture.installer, "v0.0.75")).toThrow(
-      /has no reviewed installer profile/u,
-    );
+    expect(() =>
+      patchOldInstallerFixture(fixture.installer, {
+        nemoclawCommit: "4".repeat(40),
+        nemoclawRef: "v0.0.75",
+        openclawVersion: "2026.5.28",
+      }),
+    ).toThrow(/exact reviewed ref\/commit\/OpenClaw profile/u);
+    expect(fs.readFileSync(fixture.installer, "utf8")).toBe(originalInstaller);
+  });
+
+  it("rejects a mixed historical installer profile", () => {
+    const fixture = writeHistoricalFixture();
+    const originalInstaller = fs.readFileSync(fixture.installer, "utf8");
+
+    expect(() =>
+      patchOldInstallerFixture(fixture.installer, {
+        ...historicalFixtureIdentity("v0.0.55"),
+        nemoclawCommit: HISTORICAL_NEMOCLAW_COMMITS["v0.0.36"],
+      }),
+    ).toThrow(/exact reviewed ref\/commit\/OpenClaw profile/u);
     expect(fs.readFileSync(fixture.installer, "utf8")).toBe(originalInstaller);
   });
 

--- a/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
@@ -75,6 +75,45 @@ function writeHistoricalFixture(advisoryAuditCount = 1): {
   return { archive, dockerfile, installer, sourceRoot };
 }
 
+function runReviewedHistoricalFixture(nemoclawRef: string, auditCount: 0 | 1): string {
+  const fixture = writeHistoricalFixture(auditCount);
+  patchOldInstallerFixture(fixture.installer, nemoclawRef);
+
+  const result = spawnSync("bash", [fixture.installer], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NEMOCLAW_OLD_OPENCLAW_ARCHIVE: fixture.archive,
+      NEMOCLAW_OLD_OPENCLAW_VERSION: "2026.5.27",
+    },
+  });
+  expect(result.status, result.stderr).toBe(0);
+
+  const dockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
+  const archiveContextPath = path.join(fixture.sourceRoot, OLD_INSTALLER_ARCHIVE_CONTEXT_PATH);
+  expect(fs.readFileSync(archiveContextPath, "utf8")).toBe("reviewed fixture archive");
+  expect(dockerfile).toContain(
+    `COPY ${OLD_INSTALLER_ARCHIVE_CONTEXT_PATH} /tmp/nemoclaw-e2e-old-openclaw.tgz`,
+  );
+  expect(dockerfile).toContain(
+    "npm install -g --ignore-scripts --no-audit --no-fund --no-progress /tmp/nemoclaw-e2e-old-openclaw.tgz",
+  );
+  expect(dockerfile).not.toMatch(/npm install -g [^\n]*openclaw@/u);
+
+  const stagedContext = path.join(path.dirname(fixture.sourceRoot), "staged-context");
+  fs.mkdirSync(path.join(stagedContext, "nemoclaw"), { recursive: true });
+  // Each frozen optimized-context builder copies nemoclaw/src recursively.
+  fs.cpSync(
+    path.join(fixture.sourceRoot, "nemoclaw", "src"),
+    path.join(stagedContext, "nemoclaw", "src"),
+    { recursive: true },
+  );
+  expect(
+    fs.readFileSync(path.join(stagedContext, OLD_INSTALLER_ARCHIVE_CONTEXT_PATH), "utf8"),
+  ).toBe("reviewed fixture archive");
+  return dockerfile;
+}
+
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     fs.rmSync(directory, { force: true, recursive: true });
@@ -83,56 +122,23 @@ afterEach(() => {
 
 describe("historical OpenShell gateway upgrade installer adapter", () => {
   it.each([
-    ["v0.0.36", 0],
-    ["v0.0.55", 0],
-    ["v0.0.74", 1],
-  ] as const)("accepts the reviewed %s advisory audit boundary", (nemoclawRef, auditCount) => {
-    const fixture = writeHistoricalFixture(auditCount);
-    patchOldInstallerFixture(fixture.installer, nemoclawRef);
-
-    const result = spawnSync("bash", [fixture.installer], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        NEMOCLAW_OLD_OPENCLAW_ARCHIVE: fixture.archive,
-        NEMOCLAW_OLD_OPENCLAW_VERSION: "2026.5.27",
-      },
-    });
-    expect(result.status, result.stderr).toBe(0);
-
-    const dockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
-    const archiveContextPath = path.join(fixture.sourceRoot, OLD_INSTALLER_ARCHIVE_CONTEXT_PATH);
-    expect(fs.readFileSync(archiveContextPath, "utf8")).toBe("reviewed fixture archive");
-    expect(dockerfile).toContain(
-      `COPY ${OLD_INSTALLER_ARCHIVE_CONTEXT_PATH} /tmp/nemoclaw-e2e-old-openclaw.tgz`,
+    "v0.0.36",
+    "v0.0.55",
+  ] as const)("accepts the reviewed %s profile without an advisory audit", (nemoclawRef) => {
+    const dockerfile = runReviewedHistoricalFixture(nemoclawRef, 0);
+    expect(dockerfile).not.toContain("audit --omit=dev --audit-level=low");
+    expect(dockerfile).not.toContain(
+      "Skipping current advisory audit for the immutable historical mcporter lock",
     );
+  });
+
+  it("accepts the reviewed v0.0.74 advisory and signature audit boundary", () => {
+    const dockerfile = runReviewedHistoricalFixture("v0.0.74", 1);
+    expect(dockerfile).not.toContain("audit --omit=dev --audit-level=low");
     expect(dockerfile).toContain(
-      "npm install -g --ignore-scripts --no-audit --no-fund --no-progress /tmp/nemoclaw-e2e-old-openclaw.tgz",
+      "Skipping current advisory audit for the immutable historical mcporter lock",
     );
-    expect(dockerfile).not.toMatch(/npm install -g [^\n]*openclaw@/u);
-    if (auditCount === 1) {
-      expect(dockerfile).not.toContain("audit --omit=dev --audit-level=low");
-      expect(dockerfile).toContain(
-        "Skipping current advisory audit for the immutable historical mcporter lock",
-      );
-    } else {
-      expect(dockerfile).not.toContain(
-        "Skipping current advisory audit for the immutable historical mcporter lock",
-      );
-    }
     expect(dockerfile).toContain("audit signatures");
-
-    const stagedContext = path.join(path.dirname(fixture.sourceRoot), "staged-context");
-    fs.mkdirSync(path.join(stagedContext, "nemoclaw"), { recursive: true });
-    // Each frozen optimized-context builder copies nemoclaw/src recursively.
-    fs.cpSync(
-      path.join(fixture.sourceRoot, "nemoclaw", "src"),
-      path.join(stagedContext, "nemoclaw", "src"),
-      { recursive: true },
-    );
-    expect(
-      fs.readFileSync(path.join(stagedContext, OLD_INSTALLER_ARCHIVE_CONTEXT_PATH), "utf8"),
-    ).toBe("reviewed fixture archive");
   });
 
   it("rejects an ambiguous historical advisory boundary", () => {

--- a/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   OLD_INSTALLER_ADVISORY_AUDIT,
+  OLD_INSTALLER_ARCHIVE_CONTEXT_PATH,
   OLD_INSTALLER_BOOTSTRAP_NEEDLE,
   OLD_INSTALLER_CLONE_NEEDLE,
   patchOldInstallerFixture,
@@ -20,6 +21,7 @@ function writeHistoricalFixture(advisoryAuditCount = 1): {
   archive: string;
   dockerfile: string;
   installer: string;
+  sourceRoot: string;
 } {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-old-upgrade-installer-"));
   temporaryDirectories.push(root);
@@ -28,7 +30,7 @@ function writeHistoricalFixture(advisoryAuditCount = 1): {
   const archive = path.join(root, "reviewed-openclaw.tgz");
   const payload = path.join(root, "payload.sh");
   const installer = path.join(root, "install.sh");
-  fs.mkdirSync(sourceRoot);
+  fs.mkdirSync(path.join(sourceRoot, "nemoclaw", "src"), { recursive: true });
   fs.writeFileSync(archive, "reviewed fixture archive");
 
   fs.writeFileSync(
@@ -70,7 +72,7 @@ function writeHistoricalFixture(advisoryAuditCount = 1): {
     ].join("\n"),
     { mode: 0o700 },
   );
-  return { archive, dockerfile, installer };
+  return { archive, dockerfile, installer, sourceRoot };
 }
 
 afterEach(() => {
@@ -80,9 +82,13 @@ afterEach(() => {
 });
 
 describe("historical OpenShell gateway upgrade installer adapter", () => {
-  it("keeps signature verification while isolating current advisory drift", () => {
-    const fixture = writeHistoricalFixture();
-    patchOldInstallerFixture(fixture.installer);
+  it.each([
+    ["v0.0.36", 0],
+    ["v0.0.55", 0],
+    ["v0.0.74", 1],
+  ] as const)("accepts the reviewed %s advisory audit boundary", (nemoclawRef, auditCount) => {
+    const fixture = writeHistoricalFixture(auditCount);
+    patchOldInstallerFixture(fixture.installer, nemoclawRef);
 
     const result = spawnSync("bash", [fixture.installer], {
       encoding: "utf8",
@@ -95,29 +101,43 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
     expect(result.status, result.stderr).toBe(0);
 
     const dockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
-    expect(
-      fs.readFileSync(
-        path.join(path.dirname(fixture.dockerfile), ".nemoclaw-e2e-old-openclaw.tgz"),
-        "utf8",
-      ),
-    ).toBe("reviewed fixture archive");
+    const archiveContextPath = path.join(fixture.sourceRoot, OLD_INSTALLER_ARCHIVE_CONTEXT_PATH);
+    expect(fs.readFileSync(archiveContextPath, "utf8")).toBe("reviewed fixture archive");
     expect(dockerfile).toContain(
-      "COPY .nemoclaw-e2e-old-openclaw.tgz /tmp/nemoclaw-e2e-old-openclaw.tgz",
+      `COPY ${OLD_INSTALLER_ARCHIVE_CONTEXT_PATH} /tmp/nemoclaw-e2e-old-openclaw.tgz`,
     );
     expect(dockerfile).toContain(
       "npm install -g --ignore-scripts --no-audit --no-fund --no-progress /tmp/nemoclaw-e2e-old-openclaw.tgz",
     );
     expect(dockerfile).not.toMatch(/npm install -g [^\n]*openclaw@/u);
-    expect(dockerfile).not.toContain("audit --omit=dev --audit-level=low");
-    expect(dockerfile).toContain(
-      "Skipping current advisory audit for the immutable historical mcporter lock",
-    );
+    if (auditCount === 1) {
+      expect(dockerfile).not.toContain("audit --omit=dev --audit-level=low");
+      expect(dockerfile).toContain(
+        "Skipping current advisory audit for the immutable historical mcporter lock",
+      );
+    } else {
+      expect(dockerfile).not.toContain(
+        "Skipping current advisory audit for the immutable historical mcporter lock",
+      );
+    }
     expect(dockerfile).toContain("audit signatures");
+
+    const stagedContext = path.join(path.dirname(fixture.sourceRoot), "staged-context");
+    fs.mkdirSync(path.join(stagedContext, "nemoclaw"), { recursive: true });
+    // Each frozen optimized-context builder copies nemoclaw/src recursively.
+    fs.cpSync(
+      path.join(fixture.sourceRoot, "nemoclaw", "src"),
+      path.join(stagedContext, "nemoclaw", "src"),
+      { recursive: true },
+    );
+    expect(
+      fs.readFileSync(path.join(stagedContext, OLD_INSTALLER_ARCHIVE_CONTEXT_PATH), "utf8"),
+    ).toBe("reviewed fixture archive");
   });
 
   it("rejects an ambiguous historical advisory boundary", () => {
     const fixture = writeHistoricalFixture(2);
-    patchOldInstallerFixture(fixture.installer);
+    patchOldInstallerFixture(fixture.installer, "v0.0.74");
     const originalDockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
 
     const result = spawnSync("bash", [fixture.installer], {
@@ -129,13 +149,13 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
       },
     });
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("historical mcporter advisory audits; expected exactly one");
+    expect(result.stderr).toContain("historical mcporter advisory audits; expected 1");
     expect(fs.readFileSync(fixture.dockerfile, "utf8")).toBe(originalDockerfile);
   });
 
   it("rejects a missing historical advisory boundary", () => {
     const fixture = writeHistoricalFixture(0);
-    patchOldInstallerFixture(fixture.installer);
+    patchOldInstallerFixture(fixture.installer, "v0.0.74");
     const originalDockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
 
     const result = spawnSync("bash", [fixture.installer], {
@@ -147,10 +167,36 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
       },
     });
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain(
-      "found 0 historical mcporter advisory audits; expected exactly one",
-    );
+    expect(result.stderr).toContain("found 0 historical mcporter advisory audits; expected 1");
     expect(fs.readFileSync(fixture.dockerfile, "utf8")).toBe(originalDockerfile);
+  });
+
+  it("rejects an advisory audit in a profile that predates the audit", () => {
+    const fixture = writeHistoricalFixture(1);
+    patchOldInstallerFixture(fixture.installer, "v0.0.36");
+    const originalDockerfile = fs.readFileSync(fixture.dockerfile, "utf8");
+
+    const result = spawnSync("bash", [fixture.installer], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NEMOCLAW_OLD_OPENCLAW_ARCHIVE: fixture.archive,
+        NEMOCLAW_OLD_OPENCLAW_VERSION: "2026.4.24",
+      },
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("found 1 historical mcporter advisory audits; expected 0");
+    expect(fs.readFileSync(fixture.dockerfile, "utf8")).toBe(originalDockerfile);
+  });
+
+  it("rejects an unreviewed historical installer profile", () => {
+    const fixture = writeHistoricalFixture();
+    const originalInstaller = fs.readFileSync(fixture.installer, "utf8");
+
+    expect(() => patchOldInstallerFixture(fixture.installer, "v0.0.75")).toThrow(
+      /has no reviewed installer profile/u,
+    );
+    expect(fs.readFileSync(fixture.installer, "utf8")).toBe(originalInstaller);
   });
 
   it.each([

--- a/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
@@ -14,36 +14,35 @@ import {
   patchOldInstallerFixture,
   reviewedOldOpenClawArchive,
 } from "../live/openshell-gateway-upgrade-old-installer.ts";
+import { REPO_ROOT } from "../fixtures/paths.ts";
 
 const temporaryDirectories: string[] = [];
+const HISTORICAL_BUILD_CONTEXT_MODULES = Object.freeze({
+  "v0.0.36": "src/lib/sandbox-build-context.ts",
+  "v0.0.55": "src/lib/sandbox/build-context.ts",
+  "v0.0.74": "src/lib/sandbox/build-context.ts",
+});
+const HISTORICAL_OPENCLAW_VERSIONS = Object.freeze({
+  "v0.0.36": "2026.4.24",
+  "v0.0.55": "2026.5.22",
+  "v0.0.74": "2026.5.27",
+});
 
-function writeHistoricalFixture(advisoryAuditCount = 1): {
+type ReviewedHistoricalRef = keyof typeof HISTORICAL_BUILD_CONTEXT_MODULES;
+
+function writeInstallerHarness(sourceRoot: string): {
   archive: string;
   dockerfile: string;
   installer: string;
   sourceRoot: string;
 } {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-old-upgrade-installer-"));
-  temporaryDirectories.push(root);
-  const sourceRoot = path.join(root, "source");
+  const root = path.dirname(sourceRoot);
   const dockerfile = path.join(sourceRoot, "Dockerfile");
   const archive = path.join(root, "reviewed-openclaw.tgz");
   const payload = path.join(root, "payload.sh");
   const installer = path.join(root, "install.sh");
-  fs.mkdirSync(path.join(sourceRoot, "nemoclaw", "src"), { recursive: true });
   fs.writeFileSync(archive, "reviewed fixture archive");
 
-  fs.writeFileSync(
-    dockerfile,
-    [
-      "FROM fixture",
-      "ARG OPENCLAW_VERSION=2026.5.27",
-      ...Array.from({ length: advisoryAuditCount }, () => OLD_INSTALLER_ADVISORY_AUDIT.trimEnd()),
-      "    npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime audit signatures; \\",
-      "    true",
-      "",
-    ].join("\n"),
-  );
   fs.writeFileSync(
     payload,
     [
@@ -75,8 +74,84 @@ function writeHistoricalFixture(advisoryAuditCount = 1): {
   return { archive, dockerfile, installer, sourceRoot };
 }
 
-function runReviewedHistoricalFixture(nemoclawRef: string, auditCount: 0 | 1): string {
-  const fixture = writeHistoricalFixture(auditCount);
+function writeHistoricalFixture(advisoryAuditCount = 1): {
+  archive: string;
+  dockerfile: string;
+  installer: string;
+  sourceRoot: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-old-upgrade-installer-"));
+  temporaryDirectories.push(root);
+  const sourceRoot = path.join(root, "source");
+  fs.mkdirSync(path.join(sourceRoot, "nemoclaw", "src"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(sourceRoot, "Dockerfile"),
+    [
+      "FROM fixture",
+      "ARG OPENCLAW_VERSION=2026.5.27",
+      ...Array.from({ length: advisoryAuditCount }, () => OLD_INSTALLER_ADVISORY_AUDIT.trimEnd()),
+      "    npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime audit signatures; \\",
+      "    true",
+      "",
+    ].join("\n"),
+  );
+  return writeInstallerHarness(sourceRoot);
+}
+
+function extractReviewedHistoricalSource(nemoclawRef: ReviewedHistoricalRef): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-old-upgrade-source-"));
+  temporaryDirectories.push(root);
+  const sourceRoot = path.join(root, "source");
+  fs.mkdirSync(sourceRoot);
+
+  const archive = spawnSync("git", ["-C", REPO_ROOT, "archive", nemoclawRef], {
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  expect(archive.status, archive.stderr.toString()).toBe(0);
+  const extract = spawnSync("tar", ["-xf", "-", "-C", sourceRoot], {
+    input: archive.stdout,
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  expect(extract.status, extract.stderr.toString()).toBe(0);
+  return sourceRoot;
+}
+
+function stageFrozenOptimizedBuildContext(
+  sourceRoot: string,
+  nemoclawRef: ReviewedHistoricalRef,
+): string {
+  const modulePath = path.join(sourceRoot, HISTORICAL_BUILD_CONTEXT_MODULES[nemoclawRef]);
+  const runner = String.raw`
+import { pathToFileURL } from "node:url";
+
+const modulePath = process.argv[1];
+const sourceRoot = process.argv[2];
+const temporaryRoot = process.argv[3];
+const buildContext = await import(pathToFileURL(modulePath).href);
+const staged = buildContext.stageOptimizedSandboxBuildContext(sourceRoot, temporaryRoot);
+process.stdout.write(staged.buildCtx);
+`;
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--no-warnings",
+      "--experimental-strip-types",
+      "--input-type=module",
+      "--eval",
+      runner,
+      modulePath,
+      sourceRoot,
+      path.dirname(sourceRoot),
+    ],
+    { encoding: "utf8" },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout;
+}
+
+function runReviewedHistoricalFixture(nemoclawRef: ReviewedHistoricalRef): string {
+  const fixture = writeInstallerHarness(extractReviewedHistoricalSource(nemoclawRef));
   patchOldInstallerFixture(fixture.installer, nemoclawRef);
 
   const result = spawnSync("bash", [fixture.installer], {
@@ -84,7 +159,7 @@ function runReviewedHistoricalFixture(nemoclawRef: string, auditCount: 0 | 1): s
     env: {
       ...process.env,
       NEMOCLAW_OLD_OPENCLAW_ARCHIVE: fixture.archive,
-      NEMOCLAW_OLD_OPENCLAW_VERSION: "2026.5.27",
+      NEMOCLAW_OLD_OPENCLAW_VERSION: HISTORICAL_OPENCLAW_VERSIONS[nemoclawRef],
     },
   });
   expect(result.status, result.stderr).toBe(0);
@@ -98,16 +173,11 @@ function runReviewedHistoricalFixture(nemoclawRef: string, auditCount: 0 | 1): s
   expect(dockerfile).toContain(
     "npm install -g --ignore-scripts --no-audit --no-fund --no-progress /tmp/nemoclaw-e2e-old-openclaw.tgz",
   );
-  expect(dockerfile).not.toMatch(/npm install -g [^\n]*openclaw@/u);
-
-  const stagedContext = path.join(path.dirname(fixture.sourceRoot), "staged-context");
-  fs.mkdirSync(path.join(stagedContext, "nemoclaw"), { recursive: true });
-  // Each frozen optimized-context builder copies nemoclaw/src recursively.
-  fs.cpSync(
-    path.join(fixture.sourceRoot, "nemoclaw", "src"),
-    path.join(stagedContext, "nemoclaw", "src"),
-    { recursive: true },
+  expect(dockerfile).toContain(
+    `test "$(openclaw --version | awk '{print $2}')" = "${HISTORICAL_OPENCLAW_VERSIONS[nemoclawRef]}"`,
   );
+
+  const stagedContext = stageFrozenOptimizedBuildContext(fixture.sourceRoot, nemoclawRef);
   expect(
     fs.readFileSync(path.join(stagedContext, OLD_INSTALLER_ARCHIVE_CONTEXT_PATH), "utf8"),
   ).toBe("reviewed fixture archive");
@@ -125,7 +195,7 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
     "v0.0.36",
     "v0.0.55",
   ] as const)("accepts the reviewed %s profile without an advisory audit", (nemoclawRef) => {
-    const dockerfile = runReviewedHistoricalFixture(nemoclawRef, 0);
+    const dockerfile = runReviewedHistoricalFixture(nemoclawRef);
     expect(dockerfile).not.toContain("audit --omit=dev --audit-level=low");
     expect(dockerfile).not.toContain(
       "Skipping current advisory audit for the immutable historical mcporter lock",
@@ -133,7 +203,7 @@ describe("historical OpenShell gateway upgrade installer adapter", () => {
   });
 
   it("accepts the reviewed v0.0.74 advisory and signature audit boundary", () => {
-    const dockerfile = runReviewedHistoricalFixture("v0.0.74", 1);
+    const dockerfile = runReviewedHistoricalFixture("v0.0.74");
     expect(dockerfile).not.toContain("audit --omit=dev --audit-level=low");
     expect(dockerfile).toContain(
       "Skipping current advisory audit for the immutable historical mcporter lock",

--- a/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts
@@ -139,15 +139,18 @@ function stageFrozenOptimizedBuildContext(
   nemoclawRef: ReviewedHistoricalRef,
 ): string {
   const modulePath = path.join(sourceRoot, HISTORICAL_BUILD_CONTEXT_MODULES[nemoclawRef]);
+  const outputPath = path.join(path.dirname(sourceRoot), "staged-context-path.txt");
   const runner = String.raw`
+import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const modulePath = process.argv[1];
 const sourceRoot = process.argv[2];
 const temporaryRoot = process.argv[3];
+const outputPath = process.argv[4];
 const buildContext = await import(pathToFileURL(modulePath).href);
 const staged = buildContext.stageOptimizedSandboxBuildContext(sourceRoot, temporaryRoot);
-process.stdout.write(staged.buildCtx);
+writeFileSync(outputPath, staged.buildCtx);
 `;
   const result = spawnSync(
     process.execPath,
@@ -160,11 +163,12 @@ process.stdout.write(staged.buildCtx);
       modulePath,
       sourceRoot,
       path.dirname(sourceRoot),
+      outputPath,
     ],
     { encoding: "utf8" },
   );
   expect(result.status, result.stderr).toBe(0);
-  return result.stdout;
+  return fs.readFileSync(outputPath, "utf8");
 }
 
 function runReviewedHistoricalFixture(nemoclawRef: ReviewedHistoricalRef): string {

--- a/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
@@ -101,6 +101,24 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
     expect(() =>
       validateLegacyGatewayUpgradeFixture({
         ...fixture,
+        nemoclawCommit: "3351fbdd4eb7d9b80ec471545083956327da2b10",
+      }),
+    ).toThrow(/exact reviewed ref\/commit\/OpenClaw profile/);
+    expect(() =>
+      validateLegacyGatewayUpgradeFixture({
+        ...fixture,
+        openclawVersion: "2026.4.24",
+      }),
+    ).toThrow(/exact reviewed ref\/commit\/OpenClaw profile/);
+    expect(() =>
+      validateLegacyGatewayUpgradeFixture({
+        ...fixture,
+        nemoclawRef: "v0.0.36",
+      }),
+    ).toThrow(/exact reviewed ref\/commit\/OpenClaw profile/);
+    expect(() =>
+      validateLegacyGatewayUpgradeFixture({
+        ...fixture,
         nemoclawRef: "v0.0.55; echo injected",
       }),
     ).toThrow(/NEMOCLAW_OLD_NEMOCLAW_REF/);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Repair the historical gateway-upgrade adapter after [E2E main run 29890967158](https://github.com/NVIDIA/NemoClaw/actions/runs/29890967158) exposed four deterministic failures.
The adapter now matches each pinned release's advisory-audit shape and stores the reviewed OpenClaw archive in the source subtree preserved by frozen optimized build contexts.

## Related Issue

Follow-up to #7360.

## Changes

- Bind the historical adapter to the three current gateway-upgrade consumers: `v0.0.36` and `v0.0.55` require zero advisory-audit statements, while `v0.0.74` requires one.
  A direct one-count rule cannot support the older frozen Dockerfiles because they predate the mcporter audit block.
  The E2E-support test covers every reviewed profile and rejects unknown profiles or mismatched counts.
- Store the reviewed OpenClaw archive under `nemoclaw/src` and update the injected Dockerfile `COPY` path.
  Each frozen optimized-context builder copies that subtree, while none copies arbitrary source-root files.
  The E2E-support test stages the preserved subtree and verifies that the archive remains available.
- Update the OpenClaw dependency review note with the exact staging path, per-release audit boundary, and `v0.0.74` signature-verification scope.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only historical E2E fixture construction. The internal security review note is updated to keep the reviewed boundary accurate.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer security review is pending on this PR.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/openshell-gateway-upgrade-old-installer.test.ts` passed 11 tests.
- [ ] Applicable broad gate passed — the full local E2E-support project exposed one unrelated `e2e-phase-lifecycle` missing-log failure after serial confirmation. The four other parallel timeout failures passed serially.
- [ ] Quality Gates section completed with required justifications or waivers — sensitive-path review is pending.
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — the build passed with two existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy gateway upgrade fixture patching with deterministic, reviewed per-profile installer selection and stricter validation (including profile-specific advisory-audit occurrence handling and correct conditional “skip” behavior).
  * Updated historical archive wiring to use the documented installer archive context path, with runtime checks, while preserving installer/fixture contents when validation fails.
* **Tests**
  * Expanded end-to-end coverage with pinned fixture identity, Dockerfile assertion of archive-context COPY wiring and install commands, and tighter negative cases for mismatched or unsupported profile inputs.
* **Documentation**
  * Refined legacy fixture pins documentation for archive storage location, installation behavior, and per-version advisory-audit expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->