### PR TITLE
ci(e2e): retire zero-presets policy shard

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2596,9 +2596,6 @@ jobs:
           - scenario: live-probes
             selector: "^network-policy:.+probes$"
             sandbox: e2e-net-policy-live-probes
-          - scenario: zero-presets
-            selector: "^network-policy:.+presets$"
-            sandbox: e2e-net-policy-zero-presets
     env:
       E2E_JOB: "1"
       E2E_TARGET_ID: "network-policy"

--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -1073,18 +1073,11 @@ NEMOCLAW_WEB_FETCH_PROBE`,
   });
 });
 
-// Invalid state: a default restricted OpenClaw onboard (no web-search, no
-// OpenClaw OTEL) used to leave `openclaw-pricing` applied, contradicting the
-// linked issue's "zero presets" acceptance clause. Source boundary: live
-// OpenShell `policy-list` after onboard and before any operator mutation.
-// Source-fix constraint: unit/handler tests stub policy APIs and the
-// brave-enabled `network-policy` scenario above probes the suppressed
-// preset names only, so neither proves the post-onboard applied set is
-// literally empty. Regression test: this scenario onboards a default
-// restricted OpenClaw sandbox and asserts `policy-list` shows no `●`
-// bullets. Removal condition: when the agent-required addition list moves
-// into per-agent declarative metadata so tier filtering happens at the
-// metadata layer (see `src/lib/onboard/policy-tier-suppression.ts`).
+// Transitional workflow shim for #7617. The normal integration suite now
+// owns the zero-preset plan contract. Keep this test for one merge so the
+// trusted base workflow, which still dispatches the old zero-presets shard
+// while reviewing the workflow change, can collect passing head evidence.
+// Delete it after the one-row network-policy matrix is present on main.
 //
 // Acceptance note (`NEMOCLAW_OPENCLAW_OTEL=1`): the OTEL-enabled live
 // variant is deferred to a follow-up nightly extension to keep this

--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -14,6 +14,7 @@ import { createServer, type Server } from "node:http";
 import path from "node:path";
 
 import { isPrivateIp } from "../../../nemoclaw/src/blueprint/private-networks.ts";
+import { listPresets } from "../../../src/lib/policy/index.ts";
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
@@ -28,6 +29,7 @@ import {
   requirePolicyPresetNumber,
 } from "./network-policy-interactive.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
+import { parseVerifiedActivePolicyPresets } from "./policy-list-state.ts";
 import {
   ensureDockerAvailable,
   runRestrictedOnboardWithRetry,
@@ -648,14 +650,19 @@ test("network-policy: restricted sandbox enforces live allow/deny policy probes"
     artifactName: "tc-net-01-policy-list-after-onboard",
     timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
   });
-  expect(policyListAfterOnboard.exitCode, text(policyListAfterOnboard)).toBe(0);
-  const activeBullets = (policyListAfterOnboard.stdout.match(/^[\s]*●[\s]+(\S+)/gm) ?? []).map(
-    (line) => line.replace(/^[\s]*●[\s]+/, "").trim(),
+  expect(
+    policyListAfterOnboard.exitCode,
+    "policy-list must exit successfully after default restricted onboard",
+  ).toBe(0);
+  const activePresets = parseVerifiedActivePolicyPresets(
+    text(policyListAfterOnboard),
+    listPresets({ agent: "openclaw" }).map((preset) => preset.name),
   );
   expect(
-    activeBullets,
-    `restricted tier must begin with zero active presets; got ${JSON.stringify(activeBullets)} from:\n${text(policyListAfterOnboard)}`,
-  ).toEqual([]);
+    activePresets,
+    "policy-list must return one complete, verified preset listing",
+  ).not.toBeNull();
+  expect(activePresets?.length, "restricted tier must begin with zero active presets").toBe(0);
 
   const denyDefault = await fetchStatus(sandbox, "https://example.com/", "tc-net-01-deny-default");
   expect(denyDefault, `example.com should be blocked under restricted policy`).toMatch(
@@ -1060,12 +1067,8 @@ NEMOCLAW_WEB_FETCH_PROBE`,
   });
 });
 
-// Transitional workflow shim for #7617. The normal integration suite owns
-// the zero-preset plan and the retained live journey above owns the actual
-// OpenShell applied-set boundary. Keep this duplicate test for one merge so
-// the trusted base workflow, which still dispatches the old zero-presets
-// shard while reviewing the workflow change, can collect passing head
-// evidence. Delete it after the one-row matrix is present on main.
+// Compatibility shim for #7617: the trusted base workflow still selects this
+// target while reviewing the one-row matrix change.
 //
 // Acceptance note (`NEMOCLAW_OPENCLAW_OTEL=1`): the OTEL-enabled live
 // variant is deferred to a follow-up nightly extension to keep this

--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -507,7 +507,7 @@ test("network-policy: restricted sandbox enforces live allow/deny policy probes"
     e2ePhases: [
       "confirm built CLI Docker OpenShell and credential",
       "clear the sandbox and onboard restricted policy",
-      "prove default denial and the weather allowlist",
+      "prove zero active presets, default denial, and the weather allowlist",
       "exercise package and SaaS policy presets",
       "prove dry-run and per-binary Jira approval",
       "verify hot reload inference exemption and SSRF guards",
@@ -521,6 +521,7 @@ test("network-policy: restricted sandbox enforces live allow/deny policy probes"
     boundary: "live-sandbox-network-policy",
     contracts: [
       "deny-by-default egress",
+      "restricted tier begins with zero active presets",
       "OpenShell 0.0.85 preserves the full denied endpoint and policy disposition through nemoclaw logs --tail 50 (#4760)",
       "read-only preset allowlist behavior",
       "weather preset allows wttr.in GET and HEAD but denies POST and unrelated hosts",
@@ -606,7 +607,6 @@ test("network-policy: restricted sandbox enforces live allow/deny policy probes"
           NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
           NEMOCLAW_RECREATE_SANDBOX: "1",
           NEMOCLAW_POLICY_TIER: "restricted",
-          NEMOCLAW_WEB_SEARCH_ENABLED: "1",
         }),
         redactionValues: [apiKey],
         timeoutMs: ONBOARD_TIMEOUT_MS,
@@ -641,35 +641,21 @@ test("network-policy: restricted sandbox enforces live allow/deny policy probes"
   }
   expect(onboard?.exitCode, onboard ? text(onboard) : "onboard did not run").toBe(0);
 
-  // Invalid state: prior bugs left `openclaw-pricing` (and, under
-  // `NEMOCLAW_OPENCLAW_OTEL=1` with a local endpoint,
-  // `openclaw-diagnostics-otel-local`) live on restricted OpenClaw sandboxes
-  // even though the restricted tier promises zero third-party network access.
-  // Source boundary: live OpenShell `policy-list` after a successful
-  // restricted onboard and before any operator mutation (`policy-add brew`).
-  // This scenario enables `NEMOCLAW_WEB_SEARCH_ENABLED=1` so the later brave
-  // probe has a preset to allow, so the assertion below only proves the two
-  // OpenClaw-agent suppressed presets are absent. The authoritative
-  // source-of-truth for the linked issue's literal "zero applied presets"
-  // clause is the dedicated `restricted-openclaw-policy-suppression`
-  // scenario below — it onboards a default restricted sandbox (no
-  // web-search, no OpenClaw OTEL) and asserts the `policy-list` output has
-  // no `●`-bulleted entries; that scenario must remain the gate even if
-  // this scenario's assertion is ever weakened.
-  progress.phase("prove default denial and the weather allowlist");
+  // Keep the actual OpenShell boundary in the retained journey: a default
+  // restricted onboard must have no active preset before operator mutation.
+  progress.phase("prove zero active presets, default denial, and the weather allowlist");
   const policyListAfterOnboard = await runNemoclaw(host, [SANDBOX_NAME, "policy-list"], {
     artifactName: "tc-net-01-policy-list-after-onboard",
     timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
   });
   expect(policyListAfterOnboard.exitCode, text(policyListAfterOnboard)).toBe(0);
+  const activeBullets = (policyListAfterOnboard.stdout.match(/^[\s]*●[\s]+(\S+)/gm) ?? []).map(
+    (line) => line.replace(/^[\s]*●[\s]+/, "").trim(),
+  );
   expect(
-    policyListAfterOnboard.stdout,
-    `restricted onboard must not leave openclaw-pricing applied: ${text(policyListAfterOnboard)}`,
-  ).not.toMatch(/^[\s]*●[\s]+openclaw-pricing\b/m);
-  expect(
-    policyListAfterOnboard.stdout,
-    `restricted onboard must not leave openclaw-diagnostics-otel-local applied: ${text(policyListAfterOnboard)}`,
-  ).not.toMatch(/^[\s]*●[\s]+openclaw-diagnostics-otel-local\b/m);
+    activeBullets,
+    `restricted tier must begin with zero active presets; got ${JSON.stringify(activeBullets)} from:\n${text(policyListAfterOnboard)}`,
+  ).toEqual([]);
 
   const denyDefault = await fetchStatus(sandbox, "https://example.com/", "tc-net-01-deny-default");
   expect(denyDefault, `example.com should be blocked under restricted policy`).toMatch(
@@ -1055,6 +1041,7 @@ NEMOCLAW_WEB_FETCH_PROBE`,
     id: "network-policy",
     sandboxName: SANDBOX_NAME,
     assertions: {
+      zeroInitialPresets: true,
       denyDefault: true,
       weatherReadOnlyPreset: true,
       brewPreset: true,
@@ -1073,11 +1060,12 @@ NEMOCLAW_WEB_FETCH_PROBE`,
   });
 });
 
-// Transitional workflow shim for #7617. The normal integration suite now
-// owns the zero-preset plan contract. Keep this test for one merge so the
-// trusted base workflow, which still dispatches the old zero-presets shard
-// while reviewing the workflow change, can collect passing head evidence.
-// Delete it after the one-row network-policy matrix is present on main.
+// Transitional workflow shim for #7617. The normal integration suite owns
+// the zero-preset plan and the retained live journey above owns the actual
+// OpenShell applied-set boundary. Keep this duplicate test for one merge so
+// the trusted base workflow, which still dispatches the old zero-presets
+// shard while reviewing the workflow change, can collect passing head
+// evidence. Delete it after the one-row matrix is present on main.
 //
 // Acceptance note (`NEMOCLAW_OPENCLAW_OTEL=1`): the OTEL-enabled live
 // variant is deferred to a follow-up nightly extension to keep this

--- a/test/e2e/live/policy-list-state.ts
+++ b/test/e2e/live/policy-list-state.ts
@@ -3,10 +3,17 @@
 
 export type PolicyPresetState = "active" | "inactive" | "drift" | "unverified" | "missing";
 
-const PRESET_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const PRESET_NAME_SOURCE = String.raw`[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?`;
+const PRESET_NAME_PATTERN = new RegExp(String.raw`^${PRESET_NAME_SOURCE}$`, "u");
 const PROVENANCE_PATTERN = String.raw`(?:user-added|source unverified(?: \(gateway unreachable\))?|from [a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])? (?:tier|agent))`;
 const ACTIVE_DRIFT_SUFFIX = " (active on gateway, missing from local state)";
 const INACTIVE_DRIFT_SUFFIX = " (recorded locally, not active on gateway)";
+const POLICY_LIST_HEADER_PATTERN = /^[\t ]*Policy presets for sandbox '[^'\r\n]+':[\t ]*$/u;
+const POLICY_LIST_ROW_PREFIX_PATTERN = /^[\t ]*[●○]/u;
+const POLICY_LIST_ROW_PATTERN = new RegExp(
+  String.raw`^[\t ]*[●○][\t ]+(${PRESET_NAME_SOURCE})(?:[\t ]+\[${PROVENANCE_PATTERN}\])?[\t ]+—[\t ]+[^\r\n]*$`,
+  "u",
+);
 
 /**
  * Parse one exact preset row from the human-readable `policy-list` output.
@@ -45,8 +52,58 @@ export function parsePolicyPresetState(output: string, presetName: string): Poli
   if (details.endsWith(INACTIVE_DRIFT_SUFFIX)) {
     return marker === "○" && provenance === undefined ? "drift" : "missing";
   }
+  if (marker === "●" && provenance === undefined) return "missing";
   if (provenance === "source unverified" || (marker === "○" && provenance !== undefined)) {
     return "missing";
   }
   return marker === "●" ? "active" : "inactive";
+}
+
+/**
+ * Return active presets only when the complete human-readable listing matches
+ * the verified row contract. Malformed, duplicate, drifted, or
+ * gateway-unverified listings return `null` instead of becoming evidence.
+ */
+export function parseVerifiedActivePolicyPresets(
+  output: string,
+  expectedPresetNames: readonly string[],
+): string[] | null {
+  const expected = new Set(expectedPresetNames);
+  if (
+    expected.size === 0 ||
+    expected.size !== expectedPresetNames.length ||
+    expectedPresetNames.some((name) => !PRESET_NAME_PATTERN.test(name))
+  ) {
+    return null;
+  }
+
+  const lines = output.split(/\r?\n/);
+  if (lines.filter((line) => POLICY_LIST_HEADER_PATTERN.test(line)).length !== 1) {
+    return null;
+  }
+
+  const rowLines = lines.filter((line) => POLICY_LIST_ROW_PREFIX_PATTERN.test(line));
+  if (rowLines.length === 0) return null;
+
+  const presetNames: string[] = [];
+  for (const line of rowLines) {
+    const match = POLICY_LIST_ROW_PATTERN.exec(line);
+    if (!match) return null;
+    presetNames.push(match[1]);
+  }
+  if (
+    presetNames.length !== expected.size ||
+    new Set(presetNames).size !== expected.size ||
+    presetNames.some((name) => !expected.has(name))
+  ) {
+    return null;
+  }
+
+  const activePresets: string[] = [];
+  for (const presetName of presetNames) {
+    const state = parsePolicyPresetState(output, presetName);
+    if (state !== "active" && state !== "inactive") return null;
+    if (state === "active") activePresets.push(presetName);
+  }
+  return activePresets;
 }

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -173,7 +173,7 @@ describe("e2e workflow boundary", () => {
     );
   });
 
-  it("keeps network-policy scenarios isolated with cleanup reserve", () => {
+  it("keeps the retained network-policy live probes isolated with cleanup reserve (#7617)", () => {
     const workflow = readWorkflow() as {
       jobs: Record<
         string,
@@ -207,7 +207,7 @@ describe("e2e workflow boundary", () => {
       expect.arrayContaining([
         "network-policy scenario jobs must keep the 90 minute timeout",
         "network-policy scenario matrix must disable fail-fast",
-        "network-policy job must keep the two isolated scenario shards",
+        "network-policy job must keep only the isolated live-probes scenario",
         "network-policy job must isolate artifacts by matrix.scenario",
         "network-policy job must bind NEMOCLAW_E2E_SHARD to matrix.scenario",
         "network-policy job must bind its sandbox name to matrix.sandbox",

--- a/test/e2e/support/policy-list-state.test.ts
+++ b/test/e2e/support/policy-list-state.test.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { parsePolicyPresetState } from "../live/policy-list-state.ts";
+import {
+  parsePolicyPresetState,
+  parseVerifiedActivePolicyPresets,
+} from "../live/policy-list-state.ts";
 
 describe("policy-list state parser", () => {
   it("accepts the current user-added provenance row", () => {
@@ -63,6 +66,7 @@ describe("policy-list state parser", () => {
     ["description-only name", "    ● slack [user-added] — includes telegram — access"],
     ["unknown provenance", "    ● telegram [restored somehow] — Telegram access"],
     ["unbounded provenance", `    ● telegram [from ${"a".repeat(65)} agent] — Telegram access`],
+    ["active row without provenance", "    ● telegram — Telegram access"],
     ["provenance on an inactive row", "    ○ telegram [user-added] — Telegram access"],
     ["unreconciled source without drift", "    ● telegram [source unverified] — Telegram access"],
   ])("fails closed for %s", (_label, output) => {
@@ -78,5 +82,53 @@ describe("policy-list state parser", () => {
     expect(
       parsePolicyPresetState("    ● telegram.* [user-added] — Telegram access", "telegram.*"),
     ).toBe("missing");
+  });
+});
+
+describe("verified policy-list parser (#7617)", () => {
+  const header = "  Policy presets for sandbox 'alpha':";
+  const active = "    ● telegram [user-added] — Telegram Bot API access";
+  const inactive = "    ○ tavily — Tavily web search API access (opt-in)";
+  const expected = ["telegram", "tavily"];
+
+  it("returns only active presets from a verified listing", () => {
+    expect(
+      parseVerifiedActivePolicyPresets([header, active, inactive, ""].join("\n"), expected),
+    ).toEqual(["telegram"]);
+  });
+
+  it.each([
+    ["a missing header", [active, inactive].join("\n")],
+    ["an empty listing", header],
+    ["a malformed row", [header, active, "    ○ tavily (opt-in)"].join("\n")],
+    [
+      "a malformed conflicting bullet",
+      [header, inactive, "    ●telegram [user-added] — contradictory active row"].join("\n"),
+    ],
+    ["a duplicate row", [header, active, active, inactive].join("\n")],
+    ["a truncated listing", [header, inactive].join("\n")],
+    [
+      "an unreachable gateway",
+      [header, "  ⚠ Could not query gateway — showing local state only.", active, inactive].join(
+        "\n",
+      ),
+    ],
+    [
+      "an unverified source",
+      [
+        header,
+        "    ● telegram [source unverified (gateway unreachable)] — Telegram Bot API access",
+        inactive,
+      ].join("\n"),
+    ],
+  ])("fails closed for %s", (_label, output) => {
+    expect(parseVerifiedActivePolicyPresets(output, expected)).toBeNull();
+  });
+
+  it("fails closed when the expected preset contract is empty, duplicated, or invalid", () => {
+    const output = [header, active, inactive].join("\n");
+    expect(parseVerifiedActivePolicyPresets(output, [])).toBeNull();
+    expect(parseVerifiedActivePolicyPresets(output, ["telegram", "telegram"])).toBeNull();
+    expect(parseVerifiedActivePolicyPresets(output, ["telegram", "bad preset"])).toBeNull();
   });
 });

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -710,11 +710,18 @@ describe("policy tier setup", () => {
     assert.doesNotMatch(text, /did you mean NEMOCLAW_POLICY_TIER/);
   });
 
-  it("applies zero presets for restricted OpenClaw in non-interactive suggested mode", async () => {
+  it("plans zero presets for restricted OpenClaw in non-interactive suggested mode (#7617)", async () => {
     const result = await runPolicySetup({ tierName: "restricted" }, { agent: "openclaw" });
 
     assert.deepEqual(result.applied, []);
     assert.deepEqual(result.appliedCalls, []);
+    assert.deepEqual(result.syncCalls, [
+      {
+        sandboxName: "test-sb",
+        current: [],
+        selected: [],
+      },
+    ]);
   });
 
   it("does not re-add OpenClaw OTEL presets for the restricted tier", async () => {

--- a/test/pr-e2e-gate-signal-shards.test.ts
+++ b/test/pr-e2e-gate-signal-shards.test.ts
@@ -48,7 +48,7 @@ describe("PR E2E signal shard policy", () => {
     const broadPlan = buildRiskPlan({ headSha: HEAD_SHA, changedFiles: BROAD_FILES });
     const broadShards = expectedSignalShards(riskPlanRequiredJobIds(broadPlan));
     expect(Object.keys(broadShards)).toHaveLength(13);
-    expect(Object.values(broadShards).flat()).toHaveLength(16);
+    expect(Object.values(broadShards).flat()).toHaveLength(15);
     expect(() => expectedSignalShards(["not-a-workflow-job"])).toThrow(/does not define/u);
   });
 });

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -219,11 +219,6 @@ const NETWORK_POLICY_SCENARIO_MATRIX = {
       selector: "^network-policy:.+probes$",
       sandbox: "e2e-net-policy-live-probes",
     },
-    {
-      scenario: "zero-presets",
-      selector: "^network-policy:.+presets$",
-      sandbox: "e2e-net-policy-zero-presets",
-    },
   ],
 } as const;
 const COMMON_EGRESS_AGENT_SCENARIO_MATRIX = {
@@ -1377,7 +1372,7 @@ function validateNetworkPolicyJob(errors: string[], jobs: WorkflowRecord): void 
     errors.push("network-policy scenario matrix must disable fail-fast");
   }
   if (!isDeepStrictEqual(asRecord(strategy.matrix), NETWORK_POLICY_SCENARIO_MATRIX)) {
-    errors.push("network-policy job must keep the two isolated scenario shards");
+    errors.push("network-policy job must keep only the isolated live-probes scenario");
   }
 
   const jobEnv = asRecord(job.env);


### PR DESCRIPTION
## Summary

Stop dispatching the redundant `network-policy / zero-presets` live shard while preserving the distinct OpenShell allow/deny journey. The zero-preset selection contract now has an explicit fast integration assertion, saving about four runner-minutes per full E2E run without changing restricted-policy behavior.

## Related Issue

Part of #7617

## Changes

- Pin the restricted OpenClaw policy plan to an empty synchronized selection in the normal integration suite.
- Remove only the `zero-presets` row from the network-policy workflow matrix.
- Keep the `live-probes` row, its isolated sandbox/artifacts, and its real deny-by-default, exact empty initial preset set, policy mutation, and suppressed-preset checks.
- Fail closed unless the real `policy-list` output contains the complete expected OpenClaw preset set with verified row grammar; assertion failures expose only static diagnostics.
- Update the trusted workflow validator and its fail-closed regression test for the one retained row.
- Retain the old zero-presets live test temporarily as a transition shim. Pull-request E2E uses the trusted base workflow against the PR head, so deleting the test in this PR would leave the base workflow's old selector with no passing evidence. A follow-up will delete it after this workflow change reaches `main`.

Recent exact-head evidence: the zero-presets job in [run 30244321666](https://github.com/NVIDIA/NemoClaw/actions/runs/30244321666) occupied about 4.5 minutes end to end; recent samples place the shard near four runner-minutes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only internal E2E scheduling and test placement; commands, configuration, runtime behavior, and user workflows are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent review at exact head `6da64a483` verified that credential boundaries, per-shard artifact isolation, selector binding, and risk-signal identity remain unchanged; the retained real OpenShell journey now requires a complete verified preset listing and the exact empty initial active set before any mutation. No findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: the diff changes only an internal workflow shard and test contracts. `test/e2e/README.md`, user-facing network-policy docs, and the user-guide routing skill do not document this shard or require updates.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6da64a483 -->
<!-- docs-review-agents-blob-sha: e22f25d82 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — integration policy suite: 49/49; E2E workflow, policy-list parser, and live-name contracts: 68/68; workflow boundary suite: 46/46; semantic E2E phase check: 125 tests across 82 files; live collection confirms both selectors still resolve during the transition; the fail-closed parser matched the successful real artifact's complete 28-preset OpenClaw listing and returned zero active presets; CLI build/typecheck, Biome, YAML, title, project, source-shape, size, and secret checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to one workflow matrix row and its focused contract tests; targeted validation and normal hooks cover the changed boundaries.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted OpenClaw onboarding now consistently results in **zero active presets** and an empty policy list after restricted onboarding completes.
  - Onboarding verification now checks synchronization uses empty **current** and **selected** preset lists.

- **Tests**
  - Updated network-policy E2E coverage and workflow boundary expectations to focus on the **live-probes** scenario.
  - Strengthened policy-list state parsing with new helper coverage for extracting only **verified active** presets, including additional fail-closed cases.
  - Adjusted expected shard policy derivation count for PR E2E gate signal shards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->