### PR TITLE
fix(e2e): recover current lifecycle regressions

### DIFF
--- a/src/lib/actions/sandbox/process-recovery.test.ts
+++ b/src/lib/actions/sandbox/process-recovery.test.ts
@@ -37,6 +37,8 @@ const OPENSHELL_RELAY_TARGET_NOT_FOUND_STDERR = `Error:   × code: 'The service 
 const OPENSHELL_RELAY_TARGET_REFUSED_STDERR = `Error:   × code: 'The service is currently unavailable', message: "Connection
   │ refused (os error 111)"
 `;
+const OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR =
+  "Error: sandbox 'recreated-box' is not ready (phase: Error); wait for it to reach Ready state.\n";
 
 describe("recreated sandbox OpenShell readiness", () => {
   afterEach(() => {
@@ -78,6 +80,33 @@ describe("recreated sandbox OpenShell readiness", () => {
     );
     expect(beforeProbe).toHaveBeenCalledTimes(3);
     expect(sleeps).toEqual([3, 3]);
+  });
+
+  it("retries the same-sandbox Error phase until OpenShell accepts the sandbox", () => {
+    const captureOpenshellImpl = vi
+      .fn()
+      .mockReturnValueOnce({
+        status: 1,
+        output: OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR.trim(),
+        stdout: "",
+        stderr: OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR,
+      })
+      .mockReturnValueOnce({ status: 0, output: "", stdout: "", stderr: "" });
+    const beforeProbe = vi.fn(() => true);
+    const sleeps: number[] = [];
+
+    expect(
+      waitForRecreatedSandboxOpenShellReady("recreated-box", {
+        beforeProbe,
+        captureOpenshellImpl,
+        intervalSeconds: 3,
+        sleepImpl: (seconds) => sleeps.push(seconds),
+        timeoutSeconds: 30,
+      }),
+    ).toBe(true);
+    expect(beforeProbe).toHaveBeenCalledTimes(2);
+    expect(captureOpenshellImpl).toHaveBeenCalledTimes(2);
+    expect(sleeps).toEqual([3]);
   });
 
   it("retries the exact supervisor reconnect states exposed during direct recreation", () => {
@@ -205,6 +234,8 @@ describe("recreated sandbox OpenShell readiness", () => {
   │ relay failed: status: DeadlineExceeded, message: \\"relay requester timed
   │ out\\", details: [], metadata: MetadataMap { headers: {} }"`,
     `Error:   × code: 'The service is currently unavailable', message: "permission denied"`,
+    "Error: sandbox 'other-box' is not ready (phase: Error); wait for it to reach Ready state.",
+    "Error: sandbox 'recreated-box' is not ready (phase: Failed); wait for it to reach Ready state.",
   ])("does not retry an unrelated OpenShell error", (stderr) => {
     const captureOpenshellImpl = vi.fn(() => ({
       status: 1,

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -610,10 +610,19 @@ function hasRetryableOpenshellResultShape(result: ReturnType<typeof captureOpens
 
 function isRetryableOpenshellReRegistrationState(
   result: ReturnType<typeof captureOpenshell>,
+  sandboxName: string,
 ): boolean {
   if (!hasRetryableOpenshellResultShape(result)) return false;
   const error = normalizeOpenshellStructuredError(String(result.stderr));
   if (error === OPENSHELL_SANDBOX_NOT_READY) return true;
+  // OpenShell can publish Ready before replacement registration settles.
+  // Retry only if the readiness probe reports phase Error for this sandbox.
+  if (
+    error ===
+    `Error: sandbox '${sandboxName}' is not ready (phase: Error); wait for it to reach Ready state.`
+  ) {
+    return true;
+  }
 
   // OpenShell 0.0.85 can keep the recreated sandbox's cached phase at Ready
   // while its replacement supervisor session is still registering. The exec
@@ -763,7 +772,10 @@ function waitForRecreatedSandboxOpenShellReadyResult(
     // mutation outcome to reconcile. Treat that exact timeout as inconclusive
     // and retry behind the pinned managed-health guard on the next iteration.
     // All other unexpected OpenShell failures remain definitive.
-    if (!isRetryableOpenshellReRegistrationState(result) && !isCommandTimeout(result)) {
+    if (
+      !isRetryableOpenshellReRegistrationState(result, sandboxName) &&
+      !isCommandTimeout(result)
+    ) {
       return {
         failure: "openshell-readiness-failure",
         openshellError: lastOpenshellError,

--- a/test/e2e/fixtures/phases/lifecycle.ts
+++ b/test/e2e/fixtures/phases/lifecycle.ts
@@ -85,12 +85,14 @@ export function buildOpenShellGatewayUserServiceStageScript(): string {
     "systemctl --user daemon-reload",
     "if systemctl --user cat openshell-gateway >/dev/null 2>&1; then",
     `  printf '%s%s\\n' "$result_prefix" upstream`,
+    "  trap - EXIT",
     "  exit 0",
     "fi",
     `if [ ! -f "$unit" ] || ! grep -Fxq "$marker" "$unit"; then exit ${USER_SERVICE_UNAVAILABLE_EXIT}; fi`,
     'if [ "$had_marked_unit" -eq 0 ]; then outcome=staged; else outcome=existing; fi',
     "systemctl --user enable nemoclaw-openshell-gateway >/dev/null",
     `printf '%s%s\\n' "$result_prefix" "$outcome"`,
+    "trap - EXIT",
   ].join("\n");
 }
 

--- a/test/e2e/live/openclaw-plugin-runtime-exdev-env.ts
+++ b/test/e2e/live/openclaw-plugin-runtime-exdev-env.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const RELEASE_BASELINE_TEST_SELECTOR = "release-baseline";
+export const CURRENT_LIFECYCLE_TEST_SELECTOR = "current-lifecycle";
+export const RELEASE_SANDBOX_BASE_IMAGE_REF = "ghcr.io/nvidia/nemoclaw/sandbox-base:v0.0.71";
+
+export type OpenClawPluginRuntimeExdevSelector =
+  | typeof RELEASE_BASELINE_TEST_SELECTOR
+  | typeof CURRENT_LIFECYCLE_TEST_SELECTOR;
+
+export function buildOpenClawPluginRuntimeExdevBaseImageEnv(
+  selector: OpenClawPluginRuntimeExdevSelector,
+): NodeJS.ProcessEnv {
+  return selector === RELEASE_BASELINE_TEST_SELECTOR
+    ? { NEMOCLAW_SANDBOX_BASE_IMAGE_REF: RELEASE_SANDBOX_BASE_IMAGE_REF }
+    : {};
+}

--- a/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
+++ b/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
@@ -29,6 +29,13 @@ import { CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/paths.ts";
 import type { TestProgress } from "../fixtures/progress.ts";
 import { parseJsonFromText } from "./json-envelope.ts";
 import {
+  buildOpenClawPluginRuntimeExdevBaseImageEnv,
+  CURRENT_LIFECYCLE_TEST_SELECTOR,
+  type OpenClawPluginRuntimeExdevSelector,
+  RELEASE_BASELINE_TEST_SELECTOR,
+  RELEASE_SANDBOX_BASE_IMAGE_REF,
+} from "./openclaw-plugin-runtime-exdev-env.ts";
+import {
   createOpenShellDriverConfigTestWrapper,
   type OpenShellComponents,
   type OpenShellDriverConfigTestWrapper,
@@ -72,7 +79,6 @@ const NEMOCLAW_RELEASE_COMMIT = "e4b9111f5f0535c2fc3d6fbe8dc8dca101a6fdce";
 const NEMOCLAW_RELEASE_OPENSHELL_VERSION = "0.0.71";
 const CURRENT_OPENSHELL_VERSION = "0.0.85";
 const NEMOCLAW_SOURCE_REPOSITORY = "https://github.com/NVIDIA/NemoClaw.git";
-const SANDBOX_BASE_IMAGE_REF = "ghcr.io/nvidia/nemoclaw/sandbox-base:v0.0.71";
 const RELEASE_BUILDER_IMAGE_REF =
   "node:22-trixie-slim@sha256:2d9f5c76c8f4dd36e8f253bee5d828a83a6c09f36188f0b0414325232e0b175d";
 const CURRENT_BUILDER_IMAGE_REF =
@@ -116,9 +122,6 @@ const EXDEV_PATTERNS = [
   /cross-device link not permitted/i,
 ];
 type WeatherFixtureVersion = "v1" | "v2" | "v3";
-
-const RELEASE_BASELINE_TEST_SELECTOR = "release-baseline";
-const CURRENT_LIFECYCLE_TEST_SELECTOR = "current-lifecycle";
 
 const GATEWAY_CATALOG_CALL_SOURCE = String.raw`
 import { Buffer } from "node:buffer";
@@ -488,7 +491,7 @@ function createCustomPluginDockerfile(
   ).toBe(WEATHER_OPENCLAW_VERSION);
 
   const runtime = source
-    .replace(baseImageAnchor, `ARG BASE_IMAGE=${SANDBOX_BASE_IMAGE_REF}\n`)
+    .replace(baseImageAnchor, `ARG BASE_IMAGE=${RELEASE_SANDBOX_BASE_IMAGE_REF}\n`)
     .replace(builderImageAnchor, `FROM ${builderImageRef} AS builder\n`)
     .replace(runtimeAnchor, "FROM ${BASE_IMAGE} AS nemoclaw-runtime\n");
   const pluginDirName = path.basename(context.pluginDirPath);
@@ -925,6 +928,7 @@ async function startDeploymentFixture(
   artifacts: ArtifactSink,
   cleanup: CleanupRegistry,
   progress: TestProgress,
+  selector: OpenClawPluginRuntimeExdevSelector,
 ): Promise<NodeJS.ProcessEnv> {
   const fake = await startFakeOpenAiCompatibleServer({
     apiKey: "nemoclaw-exdev-dummy-key",
@@ -944,12 +948,12 @@ async function startDeploymentFixture(
   });
 
   return liveEnv({
+    ...buildOpenClawPluginRuntimeExdevBaseImageEnv(selector),
     COMPATIBLE_API_KEY: "nemoclaw-exdev-dummy-key",
     NEMOCLAW_ENDPOINT_URL: fake.baseUrl,
     NEMOCLAW_MODEL: "nemoclaw-exdev-probe",
     NEMOCLAW_PROVIDER_KEY: "nemoclaw-exdev-dummy-key",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
-    NEMOCLAW_SANDBOX_BASE_IMAGE_REF: SANDBOX_BASE_IMAGE_REF,
     NEMOCLAW_POLICY_MODE: "skip",
     NEMOCLAW_PREFERRED_API: "openai-completions",
     NEMOCLAW_PROVIDER: "custom",
@@ -999,7 +1003,7 @@ test("the release-baseline custom plugin loads with its exact NemoClaw and OpenS
     nemoclawSourceRelease: NEMOCLAW_RELEASE_TAG,
     nemoclawSourceCommit: NEMOCLAW_RELEASE_COMMIT,
     taggedOpenshellVersion: NEMOCLAW_RELEASE_OPENSHELL_VERSION,
-    sandboxBaseImageRef: SANDBOX_BASE_IMAGE_REF,
+    sandboxBaseImageRef: RELEASE_SANDBOX_BASE_IMAGE_REF,
     openclawVersion: WEATHER_OPENCLAW_VERSION,
   });
 
@@ -1047,7 +1051,12 @@ test("the release-baseline custom plugin loads with its exact NemoClaw and OpenS
   );
   const taggedOpenShellWrapper = createOpenShellTmpfsWrapper(taggedPinnedOpenshell.cli);
   cleanup.add("remove v0.0.71 EXDEV OpenShell PATH wrapper", taggedOpenShellWrapper.remove);
-  const deploymentEnv = await startDeploymentFixture(artifacts, cleanup, progress);
+  const deploymentEnv = await startDeploymentFixture(
+    artifacts,
+    cleanup,
+    progress,
+    RELEASE_BASELINE_TEST_SELECTOR,
+  );
   const taggedSandboxEnv = withOpenShellWrapperEnv(
     deploymentEnv,
     taggedOpenShellWrapper,
@@ -1154,6 +1163,7 @@ test("the current-lifecycle custom plugin survives restart, recreation, and rebu
     regressionTargets: ["#6108", "#3513", "#3127"],
     contract: [
       "the current CLI uses OpenShell 0.0.85 for current lifecycle coverage",
+      "the current CLI selects and validates its compatible sandbox base image",
       "gateway log, runtime inspection, tools.catalog, and tools.invoke prove weather/get_weather",
       "custom-plugin v1 survives restart, recreation installs v2, and rebuild installs v3",
       "workspace state survives both onboarding recreation and rebuild",
@@ -1167,7 +1177,7 @@ test("the current-lifecycle custom plugin survives restart, recreation, and rebu
     nemoclawSourceRelease: NEMOCLAW_RELEASE_TAG,
     nemoclawSourceCommit: NEMOCLAW_RELEASE_COMMIT,
     currentOpenshellVersion: CURRENT_OPENSHELL_VERSION,
-    sandboxBaseImageRef: SANDBOX_BASE_IMAGE_REF,
+    sandboxBaseImageResolution: "current-cli",
     openclawVersion: WEATHER_OPENCLAW_VERSION,
   });
 
@@ -1218,7 +1228,12 @@ test("the current-lifecycle custom plugin survives restart, recreation, and rebu
     cleanup,
     CURRENT_BUILDER_IMAGE_REF,
   );
-  const deploymentEnv = await startDeploymentFixture(artifacts, cleanup, progress);
+  const deploymentEnv = await startDeploymentFixture(
+    artifacts,
+    cleanup,
+    progress,
+    CURRENT_LIFECYCLE_TEST_SELECTOR,
+  );
   progress.phase("install current OpenShell and onboard plugin v1");
   await stopOpenShellGatewayBeforeVersionSwitch(host, "existing");
   const pinnedOpenshell = await installAndResolvePinnedOpenShell(

--- a/test/e2e/support/lifecycle-user-service.test.ts
+++ b/test/e2e/support/lifecycle-user-service.test.ts
@@ -19,15 +19,19 @@ import {
 const installer = fileURLToPath(new URL("../../../scripts/install.sh", import.meta.url));
 
 describe("reboot lifecycle OpenShell gateway user-service fixture", () => {
-  it("stages, enables, and removes the repository service template", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-lifecycle-stage-service-"));
+  it("stages, enables, and removes the repository service without installer cleanup", () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-installer-lifecycle-stage-service-"),
+    );
     const home = path.join(root, "home");
     const configHome = path.join(root, "config");
     const bin = path.join(home, ".local", "bin");
     const log = path.join(root, "systemctl.log");
     const unit = path.join(configHome, "systemd", "user", "nemoclaw-openshell-gateway.service");
+    const installerCleanupSentinel = path.join(root, "installer-cleanup-sentinel");
 
     fs.mkdirSync(bin, { recursive: true });
+    fs.writeFileSync(installerCleanupSentinel, "fixture-owned\n");
     fs.writeFileSync(path.join(bin, "openshell-gateway"), "#!/bin/sh\n", { mode: 0o755 });
     fs.writeFileSync(
       path.join(bin, "systemctl"),
@@ -46,6 +50,7 @@ describe("reboot lifecycle OpenShell gateway user-service fixture", () => {
         PATH: `${bin}:${path.dirname(process.execPath)}:/usr/bin:/bin`,
         XDG_CONFIG_HOME: configHome,
       });
+      env.NEMOCLAW_INSTALLER_STAGED = installerCleanupSentinel;
       const staged = execFileSync(
         "bash",
         ["-lc", buildOpenShellGatewayUserServiceStageScript(), "stage-service", installer],
@@ -53,6 +58,7 @@ describe("reboot lifecycle OpenShell gateway user-service fixture", () => {
       );
 
       expect(staged).toContain("NEMOCLAW_E2E_GATEWAY_USER_SERVICE=staged");
+      expect(fs.existsSync(installerCleanupSentinel)).toBe(true);
       expect(fs.readFileSync(unit, "utf8")).toContain(`ExecStart=${bin}/openshell-gateway`);
       expect(fs.statSync(unit).mode & 0o777).toBe(0o600);
 

--- a/test/e2e/support/openclaw-plugin-runtime-exdev-env.test.ts
+++ b/test/e2e/support/openclaw-plugin-runtime-exdev-env.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOpenClawPluginRuntimeExdevBaseImageEnv,
+  CURRENT_LIFECYCLE_TEST_SELECTOR,
+  RELEASE_BASELINE_TEST_SELECTOR,
+  RELEASE_SANDBOX_BASE_IMAGE_REF,
+} from "../live/openclaw-plugin-runtime-exdev-env.ts";
+
+describe("OpenClaw plugin runtime EXDEV base image selection", () => {
+  it("pins the release baseline to its matching sandbox base image", () => {
+    expect(buildOpenClawPluginRuntimeExdevBaseImageEnv(RELEASE_BASELINE_TEST_SELECTOR)).toEqual({
+      NEMOCLAW_SANDBOX_BASE_IMAGE_REF: RELEASE_SANDBOX_BASE_IMAGE_REF,
+    });
+  });
+
+  it("does not override base-image resolution for the current-lifecycle test", () => {
+    expect(buildOpenClawPluginRuntimeExdevBaseImageEnv(CURRENT_LIFECYCLE_TEST_SELECTOR)).toEqual(
+      {},
+    );
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->
Recover three current-lifecycle E2E regressions from run [30283434843](https://github.com/NVIDIA/NemoClaw/actions/runs/30283434843). Recreated sandboxes now tolerate the exact transient OpenShell `Error` phase, current-lifecycle EXDEV coverage uses the current CLI's compatible base image, and successful post-reboot service staging no longer invokes the sourced installer's process-level cleanup trap.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Follow-up to #7618. Related to #7273 and #6108.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->
- Retry only the exact same-sandbox `phase: Error` readiness response inside the existing recreated-sandbox health guard and timeout; foreign sandboxes and other phases remain terminal.
- Clear the E2E staging fixture's inherited `EXIT` trap after successful upstream or NemoClaw service staging, while preserving rollback on staging failures.
- Keep the release EXDEV baseline pinned to its historical sandbox image and let the current-lifecycle target use the current CLI's validated base-image resolution.
- Add focused regressions for each behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal recovery behavior and E2E fixture coverage changed without changing a user-facing command, configuration, output, or supported workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [PASS with no findings](https://github.com/NVIDIA/NemoClaw/pull/7650#issuecomment-5094930864); exact same-sandbox matching remains behind existing health and timeout guards.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed all seven committed files; the changes are internal recovery behavior and E2E fixtures/tests with no user-facing documentation contract change. `git diff --check origin/main...HEAD` passed.
- Agent: Codex documentation-writer subagent
<!-- docs-review-head-sha: 497ca2dcb -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/actions/sandbox/process-recovery.test.ts` (41 passed); focused E2E-support tests (7 passed); full `e2e-support` project (1,744 passed, 17 skipped).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox recovery when OpenShell reports a temporary error state, allowing readiness checks to retry until the sandbox becomes available.
  * Prevented unrelated sandbox errors and failed states from being retried incorrectly.
  * Preserved installer cleanup sentinel files during gateway service staging.

* **Tests**
  * Expanded coverage for sandbox recovery, lifecycle behavior, and runtime base-image selection.
  * Added validation for release-baseline and current-lifecycle deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->