### PR TITLE
test(sandbox): wait for forward fixture readiness

### DIFF
--- a/test/recover-port-forward.test.ts
+++ b/test/recover-port-forward.test.ts
@@ -12,6 +12,7 @@ import { execTimeout, testTimeoutOptions } from "./helpers/timeouts";
 
 const tmpFixtures: string[] = [];
 const listenerProcesses: ChildProcess[] = [];
+const FIXTURE_LISTENER_READY_TIMEOUT_MS = 5_000;
 
 // Each fixture grabs a unique high port. Sharing port 18789 across tests
 // collides with real nemoclaw installs on the developer's machine: the
@@ -44,9 +45,10 @@ afterEach(() => {
   }
 });
 
-function forwardListenerScript(port: string): string {
+function forwardListenerScript(port: string, readyFile: string): string {
   return (
     'const net=require("node:net");' +
+    'const fs=require("node:fs");' +
     "const server=net.createServer(()=>{});" +
     "let stopping=false;" +
     'process.on("SIGTERM",()=>{' +
@@ -54,29 +56,36 @@ function forwardListenerScript(port: string): string {
     "stopping=true;" +
     "setTimeout(()=>server.close(()=>process.exit(0)),150);" +
     "});" +
-    `server.listen(${JSON.stringify(Number(port))},"127.0.0.1");`
+    `server.listen(${JSON.stringify(Number(port))},"127.0.0.1",()=>` +
+    `fs.writeFileSync(${JSON.stringify(readyFile)},"ready",{mode:0o600}));`
   );
 }
 
-function startReachableForward(port: string, listenerPidFile: string): void {
-  const child = spawn(process.execPath, ["-e", forwardListenerScript(port)], { stdio: "ignore" });
+function waitForFixtureListener(readyFile: string): boolean {
+  const deadline = Date.now() + FIXTURE_LISTENER_READY_TIMEOUT_MS;
+  const sleeper = new Int32Array(new SharedArrayBuffer(4));
+  while (!fs.existsSync(readyFile) && Date.now() < deadline) {
+    Atomics.wait(sleeper, 0, 0, 25);
+  }
+  return fs.existsSync(readyFile);
+}
+
+function startReachableForward(
+  port: string,
+  listenerPidFile: string,
+  listenerReadyFile: string,
+): void {
+  fs.rmSync(listenerReadyFile, { force: true });
+  const child = spawn(process.execPath, ["-e", forwardListenerScript(port, listenerReadyFile)], {
+    stdio: "ignore",
+  });
   listenerProcesses.push(child);
   expect(child.pid, `test forward listener failed to spawn for ${port}`).toBeDefined();
   fs.appendFileSync(listenerPidFile, `${String(child.pid)}\n`);
-
-  const probe =
-    "const net=require('node:net');" +
-    `const s=net.createConnection({host:'127.0.0.1',port:${Number(port)}});` +
-    "s.setTimeout(100);" +
-    "s.on('connect',()=>{s.destroy();process.exit(0)});" +
-    "s.on('error',()=>process.exit(1));" +
-    "s.on('timeout',()=>{s.destroy();process.exit(1)});";
-  const deadline = Date.now() + 2000;
-  let listenerReady = false;
-  while (Date.now() < deadline && !listenerReady) {
-    listenerReady = spawnSync(process.execPath, ["-e", probe], { stdio: "ignore" }).status === 0;
-  }
-  expect(listenerReady, `test forward listener failed to bind port ${port}`).toBe(true);
+  expect(
+    waitForFixtureListener(listenerReadyFile),
+    `test forward listener failed to bind port ${port}`,
+  ).toBe(true);
 }
 
 interface Fixture {
@@ -136,6 +145,7 @@ function setupFixture(opts: {
   const forwardStateFile = path.join(tmpDir, "forward-state");
   const forwardPollCountFile = path.join(tmpDir, "forward-poll-count");
   const listenerPidFile = path.join(tmpDir, "forward-listener-pids");
+  const listenerReadyFile = path.join(tmpDir, "forward-listener-ready");
   fs.writeFileSync(forwardStateFile, "initial");
   fs.writeFileSync(forwardPollCountFile, "0");
   fs.writeFileSync(listenerPidFile, "");
@@ -219,13 +229,24 @@ if (args[0] === "forward" && args[1] === "stop") {
 
 if (args[0] === "forward" && args[1] === "start") {
   if (${opts.forwardStartHeals === false ? "false" : "true"}) {
-    const listener = spawn(process.execPath, ["-e", ${JSON.stringify(forwardListenerScript(port))}], {
+    fs.rmSync(${JSON.stringify(listenerReadyFile)}, { force: true });
+    const listener = spawn(process.execPath, ["-e", ${JSON.stringify(
+      forwardListenerScript(port, listenerReadyFile),
+    )}], {
       detached: true,
       stdio: "ignore",
     });
     listener.unref();
     if (listener.pid !== undefined) {
       fs.appendFileSync(${JSON.stringify(listenerPidFile)}, String(listener.pid) + "\\n");
+    }
+    const readyDeadline = Date.now() + ${FIXTURE_LISTENER_READY_TIMEOUT_MS};
+    const readySleeper = new Int32Array(new SharedArrayBuffer(4));
+    while (!fs.existsSync(${JSON.stringify(listenerReadyFile)}) && Date.now() < readyDeadline) {
+      Atomics.wait(readySleeper, 0, 0, 25);
+    }
+    if (!fs.existsSync(${JSON.stringify(listenerReadyFile)})) {
+      process.exit(1);
     }
     fs.writeFileSync(
       ${JSON.stringify(forwardStateFile)},
@@ -259,7 +280,9 @@ process.exit(0);
   // answers. Keep the listener alive in a separate process because runRecover
   // uses spawnSync and blocks this Vitest worker's event loop.
   const reachablePorts = opts.forwardStartHeals !== false ? [port] : [];
-  reachablePorts.forEach((reachablePort) => startReachableForward(reachablePort, listenerPidFile));
+  reachablePorts.forEach((reachablePort) =>
+    startReachableForward(reachablePort, listenerPidFile, listenerReadyFile),
+  );
 
   return {
     tmpDir,


### PR DESCRIPTION
## Summary

The recovery test fixture could report a forward as healthy before its detached listener had actually bound the socket. Under runner contention that race exhausted the production recovery polling window and created an unrelated CI failure on #7596. This change makes fixture readiness event-driven while leaving production recovery behavior unchanged.

## Related Issue

Part of #7140. Follow-up to the unrelated CI failure observed on #7596.

## Changes

- Write a private ready marker from the fake listener only after the server listen callback fires.
- Wait for that marker before initial fixture setup completes and before fake forward start publishes pending or running metadata.
- Preserve listener PID tracking and cleanup, with a bounded five-second failure budget for a listener that never becomes ready.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the diff is confined to a fake test listener and changes no command, output, flag, default, or documented recovery behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: an independent Codex Desktop review checked listener lifecycle, PID cleanup, platform support, and production sandbox semantics; it reported no actionable findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: no-docs-needed
- Evidence: the exact diff only stabilizes test/recover-port-forward.test.ts; existing recover and forward documentation remains accurate.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 0aa3ebe17 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable; scripts/prepare-dgx-station-host.sh is unchanged.
- Supporting evidence:

## Verification

- [x] PR description includes a Signed-off-by line and every commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed, or npm run check:diff passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 3 focused files, 42 tests passed after rebasing onto current main.
- [ ] Applicable broad gate passed — not applicable; this is a one-file fixture-only change. The changed-file hook set, Biome, and CLI typecheck passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new doc pages only)

Additional stability evidence: ten sequential fixture repetitions passed, and a separate run passed while three CPU-saturation processes were active.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture reliability by waiting for mock forward listeners to be ready before running checks.
  * Added timeout handling when listener readiness cannot be confirmed.
  * Reduced potential race conditions during port-forwarding recovery tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->