### PR TITLE
test(onboard): isolate GPU patch DNS probe

### DIFF
--- a/src/lib/onboard/docker-gpu-patch-mode-selection.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-mode-selection.test.ts
@@ -290,6 +290,7 @@ describe("docker-gpu-patch CDI-first mode selection (#4948)", () => {
     });
     const dockerRunDetached = vi.fn(() => ({ status: 0, stdout: "new-container-id\n" }));
     const host = cdiHostDeps();
+    const detectSandboxFallbackDns = vi.fn(() => null);
 
     const result = recreateOpenShellDockerSandboxWithGpu(
       { sandboxName: "alpha", timeoutSecs: 1 },
@@ -297,6 +298,8 @@ describe("docker-gpu-patch CDI-first mode selection (#4948)", () => {
         dockerCapture,
         readDir: host.readDir,
         readFile: host.readFile,
+        // Keep the unit test independent of the runner's resolver setup.
+        detectSandboxFallbackDns,
         dockerRun: vi.fn(() => ({ status: 0, stdout: "probe-id\n" })),
         dockerRunDetached,
         dockerRename: vi.fn(() => ({ status: 0 })),
@@ -308,6 +311,7 @@ describe("docker-gpu-patch CDI-first mode selection (#4948)", () => {
       },
     );
 
+    expect(detectSandboxFallbackDns).toHaveBeenCalledOnce();
     expect(result.mode.kind).toBe("cdi");
     expect(dockerRunDetached).toHaveBeenCalledWith(
       expect.arrayContaining(["--name", "openshell-alpha", "--device", "nvidia.com/gpu=all"]),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The CDI recreate unit test no longer inherits the hosted runner's resolver
configuration. It now supplies the existing DNS-detection seam explicitly, so
a loopback host resolver cannot launch a real Docker DNS probe and exhaust the
test's five-second timeout.

## Related Issue

Part of #7140.

Observed in #7582 run 30196792927, job 89779621543.

## Changes

- Stub fallback-DNS detection in the CDI recreate command test.
- Assert that the production recreate path consumes the stubbed dependency.
- Preserve the dedicated DNS fallback and probe tests unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test isolation only; no production, CLI, configuration, API, or documented behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent exact-diff review of `4019cd995` passed with no findings; the mock overrides only the existing test dependency seam, and dedicated DNS tests retain production coverage.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The exact-head diff changes one unit test and removes dependence on the runner's resolver setup; no user-facing behavior or documentation route changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4019cd995 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `docker-gpu-patch-mode-selection.test.ts` passed 14/14.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: CLI type-checking and the complete changed-file hook set passed; a repo-wide test run is not applicable to this four-line unit-test isolation.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for GPU-enabled sandbox recreation.
  * Added validation that the correct GPU device configuration is selected and fallback network detection is invoked as expected.
  * Confirmed legacy GPU configuration options are not used in the CDI-based setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->