### PR TITLE
fix(rebuild): trust current DCode base preflight

### DIFF
--- a/src/lib/actions/sandbox/rebuild-dcode-base-image-lease.test.ts
+++ b/src/lib/actions/sandbox/rebuild-dcode-base-image-lease.test.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  configureDcodeSession,
+  makeDcodeSandboxEntry,
+} from "../../../../test/helpers/rebuild-dcode-flow-support";
+import {
+  createRebuildFlowHarness,
+  resetRebuildFlowTestEnvironment,
+  restoreRebuildFlowTestEnvironment,
+  snapshotEnv,
+} from "../../../../test/helpers/rebuild-flow-harness";
+
+const overrideEnvName = "NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF";
+const trustedLocalOverride = {
+  ref: "nemoclaw-langchain-deepagents-code-base:test",
+  provenance: `${"b".repeat(64)}.${"c".repeat(64)}`,
+};
+
+describe("rebuildSandbox DCode flow: base-image trust lease", () => {
+  beforeEach(resetRebuildFlowTestEnvironment);
+  afterEach(restoreRebuildFlowTestEnvironment);
+
+  it("keeps the current base-image trust lease active through replacement preparation (#6195)", async () => {
+    const harness = createRebuildFlowHarness({
+      agentName: "langchain-deepagents-code",
+      sandboxEntry: makeDcodeSandboxEntry(),
+    });
+    configureDcodeSession(harness);
+    let leaseActive = false;
+    harness.restoreTrustedAgentBaseImageOverrideSpy.mockImplementation(() => {
+      leaseActive = false;
+    });
+    harness.pinTrustedAgentBaseImageOverrideForOperationSpy.mockImplementation(() => {
+      leaseActive = true;
+      return harness.restoreTrustedAgentBaseImageOverrideSpy;
+    });
+    harness.prepareManagedDcodeRebuildImageSpy.mockImplementation(async () => {
+      expect(leaseActive).toBe(true);
+      expect(process.env[overrideEnvName]).toBe(trustedLocalOverride.ref);
+      return { ok: true, prepared: harness.preparedDcodeBuildContext };
+    });
+
+    await expect(
+      harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+    ).resolves.toBeUndefined();
+
+    expect(harness.pinTrustedAgentBaseImageOverrideForOperationSpy).toHaveBeenCalledWith(
+      overrideEnvName,
+      trustedLocalOverride,
+    );
+    expect(harness.restoreTrustedAgentBaseImageOverrideSpy).toHaveBeenCalledOnce();
+    expect(leaseActive).toBe(false);
+  });
+
+  it("restores the base-image trust lease when replacement preparation throws (#6195)", async () => {
+    const restoreEnv = snapshotEnv([overrideEnvName]);
+    process.env[overrideEnvName] = "caller-selected-base:current";
+    const harness = createRebuildFlowHarness({
+      agentName: "langchain-deepagents-code",
+      sandboxEntry: makeDcodeSandboxEntry(),
+    });
+    configureDcodeSession(harness);
+    let leaseActive = false;
+    harness.restoreTrustedAgentBaseImageOverrideSpy.mockImplementation(() => {
+      leaseActive = false;
+    });
+    harness.pinTrustedAgentBaseImageOverrideForOperationSpy.mockImplementation(() => {
+      leaseActive = true;
+      return harness.restoreTrustedAgentBaseImageOverrideSpy;
+    });
+    harness.prepareManagedDcodeRebuildImageSpy.mockImplementation(async () => {
+      expect(leaseActive).toBe(true);
+      expect(process.env[overrideEnvName]).toBe(trustedLocalOverride.ref);
+      throw new Error("fixture preparation failed");
+    });
+
+    try {
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("fixture preparation failed");
+
+      expect(harness.pinTrustedAgentBaseImageOverrideForOperationSpy).toHaveBeenCalledWith(
+        overrideEnvName,
+        trustedLocalOverride,
+      );
+      expect(harness.restoreTrustedAgentBaseImageOverrideSpy).toHaveBeenCalledOnce();
+      expect(leaseActive).toBe(false);
+      expect(process.env[overrideEnvName]).toBe("caller-selected-base:current");
+    } finally {
+      restoreEnv();
+    }
+  });
+});

--- a/src/lib/actions/sandbox/rebuild-dcode-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-dcode-preflight.test.ts
@@ -224,6 +224,27 @@ describe("rebuildSandbox DCode flow: preflight", () => {
     expect(harness.disposePreparedDcodeRebuildImageSpy).not.toHaveBeenCalled();
     expectNoDcodeMutation(harness);
   });
+  it("trusts only the base image built for the current DCode replacement preflight", async () => {
+    const harness = createRebuildFlowHarness({
+      agentName: "langchain-deepagents-code",
+      sandboxEntry: makeDcodeSandboxEntry(),
+    });
+    configureDcodeSession(harness);
+
+    await expect(
+      harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+    ).resolves.toBeUndefined();
+
+    expect(harness.pinTrustedAgentBaseImageOverrideForOperationSpy).toHaveBeenCalledOnce();
+    expect(harness.pinTrustedAgentBaseImageOverrideForOperationSpy).toHaveBeenCalledWith(
+      "NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF",
+      {
+        ref: "nemoclaw-langchain-deepagents-code-base:test",
+        provenance: `${"b".repeat(64)}.${"c".repeat(64)}`,
+      },
+    );
+    expect(harness.restoreTrustedAgentBaseImageOverrideSpy).toHaveBeenCalledOnce();
+  });
   it("rejects a managed DCode session with a recorded custom Dockerfile before image preparation (#6195)", async () => {
     const harness = createRebuildFlowHarness({
       agentName: "langchain-deepagents-code",

--- a/src/lib/actions/sandbox/rebuild-dcode-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-dcode-preflight.test.ts
@@ -224,27 +224,6 @@ describe("rebuildSandbox DCode flow: preflight", () => {
     expect(harness.disposePreparedDcodeRebuildImageSpy).not.toHaveBeenCalled();
     expectNoDcodeMutation(harness);
   });
-  it("trusts only the base image built for the current DCode replacement preflight", async () => {
-    const harness = createRebuildFlowHarness({
-      agentName: "langchain-deepagents-code",
-      sandboxEntry: makeDcodeSandboxEntry(),
-    });
-    configureDcodeSession(harness);
-
-    await expect(
-      harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
-    ).resolves.toBeUndefined();
-
-    expect(harness.pinTrustedAgentBaseImageOverrideForOperationSpy).toHaveBeenCalledOnce();
-    expect(harness.pinTrustedAgentBaseImageOverrideForOperationSpy).toHaveBeenCalledWith(
-      "NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF",
-      {
-        ref: "nemoclaw-langchain-deepagents-code-base:test",
-        provenance: `${"b".repeat(64)}.${"c".repeat(64)}`,
-      },
-    );
-    expect(harness.restoreTrustedAgentBaseImageOverrideSpy).toHaveBeenCalledOnce();
-  });
   it("rejects a managed DCode session with a recorded custom Dockerfile before image preparation (#6195)", async () => {
     const harness = createRebuildFlowHarness({
       agentName: "langchain-deepagents-code",

--- a/src/lib/actions/sandbox/rebuild-dcode-preflight.ts
+++ b/src/lib/actions/sandbox/rebuild-dcode-preflight.ts
@@ -1,11 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import crypto from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 
-import { dockerBuild, dockerImageInspectFormat, dockerRmi } from "../../adapters/docker";
+import { dockerImageInspectFormat, dockerRmi } from "../../adapters/docker";
 import { loadAgent } from "../../agent/defs";
+import {
+  ensureAgentBaseImage,
+  pinTrustedAgentBaseImageOverrideForOperation,
+} from "../../agent/onboard";
 import { RD as _RD, R } from "../../cli/terminal-style";
 import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
 import * as nim from "../../inference/nim";
@@ -16,8 +19,8 @@ import {
   getResumeSandboxGpuOverrides,
   resolveSandboxGpuConfig,
 } from "../../onboard/sandbox-gpu-mode";
-import { ROOT } from "../../runner";
 import { redact } from "../../security/redact";
+import type { TrustedLocalBaseImageOverride } from "../../sandbox-base-image";
 import * as onboardSession from "../../state/onboard-session";
 import * as registry from "../../state/registry";
 import * as sandboxState from "../../state/sandbox";
@@ -41,6 +44,7 @@ export type DcodeRebuildPreflightBail = (message: string, code?: number) => neve
 
 type PinnedDcodeBaseImage = {
   readonly imageRef: string;
+  readonly trustedLocalOverride: TrustedLocalBaseImageOverride;
   dispose(): boolean;
   verify(): boolean;
 };
@@ -271,21 +275,19 @@ function buildPinnedDcodeBaseImage(bail: DcodeRebuildPreflightBail): PinnedDcode
   if (!agent.dockerfileBasePath) {
     fail("DCode is missing its sandbox base Dockerfile", bail);
   }
-  const imageRef = `nemoclaw-dcode-rebuild-base:${String(process.pid)}-${crypto.randomUUID()}`;
-  const result = dockerBuild(agent.dockerfileBasePath, imageRef, ROOT, {
-    ignoreError: true,
-    stdio: ["ignore", "inherit", "inherit"],
-  });
-  if (result.error || result.status !== 0) {
-    try {
-      dockerRmi(imageRef, { ignoreError: true, suppressOutput: true });
-    } catch {
-      // The build failure is the actionable error.
-    }
-    const detail = result.error
-      ? `: ${result.error.message}`
-      : ` (exit ${String(result.status ?? "unknown")})`;
-    fail(`DCode base image could not be built${detail}`, bail);
+  let result: ReturnType<typeof ensureAgentBaseImage>;
+  try {
+    result = ensureAgentBaseImage(agent, { forceBaseImageRebuild: true });
+  } catch (error) {
+    fail(
+      `DCode base image could not be built: ${error instanceof Error ? error.message : String(error)}`,
+      bail,
+    );
+  }
+  const imageRef = result.imageTag;
+  const trustedLocalOverride = result.trustedLocalOverride;
+  if (!imageRef || !trustedLocalOverride || trustedLocalOverride.ref !== imageRef) {
+    fail("DCode base image did not retain its current build-operation proof", bail);
   }
   const imageId = inspectLocalImageId(imageRef);
   if (!imageId) {
@@ -320,6 +322,7 @@ function buildPinnedDcodeBaseImage(bail: DcodeRebuildPreflightBail): PinnedDcode
   process.on("exit", dispose);
   return {
     imageRef,
+    trustedLocalOverride,
     dispose,
     verify: () => inspectLocalImageId(imageRef) === imageId,
   };
@@ -332,10 +335,15 @@ async function withPinnedBaseImage<T>(
   const envName = "NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF";
   const hadPrevious = Object.hasOwn(process.env, envName);
   const previous = process.env[envName];
+  const restoreTrustedOverride = pinTrustedAgentBaseImageOverrideForOperation(
+    envName,
+    pinned.trustedLocalOverride,
+  );
   process.env[envName] = pinned.imageRef;
   try {
     return await action();
   } finally {
+    restoreTrustedOverride();
     if (hadPrevious && previous !== undefined) process.env[envName] = previous;
     else delete process.env[envName];
   }

--- a/test/helpers/rebuild-flow-harness.ts
+++ b/test/helpers/rebuild-flow-harness.ts
@@ -141,6 +141,8 @@ export type RebuildFlowHarness = {
   disposePreparedDcodeRebuildImageSpy: MockInstance;
   errorSpy: MockInstance;
   ensureAgentBaseImageSpy: MockInstance;
+  pinTrustedAgentBaseImageOverrideForOperationSpy: MockInstance;
+  restoreTrustedAgentBaseImageOverrideSpy: MockInstance;
   executeSandboxCommandSpy: MockInstance;
   checkAndRecoverSandboxProcessesSpy: MockInstance;
   ensureMessagingHostForwardAfterRebuildSpy: MockInstance;
@@ -323,10 +325,19 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
     return { status: 0 };
   });
   vi.spyOn(agentDefs, "loadAgent").mockReturnValue(agentDef);
+  const trustedLocalOverride = {
+    ref: agentBaseImageRef,
+    provenance: `${"b".repeat(64)}.${"c".repeat(64)}`,
+  };
   const ensureAgentBaseImageSpy = vi.spyOn(agentOnboard, "ensureAgentBaseImage").mockReturnValue({
     imageTag: agentBaseImageRef,
     built: true,
+    ...(agentName === "langchain-deepagents-code" ? { trustedLocalOverride } : {}),
   });
+  const restoreTrustedAgentBaseImageOverrideSpy = vi.fn();
+  const pinTrustedAgentBaseImageOverrideForOperationSpy = vi
+    .spyOn(agentOnboard, "pinTrustedAgentBaseImageOverrideForOperation")
+    .mockReturnValue(restoreTrustedAgentBaseImageOverrideSpy);
   const sessionAgentName =
     overrides.sessionAgentName === undefined ? agentName : overrides.sessionAgentName;
   vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(
@@ -681,6 +692,8 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
     disposePreparedDcodeRebuildImageSpy,
     errorSpy,
     ensureAgentBaseImageSpy,
+    pinTrustedAgentBaseImageOverrideForOperationSpy,
+    restoreTrustedAgentBaseImageOverrideSpy,
     executeSandboxCommandSpy,
     checkAndRecoverSandboxProcessesSpy,
     ensureMessagingHostForwardAfterRebuildSpy,

--- a/test/helpers/rebuild-flow-harness.ts
+++ b/test/helpers/rebuild-flow-harness.ts
@@ -311,7 +311,11 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
       return overrides.sandboxBaseImageLabelsOutput;
     }
     if (args[0] === "{{.Id}}") {
-      const imageId = imageIdsByRef.get(String(args[1]));
+      const imageRef = String(args[1]);
+      if (imageRef === agentBaseImageRef && dcodeBaseImageIds.length > 0) {
+        return dcodeBaseImageIds.shift()!;
+      }
+      const imageId = imageIdsByRef.get(imageRef);
       if (imageId) return imageId;
     }
     return dcodeBaseImageIds.shift() ?? "sha256:dcode-base";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Deep Agents rebuild preflight built a local base image, then rejected that same image because the rebuild did not carry its operation-scoped trust proof into managed image preparation. This change uses the existing validated base-image builder and leases its exact ref and provenance only for that preparation window.

## Changes

- Build the DCode rebuild base through `ensureAgentBaseImage` so it has current provenance, compatibility validation, and a content-addressed ref.
- Lease that exact local ref and provenance while the managed replacement image is prepared, then restore both trust and environment state.
- Add a regression test that verifies the trust lease is installed and removed around DCode replacement preflight.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores the documented managed DCode rebuild path and does not change its command, configuration, or output contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The lease requires the exact current-build ref and provenance. Existing negative resolver tests still reject arbitrary local overrides.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `rebuild-dcode-preflight.test.ts` (16 passed); rebuild base-image helper tests (36 passed); base-image trust and resolution tests (43 passed).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DCode sandbox rebuild reliability by using verified trusted base images during preflight.
  - Ensured temporary base-image settings are restored after rebuild operations, including when preparation fails.
  - Preserved the original error details when a rebuild preparation step encounters a failure.
  - Added safeguards to prevent rebuilds from continuing when trusted base-image verification is incomplete.

- **Tests**
  - Added coverage for successful and failed rebuild scenarios, including cleanup and base-image setting restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->