### PR TITLE
ci(e2e): add rolling nightly runtime history

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5795,6 +5795,7 @@ jobs:
           EXPLICIT_ONLY_JOBS: ${{ needs.generate-matrix.outputs.explicit_only_jobs }}
           JOBS: ${{ inputs.jobs }}
           RUNTIME_ARTIFACTS: ${{ runner.temp }}/e2e-runtime-audit
+          RUNTIME_SUMMARY_FILE: ${{ runner.temp }}/e2e-runtime-summary.json
           TARGETS: ${{ inputs.targets }}
         with:
           script: |
@@ -5811,6 +5812,9 @@ jobs:
             const runtimeAudit = require(
               path.join(process.env.GITHUB_WORKSPACE, 'scripts/audit-test-runtime.mts'),
             );
+            const runtimeHistory = require(
+              path.join(process.env.GITHUB_WORKSPACE, 'scripts/scorecard/analyze-runtime-history.mts'),
+            );
             const needs = ${{ toJSON(needs) }};
 
             // GitHub's jobs API is the canonical source because `needs.live`
@@ -5818,9 +5822,13 @@ jobs:
             // The typed helper owns and tests the degraded `needs` fallback.
             const apiJobs = await scorecardJobs.loadWorkflowRunJobs({ github, context, core });
             let runtimeSummaryMarkdown;
+            let runtimeHistoryRows = null;
             try {
               const runtimeRows = runtimeAudit.auditTestRuntime([process.env.RUNTIME_ARTIFACTS]);
               runtimeSummaryMarkdown = runtimeAudit.formatRuntimeAuditSummary(runtimeRows);
+              runtimeHistoryRows = runtimeAudit.collectRuntimeHistorySamples([
+                process.env.RUNTIME_ARTIFACTS,
+              ]);
             } catch {
               core.warning('E2E test phase runtime summary unavailable: invalid progress artifact');
               runtimeSummaryMarkdown = [
@@ -5830,6 +5838,18 @@ jobs:
                 '',
               ].join('\n');
             }
+            const runtimeHistoryMarkdown = runtimeHistoryRows === null
+              ? [
+                  '## E2E Nightly Runtime Trend',
+                  '',
+                  'The trend is unavailable because a `test-progress.json` artifact was invalid.',
+                  '',
+                ].join('\n')
+              : await runtimeHistory.buildRuntimeHistory(
+                  { github, context, core },
+                  runtimeHistoryRows,
+                  process.env.RUNTIME_SUMMARY_FILE,
+                );
             const trace = await traceTiming.buildTraceTimingResult({ github, context, core });
             if (trace.budgetWarningMessage) core.warning(trace.budgetWarningMessage);
 
@@ -5848,7 +5868,9 @@ jobs:
               today: new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
             });
 
-            await core.summary.addRaw(`${summaryMarkdown}\n\n${runtimeSummaryMarkdown}`).write();
+            await core.summary
+              .addRaw(`${summaryMarkdown}\n\n${runtimeSummaryMarkdown}\n${runtimeHistoryMarkdown}`)
+              .write();
             core.setOutput('scorecardData', JSON.stringify(scorecardData));
             core.setOutput('slackData', JSON.stringify(slackData));
 
@@ -5909,3 +5931,10 @@ jobs:
             if (!response.ok) {
               core.setFailed(`Slack webhook returned ${response.status}`);
             }
+
+      - name: Upload E2E runtime summary
+        if: ${{ always() && github.event_name == 'schedule' && steps.scorecard.outcome == 'success' }}
+        uses: NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@7768e15eb90d3ee2d33432f481dfe8747e4f6d57
+        with:
+          name: e2e-runtime-summary
+          path: ${{ runner.temp }}/e2e-runtime-summary.json

--- a/scripts/audit-test-runtime.mts
+++ b/scripts/audit-test-runtime.mts
@@ -7,6 +7,9 @@ import { pathToFileURL } from "node:url";
 
 import type { ProgressPhase, ProgressSummary } from "../test/e2e/fixtures/progress.ts";
 
+export type RuntimeOutcome = "passed" | "failed" | "skipped";
+type ValidatedProgressSummary = Omit<ProgressSummary, "durationMs"> & { durationMs: number };
+
 export interface RuntimeAuditRow {
   target: string;
   scenario: string;
@@ -17,10 +20,24 @@ export interface RuntimeAuditRow {
   variabilityMs: number;
   slowestPhase: string;
   slowestPhaseMs: number;
-  slowestPhaseOutcome: "passed" | "failed" | "skipped";
+  slowestPhaseOutcome: RuntimeOutcome;
 }
 
-function isProgressSummary(value: unknown): value is ProgressSummary {
+export interface RuntimeHistoryPhase {
+  label: string;
+  durationMs: number;
+  outcome: RuntimeOutcome;
+}
+
+export interface RuntimeHistorySample {
+  target: string;
+  scenario: string;
+  durationMs: number;
+  outcome: RuntimeOutcome;
+  phases: RuntimeHistoryPhase[];
+}
+
+function isProgressSummary(value: unknown): value is ValidatedProgressSummary {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const summary = value as Partial<ProgressSummary>;
   return (
@@ -65,6 +82,14 @@ function progressFiles(root: string): string[] {
   return result.sort();
 }
 
+function readProgressSummaries(roots: readonly string[]): ValidatedProgressSummary[] {
+  return roots.flatMap(progressFiles).map((file) => {
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (!isProgressSummary(parsed)) throw new Error(`${file}: invalid test progress summary`);
+    return parsed;
+  });
+}
+
 function percentile(sorted: readonly number[], fraction: number): number {
   const index = Math.max(0, Math.ceil(sorted.length * fraction) - 1);
   return sorted[index] ?? 0;
@@ -78,13 +103,57 @@ function median(sorted: readonly number[]): number {
   return sorted[middle] ?? 0;
 }
 
+function runtimeOutcome(phases: readonly Pick<ProgressPhase, "outcome">[]): RuntimeOutcome {
+  if (phases.some((phase) => phase.outcome === "failed")) return "failed";
+  if (phases.some((phase) => phase.outcome === "skipped")) return "skipped";
+  return "passed";
+}
+
+function targetIdentity(summary: ValidatedProgressSummary): string {
+  return [summary.targetId ?? "unlabeled", summary.shardId].filter(Boolean).join("/");
+}
+
+export function collectRuntimeHistorySamples(
+  roots: readonly string[],
+): RuntimeHistorySample[] {
+  const grouped = new Map<string, ValidatedProgressSummary[]>();
+  for (const summary of readProgressSummaries(roots)) {
+    const key = JSON.stringify([targetIdentity(summary), summary.scenario]);
+    const group = grouped.get(key) ?? [];
+    group.push(summary);
+    grouped.set(key, group);
+  }
+
+  return [...grouped.values()]
+    .map((runs): RuntimeHistorySample => {
+      const first = runs[0];
+      if (!first) throw new Error("runtime history group is unexpectedly empty");
+      const phasesByLabel = new Map<string, ProgressPhase[]>();
+      for (const phase of runs.flatMap((run) => run.phases)) {
+        const phases = phasesByLabel.get(phase.label) ?? [];
+        phases.push(phase);
+        phasesByLabel.set(phase.label, phases);
+      }
+      return {
+        target: targetIdentity(first),
+        scenario: first.scenario,
+        durationMs: median(runs.map((run) => run.durationMs).sort((a, b) => a - b)),
+        outcome: runtimeOutcome(runs.flatMap((run) => run.phases)),
+        phases: [...phasesByLabel.entries()]
+          .map(([label, phases]) => ({
+            label,
+            durationMs: median(phases.map((phase) => phase.durationMs).sort((a, b) => a - b)),
+            outcome: runtimeOutcome(phases),
+          }))
+          .sort((left, right) => left.label.localeCompare(right.label)),
+      };
+    })
+    .sort((left, right) => right.durationMs - left.durationMs);
+}
+
 export function auditTestRuntime(roots: readonly string[]): RuntimeAuditRow[] {
-  const summaries = roots.flatMap(progressFiles).map((file) => {
-    const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf8"));
-    if (!isProgressSummary(parsed)) throw new Error(`${file}: invalid test progress summary`);
-    return parsed;
-  });
-  const grouped = new Map<string, ProgressSummary[]>();
+  const summaries = readProgressSummaries(roots);
+  const grouped = new Map<string, ValidatedProgressSummary[]>();
   for (const summary of summaries) {
     const key = JSON.stringify([
       summary.targetId ?? "unlabeled",
@@ -109,7 +178,7 @@ export function auditTestRuntime(roots: readonly string[]): RuntimeAuditRow[] {
       const medianMs = median(durations);
       const p95Ms = percentile(durations, 0.95);
       return {
-        target: [first.targetId ?? "unlabeled", first.shardId].filter(Boolean).join("/"),
+        target: targetIdentity(first),
         scenario: first.scenario,
         runs: runs.length,
         medianMs,

--- a/scripts/scorecard/analyze-runtime-history.mts
+++ b/scripts/scorecard/analyze-runtime-history.mts
@@ -19,6 +19,7 @@ const RUNTIME_SUMMARY_SCHEMA = "nemoclaw.e2e_runtime_summary.v1";
 const WORKFLOW_FILE = "e2e.yaml";
 const HISTORY_RUN_LIMIT = 10;
 const HISTORY_QUERY_LIMIT = 20;
+const FLAKE_WATCH_LIMIT = 5;
 const MAX_SUMMARY_BYTES = 512 * 1024;
 const MAX_SUMMARY_ROWS = 200;
 const MAX_PHASES_PER_ROW = 32;
@@ -55,7 +56,9 @@ function isBoundedString(value: unknown): value is string {
 }
 
 function isDuration(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= MAX_DURATION_MS;
+  return (
+    typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= MAX_DURATION_MS
+  );
 }
 
 function isOutcome(value: unknown): value is RuntimeOutcome {
@@ -253,10 +256,7 @@ function formatDelta(currentMs: number, priorMs: number): string {
 function isSignificantRegression(currentMs: number, priorMs: number): boolean {
   const deltaMs = currentMs - priorMs;
   const percent = priorMs > 0 ? (deltaMs / priorMs) * 100 : 0;
-  return (
-    deltaMs >= RUNTIME_REGRESSION_MIN_DELTA_MS &&
-    percent >= RUNTIME_REGRESSION_MIN_PERCENT
-  );
+  return deltaMs >= RUNTIME_REGRESSION_MIN_DELTA_MS && percent >= RUNTIME_REGRESSION_MIN_PERCENT;
 }
 
 function sampleFor(
@@ -269,15 +269,19 @@ function sampleFor(
 }
 
 function outcomeRates(rows: readonly RuntimeHistorySample[]): string {
-  const counts = {
-    passed: rows.filter((row) => row.outcome === "passed").length,
-    failed: rows.filter((row) => row.outcome === "failed").length,
-    skipped: rows.filter((row) => row.outcome === "skipped").length,
-  };
+  const counts = countOutcomes(rows);
   const total = rows.length;
   if (total === 0) return "n/a";
   const rate = (count: number) => `${Math.round((count / total) * 100)}%`;
   return `${rate(counts.passed)}/${rate(counts.failed)}/${rate(counts.skipped)} (${counts.passed}/${counts.failed}/${counts.skipped})`;
+}
+
+function countOutcomes(rows: readonly RuntimeHistorySample[]) {
+  return {
+    passed: rows.filter((row) => row.outcome === "passed").length,
+    failed: rows.filter((row) => row.outcome === "failed").length,
+    skipped: rows.filter((row) => row.outcome === "skipped").length,
+  };
 }
 
 function failureStreak(
@@ -305,6 +309,74 @@ function commonFailedPhase(rows: readonly RuntimeHistorySample[]): string {
       rightCount - leftCount || leftLabel.localeCompare(rightLabel),
   )[0];
   return mostCommon ? `${mostCommon[0]} (${mostCommon[1]})` : "n/a";
+}
+
+function outcomeFlips(rows: readonly RuntimeHistorySample[]): number {
+  const outcomes = rows
+    .map((row) => row.outcome)
+    .filter((outcome): outcome is "passed" | "failed" => outcome !== "skipped");
+  return outcomes.slice(1).filter((outcome, index) => outcome !== outcomes[index]).length;
+}
+
+function formatFlakeWatch(
+  currentRows: readonly RuntimeHistorySample[],
+  priorSummaries: readonly RuntimeSummaryArtifact[],
+): string[] {
+  const rows = currentRows
+    .flatMap((current) => {
+      const observed = [
+        current,
+        ...priorSummaries.flatMap((summary) => {
+          const prior = sampleFor(summary, current);
+          return prior ? [prior] : [];
+        }),
+      ];
+      const counts = countOutcomes(observed);
+      if (counts.passed === 0 || counts.failed === 0) return [];
+      const executed = counts.passed + counts.failed;
+      return [
+        {
+          current,
+          observed,
+          counts,
+          failureRate: Math.round((counts.failed / executed) * 100),
+          flips: outcomeFlips(observed),
+          streak: failureStreak(current, priorSummaries),
+        },
+      ];
+    })
+    .sort(
+      (left, right) =>
+        right.flips - left.flips ||
+        right.counts.failed - left.counts.failed ||
+        right.failureRate - left.failureRate ||
+        right.observed.length - left.observed.length ||
+        left.current.target.localeCompare(right.current.target) ||
+        left.current.scenario.localeCompare(right.current.scenario),
+    )
+    .slice(0, FLAKE_WATCH_LIMIT);
+
+  const lines = [
+    "",
+    "### Nightly flake watch",
+    "",
+    "Tests that both passed and failed across the current run and available nightly history. Ranked by pass/fail flips, then failures; skips do not affect the failure rate or flip count.",
+    "",
+  ];
+  if (rows.length === 0) {
+    lines.push("No tests both passed and failed in the available nightly window.");
+    return lines;
+  }
+  lines.push(
+    "| Target | Scenario | Runs | P/F/S | Failure rate | Pass/fail flips | Failure streak | Common failed phase |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+  );
+  for (const row of rows) {
+    lines.push(
+      `| ${escapeCell(row.current.target)} | ${escapeCell(row.current.scenario)} | ${row.observed.length} | ${row.counts.passed}/${row.counts.failed}/${row.counts.skipped} | ${row.failureRate}% | ${row.flips} | ${row.streak} | ${escapeCell(commonFailedPhase(row.observed))} |`,
+    );
+  }
+  return lines;
 }
 
 function significantRegressions(
@@ -390,6 +462,7 @@ export function formatRuntimeHistory(
       `| ${escapeCell(current.target)} | ${escapeCell(current.scenario)} | ${priorRows.length} | ${seconds(current.durationMs)} | ${seconds(priorMedian)} | ${seconds(percentile(durations, 0.95))} | ${formatDelta(current.durationMs, priorMedian)} | ${current.outcome} | ${outcomeRates(priorRows)} | ${failureStreak(current, sortedPrior)} | ${escapeCell(commonFailedPhase([current, ...priorRows]))} | ${escapeCell(significantRegressions(current, priorRows))} |`,
     );
   }
+  lines.push(...formatFlakeWatch(currentRows, sortedPrior));
   return `${lines.join("\n")}\n`;
 }
 

--- a/scripts/scorecard/analyze-runtime-history.mts
+++ b/scripts/scorecard/analyze-runtime-history.mts
@@ -1,0 +1,426 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+
+import type {
+  RuntimeHistoryPhase,
+  RuntimeHistorySample,
+  RuntimeOutcome,
+} from "../audit-test-runtime.mts";
+import { readValidatedArtifactZipEntry } from "./read-artifact-zip.mts";
+
+export const RUNTIME_SUMMARY_ARTIFACT = "e2e-runtime-summary";
+export const RUNTIME_SUMMARY_FILE = "e2e-runtime-summary.json";
+export const RUNTIME_REGRESSION_MIN_DELTA_MS = 30_000;
+export const RUNTIME_REGRESSION_MIN_PERCENT = 20;
+
+const RUNTIME_SUMMARY_SCHEMA = "nemoclaw.e2e_runtime_summary.v1";
+const WORKFLOW_FILE = "e2e.yaml";
+const HISTORY_RUN_LIMIT = 10;
+const HISTORY_QUERY_LIMIT = 20;
+const MAX_SUMMARY_BYTES = 512 * 1024;
+const MAX_SUMMARY_ROWS = 200;
+const MAX_PHASES_PER_ROW = 32;
+const MAX_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
+
+type GitHubDeps = {
+  github: any;
+  context: { repo: { owner: string; repo: string }; runId: number };
+  core?: { warning?: (message: string) => void };
+};
+
+export interface RuntimeSummaryArtifact {
+  schemaVersion: typeof RUNTIME_SUMMARY_SCHEMA;
+  runId: number;
+  createdAt: string;
+  rows: RuntimeHistorySample[];
+}
+
+type RuntimeHistoryServices = {
+  loadPriorNightlySummaries: (deps: GitHubDeps) => Promise<RuntimeSummaryArtifact[]>;
+};
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  return Object.keys(value).sort().join("\0") === [...expected].sort().join("\0");
+}
+
+function isBoundedString(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 500 &&
+    !/[\u0000-\u001f\u007f]/u.test(value)
+  );
+}
+
+function isDuration(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= MAX_DURATION_MS;
+}
+
+function isOutcome(value: unknown): value is RuntimeOutcome {
+  return value === "passed" || value === "failed" || value === "skipped";
+}
+
+function normalizePhase(value: unknown): RuntimeHistoryPhase | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const phase = value as Record<string, unknown>;
+  if (
+    !hasExactKeys(phase, ["label", "durationMs", "outcome"]) ||
+    !isBoundedString(phase.label) ||
+    !isDuration(phase.durationMs) ||
+    !isOutcome(phase.outcome)
+  ) {
+    return null;
+  }
+  return {
+    label: phase.label,
+    durationMs: phase.durationMs,
+    outcome: phase.outcome,
+  };
+}
+
+function normalizeSample(value: unknown): RuntimeHistorySample | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (
+    !hasExactKeys(row, ["target", "scenario", "durationMs", "outcome", "phases"]) ||
+    !isBoundedString(row.target) ||
+    !isBoundedString(row.scenario) ||
+    !isDuration(row.durationMs) ||
+    !isOutcome(row.outcome) ||
+    !Array.isArray(row.phases) ||
+    row.phases.length > MAX_PHASES_PER_ROW
+  ) {
+    return null;
+  }
+  const phases = row.phases.map(normalizePhase);
+  if (phases.some((phase) => phase === null)) return null;
+  const normalizedPhases = phases as RuntimeHistoryPhase[];
+  if (new Set(normalizedPhases.map((phase) => phase.label)).size !== normalizedPhases.length) {
+    return null;
+  }
+  return {
+    target: row.target,
+    scenario: row.scenario,
+    durationMs: row.durationMs,
+    outcome: row.outcome,
+    phases: normalizedPhases,
+  };
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeRuntimeSummary(value: unknown): RuntimeSummaryArtifact | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const summary = value as Record<string, unknown>;
+  if (
+    !hasExactKeys(summary, ["schemaVersion", "runId", "createdAt", "rows"]) ||
+    summary.schemaVersion !== RUNTIME_SUMMARY_SCHEMA ||
+    !Number.isSafeInteger(summary.runId) ||
+    (summary.runId as number) < 1 ||
+    !isCanonicalTimestamp(summary.createdAt) ||
+    !Array.isArray(summary.rows) ||
+    summary.rows.length > MAX_SUMMARY_ROWS
+  ) {
+    return null;
+  }
+  const rows = summary.rows.map(normalizeSample);
+  if (rows.some((row) => row === null)) return null;
+  const normalizedRows = rows as RuntimeHistorySample[];
+  const identities = normalizedRows.map((row) => JSON.stringify([row.target, row.scenario]));
+  if (new Set(identities).size !== identities.length) return null;
+  return {
+    schemaVersion: RUNTIME_SUMMARY_SCHEMA,
+    runId: summary.runId as number,
+    createdAt: summary.createdAt,
+    rows: normalizedRows,
+  };
+}
+
+export function createRuntimeSummary(
+  runId: number,
+  createdAt: string,
+  rows: readonly RuntimeHistorySample[],
+): RuntimeSummaryArtifact {
+  const summary = normalizeRuntimeSummary({
+    schemaVersion: RUNTIME_SUMMARY_SCHEMA,
+    runId,
+    createdAt,
+    rows,
+  });
+  if (summary === null) throw new Error("invalid current E2E runtime summary");
+  return summary;
+}
+
+function parseRuntimeSummaryArchive(archive: Buffer): RuntimeSummaryArtifact | null {
+  try {
+    const contents = readValidatedArtifactZipEntry(archive, RUNTIME_SUMMARY_FILE, {
+      maxBytes: MAX_SUMMARY_BYTES,
+    });
+    return contents === null ? null : normalizeRuntimeSummary(JSON.parse(contents));
+  } catch {
+    return null;
+  }
+}
+
+async function readRuntimeSummaryFromRun(
+  { github, context }: GitHubDeps,
+  runId: number,
+): Promise<RuntimeSummaryArtifact | null> {
+  const artifacts = (await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    run_id: runId,
+    per_page: 100,
+  })) as Array<{ expired?: boolean; id: number; name: string }>;
+  const candidates = artifacts.filter(
+    (artifact) => artifact.name === RUNTIME_SUMMARY_ARTIFACT && artifact.expired !== true,
+  );
+  if (candidates.length !== 1) return null;
+  const download = await github.rest.actions.downloadArtifact({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    artifact_id: candidates[0]!.id,
+    archive_format: "zip",
+  });
+  const summary = parseRuntimeSummaryArchive(Buffer.from(download.data));
+  return summary?.runId === runId ? summary : null;
+}
+
+export async function loadPriorNightlySummaries(
+  deps: GitHubDeps,
+): Promise<RuntimeSummaryArtifact[]> {
+  const { github, context, core } = deps;
+  const response = await github.rest.actions.listWorkflowRuns({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    workflow_id: WORKFLOW_FILE,
+    event: "schedule",
+    status: "completed",
+    per_page: HISTORY_QUERY_LIMIT,
+  });
+  const runs = response.data.workflow_runs as Array<{ id: number }>;
+  const summaries: RuntimeSummaryArtifact[] = [];
+  for (const run of runs) {
+    if (run.id === context.runId) continue;
+    try {
+      const summary = await readRuntimeSummaryFromRun(deps, run.id);
+      if (summary !== null) summaries.push(summary);
+    } catch {
+      core?.warning?.(
+        "One prior nightly runtime summary was unavailable; continuing with less history.",
+      );
+    }
+    if (summaries.length === HISTORY_RUN_LIMIT) break;
+  }
+  return summaries;
+}
+
+function percentile(sorted: readonly number[], fraction: number): number {
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? 0;
+}
+
+function median(sorted: readonly number[]): number {
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2
+    : (sorted[middle] ?? 0);
+}
+
+function seconds(milliseconds: number): string {
+  return `${(milliseconds / 1000).toFixed(1)}s`;
+}
+
+function escapeCell(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function formatDelta(currentMs: number, priorMs: number): string {
+  const deltaMs = currentMs - priorMs;
+  const sign = deltaMs >= 0 ? "+" : "-";
+  const percent = priorMs > 0 ? (deltaMs / priorMs) * 100 : 0;
+  return `${sign}${seconds(Math.abs(deltaMs))} (${sign}${Math.abs(percent).toFixed(1)}%)`;
+}
+
+function isSignificantRegression(currentMs: number, priorMs: number): boolean {
+  const deltaMs = currentMs - priorMs;
+  const percent = priorMs > 0 ? (deltaMs / priorMs) * 100 : 0;
+  return (
+    deltaMs >= RUNTIME_REGRESSION_MIN_DELTA_MS &&
+    percent >= RUNTIME_REGRESSION_MIN_PERCENT
+  );
+}
+
+function sampleFor(
+  summary: RuntimeSummaryArtifact,
+  current: RuntimeHistorySample,
+): RuntimeHistorySample | undefined {
+  return summary.rows.find(
+    (row) => row.target === current.target && row.scenario === current.scenario,
+  );
+}
+
+function outcomeRates(rows: readonly RuntimeHistorySample[]): string {
+  const counts = {
+    passed: rows.filter((row) => row.outcome === "passed").length,
+    failed: rows.filter((row) => row.outcome === "failed").length,
+    skipped: rows.filter((row) => row.outcome === "skipped").length,
+  };
+  const total = rows.length;
+  if (total === 0) return "n/a";
+  const rate = (count: number) => `${Math.round((count / total) * 100)}%`;
+  return `${rate(counts.passed)}/${rate(counts.failed)}/${rate(counts.skipped)} (${counts.passed}/${counts.failed}/${counts.skipped})`;
+}
+
+function failureStreak(
+  current: RuntimeHistorySample,
+  priorSummaries: readonly RuntimeSummaryArtifact[],
+): number {
+  if (current.outcome !== "failed") return 0;
+  let streak = 1;
+  for (const summary of priorSummaries) {
+    const prior = sampleFor(summary, current);
+    if (!prior || prior.outcome !== "failed") break;
+    streak += 1;
+  }
+  return streak;
+}
+
+function commonFailedPhase(rows: readonly RuntimeHistorySample[]): string {
+  const counts = new Map<string, number>();
+  for (const phase of rows.flatMap((row) => row.phases)) {
+    if (phase.outcome !== "failed") continue;
+    counts.set(phase.label, (counts.get(phase.label) ?? 0) + 1);
+  }
+  const mostCommon = [...counts.entries()].sort(
+    ([leftLabel, leftCount], [rightLabel, rightCount]) =>
+      rightCount - leftCount || leftLabel.localeCompare(rightLabel),
+  )[0];
+  return mostCommon ? `${mostCommon[0]} (${mostCommon[1]})` : "n/a";
+}
+
+function significantRegressions(
+  current: RuntimeHistorySample,
+  priorRows: readonly RuntimeHistorySample[],
+): string {
+  const findings: Array<{ deltaMs: number; text: string }> = [];
+  const priorDurations = priorRows.map((row) => row.durationMs).sort((a, b) => a - b);
+  const priorMedian = median(priorDurations);
+  if (isSignificantRegression(current.durationMs, priorMedian)) {
+    findings.push({
+      deltaMs: current.durationMs - priorMedian,
+      text: `total ${formatDelta(current.durationMs, priorMedian)}`,
+    });
+  }
+  for (const phase of current.phases) {
+    const priorPhaseDurations = priorRows
+      .flatMap((row) => row.phases.filter((candidate) => candidate.label === phase.label))
+      .map((candidate) => candidate.durationMs)
+      .sort((a, b) => a - b);
+    if (priorPhaseDurations.length === 0) continue;
+    const priorPhaseMedian = median(priorPhaseDurations);
+    if (!isSignificantRegression(phase.durationMs, priorPhaseMedian)) continue;
+    findings.push({
+      deltaMs: phase.durationMs - priorPhaseMedian,
+      text: `${phase.label} ${formatDelta(phase.durationMs, priorPhaseMedian)}`,
+    });
+  }
+  return findings.length === 0
+    ? "—"
+    : `⚠ ${findings
+        .sort((left, right) => right.deltaMs - left.deltaMs || left.text.localeCompare(right.text))
+        .slice(0, 3)
+        .map((finding) => finding.text)
+        .join("; ")}`;
+}
+
+export function formatRuntimeHistory(
+  currentRows: readonly RuntimeHistorySample[],
+  priorSummaries: readonly RuntimeSummaryArtifact[],
+): string {
+  const sortedPrior = [...priorSummaries].sort(
+    (left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt),
+  );
+  const lines = [
+    "## E2E Nightly Runtime Trend",
+    "",
+    "Current timing compared with up to 10 prior completed scheduled runs; manual runs are excluded from history.",
+    `Regression warnings require both +${seconds(RUNTIME_REGRESSION_MIN_DELTA_MS)} and +${RUNTIME_REGRESSION_MIN_PERCENT}%.`,
+    "",
+  ];
+  if (currentRows.length === 0) {
+    lines.push("No current runtime rows were available for comparison.");
+    return `${lines.join("\n")}\n`;
+  }
+  if (sortedPrior.length === 0) {
+    lines.push(
+      "No prior nightly runtime summaries are available yet; this run starts the history.",
+    );
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push(
+    "| Target | Scenario | Prior nights | Current | Prior median | Prior p95 | Delta | Current outcome | Prior P/F/S | Failure streak | Common failed phase | Significant regressions |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- | ---: | --- | --- |",
+  );
+  for (const current of [...currentRows]
+    .sort((left, right) => right.durationMs - left.durationMs)
+    .slice(0, 10)) {
+    const priorRows = sortedPrior.flatMap((summary) => {
+      const row = sampleFor(summary, current);
+      return row ? [row] : [];
+    });
+    if (priorRows.length === 0) {
+      lines.push(
+        `| ${escapeCell(current.target)} | ${escapeCell(current.scenario)} | 0 | ${seconds(current.durationMs)} | n/a | n/a | n/a | ${current.outcome} | n/a | ${failureStreak(current, sortedPrior)} | ${escapeCell(commonFailedPhase([current]))} | — |`,
+      );
+      continue;
+    }
+    const durations = priorRows.map((row) => row.durationMs).sort((a, b) => a - b);
+    const priorMedian = median(durations);
+    lines.push(
+      `| ${escapeCell(current.target)} | ${escapeCell(current.scenario)} | ${priorRows.length} | ${seconds(current.durationMs)} | ${seconds(priorMedian)} | ${seconds(percentile(durations, 0.95))} | ${formatDelta(current.durationMs, priorMedian)} | ${current.outcome} | ${outcomeRates(priorRows)} | ${failureStreak(current, sortedPrior)} | ${escapeCell(commonFailedPhase([current, ...priorRows]))} | ${escapeCell(significantRegressions(current, priorRows))} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function buildRuntimeHistory(
+  deps: GitHubDeps,
+  currentRows: readonly RuntimeHistorySample[],
+  outputPath: string,
+  services: RuntimeHistoryServices = { loadPriorNightlySummaries },
+  now = new Date(),
+): Promise<string> {
+  let current: RuntimeSummaryArtifact;
+  try {
+    current = createRuntimeSummary(deps.context.runId, now.toISOString(), currentRows);
+    const serialized = `${JSON.stringify(current, null, 2)}\n`;
+    if (Buffer.byteLength(serialized) > MAX_SUMMARY_BYTES) {
+      throw new Error("current E2E runtime summary exceeds its size bound");
+    }
+    fs.writeFileSync(outputPath, serialized, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  } catch {
+    deps.core?.warning?.(
+      "Current E2E runtime summary was invalid or could not be saved; nightly history is unavailable.",
+    );
+    return formatRuntimeHistory([], []);
+  }
+  try {
+    const prior = await services.loadPriorNightlySummaries(deps);
+    return formatRuntimeHistory(current.rows, prior);
+  } catch {
+    deps.core?.warning?.(
+      "Nightly E2E runtime history unavailable; current summary was still saved.",
+    );
+    return formatRuntimeHistory(current.rows, []);
+  }
+}

--- a/scripts/scorecard/analyze-trace-timing.mts
+++ b/scripts/scorecard/analyze-trace-timing.mts
@@ -4,7 +4,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import zlib from "node:zlib";
+
+import { readValidatedArtifactZipEntry } from "./read-artifact-zip.mts";
 
 type SemverTag = { name: string; major: number; minor: number; patch: number; sha?: string };
 type Threshold = { minDeltaMs: number; minPercent: number };
@@ -46,17 +47,6 @@ type TraceTimingResult = {
   budgetWarningMessage: string | null;
   budgetStatus: string;
 };
-type ZipSummaryEntry = {
-  creatorSystem: number;
-  flags: number;
-  compressionMethod: number;
-  expectedCrc: number;
-  compressedSize: number;
-  uncompressedSize: number;
-  diskStart: number;
-  externalAttributes: number;
-  localHeaderOffset: number;
-};
 type GitHubDeps = { github: any; context: any; core?: { warning?: (message: string) => void } };
 type TraceTimingServices = {
   findLatestCompletedE2eRunForReleaseTag: (deps: GitHubDeps, tag: SemverTag) => Promise<any | null>;
@@ -71,9 +61,6 @@ const MAX_TRACE_SUMMARY_BYTES = 1024 * 1024;
 const MAX_TRACE_ARCHIVE_ENTRIES = 1000;
 const TRACE_ARCHIVE_REJECTION_WARNING =
   "Trace timing artifact ZIP validation failed; ignoring the malformed or unsupported archive.";
-const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
-const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
-const ZIP_LOCAL_FILE_SIGNATURE = 0x04034b50;
 const ONBOARD_PERFORMANCE_BUDGET_FILE = "ci/onboard-performance-budget.json";
 const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..");
 const ONBOARD_PHASE_PREFIX = "nemoclaw.onboard.phase.";
@@ -531,30 +518,6 @@ async function findLatestCompletedE2eRunForReleaseTag(
   return null;
 }
 
-function findZipEndOfCentralDirectory(archive: Buffer): number {
-  const minimumOffset = Math.max(0, archive.length - 22 - 0xffff);
-  for (let offset = archive.length - 22; offset >= minimumOffset; offset -= 1) {
-    if (
-      archive.readUInt32LE(offset) === ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE &&
-      offset + 22 + archive.readUInt16LE(offset + 20) === archive.length
-    ) {
-      return offset;
-    }
-  }
-  return -1;
-}
-
-function crc32(data: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of data) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit += 1) {
-      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
-
 // GitHub creates the workflow artifact ZIP outside this repository, and the
 // cloud-onboard artifact intentionally contains diagnostics beside the trusted
 // timing summary. Parse only the exact root-level summary in-process so the
@@ -562,115 +525,10 @@ function crc32(data: Buffer): number {
 // production-shape multi-entry regression test is the removal guard; retire
 // this parser if GitHub provides a verified single-file artifact API.
 function readValidatedTraceSummaryArchive(archive: Buffer): string | null {
-  const endOffset = findZipEndOfCentralDirectory(archive);
-  if (endOffset < 0) return null;
-
-  const diskNumber = archive.readUInt16LE(endOffset + 4);
-  const centralDirectoryDisk = archive.readUInt16LE(endOffset + 6);
-  const entriesOnDisk = archive.readUInt16LE(endOffset + 8);
-  const totalEntries = archive.readUInt16LE(endOffset + 10);
-  const centralDirectorySize = archive.readUInt32LE(endOffset + 12);
-  const centralDirectoryOffset = archive.readUInt32LE(endOffset + 16);
-  if (
-    diskNumber !== 0 ||
-    centralDirectoryDisk !== 0 ||
-    entriesOnDisk !== totalEntries ||
-    totalEntries < 1 ||
-    totalEntries > MAX_TRACE_ARCHIVE_ENTRIES ||
-    centralDirectoryOffset + centralDirectorySize !== endOffset
-  ) {
-    return null;
-  }
-
-  const expectedFileName = Buffer.from(TRACE_SUMMARY_FILE, "utf8");
-  let centralEntryOffset = centralDirectoryOffset;
-  let target: ZipSummaryEntry | null = null;
-  for (let entryIndex = 0; entryIndex < totalEntries; entryIndex += 1) {
-    if (
-      centralEntryOffset + 46 > endOffset ||
-      archive.readUInt32LE(centralEntryOffset) !== ZIP_CENTRAL_DIRECTORY_SIGNATURE
-    ) {
-      return null;
-    }
-    const fileNameLength = archive.readUInt16LE(centralEntryOffset + 28);
-    const extraLength = archive.readUInt16LE(centralEntryOffset + 30);
-    const commentLength = archive.readUInt16LE(centralEntryOffset + 32);
-    const centralEntryEnd = centralEntryOffset + 46 + fileNameLength + extraLength + commentLength;
-    if (centralEntryEnd > endOffset) return null;
-    const fileName = archive.subarray(
-      centralEntryOffset + 46,
-      centralEntryOffset + 46 + fileNameLength,
-    );
-    if (fileName.equals(expectedFileName)) {
-      if (target !== null) return null;
-      target = {
-        creatorSystem: archive.readUInt8(centralEntryOffset + 5),
-        flags: archive.readUInt16LE(centralEntryOffset + 8),
-        compressionMethod: archive.readUInt16LE(centralEntryOffset + 10),
-        expectedCrc: archive.readUInt32LE(centralEntryOffset + 16),
-        compressedSize: archive.readUInt32LE(centralEntryOffset + 20),
-        uncompressedSize: archive.readUInt32LE(centralEntryOffset + 24),
-        diskStart: archive.readUInt16LE(centralEntryOffset + 34),
-        externalAttributes: archive.readUInt32LE(centralEntryOffset + 38),
-        localHeaderOffset: archive.readUInt32LE(centralEntryOffset + 42),
-      };
-    }
-    centralEntryOffset = centralEntryEnd;
-  }
-  if (centralEntryOffset !== endOffset || target === null) return null;
-
-  const {
-    creatorSystem,
-    flags,
-    compressionMethod,
-    expectedCrc,
-    compressedSize,
-    uncompressedSize,
-    diskStart,
-    externalAttributes,
-    localHeaderOffset,
-  } = target;
-  const unixFileType = (externalAttributes >>> 16) & 0xf000;
-  if (
-    diskStart !== 0 ||
-    (flags & 0x1) !== 0 ||
-    (compressionMethod !== 0 && compressionMethod !== 8) ||
-    compressedSize > MAX_TRACE_SUMMARY_BYTES ||
-    uncompressedSize > MAX_TRACE_SUMMARY_BYTES ||
-    (creatorSystem !== 0 && creatorSystem !== 3) ||
-    (creatorSystem === 3 && unixFileType !== 0 && unixFileType !== 0x8000) ||
-    localHeaderOffset + 30 > centralDirectoryOffset ||
-    archive.readUInt32LE(localHeaderOffset) !== ZIP_LOCAL_FILE_SIGNATURE
-  ) {
-    return null;
-  }
-
-  const localFlags = archive.readUInt16LE(localHeaderOffset + 6);
-  const localCompressionMethod = archive.readUInt16LE(localHeaderOffset + 8);
-  const localFileNameLength = archive.readUInt16LE(localHeaderOffset + 26);
-  const localExtraLength = archive.readUInt16LE(localHeaderOffset + 28);
-  const localFileName = archive.subarray(
-    localHeaderOffset + 30,
-    localHeaderOffset + 30 + localFileNameLength,
-  );
-  const compressedDataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
-  const compressedDataEnd = compressedDataOffset + compressedSize;
-  if (
-    localFlags !== flags ||
-    localCompressionMethod !== compressionMethod ||
-    !localFileName.equals(expectedFileName) ||
-    compressedDataEnd > centralDirectoryOffset
-  ) {
-    return null;
-  }
-
-  const compressedData = archive.subarray(compressedDataOffset, compressedDataEnd);
-  const summary =
-    compressionMethod === 0
-      ? Buffer.from(compressedData)
-      : zlib.inflateRawSync(compressedData, { maxOutputLength: MAX_TRACE_SUMMARY_BYTES });
-  if (summary.length !== uncompressedSize || crc32(summary) !== expectedCrc) return null;
-  return summary.toString("utf8");
+  return readValidatedArtifactZipEntry(archive, TRACE_SUMMARY_FILE, {
+    maxBytes: MAX_TRACE_SUMMARY_BYTES,
+    maxEntries: MAX_TRACE_ARCHIVE_ENTRIES,
+  });
 }
 
 function readValidatedTraceSummaryZip(

--- a/scripts/scorecard/read-artifact-zip.mts
+++ b/scripts/scorecard/read-artifact-zip.mts
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import zlib from "node:zlib";
+
+type ZipEntry = {
+  creatorSystem: number;
+  flags: number;
+  compressionMethod: number;
+  expectedCrc: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  diskStart: number;
+  externalAttributes: number;
+  localHeaderOffset: number;
+};
+
+const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const ZIP_LOCAL_FILE_SIGNATURE = 0x04034b50;
+
+function findZipEndOfCentralDirectory(archive: Buffer): number {
+  const minimumOffset = Math.max(0, archive.length - 22 - 0xffff);
+  for (let offset = archive.length - 22; offset >= minimumOffset; offset -= 1) {
+    if (
+      archive.readUInt32LE(offset) === ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE &&
+      offset + 22 + archive.readUInt16LE(offset + 20) === archive.length
+    ) {
+      return offset;
+    }
+  }
+  return -1;
+}
+
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * Reads one exact root-level file from a GitHub artifact ZIP without
+ * extracting paths to disk. Duplicate targets, links, encryption, split
+ * archives, ZIP64, excess entries, and oversized payloads are rejected.
+ */
+export function readValidatedArtifactZipEntry(
+  archive: Buffer,
+  expectedFile: string,
+  options: { maxBytes: number; maxEntries?: number },
+): string | null {
+  const maxEntries = options.maxEntries ?? 1000;
+  const expectedFileName = Buffer.from(expectedFile, "utf8");
+  if (
+    expectedFile.length === 0 ||
+    expectedFile.includes("/") ||
+    expectedFile.includes("\\") ||
+    options.maxBytes < 1 ||
+    maxEntries < 1
+  ) {
+    return null;
+  }
+
+  const endOffset = findZipEndOfCentralDirectory(archive);
+  if (endOffset < 0) return null;
+
+  const diskNumber = archive.readUInt16LE(endOffset + 4);
+  const centralDirectoryDisk = archive.readUInt16LE(endOffset + 6);
+  const entriesOnDisk = archive.readUInt16LE(endOffset + 8);
+  const totalEntries = archive.readUInt16LE(endOffset + 10);
+  const centralDirectorySize = archive.readUInt32LE(endOffset + 12);
+  const centralDirectoryOffset = archive.readUInt32LE(endOffset + 16);
+  if (
+    diskNumber !== 0 ||
+    centralDirectoryDisk !== 0 ||
+    entriesOnDisk !== totalEntries ||
+    totalEntries < 1 ||
+    totalEntries > maxEntries ||
+    centralDirectoryOffset + centralDirectorySize !== endOffset
+  ) {
+    return null;
+  }
+
+  let centralEntryOffset = centralDirectoryOffset;
+  let target: ZipEntry | null = null;
+  for (let entryIndex = 0; entryIndex < totalEntries; entryIndex += 1) {
+    if (
+      centralEntryOffset + 46 > endOffset ||
+      archive.readUInt32LE(centralEntryOffset) !== ZIP_CENTRAL_DIRECTORY_SIGNATURE
+    ) {
+      return null;
+    }
+    const fileNameLength = archive.readUInt16LE(centralEntryOffset + 28);
+    const extraLength = archive.readUInt16LE(centralEntryOffset + 30);
+    const commentLength = archive.readUInt16LE(centralEntryOffset + 32);
+    const centralEntryEnd = centralEntryOffset + 46 + fileNameLength + extraLength + commentLength;
+    if (centralEntryEnd > endOffset) return null;
+    const fileName = archive.subarray(
+      centralEntryOffset + 46,
+      centralEntryOffset + 46 + fileNameLength,
+    );
+    if (fileName.equals(expectedFileName)) {
+      if (target !== null) return null;
+      target = {
+        creatorSystem: archive.readUInt8(centralEntryOffset + 5),
+        flags: archive.readUInt16LE(centralEntryOffset + 8),
+        compressionMethod: archive.readUInt16LE(centralEntryOffset + 10),
+        expectedCrc: archive.readUInt32LE(centralEntryOffset + 16),
+        compressedSize: archive.readUInt32LE(centralEntryOffset + 20),
+        uncompressedSize: archive.readUInt32LE(centralEntryOffset + 24),
+        diskStart: archive.readUInt16LE(centralEntryOffset + 34),
+        externalAttributes: archive.readUInt32LE(centralEntryOffset + 38),
+        localHeaderOffset: archive.readUInt32LE(centralEntryOffset + 42),
+      };
+    }
+    centralEntryOffset = centralEntryEnd;
+  }
+  if (centralEntryOffset !== endOffset || target === null) return null;
+
+  const {
+    creatorSystem,
+    flags,
+    compressionMethod,
+    expectedCrc,
+    compressedSize,
+    uncompressedSize,
+    diskStart,
+    externalAttributes,
+    localHeaderOffset,
+  } = target;
+  const unixFileType = (externalAttributes >>> 16) & 0xf000;
+  if (
+    diskStart !== 0 ||
+    (flags & 0x1) !== 0 ||
+    (compressionMethod !== 0 && compressionMethod !== 8) ||
+    compressedSize > options.maxBytes ||
+    uncompressedSize > options.maxBytes ||
+    (creatorSystem !== 0 && creatorSystem !== 3) ||
+    (creatorSystem === 3 && unixFileType !== 0 && unixFileType !== 0x8000) ||
+    localHeaderOffset + 30 > centralDirectoryOffset ||
+    archive.readUInt32LE(localHeaderOffset) !== ZIP_LOCAL_FILE_SIGNATURE
+  ) {
+    return null;
+  }
+
+  const localFlags = archive.readUInt16LE(localHeaderOffset + 6);
+  const localCompressionMethod = archive.readUInt16LE(localHeaderOffset + 8);
+  const localFileNameLength = archive.readUInt16LE(localHeaderOffset + 26);
+  const localExtraLength = archive.readUInt16LE(localHeaderOffset + 28);
+  const localFileNameEnd = localHeaderOffset + 30 + localFileNameLength;
+  const compressedDataOffset = localFileNameEnd + localExtraLength;
+  const compressedDataEnd = compressedDataOffset + compressedSize;
+  if (
+    localFileNameEnd > centralDirectoryOffset ||
+    localFlags !== flags ||
+    localCompressionMethod !== compressionMethod ||
+    !archive.subarray(localHeaderOffset + 30, localFileNameEnd).equals(expectedFileName) ||
+    compressedDataEnd > centralDirectoryOffset
+  ) {
+    return null;
+  }
+
+  const compressedData = archive.subarray(compressedDataOffset, compressedDataEnd);
+  let contents: Buffer;
+  try {
+    contents =
+      compressionMethod === 0
+        ? Buffer.from(compressedData)
+        : zlib.inflateRawSync(compressedData, { maxOutputLength: options.maxBytes });
+  } catch {
+    return null;
+  }
+  if (contents.length !== uncompressedSize || crc32(contents) !== expectedCrc) return null;
+  return contents.toString("utf8");
+}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -161,6 +161,12 @@ graph as the live targets:
   the current run, and the most common failed phase across the compared runs.
   It marks a total or phase regression only when the current duration exceeds
   the prior median by both at least 20% and at least 30 seconds.
+- A separate flake watch shows at most five current tests that both passed and
+  failed across the current run and up to ten prior completed scheduled runs.
+  It ranks them by pass/fail flips and then failure count. It reports
+  pass/fail/skip counts, failure rate, pass/fail flips, current failure streak,
+  and the most common failed phase. The failure-rate denominator and
+  pass/fail-flip count exclude skips.
 - Selective dispatches remain silent unless they run on `main` with
   `post_to_slack=true`, which uses the preview Slack route. Branch-dispatched
   runs never receive Slack webhook secrets.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -147,10 +147,20 @@ graph as the live targets:
   retired. Any future issue escalation should use a separately reviewed
   exceptional threshold, such as the same lane failing twice consecutively or
   remaining broken for 24 hours, rather than posting on every failed schedule.
-- `scorecard` writes the scheduled/manual result summary, adds this run's
-  semantic phase runtime table, compares the trusted cloud-onboard timing
-  summary with the latest prior-release `e2e.yaml` run, and posts to the daily
-  or full-run Slack route.
+- `scorecard` writes the scheduled/manual result summary and posts it to the
+  daily or full-run Slack route. The summary:
+  - adds this run's semantic phase runtime table;
+  - compares each of the ten slowest current tests with up to ten prior
+    completed scheduled runs; and
+  - compares the trusted cloud-onboard timing summary with the latest
+    prior-release `e2e.yaml` run.
+- The nightly comparison reads only validated `e2e-runtime-summary.json`
+  artifacts retained for 14 days. Manual runs can display the comparison but
+  never enter its baseline. The table reports the current outcome, prior median
+  and p95, prior pass/fail/skip counts and rates, the failure streak including
+  the current run, and the most common failed phase across the compared runs.
+  It marks a total or phase regression only when the current duration exceeds
+  the prior median by both at least 20% and at least 30 seconds.
 - Selective dispatches remain silent unless they run on `main` with
   `post_to_slack=true`, which uses the preview Slack route. Branch-dispatched
   runs never receive Slack webhook secrets.
@@ -319,12 +329,13 @@ npm run test:runtime-audit -- path/to/run-1 path/to/run-2
 The audit groups each test by target and optional shard, ranks the groups by
 p95 runtime, and reports variability plus the slowest observed phase's duration
 and outcome. Scheduled and ordinary manual runs include the same table for that
-run in the GitHub Actions scorecard summary. Keep phase
-labels specific to test behavior, call `progress.phase("literal phase label")`
-at the declared boundaries in order, and transition through the final
-test-declared phase on every passing path. Both fixtures reject a passing test
-that never reaches that phase; only the stateful live fixture enters its
-resource-release phase automatically.
+run in the GitHub Actions scorecard summary. Their nightly trend uses only the
+bounded timing and outcome summary rather than downloading historical raw test
+artifacts. Keep phase labels specific to test behavior, call
+`progress.phase("literal phase label")` at the declared boundaries in order,
+and transition through the final test-declared phase on every passing path.
+Both fixtures reject a passing test that never reaches that phase; only the
+stateful live fixture enters its resource-release phase automatically.
 Validate phase coverage without executing test bodies with:
 
 ```bash

--- a/test/e2e/support/artifact-zip.test.ts
+++ b/test/e2e/support/artifact-zip.test.ts
@@ -11,10 +11,14 @@ describe("validated GitHub artifact ZIP reader", () => {
     const archive = artifactZip([
       { name: "diagnostics/log.txt", contents: "ignored" },
       { name: "summary.json", contents: '{"safe":true}' },
+      { name: "résumé.json", contents: '{"utf8":true}' },
     ]);
 
     expect(readValidatedArtifactZipEntry(archive, "summary.json", { maxBytes: 1_024 })).toBe(
       '{"safe":true}',
+    );
+    expect(readValidatedArtifactZipEntry(archive, "résumé.json", { maxBytes: 1_024 })).toBe(
+      '{"utf8":true}',
     );
     expect(readValidatedArtifactZipEntry(archive, "log.txt", { maxBytes: 1_024 })).toBeNull();
   });

--- a/test/e2e/support/artifact-zip.test.ts
+++ b/test/e2e/support/artifact-zip.test.ts
@@ -1,70 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import zlib from "node:zlib";
-
 import { describe, expect, it } from "vitest";
 
 import { readValidatedArtifactZipEntry } from "../../../scripts/scorecard/read-artifact-zip.mts";
-
-function crc32(data: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of data) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit += 1) {
-      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
-
-function artifactZip(
-  entries: Array<{ name: string; contents: string }>,
-  compressionMethod = 0,
-): Buffer {
-  const localParts: Buffer[] = [];
-  const centralParts: Buffer[] = [];
-  let localOffset = 0;
-  for (const entry of entries) {
-    const name = Buffer.from(entry.name, "utf8");
-    const contents = Buffer.from(entry.contents, "utf8");
-    const compressed =
-      compressionMethod === 8 ? zlib.deflateRawSync(contents) : Buffer.from(contents);
-    const checksum = crc32(contents);
-    const local = Buffer.alloc(30);
-    local.writeUInt32LE(0x04034b50, 0);
-    local.writeUInt16LE(20, 4);
-    local.writeUInt16LE(compressionMethod, 8);
-    local.writeUInt32LE(checksum, 14);
-    local.writeUInt32LE(compressed.length, 18);
-    local.writeUInt32LE(contents.length, 22);
-    local.writeUInt16LE(name.length, 26);
-    localParts.push(local, name, compressed);
-
-    const central = Buffer.alloc(46);
-    central.writeUInt32LE(0x02014b50, 0);
-    central.writeUInt16LE(0x0314, 4);
-    central.writeUInt16LE(20, 6);
-    central.writeUInt16LE(compressionMethod, 10);
-    central.writeUInt32LE(checksum, 16);
-    central.writeUInt32LE(compressed.length, 20);
-    central.writeUInt32LE(contents.length, 24);
-    central.writeUInt16LE(name.length, 28);
-    central.writeUInt32LE(0x80000000, 38);
-    central.writeUInt32LE(localOffset, 42);
-    centralParts.push(central, name);
-    localOffset += local.length + name.length + compressed.length;
-  }
-  const locals = Buffer.concat(localParts);
-  const centralDirectory = Buffer.concat(centralParts);
-  const end = Buffer.alloc(22);
-  end.writeUInt32LE(0x06054b50, 0);
-  end.writeUInt16LE(entries.length, 8);
-  end.writeUInt16LE(entries.length, 10);
-  end.writeUInt32LE(centralDirectory.length, 12);
-  end.writeUInt32LE(locals.length, 16);
-  return Buffer.concat([locals, centralDirectory, end]);
-}
+import { artifactZip } from "../../helpers/artifact-zip";
 
 describe("validated GitHub artifact ZIP reader", () => {
   it("reads only the exact root-level entry from a multi-entry archive", () => {

--- a/test/e2e/support/artifact-zip.test.ts
+++ b/test/e2e/support/artifact-zip.test.ts
@@ -6,6 +6,18 @@ import { describe, expect, it } from "vitest";
 import { readValidatedArtifactZipEntry } from "../../../scripts/scorecard/read-artifact-zip.mts";
 import { artifactZip } from "../../helpers/artifact-zip";
 
+const structuralMutations: Array<[string, (archive: Buffer, centralOffset: number) => void]> = [
+  ["link", (archive, centralOffset) => archive.writeUInt32LE(0xa0000000, centralOffset + 38)],
+  [
+    "encrypted",
+    (archive, centralOffset) => {
+      archive.writeUInt16LE(0x0801, 6);
+      archive.writeUInt16LE(0x0801, centralOffset + 8);
+    },
+  ],
+  ["local-header-mismatched", (archive) => archive.writeUInt16LE(8, 8)],
+];
+
 describe("validated GitHub artifact ZIP reader", () => {
   it("reads only the exact root-level entry from a multi-entry archive", () => {
     const archive = artifactZip([
@@ -58,5 +70,13 @@ describe("validated GitHub artifact ZIP reader", () => {
     expect(
       readValidatedArtifactZipEntry(corruptArchive, "summary.json", { maxBytes: 1_024 }),
     ).toBeNull();
+  });
+
+  it.each(structuralMutations)("rejects %s artifact entries", (_name, mutate) => {
+    const archive = artifactZip([{ name: "summary.json", contents: '{"safe":true}' }]);
+    const centralOffset = archive.readUInt32LE(archive.length - 6);
+    mutate(archive, centralOffset);
+
+    expect(readValidatedArtifactZipEntry(archive, "summary.json", { maxBytes: 1_024 })).toBeNull();
   });
 });

--- a/test/e2e/support/artifact-zip.test.ts
+++ b/test/e2e/support/artifact-zip.test.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import zlib from "node:zlib";
+
+import { describe, expect, it } from "vitest";
+
+import { readValidatedArtifactZipEntry } from "../../../scripts/scorecard/read-artifact-zip.mts";
+
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function artifactZip(
+  entries: Array<{ name: string; contents: string }>,
+  compressionMethod = 0,
+): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let localOffset = 0;
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, "utf8");
+    const contents = Buffer.from(entry.contents, "utf8");
+    const compressed =
+      compressionMethod === 8 ? zlib.deflateRawSync(contents) : Buffer.from(contents);
+    const checksum = crc32(contents);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(compressionMethod, 8);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(contents.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    localParts.push(local, name, compressed);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(0x0314, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(compressionMethod, 10);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(contents.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE(0x80000000, 38);
+    central.writeUInt32LE(localOffset, 42);
+    centralParts.push(central, name);
+    localOffset += local.length + name.length + compressed.length;
+  }
+  const locals = Buffer.concat(localParts);
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(locals.length, 16);
+  return Buffer.concat([locals, centralDirectory, end]);
+}
+
+describe("validated GitHub artifact ZIP reader", () => {
+  it("reads only the exact root-level entry from a multi-entry archive", () => {
+    const archive = artifactZip([
+      { name: "diagnostics/log.txt", contents: "ignored" },
+      { name: "summary.json", contents: '{"safe":true}' },
+    ]);
+
+    expect(readValidatedArtifactZipEntry(archive, "summary.json", { maxBytes: 1_024 })).toBe(
+      '{"safe":true}',
+    );
+    expect(readValidatedArtifactZipEntry(archive, "log.txt", { maxBytes: 1_024 })).toBeNull();
+  });
+
+  it("rejects duplicate target entries and payloads over the caller's bound", () => {
+    expect(
+      readValidatedArtifactZipEntry(
+        artifactZip([
+          { name: "summary.json", contents: "one" },
+          { name: "summary.json", contents: "two" },
+        ]),
+        "summary.json",
+        { maxBytes: 1_024 },
+      ),
+    ).toBeNull();
+    expect(
+      readValidatedArtifactZipEntry(
+        artifactZip([{ name: "summary.json", contents: "too large" }]),
+        "summary.json",
+        { maxBytes: 2 },
+      ),
+    ).toBeNull();
+  });
+
+  it("reads deflated entries and rejects corrupt compressed data", () => {
+    const archive = artifactZip([{ name: "summary.json", contents: '{"compressed":true}' }], 8);
+
+    expect(readValidatedArtifactZipEntry(archive, "summary.json", { maxBytes: 1_024 })).toBe(
+      '{"compressed":true}',
+    );
+
+    const corruptArchive = Buffer.from(archive);
+    const compressedDataOffset =
+      30 + corruptArchive.readUInt16LE(26) + corruptArchive.readUInt16LE(28);
+    const compressedDataEnd = compressedDataOffset + corruptArchive.readUInt32LE(18);
+    corruptArchive.fill(0, compressedDataOffset, compressedDataEnd);
+    expect(
+      readValidatedArtifactZipEntry(corruptArchive, "summary.json", { maxBytes: 1_024 }),
+    ).toBeNull();
+  });
+});

--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -88,6 +88,19 @@ describe("E2E operations workflow boundary", () => {
     );
   });
 
+  it("publishes only the bounded scheduled runtime summary through the canonical uploader", () => {
+    const workflow = readE2eOperationsWorkflow();
+    const upload = workflow.jobs.scorecard.steps!.find(
+      (step) => step.name === "Upload E2E runtime summary",
+    )!;
+    upload.if = "always()";
+    upload.with!.path = "${{ runner.temp }}/e2e-runtime-audit";
+
+    expect(validateE2eOperationsWorkflow(workflow)).toContain(
+      "scorecard must upload only the bounded scheduled runtime summary through the canonical E2E uploader",
+    );
+  });
+
   it("rejects controller protocol and PR validation drift", () => {
     const workflow = readE2eOperationsWorkflow();
     delete workflow.on?.workflow_dispatch?.inputs?.base_sha;
@@ -401,13 +414,20 @@ describe("E2E operations workflow boundary", () => {
     };
     const runtimeAudit = {
       auditTestRuntime: vi.fn().mockReturnValue([{ target: "full-e2e" }]),
+      collectRuntimeHistorySamples: vi.fn().mockReturnValue([{ target: "full-e2e" }]),
       formatRuntimeAuditSummary: vi
         .fn()
         .mockReturnValue("## E2E Test Phase Runtime\n\n| Target | Slowest observed phase |"),
     };
+    const runtimeHistory = {
+      buildRuntimeHistory: vi
+        .fn()
+        .mockResolvedValue("## E2E Nightly Runtime Trend\n\n| Target | Prior median |"),
+    };
     const runtimeModules = new Map<string, unknown>([
       ["path", { join: (...parts: string[]) => parts.join("/") }],
       ["/workspace/scripts/audit-test-runtime.mts", runtimeAudit],
+      ["/workspace/scripts/scorecard/analyze-runtime-history.mts", runtimeHistory],
       ["/workspace/scripts/scorecard/coordinate-scorecard.mts", coordinator],
       ["/workspace/scripts/scorecard/analyze-trace-timing.mts", traceTiming],
       ["/workspace/scripts/scorecard/summarize-jobs.mts", scorecardJobs],
@@ -423,6 +443,7 @@ describe("E2E operations workflow boundary", () => {
         GITHUB_WORKSPACE: "/workspace",
         JOBS: "",
         RUNTIME_ARTIFACTS: "/runner/e2e-runtime-audit",
+        RUNTIME_SUMMARY_FILE: "/runner/e2e-runtime-summary.json",
         TARGETS: "",
       },
     };
@@ -445,6 +466,14 @@ describe("E2E operations workflow boundary", () => {
 
     expect(traceTiming.buildTraceTimingResult).toHaveBeenCalledWith({ github: {}, context, core });
     expect(runtimeAudit.auditTestRuntime).toHaveBeenCalledWith(["/runner/e2e-runtime-audit"]);
+    expect(runtimeAudit.collectRuntimeHistorySamples).toHaveBeenCalledWith([
+      "/runner/e2e-runtime-audit",
+    ]);
+    expect(runtimeHistory.buildRuntimeHistory).toHaveBeenCalledWith(
+      { github: {}, context, core },
+      [{ target: "full-e2e" }],
+      "/runner/e2e-runtime-summary.json",
+    );
     expect(runtimeAudit.auditTestRuntime.mock.invocationCallOrder[0]).toBeLessThan(
       traceTiming.buildTraceTimingResult.mock.invocationCallOrder[0],
     );
@@ -463,7 +492,9 @@ describe("E2E operations workflow boundary", () => {
       }),
     );
     expect(summary.addRaw).toHaveBeenCalledWith(
-      expect.stringMatching(/### Onboard Performance Budget[\s\S]*## E2E Test Phase Runtime/u),
+      expect.stringMatching(
+        /### Onboard Performance Budget[\s\S]*## E2E Test Phase Runtime[\s\S]*## E2E Nightly Runtime Trend/u,
+      ),
     );
     expect(summary.write).toHaveBeenCalledOnce();
     expect(setOutput).toHaveBeenCalledWith("scorecardData", expect.any(String));
@@ -486,11 +517,14 @@ describe("E2E operations workflow boundary", () => {
       auditTestRuntime: vi.fn(() => {
         throw new Error("invalid progress artifact");
       }),
+      collectRuntimeHistorySamples: vi.fn(),
       formatRuntimeAuditSummary: vi.fn(),
     };
+    const runtimeHistory = { buildRuntimeHistory: vi.fn() };
     const runtimeModules = new Map<string, unknown>([
       ["path", { join: (...parts: string[]) => parts.join("/") }],
       ["/workspace/scripts/audit-test-runtime.mts", runtimeAudit],
+      ["/workspace/scripts/scorecard/analyze-runtime-history.mts", runtimeHistory],
       [
         "/workspace/scripts/scorecard/coordinate-scorecard.mts",
         {
@@ -527,6 +561,7 @@ describe("E2E operations workflow boundary", () => {
         GITHUB_WORKSPACE: "/workspace",
         JOBS: "",
         RUNTIME_ARTIFACTS: "/runner/e2e-runtime-audit",
+        RUNTIME_SUMMARY_FILE: "/runner/e2e-runtime-summary.json",
         TARGETS: "",
       },
     };
@@ -550,9 +585,11 @@ describe("E2E operations workflow boundary", () => {
       "E2E test phase runtime summary unavailable: invalid progress artifact",
     );
     expect(runtimeAudit.formatRuntimeAuditSummary).not.toHaveBeenCalled();
+    expect(runtimeAudit.collectRuntimeHistorySamples).not.toHaveBeenCalled();
+    expect(runtimeHistory.buildRuntimeHistory).not.toHaveBeenCalled();
     expect(summary.addRaw).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "The summary is unavailable because a `test-progress.json` artifact was invalid.",
+      expect.stringMatching(
+        /The summary is unavailable because a `test-progress.json` artifact was invalid\.[\s\S]*The trend is unavailable because a `test-progress.json` artifact was invalid\./u,
       ),
     );
     expect(summary.write).toHaveBeenCalledOnce();

--- a/test/e2e/support/e2e-runtime-history.test.ts
+++ b/test/e2e/support/e2e-runtime-history.test.ts
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { RuntimeHistorySample } from "../../../scripts/audit-test-runtime.mts";
+import {
+  buildRuntimeHistory,
+  createRuntimeSummary,
+  formatRuntimeHistory,
+  loadPriorNightlySummaries,
+  normalizeRuntimeSummary,
+} from "../../../scripts/scorecard/analyze-runtime-history.mts";
+
+function runtimeSample(overrides: Partial<RuntimeHistorySample> = {}): RuntimeHistorySample {
+  return {
+    target: "rebuild-hermes",
+    scenario: "rebuild Hermes from source",
+    durationMs: 120_000,
+    outcome: "passed",
+    phases: [{ label: "build Hermes image", durationMs: 70_000, outcome: "passed" }],
+    ...overrides,
+  };
+}
+
+describe("E2E rolling runtime history", () => {
+  it("reports runtime distribution, outcomes, failure streaks, and significant phase regressions", () => {
+    const current = runtimeSample({
+      durationMs: 180_000,
+      outcome: "failed",
+      phases: [{ label: "build Hermes image", durationMs: 120_000, outcome: "failed" }],
+    });
+    const prior = [
+      createRuntimeSummary(1, "2026-07-23T00:00:00.000Z", [
+        runtimeSample({
+          durationMs: 100_000,
+          outcome: "failed",
+          phases: [{ label: "build Hermes image", durationMs: 60_000, outcome: "failed" }],
+        }),
+      ]),
+      createRuntimeSummary(2, "2026-07-22T00:00:00.000Z", [
+        runtimeSample({
+          durationMs: 120_000,
+          outcome: "failed",
+          phases: [{ label: "build Hermes image", durationMs: 70_000, outcome: "failed" }],
+        }),
+      ]),
+      createRuntimeSummary(3, "2026-07-21T00:00:00.000Z", [
+        runtimeSample({
+          durationMs: 110_000,
+          phases: [{ label: "build Hermes image", durationMs: 65_000, outcome: "passed" }],
+        }),
+      ]),
+    ];
+
+    const markdown = formatRuntimeHistory([current], prior);
+
+    expect(markdown).toContain("| rebuild-hermes | rebuild Hermes from source | 3 |");
+    expect(markdown).toContain("180.0s | 110.0s | 120.0s | +70.0s (+63.6%)");
+    expect(markdown).toContain("failed | 33%/67%/0% (1/2/0) | 3 |");
+    expect(markdown).toContain("build Hermes image (3)");
+    expect(markdown).toContain("⚠ total +70.0s (+63.6%); build Hermes image +55.0s (+84.6%)");
+  });
+
+  it("does not flag small changes that miss either regression threshold", () => {
+    const current = runtimeSample({
+      durationMs: 121_000,
+      phases: [{ label: "build Hermes image", durationMs: 71_000, outcome: "passed" }],
+    });
+    const prior = [createRuntimeSummary(1, "2026-07-23T00:00:00.000Z", [runtimeSample()])];
+
+    const markdown = formatRuntimeHistory([current], prior);
+
+    expect(markdown).toContain("+1.0s (+0.8%)");
+    expect(markdown).toContain("| — |");
+    expect(markdown).not.toContain("⚠");
+  });
+
+  it("writes a private bounded current summary when prior history is unavailable", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-runtime-history-"));
+    const output = path.join(directory, "e2e-runtime-summary.json");
+    const warning = vi.fn();
+    try {
+      const markdown = await buildRuntimeHistory(
+        {
+          github: {},
+          context: { repo: { owner: "NVIDIA", repo: "NemoClaw" }, runId: 123 },
+          core: { warning },
+        },
+        [runtimeSample()],
+        output,
+        { loadPriorNightlySummaries: vi.fn().mockRejectedValue(new Error("unavailable")) },
+        new Date("2026-07-24T00:00:00.000Z"),
+      );
+
+      expect(JSON.parse(fs.readFileSync(output, "utf8"))).toMatchObject({
+        schemaVersion: "nemoclaw.e2e_runtime_summary.v1",
+        runId: 123,
+      });
+      expect(fs.statSync(output).mode & 0o777).toBe(0o600);
+      expect(markdown).toContain("this run starts the history");
+      expect(warning).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects duplicate identities, duplicate phases, and extra fields", () => {
+    const summary = createRuntimeSummary(1, "2026-07-24T00:00:00.000Z", [runtimeSample()]);
+    expect(normalizeRuntimeSummary({ ...summary, extra: true })).toBeNull();
+    expect(
+      normalizeRuntimeSummary({ ...summary, rows: [summary.rows[0], summary.rows[0]] }),
+    ).toBeNull();
+    expect(
+      normalizeRuntimeSummary({
+        ...summary,
+        rows: [
+          {
+            ...summary.rows[0],
+            phases: [summary.rows[0]!.phases[0], summary.rows[0]!.phases[0]],
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("queries only prior completed scheduled runs and tolerates missing artifacts", async () => {
+    const listWorkflowRuns = vi.fn().mockResolvedValue({
+      data: { workflow_runs: [{ id: 123 }, { id: 122 }] },
+    });
+    const paginate = vi.fn().mockResolvedValue([]);
+    const summaries = await loadPriorNightlySummaries({
+      context: { repo: { owner: "NVIDIA", repo: "NemoClaw" }, runId: 123 },
+      github: {
+        paginate,
+        rest: {
+          actions: {
+            downloadArtifact: vi.fn(),
+            listWorkflowRunArtifacts: {},
+            listWorkflowRuns,
+          },
+        },
+      },
+    });
+
+    expect(summaries).toEqual([]);
+    expect(listWorkflowRuns).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "schedule",
+        status: "completed",
+        workflow_id: "e2e.yaml",
+      }),
+    );
+    expect(paginate).toHaveBeenCalledOnce();
+    expect(paginate.mock.calls[0]?.[1]).toMatchObject({ run_id: 122 });
+  });
+});

--- a/test/e2e/support/e2e-runtime-history.test.ts
+++ b/test/e2e/support/e2e-runtime-history.test.ts
@@ -14,7 +14,10 @@ import {
   formatRuntimeHistory,
   loadPriorNightlySummaries,
   normalizeRuntimeSummary,
+  RUNTIME_SUMMARY_ARTIFACT,
+  RUNTIME_SUMMARY_FILE,
 } from "../../../scripts/scorecard/analyze-runtime-history.mts";
+import { artifactZip } from "../../helpers/artifact-zip";
 
 function runtimeSample(overrides: Partial<RuntimeHistorySample> = {}): RuntimeHistorySample {
   return {
@@ -157,5 +160,34 @@ describe("E2E rolling runtime history", () => {
     );
     expect(paginate).toHaveBeenCalledOnce();
     expect(paginate.mock.calls[0]?.[1]).toMatchObject({ run_id: 122 });
+  });
+
+  it("rejects a runtime summary whose embedded run ID does not match its workflow run", async () => {
+    const summary = createRuntimeSummary(121, "2026-07-23T00:00:00.000Z", [runtimeSample()]);
+    const downloadArtifact = vi.fn().mockResolvedValue({
+      data: artifactZip([{ name: RUNTIME_SUMMARY_FILE, contents: JSON.stringify(summary) }]),
+    });
+    const summaries = await loadPriorNightlySummaries({
+      context: { repo: { owner: "NVIDIA", repo: "NemoClaw" }, runId: 123 },
+      github: {
+        paginate: vi
+          .fn()
+          .mockResolvedValue([{ expired: false, id: 456, name: RUNTIME_SUMMARY_ARTIFACT }]),
+        rest: {
+          actions: {
+            downloadArtifact,
+            listWorkflowRunArtifacts: {},
+            listWorkflowRuns: vi.fn().mockResolvedValue({
+              data: { workflow_runs: [{ id: 122 }] },
+            }),
+          },
+        },
+      },
+    });
+
+    expect(summaries).toEqual([]);
+    expect(downloadArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ artifact_id: 456, archive_format: "zip" }),
+    );
   });
 });

--- a/test/e2e/support/e2e-runtime-history.test.ts
+++ b/test/e2e/support/e2e-runtime-history.test.ts
@@ -67,6 +67,10 @@ describe("E2E rolling runtime history", () => {
     expect(markdown).toContain("failed | 33%/67%/0% (1/2/0) | 3 |");
     expect(markdown).toContain("build Hermes image (3)");
     expect(markdown).toContain("⚠ total +70.0s (+63.6%); build Hermes image +55.0s (+84.6%)");
+    expect(markdown).toContain("### Nightly flake watch");
+    expect(markdown).toContain(
+      "| rebuild-hermes | rebuild Hermes from source | 4 | 1/3/0 | 75% | 1 | 3 | build Hermes image (3) |",
+    );
   });
 
   it("does not flag small changes that miss either regression threshold", () => {
@@ -81,6 +85,42 @@ describe("E2E rolling runtime history", () => {
     expect(markdown).toContain("+1.0s (+0.8%)");
     expect(markdown).toContain("| — |");
     expect(markdown).not.toContain("⚠");
+  });
+
+  it("bounds the flake watch and excludes consistently passing or failing tests", () => {
+    const intermittent = Array.from({ length: 6 }, (_, index) =>
+      runtimeSample({
+        target: `target-${index}`,
+        scenario: `scenario-${index}`,
+        outcome: "failed",
+      }),
+    );
+    const current = [
+      ...intermittent,
+      runtimeSample({ target: "always-fails", scenario: "broken", outcome: "failed" }),
+      runtimeSample({ target: "always-passes", scenario: "healthy" }),
+    ];
+    const prior = [
+      createRuntimeSummary(
+        1,
+        "2026-07-23T00:00:00.000Z",
+        current.map((row) => ({
+          ...row,
+          outcome: row.target === "always-fails" ? "failed" : "passed",
+        })),
+      ),
+    ];
+
+    const flakeWatch = formatRuntimeHistory(current, prior).split(
+      "### Nightly flake watch\n",
+    )[1] as string;
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(flakeWatch).toContain(`| target-${index} | scenario-${index} |`);
+    }
+    expect(flakeWatch).not.toContain("| target-5 | scenario-5 |");
+    expect(flakeWatch).not.toContain("always-fails");
+    expect(flakeWatch).not.toContain("always-passes");
   });
 
   it("writes a private bounded current summary when prior history is unavailable", async () => {

--- a/test/e2e/support/e2e-scorecard.test.ts
+++ b/test/e2e/support/e2e-scorecard.test.ts
@@ -184,7 +184,14 @@ describe("E2E scorecard", () => {
   it("loads typed scorecard helpers through the native github-script require boundary", () => {
     const script = `
       const path = require('node:path');
-      for (const file of ['analyze-trace-timing.mts', 'summarize-jobs.mts', 'build-slack-blocks.mts', 'coordinate-scorecard.mts']) {
+      for (const file of [
+        'analyze-runtime-history.mts',
+        'analyze-trace-timing.mts',
+        'summarize-jobs.mts',
+        'build-slack-blocks.mts',
+        'coordinate-scorecard.mts',
+        'read-artifact-zip.mts',
+      ]) {
         const loaded = require(path.join(process.env.GITHUB_WORKSPACE, 'scripts/scorecard', file));
         if (Object.keys(loaded).length === 0) process.exit(2);
       }

--- a/test/e2e/support/test-runtime-audit.test.ts
+++ b/test/e2e/support/test-runtime-audit.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   auditTestRuntime,
+  collectRuntimeHistorySamples,
   formatRuntimeAudit,
   formatRuntimeAuditSummary,
 } from "../../../scripts/audit-test-runtime.mts";
@@ -89,6 +90,16 @@ describe("test runtime audit", () => {
         "| variable test-target | variable test | 2 | 30.0s | 50.0s | 50.0s | 20.0s | inference (40.0s, failed) |",
       );
       expect(formatRuntimeAuditSummary(rows)).toContain("## E2E Test Phase Runtime");
+      expect(collectRuntimeHistorySamples([root])[0]).toEqual({
+        target: "variable test-target",
+        scenario: "variable test",
+        durationMs: 30_000,
+        outcome: "failed",
+        phases: [
+          { label: "inference", durationMs: 40_000, outcome: "failed" },
+          { label: "install", durationMs: 8_000, outcome: "passed" },
+        ],
+      });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
+++ b/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
@@ -138,12 +138,21 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
-  it("binds the scorecard upload to its scheduled runtime summary contract", () => {
+  it("rejects a scorecard upload outside its scheduled runtime summary contract", () => {
     const workflow = mutableWorkflow();
     uploadStep(workflow.jobs.scorecard).with!.path = "e2e-artifacts/live/";
 
     expect(validateUploadE2eArtifactsInvocations(workflow)).toContain(
       "scorecard must use upload-e2e-artifacts exactly once with its scheduled runtime summary contract",
+    );
+  });
+
+  it("rejects steps after the scorecard runtime summary upload", () => {
+    const workflow = mutableWorkflow();
+    workflow.jobs.scorecard.steps!.push({ name: "Run after upload", run: "echo too-late" });
+
+    expect(validateUploadE2eArtifactsInvocations(workflow)).toContain(
+      "scorecard upload-e2e-artifacts invocation must follow artifact producers and precede only Docker auth cleanup",
     );
   });
 

--- a/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
+++ b/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
@@ -138,6 +138,15 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
+  it("binds the scorecard upload to its scheduled runtime summary contract", () => {
+    const workflow = mutableWorkflow();
+    uploadStep(workflow.jobs.scorecard).with!.path = "e2e-artifacts/live/";
+
+    expect(validateUploadE2eArtifactsInvocations(workflow)).toContain(
+      "scorecard must use upload-e2e-artifacts exactly once with its scheduled runtime summary contract",
+    );
+  });
+
   it("rejects default, explicit-exception, caller-key, and caller-if drift", () => {
     const workflow = mutableWorkflow();
     const defaultJob = workflow.jobs["credential-migration"];

--- a/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
+++ b/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
@@ -156,6 +156,22 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
+  it("rejects the scorecard runtime summary upload before its producer", () => {
+    const workflow = mutableWorkflow();
+    const scorecard = workflow.jobs.scorecard;
+    const upload = uploadStep(scorecard);
+    scorecard.steps!.splice(scorecard.steps!.indexOf(upload), 1);
+    const producerIndex = scorecard.steps!.findIndex(
+      (step) => step.name === "Generate E2E scorecard",
+    );
+    expect(producerIndex).toBeGreaterThanOrEqual(0);
+    scorecard.steps!.splice(producerIndex, 0, upload);
+
+    expect(validateUploadE2eArtifactsInvocations(workflow)).toContain(
+      "scorecard upload-e2e-artifacts invocation must follow artifact producers and precede only Docker auth cleanup",
+    );
+  });
+
   it("rejects default, explicit-exception, caller-key, and caller-if drift", () => {
     const workflow = mutableWorkflow();
     const defaultJob = workflow.jobs["credential-migration"];

--- a/test/helpers/artifact-zip.ts
+++ b/test/helpers/artifact-zip.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import zlib from "node:zlib";
+
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+export function artifactZip(
+  entries: Array<{ name: string; contents: string }>,
+  compressionMethod = 0,
+): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let localOffset = 0;
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, "utf8");
+    const contents = Buffer.from(entry.contents, "utf8");
+    const compressed =
+      compressionMethod === 8 ? zlib.deflateRawSync(contents) : Buffer.from(contents);
+    const checksum = crc32(contents);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(compressionMethod, 8);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(contents.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    localParts.push(local, name, compressed);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(0x0314, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(compressionMethod, 10);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(contents.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE(0x80000000, 38);
+    central.writeUInt32LE(localOffset, 42);
+    centralParts.push(central, name);
+    localOffset += local.length + name.length + compressed.length;
+  }
+  const locals = Buffer.concat(localParts);
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(locals.length, 16);
+  return Buffer.concat([locals, centralDirectory, end]);
+}

--- a/test/helpers/artifact-zip.ts
+++ b/test/helpers/artifact-zip.ts
@@ -23,6 +23,7 @@ export function artifactZip(
   let localOffset = 0;
   for (const entry of entries) {
     const name = Buffer.from(entry.name, "utf8");
+    const utf8Flag = 0x0800;
     const contents = Buffer.from(entry.contents, "utf8");
     const compressed =
       compressionMethod === 8 ? zlib.deflateRawSync(contents) : Buffer.from(contents);
@@ -30,6 +31,7 @@ export function artifactZip(
     const local = Buffer.alloc(30);
     local.writeUInt32LE(0x04034b50, 0);
     local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(utf8Flag, 6);
     local.writeUInt16LE(compressionMethod, 8);
     local.writeUInt32LE(checksum, 14);
     local.writeUInt32LE(compressed.length, 18);
@@ -41,6 +43,7 @@ export function artifactZip(
     central.writeUInt32LE(0x02014b50, 0);
     central.writeUInt16LE(0x0314, 4);
     central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(utf8Flag, 8);
     central.writeUInt16LE(compressionMethod, 10);
     central.writeUInt32LE(checksum, 16);
     central.writeUInt32LE(compressed.length, 20);

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -557,7 +557,10 @@ function validateScorecard(errors: string[], workflow: OperationsWorkflow): void
     "scorecardJobs.loadWorkflowRunJobs",
     "scripts/audit-test-runtime.mts",
     "runtimeAudit.auditTestRuntime",
+    "runtimeAudit.collectRuntimeHistorySamples",
     "runtimeAudit.formatRuntimeAuditSummary",
+    "scripts/scorecard/analyze-runtime-history.mts",
+    "runtimeHistory.buildRuntimeHistory",
     "core.summary",
     "scorecardData",
     "slackData",
@@ -572,6 +575,9 @@ function validateScorecard(errors: string[], workflow: OperationsWorkflow): void
   }
   if (generate.env?.RUNTIME_ARTIFACTS !== "${{ runner.temp }}/e2e-runtime-audit") {
     errors.push("scorecard generator must read the downloaded runtime audit directory");
+  }
+  if (generate.env?.RUNTIME_SUMMARY_FILE !== "${{ runner.temp }}/e2e-runtime-summary.json") {
+    errors.push("scorecard generator must write the bounded runtime summary under runner temp");
   }
 
   const slack = findStep(job, "Post scorecard to Slack");
@@ -613,6 +619,20 @@ function validateScorecard(errors: string[], workflow: OperationsWorkflow): void
     if (slackScript.includes(forbidden)) {
       errors.push(`scorecard Slack publisher must not execute workflow-ref code via ${forbidden}`);
     }
+  }
+
+  const runtimeUpload = findStep(job, "Upload E2E runtime summary");
+  requirePinnedAction(errors, runtimeUpload, "scorecard runtime summary upload");
+  if (
+    !String(runtimeUpload.uses ?? "").startsWith(E2E_ARTIFACT_ACTION) ||
+    runtimeUpload.if !==
+      "${{ always() && github.event_name == 'schedule' && steps.scorecard.outcome == 'success' }}" ||
+    runtimeUpload.with?.name !== "e2e-runtime-summary" ||
+    runtimeUpload.with?.path !== "${{ runner.temp }}/e2e-runtime-summary.json"
+  ) {
+    errors.push(
+      "scorecard must upload only the bounded scheduled runtime summary through the canonical E2E uploader",
+    );
   }
 }
 

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -38,6 +38,16 @@ const GATEWAY_AUTH_SCANNED_UPLOAD_CONDITION =
   "${{ always() && steps.artifact_safety.outcome == 'success' && steps.artifact_safety.outputs.approved_path != '' }}";
 const TARGET_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
+const SCORECARD_RUNTIME_UPLOAD_CONTRACT: WorkflowStep = {
+  name: "Upload E2E runtime summary",
+  if: "${{ always() && github.event_name == 'schedule' && steps.scorecard.outcome == 'success' }}",
+  uses: UPLOAD_E2E_ARTIFACTS_ACTION,
+  with: {
+    name: "e2e-runtime-summary",
+    path: "${{ runner.temp }}/e2e-runtime-summary.json",
+  },
+};
+
 const SHARED_E2E_JOBS: ReadonlyMap<string, { targetId: string }> = new Map([
   [SHARED_E2E_JOB_ID, { targetId: "${{ matrix.id }}" }],
 ]);
@@ -374,6 +384,17 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
     }
 
     const uploadSteps = jobSteps.filter((step) => step.uses === UPLOAD_E2E_ARTIFACTS_ACTION);
+    if (jobName === "scorecard") {
+      if (
+        uploadSteps.length !== 1 ||
+        !isDeepStrictEqual(uploadSteps[0], SCORECARD_RUNTIME_UPLOAD_CONTRACT)
+      ) {
+        errors.push(
+          "scorecard must use upload-e2e-artifacts exactly once with its scheduled runtime summary contract",
+        );
+      }
+      continue;
+    }
     if (!expected) {
       if (uploadSteps.length > 0) {
         errors.push(`${jobName} must not use upload-e2e-artifacts`);

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -259,6 +259,23 @@ function sortedKeys(value: WorkflowRecord): string[] {
   return Object.keys(value).sort();
 }
 
+function validateUploadPlacement(
+  errors: string[],
+  jobName: string,
+  jobSteps: readonly WorkflowStep[],
+  upload: WorkflowStep,
+): void {
+  const stepsAfterUpload = jobSteps.slice(jobSteps.indexOf(upload) + 1);
+  if (
+    stepsAfterUpload.length > 1 ||
+    stepsAfterUpload.some((step) => step.name !== "Clean up Docker auth")
+  ) {
+    errors.push(
+      `${jobName} upload-e2e-artifacts invocation must follow artifact producers and precede only Docker auth cleanup`,
+    );
+  }
+}
+
 export function validateUploadE2eArtifactsAction(actionPath = DEFAULT_ACTION_PATH): string[] {
   const source = readFileSync(actionPath, "utf8");
   const action = record(YAML.parse(source));
@@ -385,14 +402,19 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
 
     const uploadSteps = jobSteps.filter((step) => step.uses === UPLOAD_E2E_ARTIFACTS_ACTION);
     if (jobName === "scorecard") {
-      if (
-        uploadSteps.length !== 1 ||
-        !isDeepStrictEqual(uploadSteps[0], SCORECARD_RUNTIME_UPLOAD_CONTRACT)
-      ) {
+      if (uploadSteps.length !== 1) {
+        errors.push(
+          "scorecard must use upload-e2e-artifacts exactly once with its scheduled runtime summary contract",
+        );
+        continue;
+      }
+      const upload = uploadSteps[0];
+      if (!isDeepStrictEqual(upload, SCORECARD_RUNTIME_UPLOAD_CONTRACT)) {
         errors.push(
           "scorecard must use upload-e2e-artifacts exactly once with its scheduled runtime summary contract",
         );
       }
+      validateUploadPlacement(errors, jobName, jobSteps, upload);
       continue;
     }
     if (!expected) {
@@ -423,15 +445,7 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
           : `${jobName} upload-e2e-artifacts invocation must remain gated by its reviewed pre-upload checks`,
       );
     }
-    const stepsAfterUpload = jobSteps.slice(jobSteps.indexOf(upload) + 1);
-    if (
-      stepsAfterUpload.length > 1 ||
-      stepsAfterUpload.some((step) => step.name !== "Clean up Docker auth")
-    ) {
-      errors.push(
-        `${jobName} upload-e2e-artifacts invocation must follow artifact producers and precede only Docker auth cleanup`,
-      );
-    }
+    validateUploadPlacement(errors, jobName, jobSteps, upload);
 
     if (explicitContract) {
       if (!isDeepStrictEqual(record(upload.with), explicitContract)) {


### PR DESCRIPTION
## Summary

Scheduled E2E scorecards now compare the current run with up to ten prior completed nightly runs, so runtime regressions and intermittent failures are visible without adding more live terminal noise. The report includes prior median and p95, outcome history, failure streaks, common failed phases, significant phase regressions, and a five-row flake watch.

## Related Issue

Part of #7145.

## Changes

- Build one bounded, timing-and-outcome-only summary from the current run's validated `test-progress.json` artifacts.
- Retain scheduled summaries for 14 days and exclude manual runs from the historical baseline.
- Compare the ten slowest current tests with matching prior nightly samples, including phase-level regression findings.
- Rank up to five current tests that both passed and failed in the available nightly window by pass/fail flips, then failure count.
- Add a shared exact-file ZIP reader because both trace timing and runtime history consume GitHub artifact archives; direct extraction would expose path and link handling. The reader is protected by `artifact-zip.test.ts` and the existing trace artifact integration tests.
- Validate the scorecard workflow boundary and document the nightly comparison contract in `test/e2e/README.md`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Focused review of the GitHub artifact boundary confirmed exact root-file matching, no extraction, bounded entries and bytes, rejection of links/encryption/split/ZIP64/duplicates, CRC validation, strict summary schemas, and run-ID provenance.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md`
- Agent: Codex Desktop
<!-- docs-review-head-sha: f9554bac4 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused e2e-support suite: 112/112 passed; final review-focused suite: 20/20 passed; flake-watch suite: 7/7 passed; malformed ZIP cases: 6/6 passed; trace timing integration: 14/14 passed; CLI type-check passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled E2E scorecards now include a nightly runtime trend section in the report.
  * Scheduled runs publish a bounded `e2e-runtime-summary.json` artifact for trend comparisons.
* **Documentation**
  * Updated scheduled operations guidance to describe the nightly trend tables, baseline sourcing, and regression/flake-watch rules.
* **Bug Fixes**
  * Improved validation and secure parsing for artifact ZIP inputs used by scorecards.
  * Strengthened runtime-history analysis and reporting for more reliable comparisons.
* **Tests**
  * Expanded E2E coverage for runtime-history formatting, artifact ZIP reading, and scorecard workflow boundary/contract enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->