### PR TITLE
fix(docs): validate MDX href routes

### DIFF
--- a/scripts/check-docs-published-routes.mts
+++ b/scripts/check-docs-published-routes.mts
@@ -354,7 +354,34 @@ export function resolvePublishedRoute(fromRoute: string, target: string): string
 
 export type MarkdownLink = { text: string; target: string; line: number };
 
-/** Extract markdown links, skipping fenced code blocks and inline code spans. */
+function extractMdxHrefProps(line: string, lineNumber: number): MarkdownLink[] {
+  const links: MarkdownLink[] = [];
+  const hrefRe =
+    /(^|[\s<])href\s*=\s*(?:"([^"]+)"|'([^']+)'|\{\s*"([^"]+)"\s*\}|\{\s*'([^']+)'\s*\})/g;
+  let match: RegExpExecArray | null;
+  while ((match = hrefRe.exec(line)) !== null) {
+    const target = match[2] ?? match[3] ?? match[4] ?? match[5];
+    if (!target) continue;
+    links.push({
+      text: "MDX href",
+      target,
+      line: lineNumber,
+    });
+  }
+  return links;
+}
+
+function lineStartsMdxOpeningTag(line: string): boolean {
+  return /<[A-Za-z][\w.:$-]*(?=\s|>|\/>)/.test(line);
+}
+
+function isMdxOpeningTagStillOpen(line: string, startedBeforeLine: boolean): boolean {
+  if (startedBeforeLine) return !line.includes(">");
+  const tagStart = line.search(/<[A-Za-z][\w.:$-]*(?=\s|>|\/>)/);
+  return tagStart >= 0 && !line.slice(tagStart).includes(">");
+}
+
+/** Extract Markdown links and static MDX href props, skipping fenced code blocks and inline code spans. */
 export function extractMarkdownLinks(body: string): MarkdownLink[] {
   const links: MarkdownLink[] = [];
   const lines = body.split(/\r?\n/);
@@ -364,6 +391,7 @@ export function extractMarkdownLinks(body: string): MarkdownLink[] {
   let fenceChar = "";
   let fenceLen = 0;
   let inFence = false;
+  let inMdxOpeningTag = false;
   lines.forEach((rawLine, i) => {
     const fenceMatch = rawLine.match(/^\s*(`{3,}|~{3,})(.*)$/);
     if (fenceMatch) {
@@ -387,6 +415,10 @@ export function extractMarkdownLinks(body: string): MarkdownLink[] {
     while ((match = linkRe.exec(scan)) !== null) {
       links.push({ text: match[1], target: match[2], line: i + 1 });
     }
+    if (inMdxOpeningTag || lineStartsMdxOpeningTag(scan)) {
+      links.push(...extractMdxHrefProps(scan, i + 1));
+    }
+    inMdxOpeningTag = isMdxOpeningTagStillOpen(scan, inMdxOpeningTag);
   });
   return links;
 }
@@ -563,7 +595,8 @@ export function resolvePageLinksByText(
 // Pages that have repeatedly regressed on source-path-vs-published-route drift
 // (NemoClaw#5445, #6290, #5465, #5460, #6601). Guard every inference and Manage
 // Sandboxes page because their nested navigation differs from source directories.
-const GUARDED_SOURCE_PAGES = [
+export const GUARDED_SOURCE_PAGES = [
+  "index.mdx",
   "reference/commands.mdx",
   "reference/network-policies.mdx",
   "reference/platform-support.mdx",

--- a/test/check-docs-published-routes.test.ts
+++ b/test/check-docs-published-routes.test.ts
@@ -17,6 +17,7 @@ import {
   findBrokenPublishedRoutes,
   findMissingDirectLegacyManageSandboxRedirects,
   findMissingDirectLegacyReleaseNotesRedirects,
+  GUARDED_SOURCE_PAGES,
   resolvePublishedRoute,
 } from "../scripts/check-docs-published-routes.mts";
 
@@ -164,6 +165,59 @@ See [Hermes Commands](/user-guide/hermes/reference/commands).
         }),
       ]);
     });
+  });
+
+  it("validates internal MDX href props outside fenced code blocks", () => {
+    const index = buildPublishedRouteIndex(navYaml);
+    const source = commandsSource(`
+<Cards>
+
+<Card title="Missing Inference" href="../inference/missing">
+
+This card points to a missing published route.
+
+</Card>
+
+<Card title="External" href="https://www.nvidia.com/nemoclaw">
+
+External links are outside published-route validation.
+
+</Card>
+
+<Card title="Same Page" href="#same-page">
+
+Same-page anchors are outside cross-page route validation.
+
+</Card>
+
+\`\`\`mdx
+<Card title="Fenced Missing" href="../inference/fenced-missing" />
+\`\`\`
+
+</Cards>
+`);
+
+    withDocsSource(source, (docsDir) => {
+      expect(findBrokenPublishedRoutes("reference/commands.mdx", index, docsDir)).toEqual([
+        expect.objectContaining({
+          fromRoute: "/user-guide/openclaw/reference/commands",
+          resolved: "/user-guide/openclaw/inference/missing",
+          target: "../inference/missing",
+        }),
+        expect.objectContaining({
+          fromRoute: "/user-guide/hermes/reference/commands",
+          resolved: "/user-guide/hermes/inference/missing",
+          target: "../inference/missing",
+        }),
+      ]);
+    });
+  });
+
+  it("guards the docs home page route links", () => {
+    const index = buildPublishedRouteIndex();
+
+    expect(GUARDED_SOURCE_PAGES).toContain("index.mdx");
+    expect(findBrokenPublishedRoutes("index.mdx", index)).toEqual([]);
   });
 
   it("validates every changelog link against published routes", () => {


### PR DESCRIPTION
﻿<!-- markdownlint-disable MD041 -->
## Summary
The published-route checker now validates static MDX component `href` links in addition to Markdown links. The docs home page is also included in the guarded published-route set so broken first-page cards cannot slip past route validation.

## Changes
- Extract static MDX `href` props outside fenced code blocks, including quoted props and string literal expression props.
- Include `docs/index.mdx` in the guarded source pages for published route validation.
- Added regression coverage for MDX href links, fenced examples, ignored external/hash links, and home-page route coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this tightens docs validation tooling without changing published docs content.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/check-docs-published-routes.test.ts test/repro-5445-docs-published-route.test.ts test/changelog-docs.test.ts test/network-policies-published-routes.test.ts` passed locally and on DGX Spark/Linux; `npm run docs:check-routes` passed locally and on DGX Spark/Linux; `npm run typecheck:cli` passed locally.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; focused docs-tooling change covered by targeted tests and `npm run check:diff`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: HwangJohn <angelic805@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation link validation to detect internal links used in MDX components.
  * Avoided false positives for links in code blocks, external URLs, and same-page anchors.
  * Added coverage to ensure the documentation home page’s published routes are validated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->