### PR TITLE
fix(onboard): omit TLS servername for IP-literal gateway health probe hosts

### DIFF
--- a/src/lib/onboard/gateway-http-readiness.test.ts
+++ b/src/lib/onboard/gateway-http-readiness.test.ts
@@ -1,12 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
 import http from "node:http";
+import http2 from "node:http2";
 import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isGatewayHttpReady } from "./gateway-http-readiness";
+import { isDockerDriverGatewayHttpReady, isGatewayHttpReady } from "./gateway-http-readiness";
 
 const servers: http.Server[] = [];
 
@@ -82,5 +87,97 @@ describe("isGatewayHttpReady abort handling", () => {
     controller.abort();
 
     await expect(probe).resolves.toBe(false);
+  });
+});
+
+describe("isDockerDriverGatewayHttpReady TLS servername", () => {
+  const tlsDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tlsDirs.splice(0)) {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  function writeLocalTlsDir(): string {
+    const tlsDir = fs.mkdtempSync(path.join(os.tmpdir(), "gateway-tls-"));
+    tlsDirs.push(tlsDir);
+    fs.writeFileSync(path.join(tlsDir, "ca.crt"), "ca");
+    fs.mkdirSync(path.join(tlsDir, "client"));
+    fs.writeFileSync(path.join(tlsDir, "client", "tls.crt"), "cert");
+    fs.writeFileSync(path.join(tlsDir, "client", "tls.key"), "key");
+    return tlsDir;
+  }
+
+  function healthySessionStub(): http2.ClientHttp2Session {
+    const stream = new EventEmitter() as EventEmitter & {
+      close: () => void;
+      end: (payload?: Buffer) => void;
+    };
+    stream.close = () => undefined;
+    stream.end = () => {
+      setImmediate(() => {
+        stream.emit("response", {
+          [http2.constants.HTTP2_HEADER_STATUS]: 200,
+          [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "application/grpc",
+          "grpc-status": "0",
+        });
+        stream.emit("end");
+      });
+    };
+    const client = new EventEmitter() as EventEmitter & {
+      close: () => void;
+      request: () => typeof stream;
+    };
+    client.close = () => undefined;
+    client.request = () => stream;
+    return client as unknown as http2.ClientHttp2Session;
+  }
+
+  function spyOnHttp2Connect() {
+    return vi.spyOn(http2, "connect").mockImplementation(() => healthySessionStub());
+  }
+
+  function connectOptionsFrom(
+    connect: ReturnType<typeof spyOnHttp2Connect>,
+  ): Record<string, unknown> {
+    expect(connect).toHaveBeenCalledTimes(1);
+    return connect.mock.calls[0]?.[1] as Record<string, unknown>;
+  }
+
+  it("omits servername for an IP-literal gateway host, which Node 25 rejects as a TLS ServerName (#7527)", async () => {
+    vi.stubEnv("OPENSHELL_LOCAL_TLS_DIR", writeLocalTlsDir());
+    const connect = spyOnHttp2Connect();
+
+    await expect(
+      isDockerDriverGatewayHttpReady(1_000, "https://127.0.0.1:8080/openshell.v1.OpenShell/Health"),
+    ).resolves.toBe(true);
+
+    expect(connectOptionsFrom(connect)).not.toHaveProperty("servername");
+  });
+
+  it("omits servername for a bracketed IPv6 gateway host (#7527)", async () => {
+    vi.stubEnv("OPENSHELL_LOCAL_TLS_DIR", writeLocalTlsDir());
+    const connect = spyOnHttp2Connect();
+
+    await expect(
+      isDockerDriverGatewayHttpReady(1_000, "https://[::1]:8080/openshell.v1.OpenShell/Health"),
+    ).resolves.toBe(true);
+
+    expect(connectOptionsFrom(connect)).not.toHaveProperty("servername");
+  });
+
+  it("keeps servername for a DNS gateway hostname (#7527)", async () => {
+    vi.stubEnv("OPENSHELL_LOCAL_TLS_DIR", writeLocalTlsDir());
+    const connect = spyOnHttp2Connect();
+
+    await expect(
+      isDockerDriverGatewayHttpReady(
+        1_000,
+        "https://host.openshell.internal:8080/openshell.v1.OpenShell/Health",
+      ),
+    ).resolves.toBe(true);
+
+    expect(connectOptionsFrom(connect).servername).toBe("host.openshell.internal");
   });
 });

--- a/src/lib/onboard/gateway-http-readiness.test.ts
+++ b/src/lib/onboard/gateway-http-readiness.test.ts
@@ -94,8 +94,6 @@ describe("isDockerDriverGatewayHttpReady TLS servername", () => {
   const tlsDirs: string[] = [];
 
   afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.restoreAllMocks();
     for (const dir of tlsDirs.splice(0)) {
       fs.rmSync(dir, { force: true, recursive: true });
     }

--- a/src/lib/onboard/gateway-http-readiness.test.ts
+++ b/src/lib/onboard/gateway-http-readiness.test.ts
@@ -94,6 +94,8 @@ describe("isDockerDriverGatewayHttpReady TLS servername", () => {
   const tlsDirs: string[] = [];
 
   afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
     for (const dir of tlsDirs.splice(0)) {
       fs.rmSync(dir, { force: true, recursive: true });
     }

--- a/src/lib/onboard/gateway-http-readiness.ts
+++ b/src/lib/onboard/gateway-http-readiness.ts
@@ -13,6 +13,7 @@
 import fs from "node:fs";
 import http from "node:http";
 import http2 from "node:http2";
+import net from "node:net";
 import path from "node:path";
 
 import { getGatewayHttpEndpoint, getGatewayHttpsEndpoint } from "../core/gateway-address";
@@ -229,13 +230,21 @@ function dockerDriverGatewayHttp2ConnectOptions(
   const localTlsDir = process.env.OPENSHELL_LOCAL_TLS_DIR;
   if (!localTlsDir) return undefined;
   try {
-    return {
+    const options: http2.SecureClientSessionOptions = {
       ca: fs.readFileSync(path.join(localTlsDir, "ca.crt")),
       cert: fs.readFileSync(path.join(localTlsDir, "client", "tls.crt")),
       key: fs.readFileSync(path.join(localTlsDir, "client", "tls.key")),
       rejectUnauthorized: true,
-      servername: parsed.hostname,
     };
+    // Node 25 rejects an IP-literal TLS ServerName (RFC 6066; DEP0123 became a
+    // thrown error). For IP endpoints, certificate verification matches the
+    // connection IP against the certificate's IP SANs without SNI, so only
+    // send servername for DNS hostnames.
+    const bareHostname = parsed.hostname.replace(/^\[(.*)\]$/, "$1");
+    if (net.isIP(bareHostname) === 0) {
+      options.servername = parsed.hostname;
+    }
+    return options;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

On Node.js 25 and newer, the Docker-driver gateway health probe throws at `http2.connect` because it sets the TLS `servername` option to the probe URL's IP-literal hostname (`127.0.0.1`), which Node 25 rejects (`ERR_INVALID_ARG_VALUE`, formerly deprecation DEP0123); the probe's catch reports each poll as not ready, so `nemoclaw onboard` fails the gateway health wait against a healthy gateway. This change sends `servername` only for DNS hostnames — for IP endpoints, certificate verification matches the connection IP against the certificate's IP SANs without SNI, so onboarding passes the health wait on every supported Node version.

## Related Issue

Fixes #7527

## Changes

- `src/lib/onboard/gateway-http-readiness.ts`: `dockerDriverGatewayHttp2ConnectOptions` sets `servername` only when the probe hostname is not an IP literal (`net.isIP` on the bracket-stripped hostname, covering bracketed IPv6).
- `src/lib/onboard/gateway-http-readiness.test.ts`: three regression tests — IP-literal host omits `servername`, bracketed IPv6 host omits `servername`, DNS hostname keeps `servername`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the fix restores documented onboarding behavior (the health wait succeeding against a healthy gateway); no page under `docs/` describes the probe's TLS internals or the failing behavior, so no page is stale.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed; the reviewer checked `docs/` for pages describing the gateway health probe, TLS `servername`, or Node 25 behavior and found none stale; the dated changelog entry is pre-tag release prep, not a per-PR obligation. Re-run for maintainer commits bd434d896 and 153e375df (test-only teardown change and its revert; head tree is identical to the originally reviewed 464fb0e5b): pass, no docs impact.
- Agent: Claude Code
<!-- docs-review-head-sha: 153e375df -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/onboard/gateway-http-readiness.test.ts` → 5 passed (2 pre-existing, 3 new); `npm run typecheck:cli` → clean
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charles Parker <charles@parkerfolk.net>
