### PR TITLE
fix(e2e): verify Launchable image runtime

### DIFF
--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -34,6 +34,8 @@ function fixture(
     repoClean?: boolean;
     repoSha?: string;
     runtimeOverrides?: boolean;
+    schemaVersion?: number;
+    sourceRepository?: string;
     sourcePath?: string;
   } = {},
 ) {
@@ -100,9 +102,11 @@ case "$1" in
         printf 'NEMOCLAW_IDENTITY='
         jq -cn --arg bootImage "$FAKE_BOOT_IMAGE" --arg sourcePath "$FAKE_SOURCE_PATH" \
           --arg repo "$FAKE_REPO_SHA" --arg provision "$FAKE_PROVISION_SHA" \
+          --arg sourceRepository "$FAKE_SOURCE_REPOSITORY" \
           --arg imageRepositorySha "$FAKE_PROVISION_IMAGE_REPOSITORY_SHA" \
-          --argjson clean "$FAKE_REPO_CLEAN" --argjson overrides "$FAKE_RUNTIME_OVERRIDES" \
-          '{bootImage:$bootImage,schemaVersion:1,sourceRepository:"NVIDIA/NemoClaw",
+          --argjson schemaVersion "$FAKE_SCHEMA_VERSION" --argjson clean "$FAKE_REPO_CLEAN" \
+          --argjson overrides "$FAKE_RUNTIME_OVERRIDES" \
+          '{bootImage:$bootImage,schemaVersion:$schemaVersion,sourceRepository:$sourceRepository,
             sourcePath:$sourcePath,repoSha:$repo,provisionSha:$provision,
             imageRepositorySha:$imageRepositorySha,repoClean:$clean,runtimeOverrides:$overrides}'
         printf '%s\\n' "$INSTANCE_NAME" ;;
@@ -151,6 +155,8 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     FAKE_REPO_CLEAN: options.repoClean === false ? "false" : "true",
     FAKE_REPO_SHA: options.repoSha ?? candidateSha,
     FAKE_RUNTIME_OVERRIDES: options.runtimeOverrides ? "true" : "false",
+    FAKE_SCHEMA_VERSION: String(options.schemaVersion ?? 1),
+    FAKE_SOURCE_REPOSITORY: options.sourceRepository ?? "NVIDIA/NemoClaw",
     FAKE_SOURCE_PATH: options.sourcePath ?? "/opt/nemoclaw-image/NemoClaw",
     FAKE_STATE: state,
     GH_TOKEN: "github-test-token",
@@ -241,6 +247,8 @@ describe("focused staging Brev Launchable lane", () => {
       fixture({ provisionImageRepositorySha: "c".repeat(40) }),
       fixture({ repoClean: false }),
       fixture({ runtimeOverrides: true }),
+      fixture({ schemaVersion: 2 }),
+      fixture({ sourceRepository: "example/NemoClaw" }),
       fixture({ sourcePath: "/home/ubuntu/NemoClaw" }),
     ]) {
       const bootResult = run(boot.env);

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -22,13 +22,18 @@ function executable(file: string, source: string): void {
 
 function fixture(
   options: {
+    bootImage?: string;
     deleteFails?: boolean;
     e2eFails?: boolean;
+    imageRepositorySha?: string;
+    provisionImageRepositorySha?: string;
     provisionSha?: string;
     ready?: boolean;
     receiptSha?: string;
     repoClean?: boolean;
     repoSha?: string;
+    runtimeOverrides?: boolean;
+    sourcePath?: string;
   } = {},
 ) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-launchable-e2e-"));
@@ -49,8 +54,8 @@ printf 'gh %s\\n' "$*" >> "$FAKE_CALLS"
 if [ "$1" = api ]; then
   case "$*" in
     *'/dispatches'*) exit 0 ;;
-    *'/workflows/build-qualification-image.yml/runs'*)
-      jq -cn --arg title "Qualify NemoClaw $CANDIDATE_SHA ($CORRELATION_ID)" \
+    *'/workflows/build-launchable-e2e-image.yml/runs'*)
+      jq -cn --arg title "Build Launchable E2E image for NemoClaw $CANDIDATE_SHA ($CORRELATION_ID)" \
         '{workflow_runs:[{id:123,display_title:$title,head_branch:"main",created_at:"2099-01-01T00:00:00Z"}]}' ;;
     *'/actions/runs/123'*) jq -cn '{status:"completed",conclusion:"success"}' ;;
     *) exit 2 ;;
@@ -61,12 +66,14 @@ elif [ "$1 $2" = 'run download' ]; then
     shift
   done
   mkdir -p "$directory"
-  jq -n --arg sha "$FAKE_RECEIPT_SHA" --arg correlation "$CORRELATION_ID" '{
+  jq -n --arg sha "$FAKE_RECEIPT_SHA" --arg correlation "$CORRELATION_ID" \
+    --arg imageRepositorySha "$FAKE_IMAGE_REPOSITORY_SHA" '{
     kind:"nemoclaw-exact-image-manifest",nemoclawSha:$sha,correlationId:$correlation,
     requesterWorkflowRunId:"789",requesterWorkflowRunAttempt:1,
-    imageRepository:"brevdev/nemoclaw-image",producerWorkflow:".github/workflows/build-qualification-image.yml",
+    imageRepository:"brevdev/nemoclaw-image",producerWorkflow:".github/workflows/build-launchable-e2e-image.yml",
     workflowRunId:"123",workflowRunAttempt:1,
-    status:"READY",channel:"staging",variant:"cpu",observedFamily:"nemoclaw-brev-staging-cpu"
+    status:"READY",channel:"staging",variant:"cpu",observedFamily:"nemoclaw-brev-staging-cpu",
+    project:"brevdevprod",imageName:"nemoclaw-test-image",imageRepositorySha:$imageRepositorySha
   }' > "$directory/nemoclaw-image-manifest.v1.json"
 else
   exit 2
@@ -89,8 +96,13 @@ case "$1" in
     case "$3" in
       *repo_clean*)
         printf 'NEMOCLAW_IDENTITY='
-        jq -cn --arg repo "$FAKE_REPO_SHA" --arg provision "$FAKE_PROVISION_SHA" \
-          --argjson clean "$FAKE_REPO_CLEAN" '{repoSha:$repo,provisionSha:$provision,repoClean:$clean}'
+        jq -cn --arg bootImage "$FAKE_BOOT_IMAGE" --arg sourcePath "$FAKE_SOURCE_PATH" \
+          --arg repo "$FAKE_REPO_SHA" --arg provision "$FAKE_PROVISION_SHA" \
+          --arg imageRepositorySha "$FAKE_PROVISION_IMAGE_REPOSITORY_SHA" \
+          --argjson clean "$FAKE_REPO_CLEAN" --argjson overrides "$FAKE_RUNTIME_OVERRIDES" \
+          '{bootImage:$bootImage,schemaVersion:1,sourceRepository:"NVIDIA/NemoClaw",
+            sourcePath:$sourcePath,repoSha:$repo,provisionSha:$provision,
+            imageRepositorySha:$imageRepositorySha,repoClean:$clean,runtimeOverrides:$overrides}'
         printf '%s\\n' "$INSTANCE_NAME" ;;
       *) exit 2 ;;
     esac ;;
@@ -106,6 +118,8 @@ esac
 set -euo pipefail
 script="$(cat)"
 grep -q 'NEMOCLAW_E2E_SETUP_MODE=preinstalled-launchable' <<<"$script"
+grep -q 'NEMOCLAW_SOURCE_PATH=/opt/nemoclaw-image/NemoClaw' <<<"$script"
+grep -q 'runtime-overrides.json' <<<"$script"
 printf 'ssh preinstalled full-e2e.test.ts\\n' >> "$FAKE_CALLS"
 printf 'remote output contains %s\\n' "$NVIDIA_INFERENCE_API_KEY"
 [ "$FAKE_E2E_FAILS" != 1 ] || exit 7
@@ -121,14 +135,20 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     BREV_LAUNCHABLE_ID: "env-staging123",
     CANDIDATE_SHA: candidateSha,
     CORRELATION_ID: "11111111-1111-4111-8111-111111111111",
+    FAKE_BOOT_IMAGE: options.bootImage ?? "projects/brevdevprod/global/images/nemoclaw-test-image",
     FAKE_CALLS: calls,
     FAKE_DELETE_FAILS: options.deleteFails ? "1" : "0",
     FAKE_E2E_FAILS: options.e2eFails ? "1" : "0",
+    FAKE_IMAGE_REPOSITORY_SHA: options.imageRepositorySha ?? "b".repeat(40),
+    FAKE_PROVISION_IMAGE_REPOSITORY_SHA:
+      options.provisionImageRepositorySha ?? options.imageRepositorySha ?? "b".repeat(40),
     FAKE_PROVISION_SHA: options.provisionSha ?? candidateSha,
     FAKE_READY: options.ready === false ? "0" : "1",
     FAKE_RECEIPT_SHA: options.receiptSha ?? candidateSha,
     FAKE_REPO_CLEAN: options.repoClean === false ? "false" : "true",
     FAKE_REPO_SHA: options.repoSha ?? candidateSha,
+    FAKE_RUNTIME_OVERRIDES: options.runtimeOverrides ? "true" : "false",
+    FAKE_SOURCE_PATH: options.sourcePath ?? "/opt/nemoclaw-image/NemoClaw",
     FAKE_STATE: state,
     GH_TOKEN: "github-test-token",
     GITHUB_RUN_ATTEMPT: "1",
@@ -173,7 +193,14 @@ describe("focused staging Brev Launchable lane", () => {
       candidateSha,
       fullE2e: "passed",
       producer: { runId: "123", status: "success" },
-      boot: { repoSha: candidateSha, provisionSha: candidateSha, repoClean: true },
+      boot: {
+        bootImage: "projects/brevdevprod/global/images/nemoclaw-test-image",
+        sourcePath: "/opt/nemoclaw-image/NemoClaw",
+        repoSha: candidateSha,
+        provisionSha: candidateSha,
+        repoClean: true,
+        runtimeOverrides: false,
+      },
       workspace: { id: "ws-1" },
     });
   });
@@ -192,13 +219,19 @@ describe("focused staging Brev Launchable lane", () => {
     expect(fs.existsSync(unready.state)).toBe(false);
 
     for (const boot of [
+      fixture({ bootImage: "projects/brevdevprod/global/images/wrong-image" }),
       fixture({ repoSha: "b".repeat(40) }),
       fixture({ provisionSha: "b".repeat(40) }),
+      fixture({ provisionImageRepositorySha: "c".repeat(40) }),
       fixture({ repoClean: false }),
+      fixture({ runtimeOverrides: true }),
+      fixture({ sourcePath: "/home/ubuntu/NemoClaw" }),
     ]) {
       const bootResult = run(boot.env);
       expect(bootResult.status).not.toBe(0);
-      expect(bootResult.stderr).toContain("booted checkout does not match candidate");
+      expect(bootResult.stderr).toContain(
+        "booted image runtime does not match the producer handoff",
+      );
       expect(fs.readFileSync(boot.calls, "utf8")).not.toContain("full-e2e.test.ts");
       expect(fs.existsSync(boot.state)).toBe(false);
     }

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -26,6 +26,7 @@ function fixture(
     deleteFails?: boolean;
     e2eFails?: boolean;
     imageRepositorySha?: string;
+    omitReceiptField?: "imageName" | "imageRepositorySha" | "project";
     provisionImageRepositorySha?: string;
     provisionSha?: string;
     ready?: boolean;
@@ -67,14 +68,15 @@ elif [ "$1 $2" = 'run download' ]; then
   done
   mkdir -p "$directory"
   jq -n --arg sha "$FAKE_RECEIPT_SHA" --arg correlation "$CORRELATION_ID" \
-    --arg imageRepositorySha "$FAKE_IMAGE_REPOSITORY_SHA" '{
+    --arg imageRepositorySha "$FAKE_IMAGE_REPOSITORY_SHA" \
+    --arg omit "$FAKE_OMIT_RECEIPT_FIELD" '{
     kind:"nemoclaw-exact-image-manifest",nemoclawSha:$sha,correlationId:$correlation,
     requesterWorkflowRunId:"789",requesterWorkflowRunAttempt:1,
     imageRepository:"brevdev/nemoclaw-image",producerWorkflow:".github/workflows/build-launchable-e2e-image.yml",
     workflowRunId:"123",workflowRunAttempt:1,
     status:"READY",channel:"staging",variant:"cpu",observedFamily:"nemoclaw-brev-staging-cpu",
     project:"brevdevprod",imageName:"nemoclaw-test-image",imageRepositorySha:$imageRepositorySha
-  }' > "$directory/nemoclaw-image-manifest.v1.json"
+  } | if $omit == "" then . else del(.[$omit]) end' > "$directory/nemoclaw-image-manifest.v1.json"
 else
   exit 2
 fi
@@ -140,6 +142,7 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     FAKE_DELETE_FAILS: options.deleteFails ? "1" : "0",
     FAKE_E2E_FAILS: options.e2eFails ? "1" : "0",
     FAKE_IMAGE_REPOSITORY_SHA: options.imageRepositorySha ?? "b".repeat(40),
+    FAKE_OMIT_RECEIPT_FIELD: options.omitReceiptField ?? "",
     FAKE_PROVISION_IMAGE_REPOSITORY_SHA:
       options.provisionImageRepositorySha ?? options.imageRepositorySha ?? "b".repeat(40),
     FAKE_PROVISION_SHA: options.provisionSha ?? candidateSha,
@@ -211,6 +214,19 @@ describe("focused staging Brev Launchable lane", () => {
     expect(receiptResult.status).not.toBe(0);
     expect(receiptResult.stderr).toContain("producer receipt does not match the candidate");
     expect(fs.readFileSync(receipt.calls, "utf8")).not.toMatch(/brev create|full-e2e\.test\.ts/u);
+
+    for (const malformed of [
+      fixture({ omitReceiptField: "project" }),
+      fixture({ omitReceiptField: "imageName" }),
+      fixture({ imageRepositorySha: "not-a-sha" }),
+    ]) {
+      const malformedResult = run(malformed.env);
+      expect(malformedResult.status).not.toBe(0);
+      expect(malformedResult.stderr).toContain("producer receipt does not match the candidate");
+      expect(fs.readFileSync(malformed.calls, "utf8")).not.toMatch(
+        /brev create|full-e2e\.test\.ts/u,
+      );
+    }
 
     const unready = fixture({ ready: false });
     const unreadyResult = run({ ...unready.env, BREV_READY_TIMEOUT_SECONDS: "1" });

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 IMAGE_REPOSITORY=brevdev/nemoclaw-image
-IMAGE_WORKFLOW=build-qualification-image.yml
+IMAGE_WORKFLOW=build-launchable-e2e-image.yml
 cleanup_required=0
 
 log() {
@@ -94,7 +94,7 @@ log "Candidate $CANDIDATE_SHA"
 
 # Dispatch #80 once, then bind the uniquely correlated producer run.
 requested_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-title="Qualify NemoClaw $CANDIDATE_SHA ($CORRELATION_ID)"
+title="Build Launchable E2E image for NemoClaw $CANDIDATE_SHA ($CORRELATION_ID)"
 gh api --method POST "repos/$IMAGE_REPOSITORY/actions/workflows/$IMAGE_WORKFLOW/dispatches" \
   -f ref=main -f "inputs[nemoclaw_sha]=$CANDIDATE_SHA" \
   -f "inputs[correlation_id]=$CORRELATION_ID" \
@@ -139,11 +139,16 @@ jq -e --arg sha "$CANDIDATE_SHA" --arg correlation "$CORRELATION_ID" \
   .kind == "nemoclaw-exact-image-manifest" and .nemoclawSha == $sha and
   .correlationId == $correlation and .requesterWorkflowRunId == $requester and
   .requesterWorkflowRunAttempt == $attempt and .imageRepository == "brevdev/nemoclaw-image" and
-  .producerWorkflow == ".github/workflows/build-qualification-image.yml" and
+  .producerWorkflow == ".github/workflows/build-launchable-e2e-image.yml" and
   .workflowRunId == $run and .workflowRunAttempt == 1 and .status == "READY" and
   .channel == "staging" and .variant == "cpu" and
-  .observedFamily == "nemoclaw-brev-staging-cpu"' \
+  .observedFamily == "nemoclaw-brev-staging-cpu" and
+  (.project | type) == "string" and (.project | length) > 0 and
+  (.imageName | type) == "string" and (.imageName | length) > 0 and
+  (.imageRepositorySha | test("^[0-9a-f]{40}$"))' \
   "$manifest" >/dev/null || die "producer receipt does not match the candidate"
+expected_boot_image="projects/$(jq -er .project "$manifest")/global/images/$(jq -er .imageName "$manifest")"
+image_repository_sha="$(jq -er .imageRepositorySha "$manifest")"
 rm -rf "$WORK_DIR/handoff"
 
 # The standing Launchable resolves the staging family; the guest must contain the exact clean candidate.
@@ -167,25 +172,46 @@ jq -e '.status == "RUNNING" and (.shell_status // .shellStatus) == "READY" and
 workspace_id="$(jq -r '.id // ""' <<<"$ready")"
 log "Workspace $INSTANCE_NAME ($workspace_id) is ready"
 
-# launchable-e2e-identity: return only the baked SHA and clean-checkout verdict.
+# Return the booted image and the baked runtime receipt.
 # The remote shell expands the single-quoted command.
 # shellcheck disable=SC2016
 identity="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
-  repo_sha=$(git -C "$HOME/NemoClaw" rev-parse HEAD)
+  boot_image=$(curl -fsS --max-time 10 -H "Metadata-Flavor: Google" \
+    http://metadata.google.internal/computeMetadata/v1/instance/image)
+  schema_version=$(sudo -n jq -er .schemaVersion /etc/nemoclaw/provision.json)
+  source_repository=$(sudo -n jq -er .sourceRepository /etc/nemoclaw/provision.json)
+  source_path=$(sudo -n jq -er .sourcePath /etc/nemoclaw/provision.json)
   provision_sha=$(sudo -n jq -er .gitSha /etc/nemoclaw/provision.json)
-  if [ -z "$(git -C "$HOME/NemoClaw" status --porcelain --untracked-files=normal)" ]; then
+  image_repository_sha=$(sudo -n jq -er .imageRepositorySha /etc/nemoclaw/provision.json)
+  repo_sha=$(git -C "$source_path" rev-parse HEAD)
+  if [ -z "$(git -C "$source_path" status --porcelain --untracked-files=normal)" ]; then
     repo_clean=true
   else
     repo_clean=false
   fi
+  if sudo -n test -e /etc/nemoclaw/runtime-overrides.json; then
+    runtime_overrides=true
+  else
+    runtime_overrides=false
+  fi
   printf "NEMOCLAW_IDENTITY="
-  jq -cn --arg repoSha "$repo_sha" --arg provisionSha "$provision_sha" \
-    --argjson repoClean "$repo_clean" \
-    "{repoSha:\$repoSha,provisionSha:\$provisionSha,repoClean:\$repoClean}"' --host \
+  jq -cn --arg bootImage "$boot_image" --argjson schemaVersion "$schema_version" \
+    --arg sourceRepository "$source_repository" --arg sourcePath "$source_path" \
+    --arg repoSha "$repo_sha" --arg provisionSha "$provision_sha" \
+    --arg imageRepositorySha "$image_repository_sha" --argjson repoClean "$repo_clean" \
+    --argjson runtimeOverrides "$runtime_overrides" \
+    "{bootImage:\$bootImage,schemaVersion:\$schemaVersion,sourceRepository:\$sourceRepository,sourcePath:\$sourcePath,repoSha:\$repoSha,provisionSha:\$provisionSha,imageRepositorySha:\$imageRepositorySha,repoClean:\$repoClean,runtimeOverrides:\$runtimeOverrides}"' --host \
   | sed -n 's/^NEMOCLAW_IDENTITY=//p' | tail -n 1)"
-jq -e --arg sha "$CANDIDATE_SHA" '
-  .repoSha == $sha and .provisionSha == $sha and .repoClean == true' \
-  <<<"$identity" >/dev/null || die "booted checkout does not match candidate"
+jq -e --arg sha "$CANDIDATE_SHA" --arg bootImage "$expected_boot_image" \
+  --arg imageRepositorySha "$image_repository_sha" '
+  .bootImage == $bootImage and .schemaVersion == 1 and
+  .sourceRepository == "NVIDIA/NemoClaw" and
+  .sourcePath == "/opt/nemoclaw-image/NemoClaw" and
+  .repoSha == $sha and .provisionSha == $sha and
+  .imageRepositorySha == $imageRepositorySha and
+  .repoClean == true and .runtimeOverrides == false' \
+  <<<"$identity" >/dev/null || die "booted image runtime does not match the producer handoff"
+source_path="$(jq -er .sourcePath <<<"$identity")"
 
 jq -n --arg candidateSha "$CANDIDATE_SHA" --arg producerRun "$producer_run" \
   --argjson boot "$identity" --arg workspaceName "$INSTANCE_NAME" --arg workspaceId "$workspace_id" \
@@ -197,9 +223,11 @@ raw_log="${RUNNER_TEMP:-/tmp}/brev-launchable-e2e-${GITHUB_RUN_ID}.raw"
 set +e
 {
   printf 'export NVIDIA_INFERENCE_API_KEY=%q\n' "$NVIDIA_INFERENCE_API_KEY"
+  printf 'export NEMOCLAW_SOURCE_PATH=%q\n' "$source_path"
   cat <<'REMOTE'
 set -euo pipefail
-cd "$HOME/NemoClaw"
+sudo -n test ! -e /etc/nemoclaw/runtime-overrides.json
+cd "$NEMOCLAW_SOURCE_PATH"
 test -x ./node_modules/.bin/vitest
 export CI=true GITHUB_ACTIONS=true E2E_TARGET_ID=staging-brev-launchable
 export NEMOCLAW_E2E_SETUP_MODE=preinstalled-launchable NEMOCLAW_RUN_LIVE_E2E=1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Launchable E2E previously assumed the baked checkout remained under `/home/ubuntu`, but Brev supplies that home at workspace creation. Verify the booted GCE image and the image-owned runtime receipt, then run the existing full E2E suite from the receipt's stable `/opt` source path.

## Changes

- Dispatch the renamed `Build Launchable E2E Image` producer workflow and validate its project, image name, and image-repository SHA handoff.
- Compare the guest's GCE `instance/image` metadata with the handed-off project and image name.
- Require provision schema v1, the exact NemoClaw and image-repository SHAs, and `/opt/nemoclaw-image/NemoClaw`.
- Reject a guest with `/etc/nemoclaw/runtime-overrides.json`, then run the existing suite from the validated source path.
- Extend the no-cloud integration fixture to cover image, source-path, SHA, clean-checkout, and runtime-override mismatches.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes the internal trusted Launchable E2E handshake, not a supported user command, configuration, or documentation route.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed cross-repo repair; the consumer remains fail-closed and the focused tests prove every accepted identity field plus the runtime-override rejection.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Internal Launchable E2E handshake implementation and integration tests only; no supported user-facing behavior or documentation route changed. The final test-only updates verify rejection of missing or malformed producer handoff fields and invalid runtime manifest identity. Changed comments and test wording follow `WRITING.md`. Focused integration tests pass (4 tests), `bash -n` passes, and `git diff --check origin/main...HEAD` passes.
- Agent: Codex Desktop — Launchable E2E consumer and integration-test surface
<!-- docs-review-head-sha: 423365b12aecea31cd57af1cd8e16256d08151de -->
<!-- docs-review-agents-blob-sha: be20a0952 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/brev-launchable-e2e.test.ts` passed 4 tests; `bash -n tools/e2e/brev-launchable-e2e.sh` and `git diff --check origin/main...HEAD` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end validation for launchable image handoffs, including boot image details, source path, repository/provision metadata, and runtime overrides.
  * Added broader coverage across both success and failure lanes for mismatched boot/image, repository/provision SHA values, cleanliness state, and custom source-path scenarios.
  * Tightened checks for the booted environment’s runtime configuration and expected source directory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
