### PR TITLE
fix(status): recover visible post-reboot sandbox

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1367,7 +1367,7 @@ If the owning OpenShell gateway is healthy but no longer lists the registered Do
 It waits for Docker readiness, restores the in-sandbox gateway and host forwards, and refreshes preflight before probing inference.
 A successful recovery clears the stale stopped-container failure.
 <AgentOnly variant="openclaw">
-If OpenShell already reports the registered Docker-driver sandbox as present, status verifies the OpenClaw gateway and host forward.
+If OpenShell already reports the registered Docker-driver sandbox as present and `Ready`, status verifies the OpenClaw gateway and host forward.
 It recovers either component when the verification reports it absent.
 </AgentOnly>
 If Docker readiness or the agent delivery chain cannot be proven, status exits non-zero and reports the failed recovery layer.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1366,6 +1366,10 @@ When the host Docker daemon is reachable but the per-sandbox container is stoppe
 If the owning OpenShell gateway is healthy but no longer lists the registered Docker-driver sandbox, status attempts post-reboot recovery from the labeled container.
 It waits for Docker readiness, restores the in-sandbox gateway and host forwards, and refreshes preflight before probing inference.
 A successful recovery clears the stale stopped-container failure.
+<AgentOnly variant="openclaw">
+If OpenShell already reports the registered Docker-driver sandbox as present, status verifies the OpenClaw gateway and host forward.
+It recovers either component when the verification reports it absent.
+</AgentOnly>
 If Docker readiness or the agent delivery chain cannot be proven, status exits non-zero and reports the failed recovery layer.
 <AgentOnly variant="openclaw,hermes">
 If the sandbox's recorded dashboard port is also held by a foreign listener, the header escalates to the `sandbox_dashboard_port_conflict` failure layer with the message `sandbox container is stopped and the dashboard port is held by a foreign listener.` so the operator can recover the port before restarting the sandbox.

--- a/src/lib/actions/sandbox/process-recovery.test.ts
+++ b/src/lib/actions/sandbox/process-recovery.test.ts
@@ -109,6 +109,32 @@ describe("recreated sandbox OpenShell readiness", () => {
     expect(sleeps).toEqual([3]);
   });
 
+  it("retries the exact same-sandbox Error phase when OpenShell also emits informational stdout", () => {
+    const captureOpenshellImpl = vi
+      .fn()
+      .mockReturnValueOnce({
+        status: 1,
+        output:
+          `Waiting for sandbox registration\n${OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR}`.trim(),
+        stdout: "Waiting for sandbox registration\n",
+        stderr: OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR,
+      })
+      .mockReturnValueOnce({ status: 0, output: "", stdout: "", stderr: "" });
+    const sleeps: number[] = [];
+
+    expect(
+      waitForRecreatedSandboxOpenShellReady("recreated-box", {
+        beforeProbe: () => true,
+        captureOpenshellImpl,
+        intervalSeconds: 3,
+        sleepImpl: (seconds) => sleeps.push(seconds),
+        timeoutSeconds: 30,
+      }),
+    ).toBe(true);
+    expect(captureOpenshellImpl).toHaveBeenCalledTimes(2);
+    expect(sleeps).toEqual([3]);
+  });
+
   it("rides out a transient Error phase past the old 30s budget by default (#7227)", () => {
     // No timeoutSeconds option and no env override: the default recovery budget
     // must be large enough (120s, aligned with connect's readiness wait) to keep

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -599,30 +599,30 @@ function normalizeOpenshellStructuredError(value: string): string {
   return stripAnsi(value).replace(/[×│]/gu, " ").replace(/\s+/gu, " ").trim();
 }
 
-function hasRetryableOpenshellResultShape(result: ReturnType<typeof captureOpenshell>): boolean {
-  return (
-    result.status === 1 &&
-    !result.error &&
-    String(result.stdout ?? "").trim() === "" &&
-    String(result.stderr ?? "").trim() !== ""
-  );
+function hasRetryableOpenshellFailureShape(result: ReturnType<typeof captureOpenshell>): boolean {
+  return result.status === 1 && !result.error && String(result.stderr ?? "").trim() !== "";
 }
 
 function isRetryableOpenshellReRegistrationState(
   result: ReturnType<typeof captureOpenshell>,
   sandboxName: string,
 ): boolean {
-  if (!hasRetryableOpenshellResultShape(result)) return false;
+  if (!hasRetryableOpenshellFailureShape(result)) return false;
   const error = normalizeOpenshellStructuredError(String(result.stderr));
-  if (error === OPENSHELL_SANDBOX_NOT_READY) return true;
   // OpenShell can publish Ready before replacement registration settles.
   // Retry only if the readiness probe reports phase Error for this sandbox.
+  // The CLI can emit informational stdout before this exact stderr refusal;
+  // stdout does not change the result of the read-only `true` probe.
   if (
     error ===
     `Error: sandbox '${sandboxName}' is not ready (phase: Error); wait for it to reach Ready state.`
   ) {
     return true;
   }
+  // All less-specific transient signatures remain constrained to an otherwise
+  // empty stdout stream so unrelated command output cannot be reclassified.
+  if (String(result.stdout ?? "").trim() !== "") return false;
+  if (error === OPENSHELL_SANDBOX_NOT_READY) return true;
 
   // OpenShell 0.0.85 can keep the recreated sandbox's cached phase at Ready
   // while its replacement supervisor session is still registering. The exec

--- a/src/lib/actions/sandbox/status-flow.test.ts
+++ b/src/lib/actions/sandbox/status-flow.test.ts
@@ -557,7 +557,7 @@ describe("showSandboxStatus flow", () => {
       lookup: {
         state: "sandbox_recovery_failed",
         output:
-          "  Docker restored sandbox 'alpha', but its agent delivery chain is not ready " +
+          "  Sandbox 'alpha' is present, but its agent delivery chain could not be proven " +
           "(forward-recovery: OpenShell forward state unavailable).",
         recoveredSandbox: true,
       },
@@ -567,10 +567,29 @@ describe("showSandboxStatus flow", () => {
 
     const output = harness.logSpy.mock.calls.flat().join("\n");
     expect(output).toContain("restored from Docker");
-    expect(output).toContain("agent delivery chain could not be recovered safely");
+    expect(output).toContain("agent delivery chain could not be proven");
     expect(output).toContain("forward-recovery: OpenShell forward state unavailable");
     expect(output).toContain("Retry `nemoclaw alpha recover`");
     expect(output).not.toContain("Could not verify against live gateway");
+  });
+
+  it("does not claim Docker restoration when a visible sandbox fails delivery recovery", async () => {
+    const harness = createStatusFlowHarness({
+      inferenceHealth: null,
+      lookup: {
+        state: "sandbox_recovery_failed",
+        output:
+          "  Sandbox 'alpha' is present, but its agent delivery chain could not be proven " +
+          "(gateway-recovery: the managed agent gateway could not be restarted).",
+      },
+    });
+
+    await expect(harness.showSandboxStatus("alpha")).rejects.toThrow("process.exit(1)");
+
+    const output = harness.logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Sandbox 'alpha' is present");
+    expect(output).toContain("agent delivery chain could not be proven");
+    expect(output).not.toContain("restored from Docker");
   });
 
   it("renders missing gateway metadata after restart without claiming recovery", async () => {

--- a/src/lib/actions/sandbox/status-lookup-rendering.ts
+++ b/src/lib/actions/sandbox/status-lookup-rendering.ts
@@ -60,8 +60,11 @@ function printSandboxRecoveryFailedLookupStatus({
   lookup,
 }: SandboxGatewayLookupStatusContext): void {
   console.log("");
+  const recoveredFromDocker = "recoveredSandbox" in lookup && lookup.recoveredSandbox === true;
   console.log(
-    `  Sandbox '${sandboxName}' was restored from Docker, but its agent delivery chain could not be recovered safely.`,
+    recoveredFromDocker
+      ? `  Sandbox '${sandboxName}' was restored from Docker, but its agent delivery chain could not be proven.`
+      : `  Sandbox '${sandboxName}' is present, but its agent delivery chain could not be proven.`,
   );
   if (lookup.output) console.log(lookup.output);
   console.log(

--- a/src/lib/actions/sandbox/status-snapshot-recovery.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-recovery.test.ts
@@ -124,6 +124,54 @@ describe("collectSandboxStatusSnapshot Docker recovery", () => {
   });
 
   it.each([
+    "Provisioning",
+    "Failed",
+  ])("keeps the existing %s phase diagnosis ahead of markerless recovery (#7824)", async (phase) => {
+    const deps = {
+      ...snapshotDeps({
+        checked: true,
+        wasRunning: false,
+        recovered: false,
+        forwardRecovered: false,
+      }),
+      reconcile: () =>
+        Promise.resolve({
+          state: "present" as const,
+          output: `Phase: ${phase}`,
+        }),
+    };
+
+    const snapshot = await collectSandboxStatusSnapshot("alpha", { deps });
+
+    expect(deps.recoverSandboxProcesses).not.toHaveBeenCalled();
+    expect(snapshot.lookup.state).toBe("present");
+  });
+
+  it("keeps a host preflight failure ahead of markerless recovery (#7824)", async () => {
+    const deps = {
+      ...snapshotDeps({
+        checked: true,
+        wasRunning: false,
+        recovered: false,
+        forwardRecovered: false,
+      }),
+      reconcile: () =>
+        Promise.resolve({
+          state: "present" as const,
+          output: "Phase: Ready",
+        }),
+    };
+
+    const snapshot = await collectSandboxStatusSnapshot("alpha", {
+      deps,
+      preflight: stoppedPreflight,
+    });
+
+    expect(deps.recoverSandboxProcesses).not.toHaveBeenCalled();
+    expect(snapshot.lookup.state).toBe("present");
+  });
+
+  it.each([
     [
       "inspection",
       {

--- a/src/lib/actions/sandbox/status-snapshot-recovery.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-recovery.test.ts
@@ -78,6 +78,51 @@ function snapshotDeps(recoveryResult: unknown) {
 }
 
 describe("collectSandboxStatusSnapshot Docker recovery", () => {
+  it("recovers the delivery chain when OpenShell already reports the restarted container (#7824)", async () => {
+    const deps = {
+      ...snapshotDeps({
+        checked: true,
+        wasRunning: false,
+        recovered: true,
+        forwardRecovered: true,
+      }),
+      reconcile: () =>
+        Promise.resolve({
+          state: "present" as const,
+          output: "Phase: Ready",
+        }),
+    };
+
+    const snapshot = await collectSandboxStatusSnapshot("alpha", { deps });
+
+    expect(deps.recoverSandboxProcesses).toHaveBeenCalledWith("alpha", { quiet: true });
+    expect(snapshot.lookup.state).toBe("present");
+  });
+
+  it("fails closed when the visible restarted container cannot recover OpenClaw (#7824)", async () => {
+    const deps = {
+      ...snapshotDeps({
+        checked: true,
+        wasRunning: false,
+        recovered: false,
+        forwardRecovered: false,
+      }),
+      reconcile: () =>
+        Promise.resolve({
+          state: "present" as const,
+          output: "Phase: Ready",
+        }),
+    };
+
+    const snapshot = await collectSandboxStatusSnapshot("alpha", { deps });
+
+    expect(snapshot.lookup.state).toBe("sandbox_recovery_failed");
+    expect(snapshot.lookup.output).toContain(
+      "Sandbox 'alpha' is present, but its agent delivery chain could not be proven",
+    );
+    expect(deps.probeSandboxInferenceGatewayHealthImpl).not.toHaveBeenCalled();
+  });
+
   it.each([
     [
       "inspection",

--- a/src/lib/actions/sandbox/status-snapshot.ts
+++ b/src/lib/actions/sandbox/status-snapshot.ts
@@ -417,7 +417,9 @@ export async function collectSandboxStatusSnapshot(
   const managedOpenClawDeliveryMustBeProven =
     lookup.state === "present" &&
     sb?.openshellDriver === "docker" &&
-    (sb.agent ?? "openclaw") === "openclaw";
+    (sb.agent ?? "openclaw") === "openclaw" &&
+    parseSandboxPhase(lookup.output || "") === "Ready" &&
+    !opts.preflight?.failure;
   if (
     lookup.state === "present" &&
     (lookup.recoveredSandbox || managedOpenClawDeliveryMustBeProven)

--- a/src/lib/actions/sandbox/status-snapshot.ts
+++ b/src/lib/actions/sandbox/status-snapshot.ts
@@ -414,13 +414,19 @@ export async function collectSandboxStatusSnapshot(
     };
   }
   const dockerRecovered = lookup.recoveredSandbox === true;
-  if (lookup.state === "present" && lookup.recoveredSandbox) {
+  const managedOpenClawDeliveryMustBeProven =
+    lookup.state === "present" &&
+    sb?.openshellDriver === "docker" &&
+    (sb.agent ?? "openclaw") === "openclaw";
+  if (
+    lookup.state === "present" &&
+    (lookup.recoveredSandbox || managedOpenClawDeliveryMustBeProven)
+  ) {
     let failure: SandboxProcessRecoveryFailure | null;
     try {
-      // Docker recovery makes the sandbox visible to OpenShell again, but a
-      // host reboot also tears down the managed agent process and port-forward.
-      // Reuse the guarded connect recovery only for this explicit mutation
-      // path, before status probes the delivery chain.
+      // The managed gateway service can restart a Docker sandbox before status
+      // runs. OpenShell then reports Ready without a recoveredSandbox marker,
+      // while the OpenClaw gateway and host forward can still be absent.
       const recovery = (opts.deps?.recoverSandboxProcesses ?? loadRecoverSandboxProcesses())(
         sandboxName,
         {
@@ -439,7 +445,7 @@ export async function collectSandboxStatusSnapshot(
         ...lookup,
         state: "sandbox_recovery_failed",
         output:
-          `  Docker restored sandbox '${sandboxName}', but its agent delivery chain is not ready ` +
+          `  Sandbox '${sandboxName}' is present, but its agent delivery chain could not be proven ` +
           `(${failure.layer}: ${failure.detail}).`,
       };
     }

--- a/test/cli/sandbox-status-json.test.ts
+++ b/test/cli/sandbox-status-json.test.ts
@@ -28,7 +28,9 @@ function createInferenceRouteStatusSetup(options: {
   writeSandboxRegistry(home, sandboxName, {
     model: "nvidia/nemotron",
     provider: "nvidia-prod",
-    openshellDriver: "docker",
+    // These cases test only inference.local classification. Use the VM driver
+    // so Docker post-reboot delivery recovery does not affect their assertions.
+    openshellDriver: "vm",
   });
   fs.writeFileSync(
     path.join(localBin, "docker"),


### PR DESCRIPTION
## Summary

After a host reboot, OpenShell can restart a registered Docker sandbox and report it `Ready` before the managed OpenClaw gateway and host forward are restored. Status previously ran guarded delivery-chain recovery only when sandbox lookup itself had recovered a missing sandbox, so this visible-sandbox case could exit successfully while the gateway remained unreachable.

Status now proves or recovers the managed OpenClaw gateway and host forward for a present, `Ready` Docker/OpenClaw sandbox with a clear host preflight. It fails closed with `sandbox_recovery_failed` when that delivery chain cannot be proven, preserves higher-priority host and non-Ready diagnostics, and only claims Docker restoration when lookup actually recovered the sandbox.

The exact E2E then exposed a second production defect in the existing direct-recreation path: OpenShell can emit informational stdout while refusing the read-only readiness probe with the exact same-sandbox `phase: Error` response. The retry classifier required empty stdout and therefore treated that transient re-registration state as terminal. It now retries only that exact refusal; broader signatures remain constrained and unrelated errors remain terminal.

## Related Issue

Fixes #7824

## Changes

- Run guarded process and forward recovery for present, `Ready` Docker/OpenClaw sandboxes with a clear host preflight even when lookup did not recover the sandbox.
- Convert an unproven delivery chain into a precise nonzero recovery failure before inference probing.
- Avoid reporting that a sandbox was restored from Docker without corresponding lookup evidence.
- Retry the exact same-sandbox OpenShell `phase: Error` re-registration refusal even when the CLI also emits informational stdout.
- Keep all broader retry signatures constrained to empty stdout and all unrelated failures terminal.
- Cover markerless recovery success, recovery failure, diagnostic precedence, exact readiness stream shape, and rendering behavior.
- Keep inference-route-only integration cases independent from Docker recovery by using their intended VM fixture.
- Document present-sandbox delivery-chain verification and recovery for OpenClaw.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [exact-head nine-category security review completed with no findings](https://github.com/NVIDIA/NemoClaw/pull/7848#issuecomment-5123486970).
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/commands.mdx` already documents the observable present-and-Ready OpenClaw recovery and fail-closed contract; no additional docs change was needed for the exact retry-classifier follow-up. Writing review found no issues. Biome, focused tests, CLI type-check, and hooks passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: caeacc131b387d7db81d4e0f0d15ea4706944fe2 -->
<!-- docs-review-agents-blob-sha: c052d60aa2b486bac1235643a56c2d2b1e5c13d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `process-recovery.test.ts` passed 43/43; prior focused status source tests passed 46/46; exact CI integration files passed 8/8 and 18/18. `npm run test:changed` passed 692/693 with one unrelated 5-second snapshot timeout that passed immediately in isolation.
- [x] Applicable broad gate passed — [exact-head CI](https://github.com/NVIDIA/NemoClaw/actions/runs/30491945640) passed all required jobs; the [trusted PR E2E controller](https://github.com/NVIDIA/NemoClaw/actions/runs/30492704438) succeeded; and its [pinned child run](https://github.com/NVIDIA/NemoClaw/actions/runs/30492735657) passed `ubuntu-repo-docker-post-reboot-recovery` on `caeacc131b387d7db81d4e0f0d15ea4706944fe2`. Artifact evidence records post-reboot `nemoclaw status` exiting 0 with OpenClaw running and Docker healthy, followed by an HTTP 200 gateway probe.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
