### PR TITLE
ci(images): parallelize Perl regression tests

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -81,6 +81,8 @@ WORKDIR /tmp/perl-source
 # declaration, so pin the known target result instead of synthesizing a
 # conflicting prototype. Remove this override when the QEMU-backed multi-arch
 # build in .github/workflows/base-image.yaml passes without it.
+# Perl's test_harness schedules independent upstream tests through TEST_JOBS.
+# This preserves the full suite without serial QEMU execution.
 RUN curl --proto '=https' --tlsv1.2 -fsSL \
         --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
         -o /tmp/perl.tar.xz "https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.xz" \
@@ -97,7 +99,8 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL \
         -Dman1dir=none \
         -Dman3dir=none \
     && make -j"$(nproc)" \
-    && make test \
+    && TEST_JOBS="$(nproc)" PERL_TEST_HARNESS_ASAP=1 \
+        make -j"$(nproc)" test_harness \
     && make install DESTDIR=/tmp/perl-root
 
 RUN package_version="${PERL_VERSION}-${PERL_PACKAGE_REVISION}" \

--- a/test/perl-critical-cve-remediation.test.ts
+++ b/test/perl-critical-cve-remediation.test.ts
@@ -58,13 +58,15 @@ describe("sandbox base critical Perl CVE remediation", () => {
   it("runs the upstream test suite before packaging the replacement runtime (#7338)", () => {
     const builder = stageNamed("perl-builder");
     const compile = builder.indexOf('make -j"$(nproc)"');
-    const test = builder.indexOf("make test");
+    const parallelTest = builder.indexOf('TEST_JOBS="$(nproc)" PERL_TEST_HARNESS_ASAP=1');
+    const testHarness = builder.indexOf('make -j"$(nproc)" test_harness');
     const install = builder.indexOf("make install DESTDIR=/tmp/perl-root");
     const packageBuild = builder.indexOf("dpkg-deb --build --root-owner-group");
 
     expect(compile).toBeGreaterThanOrEqual(0);
-    expect(test).toBeGreaterThan(compile);
-    expect(install).toBeGreaterThan(test);
+    expect(parallelTest).toBeGreaterThan(compile);
+    expect(testHarness).toBeGreaterThan(parallelTest);
+    expect(install).toBeGreaterThan(testHarness);
     expect(packageBuild).toBeGreaterThan(install);
   });
 

--- a/test/perl-critical-cve-remediation.test.ts
+++ b/test/perl-critical-cve-remediation.test.ts
@@ -68,6 +68,7 @@ describe("sandbox base critical Perl CVE remediation", () => {
     expect(testHarness).toBeGreaterThan(parallelTest);
     expect(install).toBeGreaterThan(testHarness);
     expect(packageBuild).toBeGreaterThan(install);
+    expect(builder).not.toMatch(/\bmake\s+(?:-j[^\n]+\s+)?test(?:\s|\\|$)/m);
   });
 
   it("replaces the vulnerable distro packages without breaking dpkg ownership (#7338)", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenClaw base-image builds now use Perl's parallel test harness instead of the serial test runner. The complete Perl 5.44.0 upstream suite still runs, but independent test scripts can use all runner CPUs during QEMU builds.

## Related Issue

Follow-up to #7338.

## Changes

- Run `test_harness` with `TEST_JOBS=$(nproc)` and `PERL_TEST_HARNESS_ASAP=1`, as recommended by [Perl's parallel-test guidance](https://perldoc.perl.org/perlhack#Parallel-tests).
- Update the Perl CVE remediation contract test to require the parallel full-suite command before packaging.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change only schedules existing build-time validation concurrently. It does not change the image contents or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex security review passed on `b2bb8b44b`; the change preserves all security checks and runtime controls.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation changes are required because the full Perl suite and runtime behavior remain unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b2bb8b44b -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `vitest run test/perl-critical-cve-remediation.test.ts` passed 4 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Perl build verification by running the upstream test suite through the parallel test harness.
  - Reduced delays during emulated builds by enabling concurrent test execution.

- **Tests**
  - Updated build validation to verify parallel testing, installation, and packaging occur in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->