### PR TITLE
ci(images): allow base publisher to finish

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -64,7 +64,7 @@ jobs:
     name: Build and push ${{ matrix.display_name }} base image
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The OpenClaw base-image publisher now has 90 minutes to complete instead of 45 minutes. The previous limit canceled the arm64-emulated Perl test suite while its tests were still passing.

## Changes

- Increase the base-image publication job timeout from 45 to 90 minutes.
- Keep the existing build, test, and publication steps unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: The change updates one GitHub Actions timeout value. Run 30135226357 reproduces cancellation at the previous limit while the build tests were passing.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change does not alter a user workflow, configuration, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The failed [base-image publication run](https://github.com/NVIDIA/NemoClaw/actions/runs/30135226357) shows the OpenClaw build continuing to pass Perl tests until GitHub canceled it at 45 minutes. The diff changes only the job timeout.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The timeout is an internal CI execution limit. It does not change user workflows, configuration, or supported behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 643f9737f -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:changed` exited 0 and reported no mapped source tests; the timeout-only change is verified by the failed publication run.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
