### PR TITLE
perf(e2e): avoid second Hermes channel rebuild

### DIFF
--- a/src/lib/messaging/compiler/workflow-planner.test.ts
+++ b/src/lib/messaging/compiler/workflow-planner.test.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-
 import {
   createBuiltInChannelManifestRegistry,
   createBuiltInRenderTemplateResolver,
 } from "../channels";
 import { createBuiltInMessagingHookRegistry, MessagingHookRegistry } from "../hooks";
 import { type ChannelManifest, createChannelManifestRegistry } from "../manifest";
+import { compactSandboxMessagingPlanForPersistence } from "../persistence";
 import { MessagingWorkflowPlanner } from "./workflow-planner";
 
 const TEST_CREDENTIALS: Readonly<Record<string, string>> = {
@@ -664,6 +664,111 @@ describe("MessagingWorkflowPlanner", () => {
         (entry) => entry.channelId === "telegram" && entry.module === "telegram-diagnostics",
       ),
     ).toBe(true);
+  });
+
+  it("restores the Hermes rebuild plan after disabling and re-enabling all channels (#7144)", async () => {
+    const channels = ["telegram", "discord", "wechat", "slack", "whatsapp"] as const;
+    await withEnv(
+      {
+        TELEGRAM_ALLOWED_IDS: "1001,1002",
+        DISCORD_SERVER_ID: "guild-1",
+        DISCORD_USER_ID: "discord-user-1",
+        WECHAT_ACCOUNT_ID: "wechat-account",
+        WECHAT_ALLOWED_IDS: "wechat-user-1,wechat-user-2",
+        SLACK_ALLOWED_USERS: "U100,U200",
+        WHATSAPP_ALLOWED_IDS: "+15550000001,+15550000002",
+      },
+      async () => {
+        const lifecyclePlanner = planner();
+        const baseline = await lifecyclePlanner.buildPlan({
+          sandboxName: "demo",
+          agent: "hermes",
+          workflow: "rebuild",
+          isInteractive: false,
+          configuredChannels: channels,
+          credentialAvailability: {
+            TELEGRAM_BOT_TOKEN: true,
+            DISCORD_BOT_TOKEN: true,
+            WECHAT_BOT_TOKEN: true,
+            SLACK_BOT_TOKEN: true,
+            SLACK_APP_TOKEN: true,
+          },
+        });
+        expect(baseline.channels.every((channel) => channel.active && !channel.disabled)).toBe(
+          true,
+        );
+        expect(new Set(baseline.agentRender.map((entry) => entry.channelId))).toEqual(
+          new Set(channels),
+        );
+        expect(
+          baseline.agentRender.every(
+            (entry) =>
+              entry.target === "~/.hermes/.env" || entry.target === "~/.hermes/config.yaml",
+          ),
+        ).toBe(true);
+        expect(compactSandboxMessagingPlanForPersistence(baseline)).not.toHaveProperty(
+          "agentRender",
+        );
+        const persistedEntry = (plan: typeof baseline) => ({
+          name: "demo",
+          messaging: {
+            schemaVersion: 1 as const,
+            plan: compactSandboxMessagingPlanForPersistence(plan) as unknown as typeof baseline,
+          },
+        });
+
+        let current = baseline;
+        for (const channelId of channels) {
+          const stopped = await lifecyclePlanner.buildChannelStopPlanFromSandboxEntry({
+            sandboxName: "demo",
+            agent: "hermes",
+            sandboxEntry: persistedEntry(current),
+            channelId,
+          });
+          expect(stopped).not.toBeNull();
+          current = stopped!;
+        }
+        const disabledRebuild = await lifecyclePlanner.buildRebuildPlanFromSandboxEntry({
+          sandboxName: "demo",
+          agent: "hermes",
+          sandboxEntry: persistedEntry(current),
+        });
+        expect(disabledRebuild?.disabledChannels).toEqual([
+          "discord",
+          "slack",
+          "telegram",
+          "wechat",
+          "whatsapp",
+        ]);
+        expect(
+          disabledRebuild?.channels.every((channel) => !channel.active && channel.disabled),
+        ).toBe(true);
+        expect(disabledRebuild?.runtimeSetup).toEqual({
+          nodePreloads: [],
+          envAliases: [],
+          secretScans: [],
+        });
+
+        current = disabledRebuild!;
+        for (const channelId of channels) {
+          const started = await lifecyclePlanner.buildChannelStartPlanFromSandboxEntry({
+            sandboxName: "demo",
+            agent: "hermes",
+            sandboxEntry: persistedEntry(current),
+            channelId,
+          });
+          expect(started).not.toBeNull();
+          current = started!;
+        }
+        const restoredRebuild = await lifecyclePlanner.buildRebuildPlanFromSandboxEntry({
+          sandboxName: "demo",
+          agent: "hermes",
+          sandboxEntry: persistedEntry(current),
+        });
+
+        expect(restoredRebuild).toEqual(baseline);
+      },
+    );
   });
 
   it("removes Teams host forwarding while the channel is disabled", async () => {

--- a/test/e2e/live/channels-stop-start-helpers.ts
+++ b/test/e2e/live/channels-stop-start-helpers.ts
@@ -406,9 +406,12 @@ async function runChannelCommand(
   expectExitZero(result, `channels ${action} ${channel}`);
   const expectedText = `Marked ${channel} ${action === "stop" ? "disabled" : "enabled"}`;
   expect(resultText(result)).toContain(expectedText);
+  expect(resultText(result)).toContain(
+    `Change queued. Run 'nemoclaw ${SANDBOX_NAME} rebuild' to apply`,
+  );
 }
 
-export const CHANNELS_STOP_START_TEST_NAME = `${AGENT} channels stop/start preserves credentials and toggles runtime config`;
+export const CHANNELS_STOP_START_TEST_NAME = `${AGENT} channels stop/start preserves credentials and validates runtime config lifecycle`;
 
 export async function runChannelsStopStartTarget({
   artifacts,
@@ -434,7 +437,7 @@ export async function runChannelsStopStartTarget({
   await artifacts.target.declare({
     id: "channels-stop-start",
     boundary:
-      "install.sh messaging onboard + channels stop/start CLI + rebuild + sandbox config probes",
+      "install.sh messaging onboard + channels stop/start CLI + agent-scoped rebuilds + sandbox config probes",
     agent: AGENT,
     sandboxName: SANDBOX_NAME,
     channels: CHANNELS,
@@ -524,25 +527,29 @@ export async function runChannelsStopStartTarget({
     ).toBe("inactive");
   }
 
-  progress.phase("re-enable channels and rebuild sandbox");
+  progress.phase("re-enable channels and validate lifecycle state");
   for (const channel of CHANNELS) await runChannelCommand(host, env, redactions, "start", channel);
   expectChannelInputs(env);
   for (const channel of CHANNELS) expectPlanChannelState(channel, "active");
-  const startRebuild = await rebuildSandbox(
-    host,
-    SANDBOX_NAME,
-    env,
-    redactions,
-    `rebuild-start-all-${AGENT}`,
-  );
-  expectExitZero(startRebuild, "rebuild after starting all channels");
-  await expectAgentConfig(sandbox, "present", redactions);
+  if (AGENT === "openclaw") {
+    const startRebuild = await rebuildSandbox(
+      host,
+      SANDBOX_NAME,
+      env,
+      redactions,
+      `rebuild-start-all-${AGENT}`,
+    );
+    expectExitZero(startRebuild, "rebuild after starting all channels");
+    await expectAgentConfig(sandbox, "present", redactions);
+  } else {
+    await expectAgentConfig(sandbox, "absent", redactions);
+  }
   await expectProvidersExist(host, env, redactions, "after-start");
   for (const channel of CHANNELS) expectPlanChannelState(channel, "active");
   for (const channel of CHANNELS) {
     expect(
       await policyPresetState(host, env, redactions, channel),
-      `${channel} policy active after start+rebuild`,
+      `${channel} policy active after start${AGENT === "openclaw" ? "+rebuild" : ""}`,
     ).toBe("active");
   }
 }

--- a/test/e2e/live/channels-stop-start.test.ts
+++ b/test/e2e/live/channels-stop-start.test.ts
@@ -18,7 +18,7 @@ test(
         "onboard sandbox with all messaging channels",
         "validate active channel integrations",
         "disable channels and rebuild sandbox",
-        "re-enable channels and rebuild sandbox",
+        "re-enable channels and validate lifecycle state",
       ],
     },
   },


### PR DESCRIPTION
## Summary

The Hermes `channels-stop-start` lane rebuilt once after disabling all channels and then rebuilt the same active configuration again after re-enabling them. This keeps the uniquely valuable disabled-state rebuild, replaces only the second Hermes rebuild with exact queued-state and persisted-plan assertions, and leaves the OpenClaw two-rebuild path unchanged.

In the representative [E2E run 30181872151](https://github.com/NVIDIA/NemoClaw/actions/runs/30181872151), the removed rebuild took about 2m07s, roughly 20% of the 10m46s Hermes job.

## Related Issue

Part of #7144.
Parent epic: #7140.

## Changes

- Require every noninteractive channel stop/start command to prove that the rebuild is queued.
- Retain the Hermes rebuild after all channels are disabled and its live absent-config, provider, and inactive-policy assertions.
- After re-enabling Hermes channels, verify the active persisted plan, restored policies, retained providers, and intentionally unchanged running config without launching a second BuildKit rebuild.
- Preserve both live rebuilds for OpenClaw.
- Add a five-channel Hermes lifecycle test that compacts the plan through the real registry persistence boundary between every mutation and proves the fully hydrated rebuild plan is restored.

The persistence-aware test asserts semantic plan/render parity. It intentionally does not claim byte-identical Base64 cache input because compact-plan hydration can change JSON key insertion order.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal E2E execution optimization; CLI behavior and documented channel lifecycle are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent Codex correctness review returned GO with no blocking findings at `324ee020c`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed; the optimization is internal to E2E execution and preserves user-facing CLI semantics.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 324ee020c -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `workflow-planner.test.ts` 23/23; E2E workflow boundary 43/43; semantic phase coverage 125 tests across 82 files.
- [x] Applicable broad gate passed — `npm run checks`, CLI typecheck, plugin source/test typecheck, CLI build, and plugin build passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Channel stop and start actions now clearly indicate that a rebuild is queued before changes take effect.
  - Channel lifecycle handling now preserves credentials and restores runtime configuration consistently across rebuilds.

- **Tests**
  - Expanded coverage for stopping and restarting multiple channels.
  - Added validation for agent-specific rebuild behavior and lifecycle state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->