### PR TITLE
test(onboard): isolate gateway recovery fixture

### DIFF
--- a/src/lib/onboard/gateway-recovery.test.ts
+++ b/src/lib/onboard/gateway-recovery.test.ts
@@ -31,6 +31,7 @@ function makeVirtualClock(startMs = 1_000_000_000_000) {
 }
 
 function createDeps(overrides: Partial<GatewayRecoveryDeps> = {}): GatewayRecoveryDeps {
+  const clock = makeVirtualClock();
   return {
     assertGatewayStartAllowed: vi.fn(),
     getGatewayClusterContainerState: () => "missing",
@@ -38,7 +39,8 @@ function createDeps(overrides: Partial<GatewayRecoveryDeps> = {}): GatewayRecove
     runCaptureOpenshell: vi.fn(() => "Disconnected"),
     runOpenshell: vi.fn(() => ({ status: 0 })),
     getContainerRuntime: () => "docker",
-    sleepSeconds: vi.fn(),
+    sleepSeconds: clock.sleeper,
+    now: clock.now,
     startGatewayWithOptions: vi.fn(
       async () => undefined,
     ) as GatewayRecoveryDeps["startGatewayWithOptions"],

--- a/src/lib/onboard/gateway-recovery.test.ts
+++ b/src/lib/onboard/gateway-recovery.test.ts
@@ -37,6 +37,7 @@ function createDeps(overrides: Partial<GatewayRecoveryDeps> = {}): GatewayRecove
     getGatewayStartEnv: () => ({ OPENSHELL_DRIVERS: "docker" }),
     runCaptureOpenshell: vi.fn(() => "Disconnected"),
     runOpenshell: vi.fn(() => ({ status: 0 })),
+    getContainerRuntime: () => "docker",
     sleepSeconds: vi.fn(),
     startGatewayWithOptions: vi.fn(
       async () => undefined,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Gateway-recovery unit tests no longer invoke the host's production `docker info` runtime probe or busy-loop against real wall-clock deadlines. The fixture now owns a deterministic runtime value and virtual clock, preserving the same recovery assertions while reducing focused test execution from 4.02 seconds to 16 milliseconds.

## Related Issue

Part of #7140.

## Changes

- Stub the container runtime in the shared gateway-recovery test fixture so a healthy unit path cannot inherit Docker's 5-second probe timeout.
- Pair the fixture's mocked sleeper with its existing virtual clock so failed probes advance deterministically instead of spinning against `Date.now()`.
- Keep specialized per-test overrides authoritative and preserve every existing recovery, validation, and lifecycle-authority assertion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: all 14 gateway-recovery tests execute through the changed shared fixture and retain their existing assertions.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes test isolation and timing only; production and user-facing behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop review of exact head `f34bc4bae` against base `3c88ec303` passed with no findings. No production code or assertions changed; fail-closed gateway validation and lifecycle-authority coverage remain intact.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Test-only fixture stabilization in `src/lib/onboard/gateway-recovery.test.ts`; no production or user-facing behavior changed. Focused tests: 14/14 pass; file execution 4.02s -> 16ms.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f34bc4bae -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/gateway-recovery.test.ts --reporter=verbose`: 14/14 passed; `npm run typecheck:cli`, `npm run test:titles:check`, and `npm run source-shape:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not run for this one-file unit-fixture change; GitHub CI is the broad gate.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved gateway recovery test timing with deterministic virtual-clock behavior.
  * Updated mocked sleep handling to accurately advance time during recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->