### PR TITLE
ci(e2e): scope risk signals to selected tests

### DIFF
--- a/test/e2e-risk-signal-reporter.test.ts
+++ b/test/e2e-risk-signal-reporter.test.ts
@@ -1,12 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TestModule, Vitest } from "vitest/node";
 import {
   classifyLiveTestOutcome,
@@ -25,6 +24,10 @@ import {
   type RiskSignalEnvironment,
   writeRiskSignal,
 } from "./e2e/risk-signal-reporter.ts";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(() => "a".repeat(40)),
+}));
 
 const EXPECTED_SHA = "a".repeat(40);
 const PLAN_HASH = "b".repeat(64);
@@ -82,6 +85,10 @@ function environment(artifactDir: string): RiskSignalEnvironment {
 }
 
 describe("E2E risk signal reporter", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("stays disabled when no expected commit is configured", () => {
     expect(configuredEnvironment({})).toBeNull();
   });
@@ -151,12 +158,9 @@ describe("E2E risk signal reporter", () => {
   it("applies the configured name pattern through the reporter lifecycle", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-signal-"));
     try {
-      const testedSha = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
-        encoding: "utf8",
-      }).trim();
       vi.stubEnv("E2E_ARTIFACT_DIR", dir);
       vi.stubEnv("E2E_TARGET_ID", "network-policy");
-      vi.stubEnv("NEMOCLAW_E2E_EXPECTED_SHA", testedSha);
+      vi.stubEnv("NEMOCLAW_E2E_EXPECTED_SHA", EXPECTED_SHA);
       vi.stubEnv("NEMOCLAW_E2E_PLAN_HASH", PLAN_HASH);
       vi.stubEnv("NEMOCLAW_E2E_CORRELATION_ID", CORRELATION_ID);
       vi.stubEnv("NEMOCLAW_E2E_SHARD", "live-probes");

--- a/test/e2e-risk-signal-reporter.test.ts
+++ b/test/e2e-risk-signal-reporter.test.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
-import type { TestModule } from "vitest/node";
+import { describe, expect, it, vi } from "vitest";
+import type { TestModule, Vitest } from "vitest/node";
 import {
   classifyLiveTestOutcome,
   configuredLiveTestOutcomeFile,
@@ -18,6 +19,7 @@ import {
 } from "../tools/e2e/live-test-outcome.mts";
 import {
   configuredEnvironment,
+  default as E2eRiskSignalReporter,
   outcomeForRun,
   RISK_SIGNAL_FILE,
   type RiskSignalEnvironment,
@@ -146,11 +148,24 @@ describe("E2E risk signal reporter", () => {
     }
   });
 
-  it("does not count tests excluded by the configured name pattern", () => {
+  it("applies the configured name pattern through the reporter lifecycle", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-signal-"));
     try {
-      const signal = writeRiskSignal(
-        environment(dir),
+      const testedSha = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
+        encoding: "utf8",
+      }).trim();
+      vi.stubEnv("E2E_ARTIFACT_DIR", dir);
+      vi.stubEnv("E2E_TARGET_ID", "network-policy");
+      vi.stubEnv("NEMOCLAW_E2E_EXPECTED_SHA", testedSha);
+      vi.stubEnv("NEMOCLAW_E2E_PLAN_HASH", PLAN_HASH);
+      vi.stubEnv("NEMOCLAW_E2E_CORRELATION_ID", CORRELATION_ID);
+      vi.stubEnv("NEMOCLAW_E2E_SHARD", "live-probes");
+
+      const reporter = new E2eRiskSignalReporter();
+      reporter.onInit({
+        config: { testNamePattern: /^network-policy:.+probes$/u },
+      } as Vitest);
+      reporter.onTestRunEnd(
         [
           moduleWithNamedStates([
             {
@@ -166,9 +181,11 @@ describe("E2E risk signal reporter", () => {
         ],
         [],
         "passed",
-        /^network-policy:.+probes$/u,
       );
 
+      const signal = JSON.parse(
+        fs.readFileSync(path.join(dir, RISK_SIGNAL_FILE), "utf8"),
+      ) as Record<string, unknown>;
       expect(signal).toMatchObject({ passed: 1, failed: 0, skipped: 0, pending: 0 });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/test/e2e-risk-signal-reporter.test.ts
+++ b/test/e2e-risk-signal-reporter.test.ts
@@ -32,7 +32,26 @@ function moduleWithStates(states: Array<"passed" | "failed" | "skipped" | "pendi
   return {
     children: {
       *allTests() {
-        for (const state of states) yield { result: () => ({ state }) };
+        for (const [index, state] of states.entries()) {
+          yield { fullName: `test ${index}`, result: () => ({ state }) };
+        }
+      },
+    },
+  } as unknown as TestModule;
+}
+
+function moduleWithNamedStates(
+  tests: Array<{
+    fullName: string;
+    state: "passed" | "failed" | "skipped" | "pending";
+  }>,
+): TestModule {
+  return {
+    children: {
+      *allTests() {
+        for (const { fullName, state } of tests) {
+          yield { fullName, result: () => ({ state }) };
+        }
       },
     },
   } as unknown as TestModule;
@@ -42,7 +61,7 @@ function moduleWithFailedError(error: unknown): TestModule {
   return {
     children: {
       *allTests() {
-        yield { result: () => ({ state: "failed", errors: [error] }) };
+        yield { fullName: "failed test", result: () => ({ state: "failed", errors: [error] }) };
       },
     },
   } as unknown as TestModule;
@@ -122,6 +141,81 @@ describe("E2E risk signal reporter", () => {
       );
 
       expect(signal).toMatchObject({ passed: 2, skipped: 1, failed: 0, pending: 0 });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not count tests excluded by the configured name pattern", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-signal-"));
+    try {
+      const signal = writeRiskSignal(
+        environment(dir),
+        [
+          moduleWithNamedStates([
+            {
+              fullName: "network-policy: restricted sandbox enforces live allow/deny policy probes",
+              state: "passed",
+            },
+            {
+              fullName:
+                "network-policy: default restricted OpenClaw onboard leaves policy-list with zero active presets",
+              state: "skipped",
+            },
+          ]),
+        ],
+        [],
+        "passed",
+        /^network-policy:.+probes$/u,
+      );
+
+      expect(signal).toMatchObject({ passed: 1, failed: 0, skipped: 0, pending: 0 });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("counts a selected test that skips", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-signal-"));
+    try {
+      const signal = writeRiskSignal(
+        environment(dir),
+        [
+          moduleWithNamedStates([
+            {
+              fullName: "network-policy: restricted sandbox enforces live allow/deny policy probes",
+              state: "skipped",
+            },
+            {
+              fullName:
+                "network-policy: default restricted OpenClaw onboard leaves policy-list with zero active presets",
+              state: "skipped",
+            },
+          ]),
+        ],
+        [],
+        "passed",
+        /^network-policy:.+probes$/u,
+      );
+
+      expect(signal).toMatchObject({ passed: 0, failed: 0, skipped: 1, pending: 0 });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits no passing evidence when the name pattern matches no tests", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-signal-"));
+    try {
+      const signal = writeRiskSignal(
+        environment(dir),
+        [moduleWithNamedStates([{ fullName: "selected elsewhere", state: "skipped" }])],
+        [],
+        "passed",
+        /^missing test$/u,
+      );
+
+      expect(signal).toMatchObject({ passed: 0, failed: 0, skipped: 0, pending: 0 });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/e2e/risk-signal-reporter.ts
+++ b/test/e2e/risk-signal-reporter.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-import type { TestModule } from "vitest/node";
+import type { TestModule, Vitest } from "vitest/node";
 import type { Reporter, TestRunEndReason } from "vitest/reporters";
 import {
   classifyLiveTestOutcome,
@@ -79,10 +79,18 @@ export function configuredEnvironment(
   return { ...values, testedSha };
 }
 
-function counts(testModules: ReadonlyArray<TestModule>) {
+function matchesNamePattern(fullName: string, pattern: RegExp | undefined): boolean {
+  if (!pattern) return true;
+  const stablePattern = new RegExp(pattern.source, pattern.flags);
+  // Vitest joins suite names with spaces when it applies testNamePattern.
+  return stablePattern.test(fullName.replaceAll(" > ", " "));
+}
+
+function counts(testModules: ReadonlyArray<TestModule>, testNamePattern?: RegExp) {
   const result = { passed: 0, failed: 0, skipped: 0, pending: 0 };
   for (const module of testModules) {
     for (const test of module.children.allTests()) {
+      if (!matchesNamePattern(test.fullName, testNamePattern)) continue;
       result[test.result().state] += 1;
     }
   }
@@ -158,6 +166,7 @@ export function writeRiskSignal(
   testModules: ReadonlyArray<TestModule>,
   unhandledErrors: ReadonlyArray<unknown>,
   runReason: TestRunEndReason,
+  testNamePattern?: RegExp,
 ): E2eRiskSignal {
   const signal: E2eRiskSignal = {
     version: 1,
@@ -167,7 +176,7 @@ export function writeRiskSignal(
     testedSha: environment.testedSha,
     planHash: environment.planHash,
     correlationId: environment.correlationId,
-    ...counts(testModules),
+    ...counts(testModules, testNamePattern),
     unhandledErrors: unhandledErrors.length,
     runReason,
   };
@@ -181,11 +190,16 @@ export function writeRiskSignal(
 export default class E2eRiskSignalReporter implements Reporter {
   private readonly environment: RiskSignalEnvironment | null;
   private readonly outcomeFile: string | null;
+  private testNamePattern: RegExp | undefined;
   private processTimedOut = false;
 
   constructor() {
     this.environment = configuredEnvironment(process.env);
     this.outcomeFile = configuredLiveTestOutcomeFile(process.env);
+  }
+
+  onInit(vitest: Vitest): void {
+    this.testNamePattern = vitest.config.testNamePattern;
   }
 
   onTestRunStart(): void {
@@ -207,7 +221,7 @@ export default class E2eRiskSignalReporter implements Reporter {
     reason: TestRunEndReason,
   ): void {
     if (this.environment) {
-      writeRiskSignal(this.environment, testModules, unhandledErrors, reason);
+      writeRiskSignal(this.environment, testModules, unhandledErrors, reason, this.testNamePattern);
     }
     if (this.outcomeFile) {
       writeLiveTestOutcome(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Risk-signal evidence now counts only tests selected by Vitest's `testNamePattern`. This prevents selector-excluded sibling tests from blocking a PR while preserving failures for selected skips and selectors that match no tests.

## Changes

- Apply the resolved Vitest name pattern before the risk-signal reporter counts test results.
- Add regression coverage for an excluded sibling, a selected skip, and a selector that matches no tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal CI evidence accounting and conforms to the existing selected-shard contract.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: PR #7488; internal CI evidence only. `test/e2e/README.md` already defines counts for each selected shard.
- Agent: Codex Desktop
<!-- docs-review-head-sha: dc2c35058 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run test/e2e-risk-signal-reporter.test.ts --project integration`: 14 passed. A real reporter selection recorded `passed=1, skipped=0`; a selected static skip recorded `passed=0, skipped=1`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm test` was attempted, but the restricted local sandbox blocked loopback-server tests and caused unrelated timeouts. PR CI remains authoritative.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Risk-signal reporting now respects the configured test name pattern.
  * Evidence counts include only matching tests, including passed, failed, skipped, and pending results.
  * Reports accurately show zero counts when no tests match the configured pattern.

* **Tests**
  * Added coverage for filtered test runs, skipped tests, and patterns with no matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->