### PR TITLE
fix(policy): register shared network schema at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "nemoclaw/openclaw.plugin.json",
     "nemoclaw/package.json",
     "nemoclaw-blueprint/",
+    "schemas/network-policy.schema.json",
     "schemas/sandbox-policy.schema.json",
     "scripts/",
     "docs/resources/local-credential-form.html",

--- a/src/lib/policy/sandbox-policy-validation.ts
+++ b/src/lib/policy/sandbox-policy-validation.ts
@@ -10,6 +10,7 @@ import Ajv from "ajv/dist/2020.js";
 import { parseOpenShellPolicy } from "./merge";
 
 const PACKAGE_ROOT = path.resolve(__dirname, "..", "..", "..");
+const NETWORK_POLICY_SCHEMA_PATH = path.join(PACKAGE_ROOT, "schemas", "network-policy.schema.json");
 const SANDBOX_POLICY_SCHEMA_PATH = path.join(PACKAGE_ROOT, "schemas", "sandbox-policy.schema.json");
 const MAX_SCHEMA_ERRORS = 3;
 const MAX_SCHEMA_ERROR_MESSAGE_CHARS = 120;
@@ -20,13 +21,27 @@ let cachedSandboxPolicyValidator: ValidateFunction<unknown> | null = null;
 function loadSandboxPolicyValidator(): ValidateFunction<unknown> {
   if (cachedSandboxPolicyValidator) return cachedSandboxPolicyValidator;
 
-  let schema: AnySchemaObject;
+  let networkPolicySchema: AnySchemaObject;
+  let sandboxPolicySchema: AnySchemaObject;
   try {
-    const parsed: unknown = JSON.parse(fs.readFileSync(SANDBOX_POLICY_SCHEMA_PATH, "utf-8"));
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    const parsedNetworkPolicySchema: unknown = JSON.parse(
+      fs.readFileSync(NETWORK_POLICY_SCHEMA_PATH, "utf-8"),
+    );
+    const parsedSandboxPolicySchema: unknown = JSON.parse(
+      fs.readFileSync(SANDBOX_POLICY_SCHEMA_PATH, "utf-8"),
+    );
+    if (
+      !parsedNetworkPolicySchema ||
+      typeof parsedNetworkPolicySchema !== "object" ||
+      Array.isArray(parsedNetworkPolicySchema) ||
+      !parsedSandboxPolicySchema ||
+      typeof parsedSandboxPolicySchema !== "object" ||
+      Array.isArray(parsedSandboxPolicySchema)
+    ) {
       throw new Error("schema root is not an object");
     }
-    schema = parsed as AnySchemaObject;
+    networkPolicySchema = parsedNetworkPolicySchema as AnySchemaObject;
+    sandboxPolicySchema = parsedSandboxPolicySchema as AnySchemaObject;
   } catch {
     throw new Error(
       "Sandbox policy validation schema is unavailable from this NemoClaw installation.",
@@ -34,7 +49,9 @@ function loadSandboxPolicyValidator(): ValidateFunction<unknown> {
   }
 
   try {
-    const compiled = new Ajv({ allErrors: true, strict: false, $data: true }).compile(schema);
+    const ajv = new Ajv({ allErrors: true, strict: false, $data: true });
+    ajv.addSchema(networkPolicySchema);
+    const compiled = ajv.compile(sandboxPolicySchema);
     cachedSandboxPolicyValidator = compiled;
     return compiled;
   } catch {

--- a/test/package-contract/openshell-policy-boundary.test.ts
+++ b/test/package-contract/openshell-policy-boundary.test.ts
@@ -214,6 +214,9 @@ describe("OpenShell policy boundary package contract", () => {
       expect(fs.existsSync(path.join(installedRoot, "schemas", "sandbox-policy.schema.json"))).toBe(
         true,
       );
+      expect(fs.existsSync(path.join(installedRoot, "schemas", "network-policy.schema.json"))).toBe(
+        true,
+      );
       expect(
         fs.existsSync(
           path.join(installedRoot, "dist", "lib", "policy", "sandbox-policy-validation.js"),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

After #6877 and #7194 merged, the runtime sandbox-policy compiler could not resolve the external network-policy schema. This PR registers and ships that schema so source and installed-package validation initialize again.

## Changes

- Load and register the canonical network-policy schema before AJV compiles the sandbox-policy schema.
- Include the network-policy schema in the npm package allowlist.
- Extend the installed-package contract to require the referenced schema.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores the existing schema-validation and package contract. It changes no command, configuration, schema, default, output, or workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex completed the nine-category review. The shipped schemas remain trusted local inputs, validation fails closed, and the diff changes no auth, network, secret, dependency, or crypto behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed package.json, src/lib/policy/sandbox-policy-validation.ts, and test/package-contract/openshell-policy-boundary.test.ts. Existing network-policy docs remain accurate. CLI build and typecheck passed; 36 focused policy tests, 48 configuration validations, 681 affected tests, and all 7 OpenShell policy package-contract tests passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b22007061 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a Signed-off-by: line and every commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed, or npm run check:diff passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: CLI build and typecheck; 36 focused policy tests; 48 configuration validations; npm run test:changed (681 tests); full 7-test OpenShell policy package contract.
- [ ] Applicable broad gate passed — npm test for broad runtime/test-harness changes; npm run check for repo-wide validation/coverage changes — command/result: Not applicable to this three-file integration repair.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the network policy schema to the published package.
  * Sandbox policy validation now incorporates network policy rules for more complete validation.

* **Bug Fixes**
  * Improved validator initialization checks when required policy schemas are missing, unreadable, or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->