### PR TITLE
fix(onboard): add Jetson render device group

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -794,7 +794,8 @@ NemoClaw retries only after it verifies that no OpenShell-managed Docker contain
 On Docker Desktop WSL and Jetson/Tegra, automatic GPU onboarding uses the compatibility path directly.
 On ordinary native Linux, the compatibility path uses an available NVIDIA CDI spec before falling back to Docker `--gpus all` or the NVIDIA runtime.
 On Docker Desktop WSL, the compatibility path skips CDI and tries Docker `--gpus all` before the NVIDIA runtime.
-On Jetson/Tegra hosts, the compatibility path uses the NVIDIA runtime and adds the host group IDs that own `/dev/nvmap` and `/dev/nvhost-*` so the sandbox user can initialize CUDA.
+On Jetson/Tegra hosts, the compatibility path uses the NVIDIA runtime and adds eligible host group IDs for the supported GPU device nodes.
+These include selected `/dev/nvmap`, `/dev/nvhost-*`, and `/dev/nvgpu/igpu0/*` nodes plus real `/dev/dri/renderD*` character devices.
 If the compatibility attempt fails, onboarding keeps its diagnostics and the failed sandbox in place and prints a manual cleanup command.
 
 Prerequisites:

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -664,7 +664,8 @@ NVIDIA NIM and GPU-backed sandbox setup require a real NVIDIA GPU.
 If NemoClaw rejects the detected GPU name during preflight, select a CPU or remote inference provider, or move the setup to a host with a supported NVIDIA GPU and current drivers.
 
 Jetson/Tegra hosts support sandbox GPU passthrough through the compatibility route.
-Onboarding detects those hosts separately and propagates the supplementary groups required for `/dev/nvmap` and `/dev/nvhost-*`; if that path fails, follow the Jetson/Tegra compatibility guidance below instead of treating a missing `nvidia-smi` result as a placeholder adapter.
+Onboarding detects those hosts separately and propagates eligible host group IDs for selected `/dev/nvmap`, `/dev/nvhost-*`, and `/dev/nvgpu/igpu0/*` nodes plus real `/dev/dri/renderD*` character devices.
+If that path fails, follow the Jetson/Tegra compatibility guidance below instead of treating a missing `nvidia-smi` result as a placeholder adapter.
 
 ### Colima socket not detected (macOS)
 
@@ -2458,7 +2459,7 @@ To skip GPU passthrough entirely, rerun with `--no-gpu` or set `NEMOCLAW_SANDBOX
 #### Jetson and Tegra compatibility default
 
 Automatic GPU onboarding uses the compatibility path directly; it does not make a native attempt first.
-The path recreates the OpenShell-managed Docker container with NVIDIA GPU flags and propagates the supplementary groups required for `/dev/nvmap` and `/dev/nvhost-*` access.
+The path recreates the OpenShell-managed Docker container with NVIDIA GPU flags and propagates eligible host group IDs for the supported Jetson GPU device nodes.
 Use `NEMOCLAW_DOCKER_GPU_PATCH=0` only for troubleshooting because it bypasses that group propagation and CUDA may not initialize.
 
 #### Common compatibility-path recovery

--- a/src/lib/onboard/docker-gpu-jetson-groups.test.ts
+++ b/src/lib/onboard/docker-gpu-jetson-groups.test.ts
@@ -12,39 +12,113 @@ describe("detectTegraDeviceGroupGids", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns unique host-owned GIDs while skipping missing, root-owned, and oversized nodes", () => {
-    const deviceGids: Record<string, number> = {
-      "/dev/nvmap": 44,
-      "/dev/nvhost-ctrl": 44,
-      "/dev/nvhost-gpu": 0,
-      "/dev/nvgpu/igpu0/ctrl": 110,
-      "/dev/nvgpu/igpu0/as": 2_147_483_648,
+  it("returns unique host-owned GIDs with effective group read/write permission", () => {
+    const deviceAccess: Record<string, { gid: number; mode: number }> = {
+      "/dev/nvmap": { gid: 44, mode: 0o440 },
+      "/dev/nvhost-ctrl": { gid: 44, mode: 0o660 },
+      "/dev/nvgpu/igpu0/ctrl": { gid: 110, mode: 0o660 },
     };
 
     expect(
       detectTegraDeviceGroupGids({
-        statDeviceGid: (path: string) => (path in deviceGids ? deviceGids[path] : null),
+        statDeviceAccess: (path: string) => deviceAccess[path] ?? null,
+        listDevicePaths: () => Object.keys(deviceAccess),
       }),
     ).toEqual(["44", "110"]);
   });
 
-  it("rejects non-integer, non-numeric, negative, zero, and oversized supplementary GIDs", () => {
-    const gids = [Number.NaN, 1.5, -1, 0, 2_147_483_648];
+  it("rejects unusable or unnecessary device-group access", () => {
+    const access = [
+      { gid: Number.NaN, mode: 0o660 },
+      { gid: 1.5, mode: 0o660 },
+      { gid: -1, mode: 0o660 },
+      { gid: 0, mode: 0o660 },
+      { gid: 2_147_483_648, mode: 0o660 },
+      { gid: 44, mode: 0o600 },
+      { gid: 104, mode: 0o666 },
+    ];
     let index = 0;
 
     expect(
       detectTegraDeviceGroupGids({
-        statDeviceGid: () => gids[index++] ?? null,
+        statDeviceAccess: () => access[index++] ?? null,
+        listDevicePaths: () => access.map((_, accessIndex) => `/dev/device${accessIndex}`),
       }),
     ).toEqual([]);
   });
 
   it("returns no GIDs when Tegra nodes are missing or unreadable", () => {
-    expect(detectTegraDeviceGroupGids({ statDeviceGid: () => null })).toEqual([]);
+    expect(
+      detectTegraDeviceGroupGids({
+        statDeviceAccess: () => null,
+        listDevicePaths: () => ["/dev/nvmap"],
+      }),
+    ).toEqual([]);
 
-    vi.spyOn(fs, "statSync").mockImplementation(() => {
+    vi.spyOn(fs, "lstatSync").mockImplementation(() => {
       throw new Error("EACCES");
     });
-    expect(detectTegraDeviceGroupGids()).toEqual([]);
+    expect(detectTegraDeviceGroupGids({ listDevicePaths: () => ["/dev/nvmap"] })).toEqual([]);
+  });
+
+  it("rejects regular files and symlinks before reading their group", () => {
+    vi.spyOn(fs, "lstatSync")
+      .mockReturnValueOnce({
+        gid: 110,
+        mode: 0o660,
+        isCharacterDevice: () => false,
+        isSymbolicLink: () => false,
+      } as fs.Stats)
+      .mockReturnValueOnce({
+        gid: 120,
+        mode: 0o660,
+        isCharacterDevice: () => false,
+        isSymbolicLink: () => true,
+      } as fs.Stats);
+
+    expect(
+      detectTegraDeviceGroupGids({
+        listDevicePaths: () => ["/dev/nvgpu/igpu0/not-a-device", "/dev/nvgpu/igpu0/link"],
+      }),
+    ).toEqual([]);
+  });
+
+  it("adds the host render group from real DRI render devices only", () => {
+    vi.spyOn(fs, "readdirSync").mockImplementation(
+      () =>
+        [
+          {
+            name: "renderD128",
+            isCharacterDevice: () => true,
+            isSymbolicLink: () => false,
+          },
+          {
+            name: "renderD129",
+            isCharacterDevice: () => false,
+            isSymbolicLink: () => true,
+          },
+          {
+            name: "card0",
+            isCharacterDevice: () => true,
+            isSymbolicLink: () => false,
+          },
+        ] as never,
+    );
+    const lstat = vi.spyOn(fs, "lstatSync").mockImplementation((path) => {
+      if (path === "/dev/dri/renderD128") {
+        return {
+          gid: 104,
+          mode: 0o660,
+          isCharacterDevice: () => true,
+          isSymbolicLink: () => false,
+        } as fs.Stats;
+      }
+      throw new Error("ENOENT");
+    });
+
+    expect(detectTegraDeviceGroupGids()).toEqual(["104"]);
+    expect(lstat).toHaveBeenCalledWith("/dev/dri/renderD128");
+    expect(lstat).not.toHaveBeenCalledWith("/dev/dri/renderD129");
+    expect(lstat).not.toHaveBeenCalledWith("/dev/dri/card0");
   });
 });

--- a/src/lib/onboard/docker-gpu-jetson-groups.test.ts
+++ b/src/lib/onboard/docker-gpu-jetson-groups.test.ts
@@ -55,14 +55,19 @@ describe("detectTegraDeviceGroupGids", () => {
       }),
     ).toEqual([]);
 
-    vi.spyOn(fs, "lstatSync").mockImplementation(() => {
+    const lstat = vi.spyOn(fs, "lstatSync").mockImplementation(() => {
       throw new Error("EACCES");
     });
-    expect(detectTegraDeviceGroupGids({ listDevicePaths: () => ["/dev/nvmap"] })).toEqual([]);
+    try {
+      expect(detectTegraDeviceGroupGids({ listDevicePaths: () => ["/dev/nvmap"] })).toEqual([]);
+    } finally {
+      lstat.mockRestore();
+    }
   });
 
   it("rejects regular files and symlinks before reading their group", () => {
-    vi.spyOn(fs, "lstatSync")
+    const lstat = vi
+      .spyOn(fs, "lstatSync")
       .mockReturnValueOnce({
         gid: 110,
         mode: 0o660,
@@ -76,15 +81,19 @@ describe("detectTegraDeviceGroupGids", () => {
         isSymbolicLink: () => true,
       } as fs.Stats);
 
-    expect(
-      detectTegraDeviceGroupGids({
-        listDevicePaths: () => ["/dev/nvgpu/igpu0/not-a-device", "/dev/nvgpu/igpu0/link"],
-      }),
-    ).toEqual([]);
+    try {
+      expect(
+        detectTegraDeviceGroupGids({
+          listDevicePaths: () => ["/dev/nvgpu/igpu0/not-a-device", "/dev/nvgpu/igpu0/link"],
+        }),
+      ).toEqual([]);
+    } finally {
+      lstat.mockRestore();
+    }
   });
 
   it("adds the host render group from real DRI render devices only", () => {
-    vi.spyOn(fs, "readdirSync").mockImplementation(
+    const readdir = vi.spyOn(fs, "readdirSync").mockImplementation(
       () =>
         [
           {
@@ -104,21 +113,21 @@ describe("detectTegraDeviceGroupGids", () => {
           },
         ] as never,
     );
-    const lstat = vi.spyOn(fs, "lstatSync").mockImplementation((path) => {
-      if (path === "/dev/dri/renderD128") {
-        return {
-          gid: 104,
-          mode: 0o660,
-          isCharacterDevice: () => true,
-          isSymbolicLink: () => false,
-        } as fs.Stats;
-      }
-      throw new Error("ENOENT");
-    });
+    const lstat = vi.spyOn(fs, "lstatSync").mockReturnValue({
+      gid: 104,
+      mode: 0o660,
+      isCharacterDevice: () => true,
+      isSymbolicLink: () => false,
+    } as fs.Stats);
 
-    expect(detectTegraDeviceGroupGids()).toEqual(["104"]);
-    expect(lstat).toHaveBeenCalledWith("/dev/dri/renderD128");
-    expect(lstat).not.toHaveBeenCalledWith("/dev/dri/renderD129");
-    expect(lstat).not.toHaveBeenCalledWith("/dev/dri/card0");
+    try {
+      expect(detectTegraDeviceGroupGids()).toEqual(["104"]);
+      expect(lstat).toHaveBeenCalledWith("/dev/dri/renderD128");
+      expect(lstat).not.toHaveBeenCalledWith("/dev/dri/renderD129");
+      expect(lstat).not.toHaveBeenCalledWith("/dev/dri/card0");
+    } finally {
+      lstat.mockRestore();
+      readdir.mockRestore();
+    }
   });
 });

--- a/src/lib/onboard/docker-gpu-jetson-groups.ts
+++ b/src/lib/onboard/docker-gpu-jetson-groups.ts
@@ -24,6 +24,10 @@ type DeviceGroupAccess = {
   mode: number;
 };
 
+/**
+ * Find real DRI render character devices without following symlinks or
+ * scanning other DRI device families.
+ */
 function discoverTegraRenderDevicePaths(): string[] {
   try {
     return fs
@@ -40,10 +44,8 @@ function discoverTegraRenderDevicePaths(): string[] {
 }
 
 /**
- * A DRI render device can have a different owner GID from the selected Tegra
- * device nodes. The render node number also varies across hosts, so discover
- * only real render character devices in the flat DRI directory. Do not follow
- * symlinks or scan other DRI/Tegra device families.
+ * Combine the selected Tegra GPU nodes with DRI render devices, whose owner
+ * GID and node number can differ across hosts.
  */
 function listTegraGpuDevicePaths(): string[] {
   return [...TEGRA_GPU_DEVICE_NODES, ...discoverTegraRenderDevicePaths()];

--- a/src/lib/onboard/docker-gpu-jetson-groups.ts
+++ b/src/lib/onboard/docker-gpu-jetson-groups.ts
@@ -16,7 +16,38 @@ const TEGRA_GPU_DEVICE_NODES = [
   "/dev/nvgpu/igpu0/as",
   "/dev/nvgpu/igpu0/prof",
 ] as const;
+const READ_WRITE_PERMISSION_BITS = 0o6;
 const MAX_DOCKER_SUPPLEMENTARY_GID = 2_147_483_647;
+
+type DeviceGroupAccess = {
+  gid: number;
+  mode: number;
+};
+
+function discoverTegraRenderDevicePaths(): string[] {
+  try {
+    return fs
+      .readdirSync("/dev/dri", { withFileTypes: true })
+      .filter(
+        (entry) =>
+          /^renderD\d+$/u.test(entry.name) && entry.isCharacterDevice() && !entry.isSymbolicLink(),
+      )
+      .map((entry) => `/dev/dri/${entry.name}`)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * A DRI render device can have a different owner GID from the selected Tegra
+ * device nodes. The render node number also varies across hosts, so discover
+ * only real render character devices in the flat DRI directory. Do not follow
+ * symlinks or scan other DRI/Tegra device families.
+ */
+function listTegraGpuDevicePaths(): string[] {
+  return [...TEGRA_GPU_DEVICE_NODES, ...discoverTegraRenderDevicePaths()];
+}
 
 /**
  * Source-of-truth boundary for Jetson/Tegra supplementary device groups:
@@ -24,7 +55,8 @@ const MAX_DOCKER_SUPPLEMENTARY_GID = 2_147_483_647;
  * - Invalid state: the non-root sandbox user can see `/dev/nvmap` and `/dev/nvhost-*` but cannot
  *   open them because Docker did not copy their host-owned supplementary GIDs into the container.
  * - Source boundary: host device-node ownership is authoritative; NemoClaw only carries each
- *   bounded, non-root numeric GID into the Jetson compatibility recreation via `--group-add`.
+ *   bounded, non-root numeric GID with effective group read/write permission into the Jetson
+ *   compatibility recreation via `--group-add`.
  * - Source-fix constraint: changing host udev ownership or image-local groups cannot reliably fix
  *   device nodes whose ownership is assigned by the Jetson host at runtime.
  * - Regression coverage: docker-gpu-jetson-groups.test.ts covers discovery and hostile numeric
@@ -34,25 +66,37 @@ const MAX_DOCKER_SUPPLEMENTARY_GID = 2_147_483_647;
  *   propagates the host device groups without compatibility container recreation.
  */
 export function detectTegraDeviceGroupGids(
-  deps: { statDeviceGid?: (path: string) => number | null } = {},
+  deps: {
+    statDeviceAccess?: (path: string) => DeviceGroupAccess | null;
+    listDevicePaths?: () => string[];
+  } = {},
 ): string[] {
-  const statGid =
-    deps.statDeviceGid ??
-    ((path: string): number | null => {
+  const devicePaths = deps.listDevicePaths?.() ?? listTegraGpuDevicePaths();
+  const statAccess =
+    deps.statDeviceAccess ??
+    ((path: string): DeviceGroupAccess | null => {
       try {
-        return fs.statSync(path).gid;
+        const stat = fs.lstatSync(path);
+        return stat.isCharacterDevice() && !stat.isSymbolicLink()
+          ? { gid: stat.gid, mode: stat.mode }
+          : null;
       } catch {
         return null;
       }
     });
   const gids = new Set<string>();
-  for (const node of TEGRA_GPU_DEVICE_NODES) {
-    const gid = statGid(node);
+  for (const node of devicePaths) {
+    const access = statAccess(node);
+    const gid = access?.gid ?? null;
+    const groupAccessBits = access === null ? 0 : (access.mode >> 3) & READ_WRITE_PERMISSION_BITS;
+    const otherAccessBits = access === null ? 0 : access.mode & READ_WRITE_PERMISSION_BITS;
+    const groupAddsAccess = (groupAccessBits & ~otherAccessBits) !== 0;
     if (
       gid !== null &&
       Number.isSafeInteger(gid) &&
       gid > 0 &&
-      gid <= MAX_DOCKER_SUPPLEMENTARY_GID
+      gid <= MAX_DOCKER_SUPPLEMENTARY_GID &&
+      groupAddsAccess
     ) {
       gids.add(String(gid));
     }

--- a/src/lib/onboard/docker-gpu-patch-jetson.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-jetson.test.ts
@@ -19,7 +19,7 @@ function dockerCaptureFixture() {
   return vi.fn((args: readonly string[]) => responses[args[0]] ?? "");
 }
 
-describe("Jetson /dev/nvmap group propagation (#4231)", () => {
+describe("Jetson device-node group propagation (#4231, #7610)", () => {
   it("emits --group-add for extraGroupGids and dedupes against existing GroupAdd", () => {
     const inspect = inspectFixture();
     inspect.HostConfig!.GroupAdd = ["44"];
@@ -41,11 +41,20 @@ describe("Jetson /dev/nvmap group propagation (#4231)", () => {
     expect(args).not.toEqual(expect.arrayContaining(["--group-add"]));
   });
 
-  it("plumbs detected Tegra device GIDs into the Jetson recreate as --group-add", () => {
-    const dockerRunDetached = vi.fn(() => ({ status: 0, stdout: "new-container-id\n" }));
+  it("passes all detected Tegra device GIDs into the Jetson recreate as --group-add", () => {
+    const dockerRunDetached = vi.fn(() => ({
+      status: 0,
+      stdout: "new-container-id\n",
+    }));
     const detectTegraDeviceGroupGidsStub = vi.fn(() =>
       detectTegraDeviceGroupGids({
-        statDeviceGid: (path) => (path === "/dev/nvmap" ? 44 : null),
+        statDeviceAccess: (path) =>
+          ({
+            "/dev/nvmap": { gid: 44, mode: 0o660 },
+            "/dev/nvhost-gpu": { gid: 995, mode: 0o660 },
+            "/dev/dri/renderD128": { gid: 104, mode: 0o660 },
+          })[path] ?? null,
+        listDevicePaths: () => ["/dev/nvmap", "/dev/nvhost-gpu", "/dev/dri/renderD128"],
       }),
     );
 
@@ -68,13 +77,16 @@ describe("Jetson /dev/nvmap group propagation (#4231)", () => {
 
     expect(detectTegraDeviceGroupGidsStub).toHaveBeenCalled();
     expect(dockerRunDetached).toHaveBeenCalledWith(
-      expect.arrayContaining(["--group-add", "44"]),
+      expect.arrayContaining(["--group-add", "44", "--group-add", "104", "--group-add", "995"]),
       expect.objectContaining({ ignoreError: true }),
     );
   });
 
   it("does not add Tegra device GIDs for the generic (non-Jetson) backend", () => {
-    const dockerRunDetached = vi.fn(() => ({ status: 0, stdout: "new-container-id\n" }));
+    const dockerRunDetached = vi.fn(() => ({
+      status: 0,
+      stdout: "new-container-id\n",
+    }));
     const detectTegraDeviceGroupGidsStub = vi.fn(() => ["44"]);
 
     recreateOpenShellDockerSandboxWithGpu(

--- a/src/lib/onboard/docker-gpu-patch-recreate.ts
+++ b/src/lib/onboard/docker-gpu-patch-recreate.ts
@@ -16,8 +16,8 @@ import { detectTegraDeviceGroupGids } from "./docker-gpu-jetson-groups";
 import {
   buildDockerGpuCloneRunArgs,
   buildDockerGpuCloneRunOptions,
-  getDockerGpuCloneFallbackDns,
   dockerContainerName,
+  getDockerGpuCloneFallbackDns,
   parseDockerInspectJson,
   sameContainerId,
   validateRequiredDockerUlimits,
@@ -36,10 +36,10 @@ import type {
   DockerGpuPatchMode,
   DockerGpuPatchResult,
 } from "./docker-gpu-patch-types";
-import { isFatalContainerDnsProbeFailure, probeContainerDns } from "./preflight";
 import { waitForOpenShellSupervisorReconnect } from "./docker-gpu-supervisor-reconnect";
 import { openshellSandboxCommandEnvValue } from "./docker-startup-command-env";
 import { findOpenShellDockerSandboxContainerIds } from "./openshell-docker-sandbox-containers";
+import { isFatalContainerDnsProbeFailure, probeContainerDns } from "./preflight";
 
 const DOCKER_GPU_PATCH_WAIT_SECS = 180;
 const MAX_DOCKER_CONTAINER_NAME_LENGTH = 253;
@@ -267,9 +267,9 @@ export function recreateOpenShellDockerSandboxContainer(
       if (tegraGroupGids.length > 0) {
         cloneOptions.extraGroupGids = tegraGroupGids;
         console.log(
-          `  ✓ Granting sandbox user access to Jetson Tegra GPU device nodes via --group-add ${tegraGroupGids.join(
+          `  ✓ Granting sandbox user the detected Jetson GPU device groups via --group-add ${tegraGroupGids.join(
             ", ",
-          )} (so CUDA can open /dev/nvmap)`,
+          )} (so CUDA can initialize as a non-root user)`,
         );
       } else {
         console.warn(

--- a/src/lib/onboard/docker-gpu-patch-types.ts
+++ b/src/lib/onboard/docker-gpu-patch-types.ts
@@ -41,10 +41,10 @@ export type DockerGpuPatchDeps = {
   probeContainerDns?: ContainerDnsProbeFn;
   /**
    * Resolve the host group ID(s) that own the Jetson/Tegra GPU device nodes
-   * (`/dev/nvmap`, `/dev/nvhost-*`). Used by the Jetson recreate to grant the
-   * sandbox user matching `--group-add` membership so CUDA can open them
-   * (#4231). Injectable so the Jetson permission path is testable without
-   * Tegra hardware.
+   * (`/dev/nvmap`, `/dev/nvhost-*`, and `/dev/dri/renderD*`). Used by the
+   * Jetson recreate to grant the sandbox user matching `--group-add`
+   * membership so CUDA can open them (#4231, #7610). Injectable so the Jetson
+   * permission path is testable without Tegra hardware.
    */
   detectTegraDeviceGroupGids?: () => string[];
   /** Injectable directory lister for unit testing CDI spec discovery. */
@@ -115,9 +115,9 @@ export type DockerGpuCloneRunOptions = {
   /**
    * Extra supplementary group IDs to add to the recreated container via
    * `--group-add`. On Jetson these are the host group(s) owning the Tegra GPU
-   * device nodes (`/dev/nvmap`, `/dev/nvhost-*`); granting the sandbox user
-   * membership lets CUDA's nvmap init open them instead of failing with
-   * `NvRmMemInitNvmap ... Permission denied` (#4231).
+   * device nodes; granting the sandbox user membership lets CUDA's nvmap init
+   * open them instead of failing with `NvRmMemInitNvmap ... Permission
+   * denied` (#4231, #7610).
    */
   extraGroupGids?: readonly string[] | null;
 };

--- a/test/e2e/live/jetson-nvmap-gpu.test.ts
+++ b/test/e2e/live/jetson-nvmap-gpu.test.ts
@@ -251,7 +251,7 @@ exit "$status"`,
 
   // A4: the Jetson recreate must grant Tegra device-node groups via --group-add.
   expect(resultText(install)).toContain(
-    "Granting sandbox user access to Jetson Tegra GPU device nodes via --group-add",
+    "Granting sandbox user the detected Jetson GPU device groups via --group-add",
   );
 
   // A5: the sandbox user must be in the host /dev/nvmap owning GID.

--- a/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
@@ -904,7 +904,7 @@ it("carries the generated planner matrix through the workflow output and PR repo
   } finally {
     fs.rmSync(directory, { force: true, recursive: true });
   }
-});
+}, 15_000);
 
 it("builds controller target matrices only from trusted runner mappings (#7031)", () => {
   const target = "ubuntu-repo-cloud-langchain-deepagents-code";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Jetson GPU onboarding now carries the eligible host group ID for real DRI render devices into the recreated Docker container. This gives the non-root sandbox user the additional device-group access required for CUDA initialization on the reported IGX Orin setup while preserving the existing Tegra device allowlist.

## Related Issue

Fixes #7610

## Changes

- Discover only real `/dev/dri/renderD*` character devices and reject symlinks.
- Add a device owner GID only when its group permission grants read or write access that other users do not already have.
- Preserve the established `0440 root:video` `/dev/nvmap` behavior from #4231.
- Pass the resulting numeric GIDs through the existing Jetson `--group-add` recreation path.
- Document the selected Tegra nodes and bounded DRI render-device discovery.

The root-cause hypothesis is that the reporter already receives the video/Tegra groups but not the distinct render-device owner GID. NVIDIA's Jetson container guidance identifies both video and render group membership as required for non-root CUDA initialization. The implementation intentionally does not scan DRI card nodes, arbitrary Tegra subtrees, or symlink targets.

No matching Jetson/IGX runner is currently available, so physical IGX Orin validation remains pending. The sandbox CUDA proof remains fail-closed and will reject the recreation if this best-guess fix is insufficient.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop security review passed after narrowing discovery to real DRI render character devices, rejecting symlinks, checking effective group permission, and adding the `0440 /dev/nvmap` regression case.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/commands.mdx`, `docs/reference/troubleshooting.mdx`, and the related CLI text, code comments, and test titles. The first review found inaccurate group-name and wildcard-scan wording; the final implementation review passed after the text was aligned with the bounded numeric-GID implementation. Follow-up reviews passed at `e8dcfdb1e` after the CI-driven spy cleanup and helper JSDoc update, at `bf46f3e13` after aligning the live Jetson E2E assertion with the current stable group-propagation log prefix, and at `75a954256` after merging current `main`, retaining its 30-second E2E-support timeout, and confirming `npm run docs` with 0 Fern errors.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 75a954256 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 333 Docker/sandbox GPU onboarding tests across 32 files pass; the focused Jetson tests pass 9/9; `npm run typecheck:cli` passes. The live-E2E assertion repair passed Biome and hook checks; the hardware-mutating Jetson E2E remains delegated to the repository's self-hosted gate. After merging current `main`, the E2E report boundary tests pass 33/33 with the upstream 30-second test-local timeout, and `npm run docs` passes with 0 Fern errors.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the change is isolated to Jetson device-group discovery and propagation.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npm run docs` passes with 0 errors and the two existing Fern warnings.

---
Signed-off-by: J. Yaunches <jmyaunch@gmail.com>
