### PR TITLE
fix(installer): preserve Hermes GPU fallback selection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1521,6 +1521,7 @@ NODE
 # backup flow can run before any version bump.
 maybe_install_openshell_during_install() {
   local mode="${1:-force}"
+  local explicit_openshell_bin="${NEMOCLAW_OPENSHELL_BIN:-}"
   if truthy_env "${NEMOCLAW_DEFER_OPENSHELL_INSTALL:-}"; then
     info "Deferring OpenShell CLI installation until after pre-upgrade backup."
     return 0
@@ -1534,6 +1535,11 @@ maybe_install_openshell_during_install() {
         warn "Homebrew is not installed; using the standalone OpenShell gateway without reboot persistence."
       fi
       prefer_user_local_openshell
+      # Service discovery still uses the user-local PATH, but a source-checkout
+      # caller's executable selection remains authoritative for onboarding.
+      if [[ "$explicit_openshell_bin" == /* && -x "$explicit_openshell_bin" ]]; then
+        export NEMOCLAW_OPENSHELL_BIN="$explicit_openshell_bin"
+      fi
       install_nemoclaw_openshell_gateway_user_service
       return 0
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1537,7 +1537,7 @@ maybe_install_openshell_during_install() {
       prefer_user_local_openshell
       # Service discovery still uses the user-local PATH, but a source-checkout
       # caller's executable selection remains authoritative for onboarding.
-      if [[ "$explicit_openshell_bin" == /* && -x "$explicit_openshell_bin" ]]; then
+      if [[ "$explicit_openshell_bin" == /* && -f "$explicit_openshell_bin" && -x "$explicit_openshell_bin" ]]; then
         export NEMOCLAW_OPENSHELL_BIN="$explicit_openshell_bin"
       fi
       install_nemoclaw_openshell_gateway_user_service

--- a/test/e2e/support/hermes-gpu-startup-fallback.test.ts
+++ b/test/e2e/support/hermes-gpu-startup-fallback.test.ts
@@ -303,6 +303,41 @@ describe("Hermes GPU startup fallback OpenShell wrapper", () => {
     expect(result.stdout).toContain(`final-selection=${path.join(realDir, "openshell")}\n`);
   });
 
+  it("rejects an absolute directory fallback selection during service staging (#7140)", () => {
+    const { realDir, root, wrapper } = createWrapperFixture(
+      "hermes-gpu-fallback-directory-selection-",
+    );
+    const directoryBin = path.join(root, "openshell-directory");
+    fs.mkdirSync(directoryBin, { mode: 0o700 });
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        [
+          'source "$INSTALLER_PAYLOAD" 2>/dev/null',
+          "install_nemoclaw_openshell_gateway_user_service() { :; }",
+          "maybe_install_openshell_during_install if-missing",
+          'printf "final-selection=%s\\n" "$NEMOCLAW_OPENSHELL_BIN"',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...wrapper.componentEnv,
+          HOME: root,
+          INSTALLER_PAYLOAD,
+          NEMOCLAW_OPENSHELL_BIN: directoryBin,
+          PATH: `${realDir}:/usr/bin:/bin`,
+          XDG_BIN_HOME: realDir,
+        },
+      },
+    );
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain(`final-selection=${path.join(realDir, "openshell")}\n`);
+  });
+
   it("rejects exactly one native nvidia-smi proof when wrapper calls race", async () => {
     const { wrapper } = createWrapperFixture("hermes-gpu-fallback-race-test-");
     const env = { ...process.env, ...wrapper.componentEnv };

--- a/test/e2e/support/hermes-gpu-startup-fallback.test.ts
+++ b/test/e2e/support/hermes-gpu-startup-fallback.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../live/hermes-gpu-startup-fallback.ts";
 
 const roots: string[] = [];
+const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "..", "..", "scripts", "install.sh");
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
@@ -225,6 +226,81 @@ describe("Hermes GPU startup fallback OpenShell wrapper", () => {
       "delegated",
       "delegated",
     ]);
+  });
+
+  it("preserves the fallback wrapper while staging the existing OpenShell service (#7140)", () => {
+    const { realDir, root, wrapper } = createWrapperFixture(
+      "hermes-gpu-fallback-installer-selection-",
+    );
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        [
+          'source "$INSTALLER_PAYLOAD" 2>/dev/null',
+          "install_nemoclaw_openshell_gateway_user_service() {",
+          '  printf "service-selection=%s\\n" "$NEMOCLAW_OPENSHELL_BIN"',
+          '  printf "service-gateway=%s\\n" "$NEMOCLAW_OPENSHELL_GATEWAY_BIN"',
+          '  printf "service-path=%s\\n" "$PATH"',
+          "}",
+          "maybe_install_openshell_during_install if-missing",
+          'printf "final-selection=%s\\n" "$NEMOCLAW_OPENSHELL_BIN"',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...wrapper.componentEnv,
+          HOME: root,
+          INSTALLER_PAYLOAD,
+          PATH: `${realDir}:/usr/bin:/bin`,
+          XDG_BIN_HOME: realDir,
+        },
+      },
+    );
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain(`service-selection=${wrapper.wrapperPath}\n`);
+    expect(result.stdout).toContain(`service-gateway=${path.join(realDir, "openshell-gateway")}\n`);
+    expect(result.stdout.match(/^service-path=(.*)$/mu)?.[1]?.split(":")[0]).toBe(realDir);
+    expect(result.stdout).toContain(`final-selection=${wrapper.wrapperPath}\n`);
+  });
+
+  it("rejects a relative fallback wrapper selection during service staging (#7140)", () => {
+    const { realDir, root, wrapper } = createWrapperFixture(
+      "hermes-gpu-fallback-relative-selection-",
+    );
+    const relativeBin = path.join(root, "relative-openshell");
+    writeExecutable(relativeBin, "#!/usr/bin/env bash\nexit 0\n");
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        [
+          'source "$INSTALLER_PAYLOAD" 2>/dev/null',
+          "install_nemoclaw_openshell_gateway_user_service() { :; }",
+          "maybe_install_openshell_during_install if-missing",
+          'printf "final-selection=%s\\n" "$NEMOCLAW_OPENSHELL_BIN"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...wrapper.componentEnv,
+          HOME: root,
+          INSTALLER_PAYLOAD,
+          NEMOCLAW_OPENSHELL_BIN: "./relative-openshell",
+          PATH: `${realDir}:/usr/bin:/bin`,
+          XDG_BIN_HOME: realDir,
+        },
+      },
+    );
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain(`final-selection=${path.join(realDir, "openshell")}\n`);
   });
 
   it("rejects exactly one native nvidia-smi proof when wrapper calls race", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Source-checkout installs now retain an absolute executable selected through `NEMOCLAW_OPENSHELL_BIN` after refreshing user-local OpenShell discovery, while continuing to stage the existing gateway service. This prevents the Hermes GPU fallback test from silently bypassing its fault-injection wrapper and exercising the native route instead.

## Related Issue
Related to #7140.
Follow-up to #6333.

## Changes
- Preserve the caller-selected absolute OpenShell executable in the source-checkout `if-missing` path after adding the user-local OpenShell directory to `PATH`.
- Keep the #7319 gateway-service staging call and the fresh/pinned OpenShell installation path unchanged.
- Add focused E2E-support coverage proving that service staging observes the fallback wrapper, the real gateway component, and the user-local discovery path.
- Reject restoration of a relative executable selection so invalid overrides continue to fall back to the discovered user-local OpenShell binary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores the existing documented `NEMOCLAW_OPENSHELL_BIN` override contract and preserves the already-documented managed gateway-service behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head nine-category security review passed with no findings: https://github.com/NVIDIA/NemoClaw/pull/7710#issuecomment-5101287172
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: At exact head `03d134564`, the review confirmed that `docs/reference/commands.mdx` already documents the OpenShell executable override and `docs/reference/architecture.mdx` already documents managed gateway-service staging. Rejecting an absolute directory as a binary does not change a supported user workflow.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 03d134564 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `hermes-gpu-startup-fallback.test.ts` passed 17/17 at exact head; `install-preflight.test.ts` passed 94/94; CLI type-check and diff-scoped hooks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this two-file source-checkout selection repair; focused tests and diff-scoped hooks cover the changed behavior.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer handling when a custom OpenShell executable is configured.
  * Preserved valid absolute executable selections during managed gateway setup.
  * Added safeguards to fall back to the correct installed OpenShell binary when configured paths are relative or point to directories.
  * Improved reliability of Hermes GPU startup fallback service selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->