### PR TITLE
fix(inference): strip provider marker from URL requests

### DIFF
--- a/nemoclaw-blueprint/scripts/nemotron-inference-fix.js
+++ b/nemoclaw-blueprint/scripts/nemotron-inference-fix.js
@@ -539,17 +539,23 @@
     var origRequest = mod.request;
 
     mod.request = function (options, callback) {
-      if (typeof options === 'string' || !options) {
+      var isUrlForm =
+        typeof options === 'string' ||
+        (typeof URL !== 'undefined' && options instanceof URL);
+      var requestOptions =
+        isUrlForm && callback && typeof callback === 'object' ? callback : options;
+      if (!requestOptions || typeof requestOptions !== 'object') {
         return origRequest.apply(mod, arguments);
       }
 
-      var upstreamProvider = upstreamProviderFromHeaders(options.headers);
+      var upstreamProvider = upstreamProviderFromHeaders(requestOptions.headers);
       var req = origRequest.apply(mod, arguments);
       if (upstreamProvider !== undefined && req.removeHeader) {
         req.removeHeader(UPSTREAM_PROVIDER_HEADER);
       }
 
       // Only intercept object-form calls with a recognisable path.
+      if (isUrlForm) return req;
       var path = options.path || '';
       if (!isChatCompletionsPost(options.method, path)) {
         return req;

--- a/test/nemotron-inference-fix.test.ts
+++ b/test/nemotron-inference-fix.test.ts
@@ -309,6 +309,63 @@ console.log(JSON.stringify(records));
     expect(missingProvider.thinking).toBe(false);
   });
 
+  it("preload removes the runtime provider marker from URL-form Node requests (#6913)", () => {
+    const preload = extractStartScriptHeredoc(src, "NEMOTRON_FIX_EOF");
+    const harness = `
+const http = require('http');
+const https = require('https');
+const records = [];
+function installStub(mod) {
+  mod.request = function (url, options) {
+    const record = {
+      url: String(url),
+      headers: { ...(options && options.headers) },
+      removed: [],
+    };
+    records.push(record);
+    return {
+      end() { return true; },
+      removeHeader(name) {
+        record.removed.push(name);
+        for (const key of Object.keys(record.headers)) {
+          if (key.toLowerCase() === String(name).toLowerCase()) delete record.headers[key];
+        }
+      },
+    };
+  };
+}
+installStub(http);
+installStub(https);
+${preload}
+http.request('http://inference.local/v1/models', {
+  headers: {
+    'X-NemoClaw-Upstream-Provider': 'nvidia-prod',
+    'X-Keep': 'http',
+  },
+}).end();
+https.request(new URL('https://inference.local/v1/models'), {
+  headers: {
+    'x-nemoclaw-upstream-provider': 'compatible-endpoint',
+    'X-Keep': 'https',
+  },
+}).end();
+console.log(JSON.stringify(records));
+`;
+
+    const result = spawnSync(process.execPath, ["-e", harness], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const records = JSON.parse(result.stdout.trim());
+
+    expect(records).toHaveLength(2);
+    expect(records[0].headers).toEqual({ "X-Keep": "http" });
+    expect(records[0].removed).toContain("x-nemoclaw-upstream-provider");
+    expect(records[1].headers).toEqual({ "X-Keep": "https" });
+    expect(records[1].removed).toContain("x-nemoclaw-upstream-provider");
+  });
+
   it("preload also injects model-specific kwargs for stubbed fetch requests", () => {
     const preload = extractStartScriptHeredoc(src, "NEMOTRON_FIX_EOF");
     const harness = `

--- a/test/nemotron-inference-fix.test.ts
+++ b/test/nemotron-inference-fix.test.ts
@@ -314,42 +314,25 @@ console.log(JSON.stringify(records));
     const harness = `
 const http = require('http');
 const https = require('https');
-const records = [];
-function installStub(mod) {
-  mod.request = function (url, options) {
-    const record = {
-      url: String(url),
-      headers: { ...(options && options.headers) },
-      removed: [],
-    };
-    records.push(record);
-    return {
-      end() { return true; },
-      removeHeader(name) {
-        record.removed.push(name);
-        for (const key of Object.keys(record.headers)) {
-          if (key.toLowerCase() === String(name).toLowerCase()) delete record.headers[key];
-        }
-      },
-    };
-  };
-}
-installStub(http);
-installStub(https);
 ${preload}
-http.request('http://inference.local/v1/models', {
-  headers: {
+function inspectHeaders(mod, url, headers) {
+  const request = mod.request(url, { headers });
+  const actualHeaders = request.getHeaders();
+  request.on('error', () => {});
+  request.destroy();
+  return actualHeaders;
+}
+const headers = [
+  inspectHeaders(http, 'http://127.0.0.1:9/v1/models', {
     'X-NemoClaw-Upstream-Provider': 'nvidia-prod',
     'X-Keep': 'http',
-  },
-}).end();
-https.request(new URL('https://inference.local/v1/models'), {
-  headers: {
+  }),
+  inspectHeaders(https, new URL('https://127.0.0.1:9/v1/models'), {
     'x-nemoclaw-upstream-provider': 'compatible-endpoint',
     'X-Keep': 'https',
-  },
-}).end();
-console.log(JSON.stringify(records));
+  }),
+];
+console.log(JSON.stringify(headers));
 `;
 
     const result = spawnSync(process.execPath, ["-e", harness], {
@@ -357,13 +340,13 @@ console.log(JSON.stringify(records));
       timeout: 5000,
     });
     expect(result.status, result.stderr).toBe(0);
-    const records = JSON.parse(result.stdout.trim());
+    const headers = JSON.parse(result.stdout.trim());
 
-    expect(records).toHaveLength(2);
-    expect(records[0].headers).toEqual({ "X-Keep": "http" });
-    expect(records[0].removed).toContain("x-nemoclaw-upstream-provider");
-    expect(records[1].headers).toEqual({ "X-Keep": "https" });
-    expect(records[1].removed).toContain("x-nemoclaw-upstream-provider");
+    expect(headers).toHaveLength(2);
+    expect(headers[0]["x-nemoclaw-upstream-provider"]).toBeUndefined();
+    expect(headers[0]["x-keep"]).toBe("http");
+    expect(headers[1]["x-nemoclaw-upstream-provider"]).toBeUndefined();
+    expect(headers[1]["x-keep"]).toBe("https");
   });
 
   it("preload also injects model-specific kwargs for stubbed fetch requests", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

URL-form Node.js HTTP requests now remove NemoClaw's internal upstream-provider marker before forwarding. Object-form requests and fetch already removed this routing metadata; this closes the remaining egress gap identified after #7485.

## Related Issue

Follow-up to #7485, which fixed #6913.

## Changes

- Detect string-URL and `URL`-object forms of `http.request` and `https.request`.
- Remove `X-NemoClaw-Upstream-Provider` from the created request while preserving other headers and original request arguments.
- Add regression coverage for both URL forms and both Node.js transports.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This removes internal routing metadata and changes no command, user configuration, setup flow, policy schema, or documented workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending human review of this focused follow-up to #7485.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `nemoclaw-blueprint/scripts/nemotron-inference-fix.js` removes the internal provider marker from URL-form Node.js HTTP requests. This changes no command, user configuration, setup flow, policy schema, or documented workflow. `npx vitest run test/nemotron-inference-fix.test.ts` passed 8 tests on PR SHA `95cd894db`; the URL-form regression now inspects real Node HTTP/HTTPS `ClientRequest` headers while remaining offline.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 95cd894db -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/nemotron-inference-fix.test.ts` passed 8/8; `git diff --check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a focused transport compatibility fix.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP/HTTPS requests made using URL strings or URL objects.
  * Removed the runtime upstream provider marker header case-insensitively, while preserving unrelated headers.
  * URL-form requests now reliably avoid unintended interception, preserving prior pass-through behavior when options aren’t applicable.
* **Tests**
  * Added a Vitest coverage to validate header behavior for both `http` URL strings and `https` URL objects using the “NEMOTRON_FIX” preload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
