### PR TITLE
docs: add v0.0.92 release changelog

### DIFF
--- a/docs/changelog/2026-07-22.mdx
+++ b/docs/changelog/2026-07-22.mdx
@@ -24,7 +24,7 @@ NemoClaw v0.0.92 updates OpenClaw and its sandbox Node.js runtime, documents hea
   The WSL tag test still verifies that a rejected concurrent update cannot replace `latest`.
   Hosted Hermes image exports now provision bounded swap before the final layer export.
   Hermes guard tests raise the child-process allowance from 5 to 90 seconds and use WSL fixtures that match production ownership.
-  These changes do not alter runtime behavior or image contents.
+  The validation and test changes do not alter runtime behavior or final image contents.
 - The canonical changelog now includes the previously missed v0.0.91 entry and corrects its legacy inference-selector guidance to match the tagged code.
   This restores release-history validation without changing the immutable v0.0.91 tag.
 

--- a/docs/changelog/2026-07-22.mdx
+++ b/docs/changelog/2026-07-22.mdx
@@ -3,6 +3,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */}
 
+## v0.0.92
+
+NemoClaw v0.0.92 updates OpenClaw and its sandbox Node.js runtime, documents headless deployment, and strengthens security, installer, platform, and live E2E validation.
+
+- OpenClaw sandboxes now use OpenClaw 2026.7.1 and Node.js 22.23.1.
+  The reviewed build remediates vulnerable Axios plugin copies and the affected OpenTelemetry Jaeger diagnostics graph with integrity-pinned packages.
+  It also locks patched `mcporter` dependencies, preserves device-scope enforcement and private state during upgrades, and validates upgrades from NemoClaw v0.0.89.
+  A real-artifact regression confirms malformed Jaeger trace and baggage headers do not terminate the diagnostics process.
+- Remote deployment guidance now uses one provider-neutral headless Linux server workflow for OpenClaw, Hermes, and Deep Agents Code.
+  The guide covers unattended installation, loopback-only access, readiness checks, policy setup, updates, and recovery after a host reboot.
+  Retired Brev deployment routes redirect to the shared workflow.
+  For more information, refer to [Deploy NemoClaw to a Headless Server](/user-guide/openclaw/deployment/deploy-to-headless-server).
+- Live E2E tests now report ordered semantic phases, outcomes, durations, resource-release timing, and secret-safe stall diagnostics.
+  Each run saves a progress artifact that identifies where failures or stalls occurred.
+  Collection-time validation rejects missing or invalid phase plans before tests use live infrastructure.
+- Installer integrity checks now accept the reviewed OpenShell Homebrew formula transition only when the template hash matches its exact release asset set.
+  This maintains the fail-closed boundary while preserving the current archive-only installer contract.
+- Platform and image validation now compares canonical macOS watcher targets, raises the full WSL suite limit from 60 to 90 minutes, and capability-gates its Docker-only Hermes contract.
+  The WSL tag test still verifies that a rejected concurrent update cannot replace `latest`.
+  Hosted Hermes image exports now provision bounded swap before the final layer export.
+  Hermes guard tests raise the child-process allowance from 5 to 90 seconds and use WSL fixtures that match production ownership.
+  These changes do not alter runtime behavior or image contents.
+- The canonical changelog now includes the previously missed v0.0.91 entry and corrects its legacy inference-selector guidance to match the tagged code.
+  This restores release-history validation without changing the immutable v0.0.91 tag.
+
 ## v0.0.91
 
 NemoClaw v0.0.91 strengthens completed sandbox images, makes rebuild replacement safer, documents the Hermes API token lifecycle, expands qualified DGX Station guidance, and restores historical release validation.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the canonical `## v0.0.92` release entry to `docs/changelog/2026-07-22.mdx` before the release plan is generated. The entry summarizes all ten pull requests merged after v0.0.91, including the OpenClaw security update and Jaeger runtime regression coverage.

## Changes

- Added the canonical v0.0.92 changelog entry.
- Recorded the user-visible, security, documentation, CI, and test changes in the release range.
- #7280 -> `docs/changelog/2026-07-22.mdx`: OpenClaw 2026.7.1 and Node.js 22.23.1 security/runtime update.
- #7378 -> `docs/changelog/2026-07-22.mdx`: canonical macOS watcher path validation.
- #7379 -> `docs/changelog/2026-07-22.mdx`: stabilized full WSL platform validation.
- #7380 -> `docs/changelog/2026-07-22.mdx`: bounded swap for hosted Hermes image exports.
- #7100 -> `docs/changelog/2026-07-22.mdx`: semantic progress phases for live E2E tests.
- #7376 -> `docs/changelog/2026-07-22.mdx`: restored v0.0.91 changelog history and corrected tagged guidance.
- #7374 -> `docs/changelog/2026-07-22.mdx`: reviewed Homebrew formula transition for installer integrity checks.
- #7346 -> `docs/changelog/2026-07-22.mdx`: provider-neutral headless server deployment guidance.
- #7381 -> `docs/changelog/2026-07-22.mdx`: stabilized Hermes guard timing and WSL ownership fixtures.
- #7339 -> `docs/changelog/2026-07-22.mdx`: real-artifact Jaeger header remediation regression coverage.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates the canonical dated changelog and release heading contract.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts` passed 6/6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to a changelog-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 pre-existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `v0.0.92` release notes covering sandboxing updates (OpenClaw/Node.js bumps, integrity pinning remediation, mcporter handling, and upgrade validation).
  * Updated deployment guidance for provider-neutral headless installs, and improved live E2E test reporting plus phase-plan validation.
  * Tightened installer integrity-check messaging during an OpenShell Homebrew transition and expanded platform/image validation (including macOS/WSL timing) and hosted image export behavior.
  * Restored the previously missed `v0.0.91` changelog entry and release validation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->