### PR TITLE
feat(cua): expose task and result lifecycle

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -12,7 +12,7 @@
       "src/lib/adapters/openshell/timeouts.ts": 36,
       "src/lib/agent/defs.ts": 32,
       "src/lib/cli/branding.ts": 85,
-      "src/lib/cli/nemoclaw-oclif-command.ts": 109,
+      "src/lib/cli/nemoclaw-oclif-command.ts": 119,
       "src/lib/cli/terminal-style.ts": 45,
       "src/lib/core/json-types.ts": 37,
       "src/lib/core/ports.ts": 86,

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1543,6 +1543,7 @@ NemoClaw does not copy adapter standard error into public output.
 Attachment also requires a secret-free JSON manifest that matches `schemas/cua-target-manifest.schema.json`.
 The manifest contains immutable target, image, service-bundle, and protocol identities.
 It must not contain endpoints, credentials, host names, instance IDs, transport handles, or administration data.
+The manifest path must directly name a regular file no larger than 64 KiB; NemoClaw does not follow symbolic links.
 
 ```json
 {

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1840,9 +1840,9 @@ $$nemoclaw my-cua cua task result \
 }
 ```
 
-### `$$nemoclaw <name> cua task events|logs|plans`
+### `$$nemoclaw <name> cua task events`
 
-Retrieve a content-addressed index for one private evidence category.
+Retrieve a content-addressed index for private task events.
 The record never embeds event data, logs, plans, paths, URLs, page content, or screenshots.
 
 ```bash
@@ -1870,12 +1870,44 @@ $$nemoclaw my-cua cua task events \
 }
 ```
 
-Use the same form with `logs` or `plans` to select that category.
+### `$$nemoclaw <name> cua task logs`
 
-### `$$nemoclaw <name> cua task pause|cancel`
+Retrieve a content-addressed index for private task logs.
 
-`pause` returns the updated active attachment when the runtime advertises `task.pause`.
-`cancel` must return a terminal cancelled result and clear active-task state.
+```bash
+$$nemoclaw my-cua cua task logs \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --json
+```
+
+### `$$nemoclaw <name> cua task plans`
+
+Retrieve a content-addressed index for private task plans.
+
+```bash
+$$nemoclaw my-cua cua task plans \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --json
+```
+
+### `$$nemoclaw <name> cua task pause`
+
+Pause an active task when the runtime advertises `task.pause`.
+The runtime must return an updated attachment whose task state is `paused`; any other state fails validation without changing the recorded task.
+
+```bash
+$$nemoclaw my-cua cua task pause \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --json
+```
+
+### `$$nemoclaw <name> cua task cancel`
+
+Cancel an active task.
+The runtime must return a terminal cancelled result and clear active-task state.
 A timeout or classified cancellation also clears active-task state so reconnect cannot report a task that is no longer running.
 
 ```bash
@@ -1885,10 +1917,22 @@ $$nemoclaw my-cua cua task cancel \
   --json
 ```
 
-### `$$nemoclaw <name> cua task guide|respond`
+### `$$nemoclaw <name> cua task guide`
 
-`guide` injects private guidance when the runtime advertises `task.guide`.
-`respond` supplies private input after the runtime reports `input-required` when it advertises `task.respond`.
+Inject private guidance when the runtime advertises `task.guide`.
+The command uses the same private `--input-file` boundary as `cua task respond`.
+
+```bash
+$$nemoclaw my-cua cua task guide \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --input-file ./guidance.txt \
+  --json
+```
+
+### `$$nemoclaw <name> cua task respond`
+
+Supply private input after the runtime reports `input-required` when it advertises `task.respond`.
 An unadvertised optional operation returns `lifecycle_unavailable` and does not invoke the adapter.
 
 ```bash

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1655,6 +1655,250 @@ They exclude the target, browser profile, mutable desktop state, adapter state, 
 Recovery never reuses an attachment handle.
 The host adapter obtains fresh authority and NemoClaw validates the immutable identities again.
 
+## CUA task lifecycle
+
+These commands drive the checked-in CUA task contract through one explicit, operator-owned task adapter.
+The adapter is a protocol boundary for the selected CUA runtime; it is not a runtime plugin or a terminal-output parser.
+Interactive and headless starts use the same adapter, runtime identity, task protocol, and explicit task ID.
+
+The adapter must be an absolute executable path.
+NemoClaw starts it without a shell and writes one `task-adapter-request` JSON object to standard input.
+The request includes the recorded runtime and target identities plus the requested operation.
+Task, guidance, and input-required response text comes from a non-empty UTF-8 `--input-file` of at most 64 KiB.
+That private input is sent to the adapter only; NemoClaw does not write it to lifecycle output, canonical registry state, or backups.
+
+The adapter returns one record from `schemas/cua-lifecycle.schema.json`:
+
+- A `target-attachment` record reports active `running`, `paused`, `input-required`, or `cancelling` state.
+- A terminal `task-result` record reports `succeeded`, `failed`, or `cancelled`.
+- A `task-evidence-index` record contains content-addressed private references for events, logs, or plans.
+- A `failure` record contains one bounded failure family and no raw runtime diagnostics.
+
+NemoClaw compares every terminal result with the recorded runtime, sandbox image, target image, service bundle, policy, task protocol, inference route, capability protocols, and target identity.
+Any identity drift fails closed.
+The most recent 16 terminal results remain available through `cua task result` and `cua task status` after a normal CLI reconnect.
+Private task input, screenshots, documents, page content, logs, plans, runtime files, and adapter authority are not retained.
+
+Successful commands exit `0`.
+Validation failures exit `2`, an active-task conflict exits `3`, unavailable lifecycle or runtime operations exit `4`, and execution, compatibility, target, inference, policy, timeout, or cancellation failures exit `5`.
+
+### `$$nemoclaw <name> cua task start`
+
+Start one task with an explicit ID, execution surface, and private input file.
+A target with an active task returns `task_conflict` without invoking the adapter.
+A completed task ID must not be reused.
+
+```bash
+$$nemoclaw my-cua cua task start \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --mode headless \
+  --input-file ./task.txt \
+  --json
+```
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "kind": "target-attachment",
+  "status": "attached",
+  "target": {
+    "identityDigest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "platform": "desktop-linux-amd64",
+    "image": {
+      "name": "desktop-image",
+      "version": "1.0.0",
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "owner": "target-owner"
+    },
+    "serviceBundle": {
+      "name": "desktop-services",
+      "version": "1.0.0",
+      "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      "owner": "target-owner"
+    },
+    "capabilities": [
+      { "id": "browser", "protocolVersion": "1.0.0", "health": "healthy" },
+      { "id": "computer", "protocolVersion": "1.0.0", "health": "healthy" },
+      { "id": "terminal", "protocolVersion": "1.0.0", "health": "healthy" }
+    ]
+  },
+  "activeTask": { "taskId": "task-001", "status": "running" }
+}
+```
+
+### `$$nemoclaw <name> cua task status`
+
+Report an active task and its exact attached target identity.
+After completion, return the retained terminal result without reading runtime-private files.
+
+```bash
+$$nemoclaw my-cua cua task status \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --json
+```
+
+### `$$nemoclaw <name> cua task result`
+
+Retrieve and validate the terminal result.
+The result separates the agent-authored status, independent verification, per-capability receipts, and private evidence references.
+A succeeded result requires a succeeded agent result and passed independent verification.
+
+```bash
+$$nemoclaw my-cua cua task result \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --json
+```
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "kind": "task-result",
+  "taskId": "task-001",
+  "status": "succeeded",
+  "targetIdentityDigest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "components": {
+    "runtime": {
+      "name": "cua-runtime",
+      "version": "1.0.0",
+      "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+      "owner": "runtime-owner"
+    },
+    "sandboxImage": {
+      "name": "sandbox-image",
+      "version": "1.0.0",
+      "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+      "owner": "sandbox-owner"
+    },
+    "targetImage": {
+      "name": "desktop-image",
+      "version": "1.0.0",
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "owner": "target-owner"
+    },
+    "serviceBundle": {
+      "name": "desktop-services",
+      "version": "1.0.0",
+      "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      "owner": "target-owner"
+    },
+    "policy": {
+      "name": "cua-policy",
+      "version": "1.0.0",
+      "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+      "owner": "policy-owner"
+    },
+    "taskProtocol": {
+      "name": "cua-task-protocol",
+      "version": "1.0.0",
+      "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+      "owner": "runtime-owner"
+    }
+  },
+  "inference": { "provider": "managed-provider", "model": "managed-model" },
+  "capabilities": [
+    { "id": "browser", "protocolVersion": "1.0.0" },
+    { "id": "computer", "protocolVersion": "1.0.0" },
+    { "id": "terminal", "protocolVersion": "1.0.0" }
+  ],
+  "agentResult": {
+    "status": "succeeded",
+    "resultDigest": "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+  },
+  "verification": {
+    "status": "passed",
+    "checkIds": ["browser-form-json", "terminal-file", "computer-docx"],
+    "evidenceDigests": [
+      "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+    ]
+  },
+  "receipts": [
+    {
+      "capability": "browser",
+      "status": "completed",
+      "evidenceDigests": [
+        "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+      ]
+    },
+    { "capability": "computer", "status": "completed", "evidenceDigests": [] },
+    { "capability": "terminal", "status": "completed", "evidenceDigests": [] }
+  ],
+  "evidence": [
+    {
+      "digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+      "classification": "private",
+      "mediaType": "application/json"
+    },
+    {
+      "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+      "classification": "private",
+      "mediaType": "image/png"
+    }
+  ]
+}
+```
+
+### `$$nemoclaw <name> cua task events|logs|plans`
+
+Retrieve a content-addressed index for one private evidence category.
+The record never embeds event data, logs, plans, paths, URLs, page content, or screenshots.
+
+```bash
+$$nemoclaw my-cua cua task events \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --json
+```
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "kind": "task-evidence-index",
+  "taskId": "task-001",
+  "category": "events",
+  "targetIdentityDigest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "evidence": [
+    {
+      "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+      "classification": "private",
+      "mediaType": "application/json",
+      "sizeBytes": 42
+    }
+  ]
+}
+```
+
+Use the same form with `logs` or `plans` to select that category.
+
+### `$$nemoclaw <name> cua task pause|cancel`
+
+`pause` returns the updated active attachment when the runtime advertises `task.pause`.
+`cancel` must return a terminal cancelled result and clear active-task state.
+A timeout or classified cancellation also clears active-task state so reconnect cannot report a task that is no longer running.
+
+```bash
+$$nemoclaw my-cua cua task cancel \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --json
+```
+
+### `$$nemoclaw <name> cua task guide|respond`
+
+`guide` injects private guidance when the runtime advertises `task.guide`.
+`respond` supplies private input after the runtime reports `input-required` when it advertises `task.respond`.
+An unadvertised optional operation returns `lifecycle_unavailable` and does not invoke the adapter.
+
+```bash
+$$nemoclaw my-cua cua task respond \
+  --adapter /absolute/path/to/task-adapter \
+  --task-id task-001 \
+  --input-file ./response.txt \
+  --json
+```
+
 ### `$$nemoclaw <name> exec`
 
 Run a command non-interactively inside a running sandbox through the OpenShell exec endpoint.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1666,6 +1666,7 @@ The adapter must be an absolute executable path.
 NemoClaw starts it without a shell and writes one `task-adapter-request` JSON object to standard input.
 The request includes the recorded runtime and target identities plus the requested operation.
 Task, guidance, and input-required response text comes from a non-empty UTF-8 `--input-file` of at most 64 KiB.
+The path must directly name a regular file; NemoClaw does not follow symbolic links.
 That private input is sent to the adapter only; NemoClaw does not write it to lifecycle output, canonical registry state, or backups.
 
 The adapter returns one record from `schemas/cua-lifecycle.schema.json`:

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1686,7 +1686,7 @@ Validation failures exit `2`, an active-task conflict exits `3`, unavailable lif
 
 Start one task with an explicit ID, execution surface, and private input file.
 A target with an active task returns `task_conflict` without invoking the adapter.
-A completed task ID must not be reused.
+A task ID that remains in the retained result history must not be reused.
 
 ```bash
 $$nemoclaw my-cua cua task start \

--- a/schemas/cua-lifecycle.schema.json
+++ b/schemas/cua-lifecycle.schema.json
@@ -11,6 +11,9 @@
       "$ref": "#/$defs/targetAttachment"
     },
     {
+      "$ref": "#/$defs/taskEvidenceIndex"
+    },
+    {
       "$ref": "#/$defs/taskResult"
     },
     {
@@ -434,7 +437,8 @@
         },
         "sizeBytes": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 9007199254740991
         }
       }
     },
@@ -462,6 +466,46 @@
           "uniqueItems": true,
           "items": {
             "$ref": "#/$defs/digest"
+          }
+        }
+      }
+    },
+    "taskEvidenceIndex": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "kind",
+        "taskId",
+        "category",
+        "targetIdentityDigest",
+        "evidence"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "$ref": "#/$defs/schemaVersion"
+        },
+        "kind": {
+          "const": "task-evidence-index"
+        },
+        "taskId": {
+          "$ref": "#/$defs/safeId"
+        },
+        "category": {
+          "enum": [
+            "events",
+            "logs",
+            "plans"
+          ]
+        },
+        "targetIdentityDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "evidence": {
+          "type": "array",
+          "maxItems": 96,
+          "items": {
+            "$ref": "#/$defs/evidenceReference"
           }
         }
       }

--- a/src/commands/sandbox/cua/task/cancel.ts
+++ b/src/commands/sandbox/cua/task/cancel.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import { cuaSandboxArgs, cuaTaskIdentityFlags } from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskCancelCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:cancel";
+  static strict = true;
+  static summary = "Cancel an active CUA task and wait for a terminal result";
+  static description =
+    "Ask the task adapter to cancel the active task, then validate and record its terminal result.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task cancel alpha --adapter /opt/cua-task-adapter --task-id task-123",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = cuaTaskIdentityFlags;
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskCancelCommand);
+    const rendered = renderCuaTaskResult(
+      "task.cancel",
+      executeCuaTaskCommand({
+        operation: "task.cancel",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/events.ts
+++ b/src/commands/sandbox/cua/task/events.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import { cuaSandboxArgs, cuaTaskIdentityFlags } from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskEventsCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:events";
+  static strict = true;
+  static summary = "Retrieve private CUA event evidence references";
+  static description =
+    "Retrieve and validate content-addressed references to private event evidence for the active task.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task events alpha --adapter /opt/cua-task-adapter --task-id task-123 --json",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = cuaTaskIdentityFlags;
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskEventsCommand);
+    const rendered = renderCuaTaskResult(
+      "task.events",
+      executeCuaTaskCommand({
+        operation: "task.events",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/events.ts
+++ b/src/commands/sandbox/cua/task/events.ts
@@ -11,7 +11,7 @@ export default class SandboxCuaTaskEventsCommand extends NemoClawCommand {
   static strict = true;
   static summary = "Retrieve private CUA event evidence references";
   static description =
-    "Retrieve and validate content-addressed references to private event evidence for the active task.";
+    "Retrieve and validate content-addressed references to private event evidence for the active or retained completed task.";
   static examples = [
     "<%= config.bin %> sandbox cua task events alpha --adapter /opt/cua-task-adapter --task-id task-123 --json",
   ];

--- a/src/commands/sandbox/cua/task/guide.ts
+++ b/src/commands/sandbox/cua/task/guide.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import {
+  cuaSandboxArgs,
+  cuaTaskIdentityFlags,
+  cuaTaskInputFlag,
+} from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskGuideCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:guide";
+  static strict = true;
+  static summary = "Inject private guidance into an active CUA task when supported";
+  static description =
+    "Send bounded private guidance to an active task without persisting the input in NemoClaw state.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task guide alpha --adapter /opt/cua-task-adapter --task-id task-123 --input-file ./guidance.txt",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> --input-file <path> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = { ...cuaTaskIdentityFlags, "input-file": cuaTaskInputFlag };
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskGuideCommand);
+    const rendered = renderCuaTaskResult(
+      "task.guide",
+      executeCuaTaskCommand({
+        operation: "task.guide",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+        inputPath: flags["input-file"],
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/logs.ts
+++ b/src/commands/sandbox/cua/task/logs.ts
@@ -11,7 +11,7 @@ export default class SandboxCuaTaskLogsCommand extends NemoClawCommand {
   static strict = true;
   static summary = "Retrieve private CUA log evidence references";
   static description =
-    "Retrieve and validate content-addressed references to private log evidence for the active task.";
+    "Retrieve and validate content-addressed references to private log evidence for the active or retained completed task.";
   static examples = [
     "<%= config.bin %> sandbox cua task logs alpha --adapter /opt/cua-task-adapter --task-id task-123 --json",
   ];

--- a/src/commands/sandbox/cua/task/logs.ts
+++ b/src/commands/sandbox/cua/task/logs.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import { cuaSandboxArgs, cuaTaskIdentityFlags } from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskLogsCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:logs";
+  static strict = true;
+  static summary = "Retrieve private CUA log evidence references";
+  static description =
+    "Retrieve and validate content-addressed references to private log evidence for the active task.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task logs alpha --adapter /opt/cua-task-adapter --task-id task-123 --json",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = cuaTaskIdentityFlags;
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskLogsCommand);
+    const rendered = renderCuaTaskResult(
+      "task.logs",
+      executeCuaTaskCommand({
+        operation: "task.logs",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/pause.ts
+++ b/src/commands/sandbox/cua/task/pause.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import { cuaSandboxArgs, cuaTaskIdentityFlags } from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskPauseCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:pause";
+  static strict = true;
+  static summary = "Pause an active CUA task when supported";
+  static description =
+    "Ask the task adapter to pause an active task and validate the returned task state.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task pause alpha --adapter /opt/cua-task-adapter --task-id task-123",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = cuaTaskIdentityFlags;
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskPauseCommand);
+    const rendered = renderCuaTaskResult(
+      "task.pause",
+      executeCuaTaskCommand({
+        operation: "task.pause",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/plans.ts
+++ b/src/commands/sandbox/cua/task/plans.ts
@@ -11,7 +11,7 @@ export default class SandboxCuaTaskPlansCommand extends NemoClawCommand {
   static strict = true;
   static summary = "Retrieve private CUA plan evidence references";
   static description =
-    "Retrieve and validate content-addressed references to private plan evidence for the active task.";
+    "Retrieve and validate content-addressed references to private plan evidence for the active or retained completed task.";
   static examples = [
     "<%= config.bin %> sandbox cua task plans alpha --adapter /opt/cua-task-adapter --task-id task-123 --json",
   ];

--- a/src/commands/sandbox/cua/task/plans.ts
+++ b/src/commands/sandbox/cua/task/plans.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import { cuaSandboxArgs, cuaTaskIdentityFlags } from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskPlansCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:plans";
+  static strict = true;
+  static summary = "Retrieve private CUA plan evidence references";
+  static description =
+    "Retrieve and validate content-addressed references to private plan evidence for the active task.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task plans alpha --adapter /opt/cua-task-adapter --task-id task-123 --json",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = cuaTaskIdentityFlags;
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskPlansCommand);
+    const rendered = renderCuaTaskResult(
+      "task.plans",
+      executeCuaTaskCommand({
+        operation: "task.plans",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/respond.ts
+++ b/src/commands/sandbox/cua/task/respond.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import {
+  cuaSandboxArgs,
+  cuaTaskIdentityFlags,
+  cuaTaskInputFlag,
+} from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskRespondCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:respond";
+  static strict = true;
+  static summary = "Respond to recoverable CUA input-required state when supported";
+  static description =
+    "Send a bounded private response only when the active task reports that input is required.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task respond alpha --adapter /opt/cua-task-adapter --task-id task-123 --input-file ./response.txt",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> --input-file <path> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = { ...cuaTaskIdentityFlags, "input-file": cuaTaskInputFlag };
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskRespondCommand);
+    const rendered = renderCuaTaskResult(
+      "task.respond",
+      executeCuaTaskCommand({
+        operation: "task.respond",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+        inputPath: flags["input-file"],
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/result.ts
+++ b/src/commands/sandbox/cua/task/result.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import { cuaSandboxArgs, cuaTaskIdentityFlags } from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskResultCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:result";
+  static strict = true;
+  static summary = "Retrieve a versioned CUA task result";
+  static description =
+    "Return a retained terminal result or retrieve and validate one from the task adapter.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task result alpha --adapter /opt/cua-task-adapter --task-id task-123 --json",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = cuaTaskIdentityFlags;
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskResultCommand);
+    const rendered = renderCuaTaskResult(
+      "task.result",
+      executeCuaTaskCommand({
+        operation: "task.result",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/start.ts
+++ b/src/commands/sandbox/cua/task/start.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flags } from "@oclif/core";
+import type { CuaTaskMode } from "../../../../lib/adapters/cua-task";
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import {
+  cuaSandboxArgs,
+  cuaTaskIdentityFlags,
+  cuaTaskInputFlag,
+} from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskStartCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:start";
+  static strict = true;
+  static summary = "Start one CUA task against the attached target";
+  static description =
+    "Send bounded private input to the explicit task adapter and record the returned active task state.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task start alpha --adapter /opt/cua-task-adapter --task-id task-123 --mode headless --input-file ./task.txt",
+  ];
+  static usage = [
+    "<name> --adapter <absolute-path> --task-id <id> --mode interactive|headless --input-file <path> [--json]",
+  ];
+  static args = cuaSandboxArgs;
+  static flags = {
+    ...cuaTaskIdentityFlags,
+    mode: Flags.string({
+      description: "Runtime surface used for this task",
+      options: ["interactive", "headless"],
+      required: true,
+    }),
+    "input-file": cuaTaskInputFlag,
+  };
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskStartCommand);
+    const rendered = renderCuaTaskResult(
+      "task.start",
+      executeCuaTaskCommand({
+        operation: "task.start",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+        mode: flags.mode as CuaTaskMode,
+        inputPath: flags["input-file"],
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/commands/sandbox/cua/task/status.ts
+++ b/src/commands/sandbox/cua/task/status.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../../../lib/cli/nemoclaw-oclif-command";
+import { cuaSandboxArgs, cuaTaskIdentityFlags } from "../../../../lib/cua/task-cli-definitions";
+import { executeCuaTaskCommand, renderCuaTaskResult } from "../../../../lib/cua/task-command";
+
+export default class SandboxCuaTaskStatusCommand extends NemoClawCommand {
+  static enableJsonFlag = true;
+  static id = "sandbox:cua:task:status";
+  static strict = true;
+  static summary = "Show active or completed CUA task state";
+  static description =
+    "Return a retained terminal result or retrieve and validate the current state from the task adapter.";
+  static examples = [
+    "<%= config.bin %> sandbox cua task status alpha --adapter /opt/cua-task-adapter --task-id task-123 --json",
+  ];
+  static usage = ["<name> --adapter <absolute-path> --task-id <id> [--json]"];
+  static args = cuaSandboxArgs;
+  static flags = cuaTaskIdentityFlags;
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(SandboxCuaTaskStatusCommand);
+    const rendered = renderCuaTaskResult(
+      "task.status",
+      executeCuaTaskCommand({
+        operation: "task.status",
+        sandboxName: args.sandboxName,
+        taskId: flags["task-id"],
+        adapterPath: flags.adapter,
+      }),
+      this.jsonEnabled(),
+    );
+    this.setExitCode(rendered.exitCode);
+    if (rendered.error) console.error(rendered.error);
+    if (rendered.message) this.log(rendered.message);
+    return rendered.output;
+  }
+}

--- a/src/lib/adapters/cua-task.test.ts
+++ b/src/lib/adapters/cua-task.test.ts
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CUA_LIFECYCLE_SCHEMA_VERSION,
+  type CuaRuntimeReadiness,
+  type CuaTargetAttachment,
+  type CuaTaskEvidenceIndex,
+} from "../cua/contract";
+import {
+  CuaTaskAdapterInvocationError,
+  type CuaTaskAdapterRequest,
+  ProcessCuaTaskAdapter,
+} from "./cua-task";
+
+const temporaryDirectories: string[] = [];
+const digest = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
+const component = (name: string, value: string) => ({
+  name,
+  version: "1.0.0",
+  digest: digest(value),
+  owner: "fixture",
+});
+
+const runtime: CuaRuntimeReadiness = {
+  schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+  kind: "runtime-readiness",
+  mode: "standalone",
+  status: "available",
+  components: {
+    runtime: component("runtime", "1"),
+    sandboxImage: component("sandbox", "2"),
+    policy: component("policy", "3"),
+    taskProtocol: component("protocol", "4"),
+  },
+  inference: { provider: "fixture", model: "fixture-model" },
+  commands: { interactive: true, headless: true, version: true, smoke: true },
+  limits: { targetsPerWorker: 1, activeTasksPerTarget: 1 },
+  requiredCapabilities: ["browser", "computer", "terminal"],
+  targetOperations: [
+    "target.attach",
+    "target.status",
+    "target.health",
+    "target.detach",
+    "target.reset",
+    "target.destroy",
+  ],
+  taskOperations: [
+    "task.start",
+    "task.status",
+    "task.result",
+    "task.events",
+    "task.logs",
+    "task.plans",
+    "task.cancel",
+  ],
+};
+
+const target: CuaTargetAttachment = {
+  schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+  kind: "target-attachment",
+  status: "attached",
+  target: {
+    identityDigest: digest("5"),
+    platform: "fixture-linux-amd64",
+    image: component("target", "6"),
+    serviceBundle: component("services", "7"),
+    capabilities: [
+      { id: "browser", protocolVersion: "1.0.0", health: "healthy" },
+      { id: "computer", protocolVersion: "1.0.0", health: "healthy" },
+      { id: "terminal", protocolVersion: "1.0.0", health: "healthy" },
+    ],
+  },
+  activeTask: { taskId: "task-1", status: "running" },
+};
+
+function request(): CuaTaskAdapterRequest {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "task-adapter-request",
+    operation: "task.events",
+    sandboxName: "alpha",
+    taskId: "task-1",
+    mode: null,
+    input: null,
+    runtime,
+    target,
+  };
+}
+
+function executable(source: string): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cua-task-adapter-"));
+  temporaryDirectories.push(directory);
+  const filePath = path.join(directory, "adapter.mjs");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node\n${source}`, { mode: 0o700 });
+  return filePath;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("process CUA task adapter (#7752)", () => {
+  it("sends one bounded request and accepts a task evidence index", () => {
+    const adapterPath = executable(`
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const request = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+process.stdout.write(JSON.stringify({
+  schemaVersion: request.schemaVersion,
+  kind: "task-evidence-index",
+  taskId: request.taskId,
+  category: "events",
+  targetIdentityDigest: request.target.target.identityDigest,
+  evidence: [{
+    digest: "${digest("8")}",
+    classification: "private",
+    mediaType: "application/json",
+    sizeBytes: 42
+  }]
+}));
+`);
+
+    const record = new ProcessCuaTaskAdapter(adapterPath).execute(
+      request(),
+    ) as CuaTaskEvidenceIndex;
+
+    expect(record).toMatchObject({
+      kind: "task-evidence-index",
+      taskId: "task-1",
+      category: "events",
+    });
+    expect(record.evidence).toEqual([
+      {
+        digest: digest("8"),
+        classification: "private",
+        mediaType: "application/json",
+        sizeBytes: 42,
+      },
+    ]);
+  });
+
+  it("does not copy runtime-private stderr into a validation error", () => {
+    const adapterPath = executable(`
+process.stderr.write("private-runtime-diagnostic");
+process.stdout.write("not-json");
+`);
+    const adapter = new ProcessCuaTaskAdapter(adapterPath);
+
+    expect(() => adapter.execute(request())).toThrowError(CuaTaskAdapterInvocationError);
+    try {
+      adapter.execute(request());
+    } catch (error) {
+      expect(String(error)).not.toContain("private-runtime-diagnostic");
+    }
+  });
+
+  it("rejects a relative executable before starting a process", () => {
+    const adapter = new ProcessCuaTaskAdapter("adapter");
+    expect(() => adapter.execute(request())).toThrow("path must be absolute");
+  });
+
+  it("does not forward unrelated host credential variables", () => {
+    vi.stubEnv("CUA_TASK_TEST_AUTHORITY", "private-value");
+    const adapterPath = executable(`
+if (process.env.CUA_TASK_TEST_AUTHORITY) {
+  process.stdout.write("environment-leaked");
+  process.exit(0);
+}
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const request = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+process.stdout.write(JSON.stringify({
+  schemaVersion: request.schemaVersion,
+  kind: "task-evidence-index",
+  taskId: request.taskId,
+  category: "events",
+  targetIdentityDigest: request.target.target.identityDigest,
+  evidence: []
+}));
+`);
+
+    expect(new ProcessCuaTaskAdapter(adapterPath).execute(request()).kind).toBe(
+      "task-evidence-index",
+    );
+  });
+});

--- a/src/lib/adapters/cua-task.ts
+++ b/src/lib/adapters/cua-task.ts
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  CUA_LIFECYCLE_SCHEMA_VERSION,
+  type CUA_TASK_OPERATIONS,
+  type CuaFailure,
+  type CuaFailureFamily,
+  type CuaRuntimeReadiness,
+  type CuaTargetAttachment,
+  type CuaTaskEvidenceIndex,
+  type CuaTaskResult,
+} from "../cua/contract";
+import { parseCuaLifecycleRecord } from "../cua/schema";
+
+export type CuaTaskOperation = (typeof CUA_TASK_OPERATIONS)[number];
+export type CuaTaskMode = "interactive" | "headless";
+
+export interface CuaTaskAdapterRequest {
+  schemaVersion: typeof CUA_LIFECYCLE_SCHEMA_VERSION;
+  kind: "task-adapter-request";
+  operation: CuaTaskOperation;
+  sandboxName: string;
+  taskId: string;
+  mode: CuaTaskMode | null;
+  input: string | null;
+  runtime: CuaRuntimeReadiness;
+  target: CuaTargetAttachment;
+}
+
+export type CuaTaskAdapterResult =
+  | CuaTargetAttachment
+  | CuaTaskEvidenceIndex
+  | CuaTaskResult
+  | CuaFailure;
+
+export interface CuaTaskAdapter {
+  execute(request: CuaTaskAdapterRequest): CuaTaskAdapterResult;
+}
+
+export class CuaTaskAdapterInvocationError extends Error {
+  constructor(
+    message: string,
+    readonly family: CuaFailureFamily,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = "CuaTaskAdapterInvocationError";
+  }
+}
+
+export interface ProcessCuaTaskAdapterOptions {
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
+const ADAPTER_ENV_KEYS = [
+  "HOME",
+  "PATH",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "SystemRoot",
+  "ComSpec",
+  "PATHEXT",
+  "LANG",
+  "LC_ALL",
+] as const;
+
+function adapterEnvironment(): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    ADAPTER_ENV_KEYS.flatMap((key) => {
+      const value = process.env[key];
+      return value === undefined ? [] : [[key, value]];
+    }),
+  );
+}
+
+function validateExecutable(executable: string): void {
+  if (!path.isAbsolute(executable)) {
+    throw new CuaTaskAdapterInvocationError(
+      "the CUA task adapter path must be absolute",
+      "validation_failed",
+      false,
+    );
+  }
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(executable);
+    fs.accessSync(executable, fs.constants.X_OK);
+  } catch {
+    throw new CuaTaskAdapterInvocationError(
+      "the CUA task adapter is unavailable",
+      "lifecycle_unavailable",
+      false,
+    );
+  }
+  if (!stat.isFile()) {
+    throw new CuaTaskAdapterInvocationError(
+      "the CUA task adapter is unavailable",
+      "lifecycle_unavailable",
+      false,
+    );
+  }
+}
+
+function parseAdapterResult(
+  stdout: string,
+  operation: CuaTaskOperation,
+  processStatus: number | null,
+): CuaTaskAdapterResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new CuaTaskAdapterInvocationError(
+      "the CUA task adapter returned invalid JSON",
+      "validation_failed",
+      false,
+    );
+  }
+  let record;
+  try {
+    record = parseCuaLifecycleRecord(parsed);
+  } catch {
+    throw new CuaTaskAdapterInvocationError(
+      "the CUA task adapter returned an invalid lifecycle record",
+      "validation_failed",
+      false,
+    );
+  }
+  if (
+    record.kind !== "target-attachment" &&
+    record.kind !== "task-evidence-index" &&
+    record.kind !== "task-result" &&
+    record.kind !== "failure"
+  ) {
+    throw new CuaTaskAdapterInvocationError(
+      "the CUA task adapter returned an unsupported record",
+      "validation_failed",
+      false,
+    );
+  }
+  if (record.kind === "failure") {
+    if (record.operation !== operation) {
+      throw new CuaTaskAdapterInvocationError(
+        "the CUA task adapter returned a failure for another operation",
+        "validation_failed",
+        false,
+      );
+    }
+    return record;
+  }
+  if (processStatus !== 0) {
+    throw new CuaTaskAdapterInvocationError(
+      "the CUA task adapter exited unsuccessfully without a failure record",
+      "runtime_unavailable",
+      true,
+    );
+  }
+  return record;
+}
+
+/**
+ * Invoke the explicit CUA task protocol adapter without a shell.
+ *
+ * Task input is private, bounded command input. It is sent only to the adapter
+ * on stdin and never enters lifecycle output or canonical registry state.
+ */
+export class ProcessCuaTaskAdapter implements CuaTaskAdapter {
+  readonly timeoutMs: number;
+  readonly maxOutputBytes: number;
+
+  constructor(
+    readonly executable: string,
+    options: ProcessCuaTaskAdapterOptions = {},
+  ) {
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  }
+
+  execute(request: CuaTaskAdapterRequest): CuaTaskAdapterResult {
+    validateExecutable(this.executable);
+    const result = spawnSync(this.executable, [], {
+      encoding: "utf8",
+      input: `${JSON.stringify(request)}\n`,
+      maxBuffer: this.maxOutputBytes,
+      env: adapterEnvironment(),
+      shell: false,
+      timeout: this.timeoutMs,
+      windowsHide: true,
+    });
+    if (result.error) {
+      const timedOut = (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT";
+      throw new CuaTaskAdapterInvocationError(
+        timedOut ? "the CUA task adapter timed out" : "the CUA task adapter failed",
+        timedOut ? "task_timeout" : "runtime_unavailable",
+        timedOut,
+      );
+    }
+    return parseAdapterResult(result.stdout, request.operation, result.status);
+  }
+}

--- a/src/lib/cli/public-display-defaults.ts
+++ b/src/lib/cli/public-display-defaults.ts
@@ -292,6 +292,87 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
       flags: "--adapter <absolute-path> [--json]",
     },
   ],
+  "sandbox:cua:task:start": [
+    {
+      group: "Sandbox Management",
+      order: 6.7,
+      description: "Start one CUA task against the attached target",
+      flags:
+        "--adapter <absolute-path> --task-id <id> --mode interactive|headless --input-file <path> [--json]",
+    },
+  ],
+  "sandbox:cua:task:status": [
+    {
+      group: "Sandbox Management",
+      order: 6.8,
+      description: "Show active or completed CUA task state",
+      flags: "--adapter <absolute-path> --task-id <id> [--json]",
+    },
+  ],
+  "sandbox:cua:task:result": [
+    {
+      group: "Sandbox Management",
+      order: 6.9,
+      description: "Retrieve a versioned CUA task result",
+      flags: "--adapter <absolute-path> --task-id <id> [--json]",
+    },
+  ],
+  "sandbox:cua:task:events": [
+    {
+      group: "Sandbox Management",
+      order: 7,
+      description: "Retrieve private CUA event evidence references",
+      flags: "--adapter <absolute-path> --task-id <id> [--json]",
+    },
+  ],
+  "sandbox:cua:task:logs": [
+    {
+      group: "Sandbox Management",
+      order: 7.1,
+      description: "Retrieve private CUA log evidence references",
+      flags: "--adapter <absolute-path> --task-id <id> [--json]",
+    },
+  ],
+  "sandbox:cua:task:plans": [
+    {
+      group: "Sandbox Management",
+      order: 7.2,
+      description: "Retrieve private CUA plan evidence references",
+      flags: "--adapter <absolute-path> --task-id <id> [--json]",
+    },
+  ],
+  "sandbox:cua:task:pause": [
+    {
+      group: "Sandbox Management",
+      order: 7.3,
+      description: "Pause an active CUA task when supported",
+      flags: "--adapter <absolute-path> --task-id <id> [--json]",
+    },
+  ],
+  "sandbox:cua:task:cancel": [
+    {
+      group: "Sandbox Management",
+      order: 7.4,
+      description: "Cancel an active CUA task and wait for a terminal result",
+      flags: "--adapter <absolute-path> --task-id <id> [--json]",
+    },
+  ],
+  "sandbox:cua:task:guide": [
+    {
+      group: "Sandbox Management",
+      order: 7.5,
+      description: "Inject private guidance into an active CUA task when supported",
+      flags: "--adapter <absolute-path> --task-id <id> --input-file <path> [--json]",
+    },
+  ],
+  "sandbox:cua:task:respond": [
+    {
+      group: "Sandbox Management",
+      order: 7.6,
+      description: "Respond to recoverable CUA input-required state when supported",
+      flags: "--adapter <absolute-path> --task-id <id> --input-file <path> [--json]",
+    },
+  ],
   "sandbox:destroy": [
     {
       group: "Sandbox Management",

--- a/src/lib/cua/contract.md
+++ b/src/lib/cua/contract.md
@@ -106,6 +106,11 @@ Public command names, arguments, output envelopes, and exit codes are owned by
 the target and task implementation issues. They must produce records that
 conform to this contract without reading runtime-private files.
 
+Active task commands return the target attachment with its bounded
+`activeTask` projection. Terminal commands return `task-result`.
+`task.events`, `task.logs`, and `task.plans` return a
+`task-evidence-index` containing only content-addressed private references.
+
 ## Compatibility identities
 
 Every component identity contains:
@@ -205,6 +210,10 @@ and private evidence references as separate fields.
 succeeded task requires both a succeeded agent result and passed independent
 verification. A failed task cannot contain both of those success conditions.
 The task and agent result must agree on cancellation.
+
+NemoClaw retains at most the 16 most recent validated terminal results for
+normal CLI reconnect inspection. It never persists task input. A task ID in
+that retained set cannot be reused.
 
 The security issue owns artifact access controls, retention, redaction,
 cleanup, target credential delivery, and the deny-default network policy.

--- a/src/lib/cua/contract.test.ts
+++ b/src/lib/cua/contract.test.ts
@@ -19,6 +19,7 @@ import {
   type CuaLifecycleRecord,
   type CuaRuntimeReadiness,
   type CuaTargetAttachment,
+  type CuaTaskEvidenceIndex,
   type CuaTaskResult,
   checkCuaLifecycleSchemaVersion,
   getCuaLifecycleSemanticErrors,
@@ -151,6 +152,24 @@ function taskResult(): CuaTaskResult {
   };
 }
 
+function taskEvidenceIndex(): CuaTaskEvidenceIndex {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "task-evidence-index",
+    taskId: "task-1",
+    category: "events",
+    targetIdentityDigest: secondDigest,
+    evidence: [
+      {
+        digest,
+        classification: "private",
+        mediaType: "application/json",
+        sizeBytes: 256,
+      },
+    ],
+  };
+}
+
 function createValidator() {
   const ajv = new Ajv2020({ allErrors: true, strict: true });
   return ajv.compile(cuaLifecycleSchema as AnySchema);
@@ -166,6 +185,7 @@ describe("first-class CUA contract", () => {
     const records: CuaLifecycleRecord[] = [
       runtimeReadiness(),
       targetAttachment(),
+      taskEvidenceIndex(),
       taskResult(),
       {
         schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,

--- a/src/lib/cua/contract.ts
+++ b/src/lib/cua/contract.ts
@@ -136,6 +136,15 @@ export interface CuaCapabilityReceipt {
   evidenceDigests: readonly string[];
 }
 
+export interface CuaTaskEvidenceIndex {
+  schemaVersion: string;
+  kind: "task-evidence-index";
+  taskId: string;
+  category: "events" | "logs" | "plans";
+  targetIdentityDigest: string;
+  evidence: readonly CuaEvidenceReference[];
+}
+
 export interface CuaTaskResult {
   schemaVersion: string;
   kind: "task-result";
@@ -177,6 +186,7 @@ export interface CuaFailure {
 export type CuaLifecycleRecord =
   | CuaRuntimeReadiness
   | CuaTargetAttachment
+  | CuaTaskEvidenceIndex
   | CuaTaskResult
   | CuaFailure;
 
@@ -376,6 +386,13 @@ export function getCuaLifecycleSemanticErrors(record: CuaLifecycleRecord): strin
     }
     if ((record.status === "cancelled") !== (record.agentResult.status === "cancelled")) {
       errors.push("task and agent result cancellation status must match");
+    }
+  }
+
+  if (record.kind === "task-evidence-index") {
+    const duplicateEvidence = duplicateValues(record.evidence.map((entry) => entry.digest));
+    if (duplicateEvidence.length > 0) {
+      errors.push(`evidence contains duplicate digests: ${duplicateEvidence.join(", ")}`);
     }
   }
 

--- a/src/lib/cua/schema.test.ts
+++ b/src/lib/cua/schema.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, expect, it } from "vitest";
 import { CUA_LIFECYCLE_SCHEMA_VERSION } from "./contract";
-import { parseCuaTargetManifest } from "./schema";
+import {
+  parseCuaLifecycleRecord,
+  parseCuaTargetManifest,
+  parseCuaTaskEvidenceIndex,
+} from "./schema";
 
 const digest = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
 
@@ -57,5 +61,53 @@ describe("CUA target manifest schema (#7751)", () => {
     expect(() => parseCuaTargetManifest(duplicate)).toThrow(
       "must declare browser, computer, and terminal once",
     );
+  });
+});
+
+describe("CUA task evidence schema (#7752)", () => {
+  it("accepts only bounded private references in a task evidence index", () => {
+    const record = parseCuaTaskEvidenceIndex({
+      schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+      kind: "task-evidence-index",
+      taskId: "task-1",
+      category: "logs",
+      targetIdentityDigest: digest("4"),
+      evidence: [
+        {
+          digest: digest("5"),
+          classification: "private",
+          mediaType: "application/json",
+          sizeBytes: 42,
+        },
+      ],
+    });
+
+    expect(record.kind).toBe("task-evidence-index");
+    expect(record.evidence[0]).not.toHaveProperty("path");
+  });
+
+  it("rejects duplicate or authority-bearing task evidence", () => {
+    const evidenceDigest = digest("5");
+    const duplicate = {
+      schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+      kind: "task-evidence-index",
+      taskId: "task-1",
+      category: "events",
+      targetIdentityDigest: digest("4"),
+      evidence: [
+        { digest: evidenceDigest, classification: "private" },
+        { digest: evidenceDigest, classification: "private" },
+      ],
+    };
+
+    expect(() => parseCuaLifecycleRecord(duplicate)).toThrow("evidence contains duplicate digests");
+    expect(() =>
+      parseCuaLifecycleRecord({
+        ...duplicate,
+        evidence: [
+          { digest: evidenceDigest, classification: "private", path: "/private/evidence" },
+        ],
+      }),
+    ).toThrow("does not match its schema");
   });
 });

--- a/src/lib/cua/schema.ts
+++ b/src/lib/cua/schema.ts
@@ -11,6 +11,8 @@ import {
   type CuaLifecycleRecord,
   type CuaRuntimeReadiness,
   type CuaTargetAttachment,
+  type CuaTaskEvidenceIndex,
+  type CuaTaskResult,
   getCuaLifecycleSemanticErrors,
 } from "./contract";
 
@@ -65,6 +67,22 @@ export function parseCuaTargetAttachment(value: unknown): CuaTargetAttachment {
   const record = parseCuaLifecycleRecord(value);
   if (record.kind !== "target-attachment") {
     throw new Error("CUA target state must be a target-attachment record");
+  }
+  return record;
+}
+
+export function parseCuaTaskEvidenceIndex(value: unknown): CuaTaskEvidenceIndex {
+  const record = parseCuaLifecycleRecord(value);
+  if (record.kind !== "task-evidence-index") {
+    throw new Error("CUA task evidence state must be a task-evidence-index record");
+  }
+  return record;
+}
+
+export function parseCuaTaskResult(value: unknown): CuaTaskResult {
+  const record = parseCuaLifecycleRecord(value);
+  if (record.kind !== "task-result") {
+    throw new Error("CUA task result state must be a task-result record");
   }
   return record;
 }

--- a/src/lib/cua/target-lifecycle.test.ts
+++ b/src/lib/cua/target-lifecycle.test.ts
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 import type {
   CuaTargetAdapter,
@@ -21,6 +25,7 @@ import {
   type CuaTargetLifecycleDeps,
   detachedCuaTarget,
   executeCuaTargetLifecycle,
+  readCuaTargetManifest,
 } from "./target-lifecycle";
 
 const digest = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
@@ -129,6 +134,18 @@ function harness(target?: CuaTargetAttachment): {
 }
 
 describe("CUA target lifecycle (#7751)", () => {
+  it("rejects a symlinked target manifest before parsing it", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cua-target-manifest-"));
+    const target = path.join(directory, "target.json");
+    const link = path.join(directory, "manifest.json");
+    fs.writeFileSync(target, JSON.stringify(manifest));
+    fs.symlinkSync(target, link);
+
+    expect(() => readCuaTargetManifest(link)).toThrow();
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
   it("attaches only after immutable identity and all capability checks pass", () => {
     const { registry, deps } = harness();
     const adapter = fakeAdapter(() => attachedTarget());

--- a/src/lib/cua/target-lifecycle.ts
+++ b/src/lib/cua/target-lifecycle.ts
@@ -336,9 +336,18 @@ export function executeCuaTargetLifecycle(
 }
 
 export function readCuaTargetManifest(filePath: string): CuaTargetManifest {
-  const stat = fs.statSync(filePath);
-  if (!stat.isFile() || stat.size > MAX_TARGET_MANIFEST_BYTES) {
-    throw new Error("CUA target manifest must be a JSON file no larger than 64 KiB");
+  const descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const stat = fs.fstatSync(descriptor);
+    if (!stat.isFile() || stat.size > MAX_TARGET_MANIFEST_BYTES) {
+      throw new Error("CUA target manifest must be a JSON file no larger than 64 KiB");
+    }
+    const contents = fs.readFileSync(descriptor);
+    if (contents.byteLength > MAX_TARGET_MANIFEST_BYTES) {
+      throw new Error("CUA target manifest must be a JSON file no larger than 64 KiB");
+    }
+    return parseCuaTargetManifest(JSON.parse(contents.toString("utf8")));
+  } finally {
+    fs.closeSync(descriptor);
   }
-  return parseCuaTargetManifest(JSON.parse(fs.readFileSync(filePath, "utf8")));
 }

--- a/src/lib/cua/task-cli-definitions.ts
+++ b/src/lib/cua/task-cli-definitions.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Args, Flags } from "@oclif/core";
+
+export const cuaSandboxArgs = {
+  sandboxName: Args.string({
+    name: "sandbox",
+    description: "Sandbox name",
+    required: true,
+  }),
+};
+
+export const cuaTaskIdentityFlags = {
+  adapter: Flags.string({
+    description: "Absolute path to the operator-owned CUA task adapter",
+    required: true,
+  }),
+  "task-id": Flags.string({
+    description: "Explicit stable task ID",
+    required: true,
+  }),
+};
+
+export const cuaTaskInputFlag = Flags.string({
+  description: "Private UTF-8 task input file, up to 64 KiB",
+  required: true,
+});

--- a/src/lib/cua/task-command.ts
+++ b/src/lib/cua/task-command.ts
@@ -43,11 +43,20 @@ function validationFailure(operation: CuaTaskOperation): CuaTaskLifecycleResult 
 }
 
 function readPrivateTaskInput(filePath: string): string {
-  const stat = fs.statSync(filePath);
-  if (!stat.isFile() || stat.size === 0 || stat.size > MAX_TASK_INPUT_BYTES) {
-    throw new Error("CUA task input must be a non-empty file no larger than 64 KiB");
+  const descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const stat = fs.fstatSync(descriptor);
+    if (!stat.isFile() || stat.size === 0 || stat.size > MAX_TASK_INPUT_BYTES) {
+      throw new Error("CUA task input must be a non-empty file no larger than 64 KiB");
+    }
+    const contents = fs.readFileSync(descriptor);
+    if (contents.byteLength === 0 || contents.byteLength > MAX_TASK_INPUT_BYTES) {
+      throw new Error("CUA task input must be a non-empty file no larger than 64 KiB");
+    }
+    return new TextDecoder("utf-8", { fatal: true }).decode(contents);
+  } finally {
+    fs.closeSync(descriptor);
   }
-  return new TextDecoder("utf-8", { fatal: true }).decode(fs.readFileSync(filePath));
 }
 
 export function executeCuaTaskCommand(input: CuaTaskCommandInput): CuaTaskLifecycleResult {

--- a/src/lib/cua/task-command.ts
+++ b/src/lib/cua/task-command.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import {
+  type CuaTaskMode,
+  type CuaTaskOperation,
+  ProcessCuaTaskAdapter,
+} from "../adapters/cua-task";
+import {
+  CUA_LIFECYCLE_SCHEMA_VERSION,
+  type CuaFailure,
+  type CuaTargetAttachment,
+  type CuaTaskEvidenceIndex,
+  type CuaTaskResult,
+} from "./contract";
+import {
+  CUA_TASK_EXIT_CODES,
+  type CuaTaskLifecycleResult,
+  executeCuaTaskLifecycle,
+} from "./task-lifecycle";
+
+const MAX_TASK_INPUT_BYTES = 64 * 1024;
+
+export interface CuaTaskCommandInput {
+  operation: CuaTaskOperation;
+  sandboxName: string;
+  taskId: string;
+  adapterPath?: string;
+  mode?: CuaTaskMode;
+  inputPath?: string;
+}
+
+function validationFailure(operation: CuaTaskOperation): CuaTaskLifecycleResult {
+  const record: CuaFailure = {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "failure",
+    operation,
+    family: "validation_failed",
+    retryable: false,
+  };
+  return { record, exitCode: CUA_TASK_EXIT_CODES.validation };
+}
+
+function readPrivateTaskInput(filePath: string): string {
+  const stat = fs.statSync(filePath);
+  if (!stat.isFile() || stat.size === 0 || stat.size > MAX_TASK_INPUT_BYTES) {
+    throw new Error("CUA task input must be a non-empty file no larger than 64 KiB");
+  }
+  return new TextDecoder("utf-8", { fatal: true }).decode(fs.readFileSync(filePath));
+}
+
+export function executeCuaTaskCommand(input: CuaTaskCommandInput): CuaTaskLifecycleResult {
+  let privateInput;
+  try {
+    privateInput = input.inputPath ? readPrivateTaskInput(input.inputPath) : undefined;
+  } catch {
+    return validationFailure(input.operation);
+  }
+  const adapter = input.adapterPath ? new ProcessCuaTaskAdapter(input.adapterPath) : undefined;
+  return executeCuaTaskLifecycle({
+    operation: input.operation,
+    sandboxName: input.sandboxName,
+    taskId: input.taskId,
+    ...(adapter ? { adapter } : {}),
+    ...(input.mode ? { mode: input.mode } : {}),
+    ...(privateInput ? { input: privateInput } : {}),
+  });
+}
+
+export interface RenderedCuaTaskResult {
+  exitCode: number;
+  output?: CuaTargetAttachment | CuaTaskEvidenceIndex | CuaTaskResult | CuaFailure;
+  message?: string;
+  error?: string;
+}
+
+function successMessage(
+  operation: CuaTaskOperation,
+  record: CuaTargetAttachment | CuaTaskEvidenceIndex | CuaTaskResult,
+): string {
+  if (record.kind === "task-result") {
+    return `CUA task ${record.taskId}: ${record.status}`;
+  }
+  if (record.kind === "task-evidence-index") {
+    return `CUA task ${record.taskId} ${record.category}: ${String(record.evidence.length)} private evidence reference(s)`;
+  }
+  const task = record.activeTask;
+  return `CUA ${operation.replace(".", " ")}: ${task?.taskId ?? "unknown"} ${task?.status ?? "unknown"}`;
+}
+
+export function renderCuaTaskResult(
+  operation: CuaTaskOperation,
+  lifecycleResult: CuaTaskLifecycleResult,
+  jsonEnabled: boolean,
+): RenderedCuaTaskResult {
+  if (jsonEnabled) {
+    return { exitCode: lifecycleResult.exitCode, output: lifecycleResult.record };
+  }
+  if (lifecycleResult.record.kind === "failure") {
+    return {
+      exitCode: lifecycleResult.exitCode,
+      error: `CUA ${operation.replace(".", " ")} failed: ${lifecycleResult.record.family}`,
+    };
+  }
+  return {
+    exitCode: lifecycleResult.exitCode,
+    message: successMessage(operation, lifecycleResult.record),
+  };
+}

--- a/src/lib/cua/task-lifecycle.test.ts
+++ b/src/lib/cua/task-lifecycle.test.ts
@@ -350,6 +350,26 @@ describe("CUA task lifecycle (#7752)", () => {
     expect(JSON.stringify(registry)).not.toContain("private response");
   });
 
+  it("rejects a pause response that leaves the task running", () => {
+    const current = activeAttachment();
+    const { registry, deps } = harness(current);
+    const adapter = fakeAdapter(() => activeAttachment("task-1", "running"));
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.pause",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({ kind: "failure", family: "validation_failed" });
+    expect(registry.sandboxes.alpha?.cuaTarget).toEqual(current);
+    expect(deps.save).not.toHaveBeenCalled();
+  });
+
   it.each<[CuaTaskOperation, CuaTaskEvidenceIndex["category"]]>([
     ["task.events", "events"],
     ["task.logs", "logs"],

--- a/src/lib/cua/task-lifecycle.test.ts
+++ b/src/lib/cua/task-lifecycle.test.ts
@@ -1,0 +1,622 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  CuaTaskAdapter,
+  CuaTaskAdapterRequest,
+  CuaTaskAdapterResult,
+  CuaTaskMode,
+  CuaTaskOperation,
+} from "../adapters/cua-task";
+import type { SandboxRegistry } from "../state/registry/types";
+import {
+  CUA_FAILURE_FAMILIES,
+  CUA_LIFECYCLE_SCHEMA_VERSION,
+  CUA_TASK_OPERATIONS,
+  type CuaComponentIdentity,
+  type CuaFailureFamily,
+  type CuaRuntimeReadiness,
+  type CuaTargetAttachment,
+  type CuaTaskEvidenceIndex,
+  type CuaTaskResult,
+} from "./contract";
+import { type CuaTaskLifecycleDeps, executeCuaTaskLifecycle } from "./task-lifecycle";
+
+const digests = {
+  runtime: `sha256:${"1".repeat(64)}`,
+  sandbox: `sha256:${"2".repeat(64)}`,
+  policy: `sha256:${"3".repeat(64)}`,
+  protocol: `sha256:${"4".repeat(64)}`,
+  target: `sha256:${"5".repeat(64)}`,
+  image: `sha256:${"6".repeat(64)}`,
+  services: `sha256:${"7".repeat(64)}`,
+  result: `sha256:${"8".repeat(64)}`,
+  browser: `sha256:${"9".repeat(64)}`,
+  computer: `sha256:${"a".repeat(64)}`,
+  terminal: `sha256:${"b".repeat(64)}`,
+} as const;
+
+function component(name: string, digest: string): CuaComponentIdentity {
+  return { name, version: "1.0.0", digest, owner: "fixture-owner" };
+}
+
+function readiness(taskOperations = [...CUA_TASK_OPERATIONS]): CuaRuntimeReadiness {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "runtime-readiness",
+    mode: "standalone",
+    status: "available",
+    components: {
+      runtime: component("fixture-runtime", digests.runtime),
+      sandboxImage: component("fixture-sandbox", digests.sandbox),
+      policy: component("fixture-policy", digests.policy),
+      taskProtocol: component("fixture-protocol", digests.protocol),
+    },
+    inference: { provider: "fixture-provider", model: "fixture-model" },
+    commands: { interactive: true, headless: true, version: true, smoke: true },
+    limits: { targetsPerWorker: 1, activeTasksPerTarget: 1 },
+    requiredCapabilities: ["browser", "computer", "terminal"],
+    targetOperations: [
+      "target.attach",
+      "target.status",
+      "target.health",
+      "target.detach",
+      "target.reset",
+      "target.destroy",
+    ],
+    taskOperations,
+  };
+}
+
+function attachment(activeTask: CuaTargetAttachment["activeTask"] = null): CuaTargetAttachment {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "target-attachment",
+    status: "attached",
+    target: {
+      identityDigest: digests.target,
+      platform: "fixture-linux-amd64",
+      image: component("fixture-target", digests.image),
+      serviceBundle: component("fixture-services", digests.services),
+      capabilities: [
+        { id: "browser", protocolVersion: "1.0.0", health: "healthy" },
+        { id: "computer", protocolVersion: "1.0.0", health: "healthy" },
+        { id: "terminal", protocolVersion: "1.0.0", health: "healthy" },
+      ],
+    },
+    activeTask,
+  };
+}
+
+function activeAttachment(
+  taskId = "task-1",
+  status: NonNullable<CuaTargetAttachment["activeTask"]>["status"] = "running",
+): CuaTargetAttachment {
+  return attachment({ taskId, status });
+}
+
+function taskResult(
+  taskId = "task-1",
+  status: CuaTaskResult["status"] = "succeeded",
+): CuaTaskResult {
+  const runtime = readiness();
+  const target = attachment().target!;
+  const agentStatus = status === "cancelled" ? "cancelled" : status;
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "task-result",
+    taskId,
+    status,
+    targetIdentityDigest: target.identityDigest,
+    components: {
+      runtime: runtime.components.runtime,
+      sandboxImage: runtime.components.sandboxImage,
+      targetImage: target.image,
+      serviceBundle: target.serviceBundle,
+      policy: runtime.components.policy,
+      taskProtocol: runtime.components.taskProtocol,
+    },
+    inference: runtime.inference,
+    capabilities: [
+      { id: "browser", protocolVersion: "1.0.0" },
+      { id: "computer", protocolVersion: "1.0.0" },
+      { id: "terminal", protocolVersion: "1.0.0" },
+    ],
+    agentResult: { status: agentStatus, resultDigest: digests.result },
+    verification: {
+      status: status === "succeeded" ? "passed" : "not-run",
+      checkIds: status === "succeeded" ? ["fixture-check"] : [],
+      evidenceDigests: status === "succeeded" ? [digests.browser] : [],
+    },
+    receipts:
+      status === "succeeded"
+        ? [
+            { capability: "browser", status: "completed", evidenceDigests: [digests.browser] },
+            { capability: "computer", status: "completed", evidenceDigests: [digests.computer] },
+            { capability: "terminal", status: "completed", evidenceDigests: [digests.terminal] },
+          ]
+        : [],
+    evidence: [
+      { digest: digests.result, classification: "private", mediaType: "application/json" },
+      ...(status === "succeeded"
+        ? [
+            { digest: digests.browser, classification: "private" as const, mediaType: "image/png" },
+            {
+              digest: digests.computer,
+              classification: "private" as const,
+              mediaType: "application/json",
+            },
+            {
+              digest: digests.terminal,
+              classification: "private" as const,
+              mediaType: "text/plain",
+            },
+          ]
+        : []),
+    ],
+  };
+}
+
+function evidence(
+  category: CuaTaskEvidenceIndex["category"],
+  taskId = "task-1",
+): CuaTaskEvidenceIndex {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "task-evidence-index",
+    taskId,
+    category,
+    targetIdentityDigest: digests.target,
+    evidence: [
+      {
+        digest: digests.browser,
+        classification: "private",
+        mediaType: "application/json",
+        sizeBytes: 42,
+      },
+    ],
+  };
+}
+
+function harness(
+  target = attachment(),
+  runtime = readiness(),
+  cuaTaskResults: CuaTaskResult[] = [],
+): {
+  registry: SandboxRegistry;
+  deps: CuaTaskLifecycleDeps;
+} {
+  const registry: SandboxRegistry = {
+    sandboxes: {
+      alpha: {
+        name: "alpha",
+        cuaRuntimeReadiness: structuredClone(runtime),
+        cuaTarget: structuredClone(target),
+        cuaTaskResults: structuredClone(cuaTaskResults),
+      },
+    },
+    defaultSandbox: "alpha",
+  };
+  return {
+    registry,
+    deps: {
+      load: () => registry,
+      save: vi.fn(),
+      withLock: (fn) => fn(),
+    },
+  };
+}
+
+function fakeAdapter(
+  implementation: (request: CuaTaskAdapterRequest) => CuaTaskAdapterResult,
+): CuaTaskAdapter & { execute: ReturnType<typeof vi.fn> } {
+  return { execute: vi.fn(implementation) };
+}
+
+describe("CUA task lifecycle (#7752)", () => {
+  it.each<CuaTaskMode>([
+    "interactive",
+    "headless",
+  ])("starts %s through the same adapter contract and stores only bounded active state", (mode) => {
+    const { registry, deps } = harness();
+    const adapter = fakeAdapter((request) => activeAttachment(request.taskId));
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.start",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        mode,
+        input: "private task input",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.exitCode).toBe(0);
+    expect(adapter.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: "task.start",
+        taskId: "task-1",
+        mode,
+        input: "private task input",
+      }),
+    );
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask).toEqual({
+      taskId: "task-1",
+      status: "running",
+    });
+    expect(JSON.stringify(registry)).not.toContain("private task input");
+  });
+
+  it("rejects a second task without invoking the adapter", () => {
+    const { registry, deps } = harness(activeAttachment("task-existing"));
+    const adapter = fakeAdapter(() => activeAttachment("task-2"));
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.start",
+        sandboxName: "alpha",
+        taskId: "task-2",
+        mode: "headless",
+        input: "second task",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({ kind: "failure", family: "task_conflict" });
+    expect(adapter.execute).not.toHaveBeenCalled();
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask?.taskId).toBe("task-existing");
+  });
+
+  it("rejects reuse of a retained completed task ID", () => {
+    const { deps } = harness(attachment(), readiness(), [taskResult()]);
+    const adapter = fakeAdapter(() => activeAttachment());
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.start",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        mode: "headless",
+        input: "reused task",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({ kind: "failure", family: "validation_failed" });
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "task.pause",
+    "task.guide",
+    "task.respond",
+  ] as const)("reports unsupported optional operation %s explicitly", (operation) => {
+    const requiredOnly = readiness([
+      "task.start",
+      "task.status",
+      "task.result",
+      "task.events",
+      "task.logs",
+      "task.plans",
+      "task.cancel",
+    ]);
+    const { deps } = harness(activeAttachment(), requiredOnly);
+    const adapter = fakeAdapter(() => activeAttachment());
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation,
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+        ...(operation === "task.guide" || operation === "task.respond"
+          ? { input: "private response" }
+          : {}),
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({
+      kind: "failure",
+      family: "lifecycle_unavailable",
+    });
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it("preserves recoverable input-required state after a runtime response", () => {
+    const { registry, deps } = harness(activeAttachment("task-1", "input-required"));
+    const adapter = fakeAdapter(() => activeAttachment("task-1", "running"));
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.respond",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        input: "private response",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({
+      kind: "target-attachment",
+      activeTask: { taskId: "task-1", status: "running" },
+    });
+    expect(JSON.stringify(registry)).not.toContain("private response");
+  });
+
+  it.each<[CuaTaskOperation, CuaTaskEvidenceIndex["category"]]>([
+    ["task.events", "events"],
+    ["task.logs", "logs"],
+    ["task.plans", "plans"],
+  ])("returns a bounded private evidence index for %s", (operation, category) => {
+    const { deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => evidence(category));
+
+    const outcome = executeCuaTaskLifecycle(
+      { operation, sandboxName: "alpha", taskId: "task-1", adapter },
+      deps,
+    );
+
+    expect(outcome.record).toEqual(evidence(category));
+    expect(JSON.stringify(outcome.record)).not.toMatch(/path|url|content/i);
+  });
+
+  it("persists an identity-bound terminal result and serves it after reconnect", () => {
+    const { registry, deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => taskResult());
+
+    const completed = executeCuaTaskLifecycle(
+      {
+        operation: "task.result",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+    const reconnectAdapter = fakeAdapter(() => taskResult());
+    const reconnected = executeCuaTaskLifecycle(
+      {
+        operation: "task.result",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter: reconnectAdapter,
+      },
+      deps,
+    );
+
+    expect(completed.record).toEqual(taskResult());
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask).toBeNull();
+    expect(registry.sandboxes.alpha?.cuaTaskResults).toEqual([taskResult()]);
+    expect(reconnected.record).toEqual(taskResult());
+    expect(reconnectAdapter.execute).not.toHaveBeenCalled();
+  });
+
+  it("requires cancellation to return a terminal result and clears active state", () => {
+    const cancelled = taskResult("task-1", "cancelled");
+    const { registry, deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => cancelled);
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.cancel",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toEqual(cancelled);
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask).toBeNull();
+    expect(registry.sandboxes.alpha?.cuaTaskResults).toEqual([cancelled]);
+  });
+
+  it("rejects a cancellation response that is not cancelled", () => {
+    const { registry, deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => taskResult("task-1", "succeeded"));
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.cancel",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({ kind: "failure", family: "validation_failed" });
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask?.taskId).toBe("task-1");
+    expect(registry.sandboxes.alpha?.cuaTaskResults).toEqual([]);
+  });
+
+  it("rejects a failure record for another operation without changing task state", () => {
+    const { registry, deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => ({
+      schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+      kind: "failure",
+      operation: "task.cancel",
+      family: "task_cancelled",
+      retryable: false,
+      component: "runtime",
+    }));
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.status",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({ kind: "failure", family: "validation_failed" });
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask?.taskId).toBe("task-1");
+  });
+
+  it("clears active state when the runtime classifies a terminal timeout", () => {
+    const { registry, deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => ({
+      schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+      kind: "failure",
+      operation: "task.status",
+      family: "task_timeout",
+      retryable: false,
+      component: "runtime",
+    }));
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.status",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({ kind: "failure", family: "task_timeout" });
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask).toBeNull();
+  });
+
+  it.each<[CuaFailureFamily, CuaTargetAttachment["status"]]>([
+    ["target_unreachable", "unreachable"],
+    ["target_replaced", "replaced"],
+    ["target_incompatible", "incompatible"],
+    ["capability_unhealthy", "unreachable"],
+  ])("fails closed on %s and records target state %s", (family, status) => {
+    const { registry, deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => ({
+      schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+      kind: "failure",
+      operation: "task.status",
+      family,
+      retryable: false,
+      component: "target",
+    }));
+
+    executeCuaTaskLifecycle(
+      {
+        operation: "task.status",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(registry.sandboxes.alpha?.cuaTarget?.status).toBe(status);
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask).toBeNull();
+  });
+
+  it("rejects a result whose exact runtime identity drifts", () => {
+    const drifted = taskResult();
+    drifted.components.runtime = component("fixture-runtime", `sha256:${"c".repeat(64)}`);
+    const { registry, deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => drifted);
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.result",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toMatchObject({
+      kind: "failure",
+      family: "runtime_incompatible",
+    });
+    expect(registry.sandboxes.alpha?.cuaTarget?.activeTask?.taskId).toBe("task-1");
+    expect(registry.sandboxes.alpha?.cuaTaskResults).toEqual([]);
+  });
+
+  it.each<CuaFailureFamily>(
+    CUA_FAILURE_FAMILIES,
+  )("preserves classified adapter failure family %s without raw diagnostics", (family) => {
+    const { deps } = harness(activeAttachment());
+    const adapter = fakeAdapter(() => ({
+      schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+      kind: "failure",
+      operation: "task.status",
+      family,
+      retryable: false,
+      component: "runtime",
+    }));
+
+    const outcome = executeCuaTaskLifecycle(
+      {
+        operation: "task.status",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        adapter,
+      },
+      deps,
+    );
+
+    expect(outcome.record).toEqual({
+      schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+      kind: "failure",
+      operation: "task.status",
+      family,
+      retryable: false,
+      component: "runtime",
+    });
+  });
+
+  it("rejects malformed identifiers and missing private input before adapter invocation", () => {
+    const { deps } = harness();
+    const adapter = fakeAdapter(() => activeAttachment());
+
+    const malformed = executeCuaTaskLifecycle(
+      {
+        operation: "task.start",
+        sandboxName: "alpha",
+        taskId: "../private",
+        mode: "headless",
+        input: "task",
+        adapter,
+      },
+      deps,
+    );
+    const missingInput = executeCuaTaskLifecycle(
+      {
+        operation: "task.start",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        mode: "headless",
+        adapter,
+      },
+      deps,
+    );
+    const oversizedInput = executeCuaTaskLifecycle(
+      {
+        operation: "task.start",
+        sandboxName: "alpha",
+        taskId: "task-1",
+        mode: "headless",
+        input: "x".repeat(64 * 1024 + 1),
+        adapter,
+      },
+      deps,
+    );
+
+    expect(malformed.record).toMatchObject({ kind: "failure", family: "validation_failed" });
+    expect(missingInput.record).toMatchObject({ kind: "failure", family: "validation_failed" });
+    expect(oversizedInput.record).toMatchObject({
+      kind: "failure",
+      family: "validation_failed",
+    });
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/cua/task-lifecycle.ts
+++ b/src/lib/cua/task-lifecycle.ts
@@ -1,0 +1,367 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isDeepStrictEqual } from "node:util";
+import {
+  type CuaTaskAdapter,
+  CuaTaskAdapterInvocationError,
+  type CuaTaskAdapterResult,
+  type CuaTaskMode,
+  type CuaTaskOperation,
+} from "../adapters/cua-task";
+import { withLock } from "../state/registry/lock";
+import { load, save } from "../state/registry/persistence";
+import type { SandboxRegistry } from "../state/registry/types";
+import {
+  CUA_LIFECYCLE_SCHEMA_VERSION,
+  type CuaCapability,
+  type CuaFailure,
+  type CuaFailureFamily,
+  type CuaRuntimeReadiness,
+  type CuaTargetAttachment,
+  type CuaTaskEvidenceIndex,
+  type CuaTaskResult,
+} from "./contract";
+
+export interface CuaTaskLifecycleInput {
+  operation: CuaTaskOperation;
+  sandboxName: string;
+  taskId: string;
+  adapter?: CuaTaskAdapter;
+  mode?: CuaTaskMode;
+  input?: string;
+}
+
+export interface CuaTaskLifecycleResult {
+  record: CuaTargetAttachment | CuaTaskEvidenceIndex | CuaTaskResult | CuaFailure;
+  exitCode: number;
+}
+
+export interface CuaTaskLifecycleDeps {
+  load: () => SandboxRegistry;
+  save: (registry: SandboxRegistry) => void;
+  withLock: <T>(fn: () => T) => T;
+}
+
+const defaultDeps: CuaTaskLifecycleDeps = { load, save, withLock };
+const MAX_TASK_INPUT_BYTES = 64 * 1024;
+const MAX_COMPLETED_RESULTS = 16;
+const TASK_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export const CUA_TASK_EXIT_CODES = {
+  success: 0,
+  validation: 2,
+  conflict: 3,
+  unavailable: 4,
+  execution: 5,
+} as const;
+
+function failure(
+  operation: CuaTaskOperation,
+  family: CuaFailureFamily,
+  retryable: boolean,
+  component?: CuaCapability | "runtime" | "inference" | "policy" | "target",
+): CuaFailure {
+  return {
+    schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+    kind: "failure",
+    operation,
+    family,
+    retryable,
+    ...(component ? { component } : {}),
+  };
+}
+
+function exitCodeFor(family: CuaFailureFamily): number {
+  if (family === "validation_failed") return CUA_TASK_EXIT_CODES.validation;
+  if (family === "task_conflict") return CUA_TASK_EXIT_CODES.conflict;
+  if (family === "lifecycle_unavailable" || family === "runtime_unavailable") {
+    return CUA_TASK_EXIT_CODES.unavailable;
+  }
+  return CUA_TASK_EXIT_CODES.execution;
+}
+
+function result(
+  record: CuaTargetAttachment | CuaTaskEvidenceIndex | CuaTaskResult | CuaFailure,
+): CuaTaskLifecycleResult {
+  return {
+    record,
+    exitCode: record.kind === "failure" ? exitCodeFor(record.family) : CUA_TASK_EXIT_CODES.success,
+  };
+}
+
+function failed(
+  operation: CuaTaskOperation,
+  family: CuaFailureFamily,
+  retryable: boolean,
+  component?: CuaCapability | "runtime" | "inference" | "policy" | "target",
+): CuaTaskLifecycleResult {
+  return result(failure(operation, family, retryable, component));
+}
+
+function validPrivateInput(input: CuaTaskLifecycleInput): boolean {
+  const requiresInput =
+    input.operation === "task.start" ||
+    input.operation === "task.guide" ||
+    input.operation === "task.respond";
+  if (requiresInput !== (input.input !== undefined)) return false;
+  if (input.input === undefined) return true;
+  return input.input.length > 0 && Buffer.byteLength(input.input, "utf8") <= MAX_TASK_INPUT_BYTES;
+}
+
+function matchingStoredResult(
+  registry: SandboxRegistry,
+  sandboxName: string,
+  taskId: string,
+): CuaTaskResult | undefined {
+  return [...(registry.sandboxes[sandboxName]?.cuaTaskResults ?? [])]
+    .reverse()
+    .find((entry) => entry.taskId === taskId);
+}
+
+function capabilityIdentities(
+  target: NonNullable<CuaTargetAttachment["target"]>,
+): Array<{ id: CuaCapability; protocolVersion: string }> {
+  return target.capabilities
+    .map(({ id, protocolVersion }) => ({ id, protocolVersion }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function taskResultMatches(
+  taskResult: CuaTaskResult,
+  taskId: string,
+  runtime: CuaRuntimeReadiness,
+  target: NonNullable<CuaTargetAttachment["target"]>,
+): boolean {
+  return (
+    taskResult.taskId === taskId &&
+    taskResult.targetIdentityDigest === target.identityDigest &&
+    isDeepStrictEqual(taskResult.components.runtime, runtime.components.runtime) &&
+    isDeepStrictEqual(taskResult.components.sandboxImage, runtime.components.sandboxImage) &&
+    isDeepStrictEqual(taskResult.components.policy, runtime.components.policy) &&
+    isDeepStrictEqual(taskResult.components.taskProtocol, runtime.components.taskProtocol) &&
+    isDeepStrictEqual(taskResult.components.targetImage, target.image) &&
+    isDeepStrictEqual(taskResult.components.serviceBundle, target.serviceBundle) &&
+    isDeepStrictEqual(taskResult.inference, runtime.inference) &&
+    isDeepStrictEqual(
+      [...taskResult.capabilities].sort((left, right) => left.id.localeCompare(right.id)),
+      capabilityIdentities(target),
+    )
+  );
+}
+
+function activeAttachmentMatches(
+  observed: CuaTargetAttachment,
+  current: CuaTargetAttachment,
+  taskId: string,
+): boolean {
+  return (
+    observed.status === "attached" &&
+    observed.target !== null &&
+    current.target !== null &&
+    observed.activeTask?.taskId === taskId &&
+    isDeepStrictEqual(observed.target, current.target)
+  );
+}
+
+function expectedEvidenceCategory(
+  operation: CuaTaskOperation,
+): CuaTaskEvidenceIndex["category"] | null {
+  if (operation === "task.events") return "events";
+  if (operation === "task.logs") return "logs";
+  if (operation === "task.plans") return "plans";
+  return null;
+}
+
+function invokeAdapter(
+  input: CuaTaskLifecycleInput,
+  runtime: CuaRuntimeReadiness,
+  target: CuaTargetAttachment,
+): CuaTaskAdapterResult {
+  if (!input.adapter) return failure(input.operation, "lifecycle_unavailable", false, "runtime");
+  try {
+    return input.adapter.execute({
+      schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+      kind: "task-adapter-request",
+      operation: input.operation,
+      sandboxName: input.sandboxName,
+      taskId: input.taskId,
+      mode: input.mode ?? null,
+      input: input.input ?? null,
+      runtime,
+      target,
+    });
+  } catch (error) {
+    if (error instanceof CuaTaskAdapterInvocationError) {
+      return failure(input.operation, error.family, error.retryable, "runtime");
+    }
+    return failure(input.operation, "runtime_unavailable", false, "runtime");
+  }
+}
+
+function operationAccepts(
+  operation: CuaTaskOperation,
+  adapterResult: Exclude<CuaTaskAdapterResult, CuaFailure>,
+): boolean {
+  if (operation === "task.events" || operation === "task.logs" || operation === "task.plans") {
+    return adapterResult.kind === "task-evidence-index";
+  }
+  if (operation === "task.result" || operation === "task.cancel") {
+    return adapterResult.kind === "task-result";
+  }
+  if (operation === "task.status") {
+    return adapterResult.kind === "target-attachment" || adapterResult.kind === "task-result";
+  }
+  return adapterResult.kind === "target-attachment";
+}
+
+function persistFailureState(
+  registry: SandboxRegistry,
+  sandboxName: string,
+  taskId: string,
+  failureRecord: CuaFailure,
+): boolean {
+  const target = registry.sandboxes[sandboxName]?.cuaTarget;
+  if (!target || target.activeTask?.taskId !== taskId) return false;
+  if (failureRecord.family === "task_timeout" || failureRecord.family === "task_cancelled") {
+    target.activeTask = null;
+    return true;
+  }
+  const targetStatus =
+    failureRecord.family === "target_replaced"
+      ? "replaced"
+      : failureRecord.family === "target_incompatible"
+        ? "incompatible"
+        : failureRecord.family === "target_unreachable" ||
+            failureRecord.family === "capability_unhealthy"
+          ? "unreachable"
+          : null;
+  if (!targetStatus) return false;
+  target.status = targetStatus;
+  target.activeTask = null;
+  return true;
+}
+
+function persistResult(
+  registry: SandboxRegistry,
+  sandboxName: string,
+  taskResult: CuaTaskResult,
+): void {
+  const sandbox = registry.sandboxes[sandboxName];
+  if (!sandbox?.cuaTarget) return;
+  sandbox.cuaTarget.activeTask = null;
+  const withoutCurrent = (sandbox.cuaTaskResults ?? []).filter(
+    (entry) => entry.taskId !== taskResult.taskId,
+  );
+  sandbox.cuaTaskResults = [...withoutCurrent, taskResult].slice(-MAX_COMPLETED_RESULTS);
+}
+
+function executeLocked(
+  input: CuaTaskLifecycleInput,
+  deps: CuaTaskLifecycleDeps,
+): CuaTaskLifecycleResult {
+  if (!TASK_ID_PATTERN.test(input.taskId) || !validPrivateInput(input)) {
+    return failed(input.operation, "validation_failed", false);
+  }
+  if (input.operation === "task.start" ? input.mode === undefined : input.mode !== undefined) {
+    return failed(input.operation, "validation_failed", false);
+  }
+
+  const registry = deps.load();
+  const sandbox = registry.sandboxes[input.sandboxName];
+  if (!sandbox) return failed(input.operation, "validation_failed", false);
+
+  const runtime = sandbox.cuaRuntimeReadiness;
+  if (!runtime) return failed(input.operation, "lifecycle_unavailable", false, "runtime");
+  if (runtime.status === "incompatible") {
+    return failed(input.operation, "runtime_incompatible", false, "runtime");
+  }
+  if (runtime.status !== "available") {
+    return failed(input.operation, "runtime_unavailable", true, "runtime");
+  }
+  if (!runtime.taskOperations.includes(input.operation)) {
+    return failed(input.operation, "lifecycle_unavailable", false, "runtime");
+  }
+
+  const target = sandbox.cuaTarget;
+  if (!target?.target || target.status !== "attached") {
+    return failed(input.operation, "target_unreachable", true, "target");
+  }
+
+  const stored = matchingStoredResult(registry, input.sandboxName, input.taskId);
+  if (input.operation === "task.start" && stored) {
+    return failed(input.operation, "validation_failed", false);
+  }
+  if ((input.operation === "task.result" || input.operation === "task.status") && stored) {
+    return result(stored);
+  }
+
+  const active = target.activeTask;
+  if (input.operation === "task.start") {
+    if (active) return failed(input.operation, "task_conflict", false, "target");
+  } else {
+    const evidenceForCompleted =
+      stored &&
+      (input.operation === "task.events" ||
+        input.operation === "task.logs" ||
+        input.operation === "task.plans");
+    if (!evidenceForCompleted && active?.taskId !== input.taskId) {
+      return failed(input.operation, "validation_failed", false, "target");
+    }
+    if (input.operation === "task.respond" && active?.status !== "input-required") {
+      return failed(input.operation, "validation_failed", false, "target");
+    }
+  }
+
+  const adapterResult = invokeAdapter(input, runtime, target);
+  if (adapterResult.kind === "failure") {
+    if (adapterResult.operation !== input.operation) {
+      return failed(input.operation, "validation_failed", false, "runtime");
+    }
+    if (persistFailureState(registry, input.sandboxName, input.taskId, adapterResult)) {
+      deps.save(registry);
+    }
+    return result(adapterResult);
+  }
+  if (!operationAccepts(input.operation, adapterResult)) {
+    return failed(input.operation, "validation_failed", false, "runtime");
+  }
+
+  if (adapterResult.kind === "target-attachment") {
+    if (!activeAttachmentMatches(adapterResult, target, input.taskId)) {
+      return failed(input.operation, "validation_failed", false, "target");
+    }
+    sandbox.cuaTarget = structuredClone(adapterResult);
+    deps.save(registry);
+    return result(sandbox.cuaTarget);
+  }
+
+  if (adapterResult.kind === "task-evidence-index") {
+    const category = expectedEvidenceCategory(input.operation);
+    if (
+      adapterResult.taskId !== input.taskId ||
+      adapterResult.targetIdentityDigest !== target.target.identityDigest ||
+      adapterResult.category !== category
+    ) {
+      return failed(input.operation, "validation_failed", false, "target");
+    }
+    return result(adapterResult);
+  }
+
+  if (!taskResultMatches(adapterResult, input.taskId, runtime, target.target)) {
+    return failed(input.operation, "runtime_incompatible", false, "runtime");
+  }
+  if (input.operation === "task.cancel" && adapterResult.status !== "cancelled") {
+    return failed(input.operation, "validation_failed", false, "runtime");
+  }
+  persistResult(registry, input.sandboxName, adapterResult);
+  deps.save(registry);
+  return result(adapterResult);
+}
+
+export function executeCuaTaskLifecycle(
+  input: CuaTaskLifecycleInput,
+  deps: CuaTaskLifecycleDeps = defaultDeps,
+): CuaTaskLifecycleResult {
+  return deps.withLock(() => executeLocked(input, deps));
+}

--- a/src/lib/cua/task-lifecycle.ts
+++ b/src/lib/cua/task-lifecycle.ts
@@ -212,6 +212,11 @@ function operationAccepts(
   if (operation === "task.status") {
     return adapterResult.kind === "target-attachment" || adapterResult.kind === "task-result";
   }
+  if (operation === "task.pause") {
+    return (
+      adapterResult.kind === "target-attachment" && adapterResult.activeTask?.status === "paused"
+    );
+  }
   return adapterResult.kind === "target-attachment";
 }
 

--- a/src/lib/state/registry-cua.test.ts
+++ b/src/lib/state/registry-cua.test.ts
@@ -12,6 +12,7 @@ import {
   CUA_TARGET_OPERATIONS,
   type CuaRuntimeReadiness,
   type CuaTargetAttachment,
+  type CuaTaskResult,
 } from "../cua/contract";
 
 const testHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-registry-cua-"));
@@ -63,6 +64,35 @@ const attachment: CuaTargetAttachment = {
   activeTask: null,
 };
 
+const completedResult: CuaTaskResult = {
+  schemaVersion: CUA_LIFECYCLE_SCHEMA_VERSION,
+  kind: "task-result",
+  taskId: "task-1",
+  status: "succeeded",
+  targetIdentityDigest: digest("5"),
+  components: {
+    runtime: readiness.components.runtime,
+    sandboxImage: readiness.components.sandboxImage,
+    targetImage: attachment.target!.image,
+    serviceBundle: attachment.target!.serviceBundle,
+    policy: readiness.components.policy,
+    taskProtocol: readiness.components.taskProtocol,
+  },
+  inference: readiness.inference,
+  capabilities: CUA_CAPABILITIES.map((id) => ({ id, protocolVersion: "1.0.0" })),
+  agentResult: { status: "succeeded", resultDigest: digest("8") },
+  verification: {
+    status: "passed",
+    checkIds: ["fixture-check"],
+    evidenceDigests: [digest("9")],
+  },
+  receipts: [{ capability: "browser", status: "completed", evidenceDigests: [digest("9")] }],
+  evidence: [
+    { digest: digest("8"), classification: "private", mediaType: "application/json" },
+    { digest: digest("9"), classification: "private", mediaType: "image/png" },
+  ],
+};
+
 beforeEach(() => {
   registry.clearAll();
 });
@@ -100,5 +130,30 @@ describe("CUA canonical registry state (#7751)", () => {
     fs.writeFileSync(registry.REGISTRY_FILE, JSON.stringify(disk));
 
     expect(() => registry.load()).toThrow("CUA lifecycle record does not match its schema");
+    fs.rmSync(registry.REGISTRY_FILE);
+  });
+});
+
+describe("CUA completed-task registry state (#7752)", () => {
+  it("round-trips bounded secret-free task results for reconnect", () => {
+    const completedResults = Array.from({ length: 17 }, (_, index) => ({
+      ...completedResult,
+      taskId: `task-${String(index + 1)}`,
+    }));
+    registry.registerSandbox({
+      name: "alpha",
+      cuaRuntimeReadiness: readiness,
+      cuaTarget: attachment,
+      cuaTaskResults: completedResults,
+    });
+
+    expect(registry.getSandbox("alpha")?.cuaTaskResults).toHaveLength(16);
+    expect(registry.getSandbox("alpha")?.cuaTaskResults?.[0].taskId).toBe("task-2");
+    const disk = JSON.parse(fs.readFileSync(registry.REGISTRY_FILE, "utf8"));
+    expect(disk.sandboxes.alpha.cuaTaskResults).toHaveLength(16);
+    expect(disk.sandboxes.alpha.cuaTaskResults[15].taskId).toBe("task-17");
+    expect(JSON.stringify(disk.sandboxes.alpha.cuaTaskResults)).not.toMatch(
+      /credential|password|secret|token|endpoint|hostName|ssh|vnc|path|url/i,
+    );
   });
 });

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -153,6 +153,7 @@ export function registerSandbox(entry: SandboxEntry): void {
         ? structuredClone(entry.cuaRuntimeReadiness)
         : undefined,
       cuaTarget: entry.cuaTarget ? structuredClone(entry.cuaTarget) : undefined,
+      cuaTaskResults: entry.cuaTaskResults ? structuredClone(entry.cuaTaskResults) : undefined,
       openclawImagePluginInstalls: Array.isArray(entry.openclawImagePluginInstalls)
         ? entry.openclawImagePluginInstalls.map((install) => ({
             ...install,

--- a/src/lib/state/registry/persistence.ts
+++ b/src/lib/state/registry/persistence.ts
@@ -4,7 +4,11 @@
 import path from "node:path";
 import { isObjectRecord } from "../../core/json-types";
 import { GATEWAY_PORT } from "../../core/ports";
-import { parseCuaRuntimeReadiness, parseCuaTargetAttachment } from "../../cua/schema";
+import {
+  parseCuaRuntimeReadiness,
+  parseCuaTargetAttachment,
+  parseCuaTaskResult,
+} from "../../cua/schema";
 import { readConfigFile, writeConfigFile } from "../config-io";
 import { normalizeExtraProviders } from "../extra-providers";
 import { normalizeSandboxMcpState, serializeSandboxMcpStateForDisk } from "../registry-mcp";
@@ -95,6 +99,10 @@ function normalizeSandboxEntryForRuntime(entry: SandboxEntry): SandboxEntry {
       : parseCuaRuntimeReadiness(entry.cuaRuntimeReadiness);
   const cuaTarget =
     entry.cuaTarget === undefined ? undefined : parseCuaTargetAttachment(entry.cuaTarget);
+  const cuaTaskResults =
+    entry.cuaTaskResults === undefined
+      ? undefined
+      : entry.cuaTaskResults.slice(-16).map(parseCuaTaskResult);
   const {
     messaging: _messaging,
     mcp: _mcp,
@@ -102,6 +110,7 @@ function normalizeSandboxEntryForRuntime(entry: SandboxEntry): SandboxEntry {
     baselineExclusionTransition: _baselineExclusionTransition,
     cuaRuntimeReadiness: _cuaRuntimeReadiness,
     cuaTarget: _cuaTarget,
+    cuaTaskResults: _cuaTaskResults,
     ...rest
   } = entry;
   return {
@@ -112,6 +121,7 @@ function normalizeSandboxEntryForRuntime(entry: SandboxEntry): SandboxEntry {
     ...(baselineExclusionTransition ? { baselineExclusionTransition } : {}),
     ...(cuaRuntimeReadiness ? { cuaRuntimeReadiness } : {}),
     ...(cuaTarget ? { cuaTarget } : {}),
+    ...(cuaTaskResults ? { cuaTaskResults } : {}),
   };
 }
 
@@ -147,6 +157,10 @@ function serializeSandboxEntryForDisk(entry: SandboxEntry): SandboxEntry {
       : parseCuaRuntimeReadiness(durable.cuaRuntimeReadiness);
   const cuaTarget =
     durable.cuaTarget === undefined ? undefined : parseCuaTargetAttachment(durable.cuaTarget);
+  const cuaTaskResults =
+    durable.cuaTaskResults === undefined
+      ? undefined
+      : durable.cuaTaskResults.slice(-16).map(parseCuaTaskResult);
   const {
     messaging: _messaging,
     mcp: _mcp,
@@ -154,6 +168,7 @@ function serializeSandboxEntryForDisk(entry: SandboxEntry): SandboxEntry {
     baselineExclusionTransition: _baselineExclusionTransition,
     cuaRuntimeReadiness: _cuaRuntimeReadiness,
     cuaTarget: _cuaTarget,
+    cuaTaskResults: _cuaTaskResults,
     ...rest
   } = durable;
   return {
@@ -165,5 +180,6 @@ function serializeSandboxEntryForDisk(entry: SandboxEntry): SandboxEntry {
     ...(baselineExclusionTransition ? { baselineExclusionTransition } : {}),
     ...(cuaRuntimeReadiness ? { cuaRuntimeReadiness } : {}),
     ...(cuaTarget ? { cuaTarget } : {}),
+    ...(cuaTaskResults ? { cuaTaskResults } : {}),
   };
 }

--- a/src/lib/state/registry/types.ts
+++ b/src/lib/state/registry/types.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CuaRuntimeReadiness, CuaTargetAttachment } from "../../cua/contract";
+import type { CuaRuntimeReadiness, CuaTargetAttachment, CuaTaskResult } from "../../cua/contract";
 import type { InferenceSelection } from "../../inference/selection";
 import type { WebSearchProvider } from "../../inference/web-search";
 import type { DcodeAutoApprovalMode } from "../../onboard/dcode-auto-approval";
@@ -112,6 +112,8 @@ export interface SandboxEntry extends Partial<InferenceSelection> {
   cuaRuntimeReadiness?: CuaRuntimeReadiness;
   /** Secret-free projection of the one attached disposable desktop target. */
   cuaTarget?: CuaTargetAttachment;
+  /** Bounded completed CUA task results retained for reconnect inspection. */
+  cuaTaskResults?: CuaTaskResult[];
   /** Plugin install baseline captured before state is restored into a fresh OpenClaw image. */
   openclawImagePluginInstalls?: OpenClawImagePluginInstall[];
   // NemoClaw build fingerprint (the NemoClaw CLI/build version) stamped only on

--- a/test/cua-task-cli.test.ts
+++ b/test/cua-task-cli.test.ts
@@ -1,0 +1,355 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const CLI = path.join(ROOT, "bin", "nemoclaw.js");
+const temporaryDirectories: string[] = [];
+const digest = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
+const component = (name: string, value: string) => ({
+  name,
+  version: "1.0.0",
+  digest: digest(value),
+  owner: "fixture",
+});
+
+function fixture(): {
+  home: string;
+  adapterPath: string;
+  inputPath: string;
+  registryPath: string;
+} {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cua-task-cli-"));
+  temporaryDirectories.push(home);
+  const stateDirectory = path.join(home, ".nemoclaw");
+  fs.mkdirSync(stateDirectory, { recursive: true, mode: 0o700 });
+  const registryPath = path.join(stateDirectory, "sandboxes.json");
+  const runtime = {
+    schemaVersion: "1.0.0",
+    kind: "runtime-readiness",
+    mode: "standalone",
+    status: "available",
+    components: {
+      runtime: component("cua-fixture", "1"),
+      sandboxImage: component("sandbox-fixture", "2"),
+      policy: component("policy-fixture", "3"),
+      taskProtocol: component("task-fixture", "4"),
+    },
+    inference: { provider: "fixture", model: "fixture-model" },
+    commands: { interactive: true, headless: true, version: true, smoke: true },
+    limits: { targetsPerWorker: 1, activeTasksPerTarget: 1 },
+    requiredCapabilities: ["browser", "computer", "terminal"],
+    targetOperations: [
+      "target.attach",
+      "target.status",
+      "target.health",
+      "target.detach",
+      "target.reset",
+      "target.destroy",
+    ],
+    taskOperations: [
+      "task.start",
+      "task.status",
+      "task.result",
+      "task.events",
+      "task.logs",
+      "task.plans",
+      "task.pause",
+      "task.cancel",
+      "task.guide",
+      "task.respond",
+    ],
+  };
+  const target = {
+    schemaVersion: "1.0.0",
+    kind: "target-attachment",
+    status: "attached",
+    target: {
+      identityDigest: digest("5"),
+      platform: "fixture-linux-amd64",
+      image: component("desktop-fixture", "6"),
+      serviceBundle: component("service-fixture", "7"),
+      capabilities: [
+        { id: "browser", protocolVersion: "1.0.0", health: "healthy" },
+        { id: "computer", protocolVersion: "1.0.0", health: "healthy" },
+        { id: "terminal", protocolVersion: "1.0.0", health: "healthy" },
+      ],
+    },
+    activeTask: null,
+  };
+  fs.writeFileSync(
+    registryPath,
+    JSON.stringify({
+      defaultSandbox: "alpha",
+      sandboxes: {
+        alpha: {
+          name: "alpha",
+          cuaRuntimeReadiness: runtime,
+          cuaTarget: target,
+          cuaTaskResults: [],
+        },
+      },
+    }),
+    { mode: 0o600 },
+  );
+
+  const inputPath = path.join(home, "task-input.txt");
+  fs.writeFileSync(inputPath, "private synthetic task input", { mode: 0o600 });
+
+  const adapterPath = path.join(home, "task-adapter.mjs");
+  fs.writeFileSync(
+    adapterPath,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const request = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+const statePath = path.join(process.env.HOME, ".cua-task-fixture-state.json");
+const target = request.target.target;
+const active = (status = "running") => ({
+  ...request.target,
+  status: "attached",
+  activeTask: { taskId: request.taskId, status },
+});
+const result = (status = "succeeded") => ({
+  schemaVersion: request.schemaVersion,
+  kind: "task-result",
+  taskId: request.taskId,
+  status,
+  targetIdentityDigest: target.identityDigest,
+  components: {
+    runtime: request.runtime.components.runtime,
+    sandboxImage: request.runtime.components.sandboxImage,
+    targetImage: target.image,
+    serviceBundle: target.serviceBundle,
+    policy: request.runtime.components.policy,
+    taskProtocol: request.runtime.components.taskProtocol,
+  },
+  inference: request.runtime.inference,
+  capabilities: target.capabilities.map(({ id, protocolVersion }) => ({ id, protocolVersion })),
+  agentResult: {
+    status,
+    resultDigest: "${digest("8")}",
+  },
+  verification: {
+    status: status === "succeeded" ? "passed" : "not-run",
+    checkIds: status === "succeeded" ? ["browser-form-json", "terminal-file", "computer-docx"] : [],
+    evidenceDigests: status === "succeeded" ? ["${digest("9")}"] : [],
+  },
+  receipts: status === "succeeded"
+    ? [
+        { capability: "browser", status: "completed", evidenceDigests: ["${digest("9")}"] },
+        { capability: "computer", status: "completed", evidenceDigests: ["${digest("a")}"] },
+        { capability: "terminal", status: "completed", evidenceDigests: ["${digest("b")}"] },
+      ]
+    : [],
+  evidence: [
+    { digest: "${digest("8")}", classification: "private", mediaType: "application/json" },
+    ...(status === "succeeded"
+      ? [
+          { digest: "${digest("9")}", classification: "private", mediaType: "application/json" },
+          { digest: "${digest("a")}", classification: "private", mediaType: "image/png" },
+          { digest: "${digest("b")}", classification: "private", mediaType: "text/plain" },
+        ]
+      : []),
+  ],
+});
+const evidenceCategory = request.operation.slice("task.".length);
+const evidence = () => ({
+  schemaVersion: request.schemaVersion,
+  kind: "task-evidence-index",
+  taskId: request.taskId,
+  category: evidenceCategory,
+  targetIdentityDigest: target.identityDigest,
+  evidence: [{
+    digest: "${digest("9")}",
+    classification: "private",
+    mediaType: "application/json",
+    sizeBytes: 42,
+  }],
+});
+const responses = {
+  "task.start": () => {
+    fs.writeFileSync(statePath, JSON.stringify({
+      taskId: request.taskId,
+      mode: request.mode,
+      inputDigest: "${digest("c")}",
+    }));
+    return active();
+  },
+  "task.status": () => active(),
+  "task.events": evidence,
+  "task.logs": evidence,
+  "task.plans": evidence,
+  "task.pause": () => active("paused"),
+  "task.guide": () => active(),
+  "task.respond": () => active(),
+  "task.result": () => {
+    fs.writeFileSync(statePath, JSON.stringify({ taskId: request.taskId, status: "succeeded" }));
+    return result();
+  },
+  "task.cancel": () => {
+    fs.writeFileSync(statePath, JSON.stringify({ taskId: request.taskId, status: "cancelled" }));
+    return result("cancelled");
+  },
+};
+process.stdout.write(JSON.stringify(responses[request.operation]()));
+`,
+    { mode: 0o700 },
+  );
+  return { home, adapterPath, inputPath, registryPath };
+}
+
+function run(home: string, args: string[]) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home },
+  });
+}
+
+function taskArgs(adapterPath: string, operation: string): string[] {
+  return [
+    "sandbox",
+    "cua",
+    "task",
+    operation,
+    "alpha",
+    "--adapter",
+    adapterPath,
+    "--task-id",
+    "task-1",
+    "--json",
+  ];
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("public CUA task commands (#7752)", () => {
+  it("starts, observes, retrieves evidence, completes, and reconnects through one task ID", () => {
+    const { home, adapterPath, inputPath, registryPath } = fixture();
+    const start = run(home, [
+      ...taskArgs(adapterPath, "start"),
+      "--mode",
+      "headless",
+      "--input-file",
+      inputPath,
+    ]);
+    expect(start.status, start.stderr).toBe(0);
+    expect(JSON.parse(start.stdout)).toMatchObject({
+      kind: "target-attachment",
+      activeTask: { taskId: "task-1", status: "running" },
+    });
+
+    const conflict = run(home, [
+      ...taskArgs(adapterPath, "start"),
+      "--mode",
+      "interactive",
+      "--input-file",
+      inputPath,
+    ]);
+    expect(conflict.status).toBe(3);
+    expect(JSON.parse(conflict.stdout)).toMatchObject({
+      kind: "failure",
+      family: "task_conflict",
+    });
+
+    const status = run(home, taskArgs(adapterPath, "status"));
+    expect(status.status, status.stderr).toBe(0);
+    expect(JSON.parse(status.stdout)).toMatchObject({
+      activeTask: { taskId: "task-1", status: "running" },
+    });
+
+    const events = run(home, taskArgs(adapterPath, "events"));
+    expect(events.status, events.stderr).toBe(0);
+    expect(JSON.parse(events.stdout)).toMatchObject({
+      kind: "task-evidence-index",
+      taskId: "task-1",
+      category: "events",
+      evidence: [{ classification: "private" }],
+    });
+
+    const completed = run(home, taskArgs(adapterPath, "result"));
+    expect(completed.status, completed.stderr).toBe(0);
+    expect(JSON.parse(completed.stdout)).toMatchObject({
+      kind: "task-result",
+      taskId: "task-1",
+      status: "succeeded",
+      components: {
+        runtime: { digest: digest("1") },
+        sandboxImage: { digest: digest("2") },
+        targetImage: { digest: digest("6") },
+        serviceBundle: { digest: digest("7") },
+        policy: { digest: digest("3") },
+        taskProtocol: { digest: digest("4") },
+      },
+      receipts: [
+        { capability: "browser", status: "completed" },
+        { capability: "computer", status: "completed" },
+        { capability: "terminal", status: "completed" },
+      ],
+    });
+
+    fs.rmSync(adapterPath);
+    const reconnected = run(home, taskArgs(adapterPath, "result"));
+    expect(reconnected.status, reconnected.stderr).toBe(0);
+    expect(JSON.parse(reconnected.stdout)).toEqual(JSON.parse(completed.stdout));
+
+    const persisted = fs.readFileSync(registryPath, "utf8");
+    expect(persisted).not.toContain("private synthetic task input");
+    expect(persisted).not.toContain(adapterPath);
+    expect(persisted).not.toContain(inputPath);
+  });
+
+  it("cancels to a terminal result without leaving an active task", () => {
+    const { home, adapterPath, inputPath, registryPath } = fixture();
+    const start = run(home, [
+      ...taskArgs(adapterPath, "start"),
+      "--mode",
+      "interactive",
+      "--input-file",
+      inputPath,
+    ]);
+    expect(start.status, start.stderr).toBe(0);
+
+    const cancelled = run(home, taskArgs(adapterPath, "cancel"));
+    expect(cancelled.status, cancelled.stderr).toBe(0);
+    expect(JSON.parse(cancelled.stdout)).toMatchObject({
+      kind: "task-result",
+      taskId: "task-1",
+      status: "cancelled",
+      agentResult: { status: "cancelled" },
+    });
+    const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+    expect(registry.sandboxes.alpha.cuaTarget.activeTask).toBeNull();
+  });
+
+  it("rejects task input that is not valid UTF-8 before invoking the adapter", () => {
+    const { home, adapterPath, inputPath } = fixture();
+    fs.writeFileSync(inputPath, Buffer.from([0xc3, 0x28]));
+
+    const started = run(home, [
+      ...taskArgs(adapterPath, "start"),
+      "--mode",
+      "headless",
+      "--input-file",
+      inputPath,
+    ]);
+
+    expect(started.status).toBe(2);
+    expect(JSON.parse(started.stdout)).toMatchObject({
+      kind: "failure",
+      family: "validation_failed",
+    });
+  });
+});

--- a/test/cua-task-cli.test.ts
+++ b/test/cua-task-cli.test.ts
@@ -352,4 +352,24 @@ describe("public CUA task commands (#7752)", () => {
       family: "validation_failed",
     });
   });
+
+  it("rejects a symbolic link as private task input before invoking the adapter", () => {
+    const { home, adapterPath, inputPath } = fixture();
+    const linkedInputPath = path.join(home, "linked-task-input.txt");
+    fs.symlinkSync(inputPath, linkedInputPath);
+
+    const started = run(home, [
+      ...taskArgs(adapterPath, "start"),
+      "--mode",
+      "headless",
+      "--input-file",
+      linkedInputPath,
+    ]);
+
+    expect(started.status).toBe(2);
+    expect(JSON.parse(started.stdout)).toMatchObject({
+      kind: "failure",
+      family: "validation_failed",
+    });
+  });
 });

--- a/test/package-contract/cli/command-registry.test.ts
+++ b/test/package-contract/cli/command-registry.test.ts
@@ -56,8 +56,8 @@ describe("command-registry", () => {
   });
 
   describe("sandboxCommands()", () => {
-    it("returns exactly 68 entries", () => {
-      // 60 visible + 8 hidden (shields×3 + config get/set/rotate-token +
+    it("returns exactly 78 entries", () => {
+      // 70 visible + 8 hidden (shields×3 + config get/set/rotate-token +
       // inference get/set).
       // 60 visible includes the sessions group (root + list + reset + delete +
       // export), the agents quartet (add + apply + delete + list), the
@@ -65,9 +65,9 @@ describe("command-registry", () => {
       // download + upload host-side openshell wrappers, the stop + start
       // container lifecycle pair (#6026), the policy baseline exclude + restore
       // pair, plus five MCP bridge display entries under the `mcp` parent and
-      // the gateway restart command under the `gateway` parent, and six CUA
-      // target lifecycle commands.
-      expect(sandboxCommands()).toHaveLength(68);
+      // the gateway restart command under the `gateway` parent, six CUA target
+      // lifecycle commands, and ten CUA task lifecycle commands.
+      expect(sandboxCommands()).toHaveLength(78);
     });
 
     it("every entry has scope sandbox", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Expose the runtime-neutral public lifecycle for starting, observing, controlling, and inspecting CUA tasks. The implementation drives one explicit operator-owned task adapter, validates every response against the checked-in CUA contract, retains only bounded secret-free terminal metadata, and keeps task input and detailed evidence private.

This PR is stacked on #7779 and should be reviewed against `codex/cua-target-lifecycle-7751-v2`.

## Related Issue

Fixes #7752

Accepted product and architecture direction: https://github.com/NVIDIA/NemoClaw/issues/7750#issuecomment-5111886734

## Changes

- Add public task `start`, `status`, `result`, `events`, `logs`, `plans`, `pause`, `cancel`, `guide`, and `respond` commands with deterministic JSON records and exit codes.
- Add one explicit process adapter boundary that runs without a shell, accepts bounded private UTF-8 input on standard input, sanitizes inherited environment variables, bounds output and execution time, and never copies adapter diagnostics into public output.
- Open private input once without following symbolic links, require a direct regular file, and enforce non-empty and 64 KiB limits before and after the descriptor-bound read.
- Enforce one active task per target, explicit stable task IDs, optional-operation capability checks, input-required state, terminal cancellation, and fail-closed handling for every contract failure family.
- Require `task.pause` to return an explicitly paused attachment; a still-running response fails validation without changing recorded task state.
- Bind terminal results to the exact runtime, sandbox image, target image, service bundle, policy, task protocol, inference route, capability protocols, and target identity.
- Add bounded, content-addressed private evidence indexes and retain the most recent 16 schema-validated terminal results for reconnect inspection without retaining task input or runtime-private files.
- Add unit, integration, package-contract, negative, identity-drift, reconnect, invalid-input, symlink-input, and per-modality verification-receipt tests using a synthetic task adapter.
- Document every task command under its exact public heading with command/flag parity.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review remains required before merge; the accepted product/security boundary is recorded in #7750.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: At `39abce8890276b927d8d976405282f68a083d08b`, the documentation writer reviewed the complete 33-file diff, verified the private-input documentation matches the descriptor-bound regular-file, non-empty UTF-8, 64 KiB, and no-symlink implementation and regression test, and confirmed the complete task/result reference remains accurate and public-safe. `npm run docs` passed with 0 errors and 2 existing Fern warnings; `git diff --check`, CLI type-check, build, focused tests, and normal hooks passed.
- Agent: `Codex Desktop — CUA private task input boundary, task/result lifecycle, evidence indexes, adapter protocol, and reconnect persistence documentation`
<!-- docs-review-head-sha: 39abce8890276b927d8d976405282f68a083d08b -->
<!-- docs-review-agents-blob-sha: be20a0952410431f1039cb893d2b9168d2ceacd8 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set — 41 focused task CLI and lifecycle tests passed; `npm run typecheck:cli`, `npm run build:cli`, and Biome passed.
- [ ] Applicable broad gate passed — GitHub CI supplies the full test and coverage lanes for this stacked change.
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without errors (doc changes only) — exited 0 with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
