### PR TITLE
fix(sandbox): honor recovery wait override

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -41,7 +41,7 @@
       "src/lib/actions/sandbox/destroy.ts": 27,
       "src/lib/actions/sandbox/doctor.ts": 29,
       "src/lib/actions/sandbox/policy-channel.ts": 28,
-      "src/lib/actions/sandbox/process-recovery.ts": 22,
+      "src/lib/actions/sandbox/process-recovery.ts": 21,
       "src/lib/actions/sandbox/rebuild-pipeline.ts": 27,
       "src/lib/actions/sandbox/snapshot.ts": 38,
       "src/lib/actions/uninstall/run-plan.ts": 25,

--- a/docs/inference/configure-inference-timeouts.mdx
+++ b/docs/inference/configure-inference-timeouts.mdx
@@ -20,7 +20,8 @@ Use the error location to select the correct setting.
 |---|---|---|
 | `NEMOCLAW_AGENT_TIMEOUT` | OpenClaw per-request inference | `600` seconds |
 | `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | Ollama, vLLM, NIM, and compatible-endpoint validation during onboarding | `180` seconds |
-| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | Image build, gateway upload, and in-sandbox boot after creation; OpenShell command re-registration after policy application or after OpenClaw or Hermes managed recovery recreates the sandbox | `180` seconds |
+| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | Image build, gateway upload, in-sandbox boot after creation, and OpenShell command re-registration after policy application | `180` seconds |
+| `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` | Gateway health and OpenShell command re-registration during managed OpenClaw or Hermes recovery | `120` seconds |
 
 The readiness timeout does not govern inference requests or provider validation.
 
@@ -66,12 +67,6 @@ Raise `NEMOCLAW_SANDBOX_READY_TIMEOUT` when onboarding creates the sandbox but i
 This can occur during a first run with cold caches or on a remote VM over a slow link.
 Onboarding also uses this budget to confirm that the sandbox can execute commands again after applying policy presets.
 
-<AgentOnly variant="openclaw,hermes">
-
-The same budget applies when `start` or `recover` transactionally recreates a managed sandbox and waits for OpenShell to re-register it.
-
-</AgentOnly>
-
 ```bash
 export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
 $$nemoclaw onboard
@@ -79,7 +74,14 @@ $$nemoclaw onboard
 
 <AgentOnly variant="openclaw,hermes">
 
-For an existing sandbox, export the variable before the `start` or `recover` command that performs the recreation.
+Set `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` before `start` or `recover` when a recreated sandbox needs more than 120 seconds to restore gateway health or re-register with OpenShell.
+
+```bash
+export NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS=300
+$$nemoclaw <sandbox-name> recover
+```
+
+An explicit recovery override takes precedence over internal per-agent and per-call-site budgets.
 
 </AgentOnly>
 

--- a/docs/inference/configure-inference-timeouts.mdx
+++ b/docs/inference/configure-inference-timeouts.mdx
@@ -20,8 +20,8 @@ Use the error location to select the correct setting.
 |---|---|---|
 | `NEMOCLAW_AGENT_TIMEOUT` | OpenClaw per-request inference | `600` seconds |
 | `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | Ollama, vLLM, NIM, and compatible-endpoint validation during onboarding | `180` seconds |
-| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | Image build, gateway upload, in-sandbox boot after creation, and OpenShell command re-registration after policy application | `180` seconds |
-| `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` | Gateway health and OpenShell command re-registration during managed OpenClaw or Hermes recovery | `120` seconds |
+| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | Image build, gateway upload, and in-sandbox boot after creation | `180` seconds |
+| `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` | OpenShell command re-registration after policy application, plus gateway health and re-registration during managed OpenClaw or Hermes recovery | `120` seconds |
 
 The readiness timeout does not govern inference requests or provider validation.
 
@@ -65,12 +65,13 @@ This variable does not extend the later sandbox-readiness wait.
 
 Raise `NEMOCLAW_SANDBOX_READY_TIMEOUT` when onboarding creates the sandbox but image build, upload, or boot exceeds 180 seconds.
 This can occur during a first run with cold caches or on a remote VM over a slow link.
-Onboarding also uses this budget to confirm that the sandbox can execute commands again after applying policy presets.
 
 ```bash
 export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
 $$nemoclaw onboard
 ```
+
+Set `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` when OpenShell needs more than 120 seconds to re-register the sandbox after onboarding applies policy presets.
 
 <AgentOnly variant="openclaw,hermes">
 

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -88,7 +88,8 @@ It commits only after the replacement container identity and state restoration p
 NemoClaw removes the temporary state backup after a successful restore or rollback.
 If state restoration and rollback both fail, it retains the backup and prints host recovery guidance.
 Mounted state remains available, but a committed swap does not retain other writable-layer changes.
-After a transactional recreation, NemoClaw uses the `NEMOCLAW_SANDBOX_READY_TIMEOUT` budget (180 seconds by default) for OpenShell to re-register the sandbox before starting the primary dashboard or API host forward.
+After a transactional recreation, NemoClaw waits 120 seconds for OpenShell to re-register the sandbox before starting the primary dashboard or API host forward.
+Set `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` before the recovery command to change this budget.
 A definitive managed-health failure still stops immediately; if re-registration does not complete within the budget, the forward stays stopped.
 
 For the controller topology, trust boundary, and fail-closed conditions, refer to [Understand Gateway Lifecycle Control](../configure-sandboxes/understand-gateway-lifecycle-control).

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3946,16 +3946,15 @@ Defaults are sized for typical hardware; override only if you see false-positive
 ### Onboard and Sandbox Readiness Timeouts
 
 The following environment variables tune onboard-time and recovery wall-clock limits.
-`NEMOCLAW_SANDBOX_READY_TIMEOUT` also covers OpenShell command re-registration after onboarding applies policy presets.
 Set them before running `$$nemoclaw onboard` if a slow connection or large model pull risks tripping the default.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `NEMOCLAW_OLLAMA_PULL_TIMEOUT` | `1800` (30 minutes) | Wall-clock timeout for `ollama pull` during onboard, in seconds. Accepts integer or float values. Already-downloaded layers are kept; re-running the pull resumes them. |
 | `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | `180` | Wall-clock timeout for the inference-server validation probe during onboard, in seconds. Raise on slow networks or for very large prompts. |
-| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | `180` | Wall-clock timeout for post-create readiness and OpenShell command re-registration after policy application, in seconds. Raise when the sandbox image build, gateway upload, in-sandbox boot, or post-policy re-registration exceeds the default (typical on 70B+ models, first-time gateway uploads over slow links, or DGX Station / remote-VM first runs). When the post-create deadline expires, onboarding deletes an orphaned sandbox and prints the retry hint. |
+| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | `180` | Wall-clock timeout for post-create readiness, in seconds. Raise when the sandbox image build, gateway upload, or in-sandbox boot exceeds the default (typical on 70B+ models, first-time gateway uploads over slow links, or DGX Station / remote-VM first runs). When the post-create deadline expires, onboarding deletes an orphaned sandbox and prints the retry hint. |
 | `NEMOCLAW_SANDBOX_READY_ERROR_DEBOUNCE` | `30` | Consecutive `Error`-phase polls the post-create readiness wait tolerates before treating `Error` as terminal. Polling starts at 250ms and backs off to a 2-second cap, while `NEMOCLAW_SANDBOX_READY_TIMEOUT` remains the overall deadline. The gateway can briefly report a just-created sandbox in `Error` while it re-registers the sandbox (seen on DGX Spark); the debounce lets that transient recover to `Ready`. `Failed` and `CrashLoopBackOff` always fail immediately. Set to `1` to restore fast-fail on the first `Error` poll. |
-| `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` | `120` | Wall-clock timeout for gateway health and OpenShell command re-registration during managed OpenClaw or Hermes recovery. An explicit value overrides internal per-agent and per-call-site budgets. |
+| `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` | `120` | Wall-clock timeout for OpenShell command re-registration after policy application, plus gateway health and re-registration during managed OpenClaw or Hermes recovery. An explicit value overrides internal per-agent and per-call-site budgets. |
 
 <AgentOnly variant="openclaw,hermes">
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3945,12 +3945,8 @@ Defaults are sized for typical hardware; override only if you see false-positive
 
 ### Onboard and Sandbox Readiness Timeouts
 
-The following environment variables tune onboard-time wall-clock limits.
+The following environment variables tune onboard-time and recovery wall-clock limits.
 `NEMOCLAW_SANDBOX_READY_TIMEOUT` also covers OpenShell command re-registration after onboarding applies policy presets.
-
-<AgentOnly variant="openclaw,hermes">
-`NEMOCLAW_SANDBOX_READY_TIMEOUT` also applies when managed recovery transactionally recreates an existing sandbox.
-</AgentOnly>
 Set them before running `$$nemoclaw onboard` if a slow connection or large model pull risks tripping the default.
 
 | Variable | Default | Purpose |
@@ -3959,10 +3955,11 @@ Set them before running `$$nemoclaw onboard` if a slow connection or large model
 | `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | `180` | Wall-clock timeout for the inference-server validation probe during onboard, in seconds. Raise on slow networks or for very large prompts. |
 | `NEMOCLAW_SANDBOX_READY_TIMEOUT` | `180` | Wall-clock timeout for post-create readiness and OpenShell command re-registration after policy application, in seconds. Raise when the sandbox image build, gateway upload, in-sandbox boot, or post-policy re-registration exceeds the default (typical on 70B+ models, first-time gateway uploads over slow links, or DGX Station / remote-VM first runs). When the post-create deadline expires, onboarding deletes an orphaned sandbox and prints the retry hint. |
 | `NEMOCLAW_SANDBOX_READY_ERROR_DEBOUNCE` | `30` | Consecutive `Error`-phase polls the post-create readiness wait tolerates before treating `Error` as terminal. Polling starts at 250ms and backs off to a 2-second cap, while `NEMOCLAW_SANDBOX_READY_TIMEOUT` remains the overall deadline. The gateway can briefly report a just-created sandbox in `Error` while it re-registers the sandbox (seen on DGX Spark); the debounce lets that transient recover to `Ready`. `Failed` and `CrashLoopBackOff` always fail immediately. Set to `1` to restore fast-fail on the first `Error` poll. |
+| `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` | `120` | Wall-clock timeout for gateway health and OpenShell command re-registration during managed OpenClaw or Hermes recovery. An explicit value overrides internal per-agent and per-call-site budgets. |
 
 <AgentOnly variant="openclaw,hermes">
 
-For managed recovery, the same timeout covers OpenShell re-registration after transactional recreation.
+For managed recovery, `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` covers OpenShell re-registration after transactional recreation.
 When the deadline expires, the primary dashboard or API host forward stays stopped.
 
 </AgentOnly>
@@ -3972,6 +3969,17 @@ export NEMOCLAW_OLLAMA_PULL_TIMEOUT=3600
 export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
 $$nemoclaw onboard
 ```
+
+<AgentOnly variant="openclaw,hermes">
+
+Set the recovery override before a `start` or `recover` command that can recreate the sandbox.
+
+```bash
+export NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS=300
+$$nemoclaw <sandbox-name> recover
+```
+
+</AgentOnly>
 
 If the Ollama pull or post-create readiness timeout fires, onboarding emits the elapsed budget plus a hint to raise the relevant variable.
 The Ollama pull preserves its partial download for the next attempt.

--- a/src/lib/actions/sandbox/process-recovery.test.ts
+++ b/src/lib/actions/sandbox/process-recovery.test.ts
@@ -466,7 +466,7 @@ describe("recreated sandbox OpenShell readiness", () => {
     expect(sleeps).toEqual([3, 3]);
   });
 
-  it("does not let the legacy gateway timeout shorten the sandbox readiness budget (#7273)", () => {
+  it("lets the recovery wait override replace an explicit readiness budget", () => {
     vi.stubEnv("NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS", "1");
     vi.stubEnv("NEMOCLAW_SANDBOX_READY_TIMEOUT", "6");
     const captureOpenshellImpl = vi.fn(() => ({
@@ -485,8 +485,8 @@ describe("recreated sandbox OpenShell readiness", () => {
         timeoutSeconds: Number(process.env.NEMOCLAW_SANDBOX_READY_TIMEOUT),
       }),
     ).toBe(false);
-    expect(captureOpenshellImpl).toHaveBeenCalledTimes(3);
-    expect(sleeps).toEqual([3, 3]);
+    expect(captureOpenshellImpl).toHaveBeenCalledOnce();
+    expect(sleeps).toEqual([]);
   });
 });
 

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -1366,7 +1366,11 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     const readinessFailureDetail = relaunch
       ? (() => {
           const readinessOptions: RecreatedSandboxOpenShellReadyOptions = {
-            beforeProbe: (timeoutMs) => confirmRelaunchedManagedHealth?.(timeoutMs) ?? null,
+            ...(confirmRelaunchedManagedHealth
+              ? {
+                  beforeProbe: (timeoutMs: number) => confirmRelaunchedManagedHealth(timeoutMs),
+                }
+              : {}),
           };
           const readiness =
             waitForRecreatedSandboxOpenShellReadyImpl === waitForRecreatedSandboxOpenShellReady

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -16,7 +16,6 @@ import { OPENSHELL_PROBE_TIMEOUT_MS } from "../../adapters/openshell/timeouts";
 import * as agentRuntime from "../../agent/runtime";
 import { G, R } from "../../cli/terminal-style";
 import { sleepSeconds, waitUntil } from "../../core/wait";
-import { SANDBOX_READY_TIMEOUT_SECS } from "../../onboard/env";
 import { ROOT, shellQuote } from "../../runner";
 import {
   isDirectSandboxFallbackUnavailableError,
@@ -725,15 +724,16 @@ function waitForRecreatedSandboxOpenShellReadyResult(
   const capture = options.captureOpenshellImpl ?? captureOpenshell;
   const now = options.nowImpl ?? Date.now;
   const sleep = options.sleepImpl ?? sleepSeconds;
-  const timeoutSeconds =
+  const requestedTimeoutSeconds =
     typeof options.timeoutSeconds === "number" &&
     Number.isFinite(options.timeoutSeconds) &&
     options.timeoutSeconds >= 0
       ? options.timeoutSeconds
-      : readNonNegativeNumberEnv(
-          "NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS",
-          GATEWAY_RECOVERY_WAIT_DEFAULT_SECONDS,
-        );
+      : GATEWAY_RECOVERY_WAIT_DEFAULT_SECONDS;
+  const timeoutSeconds = readNonNegativeNumberEnv(
+    "NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS",
+    requestedTimeoutSeconds,
+  );
   const intervalSeconds = readNonNegativeNumberEnv(
     "NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS",
     options.intervalSeconds ?? 3,
@@ -1367,7 +1367,6 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
       ? (() => {
           const readinessOptions: RecreatedSandboxOpenShellReadyOptions = {
             beforeProbe: (timeoutMs) => confirmRelaunchedManagedHealth?.(timeoutMs) ?? null,
-            timeoutSeconds: SANDBOX_READY_TIMEOUT_SECS,
           };
           const readiness =
             waitForRecreatedSandboxOpenShellReadyImpl === waitForRecreatedSandboxOpenShellReady

--- a/src/lib/onboard/finalization-deps.test.ts
+++ b/src/lib/onboard/finalization-deps.test.ts
@@ -1,10 +1,32 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { VerifyDeploymentResult } from "../verify-deployment";
-import { finalizationHandlerDeps } from "./finalization-deps";
+import {
+  createWaitForSandboxControlPlaneReady,
+  finalizationHandlerDeps,
+} from "./finalization-deps";
+
+describe("finalizationHandlerDeps.waitForSandboxControlPlaneReady", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("delegates timeout selection to the recovery readiness helper", () => {
+    vi.stubEnv("NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS", "120");
+    vi.stubEnv("NEMOCLAW_SANDBOX_READY_TIMEOUT", "180");
+    const waitForRecreatedSandboxOpenShellReady = vi.fn(() => true);
+    const waitForSandboxControlPlaneReady = createWaitForSandboxControlPlaneReady(() => ({
+      waitForRecreatedSandboxOpenShellReady,
+    }));
+
+    expect(waitForSandboxControlPlaneReady("policy-box")).toBe(true);
+    expect(waitForRecreatedSandboxOpenShellReady).toHaveBeenCalledWith("policy-box");
+  });
+});
 
 describe("finalizationHandlerDeps.reportDeploymentReadiness", () => {
   const originalExitCode = process.exitCode;

--- a/src/lib/onboard/finalization-deps.test.ts
+++ b/src/lib/onboard/finalization-deps.test.ts
@@ -4,27 +4,36 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { VerifyDeploymentResult } from "../verify-deployment";
-import {
-  createWaitForSandboxControlPlaneReady,
-  finalizationHandlerDeps,
-} from "./finalization-deps";
+import { finalizationHandlerDeps, finalizationHandlerRuntime } from "./finalization-deps";
 
 describe("finalizationHandlerDeps.waitForSandboxControlPlaneReady", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
 
   it("delegates timeout selection to the recovery readiness helper", () => {
-    vi.stubEnv("NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS", "120");
+    vi.stubEnv("NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS", "75");
     vi.stubEnv("NEMOCLAW_SANDBOX_READY_TIMEOUT", "180");
-    const waitForRecreatedSandboxOpenShellReady = vi.fn(() => true);
-    const waitForSandboxControlPlaneReady = createWaitForSandboxControlPlaneReady(() => ({
+    let effectiveTimeoutSeconds: number | undefined;
+    const waitForRecreatedSandboxOpenShellReady = vi.fn(
+      (_name: string, options: { timeoutSeconds?: number } = {}) => {
+        const requestedTimeoutSeconds = options.timeoutSeconds ?? 120;
+        effectiveTimeoutSeconds = Number(
+          process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS ?? requestedTimeoutSeconds,
+        );
+        return true;
+      },
+    );
+    vi.spyOn(finalizationHandlerRuntime, "loadProcessRecovery").mockReturnValue({
+      checkAndRecoverSandboxProcesses: vi.fn(),
       waitForRecreatedSandboxOpenShellReady,
-    }));
+    });
 
-    expect(waitForSandboxControlPlaneReady("policy-box")).toBe(true);
+    expect(finalizationHandlerDeps.waitForSandboxControlPlaneReady("policy-box")).toBe(true);
     expect(waitForRecreatedSandboxOpenShellReady).toHaveBeenCalledWith("policy-box");
+    expect(effectiveTimeoutSeconds).toBe(75);
   });
 });
 

--- a/src/lib/onboard/finalization-deps.ts
+++ b/src/lib/onboard/finalization-deps.ts
@@ -6,12 +6,21 @@
 // entrypoint stays lean (codebase-growth-guardrails). The lazy `require` calls
 // avoid an import cycle: connect.ts and process-recovery.ts both pull in
 // onboard helpers, so they must not be statically imported here.
+type ProcessRecoveryReadinessDeps = Pick<
+  typeof import("../actions/sandbox/process-recovery"),
+  "waitForRecreatedSandboxOpenShellReady"
+>;
+
+export function createWaitForSandboxControlPlaneReady(
+  loadProcessRecovery: () => ProcessRecoveryReadinessDeps = () =>
+    require("../actions/sandbox/process-recovery") as ProcessRecoveryReadinessDeps,
+) {
+  return (name: string): boolean =>
+    loadProcessRecovery().waitForRecreatedSandboxOpenShellReady(name);
+}
+
 export const finalizationHandlerDeps = {
-  waitForSandboxControlPlaneReady(name: string): boolean {
-    const processRecovery: typeof import("../actions/sandbox/process-recovery") =
-      require("../actions/sandbox/process-recovery");
-    return processRecovery.waitForRecreatedSandboxOpenShellReady(name);
-  },
+  waitForSandboxControlPlaneReady: createWaitForSandboxControlPlaneReady(),
   checkAndRecoverSandboxProcesses(name: string, options: { quiet: boolean }): void {
     const processRecovery: typeof import("../actions/sandbox/process-recovery") =
       require("../actions/sandbox/process-recovery");

--- a/src/lib/onboard/finalization-deps.ts
+++ b/src/lib/onboard/finalization-deps.ts
@@ -10,10 +10,7 @@ export const finalizationHandlerDeps = {
   waitForSandboxControlPlaneReady(name: string): boolean {
     const processRecovery: typeof import("../actions/sandbox/process-recovery") =
       require("../actions/sandbox/process-recovery");
-    const { SANDBOX_READY_TIMEOUT_SECS }: typeof import("./env") = require("./env");
-    return processRecovery.waitForRecreatedSandboxOpenShellReady(name, {
-      timeoutSeconds: SANDBOX_READY_TIMEOUT_SECS,
-    });
+    return processRecovery.waitForRecreatedSandboxOpenShellReady(name);
   },
   checkAndRecoverSandboxProcesses(name: string, options: { quiet: boolean }): void {
     const processRecovery: typeof import("../actions/sandbox/process-recovery") =

--- a/src/lib/onboard/finalization-deps.ts
+++ b/src/lib/onboard/finalization-deps.ts
@@ -6,24 +6,23 @@
 // entrypoint stays lean (codebase-growth-guardrails). The lazy `require` calls
 // avoid an import cycle: connect.ts and process-recovery.ts both pull in
 // onboard helpers, so they must not be statically imported here.
-type ProcessRecoveryReadinessDeps = Pick<
+type ProcessRecoveryDeps = Pick<
   typeof import("../actions/sandbox/process-recovery"),
-  "waitForRecreatedSandboxOpenShellReady"
+  "checkAndRecoverSandboxProcesses" | "waitForRecreatedSandboxOpenShellReady"
 >;
 
-export function createWaitForSandboxControlPlaneReady(
-  loadProcessRecovery: () => ProcessRecoveryReadinessDeps = () =>
-    require("../actions/sandbox/process-recovery") as ProcessRecoveryReadinessDeps,
-) {
-  return (name: string): boolean =>
-    loadProcessRecovery().waitForRecreatedSandboxOpenShellReady(name);
-}
+export const finalizationHandlerRuntime = {
+  loadProcessRecovery: () => require("../actions/sandbox/process-recovery") as ProcessRecoveryDeps,
+};
 
 export const finalizationHandlerDeps = {
-  waitForSandboxControlPlaneReady: createWaitForSandboxControlPlaneReady(),
+  waitForSandboxControlPlaneReady(name: string): boolean {
+    return finalizationHandlerRuntime
+      .loadProcessRecovery()
+      .waitForRecreatedSandboxOpenShellReady(name);
+  },
   checkAndRecoverSandboxProcesses(name: string, options: { quiet: boolean }): void {
-    const processRecovery: typeof import("../actions/sandbox/process-recovery") =
-      require("../actions/sandbox/process-recovery");
+    const processRecovery = finalizationHandlerRuntime.loadProcessRecovery();
     processRecovery.checkAndRecoverSandboxProcesses(name, options);
   },
   // Best-effort device-approval sweep that clears pending allowlisted

--- a/test/process-recovery-supervisor-relaunch.test.ts
+++ b/test/process-recovery-supervisor-relaunch.test.ts
@@ -397,7 +397,7 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
     );
   });
 
-  it("uses the sandbox readiness budget after a longer gateway health wait (#7273)", () => {
+  it("uses the shared recreate-readiness budget after a longer gateway health wait", () => {
     mockOpenClawSandbox("unready-box", 600);
     setImmediateRecoveryPolling();
     const finalize = vi.fn(() => ({ backupRemoved: true, rolledBack: false }));
@@ -415,7 +415,12 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
       stdout: "GATEWAY_PID=4242\n",
       stderr: "",
     }));
-    const waitForRecreatedSandboxOpenShellReadyImpl = vi.fn(() => false);
+    const waitForRecreatedSandboxOpenShellReadyImpl = vi.fn(
+      (
+        _name: string,
+        _options?: { beforeProbe?: (timeoutMs: number) => boolean | null; timeoutSeconds?: number },
+      ) => false,
+    );
     const runOpenshell = vi.spyOn(openshellRuntime, "runOpenshell");
 
     const result = checkAndRecoverSandboxProcesses("unready-box", {
@@ -439,7 +444,10 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
     expect(finalize).toHaveBeenCalledWith(true);
     expect(waitForRecreatedSandboxOpenShellReadyImpl).toHaveBeenCalledWith(
       "unready-box",
-      expect.objectContaining({ beforeProbe: expect.any(Function), timeoutSeconds: 180 }),
+      expect.objectContaining({ beforeProbe: expect.any(Function) }),
+    );
+    expect(waitForRecreatedSandboxOpenShellReadyImpl.mock.calls[0]?.[1]).not.toHaveProperty(
+      "timeoutSeconds",
     );
     expect(runOpenshell).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed recovery now applies `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS`
consistently to both gateway-health and recreated-sandbox readiness waits.
The two recreate-readiness production paths use the shared 120-second default
instead of bypassing it with the unrelated 180-second onboarding budget.

## Related Issue

Fixes #7893

## Changes

- Give the operator recovery-wait override precedence over an explicit internal
  timeout in both recovery wait functions.
- Remove the explicit sandbox-readiness timeout from onboarding finalization and
  supervisor relaunch readiness checks.
- Cover override precedence and the production supervisor call shape with
  regression tests.
- Document the 120-second managed-recovery default and its environment override.
- Lower the measured source fan-out budget after removing the unused dependency.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed operator-override precedence, both production recreate-readiness call sites, zero-value handling, managed-health pinning, and the unchanged fail-closed readiness result.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed the recovery timeout table, command reference, and rebuild recovery guidance against the implementation. The pages consistently describe the 120-second default, operator override precedence, and separation from onboarding readiness.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f40bf4234 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run src/lib/actions/sandbox/process-recovery.test.ts src/lib/onboard/finalization-deps.test.ts test/process-recovery-supervisor-relaunch.test.ts` (57 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm test` was bounded after approximately 7 minutes; the focused production-path integration and required equivalent gates passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — result: passed with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional exact-head evidence:

- `npm run validate:pr`: passed.
- `npm run build:cli`: passed.
- `npm run typecheck:cli`: passed.
- `npm run lint`: passed.
- `npm run docs`: passed with 0 errors.
- `git diff --check`: passed.
- E2E-equivalent: the production supervisor relaunch regression proves its
  recreated-readiness call omits the bypassing timeout, while the direct
  readiness regression proves an operator override replaces an explicit
  internal budget.

---

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/extended `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` to control the recovery wall-clock wait for gateway health and OpenShell re-registration, with override precedence over `NEMOCLAW_SANDBOX_READY_TIMEOUT`.
  * During transactional rebuild `recover`, the system waits **120 seconds** by default before starting the primary dashboard/API forwarding.
* **Documentation**
  * Refined timeout guidance: `NEMOCLAW_SANDBOX_READY_TIMEOUT` now applies only to post-create readiness; added clearer recovery examples and when to set the gateway recovery wait variable.
* **Bug Fixes**
  * Recreated-sandbox readiness timing now consistently honors the gateway recovery wait override.
* **Tests**
  * Updated readiness-budget/probing expectations to reflect the new override behavior.
* **Chores**
  * Minor CI architecture budget adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->