### PR TITLE
test(e2e): report precise failure phases

### DIFF
--- a/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
+++ b/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
@@ -1149,7 +1149,8 @@ test("the current-lifecycle custom plugin survives restart, recreation, and rebu
     e2ePhases: [
       "confirm Docker CLI and clear the current plugin sandbox",
       "clone and prepare the current plugin fixture",
-      "install current OpenShell and onboard plugin v1",
+      "install and validate current OpenShell",
+      "build and onboard plugin v1",
       "restart the gateway and confirm plugin v1",
       "recreate the sandbox with plugin v2",
       "rebuild the sandbox with plugin v3",
@@ -1234,7 +1235,7 @@ test("the current-lifecycle custom plugin survives restart, recreation, and rebu
     progress,
     CURRENT_LIFECYCLE_TEST_SELECTOR,
   );
-  progress.phase("install current OpenShell and onboard plugin v1");
+  progress.phase("install and validate current OpenShell");
   await stopOpenShellGatewayBeforeVersionSwitch(host, "existing");
   const pinnedOpenshell = await installAndResolvePinnedOpenShell(
     host,
@@ -1264,6 +1265,7 @@ test("the current-lifecycle custom plugin survives restart, recreation, and rebu
   ).toBe(true);
   const sandboxEnv = withOpenShellWrapperEnv(deploymentEnv, openshellWrapper, pinnedOpenshell);
 
+  progress.phase("build and onboard plugin v1");
   const onboard = await host.command(
     "node",
     [

--- a/test/e2e/live/registry-targets.test.ts
+++ b/test/e2e/live/registry-targets.test.ts
@@ -42,8 +42,8 @@ const REGISTRY_TARGET_PHASES = [
   "resolve the target contract and run plan",
   "confirm the target environment is ready",
   "onboard the registry-selected sandbox",
-  "evaluate the target lifecycle profile",
-  "inspect the expected sandbox state",
+  "execute the target lifecycle boundary",
+  "verify the expected sandbox state",
   "run target-specific cloud checks",
   "record target completion evidence",
 ] as const;
@@ -113,9 +113,9 @@ for (const target of listTargets()) {
       // LifecyclePhaseFixture before state validation.
       let lifecycleResult: Awaited<ReturnType<typeof lifecycle.simulate>> | undefined;
       const profile = target.environment.lifecycle;
-      // Every registry target evaluates whether it declares an optional
-      // lifecycle transition before state validation.
-      progress.phase("evaluate the target lifecycle profile");
+      // Every registry target crosses the optional lifecycle boundary before
+      // state validation.
+      progress.phase("execute the target lifecycle boundary");
       if (profile) {
         if (!isLifecycleProfile(profile)) {
           throw new Error(
@@ -137,7 +137,7 @@ for (const target of listTargets()) {
             : await lifecycle.simulate(profile, instance);
       }
 
-      progress.phase("inspect the expected sandbox state");
+      progress.phase("verify the expected sandbox state");
       const validation = await stateValidation.from(target.expectedStateId, instance);
 
       progress.phase("run target-specific cloud checks");

--- a/test/e2e/live/snapshot-commands-helpers.ts
+++ b/test/e2e/live/snapshot-commands-helpers.ts
@@ -19,6 +19,7 @@ export type SnapshotGatewayProbeClassification =
   | "device-pairing-required";
 export type SnapshotRestoreResultClassification =
   | "restored"
+  | "restored-pairing-unverified"
   | "command-failure"
   | "missing-restored-marker";
 
@@ -61,10 +62,16 @@ export function classifySnapshotRestoreResult(result: {
   stdout: string;
   stderr: string;
 }): SnapshotRestoreResultClassification {
+  const output = `${result.stdout}\n${result.stderr}`;
+  if (
+    result.exitCode !== 0 &&
+    /\bState restored into\b/.test(output) &&
+    /gateway pairing could not be verified/i.test(output)
+  ) {
+    return "restored-pairing-unverified";
+  }
   if (result.exitCode !== 0) return "command-failure";
-  return /\bRestored\b/.test(`${result.stdout}\n${result.stderr}`)
-    ? "restored"
-    : "missing-restored-marker";
+  return /\bRestored\b/.test(output) ? "restored" : "missing-restored-marker";
 }
 
 /**

--- a/test/e2e/live/snapshot-commands-helpers.ts
+++ b/test/e2e/live/snapshot-commands-helpers.ts
@@ -64,6 +64,7 @@ export function classifySnapshotRestoreResult(result: {
 }): SnapshotRestoreResultClassification {
   const output = `${result.stdout}\n${result.stderr}`;
   if (
+    result.exitCode !== null &&
     result.exitCode !== 0 &&
     /\bState restored into\b/.test(output) &&
     /gateway pairing could not be verified/i.test(output)

--- a/test/e2e/live/snapshot-commands.test.ts
+++ b/test/e2e/live/snapshot-commands.test.ts
@@ -235,7 +235,9 @@ test("snapshot commands preserve create/list/latest restore/targeted restore/no-
     e2ePhases: [
       "confirm Docker and start hermetic inference",
       "onboard the snapshot sandbox",
-      "create, list, and restore the first snapshot into a paired clone",
+      "create and list the first snapshot",
+      "restore the first snapshot into a clone",
+      "verify the restored clone state and gateway pairing",
       "create a second snapshot from changed workspace",
       "restore latest and timestamped snapshots",
       "audit snapshot credentials and command help",
@@ -430,7 +432,7 @@ test("snapshot commands preserve create/list/latest restore/targeted restore/no-
     "phase-2-read-marker",
   );
 
-  progress.phase("create, list, and restore the first snapshot into a paired clone");
+  progress.phase("create and list the first snapshot");
   const firstCreate = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "create"], {
     artifactName: "phase-3-snapshot-create-first",
     env: commandEnv(),
@@ -450,6 +452,7 @@ test("snapshot commands preserve create/list/latest restore/targeted restore/no-
   const timestamp = firstSnapshotTimestamp(resultText(list));
   await artifacts.writeJson("phase-4-first-snapshot.json", { timestamp });
 
+  progress.phase("restore the first snapshot into a clone");
   const cloneRestore = await host.command(
     "nemoclaw",
     [SANDBOX_NAME, "snapshot", "restore", timestamp, "--to", CLONE_SANDBOX_NAME, "--yes"],
@@ -459,7 +462,11 @@ test("snapshot commands preserve create/list/latest restore/targeted restore/no-
       timeoutMs: 5 * 60_000,
     },
   );
-  expect(classifySnapshotRestoreResult(cloneRestore)).toBe("restored");
+  const cloneRestoreResult = classifySnapshotRestoreResult(cloneRestore);
+  if (cloneRestoreResult === "restored" || cloneRestoreResult === "restored-pairing-unverified") {
+    progress.phase("verify the restored clone state and gateway pairing");
+  }
+  expect(cloneRestoreResult).toBe("restored");
   await expectSandboxFileContent(
     sandbox,
     CLONE_SANDBOX_NAME,

--- a/test/e2e/live/snapshot-commands.test.ts
+++ b/test/e2e/live/snapshot-commands.test.ts
@@ -463,9 +463,8 @@ test("snapshot commands preserve create/list/latest restore/targeted restore/no-
     },
   );
   const cloneRestoreResult = classifySnapshotRestoreResult(cloneRestore);
-  if (cloneRestoreResult === "restored" || cloneRestoreResult === "restored-pairing-unverified") {
-    progress.phase("verify the restored clone state and gateway pairing");
-  }
+  expect(["restored", "restored-pairing-unverified"]).toContain(cloneRestoreResult);
+  progress.phase("verify the restored clone state and gateway pairing");
   expect(cloneRestoreResult).toBe("restored");
   await expectSandboxFileContent(
     sandbox,

--- a/test/e2e/support/snapshot-commands-helpers.test.ts
+++ b/test/e2e/support/snapshot-commands-helpers.test.ts
@@ -142,6 +142,14 @@ describe("snapshot restore result classification", () => {
       },
       "restored-pairing-unverified",
     ],
+    [
+      {
+        exitCode: null,
+        stdout: "State restored into 'clone', but gateway pairing could not be verified.",
+        stderr: "scope-upgrade-pending secret-output",
+      },
+      "command-failure",
+    ],
     [{ exitCode: 1, stdout: "Restored secret-output", stderr: "" }, "command-failure"],
     [{ exitCode: 0, stdout: "secret-output", stderr: "" }, "missing-restored-marker"],
   ] as const)("returns only fixed classification %#", (result, expected) => {

--- a/test/e2e/support/snapshot-commands-helpers.test.ts
+++ b/test/e2e/support/snapshot-commands-helpers.test.ts
@@ -134,6 +134,14 @@ describe("snapshot restored-gateway probe classification", () => {
 describe("snapshot restore result classification", () => {
   it.each([
     [{ exitCode: 0, stdout: "Restored secret-output", stderr: "" }, "restored"],
+    [
+      {
+        exitCode: 1,
+        stdout: "State restored into 'clone', but gateway pairing could not be verified.",
+        stderr: "scope-upgrade-pending secret-output",
+      },
+      "restored-pairing-unverified",
+    ],
     [{ exitCode: 1, stdout: "Restored secret-output", stderr: "" }, "command-failure"],
     [{ exitCode: 0, stdout: "secret-output", stderr: "" }, "missing-restored-marker"],
   ] as const)("returns only fixed classification %#", (result, expected) => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Live E2E artifacts currently collapse setup, lifecycle, and post-restore checks into broad phases. This PR separates those boundaries so release failures identify the behavior reached. It classifies restore success with unverified pairing without retaining command output.

## Changes

- Separate OpenShell validation from the EXDEV fixture build and onboarding phase.
- Separate snapshot creation, restore, and restored-clone verification phases.
- Classify restore success with unverified pairing using a fixed non-secret value.
- Keep null or signaled restore exits classified as command failures.
- Separate lifecycle execution from expected-state verification for registry targets.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal E2E progress metadata and fixed classifications only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Test-only diagnostics retain no command output and change no credential, policy, or runtime behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation path changed. The review confirmed internal-only E2E metadata, non-secret classifications, linear phase flow, and writing-guide compliance at `31d2b6432`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 31d2b6432 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:changed` and the focused snapshot helper suite passed 19 tests.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run test:e2e-phases:check` passed for 114 tests across 73 files; `npm run source-shape:check` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test progress reporting with clearer, more granular lifecycle and snapshot phase descriptions.
  * Updated registry target phase metadata and phase logging to reflect more precise lifecycle boundary execution and sandbox state verification.
  * Added a new snapshot restore classification for cases where state is restored but gateway pairing verification is not confirmed.
  * Enhanced snapshot command test flows to capture, assert, and verify restore classifications during clone restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->