### PR TITLE
chore(scripts): correct migrated check reference

### DIFF
--- a/scripts/check-env-var-docs.mts
+++ b/scripts/check-env-var-docs.mts
@@ -6,7 +6,7 @@
  * either documented in docs/reference/commands.mdx or explicitly allowlisted
  * in ci/env-var-doc-allowlist.json with a real reason.
  *
- * See #3184. Modeled on scripts/check-direct-credential-env.ts.
+ * See #3184. Modeled on scripts/checks/direct-credential-env.mts.
  */
 
 import { readFileSync, readdirSync, statSync } from "node:fs";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The environment-documentation checker now names the current `.mts` check that its design follows. The comment no longer points to a removed `.ts` path.

## Related Issue

Part of #6918

## Changes

- Replace the stale `scripts/check-direct-credential-env.ts` comment reference with the existing `scripts/checks/direct-credential-env.mts` path.
- Keep the checker implementation and output unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: The diff corrects one internal explanatory comment and changes no executable text.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The comment is internal provenance and changes no user-facing command, output, configuration, workflow, or supported behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Head `4f2598ebd` corrects one internal comment to the existing `.mts` path. The changed identifier is accurate and unambiguous under `WRITING.md`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4f2598ebd -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

Signed-off-by: Carlos Villela <cvillela@nvidia.com>

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — No executable text changed; pre-commit still passed the repository checks and the NEMOCLAW environment-documentation gate.
