### PR TITLE
ci(e2e): select full E2E for root image changes

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -421,6 +421,9 @@ Shared sandbox-boundary changes have a floor of `full-e2e`, `hermes-e2e`, and
 family is a conservative path boundary that includes non-documentation files
 under `tools/e2e/` and `test/e2e/`, plus the E2E and PR-CI workflows, risk
 policy, dependency and test configuration, and preparation and upload actions.
+Repository-root `Dockerfile` changes additionally select `full-e2e` alongside
+the platform-install `cloud-onboard` floor so OpenClaw final-image changes run
+through cold onboarding and a real first turn.
 The Deep Agents Code headless-inference check additionally selects the exact
 `ubuntu-repo-cloud-langchain-deepagents-code` typed target. That target is
 hashed into the risk plan beside the control-plane floor jobs, so the

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -424,8 +424,9 @@ policy, dependency and test configuration, and preparation and upload actions.
 Repository-root `Dockerfile` changes additionally select `full-e2e` alongside
 the platform-install `cloud-onboard` floor so OpenClaw final-image changes run
 through cold onboarding and a real first turn.
-All other `Dockerfile` and `Dockerfile.*` paths, including `Dockerfile.base`,
-select only `cloud-onboard`; they do not select `full-e2e`.
+The repository-root `Dockerfile.base` remains in only the `platform-install`
+family. It selects `cloud-onboard` and does not trigger the cold `full-e2e`
+path.
 The Deep Agents Code headless-inference check additionally selects the exact
 `ubuntu-repo-cloud-langchain-deepagents-code` typed target. That target is
 hashed into the risk plan beside the control-plane floor jobs, so the

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -424,6 +424,8 @@ policy, dependency and test configuration, and preparation and upload actions.
 Repository-root `Dockerfile` changes additionally select `full-e2e` alongside
 the platform-install `cloud-onboard` floor so OpenClaw final-image changes run
 through cold onboarding and a real first turn.
+All other `Dockerfile` and `Dockerfile.*` paths, including `Dockerfile.base`,
+select only `cloud-onboard`; they do not select `full-e2e`.
 The Deep Agents Code headless-inference check additionally selects the exact
 `ubuntu-repo-cloud-langchain-deepagents-code` typed target. That target is
 hashed into the risk plan beside the control-plane floor jobs, so the

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -190,7 +190,7 @@ describe("deterministic PR risk plan", () => {
     expect(riskPlanRequiredJobIds(result)).toEqual(expect.arrayContaining(jobs));
   });
 
-  it("runs cold full E2E for repository-root OpenClaw image changes (#6660)", () => {
+  it("selects cold full E2E for repository-root OpenClaw image changes (#6660)", () => {
     const rootImage = plan("Dockerfile");
     const adjacentImage = plan("Dockerfile.base");
 

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -28,7 +28,7 @@ describe("deterministic PR risk plan", () => {
     const second = plan("src/lib/onboard.ts", "src/lib/state/registry.ts");
 
     expect(first).toEqual(second);
-    expect(first.version).toBe(4);
+    expect(first.version).toBe(5);
     expect(first.headSha).toBe(HEAD_SHA);
     expect(first.planHash).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.changedFiles).toEqual(["src/lib/onboard.ts", "src/lib/state/registry.ts"]);
@@ -188,6 +188,19 @@ describe("deterministic PR risk plan", () => {
 
     expect(result.families.map((item) => item.id)).toContain(family);
     expect(riskPlanRequiredJobIds(result)).toEqual(expect.arrayContaining(jobs));
+  });
+
+  it("runs cold full E2E for repository-root OpenClaw image changes (#6660)", () => {
+    const rootImage = plan("Dockerfile");
+    const adjacentImage = plan("Dockerfile.base");
+
+    expect(rootImage.families.map((family) => family.id)).toEqual([
+      "platform-install",
+      "openclaw-image",
+    ]);
+    expect(riskPlanRequiredJobIds(rootImage)).toEqual(["cloud-onboard", "full-e2e"]);
+    expect(adjacentImage.families.map((family) => family.id)).toEqual(["platform-install"]);
+    expect(riskPlanRequiredJobIds(adjacentImage)).toEqual(["cloud-onboard"]);
   });
 
   it.each([

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -3,7 +3,7 @@
 
 import { createHash } from "node:crypto";
 
-export const RISK_PLAN_VERSION = 4 as const;
+export const RISK_PLAN_VERSION = 5 as const;
 
 export const PR_E2E_TYPED_TARGET_IDS = ["ubuntu-repo-cloud-langchain-deepagents-code"] as const;
 
@@ -19,6 +19,7 @@ export type RiskFamilyId =
   | "inference-policy"
   | "messaging-lifecycle"
   | "platform-install"
+  | "openclaw-image"
   | "credentials-security"
   | "e2e-control-plane"
   | "sandbox-boundary"
@@ -241,6 +242,17 @@ export const RISK_RULES: readonly RiskRule[] = [
       file === "scripts/e2e/sanitize-trace-timing.py" ||
       file === "ci/onboard-performance-budget.json" ||
       RISK_RELEVANT_TEST_FILES.has(file),
+  },
+  {
+    id: "openclaw-image",
+    summary: "OpenClaw final-image changes must preserve cold onboarding and a usable first turn.",
+    tier: 3,
+    requiredJobs: ["full-e2e"],
+    invariants: [
+      "the repository-root image builds through the same cold path exercised by supported hosts",
+      "the resulting OpenClaw sandbox becomes ready and completes a real first turn",
+    ],
+    matches: (file) => file === "Dockerfile",
   },
   {
     id: "credentials-security",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Repository-root `Dockerfile` changes now select the cold `full-e2e` path in addition to `cloud-onboard`. This supplies the deterministic validation prerequisite for #7486, whose final-image layer collapse must be exercised through a cold build, onboard, readiness check, and real first turn before it can address the performance failures tracked in #6660.

## Related Issue

Related to #6660

## Changes

- add a narrow `openclaw-image` risk family that matches only the repository-root `Dockerfile` and requires `full-e2e`
- retain the existing `platform-install` and `cloud-onboard` floor for `Dockerfile.base` without expanding full E2E to that adjacent root image definition
- advance the deterministic risk-plan version from 4 to 5 because selector semantics changed
- add an exact positive/negative regression and document the contributor-facing selection floor

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent nine-category review of exact current-main head `0469bf9b5` returned GO with no findings; fork gating, authorization, exact head/base/workflow binding, version/hash reconstruction, job inventory, credential surfaces, and bounded fanout were traced, with the terminal receipt at https://github.com/NVIDIA/NemoClaw/pull/7497#issuecomment-5073668449
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md`; exact-head review confirmed the text matches the v5 rule and regression, precisely scopes repository-root `Dockerfile.base`, and requires no additional Fern/user-facing page changes
- Agent: Codex Desktop
<!-- docs-review-head-sha: 0469bf9b5 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact current-main `npx vitest run --project integration test/pr-risk-plan.test.ts test/pr-e2e-gate.test.ts` (90/90), `npm run check:diff`, CLI build, and CLI typecheck
- [x] Applicable broad gate passed — ordinary CI 30119548875, self-hosted CI 30119549936, trusted controller 30120353005, selected child E2E 30120373768, and exact-head coordination all passed; see the terminal receipt linked above
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
