### PR TITLE
fix(state): allow locked OpenClaw peer links

### DIFF
--- a/scripts/state-dir-guard.py
+++ b/scripts/state-dir-guard.py
@@ -71,7 +71,12 @@ PRODUCTION_FAIL_CLOSED_CONFIG_DIRS = frozenset(
 OPENCLAW_MUTATION_MUTEX_PATH = "/run/nemoclaw/openclaw-config-mutation.lock"
 # Keep this exact source/target contract aligned with
 # src/lib/state/openclaw-managed-extensions.ts.
-OPENCLAW_GLOBAL_PACKAGE_PATH = "/usr/local/lib/node_modules/openclaw"
+OPENCLAW_IMAGE_PACKAGE_PATHS = frozenset(
+    {
+        "/usr/local/lib/node_modules/openclaw",
+        "/usr/local/lib/nemoclaw/openclaw-runtime/node_modules/openclaw",
+    }
+)
 OPENCLAW_EXTENSION_PEER_LINK_SUFFIX = ("node_modules", "openclaw")
 SAFE_EXTENSION_ID_CHARS = frozenset(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-"
@@ -555,9 +560,9 @@ def _is_allowed_openclaw_extension_peer_symlink(
     relative_path: str,
     target: str,
 ) -> bool:
-    """Recognize the one image-owned peer link that may leave the state tree."""
+    """Recognize an exact image-owned peer link that may leave the state tree."""
 
-    if target != OPENCLAW_GLOBAL_PACKAGE_PATH:
+    if target not in OPENCLAW_IMAGE_PACKAGE_PATHS:
         return False
     if posixpath.basename(context.config_path) != ".openclaw":
         return False

--- a/src/lib/state/openclaw-managed-extensions.test.ts
+++ b/src/lib/state/openclaw-managed-extensions.test.ts
@@ -115,6 +115,12 @@ describe("OpenClaw managed extension symlink policy", () => {
       ),
     ).toBe(true);
     expect(
+      isAllowedStateSymlink(
+        "extensions/whatsapp/node_modules/openclaw",
+        "/usr/local/lib/nemoclaw/openclaw-runtime/node_modules/openclaw",
+      ),
+    ).toBe(true);
+    expect(
       isAllowedStateSymlink("extensions/nemoclaw/node_modules/.bin/json5", "../json5/lib/cli.js"),
     ).toBe(true);
   });
@@ -150,6 +156,12 @@ describe("OpenClaw managed extension symlink policy", () => {
   it("rejects allowed targets outside the narrowly recognized source paths", () => {
     expect(
       isAllowedStateSymlink("workspace/openclaw", "/usr/local/lib/node_modules/openclaw"),
+    ).toBe(false);
+    expect(
+      isAllowedStateSymlink(
+        "workspace/openclaw",
+        "/usr/local/lib/nemoclaw/openclaw-runtime/node_modules/openclaw",
+      ),
     ).toBe(false);
     expect(isAllowedStateSymlink("extensions/nemoclaw/bin/json5", "../json5/lib/cli.js")).toBe(
       false,

--- a/src/lib/state/openclaw-managed-extensions.ts
+++ b/src/lib/state/openclaw-managed-extensions.ts
@@ -22,7 +22,12 @@ const EXTENSION_NPM_BIN_RE = /^extensions\/[A-Za-z0-9][A-Za-z0-9._-]*\/node_modu
 // target; source-only matching would permit repointing it to an arbitrary file.
 const OPENCLAW_EXTENSION_PEER_LINK_RE =
   /^extensions\/[A-Za-z0-9][A-Za-z0-9._-]*\/node_modules\/openclaw$/;
-const OPENCLAW_GLOBAL_PACKAGE_PATH = "/usr/local/lib/node_modules/openclaw";
+const OPENCLAW_IMAGE_PACKAGE_PATHS: ReadonlySet<string> = new Set([
+  // Legacy global install used by older sandboxes that still need to rebuild.
+  "/usr/local/lib/node_modules/openclaw",
+  // Locked runtime install used by current images; the global path points here.
+  "/usr/local/lib/nemoclaw/openclaw-runtime/node_modules/openclaw",
+]);
 
 // Preserve extensions baked into the freshly rebuilt image instead of
 // replacing them with archived copies. Messaging IDs come from the reviewed
@@ -63,7 +68,7 @@ function isAllowedOpenClawExtensionPeerSymlink(relPath: string, linkTarget: stri
   const normalizedRelPath = relPath.split(path.sep).join("/");
   return (
     OPENCLAW_EXTENSION_PEER_LINK_RE.test(normalizedRelPath) &&
-    linkTarget === OPENCLAW_GLOBAL_PACKAGE_PATH
+    OPENCLAW_IMAGE_PACKAGE_PATHS.has(linkTarget)
   );
 }
 

--- a/test/security-sandbox-tar-traversal.test.ts
+++ b/test/security-sandbox-tar-traversal.test.ts
@@ -473,23 +473,24 @@ describe("Fix: safeTarExtract blocks malicious archives and extracts safe ones",
   });
 
   it.each([
-    "weather",
-    "slack",
-  ])("allows the %s OpenClaw extension peer link with the exact global package target", async (extensionName) => {
+    ["weather", "/usr/local/lib/node_modules/openclaw"],
+    ["slack", "/usr/local/lib/node_modules/openclaw"],
+    ["whatsapp", "/usr/local/lib/nemoclaw/openclaw-runtime/node_modules/openclaw"],
+  ])("allows the %s OpenClaw extension peer link with an exact image package target", async (extensionName, packageTarget) => {
     const { safeTarExtract } = await loadSandboxState();
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-audit-whitelist-extract-"));
     try {
       const targetDir = path.join(workDir, "backup");
       fs.mkdirSync(targetDir, { recursive: true });
 
-      // Archive-installed plugins symlink their OpenClaw peer dependency to
-      // the global package. The exact target escapes both the archive and
-      // /sandbox/, so it requires the narrow extension peer-link exception.
+      // Archive-installed plugins symlink their OpenClaw peer dependency to a
+      // trusted image package location. The exact target escapes both the
+      // archive and /sandbox/, so it requires the narrow peer-link exception.
       const tar = buildTar([
         {
           path: `extensions/${extensionName}/node_modules/openclaw`,
           type: "2",
-          linkTarget: "/usr/local/lib/node_modules/openclaw",
+          linkTarget: packageTarget,
         },
       ]);
 

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -710,11 +710,11 @@ process.exit(0);
       const existingDirs = ["agents", "extensions", "workspace"];
       fs.mkdirSync(binDir, { recursive: true });
       for (const d of existingDirs) fs.mkdirSync(path.join(openclawDir, d), { recursive: true });
-
       const auditLines = [
         "l\t/sandbox/.openclaw/extensions/openclaw-weixin/node_modules/.bin/qrcode-terminal\t../qrcode-terminal/bin/qrcode-terminal.js",
         "l\t/sandbox/.openclaw/extensions/openclaw-weixin/node_modules/openclaw\t/usr/local/lib/node_modules/openclaw",
         "l\t/sandbox/.openclaw/extensions/slack/node_modules/openclaw\t/usr/local/lib/node_modules/openclaw",
+        "l\t/sandbox/.openclaw/extensions/whatsapp/node_modules/openclaw\t/usr/local/lib/nemoclaw/openclaw-runtime/node_modules/openclaw",
         "l\t/sandbox/.openclaw/extensions/weather/node_modules/openclaw\t/usr/local/lib/node_modules/openclaw",
       ].join("\n");
 

--- a/test/state-dir-guard.test.ts
+++ b/test/state-dir-guard.test.ts
@@ -372,11 +372,14 @@ describe("state-dir-guard", () => {
     expect(fs.readFileSync(outsideFile, "utf-8")).toBe("untouched\n");
   });
 
-  it("preserves the exact image-owned OpenClaw extension peer link across transitions", () => {
+  it.each([
+    ["slack", "/usr/local/lib/node_modules/openclaw"],
+    ["whatsapp", "/usr/local/lib/nemoclaw/openclaw-runtime/node_modules/openclaw"],
+  ])("preserves the exact image-owned OpenClaw %s peer link across transitions", (extensionId, target) => {
     const { configDir } = fixture(".openclaw");
-    const peerLink = path.join(configDir, "extensions", "slack", "node_modules", "openclaw");
+    const peerLink = path.join(configDir, "extensions", extensionId, "node_modules", "openclaw");
     fs.mkdirSync(path.dirname(peerLink), { recursive: true });
-    fs.symlinkSync("/usr/local/lib/node_modules/openclaw", peerLink);
+    fs.symlinkSync(target, peerLink);
 
     const preflight = runGuard("preflight", configDir);
     const locked = runGuard("lock", configDir);
@@ -386,7 +389,7 @@ describe("state-dir-guard", () => {
     expect(locked.status, locked.stderr).toBe(0);
     expect(unlocked.status, unlocked.stderr).toBe(0);
     expect(fs.lstatSync(peerLink).isSymbolicLink()).toBe(true);
-    expect(fs.readlinkSync(peerLink)).toBe("/usr/local/lib/node_modules/openclaw");
+    expect(fs.readlinkSync(peerLink)).toBe(target);
     expect(locked.lines.at(-1)).toEqual(
       expect.objectContaining({
         type: "result",
@@ -399,6 +402,12 @@ describe("state-dir-guard", () => {
 
   it.each([
     ["tampered target", "slack", "node_modules/openclaw", "/usr/local/lib/node_modules/other"],
+    [
+      "tampered locked runtime target",
+      "whatsapp",
+      "node_modules/openclaw",
+      "/usr/local/lib/nemoclaw/openclaw-runtime/node_modules/other",
+    ],
     [
       "traversal-shaped extension id",
       "%2e%2e",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Current OpenClaw messaging extensions can link their OpenClaw peer dependency to the locked runtime package path. Backup and Shields audits treated that exact image-owned link as unsafe, so the channels stop/start E2E failed before backup even though the link came from the shipped image. This change accepts only the exact legacy and current image package targets while arbitrary targets and wrong source paths still fail closed.

## Related Issue

Part of #7140. Unblocks the OpenClaw channels stop/start coverage in #7580.

## Changes

- Keep the TypeScript backup/extraction policy and privileged Python state guard on the same two-target contract.
- Accept extension peer links only at `extensions/<safe-id>/node_modules/openclaw` and only when they target the legacy global package or current locked runtime package.
- Cover pre-backup audit, post-extraction audit, Shields transitions, current-runtime sibling tampering, and wrong-source rejection.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the existing documented backup/rebuild behavior; the internal image path and narrow audit exception are not user-facing configuration.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: an independent Codex security review passed after verifying that the TypeScript and Python guards share the exact two-target allowlist and retain path-shape, state-root, sibling-target, and wrong-source rejection.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/manage-sandboxes/backup-restore.mdx`, `docs/manage-sandboxes/set-up-whatsapp.mdx`, and `docs/reference/host-files-and-state.mdx` already describe the restored durable-state behavior and unsafe-link rejection. No documentation files changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 702917d44 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, including the source-shape and 1,500-line test-file budget gates
- [x] Targeted behavior tests pass for the current change set — 24 CLI policy tests, 82 backup/extraction tests, and 5 focused guard rejection tests passed; an offline Linux container also passed both trusted targets through preflight/lock/unlock and rejected sibling/wrong-source cases.
- [x] Applicable broad gate passed — not applicable to this narrow exact-target compatibility fix; `npm run build:cli`, `npm run typecheck:cli`, source-shape, title-style, project-overlap, and full changed-file hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of OpenClaw extension links across supported installation locations.
  - Preserved valid extension links during state backups, restores, and transitions.
  - Continued rejecting untrusted or tampered links outside approved package paths.

- **Tests**
  - Expanded coverage for multiple extensions and trusted runtime package locations.
  - Added regression checks for archive extraction, snapshots, and state-directory transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
