### PR TITLE
chore(deps): refresh Perl and gosu in base images

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -32,6 +32,9 @@ on:
       - "ci/npm-audit-exceptions.json"
       # Dockerfile.base validates min_openclaw_version from this file at build time.
       - "nemoclaw-blueprint/blueprint.yaml"
+      - "scripts/build-perl-cve-backport.sh"
+      - "scripts/patches/perl/CVE-2026-12087.patch"
+      - "scripts/patches/perl/CVE-2026-13221.patch"
       - "scripts/lib/openclaw-npm-remediation.mts"
       - "scripts/lib/reviewed-npm-audit.mts"
       - "scripts/lib/reviewed-npm-archive.mts"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -18,7 +18,7 @@
 #   node:22-trixie-slim — pinned by sha256 digest, checked weekly by
 #                          docker-pin-check.yaml
 #   apt packages        — pinned to exact Debian trixie versions
-#   gosu 1.19           — pinned release + per-arch sha256 checksum
+#   gosu 1.19           — pinned source built with a patched Go toolchain
 #   gateway/sandbox     — OS users and groups; names and UIDs are a
 #     users               stable contract with OpenShell
 #   .openclaw dirs      — directory structure is dictated by the OpenClaw
@@ -38,7 +38,8 @@
 #
 #   1. OpenClaw CLI version bump    — update OPENCLAW_VERSION default below, or override via --build-arg / workflow_dispatch
 #   2. New apt package needed       — add it to the apt-get install list
-#   3. gosu upgrade                 — update URL, checksum, and version
+#   3. gosu/Go toolchain upgrade    — update source commit/archive checksum,
+#                                      Go version, and per-architecture Go hashes
 #   4. node:22-trixie-slim digest rotated — update-docker-pin.sh updates all
 #                                      Dockerfile and Dockerfile.base
 #   5. New .openclaw subdirectory   — add mkdir below
@@ -49,6 +50,21 @@
 # Expected rebuild frequency: every few weeks to months, driven mostly
 # by OpenClaw CLI version bumps or the weekly docker-pin-check.
 # ────────────────────────────────────────────────────────────────────────
+
+FROM node:22-trixie-slim@sha256:e6d9a389d34ff9678438af985c9913fbd1eb6ed36e80fea56644f4b4f6dd70ba AS perl-cve-backport-builder
+
+ARG DEBIAN_SNAPSHOT=20260724T000000Z
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY scripts/build-perl-cve-backport.sh /usr/local/bin/build-perl-cve-backport
+
+RUN chmod 0755 /usr/local/bin/build-perl-cve-backport \
+    && DEBIAN_SNAPSHOT="$DEBIAN_SNAPSHOT" /usr/local/bin/build-perl-cve-backport prepare
+
+COPY scripts/patches/perl/CVE-2026-12087.patch /opt/nemoclaw/perl-cve-patches/CVE-2026-12087.patch
+COPY scripts/patches/perl/CVE-2026-13221.patch /opt/nemoclaw/perl-cve-patches/CVE-2026-13221.patch
+
+RUN /usr/local/bin/build-perl-cve-backport build
 
 FROM node:22-trixie-slim@sha256:e6d9a389d34ff9678438af985c9913fbd1eb6ed36e80fea56644f4b4f6dd70ba
 
@@ -80,24 +96,73 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && ln -s /usr/bin/python3 /usr/local/bin/python
 
+COPY --from=perl-cve-backport-builder /out/debs/ /tmp/perl-cve-debs/
+COPY --from=perl-cve-backport-builder /out/metadata/ /usr/local/share/nemoclaw/perl-cve-backport/
+
+# Install the four Perl binary packages as one ABI-compatible cohort. The
+# custom build is based on Debian 5.40.1-8 and adds the Socket and regex fixes
+# that are not yet published for trixie.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends /tmp/perl-cve-debs/*.deb \
+    && for package in perl perl-base perl-modules-5.40 libperl5.40; do \
+        test "$(dpkg-query -W -f='${Version}' "$package")" = "5.40.1-8+nemoclaw1" \
+            || exit 1; \
+    done \
+    && perl -MSocket=pack_ip_mreq_source,INADDR_ANY -e \
+        'eval { pack_ip_mreq_source("\xe0\0\0\2", "\x0a", INADDR_ANY) }; die "short Socket source accepted\n" unless $@ =~ /Bad arg length/' \
+    && perl -e \
+        'my $x = join "|", "aaa".."mzz"; my $y = join "|", "naa".."zzz"; "fnord" =~ m/(?:$x)|(?:$y)/' \
+    && storable_so="$(find /usr/lib -path '*/auto/Storable/Storable.so' -type f -print -quit)" \
+    && test -n "$storable_so" \
+    && grep -aFq 'Invalid count of hook data items' "$storable_so" \
+    && chmod 0444 /usr/local/share/nemoclaw/perl-cve-backport/* \
+    && rm -rf /tmp/perl-cve-debs /var/lib/apt/lists/*
+
 # gosu for privilege separation (gateway vs sandbox user).
-# Install from GitHub release with checksum verification instead of
-# Debian's packaged gosu can lag upstream. Pinned to 1.19 (2025-09).
-# Binary release asset downloads can be slower than hash fetches; keep
-# longer bounded transfer timeouts while preserving checksum verification.
+# Build the pinned 1.19 source with Go 1.26.5. The published 1.19 binaries were
+# built with Go 1.24.6, which scanners correctly associate with GO-2026-4868
+# even though gosu does not contain the affected loop shape. Building from the
+# reviewed source also removes the inapplicable crypto/tls version finding.
 # hadolint ignore=DL4006
 RUN arch="$(dpkg --print-architecture)" \
     && case "$arch" in \
-        amd64) gosu_asset="gosu-amd64"; gosu_sha256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0" ;; \
-        arm64) gosu_asset="gosu-arm64"; gosu_sha256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
+        amd64) go_asset="go1.26.5.linux-amd64.tar.gz"; go_sha256="5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053" ;; \
+        arm64) go_asset="go1.26.5.linux-arm64.tar.gz"; go_sha256="fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49" ;; \
         *) echo "Unsupported architecture for gosu: $arch" >&2; exit 1 ;; \
     esac \
     && curl --proto '=https' --tlsv1.2 -fsSL \
         --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
-        -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
-    && echo "${gosu_sha256}  /usr/local/bin/gosu" | sha256sum -c - \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu --version
+        -o /tmp/go.tar.gz "https://go.dev/dl/${go_asset}" \
+    && echo "${go_sha256}  /tmp/go.tar.gz" | sha256sum -c - \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
+        -o /tmp/gosu.tar.gz \
+        "https://codeload.github.com/tianon/gosu/tar.gz/6456aaa0f3c854d199d0f037f068eb97515b7513" \
+    && echo "33d7537d588ea49458b9509bcf4554bdf5ceacc66da71e5caa1058ea3b689c3b  /tmp/gosu.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/go.tar.gz -C /tmp \
+    && tar -xzf /tmp/gosu.tar.gz -C /tmp \
+    && CGO_ENABLED=0 GOOS=linux "/tmp/go/bin/go" \
+        -C /tmp/gosu-6456aaa0f3c854d199d0f037f068eb97515b7513 build \
+        -trimpath -buildvcs=false -ldflags="-d -w" -o /usr/local/bin/gosu . \
+    && install -d -m 0755 /usr/local/share/licenses/gosu /usr/local/share/nemoclaw \
+    && install -m 0444 \
+        /tmp/gosu-6456aaa0f3c854d199d0f037f068eb97515b7513/LICENSE \
+        /usr/local/share/licenses/gosu/LICENSE \
+    && "/tmp/go/bin/go" version -m /usr/local/bin/gosu \
+        > /usr/local/share/nemoclaw/gosu-buildinfo.txt \
+    && "/tmp/go/bin/go" tool nm /usr/local/bin/gosu > /tmp/gosu.nm \
+    && ! grep -Eq 'crypto/(tls|x509)' /tmp/gosu.nm \
+    && printf '%s\n' \
+        'version=1.19' \
+        'source_commit=6456aaa0f3c854d199d0f037f068eb97515b7513' \
+        'source_sha256=33d7537d588ea49458b9509bcf4554bdf5ceacc66da71e5caa1058ea3b689c3b' \
+        'go_version=go1.26.5' \
+        > /usr/local/share/nemoclaw/gosu-source.txt \
+    && chmod 0444 /usr/local/share/nemoclaw/gosu-buildinfo.txt \
+        /usr/local/share/nemoclaw/gosu-source.txt \
+    && /usr/local/bin/gosu --version | grep -F '1.19 (go1.26.5 on linux/' \
+    && rm -rf /tmp/go /tmp/go.tar.gz /tmp/gosu.tar.gz /tmp/gosu.nm \
+        /tmp/gosu-6456aaa0f3c854d199d0f037f068eb97515b7513
 
 # Create sandbox user (matches OpenShell convention) and gateway user.
 # The gateway runs as 'gateway' so the 'sandbox' user (agent) cannot

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -13,10 +13,26 @@
 # ── When to rebuild ─────────────────────────────────────────────
 #   1. Hermes version bump      — run scripts/update-hermes-agent.sh
 #   2. New apt package needed   — add it to the apt-get install list
-#   3. gosu upgrade             — update URL, checksum, and version
+#   3. gosu/Go toolchain upgrade — update source commit/archive checksum,
+#                                   Go version, and per-architecture Go hashes
 #   4. node:24-trixie-slim digest rot — update-docker-pin.sh updates all
 #   5. New .hermes subdirectory — add mkdir/chmod below
 # ────────────────────────────────────────────────────────────────
+
+FROM node:22-trixie-slim@sha256:e6d9a389d34ff9678438af985c9913fbd1eb6ed36e80fea56644f4b4f6dd70ba AS perl-cve-backport-builder
+
+ARG DEBIAN_SNAPSHOT=20260724T000000Z
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY scripts/build-perl-cve-backport.sh /usr/local/bin/build-perl-cve-backport
+
+RUN chmod 0755 /usr/local/bin/build-perl-cve-backport \
+    && DEBIAN_SNAPSHOT="$DEBIAN_SNAPSHOT" /usr/local/bin/build-perl-cve-backport prepare
+
+COPY scripts/patches/perl/CVE-2026-12087.patch /opt/nemoclaw/perl-cve-patches/CVE-2026-12087.patch
+COPY scripts/patches/perl/CVE-2026-13221.patch /opt/nemoclaw/perl-cve-patches/CVE-2026-13221.patch
+
+RUN /usr/local/bin/build-perl-cve-backport build
 
 FROM node:24-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c
 
@@ -61,6 +77,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         vim-tiny=2:9.1.1230-2 \
     && rm -rf /var/lib/apt/lists/*
 
+COPY --from=perl-cve-backport-builder /out/debs/ /tmp/perl-cve-debs/
+COPY --from=perl-cve-backport-builder /out/metadata/ /usr/local/share/nemoclaw/perl-cve-backport/
+
+# Install the patched Perl packages as one ABI-compatible cohort.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends /tmp/perl-cve-debs/*.deb \
+    && for package in perl perl-base perl-modules-5.40 libperl5.40; do \
+        test "$(dpkg-query -W -f='${Version}' "$package")" = "5.40.1-8+nemoclaw1" \
+            || exit 1; \
+    done \
+    && perl -MSocket=pack_ip_mreq_source,INADDR_ANY -e \
+        'eval { pack_ip_mreq_source("\xe0\0\0\2", "\x0a", INADDR_ANY) }; die "short Socket source accepted\n" unless $@ =~ /Bad arg length/' \
+    && perl -e \
+        'my $x = join "|", "aaa".."mzz"; my $y = join "|", "naa".."zzz"; "fnord" =~ m/(?:$x)|(?:$y)/' \
+    && storable_so="$(find /usr/lib -path '*/auto/Storable/Storable.so' -type f -print -quit)" \
+    && test -n "$storable_so" \
+    && grep -aFq 'Invalid count of hook data items' "$storable_so" \
+    && chmod 0444 /usr/local/share/nemoclaw/perl-cve-backport/* \
+    && rm -rf /tmp/perl-cve-debs /var/lib/apt/lists/*
+
 COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts
 COPY scripts/patch-bundled-npm-tar.mts /scripts/patch-bundled-npm-tar.mts
 
@@ -70,19 +106,48 @@ COPY scripts/patch-bundled-npm-tar.mts /scripts/patch-bundled-npm-tar.mts
 RUN node --experimental-strip-types /scripts/patch-bundled-npm-tar.mts \
     --npm-root /usr/local/lib/node_modules/npm
 
-# gosu for privilege separation (gateway vs sandbox user).
-# Identical to OpenClaw base — pinned to 1.19 with checksum.
+# gosu for privilege separation (gateway vs sandbox user). Build the pinned
+# 1.19 source with Go 1.26.5 instead of retaining the Go 1.24.6 release binary.
 # hadolint ignore=DL4006
 RUN arch="$(dpkg --print-architecture)" \
     && case "$arch" in \
-        amd64) gosu_asset="gosu-amd64"; gosu_sha256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0" ;; \
-        arm64) gosu_asset="gosu-arm64"; gosu_sha256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
+        amd64) go_asset="go1.26.5.linux-amd64.tar.gz"; go_sha256="5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053" ;; \
+        arm64) go_asset="go1.26.5.linux-arm64.tar.gz"; go_sha256="fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49" ;; \
         *) echo "Unsupported architecture for gosu: $arch" >&2; exit 1 ;; \
     esac \
-    && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
-    && echo "${gosu_sha256}  /usr/local/bin/gosu" | sha256sum -c - \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu --version
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
+        -o /tmp/go.tar.gz "https://go.dev/dl/${go_asset}" \
+    && echo "${go_sha256}  /tmp/go.tar.gz" | sha256sum -c - \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
+        -o /tmp/gosu.tar.gz \
+        "https://codeload.github.com/tianon/gosu/tar.gz/6456aaa0f3c854d199d0f037f068eb97515b7513" \
+    && echo "33d7537d588ea49458b9509bcf4554bdf5ceacc66da71e5caa1058ea3b689c3b  /tmp/gosu.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/go.tar.gz -C /tmp \
+    && tar -xzf /tmp/gosu.tar.gz -C /tmp \
+    && CGO_ENABLED=0 GOOS=linux "/tmp/go/bin/go" \
+        -C /tmp/gosu-6456aaa0f3c854d199d0f037f068eb97515b7513 build \
+        -trimpath -buildvcs=false -ldflags="-d -w" -o /usr/local/bin/gosu . \
+    && install -d -m 0755 /usr/local/share/licenses/gosu /usr/local/share/nemoclaw \
+    && install -m 0444 \
+        /tmp/gosu-6456aaa0f3c854d199d0f037f068eb97515b7513/LICENSE \
+        /usr/local/share/licenses/gosu/LICENSE \
+    && "/tmp/go/bin/go" version -m /usr/local/bin/gosu \
+        > /usr/local/share/nemoclaw/gosu-buildinfo.txt \
+    && "/tmp/go/bin/go" tool nm /usr/local/bin/gosu > /tmp/gosu.nm \
+    && ! grep -Eq 'crypto/(tls|x509)' /tmp/gosu.nm \
+    && printf '%s\n' \
+        'version=1.19' \
+        'source_commit=6456aaa0f3c854d199d0f037f068eb97515b7513' \
+        'source_sha256=33d7537d588ea49458b9509bcf4554bdf5ceacc66da71e5caa1058ea3b689c3b' \
+        'go_version=go1.26.5' \
+        > /usr/local/share/nemoclaw/gosu-source.txt \
+    && chmod 0444 /usr/local/share/nemoclaw/gosu-buildinfo.txt \
+        /usr/local/share/nemoclaw/gosu-source.txt \
+    && /usr/local/bin/gosu --version | grep -F '1.19 (go1.26.5 on linux/' \
+    && rm -rf /tmp/go /tmp/go.tar.gz /tmp/gosu.tar.gz /tmp/gosu.nm \
+        /tmp/gosu-6456aaa0f3c854d199d0f037f068eb97515b7513
 
 # Create sandbox user (matches OpenShell convention) and gateway user.
 # gateway is a member of the sandbox group so it can read Hermes config files

--- a/agents/langchain-deepagents-code/Dockerfile.base
+++ b/agents/langchain-deepagents-code/Dockerfile.base
@@ -7,6 +7,21 @@
 # Node for NemoClaw build-time config generation, Python, shell tools, and a
 # hash-locked deepagents-code install with the NVIDIA provider extra.
 
+FROM node:22-trixie-slim@sha256:e6d9a389d34ff9678438af985c9913fbd1eb6ed36e80fea56644f4b4f6dd70ba AS perl-cve-backport-builder
+
+ARG DEBIAN_SNAPSHOT=20260724T000000Z
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY scripts/build-perl-cve-backport.sh /usr/local/bin/build-perl-cve-backport
+
+RUN chmod 0755 /usr/local/bin/build-perl-cve-backport \
+    && DEBIAN_SNAPSHOT="$DEBIAN_SNAPSHOT" /usr/local/bin/build-perl-cve-backport prepare
+
+COPY scripts/patches/perl/CVE-2026-12087.patch /opt/nemoclaw/perl-cve-patches/CVE-2026-12087.patch
+COPY scripts/patches/perl/CVE-2026-13221.patch /opt/nemoclaw/perl-cve-patches/CVE-2026-13221.patch
+
+RUN /usr/local/bin/build-perl-cve-backport build
+
 FROM node:22-trixie-slim@sha256:e6d9a389d34ff9678438af985c9913fbd1eb6ed36e80fea56644f4b4f6dd70ba
 
 COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts
@@ -34,6 +49,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ripgrep=14.1.1-1+b4 \
         vim-tiny=2:9.1.1230-2 \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=perl-cve-backport-builder /out/debs/ /tmp/perl-cve-debs/
+COPY --from=perl-cve-backport-builder /out/metadata/ /usr/local/share/nemoclaw/perl-cve-backport/
+
+# Install the patched Perl packages as one ABI-compatible cohort.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends /tmp/perl-cve-debs/*.deb \
+    && for package in perl perl-base perl-modules-5.40 libperl5.40; do \
+        test "$(dpkg-query -W -f='${Version}' "$package")" = "5.40.1-8+nemoclaw1" \
+            || exit 1; \
+    done \
+    && perl -MSocket=pack_ip_mreq_source,INADDR_ANY -e \
+        'eval { pack_ip_mreq_source("\xe0\0\0\2", "\x0a", INADDR_ANY) }; die "short Socket source accepted\n" unless $@ =~ /Bad arg length/' \
+    && perl -e \
+        'my $x = join "|", "aaa".."mzz"; my $y = join "|", "naa".."zzz"; "fnord" =~ m/(?:$x)|(?:$y)/' \
+    && storable_so="$(find /usr/lib -path '*/auto/Storable/Storable.so' -type f -print -quit)" \
+    && test -n "$storable_so" \
+    && grep -aFq 'Invalid count of hook data items' "$storable_so" \
+    && chmod 0444 /usr/local/share/nemoclaw/perl-cve-backport/* \
+    && rm -rf /tmp/perl-cve-debs /var/lib/apt/lists/*
 
 # Node remains available to the managed terminal at runtime, so remediate
 # npm's private node-tar copy after curl is installed even though Deep Agents

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -67,6 +67,26 @@
       "category": "security"
     },
     {
+      "file": "test/container-cve-remediation.test.ts",
+      "test": "binds the Perl backport script to the reviewed patch bytes",
+      "category": "security"
+    },
+    {
+      "file": "test/container-cve-remediation.test.ts",
+      "test": "builds gosu from one checksum-pinned source and patched Go toolchain",
+      "category": "security"
+    },
+    {
+      "file": "test/container-cve-remediation.test.ts",
+      "test": "installs and verifies the patched Perl cohort in every base image",
+      "category": "security"
+    },
+    {
+      "file": "test/container-cve-remediation.test.ts",
+      "test": "rebuilds base images when any remediation input changes",
+      "category": "security"
+    },
+    {
       "file": "test/cloudflared-update-check-workflow.test.ts",
       "test": "keeps automatic and on-demand update checks reachable and credential-free",
       "category": "security"

--- a/scripts/build-perl-cve-backport.sh
+++ b/scripts/build-perl-cve-backport.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -Eeuo pipefail
+
+readonly PERL_UPSTREAM_VERSION="5.40.1"
+readonly PERL_DEBIAN_REVISION="8"
+readonly PERL_SOURCE_VERSION="${PERL_UPSTREAM_VERSION}-${PERL_DEBIAN_REVISION}"
+readonly PERL_NEMOCLAW_VERSION="${PERL_SOURCE_VERSION}+nemoclaw1"
+readonly DEBIAN_SNAPSHOT="${DEBIAN_SNAPSHOT:-20260724T000000Z}"
+readonly SOURCE_BASE_URL="https://deb.debian.org/debian/pool/main/p/perl"
+readonly PATCH_DIR="${PERL_CVE_PATCH_DIR:-/opt/nemoclaw/perl-cve-patches}"
+readonly OUTPUT_DIR="${PERL_CVE_OUTPUT_DIR:-/out}"
+
+readonly DSC_FILE="perl_${PERL_SOURCE_VERSION}.dsc"
+readonly ORIG_FILE="perl_${PERL_UPSTREAM_VERSION}.orig.tar.xz"
+readonly REGEN_FILE="perl_${PERL_UPSTREAM_VERSION}.orig-regen-configure.tar.xz"
+readonly DEBIAN_FILE="perl_${PERL_SOURCE_VERSION}.debian.tar.xz"
+
+readonly DSC_SHA256="0df3684ddbed6c62651b8f682df33d2af54d47ee238958f30fa26ac066ee88d5"
+readonly ORIG_SHA256="dfa20c2eef2b4af133525610bbb65dd13777ecf998c9c5b1ccf0d308e732ee3f"
+readonly REGEN_SHA256="4ea023d08101443f6ed9dc3bdd9bb5f5e08087678dc9e443d195df22da36209a"
+readonly DEBIAN_SHA256="621e16fec9e822ec835071aa3665ebd329142bcd270b86a6f9bb04cb94a1de08"
+
+readonly SOCKET_PATCH="CVE-2026-12087.patch"
+readonly REGEX_PATCH="CVE-2026-13221.patch"
+readonly SOCKET_PATCH_SHA256="01e28f0887033f62c8c4c34fb8c17427a970545aaafa30b79fbce69cecbf5d8f"
+readonly REGEX_PATCH_SHA256="787bf1a1c8b62e46d6b4931cd974d0a1c0e99a9d442efa10bcece0768aa575a2"
+
+work_dir=""
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "required file is missing: ${path}"
+}
+
+download() {
+  local name="$1"
+  curl --proto '=https' --tlsv1.2 -fsSL \
+    --retry 5 --retry-all-errors --retry-delay 2 \
+    --connect-timeout 15 --max-time 300 \
+    -o "$name" "${SOURCE_BASE_URL}/${name}"
+}
+
+verify_sha256() {
+  local expected="$1"
+  local path="$2"
+  printf '%s  %s\n' "$expected" "$path" | sha256sum -c -
+}
+
+configure_snapshot() {
+  rm -f /etc/apt/sources.list
+  rm -f /etc/apt/sources.list.d/*
+  install -d -m 0755 /etc/apt/sources.list.d /etc/apt/apt.conf.d
+  {
+    printf 'Types: deb\n'
+    # APT authenticates the snapshot through its signed Release metadata.
+    # HTTP avoids depending on CA roots before this stage installs them.
+    printf 'URIs: http://snapshot.debian.org/archive/debian/%s\n' "$DEBIAN_SNAPSHOT"
+    printf 'Suites: trixie\n'
+    printf 'Components: main\n'
+    printf 'Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg\n'
+    printf 'Check-Valid-Until: no\n'
+  } >/etc/apt/sources.list.d/debian.sources
+  printf 'Acquire::Check-Valid-Until "false";\n' >/etc/apt/apt.conf.d/99snapshot
+}
+
+install_build_dependencies() {
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cpio \
+    curl \
+    debhelper \
+    debian-keyring \
+    dist \
+    dpkg-dev \
+    fakeroot \
+    file \
+    gpgv \
+    libbz2-dev \
+    libcrypt-dev \
+    libdb-dev \
+    libgdbm-compat-dev \
+    libgdbm-dev \
+    netbase \
+    patch \
+    procps \
+    quilt \
+    xz-utils \
+    zlib1g-dev
+  rm -rf /var/lib/apt/lists/*
+}
+
+extract_and_patch_source() {
+  local work_dir="$1"
+  local source_dir="${work_dir}/perl-${PERL_UPSTREAM_VERSION}"
+
+  (
+    cd "$work_dir"
+    download "$DSC_FILE"
+    download "$ORIG_FILE"
+    download "$REGEN_FILE"
+    download "$DEBIAN_FILE"
+    verify_sha256 "$DSC_SHA256" "$DSC_FILE"
+    verify_sha256 "$ORIG_SHA256" "$ORIG_FILE"
+    verify_sha256 "$REGEN_SHA256" "$REGEN_FILE"
+    verify_sha256 "$DEBIAN_SHA256" "$DEBIAN_FILE"
+    gpgv --keyring /usr/share/keyrings/debian-keyring.gpg "$DSC_FILE"
+    dpkg-source --extract "$DSC_FILE"
+  )
+
+  require_file "${PATCH_DIR}/${SOCKET_PATCH}"
+  require_file "${PATCH_DIR}/${REGEX_PATCH}"
+  verify_sha256 "$SOCKET_PATCH_SHA256" "${PATCH_DIR}/${SOCKET_PATCH}"
+  verify_sha256 "$REGEX_PATCH_SHA256" "${PATCH_DIR}/${REGEX_PATCH}"
+
+  install -m 0644 "${PATCH_DIR}/${SOCKET_PATCH}" \
+    "${source_dir}/debian/patches/fixes/${SOCKET_PATCH}"
+  install -m 0644 "${PATCH_DIR}/${REGEX_PATCH}" \
+    "${source_dir}/debian/patches/fixes/${REGEX_PATCH}"
+  {
+    printf 'fixes/%s\n' "$SOCKET_PATCH"
+    printf 'fixes/%s\n' "$REGEX_PATCH"
+  } >>"${source_dir}/debian/patches/series"
+
+  {
+    printf 'perl (%s) trixie; urgency=high\n\n' "$PERL_NEMOCLAW_VERSION"
+    printf '  * Backport fixes for CVE-2026-12087 and CVE-2026-13221.\n'
+    printf '  * Retain Debian revision 8 fixes, including CVE-2026-57433.\n\n'
+    printf ' -- NemoClaw Maintainers <nemoclaw@nvidia.com>  Fri, 24 Jul 2026 00:00:00 +0000\n\n'
+    cat "${source_dir}/debian/changelog"
+  } >"${source_dir}/debian/changelog.nemoclaw"
+  mv "${source_dir}/debian/changelog.nemoclaw" "${source_dir}/debian/changelog"
+
+  (
+    cd "$source_dir"
+    QUILT_PATCHES=debian/patches quilt push -a
+    grep -F 'source_len, interface_len;' cpan/Socket/Socket.xs >/dev/null
+    grep -F 'tail - startbranch >= U16_MAX' regcomp_study.c >/dev/null
+    grep -F 'len3 == I32_MAX' dist/Storable/Storable.xs >/dev/null
+  )
+}
+
+build_packages() {
+  local work_dir="$1"
+  local source_dir="${work_dir}/perl-${PERL_UPSTREAM_VERSION}"
+  local parallelism
+  parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '1')"
+
+  (
+    cd "$source_dir"
+    export DEB_BUILD_OPTIONS="nocheck parallel=${parallelism}"
+    export SOURCE_DATE_EPOCH="1784851200"
+    dpkg-buildpackage --build=binary --no-sign
+  )
+}
+
+collect_packages() {
+  local work_dir="$1"
+  local package
+  local matches=()
+  local output_debs="${OUTPUT_DIR}/debs"
+  local output_metadata="${OUTPUT_DIR}/metadata"
+
+  install -d -m 0755 "$output_debs" "$output_metadata"
+  for package in perl-base perl-modules-5.40 libperl5.40 perl; do
+    mapfile -t matches < <(find "$work_dir" -maxdepth 1 -type f -name "${package}_*.deb" -print)
+    [[ "${#matches[@]}" -eq 1 ]] \
+      || fail "expected one ${package} package, found ${#matches[@]}"
+    [[ "$(dpkg-deb --field "${matches[0]}" Version)" == "$PERL_NEMOCLAW_VERSION" ]] \
+      || fail "${package} has an unexpected version"
+    install -m 0644 "${matches[0]}" "$output_debs/"
+  done
+
+  (
+    cd "$output_debs"
+    sha256sum ./*.deb >"${output_metadata}/SHA256SUMS"
+  )
+  {
+    printf 'debian_snapshot=%s\n' "$DEBIAN_SNAPSHOT"
+    printf 'debian_source_version=%s\n' "$PERL_SOURCE_VERSION"
+    printf 'nemoclaw_binary_version=%s\n' "$PERL_NEMOCLAW_VERSION"
+    printf 'debian_dsc_sha256=%s\n' "$DSC_SHA256"
+    printf 'debian_orig_sha256=%s\n' "$ORIG_SHA256"
+    printf 'debian_regen_sha256=%s\n' "$REGEN_SHA256"
+    printf 'debian_packaging_sha256=%s\n' "$DEBIAN_SHA256"
+    printf 'CVE-2026-12087_patch_sha256=%s\n' "$SOCKET_PATCH_SHA256"
+    printf 'CVE-2026-13221_patch_sha256=%s\n' "$REGEX_PATCH_SHA256"
+    printf 'CVE-2026-57433_source=debian-%s\n' "$PERL_SOURCE_VERSION"
+  } >"${output_metadata}/build-manifest.txt"
+  dpkg-query -W -f='${Package}=${Version}\n' | sort \
+    >"${output_metadata}/builder-packages.txt"
+  chmod 0444 "${output_metadata}/"*
+}
+
+build() {
+  work_dir="$(mktemp -d /tmp/nemoclaw-perl-cve.XXXXXX)"
+  trap 'rm -rf -- "$work_dir"' EXIT
+
+  extract_and_patch_source "$work_dir"
+  build_packages "$work_dir"
+  collect_packages "$work_dir"
+}
+
+case "${1:-}" in
+  prepare)
+    configure_snapshot
+    install_build_dependencies
+    ;;
+  build)
+    build
+    ;;
+  *)
+    fail "usage: $0 {prepare|build}"
+    ;;
+esac

--- a/scripts/patches/perl/CVE-2026-12087.patch
+++ b/scripts/patches/perl/CVE-2026-12087.patch
@@ -1,0 +1,56 @@
+From: Paul "LeoNerd" Evans <leonerd@leonerd.org.uk>
+Date: Mon, 4 May 2026 16:12:49 +0100
+Subject: Socket: validate each pack_ip_mreq_source argument length
+
+Backport the security-relevant part of upstream commit
+de19a0b0ad1900fef976c5c1400bd8f11ec6c6cb for Debian Perl 5.40.1.
+
+Origin: upstream, commit:de19a0b0ad1900fef976c5c1400bd8f11ec6c6cb
+Bug: CVE-2026-12087
+---
+ cpan/Socket/Socket.xs | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/cpan/Socket/Socket.xs b/cpan/Socket/Socket.xs
+--- a/cpan/Socket/Socket.xs
++++ b/cpan/Socket/Socket.xs
+@@ -1331,29 +1331,29 @@ pack_ip_mreq_source(multiaddr, source, interface=&PL_sv_undef)
+         char * multiaddrbytes;
+         char * sourcebytes;
+         char * interfacebytes;
+-        STRLEN len;
++        STRLEN multiaddr_len, source_len, interface_len;
+         if (DO_UTF8(multiaddr) && !sv_utf8_downgrade(multiaddr, 1))
+             croak("Wide character in %s", "Socket::pack_ip_mreq_source");
+-        multiaddrbytes = SvPVbyte(multiaddr, len);
+-        if (len != sizeof(mreq.imr_multiaddr))
++        multiaddrbytes = SvPVbyte(multiaddr, multiaddr_len);
++        if (multiaddr_len != sizeof(mreq.imr_multiaddr))
+             croak("Bad arg length %s, length is %" UVuf ", should be %" UVuf,
+-                    "Socket::pack_ip_mreq", (UV)len, (UV)sizeof(mreq.imr_multiaddr));
++                    "Socket::pack_ip_mreq", (UV)multiaddr_len, (UV)sizeof(mreq.imr_multiaddr));
+         if (DO_UTF8(source) && !sv_utf8_downgrade(source, 1))
+             croak("Wide character in %s", "Socket::pack_ip_mreq_source");
+-        if (len != sizeof(mreq.imr_sourceaddr))
++        sourcebytes = SvPVbyte(source, source_len);
++        if (source_len != sizeof(mreq.imr_sourceaddr))
+             croak("Bad arg length %s, length is %" UVuf ", should be %" UVuf,
+-                    "Socket::pack_ip_mreq", (UV)len, (UV)sizeof(mreq.imr_sourceaddr));
+-        sourcebytes = SvPVbyte(source, len);
++                    "Socket::pack_ip_mreq", (UV)source_len, (UV)sizeof(mreq.imr_sourceaddr));
+         Zero(&mreq, sizeof(mreq), char);
+         Copy(multiaddrbytes, &mreq.imr_multiaddr, sizeof(mreq.imr_multiaddr), char);
+         Copy(sourcebytes, &mreq.imr_sourceaddr, sizeof(mreq.imr_sourceaddr), char);
+         if(SvOK(interface)) {
+             if (DO_UTF8(interface) && !sv_utf8_downgrade(interface, 1))
+                 croak("Wide character in %s", "Socket::pack_ip_mreq");
+-            interfacebytes = SvPVbyte(interface, len);
+-            if (len != sizeof(mreq.imr_interface))
++            interfacebytes = SvPVbyte(interface, interface_len);
++            if (interface_len != sizeof(mreq.imr_interface))
+                 croak("Bad arg length %s, length is %" UVuf ", should be %" UVuf,
+-                        "Socket::pack_ip_mreq", (UV)len, (UV)sizeof(mreq.imr_interface));
++                        "Socket::pack_ip_mreq", (UV)interface_len, (UV)sizeof(mreq.imr_interface));
+             Copy(interfacebytes, &mreq.imr_interface, sizeof(mreq.imr_interface), char);
+         }
+         else

--- a/scripts/patches/perl/CVE-2026-13221.patch
+++ b/scripts/patches/perl/CVE-2026-13221.patch
@@ -1,0 +1,30 @@
+From: Karl Williamson <khw@cpan.org>
+Date: Thu, 26 Mar 2026 10:13:49 -0600
+Subject: regcomp_study: do not create a trie that would overflow
+
+Backport the security-relevant change from upstream commit
+03f74bbbd3a68350d926ee93d56ee4808c28c4c7 for Debian Perl 5.40.1.
+
+Origin: upstream, commit:03f74bbbd3a68350d926ee93d56ee4808c28c4c7
+Bug: CVE-2026-13221
+---
+ regcomp_study.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/regcomp_study.c b/regcomp_study.c
+--- a/regcomp_study.c
++++ b/regcomp_study.c
+@@ -1840,6 +1840,13 @@ Perl_study_chunk(pTHX_
+                             tail = regnext( tail );
+                         }
+
++                        /* The code below currently saves the difference from
++                         * start to finish in a 16-bit field. Do not make a
++                         * trie whose final tail would overflow that field. */
++                        if (tail - startbranch >= U16_MAX) {
++                            continue;
++                        }
++
+
+                         DEBUG_TRIE_COMPILE_r({
+                             regprop(RExC_rx, RExC_mysv, tail, NULL, pRExC_state);

--- a/test/container-cve-remediation.test.ts
+++ b/test/container-cve-remediation.test.ts
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const PERL_VERSION = "5.40.1-8+nemoclaw1";
+const PERL_DOCKERFILES = [
+  "Dockerfile.base",
+  "agents/hermes/Dockerfile.base",
+  "agents/langchain-deepagents-code/Dockerfile.base",
+] as const;
+const GOSU_DOCKERFILES = ["Dockerfile.base", "agents/hermes/Dockerfile.base"] as const;
+const PERL_PATCHES = [
+  "scripts/patches/perl/CVE-2026-12087.patch",
+  "scripts/patches/perl/CVE-2026-13221.patch",
+] as const;
+
+function read(relativePath: string): string {
+  return readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+}
+
+function sha256(relativePath: string): string {
+  return createHash("sha256")
+    .update(readFileSync(path.join(REPO_ROOT, relativePath)))
+    .digest("hex");
+}
+
+describe("container CVE remediation", () => {
+  // source-shape-contract: security -- Every published base must consume the same patched Perl package cohort and final-image assertions
+  it("installs and verifies the patched Perl cohort in every base image", () => {
+    const sources = [
+      read("Dockerfile.base"),
+      read("agents/hermes/Dockerfile.base"),
+      read("agents/langchain-deepagents-code/Dockerfile.base"),
+    ];
+    for (const [index, source] of sources.entries()) {
+      const dockerfile = PERL_DOCKERFILES[index];
+      expect(source, dockerfile).toContain("AS perl-cve-backport-builder");
+      expect(source, dockerfile).toContain(
+        "COPY scripts/build-perl-cve-backport.sh /usr/local/bin/build-perl-cve-backport",
+      );
+      expect(source, dockerfile).toContain(
+        "COPY --from=perl-cve-backport-builder /out/debs/ /tmp/perl-cve-debs/",
+      );
+      expect(source, dockerfile).toContain(
+        `test "$(dpkg-query -W -f='\${Version}' "$package")" = "${PERL_VERSION}"`,
+      );
+      expect(source, dockerfile).toContain("|| exit 1;");
+      expect(source, dockerfile).toContain("short Socket source accepted");
+      expect(source, dockerfile).toContain('my $x = join "|", "aaa".."mzz"');
+      expect(source, dockerfile).toContain('test -n "$storable_so"');
+      expect(source, dockerfile).toContain(
+        `grep -aFq 'Invalid count of hook data items' "$storable_so"`,
+      );
+    }
+  });
+
+  // source-shape-contract: security -- Exact Go and gosu source identities prevent a mutable rebuild from silently restoring vulnerable compiler bytes
+  it("builds gosu from one checksum-pinned source and patched Go toolchain", () => {
+    const sources = [read("Dockerfile.base"), read("agents/hermes/Dockerfile.base")];
+    for (const [index, source] of sources.entries()) {
+      const dockerfile = GOSU_DOCKERFILES[index];
+      expect(source, dockerfile).toContain("go1.26.5.linux-amd64.tar.gz");
+      expect(source, dockerfile).toContain("go1.26.5.linux-arm64.tar.gz");
+      expect(source, dockerfile).toContain("6456aaa0f3c854d199d0f037f068eb97515b7513");
+      expect(source, dockerfile).toContain(
+        "33d7537d588ea49458b9509bcf4554bdf5ceacc66da71e5caa1058ea3b689c3b",
+      );
+      expect(source, dockerfile).toContain('go" tool nm /usr/local/bin/gosu > /tmp/gosu.nm');
+      expect(source, dockerfile).toContain("grep -Eq 'crypto/(tls|x509)' /tmp/gosu.nm");
+      expect(source, dockerfile).toContain("1.19 (go1.26.5 on linux/");
+      expect(source, dockerfile).not.toContain(
+        "52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0",
+      );
+    }
+    expect(sources[0].match(/RUN arch=.*?rm -rf[\s\S]*?gosu-[0-9a-f]+/u)?.[0]).toBe(
+      sources[1].match(/RUN arch=.*?rm -rf[\s\S]*?gosu-[0-9a-f]+/u)?.[0],
+    );
+  });
+
+  // source-shape-contract: security -- Repository patch bytes must match the immutable hashes enforced before the private Perl package build
+  it("binds the Perl backport script to the reviewed patch bytes", () => {
+    const buildScript = read("scripts/build-perl-cve-backport.sh");
+    for (const patch of PERL_PATCHES) {
+      expect(buildScript, patch).toContain(sha256(patch));
+    }
+    expect(buildScript).toContain('readonly PERL_DEBIAN_REVISION="8"');
+    expect(buildScript).toContain(
+      'readonly DEBIAN_SNAPSHOT="${DEBIAN_SNAPSHOT:-20260724T000000Z}"',
+    );
+    expect(buildScript).toContain("len3 == I32_MAX");
+  });
+
+  // source-shape-contract: security -- Publisher path filters must rebuild images whenever any authoritative CVE remediation input changes
+  it("rebuilds base images when any remediation input changes", () => {
+    const workflow = read(".github/workflows/base-image.yaml");
+    for (const input of [
+      "scripts/build-perl-cve-backport.sh",
+      ...PERL_PATCHES,
+      ...PERL_DOCKERFILES,
+    ]) {
+      expect(workflow, input).toContain(`- "${input}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Refreshes the Perl and gosu build inputs used by the NemoClaw base images. The builds now use one consistent Perl package cohort and a source-built gosu binary with pinned toolchain and source provenance.

## Changes

- Build Debian Perl `5.40.1-8+nemoclaw1` from signed, checksum-pinned source with two narrow upstream backports, then install the same four-package ABI cohort in the OpenClaw, Hermes, and Deep Agents base images.
- Build gosu 1.19 from checksum-pinned source with Go 1.26.5 for the OpenClaw and Hermes bases, retaining build and license metadata in the image.
- Add fail-closed package, runtime, symbol, and workflow-input checks plus focused contract coverage.

Dependency boundary: one Debian package revision range plus two upstream Perl fix commits; gosu remains at 1.19, so it crosses zero gosu release ranges; the Go compiler moves from 1.24.6 to 1.26.5.

### Migration concerns

| ID | Concern | Disposition | Evidence |
|---|---|---|---|
| DEP-1 | Split Perl packages could drift across ABI revisions | Guard and test | Four-package version assertions and arm64 runtime checks |
| DEP-2 | Prebuilt gosu provenance follows its original compiler | Pin and runtime-proof | Pinned source/toolchain hashes, Go build metadata, symbol audit, and user-switch check |
| DEP-3 | Remediation inputs could change without rebuilding images | Guard and test | Publisher path filters and source-shape contract tests |

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: dependency build, provenance, and validation internals only; no supported command, configuration, default, output, or user workflow changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: exact-digest multi-architecture image builds and scan remain pending in CI.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths or user-facing behavior changed; contributor maintenance comments cover the new gosu and Go update inputs.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9cfb285fd -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/container-cve-remediation.test.ts test/sandbox-provisioning.test.ts` (65 passed)
- [ ] Applicable broad gate passed — pending exact-head multi-architecture base-image builds and image scan in CI
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Remaining gates

- Complete exact-head multi-architecture builds for all three base-image families.
- Scan the produced image digests and disposition any package-metadata-only residuals.
- Complete the adjacent Go toolchain release, dependency, license, and SBOM review before marking the PR ready.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>