### PR TITLE
fix(hermes): update Hermes Agent to 0.18.2

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -245,7 +245,7 @@ RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/sandbox-init
 RUN test -x /usr/local/lib/nemoclaw/validate-hermes-env-secret-boundary.py \
     || { echo "ERROR: validate-hermes-env-secret-boundary.py missing or not executable" >&2; exit 1; }
 
-# Hermes v0.18.0 computes `sessions list` preview from the first user message,
+# Hermes v0.18.2 computes `sessions list` preview from the first user message,
 # while #5254's user-facing expectation is that the existing row reflects the
 # latest resumed/continued one-shot turn. Patch only the pinned query shape and
 # prove the SessionDB list contract at build time so a Hermes update cannot
@@ -266,7 +266,7 @@ assert rows and rows[0]["id"] == session_id, rows
 assert rows[0]["preview"] == "NEMOCLAW_PREVIEW_LATEST", rows
 PY
 
-# Hermes v0.18.0's bundled Langfuse plugin rejects OpenShell resolver
+# Hermes v0.18.2's bundled Langfuse plugin rejects OpenShell resolver
 # placeholders before the SDK can construct its Basic-auth headers. Accept only
 # the exact public/secret placeholder bound to the matching standard Langfuse
 # key; raw keys keep Hermes' upstream pk-lf-/sk-lf- validation. The patcher
@@ -354,10 +354,10 @@ RUN hermes_version_output="$(/usr/local/bin/hermes --version)" \
         echo "ERROR: could not parse Hermes semver from: $hermes_version_output" >&2; \
         exit 1; \
     fi \
-    && if [ "$hermes_semver" != "0.18.0" ] \
+    && if [ "$hermes_semver" != "0.18.2" ] \
         && { grep -q '_translate_resumed_oneshot' /usr/local/lib/nemoclaw/hermes-wrapper.py \
           || grep -q 'EXPECTED_OCCURRENCES' /usr/local/lib/nemoclaw/patch-hermes-session-list-preview.py; }; then \
-        echo "ERROR: installed Hermes ${hermes_semver} but Hermes v0.18.0 compatibility workarounds are still installed; re-review #5254 workaround removal before upgrading Hermes" >&2; \
+        echo "ERROR: installed Hermes ${hermes_semver} but Hermes v0.18.2 compatibility workarounds are still installed; re-review #5254 workaround removal before upgrading Hermes" >&2; \
         exit 1; \
     fi
 # This runs before `/usr/local/bin/hermes` is moved to `hermes.real`, so the

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -29,11 +29,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # pyproject.toml, HERMES_TARBALL_SHA256 the GitHub tarball checksum, and
 # HERMES_NPM_INTEGRITY the `npm view hermes-agent@<semver> dist.integrity`
 # sha512 used as a registry cross-check at build time.
-# Calver tag v2026.7.1 = Hermes Agent v0.18.0.
-ARG HERMES_VERSION=v2026.7.1
-ARG HERMES_SEMVER=0.18.0
-ARG HERMES_TARBALL_SHA256=ec8a380629cc2f3f2102dd92cad50c4ded706fe59c0e359a05681166a0ae2991
-ARG HERMES_NPM_INTEGRITY=sha512-fS+8MsE69shNPmFnKDrE1a+KUDEEXgbyN/QM7J+2nh294gTjh2wCknk2tfMsD03GhSxl7YwyDmp6e5HLYzw8yA==
+# Calver tag v2026.7.7.2 = Hermes Agent v0.18.2.
+ARG HERMES_VERSION=v2026.7.7.2
+ARG HERMES_SEMVER=0.18.2
+ARG HERMES_TARBALL_SHA256=f5d1022eed3763a768cf7b0f0844831f0170a35f54eb8d18223f2e93f503025e
+ARG HERMES_NPM_INTEGRITY=sha512-Zhkhl209frEHGh65S3+eGZu/M+mFPFQwQeBOnG/MtRfAFEfRMkji+deyjH7TFrQNcp+RHioiBamCFYDNR6dPlw==
 ARG HERMES_UV_EXTRAS="anthropic messaging web pty mcp"
 ARG UV_VERSION=0.11.8
 

--- a/agents/hermes/hermes-wrapper.py
+++ b/agents/hermes/hermes-wrapper.py
@@ -289,9 +289,9 @@ _VALUE_FLAGS = {
     "--resume": "--resume",
 }
 # Keep this allowlist aligned with the top-level flags accepted by the pinned
-# Hermes Agent CLI in agents/hermes/Dockerfile.base (HERMES_VERSION=v2026.7.1,
-# HERMES_SEMVER=0.18.0) and agents/hermes/manifest.yaml (expected_version
-# "0.18.0"). Unknown flags deliberately fail closed by passing the original argv
+# Hermes Agent CLI in agents/hermes/Dockerfile.base (HERMES_VERSION=v2026.7.7.2,
+# HERMES_SEMVER=0.18.2) and agents/hermes/manifest.yaml (expected_version
+# "0.18.2"). Unknown flags deliberately fail closed by passing the original argv
 # through to upstream Hermes.
 _BOOLEAN_FLAGS = {
     "--worktree",

--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -16,9 +16,9 @@ homepage: "https://github.com/NousResearch/hermes-agent"
 install_method: curl  # curl install.sh | bash
 binary_path: /usr/local/bin/hermes
 version_command: "hermes --version"
-expected_version: "0.18.0"
-# Hermes reports semver from `hermes --version` (e.g. `0.18.0`) even though its
-# GitHub release cadence is calendar-based (`v2026.7.1`). Declaring the
+expected_version: "0.18.2"
+# Hermes reports semver from `hermes --version` (e.g. `0.18.2`) even though its
+# GitHub release cadence is calendar-based (`v2026.7.7.2`). Declaring the
 # scheme keeps the staleness check off the shape heuristic when a manifest
 # could otherwise straddle both schemes (#6049).
 version_scheme: semver

--- a/agents/hermes/patch-langfuse-credentials.mts
+++ b/agents/hermes/patch-langfuse-credentials.mts
@@ -7,7 +7,7 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 
 /**
- * Patch the Langfuse validator bundled with pinned Hermes v2026.7.1 / 0.18.0.
+ * Patch the Langfuse validator bundled with pinned Hermes v2026.7.7.2 / 0.18.2.
  *
  * Hermes rejects OpenShell resolver placeholders before the Langfuse SDK can
  * turn them into outbound authentication headers. NemoClaw keeps the real

--- a/agents/hermes/patch-session-list-preview.py
+++ b/agents/hermes/patch-session-list-preview.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Patch pinned Hermes v0.18.0 session-list previews to show the latest user turn.
+"""Patch pinned Hermes v0.18.2 session-list previews to show the latest user turn.
 
 Source-of-truth note for this localized Hermes runtime patch:
-  - Invalid state: Hermes v0.18.0 computes `sessions list` preview text from
+  - Invalid state: Hermes v0.18.2 computes `sessions list` preview text from
     the first user message, but #5254's resumed/continued one-shot UX expects
     the original row to reflect the latest appended turn.
   - Value being patched: pinned/prebuilt `/opt/hermes/hermes_state.py`

--- a/src/lib/domain/sandbox/connect-env.test.ts
+++ b/src/lib/domain/sandbox/connect-env.test.ts
@@ -21,6 +21,7 @@ describe("sandbox connect environment helpers", () => {
     expect(NEMOCLAW_HERMES_LIGHT_SKIN_REVIEWED_HERMES_VERSIONS).toEqual([
       "v2026.6.19",
       "v2026.7.1",
+      "v2026.7.7.2",
     ]);
   });
 

--- a/src/lib/domain/sandbox/connect-env.ts
+++ b/src/lib/domain/sandbox/connect-env.ts
@@ -7,6 +7,7 @@ export const NEMOCLAW_HERMES_LIGHT_SKIN_NAME = "nemoclaw-light";
 export const NEMOCLAW_HERMES_LIGHT_SKIN_REVIEWED_HERMES_VERSIONS = [
   "v2026.6.19",
   "v2026.7.1",
+  "v2026.7.7.2",
 ] as const;
 
 // Compatibility boundary: remove this NemoClaw-managed light skin once the

--- a/test/hermes-doctor-config-hash.test.ts
+++ b/test/hermes-doctor-config-hash.test.ts
@@ -52,7 +52,7 @@ describe("Hermes doctor and config hash boundary", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
-        "Hermes v0.18.0 compatibility workarounds are still installed",
+        "Hermes v0.18.2 compatibility workarounds are still installed",
       );
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/test/update-hermes-agent-script.test.ts
+++ b/test/update-hermes-agent-script.test.ts
@@ -16,7 +16,7 @@ const HERMES_BASE_DOCKERFILE = path.join(
   "Dockerfile.base",
 );
 const HERMES_MANIFEST = path.join(import.meta.dirname, "..", "agents", "hermes", "manifest.yaml");
-const TARGET_TAG = "v2026.7.1";
+const TARGET_TAG = "v2026.7.7.2";
 
 const CURRENT_INSTALLED_BASE = [
   "# Calver tag v2026.6.5 = Hermes Agent v0.16.0.",
@@ -88,7 +88,7 @@ printf 'fake archive' > "$output"
     );
     writeExecutable(
       path.join(fakeBin, "tar"),
-      "#!/usr/bin/env bash\nprintf 'version = \"0.18.0\"\\n'\n",
+      "#!/usr/bin/env bash\nprintf 'version = \"0.18.2\"\\n'\n",
     );
     writeExecutable(path.join(fakeBin, "npm"), "#!/usr/bin/env bash\nprintf 'sha512-test\\n'\n");
     writeExecutable(
@@ -107,7 +107,7 @@ esac
 set -euo pipefail
 printf '%s|%s\\n' "\${NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF:-}" "$*" >> "$FAKE_NEMOHERMES_LOG"
 if [[ "$*" == "hermes exec -- hermes --version" ]]; then
-  printf '0.18.0\\n'
+  printf '0.18.2\\n'
 fi
 `,
     );
@@ -130,7 +130,7 @@ fi
       expect(run.status, `${run.stdout}\n${run.stderr}`).toBe(0);
       expect(fs.readFileSync(dockerLog, "utf8")).toContain(`tag ${baseRef} ${pinnedRef}`);
       expect(fs.readFileSync(nemohermesLog, "utf8")).toContain(`${pinnedRef}|hermes rebuild`);
-      expect(run.stdout).toContain("OK: sandbox reports Hermes Agent v0.18.0");
+      expect(run.stdout).toContain("OK: sandbox reports Hermes Agent v0.18.2");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Updates the bundled Hermes Agent from 0.18.0 to the published 0.18.2 release required by NeMo Relay. The release pin, artifact integrity values, and version-scoped compatibility checks now agree on the installed version. This is the source-side input to the established base-image publication and release-promotion flow; public installs receive 0.18.2 after that flow publishes the new image, updates the immutable final-image digest, and promotes the resulting release.

## Changes

- Pin the Hermes source archive to `v2026.7.7.2` / `0.18.2`, including its SHA-256 and npm registry integrity value. The 0.18.2 patch fixes tagged Docker builds upstream.
- Retain and revalidate the existing session-preview and Langfuse compatibility workarounds against the new pinned source. The build guard still requires a fresh review before a later Hermes upgrade.
- Add `v2026.7.7.2` to the reviewed light-skin source list and update version-bound test fixtures.
- Keep the installer unchanged: it installs a selected NemoClaw revision, while the Hermes version belongs in the published sandbox base image. Existing Hermes sandboxes require a rebuild after the release promotion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The version pin and compatibility guards do not change a documented command, configuration, or user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed the published `v2026.7.7.2` source tag, archive SHA-256, npm integrity value, retained patch contracts, and light-skin source diff. The change adds no network, credential, or policy path.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. Reviewed the changed Hermes comments and test wording against `WRITING.md`; reviewed applicable documentation style in `docs/CONTRIBUTING.md`. No user-facing workflow changed. `git diff --check` passed. Validation evidence: normal pre-commit hooks including hadolint passed; CLI connect-env 9 passed; integration dependency-pin/update-script 18 passed; E2E Langfuse 3 passed; the targeted Hermes upgrade guard passed; update script check passed. The unrelated full doctor config-hash test has a local `chmod` EPERM limit.
- Agent: Codex Desktop, documentation-writer review
<!-- docs-review-head-sha: bc88e376 -->
<!-- docs-review-agents-blob-sha: be20a095 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `src/lib/domain/sandbox/connect-env.test.ts` passed 9; `test/dependency-pins-check.test.ts` and `test/update-hermes-agent-script.test.ts` passed 18; `test/e2e/support/hermes-langfuse-credential-patch.test.ts` passed 3; the targeted Hermes upgrade guard passed 1; `bash scripts/update-hermes-agent.sh --tag v2026.7.7.2 --check` passed. The unrelated full doctor config-hash test has a local `chmod` EPERM limit for CI to confirm.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the change updates a dependency pin and focused version-bound contracts.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Antonio Martinez <anmartinez@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled Hermes Agent to v0.18.2.
  * Added compatibility support for the corresponding Hermes release.
  * Refreshed session preview and credential validation compatibility for the new version.

* **Bug Fixes**
  * Improved build-time checks to detect mismatched Hermes versions and outdated compatibility workarounds.

* **Tests**
  * Updated version and compatibility checks to validate Hermes v0.18.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->