### PR TITLE
test(e2e): bridge retired controller selectors

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -344,6 +344,35 @@ jobs:
             fi
           fi
 
+  retired-selector-compatibility:
+    needs: generate-matrix
+    if: ${{ inputs.checkout_sha != '' && (contains(format(',{0},', inputs.jobs), ',docs-validation,') || contains(format(',{0},', inputs.jobs), ',gateway-drift-preflight,') || contains(format(',{0},', inputs.jobs), ',gateway-health-honest,') || contains(format(',{0},', inputs.jobs), ',onboard-negative-paths,') || contains(format(',{0},', inputs.jobs), ',openshell-version-pin,') || contains(format(',{0},', inputs.jobs), ',ubuntu-repo-cli-smoke,')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/live/retired-selector-compatibility
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_sha || github.sha }}
+          persist-credentials: false
+
+      - name: Prepare E2E workspace
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@f6304bc25fc35bfaa441c8c2fbfee38f72805a75
+
+      - name: Verify retired selector replacements
+        env:
+          JOBS: ${{ inputs.jobs }}
+        run: npx tsx tools/e2e/retired-selector-compatibility.mts
+
+      - name: Upload retired selector compatibility evidence
+        if: always()
+        uses: NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@7768e15eb90d3ee2d33432f481dfe8747e4f6d57
+        with:
+          name: e2e-retired-selector-compatibility
+          path: e2e-artifacts/live/retired-selector-compatibility/
+
   staging-brev-launchable:
     name: Exact staging Brev Launchable
     needs: generate-matrix
@@ -5835,6 +5864,7 @@ jobs:
       [
         base-image-publication,
         generate-matrix,
+        retired-selector-compatibility,
         staging-brev-launchable,
         staging-brev-launchable-readiness,
         live,

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -680,13 +680,11 @@ describe("e2e workflow boundary", () => {
     expect(workflow.jobs["gpu-e2e"]?.env?.NEMOCLAW_MODEL).toBe("qwen3.5:9b");
     expect(workflow.jobs["gpu-double-onboard"]?.env?.NEMOCLAW_MODEL).toBe("qwen3.5:9b");
     const driftedWorkflow = structuredClone(workflow);
-    const compatibilityJob = driftedWorkflow.jobs["retired-selector-compatibility"];
-    if (compatibilityJob) {
-      compatibilityJob.if = compatibilityJob.if?.replace(
-        ",docs-validation,",
-        ",future-retired-selector,",
-      );
-    }
+    const compatibilityJob = driftedWorkflow.jobs["retired-selector-compatibility"] ?? {};
+    compatibilityJob.if = compatibilityJob.if?.replace(
+      ",docs-validation,",
+      ",future-retired-selector,",
+    );
     expect(validateE2eWorkflow(driftedWorkflow)).toContain(
       "retired-selector-compatibility job selector gate must match retired selector contract",
     );

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -662,7 +662,7 @@ describe("e2e workflow boundary", () => {
   }, () => {
     const inventory = readFreeStandingJobsInventory();
     const workflow = readWorkflow() as {
-      jobs: Record<string, { env?: Record<string, string> }>;
+      jobs: Record<string, { env?: Record<string, string>; if?: string }>;
     };
     const workflowJobs = new Set(Object.keys(workflow.jobs));
 
@@ -679,6 +679,17 @@ describe("e2e workflow boundary", () => {
     );
     expect(workflow.jobs["gpu-e2e"]?.env?.NEMOCLAW_MODEL).toBe("qwen3.5:9b");
     expect(workflow.jobs["gpu-double-onboard"]?.env?.NEMOCLAW_MODEL).toBe("qwen3.5:9b");
+    const driftedWorkflow = structuredClone(workflow);
+    const compatibilityJob = driftedWorkflow.jobs["retired-selector-compatibility"];
+    if (compatibilityJob) {
+      compatibilityJob.if = compatibilityJob.if?.replace(
+        ",docs-validation,",
+        ",future-retired-selector,",
+      );
+    }
+    expect(validateE2eWorkflow(driftedWorkflow)).toContain(
+      "retired-selector-compatibility job selector gate must match retired selector contract",
+    );
     expect(
       focusedE2eJobsForChangedFiles(
         [

--- a/test/e2e/support/retired-selector-compatibility.test.ts
+++ b/test/e2e/support/retired-selector-compatibility.test.ts
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  RETIRED_CONTROLLER_SELECTOR_IDS,
+  runRetiredSelectorCompatibility,
+  selectedRetiredControllerJobs,
+} from "../../../tools/e2e/retired-selector-compatibility.mts";
+
+const EXPECTED_SHA = "a".repeat(40);
+const PLAN_HASH = "b".repeat(64);
+const CORRELATION_ID = "123e4567-e89b-42d3-a456-426614174000";
+const REPLACEMENT_FILES = [
+  "test/package-contract/cli/public-cli-contracts.test.ts",
+  "test/gateway-drift-preflight.test.ts",
+  "test/gateway-health-honest.test.ts",
+  "test/credentials.test.ts",
+  "test/package-contract/onboard/invalid-nvidia-key.test.ts",
+  "test/install-openshell-version-pin.test.ts",
+] as const;
+
+function workspace(): { artifactRoot: string; output: string; root: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-retired-selector-"));
+  for (const file of REPLACEMENT_FILES) {
+    const fullPath = path.join(root, file);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, "export {};\n", "utf8");
+  }
+  return {
+    artifactRoot: path.join(root, "artifacts"),
+    output: path.join(root, "github-output"),
+    root,
+  };
+}
+
+function environment(target: ReturnType<typeof workspace>, jobs: string): NodeJS.ProcessEnv {
+  return {
+    E2E_ARTIFACT_DIR: target.artifactRoot,
+    GITHUB_OUTPUT: target.output,
+    GITHUB_WORKSPACE: target.root,
+    JOBS: jobs,
+    NEMOCLAW_E2E_CORRELATION_ID: CORRELATION_ID,
+    NEMOCLAW_E2E_EXPECTED_SHA: EXPECTED_SHA,
+    NEMOCLAW_E2E_PLAN_HASH: PLAN_HASH,
+    NEMOCLAW_E2E_SHARD: "default",
+  };
+}
+
+describe("retired E2E selector compatibility", () => {
+  it("selects only IDs absent from an SHA-bound candidate inventory (#7616)", () => {
+    expect(
+      selectedRetiredControllerJobs({
+        allowedJobs: ["cloud-onboard", "docs-validation"],
+        expectedSha: EXPECTED_SHA,
+        jobs: "cloud-onboard,docs-validation,gateway-health-honest",
+      }),
+    ).toEqual(["gateway-health-honest"]);
+    expect(
+      selectedRetiredControllerJobs({
+        allowedJobs: ["cloud-onboard"],
+        jobs: "cloud-onboard,gateway-health-honest",
+      }),
+    ).toEqual([]);
+  });
+
+  it("runs each ordinary replacement project once and emits bound signals (#7616)", () => {
+    const target = workspace();
+    const commands: string[] = [];
+    try {
+      const selected = runRetiredSelectorCompatibility(
+        environment(target, ["cloud-onboard", ...RETIRED_CONTROLLER_SELECTOR_IDS].join(",")),
+        {
+          allowedJobs: ["cloud-onboard"],
+          repositoryRoot: target.root,
+          resolveHead: () => EXPECTED_SHA,
+          runCommand: (command, args) => commands.push([command, ...args].join(" ")),
+        },
+      );
+
+      expect(selected).toEqual([...RETIRED_CONTROLLER_SELECTOR_IDS].sort());
+      expect(commands).toEqual([
+        "npx vitest run --project integration test/credentials.test.ts test/gateway-drift-preflight.test.ts test/gateway-health-honest.test.ts",
+        "npx vitest run --project installer-integration test/install-openshell-version-pin.test.ts",
+        "npx vitest run --project package-contract test/package-contract/cli/public-cli-contracts.test.ts test/package-contract/onboard/invalid-nvidia-key.test.ts",
+      ]);
+      expect(fs.readFileSync(target.output, "utf8")).toBe("selected=true\n");
+      for (const id of selected) {
+        const signalPath = path.join(target.artifactRoot, id, "risk-signal.json");
+        expect(JSON.parse(fs.readFileSync(signalPath, "utf8"))).toEqual({
+          version: 1,
+          jobId: id,
+          shardId: "default",
+          expectedSha: EXPECTED_SHA,
+          testedSha: EXPECTED_SHA,
+          planHash: PLAN_HASH,
+          correlationId: CORRELATION_ID,
+          passed: 1,
+          failed: 0,
+          skipped: 0,
+          pending: 0,
+          unhandledErrors: 0,
+          runReason: "passed",
+        });
+        expect(fs.statSync(signalPath).mode & 0o777).toBe(0o600);
+      }
+      expect(
+        JSON.parse(
+          fs.readFileSync(
+            path.join(target.artifactRoot, "retired-selector-compatibility.json"),
+            "utf8",
+          ),
+        ),
+      ).toMatchObject({ schemaVersion: 1, status: "passed", selected });
+    } finally {
+      fs.rmSync(target.root, { force: true, recursive: true });
+    }
+  });
+
+  it("fails before emitting passing evidence when a replacement command fails (#7616)", () => {
+    const target = workspace();
+    try {
+      expect(() =>
+        runRetiredSelectorCompatibility(
+          environment(target, "cloud-onboard,gateway-health-honest"),
+          {
+            allowedJobs: ["cloud-onboard"],
+            repositoryRoot: target.root,
+            runCommand: () => {
+              throw new Error("replacement failed");
+            },
+          },
+        ),
+      ).toThrow("replacement failed");
+      expect(fs.readFileSync(target.output, "utf8")).toBe("selected=true\n");
+      expect(fs.existsSync(target.artifactRoot)).toBe(false);
+    } finally {
+      fs.rmSync(target.root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects compatibility while a selected live E2E file exists (#7616)", () => {
+    const target = workspace();
+    const legacyFile = path.join(target.root, "test/e2e/live/gateway-health-honest.test.ts");
+    fs.mkdirSync(path.dirname(legacyFile), { recursive: true });
+    fs.writeFileSync(legacyFile, "export {};\n", "utf8");
+    try {
+      expect(() =>
+        runRetiredSelectorCompatibility(
+          environment(target, "cloud-onboard,gateway-health-honest"),
+          {
+            allowedJobs: ["cloud-onboard"],
+            repositoryRoot: target.root,
+            runCommand: () => undefined,
+          },
+        ),
+      ).toThrow("requires its live E2E file to remain retired");
+    } finally {
+      fs.rmSync(target.root, { force: true, recursive: true });
+    }
+  });
+});

--- a/test/e2e/support/retired-selector-compatibility.test.ts
+++ b/test/e2e/support/retired-selector-compatibility.test.ts
@@ -72,16 +72,20 @@ describe("retired E2E selector compatibility", () => {
   it("runs each ordinary replacement project once and emits bound signals (#7616)", () => {
     const target = workspace();
     const commands: string[] = [];
+    const suppliedEnvironment = environment(
+      target,
+      ["cloud-onboard", ...RETIRED_CONTROLLER_SELECTOR_IDS].join(","),
+    );
     try {
-      const selected = runRetiredSelectorCompatibility(
-        environment(target, ["cloud-onboard", ...RETIRED_CONTROLLER_SELECTOR_IDS].join(",")),
-        {
-          allowedJobs: ["cloud-onboard"],
-          repositoryRoot: target.root,
-          resolveHead: () => EXPECTED_SHA,
-          runCommand: (command, args) => commands.push([command, ...args].join(" ")),
+      const selected = runRetiredSelectorCompatibility(suppliedEnvironment, {
+        allowedJobs: ["cloud-onboard"],
+        repositoryRoot: target.root,
+        resolveHead: () => EXPECTED_SHA,
+        runCommand: (command, args, _cwd, commandEnvironment) => {
+          expect(commandEnvironment).toBe(suppliedEnvironment);
+          commands.push([command, ...args].join(" "));
         },
-      );
+      });
 
       expect(selected).toEqual([...RETIRED_CONTROLLER_SELECTOR_IDS].sort());
       expect(commands).toEqual([

--- a/test/e2e/support/workflow-plan.test.ts
+++ b/test/e2e/support/workflow-plan.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { discoverCredentialFreeTests } from "../../../tools/e2e/credential-free-tests.mts";
+import { RETIRED_CONTROLLER_SELECTOR_IDS } from "../../../tools/e2e/retired-selector-compatibility.mts";
 import { readFreeStandingJobsInventory } from "../../../tools/e2e/workflow-boundary.mts";
 import {
   buildE2eWorkflowPlan,
@@ -136,6 +137,71 @@ describe("E2E workflow plan", () => {
         ].join("\n"),
       );
       expect(readFileSync(summary, "utf8")).toBe(renderE2eWorkflowPlanSummary(plan));
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("plans active jobs while the candidate verifies retired controller selectors (#7616)", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "nemoclaw-workflow-plan-cli-"));
+    const output = path.join(directory, "github-output");
+    const summary = path.join(directory, "summary.md");
+    const activeJobs = "cloud-onboard,credential-sanitization,security-posture";
+    const plan = buildE2eWorkflowPlan({ jobs: activeJobs });
+    try {
+      const result = spawnSync(TSX, [PLANNER_CLI, "--ci-output"], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: output,
+          GITHUB_STEP_SUMMARY: summary,
+          INFERENCE_MODE: "mock",
+          JOBS: [activeJobs, ...RETIRED_CONTROLLER_SELECTOR_IDS].join(","),
+          TARGETS: "",
+          NEMOCLAW_E2E_EXPECTED_SHA: "a".repeat(40),
+        },
+        timeout: 30_000,
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(readFileSync(output, "utf8")).toBe(
+        [
+          `matrix=${JSON.stringify(plan.matrix)}`,
+          `test_matrix=${JSON.stringify(plan.testMatrix)}`,
+          `hermes_selected=${plan.hermesSelected}`,
+          `explicit_only_jobs=${plan.explicitOnlyJobs.join(",")}`,
+          "",
+        ].join("\n"),
+      );
+      expect(readFileSync(summary, "utf8")).toBe(renderE2eWorkflowPlanSummary(plan));
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a controller plan made only of retired selectors (#7616)", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "nemoclaw-workflow-plan-cli-"));
+    try {
+      const result = spawnSync(TSX, [PLANNER_CLI, "--ci-output"], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: path.join(directory, "github-output"),
+          GITHUB_STEP_SUMMARY: path.join(directory, "summary.md"),
+          INFERENCE_MODE: "mock",
+          JOBS: RETIRED_CONTROLLER_SELECTOR_IDS.join(","),
+          TARGETS: "",
+          NEMOCLAW_E2E_EXPECTED_SHA: "a".repeat(40),
+        },
+        timeout: 30_000,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "::error::retired selector compatibility requires another controller-selected job",
+      );
     } finally {
       rmSync(directory, { force: true, recursive: true });
     }

--- a/tools/e2e/prepare-e2e-workflow-boundary.mts
+++ b/tools/e2e/prepare-e2e-workflow-boundary.mts
@@ -22,6 +22,7 @@ export const PREPARE_E2E_STEP = "Prepare E2E workspace";
 
 const CHECKOUT_LOCAL_PREPARE_E2E_ACTION = "./.github/actions/prepare-e2e";
 const PREINSTALLED_E2E_JOBS = new Set(["staging-brev-launchable"]);
+const RETIRED_SELECTOR_COMPATIBILITY_JOB = "retired-selector-compatibility";
 
 const NO_BUILD_JOBS = new Set([
   "generate-matrix",
@@ -107,7 +108,10 @@ export function validatePrepareE2eInvocations(workflow: WorkflowRecord): string[
         const job = record(value);
         return (
           !PREINSTALLED_E2E_JOBS.has(jobName) &&
-          (jobName === "generate-matrix" || jobName === "live" || record(job.env).E2E_JOB === "1")
+          (jobName === "generate-matrix" ||
+            jobName === "live" ||
+            jobName === RETIRED_SELECTOR_COMPATIBILITY_JOB ||
+            record(job.env).E2E_JOB === "1")
         );
       })
       .map(([jobName]) => jobName),

--- a/tools/e2e/retired-selector-compatibility.mts
+++ b/tools/e2e/retired-selector-compatibility.mts
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { createPrivateRegularFile } from "./private-file.mts";
+import * as importedRiskSignal from "./risk-signal.ts";
+import { readFreeStandingJobsInventory } from "./workflow-boundary.mts";
+
+const riskSignal = (
+  "default" in importedRiskSignal && importedRiskSignal.default
+    ? importedRiskSignal.default
+    : importedRiskSignal
+) as typeof import("./risk-signal.ts");
+const { buildRiskSignal, configuredRiskSignalEnvironment, RISK_SIGNAL_FILE } = riskSignal;
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const SELECTOR_LIST_PATTERN = /^[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*$/u;
+
+export const RETIRED_CONTROLLER_SELECTOR_IDS = [
+  "docs-validation",
+  "gateway-drift-preflight",
+  "gateway-health-honest",
+  "onboard-negative-paths",
+  "openshell-version-pin",
+  "ubuntu-repo-cli-smoke",
+] as const;
+
+type RetiredControllerSelectorId = (typeof RETIRED_CONTROLLER_SELECTOR_IDS)[number];
+type ReplacementTest = {
+  files: readonly string[];
+  project: "integration" | "installer-integration" | "package-contract";
+};
+type Replacement = {
+  legacyFile?: string;
+  tests: readonly ReplacementTest[];
+};
+
+const RETIRED_SELECTOR_ID_SET = new Set<string>(RETIRED_CONTROLLER_SELECTOR_IDS);
+const REPLACEMENTS: Readonly<Record<RetiredControllerSelectorId, Replacement>> = {
+  "docs-validation": {
+    legacyFile: "test/e2e/live/docs-validation.test.ts",
+    tests: [
+      {
+        files: ["test/package-contract/cli/public-cli-contracts.test.ts"],
+        project: "package-contract",
+      },
+    ],
+  },
+  "gateway-drift-preflight": {
+    tests: [{ files: ["test/gateway-drift-preflight.test.ts"], project: "integration" }],
+  },
+  "gateway-health-honest": {
+    legacyFile: "test/e2e/live/gateway-health-honest.test.ts",
+    tests: [{ files: ["test/gateway-health-honest.test.ts"], project: "integration" }],
+  },
+  "onboard-negative-paths": {
+    legacyFile: "test/e2e/live/onboard-negative-paths.test.ts",
+    tests: [
+      { files: ["test/credentials.test.ts"], project: "integration" },
+      {
+        files: ["test/package-contract/onboard/invalid-nvidia-key.test.ts"],
+        project: "package-contract",
+      },
+    ],
+  },
+  "openshell-version-pin": {
+    legacyFile: "test/e2e/live/openshell-version-pin.test.ts",
+    tests: [
+      {
+        files: ["test/install-openshell-version-pin.test.ts"],
+        project: "installer-integration",
+      },
+    ],
+  },
+  "ubuntu-repo-cli-smoke": {
+    legacyFile: "test/e2e/live/ubuntu-repo-cli-smoke.test.ts",
+    tests: [
+      {
+        files: ["test/package-contract/cli/public-cli-contracts.test.ts"],
+        project: "package-contract",
+      },
+    ],
+  },
+};
+
+export function selectedRetiredControllerJobs(options: {
+  allowedJobs: readonly string[];
+  expectedSha?: string;
+  jobs?: string;
+}): RetiredControllerSelectorId[] {
+  if (!SHA_PATTERN.test(options.expectedSha ?? "") || !options.jobs) return [];
+  if (!SELECTOR_LIST_PATTERN.test(options.jobs)) {
+    throw new Error("retired selector compatibility requires safe comma-separated job IDs");
+  }
+  const allowedJobs = new Set(options.allowedJobs);
+  return [
+    ...new Set(
+      options.jobs
+        .split(",")
+        .filter(
+          (job): job is RetiredControllerSelectorId =>
+            RETIRED_SELECTOR_ID_SET.has(job) && !allowedJobs.has(job),
+        ),
+    ),
+  ].sort();
+}
+
+type Command = { command: string; args: string[] };
+type CommandRunner = (command: string, args: readonly string[], cwd: string) => void;
+
+function replacementCommands(selected: readonly RetiredControllerSelectorId[]): Command[] {
+  const replacements = selected.map((id) => REPLACEMENTS[id]);
+  const commands: Command[] = [];
+  const filesByProject = new Map<ReplacementTest["project"], Set<string>>();
+  for (const replacement of replacements) {
+    for (const test of replacement.tests) {
+      const files = filesByProject.get(test.project) ?? new Set<string>();
+      for (const file of test.files) files.add(file);
+      filesByProject.set(test.project, files);
+    }
+  }
+  for (const project of ["integration", "installer-integration", "package-contract"] as const) {
+    const files = filesByProject.get(project);
+    if (!files) continue;
+    commands.push({
+      command: "npx",
+      args: ["vitest", "run", "--project", project, ...[...files].sort()],
+    });
+  }
+  return commands;
+}
+
+function runCommand(command: string, args: readonly string[], cwd: string): void {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: process.env,
+    killSignal: "SIGKILL",
+    stdio: "inherit",
+    timeout: 10 * 60_000,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} exited with status ${result.status ?? "unknown"}`,
+    );
+  }
+}
+
+function verifyReplacementBoundary(
+  selected: readonly RetiredControllerSelectorId[],
+  repositoryRoot: string,
+): void {
+  for (const id of selected) {
+    const replacement = REPLACEMENTS[id];
+    if (
+      replacement.legacyFile &&
+      fs.existsSync(path.join(repositoryRoot, replacement.legacyFile))
+    ) {
+      throw new Error(`${id} compatibility requires its live E2E file to remain retired`);
+    }
+    for (const test of replacement.tests) {
+      for (const file of test.files) {
+        const fullPath = path.join(repositoryRoot, file);
+        if (!fs.existsSync(fullPath)) {
+          throw new Error(`${id} replacement test is missing: ${file}`);
+        }
+        if (fs.readFileSync(fullPath, "utf8").includes("@module-tag e2e/credential-free")) {
+          throw new Error(`${id} replacement must remain in an ordinary Vitest project: ${file}`);
+        }
+      }
+    }
+  }
+}
+
+export function runRetiredSelectorCompatibility(
+  environment: NodeJS.ProcessEnv,
+  options: {
+    allowedJobs?: readonly string[];
+    repositoryRoot?: string;
+    resolveHead?: (workspace: string) => string;
+    runCommand?: CommandRunner;
+  } = {},
+): RetiredControllerSelectorId[] {
+  const allowedJobs = options.allowedJobs ?? readFreeStandingJobsInventory().allowedJobs;
+  const selected = selectedRetiredControllerJobs({
+    allowedJobs,
+    expectedSha: environment.NEMOCLAW_E2E_EXPECTED_SHA,
+    jobs: environment.JOBS,
+  });
+  const output = environment.GITHUB_OUTPUT;
+  if (!output) throw new Error("GITHUB_OUTPUT is required");
+  fs.appendFileSync(output, `selected=${selected.length > 0}\n`, "utf8");
+  if (selected.length === 0) return [];
+
+  const repositoryRoot = options.repositoryRoot ?? REPO_ROOT;
+  const artifactRoot = environment.E2E_ARTIFACT_DIR;
+  if (!artifactRoot) throw new Error("E2E_ARTIFACT_DIR is required");
+  verifyReplacementBoundary(selected, repositoryRoot);
+
+  const commands = replacementCommands(selected);
+  for (const command of commands) {
+    (options.runCommand ?? runCommand)(command.command, command.args, repositoryRoot);
+  }
+
+  fs.mkdirSync(artifactRoot, { recursive: true, mode: 0o700 });
+  for (const id of selected) {
+    const signalDirectory = path.join(artifactRoot, id);
+    fs.mkdirSync(signalDirectory, { recursive: true, mode: 0o700 });
+    const signalEnvironment = configuredRiskSignalEnvironment(
+      {
+        ...environment,
+        E2E_ARTIFACT_DIR: signalDirectory,
+        E2E_TARGET_ID: id,
+      },
+      options.resolveHead,
+    );
+    if (!signalEnvironment) {
+      throw new Error("retired selector compatibility requires a controller-bound risk signal");
+    }
+    const signal = buildRiskSignal(signalEnvironment, {
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      pending: 0,
+      unhandledErrors: 0,
+      runReason: "passed",
+    });
+    createPrivateRegularFile(
+      path.join(signalDirectory, RISK_SIGNAL_FILE),
+      `${JSON.stringify(signal, null, 2)}\n`,
+    );
+  }
+  createPrivateRegularFile(
+    path.join(artifactRoot, "retired-selector-compatibility.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        status: "passed",
+        selected,
+        replacements: selected.map((id) => ({ id, ...REPLACEMENTS[id] })),
+        commands,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return selected;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const selected = runRetiredSelectorCompatibility(process.env);
+    if (selected.length > 0) {
+      console.log(`Verified ordinary-test replacements for: ${selected.join(", ")}`);
+    }
+  } catch (error) {
+    console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/tools/e2e/retired-selector-compatibility.mts
+++ b/tools/e2e/retired-selector-compatibility.mts
@@ -8,7 +8,12 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { createPrivateRegularFile } from "./private-file.mts";
 import * as importedRiskSignal from "./risk-signal.ts";
-import { readFreeStandingJobsInventory } from "./workflow-boundary.mts";
+import {
+  RETIRED_CONTROLLER_SELECTOR_IDS,
+  readFreeStandingJobsInventory,
+} from "./workflow-boundary.mts";
+
+export { RETIRED_CONTROLLER_SELECTOR_IDS } from "./workflow-boundary.mts";
 
 const riskSignal = (
   "default" in importedRiskSignal && importedRiskSignal.default
@@ -20,15 +25,6 @@ const { buildRiskSignal, configuredRiskSignalEnvironment, RISK_SIGNAL_FILE } = r
 const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const SELECTOR_LIST_PATTERN = /^[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*$/u;
-
-export const RETIRED_CONTROLLER_SELECTOR_IDS = [
-  "docs-validation",
-  "gateway-drift-preflight",
-  "gateway-health-honest",
-  "onboard-negative-paths",
-  "openshell-version-pin",
-  "ubuntu-repo-cli-smoke",
-] as const;
 
 type RetiredControllerSelectorId = (typeof RETIRED_CONTROLLER_SELECTOR_IDS)[number];
 type ReplacementTest = {
@@ -111,7 +107,12 @@ export function selectedRetiredControllerJobs(options: {
 }
 
 type Command = { command: string; args: string[] };
-type CommandRunner = (command: string, args: readonly string[], cwd: string) => void;
+type CommandRunner = (
+  command: string,
+  args: readonly string[],
+  cwd: string,
+  environment: NodeJS.ProcessEnv,
+) => void;
 
 function replacementCommands(selected: readonly RetiredControllerSelectorId[]): Command[] {
   const replacements = selected.map((id) => REPLACEMENTS[id]);
@@ -135,10 +136,15 @@ function replacementCommands(selected: readonly RetiredControllerSelectorId[]): 
   return commands;
 }
 
-function runCommand(command: string, args: readonly string[], cwd: string): void {
+function runCommand(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+  environment: NodeJS.ProcessEnv,
+): void {
   const result = spawnSync(command, args, {
     cwd,
-    env: process.env,
+    env: environment,
     killSignal: "SIGKILL",
     stdio: "inherit",
     timeout: 10 * 60_000,
@@ -204,7 +210,7 @@ export function runRetiredSelectorCompatibility(
 
   const commands = replacementCommands(selected);
   for (const command of commands) {
-    (options.runCommand ?? runCommand)(command.command, command.args, repositoryRoot);
+    (options.runCommand ?? runCommand)(command.command, command.args, repositoryRoot, environment);
   }
 
   fs.mkdirSync(artifactRoot, { recursive: true, mode: 0o700 });

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -32,6 +32,7 @@ const UPLOAD_ARTIFACT_ACTION = "actions/upload-artifact@043fb46d1a93c77aae656e7c
 const UPLOAD_ARTIFACT_ACTION_PREFIX = "actions/upload-artifact@";
 const INNER_ALWAYS = "${{ always() }}";
 const CALLER_ALWAYS = "always()";
+const RETIRED_SELECTOR_COMPATIBILITY_JOB = "retired-selector-compatibility";
 const MCP_SCANNED_UPLOAD_CONDITION =
   "${{ always() && steps.mcp_artifact_secret_scan.outcome == 'success' }}";
 const GATEWAY_AUTH_SCANNED_UPLOAD_CONDITION =
@@ -66,6 +67,13 @@ type ExplicitUploadContract = {
 };
 
 const EXPLICIT_UPLOAD_CONTRACTS = new Map<string, ExplicitUploadContract>([
+  [
+    "retired-selector-compatibility",
+    {
+      name: "e2e-retired-selector-compatibility",
+      path: "e2e-artifacts/live/retired-selector-compatibility/",
+    },
+  ],
   [
     "staging-brev-launchable",
     {
@@ -346,6 +354,7 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
         return (
           jobName === "staging-brev-launchable" ||
           jobName === "live" ||
+          jobName === RETIRED_SELECTOR_COMPATIBILITY_JOB ||
           env.E2E_JOB === "1" ||
           env.NEMOCLAW_RUN_LIVE_E2E === "1" ||
           SHARED_E2E_JOBS.has(jobName) ||

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -121,6 +121,14 @@ type CachedFreeStandingJobsInventory = {
 
 const SELECTOR_PATTERN = /^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$/;
 const SELECTOR_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+export const RETIRED_CONTROLLER_SELECTOR_IDS = [
+  "docs-validation",
+  "gateway-drift-preflight",
+  "gateway-health-honest",
+  "onboard-negative-paths",
+  "openshell-version-pin",
+  "ubuntu-repo-cli-smoke",
+] as const;
 const LIVE_TEST_FILE_PATTERN = /test\/e2e\/live\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.test\.ts/g;
 const FREE_STANDING_JOB_MARKER = "E2E_JOB";
 const FREE_STANDING_TARGET_MARKER = "E2E_TARGET_ID";
@@ -4310,6 +4318,23 @@ function validateStagingBrevLaunchableReadinessJob(errors: string[], jobs: Workf
   requireRunContains(errors, fail, "exit 1");
 }
 
+function validateRetiredSelectorCompatibilityJob(errors: string[], jobs: WorkflowRecord): void {
+  const job = asRecord(jobs["retired-selector-compatibility"]);
+  if (Object.keys(job).length === 0) {
+    errors.push("workflow missing retired-selector-compatibility job");
+    return;
+  }
+  const selectorGate = RETIRED_CONTROLLER_SELECTOR_IDS.map(
+    (id) => `contains(format(',{0},', inputs.jobs), ',${id},')`,
+  ).join(" || ");
+  const expectedIf = `\${{ inputs.checkout_sha != '' && (${selectorGate}) }}`;
+  if (job.if !== expectedIf) {
+    errors.push(
+      "retired-selector-compatibility job selector gate must match retired selector contract",
+    );
+  }
+}
+
 export function validateE2eWorkflow(workflowValue: unknown): string[] {
   const workflow = asRecord(workflowValue);
   const errors: string[] = [];
@@ -4365,6 +4390,7 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
   if (permissions.contents !== "read") errors.push("workflow permissions.contents must be read");
 
   const jobs = asRecord(workflow.jobs);
+  validateRetiredSelectorCompatibilityJob(errors, jobs);
   const expectedRunName =
     "${{ inputs.checkout_sha != '' && format('E2E PR #{0} ({1})', inputs.pr_number, inputs.correlation_id) || inputs.correlation_id != '' && format('E2E {0} ({1})', github.ref_name, inputs.correlation_id) || format('E2E {0}', github.ref_name) }}";
   if (workflow["run-name"] !== expectedRunName) {

--- a/tools/e2e/workflow-plan.mts
+++ b/tools/e2e/workflow-plan.mts
@@ -10,6 +10,7 @@ import {
   type CredentialFreeTestMatrixRow,
   discoverCredentialFreeTests,
 } from "./credential-free-tests.mts";
+import { selectedRetiredControllerJobs } from "./retired-selector-compatibility.mts";
 import { normalizeE2eSelectorIds } from "./selector-aliases.mts";
 import { readFreeStandingJobsInventory } from "./workflow-boundary.mts";
 
@@ -131,25 +132,37 @@ function selectTestRows(
   return rows.filter((row) => selected.has(row.id));
 }
 
-function mapTrustedControllerBootstrapJob(
+function mapTrustedControllerJobs(
   selectors: WorkflowPlanSelectors,
   environment: NodeJS.ProcessEnv,
 ): WorkflowPlanSelectors {
   if (!COMMIT_SHA_PATTERN.test(environment.NEMOCLAW_E2E_EXPECTED_SHA ?? "")) return selectors;
 
-  const jobs = selectorIds(selectors.jobs, "jobs");
-  if (!jobs.includes(LEGACY_BOOTSTRAP_INSTALL_JOB_ID)) return selectors;
-
   const inventory = readFreeStandingJobsInventory();
-  if (!inventory.allowedJobs.includes(BOOTSTRAP_INSTALL_JOB_ID)) return selectors;
+  const jobs = selectorIds(selectors.jobs, "jobs").map((job) =>
+    job === LEGACY_BOOTSTRAP_INSTALL_JOB_ID &&
+    inventory.allowedJobs.includes(BOOTSTRAP_INSTALL_JOB_ID)
+      ? BOOTSTRAP_INSTALL_JOB_ID
+      : job,
+  );
+  const retiredJobs = new Set<string>(
+    selectedRetiredControllerJobs({
+      allowedJobs: inventory.allowedJobs,
+      expectedSha: environment.NEMOCLAW_E2E_EXPECTED_SHA,
+      jobs: jobs.join(","),
+    }),
+  );
+  const compatibleJobs = jobs.filter((job) => !retiredJobs.has(job));
+  if (jobs.length > 0 && compatibleJobs.length === 0 && !selectors.targets) {
+    throw new Error("retired selector compatibility requires another controller-selected job");
+  }
 
-  // Trusted main selects the old job ID until this workflow rename merges, while
-  // the checked-out PR planner already reads the renamed inventory.
+  // Trusted main can select a renamed or newly retired job until the candidate
+  // workflow becomes the controller. Keep the raw IDs for evidence, but plan
+  // only jobs that still execute in the candidate.
   return {
     ...selectors,
-    jobs: jobs
-      .map((job) => (job === LEGACY_BOOTSTRAP_INSTALL_JOB_ID ? BOOTSTRAP_INSTALL_JOB_ID : job))
-      .join(","),
+    jobs: compatibleJobs.join(","),
   };
 }
 
@@ -240,7 +253,7 @@ export function writeE2eWorkflowPlanCiOutput(
   if (!INFERENCE_MODES.has(inferenceMode)) {
     throw new Error(`Invalid inference_mode: ${inferenceMode}`);
   }
-  const plannerSelectors = mapTrustedControllerBootstrapJob(selectors, environment);
+  const plannerSelectors = mapTrustedControllerJobs(selectors, environment);
   const plan = validateE2eWorkflowPlan(buildE2eWorkflowPlan(plannerSelectors));
   if (plan.hermesSelected !== expectedHermesSelection(plannerSelectors)) {
     throw new Error("E2E planner changed the trusted Hermes selection");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

PR #7625 correctly retired six local-only E2E scenarios, but the trusted controller on `main` can still dispatch those retired selector IDs while a candidate workflow is taking over. This adds a fail-closed transition bridge: the candidate runs the ordinary replacement tests once and emits controller-bound evidence for each retired selector while the remaining live jobs continue.

## Related Issue

Follow-up to #7625 and #7616
Parent: #7614

## Changes

- Add a compatibility job for the current requirement that trusted PR E2E controllers can select IDs retired by the candidate they dispatch. The consumer is the SHA-bound `e2e.yaml` workflow invoked by the controller on `main`.
- Keep the raw trusted selector list for evidence, filter only the six known retired IDs from candidate planning, and fail closed when no active controller-selected job remains.
- Run each replacement Vitest project once, require the retired live files to remain absent, and emit SHA-, plan-, correlation-, and shard-bound risk signals for all selected retired IDs.
- Extend the prepare/upload workflow boundary contracts and add planner and compatibility regression tests. A direct controller change is insufficient because the controller must remain on trusted `main`; restoring the retired live jobs would reintroduce the cost this migration removes.
- Keep the retired selector list authoritative in the executable workflow boundary, reject workflow-gate drift, and pass the caller-supplied environment to every replacement command.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is an internal controller-transition path. It adds no supported CLI behavior, configuration, operator action, or public documentation contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The bridge remains SHA-, plan-, correlation-, and shard-bound, rejects unsafe selectors, preserves raw trusted evidence, and fails closed without another active controller job. The exact nine-selector replay emitted six valid bound signals.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed or require updates. The reviewer checked `docs/`, `README.md`, `CONTRIBUTING.md`, and `test/e2e/README.md`; existing guidance already covers controller planning, SHA-bound checkout, protected approval, and evidence validation without promising transient selector IDs.
- Agent: Codex Desktop documentation-writer subagent (`/root/documentation_writer_review`)
<!-- docs-review-head-sha: 8980c629aa -->
<!-- docs-review-agents-blob-sha: be20a09524 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact nine-selector replay: 47 integration, 3 installer-integration, and 4 package-contract assertions passed with six bound risk signals; focused workflow contracts: 75/75; full E2E-support: 163 files passed, 3 skipped, 1,737 tests passed, 17 skipped; source-shape cases remain zero; semantic phase coverage: 117 tests across 76 files; Vitest membership: exact 1,861 files across 8 projects; `npm run build:cli` and `npm run check:diff` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm test` was attempted on the original PR head and reproduced three unchanged DGX Station host-detection fixture failures plus one unchanged root-topology fixture failure, then stopped making progress and was interrupted. GitHub CI will provide hosted aggregate evidence for the updated head.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retired-selector-compatibility checks that run targeted replacement E2E tests and generate compatibility evidence artifacts (including risk-signal and summary output).
  * Expanded CI and PR reporting to include a dedicated retired-selector-compatibility job when relevant.
  * Updated workflow planning and boundary validation to map controller-selected jobs to compatible sets and enforce retired-only selection rules.
* **Bug Fixes**
  * Prevented planning/runs when controller-selected jobs become fully retired without required targets.
* **Tests**
  * Added E2E coverage for selector filtering, artifact outputs, error/guard behaviors, and workflow selector gate drift detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->