### PR TITLE
perf(images): short-circuit reachable tag scan

### DIFF
--- a/src/lib/sandbox-base-image/source-identity.test.ts
+++ b/src/lib/sandbox-base-image/source-identity.test.ts
@@ -115,6 +115,39 @@ function createGitFixtureWithReachableOriginTags(tags: string[]) {
   return root;
 }
 
+function addUnreachableOriginTag(root: string, tag: string) {
+  const originalBranch = git(root, ["branch", "--show-current"]);
+  const branch = `unreachable-${tag.replaceAll(".", "-")}`;
+  git(root, ["switch", "--orphan", branch]);
+  git(root, ["rm", "-rf", "--ignore-unmatch", "."]);
+  writeFixture(root, "unreachable.txt", `${tag}\n`);
+  git(root, ["add", "unreachable.txt"]);
+  git(root, ["commit", "-m", `add ${tag}`]);
+  git(root, ["tag", tag]);
+  git(root, ["push", "origin", `refs/tags/${tag}`]);
+  git(root, ["switch", originalBranch]);
+}
+
+function traceReachabilityProbes<T>(operation: (env: NodeJS.ProcessEnv) => T) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-git-trace-"));
+  tmpRoots.push(root);
+  const traceFile = path.join(root, "trace.jsonl");
+  const result = operation({ ...gitEnv, GIT_TRACE2_EVENT: traceFile });
+  const probes = fs
+    .readFileSync(traceFile, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as { event?: string; argv?: string[] })
+    .filter(
+      (event) =>
+        event.event === "start" &&
+        event.argv?.includes("merge-base") &&
+        event.argv.includes("--is-ancestor"),
+    )
+    .map((event) => event.argv ?? []);
+  return { probes, result };
+}
+
 afterEach(() => {
   for (const root of tmpRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
@@ -232,12 +265,58 @@ describe("sandbox base-image source identity", () => {
     git(root, ["add", "docs/release.md"]);
     git(root, ["commit", "-m", "release 42"]);
     git(root, ["tag", "-a", "v0.0.42", "-m", "v0.0.42"]);
+    const peeledCommit = git(root, ["rev-parse", "v0.0.42^{}"]);
     git(root, ["push", "origin", "main", "refs/tags/v0.0.42"]);
     git(root, ["tag", "-d", "v0.0.42"]);
 
     expect(getVersionedBaseImageTags(root, gitEnv)).toEqual([]);
     expect(git(root, ["describe", "--tags", "--abbrev=0", "--match", "v*"])).toBe("v0.0.41");
-    expect(getNearestVersionedBaseImageTags(root, gitEnv)).toEqual(["v0.0.42"]);
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+    expect(result).toEqual(["v0.0.42"]);
+    expect(probes).toHaveLength(1);
+    expect(probes[0]).toContain(peeledCommit);
+  });
+
+  it("stops after the newest reachable origin release tag", () => {
+    const root = createGitFixtureWithReachableOriginTags(["v0.0.77", "v0.0.79"]);
+
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+
+    expect(result).toEqual(["v0.0.79"]);
+    expect(probes).toHaveLength(1);
+  });
+
+  it("checks the next release only when the newest origin tag is unreachable", () => {
+    const root = createGitFixtureWithReachableOriginTags(["v0.0.79"]);
+    addUnreachableOriginTag(root, "v0.0.80");
+
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+
+    expect(result).toEqual(["v0.0.79"]);
+    expect(probes).toHaveLength(2);
+  });
+
+  it("preserves the nearest local tag fallback when no origin tag is reachable", () => {
+    const root = createGitFixtureWithRemoteOnlyBaseRef();
+    git(root, ["tag", "v0.0.41"]);
+    git(root, ["switch", "-c", "feature"]);
+    writeFixture(root, "src/other.ts", "export const value = 42;\n");
+    git(root, ["add", "src/other.ts"]);
+    git(root, ["commit", "-m", "move off tag"]);
+    addUnreachableOriginTag(root, "v0.0.80");
+
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+
+    expect(result).toEqual(["v0.0.41"]);
+    expect(probes).toHaveLength(1);
   });
 
   it("prefers a stable reachable origin release over a prerelease created later (#6624)", () => {

--- a/src/lib/sandbox-base-image/source-identity.ts
+++ b/src/lib/sandbox-base-image/source-identity.ts
@@ -199,15 +199,13 @@ function gitRemoteReachableVersionTag(rootDir: string, env: NodeJS.ProcessEnv): 
     if (peeled || !tags.has(tag)) tags.set(tag, commit);
   }
 
-  return (
-    [...tags]
-      .filter(
-        ([, commit]) =>
-          gitStatus(rootDir, ["merge-base", "--is-ancestor", commit, "HEAD"], env) === 0,
-      )
-      .map(([tag]) => tag)
-      .sort(compareVersionTagsDesc)[0] ?? null
-  );
+  const candidates = [...tags].sort(([left], [right]) => compareVersionTagsDesc(left, right));
+  for (const [tag, commit] of candidates) {
+    if (gitStatus(rootDir, ["merge-base", "--is-ancestor", commit, "HEAD"], env) === 0) {
+      return tag;
+    }
+  }
+  return null;
 }
 
 function versionFileTag(rootDir: string): string | null {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Base-image fallback now checks remote release tags in semantic-version order and stops at the first reachable candidate. It preserves the existing selected tag and local fallback while avoiding the exhaustive reachability fan-out on the common path.

## Related Issue

Closes #7249.

## Changes

- Parse the complete remote tag response and preserve peeled annotated-tag commits before ordering candidates.
- Probe candidates newest-first and return immediately when one is reachable.
- Measure the real Git command boundary with Trace2 regressions covering one-probe success, two-probe fallback, annotated tags, and complete remote exhaustion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — internal fallback optimization; selected tags, configuration, and user-facing behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: maintainer review pending; the focused tests prove selection equivalence at the Git boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: only internal release-tag reachability ordering changes; no command, configuration, or operator workflow changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: cc02a6b64 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] `npm run check:diff`
- [x] Targeted behavior tests pass for the current change set — `npx vitest run --project cli src/lib/sandbox-base-image/source-identity.test.ts` (28 passed).
- [x] Applicable broad gate passed — `npm run test:changed` (110 files, 1,125 tests) and `npm run typecheck`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ho Lim <subhoya@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version tag selection to return the nearest reachable base image tag.
  * Stops searching once the newest reachable tag is found, improving selection accuracy and efficiency.
  * Preserves local tag fallback behavior when no remote tag is reachable.
  * Correctly handles remote tags that are not reachable from the current branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->