### PR TITLE
fix(hermes): preserve managed BuildKit failures

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2651,7 +2651,8 @@ NemoClaw does not retry that Dockerfile with the OpenShell gateway builder.
 Use the detail in the error to choose the next step:
 
 - If the local build is disabled, unavailable, or could not start, start Docker and keep BuildKit and the local prebuild enabled.
-- If the local build exits nonzero, the preceding BuildKit output contains the root cause. Fix the reported base-image, package, network, or Dockerfile error rather than treating it as a builder-selection failure.
+- If the local build exits nonzero, the preceding BuildKit output contains the root cause.
+  Fix the reported base-image, package, network, or Dockerfile error rather than treating it as a builder-selection failure.
 - If staged-context inspection or trust validation fails, resume onboarding to restage the managed context.
 
 Then resume onboarding:

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2642,18 +2642,12 @@ If you encounter issues with Podman, switch to a tested runtime (Docker Engine, 
 The issues below are common problems you may encounter when running Hermes through `nemohermes`.
 For setup, refer to [Quickstart with Hermes](../../hermes/get-started/quickstart).
 
-### Hermes onboarding reports that local BuildKit is required
+### Managed Hermes local image build fails
 
-Managed Hermes onboarding on a local Docker-driver gateway must complete the host-side BuildKit build.
-The generated Dockerfile contains BuildKit-only instructions, so NemoClaw stops if the local build is disabled, unavailable, or fails validation.
-NemoClaw does not retry that Dockerfile with the OpenShell gateway builder.
-
-Use the detail in the error to choose the next step:
-
-- If the local build is disabled, unavailable, or could not start, start Docker and keep BuildKit and the local prebuild enabled.
-- If the local build exits nonzero, the preceding BuildKit output contains the root cause.
-  Fix the reported base-image, package, network, or Dockerfile error rather than treating it as a builder-selection failure.
-- If staged-context inspection or trust validation fails, resume onboarding to restage the managed context.
+For a managed Hermes image on a local Docker-driver gateway, NemoClaw may first attempt the image build with host-side BuildKit.
+If that exact staged build starts and exits nonzero, NemoClaw preserves the BuildKit failure instead of retrying the managed Dockerfile with the incompatible gateway builder.
+The preceding BuildKit output contains the root cause.
+Fix the reported base-image, package, network, or Dockerfile error rather than treating it as a builder-selection failure.
 
 Then resume onboarding:
 
@@ -2661,7 +2655,8 @@ Then resume onboarding:
 nemohermes onboard --resume
 ```
 
-A custom Hermes Dockerfile supplied with `--from`, or a Hermes build on a remote gateway, continues through the OpenShell gateway builder.
+A disabled or unavailable local prebuild retains the existing gateway path.
+A custom Hermes Dockerfile supplied with `--from`, an OpenClaw image, or a build on a remote gateway also retains its existing builder behavior.
 
 ### Hermes dashboard config did not converge
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2645,7 +2645,7 @@ For setup, refer to [Quickstart with Hermes](../../hermes/get-started/quickstart
 ### Managed Hermes local image build fails
 
 For a managed Hermes image on a local Docker-driver gateway, NemoClaw may first attempt the image build with host-side BuildKit.
-If that exact staged build starts and exits nonzero, NemoClaw preserves the BuildKit failure instead of retrying the managed Dockerfile with the incompatible gateway builder.
+If that exact staged build starts and fails with a nonzero exit status or no exit status, NemoClaw preserves the BuildKit failure instead of retrying the managed Dockerfile with the incompatible gateway builder.
 The preceding BuildKit output contains the root cause.
 Fix the reported base-image, package, network, or Dockerfile error rather than treating it as a builder-selection failure.
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2642,6 +2642,26 @@ If you encounter issues with Podman, switch to a tested runtime (Docker Engine, 
 The issues below are common problems you may encounter when running Hermes through `nemohermes`.
 For setup, refer to [Quickstart with Hermes](../../hermes/get-started/quickstart).
 
+### Hermes onboarding reports that local BuildKit is required
+
+Managed Hermes onboarding on a local Docker-driver gateway must complete the host-side BuildKit build.
+The generated Dockerfile contains BuildKit-only instructions, so NemoClaw stops if the local build is disabled, unavailable, or fails validation.
+NemoClaw does not retry that Dockerfile with the OpenShell gateway builder.
+
+Use the detail in the error to choose the next step:
+
+- If the local build is disabled, unavailable, or could not start, start Docker and keep BuildKit and the local prebuild enabled.
+- If the local build exits nonzero, the preceding BuildKit output contains the root cause. Fix the reported base-image, package, network, or Dockerfile error rather than treating it as a builder-selection failure.
+- If staged-context inspection or trust validation fails, resume onboarding to restage the managed context.
+
+Then resume onboarding:
+
+```bash
+nemohermes onboard --resume
+```
+
+A custom Hermes Dockerfile supplied with `--from`, or a Hermes build on a remote gateway, continues through the OpenShell gateway builder.
+
 ### Hermes dashboard config did not converge
 
 `nemohermes inference set` updates the OpenShell route, registry, and `/sandbox/.hermes/config.yaml` before it refreshes the separate dashboard profile.

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2705,16 +2705,6 @@ async function createSandboxWithBaseImageResolution(
       ...baseImageResolutionFlow.getBaseImageResolutionPatchOptions(baseImageResolutionContext),
       gatewayPort: GATEWAY_PORT,
     });
-  const managedHermesBuildFailureCapability =
-    sandboxCreateLaunch.issueManagedHermesBuildFailureCapability({
-      agentName: agent?.name ?? null,
-      fromDockerfile,
-      origin,
-      dockerDriverGateway,
-      buildCtx,
-      stagedDockerfile,
-      buildId,
-    });
   const sandboxReadyTimeoutSecs = getSandboxReadyTimeoutSecs(effectiveSandboxGpuConfig);
   const { createArgv, effectiveDashboardPort, prebuild, sandboxEnv, sandboxStartupCommand } =
     await sandboxCreateLaunch.prepareSandboxCreateLaunchWithPrebuild({
@@ -2732,13 +2722,7 @@ async function createSandboxWithBaseImageResolution(
       manageDashboard,
       openshellShellCommand,
       openshellArgv,
-      prebuild: {
-        buildCtx,
-        buildId,
-        dockerDriverGateway,
-        origin,
-        managedHermesBuildFailureCapability,
-      },
+      prebuild: { buildCtx, buildId, dockerDriverGateway, origin },
     });
   const restoreBackupPath =
     pendingStateRestore?.manifest?.backupPath ?? pendingStateRestoreBackupPath;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2705,6 +2705,16 @@ async function createSandboxWithBaseImageResolution(
       ...baseImageResolutionFlow.getBaseImageResolutionPatchOptions(baseImageResolutionContext),
       gatewayPort: GATEWAY_PORT,
     });
+  const managedHermesBuildFailureCapability =
+    sandboxCreateLaunch.issueManagedHermesBuildFailureCapability({
+      agentName: agent?.name ?? null,
+      fromDockerfile,
+      origin,
+      dockerDriverGateway,
+      buildCtx,
+      stagedDockerfile,
+      buildId,
+    });
   const sandboxReadyTimeoutSecs = getSandboxReadyTimeoutSecs(effectiveSandboxGpuConfig);
   const { createArgv, effectiveDashboardPort, prebuild, sandboxEnv, sandboxStartupCommand } =
     await sandboxCreateLaunch.prepareSandboxCreateLaunchWithPrebuild({
@@ -2722,7 +2732,13 @@ async function createSandboxWithBaseImageResolution(
       manageDashboard,
       openshellShellCommand,
       openshellArgv,
-      prebuild: { buildCtx, buildId, dockerDriverGateway, origin },
+      prebuild: {
+        buildCtx,
+        buildId,
+        dockerDriverGateway,
+        origin,
+        managedHermesBuildFailureCapability,
+      },
     });
   const restoreBackupPath =
     pendingStateRestore?.manifest?.backupPath ?? pendingStateRestoreBackupPath;

--- a/src/lib/onboard/sandbox-create-launch.test.ts
+++ b/src/lib/onboard/sandbox-create-launch.test.ts
@@ -461,6 +461,49 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     expect(openshellShellCommand).not.toHaveBeenCalled();
   });
 
+  it("retries a generated Hermes build cleanly after a required BuildKit failure (#7140)", async () => {
+    const buildCtx = createTrustedBuildContext();
+    const dockerfile = path.join(buildCtx, "Dockerfile");
+    const buildImage = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+    const openshellShellCommand = vi.fn((args: string[]) => args.join(" "));
+    const input = {
+      agent: { name: "hermes" } as any,
+      chatUiUrl: "",
+      createArgs: ["--from", dockerfile, "--name", "demo"],
+      env: {},
+      extraPlaceholderKeys: [],
+      getDashboardForwardPort: () => "0",
+      hermesDashboardState: disabledHermesDashboardState,
+      manageDashboard: false,
+      openshellShellCommand,
+      sandboxName: "demo",
+      buildEnv: () => ({}),
+      prebuild: {
+        buildCtx,
+        buildId: "build-123",
+        dockerDriverGateway: true,
+        env: { NEMOCLAW_SANDBOX_PREBUILD: "1" },
+        buildImage,
+        inspectImageId: () => IMAGE_ID,
+        log: vi.fn(),
+        origin: "generated" as const,
+      },
+    };
+
+    await expect(prepareSandboxCreateLaunchWithPrebuild(input)).rejects.toThrow(
+      /Local BuildKit is required.*local build failed \(exit 1\)/,
+    );
+    expect(openshellShellCommand).not.toHaveBeenCalled();
+
+    const retry = await prepareSandboxCreateLaunchWithPrebuild(input);
+    expect(buildImage).toHaveBeenCalledTimes(2);
+    expect(openshellShellCommand).toHaveBeenCalledOnce();
+    expect(retry.prebuild.imageRef).toBe("nemoclaw-sandbox-local:demo-build-123");
+    expect(retry.createCommand).toContain(
+      "sandbox create --from nemoclaw-sandbox-local:demo-build-123 --name demo",
+    );
+  });
+
   it.each([
     ["a custom Hermes Dockerfile", "custom", true],
     ["a remote-gateway Hermes image", "generated", false],

--- a/src/lib/onboard/sandbox-create-launch.test.ts
+++ b/src/lib/onboard/sandbox-create-launch.test.ts
@@ -12,6 +12,7 @@ import { SANDBOX_BUILD_CONTEXT_PREFIX } from "../sandbox/build-context";
 import { createOpenshellCliHelpers } from "./openshell-cli";
 import {
   buildSandboxRuntimeEnvArgs,
+  issueManagedHermesBuildFailureCapability,
   prepareSandboxCreateLaunch,
   prepareSandboxCreateLaunchWithPrebuild,
 } from "./sandbox-create-launch";
@@ -394,11 +395,21 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     expect(buildImage).toHaveBeenCalledOnce();
   });
 
-  it("renders the original Dockerfile after a local build failure", async () => {
+  it("preserves OpenClaw gateway fallback after a local build failure (#7140)", async () => {
     const buildCtx = createTrustedBuildContext();
     const dockerfile = path.join(buildCtx, "Dockerfile");
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "openclaw",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: "build-123",
+    });
+    expect(managedHermesBuildFailureCapability).toBeUndefined();
     const result = await prepareSandboxCreateLaunchWithPrebuild({
-      agent: null,
+      agent: { name: "openclaw" } as any,
       chatUiUrl: "",
       createArgs: ["--from", dockerfile, "--name", "demo"],
       env: {},
@@ -417,6 +428,7 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
         buildImage: async () => 1,
         log: vi.fn(),
         origin: "generated",
+        managedHermesBuildFailureCapability,
       },
     });
 
@@ -433,6 +445,15 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     const buildCtx = createTrustedBuildContext();
     const dockerfile = path.join(buildCtx, "Dockerfile");
     const openshellShellCommand = vi.fn((args: string[]) => args.join(" "));
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: "build-123",
+    });
 
     await expect(
       prepareSandboxCreateLaunchWithPrebuild({
@@ -455,9 +476,10 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
           buildImage: async () => 1,
           log: vi.fn(),
           origin: "generated",
+          managedHermesBuildFailureCapability,
         },
       }),
-    ).rejects.toThrow(/Local BuildKit is required.*local build failed \(exit 1\)/);
+    ).rejects.toThrow(/Managed Hermes local BuildKit build failed \(exit 1\)/);
     expect(openshellShellCommand).not.toHaveBeenCalled();
   });
 
@@ -466,6 +488,15 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     const dockerfile = path.join(buildCtx, "Dockerfile");
     const buildImage = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(0);
     const openshellShellCommand = vi.fn((args: string[]) => args.join(" "));
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: "build-123",
+    });
     const input = {
       agent: { name: "hermes" } as any,
       chatUiUrl: "",
@@ -487,11 +518,12 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
         inspectImageId: () => IMAGE_ID,
         log: vi.fn(),
         origin: "generated" as const,
+        managedHermesBuildFailureCapability,
       },
     };
 
     await expect(prepareSandboxCreateLaunchWithPrebuild(input)).rejects.toThrow(
-      /Local BuildKit is required.*local build failed \(exit 1\)/,
+      /Managed Hermes local BuildKit build failed \(exit 1\)/,
     );
     expect(openshellShellCommand).not.toHaveBeenCalled();
 

--- a/src/lib/onboard/sandbox-create-launch.test.ts
+++ b/src/lib/onboard/sandbox-create-launch.test.ts
@@ -12,7 +12,6 @@ import { SANDBOX_BUILD_CONTEXT_PREFIX } from "../sandbox/build-context";
 import { createOpenshellCliHelpers } from "./openshell-cli";
 import {
   buildSandboxRuntimeEnvArgs,
-  issueManagedHermesBuildFailureCapability,
   prepareSandboxCreateLaunch,
   prepareSandboxCreateLaunchWithPrebuild,
 } from "./sandbox-create-launch";
@@ -398,16 +397,6 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
   it("preserves OpenClaw gateway fallback after a local build failure (#7140)", async () => {
     const buildCtx = createTrustedBuildContext();
     const dockerfile = path.join(buildCtx, "Dockerfile");
-    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
-      agentName: "openclaw",
-      fromDockerfile: null,
-      origin: "generated",
-      dockerDriverGateway: true,
-      buildCtx,
-      stagedDockerfile: dockerfile,
-      buildId: "build-123",
-    });
-    expect(managedHermesBuildFailureCapability).toBeUndefined();
     const result = await prepareSandboxCreateLaunchWithPrebuild({
       agent: { name: "openclaw" } as any,
       chatUiUrl: "",
@@ -428,7 +417,6 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
         buildImage: async () => 1,
         log: vi.fn(),
         origin: "generated",
-        managedHermesBuildFailureCapability,
       },
     });
 
@@ -445,15 +433,6 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     const buildCtx = createTrustedBuildContext();
     const dockerfile = path.join(buildCtx, "Dockerfile");
     const openshellShellCommand = vi.fn((args: string[]) => args.join(" "));
-    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
-      agentName: "hermes",
-      fromDockerfile: null,
-      origin: "generated",
-      dockerDriverGateway: true,
-      buildCtx,
-      stagedDockerfile: dockerfile,
-      buildId: "build-123",
-    });
 
     await expect(
       prepareSandboxCreateLaunchWithPrebuild({
@@ -476,7 +455,6 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
           buildImage: async () => 1,
           log: vi.fn(),
           origin: "generated",
-          managedHermesBuildFailureCapability,
         },
       }),
     ).rejects.toThrow(/Managed Hermes local BuildKit build failed \(exit 1\)/);
@@ -488,15 +466,6 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     const dockerfile = path.join(buildCtx, "Dockerfile");
     const buildImage = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(0);
     const openshellShellCommand = vi.fn((args: string[]) => args.join(" "));
-    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
-      agentName: "hermes",
-      fromDockerfile: null,
-      origin: "generated",
-      dockerDriverGateway: true,
-      buildCtx,
-      stagedDockerfile: dockerfile,
-      buildId: "build-123",
-    });
     const input = {
       agent: { name: "hermes" } as any,
       chatUiUrl: "",
@@ -518,7 +487,6 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
         inspectImageId: () => IMAGE_ID,
         log: vi.fn(),
         origin: "generated" as const,
-        managedHermesBuildFailureCapability,
       },
     };
 

--- a/src/lib/onboard/sandbox-create-launch.test.ts
+++ b/src/lib/onboard/sandbox-create-launch.test.ts
@@ -428,4 +428,75 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     expect(result.createCommand).toContain(`sandbox create --from ${dockerfile} --name demo`);
     expect(result.createCommand).not.toContain("nemoclaw-sandbox-local");
   });
+
+  it("does not hide a generated Hermes BuildKit failure behind the gateway builder (#7140)", async () => {
+    const buildCtx = createTrustedBuildContext();
+    const dockerfile = path.join(buildCtx, "Dockerfile");
+    const openshellShellCommand = vi.fn((args: string[]) => args.join(" "));
+
+    await expect(
+      prepareSandboxCreateLaunchWithPrebuild({
+        agent: { name: "hermes" } as any,
+        chatUiUrl: "",
+        createArgs: ["--from", dockerfile, "--name", "demo"],
+        env: {},
+        extraPlaceholderKeys: [],
+        getDashboardForwardPort: () => "0",
+        hermesDashboardState: disabledHermesDashboardState,
+        manageDashboard: false,
+        openshellShellCommand,
+        sandboxName: "demo",
+        buildEnv: () => ({}),
+        prebuild: {
+          buildCtx,
+          buildId: "build-123",
+          dockerDriverGateway: true,
+          env: { NEMOCLAW_SANDBOX_PREBUILD: "1" },
+          buildImage: async () => 1,
+          log: vi.fn(),
+          origin: "generated",
+        },
+      }),
+    ).rejects.toThrow(/Local BuildKit is required.*local build failed \(exit 1\)/);
+    expect(openshellShellCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a custom Hermes Dockerfile", "custom", true],
+    ["a remote-gateway Hermes image", "generated", false],
+  ] as const)("keeps gateway handling for %s (#7140)", async (_label, origin, dockerDriverGateway) => {
+    const buildCtx = createTrustedBuildContext();
+    const dockerfile = path.join(buildCtx, "Dockerfile");
+    const buildImage = vi.fn(async () => 1);
+    const result = await prepareSandboxCreateLaunchWithPrebuild({
+      agent: { name: "hermes" } as any,
+      chatUiUrl: "",
+      createArgs: ["--from", dockerfile, "--name", "demo"],
+      env: {},
+      extraPlaceholderKeys: [],
+      getDashboardForwardPort: () => "0",
+      hermesDashboardState: disabledHermesDashboardState,
+      manageDashboard: false,
+      openshellShellCommand: (args) => args.join(" "),
+      sandboxName: "demo",
+      buildEnv: () => ({}),
+      prebuild: {
+        buildCtx,
+        buildId: "build-123",
+        dockerDriverGateway,
+        env: { NEMOCLAW_SANDBOX_PREBUILD: "1" },
+        buildImage,
+        log: vi.fn(),
+        origin,
+      },
+    });
+
+    expect(result.prebuild).toEqual({
+      createArgs: ["--from", dockerfile, "--name", "demo"],
+      imageRef: null,
+      imageId: null,
+    });
+    expect(result.createCommand).toContain(`sandbox create --from ${dockerfile} --name demo`);
+    expect(buildImage).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/onboard/sandbox-create-launch.ts
+++ b/src/lib/onboard/sandbox-create-launch.ts
@@ -11,10 +11,13 @@ import { appendHermesDashboardEnvArgs } from "./hermes-dashboard";
 import { appendHostProxyEnvArgs } from "./host-proxy-env";
 import { appendOpenClawRuntimeEnvArgs } from "./openclaw-runtime-env";
 import {
+  issueManagedHermesBuildFailureCapability,
   prebuildSandboxImageIfEligible,
   type SandboxPrebuildInput,
   type SandboxPrebuildResult,
 } from "./sandbox-prebuild";
+
+export { issueManagedHermesBuildFailureCapability };
 
 type OpenshellShellCommand = (args: string[]) => string;
 type OpenshellArgv = (args: string[]) => string[];
@@ -68,7 +71,7 @@ export interface SandboxCreateLaunch {
 
 export interface SandboxCreateLaunchWithPrebuildInput extends SandboxCreateLaunchInput {
   sandboxName: string;
-  prebuild: Omit<SandboxPrebuildInput, "createArgs" | "gatewayFallback" | "sandboxName">;
+  prebuild: Omit<SandboxPrebuildInput, "createArgs" | "sandboxName">;
 }
 
 export interface SandboxCreateLaunchWithPrebuild extends SandboxCreateLaunch {
@@ -220,14 +223,9 @@ export async function prepareSandboxCreateLaunchWithPrebuild(
   input: SandboxCreateLaunchWithPrebuildInput,
 ): Promise<SandboxCreateLaunchWithPrebuild> {
   const { prebuild: prebuildInput, ...launchInput } = input;
-  const generatedHermesRequiresBuildKit =
-    input.agent?.name === "hermes" &&
-    prebuildInput.origin === "generated" &&
-    prebuildInput.dockerDriverGateway;
   const prebuild = await prebuildSandboxImageIfEligible({
     ...prebuildInput,
     createArgs: input.createArgs,
-    gatewayFallback: generatedHermesRequiresBuildKit ? "forbidden" : "allowed",
     sandboxName: input.sandboxName,
   });
   return {

--- a/src/lib/onboard/sandbox-create-launch.ts
+++ b/src/lib/onboard/sandbox-create-launch.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import path from "node:path";
+
 import type { AgentDefinition } from "../agent/defs";
 import { formatEnvAssignment } from "../core/url-utils";
 import { buildSubprocessEnv } from "../subprocess-env";
@@ -223,9 +225,20 @@ export async function prepareSandboxCreateLaunchWithPrebuild(
   input: SandboxCreateLaunchWithPrebuildInput,
 ): Promise<SandboxCreateLaunchWithPrebuild> {
   const { prebuild: prebuildInput, ...launchInput } = input;
+  const managedHermesBuildFailureCapability =
+    prebuildInput.managedHermesBuildFailureCapability ??
+    issueManagedHermesBuildFailureCapability({
+      agentName: input.agent?.name ?? null,
+      origin: prebuildInput.origin,
+      dockerDriverGateway: prebuildInput.dockerDriverGateway,
+      buildCtx: prebuildInput.buildCtx,
+      stagedDockerfile: path.join(prebuildInput.buildCtx, "Dockerfile"),
+      buildId: prebuildInput.buildId,
+    });
   const prebuild = await prebuildSandboxImageIfEligible({
     ...prebuildInput,
     createArgs: input.createArgs,
+    managedHermesBuildFailureCapability,
     sandboxName: input.sandboxName,
   });
   return {

--- a/src/lib/onboard/sandbox-create-launch.ts
+++ b/src/lib/onboard/sandbox-create-launch.ts
@@ -68,7 +68,7 @@ export interface SandboxCreateLaunch {
 
 export interface SandboxCreateLaunchWithPrebuildInput extends SandboxCreateLaunchInput {
   sandboxName: string;
-  prebuild: Omit<SandboxPrebuildInput, "createArgs" | "sandboxName">;
+  prebuild: Omit<SandboxPrebuildInput, "createArgs" | "gatewayFallback" | "sandboxName">;
 }
 
 export interface SandboxCreateLaunchWithPrebuild extends SandboxCreateLaunch {
@@ -220,9 +220,14 @@ export async function prepareSandboxCreateLaunchWithPrebuild(
   input: SandboxCreateLaunchWithPrebuildInput,
 ): Promise<SandboxCreateLaunchWithPrebuild> {
   const { prebuild: prebuildInput, ...launchInput } = input;
+  const generatedHermesRequiresBuildKit =
+    input.agent?.name === "hermes" &&
+    prebuildInput.origin === "generated" &&
+    prebuildInput.dockerDriverGateway;
   const prebuild = await prebuildSandboxImageIfEligible({
     ...prebuildInput,
     createArgs: input.createArgs,
+    gatewayFallback: generatedHermesRequiresBuildKit ? "forbidden" : "allowed",
     sandboxName: input.sandboxName,
   });
   return {

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -26,6 +26,7 @@ import {
 
 const BUILD_ID = "1234567890";
 const IMAGE_ID = `sha256:${"a".repeat(64)}`;
+const BUILD_START_ERROR = new Error("daemon unavailable");
 const temporaryDirectories: string[] = [];
 
 function createBuildContext(
@@ -488,37 +489,42 @@ describe("sandbox BuildKit prebuild", () => {
   it.each([
     [
       "exits nonzero",
-      async () => 1,
+      async (): Promise<number> => 1,
       /local build failed \(exit 1\).*Inspect the preceding BuildKit output/,
+      null,
     ],
     [
       "returns no exit status",
-      async () => null,
+      async (): Promise<null> => null,
       /local build failed without an exit status.*Inspect the preceding BuildKit output/,
+      null,
     ],
     [
       "cannot start",
-      async () => {
-        throw new Error("daemon unavailable");
+      async (): Promise<never> => {
+        throw BUILD_START_ERROR;
       },
       /local build could not start \(daemon unavailable\).*Start Docker.*BuildKit is enabled/,
+      BUILD_START_ERROR,
     ],
-  ])("fails closed when a required local BuildKit build %s (#7140)", async (_label, buildImage, message) => {
+  ] as const)("fails closed when a required local BuildKit build %s (#7140)", async (_label, buildImage, message, expectedCause) => {
     const { buildCtx, createArgs } = createBuildContext();
+    const failure = prebuildSandboxImageIfEligible({
+      buildCtx,
+      buildId: BUILD_ID,
+      origin: "generated",
+      createArgs,
+      sandboxName: "alpha",
+      dockerDriverGateway: true,
+      gatewayFallback: "forbidden",
+      env: {},
+      buildImage,
+      log: () => {},
+    });
 
-    await expect(
-      prebuildSandboxImageIfEligible({
-        buildCtx,
-        buildId: BUILD_ID,
-        origin: "generated",
-        createArgs,
-        sandboxName: "alpha",
-        dockerDriverGateway: true,
-        gatewayFallback: "forbidden",
-        env: {},
-        buildImage,
-        log: () => {},
-      }),
-    ).rejects.toThrow(message);
+    await expect(failure).rejects.toThrow(message);
+    if (expectedCause) {
+      await expect(failure).rejects.toMatchObject({ cause: expectedCause });
+    }
   });
 });

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -19,6 +19,7 @@ import { withStdoutRedirectedToStderr } from "../cli/stdout-guard";
 import { SANDBOX_BUILD_CONTEXT_PREFIX } from "../sandbox/build-context";
 import {
   dockerBuildSubprocessEnv,
+  issueManagedHermesBuildFailureCapability,
   prebuildSandboxImageIfEligible,
   resolveSandboxPrebuildEnabled,
   sandboxLocalImageRef,
@@ -26,7 +27,6 @@ import {
 
 const BUILD_ID = "1234567890";
 const IMAGE_ID = `sha256:${"a".repeat(64)}`;
-const BUILD_START_ERROR = new Error("daemon unavailable");
 const temporaryDirectories: string[] = [];
 
 function createBuildContext(
@@ -340,7 +340,6 @@ describe("sandbox BuildKit prebuild", () => {
       createArgs,
       sandboxName: "alpha",
       dockerDriverGateway: true,
-      gatewayFallback: "forbidden",
       env: {},
       buildImage,
       inspectImageId: () => IMAGE_ID,
@@ -425,8 +424,17 @@ describe("sandbox BuildKit prebuild", () => {
     expect(result).toEqual({ createArgs, imageRef: null, imageId: null });
   });
 
-  it("falls back to OpenShell when the Docker helper throws", async () => {
-    const { buildCtx, createArgs } = createBuildContext();
+  it("preserves optional fallback when an exact managed Hermes build cannot start", async () => {
+    const { buildCtx, createArgs, dockerfile } = createBuildContext();
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: BUILD_ID,
+    });
     const result = await prebuildSandboxImageIfEligible({
       buildCtx,
       buildId: BUILD_ID,
@@ -434,6 +442,7 @@ describe("sandbox BuildKit prebuild", () => {
       createArgs,
       sandboxName: "alpha",
       dockerDriverGateway: true,
+      managedHermesBuildFailureCapability,
       env: {},
       buildImage: async () => {
         throw new Error("unavailable");
@@ -443,9 +452,49 @@ describe("sandbox BuildKit prebuild", () => {
     expect(result).toEqual({ createArgs, imageRef: null, imageId: null });
   });
 
-  it("fails closed when a required local BuildKit prebuild is disabled (#7140)", async () => {
-    const { buildCtx, createArgs } = createBuildContext();
+  it("issues failure capability only for an exact managed local Hermes context (#7140)", () => {
+    const { buildCtx, dockerfile } = createBuildContext();
+    const base = {
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: BUILD_ID,
+    } as const;
+
+    expect(issueManagedHermesBuildFailureCapability(base)).toBeDefined();
+    expect(
+      issueManagedHermesBuildFailureCapability({ ...base, agentName: "openclaw" }),
+    ).toBeUndefined();
+    expect(
+      issueManagedHermesBuildFailureCapability({ ...base, fromDockerfile: dockerfile }),
+    ).toBeUndefined();
+    expect(issueManagedHermesBuildFailureCapability({ ...base, origin: "custom" })).toBeUndefined();
+    expect(
+      issueManagedHermesBuildFailureCapability({ ...base, dockerDriverGateway: false }),
+    ).toBeUndefined();
+    expect(
+      issueManagedHermesBuildFailureCapability({
+        ...base,
+        stagedDockerfile: path.join(buildCtx, "missing-Dockerfile"),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves optional fallback when the exact managed Hermes prebuild is disabled (#7140)", async () => {
+    const { buildCtx, createArgs, dockerfile } = createBuildContext();
     const buildImage = vi.fn(async () => 0);
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: BUILD_ID,
+    });
 
     await expect(
       prebuildSandboxImageIfEligible({
@@ -455,34 +504,11 @@ describe("sandbox BuildKit prebuild", () => {
         createArgs,
         sandboxName: "alpha",
         dockerDriverGateway: true,
-        gatewayFallback: "forbidden",
+        managedHermesBuildFailureCapability,
         env: { NEMOCLAW_SANDBOX_PREBUILD: "0" },
         buildImage,
       }),
-    ).rejects.toThrow(
-      /Local BuildKit is required.*local prebuild is disabled or unavailable.*Start Docker.*local prebuild are enabled/,
-    );
-    expect(buildImage).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when a required local BuildKit context is no longer trusted (#7140)", async () => {
-    const { buildCtx, createArgs } = createBuildContext();
-    fs.chmodSync(buildCtx, 0o770);
-    const buildImage = vi.fn(async () => 0);
-
-    await expect(
-      prebuildSandboxImageIfEligible({
-        buildCtx,
-        buildId: BUILD_ID,
-        origin: "generated",
-        createArgs,
-        sandboxName: "alpha",
-        dockerDriverGateway: true,
-        gatewayFallback: "forbidden",
-        env: {},
-        buildImage,
-      }),
-    ).rejects.toThrow(/Local BuildKit is required.*failed trust validation.*Resume onboarding/);
+    ).resolves.toEqual({ createArgs, imageRef: null, imageId: null });
     expect(buildImage).not.toHaveBeenCalled();
   });
 
@@ -490,15 +516,24 @@ describe("sandbox BuildKit prebuild", () => {
     [
       "exits nonzero",
       async (): Promise<number> => 1,
-      /local build failed \(exit 1\).*Inspect the preceding BuildKit output/,
+      /local BuildKit build failed \(exit 1\).*Inspect the preceding BuildKit output/,
     ],
     [
       "returns no exit status",
       async (): Promise<null> => null,
-      /local build failed without an exit status.*Inspect the preceding BuildKit output/,
+      /local BuildKit build failed without an exit status.*Inspect the preceding BuildKit output/,
     ],
-  ] as const)("fails closed when a required local BuildKit build %s (#7140)", async (_label, buildImage, message) => {
-    const { buildCtx, createArgs } = createBuildContext();
+  ] as const)("preserves an exact managed Hermes BuildKit failure when the build %s (#7140)", async (_label, buildImage, message) => {
+    const { buildCtx, createArgs, dockerfile } = createBuildContext();
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: BUILD_ID,
+    });
     const failure = prebuildSandboxImageIfEligible({
       buildCtx,
       buildId: BUILD_ID,
@@ -506,7 +541,7 @@ describe("sandbox BuildKit prebuild", () => {
       createArgs,
       sandboxName: "alpha",
       dockerDriverGateway: true,
-      gatewayFallback: "forbidden",
+      managedHermesBuildFailureCapability,
       env: {},
       buildImage,
       log: () => {},
@@ -515,26 +550,132 @@ describe("sandbox BuildKit prebuild", () => {
     await expect(failure).rejects.toThrow(message);
   });
 
-  it("preserves the cause when a required local BuildKit build cannot start (#7140)", async () => {
-    const { buildCtx, createArgs } = createBuildContext();
-    const failure = prebuildSandboxImageIfEligible({
-      buildCtx,
-      buildId: BUILD_ID,
+  it("does not authorize fail-fast after managed Hermes build identity drift (#7140)", async () => {
+    const { buildCtx, createArgs, dockerfile } = createBuildContext();
+    const buildImage = vi.fn(async () => 1);
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
       origin: "generated",
-      createArgs,
-      sandboxName: "alpha",
       dockerDriverGateway: true,
-      gatewayFallback: "forbidden",
-      env: {},
-      buildImage: async (): Promise<never> => {
-        throw BUILD_START_ERROR;
-      },
-      log: () => {},
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: BUILD_ID,
     });
 
-    await expect(failure).rejects.toThrow(
-      /local build could not start \(daemon unavailable\).*Start Docker.*BuildKit is enabled/,
-    );
-    await expect(failure).rejects.toMatchObject({ cause: BUILD_START_ERROR });
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: "different-build",
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        managedHermesBuildFailureCapability,
+        env: {},
+        buildImage,
+        log: () => {},
+      }),
+    ).resolves.toEqual({ createArgs, imageRef: null, imageId: null });
+    expect(buildImage).toHaveBeenCalledOnce();
+  });
+
+  it("does not authorize fail-fast for another staged context (#7140)", async () => {
+    const issued = createBuildContext();
+    const selected = createBuildContext();
+    const buildImage = vi.fn(async () => 1);
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx: issued.buildCtx,
+      stagedDockerfile: issued.dockerfile,
+      buildId: BUILD_ID,
+    });
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx: selected.buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs: selected.createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        managedHermesBuildFailureCapability,
+        env: {},
+        buildImage,
+        log: () => {},
+      }),
+    ).resolves.toEqual({
+      createArgs: selected.createArgs,
+      imageRef: null,
+      imageId: null,
+    });
+    expect(buildImage).toHaveBeenCalledOnce();
+  });
+
+  it("does not authorize fail-fast after the staged Dockerfile identity changes (#7140)", async () => {
+    const { buildCtx, createArgs, dockerfile } = createBuildContext();
+    const buildImage = vi.fn(async () => 1);
+    const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: BUILD_ID,
+    });
+    fs.renameSync(dockerfile, `${dockerfile}.original`);
+    fs.writeFileSync(dockerfile, "FROM scratch\n");
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        managedHermesBuildFailureCapability,
+        env: {},
+        buildImage,
+        log: () => {},
+      }),
+    ).resolves.toEqual({ createArgs, imageRef: null, imageId: null });
+    expect(buildImage).toHaveBeenCalledOnce();
+  });
+
+  it("does not authorize fail-fast for a copied capability token (#7140)", async () => {
+    const { buildCtx, createArgs, dockerfile } = createBuildContext();
+    const buildImage = vi.fn(async () => 1);
+    const issuedCapability = issueManagedHermesBuildFailureCapability({
+      agentName: "hermes",
+      fromDockerfile: null,
+      origin: "generated",
+      dockerDriverGateway: true,
+      buildCtx,
+      stagedDockerfile: dockerfile,
+      buildId: BUILD_ID,
+    });
+    expect(issuedCapability).toBeDefined();
+    const copiedCapability = { ...issuedCapability } as NonNullable<typeof issuedCapability>;
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        managedHermesBuildFailureCapability: copiedCapability,
+        env: {},
+        buildImage,
+        log: () => {},
+      }),
+    ).resolves.toEqual({ createArgs, imageRef: null, imageId: null });
+    expect(buildImage).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -491,23 +491,13 @@ describe("sandbox BuildKit prebuild", () => {
       "exits nonzero",
       async (): Promise<number> => 1,
       /local build failed \(exit 1\).*Inspect the preceding BuildKit output/,
-      null,
     ],
     [
       "returns no exit status",
       async (): Promise<null> => null,
       /local build failed without an exit status.*Inspect the preceding BuildKit output/,
-      null,
     ],
-    [
-      "cannot start",
-      async (): Promise<never> => {
-        throw BUILD_START_ERROR;
-      },
-      /local build could not start \(daemon unavailable\).*Start Docker.*BuildKit is enabled/,
-      BUILD_START_ERROR,
-    ],
-  ] as const)("fails closed when a required local BuildKit build %s (#7140)", async (_label, buildImage, message, expectedCause) => {
+  ] as const)("fails closed when a required local BuildKit build %s (#7140)", async (_label, buildImage, message) => {
     const { buildCtx, createArgs } = createBuildContext();
     const failure = prebuildSandboxImageIfEligible({
       buildCtx,
@@ -523,8 +513,28 @@ describe("sandbox BuildKit prebuild", () => {
     });
 
     await expect(failure).rejects.toThrow(message);
-    if (expectedCause) {
-      await expect(failure).rejects.toMatchObject({ cause: expectedCause });
-    }
+  });
+
+  it("preserves the cause when a required local BuildKit build cannot start (#7140)", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    const failure = prebuildSandboxImageIfEligible({
+      buildCtx,
+      buildId: BUILD_ID,
+      origin: "generated",
+      createArgs,
+      sandboxName: "alpha",
+      dockerDriverGateway: true,
+      gatewayFallback: "forbidden",
+      env: {},
+      buildImage: async (): Promise<never> => {
+        throw BUILD_START_ERROR;
+      },
+      log: () => {},
+    });
+
+    await expect(failure).rejects.toThrow(
+      /local build could not start \(daemon unavailable\).*Start Docker.*BuildKit is enabled/,
+    );
+    await expect(failure).rejects.toMatchObject({ cause: BUILD_START_ERROR });
   });
 });

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -428,7 +428,6 @@ describe("sandbox BuildKit prebuild", () => {
     const { buildCtx, createArgs, dockerfile } = createBuildContext();
     const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
       agentName: "hermes",
-      fromDockerfile: null,
       origin: "generated",
       dockerDriverGateway: true,
       buildCtx,
@@ -456,7 +455,6 @@ describe("sandbox BuildKit prebuild", () => {
     const { buildCtx, dockerfile } = createBuildContext();
     const base = {
       agentName: "hermes",
-      fromDockerfile: null,
       origin: "generated",
       dockerDriverGateway: true,
       buildCtx,
@@ -467,9 +465,6 @@ describe("sandbox BuildKit prebuild", () => {
     expect(issueManagedHermesBuildFailureCapability(base)).toBeDefined();
     expect(
       issueManagedHermesBuildFailureCapability({ ...base, agentName: "openclaw" }),
-    ).toBeUndefined();
-    expect(
-      issueManagedHermesBuildFailureCapability({ ...base, fromDockerfile: dockerfile }),
     ).toBeUndefined();
     expect(issueManagedHermesBuildFailureCapability({ ...base, origin: "custom" })).toBeUndefined();
     expect(
@@ -488,7 +483,6 @@ describe("sandbox BuildKit prebuild", () => {
     const buildImage = vi.fn(async () => 0);
     const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
       agentName: "hermes",
-      fromDockerfile: null,
       origin: "generated",
       dockerDriverGateway: true,
       buildCtx,
@@ -527,7 +521,6 @@ describe("sandbox BuildKit prebuild", () => {
     const { buildCtx, createArgs, dockerfile } = createBuildContext();
     const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
       agentName: "hermes",
-      fromDockerfile: null,
       origin: "generated",
       dockerDriverGateway: true,
       buildCtx,
@@ -555,7 +548,6 @@ describe("sandbox BuildKit prebuild", () => {
     const buildImage = vi.fn(async () => 1);
     const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
       agentName: "hermes",
-      fromDockerfile: null,
       origin: "generated",
       dockerDriverGateway: true,
       buildCtx,
@@ -586,7 +578,6 @@ describe("sandbox BuildKit prebuild", () => {
     const buildImage = vi.fn(async () => 1);
     const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
       agentName: "hermes",
-      fromDockerfile: null,
       origin: "generated",
       dockerDriverGateway: true,
       buildCtx: issued.buildCtx,
@@ -620,7 +611,6 @@ describe("sandbox BuildKit prebuild", () => {
     const buildImage = vi.fn(async () => 1);
     const managedHermesBuildFailureCapability = issueManagedHermesBuildFailureCapability({
       agentName: "hermes",
-      fromDockerfile: null,
       origin: "generated",
       dockerDriverGateway: true,
       buildCtx,
@@ -652,7 +642,6 @@ describe("sandbox BuildKit prebuild", () => {
     const buildImage = vi.fn(async () => 1);
     const issuedCapability = issueManagedHermesBuildFailureCapability({
       agentName: "hermes",
-      fromDockerfile: null,
       origin: "generated",
       dockerDriverGateway: true,
       buildCtx,

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -339,6 +339,7 @@ describe("sandbox BuildKit prebuild", () => {
       createArgs,
       sandboxName: "alpha",
       dockerDriverGateway: true,
+      gatewayFallback: "forbidden",
       env: {},
       buildImage,
       inspectImageId: () => IMAGE_ID,
@@ -439,5 +440,85 @@ describe("sandbox BuildKit prebuild", () => {
       log: () => {},
     });
     expect(result).toEqual({ createArgs, imageRef: null, imageId: null });
+  });
+
+  it("fails closed when a required local BuildKit prebuild is disabled (#7140)", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    const buildImage = vi.fn(async () => 0);
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        gatewayFallback: "forbidden",
+        env: { NEMOCLAW_SANDBOX_PREBUILD: "0" },
+        buildImage,
+      }),
+    ).rejects.toThrow(
+      /Local BuildKit is required.*local prebuild is disabled or unavailable.*Start Docker.*local prebuild are enabled/,
+    );
+    expect(buildImage).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a required local BuildKit context is no longer trusted (#7140)", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    fs.chmodSync(buildCtx, 0o770);
+    const buildImage = vi.fn(async () => 0);
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        gatewayFallback: "forbidden",
+        env: {},
+        buildImage,
+      }),
+    ).rejects.toThrow(/Local BuildKit is required.*failed trust validation.*Resume onboarding/);
+    expect(buildImage).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "exits nonzero",
+      async () => 1,
+      /local build failed \(exit 1\).*Inspect the preceding BuildKit output/,
+    ],
+    [
+      "returns no exit status",
+      async () => null,
+      /local build failed without an exit status.*Inspect the preceding BuildKit output/,
+    ],
+    [
+      "cannot start",
+      async () => {
+        throw new Error("daemon unavailable");
+      },
+      /local build could not start \(daemon unavailable\).*Start Docker.*BuildKit is enabled/,
+    ],
+  ])("fails closed when a required local BuildKit build %s (#7140)", async (_label, buildImage, message) => {
+    const { buildCtx, createArgs } = createBuildContext();
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        gatewayFallback: "forbidden",
+        env: {},
+        buildImage,
+        log: () => {},
+      }),
+    ).rejects.toThrow(message);
   });
 });

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -34,11 +34,7 @@ export interface SandboxPrebuildInput {
   sandboxName: string;
   dockerDriverGateway: boolean;
   origin: SandboxBuildContextOrigin;
-  /**
-   * Refuse to pass the staged Dockerfile to the gateway builder when the
-   * generated image requires a successful local BuildKit build.
-   */
-  gatewayFallback?: "allowed" | "forbidden";
+  managedHermesBuildFailureCapability?: ManagedHermesBuildFailureCapability;
   env?: NodeJS.ProcessEnv;
   buildImage?: (
     args: readonly string[],
@@ -58,6 +54,115 @@ export interface SandboxPrebuildResult {
 interface TrustedStagedBuildContext {
   buildCtx: string;
   dockerfile: string;
+}
+
+interface StagedPathIdentity {
+  path: string;
+  device: number;
+  inode: number;
+}
+
+export interface ManagedHermesBuildFailureCapability {
+  readonly buildCtx: StagedPathIdentity;
+  readonly dockerfile: StagedPathIdentity;
+  readonly buildId: string;
+}
+
+export interface ManagedHermesBuildFailureCapabilityInput {
+  agentName: string | null;
+  fromDockerfile: string | null;
+  origin: SandboxBuildContextOrigin;
+  dockerDriverGateway: boolean;
+  buildCtx: string;
+  stagedDockerfile: string;
+  buildId: string;
+}
+
+const issuedManagedHermesBuildFailureCapabilities = new WeakSet<object>();
+
+function readStagedPathIdentity(
+  filePath: string,
+  expected: "directory" | "file",
+): StagedPathIdentity {
+  const resolved = fs.realpathSync(filePath);
+  const stat = fs.statSync(resolved);
+  const matchesExpectedKind = expected === "directory" ? stat.isDirectory() : stat.isFile();
+  if (!matchesExpectedKind) {
+    throw new Error(
+      `Cannot bind managed Hermes build provenance: ${resolved} is not a ${expected}.`,
+    );
+  }
+  return Object.freeze({ path: resolved, device: stat.dev, inode: stat.ino });
+}
+
+function stagedPathIdentityMatches(
+  filePath: string,
+  identity: StagedPathIdentity,
+  expected: "directory" | "file",
+): boolean {
+  try {
+    const current = readStagedPathIdentity(filePath, expected);
+    return (
+      current.path === identity.path &&
+      current.device === identity.device &&
+      current.inode === identity.inode
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Issue an in-memory capability only for the managed, no-custom-image Hermes
+ * path. The capability is bound to the staged context, Dockerfile, and build
+ * identity so it cannot authorize failure handling for another build.
+ */
+export function issueManagedHermesBuildFailureCapability(
+  input: ManagedHermesBuildFailureCapabilityInput,
+): ManagedHermesBuildFailureCapability | undefined {
+  if (
+    input.agentName !== "hermes" ||
+    input.fromDockerfile !== null ||
+    input.origin !== "generated" ||
+    !input.dockerDriverGateway
+  ) {
+    return undefined;
+  }
+
+  try {
+    const buildCtx = readStagedPathIdentity(input.buildCtx, "directory");
+    const dockerfile = readStagedPathIdentity(input.stagedDockerfile, "file");
+    if (
+      path.dirname(dockerfile.path) !== buildCtx.path ||
+      path.basename(dockerfile.path) !== "Dockerfile"
+    ) {
+      return undefined;
+    }
+
+    const capability = Object.freeze({ buildCtx, dockerfile, buildId: input.buildId });
+    issuedManagedHermesBuildFailureCapabilities.add(capability);
+    return capability;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasExactManagedHermesBuildFailureCapability(
+  input: SandboxPrebuildInput,
+  fromDockerfile: string | undefined,
+): boolean {
+  const capability = input.managedHermesBuildFailureCapability;
+  if (!capability) return false;
+
+  return (
+    issuedManagedHermesBuildFailureCapabilities.has(capability) &&
+    input.origin === "generated" &&
+    input.dockerDriverGateway &&
+    input.buildId === capability.buildId &&
+    stagedPathIdentityMatches(input.buildCtx, capability.buildCtx, "directory") &&
+    typeof fromDockerfile === "string" &&
+    stagedPathIdentityMatches(fromDockerfile, capability.dockerfile, "file")
+  );
 }
 
 /**
@@ -150,8 +255,9 @@ export function sandboxLocalImageRef(sandboxName: string, buildId: string): stri
 /**
  * Build a NemoClaw-generated staged context with BuildKit on the shared local
  * Docker daemon. User-supplied Dockerfiles stay on the OpenShell gateway
- * builder trust boundary. Ordinary callers preserve that path on local build
- * failure; callers with BuildKit-only generated images fail closed instead.
+ * builder trust boundary, and ordinary failures preserve that original build
+ * path. An exact managed-Hermes capability preserves an attempted BuildKit
+ * failure instead of replacing it with a known-incompatible builder error.
  * Remove this bridge once OpenShell uses BuildKit for this local-driver path;
  * extraction and observable retirement criteria are tracked by #6258.
  */
@@ -161,69 +267,43 @@ export async function prebuildSandboxImageIfEligible(
   const createArgs = [...input.createArgs];
   const env = input.env ?? process.env;
   const log = input.log ?? console.log;
-  const failRequiredBuildKit = (detail: string, nextStep: string, cause?: unknown): never => {
-    throw new Error(
-      `Local BuildKit is required for this generated sandbox image, but ${detail}. ` +
-        `${nextStep} ` +
-        "Gateway-builder fallback is disabled because this Dockerfile uses BuildKit-only instructions.",
-      cause === undefined ? undefined : { cause },
-    );
-  };
-  const skipOrFailRequiredBuildKit = (
-    detail: string,
-    nextStep: string,
-    skipMessage?: string,
-    cause?: unknown,
-  ): SandboxPrebuildResult => {
-    if (input.gatewayFallback === "forbidden") {
-      failRequiredBuildKit(detail, nextStep, cause);
-    }
-    if (skipMessage) log(skipMessage);
-    return { createArgs, imageRef: null, imageId: null };
-  };
-  if (!resolveSandboxPrebuildEnabled(env, input.dockerDriverGateway)) {
-    return skipOrFailRequiredBuildKit(
-      "the local prebuild is disabled or unavailable",
-      "Start Docker, ensure BuildKit and the local prebuild are enabled, then retry.",
-    );
-  }
-  if (input.origin !== "generated") {
-    return skipOrFailRequiredBuildKit(
-      "the staged build context is not NemoClaw-generated",
-      "Resume onboarding to restage the managed build context, then retry.",
-      "  Local BuildKit build skipped for a custom Dockerfile; using the gateway builder instead.",
-    );
-  }
   const fromIndex = createArgs.indexOf("--from");
   const fromDockerfile = createArgs[fromIndex + 1];
+  const preserveManagedHermesBuildFailure = hasExactManagedHermesBuildFailureCapability(
+    input,
+    fromDockerfile,
+  );
+  if (!resolveSandboxPrebuildEnabled(env, input.dockerDriverGateway)) {
+    return { createArgs, imageRef: null, imageId: null };
+  }
+  if (input.origin !== "generated") {
+    log(
+      "  Local BuildKit build skipped for a custom Dockerfile; using the gateway builder instead.",
+    );
+    return { createArgs, imageRef: null, imageId: null };
+  }
   if (
     fromIndex < 0 ||
     !fromDockerfile ||
     path.resolve(fromDockerfile) !== path.resolve(input.buildCtx, "Dockerfile")
   ) {
-    return skipOrFailRequiredBuildKit(
-      "sandbox create arguments do not select the staged Dockerfile",
-      "Resume onboarding to restage the managed build context, then retry.",
-    );
+    return { createArgs, imageRef: null, imageId: null };
   }
   let trustedContext: TrustedStagedBuildContext | null;
   try {
     trustedContext = resolveTrustedStagedBuildContext(input.buildCtx);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    return skipOrFailRequiredBuildKit(
-      `the staged build context could not be inspected (${detail})`,
-      "Resume onboarding to restage the managed build context, then retry.",
+    log(
       `  Local BuildKit build skipped: staged build context could not be inspected (${detail}); using the gateway builder instead.`,
-      error,
     );
+    return { createArgs, imageRef: null, imageId: null };
   }
   if (!trustedContext) {
-    return skipOrFailRequiredBuildKit(
-      "the staged build context failed trust validation",
-      "Resume onboarding to restage the managed build context, then retry.",
+    log(
       "  Local BuildKit build skipped: staged build context failed trust validation; using the gateway builder instead.",
     );
+    return { createArgs, imageRef: null, imageId: null };
   }
 
   const imageRef = sandboxLocalImageRef(input.sandboxName, input.buildId);
@@ -252,21 +332,21 @@ export async function prebuildSandboxImageIfEligible(
     );
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    return skipOrFailRequiredBuildKit(
-      `the local build could not start (${detail})`,
-      "Start Docker, ensure BuildKit is enabled, then retry.",
-      `  Local BuildKit build could not start (${detail}); using the gateway builder instead.`,
-      error,
-    );
+    log(`  Local BuildKit build could not start (${detail}); using the gateway builder instead.`);
+    return { createArgs, imageRef: null, imageId: null };
   }
 
   if (status !== 0) {
     const detail = status === null ? " without an exit status" : ` (exit ${status})`;
-    return skipOrFailRequiredBuildKit(
-      `the local build failed${detail}`,
-      "Inspect the preceding BuildKit output and fix the reported image input or Dockerfile error before retrying.",
-      `  Local BuildKit build failed${detail}; using the gateway builder instead.`,
-    );
+    if (preserveManagedHermesBuildFailure) {
+      throw new Error(
+        `Managed Hermes local BuildKit build failed${detail}. ` +
+          "Inspect the preceding BuildKit output and fix the reported image input or Dockerfile error. " +
+          "Gateway-builder fallback is disabled for this exact staged build because the managed Hermes Dockerfile uses BuildKit-only instructions.",
+      );
+    }
+    log(`  Local BuildKit build failed${detail}; using the gateway builder instead.`);
+    return { createArgs, imageRef: null, imageId: null };
   }
 
   createArgs[fromIndex + 1] = imageRef;

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -161,33 +161,38 @@ export async function prebuildSandboxImageIfEligible(
   const createArgs = [...input.createArgs];
   const env = input.env ?? process.env;
   const log = input.log ?? console.log;
-  const failRequiredBuildKit = (detail: string, nextStep: string): never => {
+  const failRequiredBuildKit = (detail: string, nextStep: string, cause?: unknown): never => {
     throw new Error(
       `Local BuildKit is required for this generated sandbox image, but ${detail}. ` +
         `${nextStep} ` +
         "Gateway-builder fallback is disabled because this Dockerfile uses BuildKit-only instructions.",
+      cause === undefined ? undefined : { cause },
     );
   };
-  if (!resolveSandboxPrebuildEnabled(env, input.dockerDriverGateway)) {
+  const skipOrFailRequiredBuildKit = (
+    detail: string,
+    nextStep: string,
+    skipMessage?: string,
+    cause?: unknown,
+  ): SandboxPrebuildResult => {
     if (input.gatewayFallback === "forbidden") {
-      failRequiredBuildKit(
-        "the local prebuild is disabled or unavailable",
-        "Start Docker, ensure BuildKit and the local prebuild are enabled, then retry.",
-      );
+      failRequiredBuildKit(detail, nextStep, cause);
     }
+    if (skipMessage) log(skipMessage);
     return { createArgs, imageRef: null, imageId: null };
+  };
+  if (!resolveSandboxPrebuildEnabled(env, input.dockerDriverGateway)) {
+    return skipOrFailRequiredBuildKit(
+      "the local prebuild is disabled or unavailable",
+      "Start Docker, ensure BuildKit and the local prebuild are enabled, then retry.",
+    );
   }
   if (input.origin !== "generated") {
-    if (input.gatewayFallback === "forbidden") {
-      failRequiredBuildKit(
-        "the staged build context is not NemoClaw-generated",
-        "Resume onboarding to restage the managed build context, then retry.",
-      );
-    }
-    log(
+    return skipOrFailRequiredBuildKit(
+      "the staged build context is not NemoClaw-generated",
+      "Resume onboarding to restage the managed build context, then retry.",
       "  Local BuildKit build skipped for a custom Dockerfile; using the gateway builder instead.",
     );
-    return { createArgs, imageRef: null, imageId: null };
   }
   const fromIndex = createArgs.indexOf("--from");
   const fromDockerfile = createArgs[fromIndex + 1];
@@ -196,41 +201,29 @@ export async function prebuildSandboxImageIfEligible(
     !fromDockerfile ||
     path.resolve(fromDockerfile) !== path.resolve(input.buildCtx, "Dockerfile")
   ) {
-    if (input.gatewayFallback === "forbidden") {
-      failRequiredBuildKit(
-        "sandbox create arguments do not select the staged Dockerfile",
-        "Resume onboarding to restage the managed build context, then retry.",
-      );
-    }
-    return { createArgs, imageRef: null, imageId: null };
+    return skipOrFailRequiredBuildKit(
+      "sandbox create arguments do not select the staged Dockerfile",
+      "Resume onboarding to restage the managed build context, then retry.",
+    );
   }
   let trustedContext: TrustedStagedBuildContext | null;
   try {
     trustedContext = resolveTrustedStagedBuildContext(input.buildCtx);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    if (input.gatewayFallback === "forbidden") {
-      failRequiredBuildKit(
-        `the staged build context could not be inspected (${detail})`,
-        "Resume onboarding to restage the managed build context, then retry.",
-      );
-    }
-    log(
+    return skipOrFailRequiredBuildKit(
+      `the staged build context could not be inspected (${detail})`,
+      "Resume onboarding to restage the managed build context, then retry.",
       `  Local BuildKit build skipped: staged build context could not be inspected (${detail}); using the gateway builder instead.`,
+      error,
     );
-    return { createArgs, imageRef: null, imageId: null };
   }
   if (!trustedContext) {
-    if (input.gatewayFallback === "forbidden") {
-      failRequiredBuildKit(
-        "the staged build context failed trust validation",
-        "Resume onboarding to restage the managed build context, then retry.",
-      );
-    }
-    log(
+    return skipOrFailRequiredBuildKit(
+      "the staged build context failed trust validation",
+      "Resume onboarding to restage the managed build context, then retry.",
       "  Local BuildKit build skipped: staged build context failed trust validation; using the gateway builder instead.",
     );
-    return { createArgs, imageRef: null, imageId: null };
   }
 
   const imageRef = sandboxLocalImageRef(input.sandboxName, input.buildId);
@@ -259,26 +252,21 @@ export async function prebuildSandboxImageIfEligible(
     );
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    if (input.gatewayFallback === "forbidden") {
-      failRequiredBuildKit(
-        `the local build could not start (${detail})`,
-        "Start Docker, ensure BuildKit is enabled, then retry.",
-      );
-    }
-    log(`  Local BuildKit build could not start (${detail}); using the gateway builder instead.`);
-    return { createArgs, imageRef: null, imageId: null };
+    return skipOrFailRequiredBuildKit(
+      `the local build could not start (${detail})`,
+      "Start Docker, ensure BuildKit is enabled, then retry.",
+      `  Local BuildKit build could not start (${detail}); using the gateway builder instead.`,
+      error,
+    );
   }
 
   if (status !== 0) {
     const detail = status === null ? " without an exit status" : ` (exit ${status})`;
-    if (input.gatewayFallback === "forbidden") {
-      failRequiredBuildKit(
-        `the local build failed${detail}`,
-        "Inspect the preceding BuildKit output and fix the reported image input or Dockerfile error before retrying.",
-      );
-    }
-    log(`  Local BuildKit build failed${detail}; using the gateway builder instead.`);
-    return { createArgs, imageRef: null, imageId: null };
+    return skipOrFailRequiredBuildKit(
+      `the local build failed${detail}`,
+      "Inspect the preceding BuildKit output and fix the reported image input or Dockerfile error before retrying.",
+      `  Local BuildKit build failed${detail}; using the gateway builder instead.`,
+    );
   }
 
   createArgs[fromIndex + 1] = imageRef;

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -70,7 +70,6 @@ export interface ManagedHermesBuildFailureCapability {
 
 export interface ManagedHermesBuildFailureCapabilityInput {
   agentName: string | null;
-  fromDockerfile: string | null;
   origin: SandboxBuildContextOrigin;
   dockerDriverGateway: boolean;
   buildCtx: string;
@@ -120,12 +119,7 @@ function stagedPathIdentityMatches(
 export function issueManagedHermesBuildFailureCapability(
   input: ManagedHermesBuildFailureCapabilityInput,
 ): ManagedHermesBuildFailureCapability | undefined {
-  if (
-    input.agentName !== "hermes" ||
-    input.fromDockerfile !== null ||
-    input.origin !== "generated" ||
-    !input.dockerDriverGateway
-  ) {
+  if (input.agentName !== "hermes" || input.origin !== "generated" || !input.dockerDriverGateway) {
     return undefined;
   }
 

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -34,6 +34,11 @@ export interface SandboxPrebuildInput {
   sandboxName: string;
   dockerDriverGateway: boolean;
   origin: SandboxBuildContextOrigin;
+  /**
+   * Refuse to pass the staged Dockerfile to the gateway builder when the
+   * generated image requires a successful local BuildKit build.
+   */
+  gatewayFallback?: "allowed" | "forbidden";
   env?: NodeJS.ProcessEnv;
   buildImage?: (
     args: readonly string[],
@@ -145,7 +150,8 @@ export function sandboxLocalImageRef(sandboxName: string, buildId: string): stri
 /**
  * Build a NemoClaw-generated staged context with BuildKit on the shared local
  * Docker daemon. User-supplied Dockerfiles stay on the OpenShell gateway
- * builder trust boundary, and any failure preserves that original build path.
+ * builder trust boundary. Ordinary callers preserve that path on local build
+ * failure; callers with BuildKit-only generated images fail closed instead.
  * Remove this bridge once OpenShell uses BuildKit for this local-driver path;
  * extraction and observable retirement criteria are tracked by #6258.
  */
@@ -155,10 +161,29 @@ export async function prebuildSandboxImageIfEligible(
   const createArgs = [...input.createArgs];
   const env = input.env ?? process.env;
   const log = input.log ?? console.log;
+  const failRequiredBuildKit = (detail: string, nextStep: string): never => {
+    throw new Error(
+      `Local BuildKit is required for this generated sandbox image, but ${detail}. ` +
+        `${nextStep} ` +
+        "Gateway-builder fallback is disabled because this Dockerfile uses BuildKit-only instructions.",
+    );
+  };
   if (!resolveSandboxPrebuildEnabled(env, input.dockerDriverGateway)) {
+    if (input.gatewayFallback === "forbidden") {
+      failRequiredBuildKit(
+        "the local prebuild is disabled or unavailable",
+        "Start Docker, ensure BuildKit and the local prebuild are enabled, then retry.",
+      );
+    }
     return { createArgs, imageRef: null, imageId: null };
   }
   if (input.origin !== "generated") {
+    if (input.gatewayFallback === "forbidden") {
+      failRequiredBuildKit(
+        "the staged build context is not NemoClaw-generated",
+        "Resume onboarding to restage the managed build context, then retry.",
+      );
+    }
     log(
       "  Local BuildKit build skipped for a custom Dockerfile; using the gateway builder instead.",
     );
@@ -171,6 +196,12 @@ export async function prebuildSandboxImageIfEligible(
     !fromDockerfile ||
     path.resolve(fromDockerfile) !== path.resolve(input.buildCtx, "Dockerfile")
   ) {
+    if (input.gatewayFallback === "forbidden") {
+      failRequiredBuildKit(
+        "sandbox create arguments do not select the staged Dockerfile",
+        "Resume onboarding to restage the managed build context, then retry.",
+      );
+    }
     return { createArgs, imageRef: null, imageId: null };
   }
   let trustedContext: TrustedStagedBuildContext | null;
@@ -178,12 +209,24 @@ export async function prebuildSandboxImageIfEligible(
     trustedContext = resolveTrustedStagedBuildContext(input.buildCtx);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
+    if (input.gatewayFallback === "forbidden") {
+      failRequiredBuildKit(
+        `the staged build context could not be inspected (${detail})`,
+        "Resume onboarding to restage the managed build context, then retry.",
+      );
+    }
     log(
       `  Local BuildKit build skipped: staged build context could not be inspected (${detail}); using the gateway builder instead.`,
     );
     return { createArgs, imageRef: null, imageId: null };
   }
   if (!trustedContext) {
+    if (input.gatewayFallback === "forbidden") {
+      failRequiredBuildKit(
+        "the staged build context failed trust validation",
+        "Resume onboarding to restage the managed build context, then retry.",
+      );
+    }
     log(
       "  Local BuildKit build skipped: staged build context failed trust validation; using the gateway builder instead.",
     );
@@ -216,12 +259,24 @@ export async function prebuildSandboxImageIfEligible(
     );
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
+    if (input.gatewayFallback === "forbidden") {
+      failRequiredBuildKit(
+        `the local build could not start (${detail})`,
+        "Start Docker, ensure BuildKit is enabled, then retry.",
+      );
+    }
     log(`  Local BuildKit build could not start (${detail}); using the gateway builder instead.`);
     return { createArgs, imageRef: null, imageId: null };
   }
 
   if (status !== 0) {
     const detail = status === null ? " without an exit status" : ` (exit ${status})`;
+    if (input.gatewayFallback === "forbidden") {
+      failRequiredBuildKit(
+        `the local build failed${detail}`,
+        "Inspect the preceding BuildKit output and fix the reported image input or Dockerfile error before retrying.",
+      );
+    }
     log(`  Local BuildKit build failed${detail}; using the gateway builder instead.`);
     return { createArgs, imageRef: null, imageId: null };
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

When an exact managed Hermes image build on a local Docker-driver gateway starts in host-side BuildKit and exits unsuccessfully, retrying the same BuildKit-only Dockerfile through the gateway builder hides the useful error behind `RUN --mount requires BuildKit`. This change preserves that attempted BuildKit failure while retaining the existing fallback for every path that cannot prove the same managed build provenance.

## Related Issue

Part of #7140 and #7144.

This complements #7582, which fixes the stale Hermes base digest observed in #7580. It does not broaden #7253's OpenClaw compatibility behavior.

## Changes

- Issue an in-memory capability only for a generated Hermes build on the local Docker-driver path.
- Bind the capability to the staged context and Dockerfile identities plus the build ID, and reject copied, malformed, or drifted provenance.
- Preserve the original failure only after that exact BuildKit attempt returns a nonzero or missing exit status.
- Retain gateway fallback when prebuild is disabled or unavailable, the build cannot start, trust validation fails, provenance changes, the image is custom, the agent is OpenClaw, or the gateway is remote.
- Cover capability issuance, provenance drift, retry behavior, exact failure preservation, and all unchanged fallback paths.
- Document the narrow managed-Hermes recovery path.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: two independent exact-diff reviews found no security or correctness blocker; the final review verified the production relocation, canonical custom-image exclusion, exact context/Dockerfile/build binding, and unchanged fallback paths.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/troubleshooting.mdx` documents nonzero and missing BuildKit exit statuses, the recovery step, and unchanged optional/custom/OpenClaw/remote behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 77856d8ce -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set — 42/42 focused CLI tests passed across `sandbox-prebuild.test.ts` and `sandbox-create-launch.test.ts`.
- [x] Applicable broad gate passed — `npm run checks`, `npm run typecheck:cli`, project-membership, source-shape, title-style, test-size, and Biome checks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — Fern completed with 0 errors and 2 pre-existing hidden warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
