### PR TITLE
fix(e2e): seed historical Hermes API key

### DIFF
--- a/test/e2e/live/rebuild-hermes-old-sandbox.ts
+++ b/test/e2e/live/rebuild-hermes-old-sandbox.ts
@@ -7,6 +7,7 @@ import { formatSandboxBaseImageResolutionLabels } from "../../../src/lib/sandbox
 interface RebuildHermesOldSandboxDockerfileOptions {
   baseTag: string;
   baseResolutionMetadata: Parameters<typeof formatSandboxBaseImageResolutionLabels>[0] | null;
+  apiServerKey: string;
   discordPlaceholder: string;
   kanbanTaskTitle: string;
 }
@@ -47,6 +48,7 @@ export function buildRebuildHermesOldSandboxDockerfile(
     "    && printf '%s\\n' \\",
     "      'API_SERVER_PORT=18642' \\",
     "      'API_SERVER_HOST=127.0.0.1' \\",
+    `      'API_SERVER_KEY=${options.apiServerKey}' \\`,
     `      'DISCORD_BOT_TOKEN=${options.discordPlaceholder}' \\`,
     "      > /sandbox/.hermes/.env",
     "RUN /usr/local/bin/hermes kanban init \\",

--- a/test/e2e/live/rebuild-hermes.test.ts
+++ b/test/e2e/live/rebuild-hermes.test.ts
@@ -90,9 +90,7 @@ const KANBAN_TASK_TITLE = `NEMOCLAW_REBUILD_KANBAN_${Date.now()}`;
 const EXCLUDED_KANBAN_FILE = "/sandbox/.hermes/kanban/excluded-rebuild-marker.txt";
 const DISCORD_PLACEHOLDER = "openshell:resolve:env:DISCORD_BOT_TOKEN";
 const DISCORD_FAKE_TOKEN = "test-fake-discord-token-rebuild-e2e";
-const PRE_REBUILD_API_SERVER_KEY = createHash("sha256")
-  .update(`pre-rebuild-api-server-key:${MARKER_CONTENT}`)
-  .digest("hex");
+const PRE_REBUILD_API_SERVER_KEY = createHash("sha256").update(MARKER_CONTENT).digest("hex");
 const REGISTRY_FILE = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
 const SESSION_FILE = path.join(os.homedir(), ".nemoclaw", "onboard-session.json");
 const BACKUP_ROOT = path.join(os.homedir(), ".nemoclaw", "rebuild-backups");

--- a/test/e2e/live/rebuild-hermes.test.ts
+++ b/test/e2e/live/rebuild-hermes.test.ts
@@ -90,6 +90,9 @@ const KANBAN_TASK_TITLE = `NEMOCLAW_REBUILD_KANBAN_${Date.now()}`;
 const EXCLUDED_KANBAN_FILE = "/sandbox/.hermes/kanban/excluded-rebuild-marker.txt";
 const DISCORD_PLACEHOLDER = "openshell:resolve:env:DISCORD_BOT_TOKEN";
 const DISCORD_FAKE_TOKEN = "test-fake-discord-token-rebuild-e2e";
+const PRE_REBUILD_API_SERVER_KEY = createHash("sha256")
+  .update(`pre-rebuild-api-server-key:${MARKER_CONTENT}`)
+  .digest("hex");
 const REGISTRY_FILE = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
 const SESSION_FILE = path.join(os.homedir(), ".nemoclaw", "onboard-session.json");
 const BACKUP_ROOT = path.join(os.homedir(), ".nemoclaw", "rebuild-backups");
@@ -304,7 +307,7 @@ async function bestEffortPrecleanHermesResources(
   await host.nemoclaw([SANDBOX_NAME, "destroy", "--yes", "--cleanup-gateway"], {
     artifactName: `${artifactName}-nemoclaw-destroy`,
     env: testEnv(apiKey),
-    redactionValues: [apiKey ?? "", DISCORD_FAKE_TOKEN],
+    redactionValues: [apiKey ?? "", DISCORD_FAKE_TOKEN, PRE_REBUILD_API_SERVER_KEY],
     timeoutMs: 3 * 60_000,
   });
   await host.command(
@@ -328,7 +331,7 @@ async function bestEffortPrecleanHermesResources(
         CURRENT_BASE_REUSE_TAG,
         OLD_BASE_TAG,
       }),
-      redactionValues: [apiKey ?? "", DISCORD_FAKE_TOKEN],
+      redactionValues: [apiKey ?? "", DISCORD_FAKE_TOKEN, PRE_REBUILD_API_SERVER_KEY],
       timeoutMs: 3 * 60_000,
     },
   );
@@ -343,7 +346,7 @@ function hermesCleanupEnv(apiKey: string | undefined): NodeJS.ProcessEnv {
 }
 
 function hermesCleanupRedactions(apiKey: string | undefined): string[] {
-  return [apiKey ?? "", DISCORD_FAKE_TOKEN];
+  return [apiKey ?? "", DISCORD_FAKE_TOKEN, PRE_REBUILD_API_SERVER_KEY];
 }
 
 async function cleanupHermesNemoClawSandbox(
@@ -419,7 +422,7 @@ async function waitForSandboxReady(
     const list = await host.command("openshell", ["sandbox", "list"], {
       artifactName: `${artifactPrefix}-sandbox-list-${attempt}`,
       env: testEnv(apiKey),
-      redactionValues: [apiKey],
+      redactionValues: [apiKey, PRE_REBUILD_API_SERVER_KEY],
       timeoutMs: 30_000,
     });
     switch (new RegExp(`${SANDBOX_NAME}.*Ready`).test(resultText(list))) {
@@ -629,7 +632,7 @@ test(STALE_BASE_REBUILD
   timeout: LIVE_TIMEOUT_MS,
 }, async ({ artifacts, cleanup, host, sandbox, secrets, skip }) => {
   const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
-  const redactionValues = [apiKey, DISCORD_FAKE_TOKEN];
+  const redactionValues = [apiKey, DISCORD_FAKE_TOKEN, PRE_REBUILD_API_SERVER_KEY];
   const expectedVersion = expectedHermesVersion();
   const progress = startRebuildHermesProgress("setup");
   cleanup.trackDisposable("stop Hermes rebuild progress", progress.stop);
@@ -971,6 +974,7 @@ test(STALE_BASE_REBUILD
     buildRebuildHermesOldSandboxDockerfile({
       baseTag: OLD_BASE_TAG,
       baseResolutionMetadata: STALE_BASE_REBUILD ? oldBaseResolutionMetadata : null,
+      apiServerKey: PRE_REBUILD_API_SERVER_KEY,
       discordPlaceholder: DISCORD_PLACEHOLDER,
       kanbanTaskTitle: KANBAN_TASK_TITLE,
     }),
@@ -1473,7 +1477,7 @@ test(STALE_BASE_REBUILD
     true,
   );
   const leaks = listCredentialLeakPaths(sandboxBackupRoot, {
-    extraSecrets: [apiKey, DISCORD_FAKE_TOKEN],
+    extraSecrets: [apiKey, DISCORD_FAKE_TOKEN, PRE_REBUILD_API_SERVER_KEY],
   });
   await artifacts.writeJson("phase-7-backup-credential-scan.json", {
     backupRoot: sandboxBackupRoot,

--- a/test/e2e/support/rebuild-hermes-old-base-fixture.test.ts
+++ b/test/e2e/support/rebuild-hermes-old-base-fixture.test.ts
@@ -21,6 +21,7 @@ describe("rebuild-Hermes historical base fixture", () => {
     const dockerfile = buildRebuildHermesOldSandboxDockerfile({
       baseTag: "nemoclaw-hermes-old-base:test",
       baseResolutionMetadata: null,
+      apiServerKey: "a".repeat(64),
       discordPlaceholder: "openshell:resolve:env:DISCORD_BOT_TOKEN",
       kanbanTaskTitle: "NEMOCLAW_REBUILD_KANBAN_TEST",
     });
@@ -31,6 +32,7 @@ describe("rebuild-Hermes historical base fixture", () => {
       "&& /usr/local/bin/hermes kanban create 'NEMOCLAW_REBUILD_KANBAN_TEST' --initial-status blocked --json",
     );
     expect(dockerfile).toContain("&& test -s /sandbox/.hermes/kanban.db");
+    expect(dockerfile).toContain(`'API_SERVER_KEY=${"a".repeat(64)}'`);
     expect(dockerfile.indexOf("hermes kanban init")).toBeLessThan(
       dockerfile.indexOf('CMD ["/bin/bash"]'),
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Repair the `rebuild-hermes` and `rebuild-hermes-stale-base` live fixtures after the historical sandbox began failing the API bearer-token lifecycle check before rebuild. The synthetic old sandbox now contains a valid per-run API server key, so the test can verify that rebuild rotates it and then keeps the new token stable.

## Related Issue

Follow-up to #7144.

## Changes

- Seed `API_SERVER_KEY` in the synthetic historical Hermes `.env` file.
- Generate a valid 64-character per-run fixture key and include it in command redaction and backup leak scanning.
- Assert the historical Dockerfile contains the key required by the token-lifecycle probe.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This only repairs a synthetic live-E2E fixture and does not change product behavior or user workflows.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review is pending.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused E2E-support fixture test: 9/9; CLI build and typecheck passed.
- [x] Applicable broad gate passed — `npm run check:diff` passed.
- [ ] Quality Gates section completed with required justifications or waivers — sensitive-path review is pending.
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against sensitive API server keys appearing in rebuild artifacts, command output, and diagnostic scans.
  * Ensured rebuilt sandbox environments receive the required API server key configuration.
* **Tests**
  * Added coverage verifying API server key injection and credential redaction during rebuild workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->