### PR TITLE
ci(e2e): unify maintainer approval

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
+++ b/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
@@ -59,7 +59,7 @@ The checker requires these status-rollup entries:
 A first-time fork contributor might need **Approve and run** before `pull_request` checks appear.
 The E2E controller records the PR SHA and base SHA without running fork code.
 Do not waive a missing, neutral, or skipped E2E gate.
-Fork code can receive E2E credentials only through the protected exact-revision approval below.
+Fork code can receive E2E credentials only through the maintainer exact-revision approval below.
 
 ### GitHub Actions evidence
 
@@ -144,41 +144,35 @@ Malformed or unsafe evidence is a terminal controller error.
 Schema mismatches, identity mismatches, and traversal-limit errors are also terminal.
 The coordination check, required job, and controller must fail closed.
 
-### Authorize E2E for a fork PR
+### Approve credentialed E2E
 
-Use the protected-environment path when coordination reports `E2E reviewer authorization required to run fork E2E`.
+Use the maintainer workflow when coordination reports either of these states:
+
+- `Maintainer approval required to run E2E`
+- `Maintainer approval required to run fork E2E`
 
 1. Follow the `E2E / PR Gate Controller run <id>` link in the coordination summary.
-2. Verify the fork repository, PR SHA, base SHA, selected jobs and targets, and risk-plan artifact.
-3. Select **Review deployments**.
-4. Select `approve-credentialed-e2e-for-fork-pr`.
-5. Add a comment when useful, and approve.
+2. Verify the exact head repository, PR SHA, base SHA, selected jobs and targets, and risk-plan artifact.
+3. Select **Run workflow** on `main`.
+4. Select `approve-e2e`.
+5. Enter the exact `pr_number`, 40-character `expected_head_sha`, 40-character `expected_base_sha`, and a specific `review_reason` of 10 to 500 characters.
+6. Run the workflow.
 
-This approval authorizes the exact fork revision to run the selected work with E2E credentials.
+The first attempt requires the triggering actor to have current `maintain` or `admin` access.
+The controller checks the PR number, head repository, PR SHA, base SHA, deterministic plan, matching pending coordination check, compatible `main`, and open PR state.
+Immediately before dispatch, it confirms that the PR SHA, base SHA, head repository, and coordination identity still match.
+It fails closed if any value changed or does not match.
+
+For a fork, the trusted workflow definition comes from `main`; each PR-code checkout uses the reviewed fork repository and exact PR SHA.
 Before approval, no selected credential-bearing work runs.
-The trusted workflow definition comes from `main`; each PR-code checkout uses the reviewed fork repository and exact PR SHA.
-
-The controller reads the approval history and requires one approval for that environment.
-The environment's required reviewers are the authorization allowlist.
-The controller also checks the PR number, head repository, PR SHA, base SHA, plan, pending coordination check, compatible `main`, and PR state.
-Immediately before dispatch, it confirms that the PR is open and that the PR SHA, base SHA, and coordination identity still match.
-It also performs a bounded direct check read and requires the coordination check to remain in the exact expected phase, regardless of a matching, stale, or missing list result.
 If the run-specific authorization response is lost, the controller accepts only an exact persisted child binding and otherwise attempts to revoke coordination before requesting child cancellation.
 
 Approval returns coordination to `Running <count> E2E check(s)`.
 The gate passes only after the selected jobs and targets return verified passing evidence.
 Failed, missing, skipped, pending, or mismatched evidence keeps the gate from passing.
+Approval cannot record success by itself.
 
-Configure the environment before rollout.
-Require the intended E2E reviewers.
-Do not add secrets, variables, or a protection app. Disable administrator bypass when possible.
-
-If **Review deployments** is absent, the environment might be missing, unprotected, or no longer waiting.
-Configure it, push a change, and run PR CI again.
-Do not rerun the waiting workflow. The controller accepts an environment approval only on the first attempt.
-Per-PR concurrency cancels a waiting approval when another SHA reaches the gate.
-
-### Authorize E2E control-plane changes
+### E2E control-plane scope
 
 The `e2e-control-plane` path group includes these areas:
 
@@ -195,25 +189,8 @@ An internal PR can run automatically when it changes only these files:
 - `tools/e2e/pr-e2e-gate.mts`
 - `tools/e2e/pr-e2e-required.mts`
 
-Another control-plane change fails with `Maintainer authorization required to run E2E`.
+Another control-plane change waits with `Maintainer approval required to run E2E`.
 The gate must not run selected jobs or expose secrets before authorization.
-
-Review the PR SHA and non-secret CI.
-Then, select **Run workflow** on `main` and select `run-control-plane`.
-Provide the PR number, 40-character `expected_head_sha`, 40-character `expected_base_sha`, and a `review_reason` of 10 to 500 characters.
-Read both SHAs before dispatch.
-
-The first attempt requires the actor to have `maintain` or `admin` access.
-The workflow rejects forks, stale or closed PRs, plans that need no authorization, and empty selections.
-It also rejects a missing coordination check, an identity mismatch, or an incompatible controller commit.
-It reads the PR SHA and base SHA before dispatch.
-Before any result reaches success, it confirms that the PR is open and that the PR SHA, base SHA, and coordination identity still match.
-It fails closed if any value changed or does not match.
-
-Authorization returns `E2E / PR Gate Coordination` to `in_progress`.
-It runs selected jobs through the wait, evidence-download, and finish process.
-Authorization cannot record success by itself.
-Only verified evidence for the PR SHA can make `E2E / PR Gate` pass.
 
 ### Authorize a typed target
 

--- a/.github/workflows/pr-e2e-gate.yaml
+++ b/.github/workflows/pr-e2e-gate.yaml
@@ -22,10 +22,10 @@ on:
       operation:
         description: E2E gate action to perform.
         required: true
-        default: run-control-plane
+        default: approve-e2e
         type: choice
         options:
-          - run-control-plane
+          - approve-e2e
       pr_number:
         description: Pull request number for the selected E2E gate action.
         required: true
@@ -39,7 +39,7 @@ on:
         required: true
         type: string
       review_reason:
-        description: Why this internal PR may run control-plane E2E.
+        description: Why this PR may run credentialed E2E.
         required: true
         type: string
 
@@ -166,15 +166,9 @@ jobs:
           --superseded-head "$SUPERSEDED_HEAD_SHA"
 
   coordinate:
-    if: ${{ github.run_attempt == 1 && github.repository == 'NVIDIA/NemoClaw' && ((github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.path == '.github/workflows/pr.yaml' && endsWith(github.event.workflow_run.display_title, ' gate true')) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.operation == 'run-control-plane')) }}
+    if: ${{ github.run_attempt == 1 && github.repository == 'NVIDIA/NemoClaw' && ((github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.path == '.github/workflows/pr.yaml' && endsWith(github.event.workflow_run.display_title, ' gate true')) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.operation == 'approve-e2e')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 330
-    outputs:
-      approval_mode: ${{ steps.start.outputs.approval_mode }}
-      approval_environment: ${{ steps.start.outputs.approval_environment }}
-      approval_pr_number: ${{ steps.start.outputs.approval_pr_number }}
-      approval_head_sha: ${{ steps.start.outputs.approval_head_sha }}
-      approval_base_sha: ${{ steps.start.outputs.approval_base_sha }}
     permissions:
       actions: write
       checks: write
@@ -235,7 +229,7 @@ jobs:
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             node --experimental-strip-types tools/e2e/pr-e2e-gate.mts \
-              --mode start-control-plane \
+              --mode approve-e2e \
               --pr "$MANUAL_PR_NUMBER" \
               --head "$MANUAL_HEAD_SHA" \
               --base "$MANUAL_BASE_SHA" \
@@ -384,211 +378,6 @@ jobs:
           --workflow-run-attempt "${{ github.run_attempt }}"
 
       - name: Close incomplete check
-        if: ${{ always() && steps.start.outputs.check_id != '' && steps.start.outputs.finalized != 'true' && steps.finish.outputs.finalized != 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode abandon
-          --check-id "${{ steps.start.outputs.check_id }}"
-          --run-id "${{ steps.start.outputs.run_id }}"
-
-      - name: Remove private workspace
-        if: ${{ always() && steps.workspace.outputs.work_dir != '' }}
-        run: rm -rf -- "${{ steps.workspace.outputs.work_dir }}"
-
-  approve-fork-e2e:
-    name: Approve credentialed E2E for fork PR
-    needs: coordinate
-    if: ${{ needs.coordinate.result == 'success' && needs.coordinate.outputs.approval_mode == 'start-approved-fork' && github.run_attempt == 1 }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 330
-    environment:
-      name: approve-credentialed-e2e-for-fork-pr
-      deployment: false
-    permissions:
-      actions: write
-      checks: write
-      contents: read
-      pull-requests: read
-    concurrency:
-      group: pr-e2e-gate-${{ github.repository }}-${{ needs.coordinate.outputs.approval_pr_number }}-${{ needs.coordinate.outputs.approval_head_sha }}-${{ needs.coordinate.outputs.approval_base_sha }}
-      queue: max
-      cancel-in-progress: false
-    steps:
-      - name: Checkout controller
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.workflow_sha }}
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
-      - name: Install controller dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
-
-      - id: workspace
-        name: Create private workspace
-        shell: bash
-        run: |
-          set -euo pipefail
-          work_dir="$(mktemp -d "${RUNNER_TEMP}/nemoclaw-pr-e2e-approved.XXXXXX")"
-          chmod 700 "$work_dir"
-          printf 'work_dir=%s\n' "$work_dir" >> "$GITHUB_OUTPUT"
-
-      - id: start
-        name: Start approved fork E2E
-        env:
-          APPROVAL_RUN_ATTEMPT: ${{ github.run_attempt }}
-          APPROVAL_RUN_ID: ${{ github.run_id }}
-          EXPECTED_BASE_SHA: ${{ needs.coordinate.outputs.approval_base_sha }}
-          EXPECTED_HEAD_SHA: ${{ needs.coordinate.outputs.approval_head_sha }}
-          GATE_RUN_ID: ${{ github.run_id }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ needs.coordinate.outputs.approval_pr_number }}
-          WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
-          WORKFLOW_SHA: ${{ github.workflow_sha }}
-          WORK_DIR: ${{ steps.workspace.outputs.work_dir }}
-        run: |
-          set -euo pipefail
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts \
-            --mode start-approved-fork \
-            --pr "$PR_NUMBER" \
-            --head "$EXPECTED_HEAD_SHA" \
-            --base "$EXPECTED_BASE_SHA" \
-            --workflow-sha "$WORKFLOW_SHA" \
-            --approval-run-id "$APPROVAL_RUN_ID" \
-            --approval-run-attempt "$APPROVAL_RUN_ATTEMPT" \
-            --gate-run-id "$GATE_RUN_ID" \
-            --workflow-run-attempt "$WORKFLOW_RUN_ATTEMPT" \
-            --work-dir "$WORK_DIR"
-
-      - name: Upload approved risk plan
-        if: ${{ always() && steps.workspace.outputs.work_dir != '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pr-e2e-approved-risk-plan-${{ needs.coordinate.outputs.approval_head_sha }}
-          path: ${{ steps.workspace.outputs.work_dir }}/risk-plan.json
-          if-no-files-found: ignore
-          retention-days: 14
-
-      - id: wait
-        name: Wait for approved E2E run
-        if: ${{ steps.start.outputs.dispatched == 'true' }}
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode wait
-          --run-id "${{ steps.start.outputs.run_id }}"
-
-      - id: evidence
-        name: Download approved evidence
-        if: ${{ always() && steps.start.outputs.dispatched == 'true' }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode download
-          --work-dir "${{ steps.workspace.outputs.work_dir }}"
-          --run-id "${{ steps.start.outputs.run_id }}"
-
-      - id: finish
-        name: Verify approved evidence
-        if: ${{ always() && steps.start.outputs.dispatched == 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode finish
-          --work-dir "${{ steps.workspace.outputs.work_dir }}"
-          --state-hash "${{ steps.start.outputs.state_hash }}"
-          --check-id "${{ steps.start.outputs.check_id }}"
-          --run-id "${{ steps.start.outputs.run_id }}"
-          --evidence-outcome "${{ steps.evidence.outcome }}"
-
-      - id: retry
-        name: Retry approved E2E after hosted runner loss
-        if: ${{ always() && steps.finish.outputs.runner_loss_retry_authorized == 'true' && github.run_attempt == 1 }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode retry-runner-loss
-          --work-dir "${{ steps.workspace.outputs.work_dir }}"
-          --state-hash "${{ steps.start.outputs.state_hash }}"
-          --check-id "${{ steps.start.outputs.check_id }}"
-          --run-id "${{ steps.start.outputs.run_id }}"
-          --workflow-run-attempt "${{ github.run_attempt }}"
-
-      - id: retry_wait
-        name: Wait for approved retry E2E run
-        if: ${{ steps.retry.outputs.dispatched == 'true' }}
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode wait
-          --run-id "${{ steps.retry.outputs.run_id }}"
-
-      - id: retry_evidence
-        name: Download approved retry evidence
-        if: ${{ always() && steps.retry.outputs.dispatched == 'true' }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode download
-          --slot runner-loss-retry
-          --work-dir "${{ steps.workspace.outputs.work_dir }}"
-          --run-id "${{ steps.retry.outputs.run_id }}"
-
-      - id: retry_finish
-        name: Verify approved retry evidence
-        if: ${{ always() && steps.retry.outputs.dispatched == 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode finish
-          --slot runner-loss-retry
-          --work-dir "${{ steps.workspace.outputs.work_dir }}"
-          --state-hash "${{ steps.retry.outputs.state_hash }}"
-          --check-id "${{ steps.retry.outputs.check_id }}"
-          --run-id "${{ steps.retry.outputs.run_id }}"
-          --evidence-outcome "${{ steps.retry_evidence.outcome }}"
-
-      - name: Close incomplete approved retry check
-        if: ${{ always() && steps.retry.outputs.check_id != '' && steps.retry.outputs.finalized != 'true' && steps.retry_finish.outputs.finalized != 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode abandon
-          --check-id "${{ steps.retry.outputs.check_id }}"
-          --run-id "${{ steps.retry.outputs.run_id }}"
-
-      - name: Terminalize interrupted approved retry setup
-        if: ${{ always() && steps.finish.outputs.runner_loss_retry_authorized == 'true' && steps.retry.outcome != 'success' && steps.retry.outputs.check_id == '' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          node --experimental-strip-types tools/e2e/pr-e2e-gate.mts
-          --mode abandon-runner-loss-retry
-          --check-id "${{ steps.start.outputs.check_id }}"
-          --run-id "${{ steps.start.outputs.run_id }}"
-          --workflow-run-attempt "${{ github.run_attempt }}"
-
-      - name: Close incomplete approved check
         if: ${{ always() && steps.start.outputs.check_id != '' && steps.start.outputs.finalized != 'true' && steps.finish.outputs.finalized != 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -16,7 +16,7 @@
       "src/lib/cli/terminal-style.ts": 45,
       "src/lib/core/json-types.ts": 37,
       "src/lib/core/ports.ts": 86,
-      "src/lib/core/shell-quote.ts": 27,
+      "src/lib/core/shell-quote.ts": 26,
       "src/lib/core/url-utils.ts": 27,
       "src/lib/core/wait.ts": 35,
       "src/lib/credentials/store.ts": 44,

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -564,7 +564,7 @@ the deterministic risk plan.
 Runtime families and changes to workflow-wired live tests select
 canonical selectors from the trusted `e2e.yaml` inventory independently of
 advisor output. Ordinary internal changes execute those focused selections.
-Gate initialization, CI coordination, and protected approval share one
+Gate initialization, CI coordination, and maintainer approval share one
 non-cancelling FIFO concurrency group for the exact
 repository, PR number, PR SHA, and base SHA. `queue: max` keeps pending jobs for
 that exact identity instead of replacing them, up to GitHub's 100-job bound.
@@ -598,18 +598,18 @@ and changes to the Deep Agents Code headless-inference check select the exact
 ordinary test changes alone do not select it. The target is hashed into the
 risk plan beside any control-plane floor jobs, so the controller dispatches
 both selector types in one correlated workflow run. Fork revisions whose plans
-select credential-bearing jobs or targets instead require explicit protected
-credentialed-E2E approval. Plans with no selected jobs or targets can complete
-without an E2E run.
+select credential-bearing jobs or targets instead require explicit maintainer
+approval through the `approve-e2e` workflow operation. Plans with no selected
+jobs or targets can complete without an E2E run.
 An internal revision whose matched control-plane files are drawn only from the
 trusted controller and observer boundaries—`.github/workflows/pr-e2e-gate.yaml`,
 `tools/e2e/pr-e2e-gate.mts`, and `tools/e2e/pr-e2e-required.mts`—automatically
 dispatches those selected jobs.
 Any other or mixed internal control-plane revision requires a repository
-maintainer or administrator to authorize the exact PR SHA and base SHA through
-the trusted `run-control-plane` workflow dispatch before credentialed execution
-begins. If no job or target is selected, coordination passes without an E2E run
-and the native required job mirrors that success.
+maintainer or administrator to approve the PR SHA and base SHA through
+`approve-e2e` before credentialed execution begins. If no job or target is
+selected, coordination passes without an E2E run and the native required job
+mirrors that success.
 
 Before dispatch, the controller verifies that the live PR still matches the CI
 run's PR SHA and base SHA. It uses its own workflow commit when that commit is
@@ -673,42 +673,38 @@ terminal result.
 
 An internal revision whose control-plane matches include a file outside the
 trusted controller and observer boundaries leaves coordination in progress
-with `E2E maintainer authorization required to run E2E`. The native required
-job keeps waiting for the authorization flow. No selected job or target runs
-and no repository secret is exposed.
+with `Maintainer approval required to run E2E`. The native required job keeps
+waiting for the approval flow. No selected job or target runs and no repository
+secret is exposed. The coordination summary links the controller run and
+publishes the exact PR number, head SHA, base SHA, deterministic plan, and
+selected jobs and targets.
 
-Any repository maintainer or administrator can authorize the exact internal
-plan by dispatching the trusted controller on `main`:
+A repository maintainer or administrator chooses **Run workflow** on `main`,
+selects `approve-e2e`, and supplies the PR number, current 40-character head
+SHA as `expected_head_sha`, current 40-character base SHA as
+`expected_base_sha`, and a specific 10–500-character `review_reason`. The
+controller verifies the triggering actor's current `maintain` or `admin`
+permission. It then revalidates the open PR, PR SHA and base SHA, deterministic
+plan, matching pending coordination state, compatible trusted controller
+commit, and final live revision. It updates coordination to
+`Running <count> E2E check(s)` and dispatches the selected jobs and targets in
+one workflow run.
 
-```bash
-gh workflow run .github/workflows/pr-e2e-gate.yaml \
-  --repo NVIDIA/NemoClaw \
-  --ref main \
-  -f operation=run-control-plane \
-  -f pr_number=<pr-number> \
-  -f expected_head_sha=<40-character-pr-head-sha> \
-  -f expected_base_sha=<40-character-base-sha> \
-  -f review_reason="<specific 10-500 character reason>"
-```
-
-The dispatch itself is the authorization; internal PRs do not require a
-separate protected-environment review. The controller revalidates the
-triggering actor's `maintain` or `admin` permission, internal repository
-origin, open PR, PR SHA and base SHA, deterministic risk plan, matching pending
-coordination state, compatible trusted controller commit, and final live
-revision. It then updates coordination to `Running <count> E2E check(s)` and
-dispatches the selected jobs and targets in one workflow run. The child
-workflow receives the controller-owned coordination check ID. Before checking
-out the PR revision, it requires a GitHub Actions dispatch and verifies that
-the exact check is owned by the GitHub Actions app, matches the PR head and
+The child workflow receives the controller-owned coordination check ID. Before
+checking out the PR revision, it requires a GitHub Actions dispatch and verifies
+that the exact check is owned by the GitHub Actions app, matches the PR head and
 base identity, names the selected plan, and binds the exact current child
-Actions run in the controller-owned output summary. A direct dispatch of
-`e2e.yaml` cannot forge that one-run authorization and fails before checkout.
+Actions run in the controller-owned output summary. The child requests uncached
+check-run state up to 45 times with two-second delays, which spans GitHub's
+60-second check cache, before failing closed. It does not use the check details
+URL for this binding because GitHub may canonicalize that field to the check's
+own `/runs/<check-id>` URL. A direct manual dispatch that supplies
+otherwise-valid PR inputs cannot forge that one-run authorization and fails
+before checkout.
 
-An ordinary validation failure before child dispatch restores the maintainer
-authorization title and leaves coordination in progress. A maintainer can then
-launch a fresh first-attempt `run-control-plane` dispatch for the same exact
-PR/base SHA pair.
+An ordinary validation failure before dispatch restores the maintainer approval
+title and leaves coordination in progress. A maintainer can then launch a fresh
+first-attempt `approve-e2e` operation for the same reviewed revision.
 
 An uncertain dispatch that completes the bounded window with zero correlated
 runs instead completes coordination as `Workflow dispatch was not observed`
@@ -758,61 +754,35 @@ success; the authorization itself cannot make the gate green. A changed head or
 base requires a new authorization.
 
 A fork revision that selects jobs or typed targets leaves coordination in
-progress with `E2E reviewer authorization required to run fork E2E`. Non-secret
-PR CI remains required. Before approval, the controller does not dispatch the
+progress with `Maintainer approval required to run fork E2E`. Non-secret PR CI
+remains required. Before approval, the controller does not dispatch the
 credential-bearing work or expose repository secrets. The coordination summary
 links to the same `E2E / PR Gate Controller` run and publishes the exact PR
 number, head repository, head SHA, base SHA, plan, jobs, and targets under
 review.
 
-That controller run starts `Approve credentialed E2E for fork PR`, which
-waits on the protected `approve-credentialed-e2e-for-fork-pr` environment.
-With `deployment: false`, the job does not create a deployment record. A
-maintainer or delegated E2E reviewer reviews the exact repository, head SHA,
-base SHA, and risk plan, opens the linked run, chooses **Review deployments**,
-selects that environment, and approves it. This approval authorizes the exact
-fork revision to run the selected work with E2E credentials. It is not a skip
-and cannot make the gate pass by itself. The workflow reads the reviewer and
-optional comment from GitHub's run approval history rather than accepting an
-actor supplied by the job.
-
-Before rollout, create `approve-credentialed-e2e-for-fork-pr` in the
-repository and configure it with one or more required reviewers.
-Protected-environment reviewers are the fork authorization allowlist and may
-have repository read access without merge rights. Do not add environment
-secrets, variables, or custom protection apps. Enable **Prevent self-review**
-and prefer disabling administrator bypass so every fork decision is
-independent and appears in the approval history. Restrict deployment branches
-to protected `main`. Before approval, verify the exact head SHA, base SHA, and
-selected jobs and targets in the coordination check summary and the
+A repository maintainer or administrator reviews the exact fork repository,
+head SHA, base SHA, selected jobs and targets, and
 `pr-e2e-risk-plan-<head-sha>` artifact from the linked controller run. The
-approval job receives only its job-scoped token after approval and executes the
-trusted controller from `main`. The trusted E2E workflow definition stays on
-`main`, while every PR-code checkout is pinned to the approved head repository
-and SHA. If **Review deployments** is absent, the environment may be missing or
-unprotected, or the run may no longer be waiting. Configure the environment,
-update the PR to create a new head, and trigger fresh upstream PR CI to create a
-new gate run. GitHub approval
-history is not bound to a run attempt, so the controller rejects reruns of an
-approval run. Approval concurrency is bound to the exact PR SHA and base SHA.
-A newer revision creates a separate approval request, while an obsolete request
-cannot authorize it.
+maintainer then chooses **Run workflow** on `main`, selects `approve-e2e`, and
+supplies the exact PR number, head SHA, base SHA, and a specific review reason.
+GitHub supplies the triggering actor; the controller requires that account to
+have current `maintain` or `admin` permission.
 
-For the fork approval path, the controller requires a first-attempt, in-progress run
-of this exact workflow on `main`, at the trusted workflow SHA and with the
-`workflow_run` event. It requires exactly one approved review that names only
-the exact environment. The environment's required-reviewer configuration is
-the authority for this protected path. The shared resolver revalidates
-the open PR, head repository, PR SHA and base SHA, deterministic plan,
-matching pending coordination check, and that the controller commit is either
-still `main` or
-has only a compatible safe descendant as described above. Immediately before
-dispatch, it reads the live PR again and requires the same head repository, PR
-SHA, and base SHA. The trusted workflow runs the selected jobs and targets,
-downloads their evidence, and verifies its identity and outcome. Only passing
-evidence for every selected item completes coordination successfully. Failed,
-missing, skipped, pending, or mismatched evidence keeps the required gate from
-passing. Any new commit or base change requires a new approval.
+The shared resolver revalidates the open PR, head repository, PR SHA and base
+SHA, deterministic plan, matching fork approval state, and that the controller
+commit is either still `main` or has only a compatible safe descendant as
+described above. Immediately before dispatch, it reads the live PR again and
+requires the same head repository, PR SHA, and base SHA. The trusted workflow
+definition stays on `main`, while each PR-code checkout is pinned to the
+reviewed fork repository and exact PR SHA.
+
+The trusted workflow runs the selected jobs and targets, downloads their
+evidence, and verifies its identity and outcome. Approval cannot make the gate
+pass by itself. Only passing evidence for every selected item completes
+coordination successfully. Failed, missing, skipped, pending, or mismatched
+evidence keeps the required gate from passing. Any new commit or base change
+requires a new approval.
 
 The canonical risk-signal layer writes one `risk-signal.json` for each selected
 job shard and typed target. The Vitest reporter writes normal test evidence. The

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -770,8 +770,8 @@ GitHub supplies the triggering actor; the controller requires that account to
 have current `maintain` or `admin` permission.
 
 The shared resolver revalidates the open PR, head repository, PR SHA and base
-SHA, deterministic plan, matching fork approval state, and that the controller
-commit is either still `main` or has only a compatible safe descendant as
+SHA, deterministic plan, matching pending coordination state, and that the
+controller commit is either still `main` or has only a compatible safe descendant as
 described above. Immediately before dispatch, it reads the live PR again and
 requires the same head repository, PR SHA, and base SHA. The trusted workflow
 definition stays on `main`, while each PR-code checkout is pinned to the

--- a/test/maintainer-skills-policy.test.ts
+++ b/test/maintainer-skills-policy.test.ts
@@ -333,11 +333,13 @@ describe("maintainer skills follow canonical workflow policy", () => {
     expect(createPr).toContain("--body-file /tmp/nemoclaw-pr-body.md");
     expect(createPr).not.toContain('--body "..."');
     expect(judgment).toContain("{candidate_comments}");
-    expect(
-      mergeGate.match(
-        /the PR is open and that the PR SHA, base SHA, and coordination identity still match/gu,
-      ),
-    ).toHaveLength(2);
+    expect(mergeGate).toContain(
+      "The first attempt requires the triggering actor to have current `maintain` or `admin` access.",
+    );
+    expect(mergeGate).toContain(
+      "Immediately before dispatch, it confirms that the PR SHA, base SHA, head repository, and coordination identity still match.",
+    );
+    expect(mergeGate).toContain("Approval cannot record success by itself.");
     expect(salvage).toContain("`headRepository.nameWithOwner` is `NVIDIA/NemoClaw`");
     expect(salvage).toContain("git push origin <local-branch>:<headRefName>");
     expect(salvage).toContain("If `maintainerCanModify` is false, do not push");

--- a/test/pr-e2e-gate-command.test.ts
+++ b/test/pr-e2e-gate-command.test.ts
@@ -63,9 +63,7 @@ describe("PR E2E controller commands", () => {
     );
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain(
-      "--mode must be seed, start, start-control-plane, start-approved-fork, finish",
-    );
+    expect(result.stderr).toContain("--mode must be seed, start, approve-e2e, finish");
     expect(result.stderr).not.toContain("ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX");
   });
 
@@ -287,52 +285,12 @@ describe("PR E2E controller commands", () => {
     });
   });
 
-  it("parses an approved fork E2E run", () => {
+  it("parses a maintainer-approved E2E run inside a private workspace", () => {
     withPrivateWorkDir((workDir) => {
       expect(
         parseControllerCommand([
           "--mode",
-          "start-approved-fork",
-          "--pr",
-          "42",
-          "--head",
-          HEAD_SHA,
-          "--base",
-          BASE_SHA,
-          "--workflow-sha",
-          WORKFLOW_SHA,
-          "--approval-run-id",
-          "101",
-          "--approval-run-attempt",
-          "1",
-          "--gate-run-id",
-          "102",
-          "--workflow-run-attempt",
-          "1",
-          "--work-dir",
-          workDir,
-        ]),
-      ).toMatchObject({
-        mode: "start-approved-fork",
-        prNumber: 42,
-        headSha: HEAD_SHA,
-        baseSha: BASE_SHA,
-        workflowSha: WORKFLOW_SHA,
-        approvalRunId: 101,
-        approvalRunAttempt: 1,
-        gateRunId: 102,
-        workflowRunAttempt: 1,
-        planPath: path.join(workDir, "risk-plan.json"),
-      });
-    });
-  });
-
-  it("parses an authorized control-plane run inside a private workspace", () => {
-    withPrivateWorkDir((workDir) => {
-      expect(
-        parseControllerCommand([
-          "--mode",
-          "start-control-plane",
+          "approve-e2e",
           "--pr",
           "42",
           "--head",
@@ -353,7 +311,7 @@ describe("PR E2E controller commands", () => {
           workDir,
         ]),
       ).toMatchObject({
-        mode: "start-control-plane",
+        mode: "approve-e2e",
         prNumber: 42,
         headSha: HEAD_SHA,
         baseSha: BASE_SHA,
@@ -367,10 +325,13 @@ describe("PR E2E controller commands", () => {
     });
   });
 
-  it("rejects the removed control-plane bypass mode", () => {
-    expect(() => parseControllerCommand(["--mode", "resolve-control-plane"])).toThrow(
-      /--mode must be/u,
-    );
+  it.each([
+    "resolve-control-plane",
+    "start-control-plane",
+    "start-approved-control-plane",
+    "start-approved-fork",
+  ])("rejects removed approval mode %s", (mode) => {
+    expect(() => parseControllerCommand(["--mode", mode])).toThrow(/--mode must be/u);
   });
 
   it("parses an abandon command", () => {

--- a/test/pr-e2e-gate-dispatch-recovery.test.ts
+++ b/test/pr-e2e-gate-dispatch-recovery.test.ts
@@ -808,7 +808,7 @@ describe("PR E2E dispatch-not-observed recovery", () => {
       });
       const outputs = fs.readFileSync(outputPath, "utf8");
       expect(outputs).toContain("dispatched=true");
-      expect(outputs).not.toContain("approval_mode=");
+      expect(outputs).not.toContain("approval_");
       expect(outputs).not.toContain("finalized=true");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });

--- a/test/pr-e2e-gate-fork-approval.test.ts
+++ b/test/pr-e2e-gate-fork-approval.test.ts
@@ -7,11 +7,10 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  approvePrE2E,
   type PullRequest,
   parseControllerCommand,
   prGateExternalId,
-  startApprovedForkPrGate,
-  startControlPlanePrGate,
   startPrGate,
 } from "../tools/e2e/pr-e2e-gate.mts";
 import {
@@ -27,7 +26,6 @@ const ADVANCED_WORKFLOW_SHA = "e".repeat(40);
 const CI_RUN_ID = 99;
 const CI_RUN_ATTEMPT = 3;
 const GATE_RUN_ID = 77;
-const APPROVAL_RUN_ID = 123;
 const DCODE_PATCH = "agents/langchain-deepagents-code/patch-managed-deepagents-code.py";
 afterEach(() => {
   vi.useRealTimers();
@@ -170,10 +168,10 @@ function startCommand(workDir: string) {
   return command as Extract<ReturnType<typeof parseControllerCommand>, { mode: "start" }>;
 }
 
-function startControlPlaneCommand(workDir: string) {
+function approvalCommand(workDir: string) {
   const command = parseControllerCommand([
     "--mode",
-    "start-control-plane",
+    "approve-e2e",
     "--pr",
     "42",
     "--head",
@@ -193,91 +191,19 @@ function startControlPlaneCommand(workDir: string) {
     "--work-dir",
     workDir,
   ]);
-  expect(command.mode).toBe("start-control-plane");
-  return command as Extract<
-    ReturnType<typeof parseControllerCommand>,
-    { mode: "start-control-plane" }
-  >;
+  expect(command.mode).toBe("approve-e2e");
+  return command as Extract<ReturnType<typeof parseControllerCommand>, { mode: "approve-e2e" }>;
 }
 
-function approvalWorkflowRun(overrides: Record<string, unknown> = {}) {
-  return {
-    id: APPROVAL_RUN_ID,
-    name: `E2E Gate workflow_run ${APPROVAL_RUN_ID}`,
-    path: ".github/workflows/pr-e2e-gate.yaml",
-    event: "workflow_run",
-    head_sha: WORKFLOW_SHA,
-    head_branch: "main",
-    status: "in_progress",
-    conclusion: null,
-    run_attempt: 1,
-    html_url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${APPROVAL_RUN_ID}`,
-    ...overrides,
-  };
-}
-
-function approvalReview(comment: string | null = null, overrides: Record<string, unknown> = {}) {
-  return {
-    state: "approved",
-    comment,
-    environments: [{ name: "approve-credentialed-e2e-for-fork-pr" }],
-    user: { login: "e2e-reviewer" },
-    ...overrides,
-  };
-}
-
-function approvedForkCommand(workDir: string) {
-  const command = parseControllerCommand([
-    "--mode",
-    "start-approved-fork",
-    "--pr",
-    "42",
-    "--head",
-    HEAD_SHA,
-    "--base",
-    BASE_SHA,
-    "--workflow-sha",
-    WORKFLOW_SHA,
-    "--approval-run-id",
-    String(APPROVAL_RUN_ID),
-    "--approval-run-attempt",
-    "1",
-    "--gate-run-id",
-    String(APPROVAL_RUN_ID),
-    "--workflow-run-attempt",
-    "1",
-    "--work-dir",
-    workDir,
-  ]);
-  expect(command.mode).toBe("start-approved-fork");
-  return command as Extract<
-    ReturnType<typeof parseControllerCommand>,
-    { mode: "start-approved-fork" }
-  >;
-}
-
-function approvalRunRoute(value: unknown) {
-  return githubFetchRoute(
-    ({ url, method }) => url.endsWith(`/actions/runs/${APPROVAL_RUN_ID}`) && method === "GET",
-    () => githubResponse(value),
-  );
-}
-
-function approvalHistoryRoute(value: unknown) {
-  return githubFetchRoute(
-    ({ url, method }) =>
-      url.endsWith(`/actions/runs/${APPROVAL_RUN_ID}/approvals`) && method === "GET",
-    () => githubResponse(value),
-  );
-}
-
-function successfulApprovedForkRoutes(approvals: unknown, requests: RecordedGitHubRequest[]) {
+function successfulMaintainerForkRoutes(requests: RecordedGitHubRequest[]) {
   let check = exactPrGateCheck({
-    output: { title: "E2E reviewer authorization required to run fork E2E" },
+    output: { title: "Maintainer approval required to run fork E2E" },
   });
   return [
-    approvalRunRoute(approvalWorkflowRun()),
-    approvalHistoryRoute(approvals),
+    githubFetchRoute(
+      ({ url }) => url.endsWith("/collaborators/maintainer/permission"),
+      () => githubResponse({ role_name: "maintain", user: { login: "maintainer" } }),
+    ),
     githubFetchRoute(
       ({ url }) => url.endsWith("/pulls/42"),
       () => githubResponse(forkPullRequest()),
@@ -360,7 +286,7 @@ function reconciledForkRun(runId: number, correlationId: string) {
 }
 
 describe("PR E2E controller fork credentialed E2E approval safety", () => {
-  it("requires the selected DCode target and protected approval before a risky fork can run credentialed E2E (#7463)", async () => {
+  it("requires the selected DCode target and maintainer approval before a risky fork can run credentialed E2E (#7463)", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-fork-"));
     const outputPath = path.join(workDir, "github-output");
     fs.writeFileSync(outputPath, "", { mode: 0o600 });
@@ -406,36 +332,32 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
       expect(pending?.body).toMatchObject({
         status: "in_progress",
         output: {
-          title: "E2E reviewer authorization required to run fork E2E",
+          title: "Maintainer approval required to run fork E2E",
           summary: expect.stringContaining(
             "No selected E2E job or target ran. No repository credential was exposed to fork code.",
           ),
         },
       });
-      expect(JSON.stringify(pending?.body)).toContain("Review deployments");
       expect(JSON.stringify(pending?.body)).toContain(
         `[E2E / PR Gate Controller run ${GATE_RUN_ID}](https://github.com/NVIDIA/NemoClaw/actions/runs/${GATE_RUN_ID})`,
       );
-      expect(JSON.stringify(pending?.body)).toContain("approve-credentialed-e2e-for-fork-pr");
       expect(JSON.stringify(pending?.body)).toContain(
-        "Approval authorizes the selected fork code to run with E2E credentials.",
+        "[E2E / PR Gate Controller](https://github.com/NVIDIA/NemoClaw/actions/workflows/pr-e2e-gate.yaml)",
       );
+      expect(JSON.stringify(pending?.body)).toContain("`approve-e2e`");
+      expect(JSON.stringify(pending?.body)).toContain("`pr_number=42`");
+      expect(JSON.stringify(pending?.body)).toContain(`\`expected_head_sha=${HEAD_SHA}\``);
+      expect(JSON.stringify(pending?.body)).toContain(`\`expected_base_sha=${BASE_SHA}\``);
+      expect(JSON.stringify(pending?.body)).toContain("specific `review_reason`");
       expect(JSON.stringify(pending?.body)).toContain("Review scope: PR #42");
       expect(JSON.stringify(pending?.body)).toContain("head repository `contributor/NemoClaw`");
       expect(JSON.stringify(pending?.body)).toContain(`head SHA \`${HEAD_SHA}\``);
       expect(JSON.stringify(pending?.body)).toContain(`base SHA \`${BASE_SHA}\``);
       expect(JSON.stringify(pending?.body)).toContain("targets:");
       expect(JSON.stringify(pending?.body)).toContain("deterministic plan");
-      expect(fs.readFileSync(outputPath, "utf8")).toContain(
-        [
-          "approval_mode=start-approved-fork",
-          "approval_environment=approve-credentialed-e2e-for-fork-pr",
-          "approval_pr_number=42",
-          `approval_head_sha=${HEAD_SHA}`,
-          `approval_base_sha=${BASE_SHA}`,
-        ].join("\n"),
-      );
-      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
+      const outputs = fs.readFileSync(outputPath, "utf8");
+      expect(outputs).not.toContain("approval_");
+      expect(outputs).toContain("finalized=true");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -609,7 +531,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
       expect(completion?.body).toMatchObject({
         status: "in_progress",
         output: {
-          title: "E2E maintainer authorization required to run E2E",
+          title: "Maintainer approval required to run E2E",
           summary: expect.stringContaining(
             "No selected E2E job or target ran and no repository secret was exposed",
           ),
@@ -617,11 +539,16 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
       });
       const summary = JSON.stringify(completion?.body);
       expect(summary).not.toContain("conclusion");
-      expect(summary).toContain("repository maintainer or administrator");
-      expect(summary).toContain("operation=run-control-plane");
-      expect(summary).not.toContain("Review deployments");
-      expect(fs.readFileSync(outputPath, "utf8")).not.toContain("approval_mode=");
-      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
+      expect(summary).toContain(
+        "[E2E / PR Gate Controller](https://github.com/NVIDIA/NemoClaw/actions/workflows/pr-e2e-gate.yaml)",
+      );
+      expect(summary).toContain("`approve-e2e`");
+      expect(summary).toContain("`pr_number=42`");
+      expect(summary).toContain(`\`expected_head_sha=${HEAD_SHA}\``);
+      expect(summary).toContain(`\`expected_base_sha=${BASE_SHA}\``);
+      const outputs = fs.readFileSync(outputPath, "utf8");
+      expect(outputs).not.toContain("approval_");
+      expect(outputs).toContain("finalized=true");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -670,7 +597,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     }
   });
 
-  it("dispatches the exact fork repository and PR SHA after protected approval", async () => {
+  it("dispatches the exact fork repository and PR SHA after maintainer approval", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-fork-approved-"));
     const outputPath = path.join(workDir, "github-output");
     fs.writeFileSync(outputPath, "", { mode: 0o600 });
@@ -679,19 +606,18 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     vi.stubEnv("GITHUB_OUTPUT", outputPath);
     const requests: RecordedGitHubRequest[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(
-      createGitHubFetchRouter(
-        successfulApprovedForkRoutes(
-          [approvalReview("Reviewed the exact fork PR and selected E2E plan.")],
-          requests,
-        ),
-        requests,
-      ),
+      createGitHubFetchRouter(successfulMaintainerForkRoutes(requests), requests),
     );
 
     try {
-      await expect(startApprovedForkPrGate(approvedForkCommand(workDir))).resolves.toBeUndefined();
+      await expect(
+        approvePrE2E({
+          ...approvalCommand(workDir),
+          reason: "Reviewed the exact fork PR and selected E2E plan.",
+        }),
+      ).resolves.toBeUndefined();
 
-      expect(requests.some((request) => request.url.includes("/collaborators/"))).toBe(false);
+      expect(requests.some((request) => request.url.includes("/collaborators/"))).toBe(true);
       expect(requests.find((request) => request.url.endsWith("/dispatches"))?.body).toMatchObject({
         ref: "main",
         inputs: {
@@ -707,7 +633,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
         (request) =>
           request.url.endsWith("/check-runs/17") &&
           (request.body as { output?: { title?: string } } | undefined)?.output?.title ===
-            "E2E execution authorized by @e2e-reviewer",
+            "E2E execution authorized by @maintainer",
       );
       expect(authorization?.body).toMatchObject({
         status: "in_progress",
@@ -721,7 +647,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     }
   });
 
-  it("cancels ambiguous fork candidates and does not restore protected authorization", async () => {
+  it("cancels ambiguous fork candidates and does not restore maintainer approval", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-26T18:00:00.000Z"));
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
@@ -733,13 +659,15 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     vi.stubEnv("GITHUB_OUTPUT", outputPath);
     const requests: RecordedGitHubRequest[] = [];
     let check = exactPrGateCheck({
-      output: { title: "E2E reviewer authorization required to run fork E2E" },
+      output: { title: "Maintainer approval required to run fork E2E" },
     });
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
         [
-          approvalRunRoute(approvalWorkflowRun()),
-          approvalHistoryRoute([approvalReview("Reviewed exact fork code and risk plan.")]),
+          githubFetchRoute(
+            ({ url }) => url.endsWith("/collaborators/maintainer/permission"),
+            () => githubResponse({ role_name: "maintain", user: { login: "maintainer" } }),
+          ),
           githubFetchRoute(
             ({ url }) => url.endsWith("/pulls/42"),
             () => githubResponse(forkPullRequest()),
@@ -799,7 +727,10 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     );
 
     try {
-      const attempt = startApprovedForkPrGate(approvedForkCommand(workDir));
+      const attempt = approvePrE2E({
+        ...approvalCommand(workDir),
+        reason: "Reviewed exact fork code and risk plan.",
+      });
       const result = expect(attempt).rejects.toThrow(/multiple correlated runs/u);
       await vi.runAllTimersAsync();
       await result;
@@ -820,70 +751,9 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
           (request) =>
             request.method === "PATCH" &&
             (request.body as { output?: { title?: string } } | undefined)?.output?.title ===
-              "E2E reviewer authorization required to run fork E2E",
+              "Maintainer approval required to run fork E2E",
         ),
       ).toHaveLength(0);
-    } finally {
-      fs.rmSync(workDir, { recursive: true, force: true });
-    }
-  });
-
-  it("fails closed when the fork approval environment did not record an approval", async () => {
-    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-fork-no-review-"));
-    vi.stubEnv("GITHUB_TOKEN", "token");
-    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
-    const requests: RecordedGitHubRequest[] = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      createGitHubFetchRouter(
-        [approvalRunRoute(approvalWorkflowRun()), approvalHistoryRoute([])],
-        requests,
-      ),
-    );
-
-    try {
-      await expect(startApprovedForkPrGate(approvedForkCommand(workDir))).rejects.toThrow(
-        /No required-reviewer approval was recorded for approve-credentialed-e2e-for-fork-pr/u,
-      );
-      expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
-      expect(requests.some((request) => request.method === "PATCH")).toBe(false);
-    } finally {
-      fs.rmSync(workDir, { recursive: true, force: true });
-    }
-  });
-
-  it("parses only first-attempt protected fork execution", () => {
-    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-fork-command-"));
-    try {
-      const command = approvedForkCommand(workDir);
-      expect(command).toMatchObject({
-        mode: "start-approved-fork",
-        approvalRunAttempt: 1,
-        workflowRunAttempt: 1,
-      });
-      expect(() =>
-        parseControllerCommand([
-          "--mode",
-          "start-approved-fork",
-          "--pr",
-          "42",
-          "--head",
-          HEAD_SHA,
-          "--base",
-          BASE_SHA,
-          "--workflow-sha",
-          WORKFLOW_SHA,
-          "--approval-run-id",
-          String(APPROVAL_RUN_ID),
-          "--approval-run-attempt",
-          "2",
-          "--gate-run-id",
-          String(APPROVAL_RUN_ID),
-          "--workflow-run-attempt",
-          "1",
-          "--work-dir",
-          workDir,
-        ]),
-      ).toThrow(/must be exactly 1/u);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -901,7 +771,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
       id: 18,
       status: "in_progress",
       conclusion: null,
-      output: { title: "E2E maintainer authorization required to run E2E" },
+      output: { title: "Maintainer approval required to run E2E" },
     });
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
@@ -1002,9 +872,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     );
 
     try {
-      await expect(
-        startControlPlanePrGate(startControlPlaneCommand(workDir)),
-      ).resolves.toBeUndefined();
+      await expect(approvePrE2E(approvalCommand(workDir))).resolves.toBeUndefined();
 
       const dispatch = requests.find((request) => request.url.endsWith("/dispatches"));
       expect(dispatch?.body).toMatchObject({
@@ -1057,7 +925,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     vi.stubEnv("GITHUB_OUTPUT", outputPath);
     const requests: RecordedGitHubRequest[] = [];
     let check = exactPrGateCheck({
-      output: { title: "E2E maintainer authorization required to run E2E" },
+      output: { title: "Maintainer approval required to run E2E" },
     });
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
@@ -1116,7 +984,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     );
 
     try {
-      await expect(startControlPlanePrGate(startControlPlaneCommand(workDirs[0]!))).rejects.toThrow(
+      await expect(approvePrE2E(approvalCommand(workDirs[0]!))).rejects.toThrow(
         /child cancellation failed/u,
       );
       expect(check).toMatchObject({
@@ -1127,7 +995,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
           summary: expect.stringContaining("cannot be retried"),
         },
       });
-      await expect(startControlPlanePrGate(startControlPlaneCommand(workDirs[1]!))).rejects.toThrow(
+      await expect(approvePrE2E(approvalCommand(workDirs[1]!))).rejects.toThrow(
         /matching pending E2E authorization state/u,
       );
       expect(requests.filter((request) => request.url.endsWith("/dispatches"))).toHaveLength(1);
@@ -1161,43 +1029,11 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
 
     try {
       await expect(
-        startControlPlanePrGate({
-          ...startControlPlaneCommand(workDir),
+        approvePrE2E({
+          ...approvalCommand(workDir),
           maintainer: "contributor",
         }),
       ).rejects.toThrow(/maintainer or administrator/u);
-      expect(requests.some((request) => request.method === "PATCH")).toBe(false);
-      expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
-    } finally {
-      fs.rmSync(workDir, { recursive: true, force: true });
-    }
-  });
-
-  it("rejects control-plane authorization for a fork pull request", async () => {
-    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-fork-"));
-    vi.stubEnv("GITHUB_TOKEN", "token");
-    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
-    const requests: RecordedGitHubRequest[] = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      createGitHubFetchRouter(
-        [
-          githubFetchRoute(
-            ({ url }) => url.endsWith("/collaborators/maintainer/permission"),
-            () => githubResponse({ role_name: "maintain", user: { login: "maintainer" } }),
-          ),
-          githubFetchRoute(
-            ({ url }) => url.endsWith("/pulls/42"),
-            () => githubResponse(forkPullRequest()),
-          ),
-        ],
-        requests,
-      ),
-    );
-
-    try {
-      await expect(startControlPlanePrGate(startControlPlaneCommand(workDir))).rejects.toThrow(
-        /requires an internal pull request/u,
-      );
       expect(requests.some((request) => request.method === "PATCH")).toBe(false);
       expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
     } finally {
@@ -1228,7 +1064,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
           existingPrGateCheckRunsRoute({
             status: "completed",
             conclusion: "failure",
-            output: { title: "E2E maintainer authorization required to run E2E" },
+            output: { title: "Maintainer approval required to run E2E" },
           }),
         ],
         requests,
@@ -1236,7 +1072,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     );
 
     try {
-      await expect(startControlPlanePrGate(startControlPlaneCommand(workDir))).rejects.toThrow(
+      await expect(approvePrE2E(approvalCommand(workDir))).rejects.toThrow(
         /matching pending E2E authorization state/u,
       );
       expect(requests.some((request) => request.method === "PATCH")).toBe(false);
@@ -1253,7 +1089,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     vi.stubEnv("GITHUB_TOKEN", "token");
     vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
     const requests: RecordedGitHubRequest[] = [];
-    let checkTitle = "E2E maintainer authorization required to run E2E";
+    let checkTitle = "Maintainer approval required to run E2E";
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(
         [
@@ -1301,7 +1137,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
 
     try {
       for (const workDir of workDirs) {
-        await expect(startControlPlanePrGate(startControlPlaneCommand(workDir))).rejects.toThrow(
+        await expect(approvePrE2E(approvalCommand(workDir))).rejects.toThrow(
           /main advanced through trusted E2E control-plane changes/u,
         );
       }
@@ -1310,18 +1146,18 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
           request.url.endsWith("/check-runs/17") &&
           request.method === "PATCH" &&
           (request.body as { output?: { title?: string } } | undefined)?.output?.title ===
-            "E2E maintainer authorization required to run E2E",
+            "Maintainer approval required to run E2E",
       );
       expect(restoredAuthorizations).toHaveLength(2);
       expect(restoredAuthorizations[0]?.body).toMatchObject({
         status: "in_progress",
         output: {
-          title: "E2E maintainer authorization required to run E2E",
-          summary: expect.stringContaining("launch a first-attempt `run-control-plane`"),
+          title: "Maintainer approval required to run E2E",
+          summary: expect.stringContaining("launch a fresh first-attempt `approve-e2e`"),
         },
       });
       expect(restoredAuthorizations[0]?.body).not.toHaveProperty("conclusion");
-      expect(checkTitle).toBe("E2E maintainer authorization required to run E2E");
+      expect(checkTitle).toBe("Maintainer approval required to run E2E");
       expect(requests.some((request) => request.url.endsWith("/dispatches"))).toBe(false);
     } finally {
       for (const workDir of workDirs) fs.rmSync(workDir, { recursive: true, force: true });
@@ -1365,7 +1201,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     );
 
     try {
-      await expect(startControlPlanePrGate(startControlPlaneCommand(workDir))).rejects.toThrow(
+      await expect(approvePrE2E(approvalCommand(workDir))).rejects.toThrow(
         /Superseded by PR update/u,
       );
       expect(requests.some((request) => request.method === "PATCH")).toBe(false);
@@ -1408,7 +1244,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
           existingPrGateCheckRunsRoute({
             status: "in_progress",
             conclusion: null,
-            output: { title: "E2E maintainer authorization required to run E2E" },
+            output: { title: "Maintainer approval required to run E2E" },
           }),
           mainWorkflowRefRoute(),
         ],
@@ -1417,7 +1253,7 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
     );
 
     try {
-      await expect(startControlPlanePrGate(startControlPlaneCommand(workDir))).rejects.toThrow(
+      await expect(approvePrE2E(approvalCommand(workDir))).rejects.toThrow(
         /Superseded by PR update/u,
       );
       expect(pullReads).toBe(3);

--- a/test/pr-e2e-gate-fork-approval.test.ts
+++ b/test/pr-e2e-gate-fork-approval.test.ts
@@ -355,6 +355,9 @@ describe("PR E2E controller fork credentialed E2E approval safety", () => {
       expect(JSON.stringify(pending?.body)).toContain(`base SHA \`${BASE_SHA}\``);
       expect(JSON.stringify(pending?.body)).toContain("targets:");
       expect(JSON.stringify(pending?.body)).toContain("deterministic plan");
+      expect(JSON.stringify(pending?.body)).toContain(
+        "This gate passes only if the dispatched evidence references both SHAs and verifies successfully.",
+      );
       const outputs = fs.readFileSync(outputPath, "utf8");
       expect(outputs).not.toContain("approval_");
       expect(outputs).toContain("finalized=true");

--- a/test/pr-e2e-gate-lifecycle.test.ts
+++ b/test/pr-e2e-gate-lifecycle.test.ts
@@ -1290,7 +1290,7 @@ describe("PR E2E controller lifecycle", () => {
     const supersededCheck = exactPrGateCheck({
       head_sha: SUPERSEDED_HEAD_SHA,
       external_id: prGateExternalId(42, SUPERSEDED_HEAD_SHA, BASE_SHA),
-      output: { title: "E2E maintainer authorization required to run E2E" },
+      output: { title: "Maintainer approval required to run E2E" },
     });
     vi.spyOn(globalThis, "fetch").mockImplementation(
       createGitHubFetchRouter(

--- a/test/pr-e2e-gate-retry-history.test.ts
+++ b/test/pr-e2e-gate-retry-history.test.ts
@@ -247,7 +247,7 @@ describe("PR E2E controller retry history", () => {
       expect(completion?.body).toMatchObject({
         status: "in_progress",
         output: {
-          title: "E2E maintainer authorization required to run E2E",
+          title: "Maintainer approval required to run E2E",
           summary: expect.stringContaining(
             "No selected E2E job or target ran and no repository secret was exposed",
           ),
@@ -260,15 +260,14 @@ describe("PR E2E controller retry history", () => {
         status: "in_progress",
         conclusion: null,
         output: {
-          title: "E2E maintainer authorization required to run E2E",
+          title: "Maintainer approval required to run E2E",
           summary: expect.stringContaining(
             "No selected E2E job or target ran and no repository secret was exposed",
           ),
         },
       });
-      expect(JSON.stringify(completion?.body)).toContain("operation=run-control-plane");
-      expect(JSON.stringify(completion?.body)).not.toContain("Review deployments");
-      expect(fs.readFileSync(outputPath, "utf8")).not.toContain("approval_mode=");
+      expect(JSON.stringify(completion?.body)).toContain("`approve-e2e`");
+      expect(fs.readFileSync(outputPath, "utf8")).not.toContain("approval_");
       expect(fs.readFileSync(outputPath, "utf8")).toContain("check_id=18");
       expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
     } finally {

--- a/test/pr-e2e-gate-workflow.test.ts
+++ b/test/pr-e2e-gate-workflow.test.ts
@@ -107,7 +107,7 @@ function runStartStep(headBranch: string, prNumber = "42") {
   }
 }
 
-function runControlPlaneStartStep(reviewReason: string) {
+function runApprovalStartStep(reviewReason: string) {
   const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
   const start = step(workflow.jobs.coordinate, "Start evaluation");
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-authorize-"));
@@ -135,49 +135,6 @@ function runControlPlaneStartStep(reviewReason: string) {
         MANUAL_PR_NUMBER: "42",
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
         REVIEW_REASON: reviewReason,
-        WORKFLOW_RUN_ATTEMPT: "1",
-        WORKFLOW_SHA,
-        WORK_DIR: tempDir,
-      },
-      timeout: 5_000,
-    });
-    return {
-      arguments: fs.readFileSync(argumentsPath, "utf8").split("\0").slice(0, -1),
-      result,
-    };
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
-function runApprovedForkStartStep() {
-  const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
-  const approve = step(workflow.jobs["approve-fork-e2e"], "Start approved fork E2E");
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-approve-"));
-  const binDir = path.join(tempDir, "bin");
-  const argumentsPath = path.join(tempDir, "node-arguments");
-  fs.mkdirSync(binDir);
-  fs.writeFileSync(
-    path.join(binDir, "node"),
-    '#!/usr/bin/env bash\nset -euo pipefail\nprintf \'%s\\0\' "$@" > "$FAKE_NODE_ARGUMENTS"\n',
-    { mode: 0o755 },
-  );
-
-  try {
-    const result = spawnSync("bash", ["-e", "-o", "pipefail", "-c", approve.run!], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        APPROVAL_MODE: "start-approved-fork",
-        APPROVAL_RUN_ATTEMPT: "1",
-        APPROVAL_RUN_ID: "101",
-        EXPECTED_BASE_SHA: BASE_SHA,
-        EXPECTED_HEAD_SHA: HEAD_SHA,
-        FAKE_NODE_ARGUMENTS: argumentsPath,
-        GATE_RUN_ID: "101",
-        GITHUB_TOKEN: "token",
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
-        PR_NUMBER: "42",
         WORKFLOW_RUN_ATTEMPT: "1",
         WORKFLOW_SHA,
         WORK_DIR: tempDir,
@@ -309,7 +266,6 @@ describe("PR E2E gate workflow", () => {
     const required = workflow.jobs.required;
     const cancel = workflow.jobs["cancel-superseded"];
     const coordinate = workflow.jobs.coordinate;
-    const approveE2e = workflow.jobs["approve-fork-e2e"];
     const longestSelectedE2eMinutes = 130;
     const controllerWaitMinutes = 140;
     const evidenceAndKillGraceMinutes = 10.5;
@@ -339,9 +295,9 @@ describe("PR E2E gate workflow", () => {
           operation: {
             description: "E2E gate action to perform.",
             required: true,
-            default: "run-control-plane",
+            default: "approve-e2e",
             type: "choice",
-            options: ["run-control-plane"],
+            options: ["approve-e2e"],
           },
           pr_number: {
             description: "Pull request number for the selected E2E gate action.",
@@ -359,7 +315,7 @@ describe("PR E2E gate workflow", () => {
             type: "string",
           },
           review_reason: {
-            description: "Why this internal PR may run control-plane E2E.",
+            description: "Why this PR may run credentialed E2E.",
             required: true,
             type: "string",
           },
@@ -450,7 +406,7 @@ describe("PR E2E gate workflow", () => {
     expect(coordinate.if).toContain(
       "endsWith(github.event.workflow_run.display_title, ' gate true')",
     );
-    expect(coordinate.if).toContain("inputs.operation == 'run-control-plane'");
+    expect(coordinate.if).toContain("inputs.operation == 'approve-e2e'");
     expect(coordinate.if).toContain("github.ref == 'refs/heads/main'");
     expect(coordinate.if).toContain("github.run_attempt == 1");
     expect(coordinate.if).not.toContain("head_repository.full_name == github.repository");
@@ -466,47 +422,16 @@ describe("PR E2E gate workflow", () => {
     expect(coordinate.concurrency?.queue).toBe("max");
     expect(coordinate.concurrency?.["cancel-in-progress"]).toBe(false);
     expect(coordinate["timeout-minutes"]).toBe(330);
-    expect(coordinate.outputs).toEqual({
-      approval_mode: "${{ steps.start.outputs.approval_mode }}",
-      approval_environment: "${{ steps.start.outputs.approval_environment }}",
-      approval_pr_number: "${{ steps.start.outputs.approval_pr_number }}",
-      approval_head_sha: "${{ steps.start.outputs.approval_head_sha }}",
-      approval_base_sha: "${{ steps.start.outputs.approval_base_sha }}",
-    });
-    expect(approveE2e.name).toBe("Approve credentialed E2E for fork PR");
-    expect(approveE2e.needs).toBe("coordinate");
-    expect(approveE2e.if).toBe(
-      "${{ needs.coordinate.result == 'success' && needs.coordinate.outputs.approval_mode == 'start-approved-fork' && github.run_attempt == 1 }}",
-    );
-    expect(approveE2e.environment).toEqual({
-      name: "approve-credentialed-e2e-for-fork-pr",
-      deployment: false,
-    });
-    expect(approveE2e.permissions).toEqual({
-      actions: "write",
-      checks: "write",
-      contents: "read",
-      "pull-requests": "read",
-    });
-    expect(approveE2e.concurrency).toEqual({
-      group:
-        "pr-e2e-gate-${{ github.repository }}-${{ needs.coordinate.outputs.approval_pr_number }}-${{ needs.coordinate.outputs.approval_head_sha }}-${{ needs.coordinate.outputs.approval_base_sha }}",
-      queue: "max",
-      "cancel-in-progress": false,
-    });
-    expect(approveE2e["timeout-minutes"]).toBe(330);
+    expect(coordinate.outputs).toBeUndefined();
+    expect(workflow.jobs["approve-e2e"]).toBeUndefined();
     expect(controllerWaitMinutes).toBeGreaterThan(longestSelectedE2eMinutes);
     expect(coordinate["timeout-minutes"]).toBeGreaterThanOrEqual(
-      twoAttemptMinimum + controllerSetupReserveMinutes,
-    );
-    expect(approveE2e["timeout-minutes"]).toBeGreaterThanOrEqual(
       twoAttemptMinimum + controllerSetupReserveMinutes,
     );
     expect(observerPollMinutes).toBeGreaterThanOrEqual(
       coordinate["timeout-minutes"]! + maxPrerequisiteCiMinutes + observerApiSlackMinutes,
     );
     expect(required["timeout-minutes"]).toBeGreaterThan(observerPollMinutes);
-    expect(approveE2e.secrets).toBeUndefined();
     expect(collectStrings(initialize).some((value) => value.includes("--mode seed"))).toBe(true);
     expect(step(initialize, "Reserve PR/base SHA gate").run).toContain('--head "$HEAD_SHA"');
     expect(step(initialize, "Reserve PR/base SHA gate").env?.BASE_SHA).toBe(
@@ -519,26 +444,9 @@ describe("PR E2E gate workflow", () => {
     expect(start.env?.MAINTAINER).toBe("${{ github.triggering_actor }}");
     expect(start.env?.MANUAL_HEAD_SHA).toBe("${{ inputs.expected_head_sha }}");
     expect(start.env?.MANUAL_BASE_SHA).toBe("${{ inputs.expected_base_sha }}");
-    expect(start.run).toContain("--mode start-control-plane");
+    expect(start.run).toContain("--mode approve-e2e");
     expect(start.run).toContain('--ci-display-title "$CI_DISPLAY_TITLE"');
     expect(start.run).toContain('--gate-run-id "$GATE_RUN_ID"');
-    const approvedStart = step(approveE2e, "Start approved fork E2E");
-    expect(approvedStart.env).toMatchObject({
-      APPROVAL_RUN_ATTEMPT: "${{ github.run_attempt }}",
-      APPROVAL_RUN_ID: "${{ github.run_id }}",
-      EXPECTED_BASE_SHA: "${{ needs.coordinate.outputs.approval_base_sha }}",
-      EXPECTED_HEAD_SHA: "${{ needs.coordinate.outputs.approval_head_sha }}",
-      GATE_RUN_ID: "${{ github.run_id }}",
-      GITHUB_TOKEN: "${{ github.token }}",
-      PR_NUMBER: "${{ needs.coordinate.outputs.approval_pr_number }}",
-      WORKFLOW_RUN_ATTEMPT: "${{ github.run_attempt }}",
-      WORKFLOW_SHA: "${{ github.workflow_sha }}",
-    });
-    expect(approvedStart.run).toContain("--mode start-approved-fork");
-    expect(approvedStart.run).toContain('--approval-run-id "$APPROVAL_RUN_ID"');
-    expect(approvedStart.run).toContain('--approval-run-attempt "$APPROVAL_RUN_ATTEMPT"');
-    expect(approvedStart.run).toContain('--head "$EXPECTED_HEAD_SHA"');
-    expect(approvedStart.run).toContain('--base "$EXPECTED_BASE_SHA"');
     const wait = step(coordinate, "Wait for E2E run");
     expect(wait.env?.GITHUB_TOKEN).toBe("${{ github.token }}");
     expect(wait.run).toContain("--mode wait");
@@ -585,7 +493,7 @@ describe("PR E2E gate workflow", () => {
       (candidate) => candidate.name === "Install controller dependencies",
     );
 
-    expect(checkouts).toHaveLength(5);
+    expect(checkouts).toHaveLength(4);
     expect(
       checkouts.every(
         (checkout) =>
@@ -593,11 +501,11 @@ describe("PR E2E gate workflow", () => {
           checkout.with?.["persist-credentials"] === false,
       ),
     ).toBe(true);
-    expect(nodeSetups).toHaveLength(5);
+    expect(nodeSetups).toHaveLength(4);
     expect(nodeSetups.every((setup) => setup.uses === TRUSTED_SETUP_NODE_ACTION)).toBe(true);
     expect(nodeSetups.every((setup) => setup.with?.["node-version"] === "22")).toBe(true);
     expect(nodeSetups.every((setup) => !("cache" in (setup.with ?? {})))).toBe(true);
-    expect(installs).toHaveLength(4);
+    expect(installs).toHaveLength(3);
     expect(
       installs.every((install) => install.run === "npm ci --ignore-scripts --no-audit --no-fund"),
     ).toBe(true);
@@ -650,45 +558,14 @@ describe("PR E2E gate workflow", () => {
     expect(execution.arguments[prFlag + 1]).toBe("");
   });
 
-  it("passes the approved fork E2E identity as inert arguments", () => {
-    const execution = runApprovedForkStartStep();
-
-    expect(execution.result.status).toBe(0);
-    expect(execution.result.stderr).toBe("");
-    expect(execution.arguments).toEqual([
-      "--experimental-strip-types",
-      "tools/e2e/pr-e2e-gate.mts",
-      "--mode",
-      "start-approved-fork",
-      "--pr",
-      "42",
-      "--head",
-      HEAD_SHA,
-      "--base",
-      BASE_SHA,
-      "--workflow-sha",
-      WORKFLOW_SHA,
-      "--approval-run-id",
-      "101",
-      "--approval-run-attempt",
-      "1",
-      "--gate-run-id",
-      "101",
-      "--workflow-run-attempt",
-      "1",
-      "--work-dir",
-      expect.any(String),
-    ]);
-  });
-
-  it("passes the control-plane review reason as one inert argument", () => {
+  it("passes the maintainer review reason as one inert argument", () => {
     const reason = "Reviewed PR/base SHA pair; $(printf injected)";
-    const execution = runControlPlaneStartStep(reason);
+    const execution = runApprovalStartStep(reason);
     const reasonFlag = execution.arguments.indexOf("--reason");
 
     expect(execution.result.status).toBe(0);
     expect(execution.result.stderr).toBe("");
-    expect(execution.arguments).toContain("start-control-plane");
+    expect(execution.arguments).toContain("approve-e2e");
     expect(execution.arguments[reasonFlag + 1]).toBe(reason);
     expect(execution.arguments).toContain(HEAD_SHA);
     expect(execution.arguments).toContain(BASE_SHA);
@@ -732,7 +609,6 @@ describe("PR E2E gate workflow", () => {
   it("orders the coordinate steps and always finalizes through the controller", () => {
     const workflow = readYaml<TriggeredWorkflow>(PR_GATE_PATH);
     const coordinate = workflow.jobs.coordinate;
-    const approveE2e = workflow.jobs["approve-fork-e2e"];
 
     expect((coordinate.steps ?? []).map((candidate) => candidate.name)).toEqual([
       "Checkout controller",
@@ -764,45 +640,5 @@ describe("PR E2E gate workflow", () => {
     expect(cleanup.if).toContain("always()");
     expect(cleanup.if).toContain("steps.workspace.outputs.work_dir");
     expect(cleanup.run).toBe('rm -rf -- "${{ steps.workspace.outputs.work_dir }}"');
-
-    expect((approveE2e.steps ?? []).map((candidate) => candidate.name)).toEqual([
-      "Checkout controller",
-      "Setup Node",
-      "Install controller dependencies",
-      "Create private workspace",
-      "Start approved fork E2E",
-      "Upload approved risk plan",
-      "Wait for approved E2E run",
-      "Download approved evidence",
-      "Verify approved evidence",
-      "Retry approved E2E after hosted runner loss",
-      "Wait for approved retry E2E run",
-      "Download approved retry evidence",
-      "Verify approved retry evidence",
-      "Close incomplete approved retry check",
-      "Terminalize interrupted approved retry setup",
-      "Close incomplete approved check",
-      "Remove private workspace",
-    ]);
-    expect(step(approveE2e, "Download approved evidence").if).toContain("always()");
-    expect(step(approveE2e, "Verify approved evidence").if).toContain("always()");
-    expect(step(approveE2e, "Retry approved E2E after hosted runner loss").if).toContain(
-      "github.run_attempt == 1",
-    );
-    expect(step(approveE2e, "Download approved retry evidence").run).toContain(
-      "--slot runner-loss-retry",
-    );
-    expect(step(approveE2e, "Verify approved retry evidence").if).toContain("always()");
-    expect(step(approveE2e, "Close incomplete approved retry check").if).toContain("always()");
-    const approvedInterruptedRetry = step(
-      approveE2e,
-      "Terminalize interrupted approved retry setup",
-    );
-    expect(approvedInterruptedRetry.if).toContain("steps.retry.outcome != 'success'");
-    expect(approvedInterruptedRetry.if).not.toContain("steps.retry.outcome == 'failure'");
-    expect(approvedInterruptedRetry.if).toContain("steps.retry.outputs.check_id == ''");
-    expect(approvedInterruptedRetry.run).toContain("--mode abandon-runner-loss-retry");
-    expect(step(approveE2e, "Close incomplete approved check").if).toContain("always()");
-    expect(step(approveE2e, "Remove private workspace").if).toContain("always()");
   });
 });

--- a/test/pr-e2e-required.test.ts
+++ b/test/pr-e2e-required.test.ts
@@ -217,7 +217,7 @@ describe("native PR E2E required job", () => {
             id: 18,
             status: "in_progress",
             conclusion: null,
-            output: { title: "E2E maintainer authorization required to run E2E" },
+            output: { title: "Maintainer approval required to run E2E" },
           }),
         ]),
       ),
@@ -373,7 +373,7 @@ describe("native PR E2E required job", () => {
                   ? check(undefined, {
                       status: "in_progress",
                       conclusion: null,
-                      output: { title: "E2E maintainer authorization required to run E2E" },
+                      output: { title: "Maintainer approval required to run E2E" },
                     })
                   : coordinationQueries === 2
                     ? check(undefined, {

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -64,15 +64,14 @@ export { validateWorkflowDispatchDetails } from "./pr-e2e-dispatch-reconciliatio
 
 const E2E_WORKFLOW = "e2e.yaml";
 const E2E_WORKFLOW_PATH = `.github/workflows/${E2E_WORKFLOW}`;
-const PR_GATE_WORKFLOW_PATH = ".github/workflows/pr-e2e-gate.yaml";
-const FORK_E2E_APPROVAL_ENVIRONMENT = "approve-credentialed-e2e-for-fork-pr";
+const PR_GATE_WORKFLOW = "pr-e2e-gate.yaml";
 const CHECK_NAME = "E2E / PR Gate Coordination";
 const WORKFLOW_NAME = "E2E / PR Gate Controller";
 const RESERVED_CHECK_TITLE = "Waiting for PR CI";
 const RESERVED_CHECK_SUMMARY =
   "This PR SHA and base SHA are reserved for deterministic E2E planning after CI completes.";
-const CONTROL_PLANE_AUTHORIZATION_TITLE = "E2E maintainer authorization required to run E2E";
-const FORK_E2E_AUTHORIZATION_TITLE = "E2E reviewer authorization required to run fork E2E";
+const CONTROL_PLANE_AUTHORIZATION_TITLE = "Maintainer approval required to run E2E";
+const FORK_E2E_AUTHORIZATION_TITLE = "Maintainer approval required to run fork E2E";
 const EVALUATING_PR_COMMIT_TITLE = "Evaluating PR commit";
 const RUNNER_LOSS_RETRY_PREPARATION_TITLE = "Preparing one-time hosted-runner-loss retry";
 const AUTHORIZED_EXECUTION_TITLE_PREFIX = "E2E execution authorized by @";
@@ -106,7 +105,6 @@ const MAX_COMPATIBILITY_FILES = 300;
 const MAX_ACTIVE_RUN_PAGES_PER_STATUS = 10;
 const MAX_REPORTED_WORKFLOW_JOBS = 10;
 const MAX_WAIVER_REASON_CHARS = 500;
-const MAX_APPROVAL_REVIEWS = 20;
 const MAINTAINER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/u;
 const ACTIVE_WORKFLOW_RUN_STATUSES = [
   "requested",
@@ -148,7 +146,7 @@ type ControllerPathSlot = "initial" | "runner-loss-retry";
 
 type EvidenceStepOutcome = "success" | "failure" | "cancelled" | "skipped";
 
-type ControlPlaneCommandBase = {
+type E2EApprovalCommandBase = {
   prNumber: number;
   headSha: string;
   baseSha: string;
@@ -157,19 +155,13 @@ type ControlPlaneCommandBase = {
   workflowRunAttempt: number;
 } & ControllerPaths;
 
-type ControlPlaneDispatchCommand = ControlPlaneCommandBase & {
-  mode: "start-control-plane";
+type MaintainerApprovalCommand = E2EApprovalCommandBase & {
+  mode: "approve-e2e";
   maintainer: string;
   reason: string;
 };
 
-type ApprovedForkE2EDispatchCommand = ControlPlaneCommandBase & {
-  mode: "start-approved-fork";
-  approvalRunId: number;
-  approvalRunAttempt: number;
-};
-
-type AuthorizedE2ECommand = ControlPlaneCommandBase & {
+type AuthorizedE2ECommand = E2EApprovalCommandBase & {
   maintainer: string;
   reason: string;
 };
@@ -220,8 +212,7 @@ export type ControllerCommand =
       statePath: string;
       retryStatePath: string;
     }
-  | ControlPlaneDispatchCommand
-  | ApprovedForkE2EDispatchCommand;
+  | MaintainerApprovalCommand;
 
 type CheckConclusion = "success" | "failure" | "cancelled";
 
@@ -572,7 +563,7 @@ export function parseControllerCommand(argv: string[]): ControllerCommand {
       retryStatePath: privateControllerPaths(workDir, "runner-loss-retry").statePath,
     };
   }
-  if (args.mode === "start-control-plane") {
+  if (args.mode === "approve-e2e") {
     const maintainer = requiredArgument(args.maintainer, "maintainer");
     if (!MAINTAINER_PATTERN.test(maintainer)) throw new Error("--maintainer is invalid");
     const workflowRunAttempt = parsePositiveId(
@@ -583,7 +574,7 @@ export function parseControllerCommand(argv: string[]): ControllerCommand {
       throw new Error("--workflow-run-attempt must be exactly 1");
     }
     return {
-      mode: "start-control-plane",
+      mode: "approve-e2e",
       prNumber: parsePositiveId(requiredArgument(args.pr, "pr"), "--pr"),
       headSha: requiredArgument(args.head, "head"),
       baseSha: requiredArgument(args.base, "base"),
@@ -595,36 +586,8 @@ export function parseControllerCommand(argv: string[]): ControllerCommand {
       ...privateControllerPaths(requiredArgument(args.workDir, "work-dir")),
     };
   }
-  if (args.mode === "start-approved-fork") {
-    const workflowRunAttempt = parsePositiveId(
-      requiredArgument(args.workflowRunAttempt, "workflow-run-attempt"),
-      "--workflow-run-attempt",
-    );
-    const approvalRunAttempt = parsePositiveId(
-      requiredArgument(args.approvalRunAttempt, "approval-run-attempt"),
-      "--approval-run-attempt",
-    );
-    if (workflowRunAttempt !== 1 || approvalRunAttempt !== 1) {
-      throw new Error("workflow and approval run attempts must be exactly 1");
-    }
-    return {
-      mode: "start-approved-fork",
-      prNumber: parsePositiveId(requiredArgument(args.pr, "pr"), "--pr"),
-      headSha: requiredArgument(args.head, "head"),
-      baseSha: requiredArgument(args.base, "base"),
-      workflowSha: requiredArgument(args.workflowSha, "workflow-sha"),
-      gateRunId: parsePositiveId(requiredArgument(args.gateRunId, "gate-run-id"), "--gate-run-id"),
-      workflowRunAttempt,
-      approvalRunId: parsePositiveId(
-        requiredArgument(args.approvalRunId, "approval-run-id"),
-        "--approval-run-id",
-      ),
-      approvalRunAttempt,
-      ...privateControllerPaths(requiredArgument(args.workDir, "work-dir")),
-    };
-  }
   throw new Error(
-    "--mode must be seed, start, start-control-plane, start-approved-fork, finish, abandon, abandon-runner-loss-retry, cancel, wait, download, or retry-runner-loss",
+    "--mode must be seed, start, approve-e2e, finish, abandon, abandon-runner-loss-retry, cancel, wait, download, or retry-runner-loss",
   );
 }
 
@@ -892,11 +855,6 @@ function appendOutput(name: string, value: string): void {
   const output = process.env.GITHUB_OUTPUT;
   if (!output) return;
   const validators: Readonly<Record<string, (candidate: string) => boolean>> = {
-    approval_base_sha: (candidate) => SHA_PATTERN.test(candidate),
-    approval_environment: (candidate) => candidate === FORK_E2E_APPROVAL_ENVIRONMENT,
-    approval_head_sha: (candidate) => SHA_PATTERN.test(candidate),
-    approval_mode: (candidate) => candidate === "start-approved-fork",
-    approval_pr_number: (candidate) => /^[1-9][0-9]*$/u.test(candidate),
     check_id: (candidate) => /^[1-9][0-9]*$/u.test(candidate),
     dispatched: (candidate) => /^(?:true|false)$/u.test(candidate),
     finalized: (candidate) => /^(?:true|false)$/u.test(candidate),
@@ -921,20 +879,6 @@ function appendOutput(name: string, value: string): void {
   } finally {
     fs.closeSync(descriptor);
   }
-}
-
-function emitE2EApprovalOutputs(
-  mode: "start-approved-fork",
-  environment: typeof FORK_E2E_APPROVAL_ENVIRONMENT,
-  prNumber: number,
-  headSha: string,
-  baseSha: string,
-): void {
-  appendOutput("approval_mode", mode);
-  appendOutput("approval_environment", environment);
-  appendOutput("approval_pr_number", String(prNumber));
-  appendOutput("approval_head_sha", headSha);
-  appendOutput("approval_base_sha", baseSha);
 }
 
 export function prGateExternalId(prNumber: number, headSha: string, baseSha: string): string {
@@ -3161,6 +3105,7 @@ export async function startPrGate(
     });
     assertPullUnchanged(pull, currentPull);
     if (command.headRepository !== repository && selections.length > 0) {
+      const workflowUrl = `https://github.com/${repository}/actions/workflows/${PR_GATE_WORKFLOW}`;
       const gateRunUrl = `https://github.com/${repository}/actions/runs/${command.gateRunId}`;
       const gateRunLink = `[${WORKFLOW_NAME} run ${command.gateRunId}](${gateRunUrl})`;
       await markCheckInProgress(
@@ -3176,16 +3121,9 @@ export async function startPrGate(
         [
           `Review scope: PR #${pull.number}; head repository \`${command.headRepository}\`; head SHA \`${command.headSha}\`; base SHA \`${ciIdentity.baseSha}\`; ${selectionSummary}; deterministic plan \`${plan.planHash}\`.`,
           "No selected E2E job or target ran. No repository credential was exposed to fork code.",
-          `An authorized E2E reviewer must review the exact fork code and risk plan. Open ${gateRunLink}, choose Review deployments, and approve the \`${FORK_E2E_APPROVAL_ENVIRONMENT}\` environment. Approval authorizes the selected fork code to run with E2E credentials. GitHub records the reviewer and optional comment.`,
-          "If Review deployments is absent, configure the protected environment. Then, update the PR to create a new PR SHA and run fresh PR CI.",
+          `A repository maintainer must review the exact fork code and risk plan in ${gateRunLink}, then launch a first-attempt \`approve-e2e\` operation from the [${WORKFLOW_NAME}](${workflowUrl}) workflow.`,
+          `Use \`pr_number=${pull.number}\`, \`expected_head_sha=${command.headSha}\`, \`expected_base_sha=${ciIdentity.baseSha}\`, and a specific \`review_reason\`. The trusted controller verifies the maintainer role and exact reviewed inputs before it dispatches this plan.`,
         ].join("\n\n"),
-      );
-      emitE2EApprovalOutputs(
-        "start-approved-fork",
-        FORK_E2E_APPROVAL_ENVIRONMENT,
-        pull.number,
-        command.headSha,
-        ciIdentity.baseSha,
       );
       appendOutput("dispatched", "false");
       appendOutput("finalized", "true");
@@ -3197,7 +3135,9 @@ export async function startPrGate(
     }
     const controlPlaneFamily = plan.families.find((family) => family.id === "e2e-control-plane");
     if (controlPlaneFamily && requiresCredentialedE2eAuthorization(plan)) {
-      const workflowUrl = `https://github.com/${repository}/actions/workflows/${PR_GATE_WORKFLOW_PATH}`;
+      const workflowUrl = `https://github.com/${repository}/actions/workflows/${PR_GATE_WORKFLOW}`;
+      const gateRunUrl = `https://github.com/${repository}/actions/runs/${command.gateRunId}`;
+      const gateRunLink = `[${WORKFLOW_NAME} run ${command.gateRunId}](${gateRunUrl})`;
       await markCheckInProgress(
         {
           repository,
@@ -3211,8 +3151,9 @@ export async function startPrGate(
         [
           `This internal diff (PR SHA \`${command.headSha}\`, base SHA \`${ciIdentity.baseSha}\`) changes code that the selected credential-bearing E2E jobs or targets execute or trust (${selectionSummary}).`,
           "No selected E2E job or target ran and no repository secret was exposed.",
-          `Any repository maintainer or administrator can authorize this exact plan by dispatching [${WORKFLOW_NAME}](${workflowUrl}) on \`main\` with \`operation=run-control-plane\`, \`pr_number=${pull.number}\`, \`expected_head_sha=${command.headSha}\`, \`expected_base_sha=${ciIdentity.baseSha}\`, and a specific \`review_reason\`. The controller verifies the triggering actor's repository role before dispatch.`,
-          "The authorization dispatch is the approval; no separate protected-environment review is required. This gate passes only if the dispatched evidence references both SHAs and verifies successfully.",
+          `A repository maintainer must review PR SHA \`${command.headSha}\` against base SHA \`${ciIdentity.baseSha}\` and the risk plan in ${gateRunLink}, then launch a first-attempt \`approve-e2e\` operation from the [${WORKFLOW_NAME}](${workflowUrl}) workflow.`,
+          `Use \`pr_number=${pull.number}\`, \`expected_head_sha=${command.headSha}\`, \`expected_base_sha=${ciIdentity.baseSha}\`, and a specific \`review_reason\`. The trusted controller verifies the maintainer role and exact reviewed inputs before it dispatches this plan.`,
+          "This gate passes only if the dispatched evidence references both SHAs and verifies successfully.",
           `Deterministic plan: \`${plan.planHash}\`.`,
         ].join("\n\n"),
       );
@@ -3265,10 +3206,7 @@ export async function startPrGate(
   }
 }
 
-async function startAuthorizedPrGate(
-  command: AuthorizedE2ECommand,
-  authorizationKind: "internal-control-plane" | "fork",
-): Promise<void> {
+async function startAuthorizedPrGate(command: AuthorizedE2ECommand): Promise<void> {
   const { token, repository } = tokenAndRepository();
   if (!SHA_PATTERN.test(command.headSha)) throw new Error("PR head SHA is invalid");
   if (!SHA_PATTERN.test(command.baseSha)) throw new Error("PR base SHA is invalid");
@@ -3282,8 +3220,7 @@ async function startAuthorizedPrGate(
   }
   const reason = normalizedWaiverReason(command.reason);
   const executionTitle = authorizedExecutionTitle(command.maintainer);
-  const pendingTitle =
-    authorizationKind === "fork" ? FORK_E2E_AUTHORIZATION_TITLE : CONTROL_PLANE_AUTHORIZATION_TITLE;
+  let pendingTitle = CONTROL_PLANE_AUTHORIZATION_TITLE;
 
   let checkRunId: number | undefined;
   try {
@@ -3295,12 +3232,7 @@ async function startAuthorizedPrGate(
       baseSha: command.baseSha,
     });
     const isFork = pull.head.repo?.full_name !== repository;
-    if (authorizationKind === "internal-control-plane" && isFork) {
-      throw new Error("control-plane E2E authorization requires an internal pull request");
-    }
-    if (authorizationKind === "fork" && !isFork) {
-      throw new Error("fork E2E authorization requires a fork pull request");
-    }
+    pendingTitle = isFork ? FORK_E2E_AUTHORIZATION_TITLE : CONTROL_PLANE_AUTHORIZATION_TITLE;
     const changedFiles = await pullChangedFiles(repository, pull, token);
     const inventory = readFreeStandingJobsInventory();
     const plan = validateRiskPlan(
@@ -3311,10 +3243,7 @@ async function startAuthorizedPrGate(
       }),
       new Set(inventory.allowedJobs),
     );
-    if (
-      authorizationKind === "internal-control-plane" &&
-      !requiresCredentialedE2eAuthorization(plan)
-    ) {
+    if (!isFork && !requiresCredentialedE2eAuthorization(plan)) {
       throw new Error("pull request does not require credentialed E2E authorization");
     }
     const jobs = riskPlanRequiredJobIds(plan);
@@ -3426,9 +3355,7 @@ async function startAuthorizedPrGate(
             pendingTitle,
             [
               `The authorized E2E attempt did not produce an accepted result: \`${reason}\`.`,
-              authorizationKind === "fork"
-                ? "Review the controller error and any linked child run. Then, update the PR to create a new PR SHA and run fresh PR CI."
-                : "Review the controller error and any linked child run. Then, launch a first-attempt `run-control-plane` workflow for the PR/base SHA pair.",
+              "Review the controller error and any linked child run. Then, launch a fresh first-attempt `approve-e2e` workflow for the PR/base SHA pair.",
             ].join("\n\n"),
           );
           appendOutput("finalized", "true");
@@ -3443,71 +3370,15 @@ async function startAuthorizedPrGate(
   }
 }
 
-export async function startControlPlanePrGate(command: ControlPlaneDispatchCommand): Promise<void> {
+export async function approvePrE2E(command: MaintainerApprovalCommand): Promise<void> {
   const { token, repository } = tokenAndRepository();
   await requireMaintainerPermission(
     repository,
     token,
     command.maintainer,
-    "Control-plane E2E authorization",
+    "Credentialed E2E approval",
   );
-  await startAuthorizedPrGate(command, "internal-control-plane");
-}
-
-function approvedE2EReason(comment: string | null): string {
-  const normalizedComment = (comment ?? "")
-    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
-    .replace(/\s{2,}/gu, " ")
-    .trim();
-  const baseReason = "Protected environment approval confirmed for this credentialed E2E run.";
-  const commentPrefix = " Reviewer comment: ";
-  const maxCommentChars = MAX_WAIVER_REASON_CHARS - baseReason.length - commentPrefix.length;
-  const boundedComment = normalizedComment.slice(0, maxCommentChars);
-  return normalizedWaiverReason(
-    boundedComment ? `${baseReason}${commentPrefix}${boundedComment}` : baseReason,
-  );
-}
-
-export async function startApprovedForkPrGate(
-  command: ApprovedForkE2EDispatchCommand,
-): Promise<void> {
-  const { token, repository } = tokenAndRepository();
-  if (!Number.isSafeInteger(command.approvalRunId) || command.approvalRunId < 1) {
-    throw new Error("approval run ID is invalid");
-  }
-  if (command.approvalRunAttempt !== 1 || command.workflowRunAttempt !== 1) {
-    throw new Error("approval and workflow run attempts must be exactly 1");
-  }
-  if (command.gateRunId !== command.approvalRunId) {
-    throw new Error("approval run ID must match the gate run ID");
-  }
-  validateApprovalWorkflowRun(
-    await githubApi<unknown>(`repos/${repository}/actions/runs/${command.approvalRunId}`, token, {
-      userAgent: USER_AGENT,
-    }),
-    {
-      repository,
-      runId: command.approvalRunId,
-      runAttempt: command.approvalRunAttempt,
-      workflowSha: command.workflowSha,
-    },
-  );
-  const review = validateApprovalReview(
-    await githubApi<unknown>(
-      `repos/${repository}/actions/runs/${command.approvalRunId}/approvals`,
-      token,
-      { userAgent: USER_AGENT },
-    ),
-    FORK_E2E_APPROVAL_ENVIRONMENT,
-  );
-  await startAuthorizedPrGate(
-    {
-      ...command,
-      maintainer: review.reviewer,
-      reason: approvedE2EReason(review.comment),
-    },
-    "fork",
-  );
+  await startAuthorizedPrGate(command);
 }
 
 export function findSignalFiles(
@@ -3886,95 +3757,6 @@ export async function abandonRunnerLossRetrySource(
   appendOutput("finalized", "true");
 }
 
-function validateApprovalWorkflowRun(
-  value: unknown,
-  options: {
-    repository: string;
-    runId: number;
-    runAttempt: number;
-    workflowSha: string;
-  },
-): string {
-  if (!isObjectRecord(value)) throw new Error("GitHub returned an invalid approval workflow run");
-  const expectedUrl = `https://github.com/${options.repository}/actions/runs/${options.runId}`;
-  const valid =
-    value.id === options.runId &&
-    // The Actions REST API exposes the evaluated `run-name` as `name`, not the
-    // workflow's top-level name. Bind authority to the immutable workflow path
-    // and trusted workflow SHA below instead of mutable display text.
-    value.event === "workflow_run" &&
-    value.path === PR_GATE_WORKFLOW_PATH &&
-    value.head_branch === "main" &&
-    value.head_sha === options.workflowSha &&
-    value.status === "in_progress" &&
-    value.conclusion === null &&
-    options.runAttempt === 1 &&
-    value.run_attempt === options.runAttempt &&
-    value.html_url === expectedUrl;
-  if (!valid) {
-    throw new Error("approval workflow run does not match the trusted first-attempt gate run");
-  }
-  return expectedUrl;
-}
-
-function validateApprovalReview(
-  value: unknown,
-  environment: typeof FORK_E2E_APPROVAL_ENVIRONMENT,
-): { reviewer: string; comment: string | null } {
-  if (!Array.isArray(value)) {
-    throw new Error("GitHub returned malformed environment approval history");
-  }
-  if (value.length === 0) {
-    throw new Error(
-      `No required-reviewer approval was recorded for ${environment}. If Review deployments was absent, the environment may be missing or unprotected, or the run may no longer be waiting; configure it, update the PR to create a new PR SHA, then run fresh PR CI.`,
-    );
-  }
-  if (value.length > MAX_APPROVAL_REVIEWS) {
-    throw new Error(
-      `GitHub returned more than ${MAX_APPROVAL_REVIEWS} environment approval reviews; refusing ambiguous approval history`,
-    );
-  }
-  const reviews = value.map((candidate) => {
-    if (
-      !isObjectRecord(candidate) ||
-      typeof candidate.state !== "string" ||
-      (typeof candidate.comment !== "string" && candidate.comment !== null) ||
-      !Array.isArray(candidate.environments) ||
-      candidate.environments.length < 1 ||
-      candidate.environments.length > MAX_APPROVAL_REVIEWS ||
-      !candidate.environments.every(
-        (environment) => isObjectRecord(environment) && typeof environment.name === "string",
-      ) ||
-      !isObjectRecord(candidate.user) ||
-      typeof candidate.user.login !== "string" ||
-      !MAINTAINER_PATTERN.test(candidate.user.login)
-    ) {
-      throw new Error("GitHub returned malformed environment approval history");
-    }
-    return {
-      state: candidate.state,
-      comment: candidate.comment,
-      environments: candidate.environments as Array<{ name: string }>,
-      reviewer: candidate.user.login,
-    };
-  });
-  const matching = reviews.filter((review) =>
-    review.environments.some((candidate) => candidate.name === environment),
-  );
-  if (matching.length !== 1) {
-    throw new Error("expected exactly one protected-environment approval review");
-  }
-  const review = matching[0]!;
-  if (
-    review.environments.length !== 1 ||
-    review.environments[0]!.name !== environment ||
-    review.state !== "approved"
-  ) {
-    throw new Error(`protected-environment review did not approve only ${environment}`);
-  }
-  return { reviewer: review.reviewer, comment: review.comment };
-}
-
 async function requireMaintainerPermission(
   repository: string,
   token: string,
@@ -4125,12 +3907,8 @@ async function main(): Promise<void> {
     await startPrGate(command);
     return;
   }
-  if (command.mode === "start-control-plane") {
-    await startControlPlanePrGate(command);
-    return;
-  }
-  if (command.mode === "start-approved-fork") {
-    await startApprovedForkPrGate(command);
+  if (command.mode === "approve-e2e") {
+    await approvePrE2E(command);
     return;
   }
   if (command.mode === "retry-runner-loss") {

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -3123,6 +3123,7 @@ export async function startPrGate(
           "No selected E2E job or target ran. No repository credential was exposed to fork code.",
           `A repository maintainer must review the exact fork code and risk plan in ${gateRunLink}, then launch a first-attempt \`approve-e2e\` operation from the [${WORKFLOW_NAME}](${workflowUrl}) workflow.`,
           `Use \`pr_number=${pull.number}\`, \`expected_head_sha=${command.headSha}\`, \`expected_base_sha=${ciIdentity.baseSha}\`, and a specific \`review_reason\`. The trusted controller verifies the maintainer role and exact reviewed inputs before it dispatches this plan.`,
+          "This gate passes only if the dispatched evidence references both SHAs and verifies successfully.",
         ].join("\n\n"),
       );
       appendOutput("dispatched", "false");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Use one trusted `approve-e2e` operation for internal and fork PR authorization. Any account with current `maintain` or `admin` permission can authorize the exact PR SHA, base SHA, and risk plan. The controller still requires passing evidence before it completes the gate.

## Changes

- Require current `maintain` or `admin` repository permission for every `approve-e2e` request.
- Use the same authorization and dispatch path for internal and fork PRs.
- Remove the fork protected-environment job, approval outputs, approval-history parsing, and separate fork command mode.
- Preserve exact PR, head SHA, base SHA, risk plan, workflow revision, pending-check, and live-state validation.
- Update maintainer guidance, E2E operational documentation, and workflow contract tests for the unified flow.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes repository-maintainer CI operation, not a user-facing NemoClaw API, CLI, configuration, UI, or supported product behavior. Maintainer and E2E operational guidance changed with the workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The nine-category NemoClaw security review passed on PR SHA `426b12b16` with no findings. The controller checks current `maintain` or `admin` permission and rejects `write` permission before any credential-bearing dispatch.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md` and `test/e2e/README.md` document the maintainer prerequisite, exact-revision review, credential risk, failure behavior, and passing-evidence criterion. The review found no actionable findings and confirmed that no `docs/` source page is needed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 426b12b16 -->
<!-- docs-review-agents-blob-sha: d48a7cb55 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec -- vitest run --project integration test/pr-e2e-gate*.test.ts test/pr-e2e-required.test.ts test/maintainer-skills-policy.test.ts` passed 16 files and 276 tests on `426b12b16`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable. This change does not modify the repository-wide test harness or validation configuration. `npm run check:diff` passed, and required CI supplies the broad Linux result.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npm run docs` passed with zero errors and two existing Fern warnings.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
