### PR TITLE
fix(sandbox): preserve name in host-side hints

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -3873,10 +3873,11 @@ openclaw() {
 # denial-time curl/git/wget error itself denial-adjacent — that is intentional,
 # given the source boundary above — so the tool error stays unchanged.
 _nemoclaw_policy_denial_hint_label() {
-  # OpenShell >=0.0.44 sets OPENSHELL_SANDBOX to the sandbox name; older
-  # versions set the boolean "1". OPENSHELL_SANDBOX is untrusted input that is
-  # interpolated into a copyable `nemoclaw … logs` command, so allowlist it
-  # rather than merely stripping: only render it when it is a valid sandbox name.
+  # NemoClaw injects its host-validated name as NEMOCLAW_SANDBOX_NAME. Fall
+  # back to OpenShell's runtime marker for compatibility; supported OpenShell
+  # versions may still expose that marker as the boolean "1". Both variables
+  # are treated as untrusted here because they are interpolated into copyable
+  # `nemoclaw …` commands, so only render a valid sandbox name.
   # This mirrors NAME_VALID_PATTERN in src/lib/name-validation.ts
   # (/^[a-z]([a-z0-9-]*[a-z0-9])?$/, max 63): starts with a lowercase letter,
   # then lowercase alphanumerics/hyphens, no trailing hyphen. Anything else
@@ -3891,14 +3892,15 @@ _nemoclaw_policy_denial_hint_label() {
   # is only ever called inside $(…) command substitution (a subshell), so the
   # assignment cannot leak into the interactive shell.
   LC_ALL=C
+  _nemoclaw_sandbox_hint_candidate="${NEMOCLAW_SANDBOX_NAME:-${OPENSHELL_SANDBOX:-}}"
   # Allowlist pattern mirrors NAME_VALID_PATTERN in src/lib/name-validation.ts
   # (RFC-1123 label: /^[a-z]([a-z0-9-]*[a-z0-9])?$/, max 63). Keep them in sync.
-  case "${OPENSHELL_SANDBOX:-}" in
+  case "$_nemoclaw_sandbox_hint_candidate" in
     "" | 0 | 1 | true | TRUE | false | FALSE) printf '<name>' ;;
     [!a-z]* | *- | *[!a-z0-9-]*) printf '<name>' ;;
     *)
-      if [ "${#OPENSHELL_SANDBOX}" -le 63 ]; then
-        printf '%s' "$OPENSHELL_SANDBOX"
+      if [ "${#_nemoclaw_sandbox_hint_candidate}" -le 63 ]; then
+        printf '%s' "$_nemoclaw_sandbox_hint_candidate"
       else
         printf '<name>'
       fi

--- a/src/lib/actions/sandbox/supervisor-relaunch.test.ts
+++ b/src/lib/actions/sandbox/supervisor-relaunch.test.ts
@@ -118,6 +118,7 @@ describe("relaunchManagedSupervisorSession", () => {
     });
     const serialized = options?.openshellSandboxCommand.join(" ") ?? "";
     expect(serialized).toContain("NEMOCLAW_DASHBOARD_PORT=18789");
+    expect(serialized).toContain("NEMOCLAW_SANDBOX_NAME=alpha");
     expect(serialized).toMatch(/nemoclaw-start$/);
     expect(serialized).not.toContain("s3cr3t-token");
     expect(serialized).not.toContain("CUSTOM_PROVIDER_CREDENTIAL");

--- a/src/lib/onboard/sandbox-create-launch.test.ts
+++ b/src/lib/onboard/sandbox-create-launch.test.ts
@@ -319,13 +319,13 @@ describe("prepareSandboxCreateLaunch", () => {
     }
   });
 
-  it("forwards the validated sandbox name into the Deep Agents Code sandbox create env", () => {
+  it("forwards the validated sandbox name instead of an ambient or rendered name", () => {
     const result = prepareSandboxCreateLaunch({
-      agent: { name: "langchain-deepagents-code" } as any,
+      agent: { name: "openclaw", configPaths: { dir: "/sandbox/.openclaw" } } as any,
       chatUiUrl: "",
       createArgs: ["--name", "rendered-name"],
-      sandboxName: "dcode-demo",
-      env: {},
+      sandboxName: "openclaw-demo",
+      env: { NEMOCLAW_SANDBOX_NAME: "ambient-name" },
       extraPlaceholderKeys: [],
       getDashboardForwardPort: vi.fn(() => "0"),
       hermesDashboardState: disabledHermesDashboardState,
@@ -334,11 +334,12 @@ describe("prepareSandboxCreateLaunch", () => {
       buildEnv: () => ({}),
     });
 
-    expect(result.envArgs).toContain("NEMOCLAW_SANDBOX_NAME=dcode-demo");
+    expect(result.envArgs).toContain("NEMOCLAW_SANDBOX_NAME=openclaw-demo");
+    expect(result.envArgs).not.toContain("NEMOCLAW_SANDBOX_NAME=ambient-name");
     expect(result.envArgs).not.toContain("NEMOCLAW_SANDBOX_NAME=rendered-name");
   });
 
-  it("does not forward the sandbox name for non-Deep-Agents-Code agents", () => {
+  it("omits the sandbox name when the caller has not resolved one", () => {
     const result = prepareSandboxCreateLaunch({
       agent: { name: "openclaw", configPaths: { dir: "/sandbox/.custom-openclaw" } } as any,
       chatUiUrl: "http://127.0.0.1:19000/",

--- a/src/lib/onboard/sandbox-create-launch.ts
+++ b/src/lib/onboard/sandbox-create-launch.ts
@@ -149,11 +149,14 @@ export function buildSandboxRuntimeEnvArgs(input: SandboxRuntimeEnvArgsInput): {
     envArgs.push(formatEnvAssignment("NEMOCLAW_PROXY_PORT", sandboxProxyPort));
   }
 
+  // OpenShell exposes OPENSHELL_SANDBOX as a boolean marker on some supported
+  // versions. Preserve the host-validated name so in-sandbox recovery hints can
+  // render copyable `nemoclaw <name> ...` commands for every managed agent.
+  if (input.sandboxName) {
+    envArgs.push(formatEnvAssignment("NEMOCLAW_SANDBOX_NAME", input.sandboxName));
+  }
+
   if (agent?.name === "langchain-deepagents-code") {
-    const sandboxName = input.sandboxName;
-    if (sandboxName) {
-      envArgs.push(formatEnvAssignment("NEMOCLAW_SANDBOX_NAME", sandboxName));
-    }
     envArgs.push(
       formatEnvAssignment(
         "NEMOCLAW_OBSERVABILITY",

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -1035,7 +1035,7 @@ exit 1
       for (const op of ["add", "remove"]) {
         for (const channel of channels) {
           const result = runGuardedShell(setup, [
-            "export OPENSHELL_SANDBOX=my-assistant",
+            "export OPENSHELL_SANDBOX=1; export NEMOCLAW_SANDBOX_NAME=my-assistant",
             shellOpenclawCommand(["channels", op, channel]),
           ]);
           expect(result.status, `channels ${op} ${channel} should be blocked`).toBe(1);

--- a/test/repro-5978-policy-denial-hint.test.ts
+++ b/test/repro-5978-policy-denial-hint.test.ts
@@ -175,6 +175,26 @@ describe("sandbox policy-denial logs breadcrumb (#5978)", () => {
     expect(stdout).toContain("nemoclaw qa-5978 logs --tail 50");
   });
 
+  it("prefers NemoClaw's validated name when OpenShell exposes only a boolean marker", () => {
+    const { stdout, status } = gate({
+      NEMOCLAW_SANDBOX_NAME: "qa-7292",
+      OPENSHELL_SANDBOX: "1",
+    });
+    expect(status).toBe(0);
+    expect(stdout).toContain("nemoclaw qa-7292 logs --tail 50");
+  });
+
+  it("does not render an invalid NemoClaw sandbox name", () => {
+    const { stdout, status } = gate({
+      NEMOCLAW_SANDBOX_NAME: "qa-7292; echo injected",
+      OPENSHELL_SANDBOX: "fallback-name",
+    });
+    expect(status).toBe(0);
+    expect(stdout).toContain("nemoclaw <name> logs --tail 50");
+    expect(stdout).not.toContain("echo injected");
+    expect(stdout).not.toContain("nemoclaw fallback-name logs");
+  });
+
   it("falls back to <name> when OPENSHELL_SANDBOX is unusable (older OpenShell)", () => {
     for (const value of ["", "1", "true"]) {
       const { stdout, status } = gate({ OPENSHELL_SANDBOX: value });


### PR DESCRIPTION
## Summary

Preserve the validated sandbox name in managed startup commands so in-sandbox channel guards can print a copyable host command. This replaces the literal `<name>` fallback when supported OpenShell versions expose `OPENSHELL_SANDBOX` as a boolean marker.

## Related Issue

Fixes #7292

## Changes

- Pass `NEMOCLAW_SANDBOX_NAME` to every managed agent during sandbox creation and supervisor relaunch.
- Prefer the NemoClaw-provided name in host-side hints while retaining the existing RFC-1123 output allowlist.
- Cover OpenShell's boolean-marker behavior for channel add/remove, policy breadcrumbs, initial launch, and relaunch.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The existing host command is unchanged; this fix supplies its missing runtime value.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed the runtime value source, create and relaunch propagation, shell allowlist, boolean-marker compatibility, and injection fallback.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed; the documented command and environment variable remain unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b8659b4db -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 44 assertions passed across the channel guard, policy breadcrumb, launch renderer, observability compatibility, and supervisor relaunch suites.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run build:cli`, `npm run typecheck:cli`, `npm run lint`, and `npm run check:diff`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox name handling for recovery and policy-denial hints.
  * Preserved valid sandbox names when only a boolean sandbox marker is available.
  * Replaced invalid or unsafe names with a generic placeholder to prevent injection.

* **Tests**
  * Added regression coverage for sandbox name forwarding, validation, and secure hint rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->