### PR TITLE
docs: add v0.0.93 release changelog

### DIFF
--- a/docs/changelog/2026-07-23.mdx
+++ b/docs/changelog/2026-07-23.mdx
@@ -1,0 +1,32 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.93
+
+NemoClaw v0.0.93 updates DGX Station and DGX Spark onboarding, adds resumable managed vLLM download guidance, preserves installer cancellation status, rejects Intel macOS before downloads, and strengthens release validation.
+
+- DGX Station Express now recognizes the stock no-OTA DGX OS `7.6.x` workstation family when its release marker proves the expected GB300 lineage.
+  The existing hardware, driver, ECC, Docker, CDI, and container GPU checks still apply, and future release families remain fail-closed.
+  Stock DGX OS and AI Developer Tools profiles can keep an idle PackageKit daemon because those paths preserve factory packages, but active or malformed package transactions still block preparation.
+  Full Station Express end-to-end qualification for the accepted no-OTA DGX OS `7.6.x` profile remains pending.
+  For more information, refer to [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation) and [Platform Support and Launch Claims](/user-guide/openclaw/reference/platform-support).
+- When Station Express detects an existing vLLM workload, NemoClaw leaves the workload unchanged and reports an exact manual stop command.
+  The default choice preserves the managed Express recipe and prints an exact revision-pinned resume command.
+  The alternative keeps the running vLLM and continues through advanced manual Local vLLM setup while preserving the selected installer revision and ports across a login handoff or interrupted retry.
+  A non-interactive run preserves Express and does not change the host.
+  For more information, refer to [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation) and the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart).
+- Managed vLLM onboarding now explains optional Hugging Face read-token authentication before large public-model downloads.
+  NemoClaw passes the token only to the temporary downloader, sanitizes downloader output across standard output and standard error, and prints resumable HTTP `429` recovery steps that reuse the existing cache.
+  On DGX Spark, non-interactive onboarding with no requested or recorded provider now selects a running local vLLM first, then managed vLLM, and then NVIDIA Endpoints when neither local option is available.
+  DGX Station and other hosts keep their existing unset-provider behavior.
+  For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm) and the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart).
+- The public installer now rejects Intel macOS before it resolves a release reference or performs network work, and it reports that macOS requires Apple Silicon.
+  Pressing Ctrl+C at a hidden onboarding credential prompt now preserves exit status `130` and resumable-session guidance without printing the rejected prompt error or a Node.js stack.
+  For more information, refer to [Platform Support and Launch Claims](/user-guide/openclaw/reference/platform-support) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Release validation now waits for the relevant base image before final-main E2E fanout, tests the staging Brev Launchable, centralizes larger-runner selection, and retries one confirmed hosted-runner loss.
+  E2E runs also publish semantic phase durations and runner-comparison telemetry while ignoring base-image run history that cannot affect the candidate.
+  These controls separate infrastructure loss from product failures and keep candidate validation tied to the image under test.
+- Documentation checks now require a documentation-writer receipt for docs-only PRs and record the matching PR without redundant receipt metadata.
+  Quickstart platform guidance and inference command references now match the supported CLI paths, and the historical v0.0.91 audit follow-up remains part of the canonical changelog.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the canonical dated `## v0.0.93` release entry to `docs/changelog/2026-07-23.mdx`.
The entry records user-visible behavior, release validation, and documentation controls merged after `v0.0.92`, while preserving the pending DGX OS `7.6.x` Station Express qualification caveat.

## Changes

- Adds the parser-safe dated release entry with a summary, grouped details, and published-route links.
- Reconciles the `v0.0.92..origin/main` commit range with merged `v0.0.93` PRs.
- Records that no-OTA DGX OS `7.6.x` passed bounded host preflight, while full Station Express end-to-end qualification remains pending.
- Leaves existing product pages unchanged because the source PRs already document their supported behavior.

### Source summary

- #7285 -> `docs/changelog/2026-07-23.mdx`: Records the existing-vLLM ownership choice and resumable Station handoff.
- #7419 -> `docs/changelog/2026-07-23.mdx`: Records bounded no-OTA DGX OS `7.6.x` recognition and its pending end-to-end qualification.
- #7268 -> `docs/changelog/2026-07-23.mdx`: Records optional Hugging Face authentication, output sanitization, and resumable HTTP `429` recovery.
- #7442 -> `docs/changelog/2026-07-23.mdx`: Records clean SIGINT handling at hidden credential prompts.
- #7299 -> `docs/changelog/2026-07-23.mdx`: Records Intel macOS rejection before ref resolution or network work.
- #7296 -> `docs/changelog/2026-07-23.mdx`: Records the DGX Spark non-interactive local-vLLM selection order.
- #7342 -> `docs/changelog/2026-07-23.mdx`: Records delegated protected E2E approvals in the grouped release-validation bullet.
- #7373 -> `docs/changelog/2026-07-23.mdx`: Records base-image publication gating before final-main fanout.
- #7388 -> `docs/changelog/2026-07-23.mdx`: Records semantic phase runtime summaries.
- #7397 -> `docs/changelog/2026-07-23.mdx`: Records progress coverage hardening.
- #7391 -> `docs/changelog/2026-07-23.mdx`: Records centralized larger-runner routing.
- #7423 -> `docs/changelog/2026-07-23.mdx`: Records one retry for confirmed hosted-runner loss.
- #7399 -> `docs/changelog/2026-07-23.mdx`: Records runner-comparison telemetry.
- #7270 -> `docs/changelog/2026-07-23.mdx`: Records staging Brev Launchable validation.
- #7426 -> `docs/changelog/2026-07-23.mdx`: Records filtering of irrelevant base-image run history.
- #7333 -> `docs/changelog/2026-07-23.mdx`: Records aligned Quickstart platform guidance.
- #7343 -> `docs/changelog/2026-07-23.mdx`: Records documentation-writer receipt collection.
- #7400 -> `docs/changelog/2026-07-23.mdx`: Records the documentation-writer receipt requirement for docs-only PRs.
- #7413 -> `docs/changelog/2026-07-23.mdx`: Records removal of redundant receipt PR metadata.
- #7405 -> `docs/changelog/2026-07-23.mdx`: Records corrected inference CLI references.
- #7389 -> `docs/changelog/2026-07-23.mdx`: Records completion of the v0.0.91 documentation audit.

`#7384` is an internal refactor with no intended runtime behavior change.
`#7401` updates internal CodeQL Actions dependencies.
`#7376` is already contained in `v0.0.92`, so it is outside the release-entry scan range despite its retained planning label.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates dated changelog structure, SPDX syntax, and version headings.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `docs/changelog/2026-07-23.mdx` against `WRITING.md`, `docs/CONTRIBUTING.md`, `docs/.docs-skip`, `docs/index.yml`, the six user-visible source PRs, and the remaining grouped release commits. The review corrected an ambiguous qualification claim, confirmed all published routes, preserved the DGX OS `7.6.x` caveat, and found no remaining action.
- Agent: Codex Desktop
<!-- docs-review-head-sha: ec0a866ea -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable. This PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts`: 1 file and 6 tests passed.
- [ ] Applicable broad gate passed — Not applicable to one native changelog file.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — not applicable because native changelog entries use a parser-safe MDX SPDX comment without frontmatter.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the v0.0.93 changelog covering onboarding and validation improvements.
  * Documented support for additional DGX Station Express workstation releases and clearer handling of existing vLLM workloads.
  * Added guidance for optional Hugging Face authentication, resumable rate-limit recovery, and DGX Spark provider selection.
  * Clarified installer behavior on Intel macOS, release validation requirements, hosted-runner retries, documentation checks, and supported CLI quickstart paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->