### PR TITLE
docs: add v0.0.96 release follow-up

### DIFF
--- a/docs/changelog/2026-07-25.mdx
+++ b/docs/changelog/2026-07-25.mdx
@@ -60,7 +60,7 @@ It also hardens blueprint identifier validation, improves onboarding and recover
   If lockdown cannot be restored, the batch stops and prints the recovery command without processing the remaining sandboxes.
   Cross-sandbox snapshot restore now approves at most one pairing or scope-upgrade request that matches the restored clone, restarts that clone's gateway to publish the approval, and uses one authenticated verification as its success condition.
   NemoClaw rejects corrupt persisted Shields state before mutation.
-  Restore the state from a trusted host backup; neither `shields up` nor an ordinary rebuild replaces it.
+  Operators must restore the state from a trusted host backup; neither `shields up` nor an ordinary rebuild replaces it.
   For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
 - Managed OpenClaw and Hermes sandbox Dockerfiles now avoid BuildKit-only bind mounts.
   On Docker Engine hosts, the OpenShell gateway builder can complete the image build when the host-side BuildKit prebuild is unavailable or fails.

--- a/docs/changelog/2026-07-25.mdx
+++ b/docs/changelog/2026-07-25.mdx
@@ -6,11 +6,12 @@
 ## v0.0.96
 
 NemoClaw v0.0.96 adds persistent baseline network policy exclusions, DNS-backed HTTPS inference switching, host-managed default OpenShell gateways, and opt-in MCP tool discovery.
-It also hardens blueprint identifier validation, improves onboarding and recovery diagnostics, locks and updates managed sandbox image dependencies, reduces Hermes image size, and strengthens release validation.
+It also hardens blueprint identifier validation, improves onboarding and recovery diagnostics, preserves Shields posture during bulk backups, locks and updates managed sandbox image dependencies, reduces Hermes image size, and strengthens release validation.
 
 - `policy exclude` and `policy restore` now persist an operator-approved removal of one exact agent baseline entry across rebuild and snapshot restore.
   The commands preview the removed endpoints and affected features, reserve excluded keys, protect `managed_inference`, and require another review after agent or baseline drift.
   `policy list`, `policy explain`, `status`, `doctor`, snapshot, and rebuild output report active or inconsistent exclusions.
+  The `claude-code` preset now permits the resolved npm-installed launcher path that OpenShell enforces without broadening its endpoint or HTTP method scope.
   For more information, refer to [Network Policies](/user-guide/openclaw/reference/network-policies) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
 - `nemoclaw inference set --endpoint-url` now routes public DNS-backed HTTPS custom endpoints through a host-side HTTPS Pin Runtime adapter.
   Each route receives a separate sandbox-facing credential, while the upstream endpoint and credential remain host-only.
@@ -24,8 +25,10 @@ It also hardens blueprint identifier validation, improves onboarding and recover
   NemoClaw-managed custom ports retain the detached-process lifecycle, while a declared external supervisor retains authority for its gateway.
   Onboarding now uses deadline-based readiness waits and omits TLS Server Name Indication for IP-literal health probes.
   It accepts a positively identified Docker engine even when `ProductLicense` is `Apache-2.0`, and rejects a macOS Podman compatibility socket before gateway launch.
-  For more information, refer to [Architecture Details](/user-guide/openclaw/reference/architecture), [Platform Support and Launch Claims](/user-guide/openclaw/reference/platform-support), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+  Invalid `NEMOCLAW_GATEWAY_MANAGEMENT` declarations now return a sanitized single-line CLI error and nonzero exit instead of a Node.js stack trace.
+  For more information, refer to [Architecture Details](/user-guide/openclaw/reference/architecture), [Declare the OpenShell Gateway Lifecycle Authority](/user-guide/openclaw/deployment/gateway-lifecycle-authority), [Platform Support and Launch Claims](/user-guide/openclaw/reference/platform-support), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
 - Status and upgrade checks now scope gateway failure and agent-version probes to the sandbox's recorded gateway.
+  `nemoclaw list` and global `status` hide route-only reservations left by failed onboarding while preserving them for `onboard --resume`.
   `doctor` reports incomplete lifecycle metadata without exposing stored values.
   An explicit forced rebuild can preserve managed MCP configuration after the old sandbox loses exec access, with exact gateway, policy, and provider proofs before deletion.
   Rebuild rechecks the canonical sandbox and recorded gateway at the delete edge, restores MCP state if that target drifts, and keeps shields unlocked when an accepted deletion remains unconfirmed.
@@ -48,9 +51,16 @@ It also hardens blueprint identifier validation, improves onboarding and recover
   DGX Station preparation now distinguishes an active vLLM server from unrelated diagnostic processes.
   For more information, refer to the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart), [Update Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/update-sandboxes), [Prepare Windows for NemoClaw](/user-guide/openclaw/get-started/additional-setup/windows-preparation), and [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).
 - The Ollama model menu now shows download size, required VRAM, and available or total GPU memory when known.
+  Re-onboarding a committed local Ollama route now reuses its persisted proxy token so the existing sandbox and restarted host proxy keep the same credential.
   Resumed onboarding reports when a recorded reasoning setting takes precedence over `NEMOCLAW_REASONING`.
-  Passing the managed Hermes Dockerfile to `nemohermes onboard --from` now stages the repository root, and separate Hermes provider and model flags use the credential-resolving combined route.
+  Passing the managed Hermes Dockerfile to `nemohermes onboard --from` now stages the repository root, and separate Hermes provider and namespaced model flags use the credential-resolving combined route without dropping the model namespace.
   For more information, refer to [Set Up Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama), [Configure Model Capabilities](/user-guide/openclaw/inference/manage-inference/configure-model-capabilities), [Install Hermes Plugins](/user-guide/hermes/manage-sandboxes/install-hermes-plugins), and the [NemoHermes CLI Commands Reference](/user-guide/hermes/reference/commands).
+- `nemoclaw backup-all` now opens a separate 30-minute Shields-down window for each eligible sandbox that starts with Shields up and restores lockdown before it processes the next sandbox.
+  A sandbox that starts with Shields down remains down.
+  If lockdown cannot be restored, the batch stops and prints the recovery command without processing the remaining sandboxes.
+  Cross-sandbox snapshot restore now approves at most one pairing or scope-upgrade request that matches the restored clone, restarts that clone's gateway to publish the approval, and uses one authenticated verification as its success condition.
+  Corrupt persisted Shields state is rejected before mutation and must be restored from a trusted host backup; neither `shields up` nor an ordinary rebuild replaces it.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
 - Managed OpenClaw and Hermes sandbox Dockerfiles now avoid BuildKit-only bind mounts.
   On Docker Engine hosts, the OpenShell gateway builder can complete the image build when the host-side BuildKit prebuild is unavailable or fails.
   For more information, refer to [NemoClaw Prerequisites](/user-guide/openclaw/get-started/prerequisites) and [Platform Support and Launch Claims](/user-guide/openclaw/reference/platform-support).
@@ -59,6 +69,7 @@ It also hardens blueprint identifier validation, improves onboarding and recover
   The OpenClaw graph replaces its affected `brace-expansion` and `fast-uri` resolutions.
   All managed sandbox base images now install checksum-bound fixed Vim, jq, Oniguruma, and Expat packages and verify the reviewed Perl components.
   Their bundled npm replaces its private `brace-expansion@5.0.7` copy with SRI-pinned `5.0.8`, and each image records a root-owned, read-only package inventory.
+  OpenClaw onboarding now rejects a selected base that lacks that immutable inventory before the final image build; an incompatible exact release is refreshed once when cached, then replaced by a current local build rather than `:latest`.
   Hermes image assembly removes build-only caches and dependencies, reducing the measured final image by 624,394,525 bytes.
   For more information, refer to [Architecture Details](/user-guide/openclaw/reference/architecture).
 - Release validation now runs approved E2E targets for fork PRs, retries one confirmed hosted-runner loss, and retries classified transient base-image pulls.

--- a/docs/changelog/2026-07-25.mdx
+++ b/docs/changelog/2026-07-25.mdx
@@ -59,7 +59,8 @@ It also hardens blueprint identifier validation, improves onboarding and recover
   A sandbox that starts with Shields down remains down.
   If lockdown cannot be restored, the batch stops and prints the recovery command without processing the remaining sandboxes.
   Cross-sandbox snapshot restore now approves at most one pairing or scope-upgrade request that matches the restored clone, restarts that clone's gateway to publish the approval, and uses one authenticated verification as its success condition.
-  Corrupt persisted Shields state is rejected before mutation and must be restored from a trusted host backup; neither `shields up` nor an ordinary rebuild replaces it.
+  NemoClaw rejects corrupt persisted Shields state before mutation.
+  Restore the state from a trusted host backup; neither `shields up` nor an ordinary rebuild replaces it.
   For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
 - Managed OpenClaw and Hermes sandbox Dockerfiles now avoid BuildKit-only bind mounts.
   On Docker Engine hosts, the OpenShell gateway builder can complete the image build when the host-side BuildKit prebuild is unavailable or fails.
@@ -69,7 +70,9 @@ It also hardens blueprint identifier validation, improves onboarding and recover
   The OpenClaw graph replaces its affected `brace-expansion` and `fast-uri` resolutions.
   All managed sandbox base images now install checksum-bound fixed Vim, jq, Oniguruma, and Expat packages and verify the reviewed Perl components.
   Their bundled npm replaces its private `brace-expansion@5.0.7` copy with SRI-pinned `5.0.8`, and each image records a root-owned, read-only package inventory.
-  OpenClaw onboarding now rejects a selected base that lacks that immutable inventory before the final image build; an incompatible exact release is refreshed once when cached, then replaced by a current local build rather than `:latest`.
+  OpenClaw onboarding now rejects a selected base that lacks that immutable inventory before the final image build.
+  When a cached exact release is incompatible, onboarding refreshes it once.
+  If it remains incompatible, onboarding uses a current local build rather than `:latest`.
   Hermes image assembly removes build-only caches and dependencies, reducing the measured final image by 624,394,525 bytes.
   For more information, refer to [Architecture Details](/user-guide/openclaw/reference/architecture).
 - Release validation now runs approved E2E targets for fork PRs, retries one confirmed hosted-runner loss, and retries classified transient base-image pulls.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`docs/changelog/2026-07-25.mdx` now includes the user-facing fixes that merged after #7607 and before the v0.0.96 tag.
The follow-up covers safer bulk backup and clone restore behavior, policy and inference repairs, cleaner onboarding diagnostics, and OpenClaw base-image validation while leaving test-only and maintainer-internal merges out of the release entry.

## Changes

- Document the Shields-safe `backup-all` flow from #7557 and the clone-specific restore pairing publication from #7608.
- Record the Claude Code resolved-launcher policy repair from #7581, Hermes namespaced-model handling from #7604, and persisted Ollama proxy-token reuse from #7620.
- Record OpenClaw immutable base-inventory validation from #7606, hidden route-only reservations from #7621, and clean invalid gateway-management errors from #7630.
- Link the gateway lifecycle and snapshot authorities, retain #7622's already-merged Docker Engine wording, and exclude internal or test-only merges from the release entry.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This PR changes release-entry prose only. The changelog contract test and Fern validation cover the dated entry, published routes, and rendering requirements.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: At exact PR head `29316da26`, a Codex Desktop documentation writer reviewed `docs/changelog/2026-07-25.mdx` against `AGENTS.md`, `WRITING.md`, and `docs/CONTRIBUTING.md`. The review confirmed that the full entry accurately reflects the merged user-visible behavior, retains #7622's existing wording, appropriately excludes internal and test-only PRs, and uses conforming terminology, structure, links, and release classification. It also confirmed that the review follow-ups use active third-person release-entry voice, name the actor and recovery requirement directly, and accurately preserve the trusted-backup, cached-release refresh, and local-build fallback constraints. The changelog test passed 6/6, and the docs build completed with 0 errors and 2 pre-existing hidden warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 29316da26 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6/6 tests after the final review fix.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this prose-only changelog change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — exited 0 with 0 errors and 2 pre-existing hidden warnings after the final review fix.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the changelog to clarify persistent `policy exclude`/`policy restore` behavior across rebuilds and snapshot restores, including reporting on removed endpoints and exclusion consistency.
  * Updated `claude-code` preset guidance to allow the npm-installed OpenShell launcher path while maintaining endpoint/HTTP method scope.
  * Documented hardened handling for invalid gateway-management declarations, improved gateway/agent-version diagnostics scope, and clarified onboarding/restore credential and reasoning precedence.
  * Tightened bulk backup/restore guidance (safety windows, approval limits, and failure recovery) and refined OpenClaw base selection to avoid incompatible cached releases and `:latest` fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->