### PR TITLE
fix(mcp): accept case-variant SSE media types

### DIFF
--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -63,6 +63,7 @@ function stageMcpToolDiscoveryRuntime(rootDir: string, buildCtx: string): void {
     "install-reviewed-runtime.sh",
     "build-runtime.ts",
     "mcp-tool-discovery.ts",
+    "streamable-http-client.test.ts",
     "tool-discovery-core.ts",
   ]) {
     fs.copyFileSync(path.join(sourceDir, fileName), path.join(stagedDir, fileName));

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -54,6 +54,7 @@ describe("sandbox build context staging", () => {
       "install-reviewed-runtime.sh",
       "build-runtime.ts",
       "mcp-tool-discovery.ts",
+      "streamable-http-client.test.ts",
       "tool-discovery-core.ts",
     ]) {
       writeFixture(
@@ -233,6 +234,7 @@ describe("sandbox build context staging", () => {
       "mcp-tool-discovery.ts",
       "package-lock.json",
       "package.json",
+      "streamable-http-client.test.ts",
       "tool-discovery-core.ts",
       "tsconfig.json",
     ]);

--- a/tools/mcp-tool-discovery-runtime/build-runtime.ts
+++ b/tools/mcp-tool-discovery-runtime/build-runtime.ts
@@ -20,6 +20,7 @@ const reviewedBundledPackages = [
   "@modelcontextprotocol/sdk",
   "ajv",
   "ajv-formats",
+  "content-type",
   "eventsource-parser",
   "fast-deep-equal",
   "fast-uri",

--- a/tools/mcp-tool-discovery-runtime/dependency-review.md
+++ b/tools/mcp-tool-discovery-runtime/dependency-review.md
@@ -7,23 +7,36 @@ The shared image runtime uses the official `@modelcontextprotocol/sdk` client so
 
 ## Reviewed pin
 
-- Package: `@modelcontextprotocol/sdk@1.29.0`
-- Registry tarball: `https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz`
-- Integrity: `sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==`
+- Package: `@modelcontextprotocol/sdk@1.30.0`
+- Registry tarball: `https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz`
+- Integrity: `sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==`
 - License: MIT
 - Locked production graph: `package-lock.json` (lockfile version 3)
 - Build-only tools: `typescript@6.0.3`, `@types/node@25.5.2`, and `esbuild@0.27.4` (not copied into the final image)
 - Security overrides: `@hono/node-server@2.0.11` and `fast-uri@3.1.4`
 
-The same SDK version and integrity are already present in the separately locked OpenClaw `mcporter` dependency graph. This runtime keeps a direct lock because Hermes and LangChain Deep Agents Code must not depend on OpenClaw's adapter package.
-The client bundle includes the SDK's AJV validation path, including `ajv-formats` and `fast-uri`; the `fast-uri` override is therefore runtime-relevant. It does not include the SDK's Hono server adapter. The build enforces the exact reviewed bundle-package allowlist and emits `BUNDLED_PACKAGES.json` alongside the generated third-party license notice. The exact overrides keep the install and runtime graphs clear of `GHSA-frvp-7c67-39w9` and `GHSA-v2hh-gcrm-f6hx` without changing the SDK client pin.
+OpenClaw's `mcporter` dependency graph also resolves the official SDK but remains separately locked. This runtime keeps a direct lock because Hermes and LangChain Deep Agents Code must not depend on OpenClaw's adapter package.
+The client bundle includes the SDK's AJV validation path, including `ajv-formats` and `fast-uri`, plus `content-type` for standards-compliant response media-type parsing; the `fast-uri` override and `content-type` license are therefore runtime-relevant. It does not include the SDK's Hono server adapter. The build enforces the exact reviewed bundle-package allowlist and emits `BUNDLED_PACKAGES.json` alongside the generated third-party license notice. The exact overrides keep the install and runtime graphs clear of `GHSA-frvp-7c67-39w9` and `GHSA-v2hh-gcrm-f6hx` without changing the SDK client pin.
+
+## 1.29.0 to 1.30.0 migration review
+
+The audited adjacent range contains 10 upstream commits. The published `1.30.0` tag resolves to commit `2d889f2b329e46680ec9bdd565de4616c497825a`, descends from the published `v1.29.0` tag at `e12cbd7078db388152f6e839abdbe09ba01f3f32`, and contains the required client media-type fix at `69749aa5081ddfe675d36da8d96c7e27d83742b8`. The npm publication's `gitHead` matches the target tag, and its registry signature and build provenance verify.
+
+The required client change replaces case-sensitive substring checks with parsed, normalized media types when selecting JSON or SSE response handling. This fixes standards-valid case variants such as `Text/Event-Stream; Charset=UTF-8`. The remaining commits affect SDK server error formatting, server SSE keepalive lifecycle, stdio buffering, upstream tests and workflows, Zod type compatibility, the server-only Hono version range, and the release version. NemoClaw's bundled client does not include the server or stdio implementations, and the committed Hono override remains `2.0.11`.
+
+Concern ledger:
+
+- `MCP-SDK-130-1` — Client response dispatch rejected case-variant SSE media types. Surface: managed MCP tool discovery initialization and `tools/list`. Resolution: migrate to the official parsed-media-type implementation and cover the full session with a case-variant SSE fixture. Validation: `npm test`.
+- `MCP-SDK-130-2` — `content-type@1.0.5` becomes executable bundle input. Surface: response media-type parsing and bundled notices. Resolution: add it to the exact bundle allowlist and verify its MIT text in the generated notice. Validation: `npm run bundle`.
+- `MCP-SDK-130-3` — The upstream package widens its Hono server range. Surface: resolved install graph only; the Hono server adapter is absent from the client bundle. Resolution: retain the existing exact `@hono/node-server@2.0.11` security override. Validation: the lock diff and `BUNDLED_PACKAGES.json`.
+- `MCP-SDK-130-4` — Other adjacent commits could alter unrelated transports or server behavior. Surface: upstream stdio and server entry points. Resolution: no migration because NemoClaw imports only `client/index.js` and `client/streamableHttp.js`; classify those commits as no runtime impact. Validation: esbuild's exact input graph.
 
 ## Build and audit contract
 
 Every agent image installs this committed graph with `npm ci --ignore-scripts` through the same reviewed installer, verifies registry signatures, typechecks the package against the real SDK types, and produces a single Node.js ESM bundle. Only that bundle, its checked package manifest, and a deterministic notice containing the license text for every package in esbuild's actual input graph are copied into the final image; the build dependency tree is discarded with the builder stage. This preserves the official SDK implementation and its license obligations while avoiding a large production layer composed of thousands of small package files.
 The installer applies the existing public corporate CA build argument to npm TLS when present.
 The root CLI TypeScript project excludes only this dependency-owning image entry point; the image package's dedicated `tsconfig.json` is the source-of-truth type gate, while the dependency-free core remains covered by the root project and host tests.
-The image build requires a clean low-severity production advisory audit, verified npm registry signatures, a root-owned non-writable bundled runtime, and an executable invalid-input contract check before the image can complete.
+The image build requires a clean low-severity production advisory audit, verified npm registry signatures, the case-variant SSE session test, a root-owned non-writable bundled runtime, and an executable invalid-input contract check before the image can complete.
 
 Review evidence on 2026-07-14:
 
@@ -36,6 +49,14 @@ Replacement-port refresh evidence on 2026-07-26:
 - Pre-build `npm audit signatures`: 98 packages with verified registry signatures and 11 packages with verified attestations
 - Exact bundle: 10 packages matching the reviewed allowlist in `BUNDLED_PACKAGES.json`
 
+SDK 1.30.0 migration evidence on 2026-07-28:
+
+- `npm test`: case-variant SSE discovery passed, including initialization, session propagation, `tools/list`, and session cleanup
+- `npm audit --omit=dev --audit-level=low`: 0 vulnerabilities
+- Pre-build `npm audit signatures`: 98 packages with verified registry signatures and 11 packages with verified attestations
+- Exact bundle: 11 packages matching the reviewed allowlist in `BUNDLED_PACKAGES.json`, including `content-type@1.0.5`
+- `npm run typecheck` and `npm run bundle`: passed
+
 ## Updating
 
 Regenerate and review the graph explicitly:
@@ -44,6 +65,7 @@ Regenerate and review the graph explicitly:
 $ npm --prefix tools/mcp-tool-discovery-runtime install --package-lock-only --ignore-scripts
 $ npm --prefix tools/mcp-tool-discovery-runtime ci --ignore-scripts
 $ npm --prefix tools/mcp-tool-discovery-runtime audit signatures
+$ npm --prefix tools/mcp-tool-discovery-runtime test
 $ npm --prefix tools/mcp-tool-discovery-runtime run typecheck
 $ npm --prefix tools/mcp-tool-discovery-runtime run bundle
 $ npm --prefix tools/mcp-tool-discovery-runtime audit --omit=dev --audit-level=low

--- a/tools/mcp-tool-discovery-runtime/install-reviewed-runtime.sh
+++ b/tools/mcp-tool-discovery-runtime/install-reviewed-runtime.sh
@@ -46,6 +46,7 @@ fi
 
 npm ci --ignore-scripts --no-audit --no-fund --no-progress
 npm audit signatures
+npm test
 npm run typecheck
 npm run bundle
 npm audit --omit=dev --audit-level=low

--- a/tools/mcp-tool-discovery-runtime/package-lock.json
+++ b/tools/mcp-tool-discovery-runtime/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0"
+        "@modelcontextprotocol/sdk": "1.30.0"
       },
       "devDependencies": {
         "@types/node": "25.5.2",
@@ -475,12 +475,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/tools/mcp-tool-discovery-runtime/package.json
+++ b/tools/mcp-tool-discovery-runtime/package.json
@@ -7,7 +7,7 @@
   "description": "Locked shared runtime for names-only managed MCP tool discovery",
   "license": "Apache-2.0",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.29.0"
+    "@modelcontextprotocol/sdk": "1.30.0"
   },
   "devDependencies": {
     "@types/node": "25.5.2",
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "bundle": "node --experimental-strip-types build-runtime.ts",
+    "test": "node --experimental-strip-types --test streamable-http-client.test.ts",
     "typecheck": "tsc -p tsconfig.json"
   }
 }

--- a/tools/mcp-tool-discovery-runtime/streamable-http-client.test.ts
+++ b/tools/mcp-tool-discovery-runtime/streamable-http-client.test.ts
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import test from "node:test";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import {
+  buildMcpToolDiscoveryAuthorizationPlaceholder,
+  createBoundedMcpFetch,
+  MCP_TOOL_DISCOVERY_LIMITS,
+  type McpToolDiscoveryResult,
+  normalizeMcpToolPage,
+  runMcpToolDiscoverySession,
+} from "./tool-discovery-core.ts";
+
+interface ObservedRequest {
+  httpMethod: string;
+  rpcMethod?: string;
+  accept?: string;
+  authorization?: string;
+  protocolVersion?: string;
+  sessionId?: string;
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+test("discovers tools from case-variant SSE response media types (#7726)", async () => {
+  const observed: ObservedRequest[] = [];
+  const sessionId = "case-variant-sse-session";
+  const server = http.createServer(async (request, response) => {
+    const bodyChunks: Buffer[] = [];
+    for await (const chunk of request) {
+      bodyChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    let payload: { id?: string | number; method?: string; params?: { protocolVersion?: string } } =
+      {};
+    try {
+      payload = JSON.parse(Buffer.concat(bodyChunks).toString("utf8")) as typeof payload;
+    } catch {
+      // GET and DELETE requests have no JSON body.
+    }
+
+    observed.push({
+      httpMethod: request.method ?? "",
+      ...(payload.method ? { rpcMethod: payload.method } : {}),
+      ...(request.headers.accept ? { accept: request.headers.accept } : {}),
+      ...(request.headers.authorization ? { authorization: request.headers.authorization } : {}),
+      ...(typeof request.headers["mcp-protocol-version"] === "string"
+        ? { protocolVersion: request.headers["mcp-protocol-version"] }
+        : {}),
+      ...(typeof request.headers["mcp-session-id"] === "string"
+        ? { sessionId: request.headers["mcp-session-id"] }
+        : {}),
+    });
+
+    if (request.method === "GET") {
+      response.writeHead(405, { Allow: "POST" });
+      response.end();
+      return;
+    }
+    if (request.method === "DELETE") {
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+    if (payload.method === "notifications/initialized") {
+      response.writeHead(202);
+      response.end();
+      return;
+    }
+
+    const result =
+      payload.method === "initialize"
+        ? {
+            protocolVersion: payload.params?.protocolVersion,
+            capabilities: { tools: {} },
+            serverInfo: { name: "case-variant-sse", version: "1.0.0" },
+          }
+        : {
+            tools: [{ name: "sse_tool", inputSchema: { type: "object" } }],
+          };
+    response.writeHead(200, {
+      "Content-Type": "Text/Event-Stream; Charset=UTF-8",
+      ...(payload.method === "initialize" ? { "Mcp-Session-Id": sessionId } : {}),
+    });
+    response.end(
+      `event: message\ndata: ${JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result,
+      })}\n\n`,
+    );
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  const deadlineSignal = AbortSignal.timeout(MCP_TOOL_DISCOVERY_LIMITS.maxTotalTimeMs);
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://127.0.0.1:${address.port}/mcp`),
+    {
+      fetch: createBoundedMcpFetch(globalThis.fetch, deadlineSignal),
+      requestInit: {
+        headers: {
+          authorization: buildMcpToolDiscoveryAuthorizationPlaceholder("EXAMPLE_MCP_TOKEN"),
+        },
+        redirect: "manual",
+      },
+      reconnectionOptions: {
+        maxReconnectionDelay: 1,
+        initialReconnectionDelay: 1,
+        reconnectionDelayGrowFactor: 1,
+        maxRetries: 0,
+      },
+    },
+  );
+  const client = new Client(
+    { name: "nemoclaw-mcp-tool-discovery-test", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  const requestOptions = {
+    signal: deadlineSignal,
+    timeout: MCP_TOOL_DISCOVERY_LIMITS.maxRequestTimeMs,
+    maxTotalTimeout: MCP_TOOL_DISCOVERY_LIMITS.maxTotalTimeMs,
+  };
+  let published: McpToolDiscoveryResult | undefined;
+
+  try {
+    await runMcpToolDiscoverySession({
+      connect: () => client.connect(transport, requestOptions),
+      loadPage: async (cursor) =>
+        normalizeMcpToolPage(
+          await client.listTools(cursor ? { cursor } : undefined, requestOptions),
+        ),
+      hasSession: () => Boolean(transport.sessionId),
+      terminateSession: () => transport.terminateSession(),
+      close: () => client.close(),
+      publishResult: (result) => {
+        published = result;
+      },
+    });
+  } finally {
+    await closeServer(server);
+  }
+
+  assert.deepEqual(published, {
+    ok: true,
+    count: 1,
+    tools: ["sse_tool"],
+    truncated: false,
+  });
+  const initialize = observed.find((request) => request.rpcMethod === "initialize");
+  assert.equal(initialize?.accept, "application/json, text/event-stream");
+  assert.equal(initialize?.authorization, "Bearer openshell:resolve:env:EXAMPLE_MCP_TOKEN");
+  const toolsList = observed.find((request) => request.rpcMethod === "tools/list");
+  assert.equal(toolsList?.sessionId, sessionId);
+  const initialized = observed.find((request) => request.rpcMethod === "notifications/initialized");
+  assert.ok(initialized?.protocolVersion);
+  assert.equal(toolsList?.protocolVersion, initialized.protocolVersion);
+  const deletion = observed.find((request) => request.httpMethod === "DELETE");
+  assert.equal(deletion?.sessionId, sessionId);
+  assert.equal(deletion?.protocolVersion, initialized.protocolVersion);
+});

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -17,5 +17,5 @@
     "types": ["node"]
   },
   "include": [".agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts", ".agents/skills/nemoclaw-maintainer-day/scripts/shared.ts", "agents/hermes/**/*.ts", "bin/**/*.ts", "scripts/**/*.ts", "scripts/**/*.mts", "src/**/*.ts", "test/**/*.ts", "tools/**/*.ts", "tools/**/*.mts", "nemoclaw-blueprint/scripts/**/*.ts"],
-  "exclude": ["node_modules", "nemoclaw", "test/e2e/fixtures/plugins/weather", "tools/mcp-tool-discovery-runtime/mcp-tool-discovery.ts"]
+  "exclude": ["node_modules", "nemoclaw", "test/e2e/fixtures/plugins/weather", "tools/mcp-tool-discovery-runtime/mcp-tool-discovery.ts", "tools/mcp-tool-discovery-runtime/streamable-http-client.test.ts"]
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fix managed MCP tool discovery when a compliant Streamable HTTP server returns an SSE response media type with case variation or parameters. Upgrade the official MCP SDK to its parsed media-type implementation and make the regression session part of every reviewed runtime image build.

This replaces #7748 with the same patch on current `main`; the published branch could not be rebased because repository rules forbid force-pushes.

## Related Issue

Fixes #7726

## Changes

- Pin `@modelcontextprotocol/sdk` to `1.30.0`, refresh the exact lock, and record the adjacent-release, provenance, vulnerability, bundle, and license review.
- Add a real `initialize` → `notifications/initialized` → `tools/list` → session cleanup fixture using `Text/Event-Stream; Charset=UTF-8`.
- Stage and run that fixture in the shared reviewed runtime installer used by all agent image builds.

This restores the generic Streamable HTTP/SSE contract accepted in #6901 and implemented in #7591. It does not add a provider-specific integration or compatibility layer.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores the existing documented Streamable HTTP discovery lifecycle without changing commands, flags, configuration, schemas, or supported integrations.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex security review passed all nine repository categories; the credential placeholder, authorization, SSRF, policy, and final-image boundaries are unchanged, and the exact dependency pin is signature-, attestation-, license-, and audit-verified.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing docs already describe Streamable HTTP discovery generically. This restores standards-compliant handling of a valid response media type and changes no command, flag, configuration, workflow, supported protocol, or documented user contract. Changelog work remains part of separate pre-tag release preparation.
- Agent: Codex Desktop `/root/replacement_docs_review`
<!-- docs-review-head-sha: 646d37787 -->
<!-- docs-review-agents-blob-sha: be20a09524 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — reviewed-runtime session test (1 passed), CLI runtime tests (12 passed), build-context/image-contract tests (15 passed), runtime and CLI typechecks, bundle allowlist/license generation, zero-vulnerability production audit, 98 verified registry signatures, and 11 verified attestations.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved MCP tool discovery compatibility with case-variant SSE response media types.
  * Preserved session and protocol headers during tool discovery requests.

* **Bug Fixes**
  * Updated the MCP runtime to ensure supported bundled content is included correctly.

* **Tests**
  * Added coverage for SSE discovery, authentication, session cleanup, and request headers.
  * Runtime installation now runs its test suite as part of verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->