### PR TITLE
fix(list): hide route-only reservations from list and status (#7609)

### DIFF
--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -215,6 +215,108 @@ describe("inventory commands", () => {
     ]);
   });
 
+  it("hides a route-only reservation (never-created sandbox) from the list (#7609)", async () => {
+    const inventory = await getSandboxInventory({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          // A failed onboard (e.g. untrusted base image rejected) leaves this:
+          // pendingRouteReservation with no createdAt — never a live sandbox.
+          {
+            name: "base-img-reject",
+            provider: "nvidia-prod",
+            model: "m",
+            pendingRouteReservation: true,
+          },
+          { name: "real", provider: "nvidia-prod", model: "m", createdAt: "2026-01-01T00:00:00Z" },
+        ],
+        defaultSandbox: null,
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+    });
+
+    expect(inventory.sandboxes.map((sandbox) => sandbox.name)).toEqual(["real"]);
+  });
+
+  it("keeps a created sandbox with a lingering pending reservation flag (#7609)", async () => {
+    const inventory = await getSandboxInventory({
+      recoverRegistryEntries: async () => ({
+        // createdAt is set, so this is a real sandbox — the filter must NOT hide
+        // it just because the reservation flag was not cleared.
+        sandboxes: [
+          {
+            name: "created",
+            provider: "nvidia-prod",
+            model: "m",
+            pendingRouteReservation: true,
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        defaultSandbox: null,
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+    });
+
+    expect(inventory.sandboxes.map((sandbox) => sandbox.name)).toEqual(["created"]);
+  });
+
+  it("hides route-only reservations from status output too (#7609)", () => {
+    const report = getStatusReport({
+      listSandboxes: () => ({
+        sandboxes: [
+          {
+            name: "base-img-reject",
+            provider: "nvidia-prod",
+            model: "m",
+            pendingRouteReservation: true,
+          },
+          { name: "real", provider: "nvidia-prod", model: "m", createdAt: "2026-01-01T00:00:00Z" },
+        ],
+        defaultSandbox: "real",
+      }),
+      getLiveInference: () => null,
+      showServiceStatus: vi.fn(),
+    });
+
+    expect(report.sandboxes.map((sandbox) => sandbox.name)).toEqual(["real"]);
+
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [
+          {
+            name: "base-img-reject",
+            provider: "nvidia-prod",
+            model: "m",
+            pendingRouteReservation: true,
+          },
+        ],
+        defaultSandbox: null,
+      }),
+      getLiveInference: () => null,
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+    expect(lines.some((line) => line.includes("base-img-reject"))).toBe(false);
+  });
+
+  it("shows the empty-state hint when only route-only reservations exist (#7609)", async () => {
+    const lines: string[] = [];
+    await listSandboxesCommand({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [{ name: "base-img-reject", pendingRouteReservation: true }],
+        defaultSandbox: null,
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines.some((line) => line.includes("No sandboxes registered"))).toBe(true);
+    expect(lines.some((line) => line.includes("base-img-reject"))).toBe(false);
+  });
+
   it("normalizes invalid configured inference fields out of status rows", () => {
     const report = getStatusReport({
       listSandboxes: () => ({

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -467,8 +467,8 @@ function normalizeGatewayAuthority(
 export function getStatusReport(deps: ShowStatusCommandDeps): StatusReport {
   const sandboxList = deps.listSandboxes();
   // Hide route-only reservations from a failed onboard (#7609) — same as
-  // `nemoclaw list`. resolveDefaultSandboxName already excludes them, so
-  // filtering here keeps `status` consistent with `list`.
+  // `nemoclaw list`. Pending reservations cannot become the registry default;
+  // explicit environment overrides still control host-service selection.
   const sandboxes = sandboxList.sandboxes.filter(
     (sandbox) => !isRouteOnlySandboxReservation(sandbox),
   );

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -6,7 +6,11 @@ import type { GatewayInference } from "../inference/config";
 import { getActiveChannelIdsFromPlan } from "../messaging/plan-validation";
 import type { GatewayOwnerDescription } from "../onboard/gateway-ownership";
 import { redactFull } from "../security/redact";
-import { getSandboxEntryDisplayInference, type SandboxMessagingState } from "../state/registry";
+import {
+  getSandboxEntryDisplayInference,
+  isRouteOnlySandboxReservation,
+  type SandboxMessagingState,
+} from "../state/registry";
 import { resolveDefaultSandboxName } from "../tunnel/service-command";
 
 export interface SandboxEntry {
@@ -24,6 +28,12 @@ export interface SandboxEntry {
   messaging?: SandboxMessagingState | null;
   agent?: string | null;
   dashboardPort?: number | null;
+  // Passthrough of the durable registry reservation markers so the list can
+  // recognize (and hide) a route-only reservation left by a failed onboard
+  // (#7609). A real sandbox carries createdAt; a never-created reservation does
+  // not. Not rendered — read only by isRouteOnlySandboxReservation.
+  pendingRouteReservation?: true;
+  createdAt?: string;
   // #5714: display-only markers for a sandbox recovered directly from the live
   // gateway. `recoveredFromGateway` flags that agent/GPU are genuinely unknown
   // (the gateway sandbox list does not expose them) so the renderer shows
@@ -252,9 +262,18 @@ export async function getSandboxInventory(
       recoveredFromGateway: recovery.recoveredFromGateway || 0,
     },
     lastOnboardedSandbox,
-    sandboxes: recovery.sandboxes.map((sandbox) =>
-      buildSandboxInventoryRow(sandbox, resolvedDefault, deps.getActiveSessionCount),
-    ),
+    // A route-only reservation (pendingRouteReservation with no createdAt) is an
+    // internal artifact of an onboard that reserved the gateway route but never
+    // finished creating the sandbox — e.g. an untrusted base image was rejected
+    // (#7609), or the image build failed. The reservation is intentionally kept
+    // for `--resume` (#6572/#6626), but it must not render as a real sandbox in
+    // `nemoclaw list`. Filter it here so the display matches every other
+    // consumer that already excludes it (maintenance, upgrade-sandboxes).
+    sandboxes: recovery.sandboxes
+      .filter((sandbox) => !isRouteOnlySandboxReservation(sandbox))
+      .map((sandbox) =>
+        buildSandboxInventoryRow(sandbox, resolvedDefault, deps.getActiveSessionCount),
+      ),
   };
 }
 
@@ -447,7 +466,12 @@ function normalizeGatewayAuthority(
 
 export function getStatusReport(deps: ShowStatusCommandDeps): StatusReport {
   const sandboxList = deps.listSandboxes();
-  const { sandboxes } = sandboxList;
+  // Hide route-only reservations from a failed onboard (#7609) — same as
+  // `nemoclaw list`. resolveDefaultSandboxName already excludes them, so
+  // filtering here keeps `status` consistent with `list`.
+  const sandboxes = sandboxList.sandboxes.filter(
+    (sandbox) => !isRouteOnlySandboxReservation(sandbox),
+  );
   const resolvedDefault = resolveDefaultSandboxName(() => sandboxList) ?? null;
   const liveInference = sandboxes.length > 0 ? deps.getLiveInference() : null;
   const gatewayHealth =
@@ -486,7 +510,11 @@ export function getStatusReport(deps: ShowStatusCommandDeps): StatusReport {
 export function showStatusCommand(deps: ShowStatusCommandDeps): void {
   const log = deps.log ?? console.log;
   const sandboxList = deps.listSandboxes();
-  const { sandboxes } = sandboxList;
+  // Hide route-only reservations from a failed onboard (#7609) — same as
+  // `nemoclaw list`.
+  const sandboxes = sandboxList.sandboxes.filter(
+    (sandbox) => !isRouteOnlySandboxReservation(sandbox),
+  );
   const resolvedDefault = resolveDefaultSandboxName(() => sandboxList) ?? null;
   log("");
   log("  Global status (registered sandboxes and host services):");

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -674,8 +674,17 @@ export function reserveSandboxInferenceRoute(
   });
 }
 
-/** True only for an inference route reserved before sandbox registration. */
-export function isRouteOnlySandboxReservation(entry: SandboxEntry): boolean {
+/**
+ * True only for an inference route reserved before sandbox registration.
+ *
+ * Structural parameter (only the two fields it reads) so display-layer entry
+ * types that omit the rest of the durable registry shape can reuse this single
+ * source of truth instead of re-deriving the predicate (#7609).
+ */
+export function isRouteOnlySandboxReservation(entry: {
+  pendingRouteReservation?: true;
+  createdAt?: string;
+}): boolean {
   return entry.pendingRouteReservation === true && entry.createdAt === undefined;
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
A failed onboard that reserved the gateway inference route but never created the sandbox leaves a `pendingRouteReservation` registry entry with no `createdAt`. `nemoclaw list` and `nemoclaw status` rendered that route-only reservation as a real sandbox — a ghost the user had to `destroy` even though it never existed in the live gateway. This PR filters route-only reservations at the display boundary.

Closes #7609.

## Reproduction
On our Ubuntu 24.04 x86_64 test host (no GPU), built from `main`:

```bash
NEMOCLAW_SANDBOX_BASE_IMAGE_REF=127.0.0.1:18081/untrusted/base:latest \
  nemoclaw onboard --name base-img-reject-openclaw --non-interactive --yes --fresh
nemoclaw list
```

Reproduced for OpenClaw, Hermes and LangChain Deep Agents Code (`--agent hermes` / `--agent dcode`). OpenClaw fails at the base-image trust check; Hermes/dcode fail later in the image build — but all three leave the same ghost, because the route reservation is written before, and independently of, the agent-specific create path.

**Environment**
- Test machine: our Ubuntu 24.04 x86_64 test host (no GPU)
- NemoClaw `main` HEAD `0b1854981`
- Sandbox provider: local Ollama (`llama3.1:8b`)

**Observed on `main` (before fix)**
```
SandboxBaseImageResolutionError: OpenClaw sandbox base image override
'127.0.0.1:18081/untrusted/base:latest' is outside the trusted repository
'ghcr.io/nvidia/nemoclaw/sandbox-base'.

$ nemoclaw list
  Sandboxes:
    base-img-reject-openclaw
      agent: openclaw  provider: ollama-local  ...
    base-img-reject-hermes   ...
    base-img-reject-dcode    ...

$ nemoclaw status
  Sandboxes:
    base-img-reject-openclaw (llama3.1:8b) ...   # same ghosts
```

Registry entry left behind:
```json
"base-img-reject-openclaw": { "pendingRouteReservation": true, "provider": "ollama-local", ... }   // no createdAt
```

**Observed on `fix/...` (after fix)**
```
$ nemoclaw list
  No sandboxes registered. Run `nemoclaw onboard` to get started.

$ nemoclaw status
  Global status (registered sandboxes and host services):
  Gateway authority: nemoclaw-managed
  # no ghost rows

# The reservation is still on disk (preserved for --resume), just not displayed.
# Regression check: promoting one entry to a real sandbox (set createdAt) makes it
# show in `list` again — real sandboxes are never hidden.
```

## Analysis
The provider/inference onboard step reserves the gateway route by writing a registry entry via `registry.reserveSandboxInferenceRoute` (`src/lib/onboard/machine/handlers/provider-inference.ts`), marked `pendingRouteReservation: true`. That marker is cleared only when the sandbox is actually created (or on a resume). When a later step throws — the untrusted base image is rejected in `resolveSandboxBaseImage` (`src/lib/sandbox-base-image.ts`) inside `createSandboxWithBaseImageResolution` (`src/lib/onboard.ts`), or the image build fails — the reservation is left behind.

`registry.isRouteOnlySandboxReservation` (`pendingRouteReservation === true && createdAt === undefined`) already identifies exactly this entry, and `maintenance` / `upgrade-sandboxes` already exclude it from their listings. `nemoclaw list` (`buildSandboxInventory`) and `nemoclaw status` (`getStatusReport` / `showStatusCommand`) were the outliers that did not.

The reservation is intentionally kept for `--resume` (#6572, #6626), so the correct fix is to filter it at the display boundary — not to release it, which would break resume.

## Fix
- `src/lib/inventory/index.ts`: `buildSandboxInventory`, `getStatusReport` and `showStatusCommand` filter out `isRouteOnlySandboxReservation` entries before rendering. Two passthrough fields (`pendingRouteReservation`, `createdAt`) are added to the display `SandboxEntry` (they already ride on recovered rows at runtime) so the predicate can read them.
- `src/lib/state/registry.ts`: `isRouteOnlySandboxReservation` now takes a structural parameter (just the two fields it reads) so the display entry type can reuse this single source of truth instead of re-deriving the predicate.

Whole-class notes: the filter is keyed on the reservation shape, so it is independent of agent (OpenClaw/Hermes/dcode) and of the failure cause (trust rejection vs build failure) — verified on the test host for all three agents and both `list` and `status`. Internal consumers that must still see reservations (resume, `inference set`, `connect`) are unchanged. No new failure path is introduced; the reservation persistence is intentional. No docs describe the previous ghost display, so none need updating.

Tests (`src/lib/inventory/index.test.ts`): a route-only reservation is hidden from `list`; a created sandbox with a lingering reservation flag is still shown (regression lock); the empty-state hint appears when only reservations remain; and route-only reservations are hidden from `status` too.

## Changes
- `src/lib/inventory/index.ts`: filter route-only reservations from `list` and `status`; add passthrough fields to the display entry type.
- `src/lib/state/registry.ts`: widen `isRouteOnlySandboxReservation` to a structural parameter.
- `src/lib/inventory/index.test.ts`: coverage for the filter across `list` and `status`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/reference/commands.mdx` and `docs/manage-sandboxes/lifecycle.mdx` already define `list` and global `status` as registered-sandbox views and document environment-override precedence. The fix restores that documented behavior. The follow-up changes only a comment and accurately distinguishes the registry default from explicit environment overrides. Changed comments and test titles have no blocking `WRITING.md` findings.
- Agent: Codex Desktop documentation writer subagent
<!-- docs-review-head-sha: 6a348e3355cd4597d6ae95f66f9de1cf9aa3ae0e -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## Verification

- [x] `npx prek run` passes on the changed files
- [x] `npm test` passes (touched files at minimum)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Route-only (incomplete) sandbox reservations are no longer treated as active sandboxes in inventory listings.
  - Status reports and the status command now omit incomplete route-only reservations from their output.
  - If only route-only reservations exist, listing and status views correctly show the “no sandboxes registered” empty-state.
  - Sandboxes with a creation timestamp remain visible even when a route reservation is still pending.
- **Tests**
  - Added coverage for route-only reservation filtering behavior (including empty-state scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
