### PR TITLE
fix(readiness): classify a symlinked Station release marker as unsupported

### DIFF
--- a/src/lib/readiness/platform-qualification.test.ts
+++ b/src/lib/readiness/platform-qualification.test.ts
@@ -8,7 +8,11 @@ import {
   type PlatformQualificationInput,
   projectPlatformQualification,
 } from "./platform-qualification";
-import { isStationGb300PciDevice, isStationGb300ProductName } from "./station-qualification";
+import {
+  isStationGb300PciDevice,
+  isStationGb300ProductName,
+  STATION_RELEASE_MARKER_MAX_BYTES,
+} from "./station-qualification";
 
 function input(overrides: Partial<PlatformQualificationInput> = {}): PlatformQualificationInput {
   return {
@@ -408,6 +412,24 @@ describe("platform readiness qualification (#7410)", () => {
     ).toMatchObject({
       stationProfile: "unsupported-dgx-os",
     });
+  });
+
+  it("classifies an oversized DGX Station release marker as unqualified (#7877)", () => {
+    const identity = collectStationIdentity(
+      noOtaStationRelease(),
+      trustedMarkerStat({ size: STATION_RELEASE_MARKER_MAX_BYTES + 1 }),
+    );
+    const result = projectPlatformQualification(
+      input({
+        architecture: "arm64",
+        hasNvidiaGpu: true,
+        ...identity,
+      }),
+    );
+
+    expect(identity.stationProfile).toBe("unsupported-dgx-os");
+    expect(qualification(result, "host.platform.dgx_station")).toBe("unqualified");
+    expect(result.findings.map(({ id }) => id)).toContain("host.platform.dgx_station_unqualified");
   });
 
   it.each([

--- a/src/lib/readiness/platform-qualification.test.ts
+++ b/src/lib/readiness/platform-qualification.test.ts
@@ -410,6 +410,28 @@ describe("platform readiness qualification (#7410)", () => {
     });
   });
 
+  it.each([
+    ["a symbolic link", "ELOOP"],
+    ["a symbolic link rejected as a link count", "EMLINK"],
+  ] as const)("rejects %s Station marker as an unsupported release", (_scenario, code) => {
+    expect(
+      collectPlatformIdentity({
+        productNamePath: "/fixtures/product_name",
+        osReleasePath: "/fixtures/os-release",
+        stationReleasePath: "/fixtures/dgx-release",
+        pciDevicesPath: "/fixtures/pci",
+        readFile: stationFixtureReadFile,
+        readdir: () => ["0000:01:00.0"],
+        openFile: () => {
+          throw Object.assign(new Error("marker is a symbolic link"), { code });
+        },
+        statFileDescriptor: () => trustedMarkerStat(),
+        readFileDescriptor: () => noOtaStationRelease(),
+        closeFileDescriptor: () => undefined,
+      }),
+    ).toMatchObject({ stationProfile: "unsupported-dgx-os" });
+  });
+
   it("collects only bounded identity reads and never invokes host preparation", () => {
     const readFile = vi.fn(stationFixtureReadFile);
     const readdir = vi.fn(() => ["0000:01:00.0"]);

--- a/src/lib/readiness/platform-qualification.ts
+++ b/src/lib/readiness/platform-qualification.ts
@@ -261,7 +261,12 @@ export function collectPlatformIdentity(
       closeFileDescriptor(fileDescriptor);
     }
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") stationProfile = "unknown";
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ELOOP" || code === "EMLINK") {
+      stationProfile = "unsupported-dgx-os";
+    } else if (code !== "ENOENT") {
+      stationProfile = "unknown";
+    }
   }
   return {
     nvidiaPlatform,

--- a/test/host-readiness-station-release-marker.test.ts
+++ b/test/host-readiness-station-release-marker.test.ts
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { assessHost } from "../src/lib/onboard/preflight";
+import { createHostReadinessReport } from "../src/lib/readiness/host";
+
+const NOW = new Date("2026-07-30T12:00:00Z");
+const DOCKER_INFO = JSON.stringify({
+  CgroupVersion: "2",
+  Driver: "overlay2",
+  DriverStatus: [],
+  NCPU: 8,
+  MemTotal: 16 * 1024 ** 3,
+  OperatingSystem: "Docker Engine",
+});
+const COMMAND_OUTPUTS: Record<string, string> = {
+  'sh -c command -v "$1" -- docker': "/usr/bin/docker",
+  'sh -c command -v "$1" -- node': "/usr/bin/node",
+  'sh -c command -v "$1" -- openshell': "/usr/bin/openshell",
+  'sh -c command -v "$1" -- nvidia-ctk': "/usr/bin/nvidia-ctk",
+  'sh -c command -v "$1" -- apt-get': "/usr/bin/apt-get",
+  'sh -c command -v "$1" -- dnf': "",
+  'sh -c command -v "$1" -- yum': "",
+  'sh -c command -v "$1" -- brew': "",
+  'sh -c command -v "$1" -- pacman': "",
+  'sh -c command -v "$1" -- systemctl': "/usr/bin/systemctl",
+  "docker info --format {{json .}}": DOCKER_INFO,
+  "systemctl is-active docker": "active",
+  "systemctl is-enabled docker": "enabled",
+};
+const HOST_FILE_CONTENTS: Record<string, string> = {
+  "/proc/version": "Linux version 6.8",
+  "/etc/docker/daemon.json": "{}",
+};
+const STATION_RELEASE = [
+  'DGX_NAME="DGX GB300WS"',
+  'DGX_PRETTY_NAME="NVIDIA DGX GB300WS"',
+  'DGX_SWBUILD_DATE="2026-07-14-13-59-06"',
+  'DGX_SWBUILD_VERSION="7.6.0"',
+  'DGX_COMMIT_ID="d0e99cc"',
+  'DGX_PLATFORM="DGX Server for GALAXY-GB300"',
+].join("\n");
+
+const fixtures: string[] = [];
+
+function createStationFixture(marker: "regular-file" | "symbolic-link"): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-marker-"));
+  fixtures.push(root);
+  const device = path.join(root, "pci", "0000:01:00.0");
+  fs.mkdirSync(device, { recursive: true });
+  fs.writeFileSync(path.join(root, "product_name"), "NVIDIA DGX Station GB300\n");
+  fs.writeFileSync(path.join(root, "os-release"), 'ID=ubuntu\nVERSION_ID="24.04"\n');
+  fs.writeFileSync(path.join(device, "vendor"), "0x10de\n");
+  fs.writeFileSync(path.join(device, "device"), "0x31c2\n");
+  fs.writeFileSync(path.join(device, "class"), "0x030000\n");
+  const target = path.join(root, "dgx-release-target");
+  fs.writeFileSync(target, STATION_RELEASE);
+  const publish = {
+    "regular-file": () => fs.copyFileSync(target, path.join(root, "dgx-release")),
+    "symbolic-link": () => fs.symlinkSync(target, path.join(root, "dgx-release")),
+  };
+  publish[marker]();
+  return root;
+}
+
+function reportForStationHost(root: string) {
+  return createHostReadinessReport(
+    { nemoclawVersion: "0.0.0-test", now: () => NOW },
+    {
+      architecture: "arm64",
+      assess: () =>
+        assessHost({
+          platform: "linux",
+          gpuProbeImpl: () => true,
+          readFileImpl: (filePath: string) => HOST_FILE_CONTENTS[String(filePath)] ?? "",
+          readdirImpl: () => [],
+          runCaptureImpl: (command: readonly string[]) => COMMAND_OUTPUTS[command.join(" ")] ?? "",
+        }),
+      detectHostGpuPlatform: () => "station",
+      platformIdentityOptions: {
+        productNamePath: path.join(root, "product_name"),
+        osReleasePath: path.join(root, "os-release"),
+        stationReleasePath: path.join(root, "dgx-release"),
+        pciDevicesPath: path.join(root, "pci"),
+        statFileDescriptor: () => ({
+          isFile: () => true,
+          isSymbolicLink: () => false,
+          size: Buffer.byteLength(STATION_RELEASE),
+          uid: 0,
+          gid: 0,
+          mode: 0o100644,
+        }),
+      },
+      now: () => NOW,
+    },
+  );
+}
+
+function stationQualification(report: ReturnType<typeof createHostReadinessReport>) {
+  return report.qualifications.find(({ id }) => id === "host.platform.dgx_station")?.status;
+}
+
+function stationCapability(report: ReturnType<typeof createHostReadinessReport>) {
+  return report.capabilities.find(({ id }) => id === "host.platform.dgx_station")?.state;
+}
+
+afterEach(() => {
+  fixtures.splice(0).forEach((root) => fs.rmSync(root, { recursive: true, force: true }));
+});
+
+describe("DGX Station release marker readiness", () => {
+  it("reports a symlinked marker as an unqualified Station", () => {
+    const report = reportForStationHost(createStationFixture("symbolic-link"));
+    const findings = report.findings.map(({ id }) => id);
+
+    expect(stationQualification(report)).toBe("unqualified");
+    expect(stationCapability(report)).toBe("absent");
+    expect(findings).toContain("host.platform.dgx_station_unqualified");
+    expect(findings).not.toContain("host.platform.dgx_station_inconclusive");
+    expect(report.exitCode).toBe(2);
+  });
+
+  it("reports the same marker content in a trusted regular file as a qualified Station", () => {
+    const report = reportForStationHost(createStationFixture("regular-file"));
+    const findings = report.findings.map(({ id }) => id);
+
+    expect(stationQualification(report)).toBe("qualified");
+    expect(stationCapability(report)).toBe("present");
+    expect(findings).not.toContain("host.platform.dgx_station_unqualified");
+    expect(findings).not.toContain("host.platform.dgx_station_inconclusive");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->
NemoClaw opens `/etc/dgx-release` with `O_NOFOLLOW`, so a symlinked marker fails at `open()` with `ELOOP` and previously fell through the generic error path to the `unknown` Station profile, reporting `host.platform.dgx_station_inconclusive`. The four remaining marker constraints, which are checked after `open()` succeeds, all report `host.platform.dgx_station_unqualified`. A symlinked marker now takes the same classification as those constraints, so every rejected marker produces one qualification result.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Closes #7877

## Changes
- `src/lib/readiness/platform-qualification.ts`: classify an `ELOOP` or `EMLINK` failure from the `O_NOFOLLOW` marker open as the `unsupported-dgx-os` profile. Every other error still resolves to `unknown`, and a missing marker still resolves to `generic-ubuntu`. `EMLINK` is included because BSD-family kernels report an `O_NOFOLLOW` refusal with that code; `src/lib/policy/index.ts` already pairs the two codes for the same open pattern.
- The reported issue asks for the opposite direction, treating an oversized marker as inconclusive. `docs/reference/system-readiness.mdx` states that invalid marker metadata yields `unqualified` and that only an unreadable marker yields `unknown`, `src/lib/readiness/platform-qualification.test.ts` pins that rule for the owner and permission constraints, and `scripts/prepare-dgx-station-host.sh` classifies every rejected marker, symlink included, as `unsupported-dgx-os`. The symlink path was the only case that departed from that rule, so this change moves the code to the documented contract instead of changing the contract.
- `test/host-readiness-station-release-marker.test.ts`: new tests build a fixture tree with a real symlinked marker, run the full readiness report, and assert the Station qualification, capability, findings, and exit code. A paired case publishes the same marker content as a regular file and expects a qualified Station.
- `src/lib/readiness/platform-qualification.test.ts`: tests pin both open failure codes at the identity-collection boundary because the `EMLINK` code has no reachable filesystem vantage on Linux. The same source suite pins a marker of 4,097 bytes as unsupported and projects it to the `unqualified` finding.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `docs/reference/system-readiness.mdx` already documents invalid marker metadata as an `unqualified` qualification and an unreadable marker as an `unknown` qualification, and `docs/get-started/dgx-station-preparation.mdx` already lists the non-symlink requirement, so the existing text describes the behavior after this change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation update is required because this test-only change protects the documented 4,096-byte DGX Station release-marker classification without changing behavior. The exact-head review found no changed-text findings, and `npx vitest run --project cli src/lib/readiness/platform-qualification.test.ts` passed 55 tests.
- Agent: Codex Desktop
<!-- docs-review-head-sha: c4d9c3b48 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/readiness/platform-qualification.test.ts` — 55 passed on `c4d9c3b48`. `npx vitest run --project integration test/host-readiness-station-release-marker.test.ts` — 2 passed; with the classification reverted the symlink test fails with `expected 'unknown' to be 'unqualified'`. `npx vitest run --project cli src/lib/readiness src/commands/host` — 117 passed. `npx vitest run --project installer-integration test/install-station-dgx-os.test.ts test/install-station-platform-identity.test.ts test/install-station-package-state.test.ts` — 171 passed. `npx vitest run --project integration test/onboard-readiness.test.ts test/install-express-prompt.test.ts` — 60 passed. `npm run typecheck:cli`, `npx biome check`, and `npm run checks:repository` are clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DGX Station readiness detection when the Station release marker is a symbolic link or encounters path-loop/symlink errors.
  * Now reports “unsupported DGX OS” (unqualified) when marker size exceeds the trusted maximum, instead of falling back to an unknown status.
  * Verified that regular (non-symlink) release markers continue to be treated as qualified/present.

* **Tests**
  * Added/extended coverage for DGX Station release marker readiness, including symlink, error-code scenarios, and size boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

