### PR TITLE
fix(ci): prevent skipped E2E gate from satisfying merge

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
+++ b/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
@@ -67,11 +67,15 @@ Required PR workflows must identify the PR number, PR SHA, and base SHA.
 
 - The installer-hash workflow runs trusted verification after each `pull_request` `edited` event.
   Its run name records `gate true` and the base SHA. A metadata edit must not create skipped evidence.
-- Each `pull_request_target` E2E controller run that performs work must use an immutable `gate true` run name.
+- Each `pull_request_target` E2E controller run for an open PR must use an immutable `gate true` run name.
   The run name must identify the PR number, PR SHA, and base SHA.
+- Metadata-only edits must keep the `E2E / PR Gate` observer active.
+  They must not create a new coordination check.
+- A closed event must use `E2E / PR Gate (not applicable)` for its skipped observer.
+  It must not publish the required check name.
 - GitHub usually associates the run with the PR.
   If that association is empty, require the controller path, branch, repository, and run time to match the coordination check.
-- Discard a later all-skipped `gate false` metadata run only when a stronger run exists for the same PR SHA and base SHA.
+- Treat an all-skipped `gate false` run from an older workflow version as non-evidence.
 - Fail closed when identity, state, or timing evidence is missing, malformed, stale, contradictory, or changed.
 
 ### Controller status and PR status

--- a/.github/workflows/pr-e2e-gate.yaml
+++ b/.github/workflows/pr-e2e-gate.yaml
@@ -8,7 +8,7 @@ run-name: >-
   format('E2E Gate PR #{0} head {1} base {2} gate {3}',
   github.event.pull_request.number, github.event.pull_request.head.sha,
   github.event.pull_request.base.sha,
-  github.event.action != 'edited' || github.event.changes.base != null) ||
+  github.event.action != 'closed') ||
   format('E2E Gate {0} {1}', github.event_name, github.run_id) }}
 
 on:
@@ -93,8 +93,13 @@ jobs:
           --base "$BASE_SHA"
 
   required:
-    name: E2E / PR Gate
-    if: ${{ github.event_name == 'pull_request_target' && github.repository == 'NVIDIA/NemoClaw' && github.event.action != 'closed' && (github.event.action != 'edited' || github.event.changes.base != null) }}
+    # GitHub treats a skipped required job as passing, so only the running observer can use the required check name.
+    name: >-
+      ${{ github.event_name == 'pull_request_target' &&
+      github.repository == 'NVIDIA/NemoClaw' &&
+      github.event.action != 'closed' &&
+      'E2E / PR Gate' || 'E2E / PR Gate (not applicable)' }}
+    if: ${{ github.event_name == 'pull_request_target' && github.repository == 'NVIDIA/NemoClaw' && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:

--- a/test/pr-e2e-gate-workflow.test.ts
+++ b/test/pr-e2e-gate-workflow.test.ts
@@ -298,6 +298,8 @@ describe("PR E2E gate workflow", () => {
     const ciWorkflow = readYaml<Workflow>(".github/workflows/pr.yaml");
     const ciRequired =
       "${{ github.event.action != 'edited' || github.event.changes.base != null }}";
+    const requiredObserverCondition =
+      "github.event_name == 'pull_request_target' && github.repository == 'NVIDIA/NemoClaw' && github.event.action != 'closed'";
     const ciVerification = step(ciWorkflow.jobs.checks, "Verify required PR checks");
     const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
     const initialize = workflow.jobs.initialize;
@@ -321,7 +323,8 @@ describe("PR E2E gate workflow", () => {
     expect(workflow["run-name"]).toContain("github.event.pull_request.number");
     expect(workflow["run-name"]).toContain("github.event.pull_request.head.sha");
     expect(workflow["run-name"]).toContain("github.event.pull_request.base.sha");
-    expect(workflow["run-name"]).toContain("github.event.changes.base != null");
+    expect(workflow["run-name"]).toContain("github.event.action != 'closed'");
+    expect(workflow["run-name"]).not.toContain("github.event.changes.base != null");
     expect(workflow.on).toEqual({
       workflow_run: {
         workflows: ["CI / Pull Request"],
@@ -403,11 +406,10 @@ describe("PR E2E gate workflow", () => {
     );
     expect(initialize.concurrency?.queue).toBe("max");
     expect(initialize.concurrency?.["cancel-in-progress"]).toBe(false);
-    expect(required.name).toBe("E2E / PR Gate");
-    expect(required.if).toContain("github.event_name == 'pull_request_target'");
-    expect(required.if).toContain("github.event.action != 'closed'");
-    expect(required.if).toContain("github.event.action != 'edited'");
-    expect(required.if).toContain("github.event.changes.base != null");
+    expect(required.name).toBe(
+      `\${{ ${requiredObserverCondition} && 'E2E / PR Gate' || 'E2E / PR Gate (not applicable)' }}`,
+    );
+    expect(required.if).toBe(`\${{ ${requiredObserverCondition} }}`);
     expect(required.permissions).toEqual({
       checks: "read",
       contents: "read",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Prevent metadata-only and closed PR events from publishing a skipped job under the required `E2E / PR Gate` name. Open PR events now keep the trusted observer active, so a skipped duplicate check cannot satisfy the merge ruleset.

## Changes

- Keep the required observer active for every open `pull_request_target` event without creating a new coordination check for metadata-only edits.
- Give closed and non-PR skipped jobs the non-required `E2E / PR Gate (not applicable)` name.
- Add exact workflow-contract assertions and update maintainer guidance for open, closed, and legacy workflow runs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: No user-facing `docs/` change is required; internal maintainer guidance now matches the workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The required job name and observer execution use the same exact event predicate. The 245 focused PR-gate tests and applicable hooks passed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 14189954c -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/pr-e2e-gate*.test.ts` passed 13 files and 245 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved E2E gate handling for pull request updates and closures.
  * Closed pull requests now clearly show when the E2E gate is not applicable.
  * Updated validation for workflow evidence and skipped runs to provide more reliable gate results.

* **Documentation**
  * Clarified the rules for interpreting E2E gate workflow runs, metadata-only changes, and pull request associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->