### PR TITLE
fix(ci): clean up canonical retry reservations

### DIFF
--- a/test/pr-e2e-gate-runner-loss-retry.test.ts
+++ b/test/pr-e2e-gate-runner-loss-retry.test.ts
@@ -35,6 +35,11 @@ const JOB_LOG_RANGE_BYTES = 64 * 1024;
 const RUNNER_SHUTDOWN_MESSAGE =
   "The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.";
 const EXIT_143_MESSAGE = "Process completed with exit code 143.";
+const RESERVED_CHECK_OUTPUT = {
+  title: "Waiting for PR CI",
+  summary:
+    "This PR SHA and base SHA are reserved for deterministic E2E planning after CI completes.",
+};
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -1093,9 +1098,17 @@ describe("PR E2E one-time hosted-runner-loss retry", () => {
   });
 
   it.each([
-    { label: "before reservation", replacement: false },
-    { label: "after a create response is lost", replacement: true },
-  ])("terminalizes retry setup $label with older retryable history", async ({ replacement }) => {
+    { label: "before reservation", replacement: false, replacementDetailsUrl: null },
+    { label: "after a lost create response", replacement: true, replacementDetailsUrl: null },
+    {
+      label: "after a create response is lost with GitHub's self check URL",
+      replacement: true,
+      replacementDetailsUrl: "https://github.com/NVIDIA/NemoClaw/runs/18",
+    },
+  ])("terminalizes retry setup $label with older retryable history", async ({
+    replacement,
+    replacementDetailsUrl,
+  }) => {
     const context = setup();
     const requests: RecordedGitHubRequest[] = [];
     const older = checkRun(16, {
@@ -1109,12 +1122,8 @@ describe("PR E2E one-time hosted-runner-loss retry", () => {
     const reserved = checkRun(18, {
       status: "in_progress",
       conclusion: null,
-      details_url: null,
-      output: {
-        title: "Waiting for PR CI",
-        summary:
-          "This PR SHA and base SHA are reserved for deterministic E2E planning after CI completes.",
-      },
+      details_url: replacementDetailsUrl,
+      output: RESERVED_CHECK_OUTPUT,
     });
     const history = replacement ? [older, source, reserved] : [older, source];
     vi.spyOn(globalThis, "fetch").mockImplementation(
@@ -1155,15 +1164,18 @@ describe("PR E2E one-time hosted-runner-loss retry", () => {
     }
   });
 
-  it("rejects an ambiguous retry replacement without mutating either check", async () => {
+  it.each([
+    ["unexpected owner", null, { title: "Unexpected owner", summary: "Not canonical." }],
+    ["wrong self URL", "https://github.com/NVIDIA/NemoClaw/runs/999", RESERVED_CHECK_OUTPUT],
+  ])("rejects a reserved replacement with %s", async (_label, detailsUrl, output) => {
     const context = setup();
     const requests: RecordedGitHubRequest[] = [];
     const source = checkRun(17);
     const ambiguous = checkRun(18, {
       status: "in_progress",
       conclusion: null,
-      details_url: null,
-      output: { title: "Unexpected owner", summary: "Not a canonical reservation." },
+      details_url: detailsUrl,
+      output,
     });
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -4477,7 +4477,9 @@ export async function abandonRunnerLossRetrySource(
     const canonicalReservedReplacement =
       current?.status === "in_progress" &&
       current.conclusion === null &&
-      (current.details_url === null || current.details_url === undefined) &&
+      (current.details_url === null ||
+        current.details_url === undefined ||
+        current.details_url === `https://github.com/${repository}/runs/${current.id}`) &&
       current.output?.title === RESERVED_CHECK_TITLE &&
       current.output.summary === RESERVED_CHECK_SUMMARY;
     if (!sourceImmediatelyPrecedesCurrent || !canonicalReservedReplacement) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Closes an interrupted runner-loss retry reservation when GitHub exposes the reserved check through its canonical self URL. Before this change, the cleanup path accepted only a missing details URL and could leave the replacement check in progress after a lost create response.

## Related Issue

Part of #7146. Parent epic: #7140.

## Changes

- Accept the exact `https://github.com/<repository>/runs/<replacement-check-id>` self URL for the immediately succeeding reserved replacement.
- Retain the existing missing-URL compatibility path and the exact source identity, history position, status, title, and summary checks.
- Cover missing URLs, matching canonical self URLs, unexpected reservation ownership, and mismatched self-link check IDs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is an internal E2E retry-controller compatibility fix. The internal README already documents canonical GitHub check URLs and interrupted post-reservation cleanup.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent focused review confirmed the replacement match remains exact and fail-closed; no actionable findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact head `010d84cc0` changes only the internal PR E2E retry-cleanup controller and its focused tests. `test/e2e/README.md` already documents GitHub canonical `/runs/<check-id>` details URLs and that interrupted post-reservation cleanup closes the reserved replacement. No user-facing command, configuration, default, API, policy, or operator procedure changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 010d84cc0 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 159/159 focused PR-gate controller tests passed across six files; the exact cleanup suite passed 45/45.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this bounded two-file cleanup guard. CLI build/typecheck, test-size, title-style, source-shape, project-membership, secret scan, and the full diff-scoped hook suite passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for pull request checks when a replacement check is in progress.
  * Correctly recognizes valid GitHub check URLs during retry recovery.
  * Better handles ambiguous or incomplete retry scenarios without incorrectly abandoning the check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->