### PR TITLE
fix(sandbox): align recreate readiness-wait budget with connect (120s)

### DIFF
--- a/src/lib/actions/sandbox/process-recovery.test.ts
+++ b/src/lib/actions/sandbox/process-recovery.test.ts
@@ -109,6 +109,43 @@ describe("recreated sandbox OpenShell readiness", () => {
     expect(sleeps).toEqual([3]);
   });
 
+  it("rides out a transient Error phase past the old 30s budget by default (#7227)", () => {
+    // No timeoutSeconds option and no env override: the default recovery budget
+    // must be large enough (120s, aligned with connect's readiness wait) to keep
+    // retrying a cold-start phase:Error settling window that exceeds the old
+    // 30s / 11-attempt budget. The 12th probe (past the old 11-attempt cap) must
+    // still be reached, so the primary dashboard/API forward is not abandoned.
+    delete process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS;
+    const errorPhase = {
+      status: 1,
+      output: OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR.trim(),
+      stdout: "",
+      stderr: OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR,
+    };
+    const captureOpenshellImpl = vi.fn();
+    for (let attempt = 0; attempt < 11; attempt += 1) {
+      captureOpenshellImpl.mockReturnValueOnce(errorPhase);
+    }
+    captureOpenshellImpl.mockReturnValueOnce({
+      status: 0,
+      output: "",
+      stdout: "",
+      stderr: "",
+    });
+
+    expect(
+      waitForRecreatedSandboxOpenShellReady("recreated-box", {
+        beforeProbe: () => true,
+        captureOpenshellImpl,
+        intervalSeconds: 3,
+        sleepImpl: () => {},
+        // no timeoutSeconds -> exercise the default budget; the old 30s default
+        // capped at 11 attempts and would have given up before the 12th probe.
+      }),
+    ).toBe(true);
+    expect(captureOpenshellImpl).toHaveBeenCalledTimes(12);
+  });
+
   it("retries the exact supervisor reconnect states exposed during direct recreation", () => {
     const reconnecting = [
       OPENSHELL_SUPERVISOR_NOT_CONNECTED_STDERR,

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -700,6 +700,16 @@ function recreatedSandboxOpenShellReadinessFailureDetail(
   return openshellError ? `${detail} Last OpenShell readiness error: ${openshellError}` : detail;
 }
 
+// Default seconds to wait for OpenShell to re-register a recreated sandbox as
+// Ready before giving up and surfacing the manual-recover hint. Aligned with
+// `connect`'s readiness budget (`waitForSandboxReadyOrExit` defaults to 120s):
+// both prove the same post-recreate sandbox readiness, but this path used to
+// give up 4x sooner (30s), so a cold-start `phase: Error` settling window that
+// exceeded 30s but was within `connect`'s 120s left the primary dashboard/API
+// forward unstarted — exactly why `connect --probe-only` recovers what `start`
+// abandons (#7227). Env-tunable via NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS.
+const GATEWAY_RECOVERY_WAIT_DEFAULT_SECONDS = 120;
+
 /**
  * Wait until OpenShell has re-registered a directly recreated sandbox as
  * ready. This probe deliberately has no direct-Docker or SSH fallback: it is
@@ -718,7 +728,10 @@ function waitForRecreatedSandboxOpenShellReadyResult(
     Number.isFinite(options.timeoutSeconds) &&
     options.timeoutSeconds >= 0
       ? options.timeoutSeconds
-      : readNonNegativeNumberEnv("NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS", 30);
+      : readNonNegativeNumberEnv(
+          "NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS",
+          GATEWAY_RECOVERY_WAIT_DEFAULT_SECONDS,
+        );
   const intervalSeconds = readNonNegativeNumberEnv(
     "NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS",
     options.intervalSeconds ?? 3,
@@ -914,7 +927,7 @@ export function waitForRecoveredSandboxGateway(
     Number.isFinite(options.timeoutSeconds) &&
     options.timeoutSeconds >= 0
       ? options.timeoutSeconds
-      : 30;
+      : GATEWAY_RECOVERY_WAIT_DEFAULT_SECONDS;
   const timeoutSeconds = readNonNegativeNumberEnv(
     "NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS",
     requestedTimeoutSeconds,


### PR DESCRIPTION
## Problem (#7227)

`start`'s post-recreate recovery waits for OpenShell to re-register a just-recreated sandbox as Ready, then gives up after **30s** and surfaces the manual-recover hint. `connect`'s readiness wait (`waitForSandboxReadyOrExit`) proves the *same* post-recreate sandbox readiness but allows **120s** (`NEMOCLAW_CONNECT_TIMEOUT`).

On a cold start the sandbox can sit in a transient `phase: Error` settling window that exceeds 30s but is comfortably within 120s. When it does, the recovery path abandons the sandbox and prints the manual-recover hint, while `connect --probe-only` — with the larger budget — recovers the *exact same sandbox* and starts the primary dashboard/API forward. That 4x budget asymmetry is the intermittent start/recovery failure in #7227.

## Change

- Introduce a single `GATEWAY_RECOVERY_WAIT_DEFAULT_SECONDS = 120` and use it for both readiness-wait default sites (`waitForRecreatedSandboxOpenShellReadyResult` and `waitForRecoveredSandboxGateway`), aligning them with `connect`.
- `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` (existing env override) is unchanged.
- Deliberately **untouched** because they are different concepts: the agent health-probe timeout (30s) and the post-ready settle pause (`NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS`, 25s).

## Verification / honesty note

This is a **low-probability cold-start race**. On latest `main` it reproduced **1 in 12** start cycles on a DGX Spark and could **not** be re-triggered deterministically afterward (0 in a further 20 warm + cold retries). Because the timing is non-deterministic, this PR is a **principled budget alignment** (match the two paths that prove the same readiness) rather than an empirically-timed value — I could not produce a green/red toggle that flips solely on the 30→120 change.

Given that, keeping #7227 **open** to confirm over repeated cold starts is reasonable; hence `Refs` rather than `Fixes`.

## Tests

- New unit test locks the default: with no `timeoutSeconds` option and no env override, a persistent transient `phase: Error` is retried past the old 11-attempt (30s) cap — the 12th probe must still be reached. Would fail under the old 30s default.
- Existing `process-recovery` suite unchanged and green (42 tests). `typecheck:cli` and `prek` clean.

Refs #7227

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway recovery reliability by extending the default readiness window from 30 to 120 seconds.
  * Recovery checks now continue through longer periods of temporary OpenShell errors before reporting failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->