### PR TITLE
fix(e2e): prepare dashboard remote bind during onboard

### DIFF
--- a/test/e2e/live/dashboard-remote-bind-env.ts
+++ b/test/e2e/live/dashboard-remote-bind-env.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import os from "node:os";
+
+import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+
+export function buildDashboardRemoteBindEnv(
+  sandboxName: string,
+  extra: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...buildAvailabilityProbeEnv(),
+    PATH: `${os.homedir()}/.local/bin:${os.homedir()}/.npm-global/bin:${process.env.PATH ?? ""}`,
+    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+    NEMOCLAW_NON_INTERACTIVE: "1",
+    NEMOCLAW_RECREATE_SANDBOX: "1",
+    NEMOCLAW_SANDBOX_NAME: sandboxName,
+    OPENSHELL_GATEWAY: "nemoclaw",
+    ...extra,
+    NEMOCLAW_DASHBOARD_BIND: "0.0.0.0",
+  };
+}

--- a/test/e2e/live/dashboard-remote-bind-env.ts
+++ b/test/e2e/live/dashboard-remote-bind-env.ts
@@ -9,9 +9,10 @@ export function buildDashboardRemoteBindEnv(
   sandboxName: string,
   extra: NodeJS.ProcessEnv = {},
 ): NodeJS.ProcessEnv {
+  const baseEnv = buildAvailabilityProbeEnv();
   return {
-    ...buildAvailabilityProbeEnv(),
-    PATH: `${os.homedir()}/.local/bin:${os.homedir()}/.npm-global/bin:${process.env.PATH ?? ""}`,
+    ...baseEnv,
+    PATH: `${os.homedir()}/.local/bin:${os.homedir()}/.npm-global/bin:${baseEnv.PATH ?? ""}`,
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_RECREATE_SANDBOX: "1",

--- a/test/e2e/live/dashboard-remote-bind-env.ts
+++ b/test/e2e/live/dashboard-remote-bind-env.ts
@@ -5,6 +5,10 @@ import os from "node:os";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 
+function stripAnsi(output: string): string {
+  return output.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
 export function buildDashboardRemoteBindEnv(
   sandboxName: string,
   extra: NodeJS.ProcessEnv = {},
@@ -21,4 +25,19 @@ export function buildDashboardRemoteBindEnv(
     ...extra,
     NEMOCLAW_DASHBOARD_BIND: "0.0.0.0",
   };
+}
+
+export function dashboardRemoteBindConnectStarted(
+  result: { exitCode: number | null; stdout: string; stderr: string },
+  sandboxName: string,
+  dashboardPort: string,
+): boolean {
+  const output = stripAnsi(`${result.stdout}\n${result.stderr}`);
+  return (
+    result.exitCode === 0 ||
+    (result.exitCode === null &&
+      (output.includes("Dashboard port forward re-established.") ||
+        (output.includes(`Forwarding port ${dashboardPort}`) &&
+          output.includes(`sandbox ${sandboxName}`))))
+  );
 }

--- a/test/e2e/live/dashboard-remote-bind.test.ts
+++ b/test/e2e/live/dashboard-remote-bind.test.ts
@@ -9,6 +9,7 @@ import { sandboxAccessEnv, trustedSandboxShellScript } from "../fixtures/clients
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/paths.ts";
+import { buildDashboardRemoteBindEnv } from "./dashboard-remote-bind-env.ts";
 import { parseJsonFromText } from "./json-envelope.ts";
 
 const runDashboardRemoteBindTest =
@@ -17,16 +18,7 @@ const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME || "e2e-dashboard-remote-
 const TEST_TIMEOUT_MS = 50 * 60_000;
 
 function testEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  return {
-    ...buildAvailabilityProbeEnv(),
-    PATH: `${os.homedir()}/.local/bin:${os.homedir()}/.npm-global/bin:${process.env.PATH ?? ""}`,
-    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
-    NEMOCLAW_NON_INTERACTIVE: "1",
-    NEMOCLAW_RECREATE_SANDBOX: "1",
-    NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
-    OPENSHELL_GATEWAY: "nemoclaw",
-    ...extra,
-  };
+  return buildDashboardRemoteBindEnv(SANDBOX_NAME, extra);
 }
 
 function matchingForwardLine(output: string, sandboxName: string, dashboardPort: string): string {
@@ -208,10 +200,7 @@ runDashboardRemoteBindTest(
 
     const connect = await host.nemoclaw([sandboxName, "connect"], {
       artifactName: "dashboard-remote-bind-connect",
-      env: {
-        ...testEnv(),
-        NEMOCLAW_DASHBOARD_BIND: "0.0.0.0",
-      },
+      env: testEnv(),
       timeoutMs: 120_000,
     });
     expect(

--- a/test/e2e/live/dashboard-remote-bind.test.ts
+++ b/test/e2e/live/dashboard-remote-bind.test.ts
@@ -9,7 +9,10 @@ import { sandboxAccessEnv, trustedSandboxShellScript } from "../fixtures/clients
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/paths.ts";
-import { buildDashboardRemoteBindEnv } from "./dashboard-remote-bind-env.ts";
+import {
+  buildDashboardRemoteBindEnv,
+  dashboardRemoteBindConnectStarted,
+} from "./dashboard-remote-bind-env.ts";
 import { parseJsonFromText } from "./json-envelope.ts";
 
 const runDashboardRemoteBindTest =
@@ -51,24 +54,6 @@ function remoteHostCandidate(): string {
     .flat()
     .find((iface) => iface && iface.family === "IPv4" && !iface.internal)?.address;
   return process.env.NEMOCLAW_E2E_REMOTE_HOST || externalIpv4 || os.hostname();
-}
-
-function stripAnsi(output: string): string {
-  return output.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");
-}
-
-function connectStartedDashboardForward(
-  result: { exitCode: number | null; stdout: string; stderr: string },
-  sandboxName: string,
-  dashboardPort: string,
-): boolean {
-  const output = stripAnsi(`${result.stdout}\n${result.stderr}`);
-  return (
-    result.exitCode === 0 ||
-    (result.exitCode === null &&
-      output.includes(`Forwarding port ${dashboardPort}`) &&
-      output.includes(`sandbox ${sandboxName}`))
-  );
 }
 
 runDashboardRemoteBindTest(
@@ -204,7 +189,7 @@ runDashboardRemoteBindTest(
       timeoutMs: 120_000,
     });
     expect(
-      connectStartedDashboardForward(connect, sandboxName, dashboardPort),
+      dashboardRemoteBindConnectStarted(connect, sandboxName, dashboardPort),
       `nemoclaw connect did not complete or print background-forward proof\nstdout:\n${connect.stdout}\nstderr:\n${connect.stderr}`,
     ).toBe(true);
 

--- a/test/e2e/support/dashboard-remote-bind-env.test.ts
+++ b/test/e2e/support/dashboard-remote-bind-env.test.ts
@@ -4,7 +4,10 @@
 import { describe, expect, it } from "vitest";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { buildDashboardRemoteBindEnv } from "../live/dashboard-remote-bind-env.ts";
+import {
+  buildDashboardRemoteBindEnv,
+  dashboardRemoteBindConnectStarted,
+} from "../live/dashboard-remote-bind-env.ts";
 
 describe("dashboard remote-bind E2E environment", () => {
   it("prepares remote dashboard exposure during install and onboarding", () => {
@@ -27,5 +30,33 @@ describe("dashboard remote-bind E2E environment", () => {
     });
 
     expect(env.NEMOCLAW_DASHBOARD_BIND).toBe("0.0.0.0");
+  });
+
+  it("accepts recovery proof when connect has no numeric exit code", () => {
+    expect(
+      dashboardRemoteBindConnectStarted(
+        {
+          exitCode: null,
+          stdout: "\u001B[32m✓\u001B[0m Dashboard port forward re-established.\n",
+          stderr: "client_loop: send disconnect: Broken pipe\n",
+        },
+        "e2e-dashboard-remote-bind",
+        "18789",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a connect result with no numeric exit code and no forward proof", () => {
+    expect(
+      dashboardRemoteBindConnectStarted(
+        {
+          exitCode: null,
+          stdout: "Connecting to sandbox...\n",
+          stderr: "",
+        },
+        "e2e-dashboard-remote-bind",
+        "18789",
+      ),
+    ).toBe(false);
   });
 });

--- a/test/e2e/support/dashboard-remote-bind-env.test.ts
+++ b/test/e2e/support/dashboard-remote-bind-env.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { buildDashboardRemoteBindEnv } from "../live/dashboard-remote-bind-env.ts";
+
+describe("dashboard remote-bind E2E environment", () => {
+  it("prepares remote dashboard exposure during install and onboarding", () => {
+    const env = buildDashboardRemoteBindEnv("e2e-dashboard-remote-bind", {
+      NVIDIA_INFERENCE_API_KEY: "test-key",
+    });
+
+    expect(env).toMatchObject({
+      NEMOCLAW_DASHBOARD_BIND: "0.0.0.0",
+      NEMOCLAW_RECREATE_SANDBOX: "1",
+      NEMOCLAW_SANDBOX_NAME: "e2e-dashboard-remote-bind",
+      NVIDIA_INFERENCE_API_KEY: "test-key",
+    });
+  });
+
+  it("does not allow command overlays to disable remote exposure preparation", () => {
+    const env = buildDashboardRemoteBindEnv("e2e-dashboard-remote-bind", {
+      NEMOCLAW_DASHBOARD_BIND: "127.0.0.1",
+    });
+
+    expect(env.NEMOCLAW_DASHBOARD_BIND).toBe("0.0.0.0");
+  });
+});

--- a/test/e2e/support/dashboard-remote-bind-env.test.ts
+++ b/test/e2e/support/dashboard-remote-bind-env.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { buildDashboardRemoteBindEnv } from "../live/dashboard-remote-bind-env.ts";
 
 describe("dashboard remote-bind E2E environment", () => {
@@ -17,6 +18,7 @@ describe("dashboard remote-bind E2E environment", () => {
       NEMOCLAW_SANDBOX_NAME: "e2e-dashboard-remote-bind",
       NVIDIA_INFERENCE_API_KEY: "test-key",
     });
+    expect(env.PATH).toContain(buildAvailabilityProbeEnv().PATH);
   });
 
   it("does not allow command overlays to disable remote exposure preparation", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

PR #7632 moved dashboard remote-bind coverage into unified E2E, but the target supplied `NEMOCLAW_DASHBOARD_BIND` only when reconnecting, after install and onboarding had generated loopback-only configuration. This change enforces the remote-bind opt-in in the target command environment so onboarding prepares remote exposure before `connect`.

The first exact-head replay then reached `connect` and re-established the dashboard forward, but the test recognized only the older background-forward message. The test now accepts the current recovery proof before its existing forward-list assertions verify the actual all-interface bind.

## Changes

- Add a dashboard remote-bind environment builder that preserves the sanitized fixture `PATH` and keeps `NEMOCLAW_DASHBOARD_BIND=0.0.0.0` fixed after command overlays.
- Use the shared environment for both install/onboarding and reconnect so the generated configuration and forward request agree.
- Recognize `Dashboard port forward re-established.` as proof when `connect` has no numeric exit code; the following assertions still require an actual forward for the sandbox and port bound to `0.0.0.0`.
- Add fast E2E-support coverage for the required onboarding values, fixed remote-bind opt-in, and positive and negative connect-proof results. The helper serves only the `dashboard-remote-bind` live target; an install-only inline change would leave reconnect and future target commands free to drift.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only an internal live E2E target and its fast contract coverage; supported product behavior and user-facing configuration are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed the test-only environment boundary to confirm the all-interface bind remains confined to the explicitly opted-in `dashboard-remote-bind` target, command overlays cannot weaken it, secrets remain scoped to the install step, and no production path changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. Reviewed `test/e2e/live/dashboard-remote-bind.test.ts`, `test/e2e/live/dashboard-remote-bind-env.ts`, and `test/e2e/support/dashboard-remote-bind-env.test.ts` against the writing contract and controlled word list; final review approved with no findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6f999c436 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused E2E-support tests passed 4 tests; `npm run test:changed` passed 4 tests; Biome and `git diff --check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this target-scoped live E2E environment fix.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved remote dashboard setup so dashboard services consistently bind to all network interfaces when configured for remote access.
  - Sandbox setup now applies the selected sandbox name and supports forwarding optional inference credentials.
- **Bug Fixes**
  - Prevented command-level environment overrides from unintentionally disabling remote dashboard exposure.
- **Tests**
  - Added coverage for remote dashboard environment configuration, sandbox recreation, credential forwarding, and bind-address enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
