### PR TITLE
fix(rebuild): wait for sandbox deletion convergence

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2536,6 +2536,10 @@ For a prepared-only transaction, the redacted diagnostic points to `$$nemoclaw <
 For a pending or both-marker transaction, it points to `$$nemoclaw <name> destroy` because the registry records that OpenShell deletion was already confirmed.
 Before backup or deletion, rebuild checks the staged messaging configuration for credentials or channel resources already used by another registered sandbox.
 A conflict aborts with the original sandbox registered and intact so you can resolve the conflict before retrying.
+After OpenShell accepts the sandbox deletion, `rebuild` waits until OpenShell explicitly reports that the old sandbox is absent.
+Only then can NemoClaw perform any required local registry removal and begin creating the replacement.
+If OpenShell does not confirm absence within the bounded wait, including when gateway transport errors block the probes, `rebuild` exits nonzero before registry removal or replacement creation and preserves both the local registry entry and the state backup.
+Restore OpenShell connectivity and confirm the sandbox's live state before you retry, and keep the printed backup path for recovery.
 When rebuild starts with shields up, NemoClaw opens a 30-minute shields-down window for backup and recreation.
 A detached auto-lock timer remains active until NemoClaw commits a successful shields-up state, so it can attempt to restore lockdown if the host rebuild process exits unexpectedly.
 

--- a/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
@@ -63,12 +63,9 @@ describe("rebuild destroy phase", () => {
     });
     mocks.reattachMcpAfterDeleteFailure.mockResolvedValue(undefined);
     mocks.removeSandboxRegistryEntryWithReceipt.mockReturnValue(null);
-    mocks.waitUntil.mockImplementation((condition: () => boolean) => {
-      for (let attempt = 0; attempt < 3; attempt += 1) {
-        if (condition()) return true;
-      }
-      return false;
-    });
+    mocks.waitUntil.mockImplementation(
+      (condition: () => boolean) => condition() || condition() || condition(),
+    );
   });
 
   afterEach(() => {
@@ -111,19 +108,21 @@ describe("rebuild destroy phase", () => {
   it("removes registry state only after the gateway reports the deleted sandbox missing", async () => {
     const events: string[] = [];
     let getAttempts = 0;
-    mocks.runOpenshell.mockImplementation((args: string[]) => {
-      if (args[1] === "delete") {
-        events.push("delete");
-        return { status: 0, stdout: "deleted", stderr: "" };
-      }
+    const deleteResult = () => {
+      events.push("delete");
+      return { status: 0, stdout: "deleted", stderr: "" };
+    };
+    const getResult = () => {
       getAttempts += 1;
-      if (getAttempts === 1) {
-        events.push("get-live");
-        return { status: 0, stdout: "Name: alpha\nPhase: Terminating", stderr: "" };
-      }
-      events.push("get-missing");
-      return { status: 1, stdout: "", stderr: "Error: sandbox alpha not found" };
-    });
+      const isFirstProbe = getAttempts === 1;
+      events.push(isFirstProbe ? "get-live" : "get-missing");
+      return isFirstProbe
+        ? { status: 0, stdout: "Name: alpha\nPhase: Terminating", stderr: "" }
+        : { status: 1, stdout: "", stderr: "Error: sandbox alpha not found" };
+    };
+    mocks.runOpenshell.mockImplementation((args: string[]) =>
+      args[1] === "delete" ? deleteResult() : getResult(),
+    );
     mocks.removeSandboxRegistryEntryWithReceipt.mockImplementation(() => {
       events.push("remove-registry");
       return null;

--- a/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
@@ -4,34 +4,71 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  getSandbox: vi.fn(),
+  listSandboxes: vi.fn(),
   prepareMcpForRebuild: vi.fn(),
   reattachMcpAfterDeleteFailure: vi.fn(),
+  removeSandboxRegistryEntryWithReceipt: vi.fn(),
+  runOpenshell: vi.fn(),
+  stopNimContainer: vi.fn(),
+  stopNimContainerByName: vi.fn(),
+  waitUntil: vi.fn(),
   warnUnpreservedUserManagedFiles: vi.fn(),
 }));
 
-vi.mock("./rebuild-flow-helpers", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./rebuild-flow-helpers")>()),
+vi.mock("../../adapters/openshell/runtime", () => ({
+  runOpenshell: mocks.runOpenshell,
+}));
+
+vi.mock("../../core/wait", () => ({
+  waitUntil: mocks.waitUntil,
+}));
+
+vi.mock("../../inference/nim", () => ({
+  stopNimContainer: mocks.stopNimContainer,
+  stopNimContainerByName: mocks.stopNimContainerByName,
+}));
+
+vi.mock("../../state/registry", () => ({
+  getSandbox: mocks.getSandbox,
+  listSandboxes: mocks.listSandboxes,
+}));
+
+vi.mock("./destroy", () => ({
+  removeSandboxRegistryEntryWithReceipt: mocks.removeSandboxRegistryEntryWithReceipt,
+}));
+
+vi.mock("./rebuild-flow-helpers", () => ({
   warnUnpreservedUserManagedFiles: mocks.warnUnpreservedUserManagedFiles,
 }));
 
-vi.mock("./rebuild-mcp-phase", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./rebuild-mcp-phase")>()),
+vi.mock("./rebuild-mcp-phase", () => ({
   prepareMcpForRebuild: mocks.prepareMcpForRebuild,
   reattachMcpAfterDeleteFailure: mocks.reattachMcpAfterDeleteFailure,
 }));
 
 import { runRebuildDestroyPhase } from "./rebuild-destroy-phase";
 
-describe("rebuild destroy validation diagnostics", () => {
+describe("rebuild destroy phase", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.getSandbox.mockReturnValue(undefined);
+    mocks.listSandboxes.mockReturnValue({ sandboxes: [] });
     mocks.prepareMcpForRebuild.mockResolvedValue({
       entries: [],
       detachedProviderEntries: [],
       scrubbedAdapterEntries: [],
     });
     mocks.reattachMcpAfterDeleteFailure.mockResolvedValue(undefined);
+    mocks.removeSandboxRegistryEntryWithReceipt.mockReturnValue(null);
+    mocks.waitUntil.mockImplementation((condition: () => boolean) => {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        if (condition()) return true;
+      }
+      return false;
+    });
   });
 
   afterEach(() => {
@@ -69,5 +106,81 @@ describe("rebuild destroy validation diagnostics", () => {
     expect(diagnostics).not.toContain(secret);
     expect(mocks.reattachMcpAfterDeleteFailure).toHaveBeenCalledOnce();
     expect(relockShieldsIfNeeded).toHaveBeenCalledWith(true);
+  });
+
+  it("removes registry state only after the gateway reports the deleted sandbox missing", async () => {
+    const events: string[] = [];
+    let getAttempts = 0;
+    mocks.runOpenshell.mockImplementation((args: string[]) => {
+      if (args[1] === "delete") {
+        events.push("delete");
+        return { status: 0, stdout: "deleted", stderr: "" };
+      }
+      getAttempts += 1;
+      if (getAttempts === 1) {
+        events.push("get-live");
+        return { status: 0, stdout: "Name: alpha\nPhase: Terminating", stderr: "" };
+      }
+      events.push("get-missing");
+      return { status: 1, stdout: "", stderr: "Error: sandbox alpha not found" };
+    });
+    mocks.removeSandboxRegistryEntryWithReceipt.mockImplementation(() => {
+      events.push("remove-registry");
+      return null;
+    });
+
+    const result = await runRebuildDestroyPhase({
+      sandboxName: "alpha",
+      sandboxEntry: { name: "alpha", agent: "openclaw" },
+      staleRecovery: false,
+      backupManifest: null,
+      log: vi.fn(),
+      bail: vi.fn((message: string): never => {
+        throw new Error(message);
+      }),
+      relockShieldsIfNeeded: vi.fn(() => true),
+      onDeleted: vi.fn(() => events.push("on-deleted")),
+    });
+
+    expect(result).not.toBeNull();
+    expect(events).toEqual(["delete", "get-live", "get-missing", "on-deleted", "remove-registry"]);
+    expect(mocks.waitUntil).toHaveBeenCalledOnce();
+    expect(mocks.removeSandboxRegistryEntryWithReceipt).toHaveBeenCalledWith("alpha");
+  });
+
+  it("preserves backup and registry state when transport failures prevent deletion confirmation", async () => {
+    mocks.runOpenshell.mockImplementation((args: string[]) =>
+      args[1] === "delete"
+        ? { status: 0, stdout: "deleted", stderr: "" }
+        : { status: 1, stdout: "", stderr: "tcp connect error: Connection refused" },
+    );
+    const onDeleted = vi.fn();
+
+    await expect(
+      runRebuildDestroyPhase({
+        sandboxName: "alpha",
+        sandboxEntry: { name: "alpha", agent: "openclaw" },
+        staleRecovery: false,
+        backupManifest: { backupPath: "/tmp/rebuild-backups/alpha/backup" } as never,
+        log: vi.fn(),
+        bail: vi.fn((message: string): never => {
+          throw new Error(message);
+        }),
+        relockShieldsIfNeeded: vi.fn(() => true),
+        onDeleted,
+      }),
+    ).rejects.toThrow("Sandbox deletion could not be confirmed.");
+
+    expect(onDeleted).not.toHaveBeenCalled();
+    expect(mocks.runOpenshell).toHaveBeenCalledTimes(4);
+    expect(mocks.waitUntil).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ deadlineMs: expect.any(Number) }),
+    );
+    expect(mocks.removeSandboxRegistryEntryWithReceipt).not.toHaveBeenCalled();
+    expect(mocks.listSandboxes).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "  State backup is preserved at: /tmp/rebuild-backups/alpha/backup",
+    );
   });
 });

--- a/src/lib/actions/sandbox/rebuild-destroy-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { runOpenshell } from "../../adapters/openshell/runtime";
+import {
+  OPENSHELL_HEAVY_TIMEOUT_MS,
+  OPENSHELL_PROBE_TIMEOUT_MS,
+} from "../../adapters/openshell/timeouts";
 import { G, R } from "../../cli/terminal-style";
+import { waitUntil } from "../../core/wait";
 import { getSandboxDeleteOutcome } from "../../domain/sandbox/destroy";
 import * as nim from "../../inference/nim";
 import { redactFull } from "../../security/redact";
@@ -37,6 +42,24 @@ export interface RebuildDestroyPhaseInput {
 export type RebuildDestroyPhaseResult = McpRebuildPreparation & {
   removalReceipt: registry.SandboxRemovalReceipt | null;
 };
+
+function waitForSandboxDeletion(sandboxName: string, log: RebuildLog): boolean {
+  return waitUntil(
+    () => {
+      const getResult = runOpenshell(["sandbox", "get", sandboxName], {
+        ignoreError: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+      });
+      const { alreadyGone, gatewayUnreachable } = getSandboxDeleteOutcome(getResult);
+      log(
+        `Delete convergence probe: exit=${getResult.status}, alreadyGone=${alreadyGone}, gatewayUnreachable=${gatewayUnreachable}`,
+      );
+      return alreadyGone;
+    },
+    { deadlineMs: Date.now() + OPENSHELL_HEAVY_TIMEOUT_MS },
+  );
+}
 
 /**
  * Detach owned MCP state, stop inference, and delete the old sandbox.
@@ -145,6 +168,18 @@ export async function runRebuildDestroyPhase(
         : "Failed to delete sandbox.",
       deleteResult.status || 1,
     );
+    return null;
+  }
+  const deletionConfirmed = alreadyGone || waitForSandboxDeletion(sandboxName, log);
+  if (!deletionConfirmed) {
+    console.error(
+      "  Sandbox delete was accepted, but OpenShell did not confirm that the sandbox is absent.",
+    );
+    console.error("  Aborting rebuild before registry removal and sandbox recreation.");
+    if (backupManifest) {
+      console.error("  State backup is preserved at: " + backupManifest.backupPath);
+    }
+    bail("Sandbox deletion could not be confirmed.");
     return null;
   }
   onDeleted();

--- a/src/lib/actions/sandbox/rebuild-local-provider-recreate.test.ts
+++ b/src/lib/actions/sandbox/rebuild-local-provider-recreate.test.ts
@@ -163,20 +163,19 @@ describe("rebuild local-provider recreation", () => {
     });
     harness.session.provider = provider;
     harness.session.model = model;
-    harness.runOpenshellSpy.mockImplementation((args: string[]) => {
-      if (args[0] === "sandbox" && args[1] === "get") {
-        return {
-          status: 1,
-          stdout: "",
-          stderr: "sandbox alpha not found",
-        };
-      }
-      return {
-        status: args[0] === "provider" && args[1] === "get" ? 1 : 0,
-        stdout: "",
-        stderr: "",
-      };
-    });
+    harness.runOpenshellSpy.mockImplementation((args: string[]) =>
+      args[0] === "sandbox" && args[1] === "get"
+        ? {
+            status: 1,
+            stdout: "",
+            stderr: "sandbox alpha not found",
+          }
+        : {
+            status: args[0] === "provider" && args[1] === "get" ? 1 : 0,
+            stdout: "",
+            stderr: "",
+          },
+    );
 
     await expect(
       harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),

--- a/src/lib/actions/sandbox/rebuild-local-provider-recreate.test.ts
+++ b/src/lib/actions/sandbox/rebuild-local-provider-recreate.test.ts
@@ -163,11 +163,20 @@ describe("rebuild local-provider recreation", () => {
     });
     harness.session.provider = provider;
     harness.session.model = model;
-    harness.runOpenshellSpy.mockImplementation((args: string[]) => ({
-      status: args[0] === "provider" && args[1] === "get" ? 1 : 0,
-      stdout: "",
-      stderr: "",
-    }));
+    harness.runOpenshellSpy.mockImplementation((args: string[]) => {
+      if (args[0] === "sandbox" && args[1] === "get") {
+        return {
+          status: 1,
+          stdout: "",
+          stderr: "sandbox alpha not found",
+        };
+      }
+      return {
+        status: args[0] === "provider" && args[1] === "get" ? 1 : 0,
+        stdout: "",
+        stderr: "",
+      };
+    });
 
     await expect(
       harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),

--- a/src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts
+++ b/src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts
@@ -155,9 +155,18 @@ describe("rebuild resume snapshot repair", () => {
           policyPresets: [],
         },
       } as never),
-      vi
-        .spyOn(openshellRuntime, "runOpenshell")
-        .mockReturnValue({ status: 0, output: "" } as never),
+      vi.spyOn(openshellRuntime, "runOpenshell").mockImplementation((args: unknown) => {
+        const argv = Array.isArray(args) ? args.map(String) : [];
+        if (argv.join(" ") === "sandbox get alpha") {
+          return {
+            status: 1,
+            output: "sandbox alpha not found",
+            stdout: "",
+            stderr: "sandbox alpha not found",
+          } as never;
+        }
+        return { status: 0, output: "", stdout: "", stderr: "" } as never;
+      }),
       vi.spyOn(destroy, "removeSandboxRegistryEntry").mockReturnValue(true),
       vi.spyOn(nim, "stopNimContainer").mockImplementation(() => undefined),
       vi.spyOn(nim, "stopNimContainerByName").mockImplementation(() => undefined),

--- a/src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts
+++ b/src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts
@@ -157,15 +157,14 @@ describe("rebuild resume snapshot repair", () => {
       } as never),
       vi.spyOn(openshellRuntime, "runOpenshell").mockImplementation((args: unknown) => {
         const argv = Array.isArray(args) ? args.map(String) : [];
-        if (argv.join(" ") === "sandbox get alpha") {
-          return {
-            status: 1,
-            output: "sandbox alpha not found",
-            stdout: "",
-            stderr: "sandbox alpha not found",
-          } as never;
-        }
-        return { status: 0, output: "", stdout: "", stderr: "" } as never;
+        return argv.join(" ") === "sandbox get alpha"
+          ? ({
+              status: 1,
+              output: "sandbox alpha not found",
+              stdout: "",
+              stderr: "sandbox alpha not found",
+            } as never)
+          : ({ status: 0, output: "", stdout: "", stderr: "" } as never);
       }),
       vi.spyOn(destroy, "removeSandboxRegistryEntry").mockReturnValue(true),
       vi.spyOn(nim, "stopNimContainer").mockImplementation(() => undefined),

--- a/test/helpers/rebuild-dcode-flow-helpers.ts
+++ b/test/helpers/rebuild-dcode-flow-helpers.ts
@@ -53,6 +53,14 @@ export function expectNoDcodeMutation(harness: RebuildFlowHarness): void {
 export function setGatewayProviderMetadata(harness: RebuildFlowHarness, stdout: string): void {
   harness.runOpenshellSpy.mockImplementation((args: unknown) => {
     const argv = args as string[];
+    if (argv.join(" ") === "sandbox get alpha") {
+      return {
+        status: 1,
+        output: "sandbox alpha not found",
+        stdout: "",
+        stderr: "sandbox alpha not found",
+      };
+    }
     return argv[0] === "provider" && argv[1] === "get"
       ? { status: 0, stdout, stderr: "" }
       : { status: 0, output: "" };

--- a/test/helpers/rebuild-flow-harness.ts
+++ b/test/helpers/rebuild-flow-harness.ts
@@ -526,6 +526,14 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
     );
   const runOpenshellSpy = vi.spyOn(openshellRuntime, "runOpenshell").mockImplementation((args) => {
     const argv = args as string[];
+    if (argv.join(" ") === "sandbox get alpha") {
+      return {
+        status: 1,
+        output: "sandbox alpha not found",
+        stdout: "",
+        stderr: "sandbox alpha not found",
+      };
+    }
     return argv[0] === "provider" && argv[1] === "get"
       ? {
           status: 0,

--- a/test/helpers/rebuild-flow-test-harness.ts
+++ b/test/helpers/rebuild-flow-test-harness.ts
@@ -382,6 +382,14 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
     .spyOn(openshellRuntime, "runOpenshell")
     .mockImplementation((args: unknown) => {
       const argv = Array.isArray(args) ? args.map(String) : [];
+      if (argv.join(" ") === "sandbox get alpha") {
+        return {
+          status: 1,
+          output: "sandbox alpha not found",
+          stdout: "",
+          stderr: "sandbox alpha not found",
+        };
+      }
       return overrides.runOpenshell ? overrides.runOpenshell(argv) : { status: 0, output: "" };
     });
   const defaultRemovalReceipt = {

--- a/test/rebuild-credential-preflight.test.ts
+++ b/test/rebuild-credential-preflight.test.ts
@@ -172,6 +172,11 @@ if (a[0] === "-V" || a[0] === "--version") { process.stdout.write("openshell 0.0
 if (a[0] === "sandbox" && a[1] === "list") { process.stdout.write("${sandboxName} Ready\\n"); process.exit(0); }
 if (a[0] === "sandbox" && a[1] === "ssh-config") { process.stdout.write("${sshConfig}\\n"); process.exit(0); }
 if (a[0] === "sandbox" && a[1] === "delete") { fs.writeFileSync(${JSON.stringify(deleteMarker)}, "deleted\\n"); process.exit(${sandboxDeleteExitCode}); }
+if (a[0] === "sandbox" && a[1] === "get") {
+  if (fs.existsSync(${JSON.stringify(deleteMarker)})) { process.stderr.write("sandbox ${sandboxName} not found\\n"); process.exit(1); }
+  process.stdout.write("${sandboxName} Ready\\n");
+  process.exit(0);
+}
 if (a[0] === "sandbox" && a[1] === "exec") {
   const command = a.join(" ");
   if (command.includes("rebuild-atomicity-marker.txt")) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make sandbox rebuild fail closed until OpenShell explicitly confirms that the deleted sandbox is absent. This prevents registry removal and replacement creation from racing an asynchronous delete, while preserving the original registry entry and state backup when confirmation is inconclusive.

## Changes

- Poll `openshell sandbox get <name>` after an accepted delete until the gateway reports the sandbox missing.
- Treat live, terminating, timeout, and transport-error results as unconfirmed and abort before registry removal or recreation.
- Move the deletion callback behind confirmed absence so shield recovery still treats the old sandbox as potentially live on timeout.
- Add focused convergence, transport-failure, provider-recreate, resume-snapshot, and shared rebuild-harness coverage.
- Document the bounded wait and recovery guidance in the rebuild command reference.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent pre-publication security review found no remaining blocker after moving `onDeleted()` behind explicit absence confirmation; transport failures preserve registry/backup state and shield recovery remains fail-closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/actions/sandbox/rebuild-destroy-phase.test.ts src/lib/actions/sandbox/rebuild-flow.test.ts src/lib/actions/sandbox/rebuild-local-provider-recreate.test.ts src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts src/lib/actions/sandbox/rebuild-dcode-base-image-lease.test.ts --no-file-parallelism` (94 passed at exact final head).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Full suite deferred to PR CI; the serialized changed-test sweep passed 202 tests before the clean main rebase, and the exact final head passed 94 focused tests plus `npm run check:diff`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — 0 errors; 2 pre-existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rebuild now waits for explicit confirmation that a sandbox is absent before removing local registry state and creating a replacement.
  * If deletion can’t be confirmed within the timeout (including probe/transport issues), rebuild now exits non-zero and preserves local registry and state backup for recovery.
  * Improved behavior for resumed rebuild flows when the sandbox is already missing.
* **Documentation**
  * Clarified `nemoclaw <name> rebuild` post-deletion confirmation, bounded wait behavior, failure handling, and recovery guidance.
* **Tests**
  * Expanded teardown and resumed-path coverage with more realistic mock OpenShell behaviors and ordered-event assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->