### PR TITLE
fix(contributing): align PR limit exemptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,4 +294,4 @@ If the command trace contains no reviewer-request write, report the event as an 
 - Follow PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
 - PRs that change `scripts/prepare-dgx-station-host.sh` must include reviewable DGX Station test evidence identifying the tested commit, Station profile or scenario, result, and a supporting link. Any maintainer may review the evidence; without acceptable evidence, the PR is not ready to approve or merge. Treat the evidence as human-reviewed, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must document the reason on the PR.
 - No secrets, API keys, or credentials committed
-- Limit open PRs to fewer than 10
+- Apply the 10-open-PR limit from `.github/workflows/pr-limit.yaml` only to accounts that the workflow does not exempt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -482,7 +482,8 @@ For Markdown docs routing, user-skill guidance, and release-prep documentation w
 
 ## Pull Requests
 
-We welcome contributions. Every PR requires maintainer review before merge. To keep the review queue healthy, limit the number of open PRs you have at any time to fewer than 10.
+We welcome contributions. Every PR requires maintainer review before merge. Contributors may have up to 10 open PRs at one time.
+Core maintainers listed in `.github/workflows/pr-limit.yaml` are exempt from this limit.
 Maintainers review pull requests according to project priority, security impact, release readiness, and reviewer availability.
 PRs that solve issues with Priority set to Urgent or High are more likely to receive earlier review when maintainers have capacity.
 For substantial features or behavior changes, start with a GitHub Discussion before opening a large implementation PR.
@@ -532,7 +533,7 @@ If any commit is missing GitHub verification, fix the branch before opening a PR
 If force-push is not allowed after an unverified commit is published, open a fresh branch and fresh PR with a clean compliant history.
 
 > [!WARNING]
-> Accounts that repeatedly exceed this limit or submit automated bulk PRs may have their PRs closed or their access restricted.
+> Non-exempt accounts that repeatedly exceed this limit or submit automated bulk PRs may have their PRs closed or their access restricted.
 
 ### No External Project Links
 

--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -16,7 +16,7 @@
       "src/lib/cli/terminal-style.ts": 45,
       "src/lib/core/json-types.ts": 37,
       "src/lib/core/ports.ts": 86,
-      "src/lib/core/shell-quote.ts": 27,
+      "src/lib/core/shell-quote.ts": 26,
       "src/lib/core/url-utils.ts": 27,
       "src/lib/core/wait.ts": 35,
       "src/lib/credentials/store.ts": 44,

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -497,6 +497,11 @@
       "category": "security"
     },
     {
+      "file": "test/pr-limit-policy.test.ts",
+      "test": "keeps contributor guidance aligned with the enforced maintainer exemption",
+      "category": "compatibility"
+    },
+    {
       "file": "test/pr-workflow-contract.test.ts",
       "test": "does not persist checkout credentials in PR or main jobs",
       "category": "security"

--- a/test/pr-limit-policy.test.ts
+++ b/test/pr-limit-policy.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { expect, it } from "vitest";
+import YAML from "yaml";
+
+const repoRoot = process.cwd();
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function documentedLimit(source: string): number | undefined {
+  const match = source.match(/(?:up to|the) (\d+)(?:-open-PR| open PRs)/iu);
+  return match ? Number(match[1]) : undefined;
+}
+
+// source-shape-contract: compatibility -- Contributor guidance must match the enforced PR count and preserve the workflow-owned maintainer exemption
+it("keeps contributor guidance aligned with the enforced maintainer exemption", () => {
+  const workflow = YAML.parse(read(".github/workflows/pr-limit.yaml")) as {
+    jobs: Record<string, { steps: Array<{ run?: string }> }>;
+  };
+  const run = workflow.jobs["check-pr-limit"]?.steps.find((step) => step.run)?.run ?? "";
+  const enforcedLimit = Number(run.match(/\$OPEN_COUNT" -gt (\d+)/u)?.[1]);
+  const exemptAccounts =
+    run
+      .match(/EXEMPT="([^"]+)"/u)?.[1]
+      .trim()
+      .split(/\s+/u) ?? [];
+  const agents = read("AGENTS.md");
+  const contributing = read("CONTRIBUTING.md");
+
+  expect(enforcedLimit).toBe(10);
+  expect(exemptAccounts.length).toBeGreaterThan(0);
+  expect(documentedLimit(agents)).toBe(enforcedLimit);
+  expect(documentedLimit(contributing)).toBe(enforcedLimit);
+  expect(agents).toContain("only to accounts that the workflow does not exempt");
+  expect(contributing).toContain(
+    "Core maintainers listed in `.github/workflows/pr-limit.yaml` are exempt from this limit.",
+  );
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Aligns contributor and agent guidance with the enforced PR-count policy. Non-exempt contributors may have up to 10 open PRs, while core maintainers listed in the workflow remain exempt.

## Changes

- Replace the stricter, unconditional `AGENTS.md` instruction with the workflow-owned exemption boundary.
- Clarify the same limit and exemption in `CONTRIBUTING.md`.
- Add a compatibility contract that keeps both guidance surfaces aligned with the enforcing workflow.
- Lower the stale `shell-quote.ts` fan-in budget from 27 to its measured value of 26 so repository checks pass.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes contributor and agent workflow guidance, not supported NemoClaw product behavior. The canonical `AGENTS.md` and `CONTRIBUTING.md` surfaces are updated.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `AGENTS.md` and `CONTRIBUTING.md` accurately match `.github/workflows/pr-limit.yaml`; no Fern page is needed for contributor-only policy.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 49bd4694a -->
<!-- docs-review-agents-blob-sha: 74d0fd67c -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run test/pr-limit-policy.test.ts`: 1 test passed; source-shape, project-membership, and title-style checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the focused contract and normal repository hooks cover this guidance alignment.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that contributors may have up to 10 open pull requests.
  - Documented exemptions for designated maintainers and accounts covered by the project’s policy.
  - Added guidance that repeated limit violations or automated bulk submissions may result in pull requests being closed or access being restricted.

- **Tests**
  - Added checks to keep contribution guidance synchronized with the enforced pull request limit and exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->