### PR TITLE
fix(onboard): reject stale Deep Agents base inventories

### DIFF
--- a/src/lib/agent/base-image.test.ts
+++ b/src/lib/agent/base-image.test.ts
@@ -357,7 +357,8 @@ describe("agent base image provisioning", () => {
             "/test/root/agents/langchain-deepagents-code/requirements.lock",
           ],
           validateImage: expect.any(Function),
-          validationDescription: "deepagents-code==0.1.34",
+          validationDescription:
+            "deepagents-code==0.1.34 and the immutable security package inventory",
         }),
       );
     });

--- a/src/lib/agent/deep-agents-code-base-image.test.ts
+++ b/src/lib/agent/deep-agents-code-base-image.test.ts
@@ -39,16 +39,52 @@ describe("Deep Agents Code base image compatibility", () => {
       }),
       "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
     );
-    mocks.dockerCapture.mockReturnValue("9.8.7");
+    mocks.dockerCapture
+      .mockReturnValueOnce("9.8.7")
+      .mockReturnValueOnce("nemoclaw-security-inventory-ok");
 
     expect(options).toMatchObject({
       inputPaths: [
         "/test/root/agents/langchain-deepagents-code/manifest.yaml",
         "/test/root/agents/langchain-deepagents-code/requirements.lock",
       ],
-      validationDescription: "deepagents-code==9.8.7",
+      validationDescription: "deepagents-code==9.8.7 and the immutable security package inventory",
     });
     expect(options?.validateImage?.("dcode-base:manifest-version")).toBe(true);
+  });
+
+  it("rejects a matching distribution from a base with an old security inventory (#7809)", () => {
+    const options = createDeepAgentsCodeBaseImageResolutionOptions(
+      makeAgent({
+        name: "langchain-deepagents-code",
+        displayName: "LangChain Deep Agents Code",
+        expectedVersion: "0.1.34",
+      }),
+      "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
+    );
+    mocks.dockerCapture.mockReturnValueOnce("0.1.34").mockReturnValueOnce("");
+
+    expect(options?.validateImage?.("dcode-base:v0.0.96")).toBe(false);
+    expect(mocks.dockerCapture).toHaveBeenCalledTimes(2);
+    expect(mocks.dockerCapture.mock.calls[1]?.[0]).toEqual(
+      expect.arrayContaining([
+        "run",
+        "--network",
+        "none",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--read-only",
+        "--entrypoint",
+        "/bin/sh",
+        "dcode-base:v0.0.96",
+        "-c",
+      ]),
+    );
+    expect(mocks.dockerCapture.mock.calls[1]?.[0].at(-1)).toContain(
+      `cmp -s - "$security_inventory"`,
+    );
   });
 
   it("runs the version probe in a locked-down container (#6456)", () => {

--- a/src/lib/agent/deep-agents-code-base-image.ts
+++ b/src/lib/agent/deep-agents-code-base-image.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { dockerCapture } from "../adapters/docker";
 import type { ResolveBaseImageOptions } from "../sandbox-base-image";
+import { sandboxBaseImageHasSecurityInventory } from "../sandbox-base-image/security-inventory";
 import type { AgentDefinition } from "./defs";
 
 const DEEPAGENTS_CODE_DISTRIBUTION = "deepagents-code";
@@ -73,7 +74,11 @@ export function createDeepAgentsCodeBaseImageResolutionOptions(
     // Retain the resolver's pre-existing global inputs alongside these agent
     // inputs. Per-agent cache-policy isolation is a separate cross-agent change.
     inputPaths: [path.join(agentRoot, "manifest.yaml"), path.join(agentRoot, "requirements.lock")],
-    validateImage: (imageRef) => deepAgentsCodeBaseImageMatchesVersion(imageRef, expectedVersion),
-    validationDescription: `${DEEPAGENTS_CODE_DISTRIBUTION}==${expectedVersion}`,
+    validateImage: (imageRef) =>
+      deepAgentsCodeBaseImageMatchesVersion(imageRef, expectedVersion) &&
+      sandboxBaseImageHasSecurityInventory(imageRef),
+    validationDescription:
+      `${DEEPAGENTS_CODE_DISTRIBUTION}==${expectedVersion} and ` +
+      "the immutable security package inventory",
   };
 }

--- a/src/lib/onboard/base-image.ts
+++ b/src/lib/onboard/base-image.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { dockerCapture } from "../adapters/docker";
 import { ROOT } from "../runner";
 import {
   buildLocalBaseTag,
@@ -10,9 +9,8 @@ import {
   OPENCLAW_SANDBOX_BASE_IMAGE as SANDBOX_BASE_IMAGE,
   type SandboxBaseImageResolutionMetadata,
 } from "../sandbox-base-image";
+import { sandboxBaseImageHasSecurityInventory } from "../sandbox-base-image/security-inventory";
 import { getInstalledOpenshellVersion } from "./openshell-version";
-
-const OPENCLAW_SECURITY_INVENTORY_PROBE_OK = "nemoclaw-security-inventory-ok";
 
 /**
  * Reject a published or cached OpenClaw base that predates the immutable
@@ -20,37 +18,7 @@ const OPENCLAW_SECURITY_INVENTORY_PROBE_OK = "nemoclaw-security-inventory-ok";
  * Accepting that base only defers the mismatch to the last Dockerfile layer,
  * after the expensive final image has already been built.
  */
-export function openClawBaseImageHasSecurityInventory(imageRef: string): boolean {
-  const output = dockerCapture(
-    [
-      "run",
-      "--rm",
-      "--network",
-      "none",
-      "--cap-drop",
-      "ALL",
-      "--security-opt",
-      "no-new-privileges",
-      "--read-only",
-      "--entrypoint",
-      "/bin/sh",
-      imageRef,
-      "-c",
-      [
-        "set -eu",
-        "security_inventory=/usr/local/share/nemoclaw/security-packages.txt",
-        'arch="$(dpkg --print-architecture)"',
-        'test -f "$security_inventory"',
-        'test ! -L "$security_inventory"',
-        `test "$(stat -c '%u:%g:%a' "$security_inventory")" = "0:0:444"`,
-        `printf '%s\\n' "architecture=$arch" "libexpat1=2.8.2-1" "libonig5=6.9.9-1+b1" "libjq1=1.8.2-1" "jq=1.8.2-1" "vim-common=2:9.2.0782-1" "vim-tiny=2:9.2.0782-1" "libssh2-1t64=1.11.1-1+deb13u1+nemoclaw1" "nemoclaw-python3.13-htmlparser-fix=3.13.5-2+deb13u4+nemoclaw1" | cmp -s - "$security_inventory"`,
-        `printf '%s\\n' "${OPENCLAW_SECURITY_INVENTORY_PROBE_OK}"`,
-      ].join("; "),
-    ],
-    { ignoreError: true, timeout: 20_000 },
-  );
-  return output.trim() === OPENCLAW_SECURITY_INVENTORY_PROBE_OK;
-}
+export const openClawBaseImageHasSecurityInventory = sandboxBaseImageHasSecurityInventory;
 
 /**
  * Resolve a compatible sandbox-base image and pin it to a repo digest when

--- a/src/lib/sandbox-base-image/security-inventory.ts
+++ b/src/lib/sandbox-base-image/security-inventory.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { dockerCapture } from "../adapters/docker";
+
+const SECURITY_INVENTORY_PROBE_OK = "nemoclaw-security-inventory-ok";
+
+/**
+ * Reject a published or cached base that predates the immutable security
+ * package inventory consumed by completed-image verification.
+ */
+export function sandboxBaseImageHasSecurityInventory(imageRef: string): boolean {
+  const output = dockerCapture(
+    [
+      "run",
+      "--rm",
+      "--network",
+      "none",
+      "--cap-drop",
+      "ALL",
+      "--security-opt",
+      "no-new-privileges",
+      "--read-only",
+      "--entrypoint",
+      "/bin/sh",
+      imageRef,
+      "-c",
+      [
+        "set -eu",
+        "security_inventory=/usr/local/share/nemoclaw/security-packages.txt",
+        'arch="$(dpkg --print-architecture)"',
+        'test -f "$security_inventory"',
+        'test ! -L "$security_inventory"',
+        `test "$(stat -c '%u:%g:%a' "$security_inventory")" = "0:0:444"`,
+        `printf '%s\\n' "architecture=$arch" "libexpat1=2.8.2-1" "libonig5=6.9.9-1+b1" "libjq1=1.8.2-1" "jq=1.8.2-1" "vim-common=2:9.2.0782-1" "vim-tiny=2:9.2.0782-1" "libssh2-1t64=1.11.1-1+deb13u1+nemoclaw1" "nemoclaw-python3.13-htmlparser-fix=3.13.5-2+deb13u4+nemoclaw1" | cmp -s - "$security_inventory"`,
+        `printf '%s\\n' "${SECURITY_INVENTORY_PROBE_OK}"`,
+      ].join("; "),
+    ],
+    { ignoreError: true, timeout: 20_000 },
+  );
+  return output.trim() === SECURITY_INVENTORY_PROBE_OK;
+}

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -472,6 +472,8 @@ describe("base-image publication behavior", () => {
     expect(lock).toMatch(/^deepagents-code==[^\s\\]+\s+\\\n\s+--hash=sha256:[0-9a-f]{64}/m);
     expect(lockedVersion).toBeDefined();
     expect(agent.expectedVersion).toBe(lockedVersion);
-    expect(resolution?.validationDescription).toBe(`deepagents-code==${lockedVersion}`);
+    expect(resolution?.validationDescription).toBe(
+      `deepagents-code==${lockedVersion} and the immutable security package inventory`,
+    );
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Deep Agents Code onboarding now rejects a release base image that has the expected distribution version but an obsolete security package inventory. The resolver detects the incompatibility before completed-image construction and retains its existing release-refresh and local-build fallback behavior.

## Related Issue

Fixes #7809

## Changes

- Require Deep Agents Code base images to match both the manifest distribution version and the immutable security package inventory.
- Move the existing inventory probe to a shared base-image module because OpenClaw and Deep Agents Code must enforce one inventory definition. A second direct probe would let the two compatibility gates drift; `deep-agents-code-base-image.test.ts` protects the shared DCode consumer.
- Add regression coverage that rejects the stale `v0.0.96` inventory even when `deepagents-code==0.1.34`.
- Preserve the existing resolver contract that refreshes the selected release once, builds the current base locally when required, and does not substitute mutable `latest`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The command, configuration, recovery, and resolver fallback contracts do not change. Existing docs already describe incompatible-image rejection and compatible local builds.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the repository's nine-category security review on exact PR SHA `4fafec7ef`; all categories passed with no findings. The probe uses constant shell input and runs without network access, Linux capabilities, writable filesystem access, or privilege escalation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing Deep Agents and base-image documentation already covers incompatible-image rejection, compatible local builds, exact override validation, and fail-closed behavior. No command, flag, configuration, schema, workflow, or recovery action changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4fafec7ef -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/agent/deep-agents-code-base-image.test.ts src/lib/agent/base-image.test.ts src/lib/onboard/base-image.test.ts` passed 31 tests; `npx vitest run --project integration test/dcode-base-image-workflow.test.ts` passed 4 tests; `npm run test:changed` passed 289 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — Not run; focused CLI, integration, changed-test, type-check, and normal hook evidence cover this scoped compatibility validation.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened base-image validation to require an up-to-date immutable security package inventory.
  * Prevented otherwise compatible images from being accepted when their security inventory is outdated or invalid.
  * Improved validation details to clearly indicate both version and security-inventory requirements.

* **Tests**
  * Added regression coverage for rejecting images with stale security inventories.
  * Expanded workflow and compatibility tests for the enhanced validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->