### PR TITLE
Add Atlas Cloud provider support

### DIFF
--- a/src/lib/actions/inference-set-provider-alias.test.ts
+++ b/src/lib/actions/inference-set-provider-alias.test.ts
@@ -52,6 +52,8 @@ describe("normalizeInferenceSetProvider — facet 1 provider-name drift (#6321)"
     expect(normalizeInferenceSetProvider("openai")).toBe("openai-api");
     expect(normalizeInferenceSetProvider("openrouter")).toBe("openrouter-api");
     expect(normalizeInferenceSetProvider("open-router")).toBe("openrouter-api");
+    expect(normalizeInferenceSetProvider("atlas")).toBe("atlas-cloud");
+    expect(normalizeInferenceSetProvider("atlasCloud")).toBe("atlas-cloud");
     expect(normalizeInferenceSetProvider("custom")).toBe("compatible-endpoint");
     expect(normalizeInferenceSetProvider("ollama")).toBe("ollama-local");
   });

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -145,6 +145,7 @@ const SUPPORTED_PROVIDER_NAMES = [
   "nvidia-router",
   "openai-api",
   "openrouter-api",
+  "atlas-cloud",
   "anthropic-prod",
   "compatible-anthropic-endpoint",
   "gemini-api",
@@ -176,6 +177,8 @@ const INSTALLER_PROVIDER_ALIASES: Readonly<Record<string, string>> = {
   "open-router": "openrouter-api",
   openrouter: "openrouter-api",
   openrouterai: "openrouter-api",
+  atlas: "atlas-cloud",
+  atlascloud: "atlas-cloud",
   anthropic: "anthropic-prod",
   gemini: "gemini-api",
   // Hermes Provider (Nous portal) is reachable under several onboard synonyms;

--- a/src/lib/inference/config.test.ts
+++ b/src/lib/inference/config.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from "vitest";
 
 // Import source directly so tests cannot pass against a stale build.
 import {
+  ATLAS_CLOUD_CREDENTIAL_ENV,
+  ATLAS_CLOUD_DEFAULT_MODEL,
+  ATLAS_CLOUD_MODEL_OPTIONS,
+  ATLAS_CLOUD_PROVIDER_NAME,
   CLOUD_MODEL_OPTIONS,
   coerceAgentInferenceApi,
   DEFAULT_CLOUD_MODEL,
@@ -136,6 +140,14 @@ describe("inference selection config", () => {
     expect(HERMES_PROVIDER_MODEL_OPTIONS.length).toBeGreaterThan(10);
   });
 
+  it("exposes the Atlas Cloud OpenAI-compatible model defaults", () => {
+    expect(ATLAS_CLOUD_DEFAULT_MODEL).toBe("qwen/qwen3.5-flash");
+    expect([...ATLAS_CLOUD_MODEL_OPTIONS]).toEqual([
+      "qwen/qwen3.5-flash",
+      "deepseek-ai/deepseek-v4-pro",
+    ]);
+  });
+
   it.each([
     "z-ai/glm-5.1",
     "moonshotai/kimi-k2.6",
@@ -210,6 +222,18 @@ describe("inference selection config", () => {
       provider: "openrouter-api",
       providerLabel: "OpenRouter",
     });
+    expect(
+      getProviderSelectionConfig(ATLAS_CLOUD_PROVIDER_NAME, "deepseek-ai/deepseek-v4-pro"),
+    ).toEqual({
+      endpointType: "custom",
+      endpointUrl: INFERENCE_ROUTE_URL,
+      ncpPartner: null,
+      model: "deepseek-ai/deepseek-v4-pro",
+      profile: DEFAULT_ROUTE_PROFILE,
+      credentialEnv: ATLAS_CLOUD_CREDENTIAL_ENV,
+      provider: ATLAS_CLOUD_PROVIDER_NAME,
+      providerLabel: "Atlas Cloud",
+    });
     expect(getProviderSelectionConfig("anthropic-prod", "claude-sonnet-4-6")).toEqual(
       expect.objectContaining({ model: "claude-sonnet-4-6", providerLabel: "Anthropic" }),
     );
@@ -264,6 +288,7 @@ describe("inference selection config", () => {
       "nvidia-nim",
       "openai-api",
       "openrouter-api",
+      ATLAS_CLOUD_PROVIDER_NAME,
       "anthropic-prod",
       "compatible-anthropic-endpoint",
       "gemini-api",
@@ -299,6 +324,9 @@ describe("inference selection config", () => {
   it("falls back to provider defaults when model is omitted", () => {
     expect(getProviderSelectionConfig("openai-api")?.model).toBe("gpt-5.4");
     expect(getProviderSelectionConfig("openrouter-api")?.model).toBe(DEFAULT_CLOUD_MODEL);
+    expect(getProviderSelectionConfig(ATLAS_CLOUD_PROVIDER_NAME)?.model).toBe(
+      ATLAS_CLOUD_DEFAULT_MODEL,
+    );
     expect(getProviderSelectionConfig("anthropic-prod")?.model).toBe("claude-sonnet-4-6");
     expect(getProviderSelectionConfig("gemini-api")?.model).toBe("gemini-2.5-flash");
     expect(getProviderSelectionConfig("compatible-endpoint")?.model).toBe("custom-model");
@@ -392,6 +420,18 @@ describe("getSandboxInferenceConfig", () => {
     expect(getSandboxInferenceConfig("moonshotai/kimi-k2.6", "openrouter-api")).toEqual({
       providerKey: MANAGED_PROVIDER_ID,
       primaryModelRef: `${MANAGED_PROVIDER_ID}/moonshotai/kimi-k2.6`,
+      inferenceBaseUrl: INFERENCE_ROUTE_URL,
+      inferenceApi: "openai-completions",
+      inferenceCompat: {
+        supportsStore: false,
+      },
+    });
+  });
+
+  it("maps Atlas Cloud to the managed inference provider with store disabled", () => {
+    expect(getSandboxInferenceConfig("qwen/qwen3.5-flash", ATLAS_CLOUD_PROVIDER_NAME)).toEqual({
+      providerKey: MANAGED_PROVIDER_ID,
+      primaryModelRef: `${MANAGED_PROVIDER_ID}/qwen/qwen3.5-flash`,
       inferenceBaseUrl: INFERENCE_ROUTE_URL,
       inferenceApi: "openai-completions",
       inferenceCompat: {

--- a/src/lib/inference/config.ts
+++ b/src/lib/inference/config.ts
@@ -14,6 +14,14 @@ export const INFERENCE_ROUTE_URL = "https://inference.local/v1";
 export const NOUS_RECOMMENDED_MODELS_URL =
   "https://portal.nousresearch.com/api/nous/recommended-models";
 export const DEFAULT_CLOUD_MODEL = "nvidia/nemotron-3-super-120b-a12b";
+export const ATLAS_CLOUD_PROVIDER_NAME = "atlas-cloud";
+export const ATLAS_CLOUD_ENDPOINT_URL = "https://api.atlascloud.ai/v1";
+export const ATLAS_CLOUD_CREDENTIAL_ENV = "ATLASCLOUD_API_KEY";
+export const ATLAS_CLOUD_MODEL_OPTIONS = [
+  "qwen/qwen3.5-flash",
+  "deepseek-ai/deepseek-v4-pro",
+] as const;
+export const ATLAS_CLOUD_DEFAULT_MODEL = ATLAS_CLOUD_MODEL_OPTIONS[0];
 // Fallback context window used when no per-model value is known. Cloud providers
 // have no per-model context metadata today (CLOUD_MODEL_OPTIONS carries only
 // id/label), so they fall back to this; matches the onboarding build default in
@@ -166,6 +174,13 @@ export function getProviderSelectionConfig(
         credentialEnv: OPENROUTER_CREDENTIAL_ENV,
         providerLabel: "OpenRouter",
       };
+    case ATLAS_CLOUD_PROVIDER_NAME:
+      return {
+        ...base,
+        model: model || ATLAS_CLOUD_DEFAULT_MODEL,
+        credentialEnv: ATLAS_CLOUD_CREDENTIAL_ENV,
+        providerLabel: "Atlas Cloud",
+      };
     case "anthropic-prod":
       return {
         ...base,
@@ -268,6 +283,7 @@ export function getSandboxInferenceConfig(
       break;
     case "gemini-api":
     case OPENROUTER_PROVIDER_NAME:
+    case ATLAS_CLOUD_PROVIDER_NAME:
     case "hermes-provider":
       providerKey = MANAGED_PROVIDER_ID;
       primaryModelRef = `${MANAGED_PROVIDER_ID}/${model}`;

--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -168,12 +168,14 @@ describe("inference health", () => {
 
     it("invokes Atlas Cloud chat-completions with ATLASCLOUD_API_KEY", () => {
       let capturedArgv: string[] = [];
+      let capturedProbeOptions: { trustedConfigFiles?: readonly string[] } | undefined;
       const result = probeRemoteProviderHealth("atlas-cloud", {
         model: "qwen/qwen3.5-flash",
         getCredentialImpl: (envName) =>
           envName === "ATLASCLOUD_API_KEY" ? "atlas-test-secret" : null,
-        runCurlProbeImpl: (argv) => {
+        runCurlProbeImpl: (argv, options) => {
           capturedArgv = argv;
+          capturedProbeOptions = options;
           return httpOk();
         },
       });
@@ -184,6 +186,8 @@ describe("inference health", () => {
       expect(result?.endpoint).toBe("https://api.atlascloud.ai/v1/chat/completions");
       expect(capturedArgv.at(-1)).toBe("https://api.atlascloud.ai/v1/chat/completions");
       expect(capturedArgv.join(" ")).not.toContain("atlas-test-secret");
+      expect(capturedProbeOptions?.trustedConfigFiles).toEqual(expect.any(Array));
+      expect(capturedProbeOptions?.trustedConfigFiles?.length).toBeGreaterThan(0);
       const payload = JSON.parse(capturedArgv[capturedArgv.indexOf("-d") + 1]);
       expect(payload.model).toBe("qwen/qwen3.5-flash");
     });

--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -166,6 +166,28 @@ describe("inference health", () => {
       expect(result?.detail).toContain("GEMINI_API_KEY");
     });
 
+    it("invokes Atlas Cloud chat-completions with ATLASCLOUD_API_KEY", () => {
+      let capturedArgv: string[] = [];
+      const result = probeRemoteProviderHealth("atlas-cloud", {
+        model: "qwen/qwen3.5-flash",
+        getCredentialImpl: (envName) =>
+          envName === "ATLASCLOUD_API_KEY" ? "atlas-test-secret" : null,
+        runCurlProbeImpl: (argv) => {
+          capturedArgv = argv;
+          return httpOk();
+        },
+      });
+
+      expect(result?.ok).toBe(true);
+      expect(result?.probed).toBe(true);
+      expect(result?.providerLabel).toBe("Atlas Cloud");
+      expect(result?.endpoint).toBe("https://api.atlascloud.ai/v1/chat/completions");
+      expect(capturedArgv.at(-1)).toBe("https://api.atlascloud.ai/v1/chat/completions");
+      expect(capturedArgv.join(" ")).not.toContain("atlas-test-secret");
+      const payload = JSON.parse(capturedArgv[capturedArgv.indexOf("-d") + 1]);
+      expect(payload.model).toBe("qwen/qwen3.5-flash");
+    });
+
     it("probes non-Kimi NVIDIA models with a real chat-completions invocation (Stage A generalization)", () => {
       let capturedArgv: string[] = [];
       const result = probeRemoteProviderHealth("nvidia-prod", {

--- a/src/lib/inference/health.ts
+++ b/src/lib/inference/health.ts
@@ -13,7 +13,11 @@ import { createBearerAuthConfig, createXApiKeyAuthConfig } from "../adapters/htt
 import type { CurlProbeOptions, CurlProbeResult } from "../adapters/http/probe";
 import { runCurlProbe } from "../adapters/http/probe";
 import { normalizeCredentialValue, resolveProviderCredential } from "../credentials/store";
-import { getProviderSelectionConfig } from "./config";
+import {
+  ATLAS_CLOUD_ENDPOINT_URL,
+  ATLAS_CLOUD_PROVIDER_NAME,
+  getProviderSelectionConfig,
+} from "./config";
 import type { LocalProviderHealthProbeOptions } from "./local";
 import { probeLocalProviderHealth } from "./local";
 import { getChatCompletionsProbeCurlArgs } from "./onboard-probes";
@@ -597,6 +601,16 @@ export function probeRemoteProviderHealth(
       config.model,
       config.credentialEnv,
       GEMINI_CHAT_COMPLETIONS_ENDPOINT,
+      options,
+    );
+  }
+
+  if (provider === ATLAS_CLOUD_PROVIDER_NAME) {
+    return probeChatCompletionsProviderHealth(
+      providerLabel,
+      config.model,
+      config.credentialEnv,
+      `${ATLAS_CLOUD_ENDPOINT_URL}/chat/completions`,
       options,
     );
   }

--- a/src/lib/inference/model-prompts.test.ts
+++ b/src/lib/inference/model-prompts.test.ts
@@ -204,6 +204,25 @@ describe("model prompt helpers", () => {
     expect(result).toBe("gpt-5.4-mini");
   });
 
+  it("offers Atlas Cloud curated remote models", async () => {
+    const writeLine = vi.fn();
+    const result = await promptRemoteModel(
+      "Atlas Cloud",
+      "atlasCloud",
+      "qwen/qwen3.5-flash",
+      null,
+      {
+        promptFn: promptSequence(["2"]),
+        writeLine,
+      },
+    );
+
+    expect(result).toBe("deepseek-ai/deepseek-v4-pro");
+    expect(writeLine).toHaveBeenCalledWith("  Atlas Cloud models:");
+    expect(writeLine).toHaveBeenCalledWith("    1) qwen/qwen3.5-flash");
+    expect(writeLine).toHaveBeenCalledWith("    2) deepseek-ai/deepseek-v4-pro");
+  });
+
   it("treats non-numeric curated selections as manual-entry fallback", async () => {
     const result = await promptRemoteModel("OpenAI", "openai", "gpt-5.4-mini", null, {
       promptFn: promptSequence(["abc", "custom-model"]),

--- a/src/lib/inference/model-prompts.ts
+++ b/src/lib/inference/model-prompts.ts
@@ -3,7 +3,11 @@
 
 import { BACK_TO_SELECTION, type BackToSelection } from "../navigation";
 import { isSafeModelId } from "../validation";
-import { CLOUD_MODEL_OPTIONS, HERMES_PROVIDER_MODEL_OPTIONS } from "./config";
+import {
+  ATLAS_CLOUD_MODEL_OPTIONS,
+  CLOUD_MODEL_OPTIONS,
+  HERMES_PROVIDER_MODEL_OPTIONS,
+} from "./config";
 import { validateNvidiaEndpointModel } from "./provider-models";
 
 export { promptVllmModel, type VllmModelPromptOptions } from "./vllm-prompt";
@@ -26,6 +30,7 @@ export const REMOTE_MODEL_OPTIONS: Record<string, string[]> = {
     "gemini-2.5-flash",
     "gemini-2.5-flash-lite",
   ],
+  atlasCloud: [...ATLAS_CLOUD_MODEL_OPTIONS],
   hermesProvider: [...HERMES_PROVIDER_MODEL_OPTIONS],
 };
 

--- a/src/lib/onboard/openrouter-selection.test.ts
+++ b/src/lib/onboard/openrouter-selection.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { isOpenAiLikeRemoteProvider } from "./openrouter-selection";
+
+describe("remote OpenAI-like provider helpers", () => {
+  it.each([
+    "openai",
+    "gemini",
+    "openrouter",
+    "atlasCloud",
+  ])("treats %s as OpenAI-compatible for remote model validation", (providerKey) => {
+    expect(isOpenAiLikeRemoteProvider(providerKey)).toBe(true);
+  });
+
+  it.each([
+    "anthropic",
+    "anthropicCompatible",
+    "custom",
+  ])("does not treat %s as a curated OpenAI-like remote provider", (providerKey) => {
+    expect(isOpenAiLikeRemoteProvider(providerKey)).toBe(false);
+  });
+});

--- a/src/lib/onboard/openrouter-selection.ts
+++ b/src/lib/onboard/openrouter-selection.ts
@@ -32,7 +32,12 @@ export function isOpenRouterProvider(selectedKey: string): boolean {
 }
 
 export function isOpenAiLikeRemoteProvider(selectedKey: string): boolean {
-  return selectedKey === "openai" || selectedKey === "gemini" || isOpenRouterProvider(selectedKey);
+  return (
+    selectedKey === "openai" ||
+    selectedKey === "gemini" ||
+    selectedKey === "atlasCloud" ||
+    isOpenRouterProvider(selectedKey)
+  );
 }
 
 export function credentialValidatorForProvider(

--- a/src/lib/onboard/providers.test.ts
+++ b/src/lib/onboard/providers.test.ts
@@ -137,6 +137,29 @@ describe("onboard provider helpers", () => {
     ).toContain("OPENAI_BASE_URL=https://openrouter.ai/api/v1");
   });
 
+  it("registers Atlas Cloud with an OpenAI-compatible provider profile and aliases", () => {
+    const provider = REMOTE_PROVIDER_CONFIG.atlasCloud;
+
+    expect(provider).toMatchObject({
+      providerName: "atlas-cloud",
+      providerType: "openai",
+      credentialEnv: "ATLASCLOUD_API_KEY",
+    });
+    expect(NON_INTERACTIVE_PROVIDER_KEYS.has("atlasCloud")).toBe(true);
+    expect(NON_INTERACTIVE_PROVIDER_ALIASES.atlas).toBe("atlasCloud");
+    expect(NON_INTERACTIVE_PROVIDER_ALIASES["atlas-cloud"]).toBe("atlasCloud");
+    expect(NON_INTERACTIVE_PROVIDER_ALIASES.atlascloud).toBe("atlasCloud");
+    expect(
+      buildProviderArgs(
+        "create",
+        provider.providerName,
+        provider.providerType,
+        provider.credentialEnv,
+        "https://api.atlascloud.ai/v1",
+      ),
+    ).toContain("OPENAI_BASE_URL=https://api.atlascloud.ai/v1");
+  });
+
   it("keeps the discovery profile Anthropic before agent-specific surface selection (#6289)", () => {
     const provider = REMOTE_PROVIDER_CONFIG.anthropicCompatible;
 
@@ -474,6 +497,7 @@ describe("onboard provider helpers", () => {
 
   it.each([
     "anthropic",
+    "atlas-cloud",
     "build",
     "cloud",
     "custom",

--- a/src/lib/onboard/providers.test.ts
+++ b/src/lib/onboard/providers.test.ts
@@ -32,6 +32,7 @@ const {
       providerName: string;
       providerType: string;
       credentialEnv: string;
+      endpointUrl: string;
     }
   >;
   buildProviderArgs: (
@@ -145,6 +146,7 @@ describe("onboard provider helpers", () => {
       providerType: "openai",
       credentialEnv: "ATLASCLOUD_API_KEY",
     });
+    expect(provider.endpointUrl).toBe("https://api.atlascloud.ai/v1");
     expect(NON_INTERACTIVE_PROVIDER_KEYS.has("atlasCloud")).toBe(true);
     expect(NON_INTERACTIVE_PROVIDER_ALIASES.atlas).toBe("atlasCloud");
     expect(NON_INTERACTIVE_PROVIDER_ALIASES["atlas-cloud"]).toBe("atlasCloud");
@@ -155,7 +157,7 @@ describe("onboard provider helpers", () => {
         provider.providerName,
         provider.providerType,
         provider.credentialEnv,
-        "https://api.atlascloud.ai/v1",
+        provider.endpointUrl,
       ),
     ).toContain("OPENAI_BASE_URL=https://api.atlascloud.ai/v1");
   });

--- a/src/lib/onboard/providers.ts
+++ b/src/lib/onboard/providers.ts
@@ -7,6 +7,10 @@
 const { redact } = require("../runner");
 const { normalizeCredentialValue } = require("../credentials/store");
 const {
+  ATLAS_CLOUD_CREDENTIAL_ENV,
+  ATLAS_CLOUD_DEFAULT_MODEL,
+  ATLAS_CLOUD_ENDPOINT_URL,
+  ATLAS_CLOUD_PROVIDER_NAME,
   DEFAULT_CLOUD_MODEL,
   DEFAULT_HERMES_PROVIDER_MODEL,
   OLLAMA_LOCAL_CREDENTIAL_ENV,
@@ -43,6 +47,9 @@ const NON_INTERACTIVE_PROVIDER_ALIASES = {
   vllm: "vllm",
   "open-router": "openrouter",
   openrouterai: "openrouter",
+  atlas: "atlasCloud",
+  "atlas-cloud": "atlasCloud",
+  atlascloud: "atlasCloud",
   anthropiccompatible: "anthropicCompatible",
   hermes: "hermesProvider",
   "hermes-provider": "hermesProvider",
@@ -53,6 +60,7 @@ const NON_INTERACTIVE_PROVIDER_ALIASES = {
 const NON_INTERACTIVE_PROVIDER_KEYS = new Set([
   "build",
   "openrouter",
+  "atlasCloud",
   "openai",
   "anthropic",
   "anthropicCompatible",
@@ -69,7 +77,7 @@ const NON_INTERACTIVE_PROVIDER_KEYS = new Set([
   "start-windows-ollama",
 ]);
 const NON_INTERACTIVE_PROVIDER_VALID_VALUES =
-  "Valid values: build, openrouter, openai, anthropic, anthropicCompatible, gemini, hermes-provider, ollama, custom, nim-local, vllm, routed, install-vllm, install-ollama, install-windows-ollama, start-windows-ollama";
+  "Valid values: build, openrouter, atlas-cloud, openai, anthropic, anthropicCompatible, gemini, hermes-provider, ollama, custom, nim-local, vllm, routed, install-vllm, install-ollama, install-windows-ollama, start-windows-ollama";
 const PROVIDER_KEY_ROUTE_VALUES = new Set(
   [
     "inference",
@@ -99,6 +107,17 @@ const REMOTE_PROVIDER_CONFIG = {
     helpUrl: openrouter.OPENROUTER_HELP_URL,
     modelMode: "catalog",
     defaultModel: DEFAULT_CLOUD_MODEL,
+    skipVerify: true,
+  },
+  atlasCloud: {
+    label: "Atlas Cloud",
+    providerName: ATLAS_CLOUD_PROVIDER_NAME,
+    providerType: "openai",
+    credentialEnv: ATLAS_CLOUD_CREDENTIAL_ENV,
+    endpointUrl: ATLAS_CLOUD_ENDPOINT_URL,
+    helpUrl: "https://www.atlascloud.ai/console/api-keys",
+    modelMode: "curated",
+    defaultModel: ATLAS_CLOUD_DEFAULT_MODEL,
     skipVerify: true,
   },
   openai: {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -436,6 +436,10 @@ describe("shouldSkipResponsesProbe", () => {
     expect(shouldSkipResponsesProbe("openrouter-api")).toBe(true);
   });
 
+  it("skips the Responses probe for atlas-cloud (Atlas Cloud uses Chat Completions here)", () => {
+    expect(shouldSkipResponsesProbe("atlas-cloud")).toBe(true);
+  });
+
   it("does not skip the Responses probe for other providers", () => {
     expect(shouldSkipResponsesProbe("openai-api")).toBe(false);
     expect(shouldSkipResponsesProbe("anthropic-prod")).toBe(false);

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -321,7 +321,8 @@ export function shouldSkipResponsesProbe(provider: string): boolean {
     provider === "nvidia-prod" ||
     provider === "nvidia-nim" ||
     provider === "gemini-api" ||
-    provider === "openrouter-api"
+    provider === "openrouter-api" ||
+    provider === "atlas-cloud"
   );
 }
 

--- a/test/onboard-resume-provider-recovery.test.ts
+++ b/test/onboard-resume-provider-recovery.test.ts
@@ -81,6 +81,7 @@ describe("providerNameToOptionKey", () => {
     expect(providerNameToOptionKey("openai-api")).toBe("openai");
     expect(providerNameToOptionKey("anthropic-prod")).toBe("anthropic");
     expect(providerNameToOptionKey("gemini-api")).toBe("gemini");
+    expect(providerNameToOptionKey("atlas-cloud")).toBe("atlasCloud");
     expect(providerNameToOptionKey("compatible-endpoint")).toBe("custom");
     expect(providerNameToOptionKey("compatible-anthropic-endpoint")).toBe("anthropicCompatible");
   });


### PR DESCRIPTION
## Summary

- Add Atlas Cloud as an OpenAI-compatible remote provider for onboarding and `inference set`.
- Register `ATLASCLOUD_API_KEY`, `https://api.atlascloud.ai/v1`, and curated defaults for `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.
- Route Atlas Cloud through the managed Chat Completions path, skip unsupported Responses probes, and add health/model prompt/recovery coverage.

No README, docs, logo, sponsorship, credits, or partner-promotion changes are included.

## Testing

- `npx vitest run src/lib/inference/config.test.ts src/lib/inference/model-prompts.test.ts src/lib/inference/health.test.ts src/lib/onboard/providers.test.ts src/lib/onboard/openrouter-selection.test.ts src/lib/actions/inference-set-provider-alias.test.ts src/lib/validation.test.ts test/onboard-resume-provider-recovery.test.ts --project cli` (277 passed)
- `npx @biomejs/biome lint` on changed files
- `npm run typecheck`
- `npm run typecheck:cli`
- `npm run build:cli`
- `git diff --check`
- Atlas Cloud live `/v1/models` catalog returned 121 models and confirmed `qwen/qwen3.5-flash` plus `deepseek-ai/deepseek-v4-pro`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as a supported inference provider, including onboarding support with provider aliases and curated model selection.
  * Added Atlas Cloud routing and model prompt support for OpenAI-compatible chat-completions requests.
* **Bug Fixes**
  * Improved provider-name normalization for Atlas Cloud aliases to ensure consistent downstream selection.
  * Added/extended health-check coverage for Atlas Cloud and ensured Responses API probes are skipped where unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->