### PR TITLE
test(cli): silence Node 26 JWT bundle loader warnings

### DIFF
--- a/src/lib/onboard/docker-driver-gateway-jwt-bundle.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-jwt-bundle.test.ts
@@ -49,7 +49,7 @@ process.stdout.write("RESULT " + JSON.stringify({ kid, signingKeyHash }) + "\n")
 `;
   const child = spawn(
     process.execPath,
-    ["--import", "tsx", "--input-type=module", "--eval", script],
+    ["--no-warnings", "--import", "tsx", "--input-type=module", "--eval", script],
     {
       cwd: path.resolve(import.meta.dirname, "../../.."),
       env: {


### PR DESCRIPTION
## Summary

Keeps the concurrent gateway JWT bundle test compatible with Node 26. The test subprocess now suppresses Node and loader warnings so its stderr assertion continues to detect only diagnostics from the behavior under test.

## Related Issue

Fixes #7837

## Changes

- Add `--no-warnings` to the test-only child Node process that loads TypeScript through `tsx`.
- Preserve the assertion that each JWT bundle caller exits successfully and produces no application stderr.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this only changes a test subprocess flag and has no user-facing behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. Commit `6551e8ef6bc02ebc4f1413495aa0f1db64b692cc` only adds `--no-warnings` to a test-only Node subprocess; `npx vitest run --project cli src/lib/onboard/docker-driver-gateway-jwt-bundle.test.ts` passed 12/12.
- Agent: NemoClaw documentation writer reviewer (Codex)
<!-- docs-review-head-sha: 6551e8ef -->
<!-- docs-review-agents-blob-sha: 0082a58b -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/docker-driver-gateway-jwt-bundle.test.ts` (12 passed).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Vinay Bhagavath <bhagavathvinay@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Suppressed Node.js warnings during concurrent JWT bundle test execution for cleaner test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->