### PR TITLE
fix(onboard): reuse reachable Windows-host Ollama

### DIFF
--- a/src/lib/onboard/provider-menu.test.ts
+++ b/src/lib/onboard/provider-menu.test.ts
@@ -135,4 +135,18 @@ describe("buildInferenceProviderMenu", () => {
     expect(result.options.map((option) => option.key)).toContain("ollama");
     expect(result.options.map((option) => option.key)).not.toContain("start-windows-ollama");
   });
+
+  it("omits Windows-host install when Ollama is reachable but its executable is not detected (#7472)", () => {
+    const result = buildMenu({
+      isWsl: true,
+      hasOllama: false,
+      ollamaRunning: true,
+      ollamaHost: "host.docker.internal",
+      hasWindowsOllama: false,
+      isWindowsHostOllama: true,
+    });
+
+    expect(result.options.map((option) => option.key)).toContain("ollama");
+    expect(result.options.map((option) => option.key)).not.toContain("install-windows-ollama");
+  });
 });

--- a/src/lib/onboard/provider-menu.ts
+++ b/src/lib/onboard/provider-menu.ts
@@ -104,7 +104,7 @@ export function buildInferenceProviderMenu(
     });
   }
 
-  if (input.isWsl && !input.hasWindowsOllama) {
+  if (input.isWsl && !input.hasWindowsOllama && !input.isWindowsHostOllama) {
     options.push({
       key: "install-windows-ollama",
       label: input.windowsHostInstallLabel,

--- a/src/lib/onboard/setup-nim-flow.test.ts
+++ b/src/lib/onboard/setup-nim-flow.test.ts
@@ -476,13 +476,8 @@ describe("createSetupNim", () => {
       }),
     );
 
-    const result = await setupNim(null, null);
+    await setupNim(null, null);
 
-    expect(result).toMatchObject({
-      model,
-      provider: "ollama-local",
-      endpointUrl: "http://host.docker.internal:11434/v1",
-    });
     expect(handleRunningOllamaSelection).toHaveBeenCalledTimes(1);
   });
 

--- a/src/lib/onboard/setup-nim-flow.test.ts
+++ b/src/lib/onboard/setup-nim-flow.test.ts
@@ -443,6 +443,49 @@ describe("createSetupNim", () => {
     expect(handleRunningOllamaSelection).toHaveBeenCalledTimes(1);
   });
 
+  it("reuses reachable Windows-host Ollama when PowerShell cannot find its executable (#7472)", async () => {
+    const model = "qwen3.6:35b";
+    const handleRunningOllamaSelection = vi.fn<SetupNimFlowDeps["handleRunningOllamaSelection"]>(
+      async (_gpu, requestedModel, _recoveredModel, ollamaRunning, state) => {
+        expect(requestedModel).toBe(model);
+        expect(ollamaRunning).toBe(true);
+        state.model = model;
+        state.provider = "ollama-local";
+        state.endpointUrl = "http://host.docker.internal:11434/v1";
+        state.credentialEnv = null;
+        state.preferredInferenceApi = "openai-completions";
+        return "selected";
+      },
+    );
+    const setupNim = createSetupNim(
+      makeDeps({
+        isNonInteractive: () => true,
+        getNonInteractiveProvider: () => "install-windows-ollama",
+        getNonInteractiveModel: () => model,
+        detectInferenceProviderHostState: () =>
+          makeHostState({
+            ollamaHost: "host.docker.internal",
+            ollamaRunning: true,
+            isWindowsHostOllama: true,
+            isWsl: true,
+            hasWindowsOllama: false,
+            windowsHostOllamaDockerRequirement:
+              getWindowsHostOllamaDockerRequirement("docker-desktop"),
+          }),
+        handleRunningOllamaSelection,
+      }),
+    );
+
+    const result = await setupNim(null, null);
+
+    expect(result).toMatchObject({
+      model,
+      provider: "ollama-local",
+      endpointUrl: "http://host.docker.internal:11434/v1",
+    });
+    expect(handleRunningOllamaSelection).toHaveBeenCalledTimes(1);
+  });
+
   it("applies same-gateway discovery constraints before a provider probe (#6315)", async () => {
     const providerProbe = vi.fn();
     const routeGuard = vi.fn(

--- a/src/lib/onboard/setup-nim-ollama.test.ts
+++ b/src/lib/onboard/setup-nim-ollama.test.ts
@@ -257,6 +257,24 @@ describe("createSetupNimOllamaHandlers", () => {
     assert.equal(state.allowToolsIncompatible, true);
   });
 
+  it("uses the reachable Windows-host endpoint for running Ollama (#7472)", async () => {
+    const state = makeState();
+    const { handleRunningOllamaSelection } = createSetupNimOllamaHandlers(
+      makeDeps({
+        getLocalProviderBaseUrl: () => "http://host.docker.internal:11434/v1",
+      }),
+    );
+
+    const result = await handleRunningOllamaSelection(null, "qwen3.6:35b", null, true, state);
+
+    expect(result).toBe("selected");
+    expect(state).toMatchObject({
+      model: "llama3.1:8b",
+      provider: "ollama-local",
+      endpointUrl: "http://host.docker.internal:11434/v1",
+    });
+  });
+
   it("passes the Hermes Ollama context floor to systemd repair and model validation", async () => {
     const state = makeState();
     state.ollamaContextWindowFloor = MIN_HERMES_OLLAMA_CONTEXT_WINDOW;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Windows WSL express install now reuses a reachable Windows-host Ollama daemon when PowerShell cannot find its executable. Previously, the provider menu kept the install action and onboarding attempted an unnecessary reinstall.

## Related Issue

Fixes #7472

## Changes

- Suppress the Windows-host install action when Ollama already responds through `host.docker.internal`.
- Add provider-menu coverage for a reachable daemon whose executable is not detected.
- Add setup coordinator coverage that verifies express install selects the running Ollama provider.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The fix restores the documented Windows-host Ollama reuse behavior and changes no command, configuration, or user-facing text.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head security follow-up passed for `4b139ae77`: https://github.com/NVIDIA/NemoClaw/pull/7476#issuecomment-5072388040
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Head `4b139ae77` adds only an empty signed CI-retry commit. Its tree and effective PR diff match reviewed head `35d0bac66`. Existing WSL Ollama documentation covers the corrected behavior. Focused tests, CLI build, CLI type-check, `check:diff`, and `git diff --check` passed.
- Agent: Codex Desktop documentation writer subagent
<!-- docs-review-head-sha: 4b139ae77 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/provider-menu.test.ts src/lib/onboard/setup-nim-flow.test.ts src/lib/onboard/setup-nim-ollama.test.ts` passed 41/41. `npm run typecheck:cli`, Biome, and the test-title check passed.
- [x] Applicable broad gate passed — exact-head [CI](https://github.com/NVIDIA/NemoClaw/actions/runs/30111455252), [E2E](https://github.com/NVIDIA/NemoClaw/actions/runs/30112245814), [PR Gate](https://github.com/NVIDIA/NemoClaw/actions/runs/30111454490/job/89541719121), and [coordination](https://github.com/NVIDIA/NemoClaw/runs/89541825633) passed for `4b139ae77` on base `5faed2cbc`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>