### PR TITLE
docs: stop DeepAgents rendering three empty provider-switch sections (#7815)

### DIFF
--- a/docs/inference/switch-providers.mdx
+++ b/docs/inference/switch-providers.mdx
@@ -13,9 +13,9 @@ Move a sandbox to another provider family while keeping the OpenShell route, age
 Use onboarding first when the target is neither `compatible-endpoint` nor `compatible-anthropic-endpoint` and is not registered.
 The compatible endpoint workflow below can register an absent custom provider from complete route metadata.
 
-## Find a Registered Provider
-
 <AgentOnly variant="openclaw,hermes">
+
+## Find a Registered Provider
 
 List the configured provider credentials when you need the exact provider ID.
 
@@ -32,9 +32,9 @@ For a compatible custom endpoint, pass the complete route metadata described bel
 
 </AgentOnly>
 
-## Switch the Provider at Runtime
-
 <AgentOnly variant="openclaw,hermes">
+
+## Switch the Provider at Runtime
 
 Pass the target provider and model together.
 Target a non-default sandbox by name.
@@ -77,9 +77,9 @@ $$nemoclaw onboard --fresh --name <sandbox-name> --recreate-sandbox
 
 </AgentOnly>
 
-## Handle Compatible Endpoints
-
 <AgentOnly variant="openclaw,hermes">
+
+## Handle Compatible Endpoints
 
 When moving from another provider family to `compatible-endpoint` or `compatible-anthropic-endpoint`, provide the trusted endpoint URL and enough API metadata to record the complete route identity.
 Export the canonical credential environment variable for the target provider.


### PR DESCRIPTION
## Summary

On the DeepAgents "Switch Inference Providers" page, three headings — "Find a
Registered Provider", "Switch the Provider at Runtime", and "Handle Compatible
Endpoints" — rendered with no body content, because the headings sat outside any
`AgentOnly` block (so they rendered for every variant) while their bodies lived
only in `openclaw,hermes` blocks. This is a regression of the #7309 empty-section
fix. DeepAgents changes providers by recreating the sandbox (its own "Recreate a
Deep Agents Sandbox" block), so those runtime workflows do not apply to it. This
moves each heading inside its `openclaw,hermes` block so DeepAgents no longer
emits empty sections.

## Related Issue

Fixes #7815

## Changes

- `docs/inference/switch-providers.mdx`: move the "Find a Registered Provider",
  "Switch the Provider at Runtime", and "Handle Compatible Endpoints" headings
  inside their existing `<AgentOnly variant="openclaw,hermes">` blocks. No prose
  changes; `openclaw`/`hermes` rendering is unchanged, and DeepAgents keeps its
  own "Recreate a Deep Agents Sandbox" guidance plus the shared sections.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Doc only (prose changes, no code sample modifications)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Tests not applicable — justification: documentation variant-scoping fix; validated by the docs build and agent-variant generation.
- [x] Docs updated for user-facing behavior changes
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Non-success, skipped, or missing CI check accepted by maintainer:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass, or tests are marked not applicable above — result: regenerated the agent-variant docs and confirmed the DeepAgents page (`switch-providers.deepagents.generated.mdx`) no longer emits the three empty headings (only "Recreate a Deep Agents Sandbox", "Account for Shared Gateways", "Related Topics"), while the `openclaw` variant keeps all three headings with bodies. `npm run docs` → 0 errors, exit 0, `check-docs-published-routes: OK`, locally and on a fresh clone + `npm ci` on an Ubuntu host.
- [x] `npm run docs` builds without warnings (doc changes only) — the 2 fern warnings are pre-existing/repo-wide (FERN_TOKEN-gated redirect check and a global light-mode accent contrast ratio); neither references this page.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)
- [x] No secrets, API keys, or credentials committed

---
Signed-off-by: Jason Ma <jama@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provider-switching documentation so relevant sections display correctly for OpenClaw and Hermes users.
  * Improved heading placement and spacing within the applicable platform-specific content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->