### PR TITLE
fix(ci): publish supported conflict resolutions

### DIFF
--- a/test/pr-merge-conflict-fixer.test.ts
+++ b/test/pr-merge-conflict-fixer.test.ts
@@ -218,7 +218,9 @@ describe("PR merge conflict fixer", () => {
       "b".repeat(40),
       {
         checkConflict: (candidate) =>
-          candidate.number === 1 ? [".github/workflows/e2e.yaml"] : ["conflict.txt"],
+          candidate.number === 1
+            ? ["conflict.txt", ".github/workflows/e2e.yaml"]
+            : ["conflict.txt"],
       },
     );
 

--- a/test/pr-merge-conflict-fixer.test.ts
+++ b/test/pr-merge-conflict-fixer.test.ts
@@ -211,6 +211,20 @@ describe("PR merge conflict fixer", () => {
     expect(selected.map((item) => item.pr_number)).toEqual([1, 2]);
   });
 
+  it("skips GitHub workflow conflicts before model selection (#7542)", () => {
+    const selected = selectConflictingPullRequests(
+      [pullRequest({ number: 1 }), pullRequest({ number: 2 })],
+      "NVIDIA/NemoClaw",
+      "b".repeat(40),
+      {
+        checkConflict: (candidate) =>
+          candidate.number === 1 ? [".github/workflows/e2e.yaml"] : ["conflict.txt"],
+      },
+    );
+
+    expect(selected.map((item) => item.pr_number)).toEqual([2]);
+  });
+
   it("accepts a patch that changes only the original conflict paths (#7542)", () => {
     const fixture = createConflictFixture();
     const patchPath = path.join(temporaryDirectory(), "resolution.patch");
@@ -287,12 +301,7 @@ describe("PR merge conflict fixer", () => {
     const requests: Array<{ body: unknown; method: string; path: string }> = [];
     const graphql = vi.fn(async (_query: string, variables: Record<string, unknown>) => ({
       updateRefs: {
-        refUpdates: [
-          {
-            afterOid: commitSha,
-            name: `refs/heads/${entry.head_ref}`,
-          },
-        ],
+        clientMutationId: commitSha,
       },
       variables,
     }));
@@ -346,8 +355,14 @@ describe("PR merge conflict fixer", () => {
       tree: finalTree,
     });
     expect(JSON.stringify(commitRequest?.body)).not.toMatch(/author|committer|signature/u);
+    const blobRequests = requests.filter((item) => item.path.endsWith("/git/blobs"));
+    expect(blobRequests).toHaveLength(1);
+    expect(
+      Buffer.from((blobRequests[0]?.body as { content: string }).content, "base64").toString(),
+    ).toBe("resolved intent\n");
     expect(graphql).toHaveBeenCalledWith(expect.stringContaining("updateRefs"), {
       input: {
+        clientMutationId: commitSha,
         refUpdates: [
           {
             afterOid: commitSha,

--- a/tools/pr-merge-conflict-fixer/discover.mts
+++ b/tools/pr-merge-conflict-fixer/discover.mts
@@ -82,6 +82,7 @@ export function selectConflictingPullRequests(
   return eligibleSameRepositoryPullRequests(pullRequests, repository).flatMap((pullRequest) => {
     const conflictPaths = checkConflict(pullRequest, baseSha);
     if (!conflictPaths) return [];
+    if (conflictPaths.some((file) => file.startsWith(".github/workflows/"))) return [];
     return [
       {
         base_sha: baseSha,

--- a/tools/pr-merge-conflict-fixer/publish.mts
+++ b/tools/pr-merge-conflict-fixer/publish.mts
@@ -161,12 +161,14 @@ function treeEntry(repository: string, tree: string, filePath: string): GitTreeE
 }
 
 async function createGitHubTree(input: {
+  changedPaths: readonly string[];
   finalTree: string;
   headSha: string;
   repository: string;
   repositoryName: string;
   request: GitHubRequest;
 }): Promise<string> {
+  const changedPaths = new Set(input.changedPaths);
   const entries: GitTreeEntry[] = [];
   for (const change of changedPathStatuses(input.repository, input.headSha, input.finalTree)) {
     const sourceTree = change.status === "D" ? input.headSha : input.finalTree;
@@ -175,7 +177,7 @@ async function createGitHubTree(input: {
       entries.push({ ...entry, sha: null });
       continue;
     }
-    if (entry.type === "blob") {
+    if (entry.type === "blob" && changedPaths.has(entry.path)) {
       const content = gitBuffer(input.repository, ["cat-file", "blob", entry.sha ?? ""]);
       const created = (await input.request("POST", `/repos/${input.repositoryName}/git/blobs`, {
         content: content.toString("base64"),
@@ -199,6 +201,7 @@ async function createGitHubTree(input: {
 }
 
 async function publishValidatedTree(input: {
+  changedPaths: readonly string[];
   entry: ConflictMatrixEntry;
   finalTree: string;
   graphql: GraphqlRequest;
@@ -208,6 +211,7 @@ async function publishValidatedTree(input: {
   request: GitHubRequest;
 }): Promise<string> {
   const tree = await createGitHubTree({
+    changedPaths: input.changedPaths,
     finalTree: input.finalTree,
     headSha: input.entry.head_sha,
     repository: input.repository,
@@ -229,18 +233,17 @@ async function publishValidatedTree(input: {
     );
   }
 
+  const clientMutationId = commitSha;
   const mutation = `
     mutation UpdateConflictFixerRef($input: UpdateRefsInput!) {
       updateRefs(input: $input) {
-        refUpdates {
-          afterOid
-          name
-        }
+        clientMutationId
       }
     }
   `;
   const result = (await input.graphql(mutation, {
     input: {
+      clientMutationId,
       refUpdates: [
         {
           afterOid: commitSha,
@@ -252,10 +255,9 @@ async function publishValidatedTree(input: {
       repositoryId: input.pullRequest.base.repo.node_id,
     },
   })) as {
-    updateRefs?: { refUpdates?: Array<{ afterOid?: string; name?: string }> };
+    updateRefs?: { clientMutationId?: string };
   };
-  const update = result.updateRefs?.refUpdates?.[0];
-  if (update?.afterOid !== commitSha || update.name !== `refs/heads/${input.entry.head_ref}`) {
+  if (result.updateRefs?.clientMutationId !== clientMutationId) {
     throw new ConflictFixerError("GitHub did not confirm the atomic PR branch update");
   }
   return commitSha;
@@ -333,6 +335,7 @@ export async function publishResolution(input: {
       workDirectory: path.join(temporaryDirectory, "repository"),
     });
     return await publishValidatedTree({
+      changedPaths: validated.changedPaths,
       entry: input.entry,
       finalTree: validated.finalTree,
       graphql: input.graphql,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The first production run created three valid resolution patches but did not update a PR branch. This change fixes the publisher and excludes workflow-file conflicts that the repository `GITHUB_TOKEN` cannot publish.

## Related Issue

Follow-up to #7542

## Changes

- Select `clientMutationId` from `UpdateRefsPayload`. The live GitHub schema does not expose `refUpdates` in that payload.
- Keep `beforeOid` and `force: false` as the atomic PR-head update contract.
- Skip a PR when its conflict paths include `.github/workflows/**`. A repository `GITHUB_TOKEN` cannot publish changed workflow files.
- Upload blobs only for resolved conflict paths. GitHub already stores blobs referenced by the PR and base parents.
- Update the behavior test to use the live GraphQL payload shape. The test also verifies mixed workflow-conflict selection and one conflict-blob upload.

The original test mock returned a response shape that the GitHub schema does not provide. The production run exposed this detection gap. The updated mock fails when the invalid selection returns.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes experimental repository-maintainer automation. It adds no command, configuration, integration, or documentation route.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainers accepted the narrow no-PAT workflow-file exception in the [production amendment](https://github.com/NVIDIA/NemoClaw/issues/7542#issuecomment-5082393387). The [original Minimal V1 approval](https://github.com/NVIDIA/NemoClaw/issues/7542#issuecomment-5081359609) and [production run](https://github.com/NVIDIA/NemoClaw/actions/runs/30189296902) provide the surrounding contract and failure evidence.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The revised mixed-path fixture changes test coverage only. The PR still has no user-documentation surface. Changed text follows NemoClaw terminology, structure, voice, and behavior-oriented test-title rules. No findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 49792ea60 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as Verified in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/pr-merge-conflict-fixer.test.ts test/pr-merge-conflict-fixer-workflow-boundary.test.ts` — 2 files and 17 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pull requests with conflicts limited to GitHub workflow files are now skipped during conflict resolution.
  * Resolved updates now publish only the files that actually changed, avoiding unnecessary blob/tree uploads.
  * Branch updates now use stronger atomic verification to better ensure resolved changes are applied reliably.
* **Tests**
  * Added coverage for workflow-path conflict exclusion and tightened assertions around commit-related mutation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
