### PR TITLE
docs: add v0.0.95 release entry

### DIFF
--- a/docs/changelog/2026-07-24.mdx
+++ b/docs/changelog/2026-07-24.mdx
@@ -10,6 +10,7 @@ NemoClaw v0.0.95 adds explicit ownership for externally supervised OpenShell gat
 - Platforms can now declare whether NemoClaw or an external systemd service owns the OpenShell gateway lifecycle.
   NemoClaw validates the declared listener and keeps stop, recovery, and uninstall operations from changing an externally supervised gateway.
   Stopping a sandbox now removes its dashboard forward, forward startup retries terminated listener attempts, and managed recovery retries dropped OpenShell relay connections.
+  Hermes preserves managed gateway restart recovery.
   Uninstall keeps OpenShell-orphaned sibling sandboxes outside the selected cleanup scope.
   For more information, refer to [Declare the OpenShell Gateway Lifecycle Authority](/user-guide/openclaw/deployment/gateway-lifecycle-authority), [Run Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/run-sandboxes), [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), and [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw).
 - Snapshot restore now replaces SQLite state files through staged atomic operations.

--- a/docs/changelog/2026-07-24.mdx
+++ b/docs/changelog/2026-07-24.mdx
@@ -3,6 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */}
 
+## v0.0.95
+
+NemoClaw v0.0.95 adds explicit ownership for externally supervised OpenShell gateways, strengthens recovery and state-transfer paths, expands inference compatibility, refreshes sandbox security packages, and requires executed E2E evidence while separating runner wait time from test execution.
+
+- Platforms can now declare whether NemoClaw or an external systemd service owns the OpenShell gateway lifecycle.
+  NemoClaw validates the declared listener and keeps stop, recovery, and uninstall operations from changing an externally supervised gateway.
+  Stopping a sandbox now removes its dashboard forward, forward startup retries terminated listener attempts, and managed recovery retries dropped OpenShell relay connections.
+  Uninstall keeps OpenShell-orphaned sibling sandboxes outside the selected cleanup scope.
+  For more information, refer to [Declare the OpenShell Gateway Lifecycle Authority](/user-guide/openclaw/deployment/gateway-lifecycle-authority), [Run Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/run-sandboxes), [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), and [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw).
+- Snapshot restore now replaces SQLite state files through staged atomic operations.
+  Strict `backup-all` skips stranded orphan sandboxes, and `nemoclaw <name> download` verifies that each requested host artifact exists before reporting success.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Onboarding now reuses a reachable Ollama service on Windows hosts and falls back to the standard CDI directories when Docker reports no CDI specification directories.
+  OpenRouter forwarding applies a connection-establishment deadline, and managed NVIDIA Build Nemotron-3 requests omit the unsupported top-level `thinking` field.
+  Managed Deep Agents Code preserves configured headless retry limits while classifying provider failures.
+  For more information, refer to [Set Up Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama), [Configure Inference Timeouts](/user-guide/openclaw/inference/manage-inference/configure-inference-timeouts), and [NemoClaw Quickstart with Deep Agents](/user-guide/deepagents/get-started/quickstart).
+- When a base-image override is supplied, NemoClaw accepts only an official immutable remote digest or a local image built and pinned during the current operation.
+  Rebuilds can reuse those local images, OpenClaw runtime checks validate version output, and shields preserve `openclaw.json` when a legacy lock has no config hash.
+  The base images also update bundled npm packages, Perl, libexpat, and jq to address reviewed security findings, while the final OpenClaw image uses fewer payload layers.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), [Architecture Details](/user-guide/openclaw/reference/architecture), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- The default OpenClaw Discord policy now allows the bot to manage its own application commands without granting unrelated Discord API access.
+  For more information, refer to [Choose Messaging Channels](/user-guide/openclaw/manage-sandboxes/messaging-channels/choose-messaging-channels) and [Network Policies](/user-guide/openclaw/reference/network-policies).
+- Release E2E automation no longer accepts a skipped PR gate as passing evidence.
+  Root image changes select the full suite, direct `main` runs provision Hermes swap, retry reservations clean up after terminal outcomes, and runtime reports separate runner wait time from execution time.
+  Nightly history and selected-test risk signals make infrastructure delays and product failures easier to distinguish.
+
 ## v0.0.94
 
 NemoClaw v0.0.94 strengthens sandbox restore and update behavior, adds machine-readable onboarding progress, improves policy and security evidence, reduces Hermes image build time, and makes live E2E failures easier to classify.

--- a/docs/changelog/2026-07-24.mdx
+++ b/docs/changelog/2026-07-24.mdx
@@ -5,7 +5,7 @@
 
 ## v0.0.95
 
-NemoClaw v0.0.95 adds explicit ownership for externally supervised OpenShell gateways, strengthens recovery and state-transfer paths, expands inference compatibility, refreshes sandbox security packages, and requires executed E2E evidence while separating runner wait time from test execution.
+NemoClaw v0.0.95 adds explicit ownership for externally supervised OpenShell gateways, strengthens recovery and state-transfer paths, expands inference compatibility, refreshes sandbox security packages, and requires E2E evidence from executed runs while separating runner wait time from test execution.
 
 - Platforms can now declare whether NemoClaw or an external systemd service owns the OpenShell gateway lifecycle.
   NemoClaw validates the declared listener and keeps stop, recovery, and uninstall operations from changing an externally supervised gateway.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the canonical pre-tag `## v0.0.95` release entry to `docs/changelog/2026-07-24.mdx`, before the existing v0.0.94 entry. The entry summarizes approved user-visible changes merged since v0.0.94 and excludes internal-only prerequisites.

## Changes

- Adds the v0.0.95 summary and detailed bullets for gateway lifecycle, recovery, state transfer, inference compatibility, sandbox security, Discord policy, and E2E evidence.
- Links each user-facing theme to the most specific published documentation.
- Records the release entry in the shared native changelog used by the OpenClaw, Hermes, and Deep Agents guides.

Source summary:

- [#7246](https://github.com/NVIDIA/NemoClaw/pull/7246), [#7228](https://github.com/NVIDIA/NemoClaw/pull/7228), [#7267](https://github.com/NVIDIA/NemoClaw/pull/7267), [#7489](https://github.com/NVIDIA/NemoClaw/pull/7489), [#7509](https://github.com/NVIDIA/NemoClaw/pull/7509), [#7351](https://github.com/NVIDIA/NemoClaw/pull/7351), and [#7290](https://github.com/NVIDIA/NemoClaw/pull/7290) -> `docs/changelog/2026-07-24.mdx`: Gateway authority, forward teardown and retry, managed recovery, Hermes restart recovery, scoped uninstall, and orphan-aware backup behavior.
- [#7344](https://github.com/NVIDIA/NemoClaw/pull/7344) and [#7416](https://github.com/NVIDIA/NemoClaw/pull/7416) -> `docs/changelog/2026-07-24.mdx`: Atomic SQLite restore and host download verification.
- [#7476](https://github.com/NVIDIA/NemoClaw/pull/7476), [#7347](https://github.com/NVIDIA/NemoClaw/pull/7347), [#7281](https://github.com/NVIDIA/NemoClaw/pull/7281), [#7485](https://github.com/NVIDIA/NemoClaw/pull/7485), [#7491](https://github.com/NVIDIA/NemoClaw/pull/7491), and [#7422](https://github.com/NVIDIA/NemoClaw/pull/7422) -> `docs/changelog/2026-07-24.mdx`: Windows Ollama reuse, CDI fallback, bounded OpenRouter connection setup, Nemotron-3 request compatibility, and managed Deep Agents retry and provider-error behavior.
- [#6884](https://github.com/NVIDIA/NemoClaw/pull/6884), [#7481](https://github.com/NVIDIA/NemoClaw/pull/7481), [#6878](https://github.com/NVIDIA/NemoClaw/pull/6878), [#7467](https://github.com/NVIDIA/NemoClaw/pull/7467), [#7502](https://github.com/NVIDIA/NemoClaw/pull/7502), [#7503](https://github.com/NVIDIA/NemoClaw/pull/7503), [#7504](https://github.com/NVIDIA/NemoClaw/pull/7504), and [#7486](https://github.com/NVIDIA/NemoClaw/pull/7486) -> `docs/changelog/2026-07-24.mdx`: Trusted base-image overrides, local rebuild images, runtime validation, config preservation, reviewed package updates, and fewer final-image payload layers.
- [#7303](https://github.com/NVIDIA/NemoClaw/pull/7303) -> `docs/changelog/2026-07-24.mdx`: Scoped Discord application-command management.
- [#7488](https://github.com/NVIDIA/NemoClaw/pull/7488), [#7465](https://github.com/NVIDIA/NemoClaw/pull/7465), [#7497](https://github.com/NVIDIA/NemoClaw/pull/7497), [#7464](https://github.com/NVIDIA/NemoClaw/pull/7464), [#7501](https://github.com/NVIDIA/NemoClaw/pull/7501), [#7494](https://github.com/NVIDIA/NemoClaw/pull/7494), and [#7493](https://github.com/NVIDIA/NemoClaw/pull/7493) -> `docs/changelog/2026-07-24.mdx`: Selected-test risk signals, retry cleanup, full root-image validation, direct-main Hermes setup, executed PR-gate evidence, nightly history, and runner wait reporting.
- [#7447](https://github.com/NVIDIA/NemoClaw/pull/7447) is an internal pinned-runtime prerequisite and is intentionally excluded from canonical supported-integration documentation.
- [#7370](https://github.com/NVIDIA/NemoClaw/pull/7370) adds maintainer-only advisory reconciliation tooling and does not change supported user behavior.
- [#7495](https://github.com/NVIDIA/NemoClaw/pull/7495) updates existing documentation and does not add a new v0.0.95 behavior claim.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates the dated changelog structure, heading uniqueness, and published links.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-07-24.mdx`; writing rules, documentation style, factual release meaning, and published links reviewed at exact head `58b02f2bf`.
- Agent: Codex documentation writer reviewer
<!-- docs-review-head-sha: 58b02f2bf -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — the build passed with 0 errors and 2 Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new v0.0.95 changelog entry above v0.0.94.
  * Documented improved externally supervised gateway lifecycle ownership.
  * Improved snapshot restore reliability and SQLite state handling.
  * Tightened CLI `backup-all` behavior and host artifact verification.
  * Updated Windows onboarding guidance (including Ollama service reuse and CDI directory fallback).
  * Noted inference compatibility fixes, deeper agent failure classification, stricter base-image validation, updated Discord bot command permissions, and refined E2E release automation evidence handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
