### PR TITLE
ci(wsl): pin verified Node archives

### DIFF
--- a/.github/workflows/platform-vitest-main.yaml
+++ b/.github/workflows/platform-vitest-main.yaml
@@ -256,8 +256,36 @@ jobs:
         run: |
           $script = @'
           set -euo pipefail
-          curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-          apt-get install -y nodejs
+          node_version="22.23.1"
+          case "$(uname -m)" in
+            x86_64)
+              node_arch="x64"
+              node_sha256="9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578"
+              ;;
+            aarch64 | arm64)
+              node_arch="arm64"
+              node_sha256="0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1"
+              ;;
+            *)
+              echo "Unsupported Node.js architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          node_url="https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz"
+          temp_dir="$(mktemp -d)"
+          trap 'rm -rf "$temp_dir"' EXIT
+          archive="$temp_dir/node.tar.xz"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            --connect-timeout 15 --max-time 180 \
+            --retry 3 --retry-delay 2 --retry-max-time 240 --retry-all-errors \
+            --output "$archive" "$node_url"
+          printf '%s  %s\n' "$node_sha256" "$archive" | sha256sum --check --status || {
+            echo "Node.js archive checksum verification failed" >&2
+            exit 1
+          }
+          tar --extract --xz --file "$archive" --directory /usr/local --strip-components=1
+          test "$(node --version)" = "v${node_version}"
           node --version
           npm --version
           '@

--- a/.github/workflows/wsl-e2e.yaml
+++ b/.github/workflows/wsl-e2e.yaml
@@ -139,8 +139,36 @@ jobs:
         run: |
           $script = @'
           set -euo pipefail
-          curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-          apt-get install -y nodejs
+          node_version="22.23.1"
+          case "$(uname -m)" in
+            x86_64)
+              node_arch="x64"
+              node_sha256="9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578"
+              ;;
+            aarch64 | arm64)
+              node_arch="arm64"
+              node_sha256="0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1"
+              ;;
+            *)
+              echo "Unsupported Node.js architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          node_url="https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz"
+          temp_dir="$(mktemp -d)"
+          trap 'rm -rf "$temp_dir"' EXIT
+          archive="$temp_dir/node.tar.xz"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            --connect-timeout 15 --max-time 180 \
+            --retry 3 --retry-delay 2 --retry-max-time 240 --retry-all-errors \
+            --output "$archive" "$node_url"
+          printf '%s  %s\n' "$node_sha256" "$archive" | sha256sum --check --status || {
+            echo "Node.js archive checksum verification failed" >&2
+            exit 1
+          }
+          tar --extract --xz --file "$archive" --directory /usr/local --strip-components=1
+          test "$(node --version)" = "v${node_version}"
           node --version
           npm --version
           '@

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -448,6 +448,11 @@
     },
     {
       "file": "test/platform-vitest-main-workflow.test.ts",
+      "test": "pins and verifies the Node.js archive in both WSL workflows",
+      "category": "security"
+    },
+    {
+      "file": "test/platform-vitest-main-workflow.test.ts",
       "test": "keeps the WSL suite unprivileged with explicit root-only contracts",
       "category": "security"
     },

--- a/test/platform-vitest-main-workflow.test.ts
+++ b/test/platform-vitest-main-workflow.test.ts
@@ -43,15 +43,20 @@ describe("platform Vitest main workflow", () => {
       expect(installStep, "missing WSL Node.js install step").toBeDefined();
       const run = installStep?.run ?? "";
       expect(run).toContain('node_version="22.23.1"');
-      expect(run).toContain("9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578");
-      expect(run).toContain("0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1");
-      expect(run).toMatch(/x86_64\)\n\s+node_arch="x64"/u);
-      expect(run).toMatch(/aarch64 \| arm64\)\n\s+node_arch="arm64"/u);
+      expect(run).toMatch(
+        /x86_64\)[\s\S]*?node_arch="x64"[\s\S]*?node_sha256="9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578"[\s\S]*?;;/u,
+      );
+      expect(run).toMatch(
+        /aarch64 \| arm64\)[\s\S]*?node_arch="arm64"[\s\S]*?node_sha256="0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1"[\s\S]*?;;/u,
+      );
       expect(run).toContain(
         'node_url="https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz"',
       );
       expect(run).toContain('temp_dir="$(mktemp -d)"');
       expect(run).toContain(`trap 'rm -rf "$temp_dir"' EXIT`);
+      expect(run).toContain("--proto '=https'");
+      expect(run).toContain("--connect-timeout 15");
+      expect(run).toContain("--max-time 180");
       expect(run).toContain("--retry 3");
       expect(run).toContain("--retry-max-time 240");
       expect(run).toContain("sha256sum --check --status");

--- a/test/platform-vitest-main-workflow.test.ts
+++ b/test/platform-vitest-main-workflow.test.ts
@@ -12,8 +12,10 @@ import {
 } from "./helpers/e2e-workflow-contract";
 
 const WORKFLOW_PATH = ".github/workflows/platform-vitest-main.yaml";
+const WSL_E2E_WORKFLOW_PATH = ".github/workflows/wsl-e2e.yaml";
 const MACOS_REQUIREMENTS_PATH = "ci/platform-vitest-macos-requirements.lock";
 const workflow = readYaml<Workflow>(WORKFLOW_PATH);
+const wslE2eWorkflow = readYaml<Workflow>(WSL_E2E_WORKFLOW_PATH);
 
 function job(name: string): WorkflowJob {
   const candidate = workflow.jobs[name];
@@ -28,6 +30,39 @@ function step(jobName: string, name: string): WorkflowStep {
 }
 
 describe("platform Vitest main workflow", () => {
+  // source-shape-contract: security -- WSL jobs install only checksum-verified official Node.js archives
+  it("pins and verifies the Node.js archive in both WSL workflows", () => {
+    const installSteps = [
+      step("wsl-vitest", "Install Node.js 22 in WSL"),
+      wslE2eWorkflow.jobs["wsl-e2e"]?.steps?.find(
+        (entry) => entry.name === "Install Node.js 22 in WSL",
+      ),
+    ];
+
+    for (const installStep of installSteps) {
+      expect(installStep, "missing WSL Node.js install step").toBeDefined();
+      const run = installStep?.run ?? "";
+      expect(run).toContain('node_version="22.23.1"');
+      expect(run).toContain("9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578");
+      expect(run).toContain("0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1");
+      expect(run).toMatch(/x86_64\)\n\s+node_arch="x64"/u);
+      expect(run).toMatch(/aarch64 \| arm64\)\n\s+node_arch="arm64"/u);
+      expect(run).toContain(
+        'node_url="https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz"',
+      );
+      expect(run).toContain('temp_dir="$(mktemp -d)"');
+      expect(run).toContain(`trap 'rm -rf "$temp_dir"' EXIT`);
+      expect(run).toContain("--retry 3");
+      expect(run).toContain("--retry-max-time 240");
+      expect(run).toContain("sha256sum --check --status");
+      expect(run.indexOf("sha256sum --check --status")).toBeLessThan(run.indexOf("tar --extract"));
+      expect(run).toContain('test "$(node --version)" = "v${node_version}"');
+      expect(run).toContain("Unsupported Node.js architecture");
+      expect(run).not.toContain("deb.nodesource.com");
+      expect(run).not.toMatch(/\bcurl\b[^\n]*\|\s*bash\b/u);
+    }
+  });
+
   // source-shape-contract: compatibility -- macOS must use the same modern shell/tool semantics as the Linux sandbox fixtures
   it("provisions the pinned macOS test runtime before running the full suite", () => {
     const stepNames = job("macos-vitest").steps?.map((entry) => entry.name) ?? [];


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->
Replace the mutable NodeSource bootstrap in both WSL workflows with checksum-verified official Node.js 22.23.1 archives. This removes the shared installer failure affecting current PR lanes while keeping the runtime on the supported, security-current Node 22 LTS line.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->
- Install official Node.js 22.23.1 archives for `x64` and `arm64`, with exact SHA-256 pins, HTTPS-only bounded downloads, temporary-directory cleanup, and fail-closed architecture handling.
- Verify each archive before extraction and assert the installed runtime version.
- Protect both workflow consumers with `test/platform-vitest-main-workflow.test.ts`, including architecture-to-digest bindings and the repository's approved security source-shape contract.
- Address the same WSL bootstrap failure observed on [#7590](https://github.com/NVIDIA/NemoClaw/actions/runs/30312091098/job/90131121904), [#7629](https://github.com/NVIDIA/NemoClaw/actions/runs/30311922489/job/90131122471), [#7603](https://github.com/NVIDIA/NemoClaw/actions/runs/30311696352/job/90131123359), and [#7626](https://github.com/NVIDIA/NemoClaw/actions/runs/30312801807/job/90132378380).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal CI bootstrap behavior only; public installation requirements remain unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex security review PASS across all nine categories on exact diff fingerprint `2981cff1a79a0c0acfaf5b0a8e55353809ec472c0565fa1f168996f92107b7ae`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact-head review confirmed the change is limited to CI bootstrap workflows and their executable contract; public Node.js requirements do not change.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 062779c49 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/platform-vitest-main-workflow.test.ts` (3 passed); both embedded WSL installers pass `bash -n`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Standardized Node.js 22 installation across WSL workflows with a pinned version and architecture-specific downloads.
  * Added archive checksum verification, version validation, cleanup, and explicit failure handling.

* **Tests**
  * Added coverage to verify secure, deterministic Node.js installation behavior in both WSL workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
