### PR TITLE
fix(sandbox): strip group-write from staged Docker payloads

### DIFF
--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -27,7 +27,7 @@ function createBuildContextDir(tmpDir: string = os.tmpdir()): string {
 function normalizeReadModesForDockerCopy(rootDir: string): void {
   const stat = fs.lstatSync(rootDir);
   if (stat.isDirectory()) {
-    fs.chmodSync(rootDir, (stat.mode & 0o777) | 0o555);
+    fs.chmodSync(rootDir, (stat.mode & 0o777 & ~0o022) | 0o555);
     for (const entry of fs.readdirSync(rootDir)) {
       normalizeReadModesForDockerCopy(path.join(rootDir, entry));
     }
@@ -36,7 +36,7 @@ function normalizeReadModesForDockerCopy(rootDir: string): void {
 
   if (stat.isFile()) {
     const mode = stat.mode & 0o777;
-    fs.chmodSync(rootDir, mode | 0o444 | (mode & 0o111 ? 0o111 : 0));
+    fs.chmodSync(rootDir, (mode & ~0o022) | 0o444 | (mode & 0o111 ? 0o111 : 0));
   }
 }
 

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -129,6 +129,19 @@ describe("sandbox build context staging", () => {
     fs.chmodSync(path.join(sourceRoot, "scripts", "lib"), 0o700);
   }
 
+  function makeBuildContextFixtureGroupWritable(sourceRoot: string) {
+    for (const relativePath of [
+      "scripts",
+      path.join("scripts", "lib"),
+      "src",
+      path.join("src", "lib"),
+    ]) {
+      fs.chmodSync(path.join(sourceRoot, relativePath), 0o775);
+    }
+    fs.chmodSync(path.join(sourceRoot, "scripts", "patch-bundled-npm-tar.mts"), 0o775);
+    fs.chmodSync(path.join(sourceRoot, "src", "lib", "tool-disclosure.ts"), 0o664);
+  }
+
   function expectDockerfileScriptCopiesExist(buildCtx: string, stagedDockerfile: string) {
     const dockerfile = fs.readFileSync(stagedDockerfile, "utf8");
     const copiedScripts = [...dockerfile.matchAll(/^COPY\s+scripts\/(\S+)/gm)].map(
@@ -210,25 +223,48 @@ describe("sandbox build context staging", () => {
     expect((fs.statSync(stagedHelper).mode & 0o777).toString(8)).toBe("755");
   }
 
-  it("normalizes copied blueprint modes with chmod a+rX semantics", () => {
+  function expectStagedGroupWritablePayloadModes(buildCtx: string) {
+    expect((fs.statSync(path.join(buildCtx, "scripts")).mode & 0o777).toString(8)).toBe("755");
+    expect(
+      (
+        fs.statSync(path.join(buildCtx, "scripts", "patch-bundled-npm-tar.mts")).mode & 0o777
+      ).toString(8),
+    ).toBe("755");
+    expect(
+      (fs.statSync(path.join(buildCtx, "src", "lib", "tool-disclosure.ts")).mode & 0o777).toString(
+        8,
+      ),
+    ).toBe("644");
+  }
+
+  it("normalizes restrictive and group-writable modes for Docker COPY", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-unit-"));
     const blueprintDir = path.join(tmpDir, "nemoclaw-blueprint");
     const manifestDir = path.join(blueprintDir, "model-specific-setup", "openclaw");
     const manifestPath = path.join(manifestDir, "kimi-k2.6-managed-inference.json");
     const executablePath = path.join(blueprintDir, "scripts", "helper.sh");
+    const groupWritableDir = path.join(blueprintDir, "group-writable");
+    const groupWritableFile = path.join(groupWritableDir, "manifest.json");
+    const groupWritableExecutable = path.join(groupWritableDir, "helper.sh");
     const symlinkPath = path.join(blueprintDir, "manifest-link.json");
 
     try {
       fs.mkdirSync(manifestDir, { recursive: true });
       fs.mkdirSync(path.dirname(executablePath), { recursive: true });
+      fs.mkdirSync(groupWritableDir, { mode: 0o775 });
       fs.writeFileSync(manifestPath, "{}\n", { mode: 0o600 });
       fs.writeFileSync(executablePath, "#!/bin/sh\n", { mode: 0o700 });
+      fs.writeFileSync(groupWritableFile, "{}\n", { mode: 0o664 });
+      fs.writeFileSync(groupWritableExecutable, "#!/bin/sh\n", { mode: 0o775 });
       fs.symlinkSync(manifestPath, symlinkPath);
       fs.chmodSync(blueprintDir, 0o700);
       fs.chmodSync(path.join(blueprintDir, "model-specific-setup"), 0o700);
       fs.chmodSync(manifestDir, 0o700);
       fs.chmodSync(manifestPath, 0o600);
       fs.chmodSync(executablePath, 0o700);
+      fs.chmodSync(groupWritableDir, 0o775);
+      fs.chmodSync(groupWritableFile, 0o664);
+      fs.chmodSync(groupWritableExecutable, 0o775);
 
       normalizeReadModesForDockerCopy(blueprintDir);
 
@@ -236,6 +272,9 @@ describe("sandbox build context staging", () => {
       expect((fs.statSync(manifestDir).mode & 0o777).toString(8)).toBe("755");
       expect((fs.statSync(manifestPath).mode & 0o777).toString(8)).toBe("644");
       expect((fs.statSync(executablePath).mode & 0o777).toString(8)).toBe("755");
+      expect((fs.statSync(groupWritableDir).mode & 0o777).toString(8)).toBe("755");
+      expect((fs.statSync(groupWritableFile).mode & 0o777).toString(8)).toBe("644");
+      expect((fs.statSync(groupWritableExecutable).mode & 0o777).toString(8)).toBe("755");
       expect(fs.lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -338,6 +377,38 @@ describe("sandbox build context staging", () => {
       } finally {
         process.umask(previousUmask);
       }
+    } finally {
+      fs.rmSync(sourceRoot, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("optimized staging strips group and other write bits from copied payloads", () => {
+    const sourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-source-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-group-write-"));
+
+    try {
+      writeBuildContextFixture(sourceRoot);
+      makeBuildContextFixtureGroupWritable(sourceRoot);
+      const { buildCtx } = stageOptimizedSandboxBuildContext(sourceRoot, tmpDir);
+      expectStagedGroupWritablePayloadModes(buildCtx);
+    } finally {
+      fs.rmSync(sourceRoot, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("legacy staging strips group and other write bits from copied payloads", () => {
+    const sourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-source-"));
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-build-context-legacy-group-write-"),
+    );
+
+    try {
+      writeBuildContextFixture(sourceRoot);
+      makeBuildContextFixtureGroupWritable(sourceRoot);
+      const { buildCtx } = stageLegacySandboxBuildContext(sourceRoot, tmpDir);
+      expectStagedGroupWritablePayloadModes(buildCtx);
     } finally {
       fs.rmSync(sourceRoot, { recursive: true, force: true });
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

A normal `0002` checkout can stage executable Docker payloads as `0775`, so the exact metadata gate added by #7486 aborts a sandbox replacement build. This change clears group and other write bits while preserving owner write and executable intent, so permissive and restrictive source modes both produce canonical Docker payload modes without weakening the gate.

## Changes

- Clear group and other write bits in `normalizeReadModesForDockerCopy()` before adding the read, traverse, and executable permissions required by Docker.
- Cover optimized and legacy staging with `0775` directory and executable fixtures plus a `0664` non-executable fixture. The tests assert exact staged modes of `0755` and `0644`.
- Retain coverage that normalizes restrictive `0700` directories and executables plus `0600` ordinary files.
- Confirm the regression history: #3664 introduced read-mode normalization, #7072 applied it to scripts with restrictive-mode coverage, #7332 added `patch-bundled-npm-tar.mts`, and #7486 made its preserved `0775` mode fail the exact `0755` assertion.
- Validate the fix on Brev instance `nc-july26` from base SHA `3b2f6d557`. A transactional rebuild with `0775` and `0664` source inputs completed the strict payload metadata stage, replacement creation, state restore, policy restore, and deployment health checks.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The fix restores the existing staged-payload permission contract and does not change commands, configuration, or supported workflows.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation files changed. The fix restores canonical staged modes without changing commands, configuration, or supported workflows. The reviewer found no actionable wording issues.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 14967c555 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/sandbox-build-context.test.ts src/lib/onboard/build-context-stage.test.ts src/lib/actions/sandbox/rebuild-managed-image-preparation.test.ts` (22/22 passed); `npm run typecheck:cli` passed; Brev `nc-july26` rebuild passed the strict Docker payload metadata stage and completed successfully.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
