### PR TITLE
fix(onboard): reset persisted gateway port on re-onboard without NEMOCLAW_GATEWAY_PORT

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2383,6 +2383,20 @@ async function createSandboxWithBaseImageResolution(
     sandboxNameOverride ?? (await promptValidatedSandboxName(agent)),
     "sandbox name",
   );
+  // If NEMOCLAW_GATEWAY_PORT is not currently set and the existing sandbox was
+  // onboarded with a different (override) gateway port, migrate the registry
+  // entry to the current default gateway before any lifecycle operations run.
+  // This ensures gateway recovery selects the default gateway, not the old
+  // override port, when the user re-onboards without the env var set.
+  if (!process.env.NEMOCLAW_GATEWAY_PORT) {
+    const existingEntry = registry.getSandbox(sandboxName);
+    if (existingEntry?.gatewayPort != null && existingEntry.gatewayPort !== GATEWAY_PORT) {
+      registry.updateSandbox(sandboxName, {
+        gatewayName: GATEWAY_NAME,
+        gatewayPort: GATEWAY_PORT,
+      });
+    }
+  }
   preparedDcodeRebuild.assertPreparedDcodeTarget(preparedBuildContext, agent, fromDockerfile);
   enabledChannels = filterEnabledChannelsByAgent(enabledChannels, agent);
   const effectiveSandboxGpuConfig =


### PR DESCRIPTION
## Summary

- When a sandbox was first onboarded with `NEMOCLAW_GATEWAY_PORT=<port>`, the override port was persisted to the sandbox registry (`gatewayPort` field)
- On a subsequent `nemoclaw onboard` **without** the env var, gateway lifecycle operations (recovery/select via `resolveSandboxGatewayName`) still used the persisted override port, causing the old gateway to be restarted
- Fix: before any gateway lifecycle operations in `createSandbox`, if `NEMOCLAW_GATEWAY_PORT` is not currently set and the existing sandbox entry has a different persisted port, update the registry to the current default gateway
- Fixes T5949420: re-onboard after gateway cleanup must use the default port (8080), not the previously overridden port

## Test plan

- [ ] Run T5949420 (`nemoclaw-test`) against this branch and confirm steps 5–7 pass
- [ ] Confirm `NEMOCLAW_GATEWAY_PORT` override still works for first-time onboard
- [ ] Confirm concurrent gateway scenarios (`concurrent-gateway-ports` test) are not regressed

Signed-off-by: Lyra Liu <lyral@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing sandboxes now automatically update to the current gateway configuration before lifecycle operations begin.
  * Improved compatibility when the gateway port configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->