### PR TITLE
fix(image): preserve sandbox base layer compatibility

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -447,14 +447,19 @@ ARG OPENCLAW_2026_4_24_TARBALL=https://registry.npmjs.org/openclaw/-/openclaw-20
 ARG MCPORTER_VERSION=0.7.3
 ARG MCPORTER_0_7_3_INTEGRITY=sha512-egoPVYqTnWb3NjRIxo+xc8OrAI0dlPrJm9pAiZx0pImuNIV5rKhGtTnIfH/Y1ldGPVu74ibj3KR5c9U/QSdQFA==
 ARG MCPORTER_0_7_3_TARBALL=https://registry.npmjs.org/mcporter/-/mcporter-0.7.3.tgz
-COPY agents/openclaw/openclaw-runtime/package.json /usr/local/lib/nemoclaw/openclaw-runtime/package.json
-COPY agents/openclaw/openclaw-runtime/package-lock.json /usr/local/lib/nemoclaw/openclaw-runtime/package-lock.json
-COPY agents/openclaw/mcporter-runtime/package.json /usr/local/lib/nemoclaw/mcporter-runtime/package.json
-COPY agents/openclaw/mcporter-runtime/package-lock.json /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json
+# Keep paired runtime manifests and remediation helpers in grouped layers so
+# the published base retains its established image layout.
+COPY agents/openclaw/openclaw-runtime/package.json \
+    agents/openclaw/openclaw-runtime/package-lock.json \
+    /usr/local/lib/nemoclaw/openclaw-runtime/
+COPY agents/openclaw/mcporter-runtime/package.json \
+    agents/openclaw/mcporter-runtime/package-lock.json \
+    /usr/local/lib/nemoclaw/mcporter-runtime/
 COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json
-COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts
-COPY scripts/lib/reviewed-npm-audit.mts /scripts/lib/reviewed-npm-audit.mts
-COPY scripts/lib/openclaw-npm-remediation.mts /scripts/lib/openclaw-npm-remediation.mts
+COPY scripts/lib/reviewed-npm-archive.mts \
+    scripts/lib/reviewed-npm-audit.mts \
+    scripts/lib/openclaw-npm-remediation.mts \
+    /scripts/lib/
 COPY scripts/patch-bundled-npm-brace-expansion.mts /scripts/patch-bundled-npm-brace-expansion.mts
 COPY scripts/patch-bundled-npm-tar.mts /scripts/patch-bundled-npm-tar.mts
 COPY scripts/upgrade-bundled-npm.mts /scripts/upgrade-bundled-npm.mts

--- a/test/mcporter-supply-chain.test.ts
+++ b/test/mcporter-supply-chain.test.ts
@@ -120,12 +120,16 @@ describe("mcporter image supply-chain controls", () => {
     expect(flattenedContents).toContain(
       '--verify-only --package-spec "mcporter@${MCPORTER_VERSION}" --integrity "$MCPORTER_EXPECTED_INTEGRITY" --tarball-url "$MCPORTER_EXPECTED_TARBALL"',
     );
-    expect(contents).toContain(
+    const groupedRuntimeCopy =
+      "COPY agents/openclaw/mcporter-runtime/package.json agents/openclaw/mcporter-runtime/package-lock.json /usr/local/lib/nemoclaw/mcporter-runtime/";
+    const splitRuntimeCopies = [
       "COPY agents/openclaw/mcporter-runtime/package.json /usr/local/lib/nemoclaw/mcporter-runtime/package.json",
-    );
-    expect(contents).toContain(
       "COPY agents/openclaw/mcporter-runtime/package-lock.json /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json",
-    );
+    ];
+    expect(
+      flattenedContents.includes(groupedRuntimeCopy) ||
+        splitRuntimeCopies.every((copy) => contents.includes(copy)),
+    ).toBe(true);
     expect(flattenedContents).toContain(
       `${runtimePrefix} ci --ignore-scripts --omit=dev --no-audit --no-fund --no-progress`,
     );
@@ -156,9 +160,14 @@ describe("mcporter image supply-chain controls", () => {
     expect(contents).toContain(
       "COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json",
     );
-    expect(contents).toContain(
-      "COPY scripts/lib/reviewed-npm-audit.mts /scripts/lib/reviewed-npm-audit.mts",
-    );
+    expect(
+      flattenedContents.includes(
+        "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
+      ) ||
+        contents.includes(
+          "COPY scripts/lib/reviewed-npm-audit.mts /scripts/lib/reviewed-npm-audit.mts",
+        ),
+    ).toBe(true);
     expect(flattenedContents).toContain(
       "node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts --directory /usr/local/lib/nemoclaw/mcporter-runtime --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high",
     );

--- a/test/node-tar-dockerfile-contract.test.ts
+++ b/test/node-tar-dockerfile-contract.test.ts
@@ -85,9 +85,8 @@ describe("node-tar image remediation contract", () => {
       patchPayloadStage === undefined ? source : namedStage(dockerfile, patchPayloadStage);
     const scanInputStage =
       scanPayloadLayer >= 0 ? namedStage(dockerfile, "hermes-scan-payload") : source;
-    const reviewedCopy = patchInputStage.indexOf(
-      "COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts",
-    );
+    const flattenedPatchInputStage = patchInputStage.replace(/\\\s*\n/g, " ").replace(/\s+/g, " ");
+    const reviewedCopy = patchInputStage.indexOf("COPY scripts/lib/reviewed-npm-archive.mts");
     const patchCopy = patchInputStage.indexOf(
       "COPY scripts/patch-bundled-npm-tar.mts /scripts/patch-bundled-npm-tar.mts",
     );
@@ -104,6 +103,15 @@ describe("node-tar image remediation contract", () => {
     const scanInputReady = scanPayloadLayer >= 0 ? scanPayloadLayer : scanCopy;
 
     expect(reviewedCopy, file).toBeGreaterThanOrEqual(0);
+    expect(
+      flattenedPatchInputStage.includes(
+        "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
+      ) ||
+        patchInputStage.includes(
+          "COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts",
+        ),
+      file,
+    ).toBe(true);
     expect(patchCopy, file).toBeGreaterThan(reviewedCopy);
     expect(patchRun, file).toBeGreaterThan(patchInputReady);
     const aptInstall = source.indexOf(

--- a/test/openclaw-dependency-review.test.ts
+++ b/test/openclaw-dependency-review.test.ts
@@ -434,10 +434,11 @@ describe("OpenClaw 2026.6.10 dependency review contract", () => {
   // source-shape-contract: security -- The legacy archive remediation helper must be present in the base image before the fail-closed Docker build invokes it
   it("copies the legacy OpenClaw remediation helper before the base build invokes it", () => {
     const dockerfile = readFileSync(path.join(REPO_ROOT, "Dockerfile.base"), "utf-8");
-    const helperCopy = dockerfile.indexOf(
-      "COPY scripts/lib/openclaw-npm-remediation.mts /scripts/lib/openclaw-npm-remediation.mts",
+    const flattenedDockerfile = dockerfile.replace(/\\\s*\n/g, " ").replace(/\s+/g, " ");
+    const helperCopy = flattenedDockerfile.indexOf(
+      "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
     );
-    const helperInvocation = dockerfile.indexOf(
+    const helperInvocation = flattenedDockerfile.indexOf(
       "node --experimental-strip-types /scripts/lib/openclaw-npm-remediation.mts",
     );
 

--- a/test/openclaw-dependency-review.test.ts
+++ b/test/openclaw-dependency-review.test.ts
@@ -435,9 +435,13 @@ describe("OpenClaw 2026.6.10 dependency review contract", () => {
   it("copies the legacy OpenClaw remediation helper before the base build invokes it", () => {
     const dockerfile = readFileSync(path.join(REPO_ROOT, "Dockerfile.base"), "utf-8");
     const flattenedDockerfile = dockerfile.replace(/\\\s*\n/g, " ").replace(/\s+/g, " ");
-    const helperCopy = flattenedDockerfile.indexOf(
+    const groupedHelperCopy = flattenedDockerfile.indexOf(
       "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
     );
+    const legacyHelperCopy = flattenedDockerfile.indexOf(
+      "COPY scripts/lib/openclaw-npm-remediation.mts /scripts/lib/openclaw-npm-remediation.mts",
+    );
+    const helperCopy = groupedHelperCopy >= 0 ? groupedHelperCopy : legacyHelperCopy;
     const helperInvocation = flattenedDockerfile.indexOf(
       "node --experimental-strip-types /scripts/lib/openclaw-npm-remediation.mts",
     );

--- a/test/openclaw-locked-install.test.ts
+++ b/test/openclaw-locked-install.test.ts
@@ -312,6 +312,7 @@ describe("locked OpenClaw production installation (#5896)", () => {
     "Dockerfile.base",
   ])("invokes the locked installer before exposing OpenClaw in %s", (dockerfileName) => {
     const contents = fs.readFileSync(path.join(REPO_ROOT, dockerfileName), "utf-8");
+    const flattenedContents = contents.replace(/\\\s*\n/g, " ").replace(/\s+/g, " ");
     const verifyIndex = contents.indexOf(
       "node --experimental-strip-types /scripts/lib/reviewed-npm-archive.mts --verify-lock",
     );
@@ -335,8 +336,12 @@ describe("locked OpenClaw production installation (#5896)", () => {
     const branchEnd = contents.indexOf("else \\", installIndex);
     const currentInstallBranch = contents.slice(verifyIndex, branchEnd);
 
-    expect(contents).toContain(
-      "COPY agents/openclaw/openclaw-runtime/package-lock.json /usr/local/lib/nemoclaw/openclaw-runtime/package-lock.json",
+    const groupedRuntimeCopy =
+      "COPY agents/openclaw/openclaw-runtime/package.json agents/openclaw/openclaw-runtime/package-lock.json /usr/local/lib/nemoclaw/openclaw-runtime/";
+    const splitLockCopy =
+      "COPY agents/openclaw/openclaw-runtime/package-lock.json /usr/local/lib/nemoclaw/openclaw-runtime/package-lock.json";
+    expect(flattenedContents.includes(groupedRuntimeCopy) || contents.includes(splitLockCopy)).toBe(
+      true,
     );
     expect(verifyIndex).toBeGreaterThanOrEqual(0);
     expect(installIndex).toBeGreaterThan(verifyIndex);

--- a/test/sandbox-base-image-layout.test.ts
+++ b/test/sandbox-base-image-layout.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const dockerfile = fs.readFileSync(path.join(repoRoot, "Dockerfile.base"), "utf8");
+
+function completedStage(source: string): string {
+  const stages = source.split(/(?=^FROM )/gmu).filter((stage) => stage.startsWith("FROM "));
+  return stages.at(-1) ?? "";
+}
+
+describe("sandbox base image layout", () => {
+  it("keeps the published image within the established layer budget", () => {
+    const finalStage = completedStage(dockerfile);
+    const layerInstructions = finalStage.match(/^(?:ADD|COPY|RUN)\b/gmu) ?? [];
+
+    expect(finalStage).toContain("FROM node:22-trixie-slim@");
+    expect(layerInstructions).toHaveLength(24);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Group related sandbox-base build inputs so published images retain the established layer layout. Package paths, pins, checksums, remediation commands, audits, and the final filesystem scan remain unchanged.

## Changes

- Copy each OpenClaw and mcporter manifest-lock pair in one layer.
- Copy the three reviewed npm remediation helpers in one layer.
- Keep the completed sandbox-base stage at 24 layer-producing instructions.
- Add a layer-budget regression test and update supply-chain contracts for grouped or legacy copy syntax.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This build-layout change does not change a user command, output, configuration, workflow, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Signed rebase preserved both patches exactly. Grouped `COPY` instructions preserve all package, checksum, remediation, audit, and scan contracts while keeping the established 24-layer sandbox-base layout. The test fallback changes no user-facing behavior. Focused tests pass 79/79; `git diff --check` passes; prior Biome, Hadolint, gitleaks, repository, source-shape, test-size, test-title, Vitest membership, and commit-hook evidence remains patch-identical.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a8295a564 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — After the signed base refresh, 79 tests pass across eight image and security contract files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new check validating the final sandbox base image (node image pin) and ensuring an exact layer count/layout.
  * Updated Dockerfile contract tests to accept equivalent grouped vs separate `COPY` patterns for runtime package files and remediation/auditing helpers.
  * Improved robustness of Dockerfile inspections by normalizing whitespace and relaxing matching logic while keeping install/remediation ordering validations intact.
* **Chores**
  * Reformatted how runtime metadata and remediation/auditing helper artifacts are staged in the base Docker build via grouped `COPY` steps (no functional change intended).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->