### PR TITLE
docs: add v0.0.97 changelog

### DIFF
--- a/docs/changelog/2026-07-28.mdx
+++ b/docs/changelog/2026-07-28.mdx
@@ -1,0 +1,49 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.97
+
+NemoClaw v0.0.97 adds read-only host readiness reporting, a Deferred automatic two-Station vLLM evaluation, compatible-endpoint reasoning effort controls, and an experimental runtime identity reference for direct OpenClaw blueprints.
+It also hardens compatible-provider switching, managed sandbox images, Jetson GPU access, lifecycle recovery, network policy guidance, MCP discovery, and release E2E evidence.
+
+- `nemoclaw host probe` now produces a schema-versioned readiness report without changing host, Docker, gateway, provider, policy, credential, or sandbox state.
+  Human-readable and JSON output share the same redacted evidence, stable capability and finding IDs, deterministic exit codes, and fail-closed Linux, macOS, WSL, DGX Spark, and DGX Station qualification.
+  For more information, refer to [System Readiness](/user-guide/openclaw/reference/system-readiness) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- DGX Station Express can now select and prepare one pretrusted two-Station GB300 pair for distributed Nemotron Ultra when reciprocal Station identity, GPU, SSH, route, neighbor, rail, and jumbo-frame checks pass.
+  The installer records durable controller and pair ownership, stops for manual reboots, resumes from owner-only receipts, and cleans up the recorded pair during full uninstall.
+  If no trusted pair qualifies, automatic selection keeps the single-Station Ultra path, while an explicitly selected peer must qualify.
+  The two-Station path remains a Deferred evaluation and does not change single-Station support status.
+  For more information, refer to [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation) and [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm).
+- The direct OpenClaw blueprint runner now has an experimental, explicit opt-in provider-neutral runtime identity component with a bundled data-only Okta reference profile.
+  The runner validates the complete profile and DNS destinations before mutation, keeps refresh material out of plans and command arguments, records resource ownership as it applies changes, and uses those receipts for compensation and rollback.
+  The shipped blueprint and normal onboarding do not enable this component, custom Okta domains are outside the reviewed policy, and this release does not add Entra, OBO, OAuth bootstrap, production middleware, or real-tenant certification.
+  For more information, refer to [Architecture Details](/user-guide/openclaw/reference/architecture).
+- OpenClaw compatible endpoints can now set `NEMOCLAW_REASONING_EFFORT` or pass `inference set --reasoning-effort` with `low`, `medium`, `high`, or `default` on `openai-completions` routes.
+  NemoClaw validates the value, provider, and API before mutation, records the effective state for diagnostics, preserves it through resume, rebuild, and restart, and clears it when the resulting route no longer supports the setting.
+  For more information, refer to [Configure Model Capabilities](/user-guide/openclaw/inference/manage-inference/configure-model-capabilities), [Set Up an OpenAI-Compatible Endpoint](/user-guide/openclaw/inference/custom-endpoints/set-up-openai-compatible-endpoint), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Compatible-provider switching now creates and verifies an absent direct provider before route selection and removes that provider if selection fails.
+  An existing direct provider is reused only when its recorded endpoint and credential environment exactly match the request; NemoClaw refuses an endpoint replacement that OpenShell cannot expose safely enough to roll back.
+  Host-side `config set` also accepts the exact `http://host.openshell.internal:<unprivileged-port>` shape only for supported provider `baseUrl` fields, while generic keys and other private URL shapes remain rejected.
+  Retired NVIDIA Build MiniMax and Qwen model paths are no longer offered.
+  For more information, refer to [Switch Inference Providers](/user-guide/openclaw/inference/manage-inference/switch-providers), [Meet Custom Endpoint Security Requirements](/user-guide/openclaw/inference/custom-endpoints/custom-endpoint-security), and [Set Up Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama).
+- Docker-driver recovery now unpauses a paused original container before reporting recovery, and resumed onboarding writes a secret-free same-name recreation journal before deletion so an interrupted run can continue or fail closed on ambiguous identity.
+  Uninstall checks for the `openshell` command after confirmation and before cleanup mutation, while source-checkout installation preserves an absolute `NEMOCLAW_OPENSHELL_BIN` selection during user-local OpenShell discovery.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw).
+- Jetson setup now explains why host preparation was skipped when it encounters an unrecognized or unparseable release.
+  GPU onboarding carries eligible numeric group IDs for real, non-symlink DRI render character devices into the recreated container while preserving the established Tegra device allowlist.
+  The sandbox CUDA proof remains fail-closed, and physical IGX Orin validation of the reported configuration remains pending.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- Telegram channel status now returns `unreachable` with a nonzero exit when the Bot API startup probe receives a definitive HTTP error.
+  Managed MCP tool discovery accepts compliant case-variant or parameterized SSE media types through the reviewed SDK runtime.
+  Hermes image assembly normalizes executable modes before metadata validation, and locked restart integrity accepts the generated v1 managed MCP state record while retaining fail-closed hashing and failed-reload rollback.
+  For more information, refer to [Choose Messaging Channels](/user-guide/openclaw/manage-sandboxes/messaging-channels/choose-messaging-channels), [Manage MCP Servers with OpenClaw](/user-guide/openclaw/manage-sandboxes/mcp-servers/manage-mcp-servers), [Manage MCP Servers with Hermes](/user-guide/hermes/manage-sandboxes/mcp-servers/manage-mcp-servers), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Deep Agents now publishes the bounded approval, baseline, preset, custom-preset, and live-policy tasks that apply to its maintained runtime.
+  The `claude-code` preset permits browser login only through `GET` and `POST` on `platform.claude.com/v1/oauth/**`, without widening unrelated Anthropic or telemetry access.
+  For more information, refer to [Approve or Deny Network Requests](/user-guide/deepagents/network-policy/approve-network-requests), [Apply Policy Presets](/user-guide/deepagents/network-policy/configure-policies/apply-policy-presets), and [Security Best Practices](/user-guide/openclaw/security/best-practices).
+- Every managed OpenClaw, Hermes, and Deep Agents Code base image now installs checksum-bound backports for four libssh2 memory-safety fixes and the Python 3.13 `HTMLParser` incremental-input complexity fix.
+  Image builds verify immutable source and package identities, libssh2 compatibility and upstream tests, Python file identity and behavior, final package inventories, and clean package-manager state on amd64 and arm64.
+  For more information, refer to [Architecture Details](/user-guide/openclaw/reference/architecture).
+- Pre-tag release validation now derives its exact candidate test ledger from the candidate commit's E2E workflow, accumulates attempt-aware green evidence in parallel, and keeps every missing execution visible for an itemized maintainer decision.
+  A one-off exact-SHA Launchable qualification can contribute evidence without replacing the default suite, while phase-specific E2E diagnostics, consolidated journeys, checksum-verified official Node.js 22.23.1 archives for WSL, and stricter workflow boundaries improve failure attribution.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the canonical dated changelog entry for NemoClaw v0.0.97 before the release plan captures `origin/main`.
The entry groups the user-visible and maintainer-facing changes since v0.0.96 while preserving the Deferred dual-Station status, experimental runtime-identity boundary, and pending physical IGX validation.

## Changes

- Add `docs/changelog/2026-07-28.mdx` with the parser-safe MDX SPDX comment and exact `## v0.0.97` heading.
- Summarize the 43 merged PRs in the release range, omitting internal-only changes from the public entry and linking each grouped change to its most specific published documentation.
- Keep the experimental Okta reference explicitly opt-in and outside normal onboarding, keep the two-Station path Deferred, and state that physical IGX Orin validation remains pending.

### Source summary

- [#7440](https://github.com/NVIDIA/NemoClaw/pull/7440), [#7443](https://github.com/NVIDIA/NemoClaw/pull/7443), and [#7445](https://github.com/NVIDIA/NemoClaw/pull/7445) -> `docs/changelog/2026-07-28.mdx`: Document read-only host readiness reports and fail-closed platform qualification.
- [#7030](https://github.com/NVIDIA/NemoClaw/pull/7030) -> `docs/changelog/2026-07-28.mdx`: Document the Deferred trusted two-Station vLLM evaluation.
- [#7265](https://github.com/NVIDIA/NemoClaw/pull/7265) -> `docs/changelog/2026-07-28.mdx`: Document the bounded experimental direct-runner Okta runtime-identity reference.
- [#7711](https://github.com/NVIDIA/NemoClaw/pull/7711) and [#7648](https://github.com/NVIDIA/NemoClaw/pull/7648) -> `docs/changelog/2026-07-28.mdx`: Document compatible-endpoint reasoning effort and retired NVIDIA Build model paths.
- [#7746](https://github.com/NVIDIA/NemoClaw/pull/7746), [#7763](https://github.com/NVIDIA/NemoClaw/pull/7763), and [#7681](https://github.com/NVIDIA/NemoClaw/pull/7681) -> `docs/changelog/2026-07-28.mdx`: Document safe compatible-provider creation, replacement refusal, and narrow OpenShell bridge URL handling.
- [#7641](https://github.com/NVIDIA/NemoClaw/pull/7641), [#7690](https://github.com/NVIDIA/NemoClaw/pull/7690), [#7631](https://github.com/NVIDIA/NemoClaw/pull/7631), and [#7710](https://github.com/NVIDIA/NemoClaw/pull/7710) -> `docs/changelog/2026-07-28.mdx`: Document paused-container recovery, recreation journaling, pre-mutation uninstall checks, and source-checkout OpenShell selection.
- [#7624](https://github.com/NVIDIA/NemoClaw/pull/7624) and [#7762](https://github.com/NVIDIA/NemoClaw/pull/7762) -> `docs/changelog/2026-07-28.mdx`: Document Jetson release diagnostics and bounded render-device group propagation.
- [#7639](https://github.com/NVIDIA/NemoClaw/pull/7639), [#7760](https://github.com/NVIDIA/NemoClaw/pull/7760), [#7721](https://github.com/NVIDIA/NemoClaw/pull/7721), and [#7761](https://github.com/NVIDIA/NemoClaw/pull/7761) -> `docs/changelog/2026-07-28.mdx`: Document Telegram, MCP media-type, Hermes image-mode, and locked-restart fixes.
- [#7653](https://github.com/NVIDIA/NemoClaw/pull/7653) and [#7680](https://github.com/NVIDIA/NemoClaw/pull/7680) -> `docs/changelog/2026-07-28.mdx`: Document Deep Agents policy tasks and the bounded Claude Code OAuth path.
- [#7679](https://github.com/NVIDIA/NemoClaw/pull/7679) -> `docs/changelog/2026-07-28.mdx`: Document the checksum-bound libssh2 and Python HTMLParser backports.
- [#7655](https://github.com/NVIDIA/NemoClaw/pull/7655), [#7651](https://github.com/NVIDIA/NemoClaw/pull/7651), [#7664](https://github.com/NVIDIA/NemoClaw/pull/7664), [#7666](https://github.com/NVIDIA/NemoClaw/pull/7666), [#7670](https://github.com/NVIDIA/NemoClaw/pull/7670), [#7719](https://github.com/NVIDIA/NemoClaw/pull/7719), and [#7741](https://github.com/NVIDIA/NemoClaw/pull/7741) -> `docs/changelog/2026-07-28.mdx`: Document exact candidate E2E evidence, Launchable selection, diagnostic consolidation, and trusted WSL validation.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates the dated changelog contract, MDX header, heading uniqueness, and release-entry structure.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: The committed `docs/changelog/2026-07-28.mdx` blob exactly matches the reviewed file. Completeness, factual accuracy, link shape, parser-safe MDX header, one-sentence-per-line style, `.docs-skip` compliance, and bounded product claims passed.
- Agent: Codex Desktop documentation writer subagent
<!-- docs-review-head-sha: da6aa274b -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR changes only the dated changelog.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts` passed 6/6.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this doc-only release entry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors and 2 pre-existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — native changelog entries use the required parser-safe MDX SPDX comment and intentionally have no frontmatter.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved host readiness reporting and Jetson onboarding guidance.
  * Added controls for reasoning effort with compatible endpoints and enhanced managed MCP discovery.
  * Improved Deep Agents task publication and preset support.
* **Bug Fixes**
  * Hardened provider switching, sandbox recovery, uninstall behavior, and Telegram connectivity.
  * Improved container image integrity checks, media-type handling, and checksum validation.
  * Enhanced vLLM evaluation behavior and release diagnostics.
* **Documentation**
  * Added the NemoClaw v0.0.97 changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->