### PR TITLE
fix(policy): allow the Claude Code login host in the claude-code preset

### DIFF
--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -214,7 +214,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 |---|---|---|
 | `brave` | Brave Search API. | Agent can issue search queries. |
 | `brew` | Homebrew (Linuxbrew) package manager. The sandbox base image includes the `brew` binary; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
-| `claude-code` | Claude Code CLI API, browser login, telemetry, and crash-report endpoints. | Allows a separately installed Claude Code CLI to reach Anthropic and telemetry hosts with its own credentials, including the OAuth paths on `platform.claude.com` that the browser login uses to exchange its authorization code. Do not use this preset for NemoClaw inference routing. |
+| `claude-code` | Claude Code CLI API, browser login, telemetry, and crash-report endpoints. | Allows a separately installed Claude Code CLI to reach Anthropic and telemetry hosts with its own credentials. On `platform.claude.com` the preset allows GET and POST on `/v1/oauth/**` only, which the browser login uses to exchange its authorization code. Do not use this preset for NemoClaw inference routing. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
 | `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -214,7 +214,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 |---|---|---|
 | `brave` | Brave Search API. | Agent can issue search queries. |
 | `brew` | Homebrew (Linuxbrew) package manager. The sandbox base image includes the `brew` binary; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
-| `claude-code` | Claude Code CLI API, telemetry, and crash-report endpoints. | Allows a separately installed Claude Code CLI to reach Anthropic and telemetry hosts with its own credentials. Do not use this preset for NemoClaw inference routing. |
+| `claude-code` | Claude Code CLI API, browser login, telemetry, and crash-report endpoints. | Allows a separately installed Claude Code CLI to reach Anthropic and telemetry hosts with its own credentials, including the OAuth paths on `platform.claude.com` that the browser login uses to exchange its authorization code. Do not use this preset for NemoClaw inference routing. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
 | `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |

--- a/nemoclaw-blueprint/policies/presets/claude-code.yaml
+++ b/nemoclaw-blueprint/policies/presets/claude-code.yaml
@@ -3,7 +3,7 @@
 
 preset:
   name: claude-code
-  description: "Claude Code API, telemetry, and crash-report access"
+  description: "Claude Code API, browser login, telemetry, and crash-report access"
 
 network_policies:
   claude_code:
@@ -16,6 +16,13 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+      - host: platform.claude.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/v1/oauth/**" }
+          - allow: { method: POST, path: "/v1/oauth/**" }
       - host: statsig.anthropic.com
         port: 443
         protocol: rest

--- a/test/effective-policy-contracts.test.ts
+++ b/test/effective-policy-contracts.test.ts
@@ -502,6 +502,7 @@ describe("effective built-in policy contracts", () => {
     );
     expect((claude.endpoints ?? []).map((endpoint) => endpoint.host).sort()).toEqual([
       "api.anthropic.com",
+      "platform.claude.com",
       "sentry.io",
       "statsig.anthropic.com",
     ]);
@@ -517,5 +518,17 @@ describe("effective built-in policy contracts", () => {
     expect(binaries(claude)).toContain(
       "/tmp/npm-global/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe",
     );
+  });
+
+  it("allows the Claude Code browser login to exchange its authorization code on the OAuth paths only (#7637)", () => {
+    const effective = composePresets(["claude-code"]);
+    const claude = requireNetworkPolicy(effective, "claude_code");
+    const login = requireEndpoint(claude, "platform.claude.com");
+
+    expect(login).toMatchObject({ port: 443, protocol: "rest", enforcement: "enforce" });
+    expect(rules(login)).toEqual([
+      { method: "GET", path: "/v1/oauth/**" },
+      { method: "POST", path: "/v1/oauth/**" },
+    ]);
   });
 });

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -64,6 +64,10 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     ),
   },
   {
+    pattern: /(?:^|\/)nemoclaw-blueprint\/policies\/presets\/claude-code\.yaml$/,
+    testsToRun: runTests("test/effective-policy-contracts.test.ts"),
+  },
+  {
     pattern: /(?:^|\/)agents\/hermes\/(?:mcp-config-transaction|runtime-config-guard)\.py$/,
     testsToRun: runTests("src/lib/actions/sandbox/gateway-restart-hermes-drift.test.ts"),
   },

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -51,6 +51,7 @@ const OPAQUE_INPUTS = [
   "agents/hermes/policy-additions.yaml",
   "src/lib/messaging/channels/telegram/policy/openclaw.yaml",
   "nemoclaw-blueprint/policies/presets/local-inference.yaml",
+  "nemoclaw-blueprint/policies/presets/claude-code.yaml",
   "agents/hermes/runtime-config-guard.py",
   "agents/hermes/mcp-config-transaction.py",
   "test/e2e/lib/ci-compatible-inference.sh",
@@ -89,6 +90,9 @@ describe("Vitest opaque-input watch triggers", () => {
     ]);
     expect(triggeredBy("nemoclaw-blueprint/policies/presets/local-inference.yaml")).toEqual([
       "src/lib/onboard/inference-providers/compatible-endpoint-gateway-route.test.ts",
+    ]);
+    expect(triggeredBy("nemoclaw-blueprint/policies/presets/claude-code.yaml")).toEqual([
+      "test/effective-policy-contracts.test.ts",
     ]);
     expect(triggeredBy("agents/hermes/runtime-config-guard.py")).toEqual([
       "src/lib/actions/sandbox/gateway-restart-hermes-drift.test.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The bundled `claude-code` network-policy preset never allowed `platform.claude.com`, the host Claude Code posts its browser OAuth authorization code to, so the login path the bundled skill documents first could not complete: the CLI reported `Login failed: Socket is closed` while the sandbox logged `endpoint platform.claude.com:443 is not allowed by any policy`. The preset now allows GET and POST on `/v1/oauth/**` for that host, so a Pro/Max subscriber can finish the browser login with the preset as shipped.

## Related Issue

Fixes #7637

## Changes

- `nemoclaw-blueprint/policies/presets/claude-code.yaml`: add a `platform.claude.com:443` endpoint with `protocol: rest` and `enforcement: enforce`, allowing GET and POST on `/v1/oauth/**` only. The reporter measured the live flow and observed only `POST /v1/oauth/token`, so the rest of the host stays closed. Reword the preset `description:`, which `policy list` renders, to name the browser login.
- `test/effective-policy-contracts.test.ts`: extend the effective host list for `claude_code`, and add a test that pins the new endpoint's port, protocol, enforcement, and its exact two OAuth rules so the scope cannot widen to `/**` unnoticed.
- `test/helpers/vitest-watch-triggers.ts` and `test/vitest-watch-triggers.test.ts`: map `claude-code.yaml` to the contract test. The preset is YAML, so the import graph cannot see the dependency; the mapping is the concrete opaque-input case the helper exists for.
- `docs/security/best-practices.mdx`: update the `claude-code` preset row to name the browser login and state the allowed path scope.

This adds no abstraction, configuration, fallback, migration, or compatibility path.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

`npm run docs` exits 0 and `fern check` reports 0 errors, but it also reports 2 warnings that are present on `main` and unrelated to this change, so the "builds without warnings" verification item below is left unchecked.

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/security/best-practices.mdx`. The review found no blocking language findings and confirmed `docs/reference/network-policies.mdx` needs no change, because lines 178-180 enumerate no hosts, methods, or paths for this preset. It raised one wording nit: the risk cell described the grant more narrowly than the policy grants it, where peer rows such as `pypi` and `tavily` state their scope outright. Commit 9686bb899 applies the reviewer's own proposed rewrite to that cell and is the only change after the reviewed commit 4d1f1bb82.
- Agent: Claude Code
<!-- docs-review-head-sha: 9686bb899 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/effective-policy-contracts.test.ts test/vitest-watch-triggers.test.ts` — 2 files, 18 tests, all pass. Stashing the preset change alone and rerunning fails both Claude assertions, so the new coverage catches the reported defect.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Policy Updates**
  - Updated the `claude-code` preset to support browser login, telemetry, and crash-report access.
  - Added narrowly scoped OAuth connectivity to `platform.claude.com` for `/v1/oauth/**` authorization flows using GET and POST.
  - Clarified that the preset should not be used for NemoClaw inference routing.

- **Documentation**
  - Expanded security guidance covering OAuth behavior and independently installed Claude Code CLI access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->