### PR TITLE
docs: add Deep Agents network policy tasks

### DIFF
--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -321,9 +321,19 @@ OpenShell rejects provider deletion while any sandbox still has it attached.
 
   <Accordion title="Export traces through a local collector" id="export-traces-through-a-local-collector">
     Deep Agents trace export now has focused Monitoring pages.
+    <a id="understand-the-export-boundary"></a>
     Review [Understand Deep Agents Trace Export](../monitoring/understand-deepagents-trace-export) before you enable the exporter.
+    <a id="enable-trace-export"></a>
+    <a id="recover-a-skipped-policy"></a>
+    <a id="create-langsmith-credentials"></a>
+    <a id="find-the-private-host-bind-address"></a>
+    <a id="configure-the-collector"></a>
+    <a id="start-and-verify-the-collector"></a>
     Follow [Set Up Deep Agents Trace Export](../monitoring/set-up-deepagents-trace-export) to configure the policy and host collector.
+    <a id="verify-traces-end-to-end"></a>
+    <a id="troubleshoot-trace-export"></a>
     Use [Verify Deep Agents Trace Export](../monitoring/verify-deepagents-trace-export) to prove delivery or diagnose a failure.
+    <a id="stop-or-disable-trace-export"></a>
     Use [Manage Deep Agents Trace Export](../monitoring/manage-deepagents-trace-export) to stop, disable, reconfigure, or remove tracing.
   </Accordion>
 </AccordionGroup>

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -593,6 +593,31 @@ navigation:
                   - page: "Transfer State Manually"
                     path: _build/agent-variants/manage-sandboxes/transfer-state-manually.deepagents.generated.mdx
                     slug: transfer-state-manually
+          - section: "Network Policy"
+            slug: network-policy
+            collapsed: open-by-default
+            contents:
+              - page: "Approve or Deny Network Requests"
+                path: _build/agent-variants/network-policy/approve-network-requests.deepagents.generated.mdx
+                slug: approve-network-requests
+              - page: "Customize the Network Policy"
+                path: _build/agent-variants/network-policy/customize-network-policy.deepagents.generated.mdx
+                slug: customize-network-policy
+              - section: "Configure Policies"
+                slug: configure-policies
+                contents:
+                  - page: "Change the Baseline Policy"
+                    path: _build/agent-variants/network-policy/change-baseline-network-policy.deepagents.generated.mdx
+                    slug: change-baseline-network-policy
+                  - page: "Apply Policy Presets"
+                    path: _build/agent-variants/network-policy/apply-policy-presets.deepagents.generated.mdx
+                    slug: apply-policy-presets
+                  - page: "Create Custom Presets"
+                    path: _build/agent-variants/network-policy/create-custom-policy-presets.deepagents.generated.mdx
+                    slug: create-custom-policy-presets
+                  - page: "Replace the Live Policy"
+                    path: _build/agent-variants/network-policy/replace-live-network-policy.deepagents.generated.mdx
+                    slug: replace-live-network-policy
           - section: "Deployment"
             slug: deployment
             collapsed: open-by-default

--- a/docs/network-policy/apply-policy-presets.mdx
+++ b/docs/network-policy/apply-policy-presets.mdx
@@ -32,16 +32,33 @@ List the presets available to the sandbox:
 $$nemoclaw <name> policy list
 ```
 
+<AgentOnly variant="openclaw,hermes">
 For the maintained preset catalog and guided service workflows, refer to [Common Integration Policy Examples](../integration-policy-examples).
+</AgentOnly>
+<AgentOnly variant="deepagents">
+For Deep Agents baseline, tier, Tavily, and observability preset behavior, refer to [Network Policies](../../reference/network-policies#policy-tiers).
+</AgentOnly>
 
 ## Preview and Apply a Preset
 
 Use `--dry-run` to review the endpoints, rules, and binaries before applying the preset:
 
+<AgentOnly variant="openclaw,hermes">
+
 ```bash
 $$nemoclaw my-assistant policy add pypi --dry-run
 $$nemoclaw my-assistant policy add pypi --yes
 ```
+
+</AgentOnly>
+<AgentOnly variant="deepagents">
+
+```bash
+$$nemoclaw my-assistant policy add weather --dry-run
+$$nemoclaw my-assistant policy add weather --yes
+```
+
+</AgentOnly>
 
 Omit the preset name to use the interactive picker:
 
@@ -73,9 +90,20 @@ $$nemoclaw <name> policy list
 
 Remove a preset when the sandbox no longer needs its access:
 
+<AgentOnly variant="openclaw,hermes">
+
 ```bash
 $$nemoclaw my-assistant policy remove pypi --yes
 ```
+
+</AgentOnly>
+<AgentOnly variant="deepagents">
+
+```bash
+$$nemoclaw my-assistant policy remove weather --yes
+```
+
+</AgentOnly>
 
 `policy remove` accepts maintained and custom preset names.
 
@@ -103,5 +131,7 @@ For the complete approval workflow, refer to [Approve or Deny Network Requests](
 ## Related Topics
 
 - [Create Custom Policy Presets](create-custom-policy-presets) adds an endpoint that no maintained preset covers.
+<AgentOnly variant="openclaw,hermes">
 - [Explain Network Policy to Agents](../explain-network-policy-to-agents) summarizes active and missing presets.
+</AgentOnly>
 - [Commands](../../reference/commands#$$nemoclaw-name-policy-add) lists every policy command flag.

--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -84,6 +84,8 @@ They are not persisted to the baseline policy file.
 To keep an endpoint allowed for future sandbox instances, update the policy YAML or apply a preset as described in [Customize the Sandbox Network Policy](customize-network-policy).
 Rejected rules stay blocked unless you later approve the same rule or add a matching endpoint to the policy.
 
+<AgentOnly variant="openclaw,hermes">
+
 ## Run the Walkthrough Script
 
 The walkthrough script is available in the NemoClaw repository at [`scripts/walkthrough.sh`](https://github.com/NVIDIA/NemoClaw/blob/main/scripts/walkthrough.sh).
@@ -118,10 +120,14 @@ The script opens a split tmux session with the TUI on the left and the agent on 
 The walkthrough requires `tmux`, the `NVIDIA_INFERENCE_API_KEY` environment variable, and at least one onboarded sandbox attached to the active gateway.
 It attaches to an existing sandbox.
 
+</AgentOnly>
+
 </Steps>
 
 ## Related Topics
 
 - [Customize the Sandbox Network Policy](customize-network-policy) to add endpoints permanently.
 - [Network Policies](../reference/network-policies) for the full baseline policy reference.
+<AgentOnly variant="openclaw,hermes">
 - [Monitor Sandbox Activity](../monitoring/monitor-sandbox-activity) for general sandbox monitoring.
+</AgentOnly>

--- a/docs/network-policy/change-baseline-network-policy.mdx
+++ b/docs/network-policy/change-baseline-network-policy.mdx
@@ -4,8 +4,8 @@
 title: "Change the Baseline Network Policy"
 sidebar-title: "Change the Baseline Policy"
 description: "Edit the policy that NemoClaw applies when it creates a sandbox."
-description-agent: "Changes the baseline sandbox network policy. Use when adding durable endpoints to every future sandbox or maintaining blueprint policy additions."
-keywords: ["nemoclaw baseline network policy", "sandbox policy yaml", "blueprint policy additions"]
+description-agent: "Changes the baseline sandbox network policy. Use when adding durable endpoints to every future sandbox."
+keywords: ["nemoclaw baseline network policy", "sandbox policy yaml"]
 content:
   type: "how_to"
 skill:
@@ -31,6 +31,9 @@ Open `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` and add or modify endpo
 </AgentOnly>
 <AgentOnly variant="hermes">
 Open `agents/hermes/policy-additions.yaml` and add or modify endpoint entries.
+</AgentOnly>
+<AgentOnly variant="deepagents">
+Open `agents/langchain-deepagents-code/policy-additions.yaml` and add or modify endpoint entries.
 </AgentOnly>
 
 Edit YAML manually when a maintained preset does not cover the required host, such as a reviewed public partner API.

--- a/docs/network-policy/create-custom-policy-presets.mdx
+++ b/docs/network-policy/create-custom-policy-presets.mdx
@@ -4,8 +4,8 @@
 title: "Create Custom Policy Presets"
 sidebar-title: "Create Custom Presets"
 description: "Author and apply a scoped network policy preset for an endpoint that NemoClaw does not include."
-description-agent: "Creates and applies custom policy presets. Use when adding a reviewed endpoint, applying preset files, or allowing a URL-based MCP server."
-keywords: ["nemoclaw custom policy preset", "policy add from-file", "url mcp network policy"]
+description-agent: "Creates and applies custom policy presets. Use when adding a reviewed endpoint or applying preset files."
+keywords: ["nemoclaw custom policy preset", "policy add from-file"]
 content:
   type: "how_to"
 skill:
@@ -38,8 +38,14 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
     binaries:
-      - { path: /usr/local/bin/node }
+      - { path: /path/to/requesting-binary }
 ```
+
+Replace `/path/to/requesting-binary` with the exact executable path reported for the blocked request in `openshell term`.
+<AgentOnly variant="deepagents">
+For Deep Agents Code, OpenShell commonly reports `/usr/local/bin/dcode` or `/opt/venv/bin/python3*`.
+Authorize only the process that needs the reviewed endpoint.
+</AgentOnly>
 
 The top-level `preset.name` must be a lowercase RFC 1123 label with letters, digits, and hyphens.
 It must not collide with a maintained preset name such as `slack` or `pypi`.
@@ -113,6 +119,8 @@ $$nemoclaw my-assistant policy remove my-service-api --yes
 
 Run `$$nemoclaw <name> policy list` to see every maintained and custom preset recorded for the sandbox.
 
+<AgentOnly variant="openclaw,hermes">
+
 ## Configure a URL-Based MCP Server
 
 Prefer the managed workflow in [Add an MCP Server](../../manage-sandboxes/mcp-servers/add-an-mcp-server) when the server uses authenticated HTTPS Streamable HTTP.
@@ -184,8 +192,12 @@ If the hostname resolves to a private, loopback, or link-local address, establis
 Then follow the approved private-destination configuration.
 Refer to [Agent cannot reach a host-side HTTP service](../../reference/troubleshooting#agent-cannot-reach-a-host-side-http-service) for routing and private-destination diagnostics.
 
+</AgentOnly>
+
 ## Related Topics
 
 - [Apply Policy Presets](apply-policy-presets) explains preset persistence and reapplication.
+<AgentOnly variant="openclaw,hermes">
 - [Configure Raw TLS Passthrough](configure-raw-tls-passthrough) covers endpoints that cannot use L7 inspection.
+</AgentOnly>
 - [Network Policies](../../reference/network-policies) describes the policy schema.

--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -4,7 +4,7 @@
 title: "Customize the Sandbox Network Policy"
 sidebar-title: "Customize the Network Policy"
 description: "Choose the supported workflow for changing sandbox network access."
-description-agent: "Routes network policy changes to their canonical workflow. Use when choosing between baseline edits, policy presets, custom presets, raw TLS, live replacement, and agent policy context."
+description-agent: "Routes network policy changes to their canonical workflow. Use when choosing between baseline edits, policy presets, custom presets, live replacement, and operator approval."
 keywords: ["customize nemoclaw network policy", "sandbox egress policy configuration"]
 content:
   type: "how_to"
@@ -19,9 +19,13 @@ NemoClaw declares sandbox policy in YAML, and [NVIDIA OpenShell](https://github.
 | Change every future sandbox for an agent | [Change the Baseline Network Policy](configure-policies/change-baseline-network-policy) |
 | Add or remove a maintained preset for one sandbox | [Apply Policy Presets](configure-policies/apply-policy-presets) |
 | Add a reviewed endpoint that no maintained preset covers | [Create Custom Policy Presets](configure-policies/create-custom-policy-presets) |
+<AgentOnly variant="openclaw,hermes">
 | Allow direct TLS negotiation for an exact endpoint | [Configure Raw TLS Passthrough](configure-policies/configure-raw-tls-passthrough) |
+</AgentOnly>
 | Replace the complete live policy | [Replace the Live Network Policy](configure-policies/replace-live-network-policy) |
+<AgentOnly variant="openclaw,hermes">
 | Give the sandbox agent a redacted policy summary | [Explain Network Policy to Agents](explain-network-policy-to-agents) |
+</AgentOnly>
 | Approve or deny one blocked request | [Approve or Deny Network Requests](approve-network-requests) |
 
 <Note>
@@ -41,13 +45,25 @@ Use [`$$nemoclaw onboard --from`](../reference/commands#--from-dockerfile) inste
 
 ## Static Changes
 
+<a id="prerequisites"></a>
+<a id="edit-the-policy-file"></a>
+<a id="re-run-onboard"></a>
+<a id="verify-the-policy"></a>
+<AgentOnly variant="openclaw,hermes">
+<a id="add-blueprint-policy-additions"></a>
+</AgentOnly>
+
 Static changes modify the policy source that NemoClaw reads during sandbox creation.
-Follow [Change the Baseline Network Policy](configure-policies/change-baseline-network-policy) to edit agent policy files, add blueprint policy additions, rerun onboarding, and verify the result.
+Follow [Change the Baseline Network Policy](configure-policies/change-baseline-network-policy) to edit the agent policy file, rerun onboarding, and verify the result.
 
 ## Dynamic Changes
 
+<a id="scope-of-dynamic-changes"></a>
+<a id="add-a-preset-file-with-policy-add-recommended"></a>
+
 Dynamic changes update a running sandbox.
 Use [Apply Policy Presets](configure-policies/apply-policy-presets) for reviewed additions that NemoClaw records and replays.
+<a id="approve-requests-interactively"></a>
 Use [Approve or Deny Network Requests](approve-network-requests) for one-off access.
 Use [Replace the Live Network Policy](configure-policies/replace-live-network-policy) only when a preset cannot express the complete change.
 
@@ -55,32 +71,61 @@ Use [Replace the Live Network Policy](configure-policies/replace-live-network-po
 
 Maintained policy presets cover common integrations and package services.
 Follow [Apply Policy Presets](configure-policies/apply-policy-presets) to preview, apply, reapply, list, or remove them.
+<AgentOnly variant="openclaw,hermes">
 For guided service workflows, refer to [Common Integration Policy Examples](integration-policy-examples).
+</AgentOnly>
+<AgentOnly variant="deepagents">
+Review [Network Policies](../reference/network-policies#policy-tiers) for the maintained presets available to Deep Agents.
+</AgentOnly>
 
 ## Custom Preset Files
 
+<a id="authoring"></a>
+<a id="apply-a-single-file"></a>
+<a id="apply-every-file-in-a-directory"></a>
+<a id="remove-a-custom-preset"></a>
+<AgentOnly variant="openclaw,hermes">
+<a id="custom-recipe-url-based-mcp-server"></a>
+</AgentOnly>
+
 Custom preset files add reviewed endpoint access without changing the baseline.
 Follow [Create Custom Policy Presets](configure-policies/create-custom-policy-presets) to author, validate, apply, and remove a custom preset.
+<AgentOnly variant="openclaw,hermes">
 That page also contains the URL-based MCP server recipe formerly located in this guide.
+</AgentOnly>
+
+<AgentOnly variant="openclaw,hermes">
 
 ## Raw TLS Passthrough
+
+<a id="custom-recipe-for-raw-tls-passthrough-with-tls-skip"></a>
 
 Some endpoints require direct TLS negotiation and fail through inspected L7 proxying.
 Follow [Configure Raw TLS Passthrough](configure-policies/configure-raw-tls-passthrough) for the bounded `access: full` and `tls: skip` recipe.
 
+</AgentOnly>
+
 ## Live Policy Replacement
+
+<a id="export-edit-and-set-the-base-policy"></a>
 
 OpenShell `policy set` replaces the complete live policy.
 Follow [Replace the Live Network Policy](configure-policies/replace-live-network-policy) to export the round-trippable base, preserve existing entries, and apply a validated replacement.
+
+<AgentOnly variant="openclaw,hermes">
 
 ## Agent Policy Context
 
 Agents need a redacted view of active presets and policy verification state.
 Follow [Explain Network Policy to Agents](explain-network-policy-to-agents) to print or refresh that context and interpret failure classifications.
 
+</AgentOnly>
+
 ## Related Topics
 
+<AgentOnly variant="openclaw,hermes">
 - [Common Integration Policy Examples](integration-policy-examples) provides maintained service workflows.
+</AgentOnly>
 - [Network Policies](../reference/network-policies) is the canonical policy reference.
 - [OpenShell Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) provides the complete YAML schema.
 - [OpenShell Sandbox Policies](https://docs.nvidia.com/openshell/latest/sandboxes/policies.html) explains OpenShell-layer policy iteration.

--- a/docs/reference/cli-selection-guide.mdx
+++ b/docs/reference/cli-selection-guide.mdx
@@ -296,6 +296,8 @@ Use `openshell sandbox upload` and `openshell sandbox download` for manual file 
 
 - [Commands](commands) for the full NemoDeepAgents command reference.
 - [Network Policies](network-policies) for baseline policy and approval behavior.
+- [Customize the Network Policy](../network-policy/customize-network-policy) for persistent network access changes.
+- [Approve or Deny Network Requests](../network-policy/approve-network-requests) for the OpenShell TUI approval flow.
 - [Understand Sandbox State](../manage-sandboxes/state-and-backups/understand-sandbox-state) for Deep Agents state and file transfer guidance.
 - [Create and Restore Snapshots](../manage-sandboxes/state-and-backups/create-and-restore-snapshots) for snapshot and restore workflows.
 - [Choose an Inference Provider](../inference/learn-and-choose/choose-inference-provider) for provider configuration details.

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -239,11 +239,7 @@ To monitor requests as the agent runs, open the TUI:
 openshell term
 ```
 
-<AgentOnly variant="openclaw,hermes">
-
 For step-by-step navigation and approval controls, refer to [Approve or Deny Agent Network Requests](../network-policy/approve-network-requests).
-
-</AgentOnly>
 
 ## Modifying the Policy
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1373,7 +1373,7 @@ $$nemoclaw <name> logs --tail 50
 If the host should be reachable, allow it with a preset or a [custom preset](../network-policy/customize-network-policy#custom-preset-files):
 </AgentOnly>
 <AgentOnly variant="deepagents">
-If the host should be reachable, allow it with a built-in preset or apply a reviewed custom preset file from the host:
+If the host should be reachable, allow it with a built-in preset or apply a [reviewed custom preset file](../network-policy/configure-policies/create-custom-policy-presets) from the host:
 </AgentOnly>
 
 ```bash
@@ -2123,7 +2123,7 @@ To permanently allow an endpoint, add it to the network policy.
 Refer to [Customize the Network Policy](../network-policy/customize-network-policy) for details.
 </AgentOnly>
 <AgentOnly variant="deepagents">
-For Deep Agents, use `nemo-deepagents <name> policy add <preset>` for built-in presets or `nemo-deepagents <name> policy add --from-file <preset.yaml>` for reviewed custom presets.
+For Deep Agents, follow [Customize the Network Policy](../network-policy/customize-network-policy) to choose between built-in presets, reviewed custom presets, baseline edits, and live-policy replacement.
 </AgentOnly>
 
 <AgentOnly variant="openclaw,hermes">

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -929,6 +929,8 @@ The following patterns weaken security without providing meaningful benefit.
 <AgentOnly variant="deepagents">
 
 - [Network Policies](../reference/network-policies) for the full Deep Agents baseline policy reference.
+- [Customize the Network Policy](../network-policy/customize-network-policy) for static and dynamic policy changes.
+- [Approve or Deny Network Requests](../network-policy/approve-network-requests) for the operator approval flow.
 - [Credential Storage](credential-storage) for provider and managed MCP credential handling.
 - [Understand Sandbox State](../manage-sandboxes/state-and-backups/understand-sandbox-state) for Deep Agents state and credential-bearing file exclusions.
 - [About Managed MCP Servers](../manage-sandboxes/mcp-servers/about-managed-mcp-servers) for managed MCP credential replacement.

--- a/test/deepagents-monitoring-published-routes.test.ts
+++ b/test/deepagents-monitoring-published-routes.test.ts
@@ -18,9 +18,56 @@ const TRACE_SOURCES = [
   "monitoring/manage-deepagents-trace-export.mdx",
 ] as const;
 const QUICKSTART_SOURCE = "get-started/quickstart-langchain-deepagents-code.mdx";
+const LEGACY_TRACE_POINTERS = [
+  {
+    anchors: ["understand-the-export-boundary"],
+    linkText: "Understand Deep Agents Trace Export",
+    target: "../monitoring/understand-deepagents-trace-export",
+  },
+  {
+    anchors: [
+      "enable-trace-export",
+      "recover-a-skipped-policy",
+      "create-langsmith-credentials",
+      "find-the-private-host-bind-address",
+      "configure-the-collector",
+      "start-and-verify-the-collector",
+    ],
+    linkText: "Set Up Deep Agents Trace Export",
+    target: "../monitoring/set-up-deepagents-trace-export",
+  },
+  {
+    anchors: ["verify-traces-end-to-end", "troubleshoot-trace-export"],
+    linkText: "Verify Deep Agents Trace Export",
+    target: "../monitoring/verify-deepagents-trace-export",
+  },
+  {
+    anchors: ["stop-or-disable-trace-export"],
+    linkText: "Manage Deep Agents Trace Export",
+    target: "../monitoring/manage-deepagents-trace-export",
+  },
+] as const;
 
 function readDoc(source: string): string {
   return readFileSync(path.join(process.cwd(), "docs", source), "utf8");
+}
+
+function expectUniqueAnchorsBeforePointer(
+  source: string,
+  anchors: readonly string[],
+  linkText: string,
+  target: string,
+): void {
+  const pointer = `[${linkText}](${target})`;
+
+  for (const anchor of anchors) {
+    const marker = `<a id="${anchor}"></a>`;
+    expect(source.split(marker)).toHaveLength(2);
+    const anchorIndex = source.indexOf(marker);
+    const pointerIndex = source.indexOf(pointer, anchorIndex + marker.length);
+    expect(pointerIndex).toBeGreaterThan(anchorIndex);
+    expect(source.slice(anchorIndex + marker.length, pointerIndex)).not.toContain("](");
+  }
 }
 
 describe("Deep Agents monitoring published routes", () => {
@@ -41,20 +88,22 @@ describe("Deep Agents monitoring published routes", () => {
     }
   });
 
-  it("keeps the Quickstart compatibility pointer on the focused setup path", () => {
+  it("keeps every Quickstart trace fragment on the focused monitoring paths (#7495)", () => {
     const index = buildPublishedRouteIndex();
+    const quickstart = readDoc(QUICKSTART_SOURCE);
 
     expect(findBrokenPublishedRoutes(QUICKSTART_SOURCE, index)).toEqual([]);
-    expect([
-      ...resolvePageLinksByText(QUICKSTART_SOURCE, "Set Up Deep Agents Trace Export", index),
-    ]).toEqual([
-      {
-        fromRoute: "/user-guide/deepagents/get-started/quickstart",
-        published: true,
-        resolved: "/user-guide/deepagents/monitoring/set-up-deepagents-trace-export",
-        target: "../monitoring/set-up-deepagents-trace-export",
-      },
-    ]);
-    expect(readDoc(QUICKSTART_SOURCE)).toContain('id="export-traces-through-a-local-collector"');
+    for (const { anchors, linkText, target } of LEGACY_TRACE_POINTERS) {
+      expect([...resolvePageLinksByText(QUICKSTART_SOURCE, linkText, index)]).toEqual([
+        {
+          fromRoute: "/user-guide/deepagents/get-started/quickstart",
+          published: true,
+          resolved: `/user-guide/deepagents/monitoring/${target.split("/").at(-1)}`,
+          target,
+        },
+      ]);
+      expectUniqueAnchorsBeforePointer(quickstart, anchors, linkText, target);
+    }
+    expect(quickstart).toContain('id="export-traces-through-a-local-collector"');
   });
 });

--- a/test/network-policies-published-routes.test.ts
+++ b/test/network-policies-published-routes.test.ts
@@ -10,23 +10,98 @@ import {
   findBrokenPublishedRoutes,
   resolvePageLinksByText,
 } from "../scripts/check-docs-published-routes.mts";
+import { renderAgentVariantPage } from "../scripts/sync-agent-variant-docs.mts";
 
 const NETWORK_POLICIES_SOURCE = "reference/network-policies.mdx";
+const APPROVAL_SOURCE = "network-policy/approve-network-requests.mdx";
 const CUSTOMIZE_POLICY_SOURCE = "network-policy/customize-network-policy.mdx";
+const BASELINE_POLICY_SOURCE = "network-policy/change-baseline-network-policy.mdx";
+const APPLY_PRESETS_SOURCE = "network-policy/apply-policy-presets.mdx";
+const CUSTOM_PRESETS_SOURCE = "network-policy/create-custom-policy-presets.mdx";
+const RAW_TLS_SOURCE = "network-policy/configure-raw-tls-passthrough.mdx";
+const REPLACE_POLICY_SOURCE = "network-policy/replace-live-network-policy.mdx";
 const INTEGRATION_POLICY_SOURCE = "network-policy/integration-policy-examples.mdx";
 const GMAIL_SOURCE = "network-policy/set-up-gmail-with-an-app-password.mdx";
 const APPROVAL_LINK_TEXT = "Approve or Deny Agent Network Requests";
 const GMAIL_LINK_TEXT = "Set Up Gmail With an App Password";
-const CONFIGURATION_SOURCES = [
-  "network-policy/change-baseline-network-policy.mdx",
-  "network-policy/apply-policy-presets.mdx",
-  "network-policy/create-custom-policy-presets.mdx",
-  "network-policy/configure-raw-tls-passthrough.mdx",
-  "network-policy/replace-live-network-policy.mdx",
+const SHARED_CONFIGURATION_SOURCES = [
+  BASELINE_POLICY_SOURCE,
+  APPLY_PRESETS_SOURCE,
+  CUSTOM_PRESETS_SOURCE,
+  REPLACE_POLICY_SOURCE,
+] as const;
+const DEEPAGENTS_POLICY_ROUTES = [
+  "/user-guide/deepagents/network-policy/approve-network-requests",
+  "/user-guide/deepagents/network-policy/customize-network-policy",
+  "/user-guide/deepagents/network-policy/configure-policies/change-baseline-network-policy",
+  "/user-guide/deepagents/network-policy/configure-policies/apply-policy-presets",
+  "/user-guide/deepagents/network-policy/configure-policies/create-custom-policy-presets",
+  "/user-guide/deepagents/network-policy/configure-policies/replace-live-network-policy",
+] as const;
+const DEEPAGENTS_EXCLUDED_POLICY_ROUTES = [
+  "/user-guide/deepagents/network-policy/configure-policies/configure-raw-tls-passthrough",
+  "/user-guide/deepagents/network-policy/explain-network-policy-to-agents",
+  "/user-guide/deepagents/network-policy/integration-policy-examples",
+  "/user-guide/deepagents/network-policy/set-up-gmail-with-an-app-password",
+] as const;
+const LEGACY_CUSTOMIZE_POLICY_POINTERS = [
+  {
+    anchors: [
+      "prerequisites",
+      "edit-the-policy-file",
+      "re-run-onboard",
+      "verify-the-policy",
+      "add-blueprint-policy-additions",
+    ],
+    target: "configure-policies/change-baseline-network-policy",
+  },
+  {
+    anchors: ["scope-of-dynamic-changes", "add-a-preset-file-with-policy-add-recommended"],
+    target: "configure-policies/apply-policy-presets",
+  },
+  {
+    anchors: ["approve-requests-interactively"],
+    target: "approve-network-requests",
+  },
+  {
+    anchors: [
+      "authoring",
+      "apply-a-single-file",
+      "apply-every-file-in-a-directory",
+      "remove-a-custom-preset",
+      "custom-recipe-url-based-mcp-server",
+    ],
+    target: "configure-policies/create-custom-policy-presets",
+  },
+  {
+    anchors: ["custom-recipe-for-raw-tls-passthrough-with-tls-skip"],
+    target: "configure-policies/configure-raw-tls-passthrough",
+  },
+  {
+    anchors: ["export-edit-and-set-the-base-policy"],
+    target: "configure-policies/replace-live-network-policy",
+  },
 ] as const;
 
 function readDoc(source: string): string {
   return readFileSync(path.join(process.cwd(), "docs", source), "utf8");
+}
+
+function expectUniqueAnchorsBeforePointer(
+  source: string,
+  anchors: readonly string[],
+  target: string,
+): void {
+  const pointer = `](${target})`;
+
+  for (const anchor of anchors) {
+    const marker = `<a id="${anchor}"></a>`;
+    expect(source.split(marker)).toHaveLength(2);
+    const anchorIndex = source.indexOf(marker);
+    const pointerIndex = source.indexOf(pointer, anchorIndex + marker.length);
+    expect(pointerIndex).toBeGreaterThan(anchorIndex);
+    expect(source.slice(anchorIndex + marker.length, pointerIndex)).not.toContain("](");
+  }
 }
 
 describe("shared Network Policies published routes", () => {
@@ -39,6 +114,12 @@ describe("shared Network Policies published routes", () => {
         a.fromRoute.localeCompare(b.fromRoute),
       ),
     ).toEqual([
+      {
+        fromRoute: "/user-guide/deepagents/reference/network-policies",
+        published: true,
+        resolved: "/user-guide/deepagents/network-policy/approve-network-requests",
+        target: "../network-policy/approve-network-requests",
+      },
       {
         fromRoute: "/user-guide/hermes/reference/network-policies",
         published: true,
@@ -60,27 +141,74 @@ describe("shared Network Policies published routes", () => {
     expect(findBrokenPublishedRoutes(CUSTOMIZE_POLICY_SOURCE, index)).toEqual([]);
   });
 
-  it("publishes focused policy configuration pages for OpenClaw and Hermes", () => {
+  it("publishes the bounded policy task set for Deep Agents", () => {
     const index = buildPublishedRouteIndex();
 
-    for (const source of CONFIGURATION_SOURCES) {
+    for (const route of DEEPAGENTS_POLICY_ROUTES) {
+      expect(index.routes.has(route), route).toBe(true);
+    }
+    for (const route of DEEPAGENTS_EXCLUDED_POLICY_ROUTES) {
+      expect(index.routes.has(route), route).toBe(false);
+    }
+  });
+
+  it("publishes shared policy configuration pages for every supported agent", () => {
+    const index = buildPublishedRouteIndex();
+
+    for (const source of SHARED_CONFIGURATION_SOURCES) {
+      const slug = source
+        .split("/")
+        .at(-1)
+        ?.replace(/\.mdx$/, "");
       expect(
         index.sourceToRoutes
           .get(source)
           ?.map(({ route }) => route)
           .sort((a, b) => a.localeCompare(b)),
       ).toEqual([
-        `/user-guide/hermes/network-policy/configure-policies/${source
-          .split("/")
-          .at(-1)
-          ?.replace(/\.mdx$/, "")}`,
-        `/user-guide/openclaw/network-policy/configure-policies/${source
-          .split("/")
-          .at(-1)
-          ?.replace(/\.mdx$/, "")}`,
+        `/user-guide/deepagents/network-policy/configure-policies/${slug}`,
+        `/user-guide/hermes/network-policy/configure-policies/${slug}`,
+        `/user-guide/openclaw/network-policy/configure-policies/${slug}`,
       ]);
       expect(findBrokenPublishedRoutes(source, index)).toEqual([]);
     }
+  });
+
+  it("keeps raw TLS configuration scoped to OpenClaw and Hermes", () => {
+    const index = buildPublishedRouteIndex();
+
+    expect(
+      index.sourceToRoutes
+        .get(RAW_TLS_SOURCE)
+        ?.map(({ route }) => route)
+        .sort((a, b) => a.localeCompare(b)),
+    ).toEqual([
+      "/user-guide/hermes/network-policy/configure-policies/configure-raw-tls-passthrough",
+      "/user-guide/openclaw/network-policy/configure-policies/configure-raw-tls-passthrough",
+    ]);
+    expect(findBrokenPublishedRoutes(RAW_TLS_SOURCE, index)).toEqual([]);
+  });
+
+  it("removes unsupported workflows from the Deep Agents page variants", () => {
+    const approval = renderAgentVariantPage(readDoc(APPROVAL_SOURCE), "deepagents");
+    const customize = renderAgentVariantPage(readDoc(CUSTOMIZE_POLICY_SOURCE), "deepagents");
+    const baseline = renderAgentVariantPage(readDoc(BASELINE_POLICY_SOURCE), "deepagents");
+    const presets = renderAgentVariantPage(readDoc(APPLY_PRESETS_SOURCE), "deepagents");
+    const custom = renderAgentVariantPage(readDoc(CUSTOM_PRESETS_SOURCE), "deepagents");
+
+    expect(approval).not.toContain("## Run the Walkthrough Script");
+    expect(customize).not.toContain("Configure Raw TLS Passthrough");
+    expect(customize).not.toContain("Explain Network Policy to Agents");
+    expect(customize).not.toContain("Common Integration Policy Examples");
+    expect(baseline).toContain("agents/langchain-deepagents-code/policy-additions.yaml");
+    expect(presets).toContain("Deep Agents baseline, tier, Tavily, and observability");
+    expect(presets).not.toContain("Common Integration Policy Examples");
+    expect(presets).toContain("nemo-deepagents my-assistant policy add weather --dry-run");
+    expect(presets).toContain("nemo-deepagents my-assistant policy remove weather --yes");
+    expect(presets).not.toContain("nemo-deepagents my-assistant policy add pypi");
+    expect(custom).toContain("/opt/venv/bin/python3*");
+    expect(custom).not.toContain("## Configure a URL-Based MCP Server");
+    expect(custom).not.toContain("Configure Raw TLS Passthrough");
   });
 
   it("publishes the Gmail task only where the integration hub is available", () => {
@@ -125,8 +253,13 @@ describe("shared Network Policies published routes", () => {
     ]);
   });
 
-  it("preserves compatibility anchors on the retained policy routes", () => {
-    expect(readDoc(CUSTOMIZE_POLICY_SOURCE)).toContain("## Custom Preset Files");
+  it("preserves compatibility anchors on the retained policy routes (#7495)", () => {
+    const customizePolicy = readDoc(CUSTOMIZE_POLICY_SOURCE);
+
+    expect(customizePolicy).toContain("## Custom Preset Files");
+    for (const { anchors, target } of LEGACY_CUSTOMIZE_POLICY_POINTERS) {
+      expectUniqueAnchorsBeforePointer(customizePolicy, anchors, target);
+    }
     expect(readDoc(INTEGRATION_POLICY_SOURCE)).toContain("## Gmail With an App Password");
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the supported Deep Agents Network Policy tasks to the canonical policy guides. Preserve legacy page fragments so existing links continue to resolve after the documentation split.

## Changes

- Add Deep Agents commands for policy preset, approval, baseline, and custom preset tasks.
- Keep unsupported Deep Agents policy workflows out of generated variants.
- Update navigation, security guidance, CLI selection, troubleshooting, and network policy reference ownership.
- Preserve legacy monitoring and network policy fragments as compatibility pointers.
- Expand published-route and agent-variant tests for the new ownership and compatibility contracts.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence:
  - `docs/get-started/quickstart-langchain-deepagents-code.mdx`
  - `docs/index.yml`
  - `docs/network-policy/apply-policy-presets.mdx`
  - `docs/network-policy/approve-network-requests.mdx`
  - `docs/network-policy/change-baseline-network-policy.mdx`
  - `docs/network-policy/create-custom-policy-presets.mdx`
  - `docs/network-policy/customize-network-policy.mdx`
  - `docs/reference/cli-selection-guide.mdx`
  - `docs/reference/network-policies.mdx`
  - `docs/reference/troubleshooting.mdx`
  - `docs/security/best-practices.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1e3c33a06 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — commit hooks passed; push used `--no-verify` at the contributor's request
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/check-docs-published-routes.test.ts test/check-docs-links.test.ts test/network-policies-published-routes.test.ts test/agent-variant-docs.test.ts` passed 4 files and 64 tests; exact-head documentation review passed 4 files and 51 tests
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to this documentation-only change
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and one pre-existing Fern warning
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new pages

---

Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Network Policy section to Deep Agents documentation navigation.
  * Expanded network policy guidance with Deep Agents-specific setup, customization, presets, approvals, troubleshooting, and integration examples.
  * Improved variant-specific content so OpenClaw, Hermes, and Deep Agents users see relevant instructions.
  * Added in-page navigation anchors and refreshed related-topic links.
  * Updated trace export guidance with clearer subsection navigation.
* **Tests**
  * Expanded validation of published documentation routes, compatibility links, and agent-variant visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->