### PR TITLE
fix(policy): treat preset picker stdin EOF as cancellation

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -9,7 +9,6 @@
     "test/install-preflight.test.ts": 3921,
     "test/nemoclaw-start.test.ts": 4819,
     "test/onboard-messaging.test.ts": 2049,
-    "test/onboard-selection.test.ts": 4769,
-    "test/policies.test.ts": 1530
+    "test/onboard-selection.test.ts": 4769
   }
 }

--- a/src/lib/actions/sandbox/policy-channel-policy.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-policy.test.ts
@@ -176,6 +176,28 @@ describe("addSandboxPolicy", () => {
     expect(applyPresetMock).not.toHaveBeenCalled();
   });
 
+  it("exits non-zero when the add picker reaches stdin EOF (#7418)", async () => {
+    selectFromListMock.mockRejectedValueOnce(
+      Object.assign(new Error("Prompt closed before input"), { code: "EOF" }),
+    );
+
+    await expect(captureExit(() => addSandboxPolicy("test-sandbox"))).resolves.toBe(1);
+
+    // Names the real condition rather than reporting non-interactive mode,
+    // which is not what happened here.
+    expect(printedText()).toContain("No input available on stdin");
+    expect(applyPresetMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates a non-EOF picker failure instead of exiting (#7418)", async () => {
+    const failure = Object.assign(new Error("stdin read failed"), { code: "EIO" });
+    selectFromListMock.mockRejectedValueOnce(failure);
+
+    await expect(addSandboxPolicy("test-sandbox")).rejects.toBe(failure);
+
+    expect(applyPresetMock).not.toHaveBeenCalled();
+  });
+
   it("filters Hermes-only presets from the OpenClaw picker", async () => {
     arrangeSandbox("openclaw");
 
@@ -361,6 +383,17 @@ describe("removeSandboxPolicy", () => {
     await expect(captureExit(() => removeSandboxPolicy("test-sandbox"))).resolves.toBe(1);
 
     expect(printedText()).toContain("Non-interactive mode requires a preset name.");
+    expect(removePresetMock).not.toHaveBeenCalled();
+  });
+
+  it("exits non-zero when the remove picker reaches stdin EOF (#7418)", async () => {
+    selectForRemovalMock.mockRejectedValueOnce(
+      Object.assign(new Error("Prompt closed before input"), { code: "EOF" }),
+    );
+
+    await expect(captureExit(() => removeSandboxPolicy("test-sandbox"))).resolves.toBe(1);
+
+    expect(printedText()).toContain("No input available on stdin");
     expect(removePresetMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -63,6 +63,52 @@ import { executeSandboxCommand, executeSandboxExecCommand } from "./process-reco
 
 const isNonInteractive = isNonInteractiveEnv;
 
+/**
+ * Report that `NEMOCLAW_NON_INTERACTIVE=1` leaves no interactive picker, and
+ * exit non-zero.
+ */
+function exitPresetNameRequired(usage: string): never {
+  console.error("  Non-interactive mode requires a preset name.");
+  console.error(`  Usage: ${usage}`);
+  process.exit(1);
+}
+
+/**
+ * Report that the picker prompt reached stdin EOF, and exit non-zero.
+ *
+ * Separate from `exitPresetNameRequired` because the conditions differ. That
+ * one means the operator set `NEMOCLAW_NON_INTERACTIVE=1`. This one means
+ * stdin closed while that variable was unset, so naming the variable would
+ * misdirect whoever reads the boot-unit log.
+ */
+function exitPromptStdinClosed(usage: string): never {
+  console.error("  No input available on stdin, so the preset picker cannot prompt.");
+  console.error(`  Usage: ${usage}`);
+  process.exit(1);
+}
+
+/**
+ * Await an interactive preset picker and convert a prompt EOF into exit 1.
+ *
+ * A boot unit that pipes or closes stdin without setting
+ * `NEMOCLAW_NON_INTERACTIVE=1` reaches the picker, and the prompt then hits
+ * EOF. Before #7418 the picker promise never settled, so the command exited 0
+ * having changed nothing. Automation could not distinguish an applied preset
+ * from a no-op. Any other failure propagates unchanged.
+ */
+async function pickPresetOrExit(
+  pick: () => Promise<string | null>,
+  usage: string,
+): Promise<string | null> {
+  try {
+    return await pick();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code !== "EOF") throw error;
+    exitPromptStdinClosed(usage);
+  }
+}
+
 type ChannelMutationOptions = {
   channel?: string;
   dryRun?: boolean;
@@ -217,12 +263,11 @@ async function addSandboxPolicyUnlocked(
     }
     answer = preset.name;
   } else {
+    const usage = `${CLI_NAME} <sandbox> policy-add <preset> [--yes] [--dry-run]`;
     if (isNonInteractive()) {
-      console.error("  Non-interactive mode requires a preset name.");
-      console.error(`  Usage: ${CLI_NAME} <sandbox> policy-add <preset> [--yes] [--dry-run]`);
-      process.exit(1);
+      exitPresetNameRequired(usage);
     }
-    answer = await policies.selectFromList(allPresets, { applied });
+    answer = await pickPresetOrExit(() => policies.selectFromList(allPresets, { applied }), usage);
   }
   if (!answer) return;
 
@@ -1632,12 +1677,14 @@ async function removeSandboxPolicyUnlocked(
     }
     answer = preset.name;
   } else {
+    const usage = `${CLI_NAME} <sandbox> policy-remove <preset> [--yes] [--dry-run]`;
     if (isNonInteractive()) {
-      console.error("  Non-interactive mode requires a preset name.");
-      console.error(`  Usage: ${CLI_NAME} <sandbox> policy-remove <preset> [--yes] [--dry-run]`);
-      process.exit(1);
+      exitPresetNameRequired(usage);
     }
-    answer = await policies.selectForRemoval(allPresets, { applied });
+    answer = await pickPresetOrExit(
+      () => policies.selectForRemoval(allPresets, { applied }),
+      usage,
+    );
   }
   if (!answer) return;
 

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -850,10 +850,12 @@ function removePreset(
  * `rl.close()` itself emits `close`. Only a close that arrives before an
  * answer rejects.
  *
- * This adopts the EOF half of the `prompt()` contract in
- * `credentials/store.ts` (#5976), and not the whole contract: `prompt()` also
- * rejects on SIGINT and re-raises it, which these pickers have never done.
- * Adding SIGINT handling is a separate behavior change.
+ * Rejects with `code: "SIGINT"` when the operator presses Ctrl-C, and
+ * re-raises the signal so the process dies by SIGINT. Readline emits `close`
+ * for an interrupt as well as for EOF, so without a SIGINT listener an
+ * interrupt would be reported as a closed stdin.
+ *
+ * This matches the `prompt()` contract in `credentials/store.ts` (#5976).
  */
 function askPreset(question: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
@@ -872,6 +874,12 @@ function askPreset(question: string): Promise<string> {
       if (typeof process.stdin.unref === "function") process.stdin.unref();
       settle();
     };
+    // Runs before the `close` listener below, so an interrupt settles as
+    // SIGINT and the close that follows is ignored.
+    rl.on("SIGINT", () => {
+      finish(() => reject(Object.assign(new Error("Prompt interrupted"), { code: "SIGINT" })));
+      process.kill(process.pid, "SIGINT");
+    });
     rl.on("close", () =>
       finish(() => reject(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }))),
     );

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -838,58 +838,80 @@ function removePreset(
 }
 
 /**
- * Interactive preset picker for the `policy-remove` command. Prompts on
- * stderr and resolves to the chosen preset name, or `null` if the user
- * cancels or enters an invalid selection.
+ * Ask one preset-picker question on stderr and resolve to the raw answer.
+ *
+ * Rejects with `code: "EOF"` when readline closes before the question is
+ * answered. A boot unit runs `nemoclaw <sandbox> policy-add < /dev/null`, and
+ * the `question` callback then never fires. Without this handler the picker
+ * promise never settles and the command exits 0 having applied nothing
+ * (#7418).
+ *
+ * `finish` marks the prompt done before closing readline, because
+ * `rl.close()` itself emits `close`. Only a close that arrives before an
+ * answer rejects.
+ *
+ * This adopts the EOF half of the `prompt()` contract in
+ * `credentials/store.ts` (#5976), and not the whole contract: `prompt()` also
+ * rejects on SIGINT and re-raises it, which these pickers have never done.
+ * Adding SIGINT handling is a separate behavior change.
  */
-function selectForRemoval(
-  items: PresetInfo[],
-  { applied = [] }: SelectionOptions = {},
-): Promise<string | null> {
-  return new Promise<string | null>((resolve) => {
-    const appliedItems = items.filter((item) => applied.includes(item.name));
-    if (appliedItems.length === 0) {
-      process.stderr.write("\n  No presets are currently applied.\n\n");
-      resolve(null);
-      return;
-    }
-    process.stderr.write("\n  Applied presets:\n");
-    appliedItems.forEach((item, i) => {
-      const description = item.description ? ` — ${item.description}` : "";
-      process.stderr.write(`    ${i + 1}) ${item.name}${description}\n`);
-    });
-    process.stderr.write("\n");
-    const question = "  Choose preset to remove: ";
+function askPreset(question: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
     // Re-attach stdin to the event loop — unref() on exit is sticky and
     // would otherwise leave a follow-up prompt waiting on a detached handle.
     if (typeof process.stdin.ref === "function") process.stdin.ref();
     const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
-    rl.question(question, (answer: string) => {
+    let finished = false;
+    const finish = (settle: () => void) => {
+      if (finished) return;
+      finished = true;
       rl.close();
       // pause+unref so the process exits naturally after the last prompt.
       // The matching ref() above keeps subsequent prompts working.
       if (typeof process.stdin.pause === "function") process.stdin.pause();
       if (typeof process.stdin.unref === "function") process.stdin.unref();
-      const trimmed = answer.trim();
-      if (!trimmed) {
-        resolve(null);
-        return;
-      }
-      if (!/^\d+$/.test(trimmed)) {
-        process.stderr.write("\n  Invalid preset number.\n");
-        resolve(null);
-        return;
-      }
-      const num = Number(trimmed);
-      const item = appliedItems[num - 1];
-      if (!item) {
-        process.stderr.write("\n  Invalid preset number.\n");
-        resolve(null);
-        return;
-      }
-      resolve(item.name);
-    });
+      settle();
+    };
+    rl.on("close", () =>
+      finish(() => reject(Object.assign(new Error("Prompt closed before input"), { code: "EOF" }))),
+    );
+    rl.question(question, (answer: string) => finish(() => resolve(answer)));
   });
+}
+
+/**
+ * Interactive preset picker for the `policy-remove` command. Prompts on
+ * stderr and resolves to the chosen preset name, or `null` if the user
+ * cancels or enters an invalid selection. Rejects with `code: "EOF"` when
+ * stdin closes before an answer (see `askPreset`).
+ */
+async function selectForRemoval(
+  items: PresetInfo[],
+  { applied = [] }: SelectionOptions = {},
+): Promise<string | null> {
+  const appliedItems = items.filter((item) => applied.includes(item.name));
+  if (appliedItems.length === 0) {
+    process.stderr.write("\n  No presets are currently applied.\n\n");
+    return null;
+  }
+  process.stderr.write("\n  Applied presets:\n");
+  appliedItems.forEach((item, i) => {
+    const description = item.description ? ` — ${item.description}` : "";
+    process.stderr.write(`    ${i + 1}) ${item.name}${description}\n`);
+  });
+  process.stderr.write("\n");
+  const trimmed = (await askPreset("  Choose preset to remove: ")).trim();
+  if (!trimmed) return null;
+  if (!/^\d+$/.test(trimmed)) {
+    process.stderr.write("\n  Invalid preset number.\n");
+    return null;
+  }
+  const item = appliedItems[Number(trimmed) - 1];
+  if (!item) {
+    process.stderr.write("\n  Invalid preset number.\n");
+    return null;
+  }
+  return item.name;
 }
 
 /**
@@ -1496,64 +1518,45 @@ function presetContentMatchesGateway(sandboxName: string, presetContent: string)
 /**
  * Interactive preset picker for the `policy-add` command. Prints the
  * presets on stderr (● applied, ○ not applied), prompts for a number, and
- * resolves to the chosen preset name or `null` on cancel.
+ * resolves to the chosen preset name or `null` on cancel. Rejects with
+ * `code: "EOF"` when stdin closes before an answer (see `askPreset`).
  */
-function selectFromList(
+async function selectFromList(
   items: PresetInfo[],
   { applied = [] }: SelectionOptions = {},
 ): Promise<string | null> {
-  return new Promise<string | null>((resolve) => {
-    process.stderr.write("\n  Available presets:\n");
-    items.forEach((item, i) => {
-      const marker = applied.includes(item.name) ? "●" : "○";
-      const description = item.description ? ` — ${item.description}` : "";
-      process.stderr.write(`    ${i + 1}) ${marker} ${item.name}${description}\n`);
-    });
-    process.stderr.write("\n  ● applied, ○ not applied\n\n");
-    const defaultIdx = items.findIndex((item) => !applied.includes(item.name));
-    const defaultNum = defaultIdx >= 0 ? defaultIdx + 1 : null;
-    const question = defaultNum ? `  Choose preset [${defaultNum}]: ` : "  Choose preset: ";
-    // Re-attach stdin to the event loop — unref() on exit is sticky and
-    // would otherwise leave a follow-up prompt waiting on a detached handle.
-    if (typeof process.stdin.ref === "function") process.stdin.ref();
-    const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
-    rl.question(question, (answer: string) => {
-      rl.close();
-      // pause+unref so the process exits naturally after the last prompt.
-      // The matching ref() above keeps subsequent prompts working.
-      if (typeof process.stdin.pause === "function") process.stdin.pause();
-      if (typeof process.stdin.unref === "function") process.stdin.unref();
-      const trimmed = answer.trim();
-      const effectiveInput = trimmed || (defaultNum ? String(defaultNum) : "");
-      if (!effectiveInput) {
-        resolve(null);
-        return;
-      }
-      if (!/^\d+$/.test(effectiveInput)) {
-        process.stderr.write("\n  Invalid preset number.\n");
-        resolve(null);
-        return;
-      }
-      const num = Number(effectiveInput);
-      const item = items[num - 1];
-      if (!item) {
-        process.stderr.write("\n  Invalid preset number.\n");
-        resolve(null);
-        return;
-      }
-      if (applied.includes(item.name)) {
-        // The picker has no live-policy context to classify drift; the named
-        // path (policy-add <preset>) re-applies edited presets (#7323).
-        process.stderr.write(`\n  Preset '${item.name}' is already applied.\n`);
-        process.stderr.write(
-          `  If its preset file changed, run '${CLI_NAME} <sandbox> policy-add ${item.name}' to re-apply it.\n`,
-        );
-        resolve(null);
-        return;
-      }
-      resolve(item.name);
-    });
+  process.stderr.write("\n  Available presets:\n");
+  items.forEach((item, i) => {
+    const marker = applied.includes(item.name) ? "●" : "○";
+    const description = item.description ? ` — ${item.description}` : "";
+    process.stderr.write(`    ${i + 1}) ${marker} ${item.name}${description}\n`);
   });
+  process.stderr.write("\n  ● applied, ○ not applied\n\n");
+  const defaultIdx = items.findIndex((item) => !applied.includes(item.name));
+  const defaultNum = defaultIdx >= 0 ? defaultIdx + 1 : null;
+  const question = defaultNum ? `  Choose preset [${defaultNum}]: ` : "  Choose preset: ";
+  const trimmed = (await askPreset(question)).trim();
+  const effectiveInput = trimmed || (defaultNum ? String(defaultNum) : "");
+  if (!effectiveInput) return null;
+  if (!/^\d+$/.test(effectiveInput)) {
+    process.stderr.write("\n  Invalid preset number.\n");
+    return null;
+  }
+  const item = items[Number(effectiveInput) - 1];
+  if (!item) {
+    process.stderr.write("\n  Invalid preset number.\n");
+    return null;
+  }
+  if (applied.includes(item.name)) {
+    // The picker has no live-policy context to classify drift; the named
+    // path (policy-add <preset>) re-applies edited presets (#7323).
+    process.stderr.write(`\n  Preset '${item.name}' is already applied.\n`);
+    process.stderr.write(
+      `  If its preset file changed, run '${CLI_NAME} <sandbox> policy-add ${item.name}' to re-apply it.\n`,
+    );
+    return null;
+  }
+  return item.name;
 }
 
 const PERMISSIVE_POLICY_PATH = path.join(

--- a/test/package-contract/cli/policy-prompt-eof.test.ts
+++ b/test/package-contract/cli/policy-prompt-eof.test.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Prompt-cancellation package contract for the policy preset pickers (#7418).
+ *
+ * A boot unit runs `nemoclaw <sandbox> policy-add` with no preset name and a
+ * closed stdin. That reaches the interactive picker, and the prompt hits EOF.
+ * The `question` callback never fired, the picker promise never settled, and
+ * the CLI exited 0 having applied nothing. Automation could not distinguish
+ * an applied preset from a no-op.
+ *
+ * These tests drive the compiled CLI (`dist/nemoclaw.js`) on real stdin at
+ * EOF, so readline decides when the prompt closes. Only the registry and
+ * preset lookups are stubbed, which replaces on-disk sandbox state.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "../../..");
+const CLI_PATH = JSON.stringify(path.join(REPO_ROOT, "dist", "nemoclaw.js"));
+const POLICIES_PATH = JSON.stringify(path.join(REPO_ROOT, "dist", "lib", "policy", "index.js"));
+const REGISTRY_PATH = JSON.stringify(path.join(REPO_ROOT, "dist", "lib", "state", "registry.js"));
+
+/**
+ * Run a policy command with no preset name against a closed stdin. `input: ""`
+ * gives the child an already-ended pipe, which is the EOF a boot unit
+ * produces.
+ */
+function runPolicyCommandAtStdinEof(command: "policy-add" | "policy-remove") {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-policy-prompt-eof-"));
+  const scriptPath = path.join(tmpDir, "policy-prompt-eof-check.js");
+  const script = String.raw`
+const registry = require(${REGISTRY_PATH});
+const policies = require(${POLICIES_PATH});
+policies.listPresets = () => [
+  { file: "npm.yaml", name: "npm", description: "npm registry access" },
+  { file: "pypi.yaml", name: "pypi", description: "PyPI access" },
+];
+policies.listCustomPresets = () => [];
+policies.getAppliedPresets = () => ["npm"];
+registry.getSandbox = (name) =>
+  name === "test-sandbox" ? { name, policies: ["npm"], customPolicies: [] } : null;
+registry.listSandboxes = () => ({ sandboxes: [{ name: "test-sandbox" }] });
+process.argv = ["node", "nemoclaw.js", "test-sandbox", ${JSON.stringify(command)}];
+require(${CLI_PATH});
+`;
+  fs.writeFileSync(scriptPath, script);
+  try {
+    return spawnSync(process.execPath, [scriptPath], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      input: "",
+      // A regression here is a hang, not a wrong value, so cap it rather than
+      // letting the suite block. SIGKILL because the child is mid-prompt.
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+      env: { ...process.env, HOME: tmpDir, NEMOCLAW_NON_INTERACTIVE: undefined },
+    });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe("policy preset prompt cancellation", () => {
+  it.each([
+    { command: "policy-add" as const, menu: "Available presets:" },
+    { command: "policy-remove" as const, menu: "Applied presets:" },
+  ])("$command exits non-zero when the picker prompt hits EOF (#7418)", ({ command, menu }) => {
+    const result = runPolicyCommandAtStdinEof(command);
+
+    // The child exited on its own rather than being killed by the timeout
+    // above. The pre-#7418 promise never settled, which appears here as a
+    // SIGKILL and a null status instead of an exit status.
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    // The picker was reached, so this is prompt EOF rather than the
+    // NEMOCLAW_NON_INTERACTIVE=1 guard exiting earlier.
+    expect(result.stderr).toContain(menu);
+    expect(result.stderr).toContain("No input available on stdin");
+    expect(result.stderr).toContain(`${command} <preset>`);
+    expect(result.status).toBe(1);
+  });
+});

--- a/test/package-contract/cli/policy-prompt-eof.test.ts
+++ b/test/package-contract/cli/policy-prompt-eof.test.ts
@@ -85,5 +85,7 @@ describe("policy preset prompt cancellation", () => {
     expect(result.stderr).toContain("No input available on stdin");
     expect(result.stderr).toContain(`${command} <preset>`);
     expect(result.status).toBe(1);
-  });
+    // Above the child's 30s cap, so a hung picker fails on the assertions
+    // above rather than as a bare suite timeout.
+  }, 45_000);
 });

--- a/test/package-contract/cli/policy-prompt-eof.test.ts
+++ b/test/package-contract/cli/policy-prompt-eof.test.ts
@@ -56,8 +56,9 @@ require(${CLI_PATH});
       cwd: REPO_ROOT,
       encoding: "utf-8",
       input: "",
-      // A regression here is a hang, not a wrong value, so cap it rather than
-      // letting the suite block. SIGKILL because the child is mid-prompt.
+      // Keep defensive hang protection around the real stdin boundary. Before
+      // #7418, the unresolved picker promise let Node exit 0 after stdin closed;
+      // the status assertion below catches that original regression.
       timeout: 30_000,
       killSignal: "SIGKILL",
       env: { ...process.env, HOME: tmpDir, NEMOCLAW_NON_INTERACTIVE: undefined },
@@ -74,9 +75,9 @@ describe("policy preset prompt cancellation", () => {
   ])("$command exits non-zero when the picker prompt hits EOF (#7418)", ({ command, menu }) => {
     const result = runPolicyCommandAtStdinEof(command);
 
-    // The child exited on its own rather than being killed by the timeout
-    // above. The pre-#7418 promise never settled, which appears here as a
-    // SIGKILL and a null status instead of an exit status.
+    // The child exited on its own rather than being killed by the defensive
+    // timeout above. A hang would produce SIGKILL and a null status; the
+    // pre-#7418 regression exited 0 and is caught by the final assertion.
     expect(result.error).toBeUndefined();
     expect(result.signal).toBeNull();
     // The picker was reached, so this is prompt EOF rather than the
@@ -85,7 +86,7 @@ describe("policy preset prompt cancellation", () => {
     expect(result.stderr).toContain("No input available on stdin");
     expect(result.stderr).toContain(`${command} <preset>`);
     expect(result.status).toBe(1);
-    // Above the child's 30s cap, so a hung picker fails on the assertions
-    // above rather than as a bare suite timeout.
+    // Above the child's 30s cap, so any hang fails on the assertions above
+    // rather than as a bare suite timeout.
   }, 45_000);
 });

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -6,11 +6,9 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import type { Interface as ReadlineInterface } from "node:readline";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const requireForTest = createRequire(import.meta.url);
-const readline = requireForTest("node:readline") as typeof import("node:readline");
 const YAML = requireForTest("yaml");
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const policies = requireForTest(
@@ -22,77 +20,6 @@ const resolveOpenshellModule = requireForTest(
 const POLICIES_PATH = JSON.stringify(path.join(REPO_ROOT, "src", "lib", "policy", "index.ts"));
 const REGISTRY_PATH = JSON.stringify(path.join(REPO_ROOT, "src", "lib", "state", "registry.ts"));
 const SOURCE_NODE_ARGS = ["--import", "tsx"];
-const SELECT_FROM_LIST_ITEMS = [
-  { name: "npm", description: "npm and Yarn registry access", file: "npm.yaml" },
-  { name: "pypi", description: "Python Package Index (PyPI) access", file: "pypi.yaml" },
-];
-type AppliedOptions = {
-  applied?: string[];
-};
-
-type SelectionFunction = "selectFromList" | "selectForRemoval";
-
-async function runSelectionPrompt(
-  functionName: SelectionFunction,
-  input: string,
-  { applied = [] }: AppliedOptions = {},
-) {
-  const stderr: string[] = [];
-  const counts = { ref: 0, pause: 0, unref: 0 };
-  const stdin = process.stdin as typeof process.stdin & {
-    ref: () => typeof process.stdin;
-    pause: () => typeof process.stdin;
-    unref: () => typeof process.stdin;
-  };
-  const original = {
-    ref: stdin.ref,
-    pause: stdin.pause,
-    unref: stdin.unref,
-  };
-  const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
-    stderr.push(String(chunk));
-    return true;
-  }) as typeof process.stderr.write);
-  const close = vi.fn();
-  const createInterface = vi.spyOn(readline, "createInterface").mockImplementation((options) => {
-    expect(options).toEqual({ input: process.stdin, output: process.stderr });
-    return {
-      question: (question: string, callback: (answer: string) => void) => {
-        process.stderr.write(question);
-        callback(input);
-      },
-      close,
-    } as unknown as ReadlineInterface;
-  });
-  stdin.ref = () => {
-    counts.ref += 1;
-    return process.stdin;
-  };
-  stdin.pause = () => {
-    counts.pause += 1;
-    return process.stdin;
-  };
-  stdin.unref = () => {
-    counts.unref += 1;
-    return process.stdin;
-  };
-
-  try {
-    const selected = await policies[functionName](SELECT_FROM_LIST_ITEMS, { applied });
-    return {
-      selected,
-      stderr: stderr.join(""),
-      counts,
-      close,
-    };
-  } finally {
-    stdin.ref = original.ref;
-    stdin.pause = original.pause;
-    stdin.unref = original.unref;
-    createInterface.mockRestore();
-    stderrWrite.mockRestore();
-  }
-}
 
 function requirePresetContent(content: string | null): string {
   expect(content).toBeTruthy();
@@ -1165,61 +1092,6 @@ exit 1
     });
   });
 
-  describe("selectFromList", () => {
-    it("returns preset name by number from stdin input", async () => {
-      const result = await runSelectionPrompt("selectFromList", "1\n");
-
-      expect(result.selected).toBe("npm");
-      expect(result.stderr).toContain("Choose preset [1]:");
-    });
-
-    it("uses the first preset as the default when input is empty", async () => {
-      const result = await runSelectionPrompt("selectFromList", "\n");
-
-      expect(result.stderr).toContain("Choose preset [1]:");
-      expect(result.selected).toBe("npm");
-    });
-
-    it("defaults to the first not-applied preset", async () => {
-      const result = await runSelectionPrompt("selectFromList", "\n", { applied: ["npm"] });
-
-      expect(result.stderr).toContain("Choose preset [2]:");
-      expect(result.selected).toBe("pypi");
-    });
-
-    it("rejects selecting an already-applied preset", async () => {
-      const result = await runSelectionPrompt("selectFromList", "1\n", { applied: ["npm"] });
-
-      expect(result.stderr).toMatch(/already applied\.[\s\S]*policy-add npm'/);
-      expect(result.selected).toBeNull();
-    });
-
-    it("rejects out-of-range preset number", async () => {
-      const result = await runSelectionPrompt("selectFromList", "99\n");
-
-      expect(result.stderr).toContain("Invalid preset number.");
-      expect(result.selected).toBeNull();
-    });
-
-    it("rejects non-numeric preset input", async () => {
-      const result = await runSelectionPrompt("selectFromList", "npm\n");
-
-      expect(result.stderr).toContain("Invalid preset number.");
-      expect(result.selected).toBeNull();
-    });
-
-    it("prints numbered list with applied markers, legend, and default prompt", async () => {
-      const result = await runSelectionPrompt("selectFromList", "2\n", { applied: ["npm"] });
-
-      expect(result.stderr).toMatch(/Available presets:/);
-      expect(result.stderr).toMatch(/1\) ● npm — npm and Yarn registry access/);
-      expect(result.stderr).toMatch(/2\) ○ pypi — Python Package Index \(PyPI\) access/);
-      expect(result.stderr).toMatch(/● applied, ○ not applied/);
-      expect(result.stderr).toMatch(/Choose preset \[2\]:/);
-      expect(result.selected).toBe("pypi");
-    });
-  });
-
   describe("removePresetFromPolicy", () => {
     const pypiEntries =
       "  pypi:\n" +
@@ -1292,50 +1164,6 @@ exit 1
       expect(() => policies.removePresetFromPolicy(current, pypiEntries)).toThrow(
         /current policy is not a valid YAML mapping/i,
       );
-    });
-  });
-
-  describe("selectForRemoval", () => {
-    it("returns null when no presets are applied", async () => {
-      const result = await runSelectionPrompt("selectForRemoval", "1\n", { applied: [] });
-      expect(result.stderr).toContain("No presets are currently applied");
-      expect(result.selected).toBeNull();
-    });
-
-    it("shows only applied presets and returns selected name", async () => {
-      const result = await runSelectionPrompt("selectForRemoval", "1\n", { applied: ["npm"] });
-      expect(result.stderr).toContain("Applied presets:");
-      expect(result.stderr).toContain("1) npm");
-      expect(result.stderr).not.toContain("pypi");
-      expect(result.selected).toBe("npm");
-    });
-
-    it("returns null for empty input", async () => {
-      const result = await runSelectionPrompt("selectForRemoval", "\n", { applied: ["npm"] });
-      expect(result.selected).toBeNull();
-    });
-
-    it("rejects non-numeric input", async () => {
-      const result = await runSelectionPrompt("selectForRemoval", "npm\n", {
-        applied: ["npm"],
-      });
-      expect(result.stderr).toContain("Invalid preset number");
-      expect(result.selected).toBeNull();
-    });
-
-    it("rejects out-of-range number", async () => {
-      const result = await runSelectionPrompt("selectForRemoval", "99\n", { applied: ["npm"] });
-      expect(result.stderr).toContain("Invalid preset number");
-      expect(result.selected).toBeNull();
-    });
-
-    it("selects second preset when both are applied", async () => {
-      const result = await runSelectionPrompt("selectForRemoval", "2\n", {
-        applied: ["npm", "pypi"],
-      });
-      expect(result.stderr).toContain("1) npm");
-      expect(result.stderr).toContain("2) pypi");
-      expect(result.selected).toBe("pypi");
     });
   });
 
@@ -1505,26 +1333,6 @@ exit 1
       } finally {
         errSpy.mockRestore();
       }
-    });
-  });
-
-  describe("interactive prompt cleanup", () => {
-    it("releases and re-refs stdin around policy-add preset prompts", async () => {
-      const result = await runSelectionPrompt("selectFromList", "1\n");
-      expect(result.selected).toBe("npm");
-      expect(result.counts.ref).toBeGreaterThanOrEqual(1);
-      expect(result.counts.pause).toBeGreaterThanOrEqual(1);
-      expect(result.counts.unref).toBeGreaterThanOrEqual(1);
-      expect(result.close).toHaveBeenCalledOnce();
-    });
-
-    it("releases and re-refs stdin around policy-remove preset prompts", async () => {
-      const result = await runSelectionPrompt("selectForRemoval", "1\n", { applied: ["npm"] });
-      expect(result.selected).toBe("npm");
-      expect(result.counts.ref).toBeGreaterThanOrEqual(1);
-      expect(result.counts.pause).toBeGreaterThanOrEqual(1);
-      expect(result.counts.unref).toBeGreaterThanOrEqual(1);
-      expect(result.close).toHaveBeenCalledOnce();
     });
   });
 });

--- a/test/policy-preset-picker.test.ts
+++ b/test/policy-preset-picker.test.ts
@@ -203,8 +203,16 @@ async function runSelectionPromptAtSigint(
 
   try {
     return await policies[functionName](SELECT_FROM_LIST_ITEMS, { applied }).then(
-      () => ({ code: undefined as string | undefined, reraised: kill.mock.calls.length }),
-      (error: NodeJS.ErrnoException) => ({ code: error.code, reraised: kill.mock.calls.length }),
+      () => ({
+        code: undefined as string | undefined,
+        reraised: kill.mock.calls.length,
+        signal: kill.mock.calls[0]?.[1],
+      }),
+      (error: NodeJS.ErrnoException) => ({
+        code: error.code,
+        reraised: kill.mock.calls.length,
+        signal: kill.mock.calls[0]?.[1],
+      }),
     );
   } finally {
     stdin.ref = original.ref;
@@ -284,6 +292,9 @@ describe("policy preset pickers", () => {
 
       expect(result.code).toBe("SIGINT");
       expect(result.reraised).toBe(1);
+      // The signal itself, not just that kill ran: re-raising SIGTERM would
+      // otherwise satisfy this test.
+      expect(result.signal).toBe("SIGINT");
     }, 3_000);
   });
 
@@ -343,6 +354,9 @@ describe("policy preset pickers", () => {
 
       expect(result.code).toBe("SIGINT");
       expect(result.reraised).toBe(1);
+      // The signal itself, not just that kill ran: re-raising SIGTERM would
+      // otherwise satisfy this test.
+      expect(result.signal).toBe("SIGINT");
     }, 3_000);
   });
 

--- a/test/policy-preset-picker.test.ts
+++ b/test/policy-preset-picker.test.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Interactive preset pickers for `policy-add` and `policy-remove`: selection
+ * parsing, stdin event-loop cleanup, and prompt-EOF cancellation (#7418).
+ */
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { Interface as ReadlineInterface } from "node:readline";
+import { describe, expect, it, vi } from "vitest";
+
+const requireForTest = createRequire(import.meta.url);
+const readline = requireForTest("node:readline") as typeof import("node:readline");
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const policies = requireForTest(
+  path.join(REPO_ROOT, "src", "lib", "policy", "index.ts"),
+) as typeof import("../src/lib/policy");
+
+const SELECT_FROM_LIST_ITEMS = [
+  { name: "npm", description: "npm and Yarn registry access", file: "npm.yaml" },
+  { name: "pypi", description: "Python Package Index (PyPI) access", file: "pypi.yaml" },
+];
+type AppliedOptions = {
+  applied?: string[];
+};
+
+type SelectionFunction = "selectFromList" | "selectForRemoval";
+
+async function runSelectionPrompt(
+  functionName: SelectionFunction,
+  input: string,
+  { applied = [] }: AppliedOptions = {},
+) {
+  const stderr: string[] = [];
+  const counts = { ref: 0, pause: 0, unref: 0 };
+  const stdin = process.stdin as typeof process.stdin & {
+    ref: () => typeof process.stdin;
+    pause: () => typeof process.stdin;
+    unref: () => typeof process.stdin;
+  };
+  const original = {
+    ref: stdin.ref,
+    pause: stdin.pause,
+    unref: stdin.unref,
+  };
+  const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    stderr.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  // Readline emits `close` whenever `rl.close()` runs, including the
+  // `rl.close()` the picker performs after an answer. The fake emits it too,
+  // so a successful selection exercises the picker's reentrancy guard. Were
+  // that guard removed, the post-answer close would settle the promise a
+  // second time (#7418).
+  const closeListeners: Array<() => void> = [];
+  const close = vi.fn(() => closeListeners.forEach((listener) => listener()));
+  const createInterface = vi.spyOn(readline, "createInterface").mockImplementation((options) => {
+    expect(options).toEqual({ input: process.stdin, output: process.stderr });
+    return {
+      question: (question: string, callback: (answer: string) => void) => {
+        process.stderr.write(question);
+        callback(input);
+      },
+      on: (event: string, listener: () => void) => {
+        // No `if`: changed test files may not add one (codebase-growth-guardrails).
+        [listener].filter(() => event === "close").forEach((l) => closeListeners.push(l));
+      },
+      close,
+    } as unknown as ReadlineInterface;
+  });
+  stdin.ref = () => {
+    counts.ref += 1;
+    return process.stdin;
+  };
+  stdin.pause = () => {
+    counts.pause += 1;
+    return process.stdin;
+  };
+  stdin.unref = () => {
+    counts.unref += 1;
+    return process.stdin;
+  };
+
+  try {
+    const selected = await policies[functionName](SELECT_FROM_LIST_ITEMS, { applied });
+    return {
+      selected,
+      stderr: stderr.join(""),
+      counts,
+      close,
+    };
+  } finally {
+    stdin.ref = original.ref;
+    stdin.pause = original.pause;
+    stdin.unref = original.unref;
+    createInterface.mockRestore();
+    stderrWrite.mockRestore();
+  }
+}
+
+/**
+ * Drive a picker against a readline interface that reaches EOF. `question`
+ * writes the prompt but its callback never fires, and readline closes
+ * instead. A boot unit produces this by running `policy-add < /dev/null`.
+ */
+async function runSelectionPromptAtEof(
+  functionName: SelectionFunction,
+  { applied = [] }: AppliedOptions = {},
+) {
+  const stderr: string[] = [];
+  const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    stderr.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  const closeListeners: Array<() => void> = [];
+  const createInterface = vi.spyOn(readline, "createInterface").mockImplementation(
+    () =>
+      ({
+        question: (question: string) => {
+          process.stderr.write(question);
+          // Real readline emits `close` on EOF without answering.
+          queueMicrotask(() => closeListeners.forEach((listener) => listener()));
+        },
+        on: (event: string, listener: () => void) => {
+          [listener].filter(() => event === "close").forEach((l) => closeListeners.push(l));
+        },
+        close: vi.fn(),
+      }) as unknown as ReadlineInterface,
+  );
+
+  try {
+    return await policies[functionName](SELECT_FROM_LIST_ITEMS, { applied }).then(
+      (selected) => ({ outcome: "resolved", selected, code: undefined, stderr: stderr.join("") }),
+      (error: NodeJS.ErrnoException) => ({
+        outcome: "rejected",
+        selected: undefined,
+        code: error.code,
+        stderr: stderr.join(""),
+      }),
+    );
+  } finally {
+    createInterface.mockRestore();
+    stderrWrite.mockRestore();
+  }
+}
+
+describe("policy preset pickers", () => {
+  describe("selectFromList", () => {
+    it("returns preset name by number from stdin input", async () => {
+      const result = await runSelectionPrompt("selectFromList", "1\n");
+
+      expect(result.selected).toBe("npm");
+      expect(result.stderr).toContain("Choose preset [1]:");
+    });
+
+    it("uses the first preset as the default when input is empty", async () => {
+      const result = await runSelectionPrompt("selectFromList", "\n");
+
+      expect(result.stderr).toContain("Choose preset [1]:");
+      expect(result.selected).toBe("npm");
+    });
+
+    it("defaults to the first not-applied preset", async () => {
+      const result = await runSelectionPrompt("selectFromList", "\n", { applied: ["npm"] });
+
+      expect(result.stderr).toContain("Choose preset [2]:");
+      expect(result.selected).toBe("pypi");
+    });
+
+    it("rejects selecting an already-applied preset", async () => {
+      const result = await runSelectionPrompt("selectFromList", "1\n", { applied: ["npm"] });
+
+      expect(result.stderr).toMatch(/already applied\.[\s\S]*policy-add npm'/);
+      expect(result.selected).toBeNull();
+    });
+
+    it("rejects out-of-range preset number", async () => {
+      const result = await runSelectionPrompt("selectFromList", "99\n");
+
+      expect(result.stderr).toContain("Invalid preset number.");
+      expect(result.selected).toBeNull();
+    });
+
+    it("rejects non-numeric preset input", async () => {
+      const result = await runSelectionPrompt("selectFromList", "npm\n");
+
+      expect(result.stderr).toContain("Invalid preset number.");
+      expect(result.selected).toBeNull();
+    });
+
+    it("prints numbered list with applied markers, legend, and default prompt", async () => {
+      const result = await runSelectionPrompt("selectFromList", "2\n", { applied: ["npm"] });
+
+      expect(result.stderr).toMatch(/Available presets:/);
+      expect(result.stderr).toMatch(/1\) ● npm — npm and Yarn registry access/);
+      expect(result.stderr).toMatch(/2\) ○ pypi — Python Package Index \(PyPI\) access/);
+      expect(result.stderr).toMatch(/● applied, ○ not applied/);
+      expect(result.stderr).toMatch(/Choose preset \[2\]:/);
+      expect(result.selected).toBe("pypi");
+    });
+
+    it("cancels with an EOF code when stdin closes before an answer (#7418)", async () => {
+      const result = await runSelectionPromptAtEof("selectFromList");
+
+      expect(result.stderr).toContain("Choose preset [1]:");
+      expect(result.outcome).toBe("rejected");
+      expect(result.code).toBe("EOF");
+    }, 3_000);
+  });
+
+  describe("selectForRemoval", () => {
+    it("returns null when no presets are applied", async () => {
+      const result = await runSelectionPrompt("selectForRemoval", "1\n", { applied: [] });
+      expect(result.stderr).toContain("No presets are currently applied");
+      expect(result.selected).toBeNull();
+    });
+
+    it("shows only applied presets and returns selected name", async () => {
+      const result = await runSelectionPrompt("selectForRemoval", "1\n", { applied: ["npm"] });
+      expect(result.stderr).toContain("Applied presets:");
+      expect(result.stderr).toContain("1) npm");
+      expect(result.stderr).not.toContain("pypi");
+      expect(result.selected).toBe("npm");
+    });
+
+    it("returns null for empty input", async () => {
+      const result = await runSelectionPrompt("selectForRemoval", "\n", { applied: ["npm"] });
+      expect(result.selected).toBeNull();
+    });
+
+    it("rejects non-numeric input", async () => {
+      const result = await runSelectionPrompt("selectForRemoval", "npm\n", {
+        applied: ["npm"],
+      });
+      expect(result.stderr).toContain("Invalid preset number");
+      expect(result.selected).toBeNull();
+    });
+
+    it("rejects out-of-range number", async () => {
+      const result = await runSelectionPrompt("selectForRemoval", "99\n", { applied: ["npm"] });
+      expect(result.stderr).toContain("Invalid preset number");
+      expect(result.selected).toBeNull();
+    });
+
+    it("selects second preset when both are applied", async () => {
+      const result = await runSelectionPrompt("selectForRemoval", "2\n", {
+        applied: ["npm", "pypi"],
+      });
+      expect(result.stderr).toContain("1) npm");
+      expect(result.stderr).toContain("2) pypi");
+      expect(result.selected).toBe("pypi");
+    });
+
+    it("cancels with an EOF code when stdin closes before an answer (#7418)", async () => {
+      const result = await runSelectionPromptAtEof("selectForRemoval", { applied: ["npm"] });
+
+      expect(result.stderr).toContain("Choose preset to remove:");
+      expect(result.outcome).toBe("rejected");
+      expect(result.code).toBe("EOF");
+    }, 3_000);
+  });
+
+  describe("interactive prompt cleanup", () => {
+    it("releases and re-refs stdin around policy-add preset prompts", async () => {
+      const result = await runSelectionPrompt("selectFromList", "1\n");
+      expect(result.selected).toBe("npm");
+      expect(result.counts.ref).toBeGreaterThanOrEqual(1);
+      expect(result.counts.pause).toBeGreaterThanOrEqual(1);
+      expect(result.counts.unref).toBeGreaterThanOrEqual(1);
+      expect(result.close).toHaveBeenCalledOnce();
+    });
+
+    it("releases and re-refs stdin around policy-remove preset prompts", async () => {
+      const result = await runSelectionPrompt("selectForRemoval", "1\n", { applied: ["npm"] });
+      expect(result.selected).toBe("npm");
+      expect(result.counts.ref).toBeGreaterThanOrEqual(1);
+      expect(result.counts.pause).toBeGreaterThanOrEqual(1);
+      expect(result.counts.unref).toBeGreaterThanOrEqual(1);
+      expect(result.close).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/test/policy-preset-picker.test.ts
+++ b/test/policy-preset-picker.test.ts
@@ -110,6 +110,18 @@ async function runSelectionPromptAtEof(
   { applied = [] }: AppliedOptions = {},
 ) {
   const stderr: string[] = [];
+  // Stub the same stdin methods `runSelectionPrompt` stubs. The picker calls
+  // ref/pause/unref on the real handle otherwise, which leaves this Vitest
+  // worker's stdin unreferenced and makes later tests order-dependent.
+  const stdin = process.stdin as typeof process.stdin & {
+    ref: () => typeof process.stdin;
+    pause: () => typeof process.stdin;
+    unref: () => typeof process.stdin;
+  };
+  const original = { ref: stdin.ref, pause: stdin.pause, unref: stdin.unref };
+  stdin.ref = () => process.stdin;
+  stdin.pause = () => process.stdin;
+  stdin.unref = () => process.stdin;
   const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
     stderr.push(String(chunk));
     return true;
@@ -141,8 +153,66 @@ async function runSelectionPromptAtEof(
       }),
     );
   } finally {
+    stdin.ref = original.ref;
+    stdin.pause = original.pause;
+    stdin.unref = original.unref;
     createInterface.mockRestore();
     stderrWrite.mockRestore();
+  }
+}
+
+/**
+ * Drive a picker against a readline interface that receives an interrupt.
+ * Readline emits `SIGINT` and then `close`, so this proves an interrupt is
+ * reported as SIGINT rather than as a closed stdin (#7418).
+ */
+async function runSelectionPromptAtSigint(
+  functionName: SelectionFunction,
+  { applied = [] }: AppliedOptions = {},
+) {
+  const stdin = process.stdin as typeof process.stdin & {
+    ref: () => typeof process.stdin;
+    pause: () => typeof process.stdin;
+    unref: () => typeof process.stdin;
+  };
+  const original = { ref: stdin.ref, pause: stdin.pause, unref: stdin.unref };
+  stdin.ref = () => process.stdin;
+  stdin.pause = () => process.stdin;
+  stdin.unref = () => process.stdin;
+  const stderrWrite = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((() => true) as typeof process.stderr.write);
+  // The picker re-raises SIGINT; capture it instead of killing the worker.
+  const kill = vi.spyOn(process, "kill").mockImplementation((() => true) as typeof process.kill);
+  const listeners = new Map<string, () => void>();
+  const createInterface = vi.spyOn(readline, "createInterface").mockImplementation(
+    () =>
+      ({
+        question: () => {
+          queueMicrotask(() => {
+            listeners.get("SIGINT")?.();
+            listeners.get("close")?.();
+          });
+        },
+        on: (event: string, listener: () => void) => {
+          listeners.set(event, listener);
+        },
+        close: vi.fn(),
+      }) as unknown as ReadlineInterface,
+  );
+
+  try {
+    return await policies[functionName](SELECT_FROM_LIST_ITEMS, { applied }).then(
+      () => ({ code: undefined as string | undefined, reraised: kill.mock.calls.length }),
+      (error: NodeJS.ErrnoException) => ({ code: error.code, reraised: kill.mock.calls.length }),
+    );
+  } finally {
+    stdin.ref = original.ref;
+    stdin.pause = original.pause;
+    stdin.unref = original.unref;
+    createInterface.mockRestore();
+    stderrWrite.mockRestore();
+    kill.mockRestore();
   }
 }
 
@@ -208,6 +278,13 @@ describe("policy preset pickers", () => {
       expect(result.outcome).toBe("rejected");
       expect(result.code).toBe("EOF");
     }, 3_000);
+
+    it("reports an interrupt as SIGINT rather than closed stdin (#7418)", async () => {
+      const result = await runSelectionPromptAtSigint("selectFromList");
+
+      expect(result.code).toBe("SIGINT");
+      expect(result.reraised).toBe(1);
+    }, 3_000);
   });
 
   describe("selectForRemoval", () => {
@@ -259,6 +336,13 @@ describe("policy preset pickers", () => {
       expect(result.stderr).toContain("Choose preset to remove:");
       expect(result.outcome).toBe("rejected");
       expect(result.code).toBe("EOF");
+    }, 3_000);
+
+    it("reports an interrupt as SIGINT rather than closed stdin (#7418)", async () => {
+      const result = await runSelectionPromptAtSigint("selectForRemoval", { applied: ["npm"] });
+
+      expect(result.code).toBe("SIGINT");
+      expect(result.reraised).toBe(1);
     }, 3_000);
   });
 

--- a/test/policy-preset-picker.test.ts
+++ b/test/policy-preset-picker.test.ts
@@ -279,7 +279,7 @@ describe("policy preset pickers", () => {
       expect(result.selected).toBe("pypi");
     });
 
-    it("cancels with an EOF code when stdin closes before an answer (#7418)", async () => {
+    it("rejects with code EOF when stdin closes before an answer (#7418)", async () => {
       const result = await runSelectionPromptAtEof("selectFromList");
 
       expect(result.stderr).toContain("Choose preset [1]:");
@@ -339,7 +339,7 @@ describe("policy preset pickers", () => {
       expect(result.selected).toBe("pypi");
     });
 
-    it("cancels with an EOF code when stdin closes before an answer (#7418)", async () => {
+    it("rejects with code EOF when stdin closes before an answer (#7418)", async () => {
       const result = await runSelectionPromptAtEof("selectForRemoval", { applied: ["npm"] });
 
       expect(result.stderr).toContain("Choose preset to remove:");

--- a/test/policy-preset-picker.test.ts
+++ b/test/policy-preset-picker.test.ts
@@ -203,8 +203,16 @@ async function runSelectionPromptAtSigint(
 
   try {
     return await policies[functionName](SELECT_FROM_LIST_ITEMS, { applied }).then(
-      () => ({ code: undefined as string | undefined, reraised: kill.mock.calls.length }),
-      (error: NodeJS.ErrnoException) => ({ code: error.code, reraised: kill.mock.calls.length }),
+      () => ({
+        code: undefined as string | undefined,
+        reraised: kill.mock.calls.length,
+        signal: kill.mock.calls[0]?.[1],
+      }),
+      (error: NodeJS.ErrnoException) => ({
+        code: error.code,
+        reraised: kill.mock.calls.length,
+        signal: kill.mock.calls[0]?.[1],
+      }),
     );
   } finally {
     stdin.ref = original.ref;
@@ -284,6 +292,7 @@ describe("policy preset pickers", () => {
 
       expect(result.code).toBe("SIGINT");
       expect(result.reraised).toBe(1);
+      expect(result.signal).toBe("SIGINT");
     }, 3_000);
   });
 
@@ -343,6 +352,7 @@ describe("policy preset pickers", () => {
 
       expect(result.code).toBe("SIGINT");
       expect(result.reraised).toBe(1);
+      expect(result.signal).toBe("SIGINT");
     }, 3_000);
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`policy-add` and `policy-remove` with no preset name and a closed stdin reached the interactive picker, whose prompt hit EOF. The readline `question` callback never fired, the promise never settled, and the CLI exited 0 having applied nothing, so automation could not distinguish an applied preset from a no-op.

Both commands now report that stdin closed and exit 1. Ctrl-C at the picker terminates by SIGINT, because readline emits `close` for an interrupt as well as for EOF and the two must not report the same cause. Answered prompts and empty-line cancels are unchanged.

## Related Issue

Refs #7418

Fixes only the prompt defect in that report. The cold-boot probe/rollback root cause, the `sudo lsof` check, and preset loss on re-onboard are untouched, so the issue stays open.

## Changes

- `src/lib/policy/index.ts`: adds `askPreset()`, used by both pickers. Rejects with `code: "EOF"` when readline closes before an answer, and with `code: "SIGINT"` on Ctrl-C, re-raising the signal so the process dies by SIGINT. `finished` is set before `rl.close()` — which itself emits `close` — so only a premature close rejects. This adopts the `prompt()` contract in `credentials/store.ts` (#5990, for #5976). `onboard/messaging-selector.ts` already follows it; these pickers were the outlier.
- `src/lib/actions/sandbox/policy-channel.ts`: both call sites route through `pickPresetOrExit()`, which converts `EOF` into `exitPromptStdinClosed()` and exits 1. Other errors propagate. Kept separate from `exitPresetNameRequired()` because that means `NEMOCLAW_NON_INTERACTIVE=1` was set, while this means stdin closed with it unset.
- `test/policy-preset-picker.test.ts`: picker tests moved out of `test/policies.test.ts`, plus EOF and SIGINT coverage. The readline fake now emits `close` on `close()`, matching real readline, so successful-selection tests exercise the reentrancy guard. Both harnesses stub and restore stdin `ref`/`pause`/`unref` so the Vitest worker's stdin handle is not left unreferenced.
- `test/package-contract/cli/policy-prompt-eof.test.ts`: drives the compiled CLI on real stdin at EOF, with subprocess timeout, exact status assertions, and tmpdir cleanup. The case timeout sits above the child cap so a hung picker fails on its assertions rather than as a suite timeout.
- `src/lib/actions/sandbox/policy-channel-policy.test.ts`: caller-boundary tests for EOF conversion and non-EOF propagation.
- `ci/test-file-size-budget.json`: the move was forced — `test/policies.test.ts` was pinned at exactly 1530 lines. The split drops it to 1338, under the 1500 default, so its legacy exemption is retired rather than raised.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `docs/reference/commands.mdx` already requires the positional form in scripted workflows and documents `NEMOCLAW_NON_INTERACTIVE=1`. That contract is unchanged; this fixes an undocumented failure mode.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: maintainer review confirmed the change is confined to prompt lifecycle and does not alter policy content, merge, validation, or apply logic.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — `PR review advisor (Nemotron 3 Ultra)` timed out during final synthesis after emitting a complete zero-finding ledger and final JSON; the primary Terra lane passed. Accepted as non-blocking advisor infrastructure: https://github.com/NVIDIA/NemoClaw/actions/runs/30139892547

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing command documentation already requires positional preset names for scripted workflows. The exact-head review verified the corrected EOF regression wording and SIGINT assertions; 19 picker tests and 2 compiled-CLI EOF tests passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7d77283ae809fb8de7289dc89d10e9016cb7501b -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f99ec7dd8f40af135f5a9e55354330d7 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: see Evidence
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not run; change is confined to two CLI source files and their tests
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Evidence

A driver requires the built `dist/nemoclaw.js`, sets `process.argv` to `<sandbox> policy-add` with no preset, and stubs only registry and preset lookups. Real readline decides when the prompt closes.

Before, on `origin/main` — the settle marker never prints:

```text
  Choose preset:
__EXIT_CODE__=0
```

After, on this branch:

```text
  Choose preset:   No input available on stdin, so the preset picker cannot prompt.
  Usage: nemoclaw <sandbox> policy-add <preset> [--yes] [--dry-run]
__EXIT_CODE__=1
```

Only a premature close rejects:

| stdin | exit |
|---|---|
| `< /dev/null` | `1` |
| `printf '1\n'` | `0` |
| `printf '\n'` | `0` |

Ctrl-C at the picker, driven through a real PTY:

| sources | output | result |
|---|---|---|
| `origin/main` | none | exit `0` |
| this PR, before the SIGINT handler | `No input available on stdin` — wrong cause | exit `1` |
| this PR | none | terminated by signal 2 |

Negative control — `policy-prompt-eof.test.ts` against restored `origin/main` sources: `2 failed`. On this branch: `2 passed`.

Mutation testing:

| Mutation | Result |
|---|---|
| Delete the `rl.on("close")` handler | 4 tests fail |
| Delete the `if (finished) return;` guard | 6+ tests fail |
| Delete the `rl.on("SIGINT")` handler | 2 tests fail |

The second is why the readline fake changed. With the original fake, deleting the guard left 17/17 tests passing, so the guard had no coverage.

```bash
npx vitest run --project cli src/lib/policy src/lib/actions/sandbox/policy-channel
npx vitest run --project integration test/policy-preset-picker.test.ts test/policies.test.ts test/cli/sandbox-mutations.test.ts
npx vitest run --project package-contract test/package-contract/cli/policy-prompt-eof.test.ts
```

Final reviewed SHA `7d77283ae`: 25 caller-boundary tests, 19 picker tests, and 2 compiled-CLI EOF tests passed; CLI type-checking and normal pre-push hooks passed. `typecheck:cli`, `test-size:check`, `test:projects:check`, and `git diff --check` pass.

### Pre-existing failures

The full `package-contract` project fails 4 tests here and the identical 4 on pristine `origin/main` (`4 failed | 142 passed` there, `4 failed | 144 passed` here).

`test:fast` and the `cli` project are order-dependent on `origin/main` itself — repeating the same command changes the failing set (main: 8 then 9 files; this branch: 2 then 5). Failures are `Test timed out in 5000ms` across unrelated files. `policy-channel-refresh.test.ts` fails on pristine `origin/main`. `policy-channel-conflict.test.ts` also appeared here, so I checked it: zero picker references, failing case is `channels start`, passes 5/5 in isolation. Reporting it rather than filtering it, but not attributing it to this change.

## Limitations

- Proof uses stubbed registry and preset lookups, not a live sandbox. The prompt lifecycle is host-side and independent of sandbox state, but was not exercised against one.
- macOS arm64 only; the reporter is on Ubuntu 24.04. Nothing here is platform-specific, but I could not reproduce their cold-boot scenario.
- No regression window established. The pickers appear never to have adopted the `store.ts` contract rather than having regressed off it.
- `src/lib/sandbox/config.ts` `confirmYesNo()` has the same never-settles shape and neither handler. It is a different command surface and outside #7418, so this PR leaves it alone rather than widening the change. It looks worth its own issue.
- The documentation writer review found no canonical documentation change necessary for this error-path fix.
- Fixes one of four defects in #7418.

AI-assisted: authored with Claude Code, reviewed and verified by the contributor.

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made policy preset picker prompts EOF-safe, preventing hangs when stdin closes mid-prompt.
  * Ensured `policy-add` and `policy-remove` exit with code `1` and show “No input available on stdin” on EOF (non-EOF errors still surface as before).
* **Tests**
  * Added unit tests covering preset selection, “already applied” handling, EOF/SIGINT cancellation, and prompt cleanup.
  * Added a CLI regression test validating exit code and stderr output at stdin EOF.
  * Removed superseded interactive prompt test coverage.
* **Chores**
  * Updated the test-file-size budget configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
