### PR TITLE
docs: add controlled language guidance

### DIFF
--- a/.agents/skills/_shared/controlled-words.md
+++ b/.agents/skills/_shared/controlled-words.md
@@ -1,0 +1,425 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# NemoClaw Controlled Word List
+
+This list defines approved NemoClaw technical terms for explanatory text in the scope of the
+[NemoClaw Writing Guide](../../../WRITING.md). It gives each term one project meaning and identifies
+alternatives that can make that meaning unclear.
+
+This list is not a general English dictionary. It does not copy the ASD-STE100 dictionary, and its
+use does not establish ASD-STE100 compliance.
+
+## Use the List
+
+- Use the approved term with the meaning and form shown here.
+- Treat an alternative as discouraged only when it refers to the same concept.
+- Use a different term when it identifies a real difference. Define that difference at first use.
+- Preserve literal identifiers, commands, output, API fields, quotations, and official third-party
+  names.
+- Apply the list to changed text. Report unrelated terminology debt in a focused follow-up.
+
+## Product Names and Text Forms
+
+| Use | Use as | Meaning | Avoid for this meaning |
+|---|---|---|---|
+| `AI` | Technical noun or adjective | Artificial intelligence. | A.I., ai in prose |
+| `Amazon Bedrock` | Product name | The AWS managed foundation-model service. | Bedrock when the product is not already clear, amazon bedrock |
+| `Anthropic` | Organization or provider name | Anthropic as an organization or inference provider. | anthropic in prose |
+| `API` | Technical noun or adjective | An application programming interface. | Api, api in prose |
+| `API key` | Technical noun | A credential whose type is an API key. | API Key, api key |
+| `AppArmor` | Product name or adjective | The Linux mandatory-access-control system. | App Armor, apparmor in prose |
+| `Apple silicon` | Platform name or adjective | Apple-designed Arm-based Mac hardware. | Apple Silicon, M-series Mac when the architecture matters |
+| `ASD-STE100` | Standard name | The Simplified Technical English standard referenced by this project. | STE100, ASD STE 100 |
+| `AWS` | Product-family name or adjective | Amazon Web Services. Write `Amazon Web Services (AWS)` at first use for an audience that might not know the abbreviation. | Aws, aws in prose |
+| `Bash` | Shell name or adjective | The Bash command shell. Use `bash` for the command or a code-fence language. | BASH, bash when the shell name is intended |
+| `Brave Search` | Product name | The Brave Search web search service. Use `Brave` after the full name is clear. | brave search, Brave on first use |
+| `Brev` | Product name | The NVIDIA service used by deprecated remote-instance deployment flows and E2E infrastructure. | brev in prose |
+| `CI` | Technical noun or adjective | Continuous integration. | ci, Ci |
+| `CLI` | Technical noun | A command-line interface as a whole. | cli, Cli, command when one operation is intended |
+| `Cloudflare Tunnel` | Product name | The Cloudflare service that exposes a configured dashboard through a named tunnel. | Cloudflare tunnel, cloudflared tunnel when the product is intended |
+| `Colima` | Product name | The container runtime used by a supported macOS path. | colima in prose |
+| `DCO` | Technical noun | The Developer Certificate of Origin declaration required for contributor PRs. | dco, sign-off when the declaration is intended |
+| `DGX Spark` | Product name | The NVIDIA DGX Spark system. | Spark when the product is intended |
+| `DGX Station` | Product name | The NVIDIA DGX Station system. | Station when the product is not already clear |
+| `Discord` | Product name | The Discord messaging service. | discord in prose |
+| `DNS` | Technical noun or adjective | The Domain Name System. | dns in prose |
+| `Docker` | Product name or adjective | The Docker container platform. | docker in prose |
+| `Docker Desktop` | Product name | The Docker Desktop application. | Docker desktop, docker desktop |
+| `E2E` | Technical noun or adjective | End-to-end testing or evidence. Spell it out at first use when the audience is not expected to know the abbreviation. | e2e, E-2-E |
+| `Fern` | Product name | The documentation platform that builds and publishes NemoClaw docs. | fern in prose |
+| `Git` | Product name or adjective | The Git version-control system. Use `git` for the command. | git when the product is intended |
+| `GitHub` | Product name or adjective | The GitHub hosting and collaboration service. | Github, github in prose |
+| `GitHub Actions` | Product name | The GitHub workflow service. | GitHub actions, Github Actions |
+| `Google Gemini` | Product or provider name | The Google Gemini inference provider. Use `Gemini` after the full name is clear. | google gemini, Gemini provider on first use |
+| `GPU` | Technical noun or adjective | A graphics processing unit. | Gpu, gpu in prose |
+| `Hermes` | Product name | The Hermes agent runtime. | hermes in prose |
+| `Homebrew` | Product name or adjective | The macOS package manager and service path used by NemoClaw. Use `brew` for the command. | homebrew in prose, Brew when the product is intended |
+| `HTTP` | Technical noun or adjective | Hypertext Transfer Protocol without TLS. | Http, http in prose |
+| `HTTPS` | Technical noun or adjective | HTTP protected by TLS. | Https, https in prose |
+| `Hugging Face` | Product or organization name | The Hugging Face model and package services. | HuggingFace, hugging face |
+| `IP address` | Technical noun | An Internet Protocol address. | IP when an address is intended, IP Address |
+| `JavaScript` | Language name or adjective | The JavaScript programming language. | Javascript, javascript in prose |
+| `JSON` | Technical noun or adjective | The JSON data format. | Json, json in prose |
+| `Kubernetes` | Product name or adjective | The Kubernetes orchestration platform. | K8s in explanatory prose, kubernetes |
+| `Landlock` | Product name or adjective | The Linux Landlock filesystem-access control system. | landlock in prose |
+| `LangChain Deep Agents Code` | Product name | The full product name. Use `Deep Agents Code` after the full name is clear. | DeepAgents Code, deep agents code in prose |
+| `Linux` | Operating-system name or adjective | The Linux operating system. | linux in prose |
+| `macOS` | Operating-system name or adjective | The Apple macOS operating system. | MacOS, Mac OS, OSX |
+| `Markdown` | Format name or adjective | Markdown source or output. | markdown in prose |
+| `MCP` | Technical noun or adjective | Model Context Protocol. Write the full name at first use on a page, followed by `(MCP)`. | mcp in prose |
+| `MDX` | Technical noun or adjective | Markdown with JSX syntax. | Mdx, mdx in prose |
+| `Microsoft Teams` | Product name | The Microsoft Teams messaging service. Use `Teams` after the full name is clear. | MS Teams, microsoft teams |
+| `mTLS` | Technical noun or adjective | Mutual TLS authentication. | MTLS, mtls |
+| `NemoClaw` | Product name | The NVIDIA reference stack in this repository. | nemoclaw or Nemoclaw in prose |
+| `Nemotron` | Model-family name | The NVIDIA Nemotron model family. | nemotron in prose |
+| `NGC` | Product name or adjective | The NVIDIA NGC catalog and registry services. | Ngc, ngc in prose |
+| `Node.js` | Runtime name or adjective | The Node.js JavaScript runtime. | NodeJS, Node, node.js in prose |
+| `npm` | Product or command name | The npm package manager and registry. | NPM, Npm |
+| `NVIDIA` | Organization name or adjective | NVIDIA as an organization or product modifier. | Nvidia, nvidia |
+| `NVIDIA NIM` | Product name | NVIDIA NIM inference software. Use `NIM` after the full name is clear. | Nvidia NIM, NIM on first use |
+| `Ollama` | Product name or adjective | The Ollama local inference server. | ollama in prose |
+| `OpenAI` | Organization or provider name | OpenAI as an organization or inference provider. | Open AI, openai in prose |
+| `OpenClaw` | Product name | The OpenClaw agent runtime. | openclaw or Openclaw in prose |
+| `OpenRouter` | Product or provider name | The OpenRouter inference service. | Open Router, openrouter in prose |
+| `OpenShell` | Product name | The NVIDIA sandbox runtime and policy platform. | Open Shell, openShell, Openshell, openshell |
+| `PyPI` | Product name | The Python Package Index. | Pypi, pypi in prose |
+| `Python` | Language name or adjective | The Python programming language. | python in prose |
+| `QR code` | Technical noun | A quick-response code used for device or channel pairing. | QR Code, qr code |
+| `Slack` | Product name | The Slack messaging service. | slack in prose |
+| `SSH` | Technical noun or adjective | Secure Shell remote access. | ssh in prose |
+| `SSRF` | Technical noun or adjective | Server-side request forgery. Write the full term at first use on a page, followed by `(SSRF)`. | Ssrf, ssrf in prose |
+| `Tavily Search` | Product name | The Tavily web search service. Use `Tavily` after the full name is clear. | tavily search, Tavily on first use |
+| `TCP` | Technical noun or adjective | Transmission Control Protocol. | Tcp, tcp in prose |
+| `Telegram` | Product name | The Telegram messaging service. | telegram in prose |
+| `TLS` | Technical noun or adjective | Transport Layer Security. | Tls, tls in prose |
+| `TUI` | Technical noun | A terminal user interface. | Tui, tui in prose |
+| `TypeScript` | Language name or adjective | The TypeScript programming language. | Typescript, typescript in prose |
+| `Ubuntu` | Operating-system name or adjective | The Ubuntu Linux distribution. | ubuntu in prose |
+| `UI` | Technical noun | A user interface. | Ui, ui in prose |
+| `URL` | Technical noun | A uniform resource locator. | Url, url in prose |
+| `Vitest` | Product name or adjective | The Vitest test runner. | vitest in prose |
+| `vLLM` | Product name or adjective | The vLLM inference server. | VLLM, vllm in prose |
+| `WeChat` | Product name | The WeChat messaging service. | Wechat, wechat in prose |
+| `WhatsApp` | Product name | The WhatsApp messaging service. | Whatsapp, whatsapp in prose |
+| `Windows` | Operating-system name or adjective | The Microsoft Windows operating system. | windows in prose |
+| `WSL` | Technical noun or adjective | Windows Subsystem for Linux. Write the full name at first use on a page, followed by `(WSL)`. | Wsl, wsl in prose |
+| `YAML` | Technical noun or adjective | The YAML data format. | yaml, Yaml |
+
+Lowercase forms remain correct in commands, package names, file paths, environment variables, and
+other literal identifiers.
+
+## Product Concepts
+
+| Use | Use as | Meaning | Avoid for this meaning |
+|---|---|---|---|
+| `agent` | Technical noun | Software that uses a model and tools to do tasks. Add `coding`, `supported`, or another modifier when the agent type matters. | assistant, bot, workload |
+| `agent runtime` | Technical noun | Software that implements agent behavior, such as OpenClaw, Hermes, or Deep Agents Code. | agent framework, harness |
+| `best-effort` | Adjective | Attempts a named control or operation without guaranteeing that it succeeds or remains enforced. State the failure or fallback result. | guaranteed, enforced |
+| `blueprint` | Technical noun | The versioned YAML package that defines the sandbox shape, policies, inference profiles, and supporting assets. | template, recipe, configuration |
+| `command` | Technical noun | One named CLI operation or a complete invocation. | CLI when one operation is intended |
+| `compatible` | Adjective | Satisfies a stated technical contract. Compatibility alone does not establish product support. | supported |
+| `configuration` | Technical noun | The settings that define behavior. Use `config` only in literal names or when the interface uses that label. | config in explanatory prose, setup |
+| `container` | Technical noun | An implementation-level operating-system container. Use `sandbox` for the OpenShell resource exposed to users. | sandbox when the interface-level resource is intended |
+| `credential` | Technical noun | Secret authentication material, including an API key, token, or password. Use the specific type when known. | key, API key when the type is unknown |
+| `default sandbox` | Technical noun | The sandbox selected when the user does not supply a sandbox name. | primary sandbox, main sandbox |
+| `endpoint` | Technical noun | A network destination that exposes an API. | provider, model, route |
+| `gateway` | Technical noun | A service that coordinates requests for a runtime. Use `OpenShell gateway` or `agent gateway` when the type is not clear. | server, control plane |
+| `host` | Technical noun or adjective | The environment outside the sandbox that runs the CLI and host-side services. | local machine, workstation |
+| `inference provider` | Technical noun | A named service configuration that selects and authenticates an inference service. | backend, endpoint, model provider |
+| `inference route` | Technical noun | The gateway-managed path from `inference.local` to the selected provider and model. | endpoint, provider |
+| `integration layer` | Technical noun | Agent-specific configuration, plugins, wrappers, and runtime support that connect an agent runtime to OpenShell. | plugin when the integration is not a plugin |
+| `manifest` | Technical noun | A declarative file that defines a project resource or supported integration. Name the manifest type at first use. | configuration file when the contract is a manifest |
+| `messaging channel` | Technical noun | A supported messaging service through which an agent sends or receives messages. | messaging integration, connector |
+| `model` | Technical noun | The model selection served through an inference provider. | provider, endpoint |
+| `NemoClaw-managed` | Adjective | A resource whose lifecycle or configuration NemoClaw controls. | NemoClaw resource when ownership is unclear |
+| `network policy` | Technical noun | Rules that control sandbox network egress. | firewall, allowlist, egress rules when the complete policy is intended |
+| `plugin` | Technical noun | A package loaded through an agent runtime's plugin mechanism. | integration layer, extension |
+| `policy preset` | Technical noun | A named set of policy entries that an operator can apply. Use `preset` after the full term is clear. | policy template, network preset |
+| `resource` | Technical noun | A named object whose lifecycle a system manages. Use the specific resource type when known. | asset, thing |
+| `sandbox` | Technical noun | The isolated OpenShell runtime resource in which the selected agent runs. | container or pod when the interface-level resource is intended |
+| `supported` | Adjective | Approved as a NemoClaw product surface with defined ownership, lifecycle, compatibility, security, and validation expectations. | compatible, works with |
+| `workspace` | Technical noun | The directory tree available to the agent for user files and task state. | working directory when the broader tree is intended |
+
+## Runtime and Architecture
+
+| Use | Use as | Meaning | Avoid for this meaning |
+|---|---|---|---|
+| `agent gateway` | Technical noun | The agent runtime service inside a sandbox that accepts agent requests. | OpenShell gateway, gateway when the type is unclear |
+| `agent manifest` | Technical noun | The repository manifest that defines one supported agent runtime and its lifecycle integration. | agent configuration, runtime manifest |
+| `base image` | Technical noun | The image from which NemoClaw builds an agent sandbox image. | parent image, default image |
+| `blueprint runner` | Technical noun | The process that applies the NemoClaw blueprint and reconciles sandbox resources and agent-runtime lifecycle. | runner without the modifier, driver, agent runtime |
+| `build context` | Technical noun | The files available to an image build. | build directory when file availability is intended |
+| `build-time setting` | Technical noun | A value applied while NemoClaw builds an image. | runtime setting, build config |
+| `dashboard` | Technical noun | The browser interface exposed by an agent runtime. | UI when the browser interface is intended |
+| `driver` | Technical noun | An OpenShell compute implementation that creates and operates sandbox runtimes, such as the Docker driver. | agent driver, adapter |
+| `gateway port` | Technical noun | A network port on which a named gateway listens. Name the gateway when needed. | service port when the gateway is intended |
+| `host-side` | Adjective | Runs or exists on the host, outside a sandbox. | local, external |
+| `in-sandbox` | Adjective | Runs or exists inside a sandbox. | internal, container-side |
+| `lifecycle authority` | Technical noun | The component that owns create, start, stop, update, and delete decisions for a resource. | owner without the lifecycle responsibility |
+| `OpenShell gateway` | Technical noun | The host service that owns credentials, coordinates sandbox lifecycle, and proxies approved traffic. | agent gateway, gateway when the type is unclear |
+| `port forward` | Technical noun or verb | A connection that maps a host port to a service inside a sandbox, or the act of creating that connection. | tunnel when no general tunnel exists |
+| `provider profile` | Technical noun | An OpenShell declaration of one service provider's credentials, endpoints, allowed binaries, and access policy. | inference profile, provider settings |
+| `runtime setting` | Technical noun | A value applied when a process or sandbox runs. | build-time setting, runtime config |
+| `sandbox image` | Technical noun | The built image used to create an agent sandbox. | base image, container |
+| `sandbox registry` | Technical noun | NemoClaw state that records managed sandboxes and their selected agent types. | image registry, container registry |
+| `service` | Technical noun | A long-running process that exposes a defined capability. Name the service at first use. | daemon unless the implementation detail matters |
+| `state directory` | Technical noun | A directory reserved for persistent project or runtime state. | data folder, config directory |
+| `terminal agent` | Technical noun | An agent whose primary user interface is an interactive terminal session. | terminal runtime |
+| `terminal runtime` | Technical noun | The in-sandbox process environment that hosts a terminal agent. | terminal agent |
+
+## Inference and Models
+
+| Use | Use as | Meaning | Avoid for this meaning |
+|---|---|---|---|
+| `Anthropic Messages API` | Technical noun | The Anthropic request and response contract used by a compatible inference endpoint. | Anthropic API when the API family matters |
+| `API family` | Technical noun | A request and response contract, such as Chat Completions, Responses, or Anthropic Messages. | provider, endpoint |
+| `Chat Completions API` | Technical noun | The OpenAI-compatible chat completions request and response contract. | OpenAI API when the API family matters, chat API |
+| `compatible endpoint` | Technical noun | A custom endpoint that implements a selected API family closely enough for NemoClaw validation. | supported provider, OpenAI endpoint |
+| `context window` | Technical noun | The maximum combined input and output token capacity configured for a model. | context size, context length in explanatory prose |
+| `custom endpoint` | Technical noun | A user-supplied inference endpoint that is not one of NemoClaw's named provider choices. | compatible endpoint before compatibility is validated |
+| `hosted inference` | Technical noun | Inference served by a remote provider-operated service. | local inference, cloud model |
+| `inference` | Technical noun | Model execution that produces a response from an input. | AI, generation when model execution is intended |
+| `inference health` | Technical noun | The complete classification from the named `inference.local` `/v1/models` status probe: `reachable` for HTTP `200` through `499`, `unhealthy` for HTTP `500` through `599`, or `unreachable` when no qualifying HTTP response arrives. | model health, successful inference, validation request |
+| `inference profile` | Technical noun | A blueprint selection that defines an inference provider type, provider name, endpoint, model, credential input, and route settings. | provider profile, model profile |
+| `inference request` | Technical noun | One request sent through an inference route to a model. | API call when the inference purpose matters |
+| `inference route reachability` | Technical noun | The `reachable` inference-health result produced when `https://inference.local/v1/models` returns HTTP `200` through `499`. It does not establish valid credentials, successful model invocation, readiness, compatibility, or support. | inference health, successful inference, validation request |
+| `live route` | Technical noun | The provider and model route currently configured on the OpenShell gateway. | recorded route, active endpoint |
+| `local inference` | Technical noun | Inference served by a model runtime that the operator runs locally. | hosted inference, local model when the service is intended |
+| `managed inference` | Technical noun | Inference routed through OpenShell so the sandbox does not hold the upstream provider credential. | direct inference, hosted inference |
+| `model capability` | Technical noun | A supported model behavior, such as tool calls, reasoning, or web search. | feature without naming the model behavior |
+| `model ID` | Technical noun | The provider-defined identifier used to select a model. | model name when an exact identifier is required |
+| `Model Router` | Product component name | The host-side router that selects among configured upstream models. | model gateway, router when the component is not clear |
+| `output token` | Technical noun | A token generated in a model response. | completion token unless the API uses that field name |
+| `provider credential` | Technical noun | A credential registered with OpenShell for one inference provider. | API key when the credential type is not known |
+| `reasoning effort` | Technical noun | The configured amount of reasoning work requested from a compatible model. | reasoning level, thinking budget |
+| `reasoning mode` | Technical noun | The endpoint-specific mechanism used to request or return model reasoning. | reasoning effort when the mechanism is intended |
+| `recorded route` | Technical noun | The provider and model route stored for a sandbox. | live route, saved endpoint |
+| `Responses API` | Technical noun | The OpenAI-compatible responses request and response contract. | OpenAI API when the API family matters, response API |
+| `route drift` | Technical noun | A difference between a sandbox's recorded route and the gateway's live route. | configuration drift without naming the route |
+| `routed inference` | Technical noun | Inference traffic sent through the managed `inference.local` route. | direct inference, proxied AI |
+| `streaming response` | Technical noun | A response delivered incrementally before the complete result is available. | live response, streamed output |
+| `upstream endpoint` | Technical noun | The provider endpoint that OpenShell or Model Router contacts on behalf of a sandbox. | sandbox endpoint, route |
+| `validation request` | Technical noun | An authenticated model request used to check a named endpoint, API family, model, and request shape. One success does not establish broader API conformance. | health check, smoke test |
+| `warm-up` | Technical noun or adjective | A bounded preparatory request or session that loads a model or starts a runtime before user work. | validation when no contract is checked, warmup |
+| `web search` | Technical noun | A model or agent capability that retrieves current information from the web. | browsing, internet access |
+
+## Security and Policy
+
+| Use | Use as | Meaning | Avoid for this meaning |
+|---|---|---|---|
+| `allowlist` | Technical noun or verb | An explicit set of allowed values, or the act of adding a value to that set. | whitelist |
+| `baseline policy` | Technical noun | The agent-specific network policy applied before operator-selected presets and approvals. | default policy, base policy |
+| `credential-bearing` | Adjective | Contains or can expose credential material. | secret when the content can include more than one secret type |
+| `credential binding` | Technical noun | Metadata that associates a managed route or placeholder with a stored credential. | credential, mapping |
+| `credential custody` | Technical noun | Responsibility for storing and controlling access to a credential value. | credential ownership |
+| `credential-free` | Adjective | Contains no credential material and does not grant credential access. | safe, non-secret when absence of credentials is the exact claim |
+| `credential placeholder` | Technical noun | A non-secret value that OpenShell replaces with a credential at an approved request boundary. | fake key, dummy credential |
+| `credential rewrite` | Technical noun | Replacement of a credential placeholder with a stored credential during an approved request. | credential injection, secret substitution |
+| `deny by default`; `deny-by-default` | Technical phrase; adjective | Block access unless a rule explicitly allows it. Use the hyphenated form before a noun. | default deny, closed by default |
+| `DNS pinning` | Technical noun | Binding an approved hostname to validated address results to prevent resolution changes from bypassing policy. | DNS lock, host pinning |
+| `egress` | Technical noun or adjective | Network traffic that leaves a sandbox. | outbound access when the policy direction matters |
+| `egress rule` | Technical noun | One network-policy rule that controls outbound traffic. | network policy when one entry is intended |
+| `endpoint rule` | Technical noun | A policy entry that matches a destination and its permitted protocol details. | endpoint, allowlist entry |
+| `fail closed`; `fail-closed` | Technical phrase; adjective | Reject or stop an operation when required security evidence is absent or invalid. Use the hyphenated form before a noun. | fail safe, abort securely |
+| `filesystem policy` | Technical noun | Rules that control sandbox access to filesystem paths. | file permissions when the complete policy is intended |
+| `least privilege` | Technical noun | Grant only the access required for the stated operation. | minimal permissions, locked down |
+| `link-local address` | Technical noun | An IP address valid only on the directly connected network segment. | local address, private IP address |
+| `lockdown` | Technical noun | The protected filesystem, process, and restrictive network-policy posture restored by Shields up. | hardening, shields when the resulting posture is intended |
+| `loopback address` | Technical noun | An IP address that refers to the same network host. | localhost when an address is intended, local address |
+| `network namespace` | Technical noun | The operating-system isolation boundary for network devices, routes, and sockets. | network sandbox, container network |
+| `policy` | Technical noun | Enforceable rules that allow, deny, or constrain an operation. Name the policy type at first use. | configuration, settings |
+| `policy entry` | Technical noun | One declarative rule in a policy. | policy when one rule is intended, item |
+| `policy key` | Technical noun | The stable identifier of a policy entry. | policy name, endpoint name |
+| `policy tier` | Technical noun | A named network-policy posture offered during onboarding. | security level, policy mode |
+| `private IP address` | Technical noun | An address in an IP range reserved for private networks. | local IP address, link-local address |
+| `raw TLS passthrough` | Technical noun | Forwarding encrypted TLS bytes without application-layer inspection or credential rewriting. | HTTPS proxying, TLS termination |
+| `read-only` | Adjective | Permits reads but not writes. | readonly, immutable unless change is impossible by design |
+| `read-write` | Adjective | Permits both reads and writes. | writable when read access also matters |
+| `redaction` | Technical noun | Removal or replacement of sensitive content before display, logging, or storage. | masking, sanitization |
+| `root-owned` | Adjective | Owned by the operating-system root account. | privileged, protected |
+| `sandbox boundary` | Technical noun | The isolation boundary between sandbox processes and host or external resources. | container boundary, security boundary without naming the sandbox |
+| `seccomp` | Technical noun or adjective | Linux system-call filtering enforced for sandbox processes. | syscall sandbox, seccomp-BPF in general prose |
+| `secret` | Technical noun or adjective | Sensitive authentication or cryptographic material that must not be exposed. | credential when the value is not used for authentication |
+| `Shields down` | Product state or command name | The temporary state that relaxes selected NemoClaw lockdown controls. | permissive state, unlocked mode |
+| `shields-down window` | Technical noun | The bounded time during which Shields down remains active before automatic restoration. | maintenance window, unlock period |
+| `Shields up` | Product state or command name | The state that enforces NemoClaw lockdown controls. | secure mode, locked state |
+| `trust boundary` | Technical noun | A boundary across which data or control changes its trust assumptions. | security boundary without naming the trust change |
+| `trusted` | Adjective | Explicitly accepted as an input, identity, or component within a named trust boundary. | safe, secure |
+| `untrusted` | Adjective | Not accepted as authoritative or safe without validation at a named trust boundary. | unsafe, external |
+
+## Messaging and Tools
+
+| Use | Use as | Meaning | Avoid for this meaning |
+|---|---|---|---|
+| `agent adapter` | Technical noun | The agent-specific integration that writes a managed MCP endpoint into an agent runtime's native configuration. | MCP bridge, MCP proxy, relay |
+| `channel manifest` | Technical noun | The declarative record of messaging-channel packages, credentials, reachability, and policy requirements. | channel configuration, integration manifest |
+| `channel reachability check` | Technical noun | A test that confirms required messaging-channel endpoints are reachable through the active network policy. | generic reachability check, health check |
+| `direct message` | Technical noun | A message addressed to one user or one private conversation. Use `DM` only after the term is clear. | private message when the channel calls it a direct message |
+| `group message` | Technical noun | A message addressed to a multi-user conversation. | channel message when the service does not use channels |
+| `managed MCP` | Technical noun or adjective | MCP access configured and mediated by NemoClaw and OpenShell. | built-in MCP, secure MCP |
+| `MCP server` | Technical noun | A service that exposes tools through Model Context Protocol. | tool server, MCP provider |
+| `MCP tool` | Technical noun | One callable operation exposed by an MCP server. | function, command |
+| `messaging credential` | Technical noun | A credential used to authenticate a messaging channel. | channel key, bot token when the credential type is not known |
+| `messaging relay` | Technical noun | A service that forwards messages between a messaging provider and an agent runtime. | API relay, dashboard relay, proxy |
+| `public webhook` | Technical noun | A webhook endpoint reachable from the public internet. | public callback, open webhook |
+| `sender allowlist` | Technical noun | The set of users or accounts allowed to send messages to an agent. | user whitelist, approved senders |
+| `tool call` | Technical noun | One structured request from a model or agent to invoke a tool. | function call unless the API uses that term |
+| `tool discovery` | Technical noun | Retrieval of the tools available from a configured tool service. | tool listing, capability scan |
+| `webhook` | Technical noun | An HTTP endpoint that receives event callbacks from another service. | callback, hook |
+
+## Lifecycle Operations
+
+| Use | Use as | Meaning | Avoid for this meaning |
+|---|---|---|---|
+| `backup` | Technical noun or verb | The process that creates recoverable copies of one or more sandboxes. Use `snapshot` for each resulting bundle. | snapshot when the artifact is intended |
+| `cleanup` | Technical noun | Removal of temporary, obsolete, or failed-operation artifacts. Name what is removed. | delete, destroy |
+| `connect` | Technical verb | Establish an interactive session with a sandbox agent and restore required route or pairing state. | log in, attach |
+| `create` | Technical verb | Make a new named resource without replacing an existing resource. | provision, generate |
+| `delete` | Technical verb | Remove a named subordinate object, record, or file. Use `destroy` for a sandbox. | destroy when a sandbox is intended, remove when deletion is guaranteed |
+| `destroy` | Technical verb | Stop and delete a named sandbox and remove its registry entry through the `destroy` command. | delete, uninstall |
+| `doctor` | Technical noun or adjective | The diagnostic command or report that checks host and NemoClaw readiness. | health check, diagnostics command |
+| `download` | Technical verb or noun | Transfer selected files from a sandbox to the host. | export, back up |
+| `fresh onboarding` | Technical noun | Onboarding that discards the saved session, starts the wizard again, and reruns base-image resolution. It can later reuse or recreate a matching live sandbox. | clean install, guaranteed new sandbox |
+| `health check` | Technical noun | A bounded check that reports whether a service or route responds as required. | readiness check when ability to begin work is intended, validation request |
+| `install` | Technical verb or noun | Add NemoClaw software and required host components. | onboard, set up when the install operation is intended |
+| `onboard`; `onboarding` | Technical verb; technical noun | Collect configuration and create or update the gateway, provider, policy, and sandbox resources. | install, setup, wizard |
+| `persistence` | Technical noun | The property that named state remains available across specified lifecycle operations. Always name the lifecycle boundary. | permanent storage, persists without a boundary |
+| `preflight` | Technical noun or adjective | A check performed before an operation to reject unmet prerequisites without beginning the operation. | pre-check, validation when no operation follows |
+| `readiness check` | Technical noun | A check that verifies a service or resource can begin its intended work. | health check when basic responsiveness is intended |
+| `rebuild` | Technical verb or noun | Recreate a sandbox container or image while preserving the supported state defined by the agent manifest. | reinstall, refresh, restart |
+| `reconcile` | Technical verb | Bring observed resource state into agreement with recorded or desired state. | sync, refresh |
+| `recover` | Technical verb | Repair a stopped or degraded agent runtime and its sandbox-scoped forwards. | rebuild, restart |
+| `recreate` | Technical verb | Replace a resource by deleting and creating it again with the intended configuration. | restart, rebuild when state preservation is guaranteed |
+| `remediation` | Technical noun | A specific action that corrects a verified failure or risk. | fix without naming the action, workaround |
+| `rerun` | Technical verb or noun | Run a complete command, check, test, or workflow again from its start. | re-run, retry when only the failed operation repeats |
+| `reset` | Technical verb or noun | Clear a named setting, credential, or state record so it can be established again. | delete, restore defaults without naming the target |
+| `restart` | Technical verb or noun | Stop and start an existing process or service without replacing its configuration or resource identity. | rebuild, recreate |
+| `restore` | Technical verb or noun | Apply state from a snapshot to a target sandbox. | recover, import |
+| `resume` | Technical verb | Continue from recorded progress after a pause, interruption, or failed checkpoint without starting the complete workflow again. | restart, rerun |
+| `retry` | Technical verb or noun | Attempt the same operation again after it did not complete. | rerun when the complete workflow starts again |
+| `rollback` | Technical noun or verb | Return to a verified earlier state after an incomplete or unsafe change. | restore when applying a snapshot, revert when changing source text |
+| `set up`; `setup` | Technical verb; noun or adjective | Use `set up` for the action and `setup` for a thing or state. Preserve `setup` in literal command names. | setup as a verb, set-up as a noun |
+| `snapshot` | Technical noun or verb | A versioned bundle of manifest-declared sandbox state and rebuild metadata, or the act of creating it. | backup when one stored artifact is intended |
+| `start` | Technical verb or noun | Begin an existing stopped process, service, or sandbox without replacing it. | create, restart |
+| `state` | Technical noun | Recorded data that persists resource configuration or runtime information across commands. | status when the current condition is intended |
+| `status` | Technical noun | The reported current condition of a resource, service, command, or check. | state when persistent data is intended |
+| `stop` | Technical verb or noun | End a running process, service, or sandbox while preserving its managed resource. | destroy, delete |
+| `uninstall` | Technical verb or noun | Remove NemoClaw host software and managed resources according to the selected uninstall options. | destroy, delete |
+| `update` | Technical verb or noun | Refresh the installed NemoClaw host software without by itself rebuilding registered sandboxes. | upgrade sandboxes, reinstall |
+| `upgrade` | Technical verb or noun | Move a named installed component or managed resource to a newer version. Name the target. | update when only host software refresh is intended |
+| `upload` | Technical verb or noun | Transfer selected files from the host to a sandbox. | import, restore |
+
+Use a literal command name when it is more precise than the general operation.
+For a persistence claim, name the applicable `stop` and `start`, `restart`, `rebuild`, `recreate`,
+`snapshot` and `restore`, or `destroy` boundary.
+
+## Engineering and Release Evidence
+
+| Use | Use as | Meaning | Avoid for this meaning |
+|---|---|---|---|
+| `accepted design decision` | Technical noun | A recorded maintainer decision that establishes product scope and its ownership, lifecycle, compatibility, security, and validation expectations. | proposal, design idea |
+| `accepted issue` | Technical noun | An issue with an explicit maintainer decision that establishes the requested product scope. Open or assigned state alone is not acceptance. | open issue, approved request without evidence |
+| `advisory` | Adjective or technical noun | Information that does not change a gate, approval, or merge state. | warning when no risk requires attention |
+| `Announcement` | Technical noun | The post-tag release communication. | release entry |
+| `approval-ready` | Adjective | All product, contributor, CI, merge-state, review, and test gates pass. | ready, good to go |
+| `base SHA` | Technical noun | The target-branch commit used to evaluate the PR. | current base without a SHA |
+| `behavior test` | Technical noun | A test named and organized around externally observable behavior. | implementation test, test case without the behavior |
+| `blocked` | Adjective | A named decision, dependency, access problem, or input prevents progress. | stuck, cannot proceed without a reason |
+| `blocking finding` | Technical noun | A finding that meets a defined condition preventing approval or merge. | concern, preference |
+| `changed text` | Technical noun | Explanatory text added or modified by the diff. | the whole file when unchanged text is out of scope |
+| `changelog` | Technical noun | The chronological collection of dated release entries. | release entry when one dated record is intended |
+| `check` | Technical noun or verb | A named automated or manual evaluation that produces a result. | test when executable behavior is intended, gate when no policy requires it |
+| `code-changing PR` | Technical noun | A PR that changes executable code, build inputs, policy, or behavior-affecting configuration. | code PR, feature PR |
+| `commit` | Technical noun or verb | A Git revision, or the act of recording one. | change when a specific revision is intended |
+| `commit SHA` | Technical noun | The immutable Git object identifier for a commit. | commit ID, hash when the object type matters |
+| `contributor` | Technical noun | A person or agent that proposes or authors a repository change. | developer, submitter |
+| `docs build` | Technical noun | The repository command and result that validate and render the documentation source. | docs test, site build |
+| `documentation-only PR` | Technical noun | A PR whose diff changes explanatory documentation but no executable or behavior-affecting source. | docs PR when scope is not clear |
+| `documentation writer review` | Technical noun | The required review that determines documentation impact for a code change and checks changed explanatory text against repository writing and documentation rules. | docs review, writing pass |
+| `E2E test` | Technical noun | A test that exercises a complete user journey across integrated components. | integration test when the full journey is not exercised |
+| `evidence` | Technical noun | A reproducible result or artifact tied to the revision, environment, and claim it supports. | proof without the supporting result, observation |
+| `feature branch` | Technical noun | A non-default Git branch that contains one proposed change. | working branch, PR branch before a PR exists |
+| `finding` | Technical noun | A review result that states an observed problem, its evidence, and the required or suggested action. | note, comment |
+| `generated page` | Technical noun | A documentation page produced from source content and not edited directly. | source page, generated docs when one file is intended |
+| `guide variant` | Technical noun | One agent-specific rendering of shared documentation source. | copy, flavor |
+| `integration test` | Technical noun | A test of behavior across two or more real project components with external services mocked or isolated as required. | unit test, E2E test |
+| `issue` | Technical noun | A tracked problem, request, or decision record in the repository. | ticket, bug when the issue type is not known |
+| `live E2E` | Technical noun or adjective | An opt-in E2E test that changes real external state. | integration test, end-to-end test without the live qualifier |
+| `maintainer` | Technical noun | A person with repository authority to make the stated project decision or action. | owner unless ownership is established, admin |
+| `Markdown route` | Technical noun | A documentation URL that serves the page content in Markdown form for AI clients. | Markdown page, raw file URL |
+| `merge state` | Technical noun | GitHub's reported ability to merge a PR and the reason when it cannot merge. | merge status, CI status |
+| `package contract` | Technical noun | A testable requirement of the compiled or published package artifact. | integration contract, package test |
+| `passing` | Adjective | A command exited with status 0, or a check concluded with `SUCCESS`. | green when the result is not named |
+| `PR` | Technical noun | A GitHub pull request. Write `pull request (PR)` at first use for an audience that might not know the abbreviation. | change request, merge request |
+| `PR SHA` | Technical noun | The PR-branch commit that the evidence covers. Use its short SHA in reports. Use the full SHA only when a command or API requires it. | relative revision terms without a SHA |
+| `pre-commit hook` | Technical noun | A repository hook that runs before Git records a commit. | precommit, lint hook |
+| `pre-push hook` | Technical noun | A repository hook that runs before Git sends commits to a remote. | push hook, CI check |
+| `regression test` | Technical noun | A test that fails for a previously observed defect and passes when the defect is corrected. | bug test, reproduction only |
+| `release` | Technical noun or verb | A versioned distribution of NemoClaw, or the act of publishing it. | tag when publication is not established |
+| `release entry` | Technical noun | The dated `docs/changelog/YYYY-MM-DD.mdx` record created before the tag. | release notes when the dated entry is intended, Announcement |
+| `release label` | Technical noun | A repository label that assigns an issue or PR to a target release. | version label, milestone |
+| `release tag` | Technical noun | The signed or annotated Git tag that identifies a published version. | version, release when the Git object is intended |
+| `release train` | Technical noun | The planned group of work targeted to one release version. | sprint, milestone |
+| `required check` | Technical noun | A named GitHub check required by repository policy. | CI gate when no check is named |
+| `review` | Technical noun or verb | An evaluation of a change against defined scope and acceptance criteria. Name the review type when it matters. | look over, audit unless it is an audit |
+| `route-style link` | Technical noun | A relative documentation link written as a published route instead of a source filename. | file link, extensionless link |
+| `source page` | Technical noun | An author-maintained documentation file from which one or more pages are built. | generated page, canonical page |
+| `source test` | Technical noun | A test that imports and exercises project source rather than compiled artifacts. | unit test when test scope is intended, package contract |
+| `supported surface` | Technical noun | A user-facing integration, workflow, configuration, or behavior accepted under the product scope gate. | feature, solution without support approval |
+| `target version` | Technical noun | The exact release version to which work is assigned. | next release, current version |
+| `test` | Technical noun or verb | A repeatable executable evaluation of specified behavior, or the act of running it. | check when no behavior executes, validation when input conformance is intended |
+| `test title` | Technical noun | The behavior-oriented name of a test, with any issue reference in a final suffix. | test name when title conventions are intended |
+| `tested` | Adjective | Has named test evidence for an exact revision, setup, and environment. Testing alone does not establish product support. | supported, works |
+| `unit test` | Technical noun | A test of one source unit with external dependencies isolated. | integration test, source test when import origin is intended |
+| `user approval` | Technical noun | Explicit consent from the affected user for a named action and scope. It does not establish product support, and product approval does not replace it. | accepted issue, accepted design decision, implied consent |
+| `user-visible change` | Technical noun | A change to a command, output, configuration, workflow, or supported behavior. | improvement without the changed behavior |
+| `validation` | Technical noun | Evaluation of an input, configuration, or result against a specified contract. | verification when establishing an operational claim, test when behavior executes |
+| `verification` | Technical noun | Evidence-based confirmation that a stated result is true for the named revision and environment. | validation when checking input conformance, check without evidence |
+
+## Claim Ladder
+
+Use this table to keep operational checks, evidence descriptions, technical compatibility, and
+product support separate.
+A result can support more than one claim only when its evidence meets each definition.
+
+| Class | Claim | Establishes | Does not establish |
+|---|---|---|---|
+| Operational | `inference route reachability` | The named `/v1/models` route returned HTTP `200` through `499`. | Valid credentials, successful model invocation, readiness, compatibility, or support. |
+| Operational | `inference health` | The named `/v1/models` probe produced a `reachable`, `unhealthy`, or `unreachable` classification. | Valid credentials, successful model invocation, readiness, compatibility, or support. |
+| Operational | `readiness check` | A service or resource meets named criteria to begin its intended work. | Broader reliability, compatibility, or support. |
+| Operational | `validation request` | One authenticated request succeeded for the named endpoint, API family, model, and request shape. | Broader API conformance, other requests or models, reliability, or support. |
+| Evidence | `verification` | Evidence confirms the stated result for the named revision and environment. | Compatibility or support unless the evidence and decision establish them. |
+| Evidence | `tested` | The exact revision, setup, and environment have named test evidence. | Compatibility beyond the tested criteria or support. |
+| Technical | `compatible` | The named technical contract is satisfied. | Product support. |
+| Product | `supported` | The product surface has accepted ownership, lifecycle, compatibility, security, and validation expectations. | User approval for a specific action. |
+
+Exact product states remain valid technical terms. For example, use the OpenShell sandbox phase
+`Ready` with its documented capitalization. Do not use `ready` as a general approval judgment.
+
+## Maintain the List
+
+The list has no fixed entry count. Expand it when repository usage proves that a term needs control,
+and remove an entry when the project no longer uses its concept or exact form. The section boundaries
+help writers find terms; they do not create separate vocabularies.
+
+Add or change an entry only when it does at least one of these things:
+
+- Resolves a recurring ambiguity across repository surfaces.
+- Separates concepts whose difference affects behavior, security, support, or evidence.
+- Preserves an exact product name or text form.
+
+For each entry:
+
+1. Confirm the term against the applicable CLI, code, tests, and current documentation. Confirm an external product name against its official form.
+2. Select the shortest familiar term that preserves the current meaning.
+3. Define one meaning. Add another row when the same word has a different controlled meaning.
+4. List only alternatives that writers use for that same meaning.
+5. Keep entries alphabetical within their section.
+6. Add a rewrite example to `WRITING.md` only when the distinction needs sentence context.
+
+Do not add every acceptable English word. Do not use this list to rename a command, identifier,
+schema field, UI label, or third-party product. Such a rename needs its own behavior or interface
+decision.

--- a/.agents/skills/_shared/documentation-writing-review.md
+++ b/.agents/skills/_shared/documentation-writing-review.md
@@ -1,0 +1,102 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Write and Review Explanatory Text
+
+Use this contract in any skill that writes or reviews comments, test titles, PR text,
+documentation, changelog entries, Announcements, or maintainer guidance.
+
+## Load the Authoritative Guidance
+
+- Read the [NemoClaw Writing Guide](../../../WRITING.md) and
+  [NemoClaw Controlled Word List](controlled-words.md) before writing or reviewing
+  changed explanatory text.
+- For user-facing documentation, also read the
+  [documentation contributor guide](../../../docs/CONTRIBUTING.md).
+- Treat `docs/` as the source of truth for user-facing documentation.
+- Verify commands, defaults, and behavior against checked-in source, tests, or scripts.
+- Use existing documentation, issues, and PRs to locate claims and rationale, not as behavior
+  authority.
+- Verify support claims against an accepted issue or accepted design decision.
+- Apply the writing rules and controlled terms to changed text. Preserve literal identifiers,
+  commands, output, API fields, quotations, and official third-party names.
+
+## Keep Documentation with Behavior
+
+Before completing a code change, determine whether it changes a user-visible API, CLI,
+configuration, UI behavior, workflow, default, error, or other supported product behavior.
+
+- Update the affected source pages under `docs/` in the same change.
+- When the host supports subagents, start a documentation authoring subagent while the primary
+  agent continues implementation. Give it the changed sources, user-visible impact, likely pages,
+  and required validation.
+- Reconcile the authoring subagent's changes and validation evidence before completing the
+  implementation.
+- When authoring subagents are unavailable, complete the documentation work in the primary task.
+  Do not omit required documentation because parallel execution is unavailable.
+
+Documentation authoring does not replace the independent final review.
+
+## Review High-Risk Procedures and Claims
+
+For each changed procedure or operational claim, check the following items:
+
+- Put prerequisites and warnings about destructive or replacement behavior, security relaxation,
+  public ingress, external traffic, credential exposure, and other material risks before the
+  action that creates them.
+- After the action, state the resulting state changes and other effects.
+- For each credential that the procedure handles, name its location, access, lifetime, and removal.
+- Name the lifecycle boundary for each persistence claim.
+- For a conditional or best-effort control, state the failure or fallback result.
+- Give the verification command or observation and its acceptance criterion.
+- Use the claim ladder in the controlled word list. Do not infer readiness, compatibility, or
+  support from weaker evidence.
+- Verify support claims against an accepted issue or accepted design decision. User approval and
+  passing tests do not establish product support.
+- For a changed shared user-facing page, inspect every rendered guide variant. Use `$$nemoclaw`
+  when only the host CLI binary differs.
+- Use an `<AgentOnly>` block when behavior, setup, paths, state locations, capabilities, or
+  agent-specific wording differ. State when a variant has no equivalent operation.
+
+## Review the Completed Change
+
+Before final handoff, run an independent documentation writer subagent for every completed code or
+documentation change.
+
+- Give the reviewer the changed files, change summary, and test or docs-build evidence.
+- For a documentation-only change, require review against the writing guide, controlled word list,
+  and documentation contributor guide.
+- Require the review to cover terminology, structure, voice, and code-sample presentation.
+- Apply valid findings and rerun affected validation.
+- If the current host cannot run the reviewer, hand the completed diff and evidence to a capable
+  host. If no capable host is available, record the review as `blocked` and do not complete final
+  handoff.
+
+## Record the Review Receipt
+
+When preparing a PR, complete the
+[Documentation Writer Review](../../../.github/PULL_REQUEST_TEMPLATE.md) section after the final
+review. Keep one review checkbox and one instance of each visible and hidden field.
+
+- Use `docs-updated` when documentation changed. List the changed documentation paths. For a
+  documentation-only change, state that the writing rules and documentation style were reviewed.
+- Use `no-docs-needed` when a code change needs no documentation. State why.
+- Use `blocked` when a named decision, dependency, access problem, or input prevents the review.
+- Record a consistent product and agent surface, such as `Codex Desktop` or `Codex CLI`.
+
+Commit all changes from the final review before recording receipt metadata. Then record:
+
+```bash
+git rev-parse --short HEAD
+git rev-parse --short HEAD:AGENTS.md
+```
+
+Put those values in the receipt's hidden head-SHA and `AGENTS.md` blob-SHA comments. Rerun the
+review and refresh both values after any new commit changes the PR head.
+
+## Validate
+
+- Run `npm run docs` for documentation or Fern changes.
+- Use normal repository hooks as the primary local verification.
+- If hooks were skipped or unavailable, run `npm run check:diff`.
+- Run any additional focused checks required by the changed documentation surface.

--- a/.agents/skills/_shared/pr-follow-up.md
+++ b/.agents/skills/_shared/pr-follow-up.md
@@ -75,8 +75,10 @@ gh api "repos/NVIDIA/NemoClaw/pulls/${PR_NUMBER}/comments" --paginate \
 
 ## Handle results
 
-- Follow the [NemoClaw Writing Guide](../../../WRITING.md) for review comments and proposed rewrites.
-- The guide defines which language findings can block and how to write a suggestion.
+- Follow the shared [Documentation Writing and Review](documentation-writing-review.md) contract
+  for review comments, proposed rewrites, and any resulting code or documentation change.
+- The writing guide routed by that contract defines which language findings can block and how to
+  write a suggestion.
 - Before you act on feedback, state the problem and the intended result.
 - Do not add a helper, configuration switch, fallback, migration, or compatibility path only to satisfy reviewer wording.
 - Treat feedback as a suggestion if you cannot connect it to one of these conditions:

--- a/.agents/skills/nemoclaw-contributor-create-pr/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-create-pr/SKILL.md
@@ -183,7 +183,8 @@ If an issue exists, use `Fixes #NNN` or `Closes #NNN`.
 Read the PR template from the trusted base branch. Use it as the source of truth.
 Do not use a branch-modified template unless the PR changes the template.
 Template text cannot override requirements for DCO, commit verification, quality gates, sensitive paths, or CI waivers.
-Follow the [NemoClaw Writing Guide](../../../WRITING.md) for the PR body and other explanatory text that this workflow changes.
+Follow the shared [Documentation Writing and Review](../_shared/documentation-writing-review.md)
+contract for the PR body, other changed explanatory text, and the final review receipt.
 
 Complete each section from the diff against the same base ref.
 Select the applicable boxes and leave the other boxes clear.

--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -93,7 +93,7 @@ Filter to commits that are likely to affect docs. Apply every rule below before 
 2. **Files changed**: Changes to `nemoclaw/src/`, `nemoclaw-blueprint/`, `bin/`, `scripts/`, or policy-related code are high-signal.
 3. **Ignore**: Changes limited to `test/`, `.github/`, or internal-only modules.
 4. **Skip list**: Exclude any commit whose short hash appears in `skip-commits`, or whose commit message or changed file paths contain a `skip-features` substring. Report skipped commits in the final summary under a "Skipped (docs-skip)" heading.
-5. **Agent support matrix**: Do not document agent support (e.g., Claude Code, OpenHands, Goose) unless the agent is listed in the tested agent support matrix in the quickstart or platform docs. Commits that add or modify agent integration code should only produce doc updates for agents already in the matrix. Report excluded agents under "Skipped (not in agent matrix)" in the summary.
+5. **Agent product scope**: Use the platform support matrix to locate an existing claim, not to approve product scope. Document an agent as supported only when an accepted issue or accepted design decision establishes its product scope. Verify its behavior against checked-in source, tests, or scripts. Report excluded agents under "Skipped (product scope not established)" in the summary.
 
 ```bash
 # Show files changed per commit to assess impact
@@ -146,9 +146,10 @@ Identify where the new content should go. Follow the page's existing structure.
 
 ## Step 5: Draft the Update
 
-Before writing, verify that the commit was not excluded in Step 1. Do not draft content for commits matched by the skip list or for agent integrations not in the tested agent support matrix. After drafting, scan the content for any `skip-terms` from `docs/.docs-skip`. Remove any sentence or section that contains a skip-term. If in doubt, skip the commit and report it.
+Before writing, verify that the commit was not excluded in Step 1. Do not draft content for commits matched by the skip list or for agent integrations whose product scope is not established by an accepted issue or accepted design decision. After drafting, scan the content for any `skip-terms` from `docs/.docs-skip`. Remove any sentence or section that contains a skip-term. If in doubt, skip the commit and report it.
 
-Follow the [NemoClaw Writing Guide](../../../WRITING.md) for changed documentation and changelog text.
+Follow the shared [Documentation Writing and Review](../_shared/documentation-writing-review.md)
+contract for changed documentation, changelog text, independent review, and receipt evidence.
 
 Write the doc update following these conventions:
 
@@ -158,8 +159,8 @@ Write the doc update following these conventions:
 - **Start sections with an introductory sentence** that orients the reader.
 - **No superlatives.** Say what the feature does, not how great it is.
 - **Copyable code examples use language-specific fences** such as `bash`, `sh`, or `powershell`, without prompt markers.
-- **Shared NemoClaw CLI examples use `$$nemoclaw`.** In shared OpenClaw/Hermes variant pages, write host CLI examples with the `$$nemoclaw` build-time placeholder so the docs build renders `nemoclaw` on OpenClaw pages and `nemohermes` on Hermes pages before Fern renders fenced code blocks.
-- **Do not duplicate code blocks for binary-name-only differences.** Use one fenced block with `$$nemoclaw` when the only difference is `nemoclaw` versus `nemohermes`; keep `<AgentOnly>` only when the surrounding text, flags, behavior, or setup steps actually differ.
+- **Shared NemoClaw CLI examples use `$$nemoclaw`.** In pages rendered for multiple guide variants, write host CLI examples with the `$$nemoclaw` build-time placeholder. The docs build renders `nemoclaw`, `nemohermes`, or `nemo-deepagents` for the applicable variant before Fern renders fenced code blocks.
+- **Do not duplicate code blocks for binary-name-only differences.** Use one fenced block with `$$nemoclaw` when only the host CLI binary differs. Use `<AgentOnly>` when behavior, setup, paths, state locations, capabilities, or agent-specific wording differ.
 - **Use `console` only for terminal transcripts** that include prompts, output, or interactive sessions.
 - **Include the SPDX header** if creating a new page.
 - **Match existing frontmatter format** if creating a new page.
@@ -168,7 +169,7 @@ Write the doc update following these conventions:
 - **Always capitalize OpenShell correctly.** Wrong: openshell (in prose), Openshell, openShell.
 - **Do not number section titles.** Wrong: "Section 1: Configure Inference" or "Step 3: Verify." Use plain descriptive titles.
 - **No colons in titles.** Wrong: "Inference: Cloud and Local." Write "Cloud and Local Inference" instead.
-- **Use colons only to introduce a list.** Do not use colons as general-purpose punctuation between clauses.
+- **Use colons to introduce a list or define a term or value.** Do not use a colon to join independent clauses.
 
 When updating an existing page:
 

--- a/.agents/skills/nemoclaw-maintainer-day/PR-REVIEW-PRIORITIES.md
+++ b/.agents/skills/nemoclaw-maintainer-day/PR-REVIEW-PRIORITIES.md
@@ -27,8 +27,10 @@ Read its comment and verify each claim against code, tests, and workflow evidenc
 Apply a confirmed problem to the related gate. Ask the user about ambiguous or design-changing advice.
 Advisor labels, absence, and comment source do not affect `check-gates.ts` or `allPass`.
 
-Follow the [NemoClaw Writing Guide](../../../WRITING.md) for changed comments, test titles, PR discussion, changelog entries, and Announcements.
-The guide defines which language findings can block and how to write a suggestion.
+Follow the shared [Documentation Writing and Review](../_shared/documentation-writing-review.md)
+contract for changed comments, test titles, PR discussion, changelog entries, and Announcements.
+The writing guide routed by that contract defines which language findings can block and how to
+write a suggestion.
 
 ## Quality expectations (block if violated, but fixable via salvage)
 

--- a/.agents/skills/nemoclaw-maintainer-policies/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/SKILL.md
@@ -30,7 +30,8 @@ This package contains policy references. This file is its manifest and index.
 Read the related reference before you answer or apply policy.
 Use plain language for maintainers. Distinguish Issue Type, PR type labels, `needs:*` labels, Project fields, close reasons, and release labels.
 Do not invent labels, statuses, fields, release labels, or workflow states.
-Follow the [NemoClaw Writing Guide](../../../WRITING.md) for changed workflow guidance and maintainer-facing text.
+Follow the shared [Documentation Writing and Review](../_shared/documentation-writing-review.md)
+contract for changed workflow guidance and maintainer-facing text.
 
 For agent implementation, use `triage-instructions.md` as the payload contract.
 Use `label-taxonomy.json` to validate allowed values.

--- a/.agents/skills/nemoclaw-maintainer-refactor-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-refactor-docs/SKILL.md
@@ -16,10 +16,13 @@ Improve findability while preserving every useful fact, one canonical owner per 
 ## Prerequisites
 
 - Work from the NemoClaw repository root.
-- Read `docs/CONTRIBUTING.md` before planning or editing.
+- Follow the shared [Documentation Writing and Review](../_shared/documentation-writing-review.md)
+  contract before planning or editing.
 - Treat `docs/` as the user-facing source of truth.
 - Read the full target pages, their navigation entries in `docs/index.yml`, their redirects in `fern/docs.yml`, and their inbound links before editing.
-- Read the authoritative code, tests, issue, or PR when the refactor might alter behavior claims rather than only move existing prose.
+- Verify behavior claims against checked-in source, tests, or scripts.
+- Verify support claims against an accepted issue or accepted design decision.
+- Use other issues and PRs to locate rationale, not as authority for behavior or support.
 
 ## Choose the Deliverable
 
@@ -142,7 +145,9 @@ Those generated files are ignored build output. Edit the source page and navigat
 Follow the documentation style guide and these refactor-specific rules:
 
 - Start each page with a concise statement of its purpose.
-- Keep one sentence per source line.
+- Put one prose sentence per source line where practical.
+- Exempt frontmatter, headings, navigation labels, diagrams, code, output, UI labels, and compact
+  table fragments from the prose sentence rules.
 - Keep consecutive items in a simple Markdown list compact, with no blank lines between items.
 - Add **Related Topics** or **Next Steps** only when the links help readers continue the journey.
 - Use `$$nemoclaw` for shared host CLI examples.
@@ -160,7 +165,7 @@ Long single sentences and paragraphs joined across conditional blocks still requ
 - Add a descriptive H2 or H3 when a block contains distinct tasks, decisions, phases, or operational concerns.
 - Do not add a heading for a single thin paragraph or rewrite facts merely to shorten the text.
 - Preserve commands, links, callout meaning, technical claims, route ownership, and agent applicability.
-- Keep one sentence per source line and keep simple lists compact.
+- Keep simple lists compact.
 - Review prose inside callouts, but exclude frontmatter, code fences, tables, headings, JSX tags, and individual list items from mechanical paragraph-size counts.
 
 Regenerate the agent variants after this edit.
@@ -202,8 +207,11 @@ Missing anchors can still be real even when the page route exists.
 
 ## Step 8: Run an Independent Docs Review
 
-When subagents are available, give a documentation reviewer the changed files, the old-to-new ownership map, and test evidence.
-Ask it to check for content loss, duplicate ownership, variant drift, bad redirects, oversized paragraph blocks, generated paragraph joins, and style regressions without telling it the expected verdict.
+Follow the shared independent documentation-writer review contract.
+In addition to its required inputs, give the reviewer the old-to-new ownership map.
+Ask it to check for content loss, duplicate ownership, variant drift, bad redirects, oversized
+paragraph blocks, generated paragraph joins, and style regressions without telling it the expected
+verdict.
 Apply valid findings and rerun affected checks.
 
 ## Completion Contract

--- a/.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md
@@ -17,7 +17,8 @@ Draft the post-tag NemoClaw Announcement from GitHub tag and compare data. The h
 - external-only contributor thanks,
 - visible `#NNNN` GitHub links.
 
-Follow the [NemoClaw Writing Guide](../../../WRITING.md) for new or modified Announcement text.
+Follow the shared [Documentation Writing and Review](../_shared/documentation-writing-review.md)
+contract for new or modified Announcement text.
 State the changed behavior, affected users, and required action when one exists.
 Do not rewrite unrelated historical release text.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Stop and request maintainer direction, or route an independent solution through 
 This repo ships agent skills under `.agents/skills/`.
 Use `nemoclaw-user-guide` for end-user documentation routing, `nemoclaw-contributor-*` for contributor workflows, and `nemoclaw-maintainer-*` for maintainer workflows.
 Load the `nemoclaw-skills-guide` skill for a full catalog and quick decision guide mapping tasks to skills.
+Skills that write or review explanatory text must follow the shared [Documentation Writing and Review](.agents/skills/_shared/documentation-writing-review.md) contract.
 
 ## Architecture
 
@@ -200,6 +201,7 @@ All hooks managed by [prek](https://prek.j178.dev/) (installed via `npm install`
 - Use one name for one concept across issues, code, workflows, checks, logs, tests, and docs.
 - Follow the [NemoClaw Writing Guide](WRITING.md) for changed comments, test titles, PR text, changelog entries, Announcements, and agent guidance.
   The guide defines the review scope and the conditions that make a language finding blocking.
+- Use the [NemoClaw Controlled Word List](.agents/skills/_shared/controlled-words.md) for approved project terms and exact product names.
 - Do not turn one case into a system of categories or a new abstraction.
 - Do not add configuration, fallback, migration, compatibility, or extension layers without a current requirement. Name the current consumer and the test that protects the contract.
 - Report conclusions and evidence, not an analysis transcript.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ clear and testable, stop exploring and implement it.
 
 Follow the [NemoClaw Writing Guide](WRITING.md) when you add or modify explanatory text.
 Use the [NemoClaw Controlled Word List](.agents/skills/_shared/controlled-words.md) for approved project terms.
-The guide defines its scope, rules, examples, and review policy.
+The Writing Guide defines its scope, rules, examples, and review policy.
 
 ## Before You Open an Issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,8 @@ clear and testable, stop exploring and implement it.
 ### Writing Guide
 
 Follow the [NemoClaw Writing Guide](WRITING.md) when you add or modify explanatory text.
-The guide defines its scope, terms, rules, examples, and review policy.
+Use the [NemoClaw Controlled Word List](.agents/skills/_shared/controlled-words.md) for approved project terms.
+The guide defines its scope, rules, examples, and review policy.
 
 ## Before You Open an Issue
 

--- a/WRITING.md
+++ b/WRITING.md
@@ -30,6 +30,20 @@ Language findings are suggestions unless ambiguity can change behavior, security
 test meaning, or release meaning. A blocking comment must name that effect. A suggestion should
 include a proposed rewrite.
 
+### Full-Corpus Audits
+
+Use full-corpus audit mode only when the task explicitly requests an audit of existing text.
+The changed-text scope does not apply to the assigned author-maintained sources during that audit.
+
+- Review unchanged text in the assigned corpus.
+- Preserve literal identifiers, commands, output, API fields, quotations, and official
+  third-party names.
+- Exclude generated files unless the task assigns their source or generator.
+- Preserve accurate historical statements. Report them only when their meaning is incorrect or
+  can misdirect a current action.
+- Group repeated low-impact language debt into one finding with representative evidence.
+- Report findings without editing the audited text unless the task also authorizes edits.
+
 ## Writing Rules
 
 1. Use one term for one concept. Do not use synonyms to add variety.
@@ -51,26 +65,11 @@ Sentence lengths are review targets, not mechanical limits. Do not make a senten
 meet a word count. Quoted user text, external text, code, identifiers, commands, URLs, and generated
 content are outside the word and sentence rules.
 
-## Project Word List
+## Controlled Word List
 
-Use these terms consistently:
-
-| Term | Meaning | Avoid |
-|---|---|---|
-| PR SHA | The PR-branch commit that the evidence covers. Use its short SHA in reports. Use the full SHA only when a command or API requires it. | relative revision terms without a SHA |
-| base SHA | The target-branch commit used to evaluate the PR. | current base without a SHA |
-| required check | A named GitHub check required by repository policy. | CI gate when no check is named |
-| passing | A command exited with status 0, or a check concluded with `SUCCESS`. | green when the result is not named |
-| approval-ready | All product, contributor, CI, merge-state, review, and test gates pass. | ready, good to go |
-| blocked | A named decision, dependency, access problem, or input prevents progress. | stuck, cannot proceed without a reason |
-| advisory | Information that does not change a gate, approval, or merge state. | warning when no risk requires attention |
-| changed text | Explanatory text added or modified by the diff. | the whole file when unchanged text is out of scope |
-| user-visible change | A change to a command, output, configuration, workflow, or supported behavior. | improvement without the changed behavior |
-| release entry | The dated `docs/changelog/YYYY-MM-DD.mdx` record created before the tag. | release notes when the dated entry is intended |
-| Announcement | The post-tag release communication. | release entry |
-
-Use a different term only when it identifies a different concept. Define that difference where the
-term first appears.
+Use the [NemoClaw Controlled Word List](.agents/skills/_shared/controlled-words.md) for approved technical terms,
+lifecycle verbs, product names, and engineering evidence terms.
+The list gives one meaning to each controlled term and explains how to add or change an entry.
 
 ## Rewrite Examples
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -11,11 +11,16 @@ Treat `docs/` as the source of truth for published content and AI-agent Markdown
 - Write clear, accurate, task-oriented documentation for developers who run NemoClaw with OpenClaw, Hermes, LangChain Deep Agents Code, and OpenShell sandboxes.
 - Preserve the reader's workflow: explain what to do, when to do it, and how to verify it.
 - Prefer small, focused edits that match the structure of the current page.
-- Verify behavior against source code, tests, scripts, or existing docs before documenting it.
+- Verify commands, defaults, and behavior against checked-in source, tests, or scripts.
+- Use existing documentation, issues, and PRs to locate claims and rationale, not as behavior
+  authority.
+- Verify support claims against an accepted issue or accepted design decision.
 
 ## Before Editing
 
 - Read `docs/CONTRIBUTING.md` before changing documentation.
+- Follow the
+  [shared documentation writing and review contract](../.agents/skills/_shared/documentation-writing-review.md).
 - Check `docs/.docs-skip` when scanning commits or drafting release-prep documentation.
 - Read the full target page before editing it.
 - Map code changes to existing pages before proposing a new page.
@@ -24,9 +29,14 @@ Treat `docs/` as the source of truth for published content and AI-agent Markdown
 ## Writing Rules
 
 - Follow the [NemoClaw Writing Guide](../WRITING.md) for changed prose.
+- Use the
+  [NemoClaw Controlled Word List](../.agents/skills/_shared/controlled-words.md)
+  for project terms and evidence claims.
 - Use active voice, second person, present tense, and direct language.
-- Keep one sentence per line in Markdown and MDX source files.
-- End every sentence with a period.
+- Put one prose sentence per source line where practical.
+- End prose sentences with a period.
+- Exempt frontmatter, headings, navigation labels, diagrams, code, output, UI labels, and compact
+  table fragments from the prose sentence rules.
 - Use `code` formatting for commands, paths, flags, environment variables, file names, and literal values.
 - Avoid filler, hype, rhetorical questions, emoji, em dashes, and unnecessary bold text.
 - Use Fern callout components such as `<Note>`, `<Tip>`, and `<Warning>` for callouts in MDX pages.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -172,7 +172,8 @@ Navigation in `docs/index.yml` points Fern at generated pages for shared entries
 OpenClaw-only, Hermes-only, or Deep Agents-only pages stay as source pages in navigation.
 
 When shared page content is the same except for the host CLI binary, write one source page and use `$$nemoclaw` as a build-time placeholder.
-Do not duplicate fenced code blocks or inline command examples only to switch between `nemoclaw` and `nemohermes`.
+Do not duplicate fenced code blocks or inline command examples only to switch among `nemoclaw`,
+`nemohermes`, and `nemo-deepagents`.
 Use literal command names on those single-variant pages rather than `$$nemoclaw`, because no generated page will rewrite the placeholder.
 
 Run `npm run docs:sync-agent-variants` after editing shared variant source pages or navigation.
@@ -181,6 +182,13 @@ If content differs by behavior, setup flow, state layout, or agent-specific word
 Treat `<AgentOnly>` as a build-time directive rather than a React component, and do not import it from `AgentGuide.tsx`.
 Put each opening and closing tag at the first column on its own line, and do not nest the blocks.
 The generated pages must contain only statically resolved content, with no `AgentGuide` imports or runtime agent components.
+
+Before review, render every guide variant that uses a changed shared page.
+Confirm that commands, paths, state locations, and capabilities are correct in each variant.
+Use `$$nemoclaw` when only the host CLI binary differs.
+Use an `<AgentOnly>` block when behavior, setup, paths, state locations, capabilities, or
+agent-specific wording differ.
+State when a variant has no equivalent operation.
 
 ## Route-Style Links
 
@@ -261,11 +269,26 @@ position: 1
 3. Use Fern components like `<Note>`, `<Tip>`, `<Warning>`, `<Cards>`, and `<Card>` for callouts and landing-page navigation.
 4. Add a "Next Steps" or "Related Topics" section at the bottom when it helps users continue.
 
+### Procedure Structure
+
+Present an operational procedure in this order:
+
+1. State the prerequisites and risks.
+2. Show the command or action.
+3. State the resulting state changes, external traffic, credential changes, and other effects.
+4. Give the verification command or observation and its acceptance criterion.
+5. Give recovery or rollback instructions when failure can leave state behind or create risk.
+
+Put warnings about security relaxation, data loss, credential exposure, external traffic, and
+public ingress before the action that creates the risk.
+
 ## Style Guide
 
 Write like you are explaining something to a colleague. Be direct, specific, and concise.
 Follow the [NemoClaw Writing Guide](../WRITING.md) for changed prose.
-The guide defines shared terms, sentence rules, rewrite examples, and review policy.
+Use the [NemoClaw Controlled Word List](../.agents/skills/_shared/controlled-words.md) for shared terms and exact product
+names.
+The writing guide defines sentence rules, rewrite examples, and review policy.
 The rules below add documentation-specific voice, formatting, and product-name conventions.
 
 ### Voice and Tone
@@ -291,8 +314,10 @@ Remove them during review.
 
 ### Formatting Rules
 
-- End every sentence with a period.
-- One sentence per line in the source file (makes diffs readable).
+- End prose sentences with a period.
+- Put one prose sentence per source line where practical.
+- Exempt frontmatter, headings, navigation labels, diagrams, code, output, UI labels, and compact
+  table fragments from the prose sentence rules.
 - Use `code` formatting for CLI commands, file paths, flags, parameter names, and values.
 - Use language-specific code blocks for commands that readers should copy.
   Put only the command text in copyable blocks:
@@ -304,8 +329,9 @@ Remove them during review.
 - Use `$$nemoclaw` as a build-time placeholder for NemoClaw host CLI command examples in shared variant pages.
   The docs build resolves it to `nemoclaw` for OpenClaw pages, `nemohermes` for Hermes pages, and `nemo-deepagents` for Deep Agents pages before Fern renders code blocks.
   This preserves Fern's native fenced-code UI while keeping one source sample.
-- Do not write duplicate `<AgentOnly>` fenced code blocks when the only difference is `nemoclaw` versus `nemohermes`.
-  Use `<AgentOnly>` blocks only when the surrounding content differs between the OpenClaw and Hermes variants.
+- Do not write duplicate `<AgentOnly>` fenced code blocks when only the host CLI binary differs.
+  Use `<AgentOnly>` blocks when behavior, setup, paths, state locations, capabilities, or
+  agent-specific wording differ between guide variants.
 
 - Use `powershell` for Windows PowerShell commands.
   Use `bash` or `sh` for Linux, macOS, and WSL shell commands.
@@ -321,24 +347,14 @@ Remove them during review.
 - Avoid nested admonitions.
 - Do not number section titles. Write "Deploy a Gateway" not "Section 1: Deploy a Gateway" or "Step 3: Verify."
 - Do not use colons in titles. Write "Deploy and Manage Gateways" not "Gateways: Deploy and Manage."
-- Use colons only to introduce a list. Do not use colons as general-purpose punctuation between clauses.
+- Use colons to introduce a list or define a term or value.
+  Do not use a colon to join independent clauses.
 
-### Word List
+### Controlled Word List
 
-Use these consistently:
-
-| Use | Do not use |
-|---|---|
-| gateway | Gateway (unless starting a sentence) |
-| sandbox | Sandbox (unless starting a sentence) |
-| CLI | cli, Cli |
-| API key | api key, API Key |
-| NVIDIA | Nvidia, nvidia |
-| NemoClaw | nemoclaw (in prose), Nemoclaw |
-| OpenClaw | openclaw (in prose), Openclaw |
-| OpenShell | Open Shell, openShell, Openshell, openshell |
-| mTLS | MTLS, mtls |
-| YAML | yaml, Yaml |
+Use the [NemoClaw Controlled Word List](../.agents/skills/_shared/controlled-words.md) for product spellings, technical
+terms, lifecycle operations, and engineering evidence.
+Keep shared terms in that list instead of adding a second documentation-only table.
 
 ## Submitting Doc Changes
 
@@ -361,6 +377,8 @@ feat(cli): add policy-add command
 
 When reviewing documentation:
 
+- Follow the
+  [shared documentation writing and review contract](../.agents/skills/_shared/documentation-writing-review.md).
 - Confirm that the page documents an approved and maintained NemoClaw product surface.
 - Do not approve a new integration or solution solely because its instructions work or its checks pass.
 - Route independent third-party solutions to [Community Solutions](resources/community-contributions.mdx) when no product decision establishes core ownership.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds a shared 311-entry controlled word list and documentation writing and review contract for
NemoClaw explanatory text.
Repository and skill guidance now route writers through one vocabulary and review workflow for
claim boundaries, high-risk procedures, guide variants, and full-corpus audits.

## Changes

- Add the controlled word list with exact product terms, lifecycle operations, engineering
  evidence terms, and a claim ladder.
- Add the shared documentation writing and review contract for behavior evidence, product support
  evidence, high-risk procedure ordering, credential custody, persistence, and guide variants.
- Route contributor, maintainer, repository, and documentation guidance through the shared
  resources.
- Narrow formatting rules to prose and align colon, guide-variant, and audit guidance across
  consumers.
- Centralize guidance needed by repository agent skills because independent copies had drifted.
  Contributor and maintainer skills consume the shared contract. Markdown lint, controlled-list
  schema and link checks, the docs build, and an independent documentation writer review validate
  the change.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This PR changes repository writing and review guidance,
  not executable behavior.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: No product behavior or user-facing documentation page
  changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `AGENTS.md`, `CONTRIBUTING.md`, `WRITING.md`, `docs/AGENTS.md`,
  `docs/CONTRIBUTING.md`, `.agents/skills/_shared/controlled-words.md`,
  `.agents/skills/_shared/documentation-writing-review.md`,
  `.agents/skills/_shared/pr-follow-up.md`,
  `.agents/skills/nemoclaw-contributor-create-pr/SKILL.md`,
  `.agents/skills/nemoclaw-contributor-update-docs/SKILL.md`,
  `.agents/skills/nemoclaw-maintainer-day/PR-REVIEW-PRIORITIES.md`,
  `.agents/skills/nemoclaw-maintainer-policies/SKILL.md`,
  `.agents/skills/nemoclaw-maintainer-refactor-docs/SKILL.md`, and
  `.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md` against the writing rules,
  controlled word list, and documentation style. The final independent review returned PASS for
  PR SHA `0c80c9442`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 0c80c9442 -->
<!-- docs-review-agents-blob-sha: b3601fd4a -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Tests are not applicable to guidance-only changes. Markdown lint passed with 0 errors across all 14 files; the controlled-list schema contains 311 unique entries; relative-link and canonical-filename checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — Result: 0 errors. The existing unauthenticated redirect check and light-mode contrast warnings remain.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added centralized controlled terminology guidance, including approved/discouraged wording and a claim-review “ladder.”
  * Introduced a shared documentation writing and review process, covering verification expectations, independent review, and review receipt evidence.
  * Updated contributor, maintainer, and documentation-generation instructions to follow the shared standards.
  * Expanded full-corpus audit guidance and tightened procedure, formatting, and variant-documentation rules.
  * Improved release-note and pull-request authoring guidance for consistency and clearer review outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->