### PR TITLE
feat(readiness): project host observations

### DIFF
--- a/src/lib/readiness/host.test.ts
+++ b/src/lib/readiness/host.test.ts
@@ -130,6 +130,20 @@ describe("host system readiness projection", () => {
     expect(getSystemReadinessReferenceErrors(report)).toEqual([]);
   });
 
+  it("fails closed when a required capability is absent without an advisory", () => {
+    const report = projectHostAssessmentToSystemReadiness(
+      host({ nodeInstalled: false }),
+      [],
+      projectionOptions,
+    );
+
+    expect(report).toMatchObject({ status: "incompatible", exitCode: 2 });
+    expect(report.capabilities).toContainEqual({
+      id: "host.node",
+      state: "absent",
+    });
+  });
+
   it.each([
     {
       label: "unreachable daemon",

--- a/src/lib/readiness/host.test.ts
+++ b/src/lib/readiness/host.test.ts
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import Ajv2020, { type AnySchema } from "ajv/dist/2020.js";
+import { describe, expect, it, vi } from "vitest";
+import systemReadinessSchema from "../../../schemas/system-readiness.schema.json" with {
+  type: "json",
+};
+import type { Advisory } from "../advisories/types.js";
+import type { HostAssessment } from "../onboard/preflight.js";
+import { collectHostSystemReadiness, projectHostAssessmentToSystemReadiness } from "./host.js";
+import { getSystemReadinessReferenceErrors } from "./references.js";
+
+const projectionOptions = {
+  nemoclawVersion: "0.0.97",
+  sourceRevision: "962b2834a0000000000000000000000000000000",
+  observedAt: "2026-07-27T20:00:00.000Z",
+};
+
+function host(overrides: Partial<HostAssessment> = {}): HostAssessment {
+  return {
+    platform: "linux",
+    isWsl: false,
+    runtime: "docker",
+    packageManager: "apt",
+    systemctlAvailable: true,
+    dockerServiceActive: true,
+    dockerServiceEnabled: true,
+    dockerInstalled: true,
+    dockerRunning: true,
+    dockerReachable: true,
+    nodeInstalled: true,
+    openshellInstalled: true,
+    dockerCgroupVersion: "v2",
+    dockerDefaultCgroupnsMode: "private",
+    dockerStorageDriver: "overlay2",
+    dockerUsesContainerdSnapshotter: false,
+    dockerCpus: 8,
+    dockerMemTotalBytes: 32 * 1024 ** 3,
+    isContainerRuntimeUnderProvisioned: false,
+    hasNestedOverlayConflict: false,
+    requiresHostCgroupnsFix: false,
+    isUnsupportedRuntime: false,
+    isHeadlessLikely: true,
+    hasNvidiaGpu: false,
+    dockerCdiSpecDirs: [],
+    cdiNvidiaGpuSpecMissing: false,
+    cdiNvidiaGpuSpecNeedsRepair: false,
+    cdiNvidiaGpuRefreshUnhealthy: false,
+    nvidiaContainerToolkitInstalled: false,
+    notes: [],
+    ...overrides,
+  };
+}
+
+function advisory(overrides: Partial<Advisory> = {}): Advisory {
+  return {
+    id: "install_docker",
+    severity: "blocking",
+    phase: "preflight.host",
+    title: "Install Docker",
+    reason: "Docker is required before onboarding.",
+    resumeSafe: false,
+    ...overrides,
+  };
+}
+
+function createValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addFormat("date-time", { type: "string", validate: () => true });
+  return ajv.compile(systemReadinessSchema as AnySchema);
+}
+
+describe("host system readiness projection", () => {
+  it("projects supported host observations without exposing HostAssessment", () => {
+    const report = projectHostAssessmentToSystemReadiness(host(), [], projectionOptions);
+
+    expect(report).toMatchObject({
+      status: "supported",
+      exitCode: 0,
+      mutated: false,
+      provenance: projectionOptions,
+      qualifications: [],
+      findings: [],
+      evidence: [],
+    });
+    expect(report.observations).toContainEqual({
+      id: "runtime.docker-daemon",
+      state: "present",
+      value: true,
+    });
+    expect(report.capabilities).toContainEqual({
+      id: "host.nvidia-cdi",
+      state: "unknown",
+    });
+    expect(getSystemReadinessReferenceErrors(report)).toEqual([]);
+
+    const validate = createValidator();
+    expect(validate(report), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it("projects current blocking advisories as incompatible stable findings", () => {
+    const report = projectHostAssessmentToSystemReadiness(
+      host({
+        runtime: "unknown",
+        dockerInstalled: false,
+        dockerRunning: false,
+        dockerReachable: false,
+        dockerCgroupVersion: "unknown",
+        dockerStorageDriver: undefined,
+        dockerCpus: undefined,
+        dockerMemTotalBytes: undefined,
+      }),
+      [advisory()],
+      projectionOptions,
+    );
+
+    expect(report).toMatchObject({ status: "incompatible", exitCode: 2 });
+    expect(report.findings).toContainEqual({
+      id: "advisory.install_docker",
+      severity: "blocking",
+      summary: "Install Docker",
+      capabilityIds: ["host.container-runtime"],
+      evidenceIds: ["advisory.install_docker.detail"],
+    });
+    expect(report.evidence).toContainEqual({
+      id: "advisory.install_docker.detail",
+      summary: "Docker is required before onboarding.",
+    });
+    expect(getSystemReadinessReferenceErrors(report)).toEqual([]);
+  });
+
+  it.each([
+    {
+      label: "unreachable daemon",
+      overrides: { dockerReachable: false, dockerRunning: false },
+      advisory: advisory({ id: "start_docker" }),
+      capability: "host.container-runtime",
+    },
+    {
+      label: "under-provisioned runtime",
+      overrides: { isContainerRuntimeUnderProvisioned: true },
+      advisory: advisory({
+        id: "container_runtime_under_provisioned",
+        severity: "warning",
+      }),
+      capability: "host.runtime-resources",
+    },
+    {
+      label: "unsupported runtime",
+      overrides: { runtime: "podman" as const, isUnsupportedRuntime: true },
+      advisory: advisory({ id: "unsupported_runtime_warning", severity: "warning" }),
+      capability: "host.container-runtime",
+    },
+    {
+      label: "missing NVIDIA toolkit",
+      overrides: {
+        hasNvidiaGpu: true,
+        cdiNvidiaGpuSpecMissing: true,
+        cdiNvidiaGpuSpecNeedsRepair: true,
+      },
+      advisory: advisory({ id: "install_nvidia_container_toolkit" }),
+      capability: "host.nvidia-cdi",
+    },
+    {
+      label: "missing NVIDIA CDI spec",
+      overrides: {
+        hasNvidiaGpu: true,
+        nvidiaContainerToolkitInstalled: true,
+        cdiNvidiaGpuSpecMissing: true,
+        cdiNvidiaGpuSpecNeedsRepair: true,
+      },
+      advisory: advisory({ id: "generate_nvidia_cdi_spec" }),
+      capability: "host.nvidia-cdi",
+    },
+    {
+      label: "stale NVIDIA CDI spec",
+      overrides: {
+        hasNvidiaGpu: true,
+        nvidiaContainerToolkitInstalled: true,
+        cdiNvidiaGpuSpecNeedsRepair: true,
+      },
+      advisory: advisory({ id: "refresh_nvidia_cdi_spec" }),
+      capability: "host.nvidia-cdi",
+    },
+  ])("projects a stable capability and finding for $label", ({
+    overrides,
+    advisory,
+    capability,
+  }) => {
+    const report = projectHostAssessmentToSystemReadiness(
+      host(overrides),
+      [advisory],
+      projectionOptions,
+    );
+
+    expect(report.capabilities).toContainEqual({ id: capability, state: "absent" });
+    expect(report.findings[0]).toMatchObject({
+      id: `advisory.${advisory.id}`,
+      capabilityIds: [capability],
+    });
+    expect(getSystemReadinessReferenceErrors(report)).toEqual([]);
+  });
+
+  it("keeps unknown observations distinct from confirmed absence", () => {
+    const report = projectHostAssessmentToSystemReadiness(
+      host({
+        runtime: "unknown",
+        dockerCpus: undefined,
+        dockerMemTotalBytes: undefined,
+      }),
+      [],
+      projectionOptions,
+    );
+
+    expect(report).toMatchObject({ status: "inconclusive", exitCode: 3 });
+    expect(report.observations).toContainEqual({
+      id: "runtime.kind",
+      state: "unknown",
+    });
+    expect(report.capabilities).toContainEqual({
+      id: "host.container-runtime",
+      state: "unknown",
+    });
+    expect(report.capabilities).toContainEqual({
+      id: "host.runtime-resources",
+      state: "unknown",
+    });
+  });
+
+  it("redacts and bounds advisory evidence", () => {
+    const secret = "nvapi-abcdefghijklmnopqrstuvwxyz123456789";
+    const report = projectHostAssessmentToSystemReadiness(
+      host(),
+      [
+        advisory({
+          severity: "warning",
+          reason: `probe returned ${secret}${"x".repeat(2_000)}`,
+        }),
+      ],
+      projectionOptions,
+    );
+    const summary = report.evidence[0]?.summary ?? "";
+
+    expect(summary).not.toContain(secret);
+    expect(summary.length).toBeLessThanOrEqual(1024);
+  });
+
+  it("fails closed as unknown when host observation throws", () => {
+    const secret = "nvapi-abcdefghijklmnopqrstuvwxyz123456789";
+    const report = collectHostSystemReadiness({
+      assessHostImpl: () => {
+        throw new Error(`probe failed with ${secret}`);
+      },
+      getNemoclawVersionImpl: () => "0.0.97",
+      nowImpl: () => new Date("2026-07-27T20:00:00Z"),
+    });
+
+    expect(report).toMatchObject({ status: "inconclusive", exitCode: 3 });
+    expect(report.observations).toEqual([
+      {
+        id: "host.observation",
+        state: "unknown",
+        evidenceIds: ["host.observation-failure"],
+      },
+    ]);
+    expect(report.evidence[0]?.summary).not.toContain(secret);
+    expect(getSystemReadinessReferenceErrors(report)).toEqual([]);
+
+    const validate = createValidator();
+    expect(validate(report), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it("fails closed when build provenance cannot be resolved", () => {
+    const report = collectHostSystemReadiness({
+      getNemoclawVersionImpl: () => {
+        throw new Error("version unavailable");
+      },
+      nowImpl: () => new Date("2026-07-27T20:00:00Z"),
+    });
+
+    expect(report).toMatchObject({
+      status: "inconclusive",
+      exitCode: 3,
+      provenance: {
+        nemoclawVersion: "unknown",
+        observedAt: "2026-07-27T20:00:00.000Z",
+      },
+    });
+  });
+
+  it("collects a fresh assessment for every report", () => {
+    const assessHostImpl = vi
+      .fn<() => HostAssessment>()
+      .mockReturnValueOnce(host({ isWsl: false }))
+      .mockReturnValueOnce(host({ isWsl: true }));
+    const options = {
+      assessHostImpl,
+      planHostAdvisoriesImpl: () => [],
+      getNemoclawVersionImpl: () => "0.0.97",
+      nowImpl: () => new Date("2026-07-27T20:00:00Z"),
+    };
+
+    const first = collectHostSystemReadiness(options);
+    const second = collectHostSystemReadiness(options);
+
+    expect(assessHostImpl).toHaveBeenCalledTimes(2);
+    expect(first.observations).toContainEqual({
+      id: "host.wsl",
+      state: "absent",
+      value: false,
+    });
+    expect(second.observations).toContainEqual({
+      id: "host.wsl",
+      state: "present",
+      value: true,
+    });
+  });
+});

--- a/src/lib/readiness/host.ts
+++ b/src/lib/readiness/host.ts
@@ -177,6 +177,11 @@ function projectOutcome(
     return { status: "incompatible", exitCode: 2 };
   }
   if (
+    capabilities.some((entry) => REQUIRED_CAPABILITY_IDS.has(entry.id) && entry.state === "absent")
+  ) {
+    return { status: "incompatible", exitCode: 2 };
+  }
+  if (
     capabilities.some((entry) => REQUIRED_CAPABILITY_IDS.has(entry.id) && entry.state === "unknown")
   ) {
     return { status: "inconclusive", exitCode: 3 };

--- a/src/lib/readiness/host.ts
+++ b/src/lib/readiness/host.ts
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Advisory, AdvisorySeverity } from "../advisories/types.js";
+import { getVersion } from "../core/version.js";
+import { assessHost, type HostAssessment, planHostAdvisories } from "../onboard/preflight.js";
+import { redactFull } from "../security/redact.js";
+import {
+  type FindingSeverity,
+  type ReadinessCapability,
+  type ReadinessEvidence,
+  type ReadinessObservation,
+  type ReadinessProvenance,
+  type ReadinessState,
+  SYSTEM_READINESS_SCHEMA_VERSION,
+  type SystemReadinessReport,
+} from "./types.js";
+
+const MAX_SUMMARY_LENGTH = 512;
+const MAX_EVIDENCE_LENGTH = 1024;
+
+const REQUIRED_CAPABILITY_IDS = new Set([
+  "host.container-runtime",
+  "host.runtime-resources",
+  "host.node",
+  "host.openshell",
+]);
+
+const ADVISORY_CAPABILITIES: Readonly<Record<string, readonly string[]>> = {
+  enable_docker_desktop_wsl_integration: ["host.container-runtime"],
+  install_docker: ["host.container-runtime"],
+  docker_group_permission: ["host.container-runtime"],
+  start_docker: ["host.container-runtime"],
+  container_runtime_under_provisioned: ["host.runtime-resources"],
+  unsupported_runtime_warning: ["host.container-runtime"],
+  install_nodejs: ["host.node"],
+  install_openshell: ["host.openshell"],
+  generate_nvidia_cdi_spec: ["host.nvidia-cdi"],
+  refresh_nvidia_cdi_spec: ["host.nvidia-cdi"],
+  install_nvidia_container_toolkit: ["host.nvidia-cdi"],
+  warn_nvidia_cdi_refresh_unhealthy: ["host.nvidia-cdi"],
+  wsl_docker_desktop_gpu_compatibility: ["host.nvidia-cdi"],
+};
+
+export interface HostReadinessProjectionOptions {
+  nemoclawVersion: string;
+  observedAt: string;
+  sourceRevision?: string;
+}
+
+export interface CollectHostReadinessOptions {
+  assessHostImpl?: () => HostAssessment;
+  planHostAdvisoriesImpl?: (assessment: HostAssessment) => readonly Advisory[];
+  getNemoclawVersionImpl?: () => string;
+  nowImpl?: () => Date;
+  sourceRevision?: string;
+}
+
+function booleanObservation(id: string, value: boolean): ReadinessObservation {
+  return {
+    id,
+    state: value ? "present" : "absent",
+    value,
+  };
+}
+
+function optionalObservation(
+  id: string,
+  value: string | number | boolean | null | undefined,
+): ReadinessObservation {
+  if (value === undefined || value === null || value === "unknown") {
+    return { id, state: "unknown" };
+  }
+  return { id, state: "present", value };
+}
+
+function capability(id: string, state: ReadinessState): ReadinessCapability {
+  return { id, state };
+}
+
+function mapSeverity(severity: AdvisorySeverity): FindingSeverity {
+  return severity === "hint" ? "info" : severity;
+}
+
+function advisoryEvidence(advisory: Advisory): ReadinessEvidence {
+  const summary = redactFull(advisory.reason).slice(0, MAX_EVIDENCE_LENGTH);
+  return {
+    id: `advisory.${advisory.id}.detail`,
+    summary: summary || "Advisory detail unavailable",
+  };
+}
+
+function hostObservations(host: HostAssessment): ReadinessObservation[] {
+  const cdiSpecState: ReadinessState = !host.hasNvidiaGpu
+    ? "unknown"
+    : host.cdiNvidiaGpuSpecMissing
+      ? "absent"
+      : "present";
+  const cdiHealthState: ReadinessState =
+    !host.hasNvidiaGpu || host.cdiNvidiaGpuSpecMissing
+      ? "unknown"
+      : host.cdiNvidiaGpuSpecNeedsRepair || host.cdiNvidiaGpuRefreshUnhealthy
+        ? "absent"
+        : "present";
+
+  return [
+    optionalObservation("host.platform", host.platform),
+    booleanObservation("host.wsl", host.isWsl),
+    booleanObservation("host.headless", host.isHeadlessLikely),
+    optionalObservation("runtime.kind", host.runtime),
+    booleanObservation("runtime.docker-cli", host.dockerInstalled),
+    booleanObservation("runtime.docker-daemon", host.dockerReachable),
+    optionalObservation("runtime.cgroup-version", host.dockerCgroupVersion),
+    optionalObservation("runtime.storage-driver", host.dockerStorageDriver),
+    optionalObservation("runtime.cpu-limit", host.dockerCpus),
+    optionalObservation("runtime.memory-limit-bytes", host.dockerMemTotalBytes),
+    booleanObservation("tool.node", host.nodeInstalled),
+    booleanObservation("tool.openshell", host.openshellInstalled),
+    booleanObservation("gpu.nvidia", host.hasNvidiaGpu),
+    booleanObservation("gpu.container-toolkit", host.nvidiaContainerToolkitInstalled),
+    { id: "gpu.cdi-spec", state: cdiSpecState },
+    { id: "gpu.cdi-health", state: cdiHealthState },
+  ];
+}
+
+function hostCapabilities(host: HostAssessment): ReadinessCapability[] {
+  const containerRuntimeState: ReadinessState =
+    !host.dockerInstalled || !host.dockerReachable || host.isUnsupportedRuntime
+      ? "absent"
+      : host.runtime === "unknown"
+        ? "unknown"
+        : "present";
+  const runtimeResourcesState: ReadinessState = !host.dockerReachable
+    ? "absent"
+    : host.isContainerRuntimeUnderProvisioned
+      ? "absent"
+      : host.dockerCpus === undefined || host.dockerMemTotalBytes === undefined
+        ? "unknown"
+        : "present";
+  const nvidiaCdiState: ReadinessState = !host.hasNvidiaGpu
+    ? "unknown"
+    : !host.nvidiaContainerToolkitInstalled ||
+        host.cdiNvidiaGpuSpecMissing ||
+        host.cdiNvidiaGpuSpecNeedsRepair ||
+        host.cdiNvidiaGpuRefreshUnhealthy
+      ? "absent"
+      : "present";
+
+  return [
+    capability("host.container-runtime", containerRuntimeState),
+    capability("host.runtime-resources", runtimeResourcesState),
+    capability("host.node", host.nodeInstalled ? "present" : "absent"),
+    capability("host.openshell", host.openshellInstalled ? "present" : "absent"),
+    capability("host.nvidia-gpu", host.hasNvidiaGpu ? "present" : "absent"),
+    capability("host.nvidia-cdi", nvidiaCdiState),
+  ];
+}
+
+function provenance(options: HostReadinessProjectionOptions): ReadinessProvenance {
+  return {
+    nemoclawVersion: options.nemoclawVersion,
+    observedAt: options.observedAt,
+    ...(options.sourceRevision ? { sourceRevision: options.sourceRevision } : {}),
+  };
+}
+
+function projectOutcome(
+  advisories: readonly Advisory[],
+  capabilities: readonly ReadinessCapability[],
+):
+  | { status: "supported"; exitCode: 0 }
+  | { status: "incompatible"; exitCode: 2 }
+  | { status: "inconclusive"; exitCode: 3 } {
+  if (
+    advisories.some((advisory) => advisory.severity === "fatal" || advisory.severity === "blocking")
+  ) {
+    return { status: "incompatible", exitCode: 2 };
+  }
+  if (
+    capabilities.some((entry) => REQUIRED_CAPABILITY_IDS.has(entry.id) && entry.state === "unknown")
+  ) {
+    return { status: "inconclusive", exitCode: 3 };
+  }
+  return { status: "supported", exitCode: 0 };
+}
+
+export function projectHostAssessmentToSystemReadiness(
+  host: HostAssessment,
+  advisories: readonly Advisory[],
+  options: HostReadinessProjectionOptions,
+): SystemReadinessReport {
+  const observations = hostObservations(host);
+  const capabilities = hostCapabilities(host);
+  const evidence = advisories.map(advisoryEvidence);
+  const findings = advisories.map((advisory) => ({
+    id: `advisory.${advisory.id}`,
+    severity: mapSeverity(advisory.severity),
+    summary: advisory.title.slice(0, MAX_SUMMARY_LENGTH) || "Host readiness advisory",
+    ...(ADVISORY_CAPABILITIES[advisory.id]
+      ? { capabilityIds: ADVISORY_CAPABILITIES[advisory.id] }
+      : {}),
+    evidenceIds: [`advisory.${advisory.id}.detail`],
+  }));
+
+  return {
+    schemaVersion: SYSTEM_READINESS_SCHEMA_VERSION,
+    ...projectOutcome(advisories, capabilities),
+    mutated: false,
+    provenance: provenance(options),
+    observations,
+    capabilities,
+    qualifications: [],
+    findings,
+    evidence,
+  };
+}
+
+function observationFailureReport(
+  error: unknown,
+  options: HostReadinessProjectionOptions,
+): SystemReadinessReport {
+  const detail = redactFull(error instanceof Error ? error.message : String(error)).slice(
+    0,
+    MAX_EVIDENCE_LENGTH,
+  );
+  return {
+    schemaVersion: SYSTEM_READINESS_SCHEMA_VERSION,
+    status: "inconclusive",
+    exitCode: 3,
+    mutated: false,
+    provenance: provenance(options),
+    observations: [
+      {
+        id: "host.observation",
+        state: "unknown",
+        evidenceIds: ["host.observation-failure"],
+      },
+    ],
+    capabilities: [
+      capability("host.container-runtime", "unknown"),
+      capability("host.runtime-resources", "unknown"),
+      capability("host.node", "unknown"),
+      capability("host.openshell", "unknown"),
+      capability("host.nvidia-gpu", "unknown"),
+      capability("host.nvidia-cdi", "unknown"),
+    ],
+    qualifications: [],
+    findings: [
+      {
+        id: "host.observation-failed",
+        severity: "fatal",
+        summary: "Host observation failed",
+        evidenceIds: ["host.observation-failure"],
+      },
+    ],
+    evidence: [
+      {
+        id: "host.observation-failure",
+        summary: detail || "Host observation failed without diagnostic details",
+      },
+    ],
+  };
+}
+
+export function collectHostSystemReadiness(
+  options: CollectHostReadinessOptions = {},
+): SystemReadinessReport {
+  const observedAt = (options.nowImpl ?? (() => new Date()))().toISOString();
+  let nemoclawVersion = "unknown";
+
+  try {
+    nemoclawVersion = (options.getNemoclawVersionImpl ?? getVersion)();
+    const projectionOptions: HostReadinessProjectionOptions = {
+      nemoclawVersion,
+      observedAt,
+      ...(options.sourceRevision ? { sourceRevision: options.sourceRevision } : {}),
+    };
+    const host = (options.assessHostImpl ?? assessHost)();
+    const advisories = (options.planHostAdvisoriesImpl ?? planHostAdvisories)(host);
+    return projectHostAssessmentToSystemReadiness(host, advisories, projectionOptions);
+  } catch (error) {
+    return observationFailureReport(error, {
+      nemoclawVersion,
+      observedAt,
+      ...(options.sourceRevision ? { sourceRevision: options.sourceRevision } : {}),
+    });
+  }
+}

--- a/src/lib/readiness/index.ts
+++ b/src/lib/readiness/index.ts
@@ -3,6 +3,12 @@
 
 export type { SchemaCompatibility } from "./compatibility.js";
 export { checkSystemReadinessSchemaVersion } from "./compatibility.js";
+export {
+  type CollectHostReadinessOptions,
+  collectHostSystemReadiness,
+  type HostReadinessProjectionOptions,
+  projectHostAssessmentToSystemReadiness,
+} from "./host.js";
 export { getSystemReadinessReferenceErrors } from "./references.js";
 export type {
   EvidenceScalar,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Project NemoClaw's existing host assessment and advisory results into the versioned system-readiness contract. The adapter is read-only, preserves explicit unknowns, and fails closed as inconclusive when observation or provenance collection fails.

## Related Issue

Fixes #7408

## Changes

- Add a pure `HostAssessment` projection with stable observation, capability, finding, and evidence IDs.
- Reuse `assessHost` and `planHostAdvisories` instead of introducing a second host probe path.
- Preserve blocking advisory semantics, distinguish unknown from absent, and emit bounded fully redacted evidence.
- Add dependency-injected collection and coverage for Docker, runtime resources, unsupported runtimes, NVIDIA Toolkit/CDI, stale observations, and schema/reference integrity.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is the internal projection stage of the accepted readiness stack; it adds no public command or user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review is requested because the adapter consumes preflight observations and advisories without changing their collection or onboarding decisions.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `blocked`
- Evidence: Manual runs default to zero subagents and no delegation was requested. No documentation changes are needed before public CLI exposure because this PR adds only an internal adapter and tests.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5cf044faf -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/readiness src/lib/advisories/checks/host/index.test.ts src/lib/advisories/checks/host/docker.test.ts src/lib/advisories/checks/host/runtime.test.ts src/lib/advisories/checks/host/toolchain.test.ts`: 6 files and 33 tests passed.
- [x] Applicable broad gate passed — `npm run build:cli`, `npm run typecheck:cli -- --incremental`, pre-commit hooks, pre-push TypeScript, and version-sync checks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced host system-readiness reporting that produces supported, incompatible, or inconclusive outcomes.
  * Reports now capture host observation coverage (e.g., runtime/WSL/Docker/NVIDIA/conditions) and translate advisories into severity-based findings with redacted evidence.
  * Readiness collection performs a fresh host assessment per run and includes version/time metadata; failures now return a fail-closed, schema-valid inconclusive report.

* **Tests**
  * Added a full test suite covering successful projections, blocking/incompatible mapping, unknown vs confirmed absence behavior, redaction bounds, and error/fail-closed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->