### PR TITLE
fix(e2e): reconcile uncertain workflow dispatches

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
+++ b/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
@@ -102,6 +102,9 @@ The retry must apply to the PR SHA and base SHA.
 - `child-cancelled` — Rerun CI when the child workflow was cancelled.
   You can also rerun it when every listed non-passing job was cancelled.
 - `evidence-download` — Rerun CI when a successful child's evidence download failed, was cancelled, or was skipped.
+- `dispatch-not-observed` — Rerun CI only after the controller completed its bounded zero-match window and recorded a validated dispatch receipt on a trusted GitHub Actions check.
+  Never resubmit the child workflow manually.
+  The controller must recheck the old correlation before it creates a replacement check and fresh correlation.
 
 The controller keeps each completed coordination check as audit history.
 For a retry, it creates an `in_progress` check for the same PR SHA and base SHA.
@@ -113,9 +116,13 @@ Do not retry these terminal failures on the same SHA:
 - Selected-job or typed-target product failures.
 - Assertion failures.
 - Evidence policy or integrity failures.
-- Reconciliation or controller errors.
+- Ambiguous, incomplete, or identity-invalid reconciliation.
+- Controller errors.
 - Unknown states.
 - Failures recorded before retry reasons existed.
+
+A validated `dispatch-not-observed` receipt on a trusted GitHub Actions check is the only retryable reconciliation result.
+If a late child, incomplete inventory, or contradiction appears while the old correlation is rechecked, stop and investigate rather than dispatching again.
 
 Push a change to create another SHA, and then run CI again.
 A passing controller does not override a failing required job.
@@ -155,6 +162,8 @@ The controller reads the approval history and requires one approval for that env
 The environment's required reviewers are the authorization allowlist.
 The controller also checks the PR number, head repository, PR SHA, base SHA, plan, pending coordination check, compatible `main`, and PR state.
 Immediately before dispatch, it confirms that the PR is open and that the PR SHA, base SHA, and coordination identity still match.
+It also performs a bounded direct check read and requires the coordination check to remain in the exact expected phase, regardless of a matching, stale, or missing list result.
+If the run-specific authorization response is lost, the controller accepts only an exact persisted child binding and otherwise attempts to revoke coordination before requesting child cancellation.
 
 Approval returns coordination to `Running <count> E2E check(s)`.
 The gate passes only after the selected jobs and targets return verified passing evidence.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -572,11 +572,44 @@ projects each controller-selected target into a fixed target ID and hosted
 runner mapping. The generated live matrix must exactly match those trusted IDs
 and runners, and only the trusted projection can configure credential-bearing
 typed-target jobs. Ordinary branch dispatch is not an acceptable substitute.
-The controller uses GitHub's returned run ID for
-waiting, evidence download, and completion, then revalidates that the PR is
-still open with the PR SHA, base SHA, and coordination identity before
-recording a final result. The native observer revalidates the live revision
-before mirroring that terminal result.
+Immediately before the dispatch request, the controller also requires the
+coordination check to remain in the exact phase expected by that path.
+Regardless of the list result, a bounded direct check read must confirm the
+same identity and exact phase; pending, reserved, stale, or mismatched
+authorization state fails closed.
+The normal dispatch path uses GitHub's returned run ID for waiting, evidence
+download, and completion. A transport failure, HTTP 5xx response, invalid JSON,
+or malformed success response instead starts a 45-second read-only
+reconciliation window. The dispatch request is capped at 10 seconds, each
+inventory read is capped at 5 seconds, and the bounded adoption checks plus
+authorization publication keep the full path within the child's authorization
+window. The controller never sends a second dispatch request in that attempt.
+It waits for the full settling window and adopts exactly one
+correlated child only after validating its title, workflow path and SHA, `main`
+branch, first attempt, repository, canonical URLs, creation time, and GitHub
+Actions actor identities. It then rereads that run and revalidates the exact PR
+head, base, head repository, and unchanged pre-dispatch coordination check
+before publishing the run-specific authorization. If the authorization update
+response is lost or malformed, a bounded direct read accepts only the exact
+persisted child binding. Otherwise, the controller attempts to revoke
+coordination before requesting cancellation of the candidate child. If
+revocation itself fails,
+the controller still attempts cancellation and reports both failures. HTTP 4xx
+responses remain definitive dispatch rejections.
+
+Zero correlated runs produce the retryable `Workflow dispatch was not
+observed` result and a versioned receipt. Multiple or malformed correlated
+runs, incomplete or failed inventory reads, and identity drift fail closed as
+terminal reconciliation errors. Dispatch-reconciliation logs contain only the
+correlation ID, failure kind, optional HTTP status and safe GitHub request ID,
+and the `reconciling`, `adopted`, or `not-observed` result. API response
+excerpts are normalized to one line and limited to 512 characters. Dispatch
+inputs and tokens are not logged.
+
+After a child is selected, the controller revalidates that the PR is still open
+with the PR SHA, base SHA, and coordination identity before recording a final
+result. The native observer revalidates the live revision before mirroring that
+terminal result.
 
 An internal revision whose control-plane matches include a file outside the
 trusted controller and observer boundaries leaves coordination in progress
@@ -618,18 +651,23 @@ maintainer or administrator chooses **Run workflow** on `main`, selects
 as `expected_head_sha`, current 40-character base SHA as `expected_base_sha`,
 and a specific 10–500-character `review_reason`. This path additionally
 revalidates the triggering actor's `maintain` or `admin` permission and uses the
-same exact-revision and deterministic-plan checks. If authorization
-fails before a child run is dispatched, the controller restores the
-authorization title and leaves coordination in progress. A maintainer can then
-launch a fresh first-attempt manual authorization. To use the protected path
-again, correct its environment configuration, update the PR to create a new
-head, and trigger fresh PR CI. After a child is dispatched, a startup failure
-requests cancellation. Whether or not cancellation is confirmed, the
-controller completes coordination as
-`Authorized E2E run requires reconciliation`; that authorization for the PR/base SHA pair
-cannot be retried because the child may still execute and a retry could start
-duplicate credential-bearing work. Inspect the linked run, then update the PR
-and run fresh CI before authorizing again.
+same exact-revision and deterministic-plan checks. An ordinary validation
+failure before dispatch restores the authorization title and leaves
+coordination in progress. A maintainer can then launch a fresh first-attempt
+manual authorization. To use the protected path again, correct its environment
+configuration, update the PR to create a new head, and trigger fresh PR CI.
+
+An uncertain dispatch that completes the bounded window with zero correlated
+runs instead completes coordination as `Workflow dispatch was not observed`
+with a validated receipt on the trusted GitHub Actions-owned coordination
+check. Ambiguous reconciliation or a startup failure after a possible child
+dispatch completes coordination as `Authorized E2E run requires
+reconciliation`. The controller requests cancellation for every fully validated
+candidate child and every schema-valid run ID that carries the correlation,
+including identity-invalid candidates. That authorization for the PR/base SHA
+pair cannot be reused because a child may still execute and another dispatch
+could start duplicate credential-bearing work. Inspect any linked or candidate
+run, then update the PR and run fresh CI before authorizing again.
 The native required job treats authorization and running titles as intermediate
 waiting states only while coordination remains in progress. It also keeps
 polling when the current PR/base SHA coordination check is a completed failure
@@ -640,21 +678,28 @@ later eligible `CI / Pull Request` run can create a fresh coordination check for
 the same unchanged open head and base only when the newest failed coordination
 check carries a current-version retry reason:
 `prerequisite-ci` after the later CI run succeeds, `child-cancelled` after a
-conclusively cancelled child, or `evidence-download` after a successful child
-whose evidence download failed, was cancelled, or was skipped. The trusted
-controller leaves the completed check as audit history, creates and validates a
-new `in_progress` check with the same PR/base SHA external identity, and rebuilds
-the deterministic plan before exposing a fresh authorization state. The
+conclusively cancelled child, `evidence-download` after a successful child
+whose evidence download failed, was cancelled, or was skipped, or
+`dispatch-not-observed` after an uncertain dispatch completes its bounded
+zero-match window and records a validated receipt. Before replacing a
+`dispatch-not-observed` check, the next controller rereads the old correlation
+and fails closed if a late child, incomplete inventory, or contradiction
+appears. The trusted controller leaves the completed check as audit history,
+creates and validates a new `in_progress` check with the same PR/base SHA
+external identity and a fresh correlation, and rebuilds the deterministic plan
+before exposing a fresh authorization state. The
 controller and native observer select the highest check-run ID only when every
 older duplicate is a completed failure with a recognized versioned retry
 marker. An unexpected app or mismatched mutation identity, duplicate ID, older
 unmarked or otherwise non-retryable terminal state, or multiple active
 candidates fails closed. Selected-job product or
 assertion failures, evidence policy or integrity failures, schema or identity
-mismatches, traversal or provenance failures, reconciliation, controller
-errors, unknown states, and failures recorded before retry reasons existed
-remain terminal for that PR/base SHA pair. Update the PR and run fresh CI for
-terminal outcomes. The
+mismatches, traversal or provenance failures, ambiguous, incomplete, or
+identity-invalid reconciliation, controller errors, unknown states, and
+failures recorded before retry reasons existed remain terminal for that
+PR/base SHA pair. A validated `dispatch-not-observed` receipt on a trusted
+GitHub Actions check is the only retryable reconciliation result. Update the PR
+and run fresh CI for terminal outcomes. The
 normal wait, evidence download, and finish path is the only path that can record
 success; the authorization itself cannot make the gate green. A changed head or
 base requires a new authorization.

--- a/test/github-api.test.ts
+++ b/test/github-api.test.ts
@@ -3,13 +3,36 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { GitHubApiError, githubApi } from "../tools/advisors/github.mts";
+import { GitHubApiError, githubApi, githubApiWithResponse } from "../tools/advisors/github.mts";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe("GitHub API response identity", () => {
+  it("returns successful response status and a safe GitHub request ID when requested", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response('{"workflow_run_id":23}', {
+          status: 200,
+          headers: { "x-github-request-id": "SUCCESS:1234" },
+        }),
+      ),
+    );
+
+    await expect(
+      githubApiWithResponse<{ workflow_run_id: number }>(
+        "repos/NVIDIA/NemoClaw/actions/workflows/e2e.yaml/dispatches",
+        "token",
+      ),
+    ).resolves.toEqual({
+      data: { workflow_run_id: 23 },
+      status: 200,
+      requestId: "SUCCESS:1234",
+    });
+  });
+
   it("preserves structured HTTP status and a safe GitHub request ID", async () => {
     vi.stubGlobal(
       "fetch",

--- a/test/github-api.test.ts
+++ b/test/github-api.test.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GitHubApiError, githubApi } from "../tools/advisors/github.mts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GitHub API response identity", () => {
+  it("preserves structured HTTP status and a safe GitHub request ID", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("dispatch unavailable", {
+          status: 500,
+          headers: { "x-github-request-id": "ABCD:1234:EFGH" },
+        }),
+      ),
+    );
+
+    const request = githubApi(
+      "repos/NVIDIA/NemoClaw/actions/workflows/e2e.yaml/dispatches",
+      "token",
+      {
+        method: "POST",
+      },
+    );
+
+    await expect(request).rejects.toMatchObject({
+      name: "GitHubApiError",
+      kind: "http",
+      method: "POST",
+      apiPath: "repos/NVIDIA/NemoClaw/actions/workflows/e2e.yaml/dispatches",
+      status: 500,
+      requestId: "ABCD:1234:EFGH",
+      responseExcerpt: "dispatch unavailable",
+    });
+    await expect(request).rejects.toThrow(
+      "GitHub API repos/NVIDIA/NemoClaw/actions/workflows/e2e.yaml/dispatches failed: 500 dispatch unavailable",
+    );
+  });
+
+  it("rejects unsafe request IDs and bounds single-line response diagnostics", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(`first line\n${"x".repeat(600)}`, {
+          status: 503,
+          headers: { "x-github-request-id": "unsafe request id" },
+        }),
+      ),
+    );
+
+    const error = await githubApi("repos/NVIDIA/NemoClaw/check-runs", "token").catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(GitHubApiError);
+    expect(error).toMatchObject({
+      kind: "http",
+      status: 503,
+      requestId: undefined,
+    });
+    expect((error as GitHubApiError).responseExcerpt).toHaveLength(512);
+    expect((error as GitHubApiError).responseExcerpt).not.toMatch(/[\r\n\t]/u);
+  });
+
+  it("retains response identity when a successful response contains invalid JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("{", {
+          status: 200,
+          headers: { "x-github-request-id": "DECODE:1234" },
+        }),
+      ),
+    );
+
+    await expect(githubApi("repos/NVIDIA/NemoClaw/pulls/7593", "token")).rejects.toMatchObject({
+      name: "GitHubApiError",
+      kind: "decode",
+      method: "GET",
+      status: 200,
+      requestId: "DECODE:1234",
+      responseExcerpt: "{",
+    });
+  });
+
+  it("preserves transport failures without inventing an HTTP response", async () => {
+    const transportError = new TypeError("fetch failed");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(transportError));
+
+    await expect(githubApi("repos/NVIDIA/NemoClaw/pulls/7593", "token")).rejects.toBe(
+      transportError,
+    );
+  });
+});

--- a/test/pr-e2e-dispatch-reconciliation.test.ts
+++ b/test/pr-e2e-dispatch-reconciliation.test.ts
@@ -1,0 +1,383 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GitHubApiError, type GitHubApiResponse } from "../tools/advisors/github.mts";
+import {
+  assertDispatchStillNotObserved,
+  DispatchNotObservedError,
+  DispatchReconciliationError,
+  dispatchWorkflowWithReconciliation,
+} from "../tools/e2e/pr-e2e-dispatch-reconciliation.mts";
+
+const REPOSITORY = "NVIDIA/NemoClaw";
+const WORKFLOW_SHA = "d".repeat(40);
+const CORRELATION_ID = "123e4567-e89b-42d3-a456-426614174000";
+const SENT_AT_MS = 1_785_050_400_000;
+const WINDOW_MS = 100;
+const POLL_MS = 25;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function dispatchDetails(runId = 23) {
+  return {
+    workflow_run_id: runId,
+    run_url: `https://api.github.com/repos/${REPOSITORY}/actions/runs/${runId}`,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/${runId}`,
+  };
+}
+
+function dispatchResponse(
+  data: unknown,
+  status = 200,
+  requestId?: string,
+): GitHubApiResponse<unknown> {
+  return { data, status, ...(requestId === undefined ? {} : { requestId }) };
+}
+
+function workflowRun(runId = 23, overrides: Record<string, unknown> = {}) {
+  return {
+    id: runId,
+    name: `E2E PR #42 (${CORRELATION_ID})`,
+    path: ".github/workflows/e2e.yaml",
+    workflow_id: 901,
+    created_at: new Date(SENT_AT_MS + 10).toISOString(),
+    event: "workflow_dispatch",
+    head_branch: "main",
+    head_sha: WORKFLOW_SHA,
+    run_attempt: 1,
+    status: "queued",
+    conclusion: null,
+    display_title: `E2E PR #42 (${CORRELATION_ID})`,
+    url: `https://api.github.com/repos/${REPOSITORY}/actions/runs/${runId}`,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/${runId}`,
+    repository: { full_name: REPOSITORY },
+    head_repository: { full_name: REPOSITORY },
+    actor: { login: "github-actions[bot]" },
+    triggering_actor: { login: "github-actions[bot]" },
+    ...overrides,
+  };
+}
+
+function inventory(runs: unknown[]) {
+  return { total_count: runs.length, workflow_runs: runs };
+}
+
+function reconciliationDeps(
+  list: () => unknown | Promise<unknown>,
+  getRun: (runId: number) => unknown | Promise<unknown> = (runId) => workflowRun(runId),
+) {
+  let clock = SENT_AT_MS;
+  const api = vi.fn(async (apiPath: string) => {
+    const runMatch = /\/actions\/runs\/([1-9][0-9]*)$/u.exec(apiPath);
+    if (runMatch) return getRun(Number(runMatch[1]));
+    return list();
+  });
+  return {
+    deps: {
+      api,
+      now: () => clock,
+      sleep: async (milliseconds: number) => {
+        clock += milliseconds;
+      },
+      reconciliationWindowMs: WINDOW_MS,
+      pollIntervalMs: POLL_MS,
+      clockSkewMs: 10,
+    },
+    api,
+  };
+}
+
+function dispatchOptions(dispatch: (signal: AbortSignal) => Promise<GitHubApiResponse<unknown>>) {
+  return {
+    repository: REPOSITORY,
+    token: "token",
+    workflowSha: WORKFLOW_SHA,
+    correlationId: CORRELATION_ID,
+    prNumber: 42,
+    dispatch,
+  };
+}
+
+describe("PR E2E workflow dispatch reconciliation", () => {
+  it("accepts exact synchronous dispatch details without reading inventory", async () => {
+    const dispatch = vi.fn().mockResolvedValue(dispatchResponse(dispatchDetails()));
+    const { deps, api } = reconciliationDeps(() => inventory([]));
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).resolves.toEqual({
+      runId: 23,
+      source: "dispatch-response",
+    });
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(api).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    400, 401, 403, 404, 409, 422,
+  ])("treats HTTP %i as a definitive rejection without polling", async (status) => {
+    const rejection = new GitHubApiError({
+      kind: "http",
+      method: "POST",
+      apiPath: `repos/${REPOSITORY}/actions/workflows/e2e.yaml/dispatches`,
+      status,
+      responseText: "rejected",
+    });
+    const dispatch = vi.fn().mockRejectedValue(rejection);
+    const { deps, api } = reconciliationDeps(() => inventory([]));
+
+    await expect(dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps)).rejects.toBe(
+      rejection,
+    );
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(api).not.toHaveBeenCalled();
+  });
+
+  it("adopts one exact child after a server error and a full settling window", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(
+      new GitHubApiError({
+        kind: "http",
+        method: "POST",
+        apiPath: `repos/${REPOSITORY}/actions/workflows/e2e.yaml/dispatches`,
+        status: 500,
+        requestId: "ABCD:1234",
+        responseText: "unavailable",
+      }),
+    );
+    const { deps, api } = reconciliationDeps(() => inventory([workflowRun()]));
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).resolves.toEqual({
+      runId: 23,
+      source: "workflow-run-inventory",
+    });
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(api.mock.calls.filter(([apiPath]) => String(apiPath).includes("/runs?"))).toHaveLength(
+      5,
+    );
+    expect(api.mock.calls.at(-1)?.[0]).toBe(`repos/${REPOSITORY}/actions/runs/23`);
+  });
+
+  it("waits for delayed run visibility after transport response loss", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    let reads = 0;
+    const { deps } = reconciliationDeps(() => {
+      reads += 1;
+      return inventory(reads < 3 ? [] : [workflowRun()]);
+    });
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).resolves.toEqual({
+      runId: 23,
+      source: "workflow-run-inventory",
+    });
+    expect(reads).toBe(5);
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("bounds a lost dispatch response before entering read-only reconciliation", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let dispatchSignal: AbortSignal | undefined;
+    const dispatch = vi.fn(
+      (signal: AbortSignal) =>
+        new Promise<GitHubApiResponse<unknown>>(() => {
+          dispatchSignal = signal;
+        }),
+    );
+    const { deps } = reconciliationDeps(() => inventory([]));
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), {
+        ...deps,
+        dispatchTimeoutMs: 10,
+      }),
+    ).rejects.toBeInstanceOf(DispatchNotObservedError);
+    expect(dispatchSignal?.aborted).toBe(true);
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when a workflow inventory read exceeds its request deadline", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    const { deps } = reconciliationDeps(() => new Promise<never>(() => undefined));
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), {
+        ...deps,
+        apiTimeoutMs: 10,
+      }),
+    ).rejects.toThrow(/complete run inventory/u);
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("records a strict retry receipt only after a complete zero-match window", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dispatch = vi
+      .fn()
+      .mockResolvedValue(dispatchResponse({ malformed: true }, 200, "MALFORMED:1234"));
+    const { deps, api } = reconciliationDeps(() => inventory([]));
+
+    const error = await dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(DispatchNotObservedError);
+    expect(error).toMatchObject({
+      receipt: {
+        correlationId: CORRELATION_ID,
+        workflowSha: WORKFLOW_SHA,
+        sentAtMs: SENT_AT_MS,
+        deadlineAtMs: SENT_AT_MS + WINDOW_MS,
+        result: "not-observed",
+        failureKind: "validation",
+        status: 200,
+        requestId: "MALFORMED:1234",
+      },
+    });
+    expect((error as DispatchNotObservedError).marker()).toMatch(
+      /^<!-- nemoclaw-pr-e2e-dispatch:v1:[A-Za-z0-9_-]+ -->$/u,
+    );
+    expect(api).toHaveBeenCalledTimes(5);
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when two correlated children become visible", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    let reads = 0;
+    const { deps } = reconciliationDeps(() => {
+      reads += 1;
+      return inventory(reads < 3 ? [workflowRun(23)] : [workflowRun(23), workflowRun(24)]);
+    });
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).rejects.toMatchObject({
+      name: "DispatchReconciliationError",
+      candidateRunIds: [23, 24],
+    });
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["run name", { name: "E2E" }],
+    ["display title", { display_title: "E2E unrelated" }],
+    ["workflow path", { path: ".github/workflows/other.yaml" }],
+    ["main branch", { head_branch: "release" }],
+    ["workflow SHA", { head_sha: "e".repeat(40) }],
+    ["first attempt", { run_attempt: 2 }],
+    ["canonical API URL", { url: `https://api.github.com/repos/${REPOSITORY}/actions/runs/24` }],
+    ["canonical HTML URL", { html_url: `https://github.com/${REPOSITORY}/actions/runs/24` }],
+    ["creation window", { created_at: new Date(SENT_AT_MS - 11).toISOString() }],
+    ["GitHub Actions actor", { actor: { login: "maintainer" } }],
+  ])("rejects a correlated run with the wrong %s", async (_label, overrides) => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    const { deps } = reconciliationDeps(() => inventory([workflowRun(23, overrides)]));
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).rejects.toBeInstanceOf(DispatchReconciliationError);
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when the run inventory is incomplete", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    const { deps } = reconciliationDeps(() => ({
+      total_count: 2,
+      workflow_runs: [workflowRun()],
+    }));
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).rejects.toThrow(/complete run inventory/u);
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when the final run read changes authenticated identity", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    const { deps } = reconciliationDeps(
+      () => inventory([workflowRun()]),
+      () => workflowRun(23, { head_branch: "release" }),
+    );
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).rejects.toMatchObject({
+      name: "DispatchReconciliationError",
+      candidateRunIds: [23],
+    });
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("rechecks an old zero-match receipt before replacement", async () => {
+    const { deps, api } = reconciliationDeps(() => inventory([]));
+
+    await expect(
+      assertDispatchStillNotObserved(
+        {
+          repository: REPOSITORY,
+          token: "token",
+          prNumber: 42,
+          receipt: {
+            correlationId: CORRELATION_ID,
+            workflowSha: WORKFLOW_SHA,
+            sentAtMs: SENT_AT_MS,
+            deadlineAtMs: SENT_AT_MS + WINDOW_MS,
+            result: "not-observed",
+            failureKind: "http",
+            status: 500,
+          },
+        },
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+    expect(api).toHaveBeenCalledOnce();
+  });
+
+  it("blocks replacement when a late child appears for the old correlation", async () => {
+    const recheckTime = SENT_AT_MS + WINDOW_MS + 2_000;
+    const lateRun = workflowRun(23, {
+      created_at: new Date(SENT_AT_MS + WINDOW_MS + 1_000).toISOString(),
+    });
+    const { deps, api } = reconciliationDeps(() => inventory([lateRun]));
+
+    await expect(
+      assertDispatchStillNotObserved(
+        {
+          repository: REPOSITORY,
+          token: "token",
+          prNumber: 42,
+          receipt: {
+            correlationId: CORRELATION_ID,
+            workflowSha: WORKFLOW_SHA,
+            sentAtMs: SENT_AT_MS,
+            deadlineAtMs: SENT_AT_MS + WINDOW_MS,
+            result: "not-observed",
+            failureKind: "transport",
+          },
+        },
+        { ...deps, now: () => recheckTime },
+      ),
+    ).rejects.toMatchObject({
+      name: "DispatchReconciliationError",
+      candidateRunIds: [23],
+    });
+    const inventoryUrl = new URL(`https://api.github.com/${String(api.mock.calls[0]?.[0])}`);
+    expect(inventoryUrl.searchParams.get("created")).toBe(
+      `${new Date(SENT_AT_MS - 10).toISOString()}..${new Date(recheckTime + 10).toISOString()}`,
+    );
+  });
+});

--- a/test/pr-e2e-dispatch-reconciliation.test.ts
+++ b/test/pr-e2e-dispatch-reconciliation.test.ts
@@ -269,6 +269,46 @@ describe("PR E2E workflow dispatch reconciliation", () => {
     expect(dispatch).toHaveBeenCalledOnce();
   });
 
+  it("keeps collecting correlated run IDs after a malformed child", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    let reads = 0;
+    const malformedRun = workflowRun(24, { path: ".github/workflows/other.yaml" });
+    const { deps } = reconciliationDeps(() => {
+      reads += 1;
+      return inventory(reads === 1 ? [malformedRun] : [malformedRun, workflowRun(23)]);
+    });
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).rejects.toMatchObject({
+      name: "DispatchReconciliationError",
+      message: expect.stringMatching(/failed path validation/u),
+      candidateRunIds: [23, 24],
+    });
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("retains malformed correlated run IDs when a later inventory read fails", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dispatch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    let reads = 0;
+    const { deps } = reconciliationDeps(() => {
+      reads += 1;
+      if (reads > 1) throw new TypeError("inventory unavailable");
+      return inventory([workflowRun(24, { path: ".github/workflows/other.yaml" })]);
+    });
+
+    await expect(
+      dispatchWorkflowWithReconciliation(dispatchOptions(dispatch), deps),
+    ).rejects.toMatchObject({
+      name: "DispatchReconciliationError",
+      message: expect.stringMatching(/complete run inventory/u),
+      candidateRunIds: [24],
+    });
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
   it.each([
     ["run name", { name: "E2E" }],
     ["display title", { display_title: "E2E unrelated" }],

--- a/test/pr-e2e-dispatch-reconciliation.test.ts
+++ b/test/pr-e2e-dispatch-reconciliation.test.ts
@@ -73,8 +73,7 @@ function reconciliationDeps(
   let clock = SENT_AT_MS;
   const api = vi.fn(async (apiPath: string) => {
     const runMatch = /\/actions\/runs\/([1-9][0-9]*)$/u.exec(apiPath);
-    if (runMatch) return getRun(Number(runMatch[1]));
-    return list();
+    return runMatch ? getRun(Number(runMatch[1])) : list();
   });
   return {
     deps: {
@@ -295,8 +294,9 @@ describe("PR E2E workflow dispatch reconciliation", () => {
     let reads = 0;
     const { deps } = reconciliationDeps(() => {
       reads += 1;
-      if (reads > 1) throw new TypeError("inventory unavailable");
-      return inventory([workflowRun(24, { path: ".github/workflows/other.yaml" })]);
+      return reads > 1
+        ? Promise.reject(new TypeError("inventory unavailable"))
+        : inventory([workflowRun(24, { path: ".github/workflows/other.yaml" })]);
     });
 
     await expect(

--- a/test/pr-e2e-gate-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-dispatch-recovery.test.ts
@@ -202,6 +202,134 @@ describe("PR E2E dispatch-not-observed recovery", () => {
     expect(dispatchIndex).toBeGreaterThan(directIndex);
   });
 
+  it("rejects a stale matching list when the exact check advanced before dispatch", async () => {
+    const requests: RecordedGitHubRequest[] = [];
+    const listedCheck = reservedCheck(17, {
+      output: {
+        title: "Evaluating PR commit",
+        summary: "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+      },
+    });
+    const advancedCheck = reservedCheck(17, {
+      details_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/22",
+      output: {
+        title: "Running 1 E2E check",
+        summary: "Selected E2E is running.",
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [listedCheck] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(advancedCheck),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () => githubResponse({ workflow_run_id: 23 }),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    await expect(
+      dispatchPrGate({
+        repository: "NVIDIA/NemoClaw",
+        checkoutRepository: "NVIDIA/NemoClaw",
+        token: "token",
+        controllerCheckId: 17,
+        jobs: ["onboard-repair"],
+        prNumber: 42,
+        commitSha: HEAD_SHA,
+        baseSha: BASE_SHA,
+        workflowSha: WORKFLOW_SHA,
+        planHash: "c".repeat(64),
+        correlationId: CORRELATION_ID,
+        expectedCheckTitle: "Evaluating PR commit",
+      }),
+    ).rejects.toThrow(/exact pre-dispatch state/u);
+
+    expect(requests.filter((request) => request.url.endsWith("/check-runs/17"))).toHaveLength(1);
+    expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(0);
+  });
+
+  it("bounds the authoritative check read before dispatch", async () => {
+    vi.useFakeTimers();
+    const requests: RecordedGitHubRequest[] = [];
+    const listedCheck = reservedCheck(17, {
+      output: {
+        title: "Evaluating PR commit",
+        summary: "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [listedCheck] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => new Promise<Response>(() => undefined),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () => githubResponse({ workflow_run_id: 23 }),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    const attempt = dispatchPrGate({
+      repository: "NVIDIA/NemoClaw",
+      checkoutRepository: "NVIDIA/NemoClaw",
+      token: "token",
+      controllerCheckId: 17,
+      jobs: ["onboard-repair"],
+      prNumber: 42,
+      commitSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+      workflowSha: WORKFLOW_SHA,
+      planHash: "c".repeat(64),
+      correlationId: CORRELATION_ID,
+      expectedCheckTitle: "Evaluating PR commit",
+    });
+    const result = expect(attempt).rejects.toThrow(
+      /Pre-dispatch controller check read timed out after 5000ms/u,
+    );
+    await vi.runAllTimersAsync();
+    await result;
+
+    expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(0);
+  });
+
   it("revalidates the exact PR and current check before adopting a reconciled child", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(START_TIME);
@@ -302,6 +430,199 @@ describe("PR E2E dispatch-not-observed recovery", () => {
           request.method === "POST",
       ),
     ).toHaveLength(1);
+  });
+
+  it("cancels an adopted child when the exact check advanced behind a stale list", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_TIME);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const requests: RecordedGitHubRequest[] = [];
+    let directReads = 0;
+    const listedCheck = reservedCheck(17, {
+      output: {
+        title: "Evaluating PR commit",
+        summary: "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+      },
+    });
+    const advancedCheck = reservedCheck(17, {
+      details_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/22",
+      output: {
+        title: "Running 1 E2E check",
+        summary: "A different child was authorized.",
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [listedCheck] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => {
+              directReads += 1;
+              return githubResponse(directReads === 1 ? listedCheck : advancedCheck);
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () => githubResponse({ message: "Failed to run workflow dispatch" }, 500),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes("/actions/workflows/e2e.yaml/runs?") && method === "GET",
+            () => githubResponse({ total_count: 1, workflow_runs: [reconciledWorkflowRun()] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/actions/runs/23") && method === "GET",
+            () => githubResponse(reconciledWorkflowRun()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+            () => githubResponse(pullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/actions/runs/23/cancel") && method === "POST",
+            () => githubResponse(undefined, 202),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    const attempt = dispatchPrGate({
+      repository: "NVIDIA/NemoClaw",
+      checkoutRepository: "NVIDIA/NemoClaw",
+      token: "token",
+      controllerCheckId: 17,
+      jobs: ["onboard-repair"],
+      prNumber: 42,
+      commitSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+      workflowSha: WORKFLOW_SHA,
+      planHash: "c".repeat(64),
+      correlationId: CORRELATION_ID,
+      expectedCheckTitle: "Evaluating PR commit",
+    });
+    const result = expect(attempt).rejects.toThrow(/reconciled child cancellation requested/u);
+    await vi.runAllTimersAsync();
+    await result;
+
+    const directIndexes = requests.flatMap((request, index) =>
+      request.url.endsWith("/check-runs/17") && request.method === "GET" ? [index] : [],
+    );
+    const cancelIndex = requests.findIndex(
+      (request) => request.url.endsWith("/actions/runs/23/cancel") && request.method === "POST",
+    );
+    expect(directIndexes).toHaveLength(2);
+    expect(cancelIndex).toBeGreaterThan(directIndexes[1]!);
+    expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(1);
+  });
+
+  it("cancels every correlation-bearing run after mixed inventory validation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_TIME);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const requests: RecordedGitHubRequest[] = [];
+    const preDispatchCheck = reservedCheck(17, {
+      output: {
+        title: "Evaluating PR commit",
+        summary: "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+      },
+    });
+    const validRun = reconciledWorkflowRun();
+    const malformedRun = {
+      ...reconciledWorkflowRun(),
+      id: 24,
+      path: ".github/workflows/other.yaml",
+      url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/24",
+      html_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/24",
+    };
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [preDispatchCheck] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(preDispatchCheck),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () => githubResponse({ message: "Failed to run workflow dispatch" }, 500),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes("/actions/workflows/e2e.yaml/runs?") && method === "GET",
+            () =>
+              githubResponse({
+                total_count: 2,
+                workflow_runs: [malformedRun, validRun],
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              /\/actions\/runs\/(?:23|24)\/cancel$/u.test(url) && method === "POST",
+            () => githubResponse(undefined, 202),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    const attempt = dispatchPrGate({
+      repository: "NVIDIA/NemoClaw",
+      checkoutRepository: "NVIDIA/NemoClaw",
+      token: "token",
+      controllerCheckId: 17,
+      jobs: ["onboard-repair"],
+      prNumber: 42,
+      commitSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+      workflowSha: WORKFLOW_SHA,
+      planHash: "c".repeat(64),
+      correlationId: CORRELATION_ID,
+      expectedCheckTitle: "Evaluating PR commit",
+    });
+    const result = expect(attempt).rejects.toThrow(/failed path validation/u);
+    await vi.runAllTimersAsync();
+    await result;
+
+    expect(
+      requests
+        .filter(
+          (request) =>
+            /\/actions\/runs\/(?:23|24)\/cancel$/u.test(request.url) && request.method === "POST",
+        )
+        .map((request) => request.url)
+        .sort(),
+    ).toEqual([
+      "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/23/cancel",
+      "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/24/cancel",
+    ]);
   });
 
   it("accepts an exact child authorization after the PATCH response is lost", async () => {
@@ -437,6 +758,10 @@ describe("PR E2E dispatch-not-observed recovery", () => {
             },
           ),
           githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(check),
+          ),
+          githubFetchRoute(
             ({ url, method }) =>
               url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
             () =>
@@ -512,6 +837,11 @@ describe("PR E2E dispatch-not-observed recovery", () => {
             };
             return githubResponse(checks[index]);
           },
+        ),
+        githubFetchRoute(
+          ({ url, method }) => /\/check-runs\/(?:17|18)$/u.test(url) && method === "GET",
+          (request) =>
+            githubResponse(checks.find((check) => check.id === Number(urlRunId(request.url)))),
         ),
         githubFetchRoute(
           ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
@@ -665,6 +995,19 @@ describe("PR E2E dispatch-not-observed recovery", () => {
                   }),
                 ],
               }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () =>
+              githubResponse(
+                reservedCheck(17, {
+                  output: {
+                    title: "Evaluating PR commit",
+                    summary:
+                      "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+                  },
+                }),
+              ),
           ),
           githubFetchRoute(
             ({ url, method }) =>

--- a/test/pr-e2e-gate-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-dispatch-recovery.test.ts
@@ -1078,6 +1078,6 @@ describe("PR E2E dispatch-not-observed recovery", () => {
 
 function urlRunId(url: string): string {
   const match = /\/check-runs\/([1-9][0-9]*)$/u.exec(url);
-  if (!match) throw new Error("check run URL is invalid");
-  return match[1]!;
+  expect(match).not.toBeNull();
+  return match![1]!;
 }

--- a/test/pr-e2e-gate-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-dispatch-recovery.test.ts
@@ -1,0 +1,740 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  dispatchPrGate,
+  type PullRequest,
+  parseControllerCommand,
+  prGateExternalId,
+  startPrGate,
+} from "../tools/e2e/pr-e2e-gate.mts";
+import {
+  createGitHubFetchRouter,
+  githubFetchRoute,
+  type RecordedGitHubRequest,
+} from "./support/github-fetch-router.ts";
+
+const HEAD_SHA = "a".repeat(40);
+const BASE_SHA = "b".repeat(40);
+const WORKFLOW_SHA = "d".repeat(40);
+const CORRELATION_ID = "123e4567-e89b-42d3-a456-426614174000";
+const START_TIME = new Date("2026-07-26T18:00:00.000Z");
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+function githubResponse(value?: unknown, status = 200, headers?: Record<string, string>): Response {
+  return new Response(value === undefined ? undefined : JSON.stringify(value), {
+    status,
+    headers,
+  });
+}
+
+function pullRequest(): PullRequest {
+  return {
+    number: 42,
+    state: "open",
+    changed_files: 1,
+    head: {
+      ref: "feature/dispatch-reconciliation",
+      sha: HEAD_SHA,
+      repo: { full_name: "NVIDIA/NemoClaw" },
+    },
+    base: {
+      sha: BASE_SHA,
+      repo: { full_name: "NVIDIA/NemoClaw" },
+    },
+  };
+}
+
+function pullRequestListItem(): Omit<PullRequest, "changed_files"> {
+  const { changed_files: _changedFiles, ...item } = pullRequest();
+  return item;
+}
+
+function reservedCheck(id = 17, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name: "E2E / PR Gate Coordination",
+    head_sha: HEAD_SHA,
+    external_id: prGateExternalId(42, HEAD_SHA, BASE_SHA),
+    status: "in_progress",
+    conclusion: null,
+    details_url: null,
+    output: {
+      title: "Waiting for PR CI",
+      summary:
+        "This PR SHA and base SHA are reserved for deterministic E2E planning after CI completes.",
+    },
+    app: { id: 15368 },
+    ...overrides,
+  };
+}
+
+function startCommand(workDir: string) {
+  const command = parseControllerCommand([
+    "--mode",
+    "start",
+    "--head",
+    HEAD_SHA,
+    "--head-repo",
+    "NVIDIA/NemoClaw",
+    "--head-branch",
+    "feature/dispatch-reconciliation",
+    "--workflow-sha",
+    WORKFLOW_SHA,
+    "--ci-conclusion",
+    "success",
+    "--ci-display-title",
+    `CI PR #42 head ${HEAD_SHA} base ${BASE_SHA} gate true`,
+    "--ci-run-attempt",
+    "1",
+    "--ci-run-id",
+    "99",
+    "--gate-run-id",
+    "77",
+    "--pr",
+    "42",
+    "--work-dir",
+    workDir,
+  ]);
+  expect(command.mode).toBe("start");
+  return command as Extract<ReturnType<typeof parseControllerCommand>, { mode: "start" }>;
+}
+
+function reconciledWorkflowRun() {
+  return {
+    id: 23,
+    name: `E2E PR #42 (${CORRELATION_ID})`,
+    path: ".github/workflows/e2e.yaml",
+    workflow_id: 901,
+    created_at: new Date(START_TIME.getTime() + 1_000).toISOString(),
+    event: "workflow_dispatch",
+    head_branch: "main",
+    head_sha: WORKFLOW_SHA,
+    run_attempt: 1,
+    status: "queued",
+    conclusion: null,
+    display_title: `E2E PR #42 (${CORRELATION_ID})`,
+    url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/23",
+    html_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+    repository: { full_name: "NVIDIA/NemoClaw" },
+    head_repository: { full_name: "NVIDIA/NemoClaw" },
+    actor: { login: "github-actions[bot]" },
+    triggering_actor: { login: "github-actions[bot]" },
+  };
+}
+
+describe("PR E2E dispatch-not-observed recovery", () => {
+  it("uses the exact direct check when the new check is not yet visible in history", async () => {
+    const requests: RecordedGitHubRequest[] = [];
+    const preDispatchCheck = reservedCheck(17, {
+      output: {
+        title: "Evaluating PR commit",
+        summary: "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 0, check_runs: [] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(preDispatchCheck),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () =>
+              githubResponse({
+                workflow_run_id: 23,
+                run_url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/23",
+                html_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+              }),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    await expect(
+      dispatchPrGate({
+        repository: "NVIDIA/NemoClaw",
+        checkoutRepository: "NVIDIA/NemoClaw",
+        token: "token",
+        controllerCheckId: 17,
+        jobs: ["onboard-repair"],
+        prNumber: 42,
+        commitSha: HEAD_SHA,
+        baseSha: BASE_SHA,
+        workflowSha: WORKFLOW_SHA,
+        planHash: "c".repeat(64),
+        correlationId: CORRELATION_ID,
+        expectedCheckTitle: "Evaluating PR commit",
+      }),
+    ).resolves.toEqual({ runId: 23, workflowSha: WORKFLOW_SHA });
+
+    const listIndex = requests.findIndex((request) => request.url.includes("/check-runs?"));
+    const directIndex = requests.findIndex((request) => request.url.endsWith("/check-runs/17"));
+    const dispatchIndex = requests.findIndex((request) => request.url.endsWith("/dispatches"));
+    expect(directIndex).toBeGreaterThan(listIndex);
+    expect(dispatchIndex).toBeGreaterThan(directIndex);
+  });
+
+  it("revalidates the exact PR and current check before adopting a reconciled child", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_TIME);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const requests: RecordedGitHubRequest[] = [];
+    let checkListReads = 0;
+    const preDispatchCheck = reservedCheck(17, {
+      output: {
+        title: "Evaluating PR commit",
+        summary: "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () =>
+              githubResponse({ message: "Failed to run workflow dispatch" }, 500, {
+                "x-github-request-id": "ADOPT:1234",
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes("/actions/workflows/e2e.yaml/runs?") && method === "GET",
+            () => githubResponse({ total_count: 1, workflow_runs: [reconciledWorkflowRun()] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/actions/runs/23") && method === "GET",
+            () => githubResponse(reconciledWorkflowRun()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+            () => githubResponse(pullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => {
+              checkListReads += 1;
+              return checkListReads === 1
+                ? githubResponse({ total_count: 1, check_runs: [preDispatchCheck] })
+                : githubResponse({ total_count: 0, check_runs: [] });
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(preDispatchCheck),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    const attempt = dispatchPrGate({
+      repository: "NVIDIA/NemoClaw",
+      checkoutRepository: "NVIDIA/NemoClaw",
+      token: "token",
+      controllerCheckId: 17,
+      jobs: ["onboard-repair"],
+      prNumber: 42,
+      commitSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+      workflowSha: WORKFLOW_SHA,
+      planHash: "c".repeat(64),
+      correlationId: CORRELATION_ID,
+      expectedCheckTitle: "Evaluating PR commit",
+    });
+    const result = expect(attempt).resolves.toEqual({ runId: 23, workflowSha: WORKFLOW_SHA });
+    await vi.runAllTimersAsync();
+    await result;
+
+    const confirmationIndex = requests.findIndex((request) =>
+      request.url.endsWith("/actions/runs/23"),
+    );
+    const pullIndex = requests.findIndex((request) => request.url.endsWith("/pulls/42"));
+    const checkIndex = requests.findIndex(
+      (request, index) =>
+        index > pullIndex && request.url.includes(`/commits/${HEAD_SHA}/check-runs?`),
+    );
+    expect(confirmationIndex).toBeGreaterThanOrEqual(0);
+    expect(pullIndex).toBeGreaterThan(confirmationIndex);
+    expect(checkIndex).toBeGreaterThan(pullIndex);
+    expect(
+      requests.filter(
+        (request) =>
+          request.url.endsWith("/actions/workflows/e2e.yaml/dispatches") &&
+          request.method === "POST",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("accepts an exact child authorization after the PATCH response is lost", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-auth-response-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    let check = reservedCheck();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [check] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.includes("/pulls?state=open&head=") && method === "GET",
+            () => githubResponse([pullRequestListItem()]),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.includes("/pulls/42/files?") && method === "GET",
+            () => githubResponse([{ filename: "src/lib/onboard.ts" }]),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+            () => githubResponse(pullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            (request) => {
+              check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
+              const title = (request.body as { output?: { title?: string } } | undefined)?.output
+                ?.title;
+              return title?.startsWith("Running ")
+                ? new Response("{", { status: 200 })
+                : githubResponse(check);
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(check),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () =>
+              githubResponse({
+                workflow_run_id: 23,
+                run_url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/23",
+                html_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+              }),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir))).resolves.toBeUndefined();
+      expect(check).toMatchObject({
+        status: "in_progress",
+        conclusion: null,
+        details_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+        output: { title: expect.stringMatching(/^Running /u) },
+      });
+      expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(1);
+      expect(requests.some((request) => request.url.endsWith("/actions/runs/23/cancel"))).toBe(
+        false,
+      );
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("dispatched=true");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dispatches controller-only changes through the normal evidence path", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-controller-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const controllerFiles = [".github/workflows/pr-e2e-gate.yaml", "tools/e2e/pr-e2e-gate.mts"];
+    const controllerPull = { ...pullRequest(), changed_files: controllerFiles.length };
+    const { changed_files: _changedFiles, ...controllerPullListItem } = controllerPull;
+    const requests: RecordedGitHubRequest[] = [];
+    let check = reservedCheck();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [check] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.includes("/pulls?state=open&head=") && method === "GET",
+            () => githubResponse([controllerPullListItem]),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.includes("/pulls/42/files?") && method === "GET",
+            () => githubResponse(controllerFiles.map((filename) => ({ filename }))),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+            () => githubResponse(controllerPull),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            (request) => {
+              check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
+              return githubResponse(check);
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () =>
+              githubResponse({
+                workflow_run_id: 23,
+                run_url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/23",
+                html_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+              }),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir))).resolves.toBeUndefined();
+      expect(requests.find((request) => request.url.endsWith("/dispatches"))?.body).toMatchObject({
+        inputs: {
+          jobs: "cloud-onboard,credential-sanitization,security-posture",
+          checkout_sha: HEAD_SHA,
+          base_sha: BASE_SHA,
+        },
+      });
+      expect(check).toMatchObject({
+        details_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+        output: { title: "Running 3 E2E checks" },
+      });
+      const outputs = fs.readFileSync(outputPath, "utf8");
+      expect(outputs).toContain("dispatched=true");
+      expect(outputs).not.toContain("approval_mode=");
+      expect(outputs).not.toContain("finalized=true");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("terminalizes the uncertain attempt before creating a fresh check and correlation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_TIME);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-dispatch-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+
+    const requests: RecordedGitHubRequest[] = [];
+    const checks: Array<Record<string, unknown>> = [reservedCheck()];
+    let dispatches = 0;
+    const fetchMock = createGitHubFetchRouter(
+      [
+        githubFetchRoute(
+          ({ url, method }) => url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+          () => githubResponse({ total_count: checks.length, check_runs: checks }),
+        ),
+        githubFetchRoute(
+          ({ url, method }) => url.endsWith("/check-runs") && method === "POST",
+          (request) => {
+            const created = reservedCheck(18, request.body as Record<string, unknown>);
+            checks.push(created);
+            return githubResponse(created);
+          },
+        ),
+        githubFetchRoute(
+          ({ url, method }) => /\/check-runs\/(?:17|18)$/u.test(url) && method === "PATCH",
+          (request) => {
+            const id = Number(urlRunId(request.url));
+            const index = checks.findIndex((check) => check.id === id);
+            checks[index] = {
+              ...checks[index],
+              ...(request.body as Record<string, unknown>),
+            };
+            return githubResponse(checks[index]);
+          },
+        ),
+        githubFetchRoute(
+          ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+          () => githubResponse(pullRequest()),
+        ),
+        githubFetchRoute(
+          ({ url, method }) => url.includes("/pulls?state=open&head=") && method === "GET",
+          () => githubResponse([pullRequestListItem()]),
+        ),
+        githubFetchRoute(
+          ({ url, method }) => url.includes("/pulls/42/files?") && method === "GET",
+          () => githubResponse([{ filename: "src/lib/onboard.ts" }]),
+        ),
+        githubFetchRoute(
+          ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+          () =>
+            githubResponse({
+              ref: "refs/heads/main",
+              object: { type: "commit", sha: WORKFLOW_SHA },
+            }),
+        ),
+        githubFetchRoute(
+          ({ url, method }) =>
+            url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+          () => {
+            dispatches += 1;
+            return dispatches === 1
+              ? githubResponse({ message: "Failed to run workflow dispatch" }, 500, {
+                  "x-github-request-id": "ABCD:1234",
+                })
+              : githubResponse({
+                  workflow_run_id: 24,
+                  run_url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/24",
+                  html_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/24",
+                });
+          },
+        ),
+        githubFetchRoute(
+          ({ url, method }) =>
+            url.includes("/actions/workflows/e2e.yaml/runs?") && method === "GET",
+          () => githubResponse({ total_count: 0, workflow_runs: [] }),
+        ),
+      ],
+      requests,
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+    try {
+      const firstAttempt = startPrGate(startCommand(workDir));
+      const firstResult = expect(firstAttempt).rejects.toThrow(
+        /not observed after bounded reconciliation/u,
+      );
+      await vi.runAllTimersAsync();
+      await firstResult;
+
+      const firstDispatch = requests.find(
+        (request) =>
+          request.url.endsWith("/actions/workflows/e2e.yaml/dispatches") &&
+          request.method === "POST",
+      );
+      const firstCorrelation = (
+        firstDispatch?.body as { inputs?: { correlation_id?: string } } | undefined
+      )?.inputs?.correlation_id;
+      expect(firstCorrelation).toMatch(/^[a-f0-9-]{36}$/u);
+      expect(checks[0]).toMatchObject({
+        id: 17,
+        status: "completed",
+        conclusion: "failure",
+        output: {
+          title: "Workflow dispatch was not observed",
+          summary: expect.stringContaining(
+            "<!-- nemoclaw-pr-e2e-retry:v1:dispatch-not-observed -->",
+          ),
+        },
+      });
+      expect(JSON.stringify(checks[0])).toContain("nemoclaw-pr-e2e-dispatch:v1:");
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
+
+      const requestCountBeforeRetry = requests.length;
+      await expect(startPrGate(startCommand(workDir))).resolves.toBeUndefined();
+      const retryRequests = requests.slice(requestCountBeforeRetry);
+      const recheckIndexes = retryRequests.flatMap((request, index) =>
+        request.url.includes("/actions/workflows/e2e.yaml/runs?") ? [index] : [],
+      );
+      const createIndex = retryRequests.findIndex(
+        (request) => request.url.endsWith("/check-runs") && request.method === "POST",
+      );
+      const dispatchIndex = retryRequests.findIndex(
+        (request) =>
+          request.url.endsWith("/actions/workflows/e2e.yaml/dispatches") &&
+          request.method === "POST",
+      );
+      expect(recheckIndexes.length).toBeGreaterThanOrEqual(2);
+      expect(createIndex).toBeGreaterThan(recheckIndexes[0]!);
+      expect(recheckIndexes.at(-1)).toBeGreaterThan(createIndex);
+      expect(dispatchIndex).toBeGreaterThan(createIndex);
+      expect(dispatchIndex).toBeGreaterThan(recheckIndexes.at(-1)!);
+      const secondDispatch = retryRequests[dispatchIndex];
+      const secondCorrelation = (
+        secondDispatch?.body as { inputs?: { correlation_id?: string } } | undefined
+      )?.inputs?.correlation_id;
+      expect(secondCorrelation).toMatch(/^[a-f0-9-]{36}$/u);
+      expect(secondCorrelation).not.toBe(firstCorrelation);
+      expect(checks[0]).toMatchObject({
+        id: 17,
+        status: "completed",
+        conclusion: "failure",
+      });
+      expect(checks[1]).toMatchObject({
+        id: 18,
+        status: "in_progress",
+        conclusion: null,
+        details_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/24",
+      });
+      expect(dispatches).toBe(2);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("cancels an adopted child when the PR changes before authorization publication", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_TIME);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const requests: RecordedGitHubRequest[] = [];
+    let pullReads = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () =>
+              githubResponse({
+                total_count: 1,
+                check_runs: [
+                  reservedCheck(17, {
+                    output: {
+                      title: "Evaluating PR commit",
+                      summary:
+                        "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+                    },
+                  }),
+                ],
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () => githubResponse({ message: "dispatch response lost" }, 500),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes("/actions/workflows/e2e.yaml/runs?") && method === "GET",
+            () => githubResponse({ total_count: 1, workflow_runs: [reconciledWorkflowRun()] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/actions/runs/23") && method === "GET",
+            () => githubResponse(reconciledWorkflowRun()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+            () => {
+              pullReads += 1;
+              return githubResponse({
+                ...pullRequest(),
+                head: { ...pullRequest().head, sha: "e".repeat(40) },
+              });
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/actions/runs/23/cancel") && method === "POST",
+            () => githubResponse(undefined, 202),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    const attempt = dispatchPrGate({
+      repository: "NVIDIA/NemoClaw",
+      checkoutRepository: "NVIDIA/NemoClaw",
+      token: "token",
+      controllerCheckId: 17,
+      jobs: ["onboard-repair"],
+      prNumber: 42,
+      commitSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+      workflowSha: WORKFLOW_SHA,
+      planHash: "c".repeat(64),
+      correlationId: CORRELATION_ID,
+      expectedCheckTitle: "Evaluating PR commit",
+    });
+    const result = expect(attempt).rejects.toThrow(/reconciled child cancellation requested/u);
+    await vi.runAllTimersAsync();
+    await result;
+
+    expect(pullReads).toBe(1);
+    expect(
+      requests.filter(
+        (request) => request.url.endsWith("/actions/runs/23/cancel") && request.method === "POST",
+      ),
+    ).toHaveLength(1);
+    expect(
+      requests.filter(
+        (request) =>
+          request.url.endsWith("/actions/workflows/e2e.yaml/dispatches") &&
+          request.method === "POST",
+      ),
+    ).toHaveLength(1);
+  });
+});
+
+function urlRunId(url: string): string {
+  const match = /\/check-runs\/([1-9][0-9]*)$/u.exec(url);
+  if (!match) throw new Error("check run URL is invalid");
+  return match[1]!;
+}

--- a/test/pr-e2e-gate-fork-approval.test.ts
+++ b/test/pr-e2e-gate-fork-approval.test.ts
@@ -784,12 +784,12 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
               const correlationId = (
                 dispatch?.body as { inputs?: { correlation_id?: string } } | undefined
               )?.inputs?.correlation_id;
-              if (!correlationId) throw new Error("dispatch correlation was not recorded");
+              expect(correlationId).toMatch(/^[a-f0-9-]{36}$/u);
               return githubResponse({
                 total_count: 2,
                 workflow_runs: [
-                  reconciledForkRun(23, correlationId),
-                  reconciledForkRun(24, correlationId),
+                  reconciledForkRun(23, correlationId!),
+                  reconciledForkRun(24, correlationId!),
                 ],
               });
             },

--- a/test/pr-e2e-gate-fork-approval.test.ts
+++ b/test/pr-e2e-gate-fork-approval.test.ts
@@ -29,6 +29,7 @@ const CI_RUN_ATTEMPT = 3;
 const GATE_RUN_ID = 77;
 const APPROVAL_RUN_ID = 123;
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
@@ -270,6 +271,9 @@ function approvalHistoryRoute(value: unknown) {
 }
 
 function successfulApprovedForkRoutes(approvals: unknown, requests: RecordedGitHubRequest[]) {
+  let check = exactPrGateCheck({
+    output: { title: "E2E reviewer authorization required to run fork E2E" },
+  });
   return [
     approvalRunRoute(approvalWorkflowRun()),
     approvalHistoryRoute(approvals),
@@ -281,13 +285,17 @@ function successfulApprovedForkRoutes(approvals: unknown, requests: RecordedGitH
       ({ url }) => url.includes("/pulls/42/files?"),
       () => githubResponse([{ filename: "src/lib/onboard.ts" }]),
     ),
-    existingPrGateCheckRunsRoute({
-      output: { title: "E2E reviewer authorization required to run fork E2E" },
-    }),
+    githubFetchRoute(
+      ({ url, method }) => url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+      () => githubResponse({ total_count: 1, check_runs: [check] }),
+    ),
     mainWorkflowRefRoute(),
     githubFetchRoute(
       ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
-      (request) => prGateMutationResponse(request),
+      (request) => {
+        check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
+        return githubResponse(check);
+      },
     ),
     githubFetchRoute(
       ({ url, method }) =>
@@ -321,6 +329,29 @@ function successfulApprovedForkRoutes(approvals: unknown, requests: RecordedGitH
       },
     ),
   ];
+}
+
+function reconciledForkRun(runId: number, correlationId: string) {
+  return {
+    id: runId,
+    name: `E2E PR #42 (${correlationId})`,
+    path: ".github/workflows/e2e.yaml",
+    workflow_id: 7,
+    created_at: "2026-07-26T18:00:01.000Z",
+    event: "workflow_dispatch",
+    head_branch: "main",
+    head_sha: WORKFLOW_SHA,
+    run_attempt: 1,
+    status: "queued",
+    conclusion: null,
+    display_title: `E2E PR #42 (${correlationId})`,
+    url: `https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/${runId}`,
+    html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${runId}`,
+    repository: { full_name: "NVIDIA/NemoClaw" },
+    head_repository: { full_name: "NVIDIA/NemoClaw" },
+    actor: { login: "github-actions[bot]" },
+    triggering_actor: { login: "github-actions[bot]" },
+  };
 }
 
 describe("PR E2E controller fork credentialed E2E approval safety", () => {
@@ -692,6 +723,109 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     }
   });
 
+  it("cancels ambiguous fork candidates and does not restore protected authorization", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T18:00:00.000Z"));
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-fork-ambiguous-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    let check = exactPrGateCheck({
+      output: { title: "E2E reviewer authorization required to run fork E2E" },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          approvalRunRoute(approvalWorkflowRun()),
+          approvalHistoryRoute([approvalReview("Reviewed exact fork code and risk plan.")]),
+          githubFetchRoute(
+            ({ url }) => url.endsWith("/pulls/42"),
+            () => githubResponse(forkPullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url }) => url.includes("/pulls/42/files?"),
+            () => githubResponse([{ filename: "src/lib/onboard.ts" }]),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [check] }),
+          ),
+          mainWorkflowRefRoute(),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            (request) => {
+              check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
+              return githubResponse(check);
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () => githubResponse({ message: "dispatch response lost" }, 500),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes("/actions/workflows/e2e.yaml/runs?") && method === "GET",
+            () => {
+              const dispatch = requests.find((request) => request.url.endsWith("/dispatches"));
+              const correlationId = (
+                dispatch?.body as { inputs?: { correlation_id?: string } } | undefined
+              )?.inputs?.correlation_id;
+              if (!correlationId) throw new Error("dispatch correlation was not recorded");
+              return githubResponse({
+                total_count: 2,
+                workflow_runs: [
+                  reconciledForkRun(23, correlationId),
+                  reconciledForkRun(24, correlationId),
+                ],
+              });
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              /\/actions\/runs\/(?:23|24)\/cancel$/u.test(url) && method === "POST",
+            () => githubResponse(undefined, 202),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      const attempt = startApprovedForkPrGate(approvedForkCommand(workDir));
+      const result = expect(attempt).rejects.toThrow(/multiple correlated runs/u);
+      await vi.runAllTimersAsync();
+      await result;
+
+      expect(check).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        details_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+        output: { title: "Authorized E2E run requires reconciliation" },
+      });
+      expect(JSON.stringify(check)).not.toContain("nemoclaw-pr-e2e-retry:");
+      expect(
+        requests.filter((request) => /\/actions\/runs\/(?:23|24)\/cancel$/u.test(request.url)),
+      ).toHaveLength(2);
+      expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(1);
+      expect(
+        requests.filter(
+          (request) =>
+            request.method === "PATCH" &&
+            (request.body as { output?: { title?: string } } | undefined)?.output?.title ===
+              "E2E reviewer authorization required to run fork E2E",
+        ),
+      ).toHaveLength(0);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when the fork approval environment did not record an approval", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-fork-no-review-"));
     vi.stubEnv("GITHUB_TOKEN", "token");
@@ -761,6 +895,12 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
     vi.stubEnv("GITHUB_OUTPUT", outputPath);
     const requests: RecordedGitHubRequest[] = [];
+    let currentCheck = exactPrGateCheck({
+      id: 18,
+      status: "in_progress",
+      conclusion: null,
+      output: { title: "E2E reviewer authorization required to run E2E" },
+    });
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
         [
@@ -803,19 +943,20 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
                         "The child run was cancelled.\n\n<!-- nemoclaw-pr-e2e-retry:v1:child-cancelled -->",
                     },
                   }),
-                  exactPrGateCheck({
-                    id: 18,
-                    status: "in_progress",
-                    conclusion: null,
-                    output: { title: "E2E reviewer authorization required to run E2E" },
-                  }),
+                  currentCheck,
                 ],
               }),
           ),
           mainWorkflowRefRoute(),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/check-runs/18") && method === "PATCH",
-            (request) => prGateMutationResponse(request, 18),
+            (request) => {
+              currentCheck = {
+                ...currentCheck,
+                ...((request.body ?? {}) as Record<string, unknown>),
+              };
+              return githubResponse(currentCheck);
+            },
           ),
           githubFetchRoute(
             ({ url, method }) =>

--- a/test/pr-e2e-gate-fork-approval.test.ts
+++ b/test/pr-e2e-gate-fork-approval.test.ts
@@ -298,6 +298,10 @@ function successfulApprovedForkRoutes(approvals: unknown, requests: RecordedGitH
       },
     ),
     githubFetchRoute(
+      ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+      () => githubResponse(check),
+    ),
+    githubFetchRoute(
       ({ url, method }) =>
         url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
       () =>
@@ -764,6 +768,10 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
             },
           ),
           githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(check),
+          ),
+          githubFetchRoute(
             ({ url, method }) =>
               url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
             () => githubResponse({ message: "dispatch response lost" }, 500),
@@ -959,6 +967,10 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
             },
           ),
           githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/18") && method === "GET",
+            () => githubResponse(currentCheck),
+          ),
+          githubFetchRoute(
             ({ url, method }) =>
               url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
             () =>
@@ -1085,6 +1097,10 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
                 ? githubResponse({ message: "simulated update failure" }, 500)
                 : githubResponse(check);
             },
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(check),
           ),
           githubFetchRoute(
             ({ url, method }) =>

--- a/test/pr-e2e-gate-internal-approval.test.ts
+++ b/test/pr-e2e-gate-internal-approval.test.ts
@@ -24,6 +24,7 @@ const WORKFLOW_SHA = "d".repeat(40);
 const APPROVAL_RUN_ID = 123;
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
@@ -137,6 +138,7 @@ describe("PR E2E protected internal approval", () => {
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
     vi.stubEnv("GITHUB_OUTPUT", outputPath);
     const requests: RecordedGitHubRequest[] = [];
+    let check = exactPrGateCheck();
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
         [
@@ -160,7 +162,7 @@ describe("PR E2E protected internal approval", () => {
           githubFetchRoute(
             ({ url, method }) =>
               url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
-            () => githubResponse({ total_count: 1, check_runs: [exactPrGateCheck()] }),
+            () => githubResponse({ total_count: 1, check_runs: [check] }),
           ),
           githubFetchRoute(
             ({ url }) => url.endsWith("/git/ref/heads/main"),
@@ -172,11 +174,10 @@ describe("PR E2E protected internal approval", () => {
           ),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
-            (request) =>
-              githubResponse({
-                ...exactPrGateCheck(),
-                ...((request.body ?? {}) as Record<string, unknown>),
-              }),
+            (request) => {
+              check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
+              return githubResponse(check);
+            },
           ),
           githubFetchRoute(
             ({ url, method }) =>
@@ -244,6 +245,111 @@ describe("PR E2E protected internal approval", () => {
         },
       });
       expect(fs.readFileSync(outputPath, "utf8")).toContain("dispatched=true");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("terminalizes a zero-match uncertain dispatch without restoring internal authorization", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T18:00:00.000Z"));
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-zero-match-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    let check = exactPrGateCheck();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          approvalRunRoute(),
+          approvalHistoryRoute([
+            {
+              state: "approved",
+              comment: "Reviewed the exact internal PR and base SHAs.",
+              environments: [{ name: "approve-credentialed-e2e-for-internal-pr" }],
+              user: { login: "e2e-reviewer" },
+            },
+          ]),
+          githubFetchRoute(
+            ({ url }) => url.endsWith("/pulls/42"),
+            () => githubResponse(pullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url }) => url.includes("/pulls/42/files?"),
+            () => githubResponse([{ filename: "test/e2e/risk-signal-reporter.ts" }]),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [check] }),
+          ),
+          githubFetchRoute(
+            ({ url }) => url.endsWith("/git/ref/heads/main"),
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            (request) => {
+              check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
+              return githubResponse(check);
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            () => githubResponse({ message: "dispatch response lost" }, 500),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes("/actions/workflows/e2e.yaml/runs?") && method === "GET",
+            () => githubResponse({ total_count: 0, workflow_runs: [] }),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      const attempt = startApprovedControlPlanePrGate(approvedControlPlaneCommand(workDir));
+      const result = expect(attempt).rejects.toThrow(/not observed after bounded reconciliation/u);
+      await vi.runAllTimersAsync();
+      await result;
+
+      expect(check).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        output: {
+          title: "Workflow dispatch was not observed",
+          summary: expect.stringContaining(
+            "<!-- nemoclaw-pr-e2e-retry:v1:dispatch-not-observed -->",
+          ),
+        },
+      });
+      expect(JSON.stringify(check)).toContain("nemoclaw-pr-e2e-dispatch:v1:");
+      expect(
+        requests.filter(
+          (request) =>
+            request.url.endsWith("/actions/workflows/e2e.yaml/dispatches") &&
+            request.method === "POST",
+        ),
+      ).toHaveLength(1);
+      expect(
+        requests.filter(
+          (request) =>
+            request.method === "PATCH" &&
+            (request.body as { output?: { title?: string } } | undefined)?.output?.title ===
+              "E2E reviewer authorization required to run E2E",
+        ),
+      ).toHaveLength(0);
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/test/pr-e2e-gate-internal-approval.test.ts
+++ b/test/pr-e2e-gate-internal-approval.test.ts
@@ -180,6 +180,10 @@ describe("PR E2E protected internal approval", () => {
             },
           ),
           githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(check),
+          ),
+          githubFetchRoute(
             ({ url, method }) =>
               url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
             () =>
@@ -301,6 +305,10 @@ describe("PR E2E protected internal approval", () => {
               check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
               return githubResponse(check);
             },
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () => githubResponse(check),
           ),
           githubFetchRoute(
             ({ url, method }) =>

--- a/test/pr-e2e-gate-lifecycle.test.ts
+++ b/test/pr-e2e-gate-lifecycle.test.ts
@@ -435,6 +435,19 @@ describe("PR E2E controller lifecycle", () => {
               }),
           ),
           githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
+            () =>
+              githubResponse(
+                exactPrGateCheck({
+                  output: {
+                    title: "Evaluating PR commit",
+                    summary:
+                      "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+                  },
+                }),
+              ),
+          ),
+          githubFetchRoute(
             ({ url, method }) => url.endsWith("/actions/runs/23/cancel") && method === "POST",
             () => githubResponse(undefined, 202),
           ),
@@ -457,9 +470,18 @@ describe("PR E2E controller lifecycle", () => {
       expect(requests.some((request) => request.url.endsWith("/actions/runs/23/cancel"))).toBe(
         true,
       );
-      const checkUpdates = requests.filter((request) => request.url.endsWith("/check-runs/17"));
-      expect(checkUpdates).toHaveLength(3);
+      const checkUpdates = requests.filter(
+        (request) => request.url.endsWith("/check-runs/17") && request.method === "PATCH",
+      );
+      expect(checkUpdates).toHaveLength(4);
       expect(checkUpdates[2]?.body).toMatchObject({
+        status: "completed",
+        conclusion: "failure",
+        output: {
+          title: "Child authorization publication was not confirmed",
+        },
+      });
+      expect(checkUpdates[3]?.body).toMatchObject({
         status: "completed",
         conclusion: "failure",
         output: {
@@ -467,6 +489,11 @@ describe("PR E2E controller lifecycle", () => {
           summary: expect.stringContaining("The controller could not complete the check."),
         },
       });
+      const revocationIndex = requests.indexOf(checkUpdates[2]!);
+      const cancellationIndex = requests.findIndex((request) =>
+        request.url.endsWith("/actions/runs/23/cancel"),
+      );
+      expect(cancellationIndex).toBeGreaterThan(revocationIndex);
       expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });

--- a/test/pr-e2e-gate-runner-loss-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-runner-loss-dispatch-recovery.test.ts
@@ -312,6 +312,10 @@ describe("runner-loss retry dispatch reconciliation", () => {
             },
           ),
           githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/18") && method === "GET",
+            () => githubResponse(retryCheck),
+          ),
+          githubFetchRoute(
             ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
             () =>
               githubResponse({

--- a/test/pr-e2e-gate-runner-loss-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-runner-loss-dispatch-recovery.test.ts
@@ -1,0 +1,386 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type PrGateState,
+  prGateExternalId,
+  retryRunnerLossPrGate,
+} from "../tools/e2e/pr-e2e-gate.mts";
+import {
+  createGitHubFetchRouter,
+  githubFetchRoute,
+  type RecordedGitHubRequest,
+} from "./support/github-fetch-router.ts";
+
+const HEAD_SHA = "a".repeat(40);
+const BASE_SHA = "b".repeat(40);
+const WORKFLOW_SHA = "d".repeat(40);
+const ORIGINAL_CORRELATION_ID = "12345678-1234-4123-8123-123456789abc";
+const ORIGINAL_RUN_URL = "https://github.com/NVIDIA/NemoClaw/actions/runs/23";
+const RETRY_MARKER = "<!-- nemoclaw-pr-e2e-retry:v1:child-cancelled -->";
+const START_TIME = new Date("2026-07-26T18:00:00.000Z");
+const JOB_ID = 89_074_697_099;
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+function githubResponse(value?: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => value,
+    text: async () => (value === undefined ? "" : JSON.stringify(value)),
+  } as Response;
+}
+
+function state(): PrGateState {
+  return {
+    version: 4,
+    commitSha: HEAD_SHA,
+    baseSha: BASE_SHA,
+    checkoutRepository: "NVIDIA/NemoClaw",
+    workflowSha: WORKFLOW_SHA,
+    planHash: "c".repeat(64),
+    correlationId: ORIGINAL_CORRELATION_ID,
+    prNumber: 42,
+    expectedJobs: ["onboard-repair", "onboard-resume"],
+    expectedTargets: [],
+    expectedShards: {
+      "onboard-repair": ["default"],
+      "onboard-resume": ["default"],
+    },
+  };
+}
+
+function sourceCheck() {
+  return {
+    id: 17,
+    name: "E2E / PR Gate Coordination",
+    head_sha: HEAD_SHA,
+    external_id: prGateExternalId(42, HEAD_SHA, BASE_SHA),
+    status: "completed",
+    conclusion: "failure",
+    details_url: "https://github.com/NVIDIA/NemoClaw/runs/17",
+    output: {
+      title: "Hermes security-posture failed",
+      summary: [
+        `[Selected E2E run 23](${ORIGINAL_RUN_URL}) concluded \`failure\`. No passing result was accepted.`,
+        "Runner-loss policy: retry once after confirmed GitHub-hosted runner loss.",
+        "",
+        RETRY_MARKER,
+      ].join("\n"),
+    },
+    app: { id: 15368 },
+  };
+}
+
+function originalWorkflowRun() {
+  return {
+    id: 23,
+    name: "E2E",
+    path: ".github/workflows/e2e.yaml",
+    workflow_id: 304_268_429,
+    event: "workflow_dispatch",
+    head_sha: WORKFLOW_SHA,
+    run_attempt: 1,
+    status: "completed",
+    conclusion: "failure",
+    display_title: `E2E PR #42 (${ORIGINAL_CORRELATION_ID})`,
+    html_url: ORIGINAL_RUN_URL,
+  };
+}
+
+function hostedRunnerLossJob() {
+  return {
+    id: JOB_ID,
+    run_id: 23,
+    run_attempt: 1,
+    head_sha: WORKFLOW_SHA,
+    run_url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/23",
+    url: `https://api.github.com/repos/NVIDIA/NemoClaw/actions/jobs/${JOB_ID}`,
+    html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/23/job/${JOB_ID}`,
+    check_run_url: `https://api.github.com/repos/NVIDIA/NemoClaw/check-runs/${JOB_ID}`,
+    name: "Hermes security-posture",
+    status: "completed",
+    conclusion: "failure",
+    started_at: "2026-07-23T07:26:56Z",
+    completed_at: "2026-07-23T07:32:54Z",
+    runner_id: 1_021_277_393,
+    runner_name: "GitHub Actions 1021277393",
+    runner_group_id: 0,
+    runner_group_name: "GitHub Actions",
+    labels: ["ubuntu-latest"],
+    steps: [
+      { name: "Set up job", status: "completed", conclusion: "success" },
+      {
+        name: "Run security posture live Vitest test",
+        status: "completed",
+        conclusion: "cancelled",
+        started_at: "2026-07-23T07:27:43Z",
+        completed_at: "2026-07-23T07:32:49Z",
+      },
+      { name: "Upload security posture artifacts", status: "completed", conclusion: "skipped" },
+      { name: "Clean up Docker auth", status: "completed", conclusion: "skipped" },
+      { name: "Complete job", status: "completed", conclusion: "success" },
+    ],
+  };
+}
+
+function workflowJobCheck() {
+  const job = hostedRunnerLossJob();
+  return {
+    id: job.id,
+    name: job.name,
+    head_sha: job.head_sha,
+    url: job.check_run_url,
+    html_url: job.html_url,
+    details_url: job.html_url,
+    status: "completed",
+    conclusion: "failure",
+    app: { id: 15368, slug: "github-actions" },
+    output: {
+      annotations_count: 1,
+      annotations_url: `${job.check_run_url}/annotations`,
+    },
+  };
+}
+
+function runnerLossAnnotation() {
+  return {
+    path: ".github",
+    blob_href: `https://github.com/NVIDIA/NemoClaw/blob/${WORKFLOW_SHA}/.github`,
+    start_line: 1,
+    start_column: null,
+    end_line: 1,
+    end_column: null,
+    annotation_level: "failure",
+    title: "",
+    message:
+      "The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.",
+    raw_details: "",
+  };
+}
+
+function pullRequest() {
+  return {
+    number: 42,
+    state: "open",
+    changed_files: 1,
+    head: {
+      ref: "feature/pr-e2e-gate",
+      sha: HEAD_SHA,
+      repo: { full_name: "NVIDIA/NemoClaw" },
+    },
+    base: { sha: BASE_SHA, repo: { full_name: "NVIDIA/NemoClaw" } },
+  };
+}
+
+function reconciledRun(runId: number, correlationId: string) {
+  return {
+    id: runId,
+    name: `E2E PR #42 (${correlationId})`,
+    path: ".github/workflows/e2e.yaml",
+    workflow_id: 304_268_429,
+    created_at: new Date(START_TIME.getTime() + 1_000).toISOString(),
+    event: "workflow_dispatch",
+    head_branch: "main",
+    head_sha: WORKFLOW_SHA,
+    run_attempt: 1,
+    status: "queued",
+    conclusion: null,
+    display_title: `E2E PR #42 (${correlationId})`,
+    url: `https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/${runId}`,
+    html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${runId}`,
+    repository: { full_name: "NVIDIA/NemoClaw" },
+    head_repository: { full_name: "NVIDIA/NemoClaw" },
+    actor: { login: "github-actions[bot]" },
+    triggering_actor: { login: "github-actions[bot]" },
+  };
+}
+
+function setup() {
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-runner-loss-dispatch-"));
+  const outputPath = path.join(workDir, "github-output");
+  const statePath = path.join(workDir, "controller-state.json");
+  const retryStatePath = path.join(workDir, "controller-state-runner-loss-retry.json");
+  const serializedState = `${JSON.stringify(state(), null, 2)}\n`;
+  fs.writeFileSync(outputPath, "", { mode: 0o600 });
+  fs.writeFileSync(statePath, serializedState, { mode: 0o600 });
+  vi.stubEnv("GITHUB_TOKEN", "token");
+  vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+  vi.stubEnv("GITHUB_OUTPUT", outputPath);
+  return {
+    workDir,
+    outputPath,
+    command: {
+      mode: "retry-runner-loss" as const,
+      checkRunId: 17,
+      childRunId: 23,
+      workflowRunAttempt: 1,
+      stateHash: createHash("sha256").update(serializedState).digest("hex"),
+      statePath,
+      retryStatePath,
+    },
+  };
+}
+
+describe("runner-loss retry dispatch reconciliation", () => {
+  it.each([
+    {
+      label: "zero candidates",
+      candidateIds: [] as number[],
+      title: "Workflow dispatch was not observed",
+    },
+    {
+      label: "multiple candidates",
+      candidateIds: [24, 25],
+      title: "Runner-loss retry could not start",
+    },
+  ])("fails closed after $label without a second dispatch", async ({ candidateIds, title }) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_TIME);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const context = setup();
+    const requests: RecordedGitHubRequest[] = [];
+    const source = sourceCheck();
+    let retryCheck: Record<string, unknown> | undefined;
+    let correlationId = "";
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/actions/runs/23") && method === "GET",
+            () => githubResponse(originalWorkflowRun()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => {
+              const checks = retryCheck ? [source, retryCheck] : [source];
+              return githubResponse({ total_count: checks.length, check_runs: checks });
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes("/actions/runs/23/attempts/1/jobs?") && method === "GET",
+            () => githubResponse({ total_count: 1, jobs: [hostedRunnerLossJob()] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith(`/check-runs/${JOB_ID}`) && method === "GET",
+            () => githubResponse(workflowJobCheck()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/check-runs/${JOB_ID}/annotations?`) && method === "GET",
+            () => githubResponse([runnerLossAnnotation()]),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+            () => githubResponse(pullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs") && method === "POST",
+            (request) => {
+              retryCheck = {
+                id: 18,
+                conclusion: null,
+                details_url: null,
+                app: { id: 15368 },
+                ...((request.body ?? {}) as Record<string, unknown>),
+              };
+              return githubResponse(retryCheck);
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/18") && method === "PATCH",
+            (request) => {
+              retryCheck = {
+                ...retryCheck,
+                ...((request.body ?? {}) as Record<string, unknown>),
+              };
+              return githubResponse(retryCheck);
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
+            () =>
+              githubResponse({
+                ref: "refs/heads/main",
+                object: { type: "commit", sha: WORKFLOW_SHA },
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
+            (request) => {
+              correlationId =
+                (request.body as { inputs?: { correlation_id?: string } } | undefined)?.inputs
+                  ?.correlation_id ?? "";
+              return githubResponse({ message: "dispatch response lost" }, 500);
+            },
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes("/actions/workflows/e2e.yaml/runs?") && method === "GET",
+            () =>
+              githubResponse({
+                total_count: candidateIds.length,
+                workflow_runs: candidateIds.map((runId) => reconciledRun(runId, correlationId)),
+              }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) =>
+              /\/actions\/runs\/(?:24|25)\/cancel$/u.test(url) && method === "POST",
+            () => githubResponse(undefined, 202),
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      const attempt = retryRunnerLossPrGate(context.command);
+      const result = expect(attempt).rejects.toThrow(
+        candidateIds.length === 0
+          ? /not observed after bounded reconciliation/u
+          : /multiple correlated runs/u,
+      );
+      await vi.runAllTimersAsync();
+      await result;
+
+      expect(retryCheck).toMatchObject({
+        id: 18,
+        status: "completed",
+        conclusion: "failure",
+        output: { title },
+      });
+      expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(1);
+      expect(
+        requests.filter((request) => /\/actions\/runs\/(?:24|25)\/cancel$/u.test(request.url)),
+      ).toHaveLength(candidateIds.length);
+      expect(
+        requests.filter(
+          (request) => request.url.endsWith("/check-runs/17") && request.method === "PATCH",
+        ),
+      ).toHaveLength(0);
+      if (candidateIds.length === 0) {
+        expect(JSON.stringify(retryCheck)).toContain("nemoclaw-pr-e2e-dispatch:v1:");
+      } else {
+        expect(JSON.stringify(retryCheck)).not.toContain("dispatch-not-observed");
+      }
+      expect(fs.readFileSync(context.outputPath, "utf8")).toContain("finalized=true");
+    } finally {
+      fs.rmSync(context.workDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/pr-e2e-gate-runner-loss-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-runner-loss-dispatch-recovery.test.ts
@@ -377,11 +377,10 @@ describe("runner-loss retry dispatch reconciliation", () => {
           (request) => request.url.endsWith("/check-runs/17") && request.method === "PATCH",
         ),
       ).toHaveLength(0);
-      if (candidateIds.length === 0) {
-        expect(JSON.stringify(retryCheck)).toContain("nemoclaw-pr-e2e-dispatch:v1:");
-      } else {
-        expect(JSON.stringify(retryCheck)).not.toContain("dispatch-not-observed");
-      }
+      const serializedCheck = JSON.stringify(retryCheck);
+      const dispatchWasNotObserved = candidateIds.length === 0;
+      expect(serializedCheck.includes("nemoclaw-pr-e2e-dispatch:v1:")).toBe(dispatchWasNotObserved);
+      expect(serializedCheck.includes("dispatch-not-observed")).toBe(dispatchWasNotObserved);
       expect(fs.readFileSync(context.outputPath, "utf8")).toContain("finalized=true");
     } finally {
       fs.rmSync(context.workDir, { recursive: true, force: true });

--- a/test/pr-e2e-gate-runner-loss-retry.test.ts
+++ b/test/pr-e2e-gate-runner-loss-retry.test.ts
@@ -329,8 +329,8 @@ function mutationResponse(request: RecordedGitHubRequest, id = 18): Response {
     checkRun(id, {
       status: "in_progress",
       conclusion: null,
-      ...(request.body as Record<string, unknown> | undefined),
       details_url: `https://github.com/NVIDIA/NemoClaw/runs/${id}`,
+      ...(request.body as Record<string, unknown> | undefined),
     }),
   );
 }
@@ -387,11 +387,16 @@ function retryRoutes(
   let historyRead = 0;
   let annotationRead = 0;
   const source = canonicalRunnerLossCheck();
-  const defaultHistories = [
-    [source],
-    [source, checkRun(18, { status: "in_progress", conclusion: null, details_url: null })],
-    [source, checkRun(18, { status: "in_progress", conclusion: null, details_url: null })],
-  ];
+  const retryCheck = checkRun(18, {
+    status: "in_progress",
+    conclusion: null,
+    details_url: null,
+    output: {
+      title: "Preparing one-time hosted-runner-loss retry",
+      summary: `Revalidating the exact PR/base SHA and risk plan after [attempt 1](${ORIGINAL_RUN_URL}) lost its GitHub-hosted runner.`,
+    },
+  });
+  const defaultHistories = [[source], ...Array.from({ length: 3 }, () => [source, retryCheck])];
   return createGitHubFetchRouter(
     [
       githubFetchRoute(
@@ -477,7 +482,6 @@ describe("PR E2E one-time hosted-runner-loss retry", () => {
     const context = setup();
     const requests: RecordedGitHubRequest[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(retryRoutes(requests));
-
     try {
       await expect(
         retryRunnerLossPrGate({ ...context.command, workflowRunAttempt: 2 }),
@@ -492,7 +496,6 @@ describe("PR E2E one-time hosted-runner-loss retry", () => {
     const context = setup();
     const requests: RecordedGitHubRequest[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(retryRoutes(requests));
-
     try {
       await expect(abandonRunnerLossRetrySource(17, 23, 2)).rejects.toThrow(
         /first controller workflow run attempt/u,
@@ -591,7 +594,6 @@ describe("PR E2E one-time hosted-runner-loss retry", () => {
         ?.correlation_id;
       expect(correlationId).toMatch(/^[a-f0-9-]{36}$/u);
       expect(correlationId).not.toBe(ORIGINAL_CORRELATION_ID);
-
       const retryState = JSON.parse(fs.readFileSync(context.retryStatePath, "utf8"));
       expect(retryState).toEqual({ ...state(), correlationId });
       expect(fs.readFileSync(context.statePath, "utf8")).toBe(context.serializedState);
@@ -605,7 +607,7 @@ describe("PR E2E one-time hosted-runner-loss retry", () => {
       ).toHaveLength(0);
       expect(
         requests.filter((request) => request.url.includes(`/commits/${HEAD_SHA}/check-runs?`)),
-      ).toHaveLength(3);
+      ).toHaveLength(4);
       expect(
         requests.some((request) => request.url.includes("/actions/runs/23/attempts/1/jobs?")),
       ).toBe(true);

--- a/test/pr-e2e-gate-runner-loss-retry.test.ts
+++ b/test/pr-e2e-gate-runner-loss-retry.test.ts
@@ -45,7 +45,6 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
-
 function githubResponse(value?: unknown, status = 200): Response {
   return {
     ok: status >= 200 && status < 300,
@@ -448,8 +447,9 @@ function retryRoutes(
         (request) => mutationResponse(request),
       ),
       githubFetchRoute(
-        ({ url, method }) => url.endsWith("/check-runs/18") && method === "PATCH",
-        (request) => mutationResponse(request),
+        ({ url }) => url.endsWith("/check-runs/18"),
+        (request) =>
+          request.method === "GET" ? githubResponse(retryCheck) : mutationResponse(request),
       ),
       githubFetchRoute(
         ({ url, method }) => url.endsWith("/git/ref/heads/main") && method === "GET",
@@ -617,7 +617,7 @@ describe("PR E2E one-time hosted-runner-loss retry", () => {
       expect(
         new Set(
           requests
-            .filter((request) => request.url.endsWith("/check-runs/18"))
+            .filter((request) => request.url.endsWith("/check-runs/18") && request.body)
             .map((request) => (request.body as { output?: { title?: string } }).output?.title),
         ),
       ).toEqual(new Set(["Preparing one-time hosted-runner-loss retry", "Running 2 E2E checks"]));

--- a/test/pr-e2e-gate-typed-target.test.ts
+++ b/test/pr-e2e-gate-typed-target.test.ts
@@ -92,6 +92,7 @@ describe("PR E2E typed-target gate (#7031)", () => {
         workflowSha: WORKFLOW_SHA,
         planHash: "c".repeat(64),
         correlationId: CORRELATION_ID,
+        expectedCheckTitle: "Evaluating PR commit",
       }),
     ).rejects.toThrow(/Controller dispatch inputs are invalid/u);
   });

--- a/test/pr-e2e-gate.test.ts
+++ b/test/pr-e2e-gate.test.ts
@@ -390,6 +390,14 @@ describe("PR E2E controller", () => {
               object: { type: "commit", sha: WORKFLOW_SHA },
             }),
         ),
+        existingPrGateCheckRunsRoute({
+          id: 101,
+          output: {
+            title: "Evaluating PR commit",
+            summary:
+              "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+          },
+        }),
         githubFetchRoute(
           ({ url }) => url.endsWith("/actions/workflows/e2e.yaml/dispatches"),
           () =>
@@ -401,7 +409,6 @@ describe("PR E2E controller", () => {
         ),
       ]),
     );
-
     await expect(
       dispatchPrGate({
         repository: "NVIDIA/NemoClaw",
@@ -416,10 +423,13 @@ describe("PR E2E controller", () => {
         workflowSha: WORKFLOW_SHA,
         planHash: "c".repeat(64),
         correlationId: CORRELATION_ID,
+        expectedCheckTitle: "Evaluating PR commit",
       }),
     ).resolves.toEqual({ runId: 23, workflowSha: WORKFLOW_SHA });
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("git/ref/heads/main");
-    const request = fetchMock.mock.calls[1]!;
+    const request = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/actions/workflows/e2e.yaml/dispatches"),
+    )!;
     expect(String(request[0])).toContain("actions/workflows/e2e.yaml/dispatches");
     expect(JSON.parse(String(request[1]?.body))).toEqual({
       ref: "main",
@@ -475,6 +485,14 @@ describe("PR E2E controller", () => {
                 files: [{ filename: "docs/quickstart.mdx" }],
               }),
           ),
+          existingPrGateCheckRunsRoute({
+            id: 101,
+            output: {
+              title: "Evaluating PR commit",
+              summary:
+                "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+            },
+          }),
           githubFetchRoute(
             ({ url }) => url.endsWith("/actions/workflows/e2e.yaml/dispatches"),
             () =>
@@ -488,7 +506,6 @@ describe("PR E2E controller", () => {
         requests,
       ),
     );
-
     await expect(
       dispatchPrGate({
         repository: "NVIDIA/NemoClaw",
@@ -502,6 +519,7 @@ describe("PR E2E controller", () => {
         workflowSha: WORKFLOW_SHA,
         planHash: "c".repeat(64),
         correlationId: CORRELATION_ID,
+        expectedCheckTitle: "Evaluating PR commit",
       }),
     ).resolves.toEqual({ runId: 23, workflowSha: ADVANCED_WORKFLOW_SHA });
     const dispatch = requests.find((request) => request.url.endsWith("/dispatches"));
@@ -571,6 +589,7 @@ describe("PR E2E controller", () => {
         workflowSha: WORKFLOW_SHA,
         planHash: "c".repeat(64),
         correlationId: CORRELATION_ID,
+        expectedCheckTitle: "Evaluating PR commit",
       }),
     ).rejects.toThrow(/trusted E2E control-plane changes/u);
     expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
@@ -640,6 +659,7 @@ describe("PR E2E controller", () => {
         workflowSha: WORKFLOW_SHA,
         planHash: "c".repeat(64),
         correlationId: CORRELATION_ID,
+        expectedCheckTitle: "Evaluating PR commit",
       }),
     ).rejects.toThrow(error);
     expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
@@ -696,6 +716,7 @@ describe("PR E2E controller", () => {
         workflowSha: WORKFLOW_SHA,
         planHash: "c".repeat(64),
         correlationId: CORRELATION_ID,
+        expectedCheckTitle: "Evaluating PR commit",
       }),
     ).rejects.toThrow(/main changed again/u);
     expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
@@ -1186,90 +1207,6 @@ describe("PR E2E controller", () => {
     }
   });
 
-  it("automatically dispatches controller-only changes through the normal evidence path", async () => {
-    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-controller-"));
-    const outputPath = path.join(workDir, "github-output");
-    fs.writeFileSync(outputPath, "", { mode: 0o600 });
-    vi.stubEnv("GITHUB_TOKEN", "token");
-    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
-    vi.stubEnv("GITHUB_OUTPUT", outputPath);
-    const controllerFiles = [".github/workflows/pr-e2e-gate.yaml", "tools/e2e/pr-e2e-gate.mts"];
-    const requests: RecordedGitHubRequest[] = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      createGitHubFetchRouter(
-        [
-          existingPrGateCheckRunsRoute(),
-          githubFetchRoute(
-            ({ url }) => url.includes("/pulls?state=open&head="),
-            () => githubResponse([pullRequestListItem(pullRequest(controllerFiles.length))]),
-          ),
-          githubFetchRoute(
-            ({ url }) => url.includes("/pulls/42/files?"),
-            () => githubResponse(controllerFiles.map((filename) => ({ filename }))),
-          ),
-          pullRequestDetailRoute(pullRequest(controllerFiles.length)),
-          githubFetchRoute(
-            ({ url }) => url.endsWith("/git/ref/heads/main"),
-            () =>
-              githubResponse({
-                ref: "refs/heads/main",
-                object: { type: "commit", sha: WORKFLOW_SHA },
-              }),
-          ),
-          githubFetchRoute(
-            ({ url, method }) =>
-              url.endsWith("/actions/workflows/e2e.yaml/dispatches") && method === "POST",
-            () =>
-              githubResponse({
-                workflow_run_id: 23,
-                run_url: "https://api.github.com/repos/NVIDIA/NemoClaw/actions/runs/23",
-                html_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
-              }),
-          ),
-          githubFetchRoute(
-            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
-            (request) => prGateMutationResponse(request),
-          ),
-        ],
-        requests,
-      ),
-    );
-
-    try {
-      await startPrGate(startCommand(workDir));
-
-      const dispatch = requests.find((request) => request.url.endsWith("/dispatches"));
-      expect(dispatch?.body).toMatchObject({
-        inputs: {
-          jobs: "cloud-onboard,credential-sanitization,security-posture",
-          checkout_sha: HEAD_SHA,
-          base_sha: BASE_SHA,
-        },
-      });
-      const outputs = fs.readFileSync(outputPath, "utf8");
-      expect(outputs).toContain("dispatched=true");
-      expect(outputs).not.toContain("approval_mode=");
-      expect(outputs).not.toContain("finalized=true");
-      const runningUpdate = requests.find(
-        (request) =>
-          request.url.endsWith("/check-runs/17") &&
-          request.method === "PATCH" &&
-          (request.body as { output?: { title?: string } }).output?.title ===
-            "Running 3 E2E checks",
-      );
-      expect(runningUpdate?.body).toMatchObject({
-        details_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
-        output: {
-          summary: expect.stringContaining(
-            "Child run: https://github.com/NVIDIA/NemoClaw/actions/runs/23.",
-          ),
-        },
-      });
-    } finally {
-      fs.rmSync(workDir, { recursive: true, force: true });
-    }
-  });
-
   it("completes the check when all evidence passes", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-lifecycle-"));
     const outputPath = path.join(workDir, "github-output");
@@ -1290,7 +1227,18 @@ describe("PR E2E controller", () => {
               checkListCalls += 1;
               return checkListCalls <= 2
                 ? githubResponse({ total_count: 0, check_runs: [] })
-                : githubResponse({ total_count: 1, check_runs: [exactPrGateCheck()] });
+                : githubResponse({
+                    total_count: 1,
+                    check_runs: [
+                      exactPrGateCheck({
+                        output: {
+                          title: "Evaluating PR commit",
+                          summary:
+                            "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+                        },
+                      }),
+                    ],
+                  });
             },
           ),
           githubFetchRoute(

--- a/test/pr-e2e-gate.test.ts
+++ b/test/pr-e2e-gate.test.ts
@@ -121,6 +121,14 @@ function existingPrGateCheckRunsRoute(overrides: Record<string, unknown> = {}) {
   );
 }
 
+function directPrGateCheckRoute(overrides: Record<string, unknown> = {}) {
+  const check = exactPrGateCheck(overrides);
+  return githubFetchRoute(
+    ({ url, method }) => url.endsWith(`/check-runs/${String(check.id)}`) && method === "GET",
+    () => githubResponse(check),
+  );
+}
+
 function prGateMutationResponse(request: RecordedGitHubRequest, id = 17): Response {
   const body = (request.body ?? {}) as Record<string, unknown>;
   return githubResponse(exactPrGateCheck({ id, ...body }));
@@ -398,6 +406,14 @@ describe("PR E2E controller", () => {
               "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
           },
         }),
+        directPrGateCheckRoute({
+          id: 101,
+          output: {
+            title: "Evaluating PR commit",
+            summary:
+              "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+          },
+        }),
         githubFetchRoute(
           ({ url }) => url.endsWith("/actions/workflows/e2e.yaml/dispatches"),
           () =>
@@ -486,6 +502,14 @@ describe("PR E2E controller", () => {
               }),
           ),
           existingPrGateCheckRunsRoute({
+            id: 101,
+            output: {
+              title: "Evaluating PR commit",
+              summary:
+                "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+            },
+          }),
+          directPrGateCheckRoute({
             id: 101,
             output: {
               title: "Evaluating PR commit",
@@ -1281,6 +1305,13 @@ describe("PR E2E controller", () => {
               return githubResponse(workflowRun(gate!));
             },
           ),
+          directPrGateCheckRoute({
+            output: {
+              title: "Evaluating PR commit",
+              summary:
+                "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+            },
+          }),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
             (request) => prGateMutationResponse(request),

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -17,6 +17,10 @@ import {
   retryableGithubRead,
   waitForRequiredGate,
 } from "../tools/e2e/pr-e2e-required.mts";
+import {
+  dispatchNotObservedReceiptMarker,
+  retryableFailureMarker,
+} from "../tools/e2e/pr-e2e-retry-receipt.mts";
 import { createGitHubFetchRouter, githubFetchRoute } from "./support/github-fetch-router.ts";
 
 const HEAD_SHA = "a".repeat(40);
@@ -220,6 +224,41 @@ describe("native PR E2E required job", () => {
     );
 
     await expect(findCoordinationCheck(identity)).resolves.toMatchObject({ id: 18 });
+  });
+
+  it("waits only for a dispatch-not-observed failure with a validated receipt", () => {
+    const receipt = dispatchNotObservedReceiptMarker({
+      correlationId: "123e4567-e89b-42d3-a456-426614174000",
+      workflowSha: "d".repeat(40),
+      sentAtMs: 1_785_050_400_000,
+      deadlineAtMs: 1_785_050_445_000,
+      result: "not-observed",
+      failureKind: "http",
+      status: 500,
+      requestId: "ABCD:1234",
+    });
+    const valid = check(undefined, {
+      conclusion: "failure",
+      output: {
+        title: "Workflow dispatch was not observed",
+        summary: `No child was observed.\n\n${receipt}\n\n${retryableFailureMarker("dispatch-not-observed")}`,
+      },
+    });
+    const missingReceipt = check(undefined, {
+      conclusion: "failure",
+      output: {
+        title: "Workflow dispatch was not observed",
+        summary: `No child was observed.\n\n${retryableFailureMarker("dispatch-not-observed")}`,
+      },
+    });
+
+    expect(classifyCoordinationCheck(valid, identity.repository)).toMatchObject({
+      state: "waiting",
+    });
+    expect(classifyCoordinationCheck(missingReceipt, identity.repository)).toMatchObject({
+      state: "complete",
+      result: { conclusion: "failure" },
+    });
   });
 
   it.each([

--- a/test/pr-e2e-retry-receipt.test.ts
+++ b/test/pr-e2e-retry-receipt.test.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type DispatchNotObservedReceipt,
+  dispatchNotObservedReceiptFromSummary,
+  dispatchNotObservedReceiptMarker,
+  retryableFailureMarker,
+  retryableFailureReason,
+} from "../tools/e2e/pr-e2e-retry-receipt.mts";
+
+const RECEIPT: DispatchNotObservedReceipt = {
+  correlationId: "123e4567-e89b-42d3-a456-426614174000",
+  workflowSha: "d".repeat(40),
+  sentAtMs: 1_785_050_400_000,
+  deadlineAtMs: 1_785_050_445_000,
+  result: "not-observed",
+  failureKind: "http",
+  status: 500,
+  requestId: "ABCD:1234:EFGH",
+};
+
+function completedFailure(summary: string, title = "Workflow dispatch was not observed") {
+  return {
+    status: "completed",
+    conclusion: "failure",
+    output: { title, summary },
+  };
+}
+
+function unvalidatedReceiptMarker(receipt: DispatchNotObservedReceipt): string {
+  const encoded = Buffer.from(JSON.stringify(receipt), "utf8").toString("base64url");
+  return `<!-- nemoclaw-pr-e2e-dispatch:v1:${encoded} -->`;
+}
+
+describe("PR E2E dispatch retry receipts", () => {
+  it("validates a canonical dispatch-not-observed receipt", () => {
+    const summary = [
+      "GitHub did not expose a correlated child run.",
+      dispatchNotObservedReceiptMarker(RECEIPT),
+      retryableFailureMarker("dispatch-not-observed"),
+    ].join("\n\n");
+
+    expect(dispatchNotObservedReceiptFromSummary(summary)).toEqual(RECEIPT);
+    expect(retryableFailureReason(completedFailure(summary))).toBe("dispatch-not-observed");
+  });
+
+  it.each([
+    {
+      label: "missing its structured receipt",
+      summary: `No run was found.\n\n${retryableFailureMarker("dispatch-not-observed")}`,
+    },
+    {
+      label: "placing text after its structured receipt",
+      summary: [
+        dispatchNotObservedReceiptMarker(RECEIPT),
+        "untrusted text",
+        retryableFailureMarker("dispatch-not-observed"),
+      ].join("\n\n"),
+    },
+    {
+      label: "changing its encoded receipt",
+      summary: [
+        `${dispatchNotObservedReceiptMarker(RECEIPT).slice(0, -4)}AAAA -->`,
+        retryableFailureMarker("dispatch-not-observed"),
+      ].join("\n\n"),
+    },
+    {
+      label: "without a positive reconciliation window",
+      summary: [
+        unvalidatedReceiptMarker({
+          ...RECEIPT,
+          deadlineAtMs: RECEIPT.sentAtMs,
+        }),
+        retryableFailureMarker("dispatch-not-observed"),
+      ].join("\n\n"),
+    },
+  ])("rejects a dispatch marker $label", ({ summary }) => {
+    expect(dispatchNotObservedReceiptFromSummary(summary)).toBeUndefined();
+    expect(retryableFailureReason(completedFailure(summary))).toBeUndefined();
+  });
+
+  it("preserves existing retry reasons without requiring a dispatch receipt", () => {
+    const summary = `The child lost its runner.\n\n${retryableFailureMarker("child-cancelled")}`;
+
+    expect(retryableFailureReason(completedFailure(summary, "Selected E2E did not pass"))).toBe(
+      "child-cancelled",
+    );
+  });
+
+  it("keeps reserved non-retryable titles terminal", () => {
+    const summary = [
+      dispatchNotObservedReceiptMarker(RECEIPT),
+      retryableFailureMarker("dispatch-not-observed"),
+    ].join("\n\n");
+
+    expect(
+      retryableFailureReason(completedFailure(summary, "Run could not start")),
+    ).toBeUndefined();
+  });
+});

--- a/tools/advisors/github.mts
+++ b/tools/advisors/github.mts
@@ -14,6 +14,59 @@ export type GitHubRequestOptions = {
   signal?: AbortSignal;
 };
 
+export type GitHubApiFailureKind = "http" | "decode";
+
+const MAX_GITHUB_RESPONSE_EXCERPT_CHARS = 512;
+const GITHUB_REQUEST_ID_PATTERN = /^[A-Za-z0-9:-]{1,128}$/u;
+
+function responseExcerpt(text: string): string {
+  const singleLine = text
+    .replace(/[\r\n\t]+/gu, " ")
+    .replace(/\s{2,}/gu, " ")
+    .trim();
+  return singleLine.length > MAX_GITHUB_RESPONSE_EXCERPT_CHARS
+    ? `${singleLine.slice(0, MAX_GITHUB_RESPONSE_EXCERPT_CHARS - 3)}...`
+    : singleLine;
+}
+
+function responseRequestId(response: Response): string | undefined {
+  const requestId = response.headers.get("x-github-request-id")?.trim();
+  return requestId && GITHUB_REQUEST_ID_PATTERN.test(requestId) ? requestId : undefined;
+}
+
+export class GitHubApiError extends Error {
+  readonly kind: GitHubApiFailureKind;
+  readonly method: string;
+  readonly apiPath: string;
+  readonly status: number;
+  readonly requestId?: string;
+  readonly responseExcerpt: string;
+
+  constructor(options: {
+    kind: GitHubApiFailureKind;
+    method: string;
+    apiPath: string;
+    status: number;
+    requestId?: string;
+    responseText: string;
+    cause?: unknown;
+  }) {
+    const excerpt = responseExcerpt(options.responseText);
+    const message =
+      options.kind === "http"
+        ? `GitHub API ${options.apiPath} failed: ${options.status}${excerpt ? ` ${excerpt}` : ""}`
+        : `GitHub API ${options.apiPath} returned invalid JSON: ${options.status}`;
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "GitHubApiError";
+    this.kind = options.kind;
+    this.method = options.method;
+    this.apiPath = options.apiPath;
+    this.status = options.status;
+    this.requestId = options.requestId;
+    this.responseExcerpt = excerpt;
+  }
+}
+
 export async function githubRest<T>(apiPath: string, token: string): Promise<T> {
   const response = await fetch(`https://api.github.com/${apiPath}`, {
     headers: {
@@ -85,8 +138,9 @@ export async function githubApi<T>(
   // lgtm[js/file-access-to-http] Advisor workflows intentionally send normalized
   // artifact summaries and strictly validated dispatch inputs to GitHub APIs.
   // Callers construct apiPath from fixed workflow/comment endpoints, not PR text.
+  const method = options.method || "GET";
   const response = await fetch(`https://api.github.com/${apiPath}`, {
-    method: options.method || "GET",
+    method,
     headers: {
       Accept: "application/vnd.github+json",
       Authorization: `Bearer ${token}`,
@@ -99,9 +153,29 @@ export async function githubApi<T>(
   });
   const text = await response.text();
   if (!response.ok) {
-    throw new Error(`GitHub API ${apiPath} failed: ${response.status} ${text}`);
+    throw new GitHubApiError({
+      kind: "http",
+      method,
+      apiPath,
+      status: response.status,
+      requestId: responseRequestId(response),
+      responseText: text,
+    });
   }
-  return (text ? JSON.parse(text) : undefined) as T;
+  if (!text) return undefined as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    throw new GitHubApiError({
+      kind: "decode",
+      method,
+      apiPath,
+      status: response.status,
+      requestId: responseRequestId(response),
+      responseText: text,
+      cause: error,
+    });
+  }
 }
 
 export async function upsertStickyComment({

--- a/tools/advisors/github.mts
+++ b/tools/advisors/github.mts
@@ -14,6 +14,12 @@ export type GitHubRequestOptions = {
   signal?: AbortSignal;
 };
 
+export type GitHubApiResponse<T> = {
+  data: T;
+  status: number;
+  requestId?: string;
+};
+
 export type GitHubApiFailureKind = "http" | "decode";
 
 const MAX_GITHUB_RESPONSE_EXCERPT_CHARS = 512;
@@ -30,7 +36,11 @@ function responseExcerpt(text: string): string {
 }
 
 function responseRequestId(response: Response): string | undefined {
-  const requestId = response.headers.get("x-github-request-id")?.trim();
+  const headers = response.headers as Headers | undefined;
+  const requestId =
+    headers && typeof headers.get === "function"
+      ? headers.get("x-github-request-id")?.trim()
+      : undefined;
   return requestId && GITHUB_REQUEST_ID_PATTERN.test(requestId) ? requestId : undefined;
 }
 
@@ -130,11 +140,11 @@ export async function githubGraphql(
   return payload;
 }
 
-export async function githubApi<T>(
+export async function githubApiWithResponse<T>(
   apiPath: string,
   token: string,
   options: GitHubRequestOptions = {},
-): Promise<T> {
+): Promise<GitHubApiResponse<T>> {
   // lgtm[js/file-access-to-http] Advisor workflows intentionally send normalized
   // artifact summaries and strictly validated dispatch inputs to GitHub APIs.
   // Callers construct apiPath from fixed workflow/comment endpoints, not PR text.
@@ -151,6 +161,7 @@ export async function githubApi<T>(
     body: options.body === undefined ? undefined : JSON.stringify(options.body),
     signal: options.signal,
   });
+  const requestId = responseRequestId(response);
   const text = await response.text();
   if (!response.ok) {
     throw new GitHubApiError({
@@ -158,24 +169,38 @@ export async function githubApi<T>(
       method,
       apiPath,
       status: response.status,
-      requestId: responseRequestId(response),
+      requestId,
       responseText: text,
     });
   }
-  if (!text) return undefined as T;
+  if (!text) {
+    return { data: undefined as T, status: response.status, requestId };
+  }
   try {
-    return JSON.parse(text) as T;
+    return {
+      data: JSON.parse(text) as T,
+      status: response.status,
+      requestId,
+    };
   } catch (error) {
     throw new GitHubApiError({
       kind: "decode",
       method,
       apiPath,
       status: response.status,
-      requestId: responseRequestId(response),
+      requestId,
       responseText: text,
       cause: error,
     });
   }
+}
+
+export async function githubApi<T>(
+  apiPath: string,
+  token: string,
+  options: GitHubRequestOptions = {},
+): Promise<T> {
+  return (await githubApiWithResponse<T>(apiPath, token, options)).data;
 }
 
 export async function upsertStickyComment({

--- a/tools/e2e/pr-e2e-dispatch-reconciliation.mts
+++ b/tools/e2e/pr-e2e-dispatch-reconciliation.mts
@@ -388,7 +388,9 @@ function scanInventory(
     upperBoundMs: number;
   },
   candidates: Map<number, WorkflowRun>,
+  correlatedRunIds: Set<number>,
 ): string | undefined {
+  let contradiction: string | undefined;
   for (const run of inventory.runs) {
     if (
       !run.name.includes(options.correlationId) &&
@@ -396,15 +398,20 @@ function scanInventory(
     ) {
       continue;
     }
+    correlatedRunIds.add(run.id);
     const mismatch = candidateMismatch(run, options);
-    if (mismatch) return `correlated workflow run failed ${mismatch} validation`;
+    if (mismatch) {
+      contradiction ??= `correlated workflow run failed ${mismatch} validation`;
+      continue;
+    }
     const existing = candidates.get(run.id);
     if (existing && workflowRunIdentity(existing) !== workflowRunIdentity(run)) {
-      return "correlated workflow run identity changed between inventory reads";
+      contradiction ??= "correlated workflow run identity changed between inventory reads";
+      continue;
     }
     candidates.set(run.id, run);
   }
-  return undefined;
+  return contradiction;
 }
 
 function dispatchDiagnostics(error: unknown): DispatchDiagnostics {
@@ -469,6 +476,7 @@ async function reconcileWorkflowDispatch(
   const lowerBoundMs = options.sentAtMs - clockSkewMs;
   const upperBoundMs = deadlineAtMs + clockSkewMs;
   const candidates = new Map<number, WorkflowRun>();
+  const correlatedRunIds = new Set<number>();
   let contradiction: string | undefined;
 
   console.warn(
@@ -491,11 +499,11 @@ async function reconcileWorkflowDispatch(
     } catch (error) {
       throw new DispatchReconciliationError(
         `Workflow dispatch reconciliation could not read a complete run inventory (${diagnosticsText(options.diagnostics)})`,
-        [...candidates.keys()],
+        [...correlatedRunIds].sort((left, right) => left - right),
         error,
       );
     }
-    contradiction ??= scanInventory(
+    const inventoryContradiction = scanInventory(
       inventory,
       {
         repository: options.repository,
@@ -506,13 +514,15 @@ async function reconcileWorkflowDispatch(
         upperBoundMs,
       },
       candidates,
+      correlatedRunIds,
     );
+    contradiction ??= inventoryContradiction;
     const currentTime = now();
     if (currentTime >= deadlineAtMs) break;
     await sleep(Math.min(pollIntervalMs, deadlineAtMs - currentTime));
   }
 
-  const candidateRunIds = [...candidates.keys()].sort((left, right) => left - right);
+  const candidateRunIds = [...correlatedRunIds].sort((left, right) => left - right);
   if (contradiction || candidateRunIds.length > 1) {
     throw new DispatchReconciliationError(
       `Workflow dispatch reconciliation is ambiguous: ${contradiction ?? "multiple correlated runs were observed"} (${diagnosticsText(options.diagnostics)})`,
@@ -691,6 +701,7 @@ export async function assertDispatchStillNotObserved(
   const recheckUpperBoundMs =
     Math.max((deps.now ?? Date.now)(), options.receipt.deadlineAtMs) + clockSkewMs;
   const candidates = new Map<number, WorkflowRun>();
+  const correlatedRunIds = new Set<number>();
   let inventory: WorkflowRunInventory;
   try {
     inventory = await readInventory(
@@ -722,11 +733,12 @@ export async function assertDispatchStillNotObserved(
       upperBoundMs: recheckUpperBoundMs,
     },
     candidates,
+    correlatedRunIds,
   );
-  if (contradiction || candidates.size > 0) {
+  if (contradiction || correlatedRunIds.size > 0) {
     throw new DispatchReconciliationError(
       `The earlier dispatch correlation is no longer unobserved: ${contradiction ?? "a correlated run appeared"}`,
-      [...candidates.keys()],
+      [...correlatedRunIds].sort((left, right) => left - right),
     );
   }
 }

--- a/tools/e2e/pr-e2e-dispatch-reconciliation.mts
+++ b/tools/e2e/pr-e2e-dispatch-reconciliation.mts
@@ -1,0 +1,732 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  GitHubApiError,
+  type GitHubApiResponse,
+  type GitHubRequestOptions,
+  githubApi,
+} from "../advisors/github.mts";
+import {
+  type DispatchFailureKind,
+  type DispatchNotObservedReceipt,
+  dispatchNotObservedReceiptMarker,
+} from "./pr-e2e-retry-receipt.mts";
+
+const E2E_WORKFLOW = "e2e.yaml";
+const E2E_WORKFLOW_PATH = `.github/workflows/${E2E_WORKFLOW}`;
+const USER_AGENT = "nemoclaw-pr-e2e-dispatch-reconciliation";
+const DEFAULT_RECONCILIATION_WINDOW_MS = 45_000;
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_CLOCK_SKEW_MS = 10_000;
+const DEFAULT_DISPATCH_TIMEOUT_MS = 10_000;
+const DEFAULT_API_TIMEOUT_MS = 5_000;
+const MAX_RECONCILIATION_WINDOW_MS = 120_000;
+const MAX_DISPATCH_TIMEOUT_MS = 30_000;
+const MAX_API_TIMEOUT_MS = 10_000;
+const MAX_DISPATCH_AND_RECONCILIATION_BUDGET_MS = 65_000;
+const MAX_WORKFLOW_RUNS = 100;
+const SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const CORRELATION_PATTERN =
+  /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/u;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
+const GITHUB_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/u;
+
+export type WorkflowDispatchDetails = {
+  workflow_run_id: number;
+  run_url: string;
+  html_url: string;
+};
+
+export type DispatchReconciliationResult = {
+  runId: number;
+  source: "dispatch-response" | "workflow-run-inventory";
+};
+
+type WorkflowRun = {
+  id: number;
+  name: string;
+  path: string;
+  workflowId: number;
+  createdAt: string;
+  event: string;
+  headBranch: string;
+  headSha: string;
+  runAttempt: number;
+  status: string;
+  conclusion: string | null;
+  displayTitle: string;
+  apiUrl: string;
+  htmlUrl: string;
+  repository: string;
+  headRepository: string;
+  actor: string;
+  triggeringActor: string;
+};
+
+type WorkflowRunInventory = {
+  totalCount: number;
+  runs: WorkflowRun[];
+};
+
+type DispatchDiagnostics = {
+  failureKind: DispatchFailureKind;
+  status?: number;
+  requestId?: string;
+};
+
+type GithubApi = (
+  apiPath: string,
+  token: string,
+  options?: GitHubRequestOptions,
+) => Promise<unknown>;
+
+export type DispatchReconciliationDeps = {
+  api?: GithubApi;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  reconciliationWindowMs?: number;
+  pollIntervalMs?: number;
+  clockSkewMs?: number;
+  dispatchTimeoutMs?: number;
+  apiTimeoutMs?: number;
+};
+
+export class DispatchNotObservedError extends Error {
+  readonly receipt: DispatchNotObservedReceipt;
+
+  constructor(receipt: DispatchNotObservedReceipt) {
+    const diagnostics = [
+      `kind=${receipt.failureKind}`,
+      receipt.status === undefined ? undefined : `status=${receipt.status}`,
+      receipt.requestId === undefined ? undefined : `request_id=${receipt.requestId}`,
+      `correlation=${receipt.correlationId}`,
+    ]
+      .filter((part): part is string => Boolean(part))
+      .join(" ");
+    super(`Workflow dispatch was not observed after bounded reconciliation (${diagnostics})`);
+    this.name = "DispatchNotObservedError";
+    this.receipt = receipt;
+  }
+
+  marker(): string {
+    return dispatchNotObservedReceiptMarker(this.receipt);
+  }
+}
+
+export class DispatchReconciliationError extends Error {
+  readonly candidateRunIds: readonly number[];
+
+  constructor(message: string, candidateRunIds: readonly number[] = [], cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "DispatchReconciliationError";
+    this.candidateRunIds = [...candidateRunIds];
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function positiveSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+async function boundedOperation<T>(
+  label: string,
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([operation(controller.signal), timeout]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
+function validatedTimeout(value: number, name: string, maximum: number): number {
+  if (!positiveSafeInteger(value) || value > maximum) {
+    throw new Error(`${name} must be a positive integer no greater than ${maximum}ms`);
+  }
+  return value;
+}
+
+function assertDispatchIdentity(options: {
+  repository: string;
+  workflowSha: string;
+  correlationId: string;
+  prNumber: number;
+}): void {
+  if (
+    !REPOSITORY_PATTERN.test(options.repository) ||
+    !SHA_PATTERN.test(options.workflowSha) ||
+    !CORRELATION_PATTERN.test(options.correlationId) ||
+    !positiveSafeInteger(options.prNumber)
+  ) {
+    throw new Error("Workflow dispatch reconciliation identity is invalid");
+  }
+}
+
+function assertTimingOptions(options: {
+  sentAtMs: number;
+  reconciliationWindowMs: number;
+  pollIntervalMs: number;
+  clockSkewMs: number;
+}): void {
+  if (
+    !positiveSafeInteger(options.sentAtMs) ||
+    !positiveSafeInteger(options.reconciliationWindowMs) ||
+    options.reconciliationWindowMs > MAX_RECONCILIATION_WINDOW_MS ||
+    !positiveSafeInteger(options.pollIntervalMs) ||
+    options.pollIntervalMs > options.reconciliationWindowMs ||
+    !Number.isSafeInteger(options.clockSkewMs) ||
+    options.clockSkewMs < 0 ||
+    options.clockSkewMs > 30_000
+  ) {
+    throw new Error("Workflow dispatch reconciliation timing is invalid");
+  }
+}
+
+export function validateWorkflowDispatchDetails(
+  value: unknown,
+  repository: string,
+): WorkflowDispatchDetails {
+  if (!isObjectRecord(value)) throw new Error("GitHub returned invalid workflow dispatch details");
+  const runId = value.workflow_run_id;
+  if (!positiveSafeInteger(runId)) {
+    throw new Error("GitHub returned an invalid dispatched workflow run id");
+  }
+  const expectedApiUrl = `https://api.github.com/repos/${repository}/actions/runs/${runId}`;
+  const expectedHtmlUrl = `https://github.com/${repository}/actions/runs/${runId}`;
+  if (value.run_url !== expectedApiUrl || value.html_url !== expectedHtmlUrl) {
+    throw new Error("GitHub returned mismatched workflow dispatch URLs");
+  }
+  return value as WorkflowDispatchDetails;
+}
+
+function validateWorkflowRun(value: unknown): WorkflowRun {
+  if (
+    !isObjectRecord(value) ||
+    !positiveSafeInteger(value.id) ||
+    typeof value.name !== "string" ||
+    typeof value.path !== "string" ||
+    !positiveSafeInteger(value.workflow_id) ||
+    typeof value.created_at !== "string" ||
+    !GITHUB_TIMESTAMP_PATTERN.test(value.created_at) ||
+    !Number.isFinite(Date.parse(value.created_at)) ||
+    typeof value.event !== "string" ||
+    typeof value.head_branch !== "string" ||
+    typeof value.head_sha !== "string" ||
+    !SHA_PATTERN.test(value.head_sha) ||
+    !positiveSafeInteger(value.run_attempt) ||
+    typeof value.status !== "string" ||
+    (value.conclusion !== null && typeof value.conclusion !== "string") ||
+    typeof value.display_title !== "string" ||
+    typeof value.url !== "string" ||
+    typeof value.html_url !== "string" ||
+    !isObjectRecord(value.repository) ||
+    typeof value.repository.full_name !== "string" ||
+    !isObjectRecord(value.head_repository) ||
+    typeof value.head_repository.full_name !== "string" ||
+    !isObjectRecord(value.actor) ||
+    typeof value.actor.login !== "string" ||
+    !isObjectRecord(value.triggering_actor) ||
+    typeof value.triggering_actor.login !== "string"
+  ) {
+    throw new Error("GitHub returned an invalid workflow run");
+  }
+  return {
+    id: value.id,
+    name: value.name,
+    path: value.path,
+    workflowId: value.workflow_id,
+    createdAt: value.created_at,
+    event: value.event,
+    headBranch: value.head_branch,
+    headSha: value.head_sha,
+    runAttempt: value.run_attempt,
+    status: value.status,
+    conclusion: value.conclusion,
+    displayTitle: value.display_title,
+    apiUrl: value.url,
+    htmlUrl: value.html_url,
+    repository: value.repository.full_name,
+    headRepository: value.head_repository.full_name,
+    actor: value.actor.login,
+    triggeringActor: value.triggering_actor.login,
+  };
+}
+
+function validateWorkflowRunInventory(value: unknown): WorkflowRunInventory {
+  if (
+    !isObjectRecord(value) ||
+    !Number.isSafeInteger(value.total_count) ||
+    (value.total_count as number) < 0 ||
+    !Array.isArray(value.workflow_runs) ||
+    value.workflow_runs.length > MAX_WORKFLOW_RUNS ||
+    value.workflow_runs.length !== value.total_count
+  ) {
+    throw new Error("GitHub returned an invalid or incomplete workflow run listing");
+  }
+  const runs = value.workflow_runs.map(validateWorkflowRun);
+  if (new Set(runs.map((run) => run.id)).size !== runs.length) {
+    throw new Error("GitHub returned duplicate workflow run IDs");
+  }
+  return { totalCount: value.total_count as number, runs };
+}
+
+function inventoryApiPath(options: {
+  repository: string;
+  workflowSha: string;
+  lowerBoundMs: number;
+  upperBoundMs: number;
+}): string {
+  const created = `${new Date(options.lowerBoundMs).toISOString()}..${new Date(options.upperBoundMs).toISOString()}`;
+  const query = new URLSearchParams({
+    branch: "main",
+    event: "workflow_dispatch",
+    head_sha: options.workflowSha,
+    created,
+    per_page: String(MAX_WORKFLOW_RUNS),
+  });
+  return `repos/${options.repository}/actions/workflows/${E2E_WORKFLOW}/runs?${query}`;
+}
+
+async function readInventory(
+  options: {
+    repository: string;
+    token: string;
+    workflowSha: string;
+    lowerBoundMs: number;
+    upperBoundMs: number;
+  },
+  api: GithubApi,
+  timeoutMs: number,
+): Promise<WorkflowRunInventory> {
+  return validateWorkflowRunInventory(
+    await boundedOperation("Workflow run inventory read", timeoutMs, (signal) =>
+      api(inventoryApiPath(options), options.token, { userAgent: USER_AGENT, signal }),
+    ),
+  );
+}
+
+function expectedRunTitle(prNumber: number, correlationId: string): string {
+  return `E2E PR #${prNumber} (${correlationId})`;
+}
+
+function workflowRunIdentity(run: WorkflowRun): string {
+  return JSON.stringify({
+    id: run.id,
+    name: run.name,
+    path: run.path,
+    workflowId: run.workflowId,
+    createdAt: run.createdAt,
+    event: run.event,
+    headBranch: run.headBranch,
+    headSha: run.headSha,
+    runAttempt: run.runAttempt,
+    displayTitle: run.displayTitle,
+    apiUrl: run.apiUrl,
+    htmlUrl: run.htmlUrl,
+    repository: run.repository,
+    headRepository: run.headRepository,
+    actor: run.actor,
+    triggeringActor: run.triggeringActor,
+  });
+}
+
+function candidateMismatch(
+  run: WorkflowRun,
+  options: {
+    repository: string;
+    workflowSha: string;
+    correlationId: string;
+    prNumber: number;
+    lowerBoundMs: number;
+    upperBoundMs: number;
+  },
+): string | undefined {
+  const expectedApiUrl = `https://api.github.com/repos/${options.repository}/actions/runs/${run.id}`;
+  const expectedHtmlUrl = `https://github.com/${options.repository}/actions/runs/${run.id}`;
+  const createdAtMs = Date.parse(run.createdAt);
+  const title = expectedRunTitle(options.prNumber, options.correlationId);
+  const checks: Array<[string, boolean]> = [
+    ["name", run.name === title],
+    ["path", run.path === E2E_WORKFLOW_PATH],
+    ["event", run.event === "workflow_dispatch"],
+    ["head_branch", run.headBranch === "main"],
+    ["head_sha", run.headSha === options.workflowSha],
+    ["run_attempt", run.runAttempt === 1],
+    ["display_title", run.displayTitle === title],
+    ["url", run.apiUrl === expectedApiUrl],
+    ["html_url", run.htmlUrl === expectedHtmlUrl],
+    ["repository", run.repository === options.repository],
+    ["head_repository", run.headRepository === options.repository],
+    ["actor", run.actor === "github-actions[bot]"],
+    ["triggering_actor", run.triggeringActor === "github-actions[bot]"],
+    ["created_at", createdAtMs >= options.lowerBoundMs && createdAtMs <= options.upperBoundMs],
+  ];
+  return checks.find(([, matches]) => !matches)?.[0];
+}
+
+function scanInventory(
+  inventory: WorkflowRunInventory,
+  options: {
+    repository: string;
+    workflowSha: string;
+    correlationId: string;
+    prNumber: number;
+    lowerBoundMs: number;
+    upperBoundMs: number;
+  },
+  candidates: Map<number, WorkflowRun>,
+): string | undefined {
+  for (const run of inventory.runs) {
+    if (
+      !run.name.includes(options.correlationId) &&
+      !run.displayTitle.includes(options.correlationId)
+    ) {
+      continue;
+    }
+    const mismatch = candidateMismatch(run, options);
+    if (mismatch) return `correlated workflow run failed ${mismatch} validation`;
+    const existing = candidates.get(run.id);
+    if (existing && workflowRunIdentity(existing) !== workflowRunIdentity(run)) {
+      return "correlated workflow run identity changed between inventory reads";
+    }
+    candidates.set(run.id, run);
+  }
+  return undefined;
+}
+
+function dispatchDiagnostics(error: unknown): DispatchDiagnostics {
+  if (error instanceof GitHubApiError) {
+    return {
+      failureKind: error.kind,
+      status: error.status,
+      requestId: error.requestId,
+    };
+  }
+  return { failureKind: "transport" };
+}
+
+function diagnosticsText(diagnostics: DispatchDiagnostics): string {
+  return [
+    `kind=${diagnostics.failureKind}`,
+    diagnostics.status === undefined ? undefined : `status=${diagnostics.status}`,
+    diagnostics.requestId === undefined ? undefined : `request_id=${diagnostics.requestId}`,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
+}
+
+async function reconcileWorkflowDispatch(
+  options: {
+    repository: string;
+    token: string;
+    workflowSha: string;
+    correlationId: string;
+    prNumber: number;
+    sentAtMs: number;
+    diagnostics: DispatchDiagnostics;
+  },
+  deps: DispatchReconciliationDeps,
+): Promise<DispatchReconciliationResult> {
+  const api =
+    deps.api ??
+    ((apiPath, token, requestOptions) => githubApi<unknown>(apiPath, token, requestOptions));
+  const now = deps.now ?? Date.now;
+  const sleep =
+    deps.sleep ??
+    ((milliseconds: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, milliseconds);
+      }));
+  const reconciliationWindowMs = deps.reconciliationWindowMs ?? DEFAULT_RECONCILIATION_WINDOW_MS;
+  const pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const clockSkewMs = deps.clockSkewMs ?? DEFAULT_CLOCK_SKEW_MS;
+  const apiTimeoutMs = validatedTimeout(
+    deps.apiTimeoutMs ?? DEFAULT_API_TIMEOUT_MS,
+    "GitHub API timeout",
+    MAX_API_TIMEOUT_MS,
+  );
+  assertTimingOptions({
+    sentAtMs: options.sentAtMs,
+    reconciliationWindowMs,
+    pollIntervalMs,
+    clockSkewMs,
+  });
+  const reconciliationStartedAtMs = Math.max(now(), options.sentAtMs);
+  const deadlineAtMs = reconciliationStartedAtMs + reconciliationWindowMs;
+  const lowerBoundMs = options.sentAtMs - clockSkewMs;
+  const upperBoundMs = deadlineAtMs + clockSkewMs;
+  const candidates = new Map<number, WorkflowRun>();
+  let contradiction: string | undefined;
+
+  console.warn(
+    `Workflow dispatch response uncertain: correlation=${options.correlationId} ${diagnosticsText(options.diagnostics)} result=reconciling`,
+  );
+  while (true) {
+    let inventory: WorkflowRunInventory;
+    try {
+      inventory = await readInventory(
+        {
+          repository: options.repository,
+          token: options.token,
+          workflowSha: options.workflowSha,
+          lowerBoundMs,
+          upperBoundMs,
+        },
+        api,
+        apiTimeoutMs,
+      );
+    } catch (error) {
+      throw new DispatchReconciliationError(
+        `Workflow dispatch reconciliation could not read a complete run inventory (${diagnosticsText(options.diagnostics)})`,
+        [...candidates.keys()],
+        error,
+      );
+    }
+    contradiction ??= scanInventory(
+      inventory,
+      {
+        repository: options.repository,
+        workflowSha: options.workflowSha,
+        correlationId: options.correlationId,
+        prNumber: options.prNumber,
+        lowerBoundMs,
+        upperBoundMs,
+      },
+      candidates,
+    );
+    const currentTime = now();
+    if (currentTime >= deadlineAtMs) break;
+    await sleep(Math.min(pollIntervalMs, deadlineAtMs - currentTime));
+  }
+
+  const candidateRunIds = [...candidates.keys()].sort((left, right) => left - right);
+  if (contradiction || candidateRunIds.length > 1) {
+    throw new DispatchReconciliationError(
+      `Workflow dispatch reconciliation is ambiguous: ${contradiction ?? "multiple correlated runs were observed"} (${diagnosticsText(options.diagnostics)})`,
+      candidateRunIds,
+    );
+  }
+  if (candidateRunIds.length === 0) {
+    const receipt: DispatchNotObservedReceipt = {
+      correlationId: options.correlationId,
+      workflowSha: options.workflowSha,
+      sentAtMs: options.sentAtMs,
+      deadlineAtMs,
+      result: "not-observed",
+      failureKind: options.diagnostics.failureKind,
+      ...(options.diagnostics.status === undefined ? {} : { status: options.diagnostics.status }),
+      ...(options.diagnostics.requestId === undefined
+        ? {}
+        : { requestId: options.diagnostics.requestId }),
+    };
+    console.warn(
+      `Workflow dispatch reconciliation complete: correlation=${options.correlationId} ${diagnosticsText(options.diagnostics)} result=not-observed`,
+    );
+    throw new DispatchNotObservedError(receipt);
+  }
+
+  const runId = candidateRunIds[0]!;
+  let confirmed: WorkflowRun;
+  try {
+    confirmed = validateWorkflowRun(
+      await boundedOperation("Correlated workflow run read", apiTimeoutMs, (signal) =>
+        api(`repos/${options.repository}/actions/runs/${runId}`, options.token, {
+          userAgent: USER_AGENT,
+          signal,
+        }),
+      ),
+    );
+  } catch (error) {
+    throw new DispatchReconciliationError(
+      `Workflow dispatch reconciliation could not authenticate correlated run ${runId}`,
+      candidateRunIds,
+      error,
+    );
+  }
+  const mismatch = candidateMismatch(confirmed, {
+    repository: options.repository,
+    workflowSha: options.workflowSha,
+    correlationId: options.correlationId,
+    prNumber: options.prNumber,
+    lowerBoundMs,
+    upperBoundMs,
+  });
+  if (mismatch || workflowRunIdentity(confirmed) !== workflowRunIdentity(candidates.get(runId)!)) {
+    throw new DispatchReconciliationError(
+      `Workflow dispatch reconciliation could not confirm correlated run ${runId}${mismatch ? ` (${mismatch})` : ""}`,
+      candidateRunIds,
+    );
+  }
+  console.log(
+    `Workflow dispatch reconciliation complete: correlation=${options.correlationId} run=${runId} ${diagnosticsText(options.diagnostics)} result=adopted`,
+  );
+  return { runId, source: "workflow-run-inventory" };
+}
+
+export async function dispatchWorkflowWithReconciliation(
+  options: {
+    repository: string;
+    token: string;
+    workflowSha: string;
+    correlationId: string;
+    prNumber: number;
+    dispatch: (signal: AbortSignal) => Promise<GitHubApiResponse<unknown>>;
+  },
+  deps: DispatchReconciliationDeps = {},
+): Promise<DispatchReconciliationResult> {
+  assertDispatchIdentity(options);
+  if (!options.token) throw new Error("GitHub token is required");
+  const now = deps.now ?? Date.now;
+  const sentAtMs = now();
+  const dispatchTimeoutMs = validatedTimeout(
+    deps.dispatchTimeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS,
+    "Workflow dispatch timeout",
+    MAX_DISPATCH_TIMEOUT_MS,
+  );
+  const reconciliationWindowMs = deps.reconciliationWindowMs ?? DEFAULT_RECONCILIATION_WINDOW_MS;
+  const apiTimeoutMs = validatedTimeout(
+    deps.apiTimeoutMs ?? DEFAULT_API_TIMEOUT_MS,
+    "GitHub API timeout",
+    MAX_API_TIMEOUT_MS,
+  );
+  assertTimingOptions({
+    sentAtMs,
+    reconciliationWindowMs,
+    pollIntervalMs: deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    clockSkewMs: deps.clockSkewMs ?? DEFAULT_CLOCK_SKEW_MS,
+  });
+  if (
+    dispatchTimeoutMs + reconciliationWindowMs + apiTimeoutMs * 2 >
+    MAX_DISPATCH_AND_RECONCILIATION_BUDGET_MS
+  ) {
+    throw new Error("Workflow dispatch and reconciliation exceed the authorization time budget");
+  }
+  let response: GitHubApiResponse<unknown>;
+  try {
+    response = await boundedOperation("Workflow dispatch request", dispatchTimeoutMs, (signal) =>
+      options.dispatch(signal),
+    );
+  } catch (error) {
+    if (
+      error instanceof GitHubApiError &&
+      error.kind === "http" &&
+      error.status >= 400 &&
+      error.status < 500
+    ) {
+      throw error;
+    }
+    return reconcileWorkflowDispatch(
+      {
+        ...options,
+        sentAtMs,
+        diagnostics: dispatchDiagnostics(error),
+      },
+      deps,
+    );
+  }
+  try {
+    const details = validateWorkflowDispatchDetails(response.data, options.repository);
+    return { runId: details.workflow_run_id, source: "dispatch-response" };
+  } catch {
+    return reconcileWorkflowDispatch(
+      {
+        ...options,
+        sentAtMs,
+        diagnostics: {
+          failureKind: "validation",
+          status: response.status,
+          requestId: response.requestId,
+        },
+      },
+      deps,
+    );
+  }
+}
+
+export async function assertDispatchStillNotObserved(
+  options: {
+    repository: string;
+    token: string;
+    prNumber: number;
+    receipt: DispatchNotObservedReceipt;
+  },
+  deps: Pick<DispatchReconciliationDeps, "api" | "apiTimeoutMs" | "clockSkewMs" | "now"> = {},
+): Promise<void> {
+  assertDispatchIdentity({
+    repository: options.repository,
+    workflowSha: options.receipt.workflowSha,
+    correlationId: options.receipt.correlationId,
+    prNumber: options.prNumber,
+  });
+  if (!options.token) throw new Error("GitHub token is required");
+  const clockSkewMs = deps.clockSkewMs ?? DEFAULT_CLOCK_SKEW_MS;
+  const reconciliationWindowMs = options.receipt.deadlineAtMs - options.receipt.sentAtMs;
+  assertTimingOptions({
+    sentAtMs: options.receipt.sentAtMs,
+    reconciliationWindowMs,
+    pollIntervalMs: reconciliationWindowMs,
+    clockSkewMs,
+  });
+  const api =
+    deps.api ??
+    ((apiPath, token, requestOptions) => githubApi<unknown>(apiPath, token, requestOptions));
+  const apiTimeoutMs = validatedTimeout(
+    deps.apiTimeoutMs ?? DEFAULT_API_TIMEOUT_MS,
+    "GitHub API timeout",
+    MAX_API_TIMEOUT_MS,
+  );
+  const recheckUpperBoundMs =
+    Math.max((deps.now ?? Date.now)(), options.receipt.deadlineAtMs) + clockSkewMs;
+  const candidates = new Map<number, WorkflowRun>();
+  let inventory: WorkflowRunInventory;
+  try {
+    inventory = await readInventory(
+      {
+        repository: options.repository,
+        token: options.token,
+        workflowSha: options.receipt.workflowSha,
+        lowerBoundMs: options.receipt.sentAtMs - clockSkewMs,
+        upperBoundMs: recheckUpperBoundMs,
+      },
+      api,
+      apiTimeoutMs,
+    );
+  } catch (error) {
+    throw new DispatchReconciliationError(
+      "The earlier dispatch correlation could not be rechecked before replacement",
+      [],
+      error,
+    );
+  }
+  const contradiction = scanInventory(
+    inventory,
+    {
+      repository: options.repository,
+      workflowSha: options.receipt.workflowSha,
+      correlationId: options.receipt.correlationId,
+      prNumber: options.prNumber,
+      lowerBoundMs: options.receipt.sentAtMs - clockSkewMs,
+      upperBoundMs: recheckUpperBoundMs,
+    },
+    candidates,
+  );
+  if (contradiction || candidates.size > 0) {
+    throw new DispatchReconciliationError(
+      `The earlier dispatch correlation is no longer unobserved: ${contradiction ?? "a correlated run appeared"}`,
+      [...candidates.keys()],
+    );
+  }
+}

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -37,7 +37,6 @@ import {
   DispatchNotObservedError,
   DispatchReconciliationError,
   dispatchWorkflowWithReconciliation,
-  validateWorkflowDispatchDetails,
 } from "./pr-e2e-dispatch-reconciliation.mts";
 import {
   dispatchNotObservedReceiptFromSummary,

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -32,6 +32,11 @@ import {
   listNonPassingWorkflowJobs,
   workflowJobEvidenceFingerprint,
 } from "./hosted-runner-loss-github.mts";
+import {
+  type RetryableFailureReason,
+  retryableFailureMarker,
+  retryableFailureReason,
+} from "./pr-e2e-retry-receipt.mts";
 import { readPrivateRegularFile, writePrivateRegularFile } from "./private-file.mts";
 import type { E2eRiskSignal } from "./risk-signal.ts";
 import {
@@ -61,19 +66,6 @@ const RESERVED_CHECK_SUMMARY =
   "This PR SHA and base SHA are reserved for deterministic E2E planning after CI completes.";
 const CONTROL_PLANE_AUTHORIZATION_TITLE = "E2E reviewer authorization required to run E2E";
 const FORK_E2E_AUTHORIZATION_TITLE = "E2E reviewer authorization required to run fork E2E";
-const RETRYABLE_FAILURE_MARKER_PREFIX = "<!-- nemoclaw-pr-e2e-retry:v1:";
-const RETRYABLE_FAILURE_MARKER_SUFFIX = " -->";
-const RETRYABLE_FAILURE_REASONS = new Set([
-  "prerequisite-ci",
-  "child-cancelled",
-  "evidence-download",
-] as const);
-const NEVER_RETRY_FAILURE_TITLES = new Set([
-  "Authorized E2E run requires reconciliation",
-  "PR base changed",
-  "Controller stopped early",
-  "Run could not start",
-]);
 const CHECK_EXTERNAL_ID_PREFIX = "nemoclaw-pr-e2e:v2";
 const LEGACY_CHECK_EXTERNAL_ID_PREFIX = "nemoclaw-pr-e2e:v1";
 const CHECK_EXTERNAL_ID_PATTERN =
@@ -312,8 +304,6 @@ export type PrGateVerdict = {
   summary: string;
   retryableFailureReason?: RetryableFailureReason;
 };
-
-type RetryableFailureReason = "prerequisite-ci" | "child-cancelled" | "evidence-download";
 
 class ObsoleteExactDiffError extends Error {
   readonly verdict: PrGateVerdict;
@@ -1034,29 +1024,6 @@ function isPrGateLineage(check: CheckRun, prNumber: number, headSha: string): bo
     (typeof externalId === "string" &&
       externalId.startsWith(`${CHECK_EXTERNAL_ID_PREFIX}:${prNumber}:${headSha}:`))
   );
-}
-
-function retryableFailureMarker(reason: RetryableFailureReason): string {
-  return `${RETRYABLE_FAILURE_MARKER_PREFIX}${reason}${RETRYABLE_FAILURE_MARKER_SUFFIX}`;
-}
-
-function retryableFailureReason(check: CheckRun): RetryableFailureReason | undefined {
-  if (check.status !== "completed" || check.conclusion !== "failure") return undefined;
-  if (NEVER_RETRY_FAILURE_TITLES.has(check.output?.title ?? "")) return undefined;
-  const summary = check.output?.summary;
-  if (typeof summary !== "string") return undefined;
-  const markerBoundary = `\n\n${RETRYABLE_FAILURE_MARKER_PREFIX}`;
-  const markerStart = summary.lastIndexOf(markerBoundary);
-  if (markerStart < 0) return undefined;
-  const marker = summary.slice(markerStart + 2);
-  if (!marker.endsWith(RETRYABLE_FAILURE_MARKER_SUFFIX)) return undefined;
-  const reason = marker.slice(
-    RETRYABLE_FAILURE_MARKER_PREFIX.length,
-    -RETRYABLE_FAILURE_MARKER_SUFFIX.length,
-  );
-  if (!RETRYABLE_FAILURE_REASONS.has(reason as RetryableFailureReason)) return undefined;
-  if (marker !== retryableFailureMarker(reason as RetryableFailureReason)) return undefined;
-  return reason as RetryableFailureReason;
 }
 
 function runnerLossChildRunUrl(repository: string, check: CheckRun): string | null {

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -75,6 +75,7 @@ const RESERVED_CHECK_SUMMARY =
   "This PR SHA and base SHA are reserved for deterministic E2E planning after CI completes.";
 const CONTROL_PLANE_AUTHORIZATION_TITLE = "E2E reviewer authorization required to run E2E";
 const FORK_E2E_AUTHORIZATION_TITLE = "E2E reviewer authorization required to run fork E2E";
+const PRE_DISPATCH_CHECK_READ_TIMEOUT_MS = 5_000;
 const RECONCILED_CHILD_VALIDATION_TIMEOUT_MS = 10_000;
 const CHILD_AUTHORIZATION_PUBLISH_TIMEOUT_MS = 5_000;
 const CHILD_CANCELLATION_TIMEOUT_MS = 5_000;
@@ -2245,6 +2246,16 @@ async function requireDirectPreDispatchCheck(options: {
   assertCurrentPreDispatchCheck([check], options);
 }
 
+async function requireBoundedDirectPreDispatchCheck(
+  options: Omit<Parameters<typeof requireDirectPreDispatchCheck>[0], "signal">,
+): Promise<void> {
+  await boundedControllerOperation(
+    "Pre-dispatch controller check read",
+    PRE_DISPATCH_CHECK_READ_TIMEOUT_MS,
+    (signal) => requireDirectPreDispatchCheck({ ...options, signal }),
+  );
+}
+
 async function recheckDispatchHistoryBeforePost(options: {
   repository: string;
   token: string;
@@ -2266,15 +2277,7 @@ async function recheckDispatchHistoryBeforePost(options: {
   if (!currentListed && history.some((check) => check.status !== "completed")) {
     throw new Error("A different active controller check exists before dispatch");
   }
-  if (currentListed) {
-    try {
-      assertCurrentPreDispatchCheck(history, options);
-    } catch {
-      await requireDirectPreDispatchCheck(options);
-    }
-  } else {
-    await requireDirectPreDispatchCheck(options);
-  }
+  await requireBoundedDirectPreDispatchCheck(options);
   const historicalChecks = currentListed ? history.slice(0, -1) : history;
   const receipts = historicalChecks.flatMap((check) => {
     if (retryableFailureReason(check) !== "dispatch-not-observed") return [];
@@ -2310,15 +2313,7 @@ async function recheckDispatchHistoryBeforePost(options: {
     if (!confirmedCurrentListed && confirmedHistory.some((check) => check.status !== "completed")) {
       throw new Error("A different active controller check appeared before dispatch");
     }
-    if (confirmedCurrentListed) {
-      try {
-        assertCurrentPreDispatchCheck(confirmedHistory, options);
-      } catch {
-        await requireDirectPreDispatchCheck(options);
-      }
-    } else {
-      await requireDirectPreDispatchCheck(options);
-    }
+    await requireBoundedDirectPreDispatchCheck(options);
   }
 }
 
@@ -2456,15 +2451,7 @@ export async function dispatchPrGate(options: {
           if (!currentListed && history.some((check) => check.status !== "completed")) {
             throw new Error("A different active controller check exists before child adoption");
           }
-          if (currentListed) {
-            try {
-              assertCurrentPreDispatchCheck(history, options);
-            } catch {
-              await requireDirectPreDispatchCheck({ ...options, signal });
-            }
-          } else {
-            await requireDirectPreDispatchCheck({ ...options, signal });
-          }
+          await requireDirectPreDispatchCheck({ ...options, signal });
         },
       );
     } catch (error) {

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -11,7 +11,7 @@ import { pathToFileURL } from "node:url";
 
 import YAML from "yaml";
 
-import { githubApi, githubRestPaginated } from "../advisors/github.mts";
+import { githubApi, githubApiWithResponse, githubRestPaginated } from "../advisors/github.mts";
 import { parseArgs } from "../advisors/io.mts";
 import {
   buildRiskPlan,
@@ -33,6 +33,14 @@ import {
   workflowJobEvidenceFingerprint,
 } from "./hosted-runner-loss-github.mts";
 import {
+  assertDispatchStillNotObserved,
+  DispatchNotObservedError,
+  DispatchReconciliationError,
+  dispatchWorkflowWithReconciliation,
+  validateWorkflowDispatchDetails,
+} from "./pr-e2e-dispatch-reconciliation.mts";
+import {
+  dispatchNotObservedReceiptFromSummary,
   type RetryableFailureReason,
   retryableFailureMarker,
   retryableFailureReason,
@@ -53,6 +61,7 @@ export {
   listNonPassingWorkflowJobs,
   workflowJobEvidenceFingerprint,
 } from "./hosted-runner-loss-github.mts";
+export { validateWorkflowDispatchDetails } from "./pr-e2e-dispatch-reconciliation.mts";
 
 const E2E_WORKFLOW = "e2e.yaml";
 const E2E_WORKFLOW_PATH = `.github/workflows/${E2E_WORKFLOW}`;
@@ -66,6 +75,9 @@ const RESERVED_CHECK_SUMMARY =
   "This PR SHA and base SHA are reserved for deterministic E2E planning after CI completes.";
 const CONTROL_PLANE_AUTHORIZATION_TITLE = "E2E reviewer authorization required to run E2E";
 const FORK_E2E_AUTHORIZATION_TITLE = "E2E reviewer authorization required to run fork E2E";
+const RECONCILED_CHILD_VALIDATION_TIMEOUT_MS = 10_000;
+const CHILD_AUTHORIZATION_PUBLISH_TIMEOUT_MS = 5_000;
+const CHILD_CANCELLATION_TIMEOUT_MS = 5_000;
 const CHECK_EXTERNAL_ID_PREFIX = "nemoclaw-pr-e2e:v2";
 const LEGACY_CHECK_EXTERNAL_ID_PREFIX = "nemoclaw-pr-e2e:v1";
 const CHECK_EXTERNAL_ID_PATTERN =
@@ -268,12 +280,6 @@ type CollaboratorPermission = {
   role_name?: string;
   permission?: string;
   user?: { login?: string };
-};
-
-type WorkflowDispatchDetails = {
-  workflow_run_id: number;
-  run_url: string;
-  html_url: string;
 };
 
 type WorkflowRunIdentity = {
@@ -1004,12 +1010,13 @@ async function listPrGateChecks(options: {
   repository: string;
   token: string;
   headSha: string;
+  signal?: AbortSignal;
 }): Promise<CheckRun[]> {
   const response = validateCheckRunsResponse(
     await githubApi<unknown>(
       `repos/${options.repository}/commits/${options.headSha}/check-runs?check_name=${encodeURIComponent(CHECK_NAME)}&filter=all&per_page=100`,
       options.token,
-      { userAgent: USER_AGENT },
+      { userAgent: USER_AGENT, signal: options.signal },
     ),
   );
   return response.check_runs.filter(
@@ -1123,6 +1130,7 @@ async function matchingPrGateHistory(options: {
   headSha: string;
   baseSha: string;
   prNumber: number;
+  signal?: AbortSignal;
 }): Promise<CheckRun[]> {
   const externalId = prGateExternalId(options.prNumber, options.headSha, options.baseSha);
   const sameIdentity = (await listPrGateChecks(options)).filter(
@@ -1372,32 +1380,110 @@ async function updateRunningCheck(
   const selectionCount = options.jobs.length + options.targets.length;
   const title = `Running ${selectionCount} E2E ${selectionCount === 1 ? "check" : "checks"}`;
   const summary = `Risk plan ${options.planHash} selected jobs: ${options.jobs.join(", ") || "none"}; targets: ${options.targets.join(", ") || "none"}. Child run: ${childRunUrl}.`;
-  const check = await githubApi<unknown>(
-    `repos/${context.repository}/check-runs/${context.checkRunId}`,
-    token,
-    {
-      method: "PATCH",
-      body: {
-        status: "in_progress",
-        details_url: childRunUrl,
-        output: {
-          title,
-          summary,
-        },
-      },
-      userAgent: USER_AGENT,
-    },
-  );
-  validatePrGateMutationResponse(check, {
-    checkRunId: context.checkRunId,
-    status: "in_progress",
-    conclusion: null,
-    prNumber: context.prNumber,
-    headSha: context.headSha,
-    baseSha: context.baseSha,
-    title,
-    summary,
-  });
+  const validatePublishedCheck = (value: unknown): void => {
+    const check = validatePrGateMutationResponse(value, {
+      checkRunId: context.checkRunId,
+      status: "in_progress",
+      conclusion: null,
+      prNumber: context.prNumber,
+      headSha: context.headSha,
+      baseSha: context.baseSha,
+      title,
+      summary,
+    });
+    if (check.details_url !== childRunUrl) {
+      throw new Error("GitHub did not bind the controller check to the selected child run");
+    }
+  };
+  try {
+    validatePublishedCheck(
+      await boundedControllerOperation(
+        "Child authorization publication",
+        CHILD_AUTHORIZATION_PUBLISH_TIMEOUT_MS,
+        (signal) =>
+          githubApi<unknown>(
+            `repos/${context.repository}/check-runs/${context.checkRunId}`,
+            token,
+            {
+              method: "PATCH",
+              body: {
+                status: "in_progress",
+                details_url: childRunUrl,
+                output: {
+                  title,
+                  summary,
+                },
+              },
+              userAgent: USER_AGENT,
+              signal,
+            },
+          ),
+      ),
+    );
+    return;
+  } catch (publicationError) {
+    try {
+      validatePublishedCheck(
+        await boundedControllerOperation(
+          "Child authorization confirmation",
+          CHILD_AUTHORIZATION_PUBLISH_TIMEOUT_MS,
+          (signal) =>
+            githubApi<unknown>(
+              `repos/${context.repository}/check-runs/${context.checkRunId}`,
+              token,
+              { userAgent: USER_AGENT, signal },
+            ),
+        ),
+      );
+      return;
+    } catch (confirmationError) {
+      const revocationTitle = "Child authorization publication was not confirmed";
+      const revocationSummary = `The controller could not confirm authorization for [child run ${options.childRunId}](${childRunUrl}). Coordination was closed before child cancellation.`;
+      try {
+        const revoked = await boundedControllerOperation(
+          "Child authorization revocation",
+          CHILD_AUTHORIZATION_PUBLISH_TIMEOUT_MS,
+          (signal) =>
+            githubApi<unknown>(
+              `repos/${context.repository}/check-runs/${context.checkRunId}`,
+              token,
+              {
+                method: "PATCH",
+                body: {
+                  status: "completed",
+                  conclusion: "failure",
+                  completed_at: new Date().toISOString(),
+                  details_url: childRunUrl,
+                  output: {
+                    title: revocationTitle,
+                    summary: revocationSummary,
+                  },
+                },
+                userAgent: USER_AGENT,
+                signal,
+              },
+            ),
+        );
+        validatePrGateMutationResponse(revoked, {
+          checkRunId: context.checkRunId,
+          status: "completed",
+          conclusion: "failure",
+          prNumber: context.prNumber,
+          headSha: context.headSha,
+          baseSha: context.baseSha,
+          title: revocationTitle,
+          summary: revocationSummary,
+        });
+      } catch (revocationError) {
+        throw new Error(
+          `${controllerErrorMessage(publicationError)}; authorization confirmation failed: ${controllerErrorMessage(confirmationError)}; authorization revocation failed: ${controllerErrorMessage(revocationError)}`,
+        );
+      }
+      throw new Error(
+        `${controllerErrorMessage(publicationError)}; authorization confirmation failed: ${controllerErrorMessage(confirmationError)}; authorization revocation requested`,
+      );
+    }
+  }
 }
 
 function controllerErrorMessage(error: unknown): string {
@@ -1411,6 +1497,26 @@ function controllerErrorMessage(error: unknown): string {
     : singleLine;
 }
 
+async function boundedControllerOperation<T>(
+  label: string,
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([operation(controller.signal), timeout]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
 async function completeFailureAfterControllerError(
   context: { repository: string; checkRunId: number },
   token: string,
@@ -1420,6 +1526,7 @@ async function completeFailureAfterControllerError(
     detailsUrl?: string;
     recovery?: string;
     retryableFailureReason?: RetryableFailureReason;
+    receiptMarker?: string;
   },
 ): Promise<boolean> {
   const reason = controllerErrorMessage(options.error).replace(/`/gu, "'");
@@ -1434,6 +1541,7 @@ async function completeFailureAfterControllerError(
           "The controller could not complete the check.",
           options.recovery,
           `Controller error: \`${reason}\``,
+          options.receiptMarker,
         ]
           .filter((paragraph): paragraph is string => Boolean(paragraph))
           .join("\n\n"),
@@ -1446,6 +1554,20 @@ async function completeFailureAfterControllerError(
     console.error(`Failed to close check after controller error: ${controllerErrorMessage(error)}`);
     return false;
   }
+}
+
+async function completeDispatchNotObserved(
+  context: { repository: string; checkRunId: number },
+  token: string,
+  error: DispatchNotObservedError,
+): Promise<boolean> {
+  return completeFailureAfterControllerError(context, token, "Workflow dispatch was not observed", {
+    error,
+    recovery:
+      "GitHub accepted no observable child run during the bounded reconciliation window. A later controller may create a fresh check and correlation only after rechecking this receipt.",
+    retryableFailureReason: "dispatch-not-observed",
+    receiptMarker: error.marker(),
+  });
 }
 
 function validatePullRequestIdentity(
@@ -1503,6 +1625,7 @@ async function requireLiveExactDiff(options: {
   prNumber: number;
   headSha: string;
   baseSha: string;
+  signal?: AbortSignal;
 }): Promise<PullRequest> {
   const pull = validatePullRequest(
     await githubApi<unknown>(
@@ -1510,6 +1633,7 @@ async function requireLiveExactDiff(options: {
       options.token,
       {
         userAgent: USER_AGENT,
+        signal: options.signal,
       },
     ),
     { allowClosed: true },
@@ -1912,23 +2036,6 @@ export function expectedSignalShards(
   };
 }
 
-export function validateWorkflowDispatchDetails(
-  value: unknown,
-  repository: string,
-): WorkflowDispatchDetails {
-  if (!isObjectRecord(value)) throw new Error("GitHub returned invalid workflow dispatch details");
-  const runId = value.workflow_run_id;
-  if (!Number.isSafeInteger(runId) || (runId as number) < 1) {
-    throw new Error("GitHub returned an invalid dispatched workflow run id");
-  }
-  const expectedApiUrl = `https://api.github.com/repos/${repository}/actions/runs/${runId}`;
-  const expectedHtmlUrl = `https://github.com/${repository}/actions/runs/${runId}`;
-  if (value.run_url !== expectedApiUrl || value.html_url !== expectedHtmlUrl) {
-    throw new Error("GitHub returned mismatched workflow dispatch URLs");
-  }
-  return value as WorkflowDispatchDetails;
-}
-
 function validateMainReference(value: unknown): string {
   if (
     !isObjectRecord(value) ||
@@ -2079,6 +2186,142 @@ async function requireUnchangedCompletedWorkflowRun(
   }
 }
 
+function isValidExpectedPreDispatchTitle(title: string): boolean {
+  const authorizationPrefix = "E2E execution authorized by @";
+  return (
+    title === "Evaluating PR commit" ||
+    title === "Preparing one-time hosted-runner-loss retry" ||
+    (title.startsWith(authorizationPrefix) &&
+      MAINTAINER_PATTERN.test(title.slice(authorizationPrefix.length)))
+  );
+}
+
+function assertCurrentPreDispatchCheck(
+  history: readonly CheckRun[],
+  options: { repository: string; controllerCheckId: number; expectedCheckTitle: string },
+): void {
+  const current = history.at(-1);
+  const canonicalCheckUrl = `https://github.com/${options.repository}/runs/${options.controllerCheckId}`;
+  if (
+    current?.id !== options.controllerCheckId ||
+    current.status !== "in_progress" ||
+    current.conclusion !== null ||
+    current.output?.title !== options.expectedCheckTitle ||
+    (current.details_url !== undefined &&
+      current.details_url !== null &&
+      current.details_url !== canonicalCheckUrl)
+  ) {
+    throw new Error("Controller check is not in the exact pre-dispatch state");
+  }
+}
+
+async function requireDirectPreDispatchCheck(options: {
+  repository: string;
+  token: string;
+  controllerCheckId: number;
+  prNumber: number;
+  commitSha: string;
+  baseSha: string;
+  expectedCheckTitle: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const value = await githubApi<unknown>(
+    `repos/${options.repository}/check-runs/${options.controllerCheckId}`,
+    options.token,
+    { userAgent: USER_AGENT, signal: options.signal },
+  );
+  if (!isObjectRecord(value) || value.id !== options.controllerCheckId) {
+    throw new Error("GitHub returned an invalid current controller check");
+  }
+  const check = value as CheckRun;
+  if (
+    check.name !== CHECK_NAME ||
+    check.head_sha !== options.commitSha ||
+    check.external_id !== prGateExternalId(options.prNumber, options.commitSha, options.baseSha) ||
+    check.app?.id !== GITHUB_ACTIONS_APP_ID
+  ) {
+    throw new Error("Current controller check identity changed before dispatch");
+  }
+  assertCurrentPreDispatchCheck([check], options);
+}
+
+async function recheckDispatchHistoryBeforePost(options: {
+  repository: string;
+  token: string;
+  controllerCheckId: number;
+  prNumber: number;
+  commitSha: string;
+  baseSha: string;
+  expectedCheckTitle: string;
+}): Promise<void> {
+  const historyOptions = {
+    repository: options.repository,
+    token: options.token,
+    headSha: options.commitSha,
+    baseSha: options.baseSha,
+    prNumber: options.prNumber,
+  };
+  const history = await matchingPrGateHistory(historyOptions);
+  const currentListed = history.at(-1)?.id === options.controllerCheckId;
+  if (!currentListed && history.some((check) => check.status !== "completed")) {
+    throw new Error("A different active controller check exists before dispatch");
+  }
+  if (currentListed) {
+    try {
+      assertCurrentPreDispatchCheck(history, options);
+    } catch {
+      await requireDirectPreDispatchCheck(options);
+    }
+  } else {
+    await requireDirectPreDispatchCheck(options);
+  }
+  const historicalChecks = currentListed ? history.slice(0, -1) : history;
+  const receipts = historicalChecks.flatMap((check) => {
+    if (retryableFailureReason(check) !== "dispatch-not-observed") return [];
+    const summary = check.output?.summary;
+    const receipt =
+      typeof summary === "string" ? dispatchNotObservedReceiptFromSummary(summary) : undefined;
+    if (!receipt) {
+      throw new Error("Dispatch-not-observed history has an invalid receipt");
+    }
+    return [receipt];
+  });
+  for (const receipt of receipts) {
+    await assertDispatchStillNotObserved({
+      repository: options.repository,
+      token: options.token,
+      prNumber: options.prNumber,
+      receipt,
+    });
+  }
+  if (receipts.length > 0) {
+    const confirmedHistory = await matchingPrGateHistory(historyOptions);
+    const originalIds = history.map((check) => check.id);
+    const confirmedIds = confirmedHistory.map((check) => check.id);
+    const currentBecameVisible =
+      !currentListed &&
+      confirmedIds.length === originalIds.length + 1 &&
+      confirmedIds.at(-1) === options.controllerCheckId &&
+      JSON.stringify(confirmedIds.slice(0, -1)) === JSON.stringify(originalIds);
+    if (JSON.stringify(confirmedIds) !== JSON.stringify(originalIds) && !currentBecameVisible) {
+      throw new Error("Controller check history changed during dispatch reconciliation");
+    }
+    const confirmedCurrentListed = confirmedHistory.at(-1)?.id === options.controllerCheckId;
+    if (!confirmedCurrentListed && confirmedHistory.some((check) => check.status !== "completed")) {
+      throw new Error("A different active controller check appeared before dispatch");
+    }
+    if (confirmedCurrentListed) {
+      try {
+        assertCurrentPreDispatchCheck(confirmedHistory, options);
+      } catch {
+        await requireDirectPreDispatchCheck(options);
+      }
+    } else {
+      await requireDirectPreDispatchCheck(options);
+    }
+  }
+}
+
 export async function dispatchPrGate(options: {
   repository: string;
   checkoutRepository: string;
@@ -2092,6 +2335,7 @@ export async function dispatchPrGate(options: {
   workflowSha: string;
   planHash: string;
   correlationId: string;
+  expectedCheckTitle: string;
 }): Promise<{ runId: number; workflowSha: string }> {
   assertRepository(options.repository, "repository");
   assertRepository(options.checkoutRepository, "checkout repository");
@@ -2112,7 +2356,8 @@ export async function dispatchPrGate(options: {
     !SHA_PATTERN.test(options.baseSha) ||
     !SHA_PATTERN.test(options.workflowSha) ||
     !HASH_PATTERN.test(options.planHash) ||
-    !CORRELATION_PATTERN.test(options.correlationId)
+    !CORRELATION_PATTERN.test(options.correlationId) ||
+    !isValidExpectedPreDispatchTitle(options.expectedCheckTitle)
   ) {
     throw new Error("Controller dispatch inputs are invalid");
   }
@@ -2121,40 +2366,137 @@ export async function dispatchPrGate(options: {
     options.token,
     options.workflowSha,
   );
-  const details = await githubApi<unknown>(
-    `repos/${options.repository}/actions/workflows/${E2E_WORKFLOW}/dispatches`,
-    options.token,
-    {
-      method: "POST",
-      body: {
-        ref: "main",
-        inputs: {
-          jobs: options.jobs.join(","),
-          targets: targets.join(","),
-          controller_check_id: String(options.controllerCheckId),
-          pr_number: String(options.prNumber),
-          checkout_sha: options.commitSha,
-          checkout_repository: options.checkoutRepository,
-          base_sha: options.baseSha,
-          workflow_sha: workflowSha,
-          plan_hash: options.planHash,
-          correlation_id: options.correlationId,
+  await recheckDispatchHistoryBeforePost(options);
+  const dispatch = await dispatchWorkflowWithReconciliation({
+    repository: options.repository,
+    token: options.token,
+    workflowSha,
+    correlationId: options.correlationId,
+    prNumber: options.prNumber,
+    dispatch: (signal) =>
+      githubApiWithResponse<unknown>(
+        `repos/${options.repository}/actions/workflows/${E2E_WORKFLOW}/dispatches`,
+        options.token,
+        {
+          method: "POST",
+          body: {
+            ref: "main",
+            inputs: {
+              jobs: options.jobs.join(","),
+              targets: targets.join(","),
+              controller_check_id: String(options.controllerCheckId),
+              pr_number: String(options.prNumber),
+              checkout_sha: options.commitSha,
+              checkout_repository: options.checkoutRepository,
+              base_sha: options.baseSha,
+              workflow_sha: workflowSha,
+              plan_hash: options.planHash,
+              correlation_id: options.correlationId,
+            },
+            return_run_details: true,
+          },
+          userAgent: USER_AGENT,
+          signal,
         },
-        return_run_details: true,
-      },
-      userAgent: USER_AGENT,
-    },
-  );
-  const runId = validateWorkflowDispatchDetails(details, options.repository).workflow_run_id;
-  return { runId, workflowSha };
+      ),
+  }).catch(async (error: unknown) => {
+    if (!(error instanceof DispatchReconciliationError) || error.candidateRunIds.length === 0) {
+      throw error;
+    }
+    const cancellationFailures = (
+      await Promise.all(
+        error.candidateRunIds.map(async (runId) => {
+          try {
+            await cancelChildRun(options.repository, options.token, runId);
+            return undefined;
+          } catch (cancelError) {
+            return `run ${runId}: ${controllerErrorMessage(cancelError)}`;
+          }
+        }),
+      )
+    ).filter((failure): failure is string => failure !== undefined);
+    if (cancellationFailures.length > 0) {
+      throw new DispatchReconciliationError(
+        `${error.message}; candidate cancellation failed: ${cancellationFailures.join("; ")}`,
+        error.candidateRunIds,
+        error,
+      );
+    }
+    console.warn(
+      `Workflow dispatch reconciliation cleanup: correlation=${options.correlationId} candidate_runs=${error.candidateRunIds.join(",")} cancellation=requested`,
+    );
+    throw error;
+  });
+  if (dispatch.source === "workflow-run-inventory") {
+    try {
+      await boundedControllerOperation(
+        "Reconciled child validation",
+        RECONCILED_CHILD_VALIDATION_TIMEOUT_MS,
+        async (signal) => {
+          const pull = await requireLiveExactDiff({
+            repository: options.repository,
+            token: options.token,
+            prNumber: options.prNumber,
+            headSha: options.commitSha,
+            baseSha: options.baseSha,
+            signal,
+          });
+          if (pull.head.repo?.full_name !== options.checkoutRepository) {
+            throw new Error("PR head repository changed before child adoption");
+          }
+          const history = await matchingPrGateHistory({
+            repository: options.repository,
+            token: options.token,
+            headSha: options.commitSha,
+            baseSha: options.baseSha,
+            prNumber: options.prNumber,
+            signal,
+          });
+          const currentListed = history.at(-1)?.id === options.controllerCheckId;
+          if (!currentListed && history.some((check) => check.status !== "completed")) {
+            throw new Error("A different active controller check exists before child adoption");
+          }
+          if (currentListed) {
+            try {
+              assertCurrentPreDispatchCheck(history, options);
+            } catch {
+              await requireDirectPreDispatchCheck({ ...options, signal });
+            }
+          } else {
+            await requireDirectPreDispatchCheck({ ...options, signal });
+          }
+        },
+      );
+    } catch (error) {
+      try {
+        await cancelChildRun(options.repository, options.token, dispatch.runId);
+      } catch (cancelError) {
+        throw new DispatchedChildRunError(
+          `${controllerErrorMessage(error)}; reconciled child cancellation failed: ${controllerErrorMessage(cancelError)}`,
+          dispatch.runId,
+        );
+      }
+      throw new DispatchedChildRunError(
+        `${controllerErrorMessage(error)}; reconciled child cancellation requested`,
+        dispatch.runId,
+      );
+    }
+  }
+  return { runId: dispatch.runId, workflowSha };
 }
 
 async function cancelChildRun(repository: string, token: string, runId: number): Promise<void> {
   try {
-    await githubApi(`repos/${repository}/actions/runs/${runId}/cancel`, token, {
-      method: "POST",
-      userAgent: USER_AGENT,
-    });
+    await boundedControllerOperation(
+      "Child cancellation",
+      CHILD_CANCELLATION_TIMEOUT_MS,
+      (signal) =>
+        githubApi(`repos/${repository}/actions/runs/${runId}/cancel`, token, {
+          method: "POST",
+          userAgent: USER_AGENT,
+          signal,
+        }),
+    );
   } catch (error) {
     if (/failed: 409\b/u.test(controllerErrorMessage(error))) return;
     throw error;
@@ -2309,6 +2651,7 @@ async function dispatchSelectedPrGate(options: {
   workflowSha: string;
   plan: RiskPlan;
   checkRunId: number;
+  expectedCheckTitle: string;
   paths: ControllerPaths;
 }): Promise<void> {
   const jobs = riskPlanRequiredJobIds(options.plan);
@@ -2335,6 +2678,7 @@ async function dispatchSelectedPrGate(options: {
     workflowSha: options.workflowSha,
     planHash: options.plan.planHash,
     correlationId,
+    expectedCheckTitle: options.expectedCheckTitle,
   });
   const childRunId = dispatch.runId;
   try {
@@ -2415,6 +2759,7 @@ async function dispatchRunnerLossRetry(options: {
     workflowSha: options.state.workflowSha,
     planHash: options.state.planHash,
     correlationId,
+    expectedCheckTitle: "Preparing one-time hosted-runner-loss retry",
   });
   const childRunId = dispatch.runId;
   try {
@@ -2663,19 +3008,26 @@ export async function retryRunnerLossPrGate(
   } catch (error) {
     if (retryCheckRunId !== undefined) {
       const retryRunId = error instanceof DispatchedChildRunError ? error.childRunId : undefined;
-      const closed = await completeFailureAfterControllerError(
-        { repository, checkRunId: retryCheckRunId },
-        token,
-        "Runner-loss retry could not start",
-        {
-          error,
-          detailsUrl: retryRunId
-            ? `https://github.com/${repository}/actions/runs/${retryRunId}`
-            : originalRunUrl,
-          recovery:
-            "The original runner-loss evidence remains linked. This exact PR/base SHA pair will not receive another automatic retry.",
-        },
-      );
+      const closed =
+        error instanceof DispatchNotObservedError
+          ? await completeDispatchNotObserved(
+              { repository, checkRunId: retryCheckRunId },
+              token,
+              error,
+            )
+          : await completeFailureAfterControllerError(
+              { repository, checkRunId: retryCheckRunId },
+              token,
+              "Runner-loss retry could not start",
+              {
+                error,
+                detailsUrl: retryRunId
+                  ? `https://github.com/${repository}/actions/runs/${retryRunId}`
+                  : originalRunUrl,
+                recovery:
+                  "The original runner-loss evidence remains linked. This exact PR/base SHA pair will not receive another automatic retry.",
+              },
+            );
       if (closed) appendOutput("finalized", "true");
     }
     throw error;
@@ -2745,6 +3097,20 @@ export async function startPrGate(
     throw new Error("PR repository or branch does not match the triggering CI run");
   }
   assertCheckCanStart(existingChecks[0], command.ciConclusion);
+  if (retryableFailureReason(existingChecks[0] ?? {}) === "dispatch-not-observed") {
+    const summary = existingChecks[0]?.output?.summary;
+    const receipt =
+      typeof summary === "string" ? dispatchNotObservedReceiptFromSummary(summary) : undefined;
+    if (!receipt) {
+      throw new Error("Dispatch-not-observed retry history has an invalid receipt");
+    }
+    await assertDispatchStillNotObserved({
+      repository,
+      token,
+      prNumber: ciIdentity.prNumber,
+      receipt,
+    });
+  }
   if (existingCheckRunId) appendOutput("check_id", String(existingCheckRunId));
   const checkRunId = await ensurePrGateCheck({
     repository,
@@ -2934,16 +3300,20 @@ export async function startPrGate(
       workflowSha: command.workflowSha,
       plan,
       checkRunId,
+      expectedCheckTitle: "Evaluating PR commit",
       paths: command,
     });
   } catch (error) {
     if (!finalized) {
-      const closed = await completeFailureAfterControllerError(
-        { repository, checkRunId },
-        token,
-        "Run could not start",
-        { error },
-      );
+      const closed =
+        error instanceof DispatchNotObservedError
+          ? await completeDispatchNotObserved({ repository, checkRunId }, token, error)
+          : await completeFailureAfterControllerError(
+              { repository, checkRunId },
+              token,
+              "Run could not start",
+              { error },
+            );
       if (closed) appendOutput("finalized", "true");
     }
     throw error;
@@ -3065,20 +3435,33 @@ async function startAuthorizedPrGate(
       workflowSha: command.workflowSha,
       plan,
       checkRunId,
+      expectedCheckTitle: `E2E execution authorized by @${command.maintainer}`,
       paths: command,
     });
   } catch (error) {
     if (checkRunId) {
-      if (error instanceof DispatchedChildRunError) {
+      if (error instanceof DispatchNotObservedError) {
+        const closed = await completeDispatchNotObserved({ repository, checkRunId }, token, error);
+        if (closed) appendOutput("finalized", "true");
+      } else if (
+        error instanceof DispatchedChildRunError ||
+        error instanceof DispatchReconciliationError
+      ) {
+        const candidateRunId =
+          error instanceof DispatchedChildRunError ? error.childRunId : error.candidateRunIds[0];
         const closed = await completeFailureAfterControllerError(
           { repository, checkRunId },
           token,
           "Authorized E2E run requires reconciliation",
           {
             error,
-            detailsUrl: `https://github.com/${repository}/actions/runs/${error.childRunId}`,
+            detailsUrl: candidateRunId
+              ? `https://github.com/${repository}/actions/runs/${candidateRunId}`
+              : undefined,
             recovery:
-              "A credential-bearing child run was dispatched, so this authorization for the PR/base SHA pair cannot be retried. Inspect the linked run, then update the PR and run fresh CI before authorizing again.",
+              error instanceof DispatchedChildRunError
+                ? "A credential-bearing child run was dispatched, so this authorization for the PR/base SHA pair cannot be retried. Inspect the linked run, then update the PR and run fresh CI before authorizing again."
+                : "A credential-bearing child run may have been dispatched, so this authorization for the PR/base SHA pair cannot be reused. Inspect any candidate runs, then update the PR and run fresh CI before authorizing again.",
           },
         );
         if (closed) appendOutput("finalized", "true");

--- a/tools/e2e/pr-e2e-required.mts
+++ b/tools/e2e/pr-e2e-required.mts
@@ -6,23 +6,11 @@ import { pathToFileURL } from "node:url";
 
 import { githubApi } from "../advisors/github.mts";
 import { parseArgs } from "../advisors/io.mts";
+import { retryableFailureReason } from "./pr-e2e-retry-receipt.mts";
 
 const COORDINATION_CHECK_NAME = "E2E / PR Gate Coordination";
 const LEGACY_COORDINATION_CHECK_NAME = "E2E / PR Gate";
 const EXTERNAL_ID_PREFIX = "nemoclaw-pr-e2e:v2";
-const RETRYABLE_FAILURE_MARKER_PREFIX = "<!-- nemoclaw-pr-e2e-retry:v1:";
-const RETRYABLE_FAILURE_MARKER_SUFFIX = " -->";
-const RETRYABLE_FAILURE_REASONS = new Set([
-  "prerequisite-ci",
-  "child-cancelled",
-  "evidence-download",
-]);
-const NEVER_RETRY_FAILURE_TITLES = new Set([
-  "Authorized E2E run requires reconciliation",
-  "PR base changed",
-  "Controller stopped early",
-  "Run could not start",
-]);
 const GITHUB_ACTIONS_APP_ID = 15368;
 const USER_AGENT = "nemoclaw-pr-e2e-required";
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
@@ -240,26 +228,6 @@ export async function retryableGithubRead<T>(
   throw new Error("GitHub read retry loop ended unexpectedly");
 }
 
-function hasRetryableFailureMarker(check: CoordinationCheckRun): boolean {
-  if (check.status !== "completed" || check.conclusion !== "failure") return false;
-  if (NEVER_RETRY_FAILURE_TITLES.has(check.output?.title ?? "")) return false;
-  const summary = check.output?.summary;
-  if (typeof summary !== "string") return false;
-  const markerBoundary = `\n\n${RETRYABLE_FAILURE_MARKER_PREFIX}`;
-  const markerStart = summary.lastIndexOf(markerBoundary);
-  if (markerStart < 0) return false;
-  const marker = summary.slice(markerStart + 2);
-  if (!marker.endsWith(RETRYABLE_FAILURE_MARKER_SUFFIX)) return false;
-  const reason = marker.slice(
-    RETRYABLE_FAILURE_MARKER_PREFIX.length,
-    -RETRYABLE_FAILURE_MARKER_SUFFIX.length,
-  );
-  return (
-    RETRYABLE_FAILURE_REASONS.has(reason) &&
-    marker === `${RETRYABLE_FAILURE_MARKER_PREFIX}${reason}${RETRYABLE_FAILURE_MARKER_SUFFIX}`
-  );
-}
-
 function currentCoordinationCheck(
   checks: CoordinationCheckRun[],
 ): CoordinationCheckRun | undefined {
@@ -271,7 +239,7 @@ function currentCoordinationCheck(
   const active = ordered.filter((check) => check.status !== "completed");
   if (active.length > 1)
     throw new Error("Multiple active coordination checks exist for one PR/base SHA pair");
-  if (ordered.slice(0, -1).some((check) => !hasRetryableFailureMarker(check))) {
+  if (ordered.slice(0, -1).some((check) => retryableFailureReason(check) === undefined)) {
     throw new Error(
       "Coordination history contains a non-retryable older check for one PR/base SHA pair",
     );
@@ -404,7 +372,7 @@ export function classifyCoordinationCheck(
   if (check.status !== "completed") {
     return { state: "waiting", description: title, ...links };
   }
-  if (check.conclusion === "failure" && hasRetryableFailureMarker(check)) {
+  if (check.conclusion === "failure" && retryableFailureReason(check) !== undefined) {
     return { state: "waiting", description: title, ...links };
   }
   if (

--- a/tools/e2e/pr-e2e-retry-receipt.mts
+++ b/tools/e2e/pr-e2e-retry-receipt.mts
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const RETRYABLE_FAILURE_MARKER_PREFIX = "<!-- nemoclaw-pr-e2e-retry:v1:";
+const RETRYABLE_FAILURE_MARKER_SUFFIX = " -->";
+const DISPATCH_RECEIPT_MARKER_PREFIX = "<!-- nemoclaw-pr-e2e-dispatch:v1:";
+const DISPATCH_RECEIPT_MARKER_SUFFIX = " -->";
+const MAX_DISPATCH_RECEIPT_BYTES = 1024;
+const MAX_DISPATCH_RECONCILIATION_WINDOW_MS = 120_000;
+const SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const CORRELATION_PATTERN =
+  /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/u;
+const GITHUB_REQUEST_ID_PATTERN = /^[A-Za-z0-9:-]{1,128}$/u;
+const RETRYABLE_FAILURE_REASONS = new Set([
+  "prerequisite-ci",
+  "child-cancelled",
+  "evidence-download",
+  "dispatch-not-observed",
+] as const);
+const DISPATCH_FAILURE_KINDS = new Set(["http", "decode", "transport", "validation"] as const);
+const NEVER_RETRY_FAILURE_TITLES = new Set([
+  "Authorized E2E run requires reconciliation",
+  "PR base changed",
+  "Controller stopped early",
+  "Run could not start",
+]);
+
+export type RetryableFailureReason =
+  | "prerequisite-ci"
+  | "child-cancelled"
+  | "evidence-download"
+  | "dispatch-not-observed";
+
+export type DispatchFailureKind = "http" | "decode" | "transport" | "validation";
+
+export type DispatchNotObservedReceipt = {
+  correlationId: string;
+  workflowSha: string;
+  sentAtMs: number;
+  deadlineAtMs: number;
+  result: "not-observed";
+  failureKind: DispatchFailureKind;
+  status?: number;
+  requestId?: string;
+};
+
+type RetryableCheck = {
+  status?: string;
+  conclusion?: string | null;
+  output?: { title?: string | null; summary?: string | null };
+};
+
+function canonicalReceipt(receipt: DispatchNotObservedReceipt): DispatchNotObservedReceipt {
+  return {
+    correlationId: receipt.correlationId,
+    workflowSha: receipt.workflowSha,
+    sentAtMs: receipt.sentAtMs,
+    deadlineAtMs: receipt.deadlineAtMs,
+    result: "not-observed",
+    failureKind: receipt.failureKind,
+    ...(receipt.status === undefined ? {} : { status: receipt.status }),
+    ...(receipt.requestId === undefined ? {} : { requestId: receipt.requestId }),
+  };
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+function validateDispatchReceipt(value: unknown): DispatchNotObservedReceipt {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("dispatch receipt must be an object");
+  }
+  const receipt = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "correlationId",
+    "workflowSha",
+    "sentAtMs",
+    "deadlineAtMs",
+    "result",
+    "failureKind",
+    "status",
+    "requestId",
+  ]);
+  if (Object.keys(receipt).some((key) => !allowedKeys.has(key))) {
+    throw new Error("dispatch receipt contains an unexpected field");
+  }
+  if (
+    typeof receipt.correlationId !== "string" ||
+    !CORRELATION_PATTERN.test(receipt.correlationId) ||
+    typeof receipt.workflowSha !== "string" ||
+    !SHA_PATTERN.test(receipt.workflowSha) ||
+    !isPositiveSafeInteger(receipt.sentAtMs) ||
+    !isPositiveSafeInteger(receipt.deadlineAtMs) ||
+    receipt.deadlineAtMs <= receipt.sentAtMs ||
+    receipt.deadlineAtMs - receipt.sentAtMs > MAX_DISPATCH_RECONCILIATION_WINDOW_MS ||
+    receipt.result !== "not-observed" ||
+    typeof receipt.failureKind !== "string" ||
+    !DISPATCH_FAILURE_KINDS.has(receipt.failureKind as DispatchFailureKind) ||
+    (receipt.status !== undefined &&
+      (!Number.isSafeInteger(receipt.status) ||
+        (receipt.status as number) < 100 ||
+        (receipt.status as number) > 599)) ||
+    (receipt.requestId !== undefined &&
+      (typeof receipt.requestId !== "string" || !GITHUB_REQUEST_ID_PATTERN.test(receipt.requestId)))
+  ) {
+    throw new Error("dispatch receipt fields are invalid");
+  }
+  return canonicalReceipt(receipt as DispatchNotObservedReceipt);
+}
+
+export function retryableFailureMarker(reason: RetryableFailureReason): string {
+  return `${RETRYABLE_FAILURE_MARKER_PREFIX}${reason}${RETRYABLE_FAILURE_MARKER_SUFFIX}`;
+}
+
+export function dispatchNotObservedReceiptMarker(receipt: DispatchNotObservedReceipt): string {
+  const validated = validateDispatchReceipt(receipt);
+  const encoded = Buffer.from(JSON.stringify(validated), "utf8").toString("base64url");
+  return `${DISPATCH_RECEIPT_MARKER_PREFIX}${encoded}${DISPATCH_RECEIPT_MARKER_SUFFIX}`;
+}
+
+export function dispatchNotObservedReceiptFromSummary(
+  summary: string,
+): DispatchNotObservedReceipt | undefined {
+  const retryMarker = `\n\n${retryableFailureMarker("dispatch-not-observed")}`;
+  if (!summary.endsWith(retryMarker)) return undefined;
+  const body = summary.slice(0, -retryMarker.length);
+  const receiptBoundary = `\n\n${DISPATCH_RECEIPT_MARKER_PREFIX}`;
+  const receiptStart = body.lastIndexOf(receiptBoundary);
+  if (receiptStart < 0) return undefined;
+  const marker = body.slice(receiptStart + 2);
+  if (
+    !marker.startsWith(DISPATCH_RECEIPT_MARKER_PREFIX) ||
+    !marker.endsWith(DISPATCH_RECEIPT_MARKER_SUFFIX)
+  ) {
+    return undefined;
+  }
+  const encoded = marker.slice(
+    DISPATCH_RECEIPT_MARKER_PREFIX.length,
+    -DISPATCH_RECEIPT_MARKER_SUFFIX.length,
+  );
+  if (!/^[A-Za-z0-9_-]+$/u.test(encoded) || encoded.length > MAX_DISPATCH_RECEIPT_BYTES) {
+    return undefined;
+  }
+  try {
+    const decoded = Buffer.from(encoded, "base64url").toString("utf8");
+    const receipt = validateDispatchReceipt(JSON.parse(decoded));
+    return marker === dispatchNotObservedReceiptMarker(receipt) ? receipt : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function retryableFailureReason(check: RetryableCheck): RetryableFailureReason | undefined {
+  if (check.status !== "completed" || check.conclusion !== "failure") return undefined;
+  if (NEVER_RETRY_FAILURE_TITLES.has(check.output?.title ?? "")) return undefined;
+  const summary = check.output?.summary;
+  if (typeof summary !== "string") return undefined;
+  const markerBoundary = `\n\n${RETRYABLE_FAILURE_MARKER_PREFIX}`;
+  const markerStart = summary.lastIndexOf(markerBoundary);
+  if (markerStart < 0) return undefined;
+  const marker = summary.slice(markerStart + 2);
+  if (!marker.endsWith(RETRYABLE_FAILURE_MARKER_SUFFIX)) return undefined;
+  const reason = marker.slice(
+    RETRYABLE_FAILURE_MARKER_PREFIX.length,
+    -RETRYABLE_FAILURE_MARKER_SUFFIX.length,
+  );
+  if (!RETRYABLE_FAILURE_REASONS.has(reason as RetryableFailureReason)) return undefined;
+  if (marker !== retryableFailureMarker(reason as RetryableFailureReason)) return undefined;
+  if (
+    reason === "dispatch-not-observed" &&
+    dispatchNotObservedReceiptFromSummary(summary) === undefined
+  ) {
+    return undefined;
+  }
+  return reason as RetryableFailureReason;
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

An uncertain GitHub workflow-dispatch response can mean either “no child started” or “the child started but the response was lost.” This change sends exactly one dispatch request, reconciles the result through bounded read-only inventory checks, and prevents a retry from starting duplicate credential-bearing E2E work.

## Related Issue

Fixes #7593.
Part of #7140.

## Changes

- Preserve successful and failed GitHub API response identity, including safe request IDs.
- Record a validated retry receipt only after a complete zero-match reconciliation window.
- Adopt exactly one authenticated correlated child; terminalize ambiguous, incomplete, or identity-invalid results and attempt cancellation for every correlation-bearing run ID.
- Require a bounded authoritative coordination-check read immediately before dispatch and after reconciled adoption, independent of stale list results.
- Reconcile a lost child-authorization update by direct read; otherwise attempt authorization revocation before child cancellation.
- Document the controller and maintainer recovery behavior in the E2E README and merge-gate runbook.

The shared reconciliation path is required because retrying the dispatch POST directly cannot distinguish a rejected request from a successfully accepted request whose response was lost. The PR-E2E reconciliation, gate recovery, protected approval, and runner-loss suites cover this boundary.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes an internal E2E controller; the operational README and maintainer runbook were updated, while end-user behavior under `docs/` is unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent Codex security and code reviews passed at `1876c7683`, including duplicate-dispatch prevention, exact authorization binding, bounded reads, cancellation collection, and failure ordering; `bc1ba2071` and `4b1a1427c` are reviewed guardrail and redundant-import cleanups with no behavior change.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md`; `.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md`. No user-facing `docs/` update is needed because this is internal E2E control-plane behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4b1a1427c -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/github-api.test.ts test/pr-e2e*.test.ts`: 19 files, 306 tests passed
- [x] Applicable broad gate passed — CLI type-check and `npx prek run --from-ref origin/main --to-ref HEAD` passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 existing Fern warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved reliability when starting and reconciling E2E workflow runs.
  * Added stricter validation to prevent incorrect or duplicate workflow launches.
  * Clarified handling of uncertain dispatches, cancellations, retries, and authorization states.
  * Enhanced error details for GitHub API failures while limiting sensitive diagnostic output.

* **Documentation**
  * Updated maintainer and E2E gate guidance with clearer retry, reconciliation, and authorization procedures.

* **Tests**
  * Expanded coverage for dispatch recovery, fork and internal approvals, runner-loss retries, API errors, and terminal failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->