### PR TITLE
test(e2e): cover stale receipt page cap

### DIFF
--- a/test/pr-e2e-dispatch-reconciliation.test.ts
+++ b/test/pr-e2e-dispatch-reconciliation.test.ts
@@ -440,6 +440,11 @@ describe("PR E2E workflow dispatch reconciliation", () => {
       }),
     ).resolves.toBeUndefined();
     expect(api).toHaveBeenCalledTimes(10);
+    expect(
+      api.mock.calls.map(([apiPath]) =>
+        Number(new URL(`https://api.github.com/${apiPath}`).searchParams.get("page")),
+      ),
+    ).toEqual(Array.from({ length: 10 }, (_value, index) => index + 1));
   });
 
   it("blocks replacement when the old correlation appears after the first inventory page", async () => {

--- a/test/pr-e2e-dispatch-reconciliation.test.ts
+++ b/test/pr-e2e-dispatch-reconciliation.test.ts
@@ -426,6 +426,22 @@ describe("PR E2E workflow dispatch reconciliation", () => {
     expect(api).toHaveBeenCalledTimes(2);
   });
 
+  it("accepts a complete stale receipt inventory at GitHub's filtered-result cap", async () => {
+    const runs = Array.from({ length: 1_000 }, (_value, index) =>
+      unrelatedWorkflowRun(index + 100),
+    );
+    const api = paginatedInventoryApi(runs);
+
+    await expect(
+      assertDispatchStillNotObserved(oldReceiptOptions(), {
+        api,
+        now: () => SENT_AT_MS + WINDOW_MS + 2_000,
+        clockSkewMs: 10,
+      }),
+    ).resolves.toBeUndefined();
+    expect(api).toHaveBeenCalledTimes(10);
+  });
+
   it("blocks replacement when the old correlation appears after the first inventory page", async () => {
     const recheckTime = SENT_AT_MS + WINDOW_MS + 2_000;
     const runs = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the exact upper-bound regression requested during review of #7595. A complete stale-receipt inventory containing 1,000 workflow runs across all 10 allowed pages must remain retryable rather than failing from an off-by-one pagination error.

## Related Issue

Follow-up to #7595 and #7594 for #7593.
Part of #7140.

## Changes

- Exercise the inclusive 1,000-run filtered-search cap.
- Require the receipt recheck to consume exactly 10 complete pages.
- Preserve the existing zero-correlation success contract at the boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is a test-only boundary follow-up with no runtime or user-facing behavior change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact product-scope and nine-category security review PASS at `871b933840300068aef3f462a8ecf1d0873209dc` (tree `4e2d18d2833a353776d6936fd22d28f3c95ad2d9`, base `17a8ad1a6979de0b92b25eb93453dbbdf03cf61a`). The diff is test-only; it exercises the exact fail-closed pagination boundary and changes no production code, dependency, permission, credential path, or supported product surface.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Test-only regression coverage for the existing GitHub filtered-result pagination cap; no user-visible behavior changed and #7594's operational guidance remains accurate.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 871b93384030 -->
<!-- docs-review-agents-blob-sha: be20a0952410 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact head `871b933840300068aef3f462a8ecf1d0873209dc`: `npx vitest run --project integration test/pr-e2e-dispatch-reconciliation.test.ts` passed 35/35.
- [x] Applicable broad gate passed — CLI build and exact-head `npm run check:diff` passed after generating the required `dist/` artifacts.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for reconciling complete stale receipt inventories at GitHub’s filtered-result limit.
  * Verified reconciliation succeeds with clock skew and across paginated inventory reads, including the page-cap boundary (ensuring calls span the expected pages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->