### PR TITLE
test(openclaw): protect post-idle TUI interactions

### DIFF
--- a/test/e2e/live/issue-6194-tui-expect.ts
+++ b/test/e2e/live/issue-6194-tui-expect.ts
@@ -52,14 +52,41 @@ proc expect_or_exit {pattern markName timeoutExit eofExit} {
     eof { exit $eofExit }
   }
 }
+proc expect_pair_or_exit {firstPattern firstMark secondPattern secondMark firstTimeoutExit firstEofExit secondTimeoutExit secondEofExit} {
+  set firstSeen 0
+  set secondSeen 0
+  while {!$firstSeen || !$secondSeen} {
+    expect {
+      -nocase -re $firstPattern {
+        if {!$firstSeen} {
+          mark $firstMark
+          set firstSeen 1
+        }
+      }
+      -nocase -re $secondPattern {
+        if {!$secondSeen} {
+          mark $secondMark
+          set secondSeen 1
+        }
+      }
+      timeout {
+        send "\\003"
+        if {!$firstSeen} { exit $firstTimeoutExit }
+        exit $secondTimeoutExit
+      }
+      eof {
+        if {!$firstSeen} { exit $firstEofExit }
+        exit $secondEofExit
+      }
+    }
+  }
+}
 spawn openshell sandbox exec --name $sandbox --tty -- sh -lc "export TERM=xterm-256color; cd /sandbox; openclaw tui --session $session"
 expect_or_exit {connected[^\\r\\n]*idle} connected_idle_initial 10 11
 send -- "Reply with the three fragments joined by underscores: NEMOCLAW6194, CHAT, OK. Put only that joined token on its own line. Do not use tools.\\r"
-expect_or_exit {NEMOCLAW6194_CHAT_OK} chat_reply 20 21
-expect_or_exit {connected[^\\r\\n]*idle} connected_idle_after_chat 22 23
+expect_pair_or_exit {NEMOCLAW6194_CHAT_OK} chat_reply {connected[^\\r\\n]*idle} connected_idle_after_chat 20 21 22 23
 send -- "/nemoclaw status\\r"
-expect_or_exit {NemoClaw Status} slash_status_output 30 31
-expect_or_exit {connected[^\\r\\n]*idle} connected_idle_after_status 32 33
+expect_pair_or_exit {NemoClaw Status} slash_status_output {connected[^\\r\\n]*idle} connected_idle_after_status 30 31 32 33
 # Network-rule approvals belong to the separate OpenShell terminal UI. Keep
 # this OpenClaw TUI regression scoped to inputs it can perform directly so a
 # tool-less hosted model cannot turn assistant prose into a test oracle.

--- a/test/e2e/live/issue-6194-tui-expect.ts
+++ b/test/e2e/live/issue-6194-tui-expect.ts
@@ -32,6 +32,41 @@ export function readIssue6194Capture(path: string): Issue6194Capture {
   }
 }
 
+export function buildIssue6194PairExpectProcedure(): string {
+  return `proc expect_pair_or_exit {firstPattern firstMark secondPattern secondMark firstTimeoutExit firstEofExit secondTimeoutExit secondEofExit} {
+  set firstSeen 0
+  set secondSeen 0
+  expect {
+    -nocase -re $firstPattern {
+      if {!$firstSeen} {
+        mark $firstMark
+        set firstSeen 1
+      }
+      if {$firstSeen && $secondSeen} { return }
+      exp_continue -continue_timer
+    }
+    -nocase -re $secondPattern {
+      if {!$secondSeen} {
+        mark $secondMark
+        set secondSeen 1
+      }
+      if {$firstSeen && $secondSeen} { return }
+      exp_continue -continue_timer
+    }
+    timeout {
+      send "\\003"
+      if {!$firstSeen} { exit $firstTimeoutExit }
+      exit $secondTimeoutExit
+    }
+    eof {
+      if {!$firstSeen} { exit $firstEofExit }
+      exit $secondEofExit
+    }
+  }
+}
+`;
+}
+
 export function buildIssue6194TuiExpectScript(): string {
   return `set timeout $env(NEMOCLAW_ISSUE_6194_TUI_TIMEOUT)
 set sandbox $env(NEMOCLAW_ISSUE_6194_SANDBOX)
@@ -52,35 +87,7 @@ proc expect_or_exit {pattern markName timeoutExit eofExit} {
     eof { exit $eofExit }
   }
 }
-proc expect_pair_or_exit {firstPattern firstMark secondPattern secondMark firstTimeoutExit firstEofExit secondTimeoutExit secondEofExit} {
-  set firstSeen 0
-  set secondSeen 0
-  while {!$firstSeen || !$secondSeen} {
-    expect {
-      -nocase -re $firstPattern {
-        if {!$firstSeen} {
-          mark $firstMark
-          set firstSeen 1
-        }
-      }
-      -nocase -re $secondPattern {
-        if {!$secondSeen} {
-          mark $secondMark
-          set secondSeen 1
-        }
-      }
-      timeout {
-        send "\\003"
-        if {!$firstSeen} { exit $firstTimeoutExit }
-        exit $secondTimeoutExit
-      }
-      eof {
-        if {!$firstSeen} { exit $firstEofExit }
-        exit $secondEofExit
-      }
-    }
-  }
-}
+${buildIssue6194PairExpectProcedure()}\
 spawn openshell sandbox exec --name $sandbox --tty -- sh -lc "export TERM=xterm-256color; cd /sandbox; openclaw tui --session $session"
 expect_or_exit {connected[^\\r\\n]*idle} connected_idle_initial 10 11
 send -- "Reply with the three fragments joined by underscores: NEMOCLAW6194, CHAT, OK. Put only that joined token on its own line. Do not use tools.\\r"

--- a/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
+++ b/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import { SecretStore } from "../fixtures/secrets.ts";
 import {
   buildIssue6194OpenShellApprovalExpectScript,
+  buildIssue6194PairExpectProcedure,
   buildIssue6194TuiExpectScript,
   ISSUE6194_NETWORK_APPROVAL_ENDPOINT,
   ISSUE6194_NETWORK_APPROVAL_HOST,
@@ -64,7 +66,8 @@ describe("live TUI post-idle coverage contract (#6194)", () => {
     expect(script).toContain('send_log "ISSUE6194_MARK $name\\n"');
     expect(script).toContain("proc expect_or_exit");
     expect(script).toContain("proc expect_pair_or_exit");
-    expect(script).toContain("while {!$firstSeen || !$secondSeen}");
+    expect(script.match(/exp_continue -continue_timer/gu)).toHaveLength(2);
+    expect(script).not.toContain("while {!$firstSeen || !$secondSeen}");
     expect(script).toContain(
       "expect_or_exit {connected[^\\r\\n]*idle} connected_idle_initial 10 11",
     );
@@ -94,6 +97,59 @@ describe("live TUI post-idle coverage contract (#6194)", () => {
     expect(order.every((index) => index >= 0)).toBe(true);
     expect([...order].sort((a, b) => a - b)).toEqual(order);
   });
+
+  describe.runIf(spawnSync("expect", ["-v"], { encoding: "utf8" }).status === 0)(
+    "paired Expect behavior",
+    () => {
+      function runPair(command: string, timeoutSeconds = 1) {
+        const script = `set timeout ${timeoutSeconds}
+proc mark {name} { puts "ISSUE6194_MARK $name" }
+${buildIssue6194PairExpectProcedure()}spawn sh -c {${command}}
+expect_pair_or_exit {FIRST_SIGNAL} first {SECOND_SIGNAL} second 20 21 22 23
+exit 0
+`;
+        const startedAt = Date.now();
+        const result = spawnSync("expect", ["-c", script], {
+          encoding: "utf8",
+          timeout: 2500,
+        });
+        return { ...result, elapsedMs: Date.now() - startedAt };
+      }
+
+      it.each([
+        ["first then second", "printf 'FIRST_SIGNAL\\n'; sleep 0.05; printf 'SECOND_SIGNAL\\n'"],
+        ["second then first", "printf 'SECOND_SIGNAL\\n'; sleep 0.05; printf 'FIRST_SIGNAL\\n'"],
+      ])("accepts %s", (_name, command) => {
+        const result = runPair(command);
+
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain("ISSUE6194_MARK first");
+        expect(result.stdout).toContain("ISSUE6194_MARK second");
+      });
+
+      it.each([
+        ["first signal timeout", "printf 'SECOND_SIGNAL\\n'; sleep 2", 20],
+        ["first signal EOF", "printf 'SECOND_SIGNAL\\n'", 21],
+        ["second signal timeout", "printf 'FIRST_SIGNAL\\n'; sleep 2", 22],
+        ["second signal EOF", "printf 'FIRST_SIGNAL\\n'", 23],
+      ])("preserves the %s exit", (_name, command, expectedExit) => {
+        const result = runPair(command);
+
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(expectedExit);
+      });
+
+      it("keeps repeated redraws inside one timeout", () => {
+        const repeatedSecondSignals = Array.from(
+          { length: 30 },
+          () => "printf 'SECOND_SIGNAL\\n'; sleep 0.1",
+        ).join("; ");
+        const result = runPair(`${repeatedSecondSignals}; sleep 2`);
+
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(20);
+        expect(result.elapsedMs).toBeLessThan(2200);
+      });
+    },
+  );
 
   it("confirms the two-step Ctrl+C exit without waiting for the global timeout", () => {
     const script = buildIssue6194TuiExpectScript();

--- a/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
+++ b/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
@@ -63,18 +63,20 @@ describe("live TUI post-idle coverage contract (#6194)", () => {
     expect(script).toContain('puts "ISSUE6194_MARK $name"');
     expect(script).toContain('send_log "ISSUE6194_MARK $name\\n"');
     expect(script).toContain("proc expect_or_exit");
+    expect(script).toContain("proc expect_pair_or_exit");
+    expect(script).toContain("while {!$firstSeen || !$secondSeen}");
     expect(script).toContain(
       "expect_or_exit {connected[^\\r\\n]*idle} connected_idle_initial 10 11",
     );
-    expect(script).toContain("expect_or_exit {NEMOCLAW6194_CHAT_OK} chat_reply 20 21");
     expect(script).toContain(
-      "expect_or_exit {connected[^\\r\\n]*idle} connected_idle_after_chat 22 23",
+      "expect_pair_or_exit {NEMOCLAW6194_CHAT_OK} chat_reply {connected[^\\r\\n]*idle} connected_idle_after_chat 20 21 22 23",
     );
     expect(script).toContain("/nemoclaw status");
-    expect(script).toContain("expect_or_exit {NemoClaw Status} slash_status_output 30 31");
     expect(script).toContain(
-      "expect_or_exit {connected[^\\r\\n]*idle} connected_idle_after_status 32 33",
+      "expect_pair_or_exit {NemoClaw Status} slash_status_output {connected[^\\r\\n]*idle} connected_idle_after_status 30 31 32 33",
     );
+    expect(script).toContain("if {!$firstSeen} { exit $firstTimeoutExit }");
+    expect(script).toContain("if {!$firstSeen} { exit $firstEofExit }");
     expect(script).toContain("mark clean_exit");
 
     const markers = [

--- a/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
+++ b/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
@@ -98,58 +98,62 @@ describe("live TUI post-idle coverage contract (#6194)", () => {
     expect([...order].sort((a, b) => a - b)).toEqual(order);
   });
 
-  describe.runIf(spawnSync("expect", ["-v"], { encoding: "utf8" }).status === 0)(
-    "paired Expect behavior",
-    () => {
-      function runPair(command: string, timeoutSeconds = 1) {
-        const script = `set timeout ${timeoutSeconds}
+  describe.runIf(
+    spawnSync("expect", ["-v"], {
+      encoding: "utf8",
+      timeout: 5000,
+      killSignal: "SIGKILL",
+    }).status === 0,
+  )("paired Expect behavior", () => {
+    function runPair(command: string, timeoutSeconds = 1) {
+      const script = `set timeout ${timeoutSeconds}
 proc mark {name} { puts "ISSUE6194_MARK $name" }
 ${buildIssue6194PairExpectProcedure()}spawn sh -c {${command}}
 expect_pair_or_exit {FIRST_SIGNAL} first {SECOND_SIGNAL} second 20 21 22 23
 exit 0
 `;
-        const startedAt = Date.now();
-        const result = spawnSync("expect", ["-c", script], {
-          encoding: "utf8",
-          timeout: 2500,
-        });
-        return { ...result, elapsedMs: Date.now() - startedAt };
-      }
-
-      it.each([
-        ["first then second", "printf 'FIRST_SIGNAL\\n'; sleep 0.05; printf 'SECOND_SIGNAL\\n'"],
-        ["second then first", "printf 'SECOND_SIGNAL\\n'; sleep 0.05; printf 'FIRST_SIGNAL\\n'"],
-      ])("accepts %s", (_name, command) => {
-        const result = runPair(command);
-
-        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-        expect(result.stdout).toContain("ISSUE6194_MARK first");
-        expect(result.stdout).toContain("ISSUE6194_MARK second");
+      const startedAt = Date.now();
+      const result = spawnSync("expect", ["-c", script], {
+        encoding: "utf8",
+        timeout: 2500,
+        killSignal: "SIGKILL",
       });
+      return { ...result, elapsedMs: Date.now() - startedAt };
+    }
 
-      it.each([
-        ["first signal timeout", "printf 'SECOND_SIGNAL\\n'; sleep 2", 20],
-        ["first signal EOF", "printf 'SECOND_SIGNAL\\n'", 21],
-        ["second signal timeout", "printf 'FIRST_SIGNAL\\n'; sleep 2", 22],
-        ["second signal EOF", "printf 'FIRST_SIGNAL\\n'", 23],
-      ])("preserves the %s exit", (_name, command, expectedExit) => {
-        const result = runPair(command);
+    it.each([
+      ["first then second", "printf 'FIRST_SIGNAL\\n'; sleep 0.05; printf 'SECOND_SIGNAL\\n'"],
+      ["second then first", "printf 'SECOND_SIGNAL\\n'; sleep 0.05; printf 'FIRST_SIGNAL\\n'"],
+    ])("accepts %s", (_name, command) => {
+      const result = runPair(command);
 
-        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(expectedExit);
-      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("ISSUE6194_MARK first");
+      expect(result.stdout).toContain("ISSUE6194_MARK second");
+    });
 
-      it("keeps repeated redraws inside one timeout", () => {
-        const repeatedSecondSignals = Array.from(
-          { length: 30 },
-          () => "printf 'SECOND_SIGNAL\\n'; sleep 0.1",
-        ).join("; ");
-        const result = runPair(`${repeatedSecondSignals}; sleep 2`);
+    it.each([
+      ["first signal timeout", "printf 'SECOND_SIGNAL\\n'; sleep 2", 20],
+      ["first signal EOF", "printf 'SECOND_SIGNAL\\n'", 21],
+      ["second signal timeout", "printf 'FIRST_SIGNAL\\n'; sleep 2", 22],
+      ["second signal EOF", "printf 'FIRST_SIGNAL\\n'", 23],
+    ])("preserves the %s exit", (_name, command, expectedExit) => {
+      const result = runPair(command);
 
-        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(20);
-        expect(result.elapsedMs).toBeLessThan(2200);
-      });
-    },
-  );
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(expectedExit);
+    });
+
+    it("keeps repeated redraws inside one timeout", () => {
+      const repeatedSecondSignals = Array.from(
+        { length: 30 },
+        () => "printf 'SECOND_SIGNAL\\n'; sleep 0.1",
+      ).join("; ");
+      const result = runPair(`${repeatedSecondSignals}; sleep 2`);
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(20);
+      expect(result.elapsedMs).toBeLessThan(2200);
+    });
+  });
 
   it("confirms the two-step Ctrl+C exit without waiting for the global timeout", () => {
     const script = buildIssue6194TuiExpectScript();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The OpenClaw TUI can render its idle status before it paints the correlated reply or slash-command output. The #6194 live regression guard now accepts either order while requiring both signals inside one bounded wait.

## Related Issue

Refs #6194

## Changes

- Wait for reply and idle signals as an unordered pair after a chat request.
- Wait for status output and idle signals as an unordered pair after `/nemoclaw status`.
- Keep both signals inside one deadline with `exp_continue -continue_timer`.
- Preserve separate timeout and EOF exit codes for whichever signal is missing.
- Execute contract tests for both signal orders, all four failure exits, and repeated redraws.

The `expect_pair_or_exit` procedure serves the accepted #6194 chat and status journey because terminal redraws do not guarantee text order. Sequential waits discard a signal that renders before the preceding match. A direct ordered wait cannot distinguish a working interaction from a missing signal.

This PR does not change OpenClaw product code or close #6194. It protects the accepted user-facing journey through the existing live E2E boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change strengthens internal E2E coverage and does not change supported product behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. The change strengthens the internal #6194 E2E regression guard without changing product behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6a47eb565 -->
<!-- docs-review-agents-blob-sha: 9c9b36d -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run --project e2e-support test/e2e/support/issue-6194-tui-post-idle-contract.test.ts` passed 18 tests with real Expect.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal interaction handling when chat responses and status updates appear in either order.
  * Preserved distinct timeout and end-of-stream outcomes when expected terminal signals are missing.

* **Tests**
  * Added coverage for paired terminal signals, including reversed ordering, repeated redraws, timeouts, and early termination.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->