### PR TITLE
fix(rebuild): reuse outer backup during recreate

### DIFF
--- a/src/lib/actions/sandbox/rebuild-recreate-observability.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-observability.test.ts
@@ -222,8 +222,9 @@ describe("runRebuildRecreatePhase handoff", () => {
     const previousRecreateWithoutBackup = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
     process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = "0";
     try {
+      let observedBackupMarker: string | undefined;
       vi.spyOn(rebuildOnboardDependencies, "onboard").mockImplementation(async () => {
-        expect(process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP).toBe("1");
+        observedBackupMarker = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
         throw new Error("inner onboard failed");
       });
 
@@ -231,6 +232,7 @@ describe("runRebuildRecreatePhase handoff", () => {
         "bail: Recreate failed (stale-sandbox recovery).",
       );
 
+      expect(observedBackupMarker).toBe("1");
       expect(process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP).toBe("0");
     } finally {
       restoreEnv("NEMOCLAW_RECREATE_WITHOUT_BACKUP", previousRecreateWithoutBackup);

--- a/src/lib/actions/sandbox/rebuild-recreate-observability.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-observability.test.ts
@@ -106,7 +106,7 @@ function makeInput(overrides: Partial<RebuildRecreatePhaseInput> = {}): RebuildR
   };
 }
 
-describe("runRebuildRecreatePhase observability handoff", () => {
+describe("runRebuildRecreatePhase handoff", () => {
   let session: Session;
 
   beforeEach(() => {
@@ -188,6 +188,52 @@ describe("runRebuildRecreatePhase observability handoff", () => {
       expect(process.env.NEMOCLAW_POLICY_TIER).toBe("open");
     } finally {
       restoreEnv("NEMOCLAW_POLICY_TIER", previousPolicyTier);
+    }
+  });
+
+  it("does not take a second backup during the inner recreate", async () => {
+    const previousRecreateWithoutBackup = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
+    delete process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
+    try {
+      let observedBackupMarker: string | undefined;
+      vi.spyOn(rebuildOnboardDependencies, "onboard").mockImplementation(async () => {
+        observedBackupMarker = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
+      });
+
+      await expect(
+        runRebuildRecreatePhase(
+          makeInput({
+            backupManifest: {
+              backupPath: "/tmp/rebuild-backups/alpha/2026-07-22T04-36-37-633Z",
+              timestamp: "2026-07-22T04-36-37-633Z",
+            } as never,
+          }),
+        ),
+      ).resolves.toBe(true);
+
+      expect(observedBackupMarker).toBe("1");
+      expect(process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP).toBeUndefined();
+    } finally {
+      restoreEnv("NEMOCLAW_RECREATE_WITHOUT_BACKUP", previousRecreateWithoutBackup);
+    }
+  });
+
+  it("restores the caller backup marker after inner recreate failure", async () => {
+    const previousRecreateWithoutBackup = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
+    process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = "0";
+    try {
+      vi.spyOn(rebuildOnboardDependencies, "onboard").mockImplementation(async () => {
+        expect(process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP).toBe("1");
+        throw new Error("inner onboard failed");
+      });
+
+      await expect(runRebuildRecreatePhase(makeInput())).rejects.toThrow(
+        "bail: Recreate failed (stale-sandbox recovery).",
+      );
+
+      expect(process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP).toBe("0");
+    } finally {
+      restoreEnv("NEMOCLAW_RECREATE_WITHOUT_BACKUP", previousRecreateWithoutBackup);
     }
   });
 

--- a/src/lib/actions/sandbox/rebuild-recreate-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-phase.ts
@@ -183,8 +183,11 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
   const previousSandboxName = process.env.NEMOCLAW_SANDBOX_NAME;
   const previousRecreateWithoutBackup = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
   process.env.NEMOCLAW_SANDBOX_NAME = sandboxName;
-  // The rebuild backup phase already made the data-preservation decision before
-  // delete. Stale gateway state must not make inner onboard attempt a second backup.
+  // The outer rebuild already made its sole backup before the destroy phase deleted
+  // the sandbox without tearing down the gateway/session needed by onboard --resume.
+  // That retained state can send inner onboard through generic recreate protection,
+  // where a second backup is impossible after deletion. Keep the bypass scoped to
+  // this call; remove it when onboard accepts an explicit outer-backup handoff.
   process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = "1";
   if (recreateOptions.policyTier) {
     process.env.NEMOCLAW_POLICY_TIER = recreateOptions.policyTier;

--- a/src/lib/actions/sandbox/rebuild-recreate-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-phase.ts
@@ -181,7 +181,11 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
 
   const restoreAmbientRecreateEnv = isolateAmbientRecreateEnv();
   const previousSandboxName = process.env.NEMOCLAW_SANDBOX_NAME;
+  const previousRecreateWithoutBackup = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
   process.env.NEMOCLAW_SANDBOX_NAME = sandboxName;
+  // The rebuild backup phase already made the data-preservation decision before
+  // delete. Stale gateway state must not make inner onboard attempt a second backup.
+  process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = "1";
   if (recreateOptions.policyTier) {
     process.env.NEMOCLAW_POLICY_TIER = recreateOptions.policyTier;
   }
@@ -201,6 +205,11 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
     restoreAmbientRecreateEnv();
     if (previousSandboxName === undefined) delete process.env.NEMOCLAW_SANDBOX_NAME;
     else process.env.NEMOCLAW_SANDBOX_NAME = previousSandboxName;
+    if (previousRecreateWithoutBackup === undefined) {
+      delete process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
+    } else {
+      process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = previousRecreateWithoutBackup;
+    }
   }
 
   if (!onboardFailed) onCreated();

--- a/test/helpers/rebuild-flow-lifecycle-cases.ts
+++ b/test/helpers/rebuild-flow-lifecycle-cases.ts
@@ -33,7 +33,13 @@ export function registerRebuildFlowLifecycleTests(): void {
       ).toBe(false);
     });
 
-    it("backs up, recreates, restores, reapplies policy, and relocks on a successful OpenClaw rebuild", async () => {
+    it("backs up once, recreates, restores, reapplies policy, and relocks on a successful OpenClaw rebuild", async ({
+      onTestFinished,
+    }) => {
+      const restoreEnv = snapshotEnv(["NEMOCLAW_RECREATE_WITHOUT_BACKUP"]);
+      onTestFinished(restoreEnv);
+      process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = "0";
+      let innerBackupMarker: string | undefined;
       const mcpEntry = {
         server: "github",
         url: "https://mcp.example.test/mcp",
@@ -51,12 +57,16 @@ export function registerRebuildFlowLifecycleTests(): void {
           entries: [mcpEntry],
           detachedProviderEntries: [mcpEntry],
         },
+        onboard: () => {
+          innerBackupMarker = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
+        },
       });
 
       await expect(
         harness.rebuildSandbox("alpha", ["--yes", "--verbose"], { throwOnError: true }),
       ).resolves.toBeUndefined();
 
+      expect(harness.backupSandboxStateSpy).toHaveBeenCalledOnce();
       expect(harness.backupSandboxStateSpy).toHaveBeenCalledWith("alpha");
       expect(harness.prepareMcpBridgesForRebuildSpy).toHaveBeenCalledWith("alpha");
       expect(harness.prepareMcpBridgesForRebuildSpy.mock.invocationCallOrder[0]).toBeLessThan(
@@ -75,6 +85,8 @@ export function registerRebuildFlowLifecycleTests(): void {
           autoYes: true,
         }),
       );
+      expect(innerBackupMarker).toBe("1");
+      expect(process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP).toBe("0");
       expect(harness.registryUpdateSpy).toHaveBeenCalledWith(
         "alpha",
         expect.objectContaining({


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Prevent inner onboarding from taking a second state backup during a sandbox rebuild. A stale gateway listing can no longer abort recreation after the outer rebuild already captured the backup and deleted the sandbox, as seen in [E2E run 29890967158](https://github.com/NVIDIA/NemoClaw/actions/runs/29890967158/job/88831739932).

## Changes

- Scope the existing `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` marker to the inner onboarding call after the rebuild backup and delete phases.
- Restore the caller's marker value after successful and failed recreation.
- Test marker forwarding and environment restoration on both paths.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This internal handoff restores the documented single-backup rebuild flow and does not change a CLI contract or user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review is pending.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/actions/sandbox/rebuild-recreate-observability.test.ts` (6 passed); `npm run test:changed` (57 passed); `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; the change is limited to one rebuild phase and its focused tests.
- [ ] Quality Gates section completed with required justifications or waivers — sensitive-path review is pending.
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox rebuild/recreate reliability when stale gateway conditions are detected.
  * Prevented redundant backup attempts during the inner recreate step by temporarily enabling the “recreate without backup” behavior.
  * Ensured the recreate-without-backup setting is restored after success, and reverted to the caller’s original value when onboarding fails.
* **Tests**
  * Expanded observability and rebuild lifecycle coverage to verify correct environment-variable behavior across inner and outer onboarding paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->