### PR TITLE
chore(inference): remove retired Build model paths

### DIFF
--- a/src/lib/inference/config.test.ts
+++ b/src/lib/inference/config.test.ts
@@ -342,10 +342,14 @@ describe("getSandboxInferenceConfig", () => {
 
   it("maps NVIDIA Endpoints to the routed inference provider", () => {
     expect(
-      getSandboxInferenceConfig("qwen/qwen3.5-397b-a17b", "nvidia-prod", "openai-completions"),
+      getSandboxInferenceConfig(
+        "nvidia/nemotron-3-super-120b-a12b",
+        "nvidia-prod",
+        "openai-completions",
+      ),
     ).toEqual({
       providerKey: MANAGED_PROVIDER_ID,
-      primaryModelRef: `${MANAGED_PROVIDER_ID}/qwen/qwen3.5-397b-a17b`,
+      primaryModelRef: `${MANAGED_PROVIDER_ID}/nvidia/nemotron-3-super-120b-a12b`,
       inferenceBaseUrl: INFERENCE_ROUTE_URL,
       inferenceApi: "openai-completions",
       inferenceCompat: null,

--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -255,7 +255,6 @@ describe("inference health", () => {
 
     it.each([
       "deepseek-ai/deepseek-v4-pro",
-      "qwen/qwen3.5-397b-a17b",
       "deepseek-ai/deepseek-v4-flash",
     ])("reports the short status timeout as unverified for slow model %s", (model) => {
       const result = probeRemoteProviderHealth("nvidia-prod", {

--- a/src/lib/inference/nvidia-featured-models.test.ts
+++ b/src/lib/inference/nvidia-featured-models.test.ts
@@ -28,19 +28,6 @@ describe("NVIDIA featured model catalog", () => {
     ).toEqual([{ id: "nvidia/nemotron-3-super-120b-a12b", label: "Nemotron 3 Super 120B" }]);
   });
 
-  it("rewrites stale Minimax M2.7 catalog IDs and labels to M3 (#5827)", () => {
-    expect(
-      parseNvidiaFeaturedModels(
-        JSON.stringify({
-          "featured-models": [
-            { model: "minimaxai/minimax-m2.7", "model-name": "Minimax M2.7" },
-            { model: "minimaxai/minimax-m3", "model-name": "Minimax M3 duplicate" },
-          ],
-        }),
-      ),
-    ).toEqual([{ id: "minimaxai/minimax-m3", label: "Minimax M3" }]);
-  });
-
   it("filters models whose catalogs outlive their NVIDIA Endpoints routes", () => {
     expect(
       parseNvidiaFeaturedModels(

--- a/src/lib/inference/nvidia-featured-models.ts
+++ b/src/lib/inference/nvidia-featured-models.ts
@@ -65,14 +65,6 @@ export type FeaturedModelFetchResult =
 /** Normalizes NVIDIA featured-model catalog IDs into endpoint model IDs. */
 function normalizeFeaturedModelId(model: string): string {
   const trimmed = model.trim();
-  // Minimax rollout contract (#5827): the external feed has emitted the stale
-  // M2.7 ID/label while CLOUD_MODEL_OPTIONS and the task-fit docs define M3 as
-  // the NVIDIA Endpoints choice. This is an upstream-lag bridge; remove this ID
-  // rewrite together with the label rewrite and fixture only once the feed no
-  // longer emits M2.7 and publishes M3 directly.
-  if (trimmed === "minimaxai/minimax-m2.7") {
-    return "minimaxai/minimax-m3";
-  }
   // Nemotron namespace contract (#5827): the external feed has emitted bare
   // nemotron-3-* IDs, while CLOUD_MODEL_OPTIONS and the matching OpenClaw
   // model-specific setup manifest use the canonical nvidia/ endpoint namespace.
@@ -92,16 +84,6 @@ function sanitizeFeaturedCatalogText(value: string, maxLength: number): string {
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, maxLength);
-}
-
-/** Normalizes NVIDIA featured-model labels for known catalog lag cases. */
-function normalizeFeaturedModelLabel(id: string, label: string): string {
-  const sanitized = sanitizeFeaturedCatalogText(label, MAX_NVIDIA_FEATURED_MODEL_LABEL_LENGTH);
-  // Keep the display label coupled to the Minimax rollout contract above.
-  if (id === "minimaxai/minimax-m3" && /^minimax m2\.7$/i.test(sanitized)) {
-    return "Minimax M3";
-  }
-  return sanitized;
 }
 
 function isRetiredFeaturedModelId(
@@ -136,7 +118,7 @@ export function parseNvidiaFeaturedModels(
     const idKey = id.toLowerCase();
     const label =
       typeof item?.["model-name"] === "string"
-        ? normalizeFeaturedModelLabel(id, item["model-name"])
+        ? sanitizeFeaturedCatalogText(item["model-name"], MAX_NVIDIA_FEATURED_MODEL_LABEL_LENGTH)
         : "";
     if (
       !id ||

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -332,21 +332,19 @@ describe("OpenAI-compatible inference probes", () => {
     }
   });
 
-  it("uses an extended validation budget for slow NVIDIA Build models", () => {
-    for (const model of ["qwen/qwen3.5-397b-a17b", "deepseek-ai/deepseek-v4-flash"]) {
-      const args = getChatCompletionsProbeCurlArgs({
-        credentialArgs: FAKE_CREDENTIAL_ARGS,
-        model,
-        url: "https://integrate.api.nvidia.com/v1/chat/completions",
-        isWsl: false,
-      });
-      expect(args[args.indexOf("--connect-timeout") + 1]).toBe("10");
-      expect(args[args.indexOf("--max-time") + 1]).toBe("300");
-    }
+  it("uses an extended validation budget for DeepSeek V4 Flash", () => {
+    const args = getChatCompletionsProbeCurlArgs({
+      credentialArgs: FAKE_CREDENTIAL_ARGS,
+      model: "deepseek-ai/deepseek-v4-flash",
+      url: "https://integrate.api.nvidia.com/v1/chat/completions",
+      isWsl: false,
+    });
+    expect(args[args.indexOf("--connect-timeout") + 1]).toBe("10");
+    expect(args[args.indexOf("--max-time") + 1]).toBe("300");
 
     const wslArgs = getChatCompletionsProbeCurlArgs({
       credentialArgs: FAKE_CREDENTIAL_ARGS,
-      model: "qwen/qwen3.5-397b-a17b",
+      model: "deepseek-ai/deepseek-v4-flash",
       url: "https://integrate.api.nvidia.com/v1/chat/completions",
       isWsl: true,
     });

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -101,10 +101,7 @@ function openAiLikeFailureFromError(error) {
 
 // ── Helpers ──────────────────────────────────────────────────────
 
-const EXTENDED_NVIDIA_ENDPOINT_VALIDATION_MODELS = new Set([
-  "qwen/qwen3.5-397b-a17b",
-  "deepseek-ai/deepseek-v4-flash",
-]);
+const EXTENDED_NVIDIA_ENDPOINT_VALIDATION_MODELS = new Set(["deepseek-ai/deepseek-v4-flash"]);
 
 // Hostnames that are normally meant for the sandbox/container host boundary.
 // host.openshell.internal only resolves inside the OpenShell sandbox network,

--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -849,7 +849,7 @@ describe("inventory commands", () => {
         ],
         defaultSandbox: "alpha",
       }),
-      getLiveInference: () => ({ provider: "nvidia-prod", model: "minimaxai/minimax-m2.7" }),
+      getLiveInference: () => ({ provider: "nvidia-prod", model: "provider/runtime-model" }),
       showServiceStatus,
       log: (message = "") => lines.push(message),
     });
@@ -858,7 +858,7 @@ describe("inventory commands", () => {
     expect(lines).toContain("  Sandboxes:");
     // Default sandbox shows the live gateway model (#2369), annotated with
     // the onboarded model when they differ.
-    expect(lines).toContain("    alpha * (minimaxai/minimax-m2.7)");
+    expect(lines).toContain("    alpha * (provider/runtime-model)");
     expect(lines).toContain("      (onboarded: nvidia/nemotron-3-super-120b-a12b)");
     // Non-default sandbox keeps its stored model — the gateway only applies
     // to whichever sandbox is currently connected.
@@ -1040,12 +1040,12 @@ describe("inventory commands", () => {
         sandboxes: [{ name: "alpha" }],
         defaultSandbox: "alpha",
       }),
-      getLiveInference: () => ({ provider: "nvidia-prod", model: "minimaxai/minimax-m2.7" }),
+      getLiveInference: () => ({ provider: "nvidia-prod", model: "provider/runtime-model" }),
       showServiceStatus: vi.fn(),
       log: (message = "") => lines.push(message),
     });
 
-    expect(lines).toContain("    alpha * (minimaxai/minimax-m2.7)");
+    expect(lines).toContain("    alpha * (provider/runtime-model)");
     expect(lines).toContain("      (onboarded: unknown)");
   });
 

--- a/src/lib/onboard/compatible-endpoint-smoke.test.ts
+++ b/src/lib/onboard/compatible-endpoint-smoke.test.ts
@@ -110,7 +110,7 @@ describe("compatible endpoint sandbox smoke helpers", () => {
 
   it("retries a reasoning-only length response before failing the sandbox smoke", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-compat-smoke-reasoning-"));
-    const model = "minimaxai/minimax-m2.7";
+    const model = "provider/reasoning-model";
     const configPath = writeSmokeConfig(tmpDir, model);
     const { binDir, callFile } = writeFakeCurl(
       tmpDir,
@@ -355,7 +355,7 @@ printf '%s\n' '{"choices":[{"message":{"content":"PONG"},"finish_reason":"stop"}
 
   it("reports a model-output budget problem when the retry also has no assistant content", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-compat-smoke-no-content-"));
-    const model = "minimaxai/minimax-m2.7";
+    const model = "provider/reasoning-model";
     const configPath = writeSmokeConfig(tmpDir, model);
     const { binDir, callFile } = writeFakeCurl(
       tmpDir,

--- a/test/e2e/support/hermes-workflow-boundary.test.ts
+++ b/test/e2e/support/hermes-workflow-boundary.test.ts
@@ -144,7 +144,7 @@ describe("Hermes GPU boundary", () => {
 
   it("rejects broad drift", () => {
     const errors = wfErrors((workflow) => {
-      workflow.jobs["hermes-e2e"].env.NEMOCLAW_MODEL = "minimaxai/minimax-m2.7";
+      workflow.jobs["hermes-e2e"].env.NEMOCLAW_MODEL = "provider/unexpected-model";
       const job = workflow.jobs[GPU];
       job["runs-on"] = "ubuntu-latest";
       job.if = "${{ always() }}";

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -275,7 +275,7 @@ const TEST_NVIDIA_FEATURED_MODELS = parseNvidiaFeaturedModels(
       },
       { model: "z-ai/glm-5.1", "model-name": "GLM 5.1" },
       { model: "moonshotai/kimi-k2.6", "model-name": "Kimi K2.6" },
-      { model: "minimaxai/minimax-m2.7", "model-name": "Minimax M2.7" },
+      { model: "minimaxai/minimax-m3", "model-name": "Minimax M3" },
     ],
   }),
 );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Remove obsolete NVIDIA Build compatibility paths for MiniMax M2.7 and Qwen 3.5 397B.
NVIDIA Endpoints onboarding keeps its current M3 choices, while independent Hermes Provider entries remain unchanged.

## Related Issue

Fixes #7645

## Changes

- Remove the obsolete `minimaxai/minimax-m2.7` featured-feed ID and label rewrite.
- Remove `qwen/qwen3.5-397b-a17b` from the extended NVIDIA Endpoints validation budget.
- Replace retired Build model IDs in unrelated tests with current or provider-neutral fixture values.
- Preserve `minimax/minimax-m2.7` and `stepfun/step-3.5-flash` in the independent Hermes Provider catalog.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Published NVIDIA Endpoints pages already list M3, omit Qwen 3.5 397B, and describe Hermes Provider separately.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The reviewed diff only removes model-specific normalization and timeout entries. Authentication, credentials, provider routing, and manual `/models` validation remain unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/inference/choose-model.mdx` and `docs/inference/use-nvidia-endpoints.mdx` already list M3 and omit Qwen 3.5 397B. Hermes Provider documentation already describes its independent catalog.
- Agent: Codex Desktop
<!-- docs-review-head-sha: eda3ede2 -->
<!-- docs-review-agents-blob-sha: be20a095 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: CLI affected tests passed with 212 tests and 1 skip. `test/onboard-selection.test.ts` passed 64 tests. The Hermes workflow-boundary test passed 18 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NVIDIA featured-model listings now preserve the model IDs and labels supplied by the catalog.
  * Extended validation timing is applied to DeepSeek V4 Flash for more reliable endpoint checks.

* **Bug Fixes**
  * Updated inference routing, sandbox status, onboarding, and endpoint checks to reflect current model catalog entries.
  * Improved model-selection and workflow validation coverage for updated NVIDIA model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->