### PR TITLE
feat(readiness): expose storage remediation capability

### DIFF
--- a/docs/reference/system-readiness.mdx
+++ b/docs/reference/system-readiness.mdx
@@ -52,6 +52,24 @@ Consumers can ignore fields that they do not recognize within major version 1.
 Use stable capability and finding IDs instead of parsing human summaries.
 Treat bounded evidence as diagnostic context unless an observation, capability, or finding references that evidence ID.
 
+## Interpret Docker storage
+
+The Docker storage capabilities separate the current host configuration from NemoClaw's supported remediation path.
+
+| Capability ID | Result represented |
+| --- | --- |
+| `host.docker.storage_compatible` | The current Docker storage configuration supports nested overlay mounts without remediation. |
+| `host.docker.storage_remediation_available` | NemoClaw can build a patched cluster image for a non-WSL Linux host using Docker with an `overlayfs` containerd-snapshotter conflict. |
+
+Use `host.docker.storage_compatible` for pre-mutation host diagnosis.
+For public NemoClaw lifecycle admission, require either `host.docker.storage_compatible` or `host.docker.storage_remediation_available`.
+When remediation is available, `host.docker.storage_compatible` remains `absent`.
+The report also retains `host.docker.storage_incompatible`, status `incompatible`, and exit code `2` because `host probe` does not change the host.
+Evaluate every other blocking finding before you run onboarding.
+The remediation capability does not prove that a later image build or gateway attachment succeeds.
+Use these storage capabilities when the lifecycle may create or recreate a gateway.
+Gateway attachment is a separate readiness decision.
+
 ## Interpret platform qualification
 
 Platform checks report stable capabilities and qualifications for the detected host.

--- a/src/lib/readiness/host.test.ts
+++ b/src/lib/readiness/host.test.ts
@@ -263,10 +263,28 @@ describe("host readiness projection (#7408)", () => {
     expect(result.status).toBe("supported");
   });
 
-  it("projects nested overlay conflicts as incompatible storage", () => {
-    const result = report({ hasNestedOverlayConflict: true });
+  it("reports supported remediation for the containerd overlay conflict (#7770)", () => {
+    const result = report({
+      dockerStorageDriver: "overlayfs",
+      dockerUsesContainerdSnapshotter: true,
+      hasNestedOverlayConflict: true,
+    });
 
     expect(state(result, "host.docker.storage_compatible")).toBe("absent");
+    expect(state(result, "host.docker.storage_remediation_available")).toBe("present");
+    expect(findingIds(result)).toContain("host.docker.storage_incompatible");
+    expect(result).toMatchObject({ status: "incompatible", exitCode: 2 });
+  });
+
+  it("reports no remediation when the containerd snapshotter is absent (#7770)", () => {
+    const result = report({
+      dockerStorageDriver: "overlayfs",
+      dockerUsesContainerdSnapshotter: false,
+      hasNestedOverlayConflict: true,
+    });
+
+    expect(state(result, "host.docker.storage_compatible")).toBe("absent");
+    expect(state(result, "host.docker.storage_remediation_available")).toBe("absent");
     expect(findingIds(result)).toContain("host.docker.storage_incompatible");
     expect(result).toMatchObject({ status: "incompatible", exitCode: 2 });
   });
@@ -300,6 +318,7 @@ describe("host readiness projection (#7408)", () => {
 
     expect(state(result, "host.docker.runtime_supported")).toBe("unknown");
     expect(state(result, "host.docker.resources_sufficient")).toBe("unknown");
+    expect(state(result, "host.docker.storage_remediation_available")).toBe("unknown");
     expect(result.observations.find(({ id }) => id === "host.docker.runtime")?.state).toBe(
       "unknown",
     );

--- a/src/lib/readiness/host.ts
+++ b/src/lib/readiness/host.ts
@@ -223,6 +223,7 @@ function unknownProjection(evidenceIds: readonly string[]): {
     "host.docker.runtime_supported",
     "host.docker.resources_sufficient",
     "host.docker.storage_compatible",
+    "host.docker.storage_remediation_available",
     "host.toolchain.node_available",
     "host.toolchain.openshell_available",
     "host.gpu.nvidia_available",
@@ -292,6 +293,13 @@ export function projectHostReadiness(
       (!host.cdiNvidiaGpuSpecMissing &&
         !host.cdiNvidiaGpuSpecStale &&
         !host.cdiNvidiaGpuSpecNeedsRepair);
+    const storageRemediationAvailable =
+      host.platform === "linux" &&
+      !host.isWsl &&
+      host.runtime === "docker" &&
+      host.hasNestedOverlayConflict &&
+      host.dockerStorageDriver === "overlayfs" &&
+      host.dockerUsesContainerdSnapshotter === true;
     observations = [
       observation("host.os.platform", host.platform),
       observation("host.os.architecture", host.architecture),
@@ -361,6 +369,10 @@ export function projectHostReadiness(
       capability(
         "host.docker.storage_compatible",
         host.dockerReachable ? stateOf(!host.hasNestedOverlayConflict) : "unknown",
+      ),
+      capability(
+        "host.docker.storage_remediation_available",
+        host.dockerReachable ? stateOf(storageRemediationAvailable) : "unknown",
       ),
       capability("host.toolchain.node_available", stateOf(host.nodeInstalled)),
       capability("host.toolchain.openshell_available", stateOf(host.openshellInstalled)),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`nemoclaw host probe --json` now reports when NemoClaw supports remediation for the Linux Docker `overlayfs` containerd-snapshotter conflict.
The report preserves the raw incompatible storage capability, blocking finding, and exit code while giving lifecycle consumers a stable remediation capability.

## Related Issue
Fixes #7770

## Changes
- Add `host.docker.storage_remediation_available` for the exact non-WSL Linux Docker auto-remediation path.
- Return `absent` for other observed storage conflicts and `unknown` when Docker-dependent storage facts are unavailable.
- Add projection tests for remediable, non-remediable, and unknown results.
- Document pre-mutation host diagnosis, lifecycle admission, retained blocking semantics, and the gateway-attachment boundary.
- Record the detection gap: existing tests verified only raw incompatibility and did not require a separate remediation projection.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/system-readiness.mdx` documents the exact remediation predicate, retained raw capability and blocking result, lifecycle admission guidance, and gateway boundary. The reviewer verified terminology, structure, voice, code-sample presentation, test titles, comments, and stable capability wording. The focused suite passed 23 tests, `npm run docs` passed, and `git diff --check` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8055a4434 -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project cli src/lib/readiness/host.test.ts` passed 23 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system-readiness guidance for interpreting Docker storage compatibility and remediation signals.
  * Added a capability indicating when Docker storage remediation is available.
  * Clarified how storage findings support diagnosis and lifecycle admission decisions.

* **Bug Fixes**
  * Improved readiness reporting for nested overlay conflicts and unavailable Docker state, including accurate unknown status when required data cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->