### PR TITLE
docs(inference): update Omni model ID in sub-agent setup

### DIFF
--- a/docs/inference/set-up-sub-agent.mdx
+++ b/docs/inference/set-up-sub-agent.mdx
@@ -46,7 +46,7 @@ It adds a `vision-operator` sub-agent backed by an Omni vision model.
 | Primary model | `inference/nvidia/nemotron-3-super-120b-a12b` |
 | Auxiliary provider | `nvidia-omni` |
 | Sub-agent | `vision-operator` |
-| Sub-agent model | `nvidia-omni/private/nvidia/nemotron-3-nano-omni-reasoning-30b-a3b` |
+| Sub-agent model | `nvidia-omni/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` |
 | Delegation tool | `sessions_spawn` |
 
 The sub-agent uses Omni as the specialist model for image tasks.


### PR DESCRIPTION
## Summary
Updates the `set-up-sub-agent.mdx` documentation to use the correct model identifier (`nvidia-omni/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`) for the vision-operator sub-agent, resolving an issue where the previous documented model was returning an inference service unavailable (HTTP 503) error.

## Related Issue
Fixes #7729

## Changes
- Updated the sub-agent model string in `docs/inference/set-up-sub-agent.mdx` to reflect the functional inference endpoint.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Docs only change
- [ ] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/set-up-sub-agent.mdx`
- Agent: Antigravity

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: tests NA
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jibin Jose <jibinjose884@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Omni Vision Sub-Agent setup example to use the current sub-agent model identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->