### PR TITLE
perf(images): short-circuit reachable tag scan

### DIFF
--- a/src/lib/sandbox-base-image/source-identity.test.ts
+++ b/src/lib/sandbox-base-image/source-identity.test.ts
@@ -115,6 +115,39 @@ function createGitFixtureWithReachableOriginTags(tags: string[]) {
   return root;
 }
 
+function addUnreachableOriginTag(root: string, tag: string) {
+  const originalBranch = git(root, ["branch", "--show-current"]);
+  const branch = `unreachable-${tag.replaceAll(".", "-")}`;
+  git(root, ["switch", "--orphan", branch]);
+  git(root, ["rm", "-rf", "--ignore-unmatch", "."]);
+  writeFixture(root, "unreachable.txt", `${tag}\n`);
+  git(root, ["add", "unreachable.txt"]);
+  git(root, ["commit", "-m", `add ${tag}`]);
+  git(root, ["tag", tag]);
+  git(root, ["push", "origin", `refs/tags/${tag}`]);
+  git(root, ["switch", originalBranch]);
+}
+
+function traceReachabilityProbes<T>(operation: (env: NodeJS.ProcessEnv) => T) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-git-trace-"));
+  tmpRoots.push(root);
+  const traceFile = path.join(root, "trace.jsonl");
+  const result = operation({ ...gitEnv, GIT_TRACE2_EVENT: traceFile });
+  const probes = fs
+    .readFileSync(traceFile, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as { event?: string; argv?: string[] })
+    .filter(
+      (event) =>
+        event.event === "start" &&
+        event.argv?.includes("merge-base") &&
+        event.argv.includes("--is-ancestor"),
+    )
+    .map((event) => event.argv ?? []);
+  return { probes, result };
+}
+
 afterEach(() => {
   for (const root of tmpRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
@@ -232,12 +265,58 @@ describe("sandbox base-image source identity", () => {
     git(root, ["add", "docs/release.md"]);
     git(root, ["commit", "-m", "release 42"]);
     git(root, ["tag", "-a", "v0.0.42", "-m", "v0.0.42"]);
+    const peeledCommit = git(root, ["rev-parse", "v0.0.42^{}"]);
     git(root, ["push", "origin", "main", "refs/tags/v0.0.42"]);
     git(root, ["tag", "-d", "v0.0.42"]);
 
     expect(getVersionedBaseImageTags(root, gitEnv)).toEqual([]);
     expect(git(root, ["describe", "--tags", "--abbrev=0", "--match", "v*"])).toBe("v0.0.41");
-    expect(getNearestVersionedBaseImageTags(root, gitEnv)).toEqual(["v0.0.42"]);
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+    expect(result).toEqual(["v0.0.42"]);
+    expect(probes).toHaveLength(1);
+    expect(probes[0]).toContain(peeledCommit);
+  });
+
+  it("stops after the newest reachable origin release tag", () => {
+    const root = createGitFixtureWithReachableOriginTags(["v0.0.77", "v0.0.79"]);
+
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+
+    expect(result).toEqual(["v0.0.79"]);
+    expect(probes).toHaveLength(1);
+  });
+
+  it("checks the next release only when the newest origin tag is unreachable", () => {
+    const root = createGitFixtureWithReachableOriginTags(["v0.0.79"]);
+    addUnreachableOriginTag(root, "v0.0.80");
+
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+
+    expect(result).toEqual(["v0.0.79"]);
+    expect(probes).toHaveLength(2);
+  });
+
+  it("preserves the nearest local tag fallback when no origin tag is reachable", () => {
+    const root = createGitFixtureWithRemoteOnlyBaseRef();
+    git(root, ["tag", "v0.0.41"]);
+    git(root, ["switch", "-c", "feature"]);
+    writeFixture(root, "src/other.ts", "export const value = 42;\n");
+    git(root, ["add", "src/other.ts"]);
+    git(root, ["commit", "-m", "move off tag"]);
+    addUnreachableOriginTag(root, "v0.0.80");
+
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+
+    expect(result).toEqual(["v0.0.41"]);
+    expect(probes).toHaveLength(1);
   });
 
   it("prefers a stable reachable origin release over a prerelease created later (#6624)", () => {

--- a/src/lib/sandbox-base-image/source-identity.test.ts
+++ b/src/lib/sandbox-base-image/source-identity.test.ts
@@ -290,6 +290,17 @@ describe("sandbox base-image source identity", () => {
     expect(probes).toHaveLength(1);
   });
 
+  it("preserves remote order for comparator-equivalent release tag spellings (#7249)", () => {
+    const root = createGitFixtureWithReachableOriginTags(["v1.2.3.0", "v1.2.3"]);
+
+    const { probes, result } = traceReachabilityProbes((env) =>
+      getNearestVersionedBaseImageTags(root, env),
+    );
+
+    expect(result).toEqual(["v1.2.3"]);
+    expect(probes).toHaveLength(1);
+  });
+
   it("checks the next release only when the newest origin tag is unreachable", () => {
     const root = createGitFixtureWithReachableOriginTags(["v0.0.79"]);
     addUnreachableOriginTag(root, "v0.0.80");

--- a/src/lib/sandbox-base-image/source-identity.ts
+++ b/src/lib/sandbox-base-image/source-identity.ts
@@ -199,15 +199,13 @@ function gitRemoteReachableVersionTag(rootDir: string, env: NodeJS.ProcessEnv): 
     if (peeled || !tags.has(tag)) tags.set(tag, commit);
   }
 
-  return (
-    [...tags]
-      .filter(
-        ([, commit]) =>
-          gitStatus(rootDir, ["merge-base", "--is-ancestor", commit, "HEAD"], env) === 0,
-      )
-      .map(([tag]) => tag)
-      .sort(compareVersionTagsDesc)[0] ?? null
-  );
+  const candidates = [...tags].sort(([left], [right]) => compareVersionTagsDesc(left, right));
+  for (const [tag, commit] of candidates) {
+    if (gitStatus(rootDir, ["merge-base", "--is-ancestor", commit, "HEAD"], env) === 0) {
+      return tag;
+    }
+  }
+  return null;
 }
 
 function versionFileTag(rootDir: string): string | null {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This replacement rebuilds #7554 from current `main` while retaining Ho Lim as Author for the production optimization.
It reduces fallback reachability probes without changing tag selection, trust, or local fallback behavior.

## Related Issue

Closes #7249.
Supersedes #7554 without closing it.

## Changes

- Parse the complete remote tag response, preserve peeled annotated-tag commits, and order candidates with the existing semantic-version comparator.
- Stop after the first reachable candidate while preserving stable, prerelease, comparator-equivalent, and local-fallback behavior.
- Add deterministic probe coverage for one-probe success, two-probe fallback, annotated tags, exhaustion, and comparator-equivalent textual tags.
- Preserve Ho Lim as Author of commit `bf86e27a8`, replayed from the verified #7554 production commit `cc02a6b64`.
- Credit dfernandez365-rgb's earlier verified candidate `0e1a0e59` as prior art, as recorded in [#7249](https://github.com/NVIDIA/NemoClaw/issues/7249#issuecomment-5025848521). The replacement does not claim that #7554 copied the candidate.
- Documentation writer receipt for exact head `b67bf3a5a`: no docs change required because the documented selection contract is unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal reachability optimization; commands, configuration, output, and selection behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: exact-head nine-category maintainer review passed; published-image trust, digest pinning, override provenance, and fallback semantics are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release tag selection to consistently choose the newest reachable version from the remote repository.
  * Correctly checks tag reachability before selecting a release, avoiding unreachable or stale tags.
  * Preserves the nearest local version as a fallback when no remote release tag is reachable.
  * Maintains consistent ordering when multiple tags represent equivalent versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->