### PR TITLE
test(hermes): stabilize guard timing and WSL ownership

### DIFF
--- a/test/helpers/hermes-restart-config-seal-fixture.ts
+++ b/test/helpers/hermes-restart-config-seal-fixture.ts
@@ -17,6 +17,8 @@ export const RUNTIME_CONFIG_GUARD = path.join(
   "runtime-config-guard.py",
 );
 
+const HERMES_GUARD_TIMEOUT_MS = 90_000;
+
 export interface RestartFixture {
   root: string;
   sandboxDir: string;
@@ -123,7 +125,7 @@ export function runWriteConfig(fixture: RestartFixture, expectedDigest: string, 
       "--expected-config-sha256",
       expectedDigest,
     ],
-    { encoding: "utf-8", input: content, timeout: 5000 },
+    { encoding: "utf-8", input: content, timeout: HERMES_GUARD_TIMEOUT_MS },
   );
 }
 
@@ -155,7 +157,7 @@ export function runGuard(action: "seal-restart" | "unseal-restart", fixture: Res
   args.push(...(action === "seal-restart" ? ["--hash-file", fixture.hashPath] : []));
   return spawnSync("python3", args, {
     encoding: "utf-8",
-    timeout: 5000,
+    timeout: HERMES_GUARD_TIMEOUT_MS,
   });
 }
 
@@ -231,7 +233,10 @@ export function runShieldsTransactionAction(
     ...(options.rollbackMode ? ["--rollback-shields-mode", options.rollbackMode] : []),
     ...(options.token ? ["--lock-token", options.token] : []),
   );
-  return spawnSync("python3", args, { encoding: "utf-8", timeout: 5000 });
+  return spawnSync("python3", args, {
+    encoding: "utf-8",
+    timeout: HERMES_GUARD_TIMEOUT_MS,
+  });
 }
 
 export function strictHashIsValid(fixture: RestartFixture): boolean {

--- a/test/hermes-restart-config-seal-recovery.test.ts
+++ b/test/hermes-restart-config-seal-recovery.test.ts
@@ -359,17 +359,47 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
     let restoreTempRootMode: (() => void) | undefined;
 
     try {
+      const sandboxUidResult = spawnSync("id", ["-u", "sandbox"], {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      const sandboxGidResult = spawnSync("id", ["-g", "sandbox"], {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      expect(sandboxUidResult.status, sandboxUidResult.stderr).toBe(0);
+      expect(sandboxGidResult.status, sandboxGidResult.stderr).toBe(0);
+      const sandboxUid = Number(sandboxUidResult.stdout.trim());
+      const sandboxGid = Number(sandboxGidResult.stdout.trim());
+      expect(Number.isSafeInteger(sandboxUid)).toBe(true);
+      expect(Number.isSafeInteger(sandboxGid)).toBe(true);
+
+      for (const pathname of [
+        fixture.sandboxDir,
+        fixture.hermesDir,
+        fixture.configPath,
+        fixture.envPath,
+        fixture.compatHashPath,
+      ]) {
+        fs.chownSync(pathname, sandboxUid, sandboxGid);
+      }
+      // chown clears setgid, so restore the canonical mutable Hermes mode.
+      fs.chmodSync(fixture.hermesDir, 0o3770);
+
       restoreTempRootMode = allowRestartFixturePeerTraversal(fixture);
       const sealed = runGuard("seal-restart", fixture);
       expect(sealed.status, sealed.stderr).toBe(0);
 
-      const hermesGid = fs.statSync(fixture.hermesDir).gid;
+      const sealedHermes = fs.statSync(fixture.hermesDir);
+      expect(sealedHermes.uid).toBe(0);
+      expect(sealedHermes.gid).toBe(sandboxGid);
+      expect(mode(fixture.hermesDir)).toBe(0o3770);
       const peer = spawnSync(
         "setpriv",
         [
           "--reuid=65534",
           "--regid=65534",
-          `--groups=${hermesGid}`,
+          `--groups=${sandboxGid}`,
           "sh",
           "-c",
           'touch "$1/peer-runtime-state" || exit 10; rm "$1/config.yaml" 2>/dev/null && exit 20; test -f "$1/config.yaml"',
@@ -385,6 +415,17 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
 
       const unsealed = runGuard("unseal-restart", fixture);
       expect(unsealed.status, unsealed.stderr).toBe(0);
+      for (const pathname of [
+        fixture.sandboxDir,
+        fixture.hermesDir,
+        fixture.configPath,
+        fixture.envPath,
+        fixture.compatHashPath,
+      ]) {
+        const restored = fs.statSync(pathname);
+        expect(restored.uid).toBe(sandboxUid);
+        expect(restored.gid).toBe(sandboxGid);
+      }
     } finally {
       try {
         fs.rmSync(fixture.root, { recursive: true, force: true });

--- a/test/nemoclaw-start-perms.test.ts
+++ b/test/nemoclaw-start-perms.test.ts
@@ -594,15 +594,29 @@ describe("nemoclaw-start mutable config reclaim", () => {
         expect(fs.statSync(configDir).uid.toString()).toBe(nobodyUid);
         expect(fs.statSync(configDir).gid.toString()).toBe(nobodyGid);
 
-        const writeCheck = spawnSync("setpriv", [
-          `--reuid=${nobodyUid}`,
-          `--regid=${nobodyGid}`,
-          "--clear-groups",
-          "--",
-          "touch",
-          path.join(configDir, "nemoclaw-write-check"),
-        ]);
-        expect(writeCheck.status).toBe(0);
+        const tempRoot = path.dirname(root);
+        const tempRootMode = mode(tempRoot);
+        const writeCheck = (() => {
+          // Vitest's shared temp root is private; expose traversal only for this peer probe.
+          fs.chmodSync(tempRoot, tempRootMode | 0o001);
+          try {
+            return spawnSync(
+              "setpriv",
+              [
+                `--reuid=${nobodyUid}`,
+                `--regid=${nobodyGid}`,
+                "--clear-groups",
+                "--",
+                "touch",
+                path.join(configDir, "nemoclaw-write-check"),
+              ],
+              { encoding: "utf-8" },
+            );
+          } finally {
+            fs.chmodSync(tempRoot, tempRootMode);
+          }
+        })();
+        expect(writeCheck.status, writeCheck.stderr).toBe(0);
       } finally {
         fs.rmSync(root, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

- raise the Hermes Python guard test-harness allowance from 5 seconds to 90 seconds
- apply the shared allowance to the three runtime-config-guard helper paths only
- correct the WSL root-only peer fixture to start from the production mutable topology, `sandbox:sandbox 03770`
- assert sealing produces `root:sandbox 03770`, permits sandbox-group runtime-state creation, rejects unlink of root-owned sealed config, and restores the original ownership
- let the existing config-reclaim peer write probe traverse Vitest's private temp root only for the duration of that probe, then restore its exact mode
- leave production runtime behavior and non-guard command limits unchanged

## Evidence

- main CI job 88920894839 returned `status: null` after the first guard child exceeded its 5-second `spawnSync` limit; the runner and later guard cases remained healthy
- four prior main runs passed the same case in about 0.3 seconds, confirming a load-sensitive harness limit rather than a Hermes behavior regression
- current-main Platform Vitest run 29919416442 passed the complete WSL suite (1,642 files / 19,227 tests) and then reproduced the isolated root-fixture failure
- historical run 29307612216 reproduced that fixture failure before the OpenClaw upgrade and before #7379
- first exact-head WSL proof 29923652396 passed the complete WSL suite and both corrected Hermes root contracts; it then exposed the next root-only fixture defect
- that config-reclaim test completed production normalization and all ownership/mode assertions; only its stepped-down write probe failed because PR #6690 made Vitest's shared temp ancestor private
- current exact head `b7414d2f7f1bfd68028e9f43c11c1cc61033e266` includes current `main` at `f9924949922f8e554f94aeefdd23a993a801e7b4`
- current exact-head platform proof: https://github.com/NVIDIA/NemoClaw/actions/runs/29929199550
- focused `nemoclaw-start-perms` suite: 16 passed, 3 Linux-root capability skips on macOS
- `npm run build:cli` and `npm run check:diff`: passed
- independent review of the narrow changes: no production findings

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
