### PR TITLE
fix(ci): ignore irrelevant base-image run history

### DIFF
--- a/test/e2e/support/base-image-publication.test.ts
+++ b/test/e2e/support/base-image-publication.test.ts
@@ -379,6 +379,34 @@ describe("base-image publication evidence", () => {
     expect(selection).toMatchObject({ state: "ready", run: { id: 11, headSha: DESCENDANT_SHA } });
   });
 
+  it("ignores pre-rename workflow metadata outside the eligible history (#7372)", () => {
+    const selection = selectPublicationRun(
+      runsPayload([
+        workflowRun({
+          id: 10,
+          name: "base-image",
+          head_sha: STALE_SHA,
+          html_url: `${RUN_URL.replace(String(RUN_ID), "10")}`,
+        }),
+        workflowRun(),
+      ]),
+      history(),
+      WORKFLOW_ID,
+    );
+
+    expect(selection).toMatchObject({ state: "ready", run: { id: RUN_ID } });
+  });
+
+  it("rejects pre-rename workflow metadata inside the eligible history (#7372)", () => {
+    expect(() =>
+      selectPublicationRun(
+        runsPayload([workflowRun({ name: "base-image" })]),
+        history(),
+        WORKFLOW_ID,
+      ),
+    ).toThrow(/name must be Images \/ Base Images/u);
+  });
+
   it("waits for missing and in-progress publication evidence (#7372)", () => {
     expect(selectPublicationRun(runsPayload([]), history(), WORKFLOW_ID)).toEqual({
       state: "missing",

--- a/tools/e2e/base-image-publication.mts
+++ b/tools/e2e/base-image-publication.mts
@@ -350,7 +350,12 @@ export function selectPublicationRun(
     throw new Error("workflow run listing is incomplete");
   }
 
-  const runs = response.workflow_runs.map((run, index) => validateRun(run, index, workflowId));
+  const runs = response.workflow_runs.flatMap((value, index) => {
+    const run = asRecord(value);
+    return typeof run.head_sha === "string" && history.distanceBySha.has(run.head_sha)
+      ? [validateRun(run, index, workflowId)]
+      : [];
+  });
   if (new Set(runs.map((run) => run.id)).size !== runs.length) {
     throw new Error("workflow run listing contains duplicate run ids");
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Manual E2E runs on `main` failed when the publication verifier encountered historical runs from before the base-image workflow rename. This change validates only runs on the eligible first-parent history while preserving strict provenance checks for every eligible run.

## Changes

- Filter workflow runs by eligible first-parent SHA before validating current workflow metadata.
- Add regression coverage that ignores pre-rename metadata outside the eligible history and rejects it inside the eligible history.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal GitHub Actions evidence selection. It does not change the CLI, configuration, or supported runtime behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Eligible runs retain exact workflow, repository, branch, event, URL, status, and job provenance validation. The regression tests prove that only ineligible history bypasses those checks.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change affects internal CI evidence selection only. No user-facing commands, configuration, schemas, or supported workflows change.
- Agent: Codex CLI
- PR: #7426
<!-- docs-review-head-sha: 061672997 -->
<!-- docs-review-agents-blob-sha: 560ff38b2 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/base-image-publication.test.ts` passed 33 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publication run selection by ignoring workflow runs outside the eligible commit history.
  * Prevented outdated pre-rename workflow metadata from being selected.
  * Added validation to reject eligible runs with an incorrect workflow name.
  * Expanded end-to-end test coverage for workflow history and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->