### PR TITLE
fix(e2e): retry transient required-gate reads

### DIFF
--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -11,8 +11,10 @@ import {
   coordinationExternalId,
   findCoordinationCheck,
   formatRequiredGateOutcome,
+  isRetryableGithubReadError,
   type RequiredGateIdentity,
   type RequiredGateResult,
+  retryableGithubRead,
   waitForRequiredGate,
 } from "../tools/e2e/pr-e2e-required.mts";
 import { createGitHubFetchRouter, githubFetchRoute } from "./support/github-fetch-router.ts";
@@ -471,5 +473,247 @@ describe("native PR E2E required job", () => {
     await expect(
       waitForRequiredGate(identity, { timeoutMs: 100, pollIntervalMs: 10 }),
     ).rejects.toThrow("not the expected open PR with the observed PR SHA and base SHA");
+  });
+
+  describe("bounded GitHub read retries (#7207)", () => {
+    it("classifies only network, rate-limit, and server failures as retryable", () => {
+      expect(isRetryableGithubReadError(new TypeError("fetch failed"))).toBe(true);
+      expect(
+        isRetryableGithubReadError(new Error("GitHub API repos/x/pulls/1 failed: 429 limited")),
+      ).toBe(true);
+      expect(
+        isRetryableGithubReadError(new Error("GitHub API repos/x/pulls/1 failed: 503 unavailable")),
+      ).toBe(true);
+      expect(
+        isRetryableGithubReadError(new Error("GitHub API repos/x/pulls/1 failed: 404 missing")),
+      ).toBe(false);
+      expect(
+        isRetryableGithubReadError(new Error("GitHub API repos/x/pulls/1 failed: 401 denied")),
+      ).toBe(false);
+      expect(
+        isRetryableGithubReadError(new Error("GitHub API repos/x/pulls/1 failed: 403 denied")),
+      ).toBe(false);
+      expect(isRetryableGithubReadError(new Error("fetch failed"))).toBe(false);
+    });
+
+    it("retries a transient read with deterministic bounded delay", async () => {
+      let calls = 0;
+      const sleepCalls: number[] = [];
+
+      await expect(
+        retryableGithubRead(
+          "coordination checks",
+          async () => {
+            calls += 1;
+            if (calls === 1) throw new TypeError("fetch failed");
+            return "success";
+          },
+          null,
+          {
+            baseDelayMs: 100,
+            random: () => 0,
+            sleep: async (milliseconds) => {
+              sleepCalls.push(milliseconds);
+            },
+          },
+        ),
+      ).resolves.toBe("success");
+
+      expect(calls).toBe(2);
+      expect(sleepCalls).toEqual([50]);
+    });
+
+    it("preserves the first retryable failure as the exhaustion cause", async () => {
+      let calls = 0;
+      const error = await retryableGithubRead(
+        "coordination checks",
+        async () => {
+          calls += 1;
+          throw new TypeError(`fetch failed attempt ${calls}`);
+        },
+        null,
+        { baseDelayMs: 1, random: () => 0, sleep: async () => {} },
+      ).catch((caught: unknown) => caught);
+
+      expect(calls).toBe(3);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "E2E / PR Gate [coordination checks] attempt 3/3: network",
+      );
+      expect((error as Error & { cause?: Error }).cause?.message).toBe("fetch failed attempt 1");
+    });
+
+    it("does not retry or expose a non-retryable response body", async () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      let calls = 0;
+
+      const error = await retryableGithubRead(
+        "coordination checks",
+        async () => {
+          calls += 1;
+          throw new Error("GitHub API repos/x/pulls/1 failed: 404 secret response");
+        },
+        null,
+        { sleep: async () => {} },
+      ).catch((caught: unknown) => caught);
+
+      expect(calls).toBe(1);
+      expect((error as Error).message).toBe(
+        "E2E / PR Gate [coordination checks] attempt 1/3: http",
+      );
+      expect((error as Error).message).not.toContain("secret response");
+      expect((error as Error & { cause?: Error }).cause?.message).toContain("secret response");
+      expect(log).not.toHaveBeenCalled();
+    });
+
+    it("logs a retry class without reflecting the GitHub response body", async () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      let calls = 0;
+
+      await retryableGithubRead(
+        "coordination checks",
+        async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error("GitHub API repos/x/check-runs failed: 503 credential-like-body");
+          }
+          return "success";
+        },
+        null,
+        { baseDelayMs: 1, random: () => 0, sleep: async () => {} },
+      );
+
+      expect(log).toHaveBeenCalledWith("E2E / PR Gate [coordination checks] attempt 1/3: http");
+      expect(log.mock.calls.flat().join(" ")).not.toContain("credential-like-body");
+    });
+
+    it("does not expose a retryable response body after exhaustion", async () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      const error = await retryableGithubRead(
+        "coordination checks",
+        async () => {
+          throw new Error("GitHub API repos/x/check-runs failed: 503 credential-like-body");
+        },
+        null,
+        { baseDelayMs: 1, random: () => 0, sleep: async () => {} },
+      ).catch((caught: unknown) => caught);
+
+      expect((error as Error).message).toBe(
+        "E2E / PR Gate [coordination checks] attempt 3/3: http",
+      );
+      expect((error as Error).message).not.toContain("credential-like-body");
+      expect(log.mock.calls.flat().join(" ")).not.toContain("credential-like-body");
+      expect((error as Error & { cause?: Error }).cause?.message).toContain("credential-like-body");
+    });
+
+    it("fails closed when exact PR identity changes before a retry", async () => {
+      let calls = 0;
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        githubResponse(pullRequest({ head: { sha: "c".repeat(40) } })),
+      );
+
+      await expect(
+        retryableGithubRead(
+          "coordination checks",
+          async () => {
+            calls += 1;
+            throw new TypeError("fetch failed");
+          },
+          identity,
+          { baseDelayMs: 1, random: () => 0, sleep: async () => {} },
+        ),
+      ).rejects.toThrow("not the expected open PR with the observed PR SHA and base SHA");
+
+      expect(calls).toBe(1);
+    });
+
+    it("proves exact PR identity through transient revalidation before retrying", async () => {
+      let calls = 0;
+      let identityCalls = 0;
+      const sleepCalls: number[] = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        identityCalls += 1;
+        if (identityCalls === 1) throw new TypeError("identity fetch failed");
+        return githubResponse(pullRequest());
+      });
+
+      await expect(
+        retryableGithubRead(
+          "coordination checks",
+          async () => {
+            calls += 1;
+            if (calls === 1) throw new TypeError("coordination fetch failed");
+            return "success";
+          },
+          identity,
+          {
+            baseDelayMs: 100,
+            random: () => 0,
+            sleep: async (milliseconds) => {
+              sleepCalls.push(milliseconds);
+            },
+          },
+        ),
+      ).resolves.toBe("success");
+
+      expect(calls).toBe(2);
+      expect(identityCalls).toBe(2);
+      expect(sleepCalls).toEqual([50, 50]);
+    });
+
+    it("does not retry the original read when identity cannot be proven", async () => {
+      let calls = 0;
+      let identityCalls = 0;
+      vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        identityCalls += 1;
+        throw new TypeError(`identity fetch failed ${identityCalls}`);
+      });
+
+      await expect(
+        retryableGithubRead(
+          "coordination checks",
+          async () => {
+            calls += 1;
+            throw new TypeError("coordination fetch failed");
+          },
+          identity,
+          { baseDelayMs: 1, random: () => 0, sleep: async () => {} },
+        ),
+      ).rejects.toThrow("E2E / PR Gate [exact PR identity] attempt 3/3: network");
+
+      expect(calls).toBe(1);
+      expect(identityCalls).toBe(3);
+    });
+
+    it("revalidates identity after the backoff and before the original read", async () => {
+      let calls = 0;
+      let identityChanged = false;
+      vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+        githubResponse(
+          identityChanged ? pullRequest({ head: { sha: "c".repeat(40) } }) : pullRequest(),
+        ),
+      );
+
+      await expect(
+        retryableGithubRead(
+          "coordination checks",
+          async () => {
+            calls += 1;
+            throw new TypeError("coordination fetch failed");
+          },
+          identity,
+          {
+            baseDelayMs: 1,
+            random: () => 0,
+            sleep: async () => {
+              identityChanged = true;
+            },
+          },
+        ),
+      ).rejects.toThrow("not the expected open PR with the observed PR SHA and base SHA");
+
+      expect(calls).toBe(1);
+    });
   });
 });

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -497,29 +497,23 @@ describe("native PR E2E required job", () => {
     });
 
     it("retries a transient read with deterministic bounded delay", async () => {
-      let calls = 0;
       const sleepCalls: number[] = [];
+      const read = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValue("success");
 
       await expect(
-        retryableGithubRead(
-          "coordination checks",
-          async () => {
-            calls += 1;
-            if (calls === 1) throw new TypeError("fetch failed");
-            return "success";
+        retryableGithubRead("coordination checks", read, null, {
+          baseDelayMs: 100,
+          random: () => 0,
+          sleep: async (milliseconds) => {
+            sleepCalls.push(milliseconds);
           },
-          null,
-          {
-            baseDelayMs: 100,
-            random: () => 0,
-            sleep: async (milliseconds) => {
-              sleepCalls.push(milliseconds);
-            },
-          },
-        ),
+        }),
       ).resolves.toBe("success");
 
-      expect(calls).toBe(2);
+      expect(read).toHaveBeenCalledTimes(2);
       expect(sleepCalls).toEqual([50]);
     });
 
@@ -568,20 +562,18 @@ describe("native PR E2E required job", () => {
 
     it("logs a retry class without reflecting the GitHub response body", async () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-      let calls = 0;
+      const read = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error("GitHub API repos/x/check-runs failed: 503 credential-like-body"),
+        )
+        .mockResolvedValue("success");
 
-      await retryableGithubRead(
-        "coordination checks",
-        async () => {
-          calls += 1;
-          if (calls === 1) {
-            throw new Error("GitHub API repos/x/check-runs failed: 503 credential-like-body");
-          }
-          return "success";
-        },
-        null,
-        { baseDelayMs: 1, random: () => 0, sleep: async () => {} },
-      );
+      await retryableGithubRead("coordination checks", read, null, {
+        baseDelayMs: 1,
+        random: () => 0,
+        sleep: async () => {},
+      });
 
       expect(log).toHaveBeenCalledWith("E2E / PR Gate [coordination checks] attempt 1/3: http");
       expect(log.mock.calls.flat().join(" ")).not.toContain("credential-like-body");
@@ -629,36 +621,28 @@ describe("native PR E2E required job", () => {
     });
 
     it("proves exact PR identity through transient revalidation before retrying", async () => {
-      let calls = 0;
-      let identityCalls = 0;
       const sleepCalls: number[] = [];
-      vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-        identityCalls += 1;
-        if (identityCalls === 1) throw new TypeError("identity fetch failed");
-        return githubResponse(pullRequest());
-      });
+      const identityRead = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValueOnce(new TypeError("identity fetch failed"))
+        .mockResolvedValue(githubResponse(pullRequest()));
+      const coordinationRead = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError("coordination fetch failed"))
+        .mockResolvedValue("success");
 
       await expect(
-        retryableGithubRead(
-          "coordination checks",
-          async () => {
-            calls += 1;
-            if (calls === 1) throw new TypeError("coordination fetch failed");
-            return "success";
+        retryableGithubRead("coordination checks", coordinationRead, identity, {
+          baseDelayMs: 100,
+          random: () => 0,
+          sleep: async (milliseconds) => {
+            sleepCalls.push(milliseconds);
           },
-          identity,
-          {
-            baseDelayMs: 100,
-            random: () => 0,
-            sleep: async (milliseconds) => {
-              sleepCalls.push(milliseconds);
-            },
-          },
-        ),
+        }),
       ).resolves.toBe("success");
 
-      expect(calls).toBe(2);
-      expect(identityCalls).toBe(2);
+      expect(coordinationRead).toHaveBeenCalledTimes(2);
+      expect(identityRead).toHaveBeenCalledTimes(2);
       expect(sleepCalls).toEqual([50, 50]);
     });
 

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -560,6 +560,29 @@ describe("native PR E2E required job", () => {
       expect(log).not.toHaveBeenCalled();
     });
 
+    it("uses a later terminal failure as the cause after a transient failure", async () => {
+      const read = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockRejectedValueOnce(
+          new Error("GitHub API repos/x/pulls/1 failed: 404 terminal response"),
+        );
+
+      const error = await retryableGithubRead("coordination checks", read, null, {
+        baseDelayMs: 1,
+        random: () => 0,
+        sleep: async () => {},
+      }).catch((caught: unknown) => caught);
+
+      expect(read).toHaveBeenCalledTimes(2);
+      expect((error as Error).message).toBe(
+        "E2E / PR Gate [coordination checks] attempt 2/3: http",
+      );
+      expect((error as Error & { cause?: Error }).cause?.message).toBe(
+        "GitHub API repos/x/pulls/1 failed: 404 terminal response",
+      );
+    });
+
     it("logs a retry class without reflecting the GitHub response body", async () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
       const read = vi

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -28,8 +28,19 @@ const USER_AGENT = "nemoclaw-pr-e2e-required";
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
 const MAX_LOG_URLS = 20;
+const MAX_GITHUB_READ_ATTEMPTS = 3;
+const GITHUB_HTTP_ERROR_PATTERN = /^GitHub API [^\r\n]* failed: ([1-5]\d{2})\b/u;
+const RETRYABLE_HTTP_PATTERN = /^GitHub API [^\r\n]* failed: (?:429|5\d{2})\b/u;
 
 type CheckConclusion = "success" | "failure" | "cancelled";
+type GithubReadOperation = "check runs" | "coordination checks" | "exact PR identity";
+
+export type RetryableGithubReadOptions = {
+  baseDelayMs?: number;
+  maxAttempts?: number;
+  random?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+};
 
 export type CoordinationCheckRun = {
   id: number;
@@ -161,6 +172,73 @@ async function requireExactPullRequest(identity: RequiredGateIdentity): Promise<
   );
 }
 
+export function isRetryableGithubReadError(error: unknown): boolean {
+  return (
+    error instanceof TypeError ||
+    (error instanceof Error && RETRYABLE_HTTP_PATTERN.test(error.message))
+  );
+}
+
+export async function retryableGithubRead<T>(
+  operation: GithubReadOperation,
+  read: () => Promise<T>,
+  identity: RequiredGateIdentity | null,
+  options: RetryableGithubReadOptions = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? MAX_GITHUB_READ_ATTEMPTS;
+  const baseDelayMs = options.baseDelayMs ?? 1000;
+  if (!Number.isSafeInteger(maxAttempts) || maxAttempts < 1 || maxAttempts > 5) {
+    throw new Error("GitHub read retry attempts must be an integer from 1 through 5");
+  }
+  if (!Number.isSafeInteger(baseDelayMs) || baseDelayMs < 1 || baseDelayMs > 4000) {
+    throw new Error("GitHub read retry delay must be an integer from 1 through 4000");
+  }
+  const random = options.random ?? Math.random;
+  const sleep =
+    options.sleep ??
+    ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+
+  let firstError: Error | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await read();
+    } catch (error: unknown) {
+      if (!isRetryableGithubReadError(error) || attempt === maxAttempts) {
+        const errorClass =
+          error instanceof TypeError
+            ? "network"
+            : error instanceof Error && GITHUB_HTTP_ERROR_PATTERN.test(error.message)
+              ? "http"
+              : null;
+        if (errorClass) {
+          throw new Error(
+            `E2E / PR Gate [${operation}] attempt ${attempt}/${maxAttempts}: ${errorClass}`,
+            { cause: firstError ?? error },
+          );
+        }
+        throw error;
+      }
+      if (error instanceof Error) firstError ??= error;
+      const errorClass = error instanceof TypeError ? "network" : "http";
+      console.log(`E2E / PR Gate [${operation}] attempt ${attempt}/${maxAttempts}: ${errorClass}`);
+
+      const jitter = 0.5 + random() * 0.5;
+      const delay = Math.min(baseDelayMs * 2 ** (attempt - 1) * jitter, 4000);
+      await sleep(delay);
+
+      if (identity) {
+        await retryableGithubRead(
+          "exact PR identity",
+          () => requireExactPullRequest(identity),
+          null,
+          options,
+        );
+      }
+    }
+  }
+  throw new Error("GitHub read retry loop ended unexpectedly");
+}
+
 function hasRetryableFailureMarker(check: CoordinationCheckRun): boolean {
   if (check.status !== "completed" || check.conclusion !== "failure") return false;
   if (NEVER_RETRY_FAILURE_TITLES.has(check.output?.title ?? "")) return false;
@@ -209,10 +287,15 @@ async function matchingChecks(
   name: string,
 ): Promise<CoordinationCheckRun[]> {
   const response = validateCheckRunsResponse(
-    await githubApi<unknown>(
-      `repos/${identity.repository}/commits/${identity.headSha}/check-runs?check_name=${encodeURIComponent(name)}&filter=all&per_page=100`,
-      identity.token,
-      { userAgent: USER_AGENT },
+    await retryableGithubRead(
+      "check runs",
+      () =>
+        githubApi<unknown>(
+          `repos/${identity.repository}/commits/${identity.headSha}/check-runs?check_name=${encodeURIComponent(name)}&filter=all&per_page=100`,
+          identity.token,
+          { userAgent: USER_AGENT },
+        ),
+      identity,
     ),
   );
   const externalId = coordinationExternalId(identity.prNumber, identity.headSha, identity.baseSha);
@@ -365,14 +448,21 @@ export async function waitForRequiredGate(
   let lastDescription = "";
   let lastLogUrls: string[] | undefined;
 
-  await requireExactPullRequest(identity);
+  await retryableGithubRead("exact PR identity", () => requireExactPullRequest(identity), null, {
+    sleep,
+  });
   while (now() < deadline) {
     const classified = classifyCoordinationCheck(
       await findCoordinationCheck(identity),
       identity.repository,
     );
     if (classified.state === "complete") {
-      await requireExactPullRequest(identity);
+      await retryableGithubRead(
+        "exact PR identity",
+        () => requireExactPullRequest(identity),
+        null,
+        { sleep },
+      );
       return classified.result;
     }
     const message = `${classified.description}${logUrlSuffix(classified.logUrls)}`;

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -203,7 +203,8 @@ export async function retryableGithubRead<T>(
     try {
       return await read();
     } catch (error: unknown) {
-      if (!isRetryableGithubReadError(error) || attempt === maxAttempts) {
+      const retryable = isRetryableGithubReadError(error);
+      if (!retryable || attempt === maxAttempts) {
         const errorClass =
           error instanceof TypeError
             ? "network"
@@ -213,7 +214,7 @@ export async function retryableGithubRead<T>(
         if (errorClass) {
           throw new Error(
             `E2E / PR Gate [${operation}] attempt ${attempt}/${maxAttempts}: ${errorClass}`,
-            { cause: firstError ?? error },
+            { cause: retryable ? (firstError ?? error) : error },
           );
         }
         throw error;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Retry transient GitHub reads in the required E2E gate observer without weakening exact PR, head, or base identity checks. The observer now retries only network, HTTP 429, and HTTP 5xx failures, redacts workflow-facing terminal errors, and re-proves exact identity after each backoff before reading coordination state again.

## Related Issue

Fixes #7207

Refs #7140.

This maintainer-owned salvage supersedes #7226 after it lands.

## Changes

- Add a three-attempt, jittered, bounded retry around exact-identity and check-run reads.
- Keep authorization, schema, app-identity, immutable-history, and terminal verdict failures non-retryable.
- Sanitize terminal network and HTTP messages, preserve the first transient failure when retries exhaust, and retain a later non-retryable failure as the terminal cause.
- Add adversarial coverage for response-body redaction, authorization status handling, exhaustion, mixed transient/terminal failures, identity changes during backoff, and identity-proof exhaustion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal required-check observer resilience only; user commands, configuration, E2E authorization policy, eligibility, and terminal verdict semantics are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop nine-category review passed on the exact committed diff, including terminal redaction, mixed-error cause attribution, and identity-ordering adversarial tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing E2E documentation already covers exact PR/head/base revalidation, fail-closed handling, trusted terminal verdicts, and exclusion of network-derived content from the job summary. Retry classification, jitter, sanitized errors, and internal cause selection do not change commands, configuration, policies, APIs, or maintainer workflow.
- Agent: Codex Desktop
<!-- docs-review-head-sha: da3a9dd1782c7f24368a6d65568d91efb6486cd5 -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — normal hooks passed for the maintainer follow-up; the contributor exact head passed `npm run check:diff`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/pr-e2e-required.test.ts` (28 passed); `npm run build:cli`; `npm run typecheck:cli`; `npm run source-shape:check`; test-title and Vitest-project checks; Biome and normal hooks.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a narrow observer-only change with focused behavior, build, type, hook, and independent security coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of pull request required-gate checks by retrying transient network and temporary GitHub service failures.
  * Added bounded retry backoff to reduce excessive requests during recovery.
  * Ensured retries only proceed when the pull request identity remains consistent and is revalidated between attempts.
  * Improved error reporting to avoid exposing sensitive response details.
* **Tests**
  * Added end-to-end coverage for retry classification, bounded timing behavior, identity revalidation, and privacy-safe messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
