### PR TITLE
refactor(onboard): split core orchestration by effect boundary

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -478,10 +478,8 @@ const {
   wasSandboxDefault,
   restoreDefaultAfterRecreate,
 }: typeof import("./onboard/cancel-rollback") = require("./onboard/cancel-rollback");
-const {
-  createCoreOnboardFlowPhases,
-  runCoreOnboardFlowSlice,
-}: typeof import("./onboard/machine/core-flow-phases") = require("./onboard/machine/core-flow-phases");
+// biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+const { createProviderInferenceOnboardFlowPhase, createSandboxOnboardFlowPhase, runCoreOnboardFlowSlice }: typeof import("./onboard/machine/core-flow-phases") = require("./onboard/machine/core-flow-phases");
 const {
   createFinalOnboardFlowPhases,
   runFinalOnboardFlowSlice,
@@ -4314,22 +4312,21 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
     };
     // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
     const runCoreGatewayOpenshell = setupInferenceFactory.createGatewayScopedOpenshellRunner(runOpenshell, GATEWAY_NAME);
-    const [providerInferencePhase, sandboxPhase] = createCoreOnboardFlowPhases<
-      InitialOnboardFlowContext,
-      unknown,
-      MessagingChannelConfig,
-      import("./resources-cmd").ResourceProfile
-    >({
+    // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+    const endpointProvenance = { endpointSource: opts.endpointSource, endpointSourceProvider: opts.rebuildRegistryInferenceRoute?.route.provider ?? null, endpointSourceEndpointUrl: opts.rebuildRegistryInferenceRoute?.route.endpointUrl ?? null, getSandboxRegistryEntry: registry.getSandbox };
+    // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+    const providerInferencePhase = createProviderInferenceOnboardFlowPhase<InitialOnboardFlowContext, unknown>({
       gatewayName: GATEWAY_NAME,
       forceProviderSelection: forceProviderSelectionForAgentChange,
       ...authoritativeRebuildTarget.rebuildProviderFlowOptions(opts, coreFlowContext),
+      endpointProvenance,
       env: process.env,
       constants: {
         hermesProviderName: hermesProviderAuth.HERMES_PROVIDER_NAME,
         hermesApiKeyAuthMethod: HERMES_AUTH_METHOD_API_KEY,
         hermesApiKeyCredentialEnv: HERMES_NOUS_API_KEY_CREDENTIAL_ENV,
       },
-      providerDeps: {
+      deps: {
         checkGatewayRouteCompatibility,
         preflightGatewayRouteDiscovery,
         getSandboxRecoveryAuthority: providerRecovery.getSandboxRecoveryAuthority,
@@ -4385,20 +4382,22 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
           delete process.env[name];
         },
       },
-      sandbox: {
-        resumeAgentChanged,
-        requestedObservabilityEnabled: runtimeControlRequests.requestedObservabilityEnabled,
-        requestedDcodeAutoApprovalMode: runtimeControlRequests.requestedDcodeAutoApprovalMode,
-        authoritativePolicyTier:
-          opts.authoritativeResumeConfig === true ? (opts.policyTier ?? null) : undefined,
-        endpointSource: opts.endpointSource,
-        endpointSourceProvider: opts.rebuildRegistryInferenceRoute?.route.provider ?? null,
-        endpointSourceEndpointUrl: opts.rebuildRegistryInferenceRoute?.route.endpointUrl ?? null,
-        recreateSandbox: isRecreateSandbox,
-        controlUiPort: _preflightDashboardPort,
-        rootDir: ROOT,
-      },
-      sandboxDeps: {
+    });
+    // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+    const sandboxPhase = createSandboxOnboardFlowPhase<InitialOnboardFlowContext, MessagingChannelConfig, import("./resources-cmd").ResourceProfile>({
+      gatewayName: GATEWAY_NAME,
+      authoritativeResumeConfig: opts.authoritativeResumeConfig === true,
+      authoritativePolicyTier:
+        opts.authoritativeResumeConfig === true ? (opts.policyTier ?? null) : undefined,
+      resumeAgentChanged,
+      requestedObservabilityEnabled: runtimeControlRequests.requestedObservabilityEnabled,
+      requestedDcodeAutoApprovalMode: runtimeControlRequests.requestedDcodeAutoApprovalMode,
+      endpointProvenance,
+      recreateSandbox: isRecreateSandbox,
+      controlUiPort: _preflightDashboardPort,
+      rootDir: ROOT,
+      env: process.env,
+      deps: {
         checkGatewayRouteCompatibility,
         withGatewayRouteMutationLock: gatewayRouteMutationLock.withGatewayRouteMutationLock,
         resolvePath: preparedDcodeRuntime.resolveDockerfileProbePath,
@@ -4462,7 +4461,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
     const coreFlowResult = await runCoreOnboardFlowSlice({
       context: coreFlowContext,
       runtime: onboardRuntimeBoundary.getRuntime(),
-      phases: [providerInferencePhase, sandboxPhase],
+      phases: { providerInference: providerInferencePhase, sandbox: sandboxPhase },
       resume,
       recordStateResult,
       recordInvalidatedStateResult,

--- a/src/lib/onboard/machine/core-flow-phases.test.ts
+++ b/src/lib/onboard/machine/core-flow-phases.test.ts
@@ -533,9 +533,13 @@ describe("core onboard flow phases", () => {
     );
   });
 
-  it("uses the strict runner for fresh provider selection sessions", async () => {
-    const calls: string[] = [];
-    const applied: string[] = [];
+  it.each([
+    ["fresh", false],
+    ["resumed", true],
+  ] as const)("uses the strict runner for %s provider selection sessions", async (_label, resume) => {
+    const phaseCalls: string[] = [];
+    const appliedTransitions: string[] = [];
+    const sandboxEffect = vi.fn();
     let runtimeSession = createSession({
       machine: {
         version: 1,
@@ -544,43 +548,57 @@ describe("core onboard flow phases", () => {
         revision: 1,
       },
     });
+    const runProviderInference = vi.fn((ctx: CoreContext) => {
+      phaseCalls.push("provider_selection");
+      return {
+        context: { ...ctx, endpointUrl: "https://example.test/v1" },
+        result: [
+          advanceTo("inference", { metadata: { state: "provider_selection" } }),
+          advanceTo("sandbox", { metadata: { state: "inference" } }),
+        ],
+      };
+    });
+    const runSandbox = vi.fn((ctx: CoreContext) => {
+      phaseCalls.push("sandbox");
+      sandboxEffect(ctx);
+      return {
+        context: { ...ctx, sandboxName: "created-sandbox" },
+        result: branchTo("openclaw", { metadata: { state: "sandbox" } }),
+      };
+    });
     const phases: CoreOnboardFlowPhases<CoreContext> = {
       providerInference: {
         state: "provider_selection",
-        run: (ctx) => {
-          calls.push("provider_selection");
-          return {
-            context: ctx,
-            result: [
-              advanceTo("inference", { metadata: { state: "provider_selection" } }),
-              advanceTo("sandbox", { metadata: { state: "inference" } }),
-            ],
-          };
-        },
+        run: runProviderInference,
       },
       sandbox: {
         state: "sandbox",
-        run: (ctx) => {
-          calls.push("sandbox");
-          return {
-            context: { ...ctx, sandboxName: "created-sandbox" },
-            result: branchTo("openclaw", { metadata: { state: "sandbox" } }),
-          };
-        },
+        run: runSandbox,
       },
     };
+    const recordStateResult = vi.fn(async () => {
+      throw new Error("compatibility recorder should not run");
+    });
+    const recordInvalidatedStateResult = vi.fn(async () => {
+      throw new Error("invalidation recorder should not run on the strict runner path");
+    });
 
     const result = await runCoreOnboardFlowSlice({
-      context: context({ model: "nvidia/test", provider: "nim" }),
+      context: context({
+        resume,
+        fresh: !resume,
+        model: "nvidia/test",
+        provider: "nim",
+      }),
       runtime: {
         session: async () => runtimeSession,
         applyResult: async (stateResult) => {
-          const next = (stateResult as ReturnType<typeof advanceTo>).next;
-          applied.push(next);
+          const transition = stateResult as ReturnType<typeof advanceTo>;
+          appliedTransitions.push(`${transition.transitionKind}:${transition.next}`);
           runtimeSession = createSession({
             machine: {
               version: 1,
-              state: next,
+              state: transition.next,
               stateEnteredAt: "2026-06-09T00:03:00.000Z",
               revision: runtimeSession.machine.revision + 1,
             },
@@ -589,97 +607,39 @@ describe("core onboard flow phases", () => {
         },
       },
       phases,
-      resume: false,
-      recordStateResult: async () => {
-        throw new Error("compatibility recorder should not run");
-      },
-      recordInvalidatedStateResult: async () => {
-        throw new Error("invalidation recorder should not run on fresh strict runner path");
-      },
+      resume,
+      recordStateResult,
+      recordInvalidatedStateResult,
     });
 
-    expect(calls).toEqual(["provider_selection", "sandbox"]);
-    expect(applied).toEqual(["inference", "sandbox", "openclaw"]);
+    expect(phaseCalls).toEqual(["provider_selection", "sandbox"]);
+    expect(runProviderInference).toHaveBeenCalledOnce();
+    expect(runSandbox).toHaveBeenCalledOnce();
+    expect(sandboxEffect).toHaveBeenCalledOnce();
+    expect(sandboxEffect).toHaveBeenCalledWith(
+      expect.objectContaining({ endpointUrl: "https://example.test/v1" }),
+    );
+    expect(appliedTransitions).toEqual(["advance:inference", "advance:sandbox", "branch:openclaw"]);
+    expect(recordStateResult).not.toHaveBeenCalled();
+    expect(recordInvalidatedStateResult).not.toHaveBeenCalled();
+    expect(result.context.endpointUrl).toBe("https://example.test/v1");
     expect(result.context.sandboxName).toBe("created-sandbox");
     expect(result.session.machine.state).toBe("openclaw");
   });
 
-  it("keeps resumed provider selection and sandbox effects under one compatibility decision", async () => {
-    const calls: string[] = [];
-    const recorded: string[] = [];
-    let runtimeSession = createSession({
-      machine: {
-        version: 1,
-        state: "provider_selection",
-        stateEnteredAt: "2026-06-09T00:00:00.000Z",
-        revision: 1,
-      },
-    });
-    const phases: CoreOnboardFlowPhases<CoreContext> = {
-      providerInference: {
-        state: "provider_selection",
-        run: (ctx) => {
-          calls.push("provider_selection");
-          return {
-            context: ctx,
-            result: [
-              advanceTo("inference", { metadata: { state: "provider_selection" } }),
-              advanceTo("sandbox", { metadata: { state: "inference" } }),
-            ],
-          };
-        },
-      },
-      sandbox: {
-        state: "sandbox",
-        run: (ctx) => {
-          calls.push("sandbox");
-          return {
-            context: ctx,
-            result: branchTo("openclaw", { metadata: { state: "sandbox" } }),
-          };
-        },
-      },
-    };
-
-    await runCoreOnboardFlowSlice({
-      context: context({ resume: true }),
-      runtime: {
-        session: async () => runtimeSession,
-        applyResult: async () => {
-          throw new Error("strict runner should not run during resumed core compatibility");
-        },
-      },
-      phases,
-      resume: true,
-      recordStateResult: async (result) => {
-        const next = (result as ReturnType<typeof advanceTo>).next;
-        recorded.push(next);
-        runtimeSession = createSession({
-          machine: {
-            version: 1,
-            state: next,
-            stateEnteredAt: "2026-06-09T00:01:00.000Z",
-            revision: runtimeSession.machine.revision + 1,
-          },
-        });
-        return runtimeSession;
-      },
-      recordInvalidatedStateResult: async () => {
-        throw new Error("exact compatibility transitions should not be invalidated");
-      },
-    });
-
-    expect(calls).toEqual(["provider_selection", "sandbox"]);
-    expect(recorded).toEqual(["inference", "sandbox", "openclaw"]);
-    expect(runtimeSession.machine.state).toBe("openclaw");
-  });
-
   it.each([
+    "inference",
+    "sandbox",
+    "openclaw",
+    "agent_setup",
     "policies",
     "finalizing",
     "post_verify",
   ] as const)("lets resume sessions at %s pass through core compatibility", async (state) => {
     const recorded: string[] = [];
+    const applyResult = vi.fn(async () => {
+      throw new Error("downstream resume compatibility should not use the strict runner");
+    });
     const phases: CoreOnboardFlowPhases<CoreContext> = {
       providerInference: {
         state: "provider_selection",
@@ -703,7 +663,7 @@ describe("core onboard flow phases", () => {
               revision: 7,
             },
           }),
-        applyResult: async () => createSession(),
+        applyResult,
       },
       phases,
       resume: true,
@@ -714,6 +674,7 @@ describe("core onboard flow phases", () => {
     });
 
     expect(recorded).toEqual(["sandbox", "openclaw"]);
+    expect(applyResult).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/lib/onboard/machine/core-flow-phases.test.ts
+++ b/src/lib/onboard/machine/core-flow-phases.test.ts
@@ -6,9 +6,13 @@ import { describe, expect, it, vi } from "vitest";
 import { createSession, type Session, type SessionUpdates } from "../../state/onboard-session";
 import { recordInvalidatedTargets } from "../__test-helpers__/machine-recorders";
 import {
-  type CoreOnboardFlowPhaseOptions,
-  createCoreOnboardFlowPhases,
+  type CoreOnboardFlowPhases,
+  createProviderInferenceOnboardFlowPhase,
+  createSandboxOnboardFlowPhase,
+  type EndpointProvenanceOptions,
+  type ProviderInferenceOnboardFlowPhaseOptions,
   runCoreOnboardFlowSlice,
+  type SandboxOnboardFlowPhaseOptions,
 } from "./core-flow-phases";
 import type { OnboardFlowContext } from "./flow-context";
 import type { OnboardStateResult } from "./result";
@@ -20,7 +24,8 @@ type Gpu = { platform: string };
 type SandboxGpuConfig = { mode: string };
 type CoreContext = OnboardFlowContext<Agent, Gpu, SandboxGpuConfig>;
 type TestHost = { memoryGb: number };
-type CoreOptions = CoreOnboardFlowPhaseOptions<CoreContext, TestHost>;
+type ProviderOptions = ProviderInferenceOnboardFlowPhaseOptions<CoreContext, TestHost>;
+type SandboxOptions = SandboxOnboardFlowPhaseOptions<CoreContext>;
 
 function context(
   patch: Partial<OnboardFlowContext<Agent, Gpu, SandboxGpuConfig>> = {},
@@ -71,20 +76,37 @@ function completeStep(): Session["steps"][string] {
 
 function createPhases(
   overrides: {
-    providerDeps?: Partial<CoreOptions["providerDeps"]>;
-    sandboxDeps?: Partial<CoreOptions["sandboxDeps"]>;
+    endpointProvenance?: Partial<EndpointProvenanceOptions>;
+    providerDeps?: Partial<ProviderOptions["deps"]>;
+    sandboxDeps?: Partial<SandboxOptions["deps"]>;
   } = {},
-) {
-  return createCoreOnboardFlowPhases<CoreContext, TestHost>({
+): CoreOnboardFlowPhases<CoreContext> {
+  const getSandboxRegistryEntry = () => ({
+    name: "my-sandbox",
+    provider: "nim",
+    model: "nvidia/test",
+    endpointUrl: "https://example.test/v1",
+    credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+    preferredInferenceApi: "chat",
+    gatewayName: "nemoclaw",
+    gpuEnabled: false,
+    policies: [],
+  });
+  const endpointProvenance = {
+    getSandboxRegistryEntry,
+    ...overrides.endpointProvenance,
+  };
+  const providerInference = createProviderInferenceOnboardFlowPhase<CoreContext, TestHost>({
     gatewayName: "nemoclaw",
     forceProviderSelection: false,
+    endpointProvenance,
     env: {},
     constants: {
       hermesProviderName: "hermes",
       hermesApiKeyAuthMethod: "api_key",
       hermesApiKeyCredentialEnv: "HERMES_API_KEY",
     },
-    providerDeps: {
+    deps: {
       checkGatewayRouteCompatibility: () => ({ ok: true }),
       preflightGatewayRouteDiscovery: () => ({
         ok: true,
@@ -160,13 +182,16 @@ function createPhases(
       deleteEnv: vi.fn(),
       ...overrides.providerDeps,
     },
-    sandbox: {
-      resumeAgentChanged: false,
-      recreateSandbox: () => false,
-      controlUiPort: null,
-      rootDir: "/repo",
-    },
-    sandboxDeps: {
+  });
+  const sandbox = createSandboxOnboardFlowPhase<CoreContext>({
+    gatewayName: "nemoclaw",
+    resumeAgentChanged: false,
+    endpointProvenance,
+    recreateSandbox: () => false,
+    controlUiPort: null,
+    rootDir: "/repo",
+    env: {},
+    deps: {
       resolvePath: (value) => value,
       agentSupportsWebSearch: () => true,
       note: vi.fn(),
@@ -178,17 +203,7 @@ function createPhases(
       getDcodeSelectionDrift: () => ({ changed: false, unknown: false }),
       hasSandboxGpuDrift: () => false,
       getSandboxHermesToolGateways: () => [],
-      getSandboxRegistryEntry: () => ({
-        name: "my-sandbox",
-        provider: "nim",
-        model: "nvidia/test",
-        endpointUrl: "https://example.test/v1",
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        preferredInferenceApi: "chat",
-        gatewayName: "nemoclaw",
-        gpuEnabled: false,
-        policies: [],
-      }),
+      getSandboxRegistryEntry,
       normalizeHermesToolGatewaySelections: (value) => (Array.isArray(value) ? value : []),
       stringSetsEqual: (left, right) =>
         left.length === right.length && left.every((item) => right.includes(item)),
@@ -265,13 +280,14 @@ function createPhases(
         (async <T>(_gatewayName: string, operation: () => Promise<T> | T) => await operation()),
     },
   });
+  return { providerInference, sandbox };
 }
 
 describe("core onboard flow phases", () => {
   it("carries provider selection output into sandbox setup", async () => {
     const updateSandboxRegistry = vi.fn();
     const createSandbox = vi.fn(async () => "created-sandbox");
-    const [providerPhase, sandboxPhase] = createPhases({
+    const { providerInference: providerPhase, sandbox: sandboxPhase } = createPhases({
       sandboxDeps: {
         createSandbox,
         planRegisteredExtraProviders: vi.fn(() => ({
@@ -342,7 +358,7 @@ describe("core onboard flow phases", () => {
       compatibleEndpointReasoning: null,
       nimContainer: null,
     }));
-    const [providerPhase] = createPhases({ providerDeps: { setupNim } });
+    const { providerInference: providerPhase } = createPhases({ providerDeps: { setupNim } });
 
     await providerPhase.run(context({ fresh: true }));
 
@@ -360,7 +376,7 @@ describe("core onboard flow phases", () => {
 
   it("uses normalized context Hermes tool gateways for provider inference resume", async () => {
     const setupInference = vi.fn(async () => ({ ok: true as const }));
-    const [providerPhase, sandboxPhase] = createPhases({
+    const { providerInference: providerPhase, sandbox: sandboxPhase } = createPhases({
       providerDeps: {
         ensureResumeProviderReady: vi.fn(async (_gatewayName, _provider, _credentialEnv) => ({
           forceInferenceSetup: false,
@@ -455,6 +471,7 @@ describe("core onboard flow phases", () => {
     ["provider-mismatched", "nvidia-prod", "https://persisted.example.test/v1", null, null, false],
   ] as const)("binds %s persisted onboard provenance to its exact provider endpoint", async (_label, registeredProvider, registeredEndpointUrl, expectedSource, expectedOnboardEndpointUrl, expectTrustedUrl) => {
     const setupInference = vi.fn(async () => ({ ok: true as const }));
+    const updateSandboxRegistry = vi.fn();
     const getSandboxRegistryEntry = vi.fn((_sandboxName: string) => ({
       name: "my-sandbox",
       provider: registeredProvider,
@@ -467,14 +484,15 @@ describe("core onboard flow phases", () => {
       gpuEnabled: false,
       policies: [],
     }));
-    const [providerPhase] = createPhases({
+    const { providerInference: providerPhase, sandbox: sandboxPhase } = createPhases({
       providerDeps: {
         setupInference,
         hydrateCredentialEnv: vi.fn(() => "host-key"),
       },
-      sandboxDeps: {
+      endpointProvenance: {
         getSandboxRegistryEntry,
       },
+      sandboxDeps: { updateSandboxRegistry },
     });
     const session = createSession({
       provider: "compatible-endpoint",
@@ -506,6 +524,13 @@ describe("core onboard flow phases", () => {
     expect(result.context.endpointSource).toBe(expectedSource);
     expect(result.context.onboardEndpointUrl ?? null).toBe(expectedOnboardEndpointUrl);
     expect(getSandboxRegistryEntry).toHaveBeenCalledWith("my-sandbox");
+
+    await sandboxPhase.run(result.context);
+
+    expect(updateSandboxRegistry).toHaveBeenCalledWith(
+      "created-sandbox",
+      expect.objectContaining({ endpointSource: expectedSource }),
+    );
   });
 
   it("uses the strict runner for fresh provider selection sessions", async () => {
@@ -519,8 +544,8 @@ describe("core onboard flow phases", () => {
         revision: 1,
       },
     });
-    const phases: readonly OnboardSequencePhase<CoreContext>[] = [
-      {
+    const phases: CoreOnboardFlowPhases<CoreContext> = {
+      providerInference: {
         state: "provider_selection",
         run: (ctx) => {
           calls.push("provider_selection");
@@ -533,7 +558,7 @@ describe("core onboard flow phases", () => {
           };
         },
       },
-      {
+      sandbox: {
         state: "sandbox",
         run: (ctx) => {
           calls.push("sandbox");
@@ -543,7 +568,7 @@ describe("core onboard flow phases", () => {
           };
         },
       },
-    ];
+    };
 
     const result = await runCoreOnboardFlowSlice({
       context: context({ model: "nvidia/test", provider: "nim" }),
@@ -579,44 +604,74 @@ describe("core onboard flow phases", () => {
     expect(result.session.machine.state).toBe("openclaw");
   });
 
-  it("records each phase result on the resume compatibility path", async () => {
+  it("keeps resumed provider selection and sandbox effects under one compatibility decision", async () => {
+    const calls: string[] = [];
     const recorded: string[] = [];
-    const phases: readonly OnboardSequencePhase<
-      OnboardFlowContext<Agent, Gpu, SandboxGpuConfig>
-    >[] = [
-      {
+    let runtimeSession = createSession({
+      machine: {
+        version: 1,
         state: "provider_selection",
-        run: (ctx) => ({ context: ctx, result: advanceTo("sandbox") }),
+        stateEnteredAt: "2026-06-09T00:00:00.000Z",
+        revision: 1,
       },
-      {
+    });
+    const phases: CoreOnboardFlowPhases<CoreContext> = {
+      providerInference: {
+        state: "provider_selection",
+        run: (ctx) => {
+          calls.push("provider_selection");
+          return {
+            context: ctx,
+            result: [
+              advanceTo("inference", { metadata: { state: "provider_selection" } }),
+              advanceTo("sandbox", { metadata: { state: "inference" } }),
+            ],
+          };
+        },
+      },
+      sandbox: {
         state: "sandbox",
-        run: (ctx) => ({ context: ctx, result: advanceTo("openclaw") }),
+        run: (ctx) => {
+          calls.push("sandbox");
+          return {
+            context: ctx,
+            result: branchTo("openclaw", { metadata: { state: "sandbox" } }),
+          };
+        },
       },
-    ];
+    };
 
     await runCoreOnboardFlowSlice({
       context: context({ resume: true }),
       runtime: {
-        session: async () =>
-          createSession({
-            machine: {
-              version: 1,
-              state: "provider_selection",
-              stateEnteredAt: "2026-06-09T00:00:00.000Z",
-              revision: 1,
-            },
-          }),
-        applyResult: async () => createSession(),
+        session: async () => runtimeSession,
+        applyResult: async () => {
+          throw new Error("strict runner should not run during resumed core compatibility");
+        },
       },
       phases,
       resume: true,
       recordStateResult: async (result) => {
-        if (result.type === "transition") recorded.push(result.next);
+        const next = (result as ReturnType<typeof advanceTo>).next;
+        recorded.push(next);
+        runtimeSession = createSession({
+          machine: {
+            version: 1,
+            state: next,
+            stateEnteredAt: "2026-06-09T00:01:00.000Z",
+            revision: runtimeSession.machine.revision + 1,
+          },
+        });
+        return runtimeSession;
       },
-      recordInvalidatedStateResult: recordInvalidatedTargets(recorded),
+      recordInvalidatedStateResult: async () => {
+        throw new Error("exact compatibility transitions should not be invalidated");
+      },
     });
 
-    expect(recorded).toEqual(["sandbox", "openclaw"]);
+    expect(calls).toEqual(["provider_selection", "sandbox"]);
+    expect(recorded).toEqual(["inference", "sandbox", "openclaw"]);
+    expect(runtimeSession.machine.state).toBe("openclaw");
   });
 
   it.each([
@@ -625,16 +680,16 @@ describe("core onboard flow phases", () => {
     "post_verify",
   ] as const)("lets resume sessions at %s pass through core compatibility", async (state) => {
     const recorded: string[] = [];
-    const phases: readonly OnboardSequencePhase<CoreContext>[] = [
-      {
+    const phases: CoreOnboardFlowPhases<CoreContext> = {
+      providerInference: {
         state: "provider_selection",
         run: (ctx) => ({ context: ctx, result: advanceTo("sandbox") }),
       },
-      {
+      sandbox: {
         state: "sandbox",
         run: (ctx) => ({ context: ctx, result: advanceTo("openclaw") }),
       },
-    ];
+    };
 
     await runCoreOnboardFlowSlice({
       context: context({ resume: true }),
@@ -669,6 +724,10 @@ describe("core onboard flow phases", () => {
       state: "provider_selection",
       run: vi.fn((ctx) => ({ context: ctx, result: advanceTo("sandbox") })),
     };
+    const sandboxPhase: OnboardSequencePhase<CoreContext> = {
+      state: "sandbox",
+      run: vi.fn((ctx) => ({ context: ctx, result: advanceTo("openclaw") })),
+    };
 
     await expect(
       runCoreOnboardFlowSlice({
@@ -685,13 +744,14 @@ describe("core onboard flow phases", () => {
             }),
           applyResult: async () => createSession(),
         },
-        phases: [phase],
+        phases: { providerInference: phase, sandbox: sandboxPhase },
         resume: true,
         recordStateResult: async () => undefined,
         recordInvalidatedStateResult: recordInvalidatedTargets([]),
       }),
     ).rejects.toThrow("Unexpected onboarding live flow state before slice entry");
     expect(phase.run).not.toHaveBeenCalled();
+    expect(sandboxPhase.run).not.toHaveBeenCalled();
   });
 
   it("keeps non-resume ahead-state sessions on the compatibility path", async () => {
@@ -706,8 +766,8 @@ describe("core onboard flow phases", () => {
         revision: 7,
       },
     });
-    const phases: readonly OnboardSequencePhase<CoreContext>[] = [
-      {
+    const phases: CoreOnboardFlowPhases<CoreContext> = {
+      providerInference: {
         state: "provider_selection",
         run: (ctx) => {
           calls.push("provider_selection");
@@ -724,7 +784,7 @@ describe("core onboard flow phases", () => {
           };
         },
       },
-      {
+      sandbox: {
         state: "sandbox",
         run: (ctx) => {
           calls.push("sandbox");
@@ -734,7 +794,7 @@ describe("core onboard flow phases", () => {
           };
         },
       },
-    ];
+    };
 
     const result = await runCoreOnboardFlowSlice({
       context: context(),

--- a/src/lib/onboard/machine/core-flow-phases.ts
+++ b/src/lib/onboard/machine/core-flow-phases.ts
@@ -31,11 +31,20 @@ import type { OnboardStateResult } from "./result";
 import type { OnboardMachineRunnerResult, OnboardMachineRunnerRuntime } from "./runner";
 import type { OnboardSequencePhase } from "./sequence-runner";
 
-export interface CoreOnboardFlowPhaseOptions<
+export interface EndpointProvenanceOptions {
+  endpointSource?: InferenceEndpointSource | null;
+  endpointSourceProvider?: string | null;
+  endpointSourceEndpointUrl?: string | null;
+  getSandboxRegistryEntry: (name: string) => {
+    provider?: unknown;
+    endpointUrl?: unknown;
+    endpointSource?: unknown;
+  } | null;
+}
+
+export interface ProviderInferenceOnboardFlowPhaseOptions<
   Context extends OnboardFlowContext,
   Host = unknown,
-  MessagingChannelConfig = unknown,
-  ResourceProfile = unknown,
 > {
   gatewayName: string;
   forceProviderSelection: boolean;
@@ -43,22 +52,29 @@ export interface CoreOnboardFlowPhaseOptions<
   authoritativeResumeConfig?: boolean;
   providerRecoveryReceipt?: ProviderRecoveryReceipt | null;
   providerRecoveryReceiptLedger?: ReturnType<typeof createProviderRecoveryReceiptLedger>;
+  endpointProvenance: EndpointProvenanceOptions;
   env: NodeJS.ProcessEnv;
   constants: ProviderInferenceStateOptions<Context["gpu"], Context["agent"], Host>["constants"];
-  providerDeps: ProviderInferenceStateOptions<Context["gpu"], Context["agent"], Host>["deps"];
-  sandbox: {
-    resumeAgentChanged: boolean;
-    requestedObservabilityEnabled?: boolean | null;
-    requestedDcodeAutoApprovalMode?: DcodeAutoApprovalMode | null;
-    authoritativePolicyTier?: string | null;
-    endpointSource?: InferenceEndpointSource | null;
-    endpointSourceProvider?: string | null;
-    endpointSourceEndpointUrl?: string | null;
-    recreateSandbox: (requested?: boolean) => boolean;
-    controlUiPort: number | null;
-    rootDir: string;
-  };
-  sandboxDeps: SandboxStateOptions<
+  deps: ProviderInferenceStateOptions<Context["gpu"], Context["agent"], Host>["deps"];
+}
+
+export interface SandboxOnboardFlowPhaseOptions<
+  Context extends OnboardFlowContext,
+  MessagingChannelConfig = unknown,
+  ResourceProfile = unknown,
+> {
+  gatewayName: string;
+  authoritativeResumeConfig?: boolean;
+  authoritativePolicyTier?: string | null;
+  resumeAgentChanged: boolean;
+  requestedObservabilityEnabled?: boolean | null;
+  requestedDcodeAutoApprovalMode?: DcodeAutoApprovalMode | null;
+  endpointProvenance: EndpointProvenanceOptions;
+  recreateSandbox: (requested?: boolean) => boolean;
+  controlUiPort: number | null;
+  rootDir: string;
+  env: NodeJS.ProcessEnv;
+  deps: SandboxStateOptions<
     Context["gpu"],
     Context["agent"],
     WebSearchConfig,
@@ -68,6 +84,11 @@ export interface CoreOnboardFlowPhaseOptions<
   >["deps"];
 }
 
+export interface CoreOnboardFlowPhases<Context extends OnboardFlowContext> {
+  readonly providerInference: OnboardSequencePhase<Context>;
+  readonly sandbox: OnboardSequencePhase<Context>;
+}
+
 interface EndpointProvenance {
   endpointSource: InferenceEndpointSource | null;
   onboardEndpointUrl: string | null;
@@ -75,32 +96,27 @@ interface EndpointProvenance {
 
 function endpointProvenanceForPhase(
   context: Pick<OnboardFlowContext, "fresh" | "sandboxName" | "provider" | "endpointUrl">,
-  configuredSource: InferenceEndpointSource | null | undefined,
-  configuredProvider: string | null | undefined,
-  configuredEndpointUrl: string | null | undefined,
-  getSandboxRegistryEntry: (name: string) => {
-    provider?: unknown;
-    endpointUrl?: unknown;
-    endpointSource?: unknown;
-  } | null,
+  options: EndpointProvenanceOptions,
 ): EndpointProvenance {
   if (context.fresh) {
     return { endpointSource: "onboard", onboardEndpointUrl: context.endpointUrl };
   }
-  if (configuredSource !== undefined) {
-    const endpointSource = normalizeInferenceEndpointSource(configuredSource);
+  if (options.endpointSource !== undefined) {
+    const endpointSource = normalizeInferenceEndpointSource(options.endpointSource);
     if (
       endpointSource === "onboard" &&
-      (configuredProvider !== context.provider || configuredEndpointUrl !== context.endpointUrl)
+      (options.endpointSourceProvider !== context.provider ||
+        options.endpointSourceEndpointUrl !== context.endpointUrl)
     ) {
       return { endpointSource: null, onboardEndpointUrl: null };
     }
     return {
       endpointSource,
-      onboardEndpointUrl: endpointSource === "onboard" ? (configuredEndpointUrl ?? null) : null,
+      onboardEndpointUrl:
+        endpointSource === "onboard" ? (options.endpointSourceEndpointUrl ?? null) : null,
     };
   }
-  const entry = context.sandboxName ? getSandboxRegistryEntry(context.sandboxName) : null;
+  const entry = context.sandboxName ? options.getSandboxRegistryEntry(context.sandboxName) : null;
   const endpointSource = normalizeInferenceEndpointSource(entry?.endpointSource);
   if (endpointSource !== "onboard") {
     return { endpointSource, onboardEndpointUrl: null };
@@ -111,22 +127,12 @@ function endpointProvenanceForPhase(
   return { endpointSource, onboardEndpointUrl: context.endpointUrl };
 }
 
-export function createCoreOnboardFlowPhases<
+export function createProviderInferenceOnboardFlowPhase<
   Context extends OnboardFlowContext,
   Host = unknown,
-  MessagingChannelConfig = unknown,
-  ResourceProfile = unknown,
->(
-  options: CoreOnboardFlowPhaseOptions<Context, Host, MessagingChannelConfig, ResourceProfile>,
-): [OnboardSequencePhase<Context>, OnboardSequencePhase<Context>] {
-  const providerInferencePhase = createProviderInferencePhase<Context>(async (context) => {
-    const endpointProvenance = endpointProvenanceForPhase(
-      context,
-      options.sandbox.endpointSource,
-      options.sandbox.endpointSourceProvider,
-      options.sandbox.endpointSourceEndpointUrl,
-      options.sandboxDeps.getSandboxRegistryEntry,
-    );
+>(options: ProviderInferenceOnboardFlowPhaseOptions<Context, Host>): OnboardSequencePhase<Context> {
+  return createProviderInferencePhase<Context>(async (context) => {
+    const endpointProvenance = endpointProvenanceForPhase(context, options.endpointProvenance);
     const providerInferenceResult = await handleProviderInferenceState({
       gatewayName: options.gatewayName,
       resume: context.resume,
@@ -157,7 +163,7 @@ export function createCoreOnboardFlowPhases<
       selectedMessagingChannels: context.selectedMessagingChannels,
       env: options.env,
       constants: options.constants,
-      deps: options.providerDeps,
+      deps: options.deps,
     });
 
     return {
@@ -180,32 +186,34 @@ export function createCoreOnboardFlowPhases<
       result: providerInferenceResult.stateResults,
     };
   });
+}
 
-  const sandboxPhase = createSandboxPhase<Context>(async (context) => {
+export function createSandboxOnboardFlowPhase<
+  Context extends OnboardFlowContext,
+  MessagingChannelConfig = unknown,
+  ResourceProfile = unknown,
+>(
+  options: SandboxOnboardFlowPhaseOptions<Context, MessagingChannelConfig, ResourceProfile>,
+): OnboardSequencePhase<Context> {
+  return createSandboxPhase<Context>(async (context) => {
     const endpointProvenance =
       context.endpointSource !== undefined
         ? {
             endpointSource: context.endpointSource,
             onboardEndpointUrl: context.onboardEndpointUrl ?? null,
           }
-        : endpointProvenanceForPhase(
-            context,
-            options.sandbox.endpointSource,
-            options.sandbox.endpointSourceProvider,
-            options.sandbox.endpointSourceEndpointUrl,
-            options.sandboxDeps.getSandboxRegistryEntry,
-          );
+        : endpointProvenanceForPhase(context, options.endpointProvenance);
     const sandboxStateResult = await handleSandboxState({
       resume: context.resume,
       fresh: context.fresh,
       gatewayName: options.gatewayName,
       authoritativeResumeConfig: options.authoritativeResumeConfig,
-      authoritativePolicyTier: options.sandbox.authoritativePolicyTier,
+      authoritativePolicyTier: options.authoritativePolicyTier,
       endpointSource: endpointProvenance.endpointSource,
-      resumeAgentChanged: options.sandbox.resumeAgentChanged,
-      requestedObservabilityEnabled: options.sandbox.requestedObservabilityEnabled,
-      requestedDcodeAutoApprovalMode: options.sandbox.requestedDcodeAutoApprovalMode,
-      recreateSandbox: options.sandbox.recreateSandbox,
+      resumeAgentChanged: options.resumeAgentChanged,
+      requestedObservabilityEnabled: options.requestedObservabilityEnabled,
+      requestedDcodeAutoApprovalMode: options.requestedDcodeAutoApprovalMode,
+      recreateSandbox: options.recreateSandbox,
       session: context.session,
       sandboxName: context.sandboxName,
       model: context.model,
@@ -222,10 +230,10 @@ export function createCoreOnboardFlowPhases<
       sandboxGpuConfig: context.sandboxGpuConfig,
       hermesToolGateways: context.hermesToolGateways,
       hermesAuthMethod: context.hermesAuthMethod,
-      controlUiPort: options.sandbox.controlUiPort,
-      rootDir: options.sandbox.rootDir,
+      controlUiPort: options.controlUiPort,
+      rootDir: options.rootDir,
       env: options.env,
-      deps: options.sandboxDeps,
+      deps: options.deps,
     });
 
     return {
@@ -241,14 +249,12 @@ export function createCoreOnboardFlowPhases<
       result: sandboxStateResult.stateResult,
     };
   });
-
-  return [providerInferencePhase, sandboxPhase];
 }
 
 export async function runCoreOnboardFlowSlice<Context extends OnboardFlowContext>(options: {
   context: Context;
   runtime: OnboardMachineRunnerRuntime;
-  phases: readonly OnboardSequencePhase<Context>[];
+  phases: CoreOnboardFlowPhases<Context>;
   resume: boolean;
   recordStateResult(result: OnboardStateResult): Promise<unknown>;
   recordInvalidatedStateResult: InvalidatedOnboardStateResultRecorder;
@@ -271,7 +277,7 @@ export async function runCoreOnboardFlowSlice<Context extends OnboardFlowContext
   return runLiveOnboardFlowSlice({
     context: options.context,
     runtime: options.runtime,
-    phases: options.phases,
+    phases: [options.phases.providerInference, options.phases.sandbox],
     runWhenState: ["provider_selection"],
     compatibilityWhenState: options.resume
       ? [

--- a/src/lib/onboard/machine/core-flow-phases.ts
+++ b/src/lib/onboard/machine/core-flow-phases.ts
@@ -259,37 +259,24 @@ export async function runCoreOnboardFlowSlice<Context extends OnboardFlowContext
   recordStateResult(result: OnboardStateResult): Promise<unknown>;
   recordInvalidatedStateResult: InvalidatedOnboardStateResultRecorder;
 }): Promise<OnboardMachineRunnerResult<Context>> {
-  // Recompute plan for live resume repair when durable machine snapshots
-  // are already downstream of this slice even though provider/sandbox
-  // repair/backstop checks must still re-run. Those ahead-state snapshots can
-  // come from legacy/test step mutation that explicitly opts into
-  // `updateMachine === true` or from repaired-resume replay of persisted
-  // sessions. Recomputed transition results are explicitly applied or
-  // invalidated by runLiveOnboardFlowSlice, so stale phase output cannot update
-  // context or silently advance state. This slice cannot eliminate that source
-  // locally because the repair/backstop checks are still modeled as imperative
-  // resume work rather than strict FSM recovery states. The tolerated downstream
-  // family includes sandbox branch states and the final slice handoff states:
-  // openclaw, agent_setup, policies, finalizing, and post_verify. Phase tests
-  // cover ahead-state resume and terminal-state rejection; remove this fallback
-  // once those checks are strict FSM recovery states and legacy machine step
-  // mutation is gone.
+  // Exact provider-selection entry is runner-owned for fresh and resumed flows.
+  // Recompute only when a durable snapshot is already downstream even though
+  // provider/sandbox repair and backstop checks must still re-run. Those
+  // ahead-state snapshots can come from legacy/test step mutation that
+  // explicitly opts into `updateMachine === true` or from repaired-resume replay
+  // of persisted sessions. Recomputed transition results are explicitly applied
+  // or invalidated by runLiveOnboardFlowSlice, so stale phase output cannot
+  // update context or silently advance state. The tolerated downstream family
+  // includes inference, sandbox branch states, and the final slice handoff
+  // states. Remove this fallback once those checks are strict FSM recovery states
+  // and legacy machine step mutation is gone.
   return runLiveOnboardFlowSlice({
     context: options.context,
     runtime: options.runtime,
     phases: [options.phases.providerInference, options.phases.sandbox],
     runWhenState: ["provider_selection"],
     compatibilityWhenState: options.resume
-      ? [
-          "provider_selection",
-          "inference",
-          "sandbox",
-          "openclaw",
-          "agent_setup",
-          "policies",
-          "finalizing",
-          "post_verify",
-        ]
+      ? ["inference", "sandbox", "openclaw", "agent_setup", "policies", "finalizing", "post_verify"]
       : ["inference", "sandbox", "openclaw", "agent_setup"],
     runSlice: runCoreOnboardFlowSequence,
     recordStateResult: options.recordStateResult,

--- a/test/onboard-fsm-live-slices.test.ts
+++ b/test/onboard-fsm-live-slices.test.ts
@@ -208,16 +208,20 @@ const called = [];
 const sentinel = new Error("slice-called");
 
 if (scenario.mode.endsWith("policy-tier") || scenario.mode.endsWith("provenance-resolver")) {
-  coreFlowPhases.createCoreOnboardFlowPhases = (options) => {
-    const detail = scenario.mode.endsWith("provenance-resolver")
+  const readsProvenance = scenario.mode.endsWith("provenance-resolver");
+  const factoryName = readsProvenance
+    ? "createProviderInferenceOnboardFlowPhase"
+    : "createSandboxOnboardFlowPhase";
+  coreFlowPhases[factoryName] = (options) => {
+    const detail = readsProvenance
       ? (() => {
-          const entry = options.sandboxDeps.getSandboxRegistryEntry("fsm-sandbox");
+          const entry = options.endpointProvenance.getSandboxRegistryEntry("fsm-sandbox");
           return ["registry-provenance", entry?.provider, entry?.endpointUrl, entry?.endpointSource].join(":");
         })()
       : "authoritative-policy-tier:" +
-        (options.sandbox.authoritativePolicyTier === undefined
+        (options.authoritativePolicyTier === undefined
           ? "undefined"
-          : String(options.sandbox.authoritativePolicyTier));
+          : String(options.authoritativePolicyTier));
     called.push(detail);
     throw sentinel;
   };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This cumulative stack layer separates provider/inference and sandbox phase construction by effect boundary, then routes exact `provider_selection` entries through the strict FSM runner for fresh and resumed sessions. Compatibility replay remains for saved sessions already at `inference`, `sandbox`, a branch state, or a final-flow handoff state.

Stack layers 5 and 6 of 6. Base: `codex/onboard-fsm-initial-entry`.

## Related Issue

Refs #6224

## Changes

- Replace the combined core-phase factory with named provider/inference and sandbox factories.
- Give each factory a phase-specific option and dependency contract.
- Share endpoint-provenance inputs explicitly across the two phases.
- Replace positional phase tuples with a named `{ providerInference, sandbox }` object.
- Remove `provider_selection` from the resume compatibility state set.
- Apply provider-selection, inference, sandbox, and branch transitions through the strict runner at exact entry.
- Preserve provenance handoff, sandbox registry updates, and compatibility repair for downstream resume states.
- Strengthen tests for context propagation, one sandbox effect, transition kinds, and the absence of compatibility recorders on strict entry.

The strict-entry migration and live-slice probes now isolate provider/inference construction from sandbox effects. `runOnboard` and `runCoreOnboardFlowSlice` consume the split, while core-phase and live-slice tests protect ordering, provenance, compatibility scope, state transitions, and single-effect execution.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Commands, output, configuration, persisted contracts, and supported onboarding behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex review of the exact six-commit stack found no actionable findings and verified strict entry, compatibility bounds, state durability, recovery, rollback, and fail-closed behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The cumulative change splits provider/inference and sandbox construction, then routes exact `provider_selection` entry for fresh and resumed sessions through the strict runner. Downstream resume states retain compatibility replay. Commands, output, configuration, persisted contracts, and supported onboarding behavior are unchanged; existing documentation remains accurate.
- Agent: Codex Desktop documentation-writer subagent
<!-- docs-review-head-sha: be3764adf -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact stack-head FSM selection: PASS (9 files, 112 tests); focused CLI Vitest: PASS (18 tests); focused integration Vitest: PASS (12 tests); CLI type-check: PASS.
- [x] Applicable broad gate passed — exact-head GitHub CLI, platform, security, and selected live E2E gates passed; `cloud-onboard`, `onboard-repair`, and `onboard-resume` all succeeded.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined onboarding flow handling for provider inference and sandbox setup.
  * Improved endpoint provenance tracking during onboarding and sandbox resumption.
  * Updated resume compatibility behavior for more reliable session transitions.
* **Bug Fixes**
  * Prevented invalid or unexpected onboarding states from triggering phase execution.
  * Improved handling of persisted sandbox registry information during resumed onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
