### PR TITLE
fix(ci): build conflict trees from main

### DIFF
--- a/test/pr-merge-conflict-fixer.test.ts
+++ b/test/pr-merge-conflict-fixer.test.ts
@@ -100,7 +100,8 @@ function createConflictFixture(): {
   git(repository, ["config", "commit.gpgsign", "false"]);
   write(repository, "conflict.txt", "shared\n");
   write(repository, "clean-merge.txt", "first\nkeep-1\nkeep-2\nkeep-3\nkeep-4\nkeep-5\nlast\n");
-  git(repository, ["add", "conflict.txt", "clean-merge.txt"]);
+  write(repository, "pr-deleted.txt", "delete this on the PR branch\n");
+  git(repository, ["add", "conflict.txt", "clean-merge.txt", "pr-deleted.txt"]);
   git(repository, ["commit", "-m", "test: add shared file"]);
 
   git(repository, ["checkout", "-b", "pull-request"]);
@@ -110,7 +111,8 @@ function createConflictFixture(): {
     "clean-merge.txt",
     "pull request\nkeep-1\nkeep-2\nkeep-3\nkeep-4\nkeep-5\nlast\n",
   );
-  git(repository, ["add", "conflict.txt", "clean-merge.txt"]);
+  fs.rmSync(path.join(repository, "pr-deleted.txt"));
+  git(repository, ["add", "-A"]);
   git(repository, ["commit", "-m", "test: change PR side"]);
   const headSha = git(repository, ["rev-parse", "HEAD"]);
 
@@ -346,8 +348,14 @@ describe("PR merge conflict fixer", () => {
     ).not.toThrow();
   });
 
-  it("creates a verified two-parent commit before the atomic head update (#7542)", async () => {
+  it("creates a verified commit from a main-relative tree before the atomic head update (#7542)", async () => {
     const fixture = createConflictFixture();
+    for (let index = 0; index < 100; index += 1) {
+      write(fixture.repository, `stale-main/${index}.txt`, `main ${index}\n`);
+    }
+    git(fixture.repository, ["add", "stale-main"]);
+    git(fixture.repository, ["commit", "-m", "test: advance main beyond the PR head"]);
+    fixture.baseSha = git(fixture.repository, ["rev-parse", "HEAD"]);
     const entry = entryFor(fixture);
     const patchPath = path.join(temporaryDirectory(), "resolution.patch");
     const finalTree = createResolutionPatch(fixture, patchPath);
@@ -409,6 +417,27 @@ describe("PR merge conflict fixer", () => {
       tree: finalTree,
     });
     expect(JSON.stringify(commitRequest?.body)).not.toMatch(/author|committer|signature/u);
+    const treeRequest = required(
+      requests.find((item) => item.path.endsWith("/git/trees")),
+      "missing tree request",
+    );
+    const treeBody = treeRequest.body as {
+      base_tree: string;
+      tree: Array<{ mode: string; path: string; sha: string | null; type: string }>;
+    };
+    expect(treeBody.base_tree).toBe(entry.base_sha);
+    expect(treeBody.tree.map((item) => item.path)).toEqual([
+      "clean-merge.txt",
+      "conflict.txt",
+      "pr-deleted.txt",
+    ]);
+    expect(treeBody.tree.find((item) => item.path === "pr-deleted.txt")).toEqual({
+      mode: "100644",
+      path: "pr-deleted.txt",
+      sha: null,
+      type: "blob",
+    });
+    expect(treeBody.tree.some((item) => item.path.startsWith("stale-main/"))).toBe(false);
     const blobRequests = requests.filter((item) => item.path.endsWith("/git/blobs"));
     expect(
       blobRequests

--- a/tools/pr-merge-conflict-fixer/publish.mts
+++ b/tools/pr-merge-conflict-fixer/publish.mts
@@ -161,11 +161,7 @@ function treeEntry(repository: string, tree: string, filePath: string): GitTreeE
   return entry;
 }
 
-function parentContainsBlob(
-  repository: string,
-  parent: string,
-  entry: GitTreeEntry,
-): boolean {
+function parentContainsBlob(repository: string, parent: string, entry: GitTreeEntry): boolean {
   const parentEntry = optionalTreeEntry(repository, parent, entry.path);
   return parentEntry?.type === "blob" && parentEntry.sha === entry.sha;
 }
@@ -179,8 +175,8 @@ async function createGitHubTree(input: {
   request: GitHubRequest;
 }): Promise<string> {
   const entries: GitTreeEntry[] = [];
-  for (const change of changedPathStatuses(input.repository, input.headSha, input.finalTree)) {
-    const sourceTree = change.status === "D" ? input.headSha : input.finalTree;
+  for (const change of changedPathStatuses(input.repository, input.baseSha, input.finalTree)) {
+    const sourceTree = change.status === "D" ? input.baseSha : input.finalTree;
     const entry = treeEntry(input.repository, sourceTree, change.path);
     if (change.status === "D") {
       entries.push({ ...entry, sha: null });
@@ -204,7 +200,7 @@ async function createGitHubTree(input: {
   }
 
   const created = (await input.request("POST", `/repos/${input.repositoryName}/git/trees`, {
-    base_tree: input.headSha,
+    base_tree: input.baseSha,
     tree: entries,
   })) as { sha?: string };
   if (created.sha !== input.finalTree) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Conflict publication now constructs validated GitHub trees from the recorded `main` tree instead of the stale PR head.
Production requests for #7253 and #6054 shrink from 1,180 and 3,754 entries to 13 and 6 entries.

## Related Issue
Follow-up to #7542.

## Changes

- Build each GitHub tree from the recorded base SHA and the final tree delta.
- Read deletion entries from the base tree.
- Keep parent blob reuse, final-tree equality, verified commits, and atomic ref updates unchanged.
- Model 100 `main`-only files and a PR-side deletion in the publisher regression.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal GitHub publication mechanics and no user-facing contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer approved this repair after [production run 30193861556](https://github.com/NVIDIA/NemoClaw/actions/runs/30193861556) demonstrated the failure. Trust boundaries do not change.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change repairs internal GitHub tree publication. It does not change commands, configuration, output, or supported behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 424209c15 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/pr-merge-conflict-fixer.test.ts` passed 12/12 after formatting.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused publisher fix.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request conflict resolution publishing to correctly reflect files added, modified, or deleted on each branch.
  * Ensured resolved updates are built from the correct base revision, preventing unrelated or outdated files from being included.
  * Improved publication accuracy when the target branch has advanced with additional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->