### PR TITLE
ci(e2e): add orchestration job timeouts

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -150,6 +150,7 @@ jobs:
   generate-matrix:
     needs: base-image-publication
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.controller_matrix.outputs.matrix || steps.matrix.outputs.matrix }}
       test_matrix: ${{ steps.matrix.outputs.test_matrix }}
@@ -5872,6 +5873,7 @@ jobs:
   # comment.
   report-to-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # This entire workflow is dispatch-only. Keeping selective jobs in `needs`
     # makes the report wait for and record any requested job without adding
     # skipped checks to the normal pull_request workflow.
@@ -6011,6 +6013,7 @@ jobs:
   # ── Scheduled/manual scorecard ────────────────────────────────────────────
   scorecard:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: *e2e-result-jobs
     if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.checkout_sha == '')) }}
     permissions:

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -221,6 +221,23 @@ describe("e2e workflow boundary", () => {
     );
   });
 
+  it("keeps orchestration jobs within bounded timeouts", () => {
+    const workflow = readWorkflow() as {
+      jobs: Record<string, { "timeout-minutes"?: number }>;
+    };
+    workflow.jobs["generate-matrix"]!["timeout-minutes"] = 11;
+    delete workflow.jobs["report-to-pr"]!["timeout-minutes"];
+    workflow.jobs.scorecard!["timeout-minutes"] = 16;
+
+    expect(validateE2eWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "generate-matrix job must keep the 10 minute timeout",
+        "report-to-pr job must keep the 15 minute timeout",
+        "scorecard job must keep the 15 minute timeout",
+      ]),
+    );
+  });
+
   it("keeps controller target selection bound to the generated matrix (#7031)", () => {
     const workflow = readWorkflow() as {
       jobs: Record<

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -4176,6 +4176,9 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
   if (generateMatrix["runs-on"] !== "ubuntu-latest") {
     errors.push("generate-matrix job must run on ubuntu-latest");
   }
+  if (generateMatrix["timeout-minutes"] !== 10) {
+    errors.push("generate-matrix job must keep the 10 minute timeout");
+  }
   const generateOutputs = asRecord(generateMatrix.outputs);
   if (
     generateOutputs.matrix !==
@@ -4680,6 +4683,9 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
   if (Object.keys(reportToPr).length === 0) {
     errors.push("workflow missing report-to-pr job");
   } else {
+    if (reportToPr["timeout-minutes"] !== 15) {
+      errors.push("report-to-pr job must keep the 15 minute timeout");
+    }
     const needs = Array.isArray(reportToPr.needs) ? reportToPr.needs : [];
     for (const required of ["generate-matrix", "live"]) {
       if (!needs.includes(required)) errors.push(`report-to-pr job must wait for ${required}`);
@@ -4797,6 +4803,11 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
         );
       }
     }
+  }
+
+  const scorecard = asRecord(jobs.scorecard);
+  if (scorecard["timeout-minutes"] !== 15) {
+    errors.push("scorecard job must keep the 15 minute timeout");
   }
 
   return errors;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The E2E matrix generator, PR reporter, and scheduled scorecard now have explicit short job budgets instead of inheriting GitHub Actions' default timeout. Live test budgets and retry behavior are unchanged.

## Related Issue

Part of #7451

## Changes

- Bound `generate-matrix` to 10 minutes.
- Bound `report-to-pr` and `scorecard` to 15 minutes each.
- Extend the E2E workflow validator and focused negative test to reject missing or changed orchestration budgets.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only internal GitHub Actions orchestration budgets and their executable validator contract; no CLI, configuration, API, policy, or supported runtime behavior changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The diff only bounds three internal E2E orchestration jobs and enforces those values in the existing workflow validator. No existing documentation promises these internal job names or timeout values.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b0c8455d1 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set — `npx vitest run --project e2e-support test/e2e/support/e2e-workflow.test.ts`: 43/43 passed; `env -u E2E_LARGER_RUNNER_LABEL npm run test:changed -- --maxWorkers=2`: 210/210 passed.
- [ ] Applicable broad gate passed — not required for this focused three-file workflow-contract change; focused tests and normal hooks passed, with broad coverage delegated to CI.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit execution time limits to key end-to-end workflow jobs.
  * Improved workflow validation to detect missing or incorrect timeout settings.

* **Tests**
  * Added coverage to verify timeout requirements for matrix generation, result reporting, and scorecard jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->