### PR TITLE
fix(installer): avoid vLLM process false positives

### DIFF
--- a/scripts/lib/station-vllm-conflict.sh
+++ b/scripts/lib/station-vllm-conflict.sh
@@ -101,10 +101,15 @@ station_vllm_workload_active() {
   if awk '
     {
       comm=tolower($3)
+      executable=tolower($4)
+      sub(/^.*\//, "", executable)
       $1=$2=$3=""
       args=tolower($0)
-      if (comm == "vllm" ||
-          args ~ /(^|[[:space:]\/])vllm([[:space:]:]|\.js([[:space:]]|$)|$)/) {
+      python_module=(comm ~ /^python([0-9]+([.][0-9]+)*)?$/ &&
+                     args ~ /(^|[[:space:]])-m[[:space:]]+vllm([[:space:].]|$)/)
+      docker_init=(comm == "docker-init" &&
+                   args ~ /(^|[[:space:]])--[[:space:]]+([^[:space:]]*\/)?vllm([[:space:]]|$)/)
+      if (comm == "vllm" || executable == "vllm" || python_module || docker_init) {
         found=1
       }
     }

--- a/scripts/prepare-dgx-station-host.sh
+++ b/scripts/prepare-dgx-station-host.sh
@@ -1325,11 +1325,16 @@ check_agent_and_inference_conflicts() {
       pid=$1
       ppid=$2
       comm=tolower($3)
+      executable=tolower($4)
+      sub(/^.*\//, "", executable)
       $1=$2=$3=""
       args=tolower($0)
       if (pid == self || pid == parent) next
-      if (comm == "vllm" ||
-          args ~ /(^|[[:space:]\/])vllm([[:space:]:]|\.js([[:space:]]|$)|$)/) {
+      python_module=(comm ~ /^python([0-9]+([.][0-9]+)*)?$/ &&
+                     args ~ /(^|[[:space:]])-m[[:space:]]+vllm([[:space:].]|$)/)
+      docker_init=(comm == "docker-init" &&
+                   args ~ /(^|[[:space:]])--[[:space:]]+([^[:space:]]*\/)?vllm([[:space:]]|$)/)
+      if (comm == "vllm" || executable == "vllm" || python_module || docker_init) {
         print "pid=" pid " process=" comm " stop_command=\047kill -- " pid "\047"
       }
     }

--- a/test/install-station-host-preparation.test.ts
+++ b/test/install-station-host-preparation.test.ts
@@ -424,33 +424,44 @@ ensure_cdi_runtime
     expect(output).toContain("cdi_contract=pass_after_refresh");
   });
 
-  it("ignores the installer process while still blocking a real vLLM workload", () => {
-    const selfOnly = runSourced(
+  it("ignores installer and diagnostic processes that mention vLLM", () => {
+    const diagnostics = runSourced(
       STATION_PREPARE,
       `
 ps() {
   printf '%s %s bash bash /tmp/NemoClaw/scripts/prepare-dgx-station-host.sh --apply\n' "$$" "$PPID"
   printf '%s 1 bash bash /tmp/NemoClaw/scripts/install.sh\n' "$PPID"
+  printf '5464 1 grep grep -qi vllm\n'
+  printf '5465 1 rg rg vllm /var/log/station.log\n'
+  printf '5466 1 bash bash -c docker image ls | grep -qi vllm\n'
 }
 ss() { :; }
 check_agent_and_inference_conflicts
 `,
     );
-    expect(selfOnly.result.status, selfOnly.output).toBe(0);
+    expect(diagnostics.result.status, diagnostics.output).toBe(0);
+    expect(diagnostics.output).toContain("agent_inference_workloads=none port_8000=free");
+  });
 
+  it("blocks vLLM executables and Python modules without exposing model names", () => {
     const active = runSourced(
       STATION_PREPARE,
       `
-ps() { printf '999 1 python python -m vllm serve sensitive-model-name\n'; }
+ps() {
+  printf '998 1 vllm /usr/local/bin/vllm serve first-sensitive-model\n'
+  printf '999 1 python3 python3 -m vllm.entrypoints.openai.api_server --model second-sensitive-model\n'
+}
 ss() { :; }
 check_agent_and_inference_conflicts
 `,
     );
     expect(active.result.status, active.output).toBe(12);
-    expect(active.output).toMatch(/vLLM inference workload is active: pid=999 process=python/);
+    expect(active.output).toMatch(/vLLM inference workload is active: pid=998 process=vllm/);
+    expect(active.output).toContain("pid=999 process=python3");
+    expect(active.output).toContain("stop_command='kill -- 998'");
     expect(active.output).toContain("stop_command='kill -- 999'");
-    expect(active.output).toContain("NemoClaw did not stop or modify it");
-    expect(active.output).not.toContain("sensitive-model-name");
+    expect(active.output).not.toContain("first-sensitive-model");
+    expect(active.output).not.toContain("second-sensitive-model");
   });
 
   it("blocks vLLM during forced factory-runtime validation", () => {

--- a/test/install-station-host-preparation.test.ts
+++ b/test/install-station-host-preparation.test.ts
@@ -449,7 +449,8 @@ check_agent_and_inference_conflicts
       `
 ps() {
   printf '998 1 vllm /usr/local/bin/vllm serve first-sensitive-model\n'
-  printf '999 1 python3 python3 -m vllm.entrypoints.openai.api_server --model second-sensitive-model\n'
+  printf '999 1 python3 python3 -u -m vllm.entrypoints.openai.api_server --model second-sensitive-model\n'
+  printf '1000 1 docker-init docker-init -- /usr/bin/vllm serve third-sensitive-model\n'
 }
 ss() { :; }
 check_agent_and_inference_conflicts
@@ -458,10 +459,13 @@ check_agent_and_inference_conflicts
     expect(active.result.status, active.output).toBe(12);
     expect(active.output).toMatch(/vLLM inference workload is active: pid=998 process=vllm/);
     expect(active.output).toContain("pid=999 process=python3");
+    expect(active.output).toContain("pid=1000 process=docker-init");
     expect(active.output).toContain("stop_command='kill -- 998'");
     expect(active.output).toContain("stop_command='kill -- 999'");
+    expect(active.output).toContain("stop_command='kill -- 1000'");
     expect(active.output).not.toContain("first-sensitive-model");
     expect(active.output).not.toContain("second-sensitive-model");
+    expect(active.output).not.toContain("third-sensitive-model");
   });
 
   it("blocks vLLM during forced factory-runtime validation", () => {

--- a/test/install-station-vllm-continuation.test.ts
+++ b/test/install-station-vllm-continuation.test.ts
@@ -47,6 +47,53 @@ function runStationPreparationSourced(body: string) {
 }
 
 describe("installer Station Local vLLM continuation", () => {
+  it("ignores diagnostic processes that mention vLLM", () => {
+    const { result, output } = runInstallerSourced(`
+load_station_vllm_conflict_helpers
+ps() {
+  printf '5464 1 grep grep -qi vllm\n'
+  printf '5465 1 rg rg vllm /var/log/station.log\n'
+  printf '5466 1 bash bash -c docker image ls | grep -qi vllm\n'
+}
+docker() { :; }
+if station_vllm_workload_active; then
+  printf 'UNEXPECTED_VLLM_WORKLOAD\n'
+else
+  printf 'NO_VLLM_WORKLOAD status=%s\n' "$?"
+fi
+`);
+
+    expect(result.status, output).toBe(0);
+    expect(output).toContain("NO_VLLM_WORKLOAD status=1");
+    expect(output).not.toContain("UNEXPECTED_VLLM_WORKLOAD");
+  });
+
+  it.each([
+    ["vLLM executable", "998 1 vllm /usr/local/bin/vllm serve hidden-model"],
+    [
+      "Python vLLM module",
+      "999 1 python3 python3 -m vllm.entrypoints.openai.api_server --model hidden-model",
+    ],
+    [
+      "docker-init vLLM executable",
+      "1000 1 docker-init docker-init -- /usr/bin/vllm serve hidden-model",
+    ],
+  ])("recognizes an active %s", (_name, processRow) => {
+    const { result, output } = runInstallerSourced(`
+load_station_vllm_conflict_helpers
+ps() { printf '%s\\n' ${JSON.stringify(processRow)}; }
+if station_vllm_workload_active; then
+  printf 'VLLM_WORKLOAD_ACTIVE\n'
+else
+  printf 'VLLM_WORKLOAD_MISSING status=%s\n' "$?"
+fi
+`);
+
+    expect(result.status, output).toBe(0);
+    expect(output).toContain("VLLM_WORKLOAD_ACTIVE");
+    expect(output).not.toContain("VLLM_WORKLOAD_MISSING");
+  });
+
   it("uses Docker stop guidance when a vLLM container is also visible in the host process table", () => {
     const { result, output } = runStationPreparationSourced(`
 MODE=--check

--- a/test/install-station-vllm-continuation.test.ts
+++ b/test/install-station-vllm-continuation.test.ts
@@ -75,8 +75,12 @@ fi
       "999 1 python3 python3 -m vllm.entrypoints.openai.api_server --model hidden-model",
     ],
     [
+      "Python vLLM module after interpreter options",
+      "1000 1 python3 python3 -u -X dev -m vllm.entrypoints.openai.api_server --model hidden-model",
+    ],
+    [
       "docker-init vLLM executable",
-      "1000 1 docker-init docker-init -- /usr/bin/vllm serve hidden-model",
+      "1001 1 docker-init docker-init -- /usr/bin/vllm serve hidden-model",
     ],
   ])("recognizes an active %s", (_name, processRow) => {
     const { result, output } = runInstallerSourced(`


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

DGX Station preparation treated unrelated diagnostic commands such as `grep -qi vllm` as active inference workloads. Process checks now require a vLLM executable or Python module launch while preserving existing container and port conflict checks.

## Changes

- Recognize direct vLLM executables, `python -m vllm` modules, and `docker-init` vLLM commands.
- Ignore `grep`, `rg`, and shell diagnostics that only mention `vllm` as data.
- Apply the same classification to Station preparation and saved Local vLLM continuation.
- Add regression coverage for false-positive diagnostics, real workload detection, and model-name redaction.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing Station documentation already limits the ownership flow to an existing vLLM workload. This fix restores that documented contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer implementation review is pending. The existing-vLLM ownership contract was accepted in PR #7285.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation path changed. Existing DGX Station documentation already describes the intended active-vLLM workload contract, and this fix excludes unrelated diagnostic processes from that contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a5f7262c7 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [x] Tested on DGX Station
- Tested commit: `a5f7262c7ea2aae5762deb30a7695e477aec8edb`
- Station profile/scenario: `pmgb300ws-0016`, generic Ubuntu 24.04.4 ARM64 on a DGX Station GB300. A bounded read-only check used the exact committed script bytes against diagnostic process rows and the running managed vLLM.
- Result: PASS. `grep`, `rg`, and shell diagnostic rows did not block. The real managed vLLM still produced exit `12`, Local vLLM continuation still detected it, ECC remained 0/0, and the managed container remained running.
- Supporting evidence: [Exact-commit DGX Station classifier evidence](https://github.com/NVIDIA/NemoClaw/pull/7541#issuecomment-5080778897)

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/install-station-host-preparation.test.ts test/install-station-vllm-continuation.test.ts` passed 65 tests. The related six-file Station suite passed five files; after building its required CLI artifacts, `test/install-preflight.test.ts` passed 94 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; the focused Station preparation and continuation suites cover this classifier change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
