### PR TITLE
fix(hermes): preserve managed gateway restart recovery

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -2394,6 +2394,7 @@ ensure_hermes_supervised_auxiliaries() {
       "$DASHBOARD_PUBLIC_PORT" "$DASHBOARD_INTERNAL_PORT" "dashboard" DASHBOARD_SOCAT_PID \
       "$DASHBOARD_PID" "$dashboard_user" || return 1
   fi
+  ensure_dashboard_log_stream || return 1
   ensure_gateway_log_stream || return 1
 }
 
@@ -2417,6 +2418,9 @@ refresh_hermes_supervised_child_pids() {
     && SANDBOX_CHILD_PIDS+=("$GATEWAY_LOG_TAIL_PID")
   hermes_tracked_role_is_current dashboard-log "${DASHBOARD_LOG_TAIL_PID:-}" current \
     && SANDBOX_CHILD_PIDS+=("$DASHBOARD_LOG_TAIL_PID")
+  # Each tracked child can be absent while a service is replaced. Return success
+  # so `set -e` callers can launch the replacement gateway.
+  return 0
 }
 
 hermes_cleanup_on_signal() {
@@ -2840,7 +2844,10 @@ record_hermes_managed_gateway_exit() {
 }
 
 recover_hermes_gateway_current_user() {
+  local replacement_reached_internal_health
+
   while :; do
+    replacement_reached_internal_health=0
     until prepare_hermes_nonroot_runtime; do
       if [ "$HERMES_MCP_INTEGRITY_FAILED" -eq 1 ]; then
         echo "[SECURITY] Hermes automatic respawn is quarantined until MCP integrity is restored by rebuilding the sandbox" >&2
@@ -2856,6 +2863,7 @@ recover_hermes_gateway_current_user() {
       continue
     fi
     if wait_for_hermes_gateway_internal "$GATEWAY_PID"; then
+      replacement_reached_internal_health=1
       # The gateway and its socat relay are separate supervised children. A
       # transient relay repair failure must not churn an internally healthy,
       # identity-pinned replacement or charge that churn against the gateway
@@ -2885,7 +2893,11 @@ recover_hermes_gateway_current_user() {
       done
     fi
 
-    echo "[gateway] Hermes replacement failed health or auxiliary validation; stopping the exact child" >&2
+    if [ "$replacement_reached_internal_health" -eq 1 ]; then
+      echo "[gateway] Hermes replacement gateway lost its listener or health endpoint during auxiliary validation; stopping the exact child" >&2
+    else
+      echo "[gateway] Hermes replacement gateway failed listener or health validation; stopping the exact child" >&2
+    fi
     if ! hermes_stop_tracked_role \
       gateway "$GATEWAY_PID" current "$INTERNAL_PORT"; then
       echo "[gateway] CRITICAL: exact Hermes replacement could not be stopped; managed supervisor is quarantined without another launch" >&2

--- a/scripts/managed-gateway-control.py
+++ b/scripts/managed-gateway-control.py
@@ -102,6 +102,56 @@ CONTROL_STAGES = frozenset(
         "cleanup-expected-exit",
     }
 )
+START_LOG_PATH = "/tmp/nemoclaw-start.log"
+MAX_START_LOG_DIAGNOSTIC_BYTES = 16 * 1024
+MAX_START_LOG_DIAGNOSTIC_LINES = 6
+MAX_START_LOG_DIAGNOSTIC_LINE_CHARS = 512
+START_LOG_DIAGNOSTIC_PATTERNS = (
+    re.compile(
+        r"\[gateway\] Hermes runtime preparation refused automatic respawn; retrying in 5s"
+    ),
+    re.compile(
+        r"\[gateway\] Hermes gateway launch failed; retrying under the same supervisor"
+    ),
+    re.compile(
+        r"\[gateway\] Hermes auxiliary repair failed; retrying while the exact gateway remains healthy"
+    ),
+    re.compile(
+        r"\[gateway\] Hermes auxiliary repair failed; retrying while the exact gateway remains supervised"
+    ),
+    re.compile(
+        r"\[gateway\] Hermes replacement gateway failed listener or health validation; stopping the exact child"
+    ),
+    re.compile(
+        r"\[gateway\] Hermes replacement gateway lost its listener or health endpoint during auxiliary validation; stopping the exact child"
+    ),
+    re.compile(
+        r"\[gateway\] CRITICAL: Hermes gateway lost its listener or health endpoint; stopping the exact child for recovery"
+    ),
+    re.compile(
+        r"\[gateway\] Hermes gateway pid [1-9][0-9]* exited \(rc=[0-9]+; authenticated host authorization\); respawning without charging crash quarantine in 2s"
+    ),
+    re.compile(r"\[gateway\] Hermes gateway respawned \(pid [1-9][0-9]*\)"),
+    re.compile(
+        r"\[gateway\] CRITICAL: [1-9][0-9]* exits in 60s window — Hermes relaunch is quarantined until sandbox recreation; check /tmp/gateway\.log"
+    ),
+    re.compile(
+        r"\[gateway\] CRITICAL: (?:exact Hermes replacement|unhealthy Hermes gateway|initial Hermes gateway) could not be stopped; managed supervisor is quarantined without another launch"
+    ),
+    re.compile(
+        r"\[SECURITY\] Hermes automatic respawn is quarantined until MCP integrity is restored by rebuilding the sandbox"
+    ),
+    re.compile(
+        r"\[CRITICAL\] Newly launched Hermes (?:gateway|gateway-log|dashboard|dashboard-log|api-socat|dashboard-socat) pid [1-9][0-9]* failed exact role identity capture; quarantining the managed startup supervisor without signaling the unproven child"
+    ),
+    re.compile(
+        r"\[CRITICAL\] Unproven Hermes (?:gateway|gateway-log|dashboard|dashboard-log|api-socat|dashboard-socat) child exited; managed supervisor remains quarantined until sandbox recreation"
+    ),
+)
+ANSI_ESCAPE_RE = re.compile(
+    r"\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])"
+)
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]")
 
 
 class ControlError(RuntimeError):
@@ -115,15 +165,18 @@ class ControlError(RuntimeError):
 
 @contextmanager
 def _control_stage(stage: str) -> Iterator[None]:
-    """Attach one fixed, non-sensitive lifecycle stage to generic failures."""
+    """Attach one fixed lifecycle stage to health or supervisor loss."""
 
     if stage not in CONTROL_STAGES:
         raise AssertionError(f"unknown managed-control stage: {stage}")
     try:
         yield
     except ControlError as error:
-        if error.code == "SUPERVISOR_UNAVAILABLE" and error.stage is None:
-            raise ControlError(error.code, stage=stage) from error
+        if (
+            error.code in ("GATEWAY_HEALTH_TIMEOUT", "SUPERVISOR_UNAVAILABLE")
+            and error.stage is None
+        ):
+            error.stage = stage
         raise
 
 
@@ -1597,6 +1650,140 @@ def _control(action: str, nonce: str) -> tuple[str, int, int]:
                     _clear_expected_exit_lease(expected_exit_lease)
 
 
+def _sanitize_start_log_diagnostic_line(line: str) -> str | None:
+    # Do not normalize attacker-controlled text into an accepted event. The
+    # exact supervisor UID is shared with the sandbox agent in managed
+    # OpenShell, so these lines remain non-authoritative operator evidence.
+    if (
+        len(line) > MAX_START_LOG_DIAGNOSTIC_LINE_CHARS
+        or ANSI_ESCAPE_RE.search(line)
+        or CONTROL_CHAR_RE.search(line)
+    ):
+        return None
+    if not any(
+        pattern.fullmatch(line) for pattern in START_LOG_DIAGNOSTIC_PATTERNS
+    ):
+        return None
+    return line
+
+
+def _start_log_metadata_is_allowed(
+    metadata: os.stat_result, supervisor_uid: int
+) -> bool:
+    return bool(
+        stat.S_ISREG(metadata.st_mode)
+        and metadata.st_uid == supervisor_uid
+        and metadata.st_nlink == 1
+        and stat.S_IMODE(metadata.st_mode) == 0o600
+    )
+
+
+def _start_log_metadata_snapshot(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _read_start_log_diagnostic_excerpt(
+    reader: ProcReader, supervisor: ProcessIdentity
+) -> tuple[str, ...]:
+    """Read a stable bounded tail owned by the exact managed supervisor UID."""
+
+    path = _system_path(START_LOG_PATH)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    fd = -1
+    try:
+        _recapture_exact_identity(reader, supervisor)
+        if len(set(supervisor.uids)) != 1:
+            return ()
+        supervisor_uid = supervisor.uids[0]
+        fd = os.open(path, flags)
+        before = os.fstat(fd)
+        if not _start_log_metadata_is_allowed(before, supervisor_uid):
+            return ()
+        offset = max(0, before.st_size - MAX_START_LOG_DIAGNOSTIC_BYTES)
+        os.lseek(fd, offset, os.SEEK_SET)
+        chunks: list[bytes] = []
+        remaining = before.st_size - offset
+        while remaining > 0:
+            chunk = os.read(fd, min(4096, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        after = os.fstat(fd)
+        _recapture_exact_identity(reader, supervisor)
+        if _start_log_metadata_snapshot(before) != _start_log_metadata_snapshot(
+            after
+        ):
+            return ()
+    except (ControlError, OSError, PermissionError, ProcessLookupError):
+        return ()
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+    raw = b"".join(chunks)
+    if offset > 0:
+        _, separator, raw = raw.partition(b"\n")
+        if not separator:
+            return ()
+    lines = (
+        _sanitize_start_log_diagnostic_line(line)
+        for line in raw.decode("utf-8", errors="replace").splitlines()
+    )
+    return tuple(line for line in lines if line)[-MAX_START_LOG_DIAGNOSTIC_LINES:]
+
+
+def _managed_failure_diagnostics() -> tuple[str, ...]:
+    """Return bounded, non-authoritative evidence for an operator."""
+
+    supervisor_pid = "unavailable"
+    gateway_pid = "unavailable"
+    start_log_excerpt: tuple[str, ...] = ()
+    try:
+        agent = _detect_agent()
+        with ProcReader() as reader:
+            supervisor = _discover_supervisor(reader)
+            supervisor_pid = str(supervisor.pid)
+            spec = _agent_spec(agent, reader, supervisor)
+            candidates = _gateway_candidates(reader, supervisor, spec)
+            if candidates:
+                current_gateway = _recapture_exact_identity(reader, candidates[0])
+                gateway_pid = str(current_gateway.pid)
+            else:
+                gateway_pid = "0"
+            if agent == "hermes":
+                start_log_excerpt = _read_start_log_diagnostic_excerpt(
+                    reader, supervisor
+                )
+    except (ControlError, OSError, PermissionError, ProcessLookupError):
+        pass
+
+    diagnostics = [
+        f"NEMOCLAW_SUPERVISOR_PID={supervisor_pid}",
+        f"NEMOCLAW_GATEWAY_PID={gateway_pid}",
+    ]
+    diagnostics.extend(
+        f"NEMOCLAW_START_LOG={line}"
+        for line in start_log_excerpt
+    )
+    return tuple(diagnostics)
+
+
 def _validate_request(argv: list[str]) -> tuple[str, str]:
     if len(argv) != 2:
         raise ControlError("SUPERVISOR_INVALID_REQUEST")
@@ -1619,8 +1806,15 @@ def main(argv: list[str]) -> int:
         return 0
     except ControlError as error:
         print(error.code, file=sys.stderr)
-        if error.code == "SUPERVISOR_UNAVAILABLE" and error.stage is not None:
+        if error.stage is not None:
             print(f"NEMOCLAW_CONTROL_STAGE={error.stage}", file=sys.stderr)
+            if error.code in ("GATEWAY_HEALTH_TIMEOUT", "SUPERVISOR_UNAVAILABLE"):
+                try:
+                    diagnostics = _managed_failure_diagnostics()
+                except Exception:  # diagnostics must not hide the original failure
+                    diagnostics = ()
+                for diagnostic in diagnostics:
+                    print(diagnostic, file=sys.stderr)
         return 1
     except (OSError, subprocess.SubprocessError):
         print("GATEWAY_FAILED", file=sys.stderr)

--- a/scripts/managed-gateway-control.py
+++ b/scripts/managed-gateway-control.py
@@ -1771,6 +1771,8 @@ def _managed_failure_diagnostics() -> tuple[str, ...]:
                     reader, supervisor
                 )
     except (ControlError, OSError, PermissionError, ProcessLookupError):
+        # Diagnostics are best effort; keep fail-closed defaults when process
+        # state cannot be re-proven.
         pass
 
     diagnostics = [

--- a/src/lib/actions/sandbox/gateway-restart.test.ts
+++ b/src/lib/actions/sandbox/gateway-restart.test.ts
@@ -21,7 +21,7 @@ describe("gateway restart failure markers", () => {
       ["SUPERVISOR_UNAVAILABLE", "privileged control unavailable"],
       [
         "SUPERVISOR_UNAVAILABLE\nNEMOCLAW_CONTROL_STAGE=await-replacement",
-        "privileged control unavailable",
+        "supervisor unavailable",
       ],
       ["SUPERVISOR_NOT_RUNNING", "supervisor not running"],
       ["SUPERVISOR_REBUILD_REQUIRED", "privileged control unavailable"],
@@ -189,6 +189,36 @@ describe("restartSandboxGateway — host-mediated gateway restart", () => {
     }
   });
 
+  it("distinguishes a supervisor that becomes unavailable during replacement (#7484)", () => {
+    const restore = silenceConsole();
+    try {
+      const deps = baseDeps({
+        requestGatewaySupervisorAction: vi.fn(() => ({
+          status: 1,
+          stdout: "",
+          stderr: [
+            "SUPERVISOR_UNAVAILABLE",
+            "NEMOCLAW_CONTROL_STAGE=await-replacement",
+            "NEMOCLAW_SUPERVISOR_PID=40",
+            "NEMOCLAW_GATEWAY_PID=0",
+          ].join("\n"),
+        })),
+      });
+      const result = restartSandboxGateway("alpha", { quiet: true, deps });
+
+      expect(result).toMatchObject({
+        ok: false,
+        failureLayer: "supervisor unavailable",
+        detail: expect.stringContaining("NEMOCLAW_CONTROL_STAGE=await-replacement"),
+      });
+      expect(console.error).toHaveBeenCalledWith(
+        "  Failure layer: supervisor unavailable - gateway restart failed for 'alpha'.",
+      );
+    } finally {
+      restore();
+    }
+  });
+
   it("reports Hermes boundary refusals without hiding diagnostics in quiet mode", () => {
     const restore = silenceConsole();
     try {
@@ -262,6 +292,57 @@ describe("restartSandboxGateway — host-mediated gateway restart", () => {
       expect(errorOutput).toContain("OPENAI_API_KEY=<REDACTED>");
       expect(errorOutput).not.toContain("\u001b");
       expect(errorOutput).not.toContain("sk-review-secret");
+    } finally {
+      restore();
+    }
+  });
+
+  it("prints bounded redacted evidence for a Hermes health timeout (#7484)", () => {
+    const restore = silenceConsole();
+    try {
+      const deps = baseDeps({
+        requestGatewaySupervisorAction: vi.fn(() => ({
+          status: 1,
+          stdout: "",
+          stderr: [
+            "GATEWAY_HEALTH_TIMEOUT",
+            "NEMOCLAW_CONTROL_STAGE=await-replacement",
+            "NEMOCLAW_SUPERVISOR_PID=40",
+            "NEMOCLAW_GATEWAY_PID=5252",
+            "\u001b[31mNEMOCLAW_START_LOG=[gateway] Hermes gateway launch failed; token=sk-review-secret\u0007",
+            "NEMOCLAW_START_LOG=[gateway] Hermes URL https://user:password@example.test/path?token=query-secret",
+            "NEMOCLAW_START_LOG=[gateway] Hermes HF_TOKEN=hf-review-secret",
+            ...Array.from(
+              { length: 15 },
+              (_, index) => `NEMOCLAW_START_LOG=[gateway] Hermes bounded marker ${index}`,
+            ),
+          ].join("\n"),
+        })),
+      });
+      const result = restartSandboxGateway("alpha", { deps });
+
+      expect(result).toMatchObject({
+        ok: false,
+        failureLayer: "health timeout",
+        detail: expect.stringContaining("NEMOCLAW_GATEWAY_PID=5252"),
+      });
+      expect(result.ok).toBe(false);
+      const detail = (result as Extract<typeof result, { ok: false }>).detail;
+      expect(detail).toContain("token=<REDACTED>");
+      expect(detail).toContain("HF_TOKEN=<REDACTED>");
+      expect(detail).not.toContain("sk-review-secret");
+      expect(detail).not.toContain("password");
+      expect(detail).not.toContain("query-secret");
+      expect(detail).not.toContain("hf-review-secret");
+      expect(detail).not.toContain("\u001b");
+      expect(detail).not.toContain("\u0007");
+      const errorOutput = vi.mocked(console.error).mock.calls.join("\n");
+      expect(vi.mocked(console.error).mock.calls).toHaveLength(13);
+      expect(errorOutput).toContain("NEMOCLAW_START_LOG=[gateway] Hermes bounded marker 14");
+      expect(errorOutput).not.toContain("NEMOCLAW_START_LOG=[gateway] Hermes bounded marker 2");
+      expect(errorOutput).not.toContain("sk-review-secret");
+      expect(errorOutput).not.toContain("query-secret");
+      expect(errorOutput).not.toContain("hf-review-secret");
     } finally {
       restore();
     }

--- a/src/lib/actions/sandbox/gateway-restart.ts
+++ b/src/lib/actions/sandbox/gateway-restart.ts
@@ -4,7 +4,8 @@
 import { GATEWAY_RESTART_MARKERS as MARKERS } from "../../agent/gateway-restart-markers";
 import * as agentRuntime from "../../agent/runtime";
 import { G, R } from "../../cli/terminal-style";
-import { redactFull } from "../../security/redact";
+import { redactFull, redactUrl } from "../../security/redact";
+import { URL_TOKEN_PATTERN } from "../../security/redact-url";
 import { hermesMcpReconciliationRemediationLines } from "./mcp-bridge-hermes-reconciliation";
 import { inspectHermesMcpReconciliationRefusal } from "./mcp-bridge-recovery";
 
@@ -18,6 +19,7 @@ export type GatewayRestartFailureLayer =
   | "unsupported agent"
   | "privileged control unavailable"
   | "supervisor not running"
+  | "supervisor unavailable"
   | "secret-boundary refusal"
   | "unsafe config path"
   | "config hash mismatch"
@@ -104,7 +106,12 @@ const ANSI_CONTROL_RE =
   /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
 
 function sanitizeGatewayRestartFailureLine(line: string): string {
-  return redactFull(line.replace(ANSI_CONTROL_RE, ""));
+  const withoutControls = line.replace(ANSI_CONTROL_RE, "");
+  const withRedactedUrls = withoutControls.replace(
+    URL_TOKEN_PATTERN,
+    (url) => redactUrl(url) ?? "<REDACTED>",
+  );
+  return redactFull(withRedactedUrls);
 }
 
 function sanitizeGatewayRestartFailureDetail(detail: string): string {
@@ -132,6 +139,12 @@ export function classifyGatewayRestartFailure(result: GatewayRestartCommandResul
     return {
       layer: "supervisor not running",
       detail: detail || "the in-sandbox gateway supervisor is not running",
+    };
+  }
+  if (output.includes("SUPERVISOR_UNAVAILABLE") && output.includes("NEMOCLAW_CONTROL_STAGE=")) {
+    return {
+      layer: "supervisor unavailable",
+      detail: detail || "the managed gateway supervisor became unavailable",
     };
   }
   if (

--- a/test/hermes-gateway-auxiliary-retry.test.ts
+++ b/test/hermes-gateway-auxiliary-retry.test.ts
@@ -106,6 +106,12 @@ describe("Hermes gateway auxiliary retry", () => {
       "failure:1",
     ]);
     expect(result.stdout).not.toContain("unexpected-success");
+    expect(result.stderr).toContain(
+      "[gateway] Hermes auxiliary repair failed; retrying while the exact gateway remains healthy",
+    );
+    expect(result.stderr).toContain(
+      "[gateway] Hermes replacement gateway lost its listener or health endpoint during auxiliary validation; stopping the exact child",
+    );
   });
 });
 
@@ -200,6 +206,7 @@ describe("Hermes gateway relay convergence", () => {
         'hermes_stop_tracked_role() { trace "unexpected-stop:$2"; return 1; }',
         'start_socat_forwarder() { trace "unexpected-start:$*"; return 1; }',
         "hermes_dashboard_healthy() { return 0; }",
+        "ensure_dashboard_log_stream() { trace dashboard-log; }",
         "ensure_gateway_log_stream() { trace gateway-log; }",
         extractShellFunction(source, "hermes_api_socat_bridge_healthy"),
         extractShellFunction(source, "ensure_hermes_supervised_auxiliaries"),

--- a/test/hermes-gateway-supervisor-recovery.test.ts
+++ b/test/hermes-gateway-supervisor-recovery.test.ts
@@ -548,6 +548,36 @@ echo "state=1 lock=1 owner_active=1 token_match=0 original_locked=0 recovery_saf
 });
 
 describe("Hermes supervised auxiliary recovery", () => {
+  it("keeps restart bookkeeping alive when the dashboard log tail is absent (#7484)", () => {
+    const source = fs.readFileSync(START_SCRIPT, "utf-8");
+    const result = runBashHarness([
+      'trace() { printf "%s\\n" "$*"; }',
+      'id() { [ "${1:-}" = "-u" ] && printf "1000\\n"; }',
+      'hermes_tracked_role_is_current() { [ "$2" != "0" ] && [ "$1" != "dashboard-log" ]; }',
+      extractShellFunction(source, "refresh_hermes_supervised_child_pids"),
+      extractShellFunction(source, "mark_hermes_gateway_stopped"),
+      "GATEWAY_PID=4242",
+      'GATEWAY_PID_START_IDENTITY="777"',
+      "DASHBOARD_PID=202",
+      "SOCAT_PID=101",
+      "DASHBOARD_SOCAT_PID=303",
+      "GATEWAY_LOG_TAIL_PID=404",
+      "DASHBOARD_LOG_TAIL_PID=0",
+      "INTERNAL_PORT=18642",
+      "DASHBOARD_INTERNAL_PORT=19119",
+      "PUBLIC_PORT=8642",
+      "DASHBOARD_PUBLIC_PORT=18789",
+      "SANDBOX_WAIT_PID=4242",
+      "SANDBOX_CHILD_PIDS=()",
+      "set -e",
+      "mark_hermes_gateway_stopped",
+      'trace "survived:gateway=$GATEWAY_PID:wait=${SANDBOX_WAIT_PID:-}:children=${SANDBOX_CHILD_PIDS[*]}"',
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe("survived:gateway=0:wait=:children=202 101 303 404");
+  });
+
   it("rejects public health from a relay that loses its tracked identity during the probe", () => {
     const source = fs.readFileSync(START_SCRIPT, "utf-8");
     const result = runBashHarness([
@@ -682,6 +712,9 @@ describe("Hermes supervised auxiliary recovery", () => {
     expect(result.stdout.match(/^stop:/gm)).toHaveLength(5);
     expect(result.stdout).toContain("quarantine");
     expect(result.stderr).toContain("5 exits in 60s window");
+    expect(result.stderr).toContain(
+      "[gateway] Hermes replacement gateway failed listener or health validation; stopping the exact child",
+    );
     expect(result.stdout).not.toContain("unexpected-auxiliary");
   });
 
@@ -1132,6 +1165,7 @@ describe("Hermes supervised auxiliary recovery", () => {
       'hermes_stop_tracked_role() { trace "stop:$2"; return 0; }',
       "start_hermes_dashboard_sandbox_user() { trace start-dashboard; DASHBOARD_PID=404; DASHBOARD_SOCAT_PID=505; }",
       'start_socat_forwarder() { trace "start-forward:$*"; return 0; }',
+      "ensure_dashboard_log_stream() { trace dashboard-log; }",
       "ensure_gateway_log_stream() { trace gateway-log; }",
       extractShellFunction(source, "hermes_socat_bridge_healthy"),
       extractShellFunction(source, "hermes_api_socat_bridge_healthy"),
@@ -1163,6 +1197,7 @@ describe("Hermes supervised auxiliary recovery", () => {
       "stop:303",
       "stop:202",
       "start-dashboard",
+      "dashboard-log",
       "gateway-log",
       "success",
       "final-dashboard:404",
@@ -1183,6 +1218,7 @@ describe("Hermes supervised auxiliary recovery", () => {
       'hermes_stop_tracked_role() { trace "stop:$2"; return 0; }',
       'start_socat_forwarder() { trace "start-forward:$*"; printf -v "$4" 111; return 0; }',
       "start_hermes_dashboard_sandbox_user() { trace unexpected-dashboard-start; return 1; }",
+      "ensure_dashboard_log_stream() { trace dashboard-log; }",
       "ensure_gateway_log_stream() { trace gateway-log; }",
       extractShellFunction(source, "hermes_socat_bridge_healthy"),
       extractShellFunction(source, "hermes_api_socat_bridge_healthy"),
@@ -1213,6 +1249,7 @@ describe("Hermes supervised auxiliary recovery", () => {
       "live:202",
       "live:303",
       "listener:303:18789",
+      "dashboard-log",
       "gateway-log",
       "success",
       "final-api-bridge:111",
@@ -1232,6 +1269,7 @@ describe("Hermes supervised auxiliary recovery", () => {
       'hermes_stop_tracked_role() { trace "stop:$2"; return 0; }',
       "start_hermes_dashboard_sandbox_user() { trace start-dashboard; DASHBOARD_PID=404; DASHBOARD_SOCAT_PID=505; }",
       'start_socat_forwarder() { trace "unexpected-forward:$*"; return 1; }',
+      "ensure_dashboard_log_stream() { trace dashboard-log; }",
       "ensure_gateway_log_stream() { trace gateway-log; }",
       extractShellFunction(source, "hermes_socat_bridge_healthy"),
       extractShellFunction(source, "hermes_api_socat_bridge_healthy"),
@@ -1261,6 +1299,7 @@ describe("Hermes supervised auxiliary recovery", () => {
       "stop:303",
       "stop:202",
       "start-dashboard",
+      "dashboard-log",
       "gateway-log",
       "success",
     ]);

--- a/test/managed-gateway-control.test.ts
+++ b/test/managed-gateway-control.test.ts
@@ -942,7 +942,165 @@ with tempfile.TemporaryDirectory() as root:
 
     control.__file__ = sys.argv[1]
     os.environ["NEMOCLAW_MANAGED_CONTROL_ALLOW_NONROOT_TEST"] = "1"
+    os.environ["NEMOCLAW_MANAGED_CONTROL_PROC_ROOT"] = proc_root
+    os.environ["NEMOCLAW_MANAGED_CONTROL_SYSTEM_ROOT"] = system_root
+    os.makedirs(os.path.join(system_root, "tmp"), exist_ok=True)
+    start_log_path = os.path.join(system_root, "tmp/nemoclaw-start.log")
+    start_log_events = [
+        "[gateway] Hermes runtime preparation refused automatic respawn; retrying in 5s",
+        "[gateway] Hermes gateway launch failed; retrying under the same supervisor",
+        "[gateway] Hermes auxiliary repair failed; retrying while the exact gateway remains healthy",
+        "[gateway] Hermes replacement gateway failed listener or health validation; stopping the exact child",
+        "[gateway] Hermes replacement gateway lost its listener or health endpoint during auxiliary validation; stopping the exact child",
+        "[gateway] CRITICAL: Hermes gateway lost its listener or health endpoint; stopping the exact child for recovery",
+        "[gateway] CRITICAL: 5 exits in 60s window — Hermes relaunch is quarantined until sandbox recreation; check /tmp/gateway.log",
+        "[CRITICAL] Newly launched Hermes gateway pid 5252 failed exact role identity capture; quarantining the managed startup supervisor without signaling the unproven child",
+    ]
+    supervisor_log_uid = 1000 if os.geteuid() == 0 else os.geteuid()
+
+    def write_start_log(lines=start_log_events):
+        with open(start_log_path, "w", encoding="utf-8") as stream:
+            stream.write("\n".join(lines) + "\n")
+        os.chmod(start_log_path, 0o600)
+        if os.geteuid() == 0:
+            os.chown(start_log_path, supervisor_log_uid, os.getegid())
+
+    diagnostic_supervisor = replace(
+        supervisor,
+        uids=(supervisor_log_uid,) * 4,
+    )
+
+    class ExactSupervisorReader:
+        def __init__(self, identity=diagnostic_supervisor):
+            self.identity = identity
+            self.capture_calls = 0
+
+        def capture(self, pid):
+            assert pid == self.identity.pid
+            self.capture_calls += 1
+            return self.identity
+
+    write_start_log()
+    real_system_path = control._system_path
+    real_geteuid = control.os.geteuid
+    control.__file__ = control.INSTALLED_HELPER_PATH
+    control._system_path = lambda _path: start_log_path
+    control.os.geteuid = lambda: 0
+    installed_reader = ExactSupervisorReader()
+    try:
+        start_log_excerpt = control._read_start_log_diagnostic_excerpt(
+            installed_reader, diagnostic_supervisor
+        )
+        installed_topology = [
+            control.os.geteuid(),
+            diagnostic_supervisor.uids[0],
+            os.stat(start_log_path).st_uid,
+            installed_reader.capture_calls,
+        ]
+    finally:
+        control.os.geteuid = real_geteuid
+        control._system_path = real_system_path
+        control.__file__ = sys.argv[1]
+
+    accepted_event_lines = [
+        control._sanitize_start_log_diagnostic_line(line)
+        for line in start_log_events
+    ]
+    unsafe_line_excerpts = [
+        control._sanitize_start_log_diagnostic_line(
+            start_log_events[1] + "; token=sk-suffix-secret"
+        ),
+        control._sanitize_start_log_diagnostic_line(
+            "[gateway] Hermes HF_TOKEN=hf-secret-value"
+        ),
+        control._sanitize_start_log_diagnostic_line(
+            "\x1b[31m" + start_log_events[2] + "\x1b[0m"
+        ),
+        control._sanitize_start_log_diagnostic_line(
+            start_log_events[3] + "\x07"
+        ),
+        control._sanitize_start_log_diagnostic_line(
+            start_log_events[0] + ("x" * 600)
+        ),
+    ]
+
+    control._system_path = lambda _path: start_log_path
+    exact_reader = ExactSupervisorReader()
+    os.chmod(start_log_path, 0o644)
+    unsafe_mode_excerpt = control._read_start_log_diagnostic_excerpt(
+        exact_reader, diagnostic_supervisor
+    )
+    write_start_log()
+    os.link(start_log_path, start_log_path + ".link")
+    hardlink_excerpt = control._read_start_log_diagnostic_excerpt(
+        ExactSupervisorReader(), diagnostic_supervisor
+    )
+    os.unlink(start_log_path + ".link")
+    wrong_owner_supervisor = replace(
+        diagnostic_supervisor,
+        uids=(diagnostic_supervisor.uids[0] + 1,) * 4,
+    )
+    wrong_owner_excerpt = control._read_start_log_diagnostic_excerpt(
+        ExactSupervisorReader(wrong_owner_supervisor),
+        wrong_owner_supervisor,
+    )
+    os.rename(start_log_path, start_log_path + ".regular")
+    os.symlink(start_log_path + ".regular", start_log_path)
+    symlink_excerpt = control._read_start_log_diagnostic_excerpt(
+        ExactSupervisorReader(), diagnostic_supervisor
+    )
+    os.unlink(start_log_path)
+    os.rename(start_log_path + ".regular", start_log_path)
+    os.rename(start_log_path, start_log_path + ".regular")
+    os.mkfifo(start_log_path, 0o600)
+    non_regular_excerpt = control._read_start_log_diagnostic_excerpt(
+        ExactSupervisorReader(), diagnostic_supervisor
+    )
+    os.unlink(start_log_path)
+    os.rename(start_log_path + ".regular", start_log_path)
+
+    class ChurningSupervisorReader(ExactSupervisorReader):
+        def capture(self, pid):
+            current = super().capture(pid)
+            if self.capture_calls > 1:
+                return replace(current, start_time="replaced")
+            return current
+
+    supervisor_churn_excerpt = control._read_start_log_diagnostic_excerpt(
+        ChurningSupervisorReader(), diagnostic_supervisor
+    )
+
+    real_os_read = control.os.read
+    mutated = [False]
+
+    def mutate_during_read(fd, count):
+        chunk = real_os_read(fd, count)
+        if not mutated[0]:
+            mutated[0] = True
+            with open(start_log_path, "a", encoding="utf-8") as stream:
+                stream.write(start_log_events[1] + "\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+        return chunk
+
+    control.os.read = mutate_during_read
+    try:
+        mutation_excerpt = control._read_start_log_diagnostic_excerpt(
+            ExactSupervisorReader(), diagnostic_supervisor
+        )
+    finally:
+        control.os.read = real_os_read
+        control._system_path = real_system_path
+    write_start_log(start_log_events[-2:])
+
     real_control = control._control
+    real_start_log_reader = control._read_start_log_diagnostic_excerpt
+    diagnostic_output_events = tuple(
+        start_log_events[index] for index in (2, 3, 6)
+    )
+    control._read_start_log_diagnostic_excerpt = (
+        lambda _reader, _supervisor: diagnostic_output_events
+    )
     control._control = lambda *_args: (_ for _ in ()).throw(
         control.ControlError("SUPERVISOR_UNAVAILABLE", stage="await-replacement")
     )
@@ -953,6 +1111,32 @@ with tempfile.TemporaryDirectory() as root:
     finally:
         control._control = real_control
     staged_diagnostic = [staged_status, staged_stderr.getvalue().splitlines()]
+    control._control = lambda *_args: (_ for _ in ()).throw(
+        control.ControlError("GATEWAY_HEALTH_TIMEOUT", stage="await-replacement")
+    )
+    health_stderr = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(health_stderr):
+            health_status = control.main(["restart", "f" * 64])
+    finally:
+        control._control = real_control
+        control._read_start_log_diagnostic_excerpt = real_start_log_reader
+    health_diagnostic = [health_status, health_stderr.getvalue().splitlines()]
+    exact_failure_diagnostics = []
+    for failure_code in ("SUPERVISOR_BUSY", "SUPERVISOR_NOT_RUNNING"):
+        def fail_with_exact_marker(*_args, code=failure_code):
+            with control._control_stage("discover-supervisor"):
+                raise control.ControlError(code)
+        control._control = fail_with_exact_marker
+        exact_stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(exact_stderr):
+                exact_status = control.main(["restart", "f" * 64])
+        finally:
+            control._control = real_control
+        exact_failure_diagnostics.append(
+            [exact_status, exact_stderr.getvalue().splitlines()]
+        )
 
     print(json.dumps({
         "initial": initial_proof,
@@ -1018,7 +1202,22 @@ with tempfile.TemporaryDirectory() as root:
         "source_seams": [source_proc, source_system],
         "disabled_source_seams": [disabled_source_proc, disabled_source_system],
         "installed_seams": [installed_proc, installed_system],
+        "start_log_security": {
+            "installed_topology": installed_topology,
+            "accepted_events": accepted_event_lines,
+            "excerpt": start_log_excerpt,
+            "rejected_lines": unsafe_line_excerpts,
+            "wrong_mode": unsafe_mode_excerpt,
+            "hardlink": hardlink_excerpt,
+            "wrong_owner": wrong_owner_excerpt,
+            "symlink": symlink_excerpt,
+            "non_regular": non_regular_excerpt,
+            "supervisor_churn": supervisor_churn_excerpt,
+            "file_mutation": mutation_excerpt,
+        },
         "staged_diagnostic": staged_diagnostic,
+        "health_diagnostic": health_diagnostic,
+        "exact_failure_diagnostics": exact_failure_diagnostics,
     }))
 `;
 
@@ -1030,7 +1229,8 @@ describe("managed gateway root control", () => {
     });
 
     expect(result.status, result.stderr).toBe(0);
-    expect(JSON.parse(result.stdout)).toEqual({
+    const output = JSON.parse(result.stdout);
+    expect(output).toEqual({
       initial: {
         stable_zombie: ["Z", 0],
         supervisor: [40, "222", 1],
@@ -1120,11 +1320,70 @@ describe("managed gateway root control", () => {
       source_seams: ["/attacker/proc", "/attacker/root"],
       disabled_source_seams: ["/proc", "/"],
       installed_seams: ["/proc", "/"],
+      start_log_security: {
+        installed_topology: [0, expect.any(Number), expect.any(Number), 2],
+        accepted_events: [
+          "[gateway] Hermes runtime preparation refused automatic respawn; retrying in 5s",
+          "[gateway] Hermes gateway launch failed; retrying under the same supervisor",
+          "[gateway] Hermes auxiliary repair failed; retrying while the exact gateway remains healthy",
+          "[gateway] Hermes replacement gateway failed listener or health validation; stopping the exact child",
+          "[gateway] Hermes replacement gateway lost its listener or health endpoint during auxiliary validation; stopping the exact child",
+          "[gateway] CRITICAL: Hermes gateway lost its listener or health endpoint; stopping the exact child for recovery",
+          "[gateway] CRITICAL: 5 exits in 60s window — Hermes relaunch is quarantined until sandbox recreation; check /tmp/gateway.log",
+          "[CRITICAL] Newly launched Hermes gateway pid 5252 failed exact role identity capture; quarantining the managed startup supervisor without signaling the unproven child",
+        ],
+        excerpt: [
+          "[gateway] Hermes auxiliary repair failed; retrying while the exact gateway remains healthy",
+          "[gateway] Hermes replacement gateway failed listener or health validation; stopping the exact child",
+          "[gateway] Hermes replacement gateway lost its listener or health endpoint during auxiliary validation; stopping the exact child",
+          "[gateway] CRITICAL: Hermes gateway lost its listener or health endpoint; stopping the exact child for recovery",
+          "[gateway] CRITICAL: 5 exits in 60s window — Hermes relaunch is quarantined until sandbox recreation; check /tmp/gateway.log",
+          "[CRITICAL] Newly launched Hermes gateway pid 5252 failed exact role identity capture; quarantining the managed startup supervisor without signaling the unproven child",
+        ],
+        rejected_lines: [null, null, null, null, null],
+        wrong_mode: [],
+        hardlink: [],
+        wrong_owner: [],
+        symlink: [],
+        non_regular: [],
+        supervisor_churn: [],
+        file_mutation: [],
+      },
       staged_diagnostic: [
         1,
-        ["SUPERVISOR_UNAVAILABLE", "NEMOCLAW_CONTROL_STAGE=await-replacement"],
+        [
+          "SUPERVISOR_UNAVAILABLE",
+          "NEMOCLAW_CONTROL_STAGE=await-replacement",
+          "NEMOCLAW_SUPERVISOR_PID=40",
+          "NEMOCLAW_GATEWAY_PID=44",
+          "NEMOCLAW_START_LOG=[gateway] Hermes auxiliary repair failed; retrying while the exact gateway remains healthy",
+          "NEMOCLAW_START_LOG=[gateway] Hermes replacement gateway failed listener or health validation; stopping the exact child",
+          "NEMOCLAW_START_LOG=[gateway] CRITICAL: 5 exits in 60s window — Hermes relaunch is quarantined until sandbox recreation; check /tmp/gateway.log",
+        ],
+      ],
+      health_diagnostic: [
+        1,
+        [
+          "GATEWAY_HEALTH_TIMEOUT",
+          "NEMOCLAW_CONTROL_STAGE=await-replacement",
+          "NEMOCLAW_SUPERVISOR_PID=40",
+          "NEMOCLAW_GATEWAY_PID=44",
+          "NEMOCLAW_START_LOG=[gateway] Hermes auxiliary repair failed; retrying while the exact gateway remains healthy",
+          "NEMOCLAW_START_LOG=[gateway] Hermes replacement gateway failed listener or health validation; stopping the exact child",
+          "NEMOCLAW_START_LOG=[gateway] CRITICAL: 5 exits in 60s window — Hermes relaunch is quarantined until sandbox recreation; check /tmp/gateway.log",
+        ],
+      ],
+      exact_failure_diagnostics: [
+        [1, ["SUPERVISOR_BUSY"]],
+        [1, ["SUPERVISOR_NOT_RUNNING"]],
       ],
     });
+    expect(output.start_log_security.installed_topology[0]).not.toBe(
+      output.start_log_security.installed_topology[1],
+    );
+    expect(output.start_log_security.installed_topology[1]).toBe(
+      output.start_log_security.installed_topology[2],
+    );
   });
 
   it.each([


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

A managed Hermes restart could lose the replacement path when optional tracked children were absent under `set -e`, while the host reported only a generic health timeout for later launch, health, or auxiliary failures. This change keeps supervised recovery running, repairs both log streams, and returns bounded stage, PID, and fixed lifecycle evidence without trusting sandbox-writable diagnostics.

## Related Issue

Fixes #7484

## Changes

- Make `refresh_hermes_supervised_child_pids` a total bookkeeping operation so a missing optional child cannot abort replacement launch under `set -e`, and repair both dashboard and gateway log streams with the other supervised auxiliaries.
- Distinguish preparation, launch, gateway listener/health, auxiliary repair, exact-child stop, and quarantine events with fixed messages. The managed controller reads only full-matched events from a bounded descriptor-pinned tail owned by the exact re-proven supervisor UID; filesystem or process churn yields no excerpt.
- Add staged `GATEWAY_HEALTH_TIMEOUT` and supervisor-loss diagnostics to the privileged helper while preserving the exact one-line `SUPERVISOR_BUSY` and `SUPERVISOR_NOT_RUNNING` contracts.
- Classify staged supervisor loss separately on the host and apply URL plus full-secret redaction before rendering diagnostic detail.
- Add installed-topology and adversarial coverage for non-root supervisor ownership, symlink/hardlink/FIFO and mode attacks, concurrent mutation, process churn, arbitrary or secret-bearing text, controls, suffixes, oversized lines, `set -e` recovery, auxiliary repair, marker compatibility, and host classification.
- Exact-head CI/E2E must still prove the runtime boundary: stable supervisor/PID 1, a replaced gateway PID, and healthy internal API, public relay, dashboard, and forwards after restart.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing gateway lifecycle and troubleshooting pages already describe the restored managed Hermes recovery behavior and `SUPERVISOR_UNAVAILABLE` handling. The new bounded diagnostic fields add no command, flag, configuration, API, policy schema, or recovery action.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category review on exact head `5e2dd0603` passed with no open findings; evidence is recorded at https://github.com/NVIDIA/NemoClaw/pull/7489#issuecomment-5072845426. Exact-head CI/E2E remains required before merge.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing gateway lifecycle and troubleshooting pages already cover the managed Hermes recovery and `SUPERVISOR_UNAVAILABLE` actions. The exact-head follow-up adds only explanatory code comments and integrates current main; it changes no documentation contract or recovery action.
- Agent: `Codex Desktop`
<!-- docs-review-head-sha: 5e2dd0603 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/managed-gateway-control.test.ts test/hermes-gateway-supervisor-recovery.test.ts test/hermes-gateway-auxiliary-retry.test.ts` — 53 tests passed; `npx vitest run --project cli src/lib/actions/sandbox/gateway-restart.test.ts` — 18 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway recovery/restart behavior when supervisor services and log streams are temporarily unavailable.
  * Added clearer handling when a replacement gateway fails after health/listener readiness, including better stop-reasons.
* **Security**
  * Enhanced failure diagnostics to include only bounded, sanitized excerpts, with secrets and control/terminal characters excluded.
* **Reliability**
  * Gateway restart failures now preserve and surface control-stage details more consistently, including a distinct “supervisor unavailable” failure classification.
* **Tests**
  * Expanded regression coverage for recovery, restart classification, and log-security behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

