### PR TITLE
perf(e2e): consolidate Hermes credentialless rebuild

### DIFF
--- a/test/e2e/live/hermes-discord.test.ts
+++ b/test/e2e/live/hermes-discord.test.ts
@@ -356,7 +356,7 @@ async function rawTokenSurfaceProbe(
   });
 }
 
-test("hermes-discord: Hermes Discord schema, credential isolation, native gateway rewrite, and rebuild credential reuse", {
+test("hermes-discord: Hermes Discord schema, credential isolation, and native gateway rewrite", {
   timeout: HERMES_DISCORD_TEST_TIMEOUT_MS,
   meta: {
     e2ePhases: [
@@ -366,7 +366,6 @@ test("hermes-discord: Hermes Discord schema, credential isolation, native gatewa
       "validate Discord config and placeholders",
       "exercise native Discord gateway rewrite",
       "verify Discord token isolation and REST boundary",
-      "rebuild without host inference credentials",
       "finalize Hermes Discord resources",
     ],
   },
@@ -378,7 +377,7 @@ test("hermes-discord: Hermes Discord schema, credential isolation, native gatewa
   await artifacts.target.declare({
     id: "hermes-discord",
     boundary:
-      "install.sh --non-interactive Hermes sandbox + Discord config + OpenShell provider rewrite + sandbox leak probes + rebuild credential reuse",
+      "install.sh --non-interactive Hermes sandbox + Discord config + OpenShell provider rewrite + sandbox leak probes",
     sandboxName: SANDBOX_NAME,
     discordServerIds: DISCORD_SERVER_IDS,
     discordAllowedIds: DISCORD_ALLOWED_IDS,
@@ -723,46 +722,6 @@ done`,
   expectExitZero(bridgeResidue, "no local Discord bridge residue probe");
   expect(bridgeResidue.stdout.trim()).toBe("");
 
-  progress.phase("rebuild without host inference credentials");
-  await bestEffortLifecycleCleanup(() =>
-    host.command("docker", ["rm", "-f", fakeGateway.container], {
-      artifactName: "phase-8-remove-fake-discord-container-before-rebuild",
-      env,
-      redactionValues,
-      timeoutMs: 60_000,
-    }),
-  );
-  fs.rmSync(fakeGateway.dir, { recursive: true, force: true });
-  await bestEffortLifecycleCleanup(() =>
-    host.command(
-      "bash",
-      [
-        "-lc",
-        "sudo rm -rf .tmp/fake-discord.* 2>/dev/null || rm -rf .tmp/fake-discord.* 2>/dev/null || true",
-      ],
-      {
-        artifactName: "phase-8-remove-fake-discord-scratch-before-rebuild",
-        cwd: REPO_ROOT,
-        env,
-        redactionValues,
-        timeoutMs: 60_000,
-      },
-    ),
-  );
-
-  const rebuildEnv = commandEnv();
-  delete rebuildEnv.NVIDIA_INFERENCE_API_KEY;
-  delete rebuildEnv.NVIDIA_INFERENCE_API_KEY;
-  delete rebuildEnv.COMPATIBLE_API_KEY;
-  const rebuild = await host.command("nemoclaw", [SANDBOX_NAME, "rebuild", "--yes"], {
-    artifactName: "phase-8-rebuild-without-inference-env",
-    env: rebuildEnv,
-    redactionValues,
-    timeoutMs: 45 * 60_000,
-  });
-  expectExitZero(rebuild, "Hermes rebuild without NVIDIA_INFERENCE_API_KEY");
-  expect(resultText(rebuild)).not.toMatch(/provider credential not found/i);
-
   progress.phase("finalize Hermes Discord resources");
   await (async (): Promise<void> => {
     switch (process.env.NEMOCLAW_E2E_KEEP_SANDBOX) {
@@ -771,7 +730,7 @@ done`,
       default:
     }
     const destroy = await host.command("nemoclaw", [SANDBOX_NAME, "destroy", "--yes"], {
-      artifactName: "phase-9-nemoclaw-destroy",
+      artifactName: "phase-8-nemoclaw-destroy",
       env,
       redactionValues,
       timeoutMs: 15 * 60_000,
@@ -779,7 +738,7 @@ done`,
     expectExitZero(destroy, "destroy Hermes Discord sandbox");
     await bestEffortLifecycleCleanup(() =>
       host.command(host.openshellCommandPath, ["gateway", "destroy", "-g", "nemoclaw"], {
-        artifactName: "phase-9-openshell-gateway-destroy",
+        artifactName: "phase-8-openshell-gateway-destroy",
         env,
         redactionValues,
         timeoutMs: 120_000,
@@ -792,7 +751,7 @@ done`,
         `registry="$HOME/.nemoclaw/sandboxes.json"; if [ -f "$registry" ] && grep -Fq ${shellQuote(`"${SANDBOX_NAME}"`)} "$registry"; then echo FOUND; exit 1; else echo ABSENT; fi`,
       ],
       {
-        artifactName: "phase-9-registry-removal-probe",
+        artifactName: "phase-8-registry-removal-probe",
         env: sandboxAccessEnv(),
         redactionValues,
         timeoutMs: 30_000,
@@ -815,7 +774,6 @@ done`,
       rawTokenAbsentFromConfigEnvProcessAndFilesystem: true,
       discordRestBoundaryReachedOrSkippedOnTimeout: true,
       noLocalDiscordBridgeResidue: true,
-      rebuildReusedGatewayCredentialWithoutInferenceEnv: true,
       cleanupVerified: process.env.NEMOCLAW_E2E_KEEP_SANDBOX !== "1",
     },
   });

--- a/test/e2e/live/rebuild-hermes.test.ts
+++ b/test/e2e/live/rebuild-hermes.test.ts
@@ -654,7 +654,7 @@ test(STALE_BASE_REBUILD
       "phase 1 current Hermes base resolution plus immutable old Hermes base fixture",
       "openshell provider create/update and sandbox create/exec/list",
       "curated local ~/.nemoclaw registry and onboard-session rebuild metadata",
-      "real nemoclaw <sandbox> rebuild --yes --verbose",
+      "real nemoclaw <sandbox> rebuild --yes --verbose without host inference credentials",
       "Hermes .env/config.yaml messaging placeholder preservation",
       "backup credential leak scan under ~/.nemoclaw/rebuild-backups",
     ],
@@ -1208,12 +1208,16 @@ test(STALE_BASE_REBUILD
   }
 
   progress.phase("rebuild the Hermes sandbox");
+  const rebuildEnv = testEnv(undefined, {
+    NEMOCLAW_REBUILD_VERBOSE: "1",
+    ...baseReusePlan?.childEnv,
+  });
+  expect(rebuildEnv).not.toHaveProperty("NVIDIA_INFERENCE_API_KEY");
+  expect(rebuildEnv).not.toHaveProperty("COMPATIBLE_API_KEY");
+  expect(rebuildEnv).not.toHaveProperty("NVIDIA_API_KEY");
   const rebuild = await host.nemoclaw([SANDBOX_NAME, "rebuild", "--yes", "--verbose"], {
     artifactName: "phase-6-nemoclaw-rebuild-hermes",
-    env: testEnv(apiKey, {
-      NEMOCLAW_REBUILD_VERBOSE: "1",
-      ...baseReusePlan?.childEnv,
-    }),
+    env: rebuildEnv,
     redactionValues,
     timeoutMs: REBUILD_TIMEOUT_MS,
     captureLimitBytes: LONG_COMMAND_CAPTURE_LIMIT_BYTES,
@@ -1225,6 +1229,7 @@ test(STALE_BASE_REBUILD
   expect(rebuildOutput).toContain(`nemoclaw ${SANDBOX_NAME} gateway-token --quiet`);
   expect(rebuildOutput).toContain(`Using Hermes Agent base image: ${phase1BaseResolution.ref}`);
   expect(rebuildOutput).not.toContain("Rebuilding Hermes Agent base image");
+  expect(rebuildOutput).not.toMatch(/provider credential not found/i);
   await waitForSandboxReady(host, apiKey, "phase-6-post-rebuild");
 
   const backupPathText = rebuildOutput.match(/^\s*Backup:\s+(.+)$/mu)?.[1]?.trim();

--- a/test/e2e/support/rebuild-hermes-env.test.ts
+++ b/test/e2e/support/rebuild-hermes-env.test.ts
@@ -83,16 +83,20 @@ describe("rebuild-Hermes base reuse", () => {
         HOME: process.env.HOME,
         PATH: process.env.PATH,
         BUILDX_BUILDER: "external-builder",
+        COMPATIBLE_API_KEY: "must-not-reach-child",
         NEMOCLAW_ACCEPT_DEV_UNVERIFIED_INSTALL: "1",
         NEMOCLAW_OPENSHELL_CHANNEL: "dev",
         NVIDIA_API_KEY: "must-not-reach-child",
+        NVIDIA_INFERENCE_API_KEY: "must-not-reach-child",
       },
       {},
     );
 
     expect(childEnv.NEMOCLAW_ACCEPT_DEV_UNVERIFIED_INSTALL).toBe("1");
     expect(childEnv.NEMOCLAW_OPENSHELL_CHANNEL).toBe("dev");
+    expect(childEnv.COMPATIBLE_API_KEY).toBeUndefined();
     expect(childEnv.NVIDIA_API_KEY).toBeUndefined();
+    expect(childEnv.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
     expect(childEnv.BUILDX_BUILDER).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes Discord lane currently performs a second full sandbox rebuild only to prove that stored inference credentials survive when host keys are absent. This change moves that assertion into the canonical `rebuild-hermes` operation and removes the duplicate Discord rebuild while retaining the lane's unique gateway, token-isolation, REST, placeholder, and cleanup coverage.

## Related Issue

Part of #7144
Refs #7140

## Changes

- Run the existing normal and stale-base Hermes rebuild operation without `NVIDIA_INFERENCE_API_KEY`, `COMPATIBLE_API_KEY`, or `NVIDIA_API_KEY`, while preserving the verified current-base reuse override.
- Prove that the rebuild succeeds from persisted provider state and does not report a missing provider credential.
- Remove only the redundant rebuild phase from `hermes-discord`; keep its native Discord Gateway rewrite, REST boundary, config schema, raw-token isolation, residue, and cleanup assertions.
- Preserve the live-test phase contract and compact finalization artifact numbering.

The #7493 telemetry recorded the removed Discord rebuild at about 153 seconds; the full lane reached an approximately 11.6 GiB Docker/BuildKit process peak. This removes one high-memory build exposure without claiming that the retained initial install cannot reach a similar peak, adding a retry, or weakening product behavior coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This consolidates internal live E2E ownership without changing NemoClaw commands, supported behavior, configuration, or user workflows.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head review at `6b306be12` verified the child-process credential boundary, persisted-provider setup, base-reuse override, retained Discord assertions, and cleanup behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact head `6b306be12` changes only internal live E2E ownership and its regression coverage; no user-facing documentation contract changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6b306be12 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 52 focused E2E-support tests passed; semantic phase collection validated 125 tests across 82 files; Biome and test-title checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not run because the change is confined to two live targets and one focused E2E-support contract.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Hermes rebuild validation to run without host inference credentials.
  * Added checks confirming inference credentials are excluded from rebuild environments.
  * Added validation that rebuilds do not report missing provider credentials.
  * Expanded compatibility coverage to ensure unsupported credentials are not forwarded.
  * Removed outdated Discord credential-reuse test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->