### PR TITLE
ci: retire TypeScript migration fallbacks

### DIFF
--- a/.github/actions/ci-cli-coverage-merge/action.yaml
+++ b/.github/actions/ci-cli-coverage-merge/action.yaml
@@ -51,11 +51,7 @@ runs:
       shell: bash
       run: |
         test -s dist/nemoclaw.js
-        dist_sourcemap_check=scripts/check-dist-sourcemaps.mts
-        if [ ! -f "$dist_sourcemap_check" ]; then
-          dist_sourcemap_check=scripts/check-dist-sourcemaps.ts
-        fi
-        npx tsx "$dist_sourcemap_check" dist
+        npx tsx scripts/check-dist-sourcemaps.mts dist
 
     - name: Download CLI shard blob reports
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -99,11 +95,7 @@ runs:
           --coverage.include="src/**/*.ts" \
           --coverage.exclude="test/**/*.js" \
           --coverage.exclude="test/**/*.ts"
-        coverage_ratchet=scripts/check-coverage-ratchet.mts
-        if [ ! -f "$coverage_ratchet" ]; then
-          coverage_ratchet=scripts/check-coverage-ratchet.ts
-        fi
-        npx tsx "$coverage_ratchet" coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"
+        npx tsx scripts/check-coverage-ratchet.mts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"
 
     - name: Upload CLI coverage report
       if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -91,15 +91,11 @@ runs:
             exit 0
             ;;
         esac
-        parity_check=scripts/checks/e2e-mock-parity.mts
-        if [ ! -f "$parity_check" ]; then
-          parity_check=scripts/checks/e2e-mock-parity.ts
-        fi
-        if [ ! -f "$parity_check" ]; then
-          echo "::error title=Missing E2E mock parity entrypoint::Expected scripts/checks/e2e-mock-parity.mts or scripts/checks/e2e-mock-parity.ts."
+        if [ ! -f scripts/checks/e2e-mock-parity.mts ]; then
+          echo "::error title=Missing E2E mock parity entrypoint::Expected scripts/checks/e2e-mock-parity.mts."
           exit 1
         fi
-        npx tsx "$parity_check" --base "$base" --head "$head"
+        npx tsx scripts/checks/e2e-mock-parity.mts --base "$base" --head "$head"
 
     - name: Build TypeScript plugin
       shell: bash
@@ -110,11 +106,7 @@ runs:
       run: |
         node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
         npm run build:cli
-        dist_sourcemap_check=scripts/check-dist-sourcemaps.mts
-        if [ ! -f "$dist_sourcemap_check" ]; then
-          dist_sourcemap_check=scripts/check-dist-sourcemaps.ts
-        fi
-        npx tsx "$dist_sourcemap_check" dist
+        npx tsx scripts/check-dist-sourcemaps.mts dist
 
     - name: Upload compiled CLI artifact
       if: ${{ steps.validate-shard-inputs.outputs.upload_build_artifact == 'true' && success() }}

--- a/.github/actions/ci-plugin-coverage/action.yaml
+++ b/.github/actions/ci-plugin-coverage/action.yaml
@@ -31,11 +31,7 @@ runs:
           --coverage.include="nemoclaw/src/**/*.ts" \
           --coverage.include="nemoclaw/src/**/*.cts" \
           --coverage.exclude="**/*.test.ts"
-        coverage_ratchet=scripts/check-coverage-ratchet.mts
-        if [ ! -f "$coverage_ratchet" ]; then
-          coverage_ratchet=scripts/check-coverage-ratchet.ts
-        fi
-        npx tsx "$coverage_ratchet" coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"
+        npx tsx scripts/check-coverage-ratchet.mts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"
 
     - name: Upload plugin coverage report
       if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/test/e2e-mock-parity.test.ts
+++ b/test/e2e-mock-parity.test.ts
@@ -167,28 +167,23 @@ describe("trusted E2E parity entrypoint selection", () => {
     }
   }
 
-  it.each([
-    {
-      extensions: ["mts", "ts"],
-      expected: `${stem}.mts`,
-      title: "prefers .mts when both entrypoints exist",
-    },
-    { extensions: ["mts"], expected: `${stem}.mts`, title: "runs the migrated .mts entrypoint" },
-    { extensions: ["ts"], expected: `${stem}.ts`, title: "falls back to the .ts entrypoint" },
-  ])("$title (#6921)", ({ extensions, expected }) => {
-    withParityEntrypoints(extensions, (result, commandLog) => {
+  it("runs the migrated .mts entrypoint (#6918)", () => {
+    withParityEntrypoints(["mts"], (result, commandLog) => {
       expect(result.status, String(result.stderr)).toBe(0);
       expect(
         readFileSync(commandLog, "utf8")
           .trim()
           .split("\n")
           .map((line) => JSON.parse(line)),
-      ).toEqual([["tsx", expected, "--base", "HEAD^1", "--head", "HEAD^2"]]);
+      ).toEqual([["tsx", `${stem}.mts`, "--base", "HEAD^1", "--head", "HEAD^2"]]);
     });
   });
 
-  it("rejects a missing parity entrypoint (#6921)", () => {
-    withParityEntrypoints([], (result, commandLog) => {
+  it.each([
+    { extensions: [], title: "rejects a missing parity entrypoint" },
+    { extensions: ["ts"], title: "rejects the retired .ts parity entrypoint" },
+  ])("$title (#6918)", ({ extensions }) => {
+    withParityEntrypoints(extensions, (result, commandLog) => {
       expect(result.status, String(result.stderr)).toBe(1);
       expect(existsSync(commandLog)).toBe(false);
       expect(String(result.stdout)).toContain("Missing E2E mock parity entrypoint");

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -1021,6 +1021,8 @@ describe("pull request and main workflow contracts", () => {
     expect(parityStep.run).toContain("base=HEAD^1");
     expect(parityStep.run).toContain("head=HEAD^2");
     expect(parityStep.run).toContain('base="$PUSH_BASE_SHA"');
+    expect(parityStep.run).toContain("npx tsx scripts/checks/e2e-mock-parity.mts");
+    expect(parityStep.run).not.toContain("scripts/checks/e2e-mock-parity.ts");
     const trustedCapabilityProbe = requiredWorkflowStep(
       prWorkflow.jobs["cli-test-shards"],
       "Detect trusted E2E support sharding",
@@ -1167,7 +1169,7 @@ describe("pull request and main workflow contracts", () => {
     }
   });
 
-  it("keeps trusted coverage actions compatible across the .ts to .mts migration (#6935)", () => {
+  it("requires migrated .mts coverage entrypoints (#6918)", () => {
     const cases = [
       {
         action: sharedActions.cliCoverageShard,
@@ -1197,13 +1199,8 @@ describe("pull request and main workflow contracts", () => {
         expectedStatus: 0,
       },
       {
-        fixtureExtension: "ts",
-        expectedEntrypointExtension: "ts",
-        expectedStatus: 0,
-      },
-      {
         fixtureExtension: "missing",
-        expectedEntrypointExtension: "ts",
+        expectedEntrypointExtension: "mts",
         expectedStatus: 1,
       },
     ] as const;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Trusted coverage actions now invoke only the migrated `.mts` entrypoints. Missing entrypoints fail at the canonical path instead of falling back to deleted `.ts` files.

## Related Issue

Part of #6918

## Changes

- Remove four temporary coverage and sourcemap fallbacks added by #6969 for the migration window.
- Remove the matching E2E mock-parity fallback after the repository check suite migration landed.
- Update the behavioral parity fixture to reject the retired `.ts` entrypoint.
- Keep the existing parity missing-entrypoint diagnostic, but require the `.mts` path.
- Update the workflow contract to accept only `.mts` entrypoints and reject a missing canonical file.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: These internal CI entrypoint paths do not change a command, configuration, output, or supported workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [Refreshed security review](https://github.com/NVIDIA/NemoClaw/pull/7668#issuecomment-5097975077) passed on exact head `5d85df195`; the diff narrows trusted execution to fixed `.mts` paths and updates only regression tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Head `5d85df195` changes only internal CI actions and regression tests. Test titles and CI error text follow `WRITING.md`; no user-facing documentation is affected.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5d85df195 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

Signed-off-by: Carlos Villela <cvillela@nvidia.com>

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/e2e-mock-parity.test.ts test/pr-workflow-contract.test.ts --project integration`: 2 files and 31 tests passed. Biome and normal commit hooks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI and Validation**
  * Standardized coverage, sourcemap, and E2E mock parity checks on the migrated TypeScript entrypoints.
  * Removed compatibility handling for retired script variants, enabling faster failure when required checks are unavailable.

* **Tests**
  * Updated workflow contract tests to verify the new entrypoints.
  * Added coverage for rejecting missing or retired validation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->