### PR TITLE
feat(cua): define first-class lifecycle contract

### DIFF
--- a/schemas/cua-lifecycle.schema.json
+++ b/schemas/cua-lifecycle.schema.json
@@ -1,0 +1,662 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/NVIDIA/NemoClaw/schemas/cua-lifecycle.schema.json",
+  "title": "NemoClaw CUA lifecycle record",
+  "description": "Secret-free public records for one standalone CUA and one separately managed desktop target.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/runtimeReadiness"
+    },
+    {
+      "$ref": "#/$defs/targetAttachment"
+    },
+    {
+      "$ref": "#/$defs/taskResult"
+    },
+    {
+      "$ref": "#/$defs/failure"
+    }
+  ],
+  "$defs": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "safeId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "safeSelector": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]*$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "componentIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "digest",
+        "owner"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/safeId"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      }
+    },
+    "inferenceIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model"
+      ],
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/safeSelector"
+        },
+        "model": {
+          "$ref": "#/$defs/safeSelector"
+        }
+      }
+    },
+    "componentSetWithoutTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runtime",
+        "sandboxImage",
+        "policy",
+        "taskProtocol"
+      ],
+      "properties": {
+        "runtime": {
+          "$ref": "#/$defs/componentIdentity"
+        },
+        "sandboxImage": {
+          "$ref": "#/$defs/componentIdentity"
+        },
+        "policy": {
+          "$ref": "#/$defs/componentIdentity"
+        },
+        "taskProtocol": {
+          "$ref": "#/$defs/componentIdentity"
+        }
+      }
+    },
+    "componentSetWithTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runtime",
+        "sandboxImage",
+        "targetImage",
+        "serviceBundle",
+        "policy",
+        "taskProtocol"
+      ],
+      "properties": {
+        "runtime": {
+          "$ref": "#/$defs/componentIdentity"
+        },
+        "sandboxImage": {
+          "$ref": "#/$defs/componentIdentity"
+        },
+        "targetImage": {
+          "$ref": "#/$defs/componentIdentity"
+        },
+        "serviceBundle": {
+          "$ref": "#/$defs/componentIdentity"
+        },
+        "policy": {
+          "$ref": "#/$defs/componentIdentity"
+        },
+        "taskProtocol": {
+          "$ref": "#/$defs/componentIdentity"
+        }
+      }
+    },
+    "capabilityId": {
+      "enum": [
+        "browser",
+        "computer",
+        "terminal"
+      ]
+    },
+    "capabilityHealth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "protocolVersion",
+        "health"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/capabilityId"
+        },
+        "protocolVersion": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "health": {
+          "enum": [
+            "healthy",
+            "unhealthy",
+            "unknown"
+          ]
+        }
+      }
+    },
+    "capabilityIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "protocolVersion"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/capabilityId"
+        },
+        "protocolVersion": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      }
+    },
+    "runtimeReadiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "kind",
+        "mode",
+        "status",
+        "components",
+        "inference",
+        "commands",
+        "limits",
+        "requiredCapabilities",
+        "targetOperations",
+        "taskOperations"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "$ref": "#/$defs/schemaVersion"
+        },
+        "kind": {
+          "const": "runtime-readiness"
+        },
+        "mode": {
+          "const": "standalone"
+        },
+        "status": {
+          "enum": [
+            "available",
+            "unavailable",
+            "incompatible"
+          ]
+        },
+        "components": {
+          "$ref": "#/$defs/componentSetWithoutTarget"
+        },
+        "inference": {
+          "$ref": "#/$defs/inferenceIdentity"
+        },
+        "commands": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "interactive",
+            "headless",
+            "version",
+            "smoke"
+          ],
+          "properties": {
+            "interactive": {
+              "const": true
+            },
+            "headless": {
+              "const": true
+            },
+            "version": {
+              "const": true
+            },
+            "smoke": {
+              "const": true
+            }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "targetsPerWorker",
+            "activeTasksPerTarget"
+          ],
+          "properties": {
+            "targetsPerWorker": {
+              "const": 1
+            },
+            "activeTasksPerTarget": {
+              "const": 1
+            }
+          }
+        },
+        "requiredCapabilities": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/capabilityId"
+          }
+        },
+        "targetOperations": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "target.attach",
+              "target.status",
+              "target.health",
+              "target.detach",
+              "target.reset",
+              "target.destroy"
+            ]
+          }
+        },
+        "taskOperations": {
+          "type": "array",
+          "minItems": 7,
+          "maxItems": 10,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "task.start",
+              "task.status",
+              "task.result",
+              "task.events",
+              "task.logs",
+              "task.plans",
+              "task.pause",
+              "task.cancel",
+              "task.guide",
+              "task.respond"
+            ]
+          }
+        }
+      }
+    },
+    "targetAttachment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "kind",
+        "status",
+        "target",
+        "activeTask"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "$ref": "#/$defs/schemaVersion"
+        },
+        "kind": {
+          "const": "target-attachment"
+        },
+        "status": {
+          "enum": [
+            "attached",
+            "detached",
+            "unreachable",
+            "incompatible",
+            "replaced"
+          ]
+        },
+        "target": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "identityDigest",
+                "platform",
+                "image",
+                "serviceBundle",
+                "capabilities"
+              ],
+              "properties": {
+                "identityDigest": {
+                  "$ref": "#/$defs/digest"
+                },
+                "platform": {
+                  "$ref": "#/$defs/safeSelector"
+                },
+                "image": {
+                  "$ref": "#/$defs/componentIdentity"
+                },
+                "serviceBundle": {
+                  "$ref": "#/$defs/componentIdentity"
+                },
+                "capabilities": {
+                  "type": "array",
+                  "minItems": 3,
+                  "maxItems": 3,
+                  "uniqueItems": true,
+                  "items": {
+                    "$ref": "#/$defs/capabilityHealth"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "activeTask": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "taskId",
+                "status"
+              ],
+              "properties": {
+                "taskId": {
+                  "$ref": "#/$defs/safeId"
+                },
+                "status": {
+                  "enum": [
+                    "running",
+                    "paused",
+                    "input-required",
+                    "cancelling"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "evidenceReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "digest",
+        "classification"
+      ],
+      "properties": {
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "classification": {
+          "const": "private"
+        },
+        "mediaType": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9.+-]*/[A-Za-z0-9][A-Za-z0-9.+-]*$"
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "capabilityReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capability",
+        "status",
+        "evidenceDigests"
+      ],
+      "properties": {
+        "capability": {
+          "$ref": "#/$defs/capabilityId"
+        },
+        "status": {
+          "enum": [
+            "completed",
+            "failed"
+          ]
+        },
+        "evidenceDigests": {
+          "type": "array",
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/digest"
+          }
+        }
+      }
+    },
+    "taskResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "kind",
+        "taskId",
+        "status",
+        "targetIdentityDigest",
+        "components",
+        "inference",
+        "capabilities",
+        "agentResult",
+        "verification",
+        "receipts",
+        "evidence"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "$ref": "#/$defs/schemaVersion"
+        },
+        "kind": {
+          "const": "task-result"
+        },
+        "taskId": {
+          "$ref": "#/$defs/safeId"
+        },
+        "status": {
+          "enum": [
+            "succeeded",
+            "failed",
+            "cancelled"
+          ]
+        },
+        "targetIdentityDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "components": {
+          "$ref": "#/$defs/componentSetWithTarget"
+        },
+        "inference": {
+          "$ref": "#/$defs/inferenceIdentity"
+        },
+        "capabilities": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {
+            "$ref": "#/$defs/capabilityIdentity"
+          }
+        },
+        "agentResult": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "resultDigest"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "succeeded",
+                "failed",
+                "cancelled"
+              ]
+            },
+            "resultDigest": {
+              "$ref": "#/$defs/digest"
+            }
+          }
+        },
+        "verification": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "checkIds",
+            "evidenceDigests"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "passed",
+                "failed",
+                "not-run"
+              ]
+            },
+            "checkIds": {
+              "type": "array",
+              "maxItems": 64,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/safeId"
+              }
+            },
+            "evidenceDigests": {
+              "type": "array",
+              "maxItems": 64,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/digest"
+              }
+            }
+          }
+        },
+        "receipts": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "$ref": "#/$defs/capabilityReceipt"
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "maxItems": 96,
+          "items": {
+            "$ref": "#/$defs/evidenceReference"
+          }
+        }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "kind",
+        "operation",
+        "family",
+        "retryable"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "$ref": "#/$defs/schemaVersion"
+        },
+        "kind": {
+          "const": "failure"
+        },
+        "operation": {
+          "enum": [
+            "target.attach",
+            "target.status",
+            "target.health",
+            "target.detach",
+            "target.reset",
+            "target.destroy",
+            "task.start",
+            "task.status",
+            "task.result",
+            "task.events",
+            "task.logs",
+            "task.plans",
+            "task.pause",
+            "task.cancel",
+            "task.guide",
+            "task.respond"
+          ]
+        },
+        "family": {
+          "enum": [
+            "lifecycle_unavailable",
+            "runtime_unavailable",
+            "runtime_incompatible",
+            "inference_unavailable",
+            "policy_invalid",
+            "target_unreachable",
+            "target_replaced",
+            "target_incompatible",
+            "capability_unhealthy",
+            "target_conflict",
+            "task_conflict",
+            "task_timeout",
+            "task_cancelled",
+            "validation_failed"
+          ]
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "component": {
+          "enum": [
+            "browser",
+            "computer",
+            "terminal",
+            "runtime",
+            "inference",
+            "policy",
+            "target"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/cua-lifecycle.schema.json
+++ b/schemas/cua-lifecycle.schema.json
@@ -513,6 +513,7 @@
           "type": "array",
           "minItems": 3,
           "maxItems": 3,
+          "uniqueItems": true,
           "items": {
             "$ref": "#/$defs/capabilityIdentity"
           }

--- a/src/lib/cua/contract.md
+++ b/src/lib/cua/contract.md
@@ -1,0 +1,249 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# First-class CUA v1 contract
+
+This contract defines the NemoClaw v1 boundary for one standalone computer-use
+agent (CUA) and one separately managed desktop target. It is the implementation
+contract for issue #7750. The public lifecycle records use
+`schemas/cua-lifecycle.schema.json`.
+
+The contract does not select an upstream runtime, target environment, cloud
+provider, or qualification adapter. Runtime and target implementations must
+record their exact artifacts and owners before they become supported.
+
+## Supported topology
+
+The CUA runs in one OpenShell-managed agent sandbox. It owns planning,
+execution, task state, recovery, and evidence production. It controls one
+dedicated, disposable, non-production desktop target.
+
+The desktop target exposes three required capabilities:
+
+- `browser`
+- `computer`
+- `terminal`
+
+Each capability has its own protocol version and health result. Attachment
+fails unless all three capabilities are healthy.
+
+Another resident agent does not invoke the CUA in v1. Direct service mode,
+cross-agent delegation, A2A, and MCP delegation are outside this contract.
+NemoClaw does not provide a dashboard or messaging surface for the CUA.
+
+## Runtime manifest
+
+The ordinary agent discovery path reads `agents/*/manifest.yaml`. The current
+terminal runtime shape represents the CUA discovery and launch requirements
+without a new runtime kind:
+
+- `runtime.kind` is `terminal`.
+- `runtime.interactive_command` starts the interactive CUA surface.
+- `runtime.headless_command` starts the headless CUA surface.
+- `version_command` returns the exact runtime version.
+- `runtime.smoke_commands` verify the runtime, managed inference, and command
+  contract without attaching a target.
+
+The CUA target and task lifecycle is not a terminal command convention. It uses
+the versioned public lifecycle records in this contract. A runtime
+implementation must use the same integrity-pinned runtime identity for
+interactive and headless operation.
+
+The production manifest must identify an integrity-pinned runtime artifact,
+sandbox image, dependency graph, policy, and task protocol. The runtime issue
+records their exact values, owner, release lifecycle, and compatibility policy
+before the manifest is accepted.
+
+## Ownership
+
+| Owner | Required ownership |
+| --- | --- |
+| NemoClaw | Agent discovery, onboarding, managed inference, sandbox lifecycle, policy, compatibility validation, secret-free attachment state, bounded public task state, recovery, rebuild, backup, update, and destroy. |
+| CUA runtime | Planning, visual grounding, computer/browser/terminal clients, active task state, results, events, plans, logs, cancellation, supported guidance, and evidence production. |
+| Host target lifecycle | Target selection or provisioning, platform and target-administration credentials, private transport, immutable target and service attestation, reset, and destroy. |
+| Qualification fixture | Synthetic accounts and data, deterministic target preparation, independent final-state verification, and private qualification evidence. |
+
+The qualification adapter is scaffolding. It may map logical qualification
+actions to public NemoClaw lifecycle operations. It must report the CUA worker
+unavailable until those operations exist. It must not replace missing product
+behavior with private shell or direct OpenShell operations.
+
+## Public lifecycle
+
+NemoClaw must expose these target operations:
+
+- `target.attach`
+- `target.status`
+- `target.health`
+- `target.detach`
+- `target.reset`
+- `target.destroy`
+
+NemoClaw must expose these required task operations:
+
+- `task.start`
+- `task.status`
+- `task.result`
+- `task.events`
+- `task.logs`
+- `task.plans`
+- `task.cancel`
+
+A runtime may advertise these optional task operations:
+
+- `task.pause`
+- `task.guide`
+- `task.respond`
+
+The runtime-readiness record always lists every required task operation and
+lists an optional operation only when the runtime implements it. A request for
+an unlisted optional operation returns `lifecycle_unavailable`; it is never
+silently accepted.
+
+Public command names, arguments, output envelopes, and exit codes are owned by
+the target and task implementation issues. They must produce records that
+conform to this contract without reading runtime-private files.
+
+## Compatibility identities
+
+Every component identity contains:
+
+- a component name;
+- an immutable version;
+- a SHA-256 digest;
+- an accountable owner.
+
+Runtime readiness identifies the runtime, sandbox image, policy, task protocol,
+inference provider, and model. An attachment also identifies the target image,
+target platform, target service bundle, and three capability protocol versions.
+A task result binds all of those identities, the three capability protocol
+versions, and the content identity of the attached target.
+
+Mutable tags, `latest`, local paths, host names, provider selectors, and
+environment-specific instance identifiers are not compatibility identities.
+
+### Compatibility policy
+
+NemoClaw accepts a component only when its observed name, version, owner, and
+SHA-256 digest match the recorded identity. A tag or version match does not
+override a digest mismatch.
+
+CUA lifecycle consumers accept schema major 1 and reject unknown major
+versions before reading the record. A minor or patch schema change may add no
+authority and must preserve every required v1 field and invariant.
+
+Target attachment requires the recorded target platform, image, service
+bundle, and capability protocol versions. Recovery treats a changed target
+identity as replacement, not as the prior attachment. It obtains fresh
+authority only after compatibility validation succeeds.
+
+Any runtime, sandbox image, target image, service bundle, policy, task
+protocol, inference model, or dependency change requires the CUA compatibility
+test before release qualification. Each upstream owner must publish immutable
+release identities, supported successor rules, and an end-of-support decision
+before NemoClaw records that implementation as supported.
+
+## Cardinality and authority
+
+One CUA worker has at most one attached target. One target has at most one
+active task. A conflicting target returns `target_conflict`. A conflicting task
+returns `task_conflict` without disturbing the current attachment or task.
+
+Worker leases, attachment handles, task handles, service sessions, and
+transport identifiers are opaque, non-durable authority. They are never
+written to the public records, registry, backup, task input, or result.
+Recovery obtains fresh authority after it validates immutable component
+identities.
+
+## State
+
+| Class | State |
+| --- | --- |
+| NemoClaw persistent | Selected agent, compatibility identities, managed inference selection, policy identity, secret-free target attachment projection, and bounded completed-task metadata and evidence references. |
+| User managed | Explicit onboarding choices and supported agent preferences. Secret values remain in their supported credential boundary. |
+| Reconstructible | CUA sandbox, desktop target, browser profile, mutable fixture data, service sessions, and runtime caches. |
+| Private | Screenshots, page and screen content, documents, downloads, detailed logs, task input, runtime observations, and detailed verification output. |
+| Non-durable authority | Worker leases, attachment and task handles, service sessions, transport identifiers, host paths, and target-administration material. |
+
+Backups contain only declared NemoClaw persistent and user-managed state.
+Backups exclude reconstructible state, private artifacts, and non-durable
+authority.
+
+Rebuild and recovery validate all immutable identities before they replace or
+reuse state. They obtain a fresh target attachment and service sessions.
+Update fails before deleting the current sandbox when the replacement runtime
+or managed inference route cannot be verified.
+
+Detach invalidates target reachability and clears the attachment projection.
+Reset reconstructs the target, browser profile, and fixture state. Destroy
+removes target reachability, private artifacts subject to the retention policy,
+and all NemoClaw-owned CUA state.
+
+## Secret and artifact boundary
+
+Public CUA records contain no credential values, credential-shaped fields,
+service endpoints, host or instance identities, SSH or VNC details, arbitrary
+commands, environment values, host paths, leases, sessions, or transport
+identifiers. Producers construct component and inference identities from
+trusted manifest or registry fields, never from runtime-authored output, and
+apply NemoClaw's standard redaction before serialization.
+
+The attachment record uses only a content identity for the target. Detailed
+screenshots, logs, page content, documents, and task artifacts remain private.
+Public results refer to private evidence by SHA-256 digest, media type, and
+optional byte count. An evidence reference contains no path or URL.
+
+An agent-authored result is not independent verification. A public task result
+contains the agent's terminal status and a digest for its private result,
+independent verification status and evidence digests, per-capability receipts,
+and private evidence references as separate fields.
+
+`task-result` records are terminal: `succeeded`, `failed`, or `cancelled`.
+`input-required` is an active task status and cannot appear in a result. A
+succeeded task requires both a succeeded agent result and passed independent
+verification. A failed task cannot contain both of those success conditions.
+The task and agent result must agree on cancellation.
+
+The security issue owns artifact access controls, retention, redaction,
+cleanup, target credential delivery, and the deny-default network policy.
+
+## Failure families
+
+Public failures use one deterministic family:
+
+| Family | Condition |
+| --- | --- |
+| `lifecycle_unavailable` | A required public operation or optional runtime operation is unavailable. |
+| `runtime_unavailable` | The CUA runtime cannot start or answer its version or smoke command. |
+| `runtime_incompatible` | The runtime, sandbox image, dependency, or task protocol identity does not match. |
+| `inference_unavailable` | The managed inference route cannot serve the runtime. |
+| `policy_invalid` | The required policy is absent, malformed, changed, or cannot be applied. |
+| `target_unreachable` | The recorded target cannot be reached through the supported attachment boundary. |
+| `target_replaced` | The target identity changed after attachment. |
+| `target_incompatible` | The target image or service bundle identity does not match. |
+| `capability_unhealthy` | Browser, computer, or terminal health validation fails. |
+| `target_conflict` | The worker already has a target. |
+| `task_conflict` | The target already has an active task. |
+| `task_timeout` | The task reaches its bounded execution limit. |
+| `task_cancelled` | Cancellation reaches a terminal state. |
+| `validation_failed` | Public input, output, evidence, or independent verification is malformed or fails. |
+
+Failures identify the operation, family, retryability, and bounded component.
+They do not include raw runtime output or private target details.
+
+Attachment and task execution fail before mutation when required lifecycle
+operations, identities, capability health, managed inference, or policy cannot
+be validated.
+
+## Qualification
+
+Release qualification uses independent browser, computer, and terminal tests
+plus one integrated task. Code outside the agent verifies final state. The
+qualification receipt binds the exact runtime, sandbox, target, service,
+inference, policy, task protocol, fixture, and verifier identities.
+
+Qualification may run through a host-owned adapter, but the adapter must call
+the supported public NemoClaw lifecycle. Private qualification evidence does
+not enter the public issue, contract, or repository.

--- a/src/lib/cua/contract.test.ts
+++ b/src/lib/cua/contract.test.ts
@@ -30,6 +30,10 @@ const thirdDigest = `sha256:${"c".repeat(64)}`;
 const temporaryAgentName = `cua-contract-fixture-${String(process.pid)}`;
 const temporaryAgentDir = path.join(AGENTS_DIR, temporaryAgentName);
 
+type AttachedTargetAttachment = CuaTargetAttachment & {
+  target: NonNullable<CuaTargetAttachment["target"]>;
+};
+
 function component(name: string, componentDigest = digest): CuaComponentIdentity {
   return {
     name,
@@ -71,7 +75,7 @@ function runtimeReadiness(): CuaRuntimeReadiness {
   };
 }
 
-function targetAttachment(): CuaTargetAttachment {
+function targetAttachment(): AttachedTargetAttachment {
   return {
     schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
     kind: "target-attachment",
@@ -89,11 +93,6 @@ function targetAttachment(): CuaTargetAttachment {
     },
     activeTask: null,
   };
-}
-
-function attachedTarget(record: CuaTargetAttachment): NonNullable<CuaTargetAttachment["target"]> {
-  expect(record.target).not.toBeNull();
-  return record.target as NonNullable<CuaTargetAttachment["target"]>;
 }
 
 function taskResult(): CuaTaskResult {
@@ -250,7 +249,7 @@ describe("first-class CUA contract", () => {
     );
 
     const duplicate = targetAttachment();
-    const duplicateTarget = attachedTarget(duplicate);
+    const duplicateTarget = duplicate.target;
     duplicateTarget.capabilities = [
       ...duplicateTarget.capabilities.slice(0, 2),
       {
@@ -267,7 +266,7 @@ describe("first-class CUA contract", () => {
     );
 
     const unhealthy = targetAttachment();
-    const unhealthyTarget = attachedTarget(unhealthy);
+    const unhealthyTarget = unhealthy.target;
     unhealthyTarget.capabilities = unhealthyTarget.capabilities.map((capability) =>
       capability.id === "computer" ? { ...capability, health: "unhealthy" } : capability,
     );
@@ -320,7 +319,7 @@ describe("first-class CUA contract", () => {
     );
   });
 
-  it("rejects missing component digests and path-bearing evidence (#7750)", () => {
+  it("rejects missing component digests, duplicate capabilities, and path-bearing evidence (#7750)", () => {
     const validate = createValidator();
     const result = taskResult() as unknown as Record<string, unknown>;
     const components = { ...(result.components as Record<string, unknown>) };
@@ -333,6 +332,13 @@ describe("first-class CUA contract", () => {
       validate({
         ...result,
         capabilities: (result.capabilities as unknown[]).slice(0, 2),
+      }),
+    ).toBe(false);
+    const capabilities = result.capabilities as unknown[];
+    expect(
+      validate({
+        ...result,
+        capabilities: [capabilities[0], capabilities[0], capabilities[2]],
       }),
     ).toBe(false);
     expect(

--- a/src/lib/cua/contract.test.ts
+++ b/src/lib/cua/contract.test.ts
@@ -92,8 +92,8 @@ function targetAttachment(): CuaTargetAttachment {
 }
 
 function attachedTarget(record: CuaTargetAttachment): NonNullable<CuaTargetAttachment["target"]> {
-  if (record.target === null) throw new Error("test fixture must contain an attached target");
-  return record.target;
+  expect(record.target).not.toBeNull();
+  return record.target as NonNullable<CuaTargetAttachment["target"]>;
 }
 
 function taskResult(): CuaTaskResult {

--- a/src/lib/cua/contract.test.ts
+++ b/src/lib/cua/contract.test.ts
@@ -1,0 +1,404 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import Ajv2020, { type AnySchema } from "ajv/dist/2020.js";
+import { afterAll, describe, expect, it } from "vitest";
+import cuaLifecycleSchema from "../../../schemas/cua-lifecycle.schema.json" with { type: "json" };
+import { AGENTS_DIR, getAgentChoices, loadAgent } from "../agent/defs.js";
+import { getTerminalCommand } from "../agent/runtime.js";
+import {
+  CUA_CAPABILITIES,
+  CUA_LIFECYCLE_SCHEMA_VERSION,
+  CUA_REQUIRED_TASK_OPERATIONS,
+  CUA_TARGET_OPERATIONS,
+  CUA_TASK_OPERATIONS,
+  type CuaComponentIdentity,
+  type CuaLifecycleRecord,
+  type CuaRuntimeReadiness,
+  type CuaTargetAttachment,
+  type CuaTaskResult,
+  checkCuaLifecycleSchemaVersion,
+  getCuaLifecycleSemanticErrors,
+} from "./contract.js";
+
+const digest = `sha256:${"a".repeat(64)}`;
+const secondDigest = `sha256:${"b".repeat(64)}`;
+const thirdDigest = `sha256:${"c".repeat(64)}`;
+const temporaryAgentName = `cua-contract-fixture-${String(process.pid)}`;
+const temporaryAgentDir = path.join(AGENTS_DIR, temporaryAgentName);
+
+function component(name: string, componentDigest = digest): CuaComponentIdentity {
+  return {
+    name,
+    version: "1.2.3",
+    digest: componentDigest,
+    owner: "NVIDIA",
+  };
+}
+
+function runtimeReadiness(): CuaRuntimeReadiness {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "runtime-readiness",
+    mode: "standalone",
+    status: "available",
+    components: {
+      runtime: component("cua-runtime"),
+      sandboxImage: component("cua-sandbox"),
+      policy: component("cua-policy"),
+      taskProtocol: component("cua-task-protocol"),
+    },
+    inference: {
+      provider: "managed",
+      model: "provider/model",
+    },
+    commands: {
+      interactive: true,
+      headless: true,
+      version: true,
+      smoke: true,
+    },
+    limits: {
+      targetsPerWorker: 1,
+      activeTasksPerTarget: 1,
+    },
+    requiredCapabilities: [...CUA_CAPABILITIES],
+    targetOperations: [...CUA_TARGET_OPERATIONS],
+    taskOperations: [...CUA_TASK_OPERATIONS],
+  };
+}
+
+function targetAttachment(): CuaTargetAttachment {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "target-attachment",
+    status: "attached",
+    target: {
+      identityDigest: secondDigest,
+      platform: "linux/amd64",
+      image: component("target-image"),
+      serviceBundle: component("target-services"),
+      capabilities: CUA_CAPABILITIES.map((id) => ({
+        id,
+        protocolVersion: "1.0.0",
+        health: "healthy" as const,
+      })),
+    },
+    activeTask: null,
+  };
+}
+
+function attachedTarget(record: CuaTargetAttachment): NonNullable<CuaTargetAttachment["target"]> {
+  if (record.target === null) throw new Error("test fixture must contain an attached target");
+  return record.target;
+}
+
+function taskResult(): CuaTaskResult {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "task-result",
+    taskId: "task-1",
+    status: "succeeded",
+    targetIdentityDigest: secondDigest,
+    components: {
+      runtime: component("cua-runtime"),
+      sandboxImage: component("cua-sandbox"),
+      targetImage: component("target-image"),
+      serviceBundle: component("target-services"),
+      policy: component("cua-policy"),
+      taskProtocol: component("cua-task-protocol"),
+    },
+    inference: {
+      provider: "managed",
+      model: "provider/model",
+    },
+    capabilities: CUA_CAPABILITIES.map((id) => ({
+      id,
+      protocolVersion: "1.0.0",
+    })),
+    agentResult: {
+      status: "succeeded",
+      resultDigest: thirdDigest,
+    },
+    verification: {
+      status: "passed",
+      checkIds: ["fixture.final-state"],
+      evidenceDigests: [thirdDigest],
+    },
+    receipts: [
+      {
+        capability: "browser",
+        status: "completed",
+        evidenceDigests: [digest],
+      },
+    ],
+    evidence: [
+      {
+        digest,
+        classification: "private",
+        mediaType: "image/png",
+        sizeBytes: 1024,
+      },
+      {
+        digest: thirdDigest,
+        classification: "private",
+        mediaType: "application/json",
+        sizeBytes: 256,
+      },
+    ],
+  };
+}
+
+function createValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  return ajv.compile(cuaLifecycleSchema as AnySchema);
+}
+
+afterAll(() => {
+  fs.rmSync(temporaryAgentDir, { recursive: true, force: true });
+});
+
+describe("first-class CUA contract", () => {
+  it("validates each public lifecycle record shape (#7750)", () => {
+    const validate = createValidator();
+    const records: CuaLifecycleRecord[] = [
+      runtimeReadiness(),
+      targetAttachment(),
+      taskResult(),
+      {
+        schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+        kind: "failure",
+        operation: "task.start",
+        family: "task_conflict",
+        retryable: true,
+        component: "target",
+      },
+    ];
+
+    for (const record of records) {
+      expect(validate(record), JSON.stringify(validate.errors)).toBe(true);
+      expect(getCuaLifecycleSemanticErrors(record)).toEqual([]);
+    }
+  });
+
+  it("uses the ordinary terminal manifest path for CUA discovery and commands (#7750)", () => {
+    fs.mkdirSync(temporaryAgentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(temporaryAgentDir, "manifest.yaml"),
+      [
+        `name: ${temporaryAgentName}`,
+        'display_name: "CUA contract fixture"',
+        "binary_path: /usr/local/bin/cua-fixture",
+        'version_command: "cua-fixture version"',
+        'expected_version: "1.2.3"',
+        "version_scheme: semver",
+        "runtime:",
+        "  kind: terminal",
+        '  interactive_command: "cua-fixture interactive"',
+        '  headless_command: "cua-fixture headless"',
+        "  smoke_commands:",
+        '    - "cua-fixture version"',
+        '    - "cua-fixture smoke"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const choice = getAgentChoices().find((entry) => entry.name === temporaryAgentName);
+    const agent = loadAgent(temporaryAgentName);
+
+    expect(choice?.name).toBe(temporaryAgentName);
+    expect(agent.runtime).toEqual({
+      kind: "terminal",
+      interactive_command: "cua-fixture interactive",
+      headless_command: "cua-fixture headless",
+      smoke_commands: ["cua-fixture version", "cua-fixture smoke"],
+    });
+    expect(agent.versionCommand).toBe("cua-fixture version");
+    expect(getTerminalCommand(agent, "interactive")).toBe("cua-fixture interactive");
+    expect(getTerminalCommand(agent, "headless")).toBe("cua-fixture headless");
+  });
+
+  it("rejects unknown schema majors before consuming a lifecycle record (#7750)", () => {
+    expect(checkCuaLifecycleSchemaVersion("1.7.4")).toEqual({ compatible: true, major: 1 });
+    expect(checkCuaLifecycleSchemaVersion("2.0.0")).toEqual({
+      compatible: false,
+      major: 2,
+      reason: "unsupported CUA lifecycle schema major 2",
+    });
+    expect(checkCuaLifecycleSchemaVersion("1.01.0").compatible).toBe(false);
+    expect(checkCuaLifecycleSchemaVersion(null).compatible).toBe(false);
+  });
+
+  it("requires core task operations and advertises optional operations by presence (#7750)", () => {
+    const validate = createValidator();
+    const readiness = runtimeReadiness();
+    readiness.taskOperations = [...CUA_REQUIRED_TASK_OPERATIONS];
+
+    expect(validate(readiness), JSON.stringify(validate.errors)).toBe(true);
+    expect(getCuaLifecycleSemanticErrors(readiness)).toEqual([]);
+  });
+
+  it("rejects missing, duplicate, and unhealthy required capabilities (#7750)", () => {
+    const missing = runtimeReadiness();
+    missing.requiredCapabilities = ["browser", "computer"];
+    expect(getCuaLifecycleSemanticErrors(missing)).toContain(
+      "requiredCapabilities is missing: terminal",
+    );
+
+    const duplicate = targetAttachment();
+    const duplicateTarget = attachedTarget(duplicate);
+    duplicateTarget.capabilities = [
+      ...duplicateTarget.capabilities.slice(0, 2),
+      {
+        id: "computer",
+        protocolVersion: "1.0.0",
+        health: "healthy",
+      },
+    ];
+    expect(getCuaLifecycleSemanticErrors(duplicate)).toContain(
+      "target.capabilities contains duplicate values: computer",
+    );
+    expect(getCuaLifecycleSemanticErrors(duplicate)).toContain(
+      "target.capabilities is missing: terminal",
+    );
+
+    const unhealthy = targetAttachment();
+    const unhealthyTarget = attachedTarget(unhealthy);
+    unhealthyTarget.capabilities = unhealthyTarget.capabilities.map((capability) =>
+      capability.id === "computer" ? { ...capability, health: "unhealthy" } : capability,
+    );
+    expect(getCuaLifecycleSemanticErrors(unhealthy)).toContain(
+      "an attached target requires healthy browser, computer, and terminal capabilities",
+    );
+  });
+
+  it("rejects a detached record that retains its target projection (#7750)", () => {
+    const detached = {
+      ...targetAttachment(),
+      status: "detached" as const,
+      target: null,
+      activeTask: null,
+    };
+    expect(getCuaLifecycleSemanticErrors(detached)).toEqual([]);
+
+    const staleProjection = {
+      ...targetAttachment(),
+      status: "detached" as const,
+    };
+    expect(getCuaLifecycleSemanticErrors(staleProjection)).toContain(
+      "a detached target must clear its public projection",
+    );
+  });
+
+  it("rejects authority-bearing extensions on public lifecycle records (#7750)", () => {
+    const validate = createValidator();
+    const record = targetAttachment() as unknown as Record<string, unknown>;
+
+    for (const forbidden of [
+      { token: "not-a-real-secret" },
+      { endpoint: "https://target.invalid" },
+      { host: "target.internal" },
+      { ssh: { user: "operator" } },
+      { path: "/private/target" },
+    ]) {
+      expect(validate({ ...record, ...forbidden })).toBe(false);
+    }
+
+    const credentialRecord = {
+      ...runtimeReadiness(),
+      inference: {
+        ...runtimeReadiness().inference,
+        authToken: "not-a-real-secret",
+      },
+    } as unknown as CuaLifecycleRecord;
+    expect(getCuaLifecycleSemanticErrors(credentialRecord)).toContain(
+      "$.inference.authToken is credential-shaped and cannot enter the public CUA contract",
+    );
+  });
+
+  it("rejects missing component digests and path-bearing evidence (#7750)", () => {
+    const validate = createValidator();
+    const result = taskResult() as unknown as Record<string, unknown>;
+    const components = { ...(result.components as Record<string, unknown>) };
+    const runtime = { ...(components.runtime as Record<string, unknown>) };
+    delete runtime.digest;
+    components.runtime = runtime;
+
+    expect(validate({ ...result, components })).toBe(false);
+    expect(
+      validate({
+        ...result,
+        capabilities: (result.capabilities as unknown[]).slice(0, 2),
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...result,
+        evidence: [{ digest, classification: "private", path: "/tmp/screenshot.png" }],
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...result,
+        evidence: [{ digest, classification: "public", mediaType: "image/png" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects duplicate receipts and unresolved evidence references (#7750)", () => {
+    const result = taskResult();
+    result.receipts = [
+      ...result.receipts,
+      {
+        capability: "browser",
+        status: "completed",
+        evidenceDigests: [secondDigest],
+      },
+    ];
+
+    expect(getCuaLifecycleSemanticErrors(result)).toContain(
+      "receipts contains duplicate capabilities: browser",
+    );
+    expect(getCuaLifecycleSemanticErrors(result)).toContain(
+      `receipt browser references unknown evidence digest ${secondDigest}`,
+    );
+  });
+
+  it("keeps task results terminal and rejects contradictory statuses (#7750)", () => {
+    const validate = createValidator();
+    expect(validate({ ...taskResult(), status: "input-required" })).toBe(false);
+
+    const contradictory = taskResult();
+    contradictory.status = "failed";
+    expect(getCuaLifecycleSemanticErrors(contradictory)).toContain(
+      "a failed task cannot contain both a succeeded agent result and passed verification",
+    );
+
+    const cancelled = taskResult();
+    cancelled.status = "cancelled";
+    expect(getCuaLifecycleSemanticErrors(cancelled)).toContain(
+      "task and agent result cancellation status must match",
+    );
+  });
+
+  it("rejects unsupported operations, cardinality, and failure families (#7750)", () => {
+    const validate = createValidator();
+    const readiness = runtimeReadiness() as unknown as Record<string, unknown>;
+    const limits = { ...(readiness.limits as Record<string, unknown>), activeTasksPerTarget: 2 };
+
+    expect(validate({ ...readiness, limits })).toBe(false);
+    expect(
+      validate({
+        schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+        kind: "failure",
+        operation: "task.shell",
+        family: "unknown_failure",
+        retryable: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/cua/contract.ts
+++ b/src/lib/cua/contract.ts
@@ -1,0 +1,383 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isCredentialShapedName } from "../security/credential-env.js";
+
+export const CUA_LIFECYCLE_SCHEMA_VERSION = "1.0.0" as const;
+export const SUPPORTED_CUA_LIFECYCLE_SCHEMA_MAJOR = 1;
+
+export const CUA_CAPABILITIES = ["browser", "computer", "terminal"] as const;
+export type CuaCapability = (typeof CUA_CAPABILITIES)[number];
+
+export const CUA_TARGET_OPERATIONS = [
+  "target.attach",
+  "target.status",
+  "target.health",
+  "target.detach",
+  "target.reset",
+  "target.destroy",
+] as const;
+
+export const CUA_REQUIRED_TASK_OPERATIONS = [
+  "task.start",
+  "task.status",
+  "task.result",
+  "task.events",
+  "task.logs",
+  "task.plans",
+  "task.cancel",
+] as const;
+
+export const CUA_OPTIONAL_TASK_OPERATIONS = ["task.pause", "task.guide", "task.respond"] as const;
+
+export const CUA_TASK_OPERATIONS = [
+  ...CUA_REQUIRED_TASK_OPERATIONS,
+  ...CUA_OPTIONAL_TASK_OPERATIONS,
+] as const;
+
+export const CUA_OPERATIONS = [...CUA_TARGET_OPERATIONS, ...CUA_TASK_OPERATIONS] as const;
+export type CuaOperation = (typeof CUA_OPERATIONS)[number];
+
+export const CUA_FAILURE_FAMILIES = [
+  "lifecycle_unavailable",
+  "runtime_unavailable",
+  "runtime_incompatible",
+  "inference_unavailable",
+  "policy_invalid",
+  "target_unreachable",
+  "target_replaced",
+  "target_incompatible",
+  "capability_unhealthy",
+  "target_conflict",
+  "task_conflict",
+  "task_timeout",
+  "task_cancelled",
+  "validation_failed",
+] as const;
+export type CuaFailureFamily = (typeof CUA_FAILURE_FAMILIES)[number];
+
+export interface CuaComponentIdentity {
+  name: string;
+  version: string;
+  digest: string;
+  owner: string;
+}
+
+export interface CuaInferenceIdentity {
+  provider: string;
+  model: string;
+}
+
+export interface CuaCapabilityHealth {
+  id: CuaCapability;
+  protocolVersion: string;
+  health: "healthy" | "unhealthy" | "unknown";
+}
+
+export interface CuaCapabilityIdentity {
+  id: CuaCapability;
+  protocolVersion: string;
+}
+
+export interface CuaRuntimeReadiness {
+  schemaVersion: string;
+  kind: "runtime-readiness";
+  mode: "standalone";
+  status: "available" | "unavailable" | "incompatible";
+  components: {
+    runtime: CuaComponentIdentity;
+    sandboxImage: CuaComponentIdentity;
+    policy: CuaComponentIdentity;
+    taskProtocol: CuaComponentIdentity;
+  };
+  inference: CuaInferenceIdentity;
+  commands: {
+    interactive: true;
+    headless: true;
+    version: true;
+    smoke: true;
+  };
+  limits: {
+    targetsPerWorker: 1;
+    activeTasksPerTarget: 1;
+  };
+  requiredCapabilities: readonly CuaCapability[];
+  targetOperations: readonly (typeof CUA_TARGET_OPERATIONS)[number][];
+  taskOperations: readonly (typeof CUA_TASK_OPERATIONS)[number][];
+}
+
+export interface CuaTargetAttachment {
+  schemaVersion: string;
+  kind: "target-attachment";
+  status: "attached" | "detached" | "unreachable" | "incompatible" | "replaced";
+  target: null | {
+    identityDigest: string;
+    platform: string;
+    image: CuaComponentIdentity;
+    serviceBundle: CuaComponentIdentity;
+    capabilities: readonly CuaCapabilityHealth[];
+  };
+  activeTask: null | {
+    taskId: string;
+    status: "running" | "paused" | "input-required" | "cancelling";
+  };
+}
+
+export interface CuaEvidenceReference {
+  digest: string;
+  classification: "private";
+  mediaType?: string;
+  sizeBytes?: number;
+}
+
+export interface CuaCapabilityReceipt {
+  capability: CuaCapability;
+  status: "completed" | "failed";
+  evidenceDigests: readonly string[];
+}
+
+export interface CuaTaskResult {
+  schemaVersion: string;
+  kind: "task-result";
+  taskId: string;
+  status: "succeeded" | "failed" | "cancelled";
+  targetIdentityDigest: string;
+  components: {
+    runtime: CuaComponentIdentity;
+    sandboxImage: CuaComponentIdentity;
+    targetImage: CuaComponentIdentity;
+    serviceBundle: CuaComponentIdentity;
+    policy: CuaComponentIdentity;
+    taskProtocol: CuaComponentIdentity;
+  };
+  inference: CuaInferenceIdentity;
+  capabilities: readonly CuaCapabilityIdentity[];
+  agentResult: {
+    status: "succeeded" | "failed" | "cancelled";
+    resultDigest: string;
+  };
+  verification: {
+    status: "passed" | "failed" | "not-run";
+    checkIds: readonly string[];
+    evidenceDigests: readonly string[];
+  };
+  receipts: readonly CuaCapabilityReceipt[];
+  evidence: readonly CuaEvidenceReference[];
+}
+
+export interface CuaFailure {
+  schemaVersion: string;
+  kind: "failure";
+  operation: CuaOperation;
+  family: CuaFailureFamily;
+  retryable: boolean;
+  component?: CuaCapability | "runtime" | "inference" | "policy" | "target";
+}
+
+export type CuaLifecycleRecord =
+  | CuaRuntimeReadiness
+  | CuaTargetAttachment
+  | CuaTaskResult
+  | CuaFailure;
+
+export type CuaSchemaCompatibility =
+  | { compatible: true; major: number }
+  | { compatible: false; major: number | null; reason: string };
+
+export function checkCuaLifecycleSchemaVersion(schemaVersion: unknown): CuaSchemaCompatibility {
+  if (typeof schemaVersion !== "string") {
+    return { compatible: false, major: null, reason: "schemaVersion must be a string" };
+  }
+
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(schemaVersion);
+  if (!match) {
+    return { compatible: false, major: null, reason: "schemaVersion must use major.minor.patch" };
+  }
+
+  const major = Number(match[1]);
+  if (major !== SUPPORTED_CUA_LIFECYCLE_SCHEMA_MAJOR) {
+    return {
+      compatible: false,
+      major,
+      reason: `unsupported CUA lifecycle schema major ${String(major)}`,
+    };
+  }
+  return { compatible: true, major };
+}
+
+function duplicateValues(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates].sort();
+}
+
+function exactSetErrors(
+  label: string,
+  actual: readonly string[],
+  expected: readonly string[],
+): string[] {
+  const errors: string[] = [];
+  const duplicates = duplicateValues(actual);
+  if (duplicates.length > 0)
+    errors.push(`${label} contains duplicate values: ${duplicates.join(", ")}`);
+
+  const actualSet = new Set(actual);
+  const missing = expected.filter((value) => !actualSet.has(value));
+  const unexpected = actual.filter((value) => !expected.includes(value));
+  if (missing.length > 0) errors.push(`${label} is missing: ${missing.join(", ")}`);
+  if (unexpected.length > 0)
+    errors.push(`${label} contains unsupported values: ${unexpected.join(", ")}`);
+  return errors;
+}
+
+function requiredSetErrors(
+  label: string,
+  actual: readonly string[],
+  required: readonly string[],
+  allowed: readonly string[],
+): string[] {
+  const errors: string[] = [];
+  const duplicates = duplicateValues(actual);
+  if (duplicates.length > 0) {
+    errors.push(`${label} contains duplicate values: ${duplicates.join(", ")}`);
+  }
+
+  const actualSet = new Set(actual);
+  const missing = required.filter((value) => !actualSet.has(value));
+  const unexpected = actual.filter((value) => !allowed.includes(value));
+  if (missing.length > 0) errors.push(`${label} is missing: ${missing.join(", ")}`);
+  if (unexpected.length > 0) {
+    errors.push(`${label} contains unsupported values: ${unexpected.join(", ")}`);
+  }
+  return errors;
+}
+
+function credentialPathErrors(value: unknown, path = "$"): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) =>
+      credentialPathErrors(entry, `${path}[${String(index)}]`),
+    );
+  }
+  if (typeof value !== "object" || value === null) return [];
+
+  const errors: string[] = [];
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    if (isCredentialShapedName(key)) {
+      errors.push(`${childPath} is credential-shaped and cannot enter the public CUA contract`);
+    }
+    errors.push(...credentialPathErrors(child, childPath));
+  }
+  return errors;
+}
+
+/**
+ * Validate cross-field invariants that JSON Schema cannot express without
+ * coupling public records to array order or private runtime state.
+ */
+export function getCuaLifecycleSemanticErrors(record: CuaLifecycleRecord): string[] {
+  const errors = credentialPathErrors(record);
+  const compatibility = checkCuaLifecycleSchemaVersion(record.schemaVersion);
+  if (!compatibility.compatible) errors.push(compatibility.reason);
+
+  if (record.kind === "runtime-readiness") {
+    errors.push(
+      ...exactSetErrors("requiredCapabilities", record.requiredCapabilities, CUA_CAPABILITIES),
+      ...exactSetErrors("targetOperations", record.targetOperations, CUA_TARGET_OPERATIONS),
+      ...requiredSetErrors(
+        "taskOperations",
+        record.taskOperations,
+        CUA_REQUIRED_TASK_OPERATIONS,
+        CUA_TASK_OPERATIONS,
+      ),
+    );
+  }
+
+  if (record.kind === "target-attachment") {
+    if (record.status === "detached") {
+      if (record.target !== null) errors.push("a detached target must clear its public projection");
+      if (record.activeTask !== null) errors.push("a detached target cannot report an active task");
+      return errors;
+    }
+    if (record.target === null) {
+      errors.push(`${record.status} target status requires an immutable target projection`);
+      return errors;
+    }
+
+    const capabilityIds = record.target.capabilities.map((capability) => capability.id);
+    errors.push(...exactSetErrors("target.capabilities", capabilityIds, CUA_CAPABILITIES));
+    if (
+      record.status === "attached" &&
+      record.target.capabilities.some((capability) => capability.health !== "healthy")
+    ) {
+      errors.push(
+        "an attached target requires healthy browser, computer, and terminal capabilities",
+      );
+    }
+  }
+
+  if (record.kind === "task-result") {
+    errors.push(
+      ...exactSetErrors(
+        "capabilities",
+        record.capabilities.map((capability) => capability.id),
+        CUA_CAPABILITIES,
+      ),
+    );
+
+    const receiptCapabilities = record.receipts.map((receipt) => receipt.capability);
+    const duplicateCapabilities = duplicateValues(receiptCapabilities);
+    if (duplicateCapabilities.length > 0) {
+      errors.push(`receipts contains duplicate capabilities: ${duplicateCapabilities.join(", ")}`);
+    }
+
+    const evidenceDigests = record.evidence.map((entry) => entry.digest);
+    const duplicateEvidence = duplicateValues(evidenceDigests);
+    if (duplicateEvidence.length > 0) {
+      errors.push(`evidence contains duplicate digests: ${duplicateEvidence.join(", ")}`);
+    }
+    const evidenceSet = new Set(evidenceDigests);
+    if (!evidenceSet.has(record.agentResult.resultDigest)) {
+      errors.push(
+        `agentResult references unknown evidence digest ${record.agentResult.resultDigest}`,
+      );
+    }
+    for (const digest of record.verification.evidenceDigests) {
+      if (!evidenceSet.has(digest)) {
+        errors.push(`verification references unknown evidence digest ${digest}`);
+      }
+    }
+    for (const receipt of record.receipts) {
+      for (const digest of receipt.evidenceDigests) {
+        if (!evidenceSet.has(digest)) {
+          errors.push(`receipt ${receipt.capability} references unknown evidence digest ${digest}`);
+        }
+      }
+    }
+
+    if (
+      record.status === "succeeded" &&
+      (record.agentResult.status !== "succeeded" || record.verification.status !== "passed")
+    ) {
+      errors.push("a succeeded task requires a succeeded agent result and passed verification");
+    }
+    if (
+      record.status === "failed" &&
+      record.agentResult.status === "succeeded" &&
+      record.verification.status === "passed"
+    ) {
+      errors.push(
+        "a failed task cannot contain both a succeeded agent result and passed verification",
+      );
+    }
+    if ((record.status === "cancelled") !== (record.agentResult.status === "cancelled")) {
+      errors.push("task and agent result cancellation status must match");
+    }
+  }
+
+  return errors;
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Define the checked-in first-class CUA v1 product and architecture contract accepted in #7750. The contract is host-agnostic, keeps qualification scaffolding outside the supported lifecycle, and leaves exact runtime and target artifact identities as completion gates for their implementation and qualification issues.

## Related Issue

Fixes #7750

Product scope decision: https://github.com/NVIDIA/NemoClaw/issues/7750#issuecomment-5111886734

## Changes

- Define the standalone CUA topology, component ownership, lifecycle operations, state classes, compatibility policy, failure families, and qualification boundary.
- Add a versioned JSON Schema and TypeScript semantic checks for secret-free readiness, target attachment, task results, evidence references, and failures.
- Prove with a synthetic fixture that the existing terminal manifest supports CUA discovery, version, interactive, headless, and smoke commands without a new runtime kind.
- Add negative tests for schema compatibility, required capabilities and operations, cardinality, authority-bearing fields, immutable identities, evidence references, and terminal result consistency.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this PR adds an internal contract and schema; user documentation belongs with the later command and runtime implementation issues.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `src/lib/cua/contract.md`; no user-facing command or runtime is implemented in this PR.
- Agent: Codex Desktop
<!-- docs-review-head-sha: cc50c5754 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project cli src/lib/cua/contract.test.ts` (11 passed) and `npm run typecheck:cli`
- [x] Applicable broad gate passed — not applicable to this scoped contract/schema change; targeted tests and normal hooks cover the changed behavior.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a versioned public CUA lifecycle contract (v1) with lifecycle record types covering runtime readiness, target attachment, task results, and failures.
  * Introduced strict JSON schema validation plus semantic validation for operations/capabilities, schema compatibility, evidence/receipt integrity, and task-result status coherence.
  * Enforced public-record security boundaries to reject sensitive/credential-like fields.
* **Documentation**
  * Documented the “First-class CUA v1” boundary, lifecycle semantics, and failure families.
* **Tests**
  * Added contract tests validating supported record shapes, semantic rules, and security-boundary rejections (including version compatibility).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->