### PR TITLE
fix(ci): tolerate absent Fern previews

### DIFF
--- a/.github/workflows/docs-publish-staging.yaml
+++ b/.github/workflows/docs-publish-staging.yaml
@@ -130,6 +130,14 @@ jobs:
               continue
             fi
             preview_url="https://${FERN_ORG}-preview-${preview_id}.docs.buildwithfern.com${INSTANCE_PATH}"
-            npx --yes "fern-api@${FERN_VERSION}" docs preview delete "$preview_url"
+            if ! delete_output=$(npx --yes "fern-api@${FERN_VERSION}" docs preview delete "$preview_url" 2>&1); then
+              if grep -Fxq "Domain not registered" <<< "$delete_output"; then
+                echo "::notice::Fern preview ${preview_id} does not exist."
+                continue
+              fi
+              printf '%s\n' "$delete_output" >&2
+              exit 1
+            fi
+            printf '%s\n' "$delete_output"
             echo "Deleted Fern preview ${preview_id}."
           done <<< "$PREVIEW_IDS"

--- a/test/docs-publish-staging-workflow.test.ts
+++ b/test/docs-publish-staging-workflow.test.ts
@@ -75,4 +75,42 @@ describe("staging docs preview cleanup", () => {
       rmSync(temp, { force: true, recursive: true });
     }
   });
+
+  it.each([
+    [0, "Domain not registered", "Fern preview pr-123 does not exist."],
+    [1, "Authentication failed", "Authentication failed"],
+  ])("returns exit status %i when Fern reports %s", (expectedStatus, fernError, expectedOutput) => {
+    const deleteStep = requiredStep(workflow.jobs["delete-preview"]?.steps, "Delete Fern previews");
+    const temp = mkdtempSync(join(tmpdir(), "nemoclaw-fern-preview-cleanup-error-"));
+    const fakeBin = join(temp, "bin");
+    mkdirSync(fakeBin);
+    writeFileSync(
+      join(fakeBin, "npx"),
+      [
+        "#!/usr/bin/env node",
+        "process.stderr.write(`${process.env.FERN_ERROR}\\n`);",
+        "process.exit(1);",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    try {
+      const result = spawnSync("bash", ["-c", deleteStep.run ?? ""], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FERN_ERROR: fernError,
+          FERN_STAGING_INSTANCE: "nvidia-nemoclaw-staging.docs.buildwithfern.com/nemoclaw",
+          FERN_TOKEN: "test-token",
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          PREVIEW_IDS: "pr-123",
+        },
+      });
+
+      expect(result.status).toBe(expectedStatus);
+      expect(`${result.stdout}${result.stderr}`).toContain(expectedOutput);
+    } finally {
+      rmSync(temp, { force: true, recursive: true });
+    }
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Post-merge docs cleanup now treats Fern's `Domain not registered` response as an already-absent preview. Other Fern deletion failures continue to fail the workflow.

## Changes

- Capture Fern preview deletion output and accept only the exact missing-domain result.
- Keep authentication, network, and other Fern failures blocking.
- Add regression coverage for an absent preview and a non-absence deletion error.
- Record the escaped-defect cause: cleanup inferred a preview from the merged PR association, while fork PRs can validate docs without creating a preview. The previous test covered only successful deletion URL construction.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes post-merge CI cleanup only. It does not change user-facing behavior, commands, configuration, schemas, or supported product contracts.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change only makes post-merge Fern preview deletion idempotent for an absent preview. It does not change user-facing behavior, CLI output, configuration, schemas, or supported product contracts.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1add6cc2a -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/docs-publish-staging-workflow.test.ts` — 1 file and 4 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Staging documentation preview cleanup now continues when a preview domain is already unregistered.
  * Other deletion errors still stop the workflow and display the relevant error details.

* **Tests**
  * Added coverage for handling expected preview deletion errors and preserving failures for unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->