### PR TITLE
fix(onboard): reject incompatible OpenClaw base images

### DIFF
--- a/src/lib/onboard/base-image.test.ts
+++ b/src/lib/onboard/base-image.test.ts
@@ -23,20 +23,30 @@ describe("OpenClaw sandbox base image validation", () => {
     dockerMocks.capture.mockReturnValue("nemoclaw-security-inventory-ok\n");
 
     expect(openClawBaseImageHasSecurityInventory("nemoclaw:test")).toBe(true);
-    expect(dockerMocks.capture).toHaveBeenCalledWith(
+    const [args, options] = dockerMocks.capture.mock.calls[0];
+    expect(args).toEqual(
       expect.arrayContaining([
         "run",
         "--network",
         "none",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
         "--read-only",
+        "--entrypoint",
+        "/bin/sh",
         "nemoclaw:test",
         "-c",
-        expect.stringContaining(
-          "security_inventory=/usr/local/share/nemoclaw/security-packages.txt",
-        ),
       ]),
-      { ignoreError: true, timeout: 20_000 },
     );
+    const probe = args.at(-1);
+    expect(probe).toContain("security_inventory=/usr/local/share/nemoclaw/security-packages.txt");
+    expect(probe).toContain('test ! -L "$security_inventory"');
+    expect(probe).toContain(`stat -c '%u:%g:%a'`);
+    expect(probe).toContain('"0:0:444"');
+    expect(probe).toContain(`cmp -s - "$security_inventory"`);
+    expect(options).toEqual({ ignoreError: true, timeout: 20_000 });
   });
 
   it("rejects a base that predates the security inventory", () => {

--- a/src/lib/onboard/base-image.test.ts
+++ b/src/lib/onboard/base-image.test.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dockerMocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+}));
+
+vi.mock("../adapters/docker", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../adapters/docker")>()),
+  dockerCapture: dockerMocks.capture,
+}));
+
+import { openClawBaseImageHasSecurityInventory } from "./base-image";
+
+describe("OpenClaw sandbox base image validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts the exact immutable security package inventory", () => {
+    dockerMocks.capture.mockReturnValue("nemoclaw-security-inventory-ok\n");
+
+    expect(openClawBaseImageHasSecurityInventory("nemoclaw:test")).toBe(true);
+    expect(dockerMocks.capture).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        "run",
+        "--network",
+        "none",
+        "--read-only",
+        "nemoclaw:test",
+        "-c",
+        expect.stringContaining(
+          "security_inventory=/usr/local/share/nemoclaw/security-packages.txt",
+        ),
+      ]),
+      { ignoreError: true, timeout: 20_000 },
+    );
+  });
+
+  it("rejects a base that predates the security inventory", () => {
+    dockerMocks.capture.mockReturnValue("");
+
+    expect(openClawBaseImageHasSecurityInventory("nemoclaw:v0.0.95")).toBe(false);
+  });
+});

--- a/src/lib/onboard/base-image.ts
+++ b/src/lib/onboard/base-image.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { dockerCapture } from "../adapters/docker";
 import { ROOT } from "../runner";
 import {
   buildLocalBaseTag,
@@ -10,6 +11,46 @@ import {
   type SandboxBaseImageResolutionMetadata,
 } from "../sandbox-base-image";
 import { getInstalledOpenshellVersion } from "./openshell-version";
+
+const OPENCLAW_SECURITY_INVENTORY_PROBE_OK = "nemoclaw-security-inventory-ok";
+
+/**
+ * Reject a published or cached OpenClaw base that predates the immutable
+ * security package inventory consumed by the completed-image verification.
+ * Accepting that base only defers the mismatch to the last Dockerfile layer,
+ * after the expensive final image has already been built.
+ */
+export function openClawBaseImageHasSecurityInventory(imageRef: string): boolean {
+  const output = dockerCapture(
+    [
+      "run",
+      "--rm",
+      "--network",
+      "none",
+      "--cap-drop",
+      "ALL",
+      "--security-opt",
+      "no-new-privileges",
+      "--read-only",
+      "--entrypoint",
+      "/bin/sh",
+      imageRef,
+      "-c",
+      [
+        "set -eu",
+        "security_inventory=/usr/local/share/nemoclaw/security-packages.txt",
+        'arch="$(dpkg --print-architecture)"',
+        'test -f "$security_inventory"',
+        'test ! -L "$security_inventory"',
+        `test "$(stat -c '%u:%g:%a' "$security_inventory")" = "0:0:444"`,
+        `printf '%s\\n' "architecture=$arch" "libexpat1=2.8.2-1" "libonig5=6.9.9-1+b1" "libjq1=1.8.2-1" "jq=1.8.2-1" "vim-common=2:9.2.0782-1" "vim-tiny=2:9.2.0782-1" | cmp -s - "$security_inventory"`,
+        `printf '%s\\n' "${OPENCLAW_SECURITY_INVENTORY_PROBE_OK}"`,
+      ].join("; "),
+    ],
+    { ignoreError: true, timeout: 20_000 },
+  );
+  return output.trim() === OPENCLAW_SECURITY_INVENTORY_PROBE_OK;
+}
 
 /**
  * Resolve a compatible sandbox-base image and pin it to a repo digest when
@@ -38,6 +79,8 @@ export function pullAndResolveBaseImageDigest(
     envVar: "NEMOCLAW_SANDBOX_BASE_IMAGE_REF",
     label: "OpenClaw sandbox base image",
     requireOpenshellSandboxAbi: options.requireOpenshellSandboxAbi === true,
+    validateImage: openClawBaseImageHasSecurityInventory,
+    validationDescription: "the immutable security package inventory",
     resolutionHint: options.resolutionHint,
     forceRefresh: options.forceRefresh,
     rootDir: ROOT,

--- a/src/lib/sandbox-base-image-release-resolution.test.ts
+++ b/src/lib/sandbox-base-image-release-resolution.test.ts
@@ -208,6 +208,32 @@ describe("sandbox base-image release resolution", () => {
     });
   });
 
+  it("builds locally when the selected OpenClaw release predates its security inventory (#7605)", () => {
+    const state = installDockerState({
+      allowBuild: true,
+      present: [RELEASE_REF],
+      pullable: [RELEASE_REF],
+    });
+    const options = {
+      ...versionedResolutionOptions("1"),
+      validateImage: state.validateImage,
+      validationDescription: "the immutable security package inventory",
+    };
+
+    const resolved = resolveSandboxBaseImage(options);
+
+    expect(resolved).toMatchObject({
+      ref: LOCAL_TAG,
+      source: "local",
+    });
+    expect(dockerMocks.pull).toHaveBeenCalledWith(RELEASE_REF, {
+      ignoreError: true,
+      suppressOutput: true,
+    });
+    expect(state.validateImage).toHaveBeenCalledWith(RELEASE_REF);
+    expect(dockerMocks.build).toHaveBeenCalledTimes(1);
+  });
+
   it("fails closed when a release-tag base is unavailable and local builds are disabled (#6456)", () => {
     installDockerState();
 

--- a/src/lib/sandbox-base-image-release-resolution.test.ts
+++ b/src/lib/sandbox-base-image-release-resolution.test.ts
@@ -230,7 +230,9 @@ describe("sandbox base-image release resolution", () => {
       ignoreError: true,
       suppressOutput: true,
     });
-    expect(state.validateImage).toHaveBeenCalledWith(RELEASE_REF);
+    expect(dockerMocks.pull).toHaveBeenCalledTimes(1);
+    expect(state.validateImage).toHaveBeenNthCalledWith(1, RELEASE_REF);
+    expect(state.validateImage).toHaveBeenNthCalledWith(2, RELEASE_REF);
     expect(dockerMocks.build).toHaveBeenCalledTimes(1);
   });
 

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -272,6 +272,7 @@ if (a[0] === "image" && a[1] === "inspect") {
 if (a[0] === "tag" || a[0] === "rmi") process.exit(0);
 if (a[0] === "run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
+  else if (a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) process.stdout.write("nemoclaw-security-inventory-ok\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   process.exit(0);
 }

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -257,6 +257,9 @@ beforeEach(() => {
     path.join(homeLocalBin, "docker"),
     `#!${process.execPath}
 const a = process.argv.slice(2);
+const { isOpenClawSecurityInventoryProbe } = require(${JSON.stringify(
+      path.join(import.meta.dirname, "helpers", "onboard-script-mocks.cjs"),
+    )});
 if (a[0] === "info") {
   process.stdout.write(JSON.stringify({ServerVersion:"27.0.0", OperatingSystem:"Docker Engine", NCPU:8, MemTotal:17179869184}) + "\\n");
   process.exit(0);
@@ -272,7 +275,7 @@ if (a[0] === "image" && a[1] === "inspect") {
 if (a[0] === "tag" || a[0] === "rmi") process.exit(0);
 if (a[0] === "run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
-  else if (a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) process.stdout.write("nemoclaw-security-inventory-ok\\n");
+  else if (isOpenClawSecurityInventoryProbe(a)) process.stdout.write("nemoclaw-security-inventory-ok\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   process.exit(0);
 }

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -68,6 +68,13 @@ function mockSandboxExecCurl(command, options = {}) {
 
 function mockOnboardRunCapture(command, options = {}) {
   const normalized = normalizeCommand(command);
+  if (
+    normalized.startsWith("docker run ") &&
+    normalized.includes("security_inventory=/usr/local/share/nemoclaw/security-packages.txt") &&
+    normalized.includes("nemoclaw-security-inventory-ok")
+  ) {
+    return "nemoclaw-security-inventory-ok";
+  }
   if (/^docker run --rm --entrypoint \/usr\/bin\/ldd \S+ --version$/.test(normalized)) {
     return "ldd (GNU libc) 2.41";
   }

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -4,45 +4,93 @@
 // Node's --require preload cannot execute TypeScript directly. Reuse this
 // existing CommonJS test boundary as the minimal bootstrap for the typed
 // source loader; the codebase growth guard prevents adding another JS file.
-const fs = require("node:fs");
-const Module = require("node:module");
 const path = require("node:path");
-const ts = require("typescript");
 
-const sourceLoader = path.join(__dirname, "register-source-require.ts");
-const bootstrapTypeScriptFiles = new Set([
-  path.resolve(sourceLoader),
-  path.resolve(__dirname, "source-require-cache.ts"),
-]);
-const previousTypeScriptLoader = Module._extensions[".ts"];
+function registerSourceRequire() {
+  const fs = require("node:fs");
+  const Module = require("node:module");
+  const ts = require("typescript");
+  const sourceLoader = path.join(__dirname, "register-source-require.ts");
+  const bootstrapTypeScriptFiles = new Set([
+    path.resolve(sourceLoader),
+    path.resolve(__dirname, "source-require-cache.ts"),
+  ]);
+  const previousTypeScriptLoader = Module._extensions[".ts"];
 
-Module._extensions[".ts"] = (targetModule, filename) => {
-  if (!bootstrapTypeScriptFiles.has(path.resolve(filename))) {
-    if (previousTypeScriptLoader) {
-      previousTypeScriptLoader(targetModule, filename);
-      return;
+  Module._extensions[".ts"] = (targetModule, filename) => {
+    if (!bootstrapTypeScriptFiles.has(path.resolve(filename))) {
+      if (previousTypeScriptLoader) {
+        previousTypeScriptLoader(targetModule, filename);
+        return;
+      }
+      throw new Error(`Refusing to bootstrap unexpected TypeScript module: ${filename}`);
     }
-    throw new Error(`Refusing to bootstrap unexpected TypeScript module: ${filename}`);
-  }
 
-  // Loading source-require-cache.ts is what lets the real hook read tsconfig.src.json,
-  // so this first hop intentionally uses minimal emit options instead of that config.
-  const { outputText } = ts.transpileModule(fs.readFileSync(filename, "utf8"), {
-    compilerOptions: {
-      esModuleInterop: true,
-      inlineSourceMap: true,
-      inlineSources: true,
-      module: ts.ModuleKind.CommonJS,
-      target: ts.ScriptTarget.ES2022,
-    },
-    fileName: filename,
-  });
-  targetModule._compile(outputText, filename);
-};
-require(sourceLoader);
+    // Loading source-require-cache.ts is what lets the real hook read tsconfig.src.json,
+    // so this first hop intentionally uses minimal emit options instead of that config.
+    const { outputText } = ts.transpileModule(fs.readFileSync(filename, "utf8"), {
+      compilerOptions: {
+        esModuleInterop: true,
+        inlineSourceMap: true,
+        inlineSources: true,
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+      },
+      fileName: filename,
+    });
+    targetModule._compile(outputText, filename);
+  };
+  require(sourceLoader);
+}
+
+const helperPath = path.resolve(__filename);
+const loadedAsPreload =
+  process.execArgv.some((value) => path.resolve(value) === helperPath) ||
+  String(process.env.NODE_OPTIONS || "").includes(helperPath);
+loadedAsPreload && registerSourceRequire();
 
 function normalizeCommand(command) {
   return (Array.isArray(command) ? command.join(" ") : String(command)).replace(/'/g, "");
+}
+
+const OPENCLAW_SECURITY_INVENTORY_PROBE_PREFIX = Object.freeze([
+  "run",
+  "--rm",
+  "--network",
+  "none",
+  "--cap-drop",
+  "ALL",
+  "--security-opt",
+  "no-new-privileges",
+  "--read-only",
+  "--entrypoint",
+  "/bin/sh",
+]);
+
+const OPENCLAW_SECURITY_INVENTORY_PROBE = [
+  "set -eu",
+  "security_inventory=/usr/local/share/nemoclaw/security-packages.txt",
+  'arch="$(dpkg --print-architecture)"',
+  'test -f "$security_inventory"',
+  'test ! -L "$security_inventory"',
+  `test "$(stat -c '%u:%g:%a' "$security_inventory")" = "0:0:444"`,
+  `printf '%s\\n' "architecture=$arch" "libexpat1=2.8.2-1" "libonig5=6.9.9-1+b1" "libjq1=1.8.2-1" "jq=1.8.2-1" "vim-common=2:9.2.0782-1" "vim-tiny=2:9.2.0782-1" | cmp -s - "$security_inventory"`,
+  `printf '%s\\n' "nemoclaw-security-inventory-ok"`,
+].join("; ");
+
+function isOpenClawSecurityInventoryProbe(command) {
+  const commandArgs = Array.isArray(command) ? command.map(String) : [];
+  const dockerArgs = commandArgs[0] === "docker" ? commandArgs.slice(1) : commandArgs;
+  const matches = (
+    dockerArgs.length === 14 &&
+    OPENCLAW_SECURITY_INVENTORY_PROBE_PREFIX.every(
+      (expected, index) => dockerArgs[index] === expected,
+    ) &&
+    dockerArgs[11].length > 0 &&
+    dockerArgs[12] === "-c" &&
+    dockerArgs[13] === OPENCLAW_SECURITY_INVENTORY_PROBE
+  );
+  return matches;
 }
 
 function hasOwn(value, key) {
@@ -68,11 +116,7 @@ function mockSandboxExecCurl(command, options = {}) {
 
 function mockOnboardRunCapture(command, options = {}) {
   const normalized = normalizeCommand(command);
-  if (
-    normalized.startsWith("docker run ") &&
-    normalized.includes("security_inventory=/usr/local/share/nemoclaw/security-packages.txt") &&
-    normalized.includes("nemoclaw-security-inventory-ok")
-  ) {
+  if (isOpenClawSecurityInventoryProbe(command)) {
     return "nemoclaw-security-inventory-ok";
   }
   if (/^docker run --rm --entrypoint \/usr\/bin\/ldd \S+ --version$/.test(normalized)) {
@@ -82,6 +126,7 @@ function mockOnboardRunCapture(command, options = {}) {
 }
 
 module.exports = {
+  isOpenClawSecurityInventoryProbe,
   mockOnboardRunCapture,
   mockSandboxExecCurl,
   normalizeCommand,

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -43,11 +43,8 @@ function registerSourceRequire() {
   require(sourceLoader);
 }
 
-const helperPath = path.resolve(__filename);
-const loadedAsPreload =
-  process.execArgv.some((value) => path.resolve(value) === helperPath) ||
-  String(process.env.NODE_OPTIONS || "").includes(helperPath);
-loadedAsPreload && registerSourceRequire();
+// Vitest setup files and NODE_OPTIONS preloads both depend on this hook.
+registerSourceRequire();
 
 function normalizeCommand(command) {
   return (Array.isArray(command) ? command.join(" ") : String(command)).replace(/'/g, "");

--- a/test/rebuild-credential-preflight.test.ts
+++ b/test/rebuild-credential-preflight.test.ts
@@ -302,6 +302,7 @@ if (a[0] === "image" && a[1] === "inspect") {
 if (a[0] === "rmi") process.exit(0);
 if (a[0] === "run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
+  else if (a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) process.stdout.write("nemoclaw-security-inventory-ok\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   else process.stdout.write("nemoclaw-hermes-mcp-runtime-ok\\n");
   process.exit(0);

--- a/test/rebuild-credential-preflight.test.ts
+++ b/test/rebuild-credential-preflight.test.ts
@@ -266,6 +266,9 @@ process.exit(0);
     `#!/usr/bin/env node
 const fs = require("node:fs");
 const a = process.argv.slice(2);
+const { isOpenClawSecurityInventoryProbe } = require(${JSON.stringify(
+      path.join(REPO_ROOT, "test", "helpers", "onboard-script-mocks.cjs"),
+    )});
 const provenancePath = ${JSON.stringify(path.join(tmpDir, "docker-base-provenance"))};
 const readProvenance = () => fs.existsSync(provenancePath) ? JSON.parse(fs.readFileSync(provenancePath, "utf8")) : {};
 if (a[0] === "info") { process.stdout.write(JSON.stringify({ServerVersion:"27.0.0", OperatingSystem:"Docker Engine", NCPU:8, MemTotal:17179869184}) + "\\n"); process.exit(0); }
@@ -302,7 +305,7 @@ if (a[0] === "image" && a[1] === "inspect") {
 if (a[0] === "rmi") process.exit(0);
 if (a[0] === "run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
-  else if (a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) process.stdout.write("nemoclaw-security-inventory-ok\\n");
+  else if (isOpenClawSecurityInventoryProbe(a)) process.stdout.write("nemoclaw-security-inventory-ok\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   else process.stdout.write("nemoclaw-hermes-mcp-runtime-ok\\n");
   process.exit(0);

--- a/test/rebuild-shields-auto-unlock.test.ts
+++ b/test/rebuild-shields-auto-unlock.test.ts
@@ -246,6 +246,7 @@ if (a[0]==="image" && a[1]==="inspect") {
 if (a[0]==="tag" || a[0]==="rmi") { process.exit(0); }
 if (a[0]==="run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
+  else if (a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) process.stdout.write("nemoclaw-security-inventory-ok\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   process.exit(0);
 }

--- a/test/rebuild-shields-auto-unlock.test.ts
+++ b/test/rebuild-shields-auto-unlock.test.ts
@@ -224,6 +224,9 @@ process.exit(0);
     `#!/usr/bin/env node
 const fs = require("fs");
 const a = process.argv.slice(2);
+const { isOpenClawSecurityInventoryProbe } = require(${JSON.stringify(
+      path.join(REPO_ROOT, "test", "helpers", "onboard-script-mocks.cjs"),
+    )});
 const lockStatePath = ${JSON.stringify(lockStatePath)};
 function readLockState() {
   try { return fs.readFileSync(lockStatePath, "utf8").trim(); } catch { return "unlocked"; }
@@ -246,7 +249,7 @@ if (a[0]==="image" && a[1]==="inspect") {
 if (a[0]==="tag" || a[0]==="rmi") { process.exit(0); }
 if (a[0]==="run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
-  else if (a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) process.stdout.write("nemoclaw-security-inventory-ok\\n");
+  else if (isOpenClawSecurityInventoryProbe(a)) process.stdout.write("nemoclaw-security-inventory-ok\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   process.exit(0);
 }

--- a/test/rebuild-stale-recovery.test.ts
+++ b/test/rebuild-stale-recovery.test.ts
@@ -184,6 +184,7 @@ if (a[0]==="image" && a[1]==="inspect") {
 if (a[0]==="tag" || a[0]==="rmi") { process.exit(0); }
 if (a[0]==="run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
+  else if (a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) process.stdout.write("nemoclaw-security-inventory-ok\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   process.exit(0);
 }

--- a/test/rebuild-stale-recovery.test.ts
+++ b/test/rebuild-stale-recovery.test.ts
@@ -169,6 +169,9 @@ process.exit(0);
     path.join(tmpDir, "docker"),
     `#!/usr/bin/env node
 const a = process.argv.slice(2);
+const { isOpenClawSecurityInventoryProbe } = require(${JSON.stringify(
+      path.join(REPO_ROOT, "test", "helpers", "onboard-script-mocks.cjs"),
+    )});
 if (a[0]==="info") {
   process.stdout.write(JSON.stringify({ServerVersion:"27.0.0", OperatingSystem:"Docker Engine", NCPU:8, MemTotal:17179869184}) + "\\n");
   process.exit(0);
@@ -184,7 +187,7 @@ if (a[0]==="image" && a[1]==="inspect") {
 if (a[0]==="tag" || a[0]==="rmi") { process.exit(0); }
 if (a[0]==="run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
-  else if (a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) process.stdout.write("nemoclaw-security-inventory-ok\\n");
+  else if (isOpenClawSecurityInventoryProbe(a)) process.stdout.write("nemoclaw-security-inventory-ok\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   process.exit(0);
 }

--- a/test/repro-2201.test.ts
+++ b/test/repro-2201.test.ts
@@ -310,6 +310,10 @@ if (a[0]==="run" && a.includes("nslookup")) {
   process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
   process.exit(0);
 }
+if (a[0]==="run" && a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) {
+  process.stdout.write("nemoclaw-security-inventory-ok\\n");
+  process.exit(0);
+}
 if (a[0]==="run" && a.includes("/usr/bin/ldd")) {
   process.stdout.write("ldd (GNU libc) 2.41\\n");
   process.exit(0);

--- a/test/repro-2201.test.ts
+++ b/test/repro-2201.test.ts
@@ -271,6 +271,9 @@ process.exit(0);
     `#!/usr/bin/env node
 const fs = require("node:fs");
 const a = process.argv.slice(2);
+const { isOpenClawSecurityInventoryProbe } = require(${JSON.stringify(
+      path.join(REPO_ROOT, "test", "helpers", "onboard-script-mocks.cjs"),
+    )});
 const provenancePath = ${JSON.stringify(path.join(tmpDir, "docker-base-provenance"))};
 const readProvenance = () => fs.existsSync(provenancePath) ? JSON.parse(fs.readFileSync(provenancePath, "utf8")) : {};
 if (a[0]==="info") {
@@ -310,7 +313,7 @@ if (a[0]==="run" && a.includes("nslookup")) {
   process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
   process.exit(0);
 }
-if (a[0]==="run" && a.some((value) => value.includes("nemoclaw-security-inventory-ok"))) {
+if (a[0]==="run" && isOpenClawSecurityInventoryProbe(a)) {
   process.stdout.write("nemoclaw-security-inventory-ok\\n");
   process.exit(0);
 }

--- a/test/shellquote-sandbox.test.ts
+++ b/test/shellquote-sandbox.test.ts
@@ -11,6 +11,31 @@ import { describe, expect, it } from "vitest";
 import { writeOkOpenshell } from "./helpers/onboard-openshell-fixture";
 
 describe("sandboxName command hardening in onboard.js", () => {
+  it("rejects a marker-only security inventory fixture probe", async () => {
+    const helper = (await import("./helpers/onboard-script-mocks.cjs")) as {
+      isOpenClawSecurityInventoryProbe: (command: unknown) => boolean;
+    };
+
+    expect(
+      helper.isOpenClawSecurityInventoryProbe([
+        "run",
+        "--rm",
+        "--network",
+        "none",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--read-only",
+        "--entrypoint",
+        "/bin/sh",
+        "nemoclaw:test",
+        "-c",
+        "echo nemoclaw-security-inventory-ok",
+      ]),
+    ).toBe(false);
+  });
+
   it("re-validates sandboxName at the createSandbox boundary", async () => {
     const onboardModule = await import("../src/lib/onboard.js");
     const { createSandbox } = onboardModule as unknown as {

--- a/test/shellquote-sandbox.test.ts
+++ b/test/shellquote-sandbox.test.ts
@@ -75,6 +75,10 @@ runner.runCapture = (command) => {
   if (text.includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   if (text.includes("sandbox exec") && text.includes("http://localhost:") && text.includes("/health")) return "200";
   if (text === "uname -r") return "6.8.0";
+  const mockedCapture = require(${JSON.stringify(
+    path.join(repoRoot, "test", "helpers", "onboard-script-mocks.cjs"),
+  )}).mockOnboardRunCapture(command);
+  if (mockedCapture !== null) return mockedCapture;
   return "";
 };
 registry.getSandbox = () => null;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenClaw onboarding now rejects a release base image that lacks the immutable security package inventory. The resolver refreshes the selected release once, then builds the current base locally instead of failing in the completed image's final layer.

## Related Issue

Fixes #7605

## Changes

- Validate the OpenClaw base image's security inventory before completed-image construction.
- Run the validation probe without network access, Linux capabilities, writable filesystem access, or privilege escalation.
- Use the existing release resolver to refresh the exact selected release and build the current local base when it remains incompatible.
- Preserve the resolver contract that does not substitute mutable `latest` for a selected release.
- Add tests for the inventory probe and the release-to-local fallback.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The commands reference already documents refresh-once, local-build fallback, disabled-build failure, and no mutable `latest` substitution.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/reference/commands.mdx` already documents the resolver behavior. The latest source-loader fixture fix changes no command, option, required user action, or output contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d22283e99 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/base-image.test.ts src/lib/sandbox-base-image-release-resolution.test.ts` passed 12 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; the change is scoped to OpenClaw base-image resolution and has focused coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox base-image validation by adding a security-inventory probe that verifies the inventory file exists, is not a symlink, matches expected ownership/permissions, and contains exact expected contents.
  * Enhanced sandbox base-image release resolution to correctly handle cases where the selected release predates the security inventory.

* **Tests**
  * Added/extended tests to cover the security-inventory probe behavior and the local-image fallback scenario.
  * Updated Docker/subprocess test stubs and added a sandbox-hardening test to ensure consistent probe detection and runner capture handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->