### PR TITLE
ci(e2e): route clone pairing changes to snapshot coverage

### DIFF
--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -121,6 +121,27 @@ describe("deterministic PR risk plan", () => {
     );
   });
 
+  it("runs snapshot commands for restored-clone pairing approval changes (#7608)", () => {
+    const runtimeFile = "src/lib/actions/sandbox/auto-pair-approval.ts";
+    const changedFiles = [runtimeFile, "src/lib/actions/sandbox/auto-pair-approval.test.ts"];
+    const focusedE2eJobs = focusedE2eJobsForChangedFiles(changedFiles);
+    const result = buildRiskPlan({ headSha: HEAD_SHA, changedFiles, focusedE2eJobs });
+
+    expect(focusedE2eJobs).toEqual([
+      {
+        id: "snapshot-commands",
+        matchedFiles: [runtimeFile],
+      },
+    ]);
+    expect(result.requiredJobs).toContainEqual(
+      expect.objectContaining({
+        id: "snapshot-commands",
+        families: ["focused-e2e"],
+        matchedFiles: [runtimeFile],
+      }),
+    );
+  });
+
   it("hashes the Deep Agents headless check into its exact typed target", () => {
     const changedFile =
       "test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh";

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -561,6 +561,7 @@ export function readFreeStandingJobsInventory(
 }
 
 const RESTORED_GATEWAY_PAIRING_RUNTIME_FILES = new Set([
+  "src/lib/actions/sandbox/auto-pair-approval.ts",
   "src/lib/actions/sandbox/restore-gateway-pairing.ts",
   "src/lib/adapters/openshell/restore-gateway-pairing.ts",
 ]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The trusted PR E2E controller evaluates risk-planner code from protected `main`, not from the PR under review. Before #7652 can receive exact `snapshot-commands` coverage, `main` must know that changes to the clone pairing approval runtime require that job.

## Changes

- Map the exact `src/lib/actions/sandbox/auto-pair-approval.ts` runtime path to the existing `snapshot-commands` E2E job.
- Add a focused deterministic risk-plan regression proving the production path selects that job while the adjacent unit test does not.
- Keep authorization, dispatch, exact-SHA binding, workflow permissions, and runtime behavior unchanged.

Dependency for #7652.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This internal CI-only change adds one exact source path to existing deterministic E2E coverage. It changes no user or contributor procedure, runtime contract, interface, configuration, default, or schema.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the nine-category security review on exact SHA `5fe83a58e`; all categories passed with no actionable findings. The mapping broadens required coverage, not authorization or privilege.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation change: this internal CI-only diff adds one source path to existing deterministic `snapshot-commands` coverage and a focused regression; no user or contributor procedure, interface, configuration, runtime contract, or schema changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5fe83a58e -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/pr-risk-plan.test.ts` passed 67/67; `npm run build:cli` passed; `npm run typecheck:cli` passed; `npm run check:diff` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end test selection so changes to restored gateway pairing approval logic correctly focus the `snapshot-commands` job.
  * Improved risk planning to associate these changes with the appropriate focused E2E test family.

* **Tests**
  * Added coverage verifying the runtime file-to-test job mapping and risk plan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->