### PR TITLE
docs: update v0.0.96 release entry

### DIFF
--- a/docs/changelog/2026-07-25.mdx
+++ b/docs/changelog/2026-07-25.mdx
@@ -29,11 +29,13 @@ It also hardens blueprint identifier validation, improves onboarding and recover
   `doctor` reports incomplete lifecycle metadata without exposing stored values.
   An explicit forced rebuild can preserve managed MCP configuration after the old sandbox loses exec access, with exact gateway, policy, and provider proofs before deletion.
   Rebuild rechecks the canonical sandbox and recorded gateway at the delete edge, restores MCP state if that target drifts, and keeps shields unlocked when an accepted deletion remains unconfirmed.
+  When shields lock state before an OpenClaw agent first boots, NemoClaw creates the missing writable `agents/<id>/sessions/` carveout with existing containment checks.
+  This prevents the sessions-directory `EACCES` failure on that first boot.
   Shields failures return exit code `1` without a Node.js traceback, and policy picker EOF returns nonzero.
   A `config set` confirmation that reaches EOF exits nonzero without writing.
   The error repeats the `--config-accept-new-path` and `NEMOCLAW_CONFIG_ACCEPT_NEW_PATH=1` guidance.
   Messaging mutation guards print the exact host command.
-  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), [About Managed MCP Servers](/user-guide/openclaw/manage-sandboxes/mcp-servers/about-managed-mcp-servers), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), [About Managed MCP Servers](/user-guide/openclaw/manage-sandboxes/mcp-servers/about-managed-mcp-servers), [Security Best Practices](/user-guide/openclaw/security/best-practices), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
 - `nemoclaw <sandbox> mcp status <server> --tools` now requests the configured server's current advertised tool names without invoking any tool.
   Discovery is opt-in and sends authenticated traffic through the existing managed OpenShell credential provider and network policy.
   The shared client returns names only, bounds time, requests, response bytes, pages, tool count, cursors, and name length, and redacts failure details.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`docs/changelog/2026-07-25.mdx` now updates the `v0.0.96` release entry for the state-lock fix that merged after #7564.
The entry identifies the first-boot sessions carveout behavior and links to Security Best Practices without claiming that the separate legacy credentials symptom is fixed.

## Changes

- [#7602](https://github.com/NVIDIA/NemoClaw/pull/7602) -> `docs/changelog/2026-07-25.mdx`: Document the first-boot `agents/<id>/sessions/` carveout fix in the `v0.0.96` release entry and link to the deeper security guidance.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This PR changes release-entry prose only. The changelog contract test and Fern validation cover the dated entry, route, and rendering requirements.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: At exact PR head `f445009d2`, a Codex Desktop documentation writer reviewed `docs/changelog/2026-07-25.mdx` against `WRITING.md` and `docs/CONTRIBUTING.md`. The review confirmed the source claim matches #7602, limits the release meaning to the first-boot sessions-directory `EACCES` path, uses the specific published Security Best Practices route, and changes no code samples or skip terms. The changelog test passed 6/6, and the docs build completed with 0 errors and 2 unrelated repository warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f445009d2 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6/6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — exited 0 with 0 errors and 2 unrelated repository warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the v0.0.96 changelog with details on first-boot sandbox handling and prevention of permission errors.
  * Clarified CLI error behavior, exit statuses, configuration guidance, and messaging safeguards.
  * Added a Security Best Practices reference to the supporting documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->