### PR TITLE
fix(policy): register shared network schema at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "nemoclaw/openclaw.plugin.json",
     "nemoclaw/package.json",
     "nemoclaw-blueprint/",
+    "schemas/network-policy.schema.json",
     "schemas/sandbox-policy.schema.json",
     "scripts/",
     "docs/resources/local-credential-form.html",

--- a/src/lib/policy/sandbox-policy-validation.ts
+++ b/src/lib/policy/sandbox-policy-validation.ts
@@ -10,6 +10,7 @@ import Ajv from "ajv/dist/2020.js";
 import { parseOpenShellPolicy } from "./merge";
 
 const PACKAGE_ROOT = path.resolve(__dirname, "..", "..", "..");
+const NETWORK_POLICY_SCHEMA_PATH = path.join(PACKAGE_ROOT, "schemas", "network-policy.schema.json");
 const SANDBOX_POLICY_SCHEMA_PATH = path.join(PACKAGE_ROOT, "schemas", "sandbox-policy.schema.json");
 const MAX_SCHEMA_ERRORS = 3;
 const MAX_SCHEMA_ERROR_MESSAGE_CHARS = 120;
@@ -20,13 +21,27 @@ let cachedSandboxPolicyValidator: ValidateFunction<unknown> | null = null;
 function loadSandboxPolicyValidator(): ValidateFunction<unknown> {
   if (cachedSandboxPolicyValidator) return cachedSandboxPolicyValidator;
 
-  let schema: AnySchemaObject;
+  let networkPolicySchema: AnySchemaObject;
+  let sandboxPolicySchema: AnySchemaObject;
   try {
-    const parsed: unknown = JSON.parse(fs.readFileSync(SANDBOX_POLICY_SCHEMA_PATH, "utf-8"));
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    const networkPolicyParsed: unknown = JSON.parse(
+      fs.readFileSync(NETWORK_POLICY_SCHEMA_PATH, "utf-8"),
+    );
+    const sandboxPolicyParsed: unknown = JSON.parse(
+      fs.readFileSync(SANDBOX_POLICY_SCHEMA_PATH, "utf-8"),
+    );
+    if (
+      !networkPolicyParsed ||
+      typeof networkPolicyParsed !== "object" ||
+      Array.isArray(networkPolicyParsed) ||
+      !sandboxPolicyParsed ||
+      typeof sandboxPolicyParsed !== "object" ||
+      Array.isArray(sandboxPolicyParsed)
+    ) {
       throw new Error("schema root is not an object");
     }
-    schema = parsed as AnySchemaObject;
+    networkPolicySchema = networkPolicyParsed as AnySchemaObject;
+    sandboxPolicySchema = sandboxPolicyParsed as AnySchemaObject;
   } catch {
     throw new Error(
       "Sandbox policy validation schema is unavailable from this NemoClaw installation.",
@@ -34,7 +49,9 @@ function loadSandboxPolicyValidator(): ValidateFunction<unknown> {
   }
 
   try {
-    const compiled = new Ajv({ allErrors: true, strict: false, $data: true }).compile(schema);
+    const ajv = new Ajv({ allErrors: true, strict: false, $data: true });
+    ajv.addSchema(networkPolicySchema);
+    const compiled = ajv.compile(sandboxPolicySchema);
     cachedSandboxPolicyValidator = compiled;
     return compiled;
   } catch {

--- a/test/package-contract/openshell-policy-boundary.test.ts
+++ b/test/package-contract/openshell-policy-boundary.test.ts
@@ -211,6 +211,9 @@ describe("OpenShell policy boundary package contract", () => {
       const archivePath = path.join(tempDir, archives[0]!);
       execFileSync("tar", ["-xzf", archivePath, "-C", tempDir]);
       const installedRoot = path.join(tempDir, "package");
+      expect(fs.existsSync(path.join(installedRoot, "schemas", "network-policy.schema.json"))).toBe(
+        true,
+      );
       expect(fs.existsSync(path.join(installedRoot, "schemas", "sandbox-policy.schema.json"))).toBe(
         true,
       );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restore runtime sandbox-policy validation after #6877 extracted network policy definitions into an external schema. The runtime validator now registers that shared schema before compiling the sandbox schema, and the published package ships both files.

## Changes

- Load and register `network-policy.schema.json` before compiling the sandbox policy schema.
- Include the shared schema in the npm package.
- Extend the out-of-tree package contract to prove the referenced schema is shipped and runtime validation succeeds.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores the existing schema-validation behavior and package contents. It does not change policy syntax, CLI behavior, configuration, or a user procedure.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer comparison confirmed the runtime registers only the trusted schema shipped by NemoClaw. Policy semantics, rejected input handling, and bounded error disclosure remain unchanged. Independent PR approval remains required before merge.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The writer reviewed the live body and exact three-file diff against `WRITING.md` and `docs/CONTRIBUTING.md`. The fix restores existing policy validation and package contents without changing the schema, configuration, supported behavior, or user workflow.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d133ec1f5 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: The installed package validator contract passes 1/1, and the focused policy suites pass 56/56.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused three-file integration repair.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Follow-up to #6877. Supersedes duplicate #7533 and preserves Ho Lim's original-author credit.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Ho Lim <subhoya@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox policy validation by incorporating network policy schema checks.
  * Added clearer handling when required policy schemas are unavailable or validation cannot be initialized.

* **Chores**
  * Ensured the network policy schema is included in published packages.
  * Expanded package verification to confirm the schema is available after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
