### PR TITLE
feat(release): preflight E2E evidence in parallel

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -40,7 +40,7 @@ The downstream scheduled reconciliation remains available if the event-driven di
 - Treat the dated MDX entry as the canonical release history. A conventional Release Notes page or post-tag Announcement draft cannot replace it.
 - If `origin/main` changes after plan generation, regenerate the plan before cutting the tag.
 - Before asking for release confirmation, satisfy the canonical [pre-tag E2E evidence policy](../nemoclaw-maintainer-policies/references/release-train.md#pre-tag-e2e-evidence) for that commit.
-- Load `nemoclaw-maintainer-e2e` and run full mode when the candidate has no applicable exact Brev Launchable evidence.
+- When the readiness variable is `true`, load `nemoclaw-maintainer-e2e` and run full mode if the candidate has no applicable exact Brev Launchable evidence.
 - Ask the maintainer to paste the confirmation phrase from the plan before cutting the tag.
 - Push only the semver tag (`vX.Y.Z`) from the agent-controlled step.
 - Never push `latest` or `lkg` from this skill.
@@ -57,7 +57,7 @@ Copy this checklist and update it as you proceed:
 
 ```text
 Release Progress:
-- [ ] Step 1: Generate release plan
+- [ ] Step 1: Preflight and generate release plan
 - [ ] Step 2: Show plan, E2E evidence, and confirmation phrase
 - [ ] Step 3: Cut the semver tag from the confirmed plan
 - [ ] Step 4: Wait for workflow-managed latest
@@ -67,7 +67,18 @@ Release Progress:
 - [ ] Step 8: Verify Announcement and hand off sharing
 ```
 
-### Step 1: Generate Release Plan
+### Step 1: Preflight and Generate Release Plan
+
+Start with one read-only pass that checks these prerequisites together:
+
+- refresh `origin/main` and resolve its full SHA;
+- check the target changelog heading and release-prep docs state;
+- read `NEMOCLAW_BREV_LAUNCHABLE_E2E_ENABLED` without changing it;
+- ask a repository administrator for the authoritative Jetson runner state when that lane is required; and
+- inventory existing E2E runs for the same SHA before deciding what to dispatch.
+
+Do not wait for merges to stop. The plan captures one candidate SHA for evidence; a late drift check advances it when `origin/main` moves.
+Do not dispatch or poll a workflow during this pass.
 
 Before this step, confirm release-prep docs are merged or explicitly waived.
 Return to `nemoclaw-maintainer-evening` if docs are still pending.
@@ -116,12 +127,45 @@ When the entry is waived, show the recorded waiver reason in the plan presentati
 
 For the plan's full `origin/main` SHA, review `.github/workflows/e2e.yaml` at that commit and build the evidence ledger required by the canonical [pre-tag E2E evidence policy](../nemoclaw-maintainer-policies/references/release-train.md#pre-tag-e2e-evidence). The workflow is the sole source of truth; do not substitute or maintain a separate release-gating test list.
 
-Find an applicable full-mode E2E run for the candidate SHA.
-If none exists, load `nemoclaw-maintainer-e2e` and dispatch full mode for that SHA.
-Do not substitute an ordinary E2E run or a selective `staging-brev-launchable` run.
-Require the full-mode run to include the default-enabled suite and `Exact staging Brev Launchable`.
+From a checkout whose `HEAD` is the plan candidate SHA and whose `git status --short` is empty, generate one release E2E preflight:
 
-Before accepting that run, require:
+```bash
+CANDIDATE_SHA="<full-plan-sha>"
+BREV_READY="<true-or-false>"
+JETSON_RUNNER_ONLINE="<true-false-or-unknown>"
+npm run release:e2e-evidence -- \
+  --candidate-sha "$CANDIDATE_SHA" \
+  --brev-ready "$BREV_READY" \
+  --jetson-runner-online "$JETSON_RUNNER_ONLINE" \
+  >"$EVIDENCE_DIR/preflight.json"
+```
+
+The preflight derives every required execution and these dispatch groups from the candidate workflow:
+
+- `defaultSuite`: full mode when the protected qualification readiness variable is `true`, otherwise ordinary mode;
+- `parallelExplicit`: explicit-only selectors that require neither protected qualification nor runner confirmation; and
+- `conditional`: Jetson or another lane that must not queue until its authoritative runner inventory is confirmed online.
+
+First feed applicable existing runs for the candidate SHA into the ledger.
+Dispatch only groups that still lack green evidence.
+When no applicable exact Brev evidence exists and readiness is enabled, load `nemoclaw-maintainer-e2e` and dispatch full mode for that SHA.
+Require that run to include the default-enabled suite and `Exact staging Brev Launchable`.
+Do not substitute a selective `staging-brev-launchable` run for full-mode evidence.
+
+If readiness is disabled, dispatch the ordinary default suite instead and reserve a separate qualification exception.
+Do not stop the ordinary or unconditional explicit-only work behind that exception.
+Dispatch `parallelExplicit` immediately alongside the default/full run, with separate correlation IDs.
+Do not wait for either run to finish before dispatching the other.
+
+Dispatch a `conditional` lane only when the preflight reports its runner online.
+For Jetson, pass `allow_jetson_runner_queue=true` only after that confirmation.
+When the runner is false or unknown, do not create a job that can queue indefinitely; reserve its itemized exception.
+
+Monitor all dispatched correlation IDs as one run group.
+Use one bounded status query for the group, then collect evidence when the group reaches terminal state.
+Do not run a separate polling loop for each workflow.
+
+Before accepting full-mode exact Brev evidence, require:
 
 - the workflow `head_sha` to equal the plan candidate SHA;
 - the trusted dispatch receipt to prove empty selectors and `include_staging_brev_launchable=true`;
@@ -136,16 +180,55 @@ If the plan candidate SHA changes, discard the run and qualification evidence.
 Run full mode again for the new candidate SHA.
 No release-note-only delta exception is currently defined.
 
+For every accepted default, explicit, and conditional run, collect the run plus every job attempt:
+
+```bash
+gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID" \
+  >"$EVIDENCE_DIR/run-$RUN_ID.json"
+gh api --paginate --slurp \
+  "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID/jobs?filter=all&per_page=100" \
+  >"$EVIDENCE_DIR/jobs-$RUN_ID.json"
+```
+
+Create `manifest.json` in the private evidence directory:
+
+```json
+{
+  "candidateSha": "<full-plan-sha>",
+  "brevReady": true,
+  "jetsonRunnerOnline": "unknown",
+  "runs": [
+    {
+      "runJson": "run-123.json",
+      "jobsJson": "jobs-123.json",
+      "defaultSuiteSelected": true,
+      "selectedJobs": []
+    },
+    {
+      "runJson": "run-124.json",
+      "jobsJson": "jobs-124.json",
+      "defaultSuiteSelected": false,
+      "selectedJobs": ["mcp-bridge-dev", "hermes-gpu-startup"]
+    }
+  ]
+}
+```
+
+List the exact selectors used by each selective dispatch; do not copy the example selectors.
+Build the ledger with `npm run release:e2e-evidence -- --manifest "$EVIDENCE_DIR/manifest.json"`.
+The helper derives the denominator from the workflow, preserves matrix rows as separate semantic identifiers, binds every run to the candidate SHA, and keeps an earlier successful attempt green when a later attempt fails.
+
 Before showing the confirmation prompt, present:
 
 - the candidate SHA;
 - the number of tests with green evidence out of the number required by the workflow;
 - each required test mapped to a successful run or job URL and attempt; and
-- the full-mode workflow URL, `Exact staging Brev Launchable` job URL, attempt, qualification identity, and cleanup result; and
+- when accepted full-mode exact Brev evidence exists, its workflow URL, `Exact staging Brev Launchable` job URL, attempt, qualification identity, and cleanup result; and
 - a separate itemized maintainer exception for each test without successful evidence, including its test identifier, run links, current result, and rationale; and
 - a separate itemized maintainer exception for missing or invalid exact Brev Launchable qualification, including run and job URLs, the current result or missing receipt, and rationale.
 
-Do not ask for the phrase until each test and the exact Brev Launchable qualification has successful evidence or its own itemized maintainer exception. If `origin/main` moves or the candidate SHA otherwise changes, regenerate the plan and rebuild the ledger for the new SHA.
+Do not ask for the phrase until each test and the exact Brev Launchable qualification has successful evidence or its own itemized maintainer exception.
+Immediately before asking, refresh `origin/main` once and compare its full SHA with the plan. If it moved, regenerate the plan and rebuild the ledger for the new SHA; merges did not need to stop while the earlier evidence ran.
 
 Ask the maintainer to paste this phrase:
 
@@ -279,7 +362,7 @@ If the Announcement is valid, return its URL with the release artifacts and mark
 
 - Plan generation fails: fix the named precondition, then regenerate the plan.
 - Planned changelog entry is missing or malformed: stop before plan generation and run the pre-tag `nemoclaw-contributor-update-docs` workflow. Use post-release recovery only when the tag already exists.
-- Full-mode E2E readiness is disabled: stop before dispatch. Ask a release administrator to complete the protected environment, secrets, staging Launchable ID, and ownership setup, then enable the persistent readiness variable.
+- Full-mode E2E readiness is disabled: skip the full dispatch, run the ordinary default and unconditional explicit-only groups concurrently, and prepare the required qualification exception. Ask a release administrator to complete the protected environment, secrets, staging Launchable ID, and ownership setup before a later full-mode retry.
 - Full-mode E2E ran for another SHA or skipped `Exact staging Brev Launchable`: reject the run and dispatch full mode for the plan candidate SHA.
 - Qualification or cleanup evidence is missing or invalid: reject the run. Do not infer qualification from the workflow conclusion.
 - `origin/main` moved after plan generation: regenerate the plan and ask for the new confirmation phrase.

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -180,7 +180,7 @@ If the plan candidate SHA changes, discard the run and qualification evidence.
 Run full mode again for the new candidate SHA.
 No release-note-only delta exception is currently defined.
 
-For every accepted default, explicit, and conditional run, reuse `run-$RUN_ID.json` and `jobs-$RUN_ID.json` returned by `nemoclaw-maintainer-e2e`.
+For every accepted default, explicit, and conditional run, reuse `run-$RUN_ID.json` and `jobs-$RUN_ID.json` returned by `nemoclaw-maintainer-e2e`, and collect the workflow-produced dispatch receipt for that run.
 If those files were not returned, collect them once:
 
 ```bash
@@ -189,7 +189,19 @@ gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID" \
 gh api --paginate --slurp \
   "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID/jobs?filter=all&per_page=100" \
   >"$EVIDENCE_DIR/jobs-$RUN_ID.json"
+ARTIFACT_PAGES="$(gh api --paginate --slurp \
+  "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID/artifacts?per_page=100")"
+DISPATCH_ARTIFACT_NAME="$(jq -r --arg prefix "e2e-dispatch-$RUN_ID-" \
+  '[.[] | .artifacts[] | select(.expired != true and (.name | startswith($prefix)))]
+   | sort_by(.created_at) | last | .name // empty' <<<"$ARTIFACT_PAGES")"
+test -n "$DISPATCH_ARTIFACT_NAME"
+gh run download "$RUN_ID" \
+  --repo NVIDIA/NemoClaw \
+  --name "$DISPATCH_ARTIFACT_NAME" \
+  --dir "$EVIDENCE_DIR/dispatch-$RUN_ID"
 ```
+
+Use the latest existing receipt artifact, not the run's latest attempt number. A partial rerun can leave `generate-matrix` successful and therefore reuse its earlier receipt; the ledger permits that earlier receipt only when it binds the same run and its attempt does not exceed the run's latest attempt.
 
 Create `manifest.json` in the private evidence directory:
 
@@ -202,22 +214,21 @@ Create `manifest.json` in the private evidence directory:
     {
       "runJson": "run-123.json",
       "jobsJson": "jobs-123.json",
-      "defaultSuiteSelected": true,
-      "selectedJobs": []
+      "dispatchJson": "dispatch-123/dispatch.json"
     },
     {
       "runJson": "run-124.json",
       "jobsJson": "jobs-124.json",
-      "defaultSuiteSelected": false,
-      "selectedJobs": ["mcp-bridge-dev", "hermes-gpu-startup"]
+      "dispatchJson": "dispatch-124/dispatch.json"
     }
   ]
 }
 ```
 
-List the exact selectors used by each selective dispatch; do not copy the example selectors.
+Do not type default-suite claims or selector lists into the manifest. The helper derives them from the workflow-produced receipt and rejects a receipt whose selector fields disagree with its default-suite flag.
 Build the ledger with `npm run release:e2e-evidence -- --manifest "$EVIDENCE_DIR/manifest.json"`.
-The helper derives the denominator from the workflow, preserves matrix rows as separate semantic identifiers, binds every run to the candidate SHA, and keeps an earlier successful attempt green when a later attempt fails.
+The helper derives the denominator from the workflow, preserves matrix rows as separate semantic identifiers, binds every run and its actual dispatch inputs to the candidate SHA, and keeps an earlier successful attempt green when a later attempt fails.
+The manifest and helper cover the workflow-derived test execution ledger only. They do not replace exact Brev qualification acceptance: keep the raw `dispatch.json`, `qualification.json`, and `cleanup.json` validation in `nemoclaw-maintainer-e2e`, and carry its validated return beside this ledger or record the required qualification exception.
 
 Before showing the confirmation prompt, present:
 
@@ -229,7 +240,7 @@ Before showing the confirmation prompt, present:
 - a separate itemized maintainer exception for missing or invalid exact Brev Launchable qualification, including run and job URLs, the current result or missing receipt, and rationale.
 
 Do not ask for the phrase until each test and the exact Brev Launchable qualification has successful evidence or its own itemized maintainer exception.
-Immediately before asking, refresh `origin/main` once and compare its full SHA with the plan. If it moved, regenerate the plan and rebuild the ledger for the new SHA; merges did not need to stop while the earlier evidence ran.
+Immediately before asking, refresh `origin/main` once and compare its full SHA with the plan. If it moved, discard all prior candidate-bound evidence, regenerate the plan, rerun preflight and every required default, explicit, conditional, and exact Brev qualification group for the new SHA, capture a new manifest, and rebuild the ledger before requesting confirmation; merges did not need to stop while the earlier evidence ran.
 
 Ask the maintainer to paste this phrase:
 

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -180,7 +180,8 @@ If the plan candidate SHA changes, discard the run and qualification evidence.
 Run full mode again for the new candidate SHA.
 No release-note-only delta exception is currently defined.
 
-For every accepted default, explicit, and conditional run, collect the run plus every job attempt:
+For every accepted default, explicit, and conditional run, reuse `run-$RUN_ID.json` and `jobs-$RUN_ID.json` returned by `nemoclaw-maintainer-e2e`.
+If those files were not returned, collect them once:
 
 ```bash
 gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID" \

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts
@@ -51,10 +51,9 @@ export type ReleaseE2ePreflight = {
 };
 
 export type ReleaseE2eRunEvidence = {
-  defaultSuiteSelected: boolean;
+  dispatch: unknown;
   jobs: unknown;
   run: unknown;
-  selectedJobs: string[];
 };
 
 export type ReleaseE2eLedgerEntry = ReleaseE2eExecution & {
@@ -86,10 +85,9 @@ type ReleaseEvidenceManifest = {
   candidateSha: string;
   jetsonRunnerOnline: RunnerStatus;
   runs: Array<{
-    defaultSuiteSelected: boolean;
+    dispatchJson: string;
     jobsJson: string;
     runJson: string;
-    selectedJobs: string[];
   }>;
 };
 
@@ -128,6 +126,20 @@ function numberField(value: JsonRecord, field: string, label: string): number {
     throw new Error(`${label}.${field} must be a positive integer`);
   }
   return result as number;
+}
+
+function booleanField(value: JsonRecord, field: string, label: string): boolean {
+  const result = value[field];
+  if (typeof result !== "boolean") {
+    throw new Error(`${label}.${field} must be a boolean`);
+  }
+  return result;
+}
+
+function requireEqual(actual: unknown, expected: unknown, label: string): void {
+  if (actual !== expected) {
+    throw new Error(`${label} must equal ${JSON.stringify(expected)}`);
+  }
 }
 
 function parseBoolean(value: string, label: string): boolean {
@@ -391,20 +403,55 @@ export function buildReleaseE2eLedger(
   const attempts = new Map<string, ReleaseE2eLedgerEntry["attempts"]>();
 
   for (const [runIndex, evidence] of runs.entries()) {
-    const run = record(evidence.run, `runs[${runIndex}].run`);
-    if (stringField(run, "head_sha", `runs[${runIndex}].run`) !== preflight.candidateSha) {
-      throw new Error(`runs[${runIndex}].run.head_sha does not match the candidate SHA`);
+    const label = `runs[${runIndex}]`;
+    const run = record(evidence.run, `${label}.run`);
+    requireEqual(run.head_sha, preflight.candidateSha, `${label}.run.head_sha`);
+    requireEqual(run.head_branch, "main", `${label}.run.head_branch`);
+    requireEqual(run.event, "workflow_dispatch", `${label}.run.event`);
+    requireEqual(run.path, ".github/workflows/e2e.yaml", `${label}.run.path`);
+    const runId = numberField(run, "id", `${label}.run`);
+    const runAttempt = numberField(run, "run_attempt", `${label}.run`);
+    const runUrl = stringField(run, "html_url", `${label}.run`);
+
+    const dispatch = record(evidence.dispatch, `${label}.dispatch`);
+    requireEqual(dispatch.kind, "nemoclaw-e2e-dispatch-v1", `${label}.dispatch.kind`);
+    requireEqual(dispatch.candidateSha, preflight.candidateSha, `${label}.dispatch.candidateSha`);
+    requireEqual(dispatch.eventName, "workflow_dispatch", `${label}.dispatch.eventName`);
+    requireEqual(dispatch.workflowRunId, String(runId), `${label}.dispatch.workflowRunId`);
+    const receiptAttempt = numberField(dispatch, "workflowRunAttempt", `${label}.dispatch`);
+    if (receiptAttempt > runAttempt) {
+      throw new Error(`${label}.dispatch.workflowRunAttempt exceeds the workflow run attempt`);
     }
-    const runUrl = stringField(run, "html_url", `runs[${runIndex}].run`);
-    const selectedJobs = new Set(evidence.selectedJobs);
+    const jobsInput = dispatch.jobs;
+    const targetsInput = dispatch.targets;
+    if (typeof jobsInput !== "string" || typeof targetsInput !== "string") {
+      throw new Error(`${label}.dispatch jobs and targets must be strings`);
+    }
+    requireEqual(targetsInput, "", `${label}.dispatch.targets`);
+    const defaultSuiteSelected = jobsInput === "" && targetsInput === "";
+    requireEqual(
+      booleanField(dispatch, "defaultSuiteSelected", `${label}.dispatch`),
+      defaultSuiteSelected,
+      `${label}.dispatch.defaultSuiteSelected`,
+    );
+    booleanField(dispatch, "includeStagingBrevLaunchable", `${label}.dispatch`);
+    const allowJetsonRunnerQueue = booleanField(
+      dispatch,
+      "allowJetsonRunnerQueue",
+      `${label}.dispatch`,
+    );
+    const selectedJobs = new Set(jobsInput === "" ? [] : jobsInput.split(","));
     for (const jobId of selectedJobs) {
       if (!SELECTOR_PATTERN.test(jobId) || !knownJobs.has(jobId)) {
         throw new Error(`runs[${runIndex}] selects unknown release E2E job ${jobId}`);
       }
     }
+    if (selectedJobs.has("jetson-nvmap-gpu") && !allowJetsonRunnerQueue) {
+      throw new Error(`${label}.dispatch must allow the Jetson runner queue for its selector`);
+    }
     const selectedExecutions = preflight.executions.filter(
       (execution) =>
-        (evidence.defaultSuiteSelected && execution.group === "default") ||
+        (defaultSuiteSelected && execution.group === "default") ||
         selectedJobs.has(execution.jobId),
     );
 
@@ -512,19 +559,16 @@ function readManifest(manifestPath: string): {
   }
   const runs = manifest.runs.map((entry, index) => {
     if (
-      typeof entry.defaultSuiteSelected !== "boolean" ||
+      typeof entry.dispatchJson !== "string" ||
       typeof entry.jobsJson !== "string" ||
-      typeof entry.runJson !== "string" ||
-      !Array.isArray(entry.selectedJobs) ||
-      !entry.selectedJobs.every((job) => typeof job === "string")
+      typeof entry.runJson !== "string"
     ) {
       throw new Error(`manifest.runs[${index}] has an invalid schema`);
     }
     return {
-      defaultSuiteSelected: entry.defaultSuiteSelected,
+      dispatch: JSON.parse(readFileSync(path.resolve(directory, entry.dispatchJson), "utf8")),
       jobs: JSON.parse(readFileSync(path.resolve(directory, entry.jobsJson), "utf8")),
       run: JSON.parse(readFileSync(path.resolve(directory, entry.runJson), "utf8")),
-      selectedJobs: entry.selectedJobs,
     };
   });
   return { manifest, runs };

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts
@@ -1,0 +1,579 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import YAML from "yaml";
+import { readFreeStandingJobsInventory } from "../../../../tools/e2e/workflow-boundary.mts";
+import {
+  buildE2eWorkflowPlan,
+  type E2eWorkflowPlan,
+} from "../../../../tools/e2e/workflow-plan.mts";
+
+type JsonRecord = Record<string, unknown>;
+type RunnerStatus = "false" | "true" | "unknown";
+type ExecutionGroup = "conditional" | "default" | "parallel-explicit";
+
+export type ReleaseE2eExecution = {
+  id: string;
+  jobId: string;
+  expectedName: string;
+  group: ExecutionGroup;
+};
+
+export type ReleaseE2ePreflight = {
+  candidateSha: string;
+  dispatches: {
+    conditional: Array<{
+      allowJetsonRunnerQueue: boolean;
+      jobs: string;
+      reason: string;
+    }>;
+    defaultSuite: {
+      includeStagingBrevLaunchable: boolean;
+      jobs: "";
+      mode: "full" | "ordinary";
+      targets: "";
+    };
+    parallelExplicit: {
+      includeStagingBrevLaunchable: false;
+      jobs: string;
+      targets: "";
+    };
+  };
+  exceptionsRequired: string[];
+  executions: ReleaseE2eExecution[];
+  qualificationJobId: string;
+  requiredExecutionCount: number;
+};
+
+export type ReleaseE2eRunEvidence = {
+  defaultSuiteSelected: boolean;
+  jobs: unknown;
+  run: unknown;
+  selectedJobs: string[];
+};
+
+export type ReleaseE2eLedgerEntry = ReleaseE2eExecution & {
+  attempts: Array<{
+    attempt: number;
+    conclusion: string;
+    status: string;
+    jobUrl: string;
+    runUrl: string;
+  }>;
+  greenEvidence?: {
+    attempt: number;
+    jobUrl: string;
+    runUrl: string;
+  };
+  status: "green" | "missing";
+};
+
+export type ReleaseE2eLedger = {
+  candidateSha: string;
+  entries: ReleaseE2eLedgerEntry[];
+  greenCount: number;
+  missingCount: number;
+  requiredCount: number;
+};
+
+type ReleaseEvidenceManifest = {
+  brevReady: boolean;
+  candidateSha: string;
+  jetsonRunnerOnline: RunnerStatus;
+  runs: Array<{
+    defaultSuiteSelected: boolean;
+    jobsJson: string;
+    runJson: string;
+    selectedJobs: string[];
+  }>;
+};
+
+type CliOptions = {
+  brevReady?: boolean;
+  candidateSha?: string;
+  jetsonRunnerOnline: RunnerStatus;
+  manifest?: string;
+  workflowPath: string;
+};
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const DEFAULT_WORKFLOW_PATH = path.join(REPO_ROOT, ".github", "workflows", "e2e.yaml");
+const SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const SELECTOR_PATTERN = /^[A-Za-z0-9_-]+$/u;
+const MATRIX_EXPRESSION_PATTERN = /\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/gu;
+
+function record(value: unknown, label: string): JsonRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonRecord;
+}
+
+function stringField(value: JsonRecord, field: string, label: string): string {
+  const result = value[field];
+  if (typeof result !== "string" || result.length === 0) {
+    throw new Error(`${label}.${field} must be a non-empty string`);
+  }
+  return result;
+}
+
+function numberField(value: JsonRecord, field: string, label: string): number {
+  const result = value[field];
+  if (!Number.isInteger(result) || (result as number) < 1) {
+    throw new Error(`${label}.${field} must be a positive integer`);
+  }
+  return result as number;
+}
+
+function parseBoolean(value: string, label: string): boolean {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`${label} must be true or false`);
+}
+
+function parseRunnerStatus(value: string): RunnerStatus {
+  if (value === "true" || value === "false" || value === "unknown") return value;
+  throw new Error("--jetson-runner-online must be true, false, or unknown");
+}
+
+function matrixRows(rawMatrix: unknown, jobId: string): JsonRecord[] {
+  const matrix = record(rawMatrix, `${jobId}.strategy.matrix`);
+  if (typeof matrix.include === "string") {
+    throw new Error(`${jobId} has a dynamic matrix that needs a planner-specific expansion`);
+  }
+
+  const axes = Object.entries(matrix).filter(
+    ([key]) =>
+      key !== "exclude" && key !== "include" && key !== "fail-fast" && key !== "max-parallel",
+  );
+  let rows: JsonRecord[] = [{}];
+  for (const [key, rawValues] of axes) {
+    if (!Array.isArray(rawValues) || rawValues.length === 0) {
+      throw new Error(`${jobId} matrix axis ${key} must be a non-empty array`);
+    }
+    rows = rows.flatMap((row) =>
+      rawValues.map((value) => {
+        if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+          throw new Error(`${jobId} matrix axis ${key} contains an unsupported value`);
+        }
+        return { ...row, [key]: value };
+      }),
+    );
+  }
+
+  const excludes = Array.isArray(matrix.exclude)
+    ? matrix.exclude.map((row) => record(row, "exclude"))
+    : [];
+  rows = rows.filter(
+    (row) =>
+      !excludes.some((excluded) =>
+        Object.entries(excluded).every(([key, value]) => row[key] === value),
+      ),
+  );
+
+  if (Array.isArray(matrix.include)) {
+    if (axes.length > 0) {
+      throw new Error(
+        `${jobId} combines matrix axes and include rows; add explicit expansion support`,
+      );
+    }
+    rows = matrix.include.map((row) => record(row, `${jobId}.strategy.matrix.include`));
+  }
+  return rows;
+}
+
+function renderMatrixJobName(jobId: string, rawJob: JsonRecord, row: JsonRecord): string {
+  const configuredName = rawJob.name;
+  if (configuredName !== undefined && typeof configuredName !== "string") {
+    throw new Error(`${jobId}.name must be a string when set`);
+  }
+  if (configuredName) {
+    const rendered = configuredName.replace(MATRIX_EXPRESSION_PATTERN, (_match, key: string) => {
+      if (!Object.hasOwn(row, key)) {
+        throw new Error(`${jobId}.name references missing matrix dimension ${key}`);
+      }
+      return String(row[key]);
+    });
+    if (rendered.includes("${{ matrix.")) {
+      throw new Error(`${jobId}.name contains an unsupported matrix expression`);
+    }
+    return rendered;
+  }
+  return `${jobId} (${Object.values(row)
+    .map((value) => String(value))
+    .join(", ")})`;
+}
+
+function executionId(jobId: string, row: JsonRecord): string {
+  if (typeof row.id === "string" && row.id.length > 0) return `${jobId}[id=${row.id}]`;
+  const dimensions = Object.entries(row)
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join(",");
+  return `${jobId}[${dimensions}]`;
+}
+
+function jobExecutions(
+  jobId: string,
+  rawJob: JsonRecord,
+  group: ExecutionGroup,
+  plan: E2eWorkflowPlan,
+): ReleaseE2eExecution[] {
+  let rows: JsonRecord[] = [];
+  if (jobId === "live") rows = plan.matrix as unknown as JsonRecord[];
+  else if (jobId === "shared-e2e") rows = plan.testMatrix as unknown as JsonRecord[];
+  else {
+    const strategy = record(rawJob.strategy ?? {}, `${jobId}.strategy`);
+    if (strategy.matrix !== undefined) rows = matrixRows(strategy.matrix, jobId);
+  }
+
+  if (rows.length === 0) {
+    const configuredName = rawJob.name;
+    return [
+      {
+        expectedName: typeof configuredName === "string" ? configuredName : jobId,
+        group,
+        id: jobId,
+        jobId,
+      },
+    ];
+  }
+  return rows.map((row) => ({
+    expectedName: renderMatrixJobName(jobId, rawJob, row),
+    group,
+    id: executionId(jobId, row),
+    jobId,
+  }));
+}
+
+function workflowJobs(workflowPath: string): JsonRecord {
+  const workflow = record(YAML.parse(readFileSync(workflowPath, "utf8")), "workflow");
+  return record(workflow.jobs, "workflow.jobs");
+}
+
+function isQualificationJob(job: JsonRecord): boolean {
+  return JSON.stringify(job).includes("include_staging_brev_launchable");
+}
+
+function requiresConfirmedJetsonRunner(job: JsonRecord): boolean {
+  return JSON.stringify(job).includes("allow_jetson_runner_queue");
+}
+
+export function buildReleaseE2ePreflight(input: {
+  brevReady: boolean;
+  candidateSha: string;
+  jetsonRunnerOnline?: RunnerStatus;
+  plan?: E2eWorkflowPlan;
+  workflowPath?: string;
+}): ReleaseE2ePreflight {
+  if (!SHA_PATTERN.test(input.candidateSha)) {
+    throw new Error("candidateSha must be a lowercase 40-character commit SHA");
+  }
+  const workflowPath = input.workflowPath ?? DEFAULT_WORKFLOW_PATH;
+  const jobs = workflowJobs(workflowPath);
+  const inventory = readFreeStandingJobsInventory(workflowPath);
+  const plan = input.plan ?? buildE2eWorkflowPlan();
+  const explicitJobs = new Set(inventory.explicitOnlyJobs);
+  const qualificationJobs = inventory.explicitOnlyJobs.filter((jobId) =>
+    isQualificationJob(record(jobs[jobId], `workflow.jobs.${jobId}`)),
+  );
+  if (qualificationJobs.length !== 1) {
+    throw new Error(
+      `expected exactly one explicit qualification job, found ${qualificationJobs.length}`,
+    );
+  }
+  const qualificationJobId = qualificationJobs[0]!;
+  const conditionalJobs = inventory.explicitOnlyJobs.filter(
+    (jobId) =>
+      jobId !== qualificationJobId &&
+      requiresConfirmedJetsonRunner(record(jobs[jobId], `workflow.jobs.${jobId}`)),
+  );
+  const parallelExplicitJobs = inventory.explicitOnlyJobs.filter(
+    (jobId) => jobId !== qualificationJobId && !conditionalJobs.includes(jobId),
+  );
+
+  const defaultJobIds = inventory.workflowJobs.filter(
+    (jobId) => jobId !== "shared-e2e" && !explicitJobs.has(jobId),
+  );
+  const executions = [
+    ...defaultJobIds.flatMap((jobId) =>
+      jobExecutions(jobId, record(jobs[jobId], `workflow.jobs.${jobId}`), "default", plan),
+    ),
+    ...jobExecutions("live", record(jobs.live, "workflow.jobs.live"), "default", plan),
+    ...jobExecutions(
+      "shared-e2e",
+      record(jobs["shared-e2e"], "workflow.jobs.shared-e2e"),
+      "default",
+      plan,
+    ),
+    ...parallelExplicitJobs.flatMap((jobId) =>
+      jobExecutions(
+        jobId,
+        record(jobs[jobId], `workflow.jobs.${jobId}`),
+        "parallel-explicit",
+        plan,
+      ),
+    ),
+    ...conditionalJobs.flatMap((jobId) =>
+      jobExecutions(jobId, record(jobs[jobId], `workflow.jobs.${jobId}`), "conditional", plan),
+    ),
+  ];
+  const duplicateIds = executions
+    .map((execution) => execution.id)
+    .filter((id, index, ids) => ids.indexOf(id) !== index);
+  if (duplicateIds.length > 0) {
+    throw new Error(`release E2E execution identifiers are not unique: ${duplicateIds.join(",")}`);
+  }
+
+  const runnerStatus = input.jetsonRunnerOnline ?? "unknown";
+  const exceptionsRequired: string[] = [];
+  if (!input.brevReady) exceptionsRequired.push(qualificationJobId);
+  if (runnerStatus !== "true") exceptionsRequired.push(...conditionalJobs);
+
+  return {
+    candidateSha: input.candidateSha,
+    dispatches: {
+      conditional: conditionalJobs.map((jobId) => ({
+        allowJetsonRunnerQueue: runnerStatus === "true",
+        jobs: jobId,
+        reason:
+          runnerStatus === "true"
+            ? "authoritative runner inventory confirmed online"
+            : "do not queue until an administrator confirms the Jetson runner online",
+      })),
+      defaultSuite: {
+        includeStagingBrevLaunchable: input.brevReady,
+        jobs: "",
+        mode: input.brevReady ? "full" : "ordinary",
+        targets: "",
+      },
+      parallelExplicit: {
+        includeStagingBrevLaunchable: false,
+        jobs: parallelExplicitJobs.join(","),
+        targets: "",
+      },
+    },
+    exceptionsRequired,
+    executions,
+    qualificationJobId,
+    requiredExecutionCount: executions.length,
+  };
+}
+
+function flattenJobs(value: unknown): JsonRecord[] {
+  const pages = Array.isArray(value) ? value : [value];
+  return pages.flatMap((page, pageIndex) => {
+    const jobs = record(page, `jobs page ${pageIndex}`).jobs;
+    if (!Array.isArray(jobs)) throw new Error(`jobs page ${pageIndex}.jobs must be an array`);
+    return jobs.map((job, jobIndex) => record(job, `jobs page ${pageIndex}.jobs[${jobIndex}]`));
+  });
+}
+
+function matchesExpectedName(actual: string, expected: string): boolean {
+  if (actual === expected) return true;
+  if (!actual.endsWith("...")) return false;
+  return expected.startsWith(actual.slice(0, -3));
+}
+
+export function buildReleaseE2eLedger(
+  preflight: ReleaseE2ePreflight,
+  runs: readonly ReleaseE2eRunEvidence[],
+): ReleaseE2eLedger {
+  const knownJobs = new Set(preflight.executions.map((execution) => execution.jobId));
+  const attempts = new Map<string, ReleaseE2eLedgerEntry["attempts"]>();
+
+  for (const [runIndex, evidence] of runs.entries()) {
+    const run = record(evidence.run, `runs[${runIndex}].run`);
+    if (stringField(run, "head_sha", `runs[${runIndex}].run`) !== preflight.candidateSha) {
+      throw new Error(`runs[${runIndex}].run.head_sha does not match the candidate SHA`);
+    }
+    const runUrl = stringField(run, "html_url", `runs[${runIndex}].run`);
+    const selectedJobs = new Set(evidence.selectedJobs);
+    for (const jobId of selectedJobs) {
+      if (!SELECTOR_PATTERN.test(jobId) || !knownJobs.has(jobId)) {
+        throw new Error(`runs[${runIndex}] selects unknown release E2E job ${jobId}`);
+      }
+    }
+    const selectedExecutions = preflight.executions.filter(
+      (execution) =>
+        (evidence.defaultSuiteSelected && execution.group === "default") ||
+        selectedJobs.has(execution.jobId),
+    );
+
+    for (const job of flattenJobs(evidence.jobs)) {
+      const name = stringField(job, "name", `runs[${runIndex}].job`);
+      const matches = selectedExecutions.filter((execution) =>
+        matchesExpectedName(name, execution.expectedName),
+      );
+      if (matches.length > 1) {
+        throw new Error(
+          `GitHub job name ${JSON.stringify(name)} ambiguously matches ${matches
+            .map((execution) => execution.id)
+            .join(",")}`,
+        );
+      }
+      if (matches.length === 0) continue;
+      const execution = matches[0]!;
+      const values = attempts.get(execution.id) ?? [];
+      values.push({
+        attempt: numberField(job, "run_attempt", `runs[${runIndex}].job`),
+        conclusion: stringField(job, "conclusion", `runs[${runIndex}].job`),
+        status: stringField(job, "status", `runs[${runIndex}].job`),
+        jobUrl: stringField(job, "html_url", `runs[${runIndex}].job`),
+        runUrl,
+      });
+      attempts.set(execution.id, values);
+    }
+  }
+
+  const entries = preflight.executions.map((execution): ReleaseE2eLedgerEntry => {
+    const executionAttempts = [...(attempts.get(execution.id) ?? [])].sort(
+      (left, right) => right.attempt - left.attempt || right.jobUrl.localeCompare(left.jobUrl),
+    );
+    const green = executionAttempts.find(
+      (attempt) => attempt.status === "completed" && attempt.conclusion === "success",
+    );
+    return {
+      ...execution,
+      attempts: executionAttempts,
+      ...(green
+        ? {
+            greenEvidence: {
+              attempt: green.attempt,
+              jobUrl: green.jobUrl,
+              runUrl: green.runUrl,
+            },
+          }
+        : {}),
+      status: green ? "green" : "missing",
+    };
+  });
+  const greenCount = entries.filter((entry) => entry.status === "green").length;
+  return {
+    candidateSha: preflight.candidateSha,
+    entries,
+    greenCount,
+    missingCount: entries.length - greenCount,
+    requiredCount: entries.length,
+  };
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  const options: CliOptions = {
+    jetsonRunnerOnline: "unknown",
+    workflowPath: DEFAULT_WORKFLOW_PATH,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (
+      arg !== "--brev-ready" &&
+      arg !== "--candidate-sha" &&
+      arg !== "--jetson-runner-online" &&
+      arg !== "--manifest" &&
+      arg !== "--workflow"
+    ) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+    if (value === undefined) throw new Error(`${arg} requires a value`);
+    if (arg === "--brev-ready") options.brevReady = parseBoolean(value, arg);
+    else if (arg === "--candidate-sha") options.candidateSha = value;
+    else if (arg === "--jetson-runner-online") {
+      options.jetsonRunnerOnline = parseRunnerStatus(value);
+    } else if (arg === "--manifest") options.manifest = value;
+    else options.workflowPath = value;
+    index += 1;
+  }
+  return options;
+}
+
+function readManifest(manifestPath: string): {
+  manifest: ReleaseEvidenceManifest;
+  runs: ReleaseE2eRunEvidence[];
+} {
+  const directory = path.dirname(path.resolve(manifestPath));
+  const raw = record(JSON.parse(readFileSync(manifestPath, "utf8")), "manifest");
+  const manifest = raw as ReleaseEvidenceManifest;
+  if (
+    typeof manifest.brevReady !== "boolean" ||
+    !SHA_PATTERN.test(manifest.candidateSha) ||
+    !Array.isArray(manifest.runs) ||
+    !["false", "true", "unknown"].includes(manifest.jetsonRunnerOnline)
+  ) {
+    throw new Error("release E2E evidence manifest has an invalid schema");
+  }
+  const runs = manifest.runs.map((entry, index) => {
+    if (
+      typeof entry.defaultSuiteSelected !== "boolean" ||
+      typeof entry.jobsJson !== "string" ||
+      typeof entry.runJson !== "string" ||
+      !Array.isArray(entry.selectedJobs) ||
+      !entry.selectedJobs.every((job) => typeof job === "string")
+    ) {
+      throw new Error(`manifest.runs[${index}] has an invalid schema`);
+    }
+    return {
+      defaultSuiteSelected: entry.defaultSuiteSelected,
+      jobs: JSON.parse(readFileSync(path.resolve(directory, entry.jobsJson), "utf8")),
+      run: JSON.parse(readFileSync(path.resolve(directory, entry.runJson), "utf8")),
+      selectedJobs: entry.selectedJobs,
+    };
+  });
+  return { manifest, runs };
+}
+
+function requireCandidateCheckout(candidateSha: string): void {
+  const headSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  }).trim();
+  if (headSha !== candidateSha) {
+    throw new Error(`checkout HEAD ${headSha} does not match candidate SHA ${candidateSha}`);
+  }
+}
+
+export function runReleaseE2eEvidenceCli(argv = process.argv.slice(2)): void {
+  const options = parseArgs(argv);
+  if (options.manifest) {
+    const { manifest, runs } = readManifest(options.manifest);
+    requireCandidateCheckout(manifest.candidateSha);
+    const preflight = buildReleaseE2ePreflight({
+      brevReady: manifest.brevReady,
+      candidateSha: manifest.candidateSha,
+      jetsonRunnerOnline: manifest.jetsonRunnerOnline,
+      workflowPath: options.workflowPath,
+    });
+    process.stdout.write(`${JSON.stringify(buildReleaseE2eLedger(preflight, runs), null, 2)}\n`);
+    return;
+  }
+  if (options.brevReady === undefined || options.candidateSha === undefined) {
+    throw new Error("--candidate-sha and --brev-ready are required for preflight");
+  }
+  requireCandidateCheckout(options.candidateSha);
+  process.stdout.write(
+    `${JSON.stringify(
+      buildReleaseE2ePreflight({
+        brevReady: options.brevReady,
+        candidateSha: options.candidateSha,
+        jetsonRunnerOnline: options.jetsonRunnerOnline,
+        workflowPath: options.workflowPath,
+      }),
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+const invokedFile = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedFile === fileURLToPath(import.meta.url)) {
+  try {
+    runReleaseE2eEvidenceCli();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts
@@ -256,11 +256,15 @@ function workflowJobs(workflowPath: string): JsonRecord {
 }
 
 function isQualificationJob(job: JsonRecord): boolean {
-  return JSON.stringify(job).includes("include_staging_brev_launchable");
+  const condition = job.if;
+  return (
+    typeof condition === "string" && condition.includes("inputs.include_staging_brev_launchable")
+  );
 }
 
 function requiresConfirmedJetsonRunner(job: JsonRecord): boolean {
-  return JSON.stringify(job).includes("allow_jetson_runner_queue");
+  const runsOn = job["runs-on"];
+  return typeof runsOn === "string" && runsOn.includes("inputs.allow_jetson_runner_queue");
 }
 
 export function buildReleaseE2ePreflight(input: {

--- a/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
@@ -65,6 +65,9 @@ Report this prerequisite:
 Do not inspect, print, or handle cloud credentials.
 Do not change the readiness variable around a run.
 
+When `nemoclaw-maintainer-cut-release-tag` invokes this skill, disabled readiness blocks only the protected qualification dispatch.
+Return `brevReady=false` to the release preflight so it can run the ordinary default suite and unconditional explicit-only group concurrently while reserving the required qualification exception.
+
 ## Dispatch One Trusted Run
 
 Generate a unique correlation ID:
@@ -102,6 +105,48 @@ gh workflow run .github/workflows/e2e.yaml \
 Do not set `jobs=staging-brev-launchable` for full mode.
 Empty `jobs` and `targets` select the default suite.
 The boolean input adds qualification to that same run.
+
+### Release Coverage Dispatch Group
+
+Use this subsection only when `nemoclaw-maintainer-cut-release-tag` supplies a release E2E preflight.
+It coordinates independent workflow runs; it does not change the meaning of ordinary or full mode above.
+
+Read `dispatches` from the preflight.
+Create a different correlation ID for each run.
+Dispatch the `defaultSuite` run first, using ordinary or full mode exactly as reported.
+Without waiting for it, dispatch the non-empty `parallelExplicit.jobs` value:
+
+```bash
+gh workflow run .github/workflows/e2e.yaml \
+  --repo NVIDIA/NemoClaw \
+  --ref main \
+  -f targets= \
+  -f "jobs=${EXPLICIT_JOBS}" \
+  -f inference_mode=mock \
+  -f include_staging_brev_launchable=false \
+  -f "correlation_id=${EXPLICIT_CORRELATION_ID}"
+```
+
+Do not add `staging-brev-launchable` to that selector list.
+Do not dispatch a conditional Jetson lane unless the authoritative repository runner inventory was confirmed online.
+After that confirmation, use a separate run and opt into queueing explicitly:
+
+```bash
+gh workflow run .github/workflows/e2e.yaml \
+  --repo NVIDIA/NemoClaw \
+  --ref main \
+  -f targets= \
+  -f jobs=jetson-nvmap-gpu \
+  -f inference_mode=mock \
+  -f include_staging_brev_launchable=false \
+  -f allow_jetson_runner_queue=true \
+  -f "correlation_id=${JETSON_CORRELATION_ID}"
+```
+
+Find all correlation IDs with one bounded `gh run list` query.
+Require exactly one run per correlation ID and the candidate SHA on every match.
+Dispatch the whole group before watching any member; do not serialize independent runs.
+Watch the group with batched status snapshots and collect results after all members are terminal.
 
 Find the run by its unique title:
 
@@ -149,6 +194,14 @@ trap 'rm -rf "$EVIDENCE_DIR"' EXIT
 gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID" >"$EVIDENCE_DIR/run.json"
 gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID/jobs?filter=latest&per_page=100" \
   >"$EVIDENCE_DIR/jobs.json"
+```
+
+For a release coverage group, also collect every attempt for the matrix-preserving ledger:
+
+```bash
+gh api --paginate --slurp \
+  "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID/jobs?filter=all&per_page=100" \
+  >"$EVIDENCE_DIR/jobs-all-$RUN_ID.json"
 ```
 
 For ordinary mode, require `run.json` to report:
@@ -201,7 +254,7 @@ Return:
 - qualification identity; and
 - cleanup result.
 
-If the release candidate SHA changes, discard the earlier run and rerun full mode.
+If the release candidate SHA changes, discard the earlier run group and rerun every required release coverage group for the new SHA.
 No release-note-only delta exception is currently defined.
 
 When `nemoclaw-maintainer-cut-release-tag` invokes this skill, return the validated fields for its pre-tag E2E evidence ledger.

--- a/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
@@ -191,9 +191,9 @@ Create a private temporary evidence directory:
 EVIDENCE_DIR="$(mktemp -d)"
 chmod 700 "$EVIDENCE_DIR"
 trap 'rm -rf "$EVIDENCE_DIR"' EXIT
-gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID" >"$EVIDENCE_DIR/run.json"
+gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID" >"$EVIDENCE_DIR/run-$RUN_ID.json"
 gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID/jobs?filter=latest&per_page=100" \
-  >"$EVIDENCE_DIR/jobs.json"
+  >"$EVIDENCE_DIR/jobs-latest-$RUN_ID.json"
 ```
 
 For a release coverage group, also collect every attempt for the matrix-preserving ledger:
@@ -201,10 +201,14 @@ For a release coverage group, also collect every attempt for the matrix-preservi
 ```bash
 gh api --paginate --slurp \
   "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID/jobs?filter=all&per_page=100" \
-  >"$EVIDENCE_DIR/jobs-all-$RUN_ID.json"
+  >"$EVIDENCE_DIR/jobs-$RUN_ID.json"
 ```
 
-For ordinary mode, require `run.json` to report:
+Reuse `run-$RUN_ID.json` and `jobs-$RUN_ID.json` as the `nemoclaw-maintainer-cut-release-tag` manifest inputs.
+Do not fetch the same run again.
+`jobs-latest-$RUN_ID.json` is only the validator input for the latest full-mode attempt.
+
+For ordinary mode, require `run-$RUN_ID.json` to report:
 
 - `head_sha` equal to `CANDIDATE_SHA`;
 - `status` equal to `completed`; and
@@ -221,8 +225,8 @@ gh run download "$RUN_ID" --repo NVIDIA/NemoClaw \
 node --experimental-strip-types --no-warnings \
   .agents/skills/nemoclaw-maintainer-e2e/scripts/validate-full-e2e-evidence.mts \
   --candidate-sha "$CANDIDATE_SHA" \
-  --run-json "$EVIDENCE_DIR/run.json" \
-  --jobs-json "$EVIDENCE_DIR/jobs.json" \
+  --run-json "$EVIDENCE_DIR/run-$RUN_ID.json" \
+  --jobs-json "$EVIDENCE_DIR/jobs-latest-$RUN_ID.json" \
   --dispatch-json "$EVIDENCE_DIR/dispatch.json" \
   --qualification-json "$EVIDENCE_DIR/qualification.json" \
   --cleanup-json "$EVIDENCE_DIR/cleanup.json"

--- a/.agents/skills/nemoclaw-maintainer-evening/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-evening/SKILL.md
@@ -54,10 +54,11 @@ Load `cut-release-tag`.
 The version is already known, so use a patch bump unless the maintainer selects another bump.
 Show the commit, changelog, carry-forward plan, label-retirement plan, and release notes draft.
 
-After the release plan freezes the candidate SHA, load `nemoclaw-maintainer-e2e`.
-Run full mode when that SHA has no applicable exact Brev Launchable evidence.
+After the release plan captures the candidate SHA, load `nemoclaw-maintainer-e2e`.
+When the protected qualification readiness variable is `true`, run full mode if that SHA has no applicable exact Brev Launchable evidence.
 Review the pre-tag E2E evidence ledger from `.github/workflows/e2e.yaml` at that commit.
-Require a successful `Exact staging Brev Launchable` job, matching qualification identity, and verified workspace absence.
+When full mode runs, require a successful `Exact staging Brev Launchable` job, matching qualification identity, and verified workspace absence.
+When readiness is disabled, run the ordinary default and unconditional explicit-only groups. Record the missing qualification as its required itemized exception.
 Each missing test result requires its own itemized maintainer exception.
 Missing or invalid qualification requires a separate itemized exception with run and job URLs, the result or missing receipt, and rationale.
 Do not ask for the release confirmation phrase until each required result has successful evidence or its own exception.

--- a/.agents/skills/nemoclaw-maintainer-policies/references/daily-flow.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/daily-flow.md
@@ -68,7 +68,7 @@ Agents may recommend labels, assignments, Project field changes, comments, merge
 - A PR daily version label activates daily release work; it is not a readiness claim.
 - Release inclusion requires a PR to be both merged and carrying the relevant daily version label at release cutoff.
 - Issue daily version labels are tracking or coordination signals only.
-- Before tag confirmation, freeze the candidate SHA and review every E2E test declared by `.github/workflows/e2e.yaml` at that commit. Each test needs green evidence for that SHA or an explicit itemized maintainer exception.
+- Before tag confirmation, capture the candidate SHA and review every E2E test declared by `.github/workflows/e2e.yaml` at that commit. Merges may continue; a late drift check advances the candidate when needed. Each test needs green evidence for that SHA or an explicit itemized maintainer exception.
 - Open PRs and issues that miss a tagged release carry forward by automatically moving from the released version label to the next patch label after the tag and `latest` are verified.
 - After carry-forward leaves no open item on the released label, delete that repository label. Never rename or reuse it.
 - Durable release history belongs in releases, release notes, or manifests, not in long-lived labels.

--- a/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
@@ -55,7 +55,7 @@ Before asking for the release confirmation phrase, build and show an evidence le
 - Dispatch independent default-suite and unconditional explicit-only work concurrently. Dispatch a conditional hardware lane only after its authoritative runner inventory confirms that it is online; otherwise record its required itemized exception without queueing it.
 - If protected qualification readiness is disabled, continue the ordinary default suite and unconditional explicit-only work while recording the missing qualification as a required itemized exception. Do not serialize unrelated evidence behind that blocker.
 - Derive the denominator and dispatch selectors from the candidate workflow. Do not copy them into a second release test list.
-- When the protected qualification readiness variable is `true`, run `nemoclaw-maintainer-e2e` in full mode if no applicable full-mode run exists for the candidate SHA.
+- When the protected qualification readiness variable is `true`, run `nemoclaw-maintainer-e2e` in full mode if no applicable exact Brev Launchable evidence exists for the candidate SHA.
 - For full-mode exact Brev evidence, require one workflow run for the candidate SHA that includes the default-enabled suite and a successful `Exact staging Brev Launchable` job.
 - For that evidence, require the trusted dispatch receipt to bind the run and attempt to empty selectors and `include_staging_brev_launchable=true`.
 - Require its qualification receipt to identify the candidate SHA in the repository and provision records.

--- a/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
@@ -55,6 +55,7 @@ Before asking for the release confirmation phrase, build and show an evidence le
 - Dispatch independent default-suite and unconditional explicit-only work concurrently. Dispatch a conditional hardware lane only after its authoritative runner inventory confirms that it is online; otherwise record its required itemized exception without queueing it.
 - If protected qualification readiness is disabled, continue the ordinary default suite and unconditional explicit-only work while recording the missing qualification as a required itemized exception. Do not serialize unrelated evidence behind that blocker.
 - Derive the denominator and dispatch selectors from the candidate workflow. Do not copy them into a second release test list.
+- For every accepted run, require the workflow-produced trusted dispatch receipt to bind the candidate SHA, run ID, attempt, and actual selector inputs. Derive default-suite or selective coverage only from that receipt, never from a release manifest claim.
 - When the protected qualification readiness variable is `true`, run `nemoclaw-maintainer-e2e` in full mode if no applicable exact Brev Launchable evidence exists for the candidate SHA.
 - For full-mode exact Brev evidence, require one workflow run for the candidate SHA that includes the default-enabled suite and a successful `Exact staging Brev Launchable` job.
 - For that evidence, require the trusted dispatch receipt to bind the run and attempt to empty selectors and `include_staging_brev_launchable=true`.

--- a/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
@@ -40,7 +40,7 @@ At cutoff:
 3. List open PRs and issues still carrying the target label as post-tag stragglers.
 4. Confirm the merged release-note docs PR contains the dated changelog entry for the target version, or record an explicit waiver that names the missing entry.
 5. Generate QA handoff from merged PRs.
-6. Generate the release plan to freeze the candidate commit.
+6. Generate the release plan to capture the candidate commit. Merges may continue; a late drift check advances the candidate and invalidates evidence for the older SHA.
 7. Review the candidate commit's pre-tag E2E evidence.
 8. Cut the release tag only with explicit maintainer confirmation.
 9. After the tag and workflow-managed `latest` are verified, automatically move every open straggler to the next patch label, verify none remain, and delete the released version label.
@@ -51,11 +51,15 @@ The release candidate is the full `origin/main` commit SHA captured by the gener
 
 Before asking for the release confirmation phrase, build and show an evidence ledger for that SHA:
 
-- Run `nemoclaw-maintainer-e2e` in full mode when no applicable full-mode run exists for the candidate SHA.
-- Require one workflow run for the candidate SHA that includes the default-enabled suite and a successful `Exact staging Brev Launchable` job.
-- Require the trusted dispatch receipt to bind that run and attempt to empty selectors and `include_staging_brev_launchable=true`.
-- Require the qualification receipt to identify the candidate SHA in the repository and provision records.
-- Require the cleanup receipt to identify the qualified workspace and report `ABSENT`.
+- Preflight the candidate workflow, protected qualification readiness, conditional runner readiness, and existing candidate evidence before dispatching new work.
+- Dispatch independent default-suite and unconditional explicit-only work concurrently. Dispatch a conditional hardware lane only after its authoritative runner inventory confirms that it is online; otherwise record its required itemized exception without queueing it.
+- If protected qualification readiness is disabled, continue the ordinary default suite and unconditional explicit-only work while recording the missing qualification as a required itemized exception. Do not serialize unrelated evidence behind that blocker.
+- Derive the denominator and dispatch selectors from the candidate workflow. Do not copy them into a second release test list.
+- When the protected qualification readiness variable is `true`, run `nemoclaw-maintainer-e2e` in full mode if no applicable full-mode run exists for the candidate SHA.
+- For full-mode exact Brev evidence, require one workflow run for the candidate SHA that includes the default-enabled suite and a successful `Exact staging Brev Launchable` job.
+- For that evidence, require the trusted dispatch receipt to bind the run and attempt to empty selectors and `include_staging_brev_launchable=true`.
+- Require its qualification receipt to identify the candidate SHA in the repository and provision records.
+- Require its cleanup receipt to identify the qualified workspace and report `ABSENT`.
 - Every E2E test execution declared by the workflow must have at least one completed, successful execution for the candidate SHA. This includes tests that require explicit selection and every expanded matrix execution.
 - Treat each expanded matrix execution as a separate ledger entry. Use its matrix `id`, or all distinguishing matrix dimensions when no single ID exists, in the test identifier so results for distinct expansions are never collapsed under the parent job.
 - Green evidence may accumulate across multiple workflow runs, selective runs, reruns, and attempts. A later failure does not erase an earlier successful execution for the same test and SHA.
@@ -64,7 +68,7 @@ Before asking for the release confirmation phrase, build and show an evidence le
 - Each test without a successful execution requires its own itemized maintainer exception. Record the test identifier, relevant run links or available evidence, the current result or failure summary, and the rationale.
 - Missing or invalid exact Brev Launchable qualification requires a separate itemized maintainer exception. Record the run and job URLs, the current result or missing receipt, and the rationale.
 
-Each test and the exact Brev Launchable qualification must have successful evidence or its own itemized maintainer exception before release confirmation. If the candidate SHA changes, discard the ledger and its exceptions, including qualification evidence. Regenerate the release plan and repeat the review for the new SHA. No release-note-only delta exception is currently defined.
+Each test and the exact Brev Launchable qualification must have successful evidence or its own itemized maintainer exception before release confirmation. Immediately before confirmation, compare `origin/main` with the planned SHA. If the candidate SHA changes, discard the ledger and its exceptions, including qualification evidence. Regenerate the release plan and repeat the review for the new SHA. This does not freeze `main` or prevent merges. No release-note-only delta exception is currently defined.
 
 ## Carry Forward
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -344,6 +344,50 @@ jobs:
             fi
           fi
 
+      - name: Record trusted E2E dispatch receipt
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          ALLOW_JETSON_RUNNER_QUEUE: ${{ inputs.allow_jetson_runner_queue && 'true' || 'false' }}
+          CANDIDATE_SHA: ${{ inputs.checkout_sha || github.sha }}
+          DISPATCH_JOBS: ${{ inputs.jobs }}
+          DISPATCH_RECEIPT_DIR: ${{ runner.temp }}/nemoclaw-e2e-dispatch
+          DISPATCH_TARGETS: ${{ inputs.targets }}
+          EVENT_NAME: ${{ github.event_name }}
+          INCLUDE_STAGING_BREV_LAUNCHABLE: ${{ inputs.include_staging_brev_launchable && 'true' || 'false' }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          install -d -m 0700 "$DISPATCH_RECEIPT_DIR"
+          jq -n \
+            --arg candidateSha "$CANDIDATE_SHA" \
+            --arg eventName "$EVENT_NAME" \
+            --arg jobs "$DISPATCH_JOBS" \
+            --arg targets "$DISPATCH_TARGETS" \
+            --arg workflowRunId "$RUN_ID" \
+            --argjson allowJetsonRunnerQueue "$ALLOW_JETSON_RUNNER_QUEUE" \
+            --argjson includeStagingBrevLaunchable "$INCLUDE_STAGING_BREV_LAUNCHABLE" \
+            --argjson workflowRunAttempt "$RUN_ATTEMPT" \
+            '{
+              kind: "nemoclaw-e2e-dispatch-v1",
+              candidateSha: $candidateSha,
+              eventName: $eventName,
+              workflowRunId: $workflowRunId,
+              workflowRunAttempt: $workflowRunAttempt,
+              jobs: $jobs,
+              targets: $targets,
+              allowJetsonRunnerQueue: $allowJetsonRunnerQueue,
+              includeStagingBrevLaunchable: $includeStagingBrevLaunchable,
+              defaultSuiteSelected: ($jobs == "" and $targets == "")
+            }' >"$DISPATCH_RECEIPT_DIR/dispatch.json"
+
+      - name: Upload trusted E2E dispatch receipt
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@7768e15eb90d3ee2d33432f481dfe8747e4f6d57
+        with:
+          name: e2e-dispatch-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/nemoclaw-e2e-dispatch/dispatch.json
+
   retired-selector-compatibility:
     needs: generate-matrix
     if: ${{ inputs.checkout_sha != '' && (contains(format(',{0},', inputs.jobs), ',docs-validation,') || contains(format(',{0},', inputs.jobs), ',gateway-drift-preflight,') || contains(format(',{0},', inputs.jobs), ',gateway-health-honest,') || contains(format(',{0},', inputs.jobs), ',onboard-negative-paths,') || contains(format(',{0},', inputs.jobs), ',openshell-version-pin,') || contains(format(',{0},', inputs.jobs), ',ubuntu-repo-cli-smoke,')) }}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test-conditionals:scan": "tsx scripts/find-test-conditionals.mts",
     "bump:version": "tsx scripts/bump-version.mts",
     "release:plan": "tsx scripts/release-plan.mts",
+    "release:e2e-evidence": "node --experimental-strip-types --no-warnings .agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts",
     "release:cut": "bash scripts/release-cut-tag.sh",
     "release:wait-latest": "bash scripts/release-wait-latest.sh",
     "release:notes-data": "tsx scripts/release-notes-data.mts",

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { validateE2eWorkflow } from "../tools/e2e/workflow-boundary.mts";
 import { readYaml, type WorkflowJob } from "./helpers/e2e-workflow-contract";
 
 type E2eWorkflow = {
@@ -29,6 +30,21 @@ describe("release gate workflow resource contracts", () => {
     expect(checkout?.with?.ref).toBe("${{ inputs.checkout_sha || github.sha }}");
     expect(tuiJob.env?.NEMOCLAW_TUI_EXPECTED_CHECKOUT_SHA).toBe(
       "${{ inputs.checkout_sha || github.sha }}",
+    );
+  });
+  it("rejects trusted dispatch receipt contract drift", () => {
+    const workflow = structuredClone(e2eWorkflow);
+    const steps = workflow.jobs["generate-matrix"].steps!;
+    const receipt = steps.find((step) => step.name === "Record trusted E2E dispatch receipt")!;
+    const upload = steps.find((step) => step.name === "Upload trusted E2E dispatch receipt")!;
+    delete receipt.env!.DISPATCH_JOBS;
+    upload.with!.name = "mutable-dispatch-receipt";
+
+    expect(validateE2eWorkflow(workflow as unknown as Record<string, unknown>)).toEqual(
+      expect.arrayContaining([
+        "trusted E2E dispatch receipt must bind only the candidate, run, attempt, and dispatch inputs",
+        "generate-matrix upload-e2e-artifacts must preserve its explicit name/path contract",
+      ]),
     );
   });
 });

--- a/test/maintainer-skills-policy.test.ts
+++ b/test/maintainer-skills-policy.test.ts
@@ -151,11 +151,17 @@ describe("maintainer skills follow canonical workflow policy", () => {
     );
     expect(policy).toContain("Do not serialize unrelated evidence behind that blocker");
     expect(policy).toContain("discard the ledger and its exceptions");
+    expect(policy).toContain("actual selector inputs");
+    expect(release).toContain('"dispatchJson"');
     expect(release).toContain("the number of tests with green evidence");
     expect(release).toContain("successful run or job URL and attempt");
     expect(release).toContain("npm run release:e2e-evidence");
     expect(release).toContain("Do not wait for either run to finish before dispatching the other");
     expect(release).toContain("filter=all");
+    expect(release).toContain("actions/runs/$RUN_ID/artifacts");
+    expect(release).toContain("sort_by(.created_at)");
+    expect(release).not.toContain("RECEIPT_ATTEMPT");
+    expect(release).toContain("rerun preflight and every required default");
     expect(release).toContain("Immediately before asking, refresh `origin/main` once");
     const evidenceSummary = release.indexOf("Before showing the confirmation prompt");
     const confirmationPrompt = release.indexOf(

--- a/test/maintainer-skills-policy.test.ts
+++ b/test/maintainer-skills-policy.test.ts
@@ -145,9 +145,18 @@ describe("maintainer skills follow canonical workflow policy", () => {
     );
     expect(policy).toContain("itemized maintainer exception");
     expect(policy).toContain("If the candidate SHA changes");
+    expect(policy).toContain("This does not freeze `main` or prevent merges");
+    expect(policy).toContain(
+      "Dispatch independent default-suite and unconditional explicit-only work concurrently",
+    );
+    expect(policy).toContain("Do not serialize unrelated evidence behind that blocker");
     expect(policy).toContain("discard the ledger and its exceptions");
     expect(release).toContain("the number of tests with green evidence");
     expect(release).toContain("successful run or job URL and attempt");
+    expect(release).toContain("npm run release:e2e-evidence");
+    expect(release).toContain("Do not wait for either run to finish before dispatching the other");
+    expect(release).toContain("filter=all");
+    expect(release).toContain("Immediately before asking, refresh `origin/main` once");
     const evidenceSummary = release.indexOf("Before showing the confirmation prompt");
     const confirmationPrompt = release.indexOf(
       "Ask the maintainer to paste this phrase",
@@ -161,7 +170,7 @@ describe("maintainer skills follow canonical workflow policy", () => {
     expect(evening).toContain("Missing or invalid qualification requires a separate");
     expect(evening).toContain("Tag the confirmed release commit with `vX.Y.Z`");
     expect(evening).not.toContain("tag `main`");
-    expect(dailyFlow).toContain("freeze the candidate SHA and review every E2E test");
+    expect(dailyFlow).toContain("capture the candidate SHA and review every E2E test");
     expect(priorities).toContain("Record the release SHA and required E2E evidence");
   });
 
@@ -178,6 +187,10 @@ describe("maintainer skills follow canonical workflow policy", () => {
     expect(e2e).toContain("cleanup.json");
     expect(e2e).toContain("dispatch.json");
     expect(e2e).toContain("If the release candidate SHA changes");
+    expect(e2e).toContain("### Release Coverage Dispatch Group");
+    expect(e2e).toContain("parallelExplicit.jobs");
+    expect(e2e).toContain("do not serialize independent runs");
+    expect(e2e).toContain("jobs?filter=all&per_page=100");
     expect(release).toContain("load `nemoclaw-maintainer-e2e` and dispatch full mode");
     expect(release).toContain("Treat a skipped job as missing evidence");
     expect(release).toContain("include_staging_brev_launchable=true");
@@ -186,13 +199,19 @@ describe("maintainer skills follow canonical workflow policy", () => {
     expect(release).toContain(
       "a separate itemized maintainer exception for missing or invalid exact Brev Launchable qualification",
     );
+    expect(release).toContain("when accepted full-mode exact Brev evidence exists");
     expect(release.indexOf("load `nemoclaw-maintainer-e2e` and dispatch full mode")).toBeLessThan(
       release.indexOf("Ask the maintainer to paste this phrase"),
     );
     expect(evening).toContain("load `nemoclaw-maintainer-e2e`");
-    expect(evening).toContain("Run full mode");
+    expect(evening).toContain(
+      "When the protected qualification readiness variable is `true`, run full mode",
+    );
+    expect(evening).toContain(
+      "When readiness is disabled, run the ordinary default and unconditional explicit-only groups",
+    );
     expect(policy).toContain(
-      "Require one workflow run for the candidate SHA that includes the default-enabled suite",
+      "For full-mode exact Brev evidence, require one workflow run for the candidate SHA",
     );
     expect(policy).toContain("successful `Exact staging Brev Launchable` job");
     expect(policy).toContain("cleanup receipt");

--- a/test/maintainer-skills-policy.test.ts
+++ b/test/maintainer-skills-policy.test.ts
@@ -191,6 +191,8 @@ describe("maintainer skills follow canonical workflow policy", () => {
     expect(e2e).toContain("parallelExplicit.jobs");
     expect(e2e).toContain("do not serialize independent runs");
     expect(e2e).toContain("jobs?filter=all&per_page=100");
+    expect(e2e).toContain("Reuse `run-$RUN_ID.json` and `jobs-$RUN_ID.json`");
+    expect(release).toContain("reuse `run-$RUN_ID.json` and `jobs-$RUN_ID.json`");
     expect(release).toContain("load `nemoclaw-maintainer-e2e` and dispatch full mode");
     expect(release).toContain("Treat a skipped job as missing evidence");
     expect(release).toContain("include_staging_brev_launchable=true");
@@ -213,6 +215,7 @@ describe("maintainer skills follow canonical workflow policy", () => {
     expect(policy).toContain(
       "For full-mode exact Brev evidence, require one workflow run for the candidate SHA",
     );
+    expect(policy).toContain("if no applicable exact Brev Launchable evidence exists");
     expect(policy).toContain("successful `Exact staging Brev Launchable` job");
     expect(policy).toContain("cleanup receipt");
     expect(policy).toContain("trusted dispatch receipt");

--- a/test/release-e2e-evidence.test.ts
+++ b/test/release-e2e-evidence.test.ts
@@ -46,8 +46,21 @@ function runEvidence(
   const executions = plan.executions.filter(
     (execution) => execution.group === group && (options.only?.(execution) ?? true),
   );
+  const selectors = group === "default" ? [] : selectedJobs(plan, group);
   return {
-    defaultSuiteSelected: group === "default",
+    dispatch: {
+      allowJetsonRunnerQueue: group === "conditional",
+      candidateSha,
+      defaultSuiteSelected: group === "default",
+      eventName: "workflow_dispatch",
+      includeStagingBrevLaunchable:
+        group === "default" && plan.dispatches.defaultSuite.includeStagingBrevLaunchable,
+      jobs: selectors.join(","),
+      kind: "nemoclaw-e2e-dispatch-v1",
+      targets: "",
+      workflowRunAttempt: attempt,
+      workflowRunId: String(attempt),
+    },
     jobs: {
       jobs: executions.map((execution, index) => ({
         conclusion: options.conclusion?.(execution) ?? "success",
@@ -58,10 +71,14 @@ function runEvidence(
       })),
     },
     run: {
+      event: "workflow_dispatch",
+      head_branch: "main",
+      id: attempt,
+      path: ".github/workflows/e2e.yaml",
+      run_attempt: attempt,
       head_sha: options.sha ?? candidateSha,
       html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${attempt}`,
     },
-    selectedJobs: group === "default" ? [] : selectedJobs(plan, group),
   };
 }
 
@@ -75,7 +92,9 @@ describe("release E2E evidence", () => {
       mode: "ordinary",
       targets: "",
     });
-    expect(new Set(plan.dispatches.parallelExplicit.jobs.split(","))).toEqual(
+    const parallelExplicitJobs = plan.dispatches.parallelExplicit.jobs.split(",");
+    expect(parallelExplicitJobs).toHaveLength(4);
+    expect(new Set(parallelExplicitJobs)).toEqual(
       new Set([
         "openshell-gateway-auth-contract",
         "mcp-bridge-dev",
@@ -198,11 +217,23 @@ describe("release E2E evidence", () => {
     );
   });
 
+  it("rejects a selective dispatch receipt that claims default-suite coverage", () => {
+    const plan = preflight();
+    const selective = runEvidence(plan, "default");
+    const dispatch = selective.dispatch as Record<string, unknown>;
+    dispatch.jobs = "snapshot-commands";
+    dispatch.defaultSuiteSelected = true;
+
+    expect(() => buildReleaseE2eLedger(plan, [selective])).toThrow(
+      "runs[0].dispatch.defaultSuiteSelected must equal false",
+    );
+  });
+
   it("rejects evidence from another candidate SHA", () => {
     const plan = preflight();
 
     expect(() =>
       buildReleaseE2eLedger(plan, [runEvidence(plan, "default", { sha: "b".repeat(40) })]),
-    ).toThrow("does not match the candidate SHA");
+    ).toThrow("runs[0].run.head_sha must equal");
   });
 });

--- a/test/release-e2e-evidence.test.ts
+++ b/test/release-e2e-evidence.test.ts
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReleaseE2eLedger,
+  buildReleaseE2ePreflight,
+  type ReleaseE2eExecution,
+  type ReleaseE2ePreflight,
+  type ReleaseE2eRunEvidence,
+} from "../.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts";
+
+const candidateSha = "a".repeat(40);
+
+function preflight(input: { brevReady?: boolean; jetsonRunnerOnline?: "true" | "unknown" } = {}) {
+  return buildReleaseE2ePreflight({
+    brevReady: input.brevReady ?? true,
+    candidateSha,
+    jetsonRunnerOnline: input.jetsonRunnerOnline ?? "true",
+  });
+}
+
+function selectedJobs(plan: ReleaseE2ePreflight, group: ReleaseE2eExecution["group"]): string[] {
+  return [
+    ...new Set(
+      plan.executions
+        .filter((execution) => execution.group === group)
+        .map((execution) => execution.jobId),
+    ),
+  ];
+}
+
+function runEvidence(
+  plan: ReleaseE2ePreflight,
+  group: ReleaseE2eExecution["group"],
+  options: {
+    attempt?: number;
+    conclusion?: (execution: ReleaseE2eExecution) => string;
+    only?: (execution: ReleaseE2eExecution) => boolean;
+    sha?: string;
+    status?: (execution: ReleaseE2eExecution) => string;
+  } = {},
+): ReleaseE2eRunEvidence {
+  const attempt = options.attempt ?? 1;
+  const executions = plan.executions.filter(
+    (execution) => execution.group === group && (options.only?.(execution) ?? true),
+  );
+  return {
+    defaultSuiteSelected: group === "default",
+    jobs: {
+      jobs: executions.map((execution, index) => ({
+        conclusion: options.conclusion?.(execution) ?? "success",
+        html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${attempt}/job/${index + 1}`,
+        name: execution.expectedName,
+        run_attempt: attempt,
+        status: options.status?.(execution) ?? "completed",
+      })),
+    },
+    run: {
+      head_sha: options.sha ?? candidateSha,
+      html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${attempt}`,
+    },
+    selectedJobs: group === "default" ? [] : selectedJobs(plan, group),
+  };
+}
+
+describe("release E2E evidence", () => {
+  it("derives concurrent, conditional, and qualification work from the workflow", () => {
+    const plan = preflight({ brevReady: false, jetsonRunnerOnline: "unknown" });
+
+    expect(plan.dispatches.defaultSuite).toEqual({
+      includeStagingBrevLaunchable: false,
+      jobs: "",
+      mode: "ordinary",
+      targets: "",
+    });
+    expect(plan.dispatches.parallelExplicit.jobs.split(",")).toEqual([
+      "openshell-gateway-auth-contract",
+      "mcp-bridge-dev",
+      "hermes-gpu-startup",
+      "sandbox-rlimits-connect",
+    ]);
+    expect(plan.dispatches.conditional).toEqual([
+      expect.objectContaining({ allowJetsonRunnerQueue: false, jobs: "jetson-nvmap-gpu" }),
+    ]);
+    expect(plan.qualificationJobId).toBe("staging-brev-launchable");
+    expect(plan.exceptionsRequired).toEqual(["staging-brev-launchable", "jetson-nvmap-gpu"]);
+  });
+
+  it("keeps every static and dynamic matrix row as a distinct execution", () => {
+    const plan = preflight();
+    const ids = plan.executions.map((execution) => execution.id);
+
+    expect(ids.filter((id) => id.startsWith("mcp-bridge-dev["))).toHaveLength(3);
+    expect(ids.filter((id) => id.startsWith("hermes-gpu-startup["))).toHaveLength(3);
+    expect(ids.filter((id) => id.startsWith("openshell-gateway-upgrade["))).toHaveLength(5);
+    expect(ids).toContain("live[id=ubuntu-repo-cloud-openclaw]");
+    expect(ids).toContain("shared-e2e[id=vllm-docker-storage]");
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("accumulates successful evidence across parallel runs and attempts", () => {
+    const plan = preflight();
+    const firstDefaultRun = runEvidence(plan, "default");
+    const laterFailure = runEvidence(plan, "default", {
+      attempt: 2,
+      conclusion: () => "failure",
+      only: (execution) => execution.id === "snapshot-commands",
+    });
+    const ledger = buildReleaseE2eLedger(plan, [
+      firstDefaultRun,
+      runEvidence(plan, "parallel-explicit"),
+      runEvidence(plan, "conditional"),
+      laterFailure,
+    ]);
+
+    expect(ledger.greenCount).toBe(ledger.requiredCount);
+    expect(ledger.missingCount).toBe(0);
+    expect(ledger.entries.find((entry) => entry.id === "snapshot-commands")).toMatchObject({
+      attempts: [
+        { attempt: 2, conclusion: "failure" },
+        { attempt: 1, conclusion: "success" },
+      ],
+      greenEvidence: { attempt: 1 },
+      status: "green",
+    });
+  });
+
+  it("reports a failed matrix row without collapsing its successful siblings", () => {
+    const plan = preflight();
+    const failedId = 'hermes-gpu-startup[scenario="fallback"]';
+    const ledger = buildReleaseE2eLedger(plan, [
+      runEvidence(plan, "default"),
+      runEvidence(plan, "parallel-explicit", {
+        conclusion: (execution) => (execution.id === failedId ? "failure" : "success"),
+      }),
+      runEvidence(plan, "conditional"),
+    ]);
+
+    expect(ledger.missingCount).toBe(1);
+    expect(ledger.entries.find((entry) => entry.id === failedId)).toMatchObject({
+      status: "missing",
+      attempts: [{ conclusion: "failure" }],
+    });
+    expect(
+      ledger.entries.find(
+        (entry) => entry.id === 'hermes-gpu-startup[scenario="compatibility-only"]',
+      ),
+    ).toMatchObject({ status: "green" });
+  });
+
+  it("does not count an in-progress execution as green", () => {
+    const plan = preflight();
+    const pendingId = "snapshot-commands";
+    const ledger = buildReleaseE2eLedger(plan, [
+      runEvidence(plan, "default", {
+        status: (execution) => (execution.id === pendingId ? "in_progress" : "completed"),
+      }),
+      runEvidence(plan, "parallel-explicit"),
+      runEvidence(plan, "conditional"),
+    ]);
+
+    expect(ledger.missingCount).toBe(1);
+    expect(ledger.entries.find((entry) => entry.id === pendingId)).toMatchObject({
+      attempts: [{ conclusion: "success", status: "in_progress" }],
+      status: "missing",
+    });
+  });
+
+  it("rejects evidence from another candidate SHA", () => {
+    const plan = preflight();
+
+    expect(() =>
+      buildReleaseE2eLedger(plan, [runEvidence(plan, "default", { sha: "b".repeat(40) })]),
+    ).toThrow("does not match the candidate SHA");
+  });
+});

--- a/test/release-e2e-evidence.test.ts
+++ b/test/release-e2e-evidence.test.ts
@@ -75,12 +75,14 @@ describe("release E2E evidence", () => {
       mode: "ordinary",
       targets: "",
     });
-    expect(plan.dispatches.parallelExplicit.jobs.split(",")).toEqual([
-      "openshell-gateway-auth-contract",
-      "mcp-bridge-dev",
-      "hermes-gpu-startup",
-      "sandbox-rlimits-connect",
-    ]);
+    expect(new Set(plan.dispatches.parallelExplicit.jobs.split(","))).toEqual(
+      new Set([
+        "openshell-gateway-auth-contract",
+        "mcp-bridge-dev",
+        "hermes-gpu-startup",
+        "sandbox-rlimits-connect",
+      ]),
+    );
     expect(plan.dispatches.conditional).toEqual([
       expect.objectContaining({ allowJetsonRunnerQueue: false, jobs: "jetson-nvmap-gpu" }),
     ]);
@@ -166,6 +168,34 @@ describe("release E2E evidence", () => {
       attempts: [{ conclusion: "success", status: "in_progress" }],
       status: "missing",
     });
+  });
+
+  it("does not treat a skipped execution as successful evidence", () => {
+    const plan = preflight();
+    const skippedId = "snapshot-commands";
+    const ledger = buildReleaseE2eLedger(plan, [
+      runEvidence(plan, "default", {
+        conclusion: (execution) => (execution.id === skippedId ? "skipped" : "success"),
+      }),
+      runEvidence(plan, "parallel-explicit"),
+      runEvidence(plan, "conditional"),
+    ]);
+
+    expect(ledger.entries.find((entry) => entry.id === skippedId)).toMatchObject({
+      attempts: [{ conclusion: "skipped", status: "completed" }],
+      status: "missing",
+    });
+  });
+
+  it("rejects malformed job evidence", () => {
+    const plan = preflight();
+    const malformed = runEvidence(plan, "default");
+    const jobs = malformed.jobs as { jobs: Array<Record<string, unknown>> };
+    delete jobs.jobs[0]!.name;
+
+    expect(() => buildReleaseE2eLedger(plan, [malformed])).toThrow(
+      "runs[0].job.name must be a non-empty string",
+    );
   });
 
   it("rejects evidence from another candidate SHA", () => {

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -68,6 +68,13 @@ type ExplicitUploadContract = {
 
 const EXPLICIT_UPLOAD_CONTRACTS = new Map<string, ExplicitUploadContract>([
   [
+    "generate-matrix",
+    {
+      name: "e2e-dispatch-${{ github.run_id }}-${{ github.run_attempt }}",
+      path: "${{ runner.temp }}/nemoclaw-e2e-dispatch/dispatch.json",
+    },
+  ],
+  [
     "retired-selector-compatibility",
     {
       name: "e2e-retired-selector-compatibility",
@@ -227,6 +234,7 @@ const EXPLICIT_UPLOAD_CONTRACTS = new Map<string, ExplicitUploadContract>([
 ]);
 
 const EXPLICIT_CALLER_CONDITIONS = new Map<string, string>([
+  ["generate-matrix", "${{ github.event_name == 'workflow_dispatch' }}"],
   ["staging-brev-launchable", "${{ always() && steps.workspace.outputs.work_dir != '' }}"],
   ["mcp-bridge", MCP_SCANNED_UPLOAD_CONDITION],
   ["mcp-bridge-dev", MCP_SCANNED_UPLOAD_CONDITION],
@@ -353,6 +361,7 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
         const env = record(job.env);
         return (
           jobName === "staging-brev-launchable" ||
+          jobName === "generate-matrix" ||
           jobName === "live" ||
           jobName === RETIRED_SELECTOR_COMPATIBILITY_JOB ||
           env.E2E_JOB === "1" ||

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -4343,6 +4343,49 @@ function validateRetiredSelectorCompatibilityJob(errors: string[], jobs: Workflo
   }
 }
 
+function validateTrustedE2eDispatchReceipt(
+  errors: string[],
+  generateSteps: readonly WorkflowStep[],
+): void {
+  const dispatchReceipt = requireStep(errors, generateSteps, "Record trusted E2E dispatch receipt");
+  if (dispatchReceipt?.if !== "${{ github.event_name == 'workflow_dispatch' }}") {
+    errors.push("trusted E2E dispatch receipt must run for workflow dispatches only");
+  }
+  const dispatchReceiptEnv = asRecord(dispatchReceipt?.env);
+  const expectedDispatchReceiptEnv = {
+    ALLOW_JETSON_RUNNER_QUEUE: "${{ inputs.allow_jetson_runner_queue && 'true' || 'false' }}",
+    CANDIDATE_SHA: "${{ inputs.checkout_sha || github.sha }}",
+    DISPATCH_JOBS: "${{ inputs.jobs }}",
+    DISPATCH_RECEIPT_DIR: "${{ runner.temp }}/nemoclaw-e2e-dispatch",
+    DISPATCH_TARGETS: "${{ inputs.targets }}",
+    EVENT_NAME: "${{ github.event_name }}",
+    INCLUDE_STAGING_BREV_LAUNCHABLE:
+      "${{ inputs.include_staging_brev_launchable && 'true' || 'false' }}",
+    RUN_ATTEMPT: "${{ github.run_attempt }}",
+    RUN_ID: "${{ github.run_id }}",
+  };
+  if (!isDeepStrictEqual(dispatchReceiptEnv, expectedDispatchReceiptEnv)) {
+    errors.push(
+      "trusted E2E dispatch receipt must bind only the candidate, run, attempt, and dispatch inputs",
+    );
+  }
+  for (const fragment of [
+    'kind: "nemoclaw-e2e-dispatch-v1"',
+    "candidateSha: $candidateSha",
+    "eventName: $eventName",
+    "workflowRunId: $workflowRunId",
+    "workflowRunAttempt: $workflowRunAttempt",
+    "jobs: $jobs",
+    "targets: $targets",
+    "allowJetsonRunnerQueue: $allowJetsonRunnerQueue",
+    "includeStagingBrevLaunchable: $includeStagingBrevLaunchable",
+    'defaultSuiteSelected: ($jobs == "" and $targets == "")',
+    '>"$DISPATCH_RECEIPT_DIR/dispatch.json"',
+  ]) {
+    requireRunContains(errors, dispatchReceipt, fragment);
+  }
+}
+
 export function validateE2eWorkflow(workflowValue: unknown): string[] {
   const workflow = asRecord(workflowValue);
   const errors: string[] = [];
@@ -4514,6 +4557,7 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
     generate,
     "E2E planner matrix does not match controller-selected targets",
   );
+  validateTrustedE2eDispatchReceipt(errors, generateSteps);
 
   const liveTargets = asRecord(jobs["live"]);
   if (Object.keys(liveTargets).length === 0) errors.push("workflow missing live job");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Release preparation now derives the candidate E2E denominator before dispatch and runs independent default and explicit-only coverage concurrently. It preserves each matrix execution across runs and attempts, gates conditional hardware dispatch on authoritative availability, and keeps the final release decision bound to the latest `origin/main` candidate.

## Changes

- Add a read-only release evidence helper that derives required executions from the candidate workflow and builds a SHA-bound, attempt-aware ledger from workflow-produced dispatch receipts. The cut-release skill is the current consumer; a copied test table is insufficient because workflow matrices and run attempts change, and `test/release-e2e-evidence.test.ts` protects the contract.
- Dispatch the ordinary default suite and unconditional explicit-only jobs concurrently, while treating Jetson as conditional on runner inventory and Brev qualification readiness as an independent exception path.
- Update the cut-release, evening, E2E, and release-policy guidance so late merges trigger one final candidate refresh instead of freezing `main` during preflight work.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: No user-facing `docs/` source changes; the canonical internal maintainer skills and release policy are updated in this PR.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The helper is read-only and derives coverage only from a workflow-produced receipt bound to the candidate, run, attempt, and selector inputs. Workflow and artifact boundary validators pin the receipt producer and upload contract; focused tests cover candidate binding, matrix identity, terminal state, attempts, skipped and malformed evidence, partial reruns, and conditional dispatch.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Internal release-maintainer tooling, skills, and policy guidance are the correct documentation surface; no user-facing `docs/` source requires an update. The reviewer verified latest-existing receipt discovery for partial reruns, manifest path consistency, exact-Brev validation ownership, SHA-drift reruns, and writing and policy consistency.
- Agent: Codex Desktop documentation writer subagent
<!-- docs-review-head-sha: 0173d70cb -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:changed` — 30 files and 299 tests passed; focused release and policy integration — 3 files and 27 tests passed; workflow and artifact contracts — 2 files and 57 tests passed; source-shape and test-size budgets passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release E2E evidence preflight + ledger generation via `npm run release:e2e-evidence`.
  * Introduced coordinated “coverage” dispatch groups with correlation tracking and concurrent execution.
  * Added readiness-aware protected-qualification behavior and improved evidence/receipt collection for validation.
* **Documentation**
  * Updated release procedures for readiness gating, itemized exceptions when protected readiness is disabled, and immediate SHA-drift handling.
* **Tests**
  * Expanded ledger/evidence validation (green vs missing, aggregation, and rejection of in-progress/skipped or wrong-candidate evidence).
  * Added E2E release-gate contract validation for trusted dispatch receipt drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
