### PR TITLE
fix(e2e): accept canonical controller check URLs

### DIFF
--- a/test/pr-e2e-gate-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-dispatch-recovery.test.ts
@@ -625,7 +625,18 @@ describe("PR E2E dispatch-not-observed recovery", () => {
     ]);
   });
 
-  it("accepts an exact child authorization after the PATCH response is lost", async () => {
+  it.each([
+    {
+      label: "exact child URL",
+      publishedDetailsUrl: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+    },
+    {
+      label: "canonical check URL",
+      publishedDetailsUrl: "https://github.com/NVIDIA/NemoClaw/runs/17",
+    },
+  ])("accepts an exact child authorization with $label after the PATCH response is lost", async ({
+    publishedDetailsUrl,
+  }) => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-auth-response-"));
     const outputPath = path.join(workDir, "github-output");
     fs.writeFileSync(outputPath, "", { mode: 0o600 });
@@ -633,7 +644,7 @@ describe("PR E2E dispatch-not-observed recovery", () => {
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
     vi.stubEnv("GITHUB_OUTPUT", outputPath);
     const requests: RecordedGitHubRequest[] = [];
-    let check = reservedCheck();
+    let check: Record<string, unknown> = reservedCheck();
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
         [
@@ -668,6 +679,9 @@ describe("PR E2E dispatch-not-observed recovery", () => {
               check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
               const title = (request.body as { output?: { title?: string } } | undefined)?.output
                 ?.title;
+              if (title?.startsWith("Running ")) {
+                check.details_url = publishedDetailsUrl;
+              }
               return title?.startsWith("Running ")
                 ? new Response("{", { status: 200 })
                 : githubResponse(check);
@@ -697,7 +711,7 @@ describe("PR E2E dispatch-not-observed recovery", () => {
       expect(check).toMatchObject({
         status: "in_progress",
         conclusion: null,
-        details_url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23",
+        details_url: publishedDetailsUrl,
         output: { title: expect.stringMatching(/^Running /u) },
       });
       expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(1);

--- a/test/pr-e2e-gate-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-dispatch-recovery.test.ts
@@ -676,12 +676,15 @@ describe("PR E2E dispatch-not-observed recovery", () => {
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
             (request) => {
-              check = { ...check, ...((request.body ?? {}) as Record<string, unknown>) };
               const title = (request.body as { output?: { title?: string } } | undefined)?.output
                 ?.title;
-              if (title?.startsWith("Running ")) {
-                check.details_url = publishedDetailsUrl;
-              }
+              check = {
+                ...check,
+                ...((request.body ?? {}) as Record<string, unknown>),
+                ...(title?.startsWith("Running ")
+                  ? { details_url: publishedDetailsUrl }
+                  : undefined),
+              };
               return title?.startsWith("Running ")
                 ? new Response("{", { status: 200 })
                 : githubResponse(check);

--- a/test/pr-e2e-gate-lifecycle.test.ts
+++ b/test/pr-e2e-gate-lifecycle.test.ts
@@ -437,25 +437,21 @@ describe("PR E2E controller lifecycle", () => {
           ),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
-            () => {
-              if (failedRunningUpdate) {
-                return githubResponse(
-                  exactPrGateCheck({
-                    ...failedRunningUpdate,
-                    details_url: "https://github.com/NVIDIA/NemoClaw/runs/999",
-                  }),
-                );
-              }
-              return githubResponse(
+            () =>
+              githubResponse(
                 exactPrGateCheck({
-                  output: {
-                    title: "Evaluating PR commit",
-                    summary:
-                      "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
-                  },
+                  ...(failedRunningUpdate ?? {
+                    output: {
+                      title: "Evaluating PR commit",
+                      summary:
+                        "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
+                    },
+                  }),
+                  ...(failedRunningUpdate
+                    ? { details_url: "https://github.com/NVIDIA/NemoClaw/runs/999" }
+                    : undefined),
                 }),
-              );
-            },
+              ),
           ),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/actions/runs/23/cancel") && method === "POST",
@@ -465,11 +461,13 @@ describe("PR E2E controller lifecycle", () => {
             ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
             (request) => {
               checkPatches += 1;
-              if (checkPatches === 2) {
-                failedRunningUpdate = (request.body ?? {}) as Record<string, unknown>;
-                return githubResponse({ message: "simulated update failure" }, 500);
-              }
-              return prGateMutationResponse(request);
+              failedRunningUpdate =
+                checkPatches === 2
+                  ? ((request.body ?? {}) as Record<string, unknown>)
+                  : failedRunningUpdate;
+              return checkPatches === 2
+                ? githubResponse({ message: "simulated update failure" }, 500)
+                : prGateMutationResponse(request);
             },
           ),
         ],

--- a/test/pr-e2e-gate-lifecycle.test.ts
+++ b/test/pr-e2e-gate-lifecycle.test.ts
@@ -388,7 +388,7 @@ describe("PR E2E controller lifecycle", () => {
     }
   });
 
-  it("cancels the child and closes the check when startup fails after dispatch", async () => {
+  it("revokes and cancels when a lost PATCH publishes a foreign check URL", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-start-"));
     const outputPath = path.join(workDir, "github-output");
     fs.writeFileSync(outputPath, "", { mode: 0o600 });
@@ -397,6 +397,7 @@ describe("PR E2E controller lifecycle", () => {
     vi.stubEnv("GITHUB_OUTPUT", outputPath);
     const requests: RecordedGitHubRequest[] = [];
     let checkPatches = 0;
+    let failedRunningUpdate: Record<string, unknown> | undefined;
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
         [
@@ -436,8 +437,16 @@ describe("PR E2E controller lifecycle", () => {
           ),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/check-runs/17") && method === "GET",
-            () =>
-              githubResponse(
+            () => {
+              if (failedRunningUpdate) {
+                return githubResponse(
+                  exactPrGateCheck({
+                    ...failedRunningUpdate,
+                    details_url: "https://github.com/NVIDIA/NemoClaw/runs/999",
+                  }),
+                );
+              }
+              return githubResponse(
                 exactPrGateCheck({
                   output: {
                     title: "Evaluating PR commit",
@@ -445,7 +454,8 @@ describe("PR E2E controller lifecycle", () => {
                       "Validating the PR SHA and selecting deterministic E2E jobs and typed targets.",
                   },
                 }),
-              ),
+              );
+            },
           ),
           githubFetchRoute(
             ({ url, method }) => url.endsWith("/actions/runs/23/cancel") && method === "POST",
@@ -455,9 +465,11 @@ describe("PR E2E controller lifecycle", () => {
             ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
             (request) => {
               checkPatches += 1;
-              return checkPatches === 2
-                ? githubResponse({ message: "simulated update failure" }, 500)
-                : prGateMutationResponse(request);
+              if (checkPatches === 2) {
+                failedRunningUpdate = (request.body ?? {}) as Record<string, unknown>;
+                return githubResponse({ message: "simulated update failure" }, 500);
+              }
+              return prGateMutationResponse(request);
             },
           ),
         ],

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -1380,6 +1380,7 @@ async function updateRunningCheck(
   },
 ): Promise<void> {
   const childRunUrl = `https://github.com/${context.repository}/actions/runs/${options.childRunId}`;
+  const canonicalCheckUrl = `https://github.com/${context.repository}/runs/${context.checkRunId}`;
   const selectionCount = options.jobs.length + options.targets.length;
   const title = `Running ${selectionCount} E2E ${selectionCount === 1 ? "check" : "checks"}`;
   const summary = `Risk plan ${options.planHash} selected jobs: ${options.jobs.join(", ") || "none"}; targets: ${options.targets.join(", ") || "none"}. Child run: ${childRunUrl}.`;
@@ -1394,7 +1395,7 @@ async function updateRunningCheck(
       title,
       summary,
     });
-    if (check.details_url !== childRunUrl) {
+    if (check.details_url !== childRunUrl && check.details_url !== canonicalCheckUrl) {
       throw new Error("GitHub did not bind the controller check to the selected child run");
     }
   };


### PR DESCRIPTION
## Summary

GitHub may canonicalize a PR gate check details URL to the check own /runs/<check-id> URL even when the exact child-bound summary is persisted. The controller introduced by #7594 rejected that valid response, revoked authorization, and prevented the selected #7590 Hermes lanes from starting. This change accepts only the exact child URL or the exact canonical check URL while preserving every authorization identity check.

## Related Issue

Part of #7140. Follow-up to #7593 and #7594; aligns the parent controller with the canonicalization behavior already protected by #7515.

## Changes

- Accept the selected child Actions URL or the exact canonical /runs/<check-id> URL after the check ID, GitHub Actions app, PR head/base identity, status, title, and child-bound summary all validate.
- Continue rejecting foreign repositories, wrong check IDs, alternate schemes, query or fragment variants, and unrelated URLs.
- Cover both allowed URL forms after a lost PATCH response and prove a foreign canonical URL still revokes authorization before child cancellation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: existing E2E operational documentation already states that GitHub may canonicalize details_url to /runs/<check-id>; no user-facing command or workflow changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent Codex Desktop code and security reviews verified the exact URL allowlist and the retained check ID, app, PR/head/base, status, plan, jobs, targets, and child-run summary binding; no findings remained.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes.
- Result: `no-docs-needed`
- Evidence: Exact head `d4f53a19618b4d810494e2094c6aff6b9f6602cc` changes only the E2E controller’s canonical check-URL validation and focused tests. `test/e2e/README.md` already documents direct-read recovery, exact persisted child binding, and GitHub canonicalization to `/runs/<check-id>`. Changed test text is behavior-oriented and introduces no issue references. No docs build was needed because no documentation source changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d4f53a19618b4d810494e2094c6aff6b9f6602cc -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable; scripts/prepare-dgx-station-host.sh is unchanged.
- Supporting evidence:

## Verification

- [x] PR description includes a Signed-off-by line and every commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed, or npm run check:diff passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 19 PR-E2E files, 313 tests passed; the E2E workflow boundary added 39 passing tests.
- [x] Applicable broad gate passed — CLI typecheck, source-shape, test-size, title-style, project isolation, Biome, and the complete changed-file hook set passed. Post-rebase focused validation passed 41 tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new doc pages only)

Failure evidence: controller run 30221481816 and child run 30221620499. The parent published the exact child-bound summary but GitHub returned the canonical check URL, so the old strict URL comparison revoked the otherwise valid authorization.

Self-hosting evidence: #7599 controller run 30224207359 checked out trusted base `2f66902b`, rejected the canonical URL for check 89851619986, and could not cancel child run 30224558462 after GitHub returned HTTP 500. The orphan child then failed closed because trusted controller authorization had not been published. A same-revision retry is not supported after dispatch; the exact fix requires the repository's approved controller-bootstrap governance path.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request gate recovery when an authorization update response is lost, ensuring check details URLs are set correctly after retry behavior.
  * Updated gate check validation to accept both dispatched child run URLs and canonical controller check URLs.
* **Tests**
  * Expanded end-to-end coverage with parameterized published-details URL variants and scenarios where lost updates result in a foreign check URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
