### PR TITLE
fix(onboard): report an invalid DOCKER_HOST instead of a docker-group remediation

### DIFF
--- a/src/lib/advisories/checks/host/docker.test.ts
+++ b/src/lib/advisories/checks/host/docker.test.ts
@@ -53,6 +53,16 @@ describe("Docker host advisories (#3213)", () => {
     }
   });
 
+  it("reports an invalid DOCKER_HOST instead of a docker-group remediation (#7731)", () => {
+    const result = runAdvisories(
+      DOCKER_HOST_ADVISORY_CHECKS,
+      host({ dockerServiceActive: true, dockerHostInvalid: true }),
+      { phase: "preflight.host" },
+    );
+
+    expect(result.advisories.map((advisory) => advisory.id)).toEqual(["invalid_docker_host"]);
+  });
+
   it("re-evaluates Docker state on resume", () => {
     const context = host({ dockerInstalled: false });
     const cachedResults = new Map([["install_docker", null]]);
@@ -66,6 +76,7 @@ describe("Docker host advisories (#3213)", () => {
     expect(result.executedCheckIds).toEqual([
       "enable_docker_desktop_wsl_integration",
       "install_docker",
+      "invalid_docker_host",
       "docker_group_permission",
       "start_docker",
     ]);

--- a/src/lib/advisories/checks/host/docker.test.ts
+++ b/src/lib/advisories/checks/host/docker.test.ts
@@ -63,6 +63,16 @@ describe("Docker host advisories (#3213)", () => {
     expect(result.advisories.map((advisory) => advisory.id)).toEqual(["invalid_docker_host"]);
   });
 
+  it("reports an invalid DOCKER_HOST even when the endpoint is reachable (#7731)", () => {
+    const result = runAdvisories(
+      DOCKER_HOST_ADVISORY_CHECKS,
+      host({ dockerReachable: true, dockerHostInvalid: true }),
+      { phase: "preflight.host" },
+    );
+
+    expect(result.advisories.map((advisory) => advisory.id)).toEqual(["invalid_docker_host"]);
+  });
+
   it("re-evaluates Docker state on resume", () => {
     const context = host({ dockerInstalled: false });
     const cachedResults = new Map([["install_docker", null]]);

--- a/src/lib/advisories/checks/host/docker.ts
+++ b/src/lib/advisories/checks/host/docker.ts
@@ -66,6 +66,32 @@ export const installDocker: AdvisoryCheck<HostAssessment> = {
   },
 };
 
+export const invalidDockerHost: AdvisoryCheck<HostAssessment> = {
+  id: "invalid_docker_host",
+  phase: "preflight.host",
+  severity: "blocking",
+  resumeSafe: false,
+  check(host) {
+    if (!host.dockerHostInvalid || !host.dockerInstalled || host.dockerReachable || host.isWsl) {
+      return null;
+    }
+    return hostAdvisory(invalidDockerHost, {
+      title: "Fix the DOCKER_HOST endpoint",
+      kind: "manual",
+      reason:
+        "DOCKER_HOST is set to an endpoint onboarding cannot use, so NemoClaw could not reach the Docker daemon. " +
+        "Onboarding supports only an absolute unix:// Docker socket with no quotes or line breaks; TCP endpoints and relative paths are not supported. " +
+        "This is a DOCKER_HOST configuration problem, not a docker-group permission or stopped-daemon issue.",
+      commands: [
+        "unset DOCKER_HOST   # use Docker's default socket",
+        "# or point it at a local socket, for example:",
+        "export DOCKER_HOST=unix:///var/run/docker.sock",
+        "nemoclaw onboard",
+      ],
+    });
+  },
+};
+
 export const addUserToDockerGroup: AdvisoryCheck<HostAssessment> = {
   id: "docker_group_permission",
   phase: "preflight.host",
@@ -73,6 +99,7 @@ export const addUserToDockerGroup: AdvisoryCheck<HostAssessment> = {
   resumeSafe: false,
   check(host) {
     if (
+      host.dockerHostInvalid ||
       !host.dockerInstalled ||
       host.dockerReachable ||
       host.isWsl ||
@@ -107,7 +134,13 @@ export const startDocker: AdvisoryCheck<HostAssessment> = {
   resumeSafe: false,
   check(host) {
     const likelyGroupIssue = host.platform === "linux" && host.dockerServiceActive === true;
-    if (!host.dockerInstalled || host.dockerReachable || host.isWsl || likelyGroupIssue)
+    if (
+      host.dockerHostInvalid ||
+      !host.dockerInstalled ||
+      host.dockerReachable ||
+      host.isWsl ||
+      likelyGroupIssue
+    )
       return null;
     return hostAdvisory(startDocker, {
       title: "Start Docker",
@@ -126,6 +159,7 @@ export const startDocker: AdvisoryCheck<HostAssessment> = {
 export const DOCKER_HOST_ADVISORY_CHECKS = Object.freeze([
   enableDockerDesktopWslIntegration,
   installDocker,
+  invalidDockerHost,
   addUserToDockerGroup,
   startDocker,
 ]);

--- a/src/lib/advisories/checks/host/docker.ts
+++ b/src/lib/advisories/checks/host/docker.ts
@@ -72,15 +72,15 @@ export const invalidDockerHost: AdvisoryCheck<HostAssessment> = {
   severity: "blocking",
   resumeSafe: false,
   check(host) {
-    if (!host.dockerHostInvalid || !host.dockerInstalled || host.dockerReachable || host.isWsl) {
+    if (!host.dockerHostInvalid || !host.dockerInstalled || host.isWsl) {
       return null;
     }
     return hostAdvisory(invalidDockerHost, {
       title: "Fix the DOCKER_HOST endpoint",
       kind: "manual",
       reason:
-        "DOCKER_HOST is set to an endpoint onboarding cannot use, so NemoClaw could not reach the Docker daemon. " +
-        "Onboarding supports only an absolute unix:// Docker socket with no quotes or line breaks; TCP endpoints and relative paths are not supported. " +
+        "DOCKER_HOST is set to an endpoint onboarding cannot use. " +
+        "Onboarding supports only an absolute unix:// Docker socket with no quotes or line breaks; TCP and SSH endpoints and relative paths are not supported, even when reachable. " +
         "This is a DOCKER_HOST configuration problem, not a docker-group permission or stopped-daemon issue.",
       commands: [
         "unset DOCKER_HOST   # use Docker's default socket",

--- a/src/lib/advisories/checks/host/docker.ts
+++ b/src/lib/advisories/checks/host/docker.ts
@@ -80,7 +80,9 @@ export const invalidDockerHost: AdvisoryCheck<HostAssessment> = {
       kind: "manual",
       reason:
         "DOCKER_HOST is set to an endpoint onboarding cannot use. " +
-        "Onboarding supports only an absolute unix:// Docker socket with no quotes or line breaks; TCP and SSH endpoints and relative paths are not supported, even when reachable. " +
+        "Onboarding supports only an absolute unix:// Docker socket. " +
+        "The socket path cannot contain a single quote or line break. " +
+        "TCP and SSH endpoints and relative paths are not supported, even when reachable. " +
         "This is a DOCKER_HOST configuration problem, not a docker-group permission or stopped-daemon issue.",
       commands: [
         "unset DOCKER_HOST   # use Docker's default socket",

--- a/src/lib/advisories/checks/host/index.test.ts
+++ b/src/lib/advisories/checks/host/index.test.ts
@@ -44,6 +44,7 @@ describe("host advisory registry (#3213)", () => {
     expect(ids).toEqual([
       "enable_docker_desktop_wsl_integration",
       "install_docker",
+      "invalid_docker_host",
       "docker_group_permission",
       "start_docker",
       "container_runtime_under_provisioned",

--- a/src/lib/domain/docker-host.test.ts
+++ b/src/lib/domain/docker-host.test.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { isSupportedGatewayDockerHost } from "./docker-host";
+
+describe("isSupportedGatewayDockerHost (#7731)", () => {
+  it.each([
+    ["unset", undefined],
+    ["empty", ""],
+    ["whitespace only", "   "],
+    ["absolute unix socket", "unix:///var/run/docker.sock"],
+    ["absolute unix socket with surrounding whitespace", "  unix:///var/run/docker.sock  "],
+  ])("accepts %s DOCKER_HOST", (_case, value) => {
+    expect(isSupportedGatewayDockerHost(value)).toBe(true);
+  });
+
+  it.each([
+    ["a TCP endpoint", "tcp://203.0.113.10:2375"],
+    ["an ssh endpoint", "ssh://user@host"],
+    ["an fd endpoint", "fd://"],
+    ["a bare socket path without a scheme", "/var/run/docker.sock"],
+    ["a relative unix path", "unix://relative/docker.sock"],
+    ["a unix socket path with a quote", "unix:///var/run/dock'er.sock"],
+    ["a unix socket path with an embedded newline", "unix:///var/run/\ndocker.sock"],
+    ["a unix socket with a trailing newline", "unix:///var/run/docker.sock\n"],
+    ["a unix socket with a trailing carriage return", "unix:///var/run/docker.sock\r"],
+    ["a value with a null byte", "unix:///var/run/docker.sock\0"],
+  ])("rejects %s", (_case, value) => {
+    expect(isSupportedGatewayDockerHost(value)).toBe(false);
+  });
+});

--- a/src/lib/domain/docker-host.ts
+++ b/src/lib/domain/docker-host.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+// A DOCKER_HOST value onboarding can use. Unset means Docker's default socket,
+// which is supported; a set value must be an absolute `unix://` socket with no
+// serialization-hostile characters. TCP and SSH endpoints and relative paths
+// are unsupported, so onboarding cannot use them even when they are reachable.
+//
+// The raw value is checked for null bytes and line breaks before trimming, so a
+// trailing `\n` cannot be trimmed away and then accepted; the socket path is
+// checked for the single quote it would be wrapped in when written to the
+// gateway environment file.
+export function isSupportedGatewayDockerHost(value: string | undefined): boolean {
+  const raw = String(value ?? "");
+  if (/[\0\r\n]/.test(raw)) return false;
+  const candidate = raw.trim();
+  if (!candidate) return true;
+  const prefix = "unix://";
+  if (!candidate.startsWith(prefix)) return false;
+  const socketPath = candidate.slice(prefix.length);
+  return path.isAbsolute(socketPath) && !socketPath.includes("'");
+}

--- a/src/lib/domain/docker-host.ts
+++ b/src/lib/domain/docker-host.ts
@@ -4,9 +4,10 @@
 import path from "node:path";
 
 // A DOCKER_HOST value onboarding can use. Unset means Docker's default socket,
-// which is supported; a set value must be an absolute `unix://` socket with no
-// serialization-hostile characters. TCP and SSH endpoints and relative paths
-// are unsupported, so onboarding cannot use them even when they are reachable.
+// which is supported; a set value must be an absolute `unix://` socket that can
+// be written to the gateway environment file. TCP and SSH endpoints and
+// relative paths are unsupported, so onboarding cannot use them even when they
+// are reachable.
 //
 // The raw value is checked for null bytes and line breaks before trimming, so a
 // trailing `\n` cannot be trimmed away and then accepted; the socket path is

--- a/src/lib/onboard/docker-driver-gateway-env-service.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-env-service.test.ts
@@ -59,11 +59,12 @@ describe("package-managed Docker-driver gateway env service", () => {
   });
 
   it.each([
-    "tcp://attacker.example:2375",
-    "ssh://docker.example",
-    "unix://relative/docker.sock",
-    "unix:///tmp/docker's.sock",
-  ])("rejects unsafe package-service Docker endpoint %s (#6903)", async (dockerHost) => {
+    ["a TCP Docker endpoint", "tcp://attacker.example:2375"],
+    ["an SSH Docker endpoint", "ssh://docker.example"],
+    ["a relative Unix socket", "unix://relative/docker.sock"],
+    ["a Unix socket with a single quote", "unix:///tmp/docker's.sock"],
+    ["a Unix socket with a trailing newline", "unix:///tmp/docker.sock\n"],
+  ])("rejects %s for a package service (#6903)", async (_case, dockerHost) => {
     const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-env-"));
     const envFile = path.join(tempHome, ".config", "openshell", "gateway.env");
     const startService = vi.fn((opts?: { prepareServiceEnv?: () => void }) => {

--- a/src/lib/onboard/docker-driver-gateway-env.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.test.ts
@@ -10,34 +10,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildDockerDriverGatewayEnv,
   buildDockerGatewayDebEnvFile,
-  isSupportedGatewayDockerHost,
   startPackageManagedDockerDriverGatewayWithEnvOverride,
   writeDockerGatewayDebEnvOverride,
 } from "./docker-driver-gateway-env";
-
-describe("isSupportedGatewayDockerHost (#7731)", () => {
-  it.each([
-    ["unset", undefined],
-    ["empty", ""],
-    ["whitespace only", "   "],
-    ["absolute unix socket", "unix:///var/run/docker.sock"],
-    ["absolute unix socket with surrounding whitespace", "  unix:///var/run/docker.sock  "],
-  ])("accepts %s DOCKER_HOST", (_case, value) => {
-    expect(isSupportedGatewayDockerHost(value)).toBe(true);
-  });
-
-  it.each([
-    ["a TCP endpoint", "tcp://203.0.113.10:2375"],
-    ["an ssh endpoint", "ssh://user@host"],
-    ["an fd endpoint", "fd://"],
-    ["a bare socket path without a scheme", "/var/run/docker.sock"],
-    ["a relative unix path", "unix://relative/docker.sock"],
-    ["a unix socket path with a quote", "unix:///var/run/dock'er.sock"],
-    ["a unix socket path with an embedded newline", "unix:///var/run/\ndocker.sock"],
-  ])("rejects %s", (_case, value) => {
-    expect(isSupportedGatewayDockerHost(value)).toBe(false);
-  });
-});
 
 function homeEnv(home: string, xdgConfigHome = ""): NodeJS.ProcessEnv {
   return { HOME: home, XDG_CONFIG_HOME: xdgConfigHome } as NodeJS.ProcessEnv;

--- a/src/lib/onboard/docker-driver-gateway-env.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.test.ts
@@ -10,9 +10,34 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildDockerDriverGatewayEnv,
   buildDockerGatewayDebEnvFile,
+  isSupportedGatewayDockerHost,
   startPackageManagedDockerDriverGatewayWithEnvOverride,
   writeDockerGatewayDebEnvOverride,
 } from "./docker-driver-gateway-env";
+
+describe("isSupportedGatewayDockerHost (#7731)", () => {
+  it.each([
+    ["unset", undefined],
+    ["empty", ""],
+    ["whitespace only", "   "],
+    ["absolute unix socket", "unix:///var/run/docker.sock"],
+    ["absolute unix socket with surrounding whitespace", "  unix:///var/run/docker.sock  "],
+  ])("accepts %s DOCKER_HOST", (_case, value) => {
+    expect(isSupportedGatewayDockerHost(value)).toBe(true);
+  });
+
+  it.each([
+    ["a TCP endpoint", "tcp://203.0.113.10:2375"],
+    ["an ssh endpoint", "ssh://user@host"],
+    ["an fd endpoint", "fd://"],
+    ["a bare socket path without a scheme", "/var/run/docker.sock"],
+    ["a relative unix path", "unix://relative/docker.sock"],
+    ["a unix socket path with a quote", "unix:///var/run/dock'er.sock"],
+    ["a unix socket path with an embedded newline", "unix:///var/run/\ndocker.sock"],
+  ])("rejects %s", (_case, value) => {
+    expect(isSupportedGatewayDockerHost(value)).toBe(false);
+  });
+});
 
 function homeEnv(home: string, xdgConfigHome = ""): NodeJS.ProcessEnv {
   return { HOME: home, XDG_CONFIG_HOME: xdgConfigHome } as NodeJS.ProcessEnv;

--- a/src/lib/onboard/docker-driver-gateway-env.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.ts
@@ -257,7 +257,7 @@ function formatEnvironmentFileAssignment(key: string, value: string): string {
 function normalizePackageServiceDockerHost(value: string | undefined): string | undefined {
   const candidate = String(value || "").trim();
   if (!candidate) return undefined;
-  if (isSupportedGatewayDockerHost(candidate)) {
+  if (isSupportedGatewayDockerHost(value)) {
     return candidate;
   }
   throw new Error(

--- a/src/lib/onboard/docker-driver-gateway-env.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.ts
@@ -253,12 +253,24 @@ function formatEnvironmentFileAssignment(key: string, value: string): string {
   return `${key}=${value}`;
 }
 
+// A DOCKER_HOST value onboarding can use. Unset means Docker's default socket,
+// which is supported; a set value must be an absolute `unix://` socket with no
+// serialization-hostile characters. TCP endpoints and relative paths are
+// unsupported, so when DOCKER_HOST points at one, `docker info` cannot reach the
+// daemon and onboarding treats the host as invalid.
+export function isSupportedGatewayDockerHost(value: string | undefined): boolean {
+  const candidate = String(value ?? "").trim();
+  if (!candidate) return true;
+  const prefix = "unix://";
+  if (!candidate.startsWith(prefix)) return false;
+  const socketPath = candidate.slice(prefix.length);
+  return path.isAbsolute(socketPath) && !/[\0\r\n']/.test(socketPath);
+}
+
 function normalizePackageServiceDockerHost(value: string | undefined): string | undefined {
   const candidate = String(value || "").trim();
   if (!candidate) return undefined;
-  const prefix = "unix://";
-  const socketPath = candidate.startsWith(prefix) ? candidate.slice(prefix.length) : "";
-  if (path.isAbsolute(socketPath) && !/[\0\r\n']/.test(socketPath)) {
+  if (isSupportedGatewayDockerHost(candidate)) {
     return candidate;
   }
   throw new Error(

--- a/src/lib/onboard/docker-driver-gateway-env.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.ts
@@ -13,6 +13,7 @@ import {
   WILDCARD_GATEWAY_BIND_ADDRESS,
 } from "../core/gateway-address";
 import { DEFAULT_GATEWAY_PORT, GATEWAY_PORT } from "../core/ports";
+import { isSupportedGatewayDockerHost } from "../domain/docker-host";
 import {
   DOCKER_DRIVER_GATEWAY_JWT_TTL_SECS,
   prepareDockerDriverGatewayConfigEnv,
@@ -251,20 +252,6 @@ function formatEnvironmentFileAssignment(key: string, value: string): string {
     return `${key}='${dockerHost}'`;
   }
   return `${key}=${value}`;
-}
-
-// A DOCKER_HOST value onboarding can use. Unset means Docker's default socket,
-// which is supported; a set value must be an absolute `unix://` socket with no
-// serialization-hostile characters. TCP endpoints and relative paths are
-// unsupported, so when DOCKER_HOST points at one, `docker info` cannot reach the
-// daemon and onboarding treats the host as invalid.
-export function isSupportedGatewayDockerHost(value: string | undefined): boolean {
-  const candidate = String(value ?? "").trim();
-  if (!candidate) return true;
-  const prefix = "unix://";
-  if (!candidate.startsWith(prefix)) return false;
-  const socketPath = candidate.slice(prefix.length);
-  return path.isAbsolute(socketPath) && !/[\0\r\n']/.test(socketPath);
 }
 
 function normalizePackageServiceDockerHost(value: string | undefined): string | undefined {

--- a/src/lib/onboard/preflight-docker-host.test.ts
+++ b/src/lib/onboard/preflight-docker-host.test.ts
@@ -5,11 +5,10 @@ import { describe, expect, it } from "vitest";
 
 import { assessHost, planHostRemediation } from "./preflight";
 
-// Regression: NemoClaw #7731. An invalid DOCKER_HOST (a TCP endpoint or a
-// relative path) makes `docker info` fail, but the local docker.service is
-// still active, so preflight used to emit the docker-group remediation. The
-// host assessment now flags the invalid DOCKER_HOST so onboarding names it
-// instead.
+// Regression: NemoClaw #7731. This invalid TCP endpoint makes `docker info`
+// fail, but the local docker.service is still active. Preflight used to emit
+// the docker-group remediation. The host assessment now flags the invalid
+// DOCKER_HOST so onboarding names it instead.
 describe("assessHost invalid DOCKER_HOST (#7731)", () => {
   it("flags an invalid DOCKER_HOST so onboarding names the endpoint, not a docker-group fix", () => {
     const assessment = assessHost({

--- a/src/lib/onboard/preflight-docker-host.test.ts
+++ b/src/lib/onboard/preflight-docker-host.test.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { assessHost, planHostRemediation } from "./preflight";
+
+// Regression: NemoClaw #7731. An invalid DOCKER_HOST (a TCP endpoint or a
+// relative path) makes `docker info` fail, but the local docker.service is
+// still active, so preflight used to emit the docker-group remediation. The
+// host assessment now flags the invalid DOCKER_HOST so onboarding names it
+// instead.
+describe("assessHost invalid DOCKER_HOST (#7731)", () => {
+  it("flags an invalid DOCKER_HOST so onboarding names the endpoint, not a docker-group fix", () => {
+    const assessment = assessHost({
+      platform: "linux",
+      env: { DOCKER_HOST: "tcp://203.0.113.10:2375" },
+      dockerInfoOutput: "",
+      commandExistsImpl: (name: string) => name === "docker" || name === "systemctl",
+      runCaptureImpl: (command: readonly string[]) =>
+        command.includes("is-active") ? "active" : "",
+    });
+
+    expect(assessment.dockerHostInvalid).toBe(true);
+    expect(assessment.dockerReachable).toBe(false);
+    expect(assessment.dockerServiceActive).toBe(true);
+
+    const ids = planHostRemediation(assessment).map((action) => action.id);
+    expect(ids).toContain("invalid_docker_host");
+    expect(ids).not.toContain("docker_group_permission");
+  });
+
+  it("treats a supported absolute unix:// DOCKER_HOST as valid", () => {
+    const assessment = assessHost({
+      platform: "linux",
+      env: { DOCKER_HOST: "unix:///var/run/docker.sock" },
+      dockerInfoOutput: "",
+      commandExistsImpl: (name: string) => name === "docker" || name === "systemctl",
+      runCaptureImpl: (command: readonly string[]) =>
+        command.includes("is-active") ? "active" : "",
+    });
+
+    expect(assessment.dockerHostInvalid).toBe(false);
+  });
+
+  it("treats an unset DOCKER_HOST as valid", () => {
+    const assessment = assessHost({
+      platform: "linux",
+      env: {},
+      dockerInfoOutput: "",
+      commandExistsImpl: (name: string) => name === "docker" || name === "systemctl",
+      runCaptureImpl: (command: readonly string[]) =>
+        command.includes("is-active") ? "active" : "",
+    });
+
+    expect(assessment.dockerHostInvalid).toBe(false);
+  });
+});

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -19,12 +19,12 @@ import { HOST_ADVISORY_CHECKS } from "../advisories/checks/host";
 import { runAdvisories } from "../advisories/runner";
 import { failLine } from "../cli/terminal-style";
 import { DASHBOARD_PORT } from "../core/ports";
+import { isSupportedGatewayDockerHost } from "../domain/docker-host";
 import {
   MIN_RECOMMENDED_DOCKER_CPUS,
   MIN_RECOMMENDED_DOCKER_MEM_GIB,
 } from "./container-runtime-resources";
 import { assessNvidiaCdiHost } from "./docker-cdi";
-import { isSupportedGatewayDockerHost } from "./docker-driver-gateway-env";
 import { printUnderProvisionedRuntimeWarning } from "./preflight-messages";
 import { printRemediationActions } from "./remediation";
 import { isWslDockerDesktopRuntime } from "./wsl-docker-desktop-gpu";

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -24,6 +24,7 @@ import {
   MIN_RECOMMENDED_DOCKER_MEM_GIB,
 } from "./container-runtime-resources";
 import { assessNvidiaCdiHost } from "./docker-cdi";
+import { isSupportedGatewayDockerHost } from "./docker-driver-gateway-env";
 import { printUnderProvisionedRuntimeWarning } from "./preflight-messages";
 import { printRemediationActions } from "./remediation";
 import { isWslDockerDesktopRuntime } from "./wsl-docker-desktop-gpu";
@@ -118,6 +119,7 @@ export interface HostAssessment {
   systemctlAvailable?: boolean;
   dockerServiceActive?: boolean | null;
   dockerServiceEnabled?: boolean | null;
+  dockerHostInvalid?: boolean;
   dockerInstalled: boolean;
   dockerRunning: boolean;
   dockerReachable: boolean;
@@ -732,6 +734,7 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     systemctlAvailable,
     dockerServiceActive,
     dockerServiceEnabled,
+    dockerHostInvalid: !isSupportedGatewayDockerHost(env.DOCKER_HOST),
     dockerInstalled,
     dockerRunning,
     dockerReachable,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

On Ubuntu, an invalid `DOCKER_HOST` could make preflight report an unrelated docker-group remediation. This PR adds a blocking `invalid_docker_host` advisory for unsupported endpoints, including reachable TCP and SSH endpoints, while accepting Docker's default socket or an absolute `unix://` socket. It also validates raw package-service values before trimming so line breaks cannot be accepted.

## Related Issue

Closes #7731

## Changes

- `src/lib/domain/docker-host.ts`: define the pure `isSupportedGatewayDockerHost` predicate for values managed onboarding can use. Preflight and the package-service gateway path share this definition.
- `src/lib/onboard/preflight.ts`: add `dockerHostInvalid` to `HostAssessment`, computed from `env.DOCKER_HOST` through the shared predicate.
- `src/lib/advisories/checks/host/docker.ts`: add the blocking `invalid_docker_host` advisory before `docker_group_permission`. The advisory also blocks reachable unsupported endpoints. Guard the docker-group and stopped-daemon checks so they do not report unrelated remediations for this state.
- `src/lib/onboard/docker-driver-gateway-env.ts`: validate the raw package-service `DOCKER_HOST` before returning its trimmed form, so a boundary line break cannot be removed before validation.
- Tests: cover host assessment, advisory selection, direct endpoint classification, and the package-service line-break boundary in `preflight-docker-host.test.ts`, `docker.test.ts`, `docker-host.test.ts`, and `docker-driver-gateway-env-service.test.ts`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: existing troubleshooting and architecture pages already document the unchanged absolute local `unix://` socket contract; this PR changes diagnosis and validation timing
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending maintainer review; the change only adds a new diagnostic and tightens sibling guards, does not relax any existing check, and reuses the gateway's existing `DOCKER_HOST` validity definition
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/reference/troubleshooting.mdx` and `docs/reference/architecture.mdx` already describe the unchanged absolute local `unix://` socket contract. The changed advisory, comments, and test titles match the implementation.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 02ff5bcc8 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec -- vitest run --project cli src/lib/advisories/checks/host/docker.test.ts src/lib/advisories/checks/host/index.test.ts src/lib/domain/docker-host.test.ts src/lib/onboard/preflight-docker-host.test.ts src/lib/onboard/docker-driver-gateway-env-service.test.ts src/lib/onboard/docker-driver-gateway-env-deb-override.test.ts` → 43 pass in 6 files. Before the fix, the trailing-newline case reached the 60-second service-health deadline; after the fix, it rejects the raw value before service startup.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for Docker host configuration during onboarding.
  - Unsupported `DOCKER_HOST` values now produce a clear `invalid_docker_host` advisory with guidance to unset the setting or use an absolute Unix socket.

- **Bug Fixes**
  - Prevented misleading Docker group-permission or service-start remediation when the configured Docker endpoint is invalid.
  - Supported Docker socket configurations continue to be accepted, while unsupported TCP, SSH, and malformed values are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
