### PR TITLE
feat(cli): add experimental voice access gateway

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -12,7 +12,7 @@
       "src/lib/adapters/openshell/timeouts.ts": 36,
       "src/lib/agent/defs.ts": 32,
       "src/lib/cli/branding.ts": 85,
-      "src/lib/cli/nemoclaw-oclif-command.ts": 103,
+      "src/lib/cli/nemoclaw-oclif-command.ts": 104,
       "src/lib/cli/terminal-style.ts": 45,
       "src/lib/core/json-types.ts": 37,
       "src/lib/core/ports.ts": 86,

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3467,7 +3467,7 @@ For contributor guidance on how these command files are structured, refer to
 | `$$nemoclaw internal uninstall classify-shim` | `uninstall.sh` / `$$nemoclaw uninstall` | Classify whether a shim path is safe for the uninstaller to remove. |
 | `$$nemoclaw internal dns setup-proxy` | onboarding / sandbox setup | Configure the DNS forwarder bridge inside a sandbox pod. |
 | `$$nemoclaw internal dns fix-coredns` | onboarding / sandbox setup | Patch CoreDNS to use a non-loopback upstream resolver. |
-| `$$nemoclaw internal voice-access serve` | deployment-owned service supervisor | Serve an authenticated loopback gateway for VoiceClaw WebRTC signaling. |
+| `$$nemoclaw internal voice-access serve` | deployment-owned service supervisor | Serve the experimental, authenticated loopback gateway for VoiceClaw WebRTC signaling. Non-loopback access requires deployment-owned TLS termination; NemoClaw does not own public endpoint management, the Talker lifecycle, or service supervision. |
 | `$$nemoclaw internal dev npm-link-or-shim` | `scripts/npm-link-or-shim.sh` (development) | Run `npm link`, falling back to a user-local NemoClaw development shim. |
 
 These commands do not appear in the command-level parity check, which compares

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3467,6 +3467,7 @@ For contributor guidance on how these command files are structured, refer to
 | `$$nemoclaw internal uninstall classify-shim` | `uninstall.sh` / `$$nemoclaw uninstall` | Classify whether a shim path is safe for the uninstaller to remove. |
 | `$$nemoclaw internal dns setup-proxy` | onboarding / sandbox setup | Configure the DNS forwarder bridge inside a sandbox pod. |
 | `$$nemoclaw internal dns fix-coredns` | onboarding / sandbox setup | Patch CoreDNS to use a non-loopback upstream resolver. |
+| `$$nemoclaw internal voice-access serve` | deployment-owned service supervisor | Serve an authenticated loopback gateway for VoiceClaw WebRTC signaling. |
 | `$$nemoclaw internal dev npm-link-or-shim` | `scripts/npm-link-or-shim.sh` (development) | Run `npm link`, falling back to a user-local NemoClaw development shim. |
 
 These commands do not appear in the command-level parity check, which compares

--- a/src/commands/internal/voice-access/serve.ts
+++ b/src/commands/internal/voice-access/serve.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flags } from "@oclif/core";
+import {
+  DEFAULT_VOICE_ACCESS_LISTEN_PORT,
+  DEFAULT_VOICE_ACCESS_UPSTREAM_PORT,
+  runVoiceAccessGatewayAction,
+} from "../../../lib/actions/voice-access/serve";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
+
+export default class InternalVoiceAccessServeCommand extends NemoClawCommand {
+  static hidden = true;
+  static strict = true;
+  static summary = "Internal: serve the voice access gateway";
+  static description = "Serve an authenticated loopback gateway for VoiceClaw WebRTC signaling.";
+  static usage = [
+    "internal voice-access serve --token-file <path> [--listen-port <port>] [--upstream-port <port>]",
+  ];
+  static examples = [
+    "<%= config.bin %> internal voice-access serve --token-file /run/secrets/voice-access-token",
+  ];
+  static flags = {
+    "token-file": Flags.string({
+      description: "Absolute path to a private file containing the bearer token",
+      required: true,
+    }),
+    "listen-port": Flags.integer({
+      default: DEFAULT_VOICE_ACCESS_LISTEN_PORT,
+      description: "Loopback port for authenticated client requests",
+      min: 1024,
+      max: 65_535,
+    }),
+    "upstream-port": Flags.integer({
+      default: DEFAULT_VOICE_ACCESS_UPSTREAM_PORT,
+      description: "Loopback port for the VoiceClaw Talker service",
+      min: 1024,
+      max: 65_535,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(InternalVoiceAccessServeCommand);
+    await runVoiceAccessGatewayAction({
+      listenPort: flags["listen-port"],
+      tokenFile: flags["token-file"],
+      upstreamPort: flags["upstream-port"],
+    });
+  }
+}

--- a/src/lib/actions/voice-access/serve.test.ts
+++ b/src/lib/actions/voice-access/serve.test.ts
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EventEmitter } from "node:events";
+import type { Server } from "node:http";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_VOICE_ACCESS_LISTEN_PORT,
+  DEFAULT_VOICE_ACCESS_UPSTREAM_PORT,
+  runVoiceAccessGatewayAction,
+  type VoiceAccessGatewayActionDeps,
+} from "./serve";
+
+class FakeServer extends EventEmitter {
+  closeCalls = 0;
+  listenCall: { host: string; port: number } | null = null;
+  listening = false;
+
+  listen(port: number, host: string, callback: () => void): this {
+    this.listenCall = { host, port };
+    this.listening = true;
+    queueMicrotask(callback);
+    return this;
+  }
+
+  close(callback?: (error?: Error) => void): this {
+    this.closeCalls += 1;
+    this.listening = false;
+    this.emit("close");
+    callback?.();
+    return this;
+  }
+}
+
+function actionDeps(
+  server: FakeServer,
+  signals: EventEmitter,
+  overrides: Partial<VoiceAccessGatewayActionDeps> = {},
+): VoiceAccessGatewayActionDeps {
+  return {
+    createServer: vi.fn(() => server as unknown as Server),
+    log: vi.fn(),
+    processEvents: signals as unknown as VoiceAccessGatewayActionDeps["processEvents"],
+    readTokenFile: vi.fn(() => "test-bearer-token"),
+    ...overrides,
+  };
+}
+
+describe("voice access gateway action", () => {
+  it.each([
+    "SIGINT",
+    "SIGTERM",
+  ] as const)("binds the default ports to loopback and closes on %s", async (signal) => {
+    const server = new FakeServer();
+    const signals = new EventEmitter();
+    const deps = actionDeps(server, signals);
+
+    const running = runVoiceAccessGatewayAction(
+      { tokenFile: "/run/secrets/voice-access-token" },
+      deps,
+    );
+    await vi.waitFor(() => {
+      expect(server.listenCall).toEqual({
+        host: "127.0.0.1",
+        port: DEFAULT_VOICE_ACCESS_LISTEN_PORT,
+      });
+    });
+
+    expect(deps.readTokenFile).toHaveBeenCalledWith("/run/secrets/voice-access-token");
+    expect(deps.createServer).toHaveBeenCalledWith({
+      authToken: "test-bearer-token",
+      upstreamPort: DEFAULT_VOICE_ACCESS_UPSTREAM_PORT,
+    });
+    await vi.waitFor(() => {
+      expect(deps.log).toHaveBeenCalledWith(
+        `Voice access gateway listening on http://127.0.0.1:${DEFAULT_VOICE_ACCESS_LISTEN_PORT} and forwarding to http://127.0.0.1:${DEFAULT_VOICE_ACCESS_UPSTREAM_PORT}.`,
+      );
+    });
+
+    signals.emit(signal);
+    await running;
+
+    expect(server.closeCalls).toBe(1);
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  it.each([
+    {
+      name: "relative token path",
+      options: { tokenFile: "relative/token" },
+      message: "token file path must be absolute",
+    },
+    {
+      name: "privileged listen port",
+      options: { tokenFile: "/run/token", listenPort: 1023 },
+      message: "listen port must be an integer between 1024 and 65535",
+    },
+    {
+      name: "out-of-range upstream port",
+      options: { tokenFile: "/run/token", upstreamPort: 65_536 },
+      message: "upstream port must be an integer between 1024 and 65535",
+    },
+    {
+      name: "shared listen and upstream port",
+      options: { tokenFile: "/run/token", listenPort: 18_800, upstreamPort: 18_800 },
+      message: "listen and upstream ports must be different",
+    },
+  ])("rejects $name before reading credentials", async ({ options, message }) => {
+    const readTokenFile = vi.fn(() => "unused");
+    const createServer = vi.fn();
+
+    await expect(
+      runVoiceAccessGatewayAction(options, {
+        createServer: createServer as VoiceAccessGatewayActionDeps["createServer"],
+        readTokenFile,
+      }),
+    ).rejects.toThrow(message);
+
+    expect(readTokenFile).not.toHaveBeenCalled();
+    expect(createServer).not.toHaveBeenCalled();
+  });
+
+  it("removes signal handlers when the loopback listener cannot start", async () => {
+    class FailingServer extends FakeServer {
+      override listen(): this {
+        queueMicrotask(() => this.emit("error", new Error("address already in use")));
+        return this;
+      }
+    }
+
+    const server = new FailingServer();
+    const signals = new EventEmitter();
+
+    await expect(
+      runVoiceAccessGatewayAction(
+        { tokenFile: "/run/secrets/voice-access-token" },
+        actionDeps(server, signals),
+      ),
+    ).rejects.toThrow("address already in use");
+
+    expect(server.closeCalls).toBe(0);
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  it("closes and removes signal handlers after a runtime listener error", async () => {
+    const server = new FakeServer();
+    const signals = new EventEmitter();
+    const deps = actionDeps(server, signals);
+    const running = runVoiceAccessGatewayAction(
+      { tokenFile: "/run/secrets/voice-access-token" },
+      deps,
+    );
+    await vi.waitFor(() => expect(deps.log).toHaveBeenCalledOnce());
+    const rejection = expect(running).rejects.toThrow("runtime listener failure");
+
+    server.emit("error", new Error("runtime listener failure"));
+
+    await rejection;
+    expect(server.closeCalls).toBe(1);
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+  });
+});

--- a/src/lib/actions/voice-access/serve.ts
+++ b/src/lib/actions/voice-access/serve.ts
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Server } from "node:http";
+import path from "node:path";
+
+import {
+  createVoiceAccessGatewayServer,
+  readVoiceAccessTokenFile,
+} from "../../adapters/http/voice-access-gateway";
+
+export const DEFAULT_VOICE_ACCESS_LISTEN_PORT = 18_800;
+export const DEFAULT_VOICE_ACCESS_UPSTREAM_PORT = 18_790;
+
+const LOOPBACK_ADDRESS = "127.0.0.1";
+const MIN_SERVICE_PORT = 1024;
+const MAX_SERVICE_PORT = 65_535;
+
+type VoiceAccessSignal = "SIGINT" | "SIGTERM";
+
+interface VoiceAccessProcessEvents {
+  once(event: VoiceAccessSignal, listener: () => void): unknown;
+  removeListener(event: VoiceAccessSignal, listener: () => void): unknown;
+}
+
+export interface VoiceAccessGatewayActionOptions {
+  listenPort?: number;
+  tokenFile: string;
+  upstreamPort?: number;
+}
+
+export interface VoiceAccessGatewayActionDeps {
+  createServer?: typeof createVoiceAccessGatewayServer;
+  log?: (message: string) => void;
+  processEvents?: VoiceAccessProcessEvents;
+  readTokenFile?: typeof readVoiceAccessTokenFile;
+}
+
+function validateServicePort(port: number, label: string): void {
+  if (!Number.isInteger(port) || port < MIN_SERVICE_PORT || port > MAX_SERVICE_PORT) {
+    throw new Error(
+      `${label} must be an integer between ${MIN_SERVICE_PORT} and ${MAX_SERVICE_PORT}.`,
+    );
+  }
+}
+
+function listenOnLoopback(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.removeListener("error", onError);
+      reject(error);
+    };
+    server.once("error", onError);
+    server.listen(port, LOOPBACK_ADDRESS, () => {
+      server.removeListener("error", onError);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+/**
+ * Run the internal voice access gateway in the foreground until interrupted.
+ *
+ * The HTTP adapter owns authentication and request forwarding. This action
+ * owns only configuration validation, loopback binding, and process lifetime.
+ */
+export async function runVoiceAccessGatewayAction(
+  options: VoiceAccessGatewayActionOptions,
+  deps: VoiceAccessGatewayActionDeps = {},
+): Promise<void> {
+  const listenPort = options.listenPort ?? DEFAULT_VOICE_ACCESS_LISTEN_PORT;
+  const upstreamPort = options.upstreamPort ?? DEFAULT_VOICE_ACCESS_UPSTREAM_PORT;
+
+  if (!path.isAbsolute(options.tokenFile)) {
+    throw new Error("Voice access token file path must be absolute.");
+  }
+  validateServicePort(listenPort, "Voice access listen port");
+  validateServicePort(upstreamPort, "Voice access upstream port");
+  if (listenPort === upstreamPort) {
+    throw new Error("Voice access listen and upstream ports must be different.");
+  }
+
+  const readTokenFile = deps.readTokenFile ?? readVoiceAccessTokenFile;
+  const createServer = deps.createServer ?? createVoiceAccessGatewayServer;
+  const processEvents = deps.processEvents ?? process;
+  const log = deps.log ?? console.log;
+  const server = createServer({ authToken: readTokenFile(options.tokenFile), upstreamPort });
+
+  let resolveShutdown: () => void = () => {};
+  let rejectShutdown: (error: Error) => void = () => {};
+  const shutdown = new Promise<void>((resolve, reject) => {
+    resolveShutdown = resolve;
+    rejectShutdown = reject;
+  });
+  const onSigint = () => resolveShutdown();
+  const onSigterm = () => resolveShutdown();
+  const onClose = () => resolveShutdown();
+  const onRuntimeError = (error: Error) => rejectShutdown(error);
+
+  processEvents.once("SIGINT", onSigint);
+  processEvents.once("SIGTERM", onSigterm);
+
+  try {
+    await listenOnLoopback(server, listenPort);
+    server.once("close", onClose);
+    server.once("error", onRuntimeError);
+    log(
+      `Voice access gateway listening on http://${LOOPBACK_ADDRESS}:${listenPort} and forwarding to http://${LOOPBACK_ADDRESS}:${upstreamPort}.`,
+    );
+    await shutdown;
+  } finally {
+    processEvents.removeListener("SIGINT", onSigint);
+    processEvents.removeListener("SIGTERM", onSigterm);
+    server.removeListener("close", onClose);
+    server.removeListener("error", onRuntimeError);
+    await closeServer(server);
+  }
+}

--- a/src/lib/adapters/http/voice-access-gateway.test.ts
+++ b/src/lib/adapters/http/voice-access-gateway.test.ts
@@ -30,14 +30,16 @@ async function listen(server: http.Server): Promise<number> {
     });
   });
   const address = server.address();
-  if (!address || typeof address === "string") throw new Error("Test server did not bind TCP.");
-  return address.port;
+  return address !== null && typeof address !== "string"
+    ? address.port
+    : Promise.reject(new Error("Test server did not bind TCP."));
 }
 
 async function close(server: http.Server): Promise<void> {
   openServers.delete(server);
-  if (!server.listening) return;
-  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await (server.listening
+    ? new Promise<void>((resolve) => server.close(() => resolve()))
+    : Promise.resolve());
 }
 
 async function request(
@@ -412,10 +414,16 @@ describe("voice access gateway request boundary", () => {
   });
 
   it.each([
-    { method: "GET", path: "/api/ice-servers", body: "" },
-    { method: "PATCH", path: "/api/offer", body: '{"candidate":"candidate:1"}' },
+    { method: "GET", path: "/api/ice-servers", body: "", cacheControl: "no-store" },
+    {
+      method: "PATCH",
+      path: "/api/offer",
+      body: '{"candidate":"candidate:1"}',
+      cacheControl: undefined,
+    },
   ])("forwards an authorized $method signaling operation (#7781)", async ({
     body,
+    cacheControl,
     method,
     path,
   }) => {
@@ -447,7 +455,7 @@ describe("voice access gateway request boundary", () => {
     expect(result.status).toBe(200);
     expect(result.body.toString("utf8")).toBe('{"ok":true}');
     expect(seen).toEqual([{ body, method, url: path }]);
-    if (method === "GET") expect(result.headers["cache-control"]).toBe("no-store");
+    expect(result.headers["cache-control"]).toBe(cacheControl);
   });
 
   it("rejects an oversized body from its declared length before reaching Talker (#7781)", async () => {

--- a/src/lib/adapters/http/voice-access-gateway.test.ts
+++ b/src/lib/adapters/http/voice-access-gateway.test.ts
@@ -1,0 +1,699 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createVoiceAccessGatewayServer,
+  readVoiceAccessTokenFile,
+  VOICE_ACCESS_MAX_REQUEST_BYTES,
+  VOICE_ACCESS_MAX_RESPONSE_BYTES,
+} from "./voice-access-gateway";
+
+const AUTH_TOKEN = "voice-access-test-token-0123456789";
+const openServers = new Set<http.Server>();
+const temporaryDirectories: string[] = [];
+
+async function listen(server: http.Server): Promise<number> {
+  openServers.add(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Test server did not bind TCP.");
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  openServers.delete(server);
+  if (!server.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function request(
+  port: number,
+  options: {
+    body?: Buffer | string;
+    headers?: http.OutgoingHttpHeaders;
+    method?: string;
+    path?: string;
+  } = {},
+): Promise<{
+  body: Buffer;
+  headers: http.IncomingHttpHeaders;
+  status: number;
+}> {
+  const body = options.body ?? "";
+  return new Promise((resolve, reject) => {
+    const client = http.request(
+      {
+        headers: {
+          ...(body !== "" ? { "content-length": Buffer.byteLength(body) } : {}),
+          ...options.headers,
+        },
+        host: "127.0.0.1",
+        method: options.method ?? "GET",
+        path: options.path ?? "/healthz",
+        port,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        response.on("end", () => {
+          resolve({
+            body: Buffer.concat(chunks),
+            headers: response.headers,
+            status: response.statusCode ?? 0,
+          });
+        });
+      },
+    );
+    client.once("error", reject);
+    client.end(body);
+  });
+}
+
+async function chunkedRequest(
+  port: number,
+  body: Buffer,
+): Promise<{ body: Buffer; status: number }> {
+  return new Promise((resolve, reject) => {
+    const client = http.request(
+      {
+        headers: authorize({ "transfer-encoding": "chunked" }),
+        host: "127.0.0.1",
+        method: "POST",
+        path: "/api/offer",
+        port,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        response.on("end", () => {
+          resolve({
+            body: Buffer.concat(chunks),
+            status: response.statusCode ?? 0,
+          });
+        });
+      },
+    );
+    client.once("error", reject);
+    const midpoint = Math.floor(body.length / 2);
+    client.write(body.subarray(0, midpoint));
+    client.end(body.subarray(midpoint));
+  });
+}
+
+async function rawTcpRequest(port: number, payload: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const chunks: Buffer[] = [];
+    socket.once("connect", () => socket.end(payload));
+    socket.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    socket.once("error", reject);
+    socket.once("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+}
+
+function authorize(headers: http.OutgoingHttpHeaders = {}): http.OutgoingHttpHeaders {
+  return { authorization: `Bearer ${AUTH_TOKEN}`, ...headers };
+}
+
+async function startGateway(
+  upstreamPort: number,
+  options: { upstreamTimeoutMs?: number } = {},
+): Promise<number> {
+  return listen(
+    createVoiceAccessGatewayServer({
+      authToken: AUTH_TOKEN,
+      upstreamPort,
+      upstreamTimeoutMs: options.upstreamTimeoutMs,
+    }),
+  );
+}
+
+function makeTemporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-voice-access-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all([...openServers].map((server) => close(server)));
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("voice access token file", () => {
+  it("reads one private regular file without returning its trailing newline (#7781)", () => {
+    const filePath = path.join(makeTemporaryDirectory(), "token");
+    fs.writeFileSync(filePath, `${AUTH_TOKEN}\n`, { mode: 0o600 });
+
+    expect(readVoiceAccessTokenFile(filePath)).toBe(AUTH_TOKEN);
+  });
+
+  it.each([
+    {
+      name: "relative path",
+      arrange: () => "relative-token",
+      message: "must be absolute",
+    },
+    {
+      name: "group-readable file",
+      arrange: () => {
+        const filePath = path.join(makeTemporaryDirectory(), "token");
+        fs.writeFileSync(filePath, AUTH_TOKEN, { mode: 0o640 });
+        fs.chmodSync(filePath, 0o640);
+        return filePath;
+      },
+      message: "must not be accessible by group or others",
+    },
+    {
+      name: "directory",
+      arrange: () => makeTemporaryDirectory(),
+      message: "not a regular file",
+    },
+    {
+      name: "symbolic link",
+      arrange: () => {
+        const directory = makeTemporaryDirectory();
+        const target = path.join(directory, "target");
+        const link = path.join(directory, "token");
+        fs.writeFileSync(target, AUTH_TOKEN, { mode: 0o600 });
+        fs.symlinkSync(target, link);
+        return link;
+      },
+      message: "symbolic-link",
+    },
+    {
+      name: "token containing whitespace",
+      arrange: () => {
+        const filePath = path.join(makeTemporaryDirectory(), "token");
+        fs.writeFileSync(filePath, "first token second", { mode: 0o600 });
+        return filePath;
+      },
+      message: "bearer token is malformed",
+    },
+    {
+      name: "short token",
+      arrange: () => {
+        const filePath = path.join(makeTemporaryDirectory(), "token");
+        fs.writeFileSync(filePath, "short-token", { mode: 0o600 });
+        return filePath;
+      },
+      message: "bearer token is malformed",
+    },
+    {
+      name: "oversized token",
+      arrange: () => {
+        const filePath = path.join(makeTemporaryDirectory(), "token");
+        fs.writeFileSync(filePath, "a".repeat(4098), { mode: 0o600 });
+        return filePath;
+      },
+      message: "invalid size",
+    },
+  ])("rejects a $name before serving requests", ({ arrange, message }) => {
+    expect(() => readVoiceAccessTokenFile(arrange())).toThrow(message);
+  });
+});
+
+describe("voice access gateway request boundary", () => {
+  it.each([
+    { name: "missing authorization", authorization: undefined },
+    { name: "wrong token", authorization: "Bearer wrong-token" },
+    { name: "wrong scheme", authorization: `Basic ${AUTH_TOKEN}` },
+    { name: "token with whitespace", authorization: `Bearer ${AUTH_TOKEN} extra` },
+    { name: "non-ASCII token", authorization: "Bearer véry-secret" },
+  ])("returns an empty 401 for $name without reaching Talker (#7781)", async ({
+    authorization,
+  }) => {
+    let upstreamRequests = 0;
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        upstreamRequests += 1;
+        response.end();
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      headers: authorization ? { authorization } : {},
+      path: "/api/ice-servers",
+    });
+
+    expect(result.status).toBe(401);
+    expect(result.body).toHaveLength(0);
+    expect(upstreamRequests).toBe(0);
+  });
+
+  it("requires authorization before probing Talker health (#7781)", async () => {
+    let connections = 0;
+    const upstream = http.createServer();
+    upstream.on("connection", () => {
+      connections += 1;
+    });
+    const upstreamPort = await listen(upstream);
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort);
+
+    expect(result.status).toBe(401);
+    expect(result.body).toHaveLength(0);
+    expect(connections).toBe(0);
+  });
+
+  it.each([
+    { method: "GET", path: "/api/offer" },
+    { method: "POST", path: "/api/ice-servers" },
+    { method: "PATCH", path: "/api/offer?conversation_id=one" },
+    { method: "POST", path: "/api/offer?other=value" },
+    { method: "POST", path: "/api/offer?conversation_id=one&conversation_id=two" },
+    { method: "POST", path: "/api/offer?conversation_id=bad%20id" },
+    { method: "POST", path: "/api/offer?conversation_id=Uppercase" },
+    { method: "POST", path: "/api/offer?conversation_id=foo_bar" },
+    { method: "POST", path: "/api/offer?conversation_id=foo.bar" },
+    { method: "POST", path: "/api/offer?conversation_id=-leading" },
+    { method: "POST", path: "/api/offer?conversation_id=trailing-" },
+    { method: "POST", path: `/api/offer?conversation_id=${"a".repeat(41)}` },
+    { method: "POST", path: "/api/offer?conversation_id=ios%2Dclient" },
+    { method: "GET", path: "/api/ice-servers?extra=true" },
+    { method: "GET", path: "/api/../api/ice-servers" },
+    { method: "GET", path: "/ws" },
+    { method: "GET", path: "/health" },
+  ])("rejects $method $path without reaching Talker (#7781)", async ({ method, path }) => {
+    let upstreamRequests = 0;
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        upstreamRequests += 1;
+        response.end();
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      headers: authorize(),
+      method,
+      path,
+    });
+
+    expect(result.status).toBe(404);
+    expect(result.body).toHaveLength(0);
+    expect(upstreamRequests).toBe(0);
+  });
+
+  it("rejects an upstream host that is not a loopback IP literal (#7781)", () => {
+    expect(() =>
+      createVoiceAccessGatewayServer({
+        authToken: AUTH_TOKEN,
+        upstreamHost: "talker.example",
+        upstreamPort: 18_790,
+      }),
+    ).toThrow("must be a loopback IP literal");
+  });
+
+  it("contains a malformed request target and continues serving (#7781)", async () => {
+    let upstreamRequests = 0;
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        upstreamRequests += 1;
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const malformed = await rawTcpRequest(
+      gatewayPort,
+      ["GET /\\ HTTP/1.1", `Host: 127.0.0.1:${gatewayPort}`, "Connection: close", "", ""].join(
+        "\r\n",
+      ),
+    );
+
+    expect(malformed).toMatch(/^HTTP\/1\.1 400 Bad Request\r\n/u);
+    expect(malformed.split("\r\n\r\n", 2)[1]).toBe("");
+    expect(upstreamRequests).toBe(0);
+
+    const healthy = await request(gatewayPort, {
+      headers: authorize(),
+      path: "/api/ice-servers",
+    });
+    expect(healthy.status).toBe(200);
+    expect(upstreamRequests).toBe(1);
+  });
+
+  it("forwards an authorized offer without external credentials or proxy headers (#7781)", async () => {
+    let received:
+      | {
+          body: string;
+          headers: http.IncomingHttpHeaders;
+          method: string | undefined;
+          url: string | undefined;
+        }
+      | undefined;
+    const upstreamPort = await listen(
+      http.createServer((incoming, response) => {
+        const chunks: Buffer[] = [];
+        incoming.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        incoming.on("end", () => {
+          received = {
+            body: Buffer.concat(chunks).toString("utf8"),
+            headers: incoming.headers,
+            method: incoming.method,
+            url: incoming.url,
+          };
+          response.writeHead(201, { "content-type": "application/json", "x-internal": "omit" });
+          response.end('{"answer":"ok"}');
+        });
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+    const offer = '{"sdp":"private-offer"}';
+
+    const result = await request(gatewayPort, {
+      body: offer,
+      headers: authorize({
+        accept: "application/json",
+        connection: "content-type",
+        cookie: "private-cookie",
+        "content-type": "application/json",
+        "proxy-authorization": "Basic external-proxy-secret",
+        "x-forwarded-host": "public.example",
+      }),
+      method: "POST",
+      path: "/api/offer?conversation_id=ios-client-1",
+    });
+
+    expect(result.status).toBe(201);
+    expect(result.body.toString("utf8")).toBe('{"answer":"ok"}');
+    expect(result.headers["content-type"]).toContain("application/json");
+    expect(result.headers["x-internal"]).toBeUndefined();
+    expect(received).toMatchObject({
+      body: offer,
+      method: "POST",
+      url: "/api/offer?conversation_id=ios-client-1",
+    });
+    expect(received?.headers.authorization).toBeUndefined();
+    expect(received?.headers.cookie).toBeUndefined();
+    expect(received?.headers["content-type"]).toBeUndefined();
+    expect(received?.headers["proxy-authorization"]).toBeUndefined();
+    expect(received?.headers["x-forwarded-host"]).toBeUndefined();
+    expect(received?.headers.host).toBe(`127.0.0.1:${upstreamPort}`);
+  });
+
+  it.each([
+    { method: "GET", path: "/api/ice-servers", body: "" },
+    { method: "PATCH", path: "/api/offer", body: '{"candidate":"candidate:1"}' },
+  ])("forwards an authorized $method signaling operation (#7781)", async ({
+    body,
+    method,
+    path,
+  }) => {
+    const seen: Array<{ body: string; method: string | undefined; url: string | undefined }> = [];
+    const upstreamPort = await listen(
+      http.createServer((incoming, response) => {
+        const chunks: Buffer[] = [];
+        incoming.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        incoming.on("end", () => {
+          seen.push({
+            body: Buffer.concat(chunks).toString("utf8"),
+            method: incoming.method,
+            url: incoming.url,
+          });
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end('{"ok":true}');
+        });
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      body,
+      headers: authorize(body ? { "content-type": "application/json" } : {}),
+      method,
+      path,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.toString("utf8")).toBe('{"ok":true}');
+    expect(seen).toEqual([{ body, method, url: path }]);
+    if (method === "GET") expect(result.headers["cache-control"]).toBe("no-store");
+  });
+
+  it("rejects an oversized body from its declared length before reaching Talker (#7781)", async () => {
+    let upstreamRequests = 0;
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        upstreamRequests += 1;
+        response.end();
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      headers: authorize({ "content-length": String(VOICE_ACCESS_MAX_REQUEST_BYTES + 1) }),
+      method: "POST",
+      path: "/api/offer",
+    });
+
+    expect(result.status).toBe(413);
+    expect(result.body).toHaveLength(0);
+    expect(upstreamRequests).toBe(0);
+  });
+
+  it("rejects an oversized streamed body before reaching Talker (#7781)", async () => {
+    let upstreamRequests = 0;
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        upstreamRequests += 1;
+        response.end();
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await chunkedRequest(
+      gatewayPort,
+      Buffer.alloc(VOICE_ACCESS_MAX_REQUEST_BYTES + 1),
+    );
+
+    expect(result.status).toBe(413);
+    expect(result.body).toHaveLength(0);
+    expect(upstreamRequests).toBe(0);
+  });
+
+  it("rejects oversized request headers before reaching Talker (#7781)", async () => {
+    let upstreamRequests = 0;
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        upstreamRequests += 1;
+        response.end();
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await rawTcpRequest(
+      gatewayPort,
+      [
+        "GET /api/ice-servers HTTP/1.1",
+        `Host: 127.0.0.1:${gatewayPort}`,
+        `Authorization: Bearer ${AUTH_TOKEN}`,
+        `X-Oversized: ${"a".repeat(20 * 1024)}`,
+        "Connection: close",
+        "",
+        "",
+      ].join("\r\n"),
+    );
+
+    expect(result).toMatch(/^HTTP\/1\.1 400 Bad Request\r\n/u);
+    expect(result.split("\r\n\r\n", 2)[1]).toBe("");
+    expect(upstreamRequests).toBe(0);
+  });
+});
+
+describe("voice access gateway failure boundary", () => {
+  it("returns content-free health status from Talker reachability (#7781)", async () => {
+    const upstream = http.createServer((_incoming, response) => response.end());
+    const upstreamPort = await listen(upstream);
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const healthy = await request(gatewayPort, { headers: authorize() });
+    expect(healthy.status).toBe(204);
+    expect(healthy.body).toHaveLength(0);
+
+    await close(upstream);
+    const unhealthy = await request(gatewayPort, { headers: authorize() });
+    expect(unhealthy.status).toBe(503);
+    expect(unhealthy.body).toHaveLength(0);
+  });
+
+  it("returns an empty 502 when Talker refuses the connection (#7781)", async () => {
+    const probe = http.createServer();
+    const upstreamPort = await listen(probe);
+    await close(probe);
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      headers: authorize(),
+      path: "/api/ice-servers",
+    });
+
+    expect(result.status).toBe(502);
+    expect(result.body).toHaveLength(0);
+  });
+
+  it("returns an empty 502 and aborts a stalled Talker request (#7781)", async () => {
+    const upstreamPort = await listen(http.createServer(() => {}));
+    const gatewayPort = await startGateway(upstreamPort, { upstreamTimeoutMs: 20 });
+
+    const result = await request(gatewayPort, {
+      body: "{}",
+      headers: authorize({ "content-type": "application/json" }),
+      method: "POST",
+      path: "/api/offer",
+    });
+
+    expect(result.status).toBe(502);
+    expect(result.body).toHaveLength(0);
+  });
+
+  it("replaces a Talker server error with an empty 502 (#7781)", async () => {
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        response.writeHead(500, { "content-type": "text/plain" });
+        response.end("internal Talker error with private topology");
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      body: "{}",
+      headers: authorize({ "content-type": "application/json" }),
+      method: "POST",
+      path: "/api/offer",
+    });
+
+    expect(result.status).toBe(502);
+    expect(result.body).toHaveLength(0);
+  });
+
+  it("preserves a Talker client-error status without exposing its body (#7781)", async () => {
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        response.writeHead(400, { "content-type": "text/plain" });
+        response.end("invalid SDP: private client payload");
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      body: "{}",
+      headers: authorize({ "content-type": "application/json" }),
+      method: "POST",
+      path: "/api/offer",
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body).toHaveLength(0);
+  });
+
+  it("strips response headers nominated by Talker's Connection header (#7781)", async () => {
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        response.writeHead(200, {
+          connection: "content-type",
+          "content-type": "application/private",
+        });
+        response.end("{}");
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      headers: authorize(),
+      path: "/api/ice-servers",
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.headers["content-type"]).toBeUndefined();
+  });
+
+  it("replaces an oversized Talker response with an empty 502 (#7781)", async () => {
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(Buffer.alloc(VOICE_ACCESS_MAX_RESPONSE_BYTES + 1));
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      headers: authorize(),
+      path: "/api/ice-servers",
+    });
+
+    expect(result.status).toBe(502);
+    expect(result.body).toHaveLength(0);
+  });
+
+  it("aborts the Talker request when the downstream client disconnects (#7781)", async () => {
+    let upstreamSocketClosed = false;
+    let resolveUpstreamRequest: () => void = () => {};
+    const upstreamRequest = new Promise<void>((resolve) => {
+      resolveUpstreamRequest = resolve;
+    });
+    const upstream = http.createServer((_incoming, _response) => {
+      resolveUpstreamRequest();
+    });
+    upstream.on("connection", (socket) => {
+      socket.once("close", () => {
+        upstreamSocketClosed = true;
+      });
+    });
+    const upstreamPort = await listen(upstream);
+    const gatewayPort = await startGateway(upstreamPort);
+    const client = http.request({
+      headers: authorize(),
+      host: "127.0.0.1",
+      path: "/api/ice-servers",
+      port: gatewayPort,
+    });
+    client.on("error", () => {});
+    client.end();
+
+    await upstreamRequest;
+    client.destroy();
+
+    await vi.waitFor(() => expect(upstreamSocketClosed).toBe(true));
+  });
+
+  it("buffers the upstream response so an abort does not expose partial SDP (#7781)", async () => {
+    const upstreamPort = await listen(
+      http.createServer((_incoming, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.write('{"sdp":"partial');
+        response.destroy();
+      }),
+    );
+    const gatewayPort = await startGateway(upstreamPort);
+
+    const result = await request(gatewayPort, {
+      body: "{}",
+      headers: authorize({ "content-type": "application/json" }),
+      method: "POST",
+      path: "/api/offer",
+    });
+
+    expect(result.status).toBe(502);
+    expect(result.body).toHaveLength(0);
+  });
+});

--- a/src/lib/adapters/http/voice-access-gateway.ts
+++ b/src/lib/adapters/http/voice-access-gateway.ts
@@ -1,0 +1,505 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import path from "node:path";
+
+export const VOICE_ACCESS_MAX_REQUEST_BYTES = 1024 * 1024;
+export const VOICE_ACCESS_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+
+const DEFAULT_BODY_TIMEOUT_MS = 10_000;
+const DEFAULT_HEALTH_TIMEOUT_MS = 500;
+const DEFAULT_UPSTREAM_TIMEOUT_MS = 30_000;
+const MAX_TOKEN_BYTES = 4096;
+const MAX_HEADER_BYTES = 16 * 1024;
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1"]);
+const CONVERSATION_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+const FORWARDED_REQUEST_HEADERS = new Set(["accept", "content-type", "user-agent"]);
+const FORWARDED_RESPONSE_HEADERS = new Set(["content-language", "content-type", "vary"]);
+
+class VoiceAccessHttpError extends Error {
+  constructor(readonly status: number) {
+    super(`Voice access request failed with status ${status}`);
+  }
+}
+
+function assertLoopbackHost(host: string): void {
+  if (!LOOPBACK_HOSTS.has(host)) {
+    throw new Error("Voice access upstream host must be a loopback IP literal.");
+  }
+}
+
+function assertAuthToken(token: string): void {
+  if (
+    Buffer.byteLength(token) < 32 ||
+    Buffer.byteLength(token) > MAX_TOKEN_BYTES ||
+    !/^[\x21-\x7e]+$/u.test(token)
+  ) {
+    throw new Error("Voice access bearer token is malformed.");
+  }
+}
+
+function assertPrivateTokenFile(stat: fs.Stats, filePath: string): void {
+  if (!stat.isFile()) {
+    throw new Error(`Voice access token path is not a regular file: ${filePath}`);
+  }
+  if ((stat.mode & 0o077) !== 0) {
+    throw new Error(
+      `Voice access token file must not be accessible by group or others: ${filePath}`,
+    );
+  }
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+    throw new Error(`Voice access token file is not owned by the current user: ${filePath}`);
+  }
+  if (stat.size < 1 || stat.size > MAX_TOKEN_BYTES + 1) {
+    throw new Error(`Voice access token file has an invalid size: ${filePath}`);
+  }
+}
+
+/** Read one deployment bearer token without following the final path component. */
+export function readVoiceAccessTokenFile(filePath: string): string {
+  if (!path.isAbsolute(filePath)) {
+    throw new Error("Voice access token file path must be absolute.");
+  }
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") {
+    throw new Error("Secure no-follow file opens are unavailable on this platform.");
+  }
+
+  let descriptor: number | undefined;
+  try {
+    try {
+      descriptor = fs.openSync(
+        filePath,
+        fs.constants.O_RDONLY | noFollow | (fs.constants.O_NONBLOCK ?? 0),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+        throw new Error(`Refusing to read a symbolic-link voice access token file: ${filePath}`);
+      }
+      throw error;
+    }
+    assertPrivateTokenFile(fs.fstatSync(descriptor), filePath);
+    const buffer = Buffer.alloc(MAX_TOKEN_BYTES + 2);
+    const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
+    if (bytesRead > MAX_TOKEN_BYTES + 1) {
+      throw new Error(`Voice access token file has an invalid size: ${filePath}`);
+    }
+    const contents = buffer.subarray(0, bytesRead).toString("utf8");
+    const token = contents.endsWith("\n") ? contents.slice(0, -1) : contents;
+    assertAuthToken(token);
+    return token;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+function parseBearerToken(header: string | string[] | undefined): string {
+  if (typeof header !== "string") return "";
+  const match = /^Bearer ([^\s]+)$/u.exec(header);
+  return match?.[1] ?? "";
+}
+
+function hasExpectedAuthorization(
+  actual: string | string[] | undefined,
+  expectedTokenHash: Buffer,
+): boolean {
+  const actualHash = crypto.createHash("sha256").update(parseBearerToken(actual)).digest();
+  return crypto.timingSafeEqual(actualHash, expectedTokenHash);
+}
+
+function sendEmpty(response: http.ServerResponse, status: number): void {
+  if (response.destroyed) return;
+  if (response.headersSent) {
+    response.destroy();
+    return;
+  }
+  response.writeHead(status, {
+    "cache-control": "no-store",
+    ...(status >= 400 ? { connection: "close" } : {}),
+    "content-length": "0",
+  });
+  response.end();
+}
+
+function isAllowedOfferQuery(url: URL): boolean {
+  const keys = [...url.searchParams.keys()];
+  if (keys.length === 0) return true;
+  if (keys.length !== 1 || keys[0] !== "conversation_id") return false;
+  const values = url.searchParams.getAll("conversation_id");
+  const value = values[0] ?? "";
+  return (
+    values.length === 1 &&
+    CONVERSATION_ID_PATTERN.test(value) &&
+    url.search === `?conversation_id=${value}`
+  );
+}
+
+function isAllowedSignalingRequest(method: string | undefined, url: URL): boolean {
+  if (method === "GET" && url.pathname === "/api/ice-servers") {
+    return url.search === "";
+  }
+  if (method === "POST" && url.pathname === "/api/offer") {
+    return isAllowedOfferQuery(url);
+  }
+  return method === "PATCH" && url.pathname === "/api/offer" && url.search === "";
+}
+
+function connectionHeaderNames(value: string | string[] | undefined): Set<string> {
+  const values = Array.isArray(value) ? value : value ? [value] : [];
+  return new Set(
+    values
+      .flatMap((entry) => entry.split(","))
+      .map((entry) => entry.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function buildUpstreamHeaders(
+  request: http.IncomingMessage,
+  bodyLength: number,
+): http.OutgoingHttpHeaders {
+  const headers: http.OutgoingHttpHeaders = {};
+  const dynamicHopByHopHeaders = connectionHeaderNames(request.headers.connection);
+  for (const [name, value] of Object.entries(request.headers)) {
+    const normalized = name.toLowerCase();
+    if (
+      value === undefined ||
+      HOP_BY_HOP_HEADERS.has(normalized) ||
+      dynamicHopByHopHeaders.has(normalized) ||
+      !FORWARDED_REQUEST_HEADERS.has(normalized)
+    ) {
+      continue;
+    }
+    headers[normalized] = value;
+  }
+  headers["content-length"] = String(bodyLength);
+  return headers;
+}
+
+function buildDownstreamHeaders(
+  upstreamHeaders: http.IncomingHttpHeaders,
+  bodyLength: number,
+  noStore: boolean,
+): http.OutgoingHttpHeaders {
+  const headers: http.OutgoingHttpHeaders = {
+    "content-length": String(bodyLength),
+  };
+  const dynamicHopByHopHeaders = connectionHeaderNames(upstreamHeaders.connection);
+  for (const [name, value] of Object.entries(upstreamHeaders)) {
+    const normalized = name.toLowerCase();
+    if (
+      value === undefined ||
+      HOP_BY_HOP_HEADERS.has(normalized) ||
+      dynamicHopByHopHeaders.has(normalized) ||
+      !FORWARDED_RESPONSE_HEADERS.has(normalized)
+    ) {
+      continue;
+    }
+    headers[normalized] = value;
+  }
+  if (noStore) headers["cache-control"] = "no-store";
+  return headers;
+}
+
+function readBoundedBody(
+  request: http.IncomingMessage,
+  timeoutMs = DEFAULT_BODY_TIMEOUT_MS,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const rawLength = request.headers["content-length"];
+    const contentLength = typeof rawLength === "string" ? Number(rawLength) : 0;
+    if (
+      typeof rawLength === "string" &&
+      (!Number.isSafeInteger(contentLength) || contentLength < 0)
+    ) {
+      reject(new VoiceAccessHttpError(400));
+      return;
+    }
+    if (contentLength > VOICE_ACCESS_MAX_REQUEST_BYTES) {
+      reject(new VoiceAccessHttpError(413));
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    let byteLength = 0;
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(Buffer.concat(chunks));
+    };
+    const timer = setTimeout(() => finish(new VoiceAccessHttpError(408)), timeoutMs);
+    request.on("data", (chunk: Buffer | string) => {
+      if (settled) return;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      byteLength += buffer.length;
+      if (byteLength > VOICE_ACCESS_MAX_REQUEST_BYTES) {
+        finish(new VoiceAccessHttpError(413));
+        return;
+      }
+      chunks.push(buffer);
+    });
+    request.once("aborted", () => finish(new VoiceAccessHttpError(400)));
+    request.once("error", () => finish(new VoiceAccessHttpError(400)));
+    request.once("end", () => finish());
+  });
+}
+
+function collectBoundedResponse(upstream: http.IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let byteLength = 0;
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      if (error) reject(error);
+      else resolve(Buffer.concat(chunks));
+    };
+    upstream.on("data", (chunk: Buffer | string) => {
+      if (settled) return;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      byteLength += buffer.length;
+      if (byteLength > VOICE_ACCESS_MAX_RESPONSE_BYTES) {
+        upstream.destroy();
+        finish(new Error("Voice access upstream response exceeded the limit."));
+        return;
+      }
+      chunks.push(buffer);
+    });
+    upstream.once("aborted", () => finish(new Error("Voice access upstream response aborted.")));
+    upstream.once("error", (error) => finish(error));
+    upstream.once("end", () => finish());
+  });
+}
+
+function forwardSignalingRequest(options: {
+  body: Buffer;
+  request: http.IncomingMessage;
+  response: http.ServerResponse;
+  upstreamHost: string;
+  upstreamPort: number;
+  upstreamTimeoutMs: number;
+  url: URL;
+}): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let upstreamResponse: http.IncomingMessage | undefined;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      resolve();
+    };
+    const fail = () => {
+      if (settled) return;
+      sendEmpty(options.response, 502);
+      finish();
+    };
+    const upstreamRequest = http.request(
+      {
+        headers: buildUpstreamHeaders(options.request, options.body.length),
+        host: options.upstreamHost,
+        method: options.request.method,
+        path: `${options.url.pathname}${options.url.search}`,
+        port: options.upstreamPort,
+      },
+      async (incoming) => {
+        if (settled) {
+          incoming.destroy();
+          return;
+        }
+        upstreamResponse = incoming;
+        const status = incoming.statusCode ?? 502;
+        if (status < 200 || status >= 300) {
+          incoming.destroy();
+          sendEmpty(options.response, status >= 400 && status < 500 ? status : 502);
+          finish();
+          return;
+        }
+        try {
+          const body = await collectBoundedResponse(incoming);
+          if (settled || options.response.destroyed) return;
+          options.response.writeHead(
+            status,
+            buildDownstreamHeaders(
+              incoming.headers,
+              body.length,
+              options.url.pathname === "/api/ice-servers",
+            ),
+          );
+          options.response.end(body);
+          finish();
+        } catch {
+          fail();
+        }
+      },
+    );
+    const deadline = setTimeout(() => {
+      upstreamRequest.destroy();
+      upstreamResponse?.destroy();
+      fail();
+    }, options.upstreamTimeoutMs);
+    upstreamRequest.once("error", fail);
+    options.response.once("close", () => {
+      if (options.response.writableFinished) return;
+      upstreamRequest.destroy();
+      upstreamResponse?.destroy();
+      finish();
+    });
+    upstreamRequest.end(options.body);
+  });
+}
+
+function probeUpstream(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let settled = false;
+    const finish = (healthy: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(healthy);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
+interface VoiceAccessRequestHandlerOptions {
+  expectedTokenHash: Buffer;
+  request: http.IncomingMessage;
+  response: http.ServerResponse;
+  upstreamHost: string;
+  upstreamPort: number;
+  upstreamTimeoutMs: number;
+}
+
+async function handleVoiceAccessRequest(options: VoiceAccessRequestHandlerOptions): Promise<void> {
+  const { request, response } = options;
+  if (!request.url?.startsWith("/") || request.url.startsWith("//")) {
+    sendEmpty(response, 404);
+    return;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(request.url, "http://127.0.0.1");
+  } catch {
+    sendEmpty(response, 400);
+    return;
+  }
+  if (request.url.split("?", 1)[0] !== url.pathname) {
+    sendEmpty(response, 404);
+    return;
+  }
+  if (!hasExpectedAuthorization(request.headers.authorization, options.expectedTokenHash)) {
+    sendEmpty(response, 401);
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/healthz" && url.search === "") {
+    const healthy = await probeUpstream(
+      options.upstreamHost,
+      options.upstreamPort,
+      DEFAULT_HEALTH_TIMEOUT_MS,
+    );
+    sendEmpty(response, healthy ? 204 : 503);
+    return;
+  }
+  if (!isAllowedSignalingRequest(request.method, url)) {
+    sendEmpty(response, 404);
+    return;
+  }
+
+  try {
+    const body = await readBoundedBody(request);
+    if (request.method === "GET" && body.length !== 0) {
+      sendEmpty(response, 400);
+      return;
+    }
+    await forwardSignalingRequest({
+      body,
+      request,
+      response,
+      upstreamHost: options.upstreamHost,
+      upstreamPort: options.upstreamPort,
+      upstreamTimeoutMs: options.upstreamTimeoutMs,
+      url,
+    });
+  } catch (error) {
+    sendEmpty(response, error instanceof VoiceAccessHttpError ? error.status : 502);
+  }
+}
+
+export interface VoiceAccessGatewayServerOptions {
+  authToken: string;
+  upstreamHost?: string;
+  upstreamPort: number;
+  upstreamTimeoutMs?: number;
+}
+
+/**
+ * Create a loopback-only signaling proxy.
+ *
+ * The caller owns the listener address and process lifetime. The server never
+ * selects an upstream from request data.
+ */
+export function createVoiceAccessGatewayServer(
+  options: VoiceAccessGatewayServerOptions,
+): http.Server {
+  assertAuthToken(options.authToken);
+  const upstreamHost = options.upstreamHost ?? "127.0.0.1";
+  const upstreamPort = options.upstreamPort;
+  assertLoopbackHost(upstreamHost);
+  if (!Number.isInteger(upstreamPort) || upstreamPort < 1024 || upstreamPort > 65_535) {
+    throw new Error("Voice access upstream port must be an integer between 1024 and 65535.");
+  }
+  const upstreamTimeoutMs = options.upstreamTimeoutMs ?? DEFAULT_UPSTREAM_TIMEOUT_MS;
+  if (!Number.isInteger(upstreamTimeoutMs) || upstreamTimeoutMs < 1) {
+    throw new Error("Voice access upstream timeout must be a positive integer.");
+  }
+  const expectedTokenHash = crypto.createHash("sha256").update(options.authToken).digest();
+
+  const server = http.createServer({ maxHeaderSize: MAX_HEADER_BYTES }, (request, response) => {
+    void handleVoiceAccessRequest({
+      expectedTokenHash,
+      request,
+      response,
+      upstreamHost,
+      upstreamPort,
+      upstreamTimeoutMs,
+    }).catch(() => {
+      sendEmpty(response, 502);
+    });
+  });
+
+  server.headersTimeout = 5_000;
+  server.requestTimeout = 15_000;
+  server.keepAliveTimeout = 5_000;
+  server.on("connect", (_request, socket) => socket.destroy());
+  server.on("upgrade", (_request, socket) => socket.destroy());
+  server.on("clientError", (_error, socket) => {
+    if (!socket.writable) return;
+    socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+  });
+  return server;
+}

--- a/test/internal-cli.test.ts
+++ b/test/internal-cli.test.ts
@@ -60,6 +60,22 @@ describe("internal oclif namespace", () => {
     expect(result.stdout).toContain("nemoclaw internal dev npm-link-or-shim");
   });
 
+  it("exposes the foreground voice access gateway through oclif routing", () => {
+    const result = spawnSync(
+      process.execPath,
+      [CLI, "internal", "voice-access", "serve", "--help"],
+      {
+        encoding: "utf-8",
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Internal: serve the voice access gateway");
+    expect(result.stdout).toContain("nemoclaw internal voice-access serve --token-file <path>");
+    expect(result.stdout).toContain("--listen-port");
+    expect(result.stdout).toContain("--upstream-port");
+  });
+
   it("exposes installer plan commands through oclif routing", () => {
     const help = spawnSync(process.execPath, [CLI, "internal", "installer", "plan", "--help"], {
       encoding: "utf-8",

--- a/test/internal-commands-docs.test.ts
+++ b/test/internal-commands-docs.test.ts
@@ -108,6 +108,21 @@ describe("internal command documentation (#3782)", () => {
     const offendingHeadings = text.split("\n").filter((line) => line.startsWith(headingPrefix));
     expect(offendingHeadings).toEqual([]);
   });
+
+  it.each(references)("pins the experimental voice access ownership boundary in $name", ({
+    text,
+    binary,
+  }) => {
+    const entry = text
+      .split("\n")
+      .find((line) => line.includes(`${binary} internal voice-access serve`));
+
+    expect(entry).toContain("experimental");
+    expect(entry).toContain("deployment-owned TLS termination");
+    expect(entry).toContain("NemoClaw does not own public endpoint management");
+    expect(entry).toContain("the Talker lifecycle");
+    expect(entry).toContain("service supervision");
+  });
 });
 
 describe("exec command documentation", () => {

--- a/test/package-contract/cli/oclif-metadata.test.ts
+++ b/test/package-contract/cli/oclif-metadata.test.ts
@@ -26,6 +26,29 @@ describe("oclif metadata lookup", () => {
     );
   });
 
+  it("ships and registers the compiled voice access gateway command", async () => {
+    const commandPath = path.join(
+      process.cwd(),
+      "dist",
+      "commands",
+      "internal",
+      "voice-access",
+      "serve.js",
+    );
+    const config = await OclifConfig.load(process.cwd());
+
+    expect(fs.existsSync(commandPath)).toBe(true);
+    expect(config.commands.some((command) => command.id === "internal:voice-access:serve")).toBe(
+      true,
+    );
+    expect(getRegisteredOclifCommandMetadata("internal:voice-access:serve")).toMatchObject({
+      hidden: true,
+      id: "internal:voice-access:serve",
+      strict: true,
+      summary: "Internal: serve the voice access gateway",
+    });
+  });
+
   it("keeps generated manifest command IDs aligned with oclif Config", async () => {
     const config = await OclifConfig.load(process.cwd());
     const expectedIds = config.commands.map((command) => command.id).sort();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

NemoClaw currently has no narrow ingress component for VoiceClaw signaling. This adds a hidden, foreground `nemoclaw internal voice-access serve` command that authenticates and forwards the VoiceClaw v1.0.0 signaling surface between fixed loopback ports while keeping public ingress, TLS, TURN, media, and service supervision outside NemoClaw.

## Related Issue

Closes #7781

## Changes

- Add a loopback-only HTTP gateway for the exact VoiceClaw signaling routes, with bearer authentication from a private token file, canonical conversation identifiers, strict header and body limits, fixed upstream selection, bounded timeouts, and content-free failures. A direct public bind would exceed the narrow scope amendment in #5998 and #6387; `src/lib/adapters/http/voice-access-gateway.test.ts` protects the ingress, authentication, forwarding, and failure boundaries.
- Add a hidden foreground oclif command and lifecycle action for a deployment-owned supervisor. Integrating this experiment into NemoClaw's public lifecycle would also take ownership of excluded host-service concerns; `src/lib/actions/voice-access/serve.test.ts`, `test/internal-cli.test.ts`, and `test/package-contract/cli/oclif-metadata.test.ts` protect shutdown, help, and package registration.
- Document the hidden command in the internal command inventory and raise the measured oclif base-class fan-in budget from 103 to 104 for the new registration.
- Associated upstream Brev experiment: [brevdev/nemoclaw-image#96](https://github.com/brevdev/nemoclaw-image/pull/96).

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the final nine-category sensitive-path review with PASS, no findings, and an independent 56/56 focused test run.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/commands.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: dd899333ac -->
<!-- docs-review-agents-blob-sha: be20a09524 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project cli src/lib/adapters/http/voice-access-gateway.test.ts src/lib/actions/voice-access/serve.test.ts` (2 files, 56 tests passed); internal command integration (17 tests) and package contract (6 tests) also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — `npm run check` passed its complete pre-commit stage, but the local manual coverage stage did not pass: 285 failures were concentrated in unrelated suites and timeouts, and the nested plugin package could not resolve `json5`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — the build exited 0 with 0 Fern errors and 2 warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
