### PR TITLE
fix(sandbox): scope gateway failure checks to sandbox gateway

### DIFF
--- a/src/lib/actions/sandbox/gateway-failure-classifier.ts
+++ b/src/lib/actions/sandbox/gateway-failure-classifier.ts
@@ -7,10 +7,11 @@ import { dockerInfo } from "../../adapters/docker/info";
 import { dockerCapture } from "../../adapters/docker/run";
 import { CLI_NAME } from "../../cli/branding";
 import { GATEWAY_PORT } from "../../core/ports";
+import { resolveGatewayPortFromName } from "../../onboard/gateway-binding";
 import * as registry from "../../state/registry";
+import { getSandboxTargetGatewayName } from "./gateway-target";
 import { resolveSandboxContainerOwner } from "./sandbox-container-owner";
 
-const DEFAULT_CONTAINER = "openshell-cluster-nemoclaw";
 const DOCKER_TIMEOUT_MS = 3000;
 const PORT_PROBE_TIMEOUT_MS = 2000;
 
@@ -99,8 +100,16 @@ const defaultRunners: GatewayFailureRunners = {
   portProbe: defaultPortProbe,
 };
 
+function resolveGatewayFailureTarget(sandboxName: string): { container: string; port: number } {
+  const gatewayName = getSandboxTargetGatewayName(sandboxName);
+  return {
+    container: `openshell-cluster-${gatewayName}`,
+    port: resolveGatewayPortFromName(gatewayName) ?? GATEWAY_PORT,
+  };
+}
+
 export async function classifyGatewayFailure(
-  _sandboxName: string,
+  sandboxName: string,
   opts?: { runners?: GatewayFailureRunners },
 ): Promise<GatewayFailureResult> {
   const runners = opts?.runners ?? defaultRunners;
@@ -112,10 +121,12 @@ export async function classifyGatewayFailure(
     };
   }
 
-  if (runners.dockerIsRunning(DEFAULT_CONTAINER)) {
+  const target = resolveGatewayFailureTarget(sandboxName);
+
+  if (runners.dockerIsRunning(target.container)) {
     return {
       layer: "gateway_unreachable",
-      detail: `Container '${DEFAULT_CONTAINER}' is running but the gateway API is not responding.`,
+      detail: `Container '${target.container}' is running but the gateway API is not responding.`,
     };
   }
 
@@ -123,23 +134,23 @@ export async function classifyGatewayFailure(
   // "removed/never created" — only the former can hit container_exited*. Per
   // issue #3271 AC: container_exited_port_conflict requires `docker ps -a` to
   // confirm the container exited rather than being absent.
-  if (!runners.dockerExists(DEFAULT_CONTAINER)) {
+  if (!runners.dockerExists(target.container)) {
     return {
       layer: "container_missing",
-      detail: `Container '${DEFAULT_CONTAINER}' is not present (never created or removed).`,
+      detail: `Container '${target.container}' is not present (never created or removed).`,
     };
   }
 
-  const portInUse = await runners.portProbe(GATEWAY_PORT);
+  const portInUse = await runners.portProbe(target.port);
   if (portInUse) {
     return {
       layer: "container_exited_port_conflict",
-      detail: `Container '${DEFAULT_CONTAINER}' exited, and port ${GATEWAY_PORT} is held by another process.`,
+      detail: `Container '${target.container}' exited, and port ${target.port} is held by another process.`,
     };
   }
   return {
     layer: "container_exited",
-    detail: `Container '${DEFAULT_CONTAINER}' exited.`,
+    detail: `Container '${target.container}' exited.`,
   };
 }
 
@@ -232,8 +243,8 @@ export async function classifySandboxContainerFailure(
 type SandboxDriverLookup = (name: string) => { openshellDriver?: string | null } | null | undefined;
 
 // Drivers whose sandbox runtime does NOT live in the local Docker daemon. Only
-// `vm` qualifies: the NemoClaw gateway always runs as the local Docker
-// container `openshell-cluster-nemoclaw` (see classifyGatewayFailure), so the
+// `vm` qualifies: the NemoClaw gateway always runs as a local Docker container
+// scoped to the sandbox's target gateway (see classifyGatewayFailure), so the
 // `docker` driver and the `kubernetes`/k3s driver (k3s-in-Docker, or Docker
 // Desktop's Kubernetes — selected by `isLinuxDockerDriverGatewayEnabled()` for
 // non-Linux/non-arm64 hosts) both depend on a reachable local Docker daemon. A

--- a/test/gateway-failure-classifier.test.ts
+++ b/test/gateway-failure-classifier.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   classifyGatewayFailure,
@@ -12,6 +12,7 @@ import {
   printDockerRuntimeDownGuidance,
   type SandboxContainerFailureRunners,
 } from "../src/lib/actions/sandbox/gateway-failure-classifier.js";
+import * as registry from "../src/lib/state/registry.js";
 
 function makeRunners(overrides: Partial<GatewayFailureRunners> = {}): GatewayFailureRunners {
   return {
@@ -76,6 +77,44 @@ describe("classifyGatewayFailure", () => {
     });
     expect(result.layer).toBe("container_exited");
     expect(result.detail).toContain("exited");
+  });
+
+  it("uses the sandbox owning gateway container and port for non-default gateway sandboxes", async () => {
+    const getSandbox = vi.spyOn(registry, "getSandbox").mockReturnValue({
+      name: "my-sandbox",
+      gatewayName: "nemoclaw-8081",
+      gatewayPort: 8081,
+    } as never);
+    const checkedRunning: string[] = [];
+    const checkedExisting: string[] = [];
+    const probedPorts: number[] = [];
+
+    try {
+      const result = await classifyGatewayFailure("my-sandbox", {
+        runners: makeRunners({
+          dockerIsRunning: (container) => {
+            checkedRunning.push(container);
+            return false;
+          },
+          dockerExists: (container) => {
+            checkedExisting.push(container);
+            return container === "openshell-cluster-nemoclaw-8081";
+          },
+          portProbe: async (port) => {
+            probedPorts.push(port);
+            return false;
+          },
+        }),
+      });
+
+      expect(result.layer).toBe("container_exited");
+      expect(result.detail).toContain("openshell-cluster-nemoclaw-8081");
+      expect(checkedRunning).toEqual(["openshell-cluster-nemoclaw-8081"]);
+      expect(checkedExisting).toEqual(["openshell-cluster-nemoclaw-8081"]);
+      expect(probedPorts).toEqual([8081]);
+    } finally {
+      getSandbox.mockRestore();
+    }
   });
 
   it("does not call dockerIsRunning / dockerExists / portProbe when docker info fails", async () => {


### PR DESCRIPTION
## Summary

This fixes gateway failure classification for sandboxes that use a non-default `NEMOCLAW_GATEWAY_PORT`. The classifier now resolves the sandbox's owning gateway container and port before reporting gateway runtime failures, instead of probing the default gateway container and port.

## Related Issue

Fixes #7348

## Changes

- Resolve gateway failure checks through the existing sandbox target gateway helper.
- Use the resolved gateway port when distinguishing exited-container port conflicts.
- Add a regression for a non-default gateway sandbox using `nemoclaw-8081` and port `8081`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: classifier behavior changed, but no user-facing command text or documentation path changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending maintainer review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: CI is pending after the latest push.

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed; the patch is limited to gateway failure classification behavior and its regression test.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d31dfd2 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub — commit `d31dfd279` reports `verified: true`, reason `valid`.
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — `npm run check:diff` passed locally on `d31dfd279`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project integration test/gateway-failure-classifier.test.ts --reporter=dot` passed locally on `d31dfd279`: 30 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable for this narrow classifier patch. For due diligence, `npm test` was attempted locally and exited 1 with 270 failed, 20,253 passed, and 253 skipped tests; failures were in unrelated installer/onboard/Hermes/runtime areas and host prerequisites, not in the touched classifier regression.
- [ ] Quality Gates section completed with required justifications or waivers — sensitive-path maintainer review is pending.
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Disclosure: This PR was prepared with AI assistance under human direction and review.

Signed-off-by: ScarabSystems <scarab.systems@yahoo.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway failure detection now checks the correct sandbox-specific container and port instead of using a fixed target.
  * Failure details more accurately identify the gateway container and port involved.

* **Tests**
  * Added coverage for non-default gateway sandboxes to verify target selection and failure classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->