### PR TITLE
docs: complete v0.0.96 post-tag audit fixes

### DIFF
--- a/docs/changelog/2026-07-25.mdx
+++ b/docs/changelog/2026-07-25.mdx
@@ -49,7 +49,7 @@ It also hardens blueprint identifier validation, improves onboarding and recover
   A version-tag install reports the requested tag, and a near-miss license response such as `y` receives an in-place hint without weakening exact `yes` acceptance.
   WSL Express selects Windows-host Ollama only with Docker Desktop integration and otherwise configures WSL-local Ollama.
   DGX Station preparation now distinguishes an active vLLM server from unrelated diagnostic processes.
-  For more information, refer to the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart), [Update Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/update-sandboxes), [Prepare Windows for NemoClaw](/user-guide/openclaw/get-started/additional-setup/windows-preparation), and [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).
+  For more information, refer to the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart), [Update Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/update-sandboxes), [Prepare a Windows Machine to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/windows-preparation), and [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).
 - The Ollama model menu now shows download size, required VRAM, and available or total GPU memory when known.
   Re-onboarding a committed local Ollama route now reuses its persisted proxy token so the existing sandbox and restarted host proxy keep the same credential.
   Resumed onboarding reports when a recorded reasoning setting takes precedence over `NEMOCLAW_REASONING`.

--- a/docs/inference/custom-endpoint-security.mdx
+++ b/docs/inference/custom-endpoint-security.mdx
@@ -19,7 +19,7 @@ The sandbox does not receive the raw API key.
 
 Use `COMPATIBLE_API_KEY` for an OpenAI-compatible endpoint that requires authentication.
 For an HTTP endpoint on `localhost`, `127.0.0.1`, or `[::1]` and port `8000`, `11434`, or `11435`, you can select no authentication.
-For non-interactive onboarding, set `NEMOCLAW_COMPATIBLE_AUTH_MODE=none`.
+For non-interactive onboarding of that OpenAI-compatible endpoint, set `NEMOCLAW_COMPATIBLE_AUTH_MODE=none`.
 Use `COMPATIBLE_ANTHROPIC_API_KEY` for a custom Anthropic-compatible endpoint.
 Anthropic-compatible onboarding requires a non-empty value even when the upstream server does not authenticate requests.
 Use a non-empty placeholder such as `dummy` for an unauthenticated Anthropic-compatible endpoint.

--- a/docs/inference/custom-endpoint-security.mdx
+++ b/docs/inference/custom-endpoint-security.mdx
@@ -17,10 +17,12 @@ The agent inside the sandbox sends requests to `inference.local` instead of conn
 OpenShell forwards the traffic and injects the provider credential at egress.
 The sandbox does not receive the raw API key.
 
-Use `COMPATIBLE_API_KEY` for a custom OpenAI-compatible endpoint.
+Use `COMPATIBLE_API_KEY` for an OpenAI-compatible endpoint that requires authentication.
+For an HTTP endpoint on `localhost`, `127.0.0.1`, or `[::1]` and port `8000`, `11434`, or `11435`, you can select no authentication.
+For non-interactive onboarding, set `NEMOCLAW_COMPATIBLE_AUTH_MODE=none`.
 Use `COMPATIBLE_ANTHROPIC_API_KEY` for a custom Anthropic-compatible endpoint.
-Both onboarding flows require a non-empty value, even when the upstream server does not authenticate requests.
-Use a non-empty placeholder such as `dummy` for an unauthenticated local server.
+Anthropic-compatible onboarding requires a non-empty value even when the upstream server does not authenticate requests.
+Use a non-empty placeholder such as `dummy` for an unauthenticated Anthropic-compatible endpoint.
 
 ## Understand URL Validation
 

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -71,6 +71,8 @@ $$nemoclaw onboard
 Select the Ollama entry for your host.
 The menu identifies a reachable daemon as running and labels an installed but stopped daemon **Start local Ollama**.
 NemoClaw lists installed models or offers starter models when none are installed.
+For registry-known models, each menu entry shows the download size and approximate VRAM requirement.
+The menu shows currently available GPU memory when the host reports it, or total GPU memory when available memory is unknown.
 
 The starter list includes `qwen3.6:35b` and selects it by default when current GPU memory can accommodate it.
 When another GPU workload consumes most of the available memory, NemoClaw selects the largest starter model that still fits.
@@ -139,7 +141,7 @@ The wizard manages the proxy lifecycle:
 - It removes stale matching proxy processes from previous runs.
 - It probes the sandbox Docker network path before saving the inference route.
 - It stops matching proxy processes during uninstall.
-- It reuses the persisted token after a host reboot.
+- It reuses the persisted token after a host reboot and during re-onboarding for the committed local Ollama route.
 
 All proxy endpoints require the token, including `GET /api/tags`.
 The host-side proxy liveness check treats any HTTP response, including `401`, as evidence that the proxy answered.

--- a/docs/security/sandbox-base-2026-07-25-dependency-review.md
+++ b/docs/security/sandbox-base-2026-07-25-dependency-review.md
@@ -1,7 +1,7 @@
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-# Sandbox base dependency review: Vim, jq, Expat, Perl modules, and bundled npm
+# Sandbox base dependency review for Vim, jq, Expat, Perl modules, and bundled npm
 
 Date: 2026-07-25
 
@@ -124,7 +124,7 @@ The core interpreter version check also remains the binding for core-language fi
 
 ## Concern ledger
 
-### DEP-1: affected trixie Vim package
+### DEP-1 affected trixie Vim package
 
 - Range: `2:9.1.1230-2..2:9.2.0782-1`
 - Surface: native package and runtime editor
@@ -136,7 +136,7 @@ The core interpreter version check also remains the binding for core-language fi
 - Verification: exact `RUN`-chain execution, checksum-rejection tests, dpkg identity checks, Vim runtime checks, and native image builds.
 - Remaining gate: multi-image, multi-architecture CI.
 
-### DEP-2: affected package inside npm's private tree
+### DEP-2 affected package inside npm's private tree
 
 - Range: `brace-expansion 5.0.7..5.0.8`
 - Surface: transitive bundled npm dependency
@@ -148,7 +148,7 @@ The core interpreter version check also remains the binding for core-language fi
 - Verification: pre-swap and post-swap rollback, idempotence, unsafe-tree, layout-drift, command-order, Dockerfile-order, and real-registry tests.
 - Remaining gate: multi-image CI.
 
-### DEP-3: Perl package identity does not expose dual-life module versions
+### DEP-3 Perl package identity does not expose dual-life module versions
 
 - Range: Perl `5.44.0` with bundled component versions
 - Surface: native package inventory and runtime modules
@@ -160,7 +160,7 @@ The core interpreter version check also remains the binding for core-language fi
 - Verification: native amd64 and arm64 image builds.
 - Remaining gate: multi-architecture base-image build.
 
-### DEP-4: managed jq, Oniguruma, and Expat identities differ
+### DEP-4 managed jq, Oniguruma, and Expat identities differ
 
 - Range: `libexpat1` distro-selected or `2.8.2-1` to `2.8.2-1`; `libjq1` and `jq` `1.7.1-6+deb13u2..1.8.2-1`; `libonig5 >= 6.9.7.1` to exact `6.9.9-1+b1`.
 - Surface: native packages and runtime libraries


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR corrects post-tag v0.0.96 documentation drift for exact-loopback no-auth compatible endpoints and local Ollama onboarding.
It also aligns the Windows changelog link label and source-only dependency review headings with their canonical titles and writing rules.

## Changes

- Distinguish OpenAI-compatible exact-loopback no-auth mode from the Anthropic-compatible non-empty placeholder requirement from #7427.
- Document the Ollama menu download size, approximate VRAM requirement, and available or total GPU memory fields from #7482.
- Document persisted Ollama proxy-token reuse during re-onboarding from #7620.
- Match the Windows changelog link label to the target page title and remove colons from the source-only dependency review headings.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: Source tests from #7427, #7482, and #7620 protect the shipped behavior, and 21 changelog and link tests pass for this documentation diff.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `docs/changelog/2026-07-25.mdx`, `docs/inference/custom-endpoint-security.mdx`, `docs/inference/set-up-ollama.mdx`, and `docs/security/sandbox-base-2026-07-25-dependency-review.md` against `docs/CONTRIBUTING.md` and `WRITING.md`. The exact-head review found no remaining findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5d103d990 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts test/check-docs-links.test.ts` passed 21 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not run because this is a focused documentation-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only). The command passed with 0 errors and two Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified authentication requirements for OpenAI- and Anthropic-compatible endpoints, including options for unauthenticated local services.
  - Updated Ollama onboarding to show download size and VRAM needs, explain GPU memory reporting behavior, and clarify persisted proxy token reuse.
  - Refreshed Windows setup link text and improved sandbox dependency review heading formatting for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
