### PR TITLE
docs: add v0.0.94 release entry

### DIFF
--- a/docs/changelog/2026-07-24.mdx
+++ b/docs/changelog/2026-07-24.mdx
@@ -1,0 +1,37 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.94
+
+NemoClaw v0.0.94 strengthens sandbox restore and update behavior, adds machine-readable onboarding progress, improves policy and security evidence, reduces Hermes image build time, and makes live E2E failures easier to classify.
+
+- Snapshot restore now clears stale contents only from state directories declared by the snapshot manifest.
+  It preserves target-only directories and directories whose backup failed.
+  Cross-sandbox OpenClaw restores re-establish gateway pairing and verify it with an authenticated agent run.
+  Hermes images repair virtual-environment access for the sandbox user, and session exports verify that each download produced the expected host artifact.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- `nemoclaw upgrade-sandboxes --check` now reads sandbox state without starting, recovering, or selecting a gateway.
+  When registered sandboxes resolve to one recorded gateway, the command queries that gateway instead of the gateway selected by the current environment.
+  For more information, refer to [Update Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/update-sandboxes).
+- `policy-add` now compares an already-applied catalog preset with the live policy.
+  It exits without mutation when the content matches and previews the update when the preset changed.
+  Network policy guidance now explains when an endpoint requires `tls: skip` raw TLS passthrough and identifies the lost L7 inspection and credential-resolution controls.
+  For more information, refer to [Customize the Network Policy](/user-guide/openclaw/network-policy/customize-network-policy), [Common NemoClaw Integration Policy Examples](/user-guide/openclaw/network-policy/integration-policy-examples), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Onboarding now supports `--events=jsonl` for a versioned, redacted stream of canonical state-machine events.
+  The human-readable progress stream remains on standard error, and closing or slowing the event stream does not cancel onboarding.
+  DGX Spark resume preserves the selected managed vLLM Express path, managed vLLM rejects a model that does not support the detected platform before downloads, and compatibility recovery selects and probes one usable IPv4 resolver.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands), [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- DGX Station qualification now accepts an OTA-upgraded GB300 release marker that omits `DGX_OTA_PRETTY_NAME` when the base workstation identity is present.
+  The metadata override guidance now distinguishes recognized GB300 hardware from release-marker variants without weakening runtime checks.
+  For more information, refer to [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).
+- `sandbox doctor --json` now redacts token-shaped values at both machine-readable output boundaries while preserving the exit status from the original report.
+  Reviewed npm audits now retain scanner, registry, timing, package, advisory, report-path, and failure provenance.
+  A read-only advisory correlation tool can identify exact npm package and range matches before a reviewed audit record appears, while ambiguous matches remain informational and do not block a release.
+- Hermes image assembly now groups repository payloads into five ownership-preserving BuildKit layers.
+  The first hosted comparison reduced the production build step from 205 seconds to 101 seconds and the layer export from 178.8 seconds to 70.4 seconds.
+  Build-time checks preserve file contents, modes, owners, scanner ordering, and cache boundaries.
+- Live E2E validation now isolates long-running lanes, trusts exact-head Hermes swap setup, stabilizes cancelled child lifecycles, parallelizes plugin EXDEV coverage, and records periodic runner-pressure telemetry.
+  These changes distinguish hosted-runner loss from product failures while retaining the cold-onboard performance budget as a separate release signal.
+  Documentation validation also keeps agent-variant checks read-only, accepts an absent Fern preview as a non-blocking condition, and uses Fern `5.80.1`.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR adds the canonical dated release entry for NemoClaw v0.0.94 before the tag is cut.
The entry reconciles all 26 commits since v0.0.93 and links each user-visible change to its owning documentation.

## Changes

- Add `docs/changelog/2026-07-24.mdx` with the exact `## v0.0.94` heading, parser-safe SPDX comment, release summary, and detailed bullets.
- Record sandbox restore and update behavior, onboarding and inference changes, network policy behavior, security evidence, Hermes build performance, DGX Station guidance, and E2E validation changes.
- Preserve `docs/` as the source of truth without changing the AI-agent documentation routing skill.
- Use [E2E run 30075443016](https://github.com/NVIDIA/NemoClaw/actions/runs/30075443016) for release QA evidence at exact tested SHA `04e6dfa883071dda9df429c66e73168e1a995cba`.

### Source summary

- [#7461](https://github.com/NVIDIA/NemoClaw/pull/7461) -> `docs/changelog/2026-07-24.mdx`: Record the ownership-preserving Hermes image layer reduction and hosted timing comparison.
- [#7460](https://github.com/NVIDIA/NemoClaw/pull/7460) -> `docs/changelog/2026-07-24.mdx`: Record removal of candidate Hermes swap setup from E2E validation.
- [#7458](https://github.com/NVIDIA/NemoClaw/pull/7458) -> `docs/security/fern-5.80.1-dependency-review.md`, `docs/changelog/2026-07-24.mdx`: Record the reviewed Fern CLI update.
- [#7457](https://github.com/NVIDIA/NemoClaw/pull/7457) -> `docs/changelog/2026-07-24.mdx`: Record periodic runner-pressure telemetry.
- [#7455](https://github.com/NVIDIA/NemoClaw/pull/7455) -> `docs/changelog/2026-07-24.mdx`: Record non-blocking absent Fern previews.
- [#7450](https://github.com/NVIDIA/NemoClaw/pull/7450) -> `docs/changelog/2026-07-24.mdx`: Record stable cancellation handling for live-test child processes.
- [#7449](https://github.com/NVIDIA/NemoClaw/pull/7449) -> `docs/changelog/2026-07-24.mdx`: Record parallel plugin EXDEV coverage.
- [#7448](https://github.com/NVIDIA/NemoClaw/pull/7448) -> `docs/changelog/2026-07-24.mdx`: Record isolated long-running E2E lanes.
- [#7444](https://github.com/NVIDIA/NemoClaw/pull/7444) -> `docs/changelog/2026-07-24.mdx`: Record exact-head Hermes swap validation.
- [#7437](https://github.com/NVIDIA/NemoClaw/pull/7437) -> `docs/manage-sandboxes/backup-restore.mdx`, `docs/changelog/2026-07-24.mdx`: Record gateway pairing and authenticated verification after cross-sandbox restore.
- [#7436](https://github.com/NVIDIA/NemoClaw/pull/7436) -> `docs/manage-sandboxes/backup-restore.mdx`, `docs/reference/commands.mdx`, `docs/changelog/2026-07-24.mdx`: Record selected stale-state cleanup and Hermes virtual-environment access repair.
- [#7385](https://github.com/NVIDIA/NemoClaw/pull/7385) -> `docs/network-policy/customize-network-policy.mdx`, `docs/changelog/2026-07-24.mdx`: Record the read-only agent-variant route check.
- [#7371](https://github.com/NVIDIA/NemoClaw/pull/7371) -> `docs/changelog/2026-07-24.mdx`: Record host-artifact verification for session exports.
- [#7359](https://github.com/NVIDIA/NemoClaw/pull/7359) -> `docs/changelog/2026-07-24.mdx`: Record platform validation for managed vLLM model overrides.
- [#7356](https://github.com/NVIDIA/NemoClaw/pull/7356) -> `docs/changelog/2026-07-24.mdx`: Record token-shaped value redaction for `sandbox doctor --json`.
- [#7354](https://github.com/NVIDIA/NemoClaw/pull/7354) -> `docs/security/advisory-early-warning.md`, `docs/changelog/2026-07-24.mdx`: Record advisory correlation and retained audit provenance.
- [#7352](https://github.com/NVIDIA/NemoClaw/pull/7352) -> `docs/network-policy/customize-network-policy.mdx`, `docs/network-policy/integration-policy-examples.mdx`, `docs/reference/commands.mdx`, `docs/changelog/2026-07-24.mdx`: Record preset reapplication and bounded `tls: skip` guidance.
- [#7345](https://github.com/NVIDIA/NemoClaw/pull/7345) -> `docs/security/openclaw-2026.6.10-dependency-review.md`, `docs/security/openclaw-2026.7.1-dependency-review.md`, `docs/changelog/2026-07-24.mdx`: Record reviewed npm audit exception enforcement.
- [#7340](https://github.com/NVIDIA/NemoClaw/pull/7340) -> `docs/network-policy/customize-network-policy.mdx`, `docs/changelog/2026-07-24.mdx`: Record the repaired CLI-reference route.
- [#7334](https://github.com/NVIDIA/NemoClaw/pull/7334) -> `docs/get-started/dgx-station-preparation.mdx`, `docs/changelog/2026-07-24.mdx`: Record the qualified OTA metadata fallback and narrowed override wording.
- [#7322](https://github.com/NVIDIA/NemoClaw/pull/7322) -> `docs/changelog/2026-07-24.mdx`: Reconcile the gateway source tag added to plugin registration banners.
- [#7284](https://github.com/NVIDIA/NemoClaw/pull/7284) -> `docs/manage-sandboxes/update-sandboxes.mdx`, `docs/changelog/2026-07-24.mdx`: Record read-only `upgrade-sandboxes --check` behavior and recorded-gateway selection.
- [#7277](https://github.com/NVIDIA/NemoClaw/pull/7277) -> `docs/changelog/2026-07-24.mdx`: Reconcile deterministic gateway TCP refusal coverage.
- [#7234](https://github.com/NVIDIA/NemoClaw/pull/7234) -> `docs/reference/troubleshooting.mdx`, `docs/changelog/2026-07-24.mdx`: Record preserved DGX Spark managed vLLM Express intent on resume.
- [#7185](https://github.com/NVIDIA/NemoClaw/pull/7185) -> `docs/reference/troubleshooting.mdx`, `docs/changelog/2026-07-24.mdx`: Record IPv4 fallback DNS selection and exact resolver probing.
- [#6820](https://github.com/NVIDIA/NemoClaw/pull/6820) -> `docs/reference/commands.mdx`, `docs/changelog/2026-07-24.mdx`: Record the versioned, redacted `--events=jsonl` onboarding stream.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `npx vitest run test/changelog-docs.test.ts` passed 6/6 tests.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-07-24.mdx`; the writing rules, documentation style, exact release range, skip terms, published routes, and product scope were reviewed; the changelog test passed 6/6; `npm run docs` passed with route checking OK, zero errors, and two existing warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 65368f90b -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable. This PR does not change `scripts/prepare-dgx-station-host.sh`.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts` passed 6/6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to the dated changelog entry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only). The build passed with zero errors and two existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only). Native dated changelog entries use the required parser-safe MDX SPDX comment and no frontmatter.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the v0.0.94 release changelog.
  * Documented improvements to sandbox snapshot and restore behavior.
  * Added updates for gateway selection, policy comparisons, onboarding event output, and DGX recovery workflows.
  * Documented enhanced diagnostics redaction, npm audit provenance, image assembly performance, and validation stability improvements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->