### PR TITLE
fix(security): align SSRF denylists and reject endpoint userinfo

### DIFF
--- a/nemoclaw-blueprint/private-networks.yaml
+++ b/nemoclaw-blueprint/private-networks.yaml
@@ -111,6 +111,9 @@ ipv6:
   - address: "100::"
     prefix: 64
     purpose: Discard prefix
+  - address: "100:0:0:1::"
+    prefix: 64
+    purpose: Dummy IPv6 Prefix (IANA non-forwardable)
   - address: "2001::"
     prefix: 23
     purpose: IETF protocol assignments (Teredo, benchmarking, ORCHID, and related special-purpose space)

--- a/nemoclaw-blueprint/private-networks.yaml
+++ b/nemoclaw-blueprint/private-networks.yaml
@@ -62,9 +62,21 @@ ipv4:
   - address: 192.0.2.0
     prefix: 24
     purpose: TEST-NET-1 documentation
+  - address: 192.31.196.0
+    prefix: 24
+    purpose: AS112 DNS anycast (RFC 7535)
+  - address: 192.52.193.0
+    prefix: 24
+    purpose: AMT relay anycast (RFC 7450)
+  - address: 192.88.99.0
+    prefix: 24
+    purpose: Deprecated 6to4 relay anycast (RFC 7526)
   - address: 192.168.0.0
     prefix: 16
     purpose: Private /16 (home/small-network default)
+  - address: 192.175.48.0
+    prefix: 24
+    purpose: AS112 direct delegation anycast (RFC 7534)
   - address: 198.18.0.0
     prefix: 15
     purpose: Benchmark testing
@@ -87,6 +99,9 @@ ipv6:
   - address: "::1"
     prefix: 128
     purpose: Loopback
+  - address: "::"
+    prefix: 96
+    purpose: Deprecated IPv4-compatible encodings that can hide private IPv4 targets
   - address: "64:ff9b::"
     prefix: 96
     purpose: NAT64 well-known prefix
@@ -97,20 +112,32 @@ ipv6:
     prefix: 64
     purpose: Discard prefix
   - address: "2001::"
-    prefix: 32
-    purpose: Teredo tunneling
+    prefix: 23
+    purpose: IETF protocol assignments (Teredo, benchmarking, ORCHID, and related special-purpose space)
   - address: "2001:db8::"
     prefix: 32
     purpose: Documentation
   - address: "2002::"
     prefix: 16
     purpose: 6to4
+  - address: "2620:4f:8000::"
+    prefix: 48
+    purpose: AS112 IPv6 anycast (RFC 7534)
+  - address: "3fff::"
+    prefix: 20
+    purpose: Documentation (RFC 9637)
+  - address: "5f00::"
+    prefix: 16
+    purpose: IPv6 Segment Routing (SRv6) SIDs (RFC 9602)
   - address: "fc00::"
     prefix: 7
     purpose: Unique local addresses
   - address: "fe80::"
     prefix: 10
     purpose: Link-local
+  - address: "fec0::"
+    prefix: 10
+    purpose: Deprecated site-local addresses
   - address: "ff00::"
     prefix: 8
     purpose: Multicast
@@ -121,3 +148,5 @@ names:
     purpose: RFC 6762 mDNS link-local names (Bonjour / Avahi / zeroconf)
   - name: internal
     purpose: ICANN-reserved private-use TLD (2024-02-11 Board Resolution)
+  - name: metadata
+    purpose: Cloud instance metadata service hostname alias

--- a/nemoclaw/src/blueprint/private-networks.ts
+++ b/nemoclaw/src/blueprint/private-networks.ts
@@ -219,7 +219,7 @@ export function resetCache(): void {
  *
  * IPv4-mapped IPv6 addresses (::ffff:a.b.c.d) are auto-matched against
  * IPv4 rules by node:net BlockList, so no explicit handling is needed.
- * NAT64, 6to4, and Teredo prefixes are blocked by prefix in the YAML
+ * NAT64, 6to4, and IETF special-purpose prefixes are blocked by prefix in the YAML
  * because BlockList does not extract embedded IPv4 from those forms.
  */
 export function isPrivateIp(address: string): boolean {

--- a/nemoclaw/src/blueprint/ssrf.test.ts
+++ b/nemoclaw/src/blueprint/ssrf.test.ts
@@ -407,6 +407,7 @@ describe("validateEndpointUrl – URL parsing edge cases", () => {
   });
 
   it("rejects URL with userinfo/basic auth credentials", async () => {
+    mockLookup.mockClear();
     const cases = [
       {
         url: "https://alice:s3cret-token@api.example.com/v1",
@@ -440,5 +441,6 @@ describe("validateEndpointUrl – URL parsing edge cases", () => {
         expect(message).not.toContain(secret);
       }
     }
+    expect(mockLookup).not.toHaveBeenCalled();
   });
 });

--- a/nemoclaw/src/blueprint/ssrf.test.ts
+++ b/nemoclaw/src/blueprint/ssrf.test.ts
@@ -406,12 +406,12 @@ describe("validateEndpointUrl – URL parsing edge cases", () => {
     expect(() => safeEndpointUrlForDownstream(result)).toThrow(/DNS-backed HTTPS endpoint/);
   });
 
-  it("parses URL with userinfo/basic auth but does not mark DNS-backed HTTPS downstream-safe", async () => {
-    mockPublicDns();
-    // URL parser extracts hostname correctly even with userinfo.
-    const url = "https://user:pass@api.example.com/v1";
-    const result = await validateEndpointUrl(url);
-    expect(result.url).toBe(url);
-    expect(() => safeEndpointUrlForDownstream(result)).toThrow(/DNS-backed HTTPS endpoint/);
+  it("rejects URL with userinfo/basic auth credentials", async () => {
+    await expect(validateEndpointUrl("https://user:pass@api.example.com/v1")).rejects.toThrow(
+      /must not contain credentials/,
+    );
+    await expect(validateEndpointUrl("http://user:pass@api.example.com/v1")).rejects.toThrow(
+      /must not contain credentials/,
+    );
   });
 });

--- a/nemoclaw/src/blueprint/ssrf.test.ts
+++ b/nemoclaw/src/blueprint/ssrf.test.ts
@@ -407,11 +407,38 @@ describe("validateEndpointUrl – URL parsing edge cases", () => {
   });
 
   it("rejects URL with userinfo/basic auth credentials", async () => {
-    await expect(validateEndpointUrl("https://user:pass@api.example.com/v1")).rejects.toThrow(
-      /must not contain credentials/,
-    );
-    await expect(validateEndpointUrl("http://user:pass@api.example.com/v1")).rejects.toThrow(
-      /must not contain credentials/,
-    );
+    const cases = [
+      {
+        url: "https://alice:s3cret-token@api.example.com/v1",
+        secrets: ["alice", "s3cret-token", "alice:s3cret-token"],
+      },
+      {
+        url: "http://alice:s3cret-token@api.example.com/v1",
+        secrets: ["alice", "s3cret-token", "alice:s3cret-token"],
+      },
+      {
+        url: "https://only-alice@api.example.com/v1",
+        secrets: ["only-alice"],
+      },
+      {
+        url: "https://:only-s3cret@api.example.com/v1",
+        secrets: ["only-s3cret"],
+      },
+    ] as const;
+
+    for (const { url, secrets } of cases) {
+      let thrown: unknown;
+      try {
+        await validateEndpointUrl(url);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      const message = thrown instanceof Error ? thrown.message : String(thrown);
+      expect(message).toMatch(/must not contain credentials/);
+      for (const secret of secrets) {
+        expect(message).not.toContain(secret);
+      }
+    }
   });
 });

--- a/nemoclaw/src/blueprint/ssrf.ts
+++ b/nemoclaw/src/blueprint/ssrf.ts
@@ -60,6 +60,11 @@ export async function validateEndpointUrl(url: string): Promise<ValidatedEndpoin
   if (!hostname) {
     throw new Error(`No hostname found in URL: ${url}`);
   }
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw new Error(
+      "Endpoint URL must not contain credentials. Remove the username and password from the URL.",
+    );
+  }
   if (isPrivateHostname(hostname)) {
     throw new Error(
       `Endpoint URL points to private/internal address ${hostname}. ` +

--- a/src/lib/private-networks.ts
+++ b/src/lib/private-networks.ts
@@ -158,7 +158,7 @@ export function resetCache(): void {
  *
  * IPv4-mapped IPv6 addresses (::ffff:a.b.c.d) are auto-matched against
  * IPv4 rules by node:net BlockList, so no explicit handling is needed.
- * NAT64, 6to4, and Teredo prefixes are blocked by prefix in the YAML
+ * NAT64, 6to4, and IETF special-purpose prefixes are blocked by prefix in the YAML
  * because BlockList does not extract embedded IPv4 from those forms.
  */
 export function isPrivateIp(address: string): boolean {

--- a/src/lib/security/mcp-url-target.ts
+++ b/src/lib/security/mcp-url-target.ts
@@ -45,6 +45,8 @@ for (const [address, prefix] of [
   ["64:ff9b::", 96],
   ["64:ff9b:1::", 48],
   ["100::", 64],
+  // IANA Dummy IPv6 Prefix — outside 100::/64, so listed separately.
+  ["100:0:0:1::", 64],
   // IETF protocol assignments including Teredo, benchmarking, ORCHID, and
   // other non-global special-purpose destinations.
   ["2001::", 23],

--- a/test/mcp-url-target.test.ts
+++ b/test/mcp-url-target.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { isPrivateHostname } from "../src/lib/private-networks";
 import { isBlockedMcpUrlTargetHost } from "../src/lib/security/mcp-url-target";
 
 describe("MCP URL target special-use filtering", () => {
@@ -33,5 +34,26 @@ describe("MCP URL target special-use filtering", () => {
     "2606:4700:4700::1111",
   ])("keeps globally routable address %s eligible", (address) => {
     expect(isBlockedMcpUrlTargetHost(address)).toBe(false);
+  });
+});
+
+describe("MCP and private-networks.yaml SSRF denylist parity", () => {
+  it.each([
+    "192.31.196.1",
+    "192.52.193.1",
+    "192.88.99.1",
+    "192.175.48.1",
+    "::7f00:1",
+    "2001:2::1",
+    "2001:20::1",
+    "2620:4f:8000::1",
+    "3fff::1",
+    "5f00::1",
+    "fec0::1",
+    "metadata",
+    "foo.metadata",
+  ])("blocks MCP-denied target %s in shared private-networks rules", (address) => {
+    expect(isBlockedMcpUrlTargetHost(address)).toBe(true);
+    expect(isPrivateHostname(address)).toBe(true);
   });
 });

--- a/test/mcp-url-target.test.ts
+++ b/test/mcp-url-target.test.ts
@@ -24,6 +24,7 @@ describe("MCP URL target special-use filtering", () => {
     "3fff::1",
     "5f00::1",
     "fec0::1",
+    "100:0:0:1::1",
   ])("blocks non-global special-purpose address %s", (address) => {
     expect(isBlockedMcpUrlTargetHost(address)).toBe(true);
   });
@@ -50,6 +51,7 @@ describe("MCP and private-networks.yaml SSRF denylist parity", () => {
     "3fff::1",
     "5f00::1",
     "fec0::1",
+    "100:0:0:1::1",
     "metadata",
     "foo.metadata",
   ])("blocks MCP-denied target %s in shared private-networks rules", (address) => {

--- a/test/package-contract/ssrf-parity.test.ts
+++ b/test/package-contract/ssrf-parity.test.ts
@@ -179,6 +179,27 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
     ["192.0.2.192", true, "192.0.2.0/24 three-quarter"],
     ["192.0.1.255", false, "192.0.2.0/24 before-start"],
     ["192.0.3.0", false, "192.0.2.0/24 after-end"],
+    // 192.31.196.0/24 — AS112 DNS anycast
+    ["192.31.196.0", true, "192.31.196.0/24 start"],
+    ["192.31.196.255", true, "192.31.196.0/24 end"],
+    ["192.31.196.64", true, "192.31.196.0/24 quarter"],
+    ["192.31.196.192", true, "192.31.196.0/24 three-quarter"],
+    ["192.31.195.255", false, "192.31.196.0/24 before-start"],
+    ["192.31.197.0", false, "192.31.196.0/24 after-end"],
+    // 192.52.193.0/24 — AMT relay anycast
+    ["192.52.193.0", true, "192.52.193.0/24 start"],
+    ["192.52.193.255", true, "192.52.193.0/24 end"],
+    ["192.52.193.64", true, "192.52.193.0/24 quarter"],
+    ["192.52.193.192", true, "192.52.193.0/24 three-quarter"],
+    ["192.52.192.255", false, "192.52.193.0/24 before-start"],
+    ["192.52.194.0", false, "192.52.193.0/24 after-end"],
+    // 192.88.99.0/24 — Deprecated 6to4 relay anycast
+    ["192.88.99.0", true, "192.88.99.0/24 start"],
+    ["192.88.99.255", true, "192.88.99.0/24 end"],
+    ["192.88.99.64", true, "192.88.99.0/24 quarter"],
+    ["192.88.99.192", true, "192.88.99.0/24 three-quarter"],
+    ["192.88.98.255", false, "192.88.99.0/24 before-start"],
+    ["192.88.100.0", false, "192.88.99.0/24 after-end"],
     // 192.168.0.0/16 — Private /16
     ["192.168.0.0", true, "192.168.0.0/16 start"],
     ["192.168.255.255", true, "192.168.0.0/16 end"],
@@ -186,6 +207,13 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
     ["192.168.192.0", true, "192.168.0.0/16 three-quarter"],
     ["192.167.255.255", false, "192.168.0.0/16 before-start"],
     ["192.169.0.0", false, "192.168.0.0/16 after-end"],
+    // 192.175.48.0/24 — AS112 direct delegation anycast
+    ["192.175.48.0", true, "192.175.48.0/24 start"],
+    ["192.175.48.255", true, "192.175.48.0/24 end"],
+    ["192.175.48.64", true, "192.175.48.0/24 quarter"],
+    ["192.175.48.192", true, "192.175.48.0/24 three-quarter"],
+    ["192.175.47.255", false, "192.175.48.0/24 before-start"],
+    ["192.175.49.0", false, "192.175.48.0/24 after-end"],
     // 198.18.0.0/15 — Benchmark
     ["198.18.0.0", true, "198.18.0.0/15 start"],
     ["198.19.255.255", true, "198.18.0.0/15 end"],
@@ -224,12 +252,16 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
     ["244.0.0.0", true, "240.0.0.0/4 quarter"],
     ["252.0.0.0", true, "240.0.0.0/4 three-quarter"],
     // ::/128 — Unspecified. No before-start (0 is the minimum IPv6
-    // address). No after-end vector: ::1 is the next blocked CIDR.
+    // address). Covered again by ::/96 below.
     ["::", true, "::/128 start"],
-    // ::1/128 — Loopback. No before-start vector: :: is the start of
-    // the previous block.
+    // ::1/128 — Loopback. Also covered by ::/96.
     ["::1", true, "::1/128 start"],
-    ["::2", false, "::1/128 after-end"],
+    // ::/96 — Deprecated IPv4-compatible encodings
+    ["::", true, "::/96 start"],
+    ["::ffff:ffff", true, "::/96 end"],
+    ["::4000:0", true, "::/96 quarter"],
+    ["::c000:0", true, "::/96 three-quarter"],
+    ["0:0:0:0:0:1::", false, "::/96 after-end"],
     // 64:ff9b::/96 — NAT64 well-known
     ["64:ff9b::", true, "64:ff9b::/96 start"],
     ["64:ff9b::ffff:ffff", true, "64:ff9b::/96 end"],
@@ -251,13 +283,13 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
     ["100::c000:0:0:0", true, "100::/64 three-quarter"],
     ["ff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "100::/64 before-start"],
     ["100:0:0:1::", false, "100::/64 after-end"],
-    // 2001::/32 — Teredo
-    ["2001::", true, "2001::/32 start"],
-    ["2001:0:ffff:ffff:ffff:ffff:ffff:ffff", true, "2001::/32 end"],
-    ["2001:0:4000::", true, "2001::/32 quarter"],
-    ["2001:0:c000::", true, "2001::/32 three-quarter"],
-    ["2000:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "2001::/32 before-start"],
-    ["2001:1::", false, "2001::/32 after-end"],
+    // 2001::/23 — IETF protocol assignments (includes Teredo)
+    ["2001::", true, "2001::/23 start"],
+    ["2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff", true, "2001::/23 end"],
+    ["2001:80::", true, "2001::/23 quarter"],
+    ["2001:180::", true, "2001::/23 three-quarter"],
+    ["2000:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "2001::/23 before-start"],
+    ["2001:200::", false, "2001::/23 after-end"],
     // 2001:db8::/32 — Documentation
     ["2001:db8::", true, "2001:db8::/32 start"],
     ["2001:db8:ffff:ffff:ffff:ffff:ffff:ffff", true, "2001:db8::/32 end"],
@@ -272,6 +304,27 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
     ["2002:c000::", true, "2002::/16 three-quarter"],
     ["2001:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "2002::/16 before-start"],
     ["2003::", false, "2002::/16 after-end"],
+    // 2620:4f:8000::/48 — AS112 IPv6 anycast
+    ["2620:4f:8000::", true, "2620:4f:8000::/48 start"],
+    ["2620:4f:8000:ffff:ffff:ffff:ffff:ffff", true, "2620:4f:8000::/48 end"],
+    ["2620:4f:8000:4000::", true, "2620:4f:8000::/48 quarter"],
+    ["2620:4f:8000:c000::", true, "2620:4f:8000::/48 three-quarter"],
+    ["2620:4f:7fff:ffff:ffff:ffff:ffff:ffff", false, "2620:4f:8000::/48 before-start"],
+    ["2620:4f:8001::", false, "2620:4f:8000::/48 after-end"],
+    // 3fff::/20 — Documentation
+    ["3fff::", true, "3fff::/20 start"],
+    ["3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff", true, "3fff::/20 end"],
+    ["3fff:400::", true, "3fff::/20 quarter"],
+    ["3fff:c00::", true, "3fff::/20 three-quarter"],
+    ["3ffe:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "3fff::/20 before-start"],
+    ["3fff:1000::", false, "3fff::/20 after-end"],
+    // 5f00::/16 — SRv6 SIDs
+    ["5f00::", true, "5f00::/16 start"],
+    ["5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true, "5f00::/16 end"],
+    ["5f00:4000::", true, "5f00::/16 quarter"],
+    ["5f00:c000::", true, "5f00::/16 three-quarter"],
+    ["5eff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "5f00::/16 before-start"],
+    ["5f01::", false, "5f00::/16 after-end"],
     // fc00::/7 — Unique local
     ["fc00::", true, "fc00::/7 start"],
     ["fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true, "fc00::/7 end"],
@@ -279,19 +332,26 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
     ["fd80::", true, "fc00::/7 three-quarter"],
     ["fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "fc00::/7 before-start"],
     ["fe00::", false, "fc00::/7 after-end"],
-    // fe80::/10 — Link-local
+    // fe80::/10 — Link-local. No after-end vector: fec0:: is the start
+    // of the next blocked site-local block.
     ["fe80::", true, "fe80::/10 start"],
     ["febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true, "fe80::/10 end"],
     ["fe90::", true, "fe80::/10 quarter"],
     ["feb0::", true, "fe80::/10 three-quarter"],
     ["fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "fe80::/10 before-start"],
-    ["fec0::", false, "fe80::/10 after-end"],
-    // ff00::/8 — Multicast
+    // fec0::/10 — Deprecated site-local. No before-start vector: febf:: is
+    // the end of the previous link-local block. No after-end: ff00:: starts
+    // multicast.
+    ["fec0::", true, "fec0::/10 start"],
+    ["feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true, "fec0::/10 end"],
+    ["fed0::", true, "fec0::/10 quarter"],
+    ["fef0::", true, "fec0::/10 three-quarter"],
+    // ff00::/8 — Multicast. No before-start vector: feff:: is the end of
+    // the previous site-local block.
     ["ff00::", true, "ff00::/8 start"],
     ["ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true, "ff00::/8 end"],
     ["ff40::", true, "ff00::/8 quarter"],
     ["ffc0::", true, "ff00::/8 three-quarter"],
-    ["feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "ff00::/8 before-start"],
   ];
 
   for (const [addr, expected, label] of vectors) {
@@ -324,8 +384,11 @@ describe("CLI and plugin isPrivateHostname agree on wrapper-level cases", () => 
     ["printer.local", true, "RFC 6762 mDNS .local"],
     ["PRINTER.LOCAL.", true, "mDNS .local uppercase with trailing dot"],
     ["my-vm.c.my-project.internal", true, "ICANN-reserved .internal subdomain"],
+    ["metadata", true, "cloud metadata reserved name"],
+    ["instance.metadata", true, "*.metadata subdomain"],
     ["local.example.com", false, "'.local' as a non-final label"],
     ["internal.example.com", false, "'.internal' as a non-final label"],
+    ["metadata.example.com", false, "'.metadata' as a non-final label"],
     ["example.com", false, "DNS name"],
     ["not-an-ip", false, "garbage"],
     ["", false, "empty"],

--- a/test/package-contract/ssrf-parity.test.ts
+++ b/test/package-contract/ssrf-parity.test.ts
@@ -282,7 +282,14 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
     ["100::4000:0:0:0", true, "100::/64 quarter"],
     ["100::c000:0:0:0", true, "100::/64 three-quarter"],
     ["ff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false, "100::/64 before-start"],
-    ["100:0:0:1::", false, "100::/64 after-end"],
+    ["100:0:1::", false, "100::/64 after-end"],
+    // 100:0:0:1::/64 — Dummy IPv6 Prefix. No before-start vector: the
+    // previous hextet is covered by the 100::/64 discard prefix.
+    ["100:0:0:1::", true, "100:0:0:1::/64 start"],
+    ["100:0:0:1:ffff:ffff:ffff:ffff", true, "100:0:0:1::/64 end"],
+    ["100:0:0:1:4000:0:0:0", true, "100:0:0:1::/64 quarter"],
+    ["100:0:0:1:c000:0:0:0", true, "100:0:0:1::/64 three-quarter"],
+    ["100:0:0:2::", false, "100:0:0:1::/64 after-end"],
     // 2001::/23 — IETF protocol assignments (includes Teredo)
     ["2001::", true, "2001::/23 start"],
     ["2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff", true, "2001::/23 end"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Inference SSRF used `private-networks.yaml` while MCP used a harder-coded denylist, so special-purpose IPs and the `metadata` hostname that MCP already rejects could still pass endpoint validation. Plugin SSRF also accepted URL userinfo that CLI onboard and `inference set` reject. This change aligns the shared YAML denylist with MCP and rejects credentialed endpoint URLs in plugin validation.

## Changes

- Extended `nemoclaw-blueprint/private-networks.yaml` with MCP-parity blocks: AS112 / AMT / 6to4 anycast IPv4 ranges, `::/96`, broader `2001::/23`, AS112 / documentation / SRv6 / site-local IPv6 ranges, and the reserved `metadata` name.
- Rejected username/password userinfo in `nemoclaw/src/blueprint/ssrf.ts` with the same credentials-in-URL contract used by onboard and inference set.
- Updated package-contract SSRF boundary vectors and added MCP ↔ `isPrivateHostname` parity coverage in `test/mcp-url-target.test.ts`.
- Updated plugin SSRF tests to assert credentialed URLs fail closed.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Tightens existing SSRF rejection behavior; no new user-facing configure or operate docs surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Awaiting maintainer security review on this PR.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No `docs/` pages changed. Change hardens existing private-network and endpoint URL validation; users already cannot point inference at private or credentialed endpoints under CLI paths.
- Agent: Cursor
<!-- docs-review-head-sha: b24b12d3 -->
<!-- docs-review-agents-blob-sha: be20a095 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [ ] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project package-contract test/package-contract/ssrf-parity.test.ts` → 214 passed; `npx vitest run test/mcp-url-target.test.ts` → 32 passed; `npx vitest run --project plugin nemoclaw/src/blueprint/ssrf.test.ts` → 101 passed; CLI and plugin builds for parity artifacts passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Ayush7614 <ayushknj3@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Endpoint URLs containing usernames or passwords are now rejected immediately.
  * Expanded SSRF private-network protection by adding/additionally covering reserved IPv4 and IPv6 ranges.
  * Added a new cloud metadata hostname alias (e.g., `metadata` / `instance.metadata`) and ensured `metadata.example.com` remains allowed.
  * Updated MCP URL target filtering with an additional special-purpose IPv6 denylist entry.
* **Bug Fixes**
  * Improved parity between SSRF/private-hostname filtering at CIDR boundaries.
* **Tests**
  * Expanded SSRF and MCP/private-network parity test coverage for the updated ranges and metadata cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->