### PR TITLE
test(readiness): cover DGX Station marker classifications

### DIFF
--- a/src/lib/readiness/platform-qualification.test.ts
+++ b/src/lib/readiness/platform-qualification.test.ts
@@ -8,7 +8,11 @@ import {
   type PlatformQualificationInput,
   projectPlatformQualification,
 } from "./platform-qualification";
-import { isStationGb300PciDevice, isStationGb300ProductName } from "./station-qualification";
+import {
+  isStationGb300PciDevice,
+  isStationGb300ProductName,
+  STATION_RELEASE_MARKER_MAX_BYTES,
+} from "./station-qualification";
 
 function input(overrides: Partial<PlatformQualificationInput> = {}): PlatformQualificationInput {
   return {
@@ -408,6 +412,52 @@ describe("platform readiness qualification (#7410)", () => {
     ).toMatchObject({
       stationProfile: "unsupported-dgx-os",
     });
+  });
+
+  it("classifies an oversized DGX Station release marker as unqualified (#7877)", () => {
+    const identity = collectStationIdentity(
+      noOtaStationRelease(),
+      trustedMarkerStat({ size: STATION_RELEASE_MARKER_MAX_BYTES + 1 }),
+    );
+    const result = projectPlatformQualification(
+      input({
+        architecture: "arm64",
+        hasNvidiaGpu: true,
+        ...identity,
+      }),
+    );
+
+    expect(identity.stationProfile).toBe("unsupported-dgx-os");
+    expect(qualification(result, "host.platform.dgx_station")).toBe("unqualified");
+    expect(result.findings.map(({ id }) => id)).toContain("host.platform.dgx_station_unqualified");
+  });
+
+  it("classifies an unopenable DGX Station release marker as inconclusive (#7877)", () => {
+    const identity = collectPlatformIdentity({
+      productNamePath: "/fixtures/product_name",
+      osReleasePath: "/fixtures/os-release",
+      stationReleasePath: "/fixtures/dgx-release",
+      pciDevicesPath: "/fixtures/pci",
+      readFile: stationFixtureReadFile,
+      readdir: () => ["0000:01:00.0"],
+      openFile: () => {
+        throw Object.assign(new Error("release marker is a symbolic link"), { code: "ELOOP" });
+      },
+      statFileDescriptor: () => trustedMarkerStat(),
+      readFileDescriptor: () => noOtaStationRelease(),
+      closeFileDescriptor: () => undefined,
+    });
+    const result = projectPlatformQualification(
+      input({
+        architecture: "arm64",
+        hasNvidiaGpu: true,
+        ...identity,
+      }),
+    );
+
+    expect(identity.stationProfile).toBe("unknown");
+    expect(qualification(result, "host.platform.dgx_station")).toBe("unknown");
+    expect(result.findings.map(({ id }) => id)).toContain("host.platform.dgx_station_inconclusive");
   });
 
   it("collects only bounded identity reads and never invokes host preparation", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add regression coverage for the DGX Station marker classification contract introduced by #7445.
The tests distinguish invalid marker metadata from evidence collection failures without changing
runtime behavior.

## Related Issue

Refs #7877
Follow-up to #7445

## Changes

- Assert that a marker larger than the 4,096-byte limit produces the unqualified Station finding.
- Assert that an `ELOOP` marker open failure produces the inconclusive Station finding.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This test-only change locks existing documented behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change updates one source test and does not change a public API, CLI, configuration,
  workflow, default, error, or supported behavior. Existing system-readiness documentation already
  states that invalid marker metadata is unqualified and unreadable evidence is inconclusive.
- Agent: Codex Desktop (`/root/documentation_writer_review`)
<!-- docs-review-head-sha: 4a775c394 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/readiness/platform-qualification.test.ts` passed 54/54.
- [ ] Applicable broad gate passed — not applicable; this PR changes one focused source test and no runtime or test-harness code.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for DGX Station release marker qualification.
  * Verified oversized markers are reported as **unqualified**.
  * Verified inaccessible markers are reported as **inconclusive/unknown**, with the expected findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->