### PR TITLE
fix(ci): install hadolint for docs-only checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,6 +63,18 @@ jobs:
       - name: Install docs-only check dependencies
         run: npm install --ignore-scripts
 
+      - name: Install hadolint
+        shell: bash
+        run: |
+          set -euo pipefail
+          HADOLINT_VERSION="v2.14.0"
+          HADOLINT_URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-linux-x86_64"
+          HADOLINT_SHA256="6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47"
+          curl -fsSL -o /usr/local/bin/hadolint "$HADOLINT_URL"
+          ACTUAL=$(sha256sum /usr/local/bin/hadolint | awk '{print $1}')
+          [ "$HADOLINT_SHA256" = "$ACTUAL" ] || { echo "::error::hadolint checksum mismatch"; exit 1; }
+          chmod +x /usr/local/bin/hadolint
+
       - name: Fetch checked-out merge base for docs-only checks
         shell: bash
         run: |

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -1119,13 +1119,12 @@ describe("pull request and main workflow contracts", () => {
 
   // source-shape-contract: security -- Downloaded CI tooling must use a committed digest rather than upstream metadata
   it("pins downloaded CI tooling to reviewed integrity", () => {
-    const staticRunsJoined = stepRuns(sharedActions.staticChecks).join("\n");
-
-    expect(staticRunsJoined).toContain(
-      'HADOLINT_SHA256="6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47"',
-    );
-    expect(staticRunsJoined).not.toContain('"${HADOLINT_URL}.sha256"');
-    expect(staticRunsJoined).not.toContain("EXPECTED=$(curl");
+    const docsRuns = stepRuns(prWorkflow.jobs["docs-only-checks"]).join("\n");
+    for (const runs of [stepRuns(sharedActions.staticChecks).join("\n"), docsRuns]) {
+      expect(runs).toContain("6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47");
+      expect(runs).not.toMatch(/HADOLINT_URL.*sha256|EXPECTED=\$\(curl/);
+    }
+    expect(docsRuns.indexOf("HADOLINT_SHA256")).toBeLessThan(docsRuns.indexOf("prek run"));
   });
 
   it("validates CLI shard inputs before using them in shell commands", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Docs-only pull requests run the system `hadolint` hook without installing its executable, so their required check fails before reviewing Dockerfiles. Install the same pinned and checksum-verified hadolint release used by static checks before the docs-only hook suite.

## Changes

- Install hadolint 2.14.0 in the docs-only job and verify its reviewed SHA-256 digest.
- Extend the workflow contract test to cover the hadolint pin in both jobs and require installation before `prek run`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This only corrects dependency setup in an internal GitHub Actions job.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `.github/workflows/pr.yaml` and `test/pr-workflow-contract.test.ts` only change internal CI setup and its contract test; no user command, configuration, output, or supported behavior changes. No writing-rule findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7bf559675 -->
<!-- docs-review-agents-blob-sha: 9c9b36d7f -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/pr-workflow-contract.test.ts` passed 22 tests; the regression failed before the workflow fix.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: [CI / Pull Request run 30175517417](https://github.com/NVIDIA/NemoClaw/actions/runs/30175517417) passed static checks, all eight CLI coverage shards, and merged coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation checks by adding verified Dockerfile linting.
  * CI tooling is now pinned to a reviewed version and checksum for more reliable validation.

* **Tests**
  * Expanded workflow validation to cover Dockerfile linting in documentation checks.
  * Added checks for tool integrity and execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->