### PR TITLE
feat: require writer receipts for docs-only PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,8 +27,8 @@
 - [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:
 
 ## Documentation Writer Review
-<!-- Required for code changes after implementation is complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed doc paths or name the reason that no doc change is needed or the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. Record this PR number. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after new implementation commits. This receipt is advisory during the data-collection pilot. -->
-- [ ] Documentation writer subagent reviewed the completed implementation
+<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. Record this PR number. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
+- [ ] Documentation writer subagent reviewed the completed changes
 - Result: `docs-updated` | `no-docs-needed` | `blocked`
 - Evidence:
 - Agent:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,9 +252,9 @@ Follow `.agents/skills/_shared/pr-follow-up.md`: after opening or pushing to a P
 ## Documentation
 
 - Treat `docs/` as the source of truth for user-facing documentation and follow `docs/CONTRIBUTING.md`.
-- After completing development changes, run a documentation writer subagent before final handoff. Give it the changed files, behavior summary, and test evidence so it can update docs or report that no doc changes are needed.
+- After completing code or documentation changes, run a documentation writer subagent before final handoff. Give it the changed files, change summary, and test or docs-build evidence. For documentation-only changes, ask it to verify the writing rules and documentation style.
 - After the review, complete the PR template's Documentation Writer Review section. Record the result, evidence, agent surface, and PR number. Put the reviewed head SHA and current `AGENTS.md` blob SHA in the template's hidden metadata comments.
-- If implementation changes after the hidden head SHA, rerun the documentation writer review and refresh the hidden metadata. The receipt check runs again when new commits are pushed.
+- If any commit changes the pull-request head after the hidden head SHA, rerun the documentation writer review and refresh the hidden metadata. The receipt check runs again when new commits are pushed.
 - For normal docs changes, include source pages under `docs/`.
 - Update `.agents/skills/nemoclaw-user-guide/SKILL.md` only when the AI-agent docs routing guidance changes.
 - During pre-tag release prep, run `nemoclaw-contributor-update-docs` and include the canonical release entry in the release-note docs PR. Create or update `docs/changelog/YYYY-MM-DD.mdx` for `vX.Y.Z` following `docs/CONTRIBUTING.md`; a PR that updates ordinary pages without the dated changelog entry is incomplete. Merge that PR, or record an explicit maintainer waiver, before generating the release plan.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -402,14 +402,18 @@ During release prep, run that skill first, make any doc version bumps, then open
 
 ### Documentation Writer Review Receipt
 
-After you complete a code change, a documentation writer subagent must review the implementation.
+After you complete a code or documentation change, a documentation writer subagent must review the completed changes.
+For a documentation-only change, the subagent must verify the changed pages against [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) and [WRITING.md](WRITING.md).
+The review must cover terminology, structure, voice, and code-sample presentation.
 Complete the Documentation Writer Review section in the PR description after that review.
 Keep one review completion checkbox and one instance of each visible or hidden field.
 
 Record one result:
 
-- `docs-updated` when the review changes documentation. List the changed documentation paths as evidence.
-- `no-docs-needed` when the evidence explains why documentation does not change.
+- `docs-updated` when the reviewed pull request changes documentation.
+  List the changed documentation paths as evidence.
+  For a documentation-only change, state that the subagent reviewed the writing rules and documentation style.
+- `no-docs-needed` when a code change does not require documentation and the evidence explains why.
 - `blocked` when a named decision, dependency, access problem, or input prevents the review.
 
 Record the product and surface that ran the review, such as `Codex Desktop`, `Codex CLI`, `Claude Code`, or `Cursor`.
@@ -424,8 +428,8 @@ git rev-parse --short HEAD
 git rev-parse --short HEAD:AGENTS.md
 ```
 
-The visible PR number ties the receipt to this PR, while the hidden head SHA identifies the implementation revision that the review covered.
-Rerun the review when implementation changes after the hidden head SHA.
+The visible PR number ties the receipt to this PR, while the hidden head SHA identifies the pull-request revision that the review covered.
+Rerun the review after any new commit changes the pull-request head.
 Pushing a new commit runs the receipt check again and reports the review as stale until the hidden metadata is refreshed.
 The Documentation Writer Review check reports an advisory finding when the receipt is missing, incomplete, or stale.
 The check compares the receipt's PR number with the current PR number, the hidden head SHA with the current PR head, and the hidden `AGENTS.md` blob SHA with the current PR's file.
@@ -438,9 +442,11 @@ npm run docs-review:report -- --since 2026-06-12 --format csv > /tmp/nemoclaw-do
 
 The report uses the authenticated GitHub CLI session and returns JSON by default.
 It measures receipt coverage, PR-number integrity, head-revision freshness, review results, and agent-surface counts.
+The `eligiblePrs` JSON metric reports the total eligible pull requests.
+The `eligibleCodePrs` and `eligibleDocsOnlyPrs` metrics report the code and documentation-only counts.
 It records the `AGENTS.md` blob SHA, but only the PR check compares that SHA with the current PR's file.
 It does not prove that an agent loaded `AGENTS.md`; it records observable workflow compliance.
-The retrospective report classifies code changes from the checked Type of Change field.
+The retrospective report classifies code and documentation changes from the checked Type of Change field.
 It reports a PR as unclassified when that field is incomplete or contradictory.
 Use `--format summary` to print only aggregate metrics.
 Use `--until YYYY-MM-DD` to set the end of the reporting period.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -203,6 +203,16 @@ Commit and push normally so the Git hooks run, then run:
 npm run docs
 ```
 
+After the documentation changes and build are complete, run a documentation writer subagent.
+Give it the changed pages, the documentation intent, and the build evidence.
+Ask it to verify the changes against this guide and `WRITING.md`.
+The review must cover terminology, structure, voice, and code-sample presentation.
+Apply any required corrections.
+Rerun the applicable documentation validation.
+Commit the reviewed changes.
+Then complete the pull-request template's Documentation Writer Review receipt with the reviewed head SHA.
+Rerun the review after any later commit because the receipt is tied to the exact pull-request head.
+
 Leave the broad-gate verification item unchecked unless you actually ran the applicable command.
 If normal `pre-commit`, `commit-msg`, or `pre-push` hooks were skipped or unavailable, run `npm run check:diff` once to reproduce those checks before opening the PR.
 The command uses `origin/main`, so refresh it with `git fetch origin main` first.

--- a/docs/resources/engineer-agentic-documentation.mdx
+++ b/docs/resources/engineer-agentic-documentation.mdx
@@ -83,7 +83,7 @@ Routine pull-request updates that already meet the documentation contract do not
 ## Make Documentation Review Observable
 
 A repository instruction can require a documentation writer subagent, but the instruction alone does not show whether an engineering agent followed it.
-Add a structured pull-request receipt so each code change produces observable documentation-review evidence.
+Add a structured pull-request receipt so each code or documentation change produces observable documentation-review evidence.
 
 NemoClaw records the following fields in the Documentation Writer Review section of the pull-request description:
 
@@ -99,18 +99,20 @@ The pull-request number detects a receipt copied from another pull request.
 The head SHA binds the review to one pull-request revision.
 The `AGENTS.md` blob SHA records which repository instruction version the review covered.
 
-Use the following sequence for a code-changing pull request:
+Use the following sequence for a pull request that changes code or documentation:
 
-1. Run the documentation writer subagent after implementation and targeted tests are complete.
-2. Update the canonical documentation or record why no documentation change is required.
-3. Commit all changes from the review.
-4. Complete the visible receipt and hidden metadata for the committed head.
-5. Rerun the documentation review after any later commit.
+1. Run the documentation writer subagent after the changes and applicable validation are complete.
+2. For code changes, update the canonical documentation or record why no documentation change is required.
+3. For documentation changes, verify the writing rules and documentation style.
+4. Commit all changes from the review.
+5. Complete the visible receipt and hidden metadata for the committed head.
+6. Rerun the documentation review after any later commit.
 
-The `CI / Documentation Writer Review` workflow runs when a pull request opens, its description is edited, receives a new commit, or reopens.
+The `CI / Documentation Writer Review` workflow runs when a pull request opens or reopens, when its description is edited, or when it receives a new commit.
 It compares the receipt with the pull-request number, current head, and current `AGENTS.md` blob.
 A new commit makes the previous receipt stale until the documentation writer subagent runs again and refreshes the metadata.
-The checker evaluates code-changing pull requests and classifies documentation-only pull requests as not required.
+The checker evaluates code-changing and documentation-only pull requests.
+For documentation-only changes, the receipt records the agent's review of writing rules and documentation style.
 NemoClaw keeps this check advisory during the data-collection pilot.
 
 <Note>
@@ -131,12 +133,13 @@ Use a consistent reporting window and track the following measures:
 
 | Measure | What it shows |
 |---|---|
-| Receipt coverage | The share of eligible code-changing pull requests that contain a receipt. |
+| Eligible pull requests | The total in `eligiblePrs`, plus the code and documentation-only counts in `eligibleCodePrs` and `eligibleDocsOnlyPrs`. |
+| Receipt coverage | The share of eligible code-changing and documentation-only pull requests that contain a receipt. |
 | Valid receipt rate | The share of eligible pull requests whose receipt has one complete and consistent set of fields. |
 | Fresh receipt rate | The share of recorded receipts tied to the pull request's current head. |
-| Result distribution | The number of reviews that updated docs, required no docs, or were blocked. |
+| Result distribution | The number of receipts that report `docs-updated`, `no-docs-needed`, or `blocked`. |
 | Agent surface | The agent products and surfaces recorded by valid receipts. |
-| Unclassified pull requests | Pull requests whose Type of Change selection does not establish whether code changed. |
+| Unclassified pull requests | Pull requests whose Type of Change selection does not establish whether code or documentation changed. |
 
 Receipt trends show whether the repository workflow is being followed.
 They do not establish that the instructions caused a documentation improvement.
@@ -578,7 +581,7 @@ Before calling a documentation system agent-ready, confirm the following conditi
 - Routing prompts and skills point to the source instead of copying it.
 - Variant generation is deterministic and variant behavior is tested.
 - Agent workflows define scope, approvals, stop conditions, and completion evidence.
-- Code-changing pull requests record a documentation-review result tied to the pull-request number, current head, and instruction version.
+- Code-changing and documentation-only pull requests record a documentation-review result tied to the pull-request number, current head, and instruction version.
 - New commits invalidate the recorded review until the documentation writer subagent runs again.
 - Pull requests validate generated output, routes, links, product parity, and rendered previews.
 - Release publication uses an approved immutable revision.

--- a/docs/resources/engineer-agentic-documentation.mdx
+++ b/docs/resources/engineer-agentic-documentation.mdx
@@ -96,7 +96,7 @@ NemoClaw records the following fields in the Documentation Writer Review section
 
 Keep one instance of each field.
 The pull-request number detects a receipt copied from another pull request.
-The head SHA binds the review to one implementation revision.
+The head SHA binds the review to one pull-request revision.
 The `AGENTS.md` blob SHA records which repository instruction version the review covered.
 
 Use the following sequence for a code-changing pull request:
@@ -105,11 +105,11 @@ Use the following sequence for a code-changing pull request:
 2. Update the canonical documentation or record why no documentation change is required.
 3. Commit all changes from the review.
 4. Complete the visible receipt and hidden metadata for the committed head.
-5. Rerun the documentation review after any later implementation commit.
+5. Rerun the documentation review after any later commit.
 
 The `CI / Documentation Writer Review` workflow runs when a pull request opens, changes, receives a new commit, or reopens.
 It compares the receipt with the pull-request number, current head, and current `AGENTS.md` blob.
-A new implementation commit makes the previous receipt stale until the documentation writer subagent runs again and refreshes the metadata.
+A new commit makes the previous receipt stale until the documentation writer subagent runs again and refreshes the metadata.
 The checker evaluates code-changing pull requests and classifies documentation-only pull requests as not required.
 NemoClaw keeps this check advisory during the data-collection pilot.
 
@@ -579,7 +579,7 @@ Before calling a documentation system agent-ready, confirm the following conditi
 - Variant generation is deterministic and variant behavior is tested.
 - Agent workflows define scope, approvals, stop conditions, and completion evidence.
 - Code-changing pull requests record a documentation-review result tied to the pull-request number, current head, and instruction version.
-- New implementation commits invalidate the recorded review until the documentation writer subagent runs again.
+- New commits invalidate the recorded review until the documentation writer subagent runs again.
 - Pull requests validate generated output, routes, links, product parity, and rendered previews.
 - Release publication uses an approved immutable revision.
 - Retrieval, citation, task, variant, safety, and freshness regressions have repeatable evaluations.

--- a/docs/resources/engineer-agentic-documentation.mdx
+++ b/docs/resources/engineer-agentic-documentation.mdx
@@ -4,8 +4,8 @@
 title: "Engineer Documentation for AI Agents"
 sidebar-title: "Engineer Agentic Docs"
 description: "A practical architecture and operating model for making technical documentation reliable for both people and AI agents."
-description-agent: "Explains how to engineer agent-ready documentation with one canonical source, Markdown and MCP delivery, thin routing skills, workflow automation, variants, governance, and deterministic quality gates. Use when designing agentic documentation, docs engineering systems, AI documentation workflows, or docs-as-code automation."
-keywords: ["agentic documentation", "agent-ready docs", "documentation engineering", "AI documentation workflow", "docs as code", "llms.txt", "docs MCP server"]
+description-agent: "Explains how to engineer agent-ready documentation with one canonical source, Markdown and MCP delivery, thin routing skills, workflow automation, review receipts, adoption metrics, variants, governance, and deterministic quality gates. Use when designing agentic documentation, docs engineering systems, AI documentation workflows, or docs-as-code automation."
+keywords: ["agentic documentation", "agent-ready docs", "documentation engineering", "AI documentation workflow", "documentation review receipt", "docs as code", "llms.txt", "docs MCP server"]
 content:
   type: "how_to"
 ---
@@ -79,6 +79,68 @@ It does not remove documentation ownership.
 It shifts the writer's role toward designing the system, maintaining the instructions, monitoring outcomes, and handling work that requires editorial judgment.
 When the instructions are working, the writer can review by exception.
 Routine pull-request updates that already meet the documentation contract do not need line editing, so the writer can focus on unclear product scope, structural pressure, and recurring failure patterns.
+
+## Make Documentation Review Observable
+
+A repository instruction can require a documentation writer subagent, but the instruction alone does not show whether an engineering agent followed it.
+Add a structured pull-request receipt so each code change produces observable documentation-review evidence.
+
+NemoClaw records the following fields in the Documentation Writer Review section of the pull-request description:
+
+- A completed-review checkbox.
+- One result: `docs-updated`, `no-docs-needed`, or `blocked`.
+- Evidence that names the changed documentation or explains the result.
+- The agent product and surface that ran the review.
+- The pull-request number.
+- Hidden metadata for the reviewed head SHA and the `AGENTS.md` blob SHA.
+
+Keep one instance of each field.
+The pull-request number detects a receipt copied from another pull request.
+The head SHA binds the review to one implementation revision.
+The `AGENTS.md` blob SHA records which repository instruction version the review covered.
+
+Use the following sequence for a code-changing pull request:
+
+1. Run the documentation writer subagent after implementation and targeted tests are complete.
+2. Update the canonical documentation or record why no documentation change is required.
+3. Commit all changes from the review.
+4. Complete the visible receipt and hidden metadata for the committed head.
+5. Rerun the documentation review after any later implementation commit.
+
+The `CI / Documentation Writer Review` workflow runs when a pull request opens, changes, receives a new commit, or reopens.
+It compares the receipt with the pull-request number, current head, and current `AGENTS.md` blob.
+A new implementation commit makes the previous receipt stale until the documentation writer subagent runs again and refreshes the metadata.
+The checker evaluates code-changing pull requests and classifies documentation-only pull requests as not required.
+NemoClaw keeps this check advisory during the data-collection pilot.
+
+<Note>
+A valid receipt does not prove that an agent loaded or understood `AGENTS.md`.
+It records observable workflow compliance that can be compared with documentation outcomes.
+</Note>
+
+### Measure Workflow Adoption
+
+Export receipt data from pull-request descriptions with the authenticated GitHub CLI session.
+The report returns JSON by default and also supports CSV and summary output.
+
+```bash
+npm run docs-review:report -- --since 2026-07-01 --format summary
+```
+
+Use a consistent reporting window and track the following measures:
+
+| Measure | What it shows |
+|---|---|
+| Receipt coverage | The share of eligible code-changing pull requests that contain a receipt. |
+| Valid receipt rate | The share of eligible pull requests whose receipt has one complete and consistent set of fields. |
+| Fresh receipt rate | The share of recorded receipts tied to the pull request's current head. |
+| Result distribution | The number of reviews that updated docs, required no docs, or were blocked. |
+| Agent surface | The agent products and surfaces recorded by valid receipts. |
+| Unclassified pull requests | Pull requests whose Type of Change selection does not establish whether code changed. |
+
+Receipt trends show whether the repository workflow is being followed.
+They do not establish that the instructions caused a documentation improvement.
+Pair the report with accuracy sampling, editorial-intervention rates, and recurring review findings before changing the instruction or making the check required.
 
 ## Use a Layered Architecture
 
@@ -497,6 +559,7 @@ The current NemoClaw repository provides concrete examples for each layer.
 | Variant generation | `scripts/sync-agent-variant-docs.mts`. |
 | Route validation | `scripts/check-docs-published-routes.mts`. |
 | Update workflow | `.agents/skills/nemoclaw-contributor-update-docs/SKILL.md`. |
+| Documentation review receipt | `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/docs-review-receipt.yaml`, and `scripts/docs-review-receipt.mts`. |
 | Information-architecture workflow | `.agents/skills/nemoclaw-maintainer-refactor-docs/SKILL.md`. |
 | Pull-request assurance | Docs link, product parity, and preview workflows under `.github/workflows/`. |
 | Release history | Dated entries under `docs/changelog/` that land before the release tag. |
@@ -515,6 +578,8 @@ Before calling a documentation system agent-ready, confirm the following conditi
 - Routing prompts and skills point to the source instead of copying it.
 - Variant generation is deterministic and variant behavior is tested.
 - Agent workflows define scope, approvals, stop conditions, and completion evidence.
+- Code-changing pull requests record a documentation-review result tied to the pull-request number, current head, and instruction version.
+- New implementation commits invalidate the recorded review until the documentation writer subagent runs again.
 - Pull requests validate generated output, routes, links, product parity, and rendered previews.
 - Release publication uses an approved immutable revision.
 - Retrieval, citation, task, variant, safety, and freshness regressions have repeatable evaluations.

--- a/docs/resources/engineer-agentic-documentation.mdx
+++ b/docs/resources/engineer-agentic-documentation.mdx
@@ -107,7 +107,7 @@ Use the following sequence for a code-changing pull request:
 4. Complete the visible receipt and hidden metadata for the committed head.
 5. Rerun the documentation review after any later commit.
 
-The `CI / Documentation Writer Review` workflow runs when a pull request opens, changes, receives a new commit, or reopens.
+The `CI / Documentation Writer Review` workflow runs when a pull request opens, its description is edited, receives a new commit, or reopens.
 It compares the receipt with the pull-request number, current head, and current `AGENTS.md` blob.
 A new commit makes the previous receipt stale until the documentation writer subagent runs again and refreshes the metadata.
 The checker evaluates code-changing pull requests and classifies documentation-only pull requests as not required.

--- a/scripts/docs-review-receipt.mts
+++ b/scripts/docs-review-receipt.mts
@@ -180,7 +180,7 @@ function evaluateReceipt(
   const { codeChanged, docsChanged } = changes;
   const issues: string[] = [];
 
-  if (codeChanged === null) {
+  if (codeChanged === null || docsChanged === null) {
     issues.push("The PR description does not select one code or documentation-only change type.");
     return {
       agent: parsed.agent,
@@ -199,7 +199,7 @@ function evaluateReceipt(
     };
   }
 
-  if (!codeChanged) {
+  if (!codeChanged && !docsChanged) {
     return {
       agent: parsed.agent,
       agentsBlobSha: parsed.agentsBlobSha,
@@ -218,7 +218,9 @@ function evaluateReceipt(
   }
 
   if (!parsed.present) {
-    issues.push("Code-changing PRs must include the Documentation Writer Review section.");
+    issues.push(
+      "Pull requests that change code or documentation must include the Documentation Writer Review section.",
+    );
   } else {
     if (parsed.duplicateSections) {
       issues.push("The PR description contains more than one Documentation Writer Review section.");
@@ -266,7 +268,7 @@ function evaluateReceipt(
     ? headPrSha.toLowerCase().startsWith(parsed.reviewedHeadSha)
     : null;
   if (headShaMatches === false) {
-    issues.push("The documentation writer review is stale after a new implementation commit.");
+    issues.push("The documentation writer review is stale after a new commit.");
   }
 
   const normalizedAgentsBlob = expectedAgentsBlob?.trim().toLowerCase();
@@ -320,9 +322,9 @@ function parseReceipt(body: string): ParsedReceipt {
   const section = remaining.slice(0, nextHeading?.index ?? remaining.length);
   const lines = section.split(/\r?\n/u).map((line) => line.trim());
   const reviewCheckboxPattern =
-    /^- \[[ xX]\] Documentation writer subagent reviewed the completed implementation$/u;
+    /^- \[[ xX]\] Documentation writer subagent reviewed the completed (?:changes|implementation)$/u;
   const completionPattern =
-    /^- \[[xX]\] Documentation writer subagent reviewed the completed implementation$/u;
+    /^- \[[xX]\] Documentation writer subagent reviewed the completed (?:changes|implementation)$/u;
   const duplicateFields = ["Result", "Evidence", "Agent", "PR"].filter(
     (name) => fieldValues(lines, name).length > 1,
   );
@@ -503,8 +505,16 @@ function formatDate(value: Date): string {
 }
 
 function buildReport(repository: string, since: string, through: string, records: ReportRecord[]) {
-  const eligible = records.filter((record) => record.codeChanged);
-  const unclassified = records.filter((record) => record.codeChanged === null);
+  const eligible = records.filter(
+    (record) => record.codeChanged === true || record.docsChanged === true,
+  );
+  const eligibleCode = eligible.filter((record) => record.codeChanged === true);
+  const eligibleDocsOnly = eligible.filter(
+    (record) => record.codeChanged === false && record.docsChanged === true,
+  );
+  const unclassified = records.filter(
+    (record) => record.codeChanged === null || record.docsChanged === null,
+  );
   const recorded = eligible.filter((record) => record.status !== "missing");
   const valid = eligible.filter((record) => record.status === "valid");
   const fresh = recorded.filter(
@@ -530,7 +540,9 @@ function buildReport(repository: string, since: string, through: string, records
     through,
     metrics: {
       totalPrs: records.length,
-      eligibleCodePrs: eligible.length,
+      eligiblePrs: eligible.length,
+      eligibleCodePrs: eligibleCode.length,
+      eligibleDocsOnlyPrs: eligibleDocsOnly.length,
       unclassifiedPrs: unclassified.length,
       recordedReceipts: recorded.length,
       receiptCoverage: ratio(recorded.length, eligible.length),

--- a/test/docs-review-receipt.test.ts
+++ b/test/docs-review-receipt.test.ts
@@ -25,7 +25,7 @@ function receipt(overrides: Partial<Record<string, string>> = {}): string {
   };
   return `## Documentation Writer Review
 
-- [${values.checked}] Documentation writer subagent reviewed the completed implementation
+- [${values.checked}] Documentation writer subagent reviewed the completed changes
 - Result: ${values.result}
 - Evidence: ${values.evidence}
 - Agent: ${values.agent}
@@ -113,7 +113,7 @@ describe("documentation writer review receipt", () => {
 
     expect(result.status).toBe(0);
     expect(result.output.status).toBe("missing");
-    expect(result.stderr).toContain("Code-changing PRs must include");
+    expect(result.stderr).toContain("change code or documentation must include");
   });
 
   it("fails required mode when a code change has no receipt", () => {
@@ -125,24 +125,59 @@ describe("documentation writer review receipt", () => {
     expect(result.output.status).toBe("missing");
   });
 
-  it("does not require a receipt for a documentation-only change", () => {
-    const result = runCheck("## Summary\n\nUpdate prose.\n", ["README.md", "docs/index.mdx"]);
+  it("accepts a fresh receipt for a documentation-only change", () => {
+    const result = runCheck(receipt(), ["README.md", "docs/index.mdx"]);
 
     expect(result.status).toBe(0);
-    expect(result.output).toMatchObject({ status: "not-required", codeChanged: false });
+    expect(result.output).toMatchObject({
+      status: "valid",
+      codeChanged: false,
+      docsChanged: true,
+    });
+    expect(result.output.issues).toEqual([]);
     expect(result.stderr).toBe("");
   });
 
-  it("does not require a receipt for an MDX file outside docs", () => {
+  it("reports a missing receipt for a documentation-only change", () => {
+    const result = runCheck("## Summary\n\nUpdate prose.\n", ["docs/index.mdx"]);
+
+    expect(result.status).toBe(0);
+    expect(result.output).toMatchObject({
+      status: "missing",
+      codeChanged: false,
+      docsChanged: true,
+    });
+    expect(result.stderr).toContain("change code or documentation must include");
+  });
+
+  it("fails required mode when a documentation-only change has no receipt", () => {
+    const result = runCheck("## Summary\n\nUpdate prose.\n", ["docs/index.mdx"], {
+      mode: "required",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.output.status).toBe("missing");
+  });
+
+  it("requires a receipt for an MDX file outside docs", () => {
     const result = runCheck("## Summary\n\nUpdate prose.\n", ["examples/guide.mdx"]);
 
     expect(result.status).toBe(0);
     expect(result.output).toMatchObject({
-      status: "not-required",
+      status: "missing",
       codeChanged: false,
       docsChanged: true,
     });
-    expect(result.stderr).toBe("");
+    expect(result.stderr).toContain("change code or documentation must include");
+  });
+
+  it("accepts the completed-implementation wording in historical receipts", () => {
+    const result = runCheck(
+      receipt().replace("reviewed the completed changes", "reviewed the completed implementation"),
+      ["src/lib/example.ts", "docs/index.mdx"],
+    );
+
+    expect(result.output.status).toBe("valid");
   });
 
   it("rejects repeated singleton receipt fields", () => {
@@ -160,10 +195,10 @@ describe("documentation writer review receipt", () => {
 
   it("rejects repeated review completion checkboxes", () => {
     const body = receipt().replace(
-      "- [x] Documentation writer subagent reviewed the completed implementation",
+      "- [x] Documentation writer subagent reviewed the completed changes",
       [
-        "- [ ] Documentation writer subagent reviewed the completed implementation",
-        "- [x] Documentation writer subagent reviewed the completed implementation",
+        "- [ ] Documentation writer subagent reviewed the completed changes",
+        "- [x] Documentation writer subagent reviewed the completed changes",
       ].join("\n"),
     );
     const result = runCheck(body, ["src/lib/example.ts", "docs/index.mdx"]);
@@ -190,7 +225,7 @@ describe("documentation writer review receipt", () => {
     expect(result.output.issues).toEqual(
       expect.arrayContaining([
         "The receipt PR number does not match this pull request.",
-        "The documentation writer review is stale after a new implementation commit.",
+        "The documentation writer review is stale after a new commit.",
         "The reviewed AGENTS.md blob SHA does not match the pull request version.",
       ]),
     );
@@ -309,12 +344,14 @@ printf '%s' '${JSON.stringify(pullRequests)}'
       expect(jsonResult.status).toBe(0);
       expect(report.metrics).toEqual({
         totalPrs: 3,
+        eligiblePrs: 3,
         eligibleCodePrs: 2,
+        eligibleDocsOnlyPrs: 1,
         unclassifiedPrs: 0,
         recordedReceipts: 1,
-        receiptCoverage: 0.5,
+        receiptCoverage: 0.3333,
         validReceipts: 1,
-        validReceiptRate: 0.5,
+        validReceiptRate: 0.3333,
         freshReceipts: 1,
         freshReceiptRate: 1,
         results: { blocked: 0, "docs-updated": 1, "no-docs-needed": 0 },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Extends the documentation-writer receipt pilot from code-changing pull requests to documentation-only pull requests so the writer subagent also verifies writing rules and documentation style. The architecture and contributor guidance now describe the shared workflow, exact-head freshness, and code-versus-docs-only adoption metrics.

## Changes

- Require a valid receipt when changed files include code or documentation, while leaving the pilot advisory.
- Count documentation-only pull requests in receipt coverage and report `eligiblePrs`, `eligibleCodePrs`, and `eligibleDocsOnlyPrs`.
- Update the PR template and contributor instructions to require writing-rules and style review for documentation-only changes.
- Preserve the original completed-implementation checkbox wording for historical pilot receipts; the retrospective report is the current consumer, and the focused receipt test protects it.
- Document the receipt workflow, metric meanings, and exact-head refresh behavior in the engineer agentic documentation guide.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. Record this PR number. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `.github/PULL_REQUEST_TEMPLATE.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRIBUTING.md`, and `docs/resources/engineer-agentic-documentation.mdx`; aligned the writing-rules and documentation-style instructions, metric names, checker messages, and test titles.
- Agent: Codex Desktop
- PR: #7400
<!-- docs-review-head-sha: 673851275 -->
<!-- docs-review-agents-blob-sha: 560ff38b2 -->

## DGX Station Hardware Evidence

<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/docs-review-receipt.test.ts` passed 14 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused receipt classifier and report change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
  - Result: Passed with 0 errors; Fern emitted one existing CLI version-upgrade warning.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for making documentation reviews observable through structured pull-request receipts.
  - Documented review requirements for documentation-only changes, including terminology, structure, voice, and code samples.
  - Clarified when reviews become stale and must be rerun after new commits.

- **Workflow Improvements**
  - Documentation review validation now covers both code and documentation changes.
  - Added separate reporting metrics for code-related and documentation-only pull requests.
  - Updated receipt wording and validation guidance for completed changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->