### PR TITLE
test(e2e): harden image reuse workflow validator

### DIFF
--- a/test/e2e/support/sandbox-images-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-images-workflow-boundary.test.ts
@@ -170,6 +170,27 @@ describe("sandbox image workflow boundary", () => {
     );
   });
 
+  it("rejects action-based Docker auth and secrets in Hermes consumer inputs", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    imageWorkflow.jobs["test-hermes-sandbox-image"].steps!.push({
+      name: "Authenticate with Docker action",
+      uses: `docker/login-action@${"0".repeat(40)}`,
+      with: {
+        username: "${{ secrets.DOCKERHUB_USERNAME }}",
+        password: "${{ secrets.DOCKERHUB_TOKEN }}",
+      },
+    });
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toEqual(
+      expect.arrayContaining([
+        "Hermes image test consumer must not authenticate to Docker Hub",
+        "test-hermes-sandbox-image step \x27Authenticate with Docker action\x27 must not receive DOCKERHUB_USERNAME",
+        "test-hermes-sandbox-image step \x27Authenticate with Docker action\x27 must not receive DOCKERHUB_TOKEN",
+        "test-hermes-sandbox-image step \x27Authenticate with Docker action\x27 must not authenticate to a registry",
+      ]),
+    );
+  });
+
   it("rejects a duplicate Hermes production-image build", () => {
     const { imageWorkflow, mainWorkflow } = readWorkflows();
     const producer = imageWorkflow.jobs["build-hermes-sandbox-image"];
@@ -179,6 +200,71 @@ describe("sandbox image workflow boundary", () => {
 
     expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
       "Hermes producer must build the production image exactly once with the canonical local-load Buildx action and OS/architecture-scoped GHA cache",
+    );
+  });
+
+  it("rejects a second Hermes production build through the Buildx CLI", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    const producer = imageWorkflow.jobs["build-hermes-sandbox-image"];
+    producer.steps!.splice(-1, 0, {
+      name: "Build Hermes production image again",
+      run: "docker buildx build --load -f agents/hermes/Dockerfile -t nemoclaw-hermes-production .",
+    });
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
+      "Hermes producer must build the production image exactly once with the canonical local-load Buildx action and OS/architecture-scoped GHA cache",
+    );
+  });
+
+  it("rejects a multiline Hermes Buildx registry write", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    const producer = imageWorkflow.jobs["build-hermes-sandbox-image"];
+    producer.steps!.splice(-1, 0, {
+      name: "Publish Hermes production image",
+      run: [
+        "docker buildx build \\",
+        "  --push -t registry.example.invalid/nemoclaw-hermes .",
+      ].join("\n"),
+    });
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
+      "build-hermes-sandbox-image step \x27Publish Hermes production image\x27 must not write images to a registry",
+    );
+  });
+
+  it("requires the Hermes artifact download before its load", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    const consumer = imageWorkflow.jobs["test-hermes-sandbox-image"];
+    const downloadIndex = consumer.steps!.findIndex(
+      (step) => step.name === "Download Hermes production image",
+    );
+    const [download] = consumer.steps!.splice(downloadIndex, 1);
+    const loadIndex = consumer.steps!.findIndex(
+      (step) => step.name === "Load Hermes production image",
+    );
+    consumer.steps!.splice(loadIndex + 1, 0, download);
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
+      "Hermes image tests must download and load the producer artifact exactly once with the canonical action",
+    );
+  });
+
+  it("rejects non-canonical Hermes artifact upload and metadata download pins", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    const upload = imageWorkflow.jobs["build-hermes-sandbox-image"].steps!.find(
+      (step) => step.name === "Upload Hermes isolation image",
+    )!;
+    upload.uses = `actions/upload-artifact@${"0".repeat(40)}`;
+    const download = imageWorkflow.jobs["state-dir-guard-metadata"].steps!.find(
+      (step) => step.name === "Download Hermes production image",
+    )!;
+    download.uses = `actions/download-artifact@${"0".repeat(40)}`;
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toEqual(
+      expect.arrayContaining([
+        "Hermes producer must upload the saved production image before auth cleanup",
+        "state-dir guard metadata must download the saved Hermes production image",
+      ]),
     );
   });
 

--- a/tools/e2e/sandbox-images-workflow-boundary.mts
+++ b/tools/e2e/sandbox-images-workflow-boundary.mts
@@ -29,6 +29,8 @@ const HERMES_BUILD_PUSH_ACTION =
   "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a";
 const HERMES_DOWNLOAD_ARTIFACT_ACTION =
   "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c";
+const HERMES_UPLOAD_ARTIFACT_ACTION =
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 const HERMES_CACHE_FROM = "type=gha,scope=hermes-production-${{ runner.os }}-${{ runner.arch }}";
 const HERMES_CACHE_TO =
   "type=gha,mode=max,scope=hermes-production-${{ runner.os }}-${{ runner.arch }}";
@@ -63,6 +65,10 @@ const EXPECTED_AUTH_ENV = {
 const FULL_SHA_ACTION = /^[^\s@]+@[0-9a-f]{40}$/u;
 const REGISTRY_WRITE =
   /(?:\bdocker\s+(?:image\s+)?push\b|\bdocker\s+buildx\s+build\b[^\n]*\s--push(?:\s|$)|\b(?:oras|crane)\s+push\b|\bskopeo\s+copy\b)/u;
+
+function normalizeShellContinuations(run: string): string {
+  return run.replace(/\\\r?\n[ \t]*/gu, " ");
+}
 
 type GuardedProductionBuildContract = {
   args: string;
@@ -345,7 +351,12 @@ function validateSecretScopeAndRegistryWrites(
     for (const step of steps(job)) {
       const label = `${jobName} step '${step.name ?? step.uses ?? "<unnamed>"}'`;
       const run = typeof step.run === "string" ? step.run : "";
-      const serialized = `${JSON.stringify(record(step.env))}\n${run}`;
+      const normalizedRun = normalizeShellContinuations(run);
+      const serialized = [
+        JSON.stringify(record(step.env)),
+        JSON.stringify(record(step.with)),
+        run,
+      ].join("\n");
       for (const secret of FORBIDDEN_RUNTIME_SECRETS) {
         if (serialized.includes(secret)) {
           errors.push(`${label} must not receive ${secret}`);
@@ -357,14 +368,17 @@ function validateSecretScopeAndRegistryWrites(
             errors.push(`${label} must not receive ${secret}`);
           }
         }
-        if (/\bdocker\s+login\b/u.test(run)) {
+        if (
+          /\bdocker\s+login\b/u.test(normalizedRun) ||
+          String(step.uses ?? "").startsWith("docker/login-action@")
+        ) {
           errors.push(`${label} must not authenticate to a registry`);
         }
       }
       const buildActionWritesRegistry =
         String(step.uses ?? "").startsWith("docker/build-push-action@") &&
         record(step.with).push !== false;
-      if (REGISTRY_WRITE.test(run) || buildActionWritesRegistry) {
+      if (REGISTRY_WRITE.test(normalizedRun) || buildActionWritesRegistry) {
         errors.push(`${label} must not write images to a registry`);
       }
     }
@@ -373,10 +387,10 @@ function validateSecretScopeAndRegistryWrites(
 
 function dockerBuildLines(job: SandboxImagesWorkflowJob): string[] {
   return steps(job).flatMap((step) =>
-    (step.run ?? "")
+    normalizeShellContinuations(step.run ?? "")
       .split("\n")
       .map((line) => line.trim())
-      .filter((line) => /^docker\s+build(?:\s|$)/u.test(line)),
+      .filter((line) => /^docker\s+(?:build|buildx\s+build)(?:\s|$)/u.test(line)),
   );
 }
 
@@ -839,7 +853,13 @@ function validateHermesImageReuse(errors: string[], workflow: SandboxImagesWorkf
   if (testJob.needs !== producerName) {
     errors.push("Hermes image tests must depend on the Hermes image producer");
   }
-  if (steps(testJob).some((step) => step.name === AUTH_STEP_NAME)) {
+  const consumerAuthSteps = steps(testJob).filter(
+    (step) =>
+      step.name === AUTH_STEP_NAME ||
+      String(step.uses ?? "").startsWith("docker/login-action@") ||
+      /\bdocker\s+login\b/u.test(normalizeShellContinuations(step.run ?? "")),
+  );
+  if (consumerAuthSteps.length !== 0) {
     errors.push("Hermes image test consumer must not authenticate to Docker Hub");
   }
   const consumerBuilds = steps(testJob).filter(
@@ -929,7 +949,8 @@ function validateHermesImageReuse(errors: string[], workflow: SandboxImagesWorkf
     }) ||
     steps(testJob).filter((step) => step.name === "Load Hermes production image").length !== 1 ||
     !(load.run ?? "").includes("/tmp/hermes-isolation-image.tar.gz | docker load") ||
-    !(load.run ?? "").includes("docker image inspect nemoclaw-hermes-production")
+    !(load.run ?? "").includes("docker image inspect nemoclaw-hermes-production") ||
+    stepIndex(testJob, download.name ?? "") >= stepIndex(testJob, load.name ?? "")
   ) {
     errors.push(
       "Hermes image tests must download and load the producer artifact exactly once with the canonical action",
@@ -949,8 +970,7 @@ function validateHermesImageReuse(errors: string[], workflow: SandboxImagesWorkf
   const upload = requireStep(errors, producerName, producer, "Upload Hermes isolation image");
   if (
     steps(producer).filter((step) => step.name === "Upload Hermes isolation image").length !== 1 ||
-    !(upload.uses ?? "").startsWith("actions/upload-artifact@") ||
-    !FULL_SHA_ACTION.test(upload.uses ?? "") ||
+    upload.uses !== HERMES_UPLOAD_ARTIFACT_ACTION ||
     !isDeepStrictEqual(record(upload.with), {
       name: "hermes-isolation-image",
       path: "/tmp/hermes-isolation-image.tar.gz",
@@ -1017,8 +1037,7 @@ function validateStateDirGuardMetadataImageReuse(
     ["Hermes", hermesDownload, { name: "hermes-isolation-image", path: "/tmp" }],
   ] as const) {
     if (
-      !(step.uses ?? "").startsWith("actions/download-artifact@") ||
-      !FULL_SHA_ACTION.test(step.uses ?? "") ||
+      step.uses !== HERMES_DOWNLOAD_ARTIFACT_ACTION ||
       !isDeepStrictEqual(record(step.with), expectedWith)
     ) {
       errors.push(`state-dir guard metadata must download the saved ${label} production image`);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Harden the merged Hermes image-reuse workflow validator so action inputs and shell continuations cannot bypass credential, registry-write, build-cardinality, or artifact-handoff safeguards. Production workflow behavior is unchanged.

## Related Issue

Part of #7451. Follow-up to #7508.

## Changes

- Scan action `with` inputs for protected secrets and reject `docker/login-action` outside the canonical producer authentication step.
- Normalize shell continuations and recognize `docker buildx build` so multiline pushes and duplicate CLI builds fail closed.
- Require the reviewed artifact action pins and download-before-load ordering on every Hermes artifact leg.
- Add five adversarial regression tests for the reproduced bypasses.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this hardens an internal workflow validator and its support tests; the production workflow and documented operator contract are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: an independent exact-diff maintainer/security review reproduced five fail-open mutations before the patch and verified the five guarded cases after the patch.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: At reviewed head `a6e864323`, the only changes are internal E2E workflow-boundary validator hardening and adversarial support tests. The production workflow remains unchanged. Existing `test/e2e/README.md` already documents the Hermes producer/consumer artifact flow, exact action pins, local image loading, and disabled registry writes. The explicit affected suite passed 26/26 and `npm run check:diff` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a6e864323 -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed; `npm run check:diff` also passed on exact refreshed head `a6e864323`.
- [x] Targeted behavior tests pass for the current change set — explicit E2E-support suite passed 26/26 on exact refreshed head. Before the main refresh, `npm run test:changed -- --coverage=false` also passed 26/26; after the merge-topology refresh it selected no tests, so the affected files were run explicitly.
- [x] Applicable broad gate passed — not applicable to this narrow validator/test-only delta; exact focused tests and the complete diff gate passed, and GitHub CI remains required before approval.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened workflow validation for Hermes image consumers and producers.
  * Blocked unauthorized Docker authentication and secret propagation in consumer jobs.
  * Added validation against duplicate production builds, registry writes, and unsafe multiline commands.
  * Enforced correct artifact upload/download actions, image loading, and step ordering.
  * Improved detection of Docker Buildx commands and authentication methods across workflow formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->