### PR TITLE
ci(installer): trust stable formula cleanup transition

### DIFF
--- a/scripts/checks/extract-installer-pins.mts
+++ b/scripts/checks/extract-installer-pins.mts
@@ -47,16 +47,16 @@ const MAX_INSTALLER_INPUT_BYTES = 1024 * 1024;
 // only in a prerequisite trust-anchor PR that keeps the currently selected
 // release; the later pin PR may then change release data without authorizing
 // any operational installer change. A mismatch reports the candidate hash.
-// This transition accepts the current installer and the reviewed Homebrew
+// This transition accepts the current installer and the corrected Homebrew
 // trust lifecycle consumed by #7555. The successor trusts only a
-// checksum-verified stable formula and removes inherited or automatic trust
-// around an unverified dev install, including failure cleanup. After this
-// prerequisite merges, #7555 must remove the legacy hash and keep only the
-// reviewed successor hash before it can merge.
+// checksum-verified stable formula, revokes that temporary trust after success
+// or failure, and removes inherited or automatic trust around an unverified
+// dev install. After this prerequisite merges, #7555 must remove the legacy
+// hash and keep only the corrected successor hash before it can merge.
 // Base-trusted CI must validate both the prerequisite branch and #7555.
 const TRUSTED_INSTALLER_TEMPLATE_SHA256_ALLOWLIST = [
   "2b6a6195241d6b946fe29503d8d2d99d5b864864458f510ca129e3396248ac58",
-  "ee10afaeb5dc1477ca4b35a70a654ed32092399dbb290266f9f138d64484f1e2",
+  "0fa737a64cf2a7a6a437dc5f203dad81f66f191dc316214c2f343f762ad9b0a5",
 ] as const;
 const TRUSTED_BREV_TEMPLATE_SHA256_ALLOWLIST = [
   "c0a4ddf25a02a9fe02b2df53a60942ea887610f04d4ce16a121b6e79a5aeff1a",

--- a/test/installer-hash-check.test.ts
+++ b/test/installer-hash-check.test.ts
@@ -106,6 +106,7 @@ type FixtureMode =
   | "installer-min-version-drift"
   | "installer-homebrew-trust-transition"
   | "installer-homebrew-trust-transition-drift"
+  | "installer-homebrew-trust-transition-stable-leak"
   | "installer-homebrew-trust-transition-complete-current"
   | "installer-homebrew-trust-transition-complete-future"
   | "installer-pin-selector-drift"
@@ -298,6 +299,7 @@ install_macos_homebrew_formula() {
       `  if [ "$formula_checksum_verified" = "1" ] && [ "$homebrew_trust_supported" = "1" ]; then
     brew trust --formula "$formula_ref" \\
       || fail "Homebrew refused to trust the checksum-verified OpenShell formula \${formula_ref}"
+    OPENSHELL_HOMEBREW_UNTRUST_FORMULA_REF="$formula_ref"
   fi
   if brew list --formula "$HOMEBREW_FORMULA_NAME" >/dev/null 2>&1; then`,
       "stable trust",
@@ -315,7 +317,7 @@ install_macos_homebrew_formula() {
   fi
   if [ -n "$OPENSHELL_HOMEBREW_UNTRUST_FORMULA_REF" ]; then
     brew untrust --formula "$OPENSHELL_HOMEBREW_UNTRUST_FORMULA_REF" >/dev/null \\
-      || fail "Homebrew refused to remove temporary trust for the unverified OpenShell dev formula \${formula_ref}"
+      || fail "Homebrew refused to remove temporary trust for OpenShell formula \${OPENSHELL_HOMEBREW_UNTRUST_FORMULA_REF}"
     OPENSHELL_HOMEBREW_UNTRUST_FORMULA_REF=""
   fi
 
@@ -325,20 +327,37 @@ install_macos_homebrew_formula() {
   ] as const;
   return replacements.reduce((current, [marker, replacement, label]) => {
     assert.ok(current.includes(marker), `installer Homebrew ${label} marker must exist`);
-    return current.replace(marker, replacement);
+    return current.replace(marker, () => replacement);
   }, source);
+};
+
+const restorePersistentStableHomebrewTrust = (source: string): string => {
+  const stableTrust = `    brew trust --formula "$formula_ref" \\
+      || fail "Homebrew refused to trust the checksum-verified OpenShell formula \${formula_ref}"
+    OPENSHELL_HOMEBREW_UNTRUST_FORMULA_REF="$formula_ref"`;
+  assert.ok(source.includes(stableTrust), "temporary stable Homebrew trust marker must exist");
+  return source
+    .replace(
+      stableTrust,
+      `    brew trust --formula "$formula_ref" \\
+      || fail "Homebrew refused to trust the checksum-verified OpenShell formula \${formula_ref}"`,
+    )
+    .replace(
+      "Homebrew refused to remove temporary trust for OpenShell formula \${OPENSHELL_HOMEBREW_UNTRUST_FORMULA_REF}",
+      "Homebrew refused to remove temporary trust for the unverified OpenShell dev formula \${formula_ref}",
+    );
 };
 
 const completeHomebrewTrustTransition = (source: string): string => {
   const marker = `const TRUSTED_INSTALLER_TEMPLATE_SHA256_ALLOWLIST = [
   "2b6a6195241d6b946fe29503d8d2d99d5b864864458f510ca129e3396248ac58",
-  "ee10afaeb5dc1477ca4b35a70a654ed32092399dbb290266f9f138d64484f1e2",
+  "0fa737a64cf2a7a6a437dc5f203dad81f66f191dc316214c2f343f762ad9b0a5",
 ] as const;`;
   assert.ok(source.includes(marker), "Homebrew trust transition allowlist must exist");
   return source.replace(
     marker,
     `const TRUSTED_INSTALLER_TEMPLATE_SHA256_ALLOWLIST = [
-  "ee10afaeb5dc1477ca4b35a70a654ed32092399dbb290266f9f138d64484f1e2",
+  "0fa737a64cf2a7a6a437dc5f203dad81f66f191dc316214c2f343f762ad9b0a5",
 ] as const;`,
   );
 };
@@ -408,6 +427,8 @@ const INSTALLER_MUTATIONS: Partial<Record<FixtureMode, (source: string) => strin
       'brew trust --formula "$formula_ref" \\',
       'brew trust --formula "$HOMEBREW_TAP" \\',
     ),
+  "installer-homebrew-trust-transition-stable-leak": (source) =>
+    restorePersistentStableHomebrewTrust(applyHomebrewTrustTransition(source)),
   "installer-max-version-drift": (source) =>
     source.replace('MAX_VERSION="0.0.72"', 'MAX_VERSION="0.0.85"'),
   "installer-pin-selector-drift": (source) =>
@@ -891,6 +912,17 @@ describe("installer hash verification", () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain("installer operational template is not base-trusted");
+    expect(result.stdout).not.toContain("All installer hashes are current");
+  });
+
+  it("rejects the prior template that leaves stable formula trust behind", () => {
+    const result = runFixture("installer-homebrew-trust-transition-stable-leak", undefined, true);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("installer operational template is not base-trusted");
+    expect(result.stdout).toContain(
+      "actual_sha256=ee10afaeb5dc1477ca4b35a70a654ed32092399dbb290266f9f138d64484f1e2",
+    );
     expect(result.stdout).not.toContain("All installer hashes are current");
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the base-trusted installer transition needed for #7555 to make stable Homebrew formula trust temporary. The verifier now accepts the current installer plus the exact reviewed successor template and rejects the superseded template that could leave stable trust behind.

## Related Issue

Related to #7451.

## Changes

- Replace the superseded future normalized installer hash with the exact corrected successor hash `0fa737a64cf2a7a6a437dc5f203dad81f66f191dc316214c2f343f762ad9b0a5`, while retaining the current `main` hash for the transition.
- Model successful stable-formula trust as temporary: record the trusted formula immediately, revoke it after installation, and preserve EXIT-trap revocation for failures.
- Use the exact pending-untrust variable in the cleanup diagnostic.
- Add a regression that reconstructs and rejects the superseded `ee10afa...` template, alongside the existing drift coverage.
- Establish the trust anchor consumed by #7555. A direct change in #7555 is insufficient because the mutable installer cannot authorize its own successor template; the base-trusted verifier must recognize that exact operational contract first.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is a CI trust-anchor update for an exact future installer template; it does not change shipped runtime behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: revision-specific review of `69a2c57edde4c5986b35574bb414545a158e8cec` passed all nine repository security categories. The accepted set is exact and transitional, the insecure predecessor is denied by regression, and no secrets, authentication, dependencies, logging, cryptographic primitives, or runtime configuration are introduced.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: At exact merged head `69a2c57edde4c5986b35574bb414545a158e8cec`, reviewed the two-file installer trust-anchor diff. The corrected `0fa737a...` template revokes temporary stable-formula trust on success or failure, the superseded `ee10afa...` template is rejected, and the change creates no user-facing surface. The trusted hash check, 76 focused tests, CLI build, and `npm run check:diff` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 69a2c57edde4c5986b35574bb414545a158e8cec -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `./node_modules/.bin/vitest run --project integration test/installer-hash-check.test.ts` (76 passed); `npm run build:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installer trust verification to recognize the latest approved installer template.
  * Added validation for a Homebrew trust-transition scenario that leaves persistent trust behind, ensuring such installers are rejected.
  * Improved installer trust-transition checks and error handling for more reliable security validation.

* **Tests**
  * Expanded coverage for installer template integrity and Homebrew trust cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

