### PR TITLE
test(e2e): reject continued Hermes consumer builds

### DIFF
--- a/test/e2e/support/sandbox-images-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-images-workflow-boundary.test.ts
@@ -191,6 +191,21 @@ describe("sandbox image workflow boundary", () => {
     );
   });
 
+  it("rejects a continued Buildx rebuild in the Hermes image consumer", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    imageWorkflow.jobs["test-hermes-sandbox-image"].steps!.push({
+      name: "Rebuild Hermes production image",
+      run: [
+        "docker buildx \\",
+        "  build --load -f agents/hermes/Dockerfile -t nemoclaw-hermes-production .",
+      ].join("\n"),
+    });
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
+      "Hermes image test consumer must not rebuild the prebuilt image",
+    );
+  });
+
   it("rejects a duplicate Hermes production-image build", () => {
     const { imageWorkflow, mainWorkflow } = readWorkflows();
     const producer = imageWorkflow.jobs["build-hermes-sandbox-image"];

--- a/test/e2e/support/sandbox-images-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-images-workflow-boundary.test.ts
@@ -295,6 +295,30 @@ describe("sandbox image workflow boundary", () => {
     );
   });
 
+  it("rejects a shell-expanded Buildx push flag in an image consumer", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    imageWorkflow.jobs["state-dir-guard-metadata"].steps!.push({
+      name: "Publish from expanded metadata consumer",
+      run: 'docker buildx build --push="${PUSH_IMAGES}" -t registry.example.invalid/nemoclaw .',
+    });
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
+      "state-dir-guard-metadata step \x27Publish from expanded metadata consumer\x27 must not write images to a registry",
+    );
+  });
+
+  it("treats an explicit false Buildx push assignment as non-writing", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    imageWorkflow.jobs["state-dir-guard-metadata"].steps!.push({
+      name: "Disable publishing from metadata consumer",
+      run: "docker buildx build --push=false -t nemoclaw-metadata-consumer .",
+    });
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).not.toContain(
+      "state-dir-guard-metadata step \x27Disable publishing from metadata consumer\x27 must not write images to a registry",
+    );
+  });
+
   it("requires the Hermes artifact download before its load", () => {
     const { imageWorkflow, mainWorkflow } = readWorkflows();
     const consumer = imageWorkflow.jobs["test-hermes-sandbox-image"];

--- a/test/e2e/support/sandbox-images-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-images-workflow-boundary.test.ts
@@ -283,6 +283,18 @@ describe("sandbox image workflow boundary", () => {
     );
   });
 
+  it("rejects a mixed-case assigned Buildx push flag in an image consumer", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    imageWorkflow.jobs["state-dir-guard-metadata"].steps!.push({
+      name: "Publish from metadata consumer",
+      run: "docker buildx build --push=True -t registry.example.invalid/nemoclaw .",
+    });
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
+      "state-dir-guard-metadata step \x27Publish from metadata consumer\x27 must not write images to a registry",
+    );
+  });
+
   it("requires the Hermes artifact download before its load", () => {
     const { imageWorkflow, mainWorkflow } = readWorkflows();
     const consumer = imageWorkflow.jobs["test-hermes-sandbox-image"];

--- a/test/e2e/support/sandbox-images-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-images-workflow-boundary.test.ts
@@ -247,6 +247,18 @@ describe("sandbox image workflow boundary", () => {
     );
   });
 
+  it("rejects an assigned Buildx push flag in an image consumer", () => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    imageWorkflow.jobs["state-dir-guard-metadata"].steps!.push({
+      name: "Publish from metadata consumer",
+      run: "docker buildx build --push=true -t registry.example.invalid/nemoclaw .",
+    });
+
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
+      "state-dir-guard-metadata step \x27Publish from metadata consumer\x27 must not write images to a registry",
+    );
+  });
+
   it("requires the Hermes artifact download before its load", () => {
     const { imageWorkflow, mainWorkflow } = readWorkflows();
     const consumer = imageWorkflow.jobs["test-hermes-sandbox-image"];

--- a/tools/e2e/sandbox-images-workflow-boundary.mts
+++ b/tools/e2e/sandbox-images-workflow-boundary.mts
@@ -63,8 +63,9 @@ const EXPECTED_AUTH_ENV = {
   DOCKERHUB_TOKEN: `\${{ ${TRUSTED_PREDICATE} && secrets.DOCKERHUB_TOKEN || '' }}`,
 };
 const FULL_SHA_ACTION = /^[^\s@]+@[0-9a-f]{40}$/u;
+// Shell-expanded values are unknown; only literal `--push=false` is statically non-writing.
 const REGISTRY_WRITE =
-  /(?:\bdocker\s+(?:image\s+)?push\b|\bdocker\s+buildx\s+build\b[^\n]*\s--push(?:=(?:1|[tT](?:[rR][uU][eE])?))?(?=$|[\s;&|<>()])|\b(?:oras|crane)\s+push\b|\bskopeo\s+copy\b)/u;
+  /(?:\bdocker\s+(?:image\s+)?push\b|\bdocker\s+buildx\s+build\b[^\n]*\s--push(?:=(?!false(?=$|[\s;&|<>()]))[^\s;&|<>()]+)?(?=$|[\s;&|<>()])|\b(?:oras|crane)\s+push\b|\bskopeo\s+copy\b)/u;
 
 function normalizeShellContinuations(run: string): string {
   return run.replace(/\\\r?\n[ \t]*/gu, " ");

--- a/tools/e2e/sandbox-images-workflow-boundary.mts
+++ b/tools/e2e/sandbox-images-workflow-boundary.mts
@@ -64,7 +64,7 @@ const EXPECTED_AUTH_ENV = {
 };
 const FULL_SHA_ACTION = /^[^\s@]+@[0-9a-f]{40}$/u;
 const REGISTRY_WRITE =
-  /(?:\bdocker\s+(?:image\s+)?push\b|\bdocker\s+buildx\s+build\b[^\n]*\s--push(?:\s|$)|\b(?:oras|crane)\s+push\b|\bskopeo\s+copy\b)/u;
+  /(?:\bdocker\s+(?:image\s+)?push\b|\bdocker\s+buildx\s+build\b[^\n]*\s--push(?:=(?:1|[tT](?:[rR][uU][eE])?))?(?=$|[\s;&|<>()])|\b(?:oras|crane)\s+push\b|\bskopeo\s+copy\b)/u;
 
 function normalizeShellContinuations(run: string): string {
   return run.replace(/\\\r?\n[ \t]*/gu, " ");

--- a/tools/e2e/sandbox-images-workflow-boundary.mts
+++ b/tools/e2e/sandbox-images-workflow-boundary.mts
@@ -865,7 +865,7 @@ function validateHermesImageReuse(errors: string[], workflow: SandboxImagesWorkf
   const consumerBuilds = steps(testJob).filter(
     (step) =>
       String(step.uses ?? "").startsWith("docker/build-push-action@") ||
-      /\bdocker\s+(?:build|buildx\s+build)\b/u.test(step.run ?? ""),
+      /\bdocker\s+(?:build|buildx\s+build)\b/u.test(normalizeShellContinuations(step.run ?? "")),
   );
   if (consumerBuilds.length !== 0) {
     errors.push("Hermes image test consumer must not rebuild the prebuilt image");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Close the remaining Hermes image-consumer validator bypasses identified after #7551 merged. Shell continuations are normalized before the no-rebuild check, and assigned Buildx push values are evaluated case-insensitively. Literal `false` remains non-writing; true, empty, mixed-case, and dynamic or otherwise nonliteral values are rejected so the consumer cannot hide a rebuild or registry write.

## Related Issue

Part of #7451. Follow-up to #7508 and #7551.

## Changes

- Normalize Hermes consumer shell continuations before checking for Docker and Buildx builds.
- Detect assigned, mixed-case, and dynamic Buildx registry-push values in the consumer guard.
- Preserve literal `--push=false` as non-writing.
- Add adversarial regressions for multiline rebuilds and assigned push values.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the production workflow and documented no-rebuild contract are unchanged; this makes the internal validator enforce that existing contract for continued commands.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: CodeRabbit reproduced the bypass on #7551; the exact mutation is now an adversarial test and passes only with normalization at the consumer guard.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: At PR SHA `2cef897b4fcba8033d115d94f2dd4c2ae12d86ed`, the change only strengthens the repository-internal Hermes image-consumer validator for multiline rebuilds and assigned, mixed-case, or dynamic Buildx push values. Literal `--push=false` remains non-writing. `test/e2e/README.md` already documents the no-rebuild/no-registry-write contract. The focused E2E-support suite passed 29/29, the PR workflow-contract suite passed 22/22, and `npm run build:cli` plus `npm run check:diff` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 2cef897b4fcba8033d115d94f2dd4c2ae12d86ed -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed; `npm run build:cli` and `npm run check:diff` also passed on exact head `2cef897b4fcba8033d115d94f2dd4c2ae12d86ed`.
- [x] Targeted behavior tests pass for the current change set — E2E-support passed 29/29 and the PR workflow-contract suite passed 22/22.
- [x] Applicable broad gate passed — not applicable to this validator/test-only delta; the exact affected suites, CLI build, and complete diff gate passed, and GitHub CI remains required before approval.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox image workflow validation to more precisely detect `docker buildx build ... --push` commands, including shell line continuations and `--push` casing/formatting.
  * Strengthened Hermes prebuilt-image reuse checks by normalizing command formatting before validating consumer steps.
* **Tests**
  * Added new end-to-end negative cases covering consumer attempts to rebuild the prebuilt Hermes production image.
  * Added coverage to ensure consumers attempting registry writes via `--push` are rejected, while explicitly using `--push=false` is allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->