### PR TITLE
fix(hermes): repin published sandbox base

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -6,7 +6,7 @@
 # Layers PR-specific code (plugin, config, startup script) on top of the
 # pre-built Hermes base image. Mirrors the OpenClaw Dockerfile structure.
 
-ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:fa05221f5c7bcafea7e263c84e5d06f87e37d1ccb78dc28c113f1a4066aa544c
+ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:c925afe7c0742474166a4813a59f5961a93da4d130e9b35fb04088a384702142
 
 # Group repository-owned files outside the final image so BuildKit can collapse
 # related files without invalidating earlier final-image work.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes final image still trusted an older sandbox-base digest even after the current security-remediated base was published successfully. This change advances only that immutable trust anchor to the reviewed multi-platform manifest produced from main.

## Related Issue

Refs #7144

## Changes

- Repin `agents/hermes/Dockerfile` to `ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:c925afe7c0742474166a4813a59f5961a93da4d130e9b35fb04088a384702142`.
- Keep the existing final-image remediation and validation layers unchanged.
- Preserve the tracked-digest-first resolver contract used by Hermes builds and E2E.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the existing resolver, immutable-pin, final-layout, and E2E base-identity contracts deliberately accept any one reviewed 64-hex digest and passed against the new pin.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only an internal immutable image digest; no command, option, configuration, API, policy, workflow, or user action changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent focused review verified that successful publisher run `30195335992` built the digest from main commit `a02831b2`, that later commits changed no base-image input, that no open PR duplicates the repin, and that the immutable manifest resolves to the expected supported architectures.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed `agents/hermes/Dockerfile`, the full diff, Hermes manifest, image/rebuild documentation, and `docs/security/sandbox-base-2026-07-25-dependency-review.md`. The immutable digest repin requires no user-facing documentation change. Validation: CLI base-image 29/29; integration resolver/layout/updater 75/75; E2E-support identity/publication 45/45; `build:cli`; `typecheck:cli`; and diff check passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8e1c6c3f -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 10 CLI resolver tests, 79 integration layout/resolver tests, and 18 E2E-support base-identity tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to a one-line immutable digest repin; `npm run build:cli`, `npm run typecheck:cli`, `npm run source-shape:check`, `npm run test:projects:check`, `git diff --check`, and the complete changed-file hook set passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Published Manifest Evidence

- Publisher: [base-image run 30195335992](https://github.com/NVIDIA/NemoClaw/actions/runs/30195335992), source `a02831b2`
- Immutable index: `sha256:c925afe7c0742474166a4813a59f5961a93da4d130e9b35fb04088a384702142`
- Linux amd64 child: `sha256:60dabeaf36d2e304dbfb7fe971505e77cb7e833a1a81a7da2a27ff8ea19f5622`
- Linux arm64 child: `sha256:e1d52c73ec6e870a0eb38a3f22ffa62a74dc591c3e2c1c92db7a75ca63185169`

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Hermes sandbox base image to a newer verified version.
  * No end-user-facing behavior or runtime configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->