### PR TITLE
fix(sandbox): name the quarantined gateway relaunch and its repair

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1241,7 +1241,8 @@ Run `$$nemoclaw <name> shields down` before a Hermes config or inference change;
 
 <AgentOnly variant="openclaw,hermes">
 
-The command can fail at these layers: unsupported agent, privileged control unavailable, supervisor not running, secret-boundary refusal, unsafe config path, config hash mismatch when a strict hash is available, launch failure, health timeout, or forward recovery failure.
+The command can fail at these layers: unsupported agent, privileged control unavailable, supervisor not running, secret-boundary refusal, unsafe config path, config hash mismatch when a strict hash is available, MCP reconciliation refusal, relaunch quarantined, launch failure, health timeout, or forward recovery failure.
+`relaunch quarantined` means the in-sandbox supervisor stopped attempting relaunch after a startup refusal or repeated gateway exits, so restart and recovery report the supported repair, `$$nemoclaw <name> rebuild --yes`, instead of a retry.
 An older direct-container image without the matching supervisor or managed controller helper reports `privileged control unavailable` and requires `$$nemoclaw <name> rebuild --yes`.
 Ordinary OpenShell exec and manual in-sandbox relaunch are not fallback paths.
 Terminal agents do not have a gateway runtime and fail as unsupported.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2713,6 +2713,21 @@ The Hermes entrypoint supervisor remains responsible for the gateway, dashboard,
 In the OpenShell-managed topology, that nonroot supervisor repairs failed auxiliaries continuously, recovers a gateway after four consecutive failed listener or HTTP health checks, and quarantines relaunch after five exits within 60 seconds until the sandbox is recreated.
 The host only repairs the host-side OpenShell forwards after the supervised processes pass health checks.
 
+### Restart or recovery reports `relaunch quarantined`
+
+In the OpenShell-managed topology the strict root-owned hash is not a trust anchor for mutable config, so a direct edit of `/sandbox/.hermes/config.yaml` or `/sandbox/.hermes/.env` is not refused by the host controller.
+The in-sandbox supervisor still refuses to start a gateway on configuration it cannot match to the persisted managed state, and it stops attempting relaunch once that refusal or repeated gateway exits exhaust its crash budget.
+`$$nemoclaw <name> gateway restart`, `$$nemoclaw <name> recover`, and `$$nemoclaw <name> connect` then report the `relaunch quarantined` failure layer.
+
+The refusal is deterministic, so retrying any of those commands cannot clear it.
+Restore the registered configuration and refresh its integrity metadata in one transaction:
+
+```bash
+nemohermes <name> rebuild --yes
+```
+
+After the rebuild, make the intended change through a supported command such as `$$nemoclaw <name> config set` or `$$nemoclaw inference set`, which update the configuration and its hashes together.
+
 ### Port 8642 in a browser shows a blank page or `Cannot GET /`
 
 `nemohermes onboard` forwards port `8642`, but Hermes serves an OpenAI-compatible API at that port, not a chat dashboard.

--- a/src/lib/actions/sandbox/connect-boundary-refusal.ts
+++ b/src/lib/actions/sandbox/connect-boundary-refusal.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  type GatewayRestartFailureLayer,
+  gatewayIntegrityRepairLines,
+  isGatewayIntegrityRepairLayer,
+} from "./gateway-restart";
 import type { SecretBoundaryRefusalReason } from "./hermes-secret-boundary-recovery";
 import {
   hermesMcpReconciliationRemediationLines,
@@ -8,6 +13,25 @@ import {
 } from "./mcp-bridge-hermes-reconciliation";
 
 type ConnectBoundaryContext = "Probe" | "Connect";
+
+/**
+ * A managed recovery that failed on a deterministic integrity refusal cannot be
+ * retried: every relaunch re-reads the same drifted protected configuration.
+ * The probe path recovers quietly, so without this the operator only sees the
+ * generic "check the gateway log" and never learns the supported repair (#7801).
+ * Returns false when the layer is a retryable failure, leaving the caller's
+ * existing wedge diagnostics in charge.
+ */
+export function printGatewayIntegrityRepairGuidance(
+  sandboxName: string,
+  layer: GatewayRestartFailureLayer | null | undefined,
+): boolean {
+  if (!isGatewayIntegrityRepairLayer(layer)) return false;
+  for (const line of gatewayIntegrityRepairLines(sandboxName, layer)) {
+    console.error(`  ${line}`);
+  }
+  return true;
+}
 
 export function exitOnSecretBoundaryRefusal(
   sandboxName: string,

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -460,7 +460,10 @@ describe("connectSandbox flow", () => {
 
     await expect(harness.connectSandbox("alpha", { probeOnly: true })).resolves.toBeUndefined();
 
-    expect(harness.checkAndRecoverSpy).toHaveBeenCalledWith("alpha", { quiet: true });
+    expect(harness.checkAndRecoverSpy).toHaveBeenCalledWith(
+      "alpha",
+      expect.objectContaining({ quiet: true }),
+    );
     expect(harness.runAutoPairSpy).toHaveBeenCalledWith("alpha", expect.any(Object));
     expect(harness.spawnSyncSpy).not.toHaveBeenCalledWith(
       "openshell",
@@ -489,6 +492,30 @@ describe("connectSandbox flow", () => {
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+  it("probe-only mode reports the supported repair when relaunch is quarantined (#7801)", async () => {
+    const harness = createConnectHarness({
+      processCheck: { checked: true, wasRunning: false, recovered: false },
+    });
+    // Managed recovery runs quiet on this path, so the classified layer only
+    // reaches the operator through the callback the probe passes in.
+    harness.checkAndRecoverSpy.mockImplementation((_sandboxName: unknown, options: unknown) => {
+      (
+        options as { onRecoveryFailureLayer?: (layer: string) => void } | undefined
+      )?.onRecoveryFailureLayer?.("relaunch quarantined");
+      return { checked: true, wasRunning: false, recovered: false };
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(errorOutput).toContain("quarantined gateway relaunch");
+    expect(errorOutput).toContain("nemoclaw alpha rebuild --yes");
+    expect(errorOutput).not.toContain("Check /tmp/gateway.log inside the sandbox for details.");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
   it("probe-only mode exits when primary dashboard/API forward recovery fails", async () => {
     const harness = createConnectHarness({
       processCheck: {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -62,6 +62,7 @@ import {
 import {
   exitOnMcpReconciliationRefusal,
   exitOnSecretBoundaryRefusal,
+  printGatewayIntegrityRepairGuidance,
 } from "./connect-boundary-refusal";
 import { prepareHermesLightTerminalSkin } from "./connect-hermes-light-skin";
 import {
@@ -82,6 +83,7 @@ import { printGatewayWedgeDiagnostics } from "./gateway-wedge-diagnostics";
 import {
   checkAndRecoverSandboxProcesses,
   executeSandboxExecCommand,
+  type GatewayRestartFailureLayer,
   resolveSandboxDashboardPort,
 } from "./process-recovery";
 import { runTerminalAgentConnectProbe } from "./terminal-connect-probe";
@@ -245,7 +247,16 @@ async function runSandboxConnectProbe(sandboxName: string): Promise<void> {
     return;
   }
 
-  const processCheck = checkAndRecoverSandboxProcesses(sandboxName, { quiet: true });
+  // Managed recovery runs quiet here, so its classified failure layer is the
+  // only way this path can tell a retryable wedge apart from a deterministic
+  // integrity refusal that no restart, recover, or connect can clear (#7801).
+  let recoveryFailureLayer: GatewayRestartFailureLayer | null = null;
+  const processCheck = checkAndRecoverSandboxProcesses(sandboxName, {
+    quiet: true,
+    onRecoveryFailureLayer: (layer) => {
+      recoveryFailureLayer = layer;
+    },
+  });
   if (!processCheck.checked) {
     console.error(
       `  Probe failed: could not inspect the ${agentName} gateway inside sandbox '${sandboxName}'.`,
@@ -296,6 +307,9 @@ async function runSandboxConnectProbe(sandboxName: string): Promise<void> {
   console.error(
     `  Probe failed: ${agentName} gateway is not running in '${sandboxName}' and automatic recovery failed.`,
   );
+  if (printGatewayIntegrityRepairGuidance(sandboxName, recoveryFailureLayer)) {
+    process.exit(1);
+  }
   // Surface the #4710 wedge signature: recovery ran with quiet=true, so this
   // is the operator's only window into a gateway that served briefly and
   // then dropped its listener.

--- a/src/lib/actions/sandbox/gateway-restart-quarantine-repair.test.ts
+++ b/src/lib/actions/sandbox/gateway-restart-quarantine-repair.test.ts
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  classifyGatewayRestartFailure,
+  gatewayIntegrityRepairLines,
+  isGatewayIntegrityRepairLayer,
+  printGatewayRestartFailure,
+} from "./gateway-restart";
+
+// The exact lines the in-sandbox Hermes supervisor emits when it stops
+// attempting relaunch. `scripts/managed-gateway-control.py` allowlists these
+// before forwarding them to the host as `NEMOCLAW_START_LOG=` lines.
+const QUARANTINE_LINES = [
+  "[gateway] CRITICAL: 5 exits in 60s window — Hermes relaunch is quarantined until sandbox recreation; check /tmp/gateway.log",
+  "[SECURITY] Hermes automatic respawn is quarantined until MCP integrity is restored by rebuilding the sandbox",
+  "[gateway] CRITICAL: exact Hermes replacement could not be stopped; managed supervisor is quarantined without another launch",
+  "[CRITICAL] Unproven Hermes gateway child exited; managed supervisor remains quarantined until sandbox recreation",
+  "[CRITICAL] Newly launched Hermes gateway pid 4242 failed exact role identity capture; quarantining the managed startup supervisor without signaling the unproven child",
+] as const;
+
+// Verbatim controller output captured on a Hermes sandbox whose protected
+// `config.yaml` was edited outside a supported command, then restarted.
+const REPORTED_RESTART_OUTPUT = [
+  "GATEWAY_HEALTH_TIMEOUT",
+  "NEMOCLAW_CONTROL_STAGE=await-replacement",
+  "NEMOCLAW_SUPERVISOR_PID=42",
+  "NEMOCLAW_GATEWAY_PID=0",
+  "NEMOCLAW_START_LOG=[gateway] Hermes gateway respawned (pid 18424)",
+  "NEMOCLAW_START_LOG=[SECURITY] Hermes automatic respawn is quarantined until MCP integrity is restored by rebuilding the sandbox",
+].join("\n");
+
+function classify(stdout: string) {
+  return classifyGatewayRestartFailure({ status: 1, stdout, stderr: "" });
+}
+
+function captureStderr(run: () => void): string[] {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, "error").mockImplementation((value?: unknown) => {
+    lines.push(String(value));
+  });
+  run();
+  spy.mockRestore();
+  return lines;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("supervisor relaunch quarantine classification (#7801)", () => {
+  it.each(QUARANTINE_LINES)("classifies %s as a relaunch quarantine", (line) => {
+    expect(classify(line)).toMatchObject({ layer: "relaunch quarantined" });
+  });
+
+  it("classifies the reported restart output as a quarantine, not a health timeout", () => {
+    expect(classify(REPORTED_RESTART_OUTPUT)).toMatchObject({ layer: "relaunch quarantined" });
+  });
+
+  it("prefers the quarantine over the MCP drift it is reported through", () => {
+    const output = [
+      "HERMES_MCP_CONFIG_DRIFT",
+      "[SECURITY] Hermes automatic respawn is quarantined until MCP integrity is restored by rebuilding the sandbox",
+    ].join("\n");
+    expect(classify(output)).toMatchObject({ layer: "relaunch quarantined" });
+  });
+
+  it("keeps the pre-existing layers for output without a quarantine line", () => {
+    expect(classify("GATEWAY_HEALTH_TIMEOUT")).toMatchObject({ layer: "health timeout" });
+    expect(classify("HERMES_MCP_CONFIG_DRIFT")).toMatchObject({
+      layer: "MCP reconciliation refusal",
+    });
+    expect(classify("GATEWAY_CONFIG_HASH_MISMATCH")).toMatchObject({
+      layer: "config hash mismatch",
+    });
+    expect(classify("SUPERVISOR_NOT_RUNNING")).toMatchObject({ layer: "supervisor not running" });
+  });
+
+  it("ignores an unrelated line that merely mentions the supervisor", () => {
+    expect(classify("[gateway] Hermes gateway respawned (pid 18424)")).toMatchObject({
+      layer: "launch failure",
+    });
+  });
+});
+
+describe("integrity repair guidance (#7801)", () => {
+  it("treats both deterministic integrity refusals as repairable layers", () => {
+    expect(isGatewayIntegrityRepairLayer("relaunch quarantined")).toBe(true);
+    expect(isGatewayIntegrityRepairLayer("config hash mismatch")).toBe(true);
+    expect(isGatewayIntegrityRepairLayer("health timeout")).toBe(false);
+    expect(isGatewayIntegrityRepairLayer("launch failure")).toBe(false);
+    expect(isGatewayIntegrityRepairLayer(null)).toBe(false);
+    expect(isGatewayIntegrityRepairLayer(undefined)).toBe(false);
+  });
+
+  it.each([
+    "relaunch quarantined",
+    "config hash mismatch",
+  ] as const)("names the supported repair command for %s", (layer) => {
+    const lines = gatewayIntegrityRepairLines("repro-7801", layer).join("\n");
+    expect(lines).toContain("nemoclaw repro-7801 rebuild --yes");
+    expect(lines).toContain("Retrying the restart cannot clear it.");
+    expect(lines).toContain("nemoclaw repro-7801 config set");
+  });
+
+  it("describes the two refusals differently", () => {
+    const quarantined = gatewayIntegrityRepairLines("alpha", "relaunch quarantined")[0];
+    const drifted = gatewayIntegrityRepairLines("alpha", "config hash mismatch")[0];
+    expect(quarantined).not.toEqual(drifted);
+    expect(drifted).toContain("integrity hash");
+    expect(quarantined).toContain("quarantined");
+  });
+});
+
+describe("printGatewayRestartFailure repair guidance (#7801)", () => {
+  it("appends the repair to a quarantined restart failure", () => {
+    const lines = captureStderr(() =>
+      printGatewayRestartFailure("repro-7801", "relaunch quarantined", REPORTED_RESTART_OUTPUT),
+    ).join("\n");
+    expect(lines).toContain("Failure layer: relaunch quarantined");
+    expect(lines).toContain("nemoclaw repro-7801 rebuild --yes");
+  });
+
+  it("still prints the repair when the controller returned no detail", () => {
+    const lines = captureStderr(() =>
+      printGatewayRestartFailure("repro-7801", "config hash mismatch", ""),
+    ).join("\n");
+    expect(lines).toContain("nemoclaw repro-7801 rebuild --yes");
+  });
+
+  it("leaves retryable failure layers without a rebuild instruction", () => {
+    const timeout = captureStderr(() =>
+      printGatewayRestartFailure("repro-7801", "health timeout", "GATEWAY_HEALTH_TIMEOUT"),
+    ).join("\n");
+    const launch = captureStderr(() =>
+      printGatewayRestartFailure("repro-7801", "launch failure", "GATEWAY_FAILED"),
+    ).join("\n");
+    expect(timeout).not.toContain("rebuild --yes");
+    expect(launch).not.toContain("rebuild --yes");
+  });
+
+  it("keeps the MCP reconciliation remediation it already emitted", () => {
+    const lines = captureStderr(() =>
+      printGatewayRestartFailure("repro-7801", "MCP reconciliation refusal", "mcp-integrity"),
+    ).join("\n");
+    expect(lines).toContain("nemoclaw repro-7801 mcp restart");
+  });
+});

--- a/src/lib/actions/sandbox/gateway-restart.ts
+++ b/src/lib/actions/sandbox/gateway-restart.ts
@@ -24,6 +24,7 @@ export type GatewayRestartFailureLayer =
   | "unsafe config path"
   | "config hash mismatch"
   | "MCP reconciliation refusal"
+  | "relaunch quarantined"
   | "launch failure"
   | "health timeout"
   | "forward recovery failure";
@@ -56,6 +57,18 @@ type SandboxExec = (
 ) => GatewayRestartCommandResult | null;
 
 const GATEWAY_RESTART_SUPPORTED_AGENTS = ["openclaw", "hermes"] as const;
+
+// Substrings of the in-sandbox supervisor's quarantine lines. The supervisor
+// only forwards allowlisted lines to the host, so matching them is what tells
+// the host that no further relaunch will be attempted until the sandbox is
+// rebuilt. Keep in sync with the quarantine messages in agents/hermes/start.sh
+// and their allowlist in scripts/managed-gateway-control.py.
+const GATEWAY_RELAUNCH_QUARANTINE_MARKERS = [
+  "quarantined until sandbox recreation",
+  "quarantined until MCP integrity is restored",
+  "quarantined without another launch",
+  "quarantining the managed startup supervisor",
+] as const;
 
 export type GatewayRestartDeps = {
   getSessionAgent: typeof agentRuntime.getSessionAgent;
@@ -175,6 +188,18 @@ export function classifyGatewayRestartFailure(result: GatewayRestartCommandResul
   ) {
     return { layer: "unsafe config path", detail: detail || "unsafe config path" };
   }
+  // A quarantined supervisor is the strictly more specific and terminal fact:
+  // it stops attempting relaunch entirely, so the controller then reports the
+  // generic health timeout it would report for any unresponsive gateway, and a
+  // config refusal that tripped the crash budget is reported as MCP drift by the
+  // non-root startup guard. Classify the quarantine ahead of both so the host
+  // names the state that actually blocks recovery instead of its side effect.
+  if (GATEWAY_RELAUNCH_QUARANTINE_MARKERS.some((marker) => output.includes(marker))) {
+    return {
+      layer: "relaunch quarantined",
+      detail: detail || "the in-sandbox supervisor quarantined gateway relaunch",
+    };
+  }
   if (
     output.includes("mcp-integrity") ||
     output.includes("mcp-reconcile-required") ||
@@ -201,23 +226,60 @@ export function classifyGatewayRestartFailure(result: GatewayRestartCommandResul
   return { layer: "launch failure", detail: detail || `restart exited ${result.status}` };
 }
 
+export function isGatewayIntegrityRepairLayer(
+  layer: GatewayRestartFailureLayer | null | undefined,
+): layer is "config hash mismatch" | "relaunch quarantined" {
+  return layer === "config hash mismatch" || layer === "relaunch quarantined";
+}
+
+/**
+ * The supported repair for a sandbox whose protected configuration drifted away
+ * from its recorded integrity metadata. Both layers are deterministic refusals:
+ * every relaunch re-reads the same drifted file, so retrying a restart or a
+ * recover only burns the supervisor's crash budget. `rebuild` is the documented
+ * command that restores the registered configuration, refreshes the integrity
+ * hashes, and brings the gateway back in one transaction (#7801).
+ */
+export function gatewayIntegrityRepairLines(
+  sandboxName: string,
+  layer: "config hash mismatch" | "relaunch quarantined",
+): readonly string[] {
+  const cause =
+    layer === "config hash mismatch"
+      ? "A protected configuration file no longer matches its recorded integrity hash."
+      : "The in-sandbox supervisor quarantined gateway relaunch after a startup refusal.";
+  return [
+    `${cause} Retrying the restart cannot clear it.`,
+    `Restore the registered configuration and refresh its integrity metadata with \`nemoclaw ${sandboxName} rebuild --yes\`.`,
+    `Then make intended changes through supported commands such as \`nemoclaw ${sandboxName} config set\` or \`nemoclaw inference set --sandbox ${sandboxName}\`, which update the configuration and its hashes together.`,
+  ];
+}
+
 export function printGatewayRestartFailure(
   sandboxName: string,
   layer: GatewayRestartFailureLayer,
   detail: string,
 ): void {
   console.error(`  Failure layer: ${layer} - gateway restart failed for '${sandboxName}'.`);
-  if (!detail.trim()) return;
-  const lines = detail
-    .split(/\r?\n/)
-    .map((line) => sanitizeGatewayRestartFailureLine(line.trim()))
-    .filter(Boolean)
-    .slice(-12);
-  for (const line of lines) {
-    console.error(`  ${line}`);
+  if (detail.trim()) {
+    const lines = detail
+      .split(/\r?\n/)
+      .map((line) => sanitizeGatewayRestartFailureLine(line.trim()))
+      .filter(Boolean)
+      .slice(-12);
+    for (const line of lines) {
+      console.error(`  ${line}`);
+    }
   }
+  // Remediation is emitted outside the detail guard: an empty controller detail
+  // is exactly the case where the operator has nothing else to go on.
   if (layer === "MCP reconciliation refusal") {
     for (const line of hermesMcpReconciliationRemediationLines(sandboxName)) {
+      console.error(`  ${line}`);
+    }
+  }
+  if (isGatewayIntegrityRepairLayer(layer)) {
+    for (const line of gatewayIntegrityRepairLines(sandboxName, layer)) {
       console.error(`  ${line}`);
     }
   }

--- a/src/lib/actions/sandbox/mcp-bridge-adapter-hermes.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-adapter-hermes.ts
@@ -188,6 +188,7 @@ export function assertHermesMcpMutationRuntimeCapability(sandboxName: string): v
       classification.layer === "secret-boundary refusal" ||
       classification.layer === "unsafe config path" ||
       classification.layer === "config hash mismatch" ||
+      classification.layer === "relaunch quarantined" ||
       classification.layer === "health timeout" ||
       recoveryFailureDetail.includes("SUPERVISOR_REBUILD_REQUIRED") ||
       recoveryFailureDetail.includes("SUPERVISOR_UNSAFE_CONTROL_DIR") ||

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -39,6 +39,8 @@ import {
   type GatewayRestartDeps,
   type GatewayRestartFailureLayer,
   type GatewayRestartResult,
+  gatewayIntegrityRepairLines,
+  isGatewayIntegrityRepairLayer,
   printGatewayRestartFailure,
   type RestartSandboxGatewayOptions,
   restartSandboxGatewayWithDeps,
@@ -851,6 +853,15 @@ function printHostManagedGatewayRecoveryHints(
     console.error("  If rebuild is blocked, destroy and re-onboard the sandbox to restore it.");
     return;
   }
+  // A drifted protected config and a quarantined supervisor both refuse every
+  // relaunch deterministically, so the generic "retry the managed restart" hint
+  // below would send the operator into a loop that cannot succeed (#7801).
+  if (isGatewayIntegrityRepairLayer(failureLayer)) {
+    for (const line of gatewayIntegrityRepairLines(quotedSandboxName, failureLayer)) {
+      console.error(`  ${line}`);
+    }
+    return;
+  }
   let agentName = agent?.name ?? null;
   if (!agentName) {
     try {
@@ -1024,6 +1035,10 @@ function isHermesAgent(
  * host-side dashboard port-forward when it has gone dead independently
  * of the gateway. Returns an object describing the outcome:
  * `{ checked, wasRunning, recovered, forwardRecovered, forwardRecoveryFailed?, secretBoundaryRefused?, secretBoundaryReason? }`.
+ * `onRecoveryFailureLayer` reports the classified managed-restart failure so a
+ * quiet caller (`recover`, `connect --probe-only`) can still explain why
+ * recovery is not retryable instead of printing a generic "check the gateway
+ * log". The result shape is unchanged so existing callers keep their contract.
  */
 function checkAndRecoverSandboxProcessesWithoutHostLock(
   sandboxName: string,
@@ -1035,6 +1050,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     isSandboxGatewayRunningImpl = isSandboxGatewayRunning,
     waitForRecreatedSandboxOpenShellReadyImpl = waitForRecreatedSandboxOpenShellReady,
     isWsl: isWslOverride,
+    onRecoveryFailureLayer,
   }: {
     quiet?: boolean;
     requestGatewaySupervisorAction?: typeof executeGatewaySupervisorAction;
@@ -1043,6 +1059,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     isSandboxGatewayRunningImpl?: typeof isSandboxGatewayRunning;
     waitForRecreatedSandboxOpenShellReadyImpl?: typeof waitForRecreatedSandboxOpenShellReady;
     isWsl?: boolean;
+    onRecoveryFailureLayer?: (layer: GatewayRestartFailureLayer | null) => void;
   } = {},
 ) {
   const recoveryAgent = agentRuntime.getSessionAgent(sandboxName);
@@ -1297,6 +1314,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
           managedRecoveryFailureLayer,
         );
       }
+      onRecoveryFailureLayer?.(managedRecoveryFailureLayer);
       return { checked: true, wasRunning: false, recovered: false, forwardRecovered: false };
     }
     if (relaunch) {
@@ -1419,6 +1437,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     printHostManagedGatewayRecoveryHints(sandboxName, recoveryAgent, managedRecoveryFailureLayer);
   }
 
+  onRecoveryFailureLayer?.(managedRecoveryFailureLayer);
   return { checked: true, wasRunning: false, recovered: false, forwardRecovered: false };
 }
 
@@ -1432,6 +1451,7 @@ export function checkAndRecoverSandboxProcesses(
     isSandboxGatewayRunningImpl?: typeof isSandboxGatewayRunning;
     waitForRecreatedSandboxOpenShellReadyImpl?: typeof waitForRecreatedSandboxOpenShellReady;
     isWsl?: boolean;
+    onRecoveryFailureLayer?: (layer: GatewayRestartFailureLayer | null) => void;
   } = {},
 ) {
   return withTimerBoundShieldsMutationLock(sandboxName, "gateway process recovery", () =>


### PR DESCRIPTION
> **Supersedes #7816.** That branch could not be rewritten (the `No force push` ruleset
> covers every branch except `main`), so this is a fresh branch carrying the same change as
> a single GitHub-Verified commit, rebased onto current `main`. #7816 had 68/68 CI green;
> the only differences here are the signed history, the rebase, and the three commits
> squashed into one.

<!-- markdownlint-disable MD041 -->
## Summary
An unsupported edit of a protected Hermes configuration file leaves the sandbox
in a state the CLI never names: the in-sandbox supervisor refuses every gateway
start and quarantines relaunch, but `gateway restart` reports the generic
`health timeout` layer and `recover` prints only "check /tmp/gateway.log". This
PR classifies the quarantine as its own failure layer and makes all three
restart/recovery surfaces print the supported repair command.

Closes #7801.

## Reproduction
Run on our Ubuntu 24.04 x86_64 test host (no GPU), against a Hermes sandbox
onboarded from `main` in this run:

```bash
# 1. healthy Hermes sandbox with protected configuration integrity in effect
nemoclaw <name> gateway restart          # exit 0, gateway healthy

# 2. modify a protected Hermes configuration file outside a supported command
#    (as the ordinary sandbox user, the same shape as the shipped
#    phase-5 Hermes e2e drift step)
printf '\n# unsupported manual edit\n' >> /sandbox/.hermes/config.yaml

# 3. restart / recover the gateway
nemoclaw <name> gateway restart
nemoclaw <name> recover
```

**Environment**
- Test machine: our Ubuntu 24.04 x86_64 test host (no GPU)
- Linux 6.14 x86_64, Node v22.22.2, Docker 28.2.2, OpenShell 0.0.85
- NemoClaw `main` HEAD `eeab81cc5542902538c97db63c132c0fdbd4341c` at repro time; this branch is rebased onto `376beb50b`
- Sandbox: Hermes Agent v0.18.0, provider `ollama-local`, model `llama3.1:8b`
- The reporter is on the direct root-entrypoint topology (strict hash always
  enforced); this repro is the OpenShell-managed topology, where the same
  in-sandbox refusal arrives through the non-root startup guard. Both end in
  the same quarantined supervisor.

**Observed on `main` (before fix)**

`nemoclaw <name> gateway restart` — exit 1:

```
  Restarting Hermes Agent gateway in '<name>'...
  Failure layer: health timeout - gateway restart failed for '<name>'.
  GATEWAY_HEALTH_TIMEOUT
  NEMOCLAW_CONTROL_STAGE=await-replacement
  NEMOCLAW_SUPERVISOR_PID=42
  NEMOCLAW_GATEWAY_PID=0
  NEMOCLAW_START_LOG=[gateway] Hermes gateway respawned (pid 18424)
  NEMOCLAW_START_LOG=[SECURITY] Hermes automatic respawn is quarantined until MCP integrity is restored by rebuilding the sandbox
```

`nemoclaw <name> recover` — exit 1:

```
  Probe failed: Hermes Agent gateway is not running in '<name>' and automatic recovery failed.
  Check /tmp/gateway.log inside the sandbox for details.
```

The gateway did not time out — it was refused and the supervisor stopped
relaunching. The only surviving signal is a raw forwarded log line that
attributes the refusal to MCP integrity, and neither command names a repair.

**Observed on `fix/...` (after fix)**

`nemoclaw <name> gateway restart` — exit 1:

```
  Restarting Hermes Agent gateway in '<name>'...
  Failure layer: relaunch quarantined - gateway restart failed for '<name>'.
  GATEWAY_HEALTH_TIMEOUT
  NEMOCLAW_CONTROL_STAGE=await-replacement
  NEMOCLAW_SUPERVISOR_PID=42
  NEMOCLAW_GATEWAY_PID=0
  NEMOCLAW_START_LOG=[gateway] Hermes gateway respawned (pid 19396)
  NEMOCLAW_START_LOG=[SECURITY] Hermes automatic respawn is quarantined until MCP integrity is restored by rebuilding the sandbox
  The in-sandbox supervisor quarantined gateway relaunch after a startup refusal. Retrying the restart cannot clear it.
  Restore the registered configuration and refresh its integrity metadata with `nemoclaw <name> rebuild --yes`.
  Then make intended changes through supported commands such as `nemoclaw <name> config set` or `nemoclaw inference set --sandbox <name>`, which update the configuration and its hashes together.
```

`nemoclaw <name> recover` — exit 1:

```
  Probe failed: Hermes Agent gateway is not running in '<name>' and automatic recovery failed.
  The in-sandbox supervisor quarantined gateway relaunch after a startup refusal. Retrying the restart cannot clear it.
  Restore the registered configuration and refresh its integrity metadata with `nemoclaw <name> rebuild --yes`.
  Then make intended changes through supported commands such as `nemoclaw <name> config set` or `nemoclaw inference set --sandbox <name>`, which update the configuration and its hashes together.
```

The advertised repair was then executed end to end on the same sandbox to
confirm it is not just plausible advice:

```
nemoclaw <name> rebuild --yes            # exit 0
grep -c 'unsupported manual edit' /sandbox/.hermes/config.yaml   # 0 (drift gone)
nemoclaw <name> gateway restart          # exit 0, health passed
nemoclaw <name> recover                  # exit 0, probe complete
```

## Analysis
`classifyGatewayRestartFailure` in `src/lib/actions/sandbox/gateway-restart.ts`
matched `GATEWAY_HEALTH_TIMEOUT` and stopped there. That marker is what the
managed controller emits whenever no replacement gateway appears within the
await-replacement stage, including when the supervisor deliberately stopped
launching one. In the OpenShell-managed topology, `prepare_hermes_nonroot_runtime`
in `agents/hermes/start.sh` reaches the drifted config through
`inspect_hermes_mcp_integrity`, so the refusal is reported as MCP drift, and
`recover_hermes_gateway_current_user` then calls
`quarantine_hermes_managed_gateway_relaunch`. The quarantine lines are
allowlisted for forwarding by `scripts/managed-gateway-control.py`, so the host
already receives the decisive evidence — it just never classified it.

Two consequences followed. `printGatewayRestartFailure` printed the layer plus
raw detail with no remediation (only the `MCP reconciliation refusal` layer had
any), and `printHostManagedGatewayRecoveryHints` in `process-recovery.ts` fell
into its generic branch, which tells the operator to retry
`nemoclaw <name> gateway restart` — a retry that re-reads the same drifted file
and cannot succeed. On the `recover` path the situation was worse: managed
recovery runs with `quiet: true`, so `runSandboxConnectProbe` in `connect.ts`
discarded the classified layer entirely and fell through to the generic
"check /tmp/gateway.log" wedge message.

## Fix
- New `relaunch quarantined` failure layer, matched on the four quarantine
  phrases the Hermes supervisor emits. It is classified **before** the MCP-drift
  and health-timeout branches because a quarantine is the strictly more specific
  and terminal fact: those two layers are how the quarantine surfaces, not what
  it is. Output without a quarantine line keeps its previous layer.
- `gatewayIntegrityRepairLines()` is the single source of the repair text,
  shared by the new layer and the pre-existing `config hash mismatch` layer.
  Both are deterministic refusals of the same protected-configuration contract,
  and `rebuild --yes` is the documented command that restores the registered
  configuration, refreshes the integrity hashes, and returns the gateway in one
  transaction.
- `printGatewayRestartFailure` emits it. The remediation block moved outside the
  empty-detail early return, so a controller result with no detail — exactly the
  case where the operator has nothing else — still gets the repair. This also
  makes the existing MCP remediation reachable on empty detail.
- `printHostManagedGatewayRecoveryHints` returns early for both layers instead
  of advising a retry that cannot succeed.
- `checkAndRecoverSandboxProcesses` now returns `recoveryFailureLayer` on its two
  terminal failure paths, and `printGatewayIntegrityRepairGuidance` (added next
  to the sibling `exitOnSecretBoundaryRefusal` / `exitOnMcpReconciliationRefusal`
  helpers) lets the quiet probe path behind `recover` report it. It returns
  `false` for retryable layers, so the `#4710` wedge diagnostics stay in charge
  of everything else.
- `mcp-bridge-adapter-hermes.ts` counts the new layer as a terminal integrity
  failure, so an MCP mutation against a quarantined sandbox still fails closed
  rather than falling through to the retry path.

No classification is weakened and no refusal is relaxed: the managed controller
still declines to treat a mutable compatibility hash as a trust anchor, which
is the intentional behavior documented in
`docs/manage-sandboxes/gateway-lifecycle-control.mdx`. The change is diagnostic
only — the same commands still fail with the same exit codes.

**Whole-class review of the `GatewayRestartFailureLayer` consumers**

| Site | Disposition |
| --- | --- |
| `gateway-restart.ts` `printGatewayRestartFailure` | fixed |
| `process-recovery.ts` `printHostManagedGatewayRecoveryHints` | fixed |
| `connect.ts` `runSandboxConnectProbe` terminal branch (`recover`, `connect --probe-only`) | fixed |
| `mcp-bridge-adapter-hermes.ts` `terminalIntegrityFailure` | fixed |
| `inference-set-gateway-restart.ts` | not affected — uses the layer as an audit string, and its retry message is layer-independent |
| `status-preflight.ts` / `status-snapshot.ts` | not affected — different `SandboxStatusFailureLayer` union with its own classifier; never sees restart output |
| `adapters/openshell/restore-gateway-pairing.ts` | not affected — unrelated `RestoreGatewayPairingFailureLayer` union |
| `doctor` | not changed — its serving-process check is documented as not implemented (`[info] Serving process: not checked`), so gateway-process health in `doctor` is a separate feature rather than a regression introduced here |

**Tests added** (`gateway-restart-quarantine-repair.test.ts`) pin: every
quarantine line the supervisor can emit; the verbatim controller output captured
above classifying as a quarantine rather than a health timeout; quarantine
winning over a co-occurring MCP-drift marker; the regression lock that
health-timeout, MCP-drift, config-hash and supervisor-not-running output without
a quarantine line keep their existing layers; the repair text naming
`rebuild --yes` for both integrity layers; the repair surviving an empty
controller detail; retryable layers still getting no rebuild instruction; the
MCP remediation still emitted; and a contract check that the matched marker
substrings still exist verbatim in `agents/hermes/start.sh` and its forwarding
allowlist in `scripts/managed-gateway-control.py`.

## Changes
- `src/lib/actions/sandbox/gateway-restart.ts`: new `relaunch quarantined` layer, quarantine markers, shared repair lines, repair emitted outside the empty-detail guard
- `src/lib/actions/sandbox/process-recovery.ts`: repair branch in the recovery hints; `recoveryFailureLayer` returned from the terminal failure paths
- `src/lib/actions/sandbox/connect-boundary-refusal.ts`: `printGatewayIntegrityRepairGuidance` next to the sibling refusal helpers
- `src/lib/actions/sandbox/connect.ts`: `recover` / probe path reports the repair instead of the generic gateway-log message
- `src/lib/actions/sandbox/mcp-bridge-adapter-hermes.ts`: new layer treated as a terminal integrity failure
- `src/lib/actions/sandbox/gateway-restart-quarantine-repair.test.ts`: new regression tests
- `docs/reference/commands.mdx`: failure-layer list updated with the new layer
- `docs/reference/troubleshooting.mdx`: new `relaunch quarantined` section with the repair

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes (touched files at minimum)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of gateway relaunch quarantine failures during restart, recovery, and connection checks.
  - Displays clear repair guidance instead of suggesting repeated retries when recovery is deterministically blocked.
  - Recommends rebuilding the sandbox to restore managed configuration integrity.
  - Prevents MCP configuration changes when the gateway is in a terminal integrity failure state.

- **Documentation**
  - Added troubleshooting guidance for `relaunch quarantined` failures.
  - Clarified when to use rebuild and how to apply future configuration changes safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->