### PR TITLE
fix(rebuild): emit 'Aborting rebuild' in preflight failure diagnostic

### DIFF
--- a/src/lib/actions/sandbox/rebuild-preflight-error.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-error.ts
@@ -13,6 +13,6 @@ export function printRebuildPreflightFailure(
   console.error("");
   console.error(`  ${_RD}Rebuild preflight failed:${R} ${summary}`);
   console.error(`  ${detail}`);
-  console.error("  Sandbox is untouched — no data was lost.");
+  console.error("  Aborting rebuild — sandbox is untouched, no data was lost.");
   bail(bailMessage);
 }


### PR DESCRIPTION
## Summary

- When `nemoclaw rebuild` fails during the preflight phase (e.g. a policy apply error in v0.0.96), `printRebuildPreflightFailure` now emits `Aborting rebuild` so all failure paths produce an actionable diagnostic matching `/Aborting rebuild/i`
- Previously, only backup-phase failures (in `rebuild-flow-helpers.ts`) produced this marker; preflight failures printed `Rebuild preflight failed:` and `Sandbox is untouched` but no `Aborting rebuild` line
- Fixes T5951690: `nemoclaw rebuild --yes` must either complete cleanly **or** report a recoverable diagnostic

## Test plan

- [ ] Run T5951690 (`nemoclaw-test`) against this branch and confirm it passes
- [ ] Confirm no regression on existing rebuild flow tests

Signed-off-by: Lyra Liu <lyral@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the rebuild failure message to clearly state that the rebuild was aborted and the sandbox remains unchanged, with no data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->