### PR TITLE
fix(rebuild): guard destructive delete target

### DIFF
--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -114,6 +114,12 @@ export function isExplicitMissingSandboxGatewayOutput(
   const exactNoSpec =
     /^(?:error:\s*)?status:\s*Internal,\s*message:\s*["']sandbox has no spec["'](?:,\s*details:\s*\[\])?(?:,\s*metadata:\s*MetadataMap\s*\{\s*\})?$/i;
   if (exactNoSpec.test(clean)) return true;
+  // OpenShell can omit the requested name from an owner-scoped lookup.
+  // Require both exact structured fields so gateway/provider absence and
+  // transport diagnostics remain ambiguous.
+  const exactStructuredNotFound =
+    /^(?:error:\s*)?(?:×\s*)?code:\s*["']Some requested entity was not found["']\s*,\s*message:\s*["']sandbox not found["']$/i;
+  if (exactStructuredNotFound.test(clean)) return true;
 
   const escapedName = sandboxName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const namedSandbox = `(?:['\"]${escapedName}['\"]|${escapedName})`;

--- a/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
@@ -6,7 +6,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   captureOpenshell: vi.fn(),
   getSandbox: vi.fn(
-    (_name: string): { name: string; agent: string; nimContainer?: string | null } | null => null,
+    (
+      _name: string,
+    ): {
+      name: string;
+      agent: string;
+      nimContainer?: string | null;
+      gatewayName?: string | null;
+      gatewayPort?: number | null;
+    } | null => null,
   ),
   listSandboxes: vi.fn(() => ({ sandboxes: [] })),
   prepareMcpForRebuild: vi.fn(),
@@ -69,7 +77,10 @@ describe("rebuild destroy phase", () => {
     vi.clearAllMocks();
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.getSandbox.mockReturnValue(null);
+    mocks.getSandbox.mockReturnValue({
+      name: "alpha",
+      agent: "openclaw",
+    });
     mocks.listSandboxes.mockReturnValue({ sandboxes: [] });
     mocks.prepareMcpForRebuild.mockResolvedValue({
       entries: [],
@@ -200,6 +211,12 @@ describe("rebuild destroy phase", () => {
 
   it("pins deletion to the recorded gateway when ambient selection changes (#7062)", async () => {
     vi.stubEnv("OPENSHELL_GATEWAY", "nemoclaw-29080");
+    mocks.getSandbox.mockReturnValue({
+      name: "alpha",
+      agent: "openclaw",
+      gatewayName: "nemoclaw-19080",
+      gatewayPort: 19080,
+    });
 
     await runRebuildDestroyPhase({
       sandboxName: "alpha",
@@ -224,6 +241,71 @@ describe("rebuild destroy phase", () => {
       ["sandbox", "delete", "-g", "nemoclaw-19080", "alpha"],
       expect.objectContaining({ ignoreError: true }),
     );
+  });
+
+  it.each([
+    [
+      "sandbox name",
+      {
+        name: "beta",
+        agent: "openclaw",
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
+      },
+    ],
+    [
+      "gateway binding",
+      {
+        name: "alpha",
+        agent: "openclaw",
+        gatewayName: "nemoclaw-29080",
+        gatewayPort: 29080,
+      },
+    ],
+  ])("refuses deletion when the registry %s changes before MCP preparation (#7062)", async (_label, currentEntry) => {
+    mocks.getSandbox.mockReturnValue(currentEntry);
+    mocks.prepareMcpForRebuild.mockResolvedValue({
+      entries: [{ server: "github" }],
+      detachedProviderEntries: [{ server: "github" }],
+      scrubbedAdapterEntries: [],
+    });
+    const relockShieldsIfNeeded = vi.fn(() => true);
+
+    await expect(
+      runRebuildDestroyPhase({
+        sandboxName: "alpha",
+        sandboxEntry: {
+          name: "alpha",
+          agent: "openclaw",
+          gatewayName: "nemoclaw",
+          gatewayPort: 8080,
+        },
+        staleRecovery: false,
+        backupManifest: null,
+        force: true,
+        log: vi.fn(),
+        bail: vi.fn((message: string): never => {
+          throw new Error(message);
+        }),
+        relockShieldsIfNeeded,
+        onDeleted: vi.fn(),
+      }),
+    ).rejects.toThrow("Sandbox delete target changed during rebuild preparation.");
+
+    expect(mocks.getSandbox).toHaveBeenCalledTimes(2);
+    expect(mocks.prepareMcpForRebuild.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.getSandbox.mock.invocationCallOrder[1] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(mocks.runOpenshell).not.toHaveBeenCalled();
+    expect(mocks.reattachMcpAfterDeleteFailure).toHaveBeenCalledWith(
+      "alpha",
+      [{ server: "github" }],
+      [],
+    );
+    expect(mocks.removeSandboxRegistryEntryWithReceipt).not.toHaveBeenCalled();
+    expect(mocks.stopNimContainer).not.toHaveBeenCalled();
+    expect(mocks.stopNimContainerByName).not.toHaveBeenCalled();
+    expect(relockShieldsIfNeeded).toHaveBeenCalledWith(true);
   });
 
   it("refuses sandbox deletion when read-only MCP state drifts at the delete edge (#7062)", async () => {
@@ -757,7 +839,7 @@ describe("rebuild destroy phase", () => {
     expect(mocks.removeSandboxRegistryEntryWithReceipt).toHaveBeenCalledWith("alpha");
   });
 
-  it("preserves backup and registry state when transport failures prevent deletion confirmation", async () => {
+  it("marks accepted deletion as ambiguous when transport failures prevent confirmation", async () => {
     mocks.runOpenshell.mockReturnValue({ status: 0, stdout: "deleted", stderr: "" });
     mocks.captureOpenshell.mockReturnValue({
       status: 1,
@@ -765,6 +847,8 @@ describe("rebuild destroy phase", () => {
       stderr: "tcp connect error: Connection refused",
     });
     const onDeleted = vi.fn();
+    const onDeleteStateAmbiguous = vi.fn();
+    const relockShieldsIfNeeded = vi.fn(() => true);
 
     await expect(
       runRebuildDestroyPhase({
@@ -776,12 +860,15 @@ describe("rebuild destroy phase", () => {
         bail: vi.fn((message: string): never => {
           throw new Error(message);
         }),
-        relockShieldsIfNeeded: vi.fn(() => true),
+        relockShieldsIfNeeded,
         onDeleted,
+        onDeleteStateAmbiguous,
       }),
     ).rejects.toThrow("Sandbox deletion could not be confirmed.");
 
     expect(onDeleted).not.toHaveBeenCalled();
+    expect(onDeleteStateAmbiguous).toHaveBeenCalledOnce();
+    expect(relockShieldsIfNeeded).not.toHaveBeenCalled();
     expect(mocks.runOpenshell).toHaveBeenCalledTimes(1);
     expect(mocks.captureOpenshell).toHaveBeenCalledTimes(3);
     expect(mocks.waitUntil).toHaveBeenCalledWith(

--- a/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.test.ts
@@ -734,6 +734,23 @@ describe("rebuild destroy phase", () => {
     expect(currentMs).toBeLessThanOrEqual(15_000);
   });
 
+  it("recognizes the exact structured OpenShell sandbox-absence response (#7062)", () => {
+    const log = vi.fn();
+
+    expect(
+      waitForRebuildDeleteAbsence("alpha", "nemoclaw", log, {
+        captureSandboxGet: vi.fn(() => ({
+          status: 1,
+          stdout: "",
+          stderr:
+            "Error:   × code: 'Some requested entity was not found', message: \"sandbox not found\"",
+        })),
+      }),
+    ).toBe(true);
+
+    expect(log).toHaveBeenCalledWith("Delete convergence probe 1: status=1, state=absent");
+  });
+
   it.each([
     ["another sandbox", { status: 1, stderr: "sandbox beta not found" }],
     [
@@ -743,6 +760,22 @@ describe("rebuild destroy phase", () => {
     [
       "a missing provider",
       { status: 1, stderr: 'status: NotFound, message: "provider alpha-mcp-github not found"' },
+    ],
+    [
+      "a structured missing gateway",
+      {
+        status: 1,
+        stderr:
+          "Error:   × code: 'Some requested entity was not found', message: \"gateway not found\"",
+      },
+    ],
+    [
+      "a structured missing provider",
+      {
+        status: 1,
+        stderr:
+          "Error:   × code: 'Some requested entity was not found', message: \"provider not found\"",
+      },
     ],
     [
       "mixed gateway and sandbox diagnostics",

--- a/src/lib/actions/sandbox/rebuild-destroy-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.ts
@@ -7,9 +7,10 @@ import { G, R } from "../../cli/terminal-style";
 import { waitUntil } from "../../core/wait";
 import { getSandboxDeleteOutcome } from "../../domain/sandbox/destroy";
 import * as nim from "../../inference/nim";
-import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
+import { resolveGatewayName, resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import { redactFull } from "../../security/redact";
 import { parseSandboxPhase } from "../../state/gateway";
+import { registryEntryGatewayPort } from "../../state/gateway-registry";
 import * as registry from "../../state/registry";
 import { removeSandboxRegistryEntryWithReceipt } from "./destroy";
 import { isExplicitMissingSandboxGatewayOutput } from "./gateway-state";
@@ -51,6 +52,12 @@ type PostDeleteReconciliation =
   | { state: "intact"; phase: "Ready" | "Running"; status: 0 }
   | { state: "ambiguous"; phase: string | null; status: number | null };
 
+interface RebuildDeleteTarget {
+  gatewayName: string;
+  gatewayPort: number;
+  sandboxName: string;
+}
+
 interface RebuildDeleteAbsenceDeps {
   captureSandboxGet?: (
     sandboxName: string,
@@ -70,6 +77,38 @@ interface RebuildDeleteAbsenceDeps {
 const REBUILD_DELETE_ABSENCE_MAX_ATTEMPTS = 20;
 const REBUILD_DELETE_ABSENCE_INITIAL_INTERVAL_MS = 250;
 const REBUILD_DELETE_ABSENCE_MAX_INTERVAL_MS = 1_000;
+
+function resolveRebuildDeleteTarget(
+  sandboxName: string,
+  sandboxEntry: RebuildSandboxEntry,
+): RebuildDeleteTarget {
+  if (sandboxEntry.name !== sandboxName) {
+    throw new Error("Rebuild sandbox entry does not match the requested delete target.");
+  }
+  const gatewayPort = registryEntryGatewayPort({
+    name: sandboxEntry.name,
+    gatewayName: sandboxEntry.gatewayName,
+    gatewayPort: sandboxEntry.gatewayPort,
+  });
+  return {
+    gatewayName: resolveGatewayName(gatewayPort),
+    gatewayPort,
+    sandboxName,
+  };
+}
+
+function rebuildDeleteTargetMatchesRegistry(expected: RebuildDeleteTarget): boolean {
+  const currentEntry = registry.getSandbox(expected.sandboxName);
+  if (!currentEntry) return false;
+  try {
+    const current = resolveRebuildDeleteTarget(expected.sandboxName, currentEntry);
+    return (
+      current.gatewayName === expected.gatewayName && current.gatewayPort === expected.gatewayPort
+    );
+  } catch {
+    return false;
+  }
+}
 
 /** Wait for explicit absence from the same `sandbox get` boundary used by inner onboard. */
 export function waitForRebuildDeleteAbsence(
@@ -192,7 +231,8 @@ export async function runRebuildDestroyPhase(
     validateAfterMcpPreparation,
     onDeleted,
   } = input;
-  const gatewayName = resolveSandboxGatewayName(input.sandboxEntry);
+  const deleteTarget = resolveRebuildDeleteTarget(sandboxName, input.sandboxEntry);
+  const { gatewayName } = deleteTarget;
 
   if (blockRebuildOnPendingBaselineTransition(input.sandboxEntry, sandboxName, bail)) return null;
 
@@ -298,6 +338,23 @@ export async function runRebuildDestroyPhase(
     }
   }
 
+  // MCP preparation can await external systems. Re-read the registry at the
+  // synchronous delete edge so those checks and deletion use one target.
+  if (!rebuildDeleteTargetMatchesRegistry(deleteTarget)) {
+    const mcpRecoveryFailure = await reattachMcpAfterDeleteFailure(
+      sandboxName,
+      rebuildDetachedMcpProviderEntries,
+      rebuildScrubbedMcpAdapterEntries,
+    );
+    relockShieldsIfNeeded(true);
+    bail(
+      mcpRecoveryFailure
+        ? `Sandbox delete target changed during rebuild preparation; MCP provider recovery also failed: ${mcpRecoveryFailure}`
+        : "Sandbox delete target changed during rebuild preparation.",
+    );
+    return null;
+  }
+
   log(`Running: openshell sandbox delete -g ${gatewayName} ${sandboxName}`);
   const deleteResult = runOpenshell(["sandbox", "delete", "-g", gatewayName, sandboxName], {
     ignoreError: true,
@@ -364,6 +421,7 @@ export async function runRebuildDestroyPhase(
     if (backupManifest) {
       console.error("  State backup is preserved at: " + backupManifest.backupPath);
     }
+    input.onDeleteStateAmbiguous?.();
     bail("Sandbox deletion could not be confirmed.");
     return null;
   }

--- a/src/lib/actions/sandbox/rebuild-shields-finally.test.ts
+++ b/src/lib/actions/sandbox/rebuild-shields-finally.test.ts
@@ -32,6 +32,7 @@ describe("rebuild shields relock guard", () => {
   const rebuildWindow = { relocked: false, wasLocked: true };
   const cleanupDcodePreflight = vi.fn();
   const releaseOnboardLock = vi.fn();
+  const revalidateDcodeBeforeDelete = vi.fn(async () => true);
   const relockShields = vi.fn(() => {
     rebuildWindow.relocked = true;
     return true;
@@ -46,7 +47,10 @@ describe("rebuild shields relock guard", () => {
       recreateOptions: { observabilityEnabled: false },
       liveState: { staleRecovery: false, staleRegistrySnapshot: null },
       recoveryManifest: null,
-      dcodePreflight: { cleanup: cleanupDcodePreflight },
+      dcodePreflight: {
+        cleanup: cleanupDcodePreflight,
+        revalidateBeforeDelete: revalidateDcodeBeforeDelete,
+      },
       preparedImage: null,
       releaseOnboardLock,
       log: vi.fn(),
@@ -70,6 +74,24 @@ describe("rebuild shields relock guard", () => {
     expect(phaseMocks.runBackup).toHaveBeenCalledOnce();
     expect(relockShields).toHaveBeenCalledWith(true);
     expect(rebuildWindow.relocked).toBe(true);
+  });
+
+  it("does not relock shields when sandbox deletion remains ambiguous (#7062)", async () => {
+    phaseMocks.runBackup.mockReturnValue({ backupManifest: null });
+    phaseMocks.runDestroy.mockImplementation(
+      ({ onDeleteStateAmbiguous }: { onDeleteStateAmbiguous?: () => void }) => {
+        onDeleteStateAmbiguous?.();
+        throw new Error("Sandbox deletion could not be confirmed.");
+      },
+    );
+
+    await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
+      "Sandbox deletion could not be confirmed.",
+    );
+
+    expect(phaseMocks.runDestroy).toHaveBeenCalledOnce();
+    expect(relockShields).not.toHaveBeenCalled();
+    expect(rebuildWindow.relocked).toBe(false);
   });
 
   it("blocks a pending baseline transition before shields, backup, or destroy phases begin (#7194)", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Closes two destructive-delete safety gaps discovered after #7196 merged. Rebuild now rereads the sandbox registry immediately before deletion, verifies the canonical sandbox and recorded gateway binding still match the prepared target, and treats an accepted but unconfirmed deletion as ambiguous so shields are not relocked prematurely.

## Related Issue

Follow-up to #7196 and #7062.

## Changes

- Reread and resolve the canonical sandbox target and recorded gateway at the delete edge.
- Abort deletion, restore MCP state, and relock shields when the sandbox identity or gateway binding drifts after MCP preparation.
- Mark an accepted but unconfirmed delete as ambiguous so the outer finally path does not claim a locked posture.
- Recognize OpenShell's exact structured sandbox-absence response while leaving gateway, provider, transport, and mixed diagnostics ambiguous.
- Add regressions for sandbox-name drift, gateway-binding drift, MCP restoration, ambiguous deletion, and structured absence classification.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This correction restores the delete-edge identity and ambiguous-deletion behavior already documented in the rebuild, MCP, and trusted-boundary guides.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The correction narrows the destructive action by revalidating the exact target and gateway at the delete edge, fails closed on drift, restores MCP before relocking, and only classifies the exact structured sandbox-not-found response as absence.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing canonical docs already require delete-edge target/gateway revalidation and ambiguous-deletion handling; the structured response classifier is an internal compatibility correction that does not change commands, configuration, supported surfaces, or operator guidance.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a3d588227a679860aa207ed6959060123aa85b16 -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — normal hooks passed for the maintainer follow-up commit; the original exact head passed `npm run check:diff`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 46 focused CLI tests passed for the current exact head; CLI typecheck, build, source-shape, test-title, project-membership, and formatting checks passed. The original change also passed its 88 changed tests and 52 adjacent integration tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the correction is isolated to the rebuild destroy phase and its focused tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sandbox deletion when gateway/registry details change during rebuild preparation by re-checking the delete target right before execution.
  * Improved gateway pinning so the delete targets the intended gateway even if ambient gateway selection shifts.
  * Treated deletion as ambiguous when transport errors block confirmation, triggering the ambiguous-delete flow rather than “deleted” handling.
  * Expanded handling of structured “sandbox not found” responses for destructive reconciliation.
* **Tests**
  * Added/extended coverage for gateway mismatch scenarios, ambiguous deletion behavior, and structured absence variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
