### PR TITLE
fix(state): isolate registry seam ownership

### DIFF
--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -7,24 +7,22 @@ import {
   inferenceSelectionRegistryFields,
   normalizeInferenceSelection,
 } from "../inference/selection";
-import { normalizeToolDisclosure, type ToolDisclosure } from "../tool-disclosure";
+import { normalizeToolDisclosure } from "../tool-disclosure";
 import {
   applyAddExtraProvider,
   applyRemoveExtraProvider,
   isValidExtraProviderName,
   readExtraProviders,
 } from "./extra-providers";
-import type { OpenClawImagePluginInstall } from "./openclaw-plugin-restore";
-import { normalizeSandboxMcpState, type SandboxMcpState } from "./registry-mcp";
-import type { SandboxMessagingState } from "./registry-messaging";
+import { withLock } from "./registry/lock";
+import { load, save } from "./registry/persistence";
+import { normalizeSandboxMcpState } from "./registry-mcp";
 import {
   normalizeBaselineExclusions,
   normalizeBaselineExclusionTransition,
   retainedDefaultSandbox,
 } from "./registry-normalization";
 import * as reversibleRemoval from "./registry-reversible-removal";
-import { withLock } from "./registry/lock";
-import { load, save } from "./registry/persistence";
 
 export {
   getSandboxEntryDisplayInference,
@@ -33,11 +31,13 @@ export {
   type SandboxEntryInference,
 } from "./registry-entry-view";
 
-import type { WebSearchProvider } from "../inference/web-search";
-import {
-  type DcodeAutoApprovalMode,
-  isDcodeAutoApprovalMode,
-} from "../onboard/dcode-auto-approval";
+import { isDcodeAutoApprovalMode } from "../onboard/dcode-auto-approval";
+import type {
+  BaselineExclusionEntry,
+  BaselineExclusionTransition,
+  CustomPolicyEntry,
+  SandboxEntry,
+} from "./registry/types";
 import {
   cloneSandboxMessagingState,
   getConfiguredMessagingChannels as getRegistryConfiguredMessagingChannels,
@@ -45,8 +45,9 @@ import {
   setChannelDisabled as setRegistryChannelDisabled,
 } from "./registry-messaging";
 
-export type { McpBridgeEntry, SandboxMcpState } from "./registry-mcp";
-
+// Compatibility exports for #7694. The registry/types, registry/lock, and
+// registry/persistence modules are authoritative. New code must import those
+// modules directly. Remove these exports after facade callers migrate.
 export {
   acquireLock,
   classifyExistingLock,
@@ -55,12 +56,22 @@ export {
   LOCK_OWNER,
   LOCK_RETRY_MS,
   LOCK_STALE_MS,
-  releaseLock,
   type RegistryLockDecision,
+  releaseLock,
   withLock,
 } from "./registry/lock";
-
 export { load, REGISTRY_FILE, save } from "./registry/persistence";
+export type {
+  BaselineExclusionEntry,
+  BaselineExclusionTransition,
+  BaselineExclusionTransitionOperation,
+  CustomPolicyEntry,
+  SandboxEntry,
+  SandboxGpuProofResult,
+  SandboxGpuProofStatus,
+  SandboxRegistry,
+} from "./registry/types";
+export type { McpBridgeEntry, SandboxMcpState } from "./registry-mcp";
 
 export {
   getConfiguredMessagingChannelsFromEntry,
@@ -69,145 +80,6 @@ export {
   getMessagingPlanFromEntry,
   type SandboxMessagingState,
 } from "./registry-messaging";
-
-export interface CustomPolicyEntry {
-  name: string;
-  content: string;
-  /** Desired content reserved before a crash-safe generated-policy transition. */
-  pendingContent?: string;
-  sourcePath?: string;
-  appliedAt?: string;
-}
-
-export interface BaselineExclusionEntry {
-  /** Persistence schema version for this reviewed exclusion intent. */
-  version: 1;
-  /** Agent baseline that supplied the reviewed entry. */
-  agent: string;
-  /** Exact baseline network policy key excluded, e.g. "nous_research". */
-  key: string;
-  /** Digest of the reviewed baseline entry content the approval was bound to. */
-  digest: string;
-  /** When the exclusion was acknowledged. */
-  acknowledgedAt?: string;
-  /** Agent build/version recorded when the exclusion was last applied. */
-  appliedAgentVersion?: string | null;
-}
-
-export type BaselineExclusionTransitionOperation = "exclude" | "restore";
-
-/**
- * Durable journal for the one cross-system baseline mutation that is in flight.
- * `baselineExclusions` remains the last committed operator intent until this
- * transaction is published after the live OpenShell mutation succeeds.
- */
-export interface BaselineExclusionTransition {
-  id: string;
-  operation: BaselineExclusionTransitionOperation;
-  exclusion: BaselineExclusionEntry;
-  /** Exact live-entry digest that completes the transition; null means absent. */
-  targetLiveDigest: string | null;
-  startedAt: string;
-}
-
-// Outcome of the last live sandbox GPU proof run during onboarding/recovery.
-// `status` separates a configured-but-unverified GPU from one whose CUDA
-// usability was actually proven (`verified`) or actively failed a live proof
-// (`failed`, e.g. Jetson `/dev/nvmap` permission errors). Persisted so
-// `nemoclaw <sandbox> status` can report proof state instead of treating any
-// configured GPU as healthy (#4231).
-export type SandboxGpuProofStatus = "verified" | "unverified" | "failed";
-
-export interface SandboxGpuProofResult {
-  status: SandboxGpuProofStatus;
-  // True only when a CUDA-usability proof (cuInit via libcuda) actually passed.
-  cudaVerified: boolean;
-  // Label of the last proof that determined `status`.
-  label?: string | null;
-  // Redacted, truncated diagnostic captured when the proof failed.
-  detail?: string | null;
-  at: string;
-}
-
-export interface SandboxEntry extends Partial<InferenceSelection> {
-  name: string;
-  /** Route-only placeholder created before sandbox creation; never eligible as the default. */
-  pendingRouteReservation?: true;
-  /** Onboard session that owns a pending reservation, so resume preserves its own row while abandoned reservations stay reconcilable. */
-  reservationSessionId?: string;
-  createdAt?: string;
-  gpuEnabled?: boolean;
-  hostGpuDetected?: boolean;
-  sandboxGpuEnabled?: boolean;
-  sandboxGpuMode?: "auto" | "1" | "0" | string | null;
-  sandboxGpuDevice?: string | null;
-  sandboxGpuProof?: SandboxGpuProofResult | null;
-  openshellDriver?: string | null;
-  openshellVersion?: string | null;
-  policies?: string[];
-  customPolicies?: CustomPolicyEntry[];
-  /** Operator exclusions from the agent baseline policy, replayed on rebuild. */
-  baselineExclusions?: BaselineExclusionEntry[];
-  /** Crash-recoverable journal for an exclusion/restore live-policy mutation. */
-  baselineExclusionTransition?: BaselineExclusionTransition;
-  policyTier?: string | null;
-  // True once the onboard policy step has fully completed and reconciled the
-  // effective preset selection (set by the post-policy registry write). Absent
-  // on a sandbox whose registration recorded only boot-time presets but whose
-  // policy step never finished — so re-onboard knows whether `policies`
-  // represents a final selection it can carry forward. See #4621.
-  policyPresetsFinalized?: boolean;
-  webSearchEnabled?: boolean;
-  /** Selected disclosure preference; model compatibility safeguards may downgrade runtime behavior. */
-  toolDisclosure?: ToolDisclosure;
-  /** Enables backend-neutral trace export to the fixed local OTLP collector boundary. */
-  observabilityEnabled?: boolean;
-  /** Image-baked permission to expose DCode's per-thread auto-approval opt-in. */
-  dcodeAutoApprovalMode?: DcodeAutoApprovalMode;
-  /** Durable provider identity for enabled managed web search. */
-  webSearchProvider?: WebSearchProvider | null;
-  agent?: string | null;
-  agentVersion?: string | null;
-  /** Plugin install baseline captured before state is restored into a fresh OpenClaw image. */
-  openclawImagePluginInstalls?: OpenClawImagePluginInstall[];
-  // NemoClaw build fingerprint (the NemoClaw CLI/build version) stamped only on
-  // NemoClaw-managed images at create/rebuild time. `upgrade-sandboxes` compares
-  // it against the running NemoClaw build so an image/build change with an
-  // unchanged agent version is still detected as needing a rebuild. Custom-image
-  // (`--from`) sandboxes are intentionally left without a fingerprint so they
-  // are never auto-rebuilt onto the default image (#5026).
-  nemoclawVersion?: string | null;
-  fromDockerfile?: string | null;
-  hermesAuthMethod?: "oauth" | "api_key" | null;
-  imageTag?: string | null;
-  messaging?: SandboxMessagingState;
-  mcp?: SandboxMcpState;
-  hermesToolGateways?: string[];
-  hermesDashboardEnabled?: boolean;
-  hermesDashboardPort?: number | null;
-  hermesDashboardInternalPort?: number | null;
-  hermesDashboardTui?: boolean;
-  dashboardPort?: number | null;
-  /** Remote dashboard exposure was included in the sandbox's generated config. */
-  dashboardRemoteBindPrepared?: boolean;
-  /** Generation proving which durable same-name recreate registered this row. */
-  lifecycleGeneration?: string;
-  /** Hashed OpenShell identity paired with lifecycleGeneration for exact recovery. */
-  lifecycleLiveIdentityFingerprint?: string;
-  // OpenShell gateway registration name and host port bound to this sandbox.
-  // Persisted so later lifecycle commands operate on the sandbox's own gateway
-  // instead of the process-global `nemoclaw` singleton — a second sandbox on a
-  // different NEMOCLAW_GATEWAY_PORT no longer recreates/kills the first (#4422).
-  gatewayName?: string | null;
-  gatewayPort?: number | null;
-}
-
-export interface SandboxRegistry {
-  sandboxes: Record<string, SandboxEntry>;
-  defaultSandbox: string | null;
-  defaultSelectionRevision?: number;
-  extraProviders?: string[];
-}
 
 export type SandboxRemovalReceipt = reversibleRemoval.RegistryRemovalReceipt<SandboxEntry>;
 

--- a/src/lib/state/registry/lock.ts
+++ b/src/lib/state/registry/lock.ts
@@ -100,29 +100,6 @@ export function acquireLock(): void {
   for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
     try {
       fs.mkdirSync(LOCK_DIR);
-      const ownerTmp = `${LOCK_OWNER}.tmp.${process.pid}`;
-      try {
-        fs.writeFileSync(ownerTmp, String(process.pid), { mode: 0o600 });
-        fs.renameSync(ownerTmp, LOCK_OWNER);
-      } catch (ownerErr) {
-        try {
-          fs.unlinkSync(ownerTmp);
-        } catch {
-          /* best effort */
-        }
-        try {
-          fs.unlinkSync(LOCK_OWNER);
-        } catch {
-          /* best effort */
-        }
-        try {
-          fs.rmdirSync(LOCK_DIR);
-        } catch {
-          /* best effort */
-        }
-        throw ownerErr;
-      }
-      return;
     } catch (error) {
       if (!isErrnoException(error) || error.code !== "EEXIST") {
         throw error;
@@ -178,7 +155,32 @@ export function acquireLock(): void {
         }
       }
       Atomics.wait(sleepBuf, 0, 0, LOCK_RETRY_MS);
+      continue;
     }
+
+    const ownerTmp = `${LOCK_OWNER}.tmp.${process.pid}`;
+    try {
+      fs.writeFileSync(ownerTmp, String(process.pid), { mode: 0o600 });
+      fs.renameSync(ownerTmp, LOCK_OWNER);
+    } catch (ownerError) {
+      try {
+        fs.unlinkSync(ownerTmp);
+      } catch {
+        /* best effort */
+      }
+      try {
+        fs.unlinkSync(LOCK_OWNER);
+      } catch {
+        /* best effort */
+      }
+      try {
+        fs.rmdirSync(LOCK_DIR);
+      } catch {
+        /* best effort */
+      }
+      throw ownerError;
+    }
+    return;
   }
   throw new Error(`Failed to acquire lock on ${REGISTRY_FILE} after ${LOCK_MAX_RETRIES} retries`);
 }

--- a/src/lib/state/registry/persistence.ts
+++ b/src/lib/state/registry/persistence.ts
@@ -18,8 +18,8 @@ import {
   retainedDefaultSandbox,
 } from "../registry-normalization";
 import * as reversibleRemoval from "../registry-reversible-removal";
-import type { SandboxEntry, SandboxRegistry } from "../registry";
 import { nemoclawStateRoot } from "../state-root";
+import type { SandboxEntry, SandboxRegistry } from "./types";
 
 export const REGISTRY_FILE = path.join(
   nemoclawStateRoot(process.env.HOME || "/tmp", GATEWAY_PORT),

--- a/src/lib/state/registry/types.ts
+++ b/src/lib/state/registry/types.ts
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { InferenceSelection } from "../../inference/selection";
+import type { WebSearchProvider } from "../../inference/web-search";
+import type { DcodeAutoApprovalMode } from "../../onboard/dcode-auto-approval";
+import type { ToolDisclosure } from "../../tool-disclosure";
+import type { OpenClawImagePluginInstall } from "../openclaw-plugin-restore";
+import type { SandboxMcpState } from "../registry-mcp";
+import type { SandboxMessagingState } from "../registry-messaging";
+
+export interface CustomPolicyEntry {
+  name: string;
+  content: string;
+  /** Desired content reserved before a crash-safe generated-policy transition. */
+  pendingContent?: string;
+  sourcePath?: string;
+  appliedAt?: string;
+}
+
+export interface BaselineExclusionEntry {
+  /** Persistence schema version for this reviewed exclusion intent. */
+  version: 1;
+  /** Agent baseline that supplied the reviewed entry. */
+  agent: string;
+  /** Exact baseline network policy key excluded, e.g. "nous_research". */
+  key: string;
+  /** Digest of the reviewed baseline entry content the approval was bound to. */
+  digest: string;
+  /** When the exclusion was acknowledged. */
+  acknowledgedAt?: string;
+  /** Agent build/version recorded when the exclusion was last applied. */
+  appliedAgentVersion?: string | null;
+}
+
+export type BaselineExclusionTransitionOperation = "exclude" | "restore";
+
+/**
+ * Durable journal for the one cross-system baseline mutation that is in flight.
+ * `baselineExclusions` remains the last committed operator intent until this
+ * transaction is published after the live OpenShell mutation succeeds.
+ */
+export interface BaselineExclusionTransition {
+  id: string;
+  operation: BaselineExclusionTransitionOperation;
+  exclusion: BaselineExclusionEntry;
+  /** Exact live-entry digest that completes the transition; null means absent. */
+  targetLiveDigest: string | null;
+  startedAt: string;
+}
+
+// Outcome of the last live sandbox GPU proof run during onboarding/recovery.
+// `status` separates a configured-but-unverified GPU from one whose CUDA
+// usability was actually proven (`verified`) or actively failed a live proof
+// (`failed`, e.g. Jetson `/dev/nvmap` permission errors). Persisted so
+// `nemoclaw <sandbox> status` can report proof state instead of treating any
+// configured GPU as healthy (#4231).
+export type SandboxGpuProofStatus = "verified" | "unverified" | "failed";
+
+export interface SandboxGpuProofResult {
+  status: SandboxGpuProofStatus;
+  // True only when a CUDA-usability proof (cuInit via libcuda) actually passed.
+  cudaVerified: boolean;
+  // Label of the last proof that determined `status`.
+  label?: string | null;
+  // Redacted, truncated diagnostic captured when the proof failed.
+  detail?: string | null;
+  at: string;
+}
+
+export interface SandboxEntry extends Partial<InferenceSelection> {
+  name: string;
+  /** Route-only placeholder created before sandbox creation; never eligible as the default. */
+  pendingRouteReservation?: true;
+  /** Onboard session that owns a pending reservation, so resume preserves its own row while abandoned reservations stay reconcilable. */
+  reservationSessionId?: string;
+  createdAt?: string;
+  gpuEnabled?: boolean;
+  hostGpuDetected?: boolean;
+  sandboxGpuEnabled?: boolean;
+  sandboxGpuMode?: "auto" | "1" | "0" | string | null;
+  sandboxGpuDevice?: string | null;
+  sandboxGpuProof?: SandboxGpuProofResult | null;
+  openshellDriver?: string | null;
+  openshellVersion?: string | null;
+  policies?: string[];
+  customPolicies?: CustomPolicyEntry[];
+  /** Operator exclusions from the agent baseline policy, replayed on rebuild. */
+  baselineExclusions?: BaselineExclusionEntry[];
+  /** Crash-recoverable journal for an exclusion/restore live-policy mutation. */
+  baselineExclusionTransition?: BaselineExclusionTransition;
+  policyTier?: string | null;
+  // True once the onboard policy step has fully completed and reconciled the
+  // effective preset selection (set by the post-policy registry write). Absent
+  // on a sandbox whose registration recorded only boot-time presets but whose
+  // policy step never finished — so re-onboard knows whether `policies`
+  // represents a final selection it can carry forward. See #4621.
+  policyPresetsFinalized?: boolean;
+  webSearchEnabled?: boolean;
+  /** Selected disclosure preference; model compatibility safeguards may downgrade runtime behavior. */
+  toolDisclosure?: ToolDisclosure;
+  /** Enables backend-neutral trace export to the fixed local OTLP collector boundary. */
+  observabilityEnabled?: boolean;
+  /** Image-baked permission to expose DCode's per-thread auto-approval opt-in. */
+  dcodeAutoApprovalMode?: DcodeAutoApprovalMode;
+  /** Durable provider identity for enabled managed web search. */
+  webSearchProvider?: WebSearchProvider | null;
+  agent?: string | null;
+  agentVersion?: string | null;
+  /** Plugin install baseline captured before state is restored into a fresh OpenClaw image. */
+  openclawImagePluginInstalls?: OpenClawImagePluginInstall[];
+  // NemoClaw build fingerprint (the NemoClaw CLI/build version) stamped only on
+  // NemoClaw-managed images at create/rebuild time. `upgrade-sandboxes` compares
+  // it against the running NemoClaw build so an image/build change with an
+  // unchanged agent version is still detected as needing a rebuild. Custom-image
+  // (`--from`) sandboxes are intentionally left without a fingerprint so they
+  // are never auto-rebuilt onto the default image (#5026).
+  nemoclawVersion?: string | null;
+  fromDockerfile?: string | null;
+  hermesAuthMethod?: "oauth" | "api_key" | null;
+  imageTag?: string | null;
+  messaging?: SandboxMessagingState;
+  mcp?: SandboxMcpState;
+  hermesToolGateways?: string[];
+  hermesDashboardEnabled?: boolean;
+  hermesDashboardPort?: number | null;
+  hermesDashboardInternalPort?: number | null;
+  hermesDashboardTui?: boolean;
+  dashboardPort?: number | null;
+  /** Remote dashboard exposure was included in the sandbox's generated config. */
+  dashboardRemoteBindPrepared?: boolean;
+  /** Generation proving which durable same-name recreate registered this row. */
+  lifecycleGeneration?: string;
+  /** Hashed OpenShell identity paired with lifecycleGeneration for exact recovery. */
+  lifecycleLiveIdentityFingerprint?: string;
+  // OpenShell gateway registration name and host port bound to this sandbox.
+  // Persisted so later lifecycle commands operate on the sandbox's own gateway
+  // instead of the process-global `nemoclaw` singleton — a second sandbox on a
+  // different NEMOCLAW_GATEWAY_PORT no longer recreates/kills the first (#4422).
+  gatewayName?: string | null;
+  gatewayPort?: number | null;
+}
+
+export interface SandboxRegistry {
+  sandboxes: Record<string, SandboxEntry>;
+  defaultSandbox: string | null;
+  defaultSelectionRevision?: number;
+  extraProviders?: string[];
+}

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1175,6 +1175,24 @@ describe("advisory file locking", () => {
     }
   });
 
+  it("acquireLock does not treat an owner file EEXIST as lock contention (#7694)", () => {
+    const origWrite = fs.writeFileSync;
+    let firstCall = true;
+    fs.writeFileSync = (...args) => {
+      if (String(args[0]).includes("owner.tmp.") && firstCall) {
+        firstCall = false;
+        throw Object.assign(new Error("owner write EEXIST"), { code: "EEXIST" });
+      }
+      return origWrite.apply(fs, args);
+    };
+    try {
+      expect(() => registry.acquireLock()).toThrow("owner write EEXIST");
+      expect(fs.existsSync(lockDir)).toBe(false);
+    } finally {
+      fs.writeFileSync = origWrite;
+    }
+  });
+
   it("acquireLock removes stale lock owned by dead process", () => {
     // Create a lock with a PID that doesn't exist (99999999)
     fs.mkdirSync(lockDir, { recursive: true });

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1177,13 +1177,8 @@ describe("advisory file locking", () => {
 
   it("acquireLock does not treat an owner file EEXIST as lock contention (#7694)", () => {
     const origWrite = fs.writeFileSync;
-    let firstCall = true;
-    fs.writeFileSync = (...args) => {
-      if (String(args[0]).includes("owner.tmp.") && firstCall) {
-        firstCall = false;
-        throw Object.assign(new Error("owner write EEXIST"), { code: "EEXIST" });
-      }
-      return origWrite.apply(fs, args);
+    fs.writeFileSync = () => {
+      throw Object.assign(new Error("owner write EEXIST"), { code: "EEXIST" });
     };
     try {
       expect(() => registry.acquireLock()).toThrow("owner write EEXIST");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Follow up on #7720. Move durable registry types below the compatibility facade so persistence no longer imports upward. Propagate owner-file failures instead of treating them as lock contention.

## Related Issue

Related to #7694.
Follow-up to #7720.

## Changes

- Make `state/registry/types.ts` authoritative for durable registry types.
- Keep facade reexports for current callers. Issue #7694 tracks caller migration and removal.
- Restrict `EEXIST` contention handling to atomic lock-directory acquisition.
- Propagate owner write and rename failures after cleanup.
- Add an integration regression test for owner-file `EEXIST` failures.

The direct seam import removes the upward dependency. The regression test protects the error-classification contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change adjusts internal module ownership and lock error classification. It adds no user-facing surface.
- [x] Sensitive paths changed (security, sandbox, credentials, supply chain, installer, or privileged runtime)
- [ ] Sensitive-path review completed — reviewer/approval link: Pending maintainer review.
- [x] Non-success, cancellation, timeout, retry, or partial-failure behavior is changed — rationale and tests: Owner-file failures now propagate instead of entering lock-contention retries. The integration test covers `EEXIST` at the owner-file write.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the final diff and no-doc rationale
- Result: `no-docs-needed`
- Evidence: The change has no public command, configuration, policy, or workflow effect. The compatibility comment identifies authoritative modules and the #7694 removal condition. Registry integration tests pass 68/68. The conditional guardrail scan passes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: da6faf820 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

Not applicable. This PR does not change `scripts/prepare-dgx-station-host.sh`.

## Verification

- [x] DCO sign-off present in every commit and commits show GitHub `Verified`
- [x] Normal repository hooks ran successfully, or `npm run check:diff` passed against current `origin/main`
- [x] Targeted behavior tests pass: registry integration 68/68; package contracts 327/327; conditional guardrail scan passes
- [ ] Applicable broad gate completed — usually `npm test` or `npm run check`
- [ ] Quality Gates above are completed
- [x] No secrets, credentials, or private keys are included
- [ ] Docs-only: `npm run docs` passes
- [ ] Docs-only with code samples: tested sample commands or fenced-code syntax

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry lock acquisition to avoid misclassifying an owner-file creation error as lock contention.
  * Prevented lock directories from being left behind after failed lock acquisition.
* **Refactor**
  * Consolidated registry persistence type definitions into a shared types module and re-exported them for the registry’s public type surface.
* **Tests**
  * Added a unit test covering lock acquisition failure during owner-file creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->