### PR TITLE
fix(hermes): normalize image executable modes for the metadata gate

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -716,6 +716,12 @@ RUN if [ "$NEMOCLAW_DARWIN_VM_COMPAT" = "1" ]; then \
 # container and retains evidence keyed to the final image ID.
 COPY --from=hermes-scan-payload / /
 
+# These executables are git-tracked 0755 but check out group-writable (0775)
+# under umask 002, and COPY carries that source mode into the image. Normalize
+# before the check_metadata gate below asserts root:root 755. A RUN chmod is
+# builder-independent; COPY --chmod requires BuildKit.
+RUN chmod 755 /usr/local/lib/nemoclaw/hermes-wrapper.py /scripts/checks/node-tar-image-scan.mts
+
 RUN check_metadata() { \
         path="$1"; \
         expected="$2"; \

--- a/test/hermes-final-image-layout.test.ts
+++ b/test/hermes-final-image-layout.test.ts
@@ -204,6 +204,10 @@ describe("Hermes final image layout", () => {
       'RUN if [ "$NEMOCLAW_DARWIN_VM_COMPAT" = "1" ]',
     );
     const metadataCheck = indexOfRequired(finalStage, "RUN check_metadata()");
+    const modeNormalize = indexOfRequired(
+      finalStage,
+      "RUN chmod 755 /usr/local/lib/nemoclaw/hermes-wrapper.py /scripts/checks/node-tar-image-scan.mts",
+    );
     const imageScan = indexOfRequired(
       finalStage,
       "node --experimental-strip-types /scripts/checks/node-tar-image-scan.mts",
@@ -218,6 +222,8 @@ describe("Hermes final image layout", () => {
     expect(wrapper).toBeLessThan(pythonCheck);
     expect(scan).toBeGreaterThan(darwinCompatibility);
     expect(scan).toBeLessThan(metadataCheck);
+    expect(modeNormalize).toBeGreaterThan(scan);
+    expect(modeNormalize).toBeLessThan(metadataCheck);
     for (const metadataContract of [
       "/scripts/patch-bundled-npm-brace-expansion.mts 'root:root 444'",
       "/scripts/patch-bundled-npm-tar.mts 'root:root 444'",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

v0.0.96 Hermes onboarding aborts at the sandbox image build: the final-stage `check_metadata` gate fails with `metadata is root:root 775, expected root:root 755` on `hermes-wrapper.py` and `node-tar-image-scan.mts`. Both files are git-tracked `100755` but check out group-writable (`0775`) under a umask-002 checkout, and `COPY` preserves the host file mode under the classic (non-BuildKit) builder the OpenShell gateway uses. Every other `check_metadata`-asserted file is normalized with an explicit `chmod` in the final stage; these two were the only ones relying on `COPY` mode preservation. This adds the missing normalization.

## Related Issue

Closes #7708

## Changes

- `agents/hermes/Dockerfile`: add `RUN chmod 0755 /usr/local/lib/nemoclaw/hermes-wrapper.py /scripts/checks/node-tar-image-scan.mts` between the scan `COPY` and the `check_metadata` gate, matching the established "normalize in a RUN, verify with a later `check_metadata`" pattern (e.g. `chmod 755` at line 211 → assertion at the gate). `COPY --chmod` is not used because it is BuildKit-only and the gateway's classic builder ignores it; a `RUN chmod` is builder-independent. The content-hash gate over `hermes-wrapper.py` is over file bytes, so the mode change does not affect it.
- `test/hermes-final-image-layout.test.ts`: extend the existing Dockerfile-string contract test to assert the normalizing `chmod 0755` RUN is present and ordered after the scan `COPY` and before `check_metadata`. Red before the Dockerfile change, green after.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: build-internal image-layout fix; no user-facing docs surface
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending maintainer review; the change only tightens two executables from 0775 to 0755 (removes the group-write bit) to satisfy the existing image-metadata gate, and does not relax any assertion
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no user-facing docs surface; the Dockerfile comment and commit message were reviewed for accuracy and repo voice
- Agent: Claude Code
<!-- docs-review-head-sha: 070967814 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/hermes-final-image-layout.test.ts` → 8 pass; the new contract assertion fails on the pre-fix Dockerfile (red→green verified). Root cause and fix confirmed with a local `DOCKER_BUILDKIT=0 docker build`: `COPY` yields `root:root 775`, `chmod 0755` corrects it to `root:root 755`. hadolint clean (0 findings via `hadolint/hadolint` image).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file permissions in the Hermes sandbox image to ensure required tools run reliably.
  * Improved image validation by enforcing the expected permission settings before metadata checks.

* **Tests**
  * Added coverage to verify permission normalization occurs in the correct build sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->