### PR TITLE
fix(preflight): trust Docker version identity

### DIFF
--- a/src/lib/onboard/preflight-podman-compat.test.ts
+++ b/src/lib/onboard/preflight-podman-compat.test.ts
@@ -71,13 +71,14 @@ describe("assessHost Podman docker-compat detection (#7320)", () => {
     expect(result.isUnsupportedRuntime).toBe(true);
   });
 
-  it("keeps real Docker classified as supported (no Podman false positive)", () => {
+  it("keeps Docker Engine supported when ProductLicense reports Apache-2.0", () => {
     const realDockerInfo = JSON.stringify({
       ServerVersion: "29.6.2",
       OperatingSystem: "Ubuntu 24.04.3 LTS",
       OSType: "linux",
       Architecture: "x86_64",
       DefaultRuntime: "runc",
+      ProductLicense: "Apache-2.0",
       DockerRootDir: "/var/lib/docker",
       DefaultAddressPools: [{ Base: "192.168.240.0/20", Size: 24 }],
       ClientInfo: { Platform: { Name: "Docker Engine - Community" } },

--- a/src/lib/onboard/preflight-podman-compat.test.ts
+++ b/src/lib/onboard/preflight-podman-compat.test.ts
@@ -74,7 +74,7 @@ describe("assessHost Podman docker-compat detection (#7320)", () => {
   it.each([
     ["an empty JSON object", "{}"],
     ["unexpected plain text", "unexpected version output"],
-  ])("keeps the Podman info backstop for %s from the version probe", (_case, versionOutput) => {
+  ])("rejects a Podman-compatible runtime when version output is %s (#7320)", (_case, versionOutput) => {
     const result = assessHost({
       platform: "darwin",
       env: {},

--- a/src/lib/onboard/preflight-podman-compat.test.ts
+++ b/src/lib/onboard/preflight-podman-compat.test.ts
@@ -71,6 +71,23 @@ describe("assessHost Podman docker-compat detection (#7320)", () => {
     expect(result.isUnsupportedRuntime).toBe(true);
   });
 
+  it.each([
+    ["an empty JSON object", "{}"],
+    ["unexpected plain text", "unexpected version output"],
+  ])("keeps the Podman info backstop for %s from the version probe", (_case, versionOutput) => {
+    const result = assessHost({
+      platform: "darwin",
+      env: {},
+      dockerInfoOutput: PODMAN_COMPAT_DOCKER_INFO,
+      dockerVersionOutput: versionOutput,
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+
+    expect(result.dockerReachable).toBe(true);
+    expect(result.runtime).toBe("podman");
+    expect(result.isUnsupportedRuntime).toBe(true);
+  });
+
   it("keeps Docker Engine supported when ProductLicense reports Apache-2.0", () => {
     const realDockerInfo = JSON.stringify({
       ServerVersion: "29.6.2",

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -260,11 +260,11 @@ function dockerVersionReportsPodman(versionOutput = ""): boolean {
 }
 
 /**
- * Backstop Podman signal from `docker info --format '{{json .}}'` when the
- * `docker version` probe is unavailable: Podman's docker-compat `/info` reports
- * `ProductLicense: "Apache-2.0"` (Podman is Apache-2.0 licensed), whereas Docker
- * Engine omits `ProductLicense` (Docker CE) or reports a Docker license string.
- * Observed Apache-2.0 on the reporter-equivalent Podman machine (#7320).
+ * Use `ProductLicense: "Apache-2.0"` as a Podman backstop only when the
+ * authoritative `docker version` probe is unavailable. Podman's docker-compat
+ * `/info` reports this value, but Docker Engine can also report it. Without
+ * version evidence, preflight conservatively rejects that ambiguous runtime
+ * before the Docker-driver path (#7320).
  */
 function dockerInfoReportsPodmanCompat(infoOutput = ""): boolean {
   const text = String(infoOutput || "").trim();
@@ -287,10 +287,10 @@ function dockerInfoReportsPodmanCompat(infoOutput = ""): boolean {
  * `EADDRNOTAVAIL` (#7320).
  */
 function isDockerCompatPodman(dockerInfoOutput = "", dockerVersionOutput = ""): boolean {
-  return (
-    dockerVersionReportsPodman(dockerVersionOutput) ||
-    dockerInfoReportsPodmanCompat(dockerInfoOutput)
-  );
+  if (String(dockerVersionOutput || "").trim()) {
+    return dockerVersionReportsPodman(dockerVersionOutput);
+  }
+  return dockerInfoReportsPodmanCompat(dockerInfoOutput);
 }
 
 function parseDockerCgroupVersion(info = ""): "v1" | "v2" | "unknown" {

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -216,9 +216,11 @@ function inferContainerRuntime(info = ""): ContainerRuntime {
   return "unknown";
 }
 
+type DockerVersionIdentity = "docker" | "podman" | "unknown";
+
 /**
- * Detect Podman fronting the Docker CLI compatibility socket from the explicit
- * `docker version --format '{{json .}}'` engine banner.
+ * Classify the engine identity from the explicit
+ * `docker version --format '{{json .}}'` banner.
  *
  * Podman's docker-compat `/info` endpoint mimics Docker so closely that
  * `docker info` carries no "podman" marker (observed on Apple Silicon macOS:
@@ -228,35 +230,43 @@ function inferContainerRuntime(info = ""): ContainerRuntime {
  * `Server.Components[].Name` of "Podman Engine" and a `Server.Platform.Name`
  * like "linux/arm64/fedora-42". Real Docker reports
  * `Server.Platform.Name: "Docker Engine - Community"` and components
- * `Engine`/`containerd`/`runc`, so this stays false on Docker Engine,
- * Docker Desktop, and Colima (#7320).
+ * `Engine`/`containerd`/`runc`, which provide positive Docker identity on
+ * Docker Engine, Docker Desktop, and Colima (#7320).
  */
-function dockerVersionReportsPodman(versionOutput = ""): boolean {
+function classifyDockerVersionIdentity(versionOutput = ""): DockerVersionIdentity {
   const text = String(versionOutput || "").trim();
-  if (!text) return false;
+  if (!text) return "unknown";
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
   } catch {
     // Plain-text `docker version` still prints the "Podman Engine" server banner.
-    return /podman/i.test(text);
+    if (/podman/i.test(text)) return "podman";
+    return /docker engine/i.test(text) ? "docker" : "unknown";
   }
   const server = (parsed as Record<string, unknown> | null)?.Server;
-  if (!server || typeof server !== "object") return false;
+  if (!server || typeof server !== "object") return "unknown";
   const s = server as Record<string, unknown>;
   const platformName = (s.Platform as Record<string, unknown> | undefined)?.Name;
-  if (typeof platformName === "string" && /podman/i.test(platformName)) return true;
+  if (typeof platformName === "string" && /podman/i.test(platformName)) return "podman";
   const components = s.Components;
-  return (
-    Array.isArray(components) &&
-    components.some((component) => {
-      const name =
-        component && typeof component === "object"
-          ? (component as Record<string, unknown>).Name
-          : undefined;
-      return typeof name === "string" && /podman/i.test(name);
-    })
-  );
+  const componentNames = Array.isArray(components)
+    ? components.flatMap((component) => {
+        const name =
+          component && typeof component === "object"
+            ? (component as Record<string, unknown>).Name
+            : undefined;
+        return typeof name === "string" ? [name] : [];
+      })
+    : [];
+  if (componentNames.some((name) => /podman/i.test(name))) return "podman";
+  if (
+    (typeof platformName === "string" && /^docker (?:engine|desktop)\b/i.test(platformName)) ||
+    componentNames.some((name) => name.trim().toLowerCase() === "engine")
+  ) {
+    return "docker";
+  }
+  return "unknown";
 }
 
 /**
@@ -287,9 +297,9 @@ function dockerInfoReportsPodmanCompat(infoOutput = ""): boolean {
  * `EADDRNOTAVAIL` (#7320).
  */
 function isDockerCompatPodman(dockerInfoOutput = "", dockerVersionOutput = ""): boolean {
-  if (String(dockerVersionOutput || "").trim()) {
-    return dockerVersionReportsPodman(dockerVersionOutput);
-  }
+  const versionIdentity = classifyDockerVersionIdentity(dockerVersionOutput);
+  if (versionIdentity === "podman") return true;
+  if (versionIdentity === "docker") return false;
   return dockerInfoReportsPodmanCompat(dockerInfoOutput);
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fixes a Docker Engine false positive discovered after #7353 merged. Positive `docker version` identity now overrides the ambiguous `ProductLicense: "Apache-2.0"` signal. Ambiguous version output retains the conservative Podman-compatible runtime rejection.

## Related Issue

Follow-up to #7353 and #7320.

## Changes

- Classify `docker version` output as Docker, Podman, or unknown.
- Treat positive Docker identity as authoritative over the ambiguous info response.
- Use the `ProductLicense` backstop when version output does not identify Docker or Podman.
- Add regressions for Docker Engine reporting `Apache-2.0` and Podman-compatible info paired with ambiguous version output.
- Use a behavior-oriented regression-test title with the required issue suffix.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing commands, platform-support, and troubleshooting docs already state that Docker is supported and Podman is unsupported. This correction changes no supported surface or procedure.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The correction accepts only positive Docker identity and retains the conservative rejection when version identity is unknown.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed `src/lib/onboard/preflight.ts`, `src/lib/onboard/preflight-podman-compat.test.ts`, `docs/reference/commands.mdx`, `docs/reference/platform-support.mdx`, and `docs/reference/troubleshooting.mdx`. Existing docs already state that Docker is supported and Podman is unsupported; this correction changes no supported surface or procedure.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 60f8b094ad8e20fc6325630e8c00a2c435745768 -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — normal pre-commit and commit-msg hooks passed; `npm run check:diff` passed at `60f8b094a`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/preflight-podman-compat.test.ts src/lib/onboard/preflight.test.ts` passed 136 tests; `npm run test:titles:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the correction changes one preflight identity predicate and its regression fixture.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding runtime detection by more reliably classifying Docker vs Podman from version identity.
  * When Docker compatibility sockets are present but the version probe is empty or unexpected, Podman is still correctly detected and flagged as unsupported.
  * Real Docker installations are now correctly recognized as supported, including when the product license reports Apache-2.0.
* **Tests**
  * Expanded compatibility preflight coverage for Podman masquerading scenarios and refined the Docker “supported” regression assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->