### PR TITLE
ci(wsl): stabilize full platform suite

### DIFF
--- a/.github/workflows/platform-vitest-main.yaml
+++ b/.github/workflows/platform-vitest-main.yaml
@@ -147,7 +147,7 @@ jobs:
 
   wsl-vitest:
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       WSL_DISTRO: Ubuntu
       WSL_TEST_USER: nemoclaw-ci

--- a/test/hermes-runtime-config-guard-topology.test.ts
+++ b/test/hermes-runtime-config-guard-topology.test.ts
@@ -17,6 +17,12 @@ const RUNTIME_CONFIG_GUARD = path.join(
 );
 const ROOT_RUNTIME_IMAGE =
   "python:3.12-slim@sha256:cab2dbf575e971934a81e4622f5aba17aa7929719bd7e31033a3a83b97fd0464";
+const ROOT_CONTAINER_RUNTIME_AVAILABLE =
+  process.platform === "linux" &&
+  dockerSpawnSync(["info"], {
+    stdio: "ignore",
+    timeout: 15_000,
+  }).status === 0;
 const ROOT_CONTAINER_DRIVER = String.raw`
 import json
 import os
@@ -506,7 +512,7 @@ print(json.dumps({
   });
 
   // source-shape-contract: security -- Executes the shipped guard as root to prove real Linux repair and rollback metadata
-  it.skipIf(process.platform !== "linux")(
+  it.skipIf(!ROOT_CONTAINER_RUNTIME_AVAILABLE)(
     "restores exact locked posture after root-separated repair and later failure (#7033)",
     () => {
       const result = runRootContainerHarness(`${loadGuardModule}
@@ -627,7 +633,9 @@ with tempfile.TemporaryDirectory() as tmp:
     }))
 `);
 
-      expect(result.status, String(result.stderr)).toBe(0);
+      expect(result.status, result.error?.message || String(result.stderr || result.stdout)).toBe(
+        0,
+      );
       expect(JSON.parse(String(result.stdout))).toEqual({
         aborting_state: "shields-transition-aborting",
         applied_state: "shields-transition-applied",

--- a/test/platform-vitest-main-workflow.test.ts
+++ b/test/platform-vitest-main-workflow.test.ts
@@ -82,7 +82,7 @@ describe("platform Vitest main workflow", () => {
     const fullSuite = step("wsl-vitest", "Run full Vitest suite in WSL").run ?? "";
     const rootSuite = step("wsl-vitest", "Run root-required Vitest contracts in WSL").run ?? "";
 
-    expect(job("wsl-vitest")["timeout-minutes"]).toBe(60);
+    expect(job("wsl-vitest")["timeout-minutes"]).toBe(90);
     expect(checkout.with).toMatchObject({
       "fetch-depth": 0,
       "persist-credentials": false,

--- a/test/release-latest-tag.test.ts
+++ b/test/release-latest-tag.test.ts
@@ -358,7 +358,6 @@ describe("release-latest-tag.sh", () => {
     const result = runReleaseLatest(fixture, "v0.0.2");
 
     expect(result.status).not.toBe(0);
-    expect(`${result.stdout}\n${result.stderr}`).toContain("cannot lock ref 'refs/tags/latest'");
     expect(remoteObject(fixture, "refs/tags/latest")).toBe(concurrentObject);
     expect(remoteObject(fixture, "refs/tags/latest")).not.toBe(
       remoteObject(fixture, "refs/tags/v0.0.2"),


### PR DESCRIPTION
## Summary

- raise the Platform Vitest Main Watch WSL job limit from 60 to 90 minutes
- capability-gate the one Docker-backed Hermes root-container contract when the platform has no Docker daemon
- keep the concurrent `latest` safety test semantic across Git rejection-message variants

## Why

The preserved current-main platform run [29914791092](https://github.com/NVIDIA/NemoClaw/actions/runs/29914791092) completed 19,226 WSL tests and exposed two platform assumptions after the earlier timeout was removed:

- the fresh WSL distro intentionally installs no Docker CLI or daemon, while one Hermes test gated only on `process.platform === "linux"`; Node returned immediate Docker `ENOENT` with `status: null`
- WSL Git correctly rejected the stale compare-and-swap with `incorrect old value provided` instead of the older `cannot lock ref` prose; the remote object invariants prove `latest` was not overwritten

The job-level 90-minute allowance remains necessary because [29910675239](https://github.com/NVIDIA/NemoClaw/actions/runs/29910675239) previously reached the exact 60-minute cap while the suite was still passing and progressing. Production Hermes and release behavior are unchanged.

## Verification

- focused concurrent-tag safety test passed at a 60-second budget
- Hermes topology and platform workflow contracts: 5 passed, 2 intentional capability skips
- Biome check passed
- `git diff --check` passed

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum runtime for the WSL test workflow from 60 to 90 minutes to reduce timeout risk during longer runs.
* **Tests**
  * Improved Linux root-container integration tests to run only when the needed container runtime capability is available.
  * Made assertion failure reporting more reliable by using additional error context when available.
  * Relaxed a concurrent “latest tag” test to check failure behavior without requiring a specific error message, while still verifying the remote tag was not overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->