### PR TITLE
test(macos): accept canonical watcher paths

### DIFF
--- a/src/lib/actions/uninstall/hermes-forward-watcher-installer.test.ts
+++ b/src/lib/actions/uninstall/hermes-forward-watcher-installer.test.ts
@@ -62,7 +62,9 @@ exec ${JSON.stringify(process.execPath)} "$@"
       );
 
       expect(result.status, result.stderr).toBe(0);
-      expect(fs.readFileSync(watcherLog, "utf-8").trim()).toBe(openshell);
+      const watcherOpenshell = fs.readFileSync(watcherLog, "utf-8").trim();
+      expect(path.isAbsolute(watcherOpenshell)).toBe(true);
+      expect(fs.realpathSync(watcherOpenshell)).toBe(fs.realpathSync(openshell));
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Keep the installer production contract unchanged: relative OpenShell overrides are resolved to an absolute physical path with `pwd -P`.
- Make the focused test assert the actual contract: the watcher receives an absolute path resolving to the same executable.
- Accept the standard macOS `/var` to `/private/var` canonicalization.

## Why

The post-merge main platform watch failed only because the test compared path spellings lexically. The identical assertion failed on the immediately previous completed main-watch run and on the first completed run after the test was introduced, so this was not introduced by #7280.

Evidence: https://github.com/NVIDIA/NemoClaw/actions/runs/29910675239/job/88892568917 and https://github.com/NVIDIA/NemoClaw/actions/runs/29897085188/job/88849484779

## Verification

- `CI=1 npx vitest run --project cli src/lib/actions/uninstall/hermes-forward-watcher-installer.test.ts --reporter=verbose`
- `npx @biomejs/biome check src/lib/actions/uninstall/hermes-forward-watcher-installer.test.ts`
- `npm run build:cli && npm run typecheck`
- `git diff --check`

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage to verify that the Hermes forward watcher logs an absolute OpenShell path.
  * Confirmed the logged path resolves to the same filesystem target as the generated executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->