### PR TITLE
ci(e2e): sample rebuild pressure more frequently

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -205,7 +205,9 @@ Each execution writes one bounded, ordered v2 time series to the canonical
 - an `initialize` endpoint after workspace preparation and any fixed-capacity
   rebuild swap;
 - a distinct `scenario-start` for every test handled by the execution;
-- a `periodic` sample on an approximately 60-second fixed cadence;
+- a `periodic` sample on an approximately 15-second fixed cadence for
+  `rebuild-hermes` and `rebuild-hermes-stale-base`, and an approximately
+  60-second fixed cadence for every other execution;
 - a `phase` sample before each semantic phase transition and when the final
   phase stops; and
 - a `finalize` endpoint from an `always()` step immediately before artifact
@@ -220,11 +222,14 @@ catch-up burst. Each successful append also prints one bounded
 The v2 ledger accepts at most 256 samples. Ordinary sampling stops once 255
 records exist to reserve the last slot for `finalize`. A missing, historical-v1,
 already-finalized, full, or invalid ledger permanently disables comparison
-sampling for that test progress instance. In `rebuild-hermes` and
-`rebuild-hermes-stale-base`, where legacy phase resource evidence is configured,
-the workflow establishes its 32 GiB swap before `initialize` so the ledger sees
-one stable swap capacity. If canonical sampling becomes unavailable, the
-existing five-minute full snapshot becomes the best-effort fallback.
+sampling for that test progress instance. The two Hermes rebuild lanes use their
+shorter cadence to improve Docker/BuildKit peak-RSS evidence without changing
+the ledger bound, schema, privacy contract, or reserved final slot. In
+`rebuild-hermes` and `rebuild-hermes-stale-base`, where legacy phase resource
+evidence is configured, the workflow establishes its 32 GiB swap before
+`initialize` so the ledger sees one stable swap capacity. If canonical sampling
+becomes unavailable, the existing five-minute full snapshot becomes the
+best-effort fallback.
 That full profile may run `ps`, `docker stats`, and `docker system df`
 sequentially with a 15-second timeout each, or 45 seconds in the worst case;
 canonical sampling suppresses this heavier collection while it remains active.

--- a/test/e2e/fixtures/e2e-test.ts
+++ b/test/e2e/fixtures/e2e-test.ts
@@ -30,7 +30,13 @@ import {
   RuntimePhaseFixture,
   StateValidationPhaseFixture,
 } from "./phases/index.ts";
-import { type ProgressPhaseOutcome, startTestProgress, type TestProgress } from "./progress.ts";
+import {
+  type ProgressPhaseOutcome,
+  type ProgressResourceSampleKind,
+  startTestProgress,
+  type TestProgress,
+  type TestProgressOptions,
+} from "./progress.ts";
 import { SecretStore } from "./secrets.ts";
 import { ShellProbe } from "./shell-probe.ts";
 
@@ -74,6 +80,33 @@ export function runnerComparisonSampleIntervalMs(targetId: string | null): numbe
     default:
       return 60_000;
   }
+}
+
+type RunnerComparisonProgressOptions = Pick<
+  TestProgressOptions,
+  "recordResourceSample" | "resourceSampleIntervalMs"
+>;
+
+export function runnerComparisonProgressOptions(
+  environment: NodeJS.ProcessEnv = process.env,
+  appendSample: (
+    phase: string,
+    kind: ProgressResourceSampleKind,
+  ) => boolean = appendRunnerComparisonSample,
+): RunnerComparisonProgressOptions {
+  const targetId =
+    environment.NEMOCLAW_RUN_LIVE_E2E === "1" &&
+    environment.E2E_ARTIFACT_DIR &&
+    environment.E2E_TARGET_ID
+      ? environment.E2E_TARGET_ID
+      : null;
+  return targetId
+    ? {
+        resourceSampleIntervalMs: runnerComparisonSampleIntervalMs(targetId),
+        recordResourceSample: (phase, kind) =>
+          appendSample(resourcePhaseLabel(targetId, phase), kind),
+      }
+    : {};
 }
 
 export function resourcePhaseLabel(targetId: string, phase: string): string {
@@ -122,12 +155,6 @@ export const test = base.extend<E2ETargetFixtures>({
   progress: [
     async ({ artifacts, onTestFinished, secrets, task }, use) => {
       const targetId = process.env.E2E_TARGET_ID || process.env.GITHUB_JOB;
-      const comparisonTargetId =
-        process.env.NEMOCLAW_RUN_LIVE_E2E === "1" &&
-        process.env.E2E_ARTIFACT_DIR &&
-        process.env.E2E_TARGET_ID
-          ? process.env.E2E_TARGET_ID
-          : null;
       const shardId = process.env.NEMOCLAW_E2E_SHARD;
       const baselinePath = process.env.E2E_RESOURCE_PHASE_BASELINES_FILE;
       const phasePlan = task.meta.e2ePhases;
@@ -160,16 +187,7 @@ export const test = base.extend<E2ETargetFixtures>({
                 appendResourcePhaseBaseline(baselinePath, resourcePhaseLabel(targetId, phase)),
             }
           : {}),
-        ...(comparisonTargetId
-          ? {
-              resourceSampleIntervalMs: runnerComparisonSampleIntervalMs(comparisonTargetId),
-              recordResourceSample: (
-                phase: string,
-                kind: "periodic" | "scenario-start" | "phase",
-              ) =>
-                appendRunnerComparisonSample(resourcePhaseLabel(comparisonTargetId, phase), kind),
-            }
-          : {}),
+        ...runnerComparisonProgressOptions(),
       });
       const completeSupportPlan = phasePlan
         ? () => undefined

--- a/test/e2e/fixtures/e2e-test.ts
+++ b/test/e2e/fixtures/e2e-test.ts
@@ -66,6 +66,16 @@ const SUPPORT_PHASES = [
 ] as const;
 export const E2E_TEARDOWN_PHASE = "release registered E2E resources";
 
+export function runnerComparisonSampleIntervalMs(targetId: string | null): number {
+  switch (targetId) {
+    case "rebuild-hermes":
+    case "rebuild-hermes-stale-base":
+      return 15_000;
+    default:
+      return 60_000;
+  }
+}
+
 export function resourcePhaseLabel(targetId: string, phase: string): string {
   const slug = (value: string, fallback: string) =>
     value
@@ -152,6 +162,7 @@ export const test = base.extend<E2ETargetFixtures>({
           : {}),
         ...(comparisonTargetId
           ? {
+              resourceSampleIntervalMs: runnerComparisonSampleIntervalMs(comparisonTargetId),
               recordResourceSample: (
                 phase: string,
                 kind: "periodic" | "scenario-start" | "phase",

--- a/test/e2e/support/e2e-progress-fixture.test.ts
+++ b/test/e2e/support/e2e-progress-fixture.test.ts
@@ -11,6 +11,7 @@ import { assertPhaseLabel } from "../../../tools/e2e/runner-pressure-core.mts";
 import {
   E2E_TEARDOWN_PHASE,
   resourcePhaseLabel,
+  runnerComparisonProgressOptions,
   runnerComparisonSampleIntervalMs,
 } from "../fixtures/e2e-test.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
@@ -34,6 +35,48 @@ it.each([
   null,
 ])("keeps the 60-second runner-pressure cadence for %s (#7144)", (targetId) => {
   expect(runnerComparisonSampleIntervalMs(targetId)).toBe(60_000);
+});
+
+it.each([
+  ["rebuild-hermes", 15_000],
+  ["rebuild-hermes-stale-base", 15_000],
+  ["hermes-dashboard", 60_000],
+] as const)("wires the live %s comparison cadence into progress options (#7144)", (targetId, intervalMs) => {
+  const samples: Array<{ kind: string; phase: string }> = [];
+  const options = runnerComparisonProgressOptions(
+    {
+      E2E_ARTIFACT_DIR: "artifacts",
+      E2E_TARGET_ID: targetId,
+      NEMOCLAW_RUN_LIVE_E2E: "1",
+    },
+    (phase, kind) => {
+      samples.push({ kind, phase });
+      return true;
+    },
+  );
+
+  expect(options.resourceSampleIntervalMs).toBe(intervalMs);
+  expect(options.recordResourceSample?.("build Hermes image", "periodic")).toBe(true);
+  expect(samples).toEqual([
+    {
+      kind: "periodic",
+      phase: resourcePhaseLabel(targetId, "build Hermes image"),
+    },
+  ]);
+});
+
+it.each([
+  [{ E2E_ARTIFACT_DIR: "artifacts", E2E_TARGET_ID: "rebuild-hermes" }],
+  [
+    {
+      E2E_ARTIFACT_DIR: "artifacts",
+      E2E_TARGET_ID: "rebuild-hermes",
+      NEMOCLAW_RUN_LIVE_E2E: "0",
+    },
+  ],
+  [{ E2E_TARGET_ID: "rebuild-hermes", NEMOCLAW_RUN_LIVE_E2E: "1" }],
+])("keeps comparison progress disabled outside a qualifying live environment (#7144)", (environment) => {
+  expect(runnerComparisonProgressOptions(environment)).toEqual({});
 });
 
 it("bounds long resource phase labels without losing deterministic identity", () => {

--- a/test/e2e/support/e2e-progress-fixture.test.ts
+++ b/test/e2e/support/e2e-progress-fixture.test.ts
@@ -8,13 +8,33 @@ import path from "node:path";
 
 import { expect, it } from "vitest";
 import { assertPhaseLabel } from "../../../tools/e2e/runner-pressure-core.mts";
-import { E2E_TEARDOWN_PHASE, resourcePhaseLabel } from "../fixtures/e2e-test.ts";
+import {
+  E2E_TEARDOWN_PHASE,
+  resourcePhaseLabel,
+  runnerComparisonSampleIntervalMs,
+} from "../fixtures/e2e-test.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 import type { ProgressSummary } from "../fixtures/progress.ts";
 
 const VITEST = path.join(REPO_ROOT, "node_modules", "vitest", "vitest.mjs");
 const FIXTURE = "test/e2e/support/fixtures/e2e-progress.fixture.test.ts";
 const ARTIFACT_SLUG = "automatic-progress-fixture-writes-completed-target-and-shard-evidence";
+
+it.each([
+  "rebuild-hermes",
+  "rebuild-hermes-stale-base",
+])("samples runner pressure every 15 seconds for %s (#7144)", (targetId) => {
+  expect(runnerComparisonSampleIntervalMs(targetId)).toBe(15_000);
+});
+
+it.each([
+  "hermes-dashboard",
+  "hermes-discord",
+  "hermes-shields-config",
+  null,
+])("keeps the 60-second runner-pressure cadence for %s (#7144)", (targetId) => {
+  expect(runnerComparisonSampleIntervalMs(targetId)).toBe(60_000);
+});
 
 it("bounds long resource phase labels without losing deterministic identity", () => {
   const target = "openshell-gateway-auth-contract";

--- a/test/e2e/support/e2e-progress-resource-sampling.test.ts
+++ b/test/e2e/support/e2e-progress-resource-sampling.test.ts
@@ -158,6 +158,30 @@ describe("canonical runner comparison progress sampling", () => {
     expect(state.legacySamples).toEqual([]);
   });
 
+  it("schedules rebuild samples at the selected 15-second cadence (#7144)", () => {
+    const records: Array<{ atMs: number; kind: string }> = [];
+    let state: ReturnType<typeof progressHarness>["state"];
+    const harness = progressHarness((_phase, kind) => {
+      records.push({ atMs: state.now(), kind });
+      return true;
+    });
+    state = harness.state;
+    harness.options.resourceSampleIntervalMs = 15_000;
+    const progress = startTestProgress(
+      "rebuild runner comparison",
+      ["build Hermes image", "validate Hermes sandbox"],
+      harness.options,
+    );
+
+    expect(state.nextTimerAt()).toBe(15_000);
+    state.fireNext();
+    expect(records.at(-1)).toEqual({ atMs: 15_000, kind: "periodic" });
+    expect(state.nextTimerAt()).toBe(30_000);
+    state.fireNext();
+    expect(records.at(-1)).toEqual({ atMs: 30_000, kind: "periodic" });
+    progress.stop();
+  });
+
   it("takes one canonical periodic sample and no legacy full sample at the five-minute collision (#7146)", () => {
     const records: string[] = [];
     const harness = progressHarness((phase, kind) => {

--- a/tools/e2e/runner-comparison-schema.mts
+++ b/tools/e2e/runner-comparison-schema.mts
@@ -7,8 +7,9 @@ import { PROCESS_CLASSES, type ProcessClass } from "./runner-pressure-core.mts";
 
 export const RUNNER_COMPARISON_LEDGER_FILE = "runner-comparison.jsonl";
 export const RUNNER_COMPARISON_SUMMARY_FILE = "runner-comparison-summary.json";
-// The 60-second cadence and semantic boundaries must outlast the longest
-// instrumented 120-minute job while reserving one finalization slot.
+// The shared bound accommodates the default 60-second cadence for the longest
+// instrumented job. Faster rebuild sampling stops early to reserve one
+// finalization slot.
 export const RUNNER_COMPARISON_MAX_SAMPLES = 256;
 export const RUNNER_COMPARISON_LEDGER_MAX_BYTES = RUNNER_COMPARISON_MAX_SAMPLES * (4096 + 1);
 export const RUNNER_COMPARISON_SUMMARY_MAX_BYTES = 8192;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

The two rebuild-Hermes E2E lanes now record runner pressure every 15 seconds instead of once per minute, increasing resolution around short-lived BuildKit memory spikes that can precede runner loss. Every other E2E target retains the 60-second cadence, and the existing bounded, numeric-only evidence and finalization behavior remain unchanged.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

Part of #7144.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- Select a 15-second comparison-sample interval only for `rebuild-hermes` and `rebuild-hermes-stale-base`.
- Preserve the 60-second default for dashboard, Discord, Shields, and every other or unknown target.
- Protect the target mapping, qualifying live-environment wiring, and selected 15-second/30-second timer deadlines with focused progress-fixture tests.
- Document that faster rebuild sampling may reach the shared 256-record bound early, while reserving the finalization slot and allowing the existing lower-frequency evidence path to continue.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes maintainer-only E2E diagnostics; the internal sampling contract is documented in `test/e2e/README.md`.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop review of the complete diff through exact head `4f875025c` passed, including merge-resolution integrity, deterministic scheduling, and live-environment wiring coverage. The 15-second cadence is limited to two targets, retains one timer and the bounded ledger/finalization contract, invokes no Docker command, and persists only numeric or fixed-enum telemetry without command lines, environment values, container names, or raw process names.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md` documents the target-specific cadence, bounded-record behavior, reserved finalization slot, and fallback evidence path. No user-facing documentation change is needed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4f875025c -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-progress-fixture.test.ts test/e2e/support/e2e-progress-resource-sampling.test.ts`: 2 files and 26 tests passed; `npm run typecheck:cli` and `npm run test:titles:check` also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not run for this narrow cadence selector; GitHub CI is the broad gate.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable resource sampling for runner comparisons.
  * Hermes rebuild comparisons now sample approximately every 15 seconds; other comparisons retain the approximately 60-second cadence.
  * Improved peak memory usage evidence while preserving existing reporting and privacy safeguards.
  * Added fallback behavior using the existing five-minute snapshot when periodic sampling is unavailable.

* **Tests**
  * Added coverage validating sampling intervals, progress wiring, and scheduled resource samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

