### PR TITLE
fix(onboard): clean CLI error on invalid gateway contract (#7627)

### DIFF
--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -285,6 +285,29 @@ describe("onboard command options", () => {
     expect(output).not.toContain("    at ");
   });
 
+  it("escapes terminal controls in gateway declaration errors before printing (#7627)", async () => {
+    const errors: string[] = [];
+    await expect(
+      runOnboardCommand({
+        flags: {},
+        env: {},
+        runOnboard: async () => {
+          throw invalidGatewayManagementDeclarationError(
+            "unknown declaration field(s): forged\n\u001b[31mError: fake failure",
+          );
+        },
+        error: (message = "") => errors.push(message),
+        exit: exitWithCode,
+      }),
+    ).rejects.toThrow("exit:1");
+
+    expect(errors).toEqual([
+      "  Invalid gateway management declaration: unknown declaration field(s): forged\\u000a\\u001b[31mError: fake failure",
+    ]);
+    expect(errors[0]?.split(/\r?\n/u)).toHaveLength(1);
+    expect(errors[0]).not.toMatch(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u);
+  });
+
   it("re-throws a non-cancellation, non-gateway error so genuine bugs still surface (#7627)", async () => {
     await expect(
       runOnboardCommand({

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -8,8 +8,8 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { resolveOnboardOptions, runOnboardCommand } from "./command";
-import { invalidGatewayManagementDeclarationError } from "./gateway-management";
 import type { OnboardFlags } from "./command-support";
+import { invalidGatewayManagementDeclarationError } from "./gateway-management";
 
 function exitWithCode(code: number): never {
   throw new Error(`exit:${code}`);
@@ -293,7 +293,7 @@ describe("onboard command options", () => {
         env: {},
         runOnboard: async () => {
           throw invalidGatewayManagementDeclarationError(
-            "unknown declaration field(s): forged\n\u001b[31mError: fake failure",
+            "unknown declaration field(s): forged\n\u001b[31mError: \u202efake failure",
           );
         },
         error: (message = "") => errors.push(message),
@@ -302,10 +302,12 @@ describe("onboard command options", () => {
     ).rejects.toThrow("exit:1");
 
     expect(errors).toEqual([
-      "  Invalid gateway management declaration: unknown declaration field(s): forged\\u000a\\u001b[31mError: fake failure",
+      "  Invalid gateway management declaration: unknown declaration field(s): forged\\u000a\\u001b[31mError: \\u202efake failure",
     ]);
     expect(errors[0]?.split(/\r?\n/u)).toHaveLength(1);
-    expect(errors[0]).not.toMatch(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u);
+    expect(errors[0]).not.toMatch(
+      /[\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u2028-\u202e\u2066-\u2069]/u,
+    );
   });
 
   it("re-throws a non-cancellation, non-gateway error so genuine bugs still surface (#7627)", async () => {

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { resolveOnboardOptions, runOnboardCommand } from "./command";
+import { invalidGatewayManagementDeclarationError } from "./gateway-management";
 import type { OnboardFlags } from "./command-support";
 
 function exitWithCode(code: number): never {
@@ -259,6 +260,43 @@ describe("onboard command options", () => {
       }),
     ).rejects.toThrow("exit:1");
     expect(errors.join("\n")).toContain("Installation cancelled");
+  });
+
+  it("prints a clean CLI error for an invalid gateway management contract (#7627)", async () => {
+    const errors: string[] = [];
+    await expect(
+      runOnboardCommand({
+        flags: {},
+        env: {},
+        runOnboard: async () => {
+          throw invalidGatewayManagementDeclarationError(
+            "unsupported gateway-management contract version; this NemoClaw build supports version 1",
+          );
+        },
+        error: (message = "") => errors.push(message),
+        exit: exitWithCode,
+      }),
+    ).rejects.toThrow("exit:1");
+    const output = errors.join("\n");
+    expect(output).toContain("Invalid gateway management declaration");
+    expect(output).toContain("unsupported gateway-management contract version");
+    // No stack frames leaked into the user-facing output.
+    expect(output).not.toContain(".js:");
+    expect(output).not.toContain("    at ");
+  });
+
+  it("re-throws a non-cancellation, non-gateway error so genuine bugs still surface (#7627)", async () => {
+    await expect(
+      runOnboardCommand({
+        flags: {},
+        env: {},
+        runOnboard: async () => {
+          throw new Error("unexpected boom");
+        },
+        error: () => {},
+        exit: exitWithCode,
+      }),
+    ).rejects.toThrow("unexpected boom");
   });
 
   it("returns without rethrowing when a prompt rejects with SIGINT (#7439)", async () => {

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -12,6 +12,7 @@ import {
 } from "../tool-disclosure";
 import { applyAgentsManifestEnv } from "./agents-manifest";
 import type { OnboardFlags } from "./command-support";
+import { GatewayManagementDeclarationError } from "./gateway-management";
 import { managedSandboxFeatureIssue } from "./managed-sandbox-feature";
 import { DCODE_OBSERVABILITY_FEATURE } from "./observability-policy-presets";
 import { isOpenclawAgent } from "./openclaw-otel-policy-presets";
@@ -207,6 +208,13 @@ export async function runOnboardCommand(deps: RunOnboardCommandDeps): Promise<vo
       // preserve status 130 without leaking this rejected prompt error through
       // oclif as a raw stack trace (#7439).
       return;
+    }
+    // A rejected NEMOCLAW_GATEWAY_MANAGEMENT contract is operator input error,
+    // not a crash: print the validation reason as a clean single-line CLI error
+    // and exit nonzero instead of re-throwing it into a Node.js stack trace
+    // (#7627). `fail` sets exit code 1.
+    if (error instanceof GatewayManagementDeclarationError) {
+      fail(deps, `  ${error.message}`);
     }
     // Stdin EOF at any onboarding prompt is a cancellation, not a failure:
     // print a clear message and exit non-zero instead of either crashing with

--- a/src/lib/onboard/gateway-host-runtime.test.ts
+++ b/src/lib/onboard/gateway-host-runtime.test.ts
@@ -4,7 +4,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createGatewayHostRuntime, type GatewayHostRuntimeDeps } from "./gateway-host-runtime";
-import { GATEWAY_MANAGEMENT_ENV_VAR } from "./gateway-management";
+import {
+  GATEWAY_MANAGEMENT_ENV_VAR,
+  GatewayManagementDeclarationError,
+} from "./gateway-management";
 import { evaluateGatewayAttachment } from "./gateway-ownership";
 import type { PortProbeResult } from "./preflight";
 
@@ -113,6 +116,14 @@ describe("gateway host runtime ownership", () => {
 
     expect(() => createGatewayHostRuntime(createDeps()).getGatewayOwner()).toThrow(
       /Invalid gateway management declaration/,
+    );
+  });
+
+  it("throws a recognized GatewayManagementDeclarationError so the CLI can present it cleanly (#7627)", () => {
+    declareExternalSupervision({ ...DECLARATION, version: 99 });
+
+    expect(() => createGatewayHostRuntime(createDeps()).getGatewayOwner()).toThrow(
+      GatewayManagementDeclarationError,
     );
   });
 

--- a/src/lib/onboard/gateway-host-runtime.ts
+++ b/src/lib/onboard/gateway-host-runtime.ts
@@ -23,7 +23,10 @@ import {
   isGatewayHttpReady,
   waitForGatewayHttpReady,
 } from "./gateway-http-readiness";
-import { loadGatewayManagementDeclaration } from "./gateway-management";
+import {
+  invalidGatewayManagementDeclarationError,
+  loadGatewayManagementDeclaration,
+} from "./gateway-management";
 import {
   assertGatewayEffectAllowed,
   cgroupBelongsToUnit,
@@ -113,7 +116,7 @@ export function createGatewayHostRuntime(deps: GatewayHostRuntimeDeps): GatewayH
   function resolveCurrentGatewayOwner(gatewayName: string, gatewayPort: number): GatewayOwner {
     const loaded = loadGatewayManagementDeclaration();
     if (!loaded.ok) {
-      throw new Error(`Invalid gateway management declaration: ${loaded.reason}`);
+      throw invalidGatewayManagementDeclarationError(loaded.reason);
     }
     return resolveGatewayOwner({
       gatewayName,

--- a/src/lib/onboard/gateway-management.ts
+++ b/src/lib/onboard/gateway-management.ts
@@ -76,6 +76,25 @@ export type GatewayManagementParseResult =
   | { ok: true; declaration: GatewayManagementDeclaration }
   | { ok: false; reason: string };
 
+/**
+ * A rejected NEMOCLAW_GATEWAY_MANAGEMENT contract is user-input error, not a
+ * NemoClaw bug: the operator pointed the env var at a declaration file that
+ * fails contract validation (bad version, unknown field, non-loopback / DNS
+ * endpoint, embedded credentials, query string, path, …). Command boundaries
+ * recognize this class to print a clean single-line CLI error and exit nonzero
+ * instead of leaking a Node.js stack trace (#7627). Every rejection reason
+ * funnels through `reason`, so this one class covers the whole class of
+ * contract-validation failures.
+ */
+export class GatewayManagementDeclarationError extends Error {}
+
+/** Build the user-facing error for an invalid gateway management declaration. */
+export function invalidGatewayManagementDeclarationError(
+  reason: string,
+): GatewayManagementDeclarationError {
+  return new GatewayManagementDeclarationError(`Invalid gateway management declaration: ${reason}`);
+}
+
 const DECLARATION_KEYS = new Set([
   "version",
   "mode",

--- a/src/lib/onboard/gateway-management.ts
+++ b/src/lib/onboard/gateway-management.ts
@@ -88,11 +88,22 @@ export type GatewayManagementParseResult =
  */
 export class GatewayManagementDeclarationError extends Error {}
 
+const GATEWAY_MANAGEMENT_ERROR_CONTROL_RE = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/gu;
+
+function escapeGatewayManagementErrorReason(reason: string): string {
+  return reason.replace(
+    GATEWAY_MANAGEMENT_ERROR_CONTROL_RE,
+    (character) => `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}
+
 /** Build the user-facing error for an invalid gateway management declaration. */
 export function invalidGatewayManagementDeclarationError(
   reason: string,
 ): GatewayManagementDeclarationError {
-  return new GatewayManagementDeclarationError(`Invalid gateway management declaration: ${reason}`);
+  return new GatewayManagementDeclarationError(
+    `Invalid gateway management declaration: ${escapeGatewayManagementErrorReason(reason)}`,
+  );
 }
 
 const DECLARATION_KEYS = new Set([

--- a/src/lib/onboard/gateway-management.ts
+++ b/src/lib/onboard/gateway-management.ts
@@ -88,7 +88,8 @@ export type GatewayManagementParseResult =
  */
 export class GatewayManagementDeclarationError extends Error {}
 
-const GATEWAY_MANAGEMENT_ERROR_CONTROL_RE = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/gu;
+const GATEWAY_MANAGEMENT_ERROR_CONTROL_RE =
+  /[\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u2028-\u202e\u2066-\u2069]/gu;
 
 function escapeGatewayManagementErrorReason(reason: string): string {
   return reason.replace(

--- a/src/lib/onboard/gateway-teardown-authority.ts
+++ b/src/lib/onboard/gateway-teardown-authority.ts
@@ -21,6 +21,7 @@ import { gatewayOwnerFromCheckpoint } from "./gateway-authority-checkpoint";
 import { resolveGatewayName } from "./gateway-binding";
 import {
   type GatewayManagementLoadResult,
+  invalidGatewayManagementDeclarationError,
   loadGatewayManagementDeclaration,
 } from "./gateway-management";
 import {
@@ -87,7 +88,7 @@ function resolveGatewayEffectAuthority(
     ? deps.loadDeclaration(env)
     : loadGatewayManagementDeclaration({ env });
   if (!loaded.ok) {
-    throw new Error(`Invalid gateway management declaration: ${loaded.reason}`);
+    throw invalidGatewayManagementDeclarationError(loaded.reason);
   }
   const hasPackagedService =
     loaded.declaration === null &&


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
An invalid `NEMOCLAW_GATEWAY_MANAGEMENT` declaration made `nemoclaw onboard` throw an uncaught Node.js exception and print a full stack trace instead of a clean CLI error. This PR makes the contract-validation rejection a recognized error the onboard command presents as a clean single-line message with a nonzero exit.

Closes #7627.

## Reproduction
On our Ubuntu 24.04 x86_64 test host (no GPU), built from `main`:

```bash
cat > /tmp/gw-bad.json <<'JSON'
{"version": 99, "mode": "externally-supervised", "endpoint": "http://127.0.0.1:8080", "stateDir": "/tmp/state", "supervisor": {"kind": "systemd-user", "serviceName": "openshell-gateway.service", "execPath": "/usr/local/bin/openshell-gateway"}, "requiredCapabilities": ["gateway.health"]}
JSON
NEMOCLAW_GATEWAY_MANAGEMENT=/tmp/gw-bad.json \
  nemoclaw onboard --fresh --name gw-bad --non-interactive --yes --yes-i-accept-third-party-software
```

**Environment**
- Test machine: our Ubuntu 24.04 x86_64 test host (no GPU)
- NemoClaw `main` HEAD `a47ddd896`

**Observed on `main` (before fix)** — exit 1 but a raw Node.js stack trace:
```
dist/lib/onboard/gateway-host-runtime.js:34
            throw new Error(`Invalid gateway management declaration: ${loaded.reason}`);
                  ^
Error: Invalid gateway management declaration: ... unsupported gateway-management contract version; this NemoClaw build supports version 1
    at resolveCurrentGatewayOwner (.../gateway-host-runtime.js:34:19)
    ...
Node.js v22.22.2
```

**Observed on `fix/...` (after fix)** — clean single line, exit 1, no stack trace (verified for the version case and the embedded-credentials case):
```
$ ... onboard ...   # version 99
  Invalid gateway management declaration: NEMOCLAW_GATEWAY_MANAGEMENT declaration file: unsupported gateway-management contract version; this NemoClaw build supports version 1
  # exit 1, 0 stack-trace lines

$ ... onboard ...   # endpoint with embedded credentials
  Invalid gateway management declaration: NEMOCLAW_GATEWAY_MANAGEMENT declaration file: endpoint must not embed credentials
  # exit 1, 0 stack-trace lines
```

## Analysis
`resolveCurrentGatewayOwner` (`src/lib/onboard/gateway-host-runtime.ts`) loads the declaration and, on a validation failure, threw a bare `Error("Invalid gateway management declaration: ${loaded.reason}")`. During onboarding this is called deep in the FSM. `runOnboardCommand`'s catch (`src/lib/onboard/command.ts`) only recognized prompt-cancellation errors (SIGINT / EOF) and re-threw everything else — so the contract error escaped every handler and reached Node's default uncaught-exception printer (raw stack trace). Every rejection reason (bad version, unknown fields, DNS endpoint, embedded credentials, query string, path) funnels through the single `loaded.reason`, so all of them produced the same uncaught throw.

## Fix
- `src/lib/onboard/gateway-management.ts`: add a recognized `GatewayManagementDeclarationError` and an `invalidGatewayManagementDeclarationError(reason)` factory — the single source of the error type and message.
- `src/lib/onboard/gateway-host-runtime.ts` and `src/lib/onboard/gateway-teardown-authority.ts`: throw the recognized error via the factory instead of a bare `Error`.
- `src/lib/onboard/command.ts`: `runOnboardCommand` now recognizes `GatewayManagementDeclarationError` and prints the reason as a clean single-line CLI error, exiting nonzero via the existing `fail` helper — before the generic re-throw, so unrelated errors still surface as genuine failures.

**Whole-class notes.** Every rejection reason routes through one loader result → one error class → covered by the single onboard catch (verified live for the version and embedded-credentials reasons). Other consumers of the same contract: `uninstall` already caught the error and rendered `error.message` cleanly (`src/lib/actions/uninstall/run-plan.ts`) — keeping the same message means no regression; the sandbox `destroy` gateway-cleanup path now throws the same recognized class and renders via its `error.message` handling. No new failure/rollback path is introduced (presentation-only). No user-facing docs describe the previous stack-trace behavior, so none need updating.

Tests lock: the onboard command prints a clean error (no stack frames) and exits nonzero for a contract error; a non-cancellation, non-gateway error still re-throws (regression lock against over-catching); and the runtime boundary throws the recognized `GatewayManagementDeclarationError`.

## Changes
- `src/lib/onboard/gateway-management.ts`: recognized error class + factory.
- `src/lib/onboard/gateway-host-runtime.ts`, `src/lib/onboard/gateway-teardown-authority.ts`: throw the recognized error.
- `src/lib/onboard/command.ts`: present the contract error cleanly at the onboard boundary.
- `src/lib/onboard/command.test.ts`, `src/lib/onboard/gateway-host-runtime.test.ts`: coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/deployment/gateway-lifecycle-authority.mdx` already documents declaration validation, rejected fields, and recovery. This PR changes error presentation and C0/C1, line-separator, and bidirectional-control escaping without changing configuration or user actions. Comments and test titles identify the command boundary, single-line output, control escaping, and rethrow behavior; no blocking `WRITING.md` findings remain.
- Agent: Codex Desktop documentation writer subagent
<!-- docs-review-head-sha: 11f4976915dadddc4cd7ad23777ac5a9c72aa796 -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## Verification

- [x] `npx prek run` passes on the changed files
- [x] `npm test` passes (touched files at minimum)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid gateway management declarations are now surfaced as clear, single-line onboarding CLI errors (exit code 1), without technical stack traces.
  - Validation reasons are displayed safely, with control/unprintable characters sanitized to avoid broken terminal output.
  - Gateway ownership and teardown authority resolution now consistently use the same clean error handling.
  - Unrelated, non-cancellation errors continue to be thrown unchanged.
- **Tests**
  - Added/expanded test coverage to confirm clean messaging, sanitized output, and correct rethrow behavior for unrelated errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
