### PR TITLE
test(hermes): stabilize maximum-size seal write

### DIFF
--- a/test/hermes-restart-config-seal-write-lock.test.ts
+++ b/test/hermes-restart-config-seal-write-lock.test.ts
@@ -45,7 +45,7 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
   });
 
   it("keeps a maximum-size config write journal below its bounded state cap", {
-    timeout: 60_000,
+    timeout: 120_000,
   }, () => {
     const fixture = createRestartFixture();
     const boundarySize = 16 * 1024 * 1024;
@@ -59,23 +59,19 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
     const expectedDigest = createHash("sha256").update(originalConfig).digest("hex");
 
     try {
-      const updated = spawnSync(
-        "python3",
+      const startedAt = Date.now();
+      const updated = runWriteConfig(fixture, expectedDigest, updatedConfig);
+      const elapsedMs = Date.now() - startedAt;
+      const errorCode = (updated.error as NodeJS.ErrnoException | undefined)?.code ?? "<none>";
+      expect(
+        updated.status,
         [
-          RUNTIME_CONFIG_GUARD,
-          "write-config",
-          "--hermes-dir",
-          fixture.hermesDir,
-          "--hash-file",
-          fixture.hashPath,
-          "--state-file",
-          fixture.statePath,
-          "--expected-config-sha256",
-          expectedDigest,
-        ],
-        { encoding: "utf-8", input: updatedConfig, timeout: 45_000 },
-      );
-      expect(updated.status, updated.stderr).toBe(0);
+          `write-config failed after ${elapsedMs} ms`,
+          `error.code=${errorCode}`,
+          `signal=${updated.signal ?? "<none>"}`,
+          `stderr=${updated.stderr || "<empty>"}`,
+        ].join("\n"),
+      ).toBe(0);
       const updatedBytes = fs.readFileSync(fixture.configPath);
       expect(updatedBytes).toHaveLength(boundarySize);
       expect(createHash("sha256").update(updatedBytes).digest("hex")).toBe(


### PR DESCRIPTION
## Summary

Stabilize the maximum-size Hermes restart-config seal test after hosted CI showed its child process reaching the hard 45-second cap. The production guard completed successfully on rerun and the runner remained healthy, so this is a test-budget false negative rather than a product failure or runner loss.

The test now uses the shared Hermes guard helper's 90-second child timeout, gives Vitest a 120-second outer budget, and reports the timeout code, signal, elapsed time, and stderr when the subprocess fails.

## Related Issue

Part of #7140

Follow-up to the false CI failure observed on #7604 in [run 30239103733](https://github.com/NVIDIA/NemoClaw/actions/runs/30239103733).

## Changes

- Reuse `runWriteConfig` so the maximum-size case follows the same 90-second subprocess budget as the other Hermes guard tests.
- Raise only this test's outer timeout from 60 to 120 seconds so it remains above the child-process ceiling.
- Preserve the exact 16 MiB boundary and all journal/hash/state assertions.
- Include `error.code`, signal, elapsed milliseconds, and stderr in a failed assertion so future infrastructure or product failures are distinguishable.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only a test timeout and its failure diagnostics; production Hermes sealing behavior and user-facing interfaces are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: exact-diff review confirmed the 16 MiB boundary, guard inputs, hash validation, and bounded-state assertions are unchanged; the patch only reuses the existing shared timeout helper and improves failure evidence.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: only a test timeout and failure diagnostics changed. Production Hermes sealing behavior, commands, configuration, defaults, and outputs are untouched.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6662e78c7 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable; no DGX Station or runtime behavior changed.
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every pushed commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused integration file passed 8/8 with PyYAML available.
- [ ] Applicable broad gate passed — not applicable; one focused test file changed and targeted integration, CLI build/typecheck, title, size, project-membership, source-shape, formatting, secret-scan, commit, and push gates passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage and diagnostics for configuration write-journal limit testing.
  * Extended the test timeout to accommodate slower environments.
  * Added clearer failure details, including execution time, error codes, signals, and error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->