### PR TITLE
fix(dcode): preserve max retries in headless runs

### DIFF
--- a/agents/langchain-deepagents-code/patch-managed-deepagents-code.py
+++ b/agents/langchain-deepagents-code/patch-managed-deepagents-code.py
@@ -758,7 +758,14 @@ async def run_non_interactive(*args, **kwargs):
     """Enforce the managed headless boundary at the final Python call site."""
     settings.shell_allow_list = None
     kwargs["startup_cmd"] = None
-    kwargs["model_params"] = None
+    from deepagents_code.config import CLI_MAX_RETRIES_KEY
+
+    model_params = kwargs.get("model_params")
+    kwargs["model_params"] = (
+        {CLI_MAX_RETRIES_KEY: model_params[CLI_MAX_RETRIES_KEY]}
+        if isinstance(model_params, dict) and CLI_MAX_RETRIES_KEY in model_params
+        else None
+    )
     kwargs["profile_override"] = None
     kwargs["sandbox_type"] = "none"
     from deepagents_code._nemoclaw_managed import managed_mcp_config_path

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -166,6 +166,8 @@ They disable Deep Agents Code package update checks and the LangGraph server ver
 The managed model constructor accepts only Deep Agents Code's `openai` provider path and reads its endpoint from a root-owned image file.
 It supplies the non-secret gateway placeholder key and ignores mutable provider classes, credentials, endpoints, and constructor parameters in Deep Agents Code config.
 CLI and TUI model parameter overrides and custom rubric models are blocked.
+For headless runs, `--max-retries` remains available after Deep Agents Code validates the retry count.
+The managed boundary discards every other model parameter, including credentials, endpoints, and provider settings.
 Project and user-defined subagents remain available, but they inherit the managed chat model instead of accepting their own model override.
 MCP servers registered through `nemoclaw <sandbox-name> mcp add` remain available through NemoClaw's dedicated `/sandbox/.deepagents/.nemoclaw-mcp.json` projection and OpenShell egress policy.
 Project and user MCP files are never auto-loaded.

--- a/test/helpers/langchain-deepagents-code-patch-fixture.ts
+++ b/test/helpers/langchain-deepagents-code-patch-fixture.ts
@@ -254,6 +254,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 _dotenv_loaded_values = {}
+CLI_MAX_RETRIES_KEY = "__deepagents_cli_max_retries__"
 
 
 def _preview_dotenv_environ(*, start_path=None):

--- a/test/langchain-deepagents-code-retry-boundary.test.ts
+++ b/test/langchain-deepagents-code-retry-boundary.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanupPackageFixtures,
+  createPackageFixture,
+  patchFixture,
+} from "./helpers/langchain-deepagents-code-patch-fixture";
+
+afterEach(cleanupPackageFixtures);
+
+describe("LangChain Deep Agents Code managed retry boundary", () => {
+  it("preserves only the parsed retry count in headless runs (#7414)", () => {
+    const tempDir = createPackageFixture();
+    patchFixture(tempDir);
+    const validation = `
+import asyncio
+
+from deepagents_code.client import non_interactive
+from deepagents_code.config import CLI_MAX_RETRIES_KEY
+
+
+async def validate():
+    retry_params = await non_interactive.run_non_interactive(
+        "message",
+        "assistant",
+        model_params={
+            CLI_MAX_RETRIES_KEY: 4,
+            "api_key": "secret",
+            "base_url": "https://attacker.example",
+            "model_provider": "attacker",
+        },
+    )
+    assert retry_params["model_params"] == {CLI_MAX_RETRIES_KEY: 4}
+
+    blocked_params = await non_interactive.run_non_interactive(
+        "message",
+        "assistant",
+        model_params={
+            "api_key": "secret",
+            "base_url": "https://attacker.example",
+            "model_provider": "attacker",
+        },
+    )
+    assert blocked_params["model_params"] is None
+
+
+asyncio.run(validate())
+print("managed-retry-boundary-ok")
+`;
+    const output = execFileSync("python3", ["-c", validation], {
+      env: { PATH: process.env.PATH, PYTHONPATH: tempDir },
+      encoding: "utf8",
+    });
+    expect(output).toContain("managed-retry-boundary-ok");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed headless DCode runs now preserve the validated `--max-retries` value instead of silently discarding it. The managed boundary continues to reject credentials, endpoints, provider settings, and all unrelated model parameters.

## Related Issue

Fixes #7414

## Changes

- Preserve only Deep Agents Code's internal `CLI_MAX_RETRIES_KEY` carrier in `run_non_interactive`.
- Add a focused regression test for the retry carrier and blocked model parameters.
- Document the supported headless retry option and the unchanged managed security boundary.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [Issue #7414](https://github.com/NVIDIA/NemoClaw/issues/7414) defines the single allowed retry carrier. The focused regression test proves credentials, endpoints, provider settings, and unrelated model parameters remain blocked.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/get-started/quickstart-langchain-deepagents-code.mdx`; exact-head review confirmed the text against the implementation, `WRITING.md`, and `docs/CONTRIBUTING.md`. Focused tests passed 56 with 1 platform-specific skip; `npm run docs` passed with 0 errors and 2 existing Fern warnings; `git diff --check` passed.
- Agent: Codex Desktop documentation writer subagent
<!-- docs-review-head-sha: 9fb793e5b -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/langchain-deepagents-code-retry-boundary.test.ts` passed 1/1. The existing direct patch suite passed 57/57 before the focused case moved to satisfy the test-file size budget.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — command passed with 0 errors and 2 unprinted Fern warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: J. Yaunches <jmyaunch@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Headless managed runs now preserve the validated maximum retry setting while discarding other model parameters.
  * Runs without a valid retry setting continue without model parameters.

* **Documentation**
  * Clarified support for `--max-retries` and the handling of other model settings in managed headless runs.

* **Tests**
  * Added coverage for retry preservation and model parameter filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
