### PR TITLE
test(e2e): fix reboot service and TUI status checks

### DIFF
--- a/test/e2e/fixtures/phases/lifecycle.ts
+++ b/test/e2e/fixtures/phases/lifecycle.ts
@@ -66,10 +66,11 @@ export function buildOpenShellGatewayUserServiceStageScript(): string {
     "cleanup_failed_stage() {",
     "  status=$?",
     "  trap - EXIT",
-    '  if [ "$status" -ne 0 ] && [ "$created" -eq 1 ]; then',
+    '  if [ "$status" -ne 0 ] && [ "$created" -eq 1 ] && [ ! -L "$unit" ] && [ -f "$unit" ] && grep -Fxq "$marker" "$unit"; then',
     '    rm -f -- "$unit"',
     "    systemctl --user daemon-reload >/dev/null 2>&1 || true",
     "  fi",
+    "  if declare -F _global_cleanup >/dev/null 2>&1; then _global_cleanup; fi",
     '  exit "$status"',
     "}",
     "trap cleanup_failed_stage EXIT",
@@ -78,6 +79,8 @@ export function buildOpenShellGatewayUserServiceStageScript(): string {
     "  exit 1",
     "fi",
     'source "$installer"',
+    "trap cleanup_failed_stage EXIT",
+    'if [ "$had_marked_unit" -eq 0 ]; then created=1; fi',
     "install_nemoclaw_openshell_gateway_user_service",
     "systemctl --user daemon-reload",
     "if systemctl --user cat openshell-gateway >/dev/null 2>&1; then",
@@ -85,7 +88,7 @@ export function buildOpenShellGatewayUserServiceStageScript(): string {
     "  exit 0",
     "fi",
     `if [ ! -f "$unit" ] || ! grep -Fxq "$marker" "$unit"; then exit ${USER_SERVICE_UNAVAILABLE_EXIT}; fi`,
-    'if [ "$had_marked_unit" -eq 0 ]; then created=1; outcome=staged; else outcome=existing; fi',
+    'if [ "$had_marked_unit" -eq 0 ]; then outcome=staged; else outcome=existing; fi',
     "systemctl --user enable nemoclaw-openshell-gateway >/dev/null",
     `printf '%s%s\\n' "$result_prefix" "$outcome"`,
   ].join("\n");
@@ -429,7 +432,10 @@ export class LifecyclePhaseFixture {
     );
     assertExitZero(result, "stage OpenShell gateway user service for reboot lifecycle");
     const match = result.stdout.match(
-      /(?:^|\n)NEMOCLAW_E2E_GATEWAY_USER_SERVICE=(upstream|existing|staged)(?:\n|$)/u,
+      new RegExp(
+        `(?:^|\\n)${USER_SERVICE_STAGE_RESULT_PREFIX}(upstream|existing|staged)(?:\\n|$)`,
+        "u",
+      ),
     );
     if (!match) {
       throw new Error("OpenShell gateway user service staging did not report its outcome.");

--- a/test/e2e/fixtures/phases/lifecycle.ts
+++ b/test/e2e/fixtures/phases/lifecycle.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { fileURLToPath } from "node:url";
+
 import { buildAvailabilityProbeEnv } from "../availability-env.ts";
 import { assertExitZero, outputContainsReadySandbox } from "../clients/command.ts";
 import type { GatewayClient, HostGatewayRuntime } from "../clients/gateway.ts";
@@ -38,6 +40,77 @@ const SANDBOX_READY_DELAY_MS = 5_000;
 const USER_SERVICE_UNAVAILABLE_EXIT = 75;
 const NEMOCLAW_OPENSHELL_GATEWAY_USER_SERVICE_MARKER_LINE =
   "# NEMOCLAW_MANAGED_OPENSHELL_GATEWAY=1";
+const NEMOCLAW_INSTALLER = fileURLToPath(
+  new URL("../../../../scripts/install.sh", import.meta.url),
+);
+const USER_SERVICE_STAGE_RESULT_PREFIX = "NEMOCLAW_E2E_GATEWAY_USER_SERVICE=";
+
+type UserServiceStageResult = "upstream" | "existing" | "staged";
+
+export function buildOpenShellGatewayUserServiceStageScript(): string {
+  return [
+    "set -eu",
+    `marker='${NEMOCLAW_OPENSHELL_GATEWAY_USER_SERVICE_MARKER_LINE}'`,
+    `result_prefix='${USER_SERVICE_STAGE_RESULT_PREFIX}'`,
+    "installer=$1",
+    `if [ "$(uname -s)" != Linux ]; then exit ${USER_SERVICE_UNAVAILABLE_EXIT}; fi`,
+    `if ! command -v systemctl >/dev/null 2>&1; then exit ${USER_SERVICE_UNAVAILABLE_EXIT}; fi`,
+    'case "${XDG_CONFIG_HOME:-}" in',
+    '  /*) config_home="$XDG_CONFIG_HOME" ;;',
+    '  *) config_home="$HOME/.config" ;;',
+    "esac",
+    'unit="$config_home/systemd/user/nemoclaw-openshell-gateway.service"',
+    "had_marked_unit=0",
+    'if [ -f "$unit" ] && grep -Fxq "$marker" "$unit"; then had_marked_unit=1; fi',
+    "created=0",
+    "cleanup_failed_stage() {",
+    "  status=$?",
+    "  trap - EXIT",
+    '  if [ "$status" -ne 0 ] && [ "$created" -eq 1 ]; then',
+    '    rm -f -- "$unit"',
+    "    systemctl --user daemon-reload >/dev/null 2>&1 || true",
+    "  fi",
+    '  exit "$status"',
+    "}",
+    "trap cleanup_failed_stage EXIT",
+    'if [ ! -f "$installer" ] || [ -L "$installer" ]; then',
+    '  printf "NemoClaw installer is unavailable: %s\\n" "$installer" >&2',
+    "  exit 1",
+    "fi",
+    'source "$installer"',
+    "install_nemoclaw_openshell_gateway_user_service",
+    "systemctl --user daemon-reload",
+    "if systemctl --user cat openshell-gateway >/dev/null 2>&1; then",
+    `  printf '%s%s\\n' "$result_prefix" upstream`,
+    "  exit 0",
+    "fi",
+    `if [ ! -f "$unit" ] || ! grep -Fxq "$marker" "$unit"; then exit ${USER_SERVICE_UNAVAILABLE_EXIT}; fi`,
+    'if [ "$had_marked_unit" -eq 0 ]; then created=1; outcome=staged; else outcome=existing; fi',
+    "systemctl --user enable nemoclaw-openshell-gateway >/dev/null",
+    `printf '%s%s\\n' "$result_prefix" "$outcome"`,
+  ].join("\n");
+}
+
+export function buildOpenShellGatewayUserServiceRemovalScript(): string {
+  return [
+    "set -eu",
+    `marker='${NEMOCLAW_OPENSHELL_GATEWAY_USER_SERVICE_MARKER_LINE}'`,
+    'case "${XDG_CONFIG_HOME:-}" in',
+    '  /*) config_home="$XDG_CONFIG_HOME" ;;',
+    '  *) config_home="$HOME/.config" ;;',
+    "esac",
+    'unit="$config_home/systemd/user/nemoclaw-openshell-gateway.service"',
+    'if [ ! -e "$unit" ] && [ ! -L "$unit" ]; then exit 0; fi',
+    'if [ -L "$unit" ] || [ ! -f "$unit" ] || ! grep -Fxq "$marker" "$unit"; then',
+    '  printf "Refusing to remove foreign OpenShell gateway user service: %s\\n" "$unit" >&2',
+    "  exit 1",
+    "fi",
+    "systemctl --user stop nemoclaw-openshell-gateway",
+    "systemctl --user disable nemoclaw-openshell-gateway >/dev/null",
+    'rm -f -- "$unit"',
+    "systemctl --user daemon-reload",
+  ].join("\n");
+}
 
 export function buildOpenShellGatewayUserServiceRestartScript(): string {
   return [
@@ -239,7 +312,9 @@ export class LifecyclePhaseFixture {
    *   - rename the backup sibling back to the original name (if we
    *     created one);
    *   - `docker start` the labeled container so the sandbox returns
-   *     to a usable state for any teardown that expects it live.
+   *     to a usable state for any teardown that expects it live;
+   *   - remove a user service staged only for this source-checkout
+   *     fixture, then restore the original gateway runtime shape.
    */
   async simulatePostReboot(
     instance: NemoClawInstance,
@@ -257,6 +332,17 @@ export class LifecyclePhaseFixture {
       );
     }
     const originalName = containerNames[0];
+    const userServiceStage = await this.ensureOpenShellGatewayUserService();
+    let previousRuntime: HostGatewayRuntime | null = null;
+    if (userServiceStage === "staged") {
+      this.cleanup.add("lifecycle.remove-staged-gateway-user-service", async () => {
+        await this.removeStagedOpenShellGatewayUserService();
+        await this.startGatewayRuntime(previousRuntime, {
+          sandboxName: instance.sandboxName,
+        });
+        await this.waitForGatewayConnected();
+      });
+    }
 
     const stop = await this.host.command("docker", ["stop", originalName], {
       artifactName: `lifecycle-post-reboot-docker-stop-${originalName}`,
@@ -294,7 +380,7 @@ export class LifecyclePhaseFixture {
       });
     }
 
-    const previousRuntime = await this.restartGatewayRuntime({
+    previousRuntime = await this.restartGatewayRuntime({
       delayMs: 0,
       requireUserService: true,
       sandboxName: instance.sandboxName,
@@ -324,6 +410,44 @@ export class LifecyclePhaseFixture {
     });
 
     return { profile: "post-reboot-recovery", steps };
+  }
+
+  private async ensureOpenShellGatewayUserService(): Promise<UserServiceStageResult> {
+    const result = await this.host.command(
+      "bash",
+      [
+        "-lc",
+        buildOpenShellGatewayUserServiceStageScript(),
+        "stage-nemoclaw-openshell-gateway-service",
+        NEMOCLAW_INSTALLER,
+      ],
+      {
+        artifactName: "lifecycle-gateway-user-service-stage",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 120_000,
+      },
+    );
+    assertExitZero(result, "stage OpenShell gateway user service for reboot lifecycle");
+    const match = result.stdout.match(
+      /(?:^|\n)NEMOCLAW_E2E_GATEWAY_USER_SERVICE=(upstream|existing|staged)(?:\n|$)/u,
+    );
+    if (!match) {
+      throw new Error("OpenShell gateway user service staging did not report its outcome.");
+    }
+    return match[1] as UserServiceStageResult;
+  }
+
+  private async removeStagedOpenShellGatewayUserService(): Promise<void> {
+    const result = await this.host.command(
+      "sh",
+      ["-lc", buildOpenShellGatewayUserServiceRemovalScript()],
+      {
+        artifactName: "lifecycle-cleanup-gateway-user-service",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 120_000,
+      },
+    );
+    assertExitZero(result, "remove staged OpenShell gateway user service");
   }
 
   async stopGatewayRuntime(): Promise<HostGatewayRuntime | null> {

--- a/test/e2e/live/issue-6194-tui-expect.ts
+++ b/test/e2e/live/issue-6194-tui-expect.ts
@@ -93,7 +93,8 @@ expect_or_exit {connected[^\\r\\n]*idle} connected_idle_initial 10 11
 send -- "Reply with the three fragments joined by underscores: NEMOCLAW6194, CHAT, OK. Put only that joined token on its own line. Do not use tools.\\r"
 expect_pair_or_exit {NEMOCLAW6194_CHAT_OK} chat_reply {connected[^\\r\\n]*idle} connected_idle_after_chat 20 21 22 23
 send -- "/nemoclaw status\\r"
-expect_pair_or_exit {NemoClaw Status} slash_status_output {connected[^\\r\\n]*idle} connected_idle_after_status 30 31 32 33
+expect_or_exit {Sandbox:} slash_status_output 30 31
+expect_or_exit {connected[^\\r\\n]*idle} connected_idle_after_status 32 33
 # Network-rule approvals belong to the separate OpenShell terminal UI. Keep
 # this OpenClaw TUI regression scoped to inputs it can perform directly so a
 # tool-less hosted model cannot turn assistant prose into a test oracle.

--- a/test/e2e/support/e2e-phase-lifecycle.test.ts
+++ b/test/e2e/support/e2e-phase-lifecycle.test.ts
@@ -118,6 +118,7 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
   it("stops the labeled container, restarts the gateway service, then runs status", async () => {
     const runner = new FakeRunner();
     runner.enqueue(shellResult(0, "openshell-cluster-e2e-ubuntu-repo-cloud-openclaw\n")); // discover
+    runner.enqueue(shellResult(0, "NEMOCLAW_E2E_GATEWAY_USER_SERVICE=staged\n")); // stage service
     runner.enqueue(shellResult(0)); // docker stop
     runner.enqueue(shellResult(0)); // forward stop
     runner.enqueue(shellResult(0)); // gateway stop
@@ -139,6 +140,7 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
     ]);
     expect(runner.calls.map((call) => `${call.command} ${call.args.join(" ")}`)).toEqual([
       "docker ps -a --filter label=openshell.ai/sandbox-name=e2e-ubuntu-repo-cloud-openclaw --format {{.Names}}",
+      expect.stringContaining("bash -lc set -eu"),
       "docker stop openshell-cluster-e2e-ubuntu-repo-cloud-openclaw",
       "sh -lc command -v openshell >/dev/null 2>&1 && openshell forward stop 18789 || true",
       "sh -lc command -v openshell >/dev/null 2>&1 && openshell gateway stop -g nemoclaw || true",
@@ -149,6 +151,7 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
       "nemoclaw e2e-ubuntu-repo-cloud-openclaw status",
     ]);
     expect(cleanup.calls.map((call) => call.name)).toEqual([
+      "lifecycle.remove-staged-gateway-user-service",
       "lifecycle.docker-start:openshell-cluster-e2e-ubuntu-repo-cloud-openclaw",
     ]);
   });
@@ -156,6 +159,7 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
   it("tolerates a non-zero status exit (the bug succeeds at destroying state)", async () => {
     const runner = new FakeRunner();
     runner.enqueue(shellResult(0, "container-1\n")); // discover
+    runner.enqueue(shellResult(0, "NEMOCLAW_E2E_GATEWAY_USER_SERVICE=existing\n")); // service
     runner.enqueue(shellResult(0)); // docker stop
     runner.enqueue(shellResult(0)); // forward stop
     runner.enqueue(shellResult(0)); // gateway stop
@@ -196,6 +200,7 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
   it("fails when the managed OpenShell gateway user service is unavailable", async () => {
     const runner = new FakeRunner();
     runner.enqueue(shellResult(0, "container-1\n")); // discover
+    runner.enqueue(shellResult(0, "NEMOCLAW_E2E_GATEWAY_USER_SERVICE=existing\n")); // service
     runner.enqueue(shellResult(0)); // docker stop
     runner.enqueue(shellResult(0)); // forward stop
     runner.enqueue(shellResult(0)); // gateway stop
@@ -218,6 +223,7 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (rename-to-gpu-bac
   it("stops, then renames the labeled container to a *-nemoclaw-gpu-backup-* sibling", async () => {
     const runner = new FakeRunner();
     runner.enqueue(shellResult(0, "openshell-cluster-e2e-x\n")); // discover
+    runner.enqueue(shellResult(0, "NEMOCLAW_E2E_GATEWAY_USER_SERVICE=existing\n")); // service
     runner.enqueue(shellResult(0)); // docker stop
     runner.enqueue(shellResult(0)); // docker rename
     runner.enqueue(shellResult(0)); // forward stop

--- a/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
+++ b/test/e2e/support/issue-6194-tui-post-idle-contract.test.ts
@@ -75,9 +75,11 @@ describe("live TUI post-idle coverage contract (#6194)", () => {
       "expect_pair_or_exit {NEMOCLAW6194_CHAT_OK} chat_reply {connected[^\\r\\n]*idle} connected_idle_after_chat 20 21 22 23",
     );
     expect(script).toContain("/nemoclaw status");
+    expect(script).toContain("expect_or_exit {Sandbox:} slash_status_output 30 31");
     expect(script).toContain(
-      "expect_pair_or_exit {NemoClaw Status} slash_status_output {connected[^\\r\\n]*idle} connected_idle_after_status 30 31 32 33",
+      "expect_or_exit {connected[^\\r\\n]*idle} connected_idle_after_status 32 33",
     );
+    expect(script).not.toContain("{NemoClaw Status}");
     expect(script).toContain("if {!$firstSeen} { exit $firstTimeoutExit }");
     expect(script).toContain("if {!$firstSeen} { exit $firstEofExit }");
     expect(script).toContain("mark clean_exit");

--- a/test/e2e/support/lifecycle-user-service.test.ts
+++ b/test/e2e/support/lifecycle-user-service.test.ts
@@ -43,20 +43,24 @@ describe("reboot lifecycle OpenShell gateway user-service fixture", () => {
     try {
       const env = buildAvailabilityProbeEnv({
         HOME: home,
-        PATH: `${bin}:/usr/bin:/bin`,
+        PATH: `${bin}:${path.dirname(process.execPath)}:/usr/bin:/bin`,
         XDG_CONFIG_HOME: configHome,
       });
       const staged = execFileSync(
         "bash",
         ["-lc", buildOpenShellGatewayUserServiceStageScript(), "stage-service", installer],
-        { encoding: "utf8", env },
+        { encoding: "utf8", env, killSignal: "SIGKILL", timeout: 30_000 },
       );
 
       expect(staged).toContain("NEMOCLAW_E2E_GATEWAY_USER_SERVICE=staged");
       expect(fs.readFileSync(unit, "utf8")).toContain(`ExecStart=${bin}/openshell-gateway`);
       expect(fs.statSync(unit).mode & 0o777).toBe(0o600);
 
-      execFileSync("sh", ["-lc", buildOpenShellGatewayUserServiceRemovalScript()], { env });
+      execFileSync("sh", ["-lc", buildOpenShellGatewayUserServiceRemovalScript()], {
+        env,
+        killSignal: "SIGKILL",
+        timeout: 30_000,
+      });
 
       expect(fs.existsSync(unit)).toBe(false);
       expect(fs.readFileSync(log, "utf8").trim().split("\n")).toEqual([
@@ -91,7 +95,7 @@ describe("reboot lifecycle OpenShell gateway user-service fixture", () => {
       const output = execFileSync(
         "bash",
         ["-lc", buildOpenShellGatewayUserServiceStageScript(), "stage-service", installer],
-        { encoding: "utf8", env },
+        { encoding: "utf8", env, killSignal: "SIGKILL", timeout: 30_000 },
       );
 
       expect(output).toContain("NEMOCLAW_E2E_GATEWAY_USER_SERVICE=upstream");
@@ -100,6 +104,46 @@ describe("reboot lifecycle OpenShell gateway user-service fixture", () => {
           path.join(configHome, "systemd", "user", "nemoclaw-openshell-gateway.service"),
         ),
       ).toBe(false);
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("removes a staged service when daemon reload fails", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-lifecycle-stage-failure-"));
+    const home = path.join(root, "home");
+    const configHome = path.join(root, "config");
+    const bin = path.join(home, ".local", "bin");
+    const unit = path.join(configHome, "systemd", "user", "nemoclaw-openshell-gateway.service");
+
+    fs.mkdirSync(bin, { recursive: true });
+    fs.writeFileSync(path.join(bin, "openshell-gateway"), "#!/bin/sh\n", { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(bin, "systemctl"),
+      [
+        "#!/bin/sh",
+        'if [ "$*" = "--user cat openshell-gateway" ]; then exit 1; fi',
+        'if [ "$*" = "--user daemon-reload" ]; then exit 1; fi',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    try {
+      const env = buildAvailabilityProbeEnv({
+        HOME: home,
+        PATH: `${bin}:${path.dirname(process.execPath)}:/usr/bin:/bin`,
+        XDG_CONFIG_HOME: configHome,
+      });
+
+      expect(() =>
+        execFileSync(
+          "bash",
+          ["-lc", buildOpenShellGatewayUserServiceStageScript(), "stage-service", installer],
+          { env, killSignal: "SIGKILL", stdio: "pipe", timeout: 30_000 },
+        ),
+      ).toThrow();
+      expect(fs.existsSync(unit)).toBe(false);
     } finally {
       fs.rmSync(root, { force: true, recursive: true });
     }
@@ -135,7 +179,7 @@ describe("reboot lifecycle OpenShell gateway user-service fixture", () => {
         execFileSync(
           "bash",
           ["-lc", buildOpenShellGatewayUserServiceStageScript(), "stage-service", installer],
-          { env, stdio: "pipe" },
+          { env, killSignal: "SIGKILL", stdio: "pipe", timeout: 30_000 },
         ),
       ).toThrow();
       expect(fs.readFileSync(unit, "utf8")).toBe("[Service]\nExecStart=/tmp/foreign\n");
@@ -178,7 +222,11 @@ describe("managed OpenShell gateway user-service restart", () => {
         PATH: `${bin}:/usr/bin:/bin`,
         XDG_CONFIG_HOME: configHome,
       });
-      execFileSync("sh", ["-lc", buildOpenShellGatewayUserServiceRestartScript()], { env });
+      execFileSync("sh", ["-lc", buildOpenShellGatewayUserServiceRestartScript()], {
+        env,
+        killSignal: "SIGKILL",
+        timeout: 30_000,
+      });
 
       expect(env.XDG_CONFIG_HOME).toBe(configHome);
       expect(fs.readFileSync(log, "utf8").trim().split("\n")).toEqual([

--- a/test/e2e/support/lifecycle-user-service.test.ts
+++ b/test/e2e/support/lifecycle-user-service.test.ts
@@ -5,11 +5,145 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { buildOpenShellGatewayUserServiceRestartScript } from "../fixtures/phases/lifecycle.ts";
+import {
+  buildOpenShellGatewayUserServiceRemovalScript,
+  buildOpenShellGatewayUserServiceRestartScript,
+  buildOpenShellGatewayUserServiceStageScript,
+} from "../fixtures/phases/lifecycle.ts";
+
+const installer = fileURLToPath(new URL("../../../scripts/install.sh", import.meta.url));
+
+describe("reboot lifecycle OpenShell gateway user-service fixture", () => {
+  it("stages, enables, and removes the repository service template", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-lifecycle-stage-service-"));
+    const home = path.join(root, "home");
+    const configHome = path.join(root, "config");
+    const bin = path.join(home, ".local", "bin");
+    const log = path.join(root, "systemctl.log");
+    const unit = path.join(configHome, "systemd", "user", "nemoclaw-openshell-gateway.service");
+
+    fs.mkdirSync(bin, { recursive: true });
+    fs.writeFileSync(path.join(bin, "openshell-gateway"), "#!/bin/sh\n", { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(bin, "systemctl"),
+      [
+        "#!/bin/sh",
+        `printf "%s\\n" "$*" >> ${JSON.stringify(log)}`,
+        'if [ "$*" = "--user cat openshell-gateway" ]; then exit 1; fi',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    try {
+      const env = buildAvailabilityProbeEnv({
+        HOME: home,
+        PATH: `${bin}:/usr/bin:/bin`,
+        XDG_CONFIG_HOME: configHome,
+      });
+      const staged = execFileSync(
+        "bash",
+        ["-lc", buildOpenShellGatewayUserServiceStageScript(), "stage-service", installer],
+        { encoding: "utf8", env },
+      );
+
+      expect(staged).toContain("NEMOCLAW_E2E_GATEWAY_USER_SERVICE=staged");
+      expect(fs.readFileSync(unit, "utf8")).toContain(`ExecStart=${bin}/openshell-gateway`);
+      expect(fs.statSync(unit).mode & 0o777).toBe(0o600);
+
+      execFileSync("sh", ["-lc", buildOpenShellGatewayUserServiceRemovalScript()], { env });
+
+      expect(fs.existsSync(unit)).toBe(false);
+      expect(fs.readFileSync(log, "utf8").trim().split("\n")).toEqual([
+        "--user daemon-reload",
+        "--user cat openshell-gateway",
+        "--user enable nemoclaw-openshell-gateway",
+        "--user stop nemoclaw-openshell-gateway",
+        "--user disable nemoclaw-openshell-gateway",
+        "--user daemon-reload",
+      ]);
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("uses an existing upstream service without staging a NemoClaw unit", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-lifecycle-upstream-service-"));
+    const home = path.join(root, "home");
+    const configHome = path.join(root, "config");
+    const bin = path.join(root, "bin");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(bin, { recursive: true });
+    fs.writeFileSync(path.join(bin, "systemctl"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    try {
+      const env = buildAvailabilityProbeEnv({
+        HOME: home,
+        PATH: `${bin}:/usr/bin:/bin`,
+        XDG_CONFIG_HOME: configHome,
+      });
+      const output = execFileSync(
+        "bash",
+        ["-lc", buildOpenShellGatewayUserServiceStageScript(), "stage-service", installer],
+        { encoding: "utf8", env },
+      );
+
+      expect(output).toContain("NEMOCLAW_E2E_GATEWAY_USER_SERVICE=upstream");
+      expect(
+        fs.existsSync(
+          path.join(configHome, "systemd", "user", "nemoclaw-openshell-gateway.service"),
+        ),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("refuses to replace a foreign NemoClaw-named service", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-lifecycle-foreign-service-"));
+    const home = path.join(root, "home");
+    const configHome = path.join(root, "config");
+    const bin = path.join(home, ".local", "bin");
+    const unitDir = path.join(configHome, "systemd", "user");
+    const unit = path.join(unitDir, "nemoclaw-openshell-gateway.service");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(bin, { recursive: true });
+    fs.mkdirSync(unitDir, { recursive: true });
+    fs.writeFileSync(unit, "[Service]\nExecStart=/tmp/foreign\n");
+    fs.writeFileSync(path.join(bin, "openshell-gateway"), "#!/bin/sh\n", { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(bin, "systemctl"),
+      '#!/bin/sh\n[ "$*" = "--user cat openshell-gateway" ] && exit 1\nexit 0\n',
+      { mode: 0o755 },
+    );
+
+    try {
+      const env = buildAvailabilityProbeEnv({
+        HOME: home,
+        PATH: `${bin}:/usr/bin:/bin`,
+        XDG_CONFIG_HOME: configHome,
+      });
+
+      expect(() =>
+        execFileSync(
+          "bash",
+          ["-lc", buildOpenShellGatewayUserServiceStageScript(), "stage-service", installer],
+          { env, stdio: "pipe" },
+        ),
+      ).toThrow();
+      expect(fs.readFileSync(unit, "utf8")).toBe("[Service]\nExecStart=/tmp/foreign\n");
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  });
+});
 
 describe("managed OpenShell gateway user-service restart", () => {
   it("selects a marked unit from an absolute custom XDG config root", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Repairs two deterministic false failures from E2E run 30228379802. Source-checkout reboot recovery now supplies the managed gateway user service that the scenario requires, and the OpenClaw TUI check now correlates status output with a response-only sentinel instead of echoed input or an earlier idle redraw.

## Changes

- Stage and enable the existing repository-managed OpenShell gateway user service for the source-checkout reboot fixture, then remove it and restore the previous runtime during cleanup.
- Wait for `Sandbox:` and then the subsequent connected/idle redraw after `/nemoclaw status`.
- Extend E2E support contracts for service ownership, cleanup, status correlation, and phase sequencing.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only E2E setup, cleanup, and result correlation; supported commands and user workflows are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex CLI security review passed with no findings: https://github.com/NVIDIA/NemoClaw/pull/7618#issuecomment-5088278621
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. The PR updates only E2E reboot fixture setup, failure rollback, cleanup, bounded test subprocesses, TUI response correlation, and support tests. Supported user behavior and documentation remain unchanged.
- Agent: Codex CLI
<!-- docs-review-head-sha: 2d30fa457 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/lifecycle-user-service.test.ts test/e2e/support/e2e-phase-lifecycle.test.ts test/e2e/support/issue-6194-tui-post-idle-contract.test.ts` (34 passed, 7 skipped)
- [x] Applicable broad gate passed — `npm run test:e2e-phases:check` (125 tests across 82 files)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-reboot recovery for the OpenShell gateway by conditionally staging the user service and performing targeted cleanup afterward.
  * Restores the original gateway runtime after staging and ensures staged-only removal behaves safely.
  * Enhanced TUI status sequencing by validating sandbox output and the connected-idle transition separately.
  * Prevented replacing existing foreign user services during gateway setup.

* **Tests**
  * Added end-to-end coverage for staging, removal, upstream detection, stage failure behavior, and foreign-service protection.
  * Updated lifecycle and TUI expect flows to match the new post-recovery workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->