### PR TITLE
refactor(architecture): remove final runtime cycle

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -53,12 +53,7 @@
       "src/lib/shields/index.ts": 23
     }
   },
-  "allowedCycles": [
-    [
-      "src/lib/onboard/policy-resume-selection.ts",
-      "src/lib/onboard/policy-selection.ts"
-    ]
-  ],
+  "allowedCycles": [],
   "maxRootFiles": {
     "src/lib/onboard": 307,
     "src/lib/actions": 19,

--- a/src/lib/onboard/policy-resume-selection.ts
+++ b/src/lib/onboard/policy-resume-selection.ts
@@ -18,8 +18,7 @@ import {
 import {
   isStaleBuiltinWebSearchPolicyPreset,
   mergeRequiredSetupPolicyPresets,
-  type PreparedPolicyResumeSelection,
-} from "./policy-selection";
+} from "./policy-preset-reconciliation";
 import { suppressedAgentRequiredPresets } from "./policy-tier-suppression";
 
 type Preset = { name: string; access?: string };
@@ -43,6 +42,13 @@ type PoliciesApi = {
     options?: { webSearchSupported?: boolean | null },
     customPresetNames?: Set<string>,
   ): string[];
+};
+
+export type PreparedPolicyResumeSelection = {
+  policyPresets: string[];
+  recordedPolicyPresetsNeedReconcile: boolean;
+  disabledMessagingPolicyPresetApplied: boolean;
+  suppressedAgentRequiredPresetsLive: boolean;
 };
 
 export function preparePolicyPresetResumeSelection(

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -115,13 +115,6 @@ export type SetupPolicySelectionDeps = {
   env?: NodeJS.ProcessEnv;
 };
 
-export type PreparedPolicyResumeSelection = {
-  policyPresets: string[];
-  recordedPolicyPresetsNeedReconcile: boolean;
-  disabledMessagingPolicyPresetApplied: boolean;
-  suppressedAgentRequiredPresetsLive: boolean;
-};
-
 export function computeSetupPresetSuggestions(
   deps: {
     policies: PoliciesApi;
@@ -217,7 +210,10 @@ export function computeSetupPresetSuggestions(
   return suggestions;
 }
 
-export { preparePolicyPresetResumeSelection } from "./policy-resume-selection";
+export {
+  preparePolicyPresetResumeSelection,
+  type PreparedPolicyResumeSelection,
+} from "./policy-resume-selection";
 
 export async function setupPoliciesWithSelection(
   deps: SetupPolicySelectionDeps,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Removes the final production TypeScript runtime cycle. Policy resume selection now imports reconciliation helpers from their owner. The architecture ratchet now permits zero cycles.

## Related Issue

Closes #7745

Depends on #7749.

## Changes

- Import policy reconciliation helpers directly from `policy-preset-reconciliation`.
- Move the resume result type to `policy-resume-selection`. Keep its public re-export from `policy-selection`.
- Set the allowed runtime cycle list to empty.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: Policy resume and recorded-tier tests passed 15/15. The CLI type check protects the public re-export. The architecture guard protects the zero-cycle ratchet.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change moves type and import ownership. It does not change commands, output, configuration, workflows, persisted data, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex completed an exact-head nine-category review at `107e333ce`. All categories passed with no findings: https://github.com/NVIDIA/NemoClaw/pull/7813#issuecomment-5116746384
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed the three changed files at exact head `107e333cea92be220d3b88dfb127835a42d3492e`. The type moved verbatim, its public re-export remains, and the architecture budget records zero cycles. No explanatory text or user-visible behavior changed.
- Agent: Codex documentation writer subagent `/root/doc_writer_policy_cycle`
<!-- docs-review-head-sha: 107e333ce -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/policy-resume-selection.test.ts src/lib/onboard/policy-selection-recorded-tier.test.ts`: 15/15 passed. `npm run typecheck:cli` passed. The source architecture check reported 1,398 files, 4,106 edges, and 0 cycles.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
