### PR TITLE
fix(onboard): normalize managed agent build modes

### DIFF
--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -16,7 +16,10 @@ import {
 } from "../adapters/docker";
 import { createCustomBuildContextFilter } from "../onboard/custom-build-context";
 import { ROOT } from "../runner";
-import { SANDBOX_BUILD_CONTEXT_PREFIX } from "../sandbox/build-context";
+import {
+  normalizeReadModesForDockerCopy,
+  SANDBOX_BUILD_CONTEXT_PREFIX,
+} from "../sandbox/build-context";
 import {
   buildLocalBaseTag,
   createSandboxBaseImageBuildProvenance,
@@ -668,6 +671,9 @@ export function createAgentSandbox(
       stagedDockerfile,
       dockerfile.replace(/^ARG BASE_IMAGE(?:=.*)?$/m, `ARG BASE_IMAGE=${baseImageRef}`),
     );
+  }
+  for (const entry of fs.readdirSync(buildCtx)) {
+    normalizeReadModesForDockerCopy(path.join(buildCtx, entry));
   }
   console.log(`  Using ${agent.displayName} Dockerfile: ${agentDockerfile}`);
 

--- a/src/lib/onboard/build-context-stage.test.ts
+++ b/src/lib/onboard/build-context-stage.test.ts
@@ -176,6 +176,42 @@ describe("stageCreateSandboxBuildContext", () => {
     expect(stagedBytes).not.toContain("forbidden-dockerignore-canary");
   });
 
+  it("strips group-write from managed agent build context files (#7708)", () => {
+    const repoRoot = makeTmpDir("nemoclaw-managed-context-modes-");
+    const agentDockerfile = path.join(repoRoot, "agents", "hermes", "Dockerfile");
+    const wrapper = path.join(repoRoot, "agents", "hermes", "hermes-wrapper.py");
+    const scanner = path.join(repoRoot, "scripts", "checks", "node-tar-image-scan.mts");
+    writeFixtureFile(repoRoot, "agents/hermes/Dockerfile", "FROM scratch\n");
+    writeFixtureFile(repoRoot, "agents/hermes/hermes-wrapper.py", "#!/usr/bin/env python3\n");
+    writeFixtureFile(repoRoot, "scripts/checks/node-tar-image-scan.mts", "#!/usr/bin/env node\n");
+    fs.chmodSync(wrapper, 0o775);
+    fs.chmodSync(scanner, 0o775);
+
+    const result = stageCreateSandboxBuildContext({
+      root: repoRoot,
+      fromDockerfile: agentDockerfile,
+      agent: {
+        name: "hermes",
+        displayName: "Hermes",
+        dockerfileBasePath: null,
+        dockerfilePath: agentDockerfile,
+      } as any,
+      createAgentSandbox: (agent) => createManagedAgentSandbox(agent, { rootDir: repoRoot }),
+      log: vi.fn(),
+      exit: throwingExit,
+    });
+    tmpDirs.push(result.buildCtx);
+
+    expect(fs.statSync(result.buildCtx).mode & 0o777).toBe(0o700);
+    expect(
+      fs.statSync(path.join(result.buildCtx, "agents", "hermes", "hermes-wrapper.py")).mode & 0o777,
+    ).toBe(0o755);
+    expect(
+      fs.statSync(path.join(result.buildCtx, "scripts", "checks", "node-tar-image-scan.mts")).mode &
+        0o777,
+    ).toBe(0o755);
+  });
+
   it("stages the managed agent build context when --from reaches the agent Dockerfile through a symlink", () => {
     const repoRoot = makeTmpDir("nemoclaw-repo-symlink-");
     const agentDir = path.join(repoRoot, "agents", "hermes");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Managed Hermes sandbox staging now normalizes copied file and directory modes before OpenShell archives the context. Previously, a source checkout created under `umask 0002` could contain `0775` executables; `fs.cpSync`, tar, and Docker `COPY` preserved that group-write bit, so the image's strict metadata gate rejected the wrapper and scanner. The staged payload is now deterministic while the temporary context root remains owner-only.

## Related Issue

## Changes
- Reuse the existing Docker COPY mode normalizer for every copied top-level entry in managed agent build contexts.
- Add a managed Hermes staging regression test that verifies `0775` executables become `0755` while the context root remains `0700`.
- Keep the final image metadata assertions unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Restores the existing managed-agent staging contract without changing commands, configuration, output, or supported workflows.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex CLI completed the repository's nine-category security checklist with no findings. The change removes group and other write bits, preserves executable intent, and introduces no new input, dependency, credential, or configuration surface.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. The review confirmed that the fix restores existing behavior and that the test wording and code naming follow repository conventions.
- Agent: Codex CLI
<!-- docs-review-head-sha: ff3d091f2 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/build-context-stage.test.ts` passed (12 tests).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused staging fix.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox build-context staging to ensure Docker-copied files and directories use secure, consistent read and write permissions.
  * Preserved executable permissions for required scripts while removing unnecessary group-write access.

* **Tests**
  * Added coverage verifying permissions for staged directories and executable files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->