### PR TITLE
fix(security): remediate managed image dependencies

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -75,7 +75,8 @@ ARG HERMES_SEMVER=0.19.0
 ARG HERMES_TARBALL_SHA256=285f3fc134ff466a90065e1517801a68993733b807158ee8f32aa01613786990
 ARG HERMES_NPM_INTEGRITY=sha512-+oVKG3lXbk2kEP+J6BXZjtmSBSaFfczIdOWQ9CUSTdTqq2uyHbk4p+kPyZ6MeGs56JU5qXzMNbqGKRVOQRGC1A==
 ARG HERMES_UV_EXTRAS="anthropic messaging web pty mcp"
-ARG UV_VERSION=0.11.8
+ARG NODE_VERSION=24.18.1
+ARG UV_VERSION=0.11.33
 
 # build-essential: hermes-agent >= 0.16.0 ships npm dependencies that need a
 # node-gyp native build during `npm ci`; the runtime Dockerfile purges build
@@ -220,12 +221,41 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && test -z "$(dpkg --audit)"
 
+# The current node:24-trixie-slim digest still contains Node.js 24.16.0. Overlay
+# the reviewed Node.js 24.18.1 release from nodejs.org so the Hermes runtime
+# includes the security fixes without waiting for Docker Hub tag rotation.
+# hadolint ignore=DL4006
+RUN arch="$(dpkg --print-architecture)" \
+    && case "$arch" in \
+        amd64) node_asset_arch="x64"; node_sha256="9f5eb6ac21845a66c493c91a253b1da32fd684e89e9b7202d4936982336be4ca" ;; \
+        arm64) node_asset_arch="arm64"; node_sha256="df224555a083b918e46260cc969838501b9f9a87140c1195e5b9597b56d5dae2" ;; \
+        *) echo "Unsupported architecture for Node.js: $arch" >&2; exit 1 ;; \
+    esac \
+    && node_archive="/tmp/node-v${NODE_VERSION}-linux-${node_asset_arch}.tar.gz" \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 300 \
+        -o "$node_archive" \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_asset_arch}.tar.gz" \
+    && printf '%s  %s\n' "$node_sha256" "$node_archive" | sha256sum -c - \
+    && rm -rf \
+        /usr/local/include/node \
+        /usr/local/lib/node_modules/corepack \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/share/doc/node \
+        /usr/local/share/man/man1/node.1 \
+    && rm -f /usr/local/bin/corepack /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx \
+    && tar --extract --gzip --file "$node_archive" \
+        --directory /usr/local --strip-components=1 --no-same-owner \
+    && rm -f "$node_archive" \
+    && test "$(node --version)" = "v${NODE_VERSION}" \
+    && test "$(npm --version)" = "11.16.0"
+
 COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts
 COPY scripts/patch-bundled-npm-brace-expansion.mts /scripts/patch-bundled-npm-brace-expansion.mts
 COPY scripts/patch-bundled-npm-tar.mts /scripts/patch-bundled-npm-tar.mts
 COPY scripts/upgrade-bundled-npm.mts /scripts/upgrade-bundled-npm.mts
 
-# npm 11.13.0 in the pinned Node 24 image bundles an affected node-tar copy.
+# npm 11.16.0 in Node.js 24.18.1 bundles an affected node-tar copy.
 # Patch that private package after curl is installed and before npm processes
 # the reviewed npm archive.
 RUN node --experimental-strip-types /scripts/patch-bundled-npm-tar.mts \
@@ -381,7 +411,8 @@ RUN printf '%s\n' \
 # writes under /opt/hermes. If a future Hermes tarball removes the lockfile,
 # skip rather than doing a nondeterministic dependency resolve during image
 # build.
-RUN pip3 install --no-cache-dir --break-system-packages "uv==${UV_VERSION}"
+RUN pip3 install --no-cache-dir --break-system-packages "uv==${UV_VERSION}" \
+    && test "$(uv --version)" = "uv ${UV_VERSION}"
 # Upstream tests are not part of the production runtime and can contain
 # intentionally hostile security-test fixtures. Remove them in the extraction
 # RUN so their bytes never enter a published image layer.
@@ -444,7 +475,7 @@ RUN set -eu; \
     uv sync --frozen --no-dev "$@" --no-cache \
     && uv pip check --python /opt/hermes/.venv/bin/python \
     && /opt/hermes/.venv/bin/python -I -c \
-        "from importlib.metadata import version; expected = {'cryptography': '48.0.1', 'pillow': '12.3.0', 'starlette': '1.3.1'}; actual = {name: version(name) for name in expected}; assert actual == expected, actual" \
+        "from importlib.metadata import version; expected = {'cryptography': '48.0.1', 'mcp': '1.28.1', 'pillow': '12.3.0', 'starlette': '1.3.1', 'tornado': '6.5.7'}; actual = {name: version(name) for name in expected}; assert actual == expected, actual" \
     && npm ci --prefer-offline --no-audit --no-fund \
     && for ui_dir in ui-tui web; do \
         if [ -f "${ui_dir}/package-lock.json" ]; then \

--- a/agents/hermes/security-dependencies.patch
+++ b/agents/hermes/security-dependencies.patch
@@ -4,19 +4,22 @@
 # Applies reviewed dependency fixes to the checksum-pinned Hermes v2026.7.20
 # source metadata and frozen lock before installation.
 diff --git a/pyproject.toml b/pyproject.toml
-index c630b3c..613e1b8 100644
+index c630b3cf7..125d98a55 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -89,7 +89,7 @@ dependencies = [
+@@ -89,7 +89,10 @@ dependencies = [
    "urllib3>=2.7.0,<3",
    # cryptography is pulled in transitively by PyJWT[crypto]; pin it explicitly
    # so the WeCom/Weixin crypto paths can't drift below the CVE-fixed floor.
 -  "cryptography==46.0.7",  # CVE-2026-39892, CVE-2026-34073
 +  "cryptography==48.0.1",  # GHSA-537c-gmf6-5ccf
++  # Tornado 6.5.7 fixes GHSA-3x9g-8vmp-wqvf, GHSA-mgf9-4vpg-hj56,
++  # and GHSA-pw6j-qg29-8w7f.
++  "tornado==6.5.7",
    # Windows has no IANA tzdata shipped with the OS, so Python's ``zoneinfo``
    # (PEP 615) raises ``ZoneInfoNotFoundError`` for every non-UTC timezone
    # out of the box.  ``tzdata`` ships the Olson database as a data package
-@@ -123,7 +123,7 @@ dependencies = [
+@@ -123,7 +126,7 @@ dependencies = [
    # libs required for the codecs we use, so it's safe to ship in the base
    # install rather than gating it behind an extra + a mid-session lazy install
    # (which deadlocked the CLI under prompt_toolkit — see #40490).
@@ -25,34 +28,34 @@ index c630b3c..613e1b8 100644
    # Windows log rotation. Stdlib ``RotatingFileHandler.doRollover()`` uses
    # ``os.rename()`` which fails with ``PermissionError [WinError 32]`` on
    # Windows whenever any other process holds an append-mode handle on
-@@ -157,7 +157,7 @@ edge-tts = ["edge-tts==7.2.7"]
+@@ -157,7 +160,7 @@ edge-tts = ["edge-tts==7.2.7"]
  modal = ["modal==1.3.4"]
  daytona = ["daytona==0.155.0"]
  hindsight = ["hindsight-client==0.6.1"]
 -dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
-+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: GHSA-82w8-qh3p-5jfq; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
++dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.28.1", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: GHSA-82w8-qh3p-5jfq; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
  messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
  cron = []  # croniter is now a core dependency; this extra kept for back-compat
  slack = ["slack-bolt==1.29.0", "slack-sdk==3.43.0", "aiohttp==3.14.1"]
-@@ -204,7 +204,7 @@ vision = []
+@@ -204,7 +207,7 @@ vision = []
  # `request.url` can be bypassed. We pin a patched Starlette directly in every
  # extra that exposes a Starlette-backed server surface so pip/uv can't resolve
  # a vulnerable pre-1.0.1 transitive. Bump in lockstep with uv.lock.
 -mcp = ["mcp==1.26.0", "starlette==1.0.1"]  # starlette: CVE-2026-48710
-+mcp = ["mcp==1.26.0", "starlette==1.3.1"]  # starlette: GHSA-82w8-qh3p-5jfq
++mcp = ["mcp==1.28.1", "starlette==1.3.1"]  # starlette: GHSA-82w8-qh3p-5jfq
  nemo-relay = ["nemo-relay>=0.5,<1.0"]
  homeassistant = ["aiohttp==3.14.1"]
  sms = ["aiohttp==3.14.1"]
-@@ -213,7 +213,7 @@ teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"]  # aiohttp 3.14.1:
+@@ -213,7 +216,7 @@ teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"]  # aiohttp 3.14.1:
  # The cua-driver binary itself is installed via `hermes tools` post-setup
  # (curl install script); this extra just pins the MCP client used to talk
  # to it, which is already provided by the `mcp` extra.
 -computer-use = ["mcp==1.26.0", "starlette==1.0.1"]  # starlette: CVE-2026-48710
-+computer-use = ["mcp==1.26.0", "starlette==1.3.1"]  # starlette: GHSA-82w8-qh3p-5jfq
++computer-use = ["mcp==1.28.1", "starlette==1.3.1"]  # starlette: GHSA-82w8-qh3p-5jfq
  acp = ["agent-client-protocol==0.9.0"]
  # mistral: Voxtral STT + TTS. Pinned to an exact verified-clean version.
  # The `mistralai` PyPI project was quarantined 2026-05-12 after the malicious
-@@ -267,9 +267,8 @@ youtube = [
+@@ -267,9 +270,8 @@ youtube = [
    "youtube-transcript-api==1.2.4",
  ]
  # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
@@ -65,7 +68,7 @@ index c630b3c..613e1b8 100644
    # Policy (2026-05-12): `[all]` includes only extras that genuinely
    # CAN'T be lazy-installed via `tools/lazy_deps.py` — i.e. things every
 diff --git a/uv.lock b/uv.lock
-index 257f7d6..212be19 100644
+index 257f7d696..513c3031d 100644
 --- a/uv.lock
 +++ b/uv.lock
 @@ -249,7 +249,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/9a/7d/b22cb9a0d4f396ee0
@@ -194,7 +197,15 @@ index 257f7d6..212be19 100644
  ]
 
  [[package]]
-@@ -1750,7 +1752,7 @@ requires-dist = [
+@@ -1545,6 +1547,7 @@ dependencies = [
+     { name = "rich" },
+     { name = "ruamel-yaml" },
+     { name = "tenacity" },
++    { name = "tornado" },
+     { name = "tzdata", marker = "sys_platform == 'win32'" },
+     { name = "urllib3" },
+     { name = "uvicorn", extra = ["standard"] },
+@@ -1750,7 +1753,7 @@ requires-dist = [
      { name = "certifi", specifier = "==2026.5.20" },
      { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
      { name = "croniter", specifier = "==6.0.0" },
@@ -203,7 +214,20 @@ index 257f7d6..212be19 100644
      { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
      { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
      { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
-@@ -1810,7 +1812,7 @@ requires-dist = [
+@@ -1797,9 +1800,9 @@ requires-dist = [
+     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
+     { name = "markdown", specifier = "==3.10.2" },
+     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
+-    { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.26.0" },
+-    { name = "mcp", marker = "extra == 'dev'", specifier = "==1.26.0" },
+-    { name = "mcp", marker = "extra == 'mcp'", specifier = "==1.26.0" },
++    { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.28.1" },
++    { name = "mcp", marker = "extra == 'dev'", specifier = "==1.28.1" },
++    { name = "mcp", marker = "extra == 'mcp'", specifier = "==1.28.1" },
+     { name = "mem0ai", marker = "extra == 'mem0'", specifier = "==2.0.10" },
+     { name = "microsoft-teams-apps", marker = "extra == 'teams'", specifier = "==2.0.13.4" },
+     { name = "mistralai", marker = "extra == 'mistral'", specifier = "==2.4.8" },
+@@ -1810,7 +1813,7 @@ requires-dist = [
      { name = "packaging", specifier = "==26.0" },
      { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
      { name = "pathspec", specifier = "==1.1.1" },
@@ -212,7 +236,7 @@ index 257f7d6..212be19 100644
      { name = "prompt-toolkit", specifier = "==3.0.52" },
      { name = "psutil", specifier = "==7.2.2" },
      { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
-@@ -1839,10 +1841,10 @@ requires-dist = [
+@@ -1839,12 +1842,13 @@ requires-dist = [
      { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.43.0" },
      { name = "slack-sdk", marker = "extra == 'slack'", specifier = "==3.43.0" },
      { name = "sounddevice", marker = "extra == 'voice'", specifier = "==0.5.5" },
@@ -226,8 +250,32 @@ index 257f7d6..212be19 100644
 +    { name = "starlette", marker = "extra == 'web'", specifier = "==1.3.1" },
      { name = "supermemory", marker = "extra == 'supermemory'", specifier = "==3.50.0" },
      { name = "tenacity", specifier = "==9.1.4" },
++    { name = "tornado", specifier = "==6.5.7" },
      { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.21" },
-@@ -2953,64 +2955,45 @@ wheels = [
+     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
+     { name = "urllib3", specifier = ">=2.7.0,<3" },
+@@ -2303,7 +2307,7 @@ encryption = [
+
+ [[package]]
+ name = "mcp"
+-version = "1.26.0"
++version = "1.28.1"
+ source = { registry = "https://pypi.org/simple" }
+ dependencies = [
+     { name = "anyio" },
+@@ -2321,9 +2325,9 @@ dependencies = [
+     { name = "typing-inspection" },
+     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+ ]
+-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
++sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+ wheels = [
+-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
++    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+ ]
+
+ [[package]]
+@@ -2953,64 +2957,45 @@ wheels = [
 
  [[package]]
  name = "pillow"
@@ -331,7 +379,7 @@ index 257f7d6..212be19 100644
  ]
 
  [[package]]
-@@ -3991,15 +3974,15 @@ wheels = [
+@@ -3991,15 +3976,15 @@ wheels = [
 
  [[package]]
  name = "starlette"
@@ -350,7 +398,38 @@ index 257f7d6..212be19 100644
  ]
 
  [[package]]
-@@ -4395,6 +4378,15 @@ wheels = [
+@@ -4107,19 +4092,19 @@ wheels = [
+
+ [[package]]
+ name = "tornado"
+-version = "6.5.5"
++version = "6.5.7"
+ source = { registry = "https://pypi.org/simple" }
+-sdist = { url = "https://files.pythonhosted.org/packages/f8/f1/3173dfa4a18db4a9b03e5d55325559dab51ee653763bb8745a75af491286/tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9", size = 516006, upload-time = "2026-03-10T21:31:02.067Z" }
++sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+ wheels = [
+-    { url = "https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa", size = 445983, upload-time = "2026-03-10T21:30:44.28Z" },
+-    { url = "https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521", size = 444246, upload-time = "2026-03-10T21:30:46.571Z" },
+-    { url = "https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5", size = 447229, upload-time = "2026-03-10T21:30:48.273Z" },
+-    { url = "https://files.pythonhosted.org/packages/34/01/74e034a30ef59afb4097ef8659515e96a39d910b712a89af76f5e4e1f93c/tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07", size = 448192, upload-time = "2026-03-10T21:30:51.22Z" },
+-    { url = "https://files.pythonhosted.org/packages/be/00/fe9e02c5a96429fce1a1d15a517f5d8444f9c412e0bb9eadfbe3b0fc55bf/tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e", size = 448039, upload-time = "2026-03-10T21:30:53.52Z" },
+-    { url = "https://files.pythonhosted.org/packages/82/9e/656ee4cec0398b1d18d0f1eb6372c41c6b889722641d84948351ae19556d/tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca", size = 447445, upload-time = "2026-03-10T21:30:55.541Z" },
+-    { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
+-    { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
+-    { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
++    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
++    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
++    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
++    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
++    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
++    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
++    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
++    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
++    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
+ ]
+
+ [[package]]
+@@ -4395,6 +4380,15 @@ wheels = [
      { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
  ]
 

--- a/agents/langchain-deepagents-code/Dockerfile.base
+++ b/agents/langchain-deepagents-code/Dockerfile.base
@@ -287,7 +287,7 @@ RUN python3 -m venv --copies "$VIRTUAL_ENV" \
         -r /tmp/deepagents-code-requirements.lock \
     && "$VIRTUAL_ENV/bin/pip3" check \
     && "$VIRTUAL_ENV/bin/python3" -I -c \
-        "from importlib.metadata import version; assert version('pillow') == '12.3.0', version('pillow')" \
+        "from importlib.metadata import version; expected = {'deepagents-code': '0.1.34', 'mcp': '1.28.1', 'pillow': '12.3.0', 'pyasn1': '0.6.4', 'uv': '0.11.33'}; actual = {name: version(name) for name in expected}; assert actual == expected, actual" \
     && ln -sf "$VIRTUAL_ENV/bin/dcode" /usr/local/bin/dcode \
     && ln -sf "$VIRTUAL_ENV/bin/deepagents-code" /usr/local/bin/deepagents-code \
     && rm -f /tmp/deepagents-code-requirements.lock \

--- a/agents/langchain-deepagents-code/dependency-review.md
+++ b/agents/langchain-deepagents-code/dependency-review.md
@@ -7,24 +7,26 @@ This file records the reviewed dependency baseline for the Deep Agents Code sand
 Update it whenever `requirements.lock` changes.
 
 - Lockfile: `agents/langchain-deepagents-code/requirements.lock`
-- Lockfile SHA-256: `d112ad4a01ff2b87211b1a10ecb98950e62d4bdffb37a122326af7b352250d25`
+- Lockfile SHA-256: `b348f12ea2874c4240b523dc4e5814dce58893cd70de5ebbd74d313cbf6cc1e1`
 - Audit command: `uv tool run --python 3.13 pip-audit -r agents/langchain-deepagents-code/requirements.lock --progress-spinner off --disable-pip`
-- Audit date: 2026-07-29
-- Targeted audit result: `Pillow 12.3.0 has no known vulnerabilities`
-- Complete-lock audit result: `6 records in 3 unrelated packages`
+- Audit date: 2026-07-30
+- Targeted audit result: `uv 0.11.33, MCP 1.28.1, Pillow 12.3.0, and pyasn1 0.6.4 have no known vulnerabilities`
+- Complete-lock audit result: `2 duplicate records in 1 unrelated package`
 
 The Dockerfile installs this lockfile with `pip3 install --require-hashes`, so this review covers the exact package versions selected for the managed image install.
-The lock now selects `Pillow==12.3.0` instead of the transitive `12.2.0`
-resolution, removing the image-parser advisories in this remediation scope.
-The image build runs `pip3 check` and asserts the exact installed Pillow
-version before publishing.
+The lock now selects `uv==0.11.33`, `mcp==1.28.1`, `Pillow==12.3.0`, and
+`pyasn1==0.6.4`. The direct MCP and pyasn1 requirements are temporary,
+hash-locked constraints for the released Deep Agents Code `0.1.34` graph.
+Deep Agents Code `0.1.45` and later contain both dependency fixes, but their hook
+boundary has changed. Remove the temporary direct constraints only as part of a
+separately validated semantic migration to `>=0.1.45` that preserves NemoClaw's
+managed runtime hooks.
 
-The complete point-in-time audit also reports one record for `mcp==1.28.0`,
-three for `pyasn1==0.6.3`, and two duplicate database records for
-`setuptools==82.0.1`. These newly published records are not introduced by the
-Pillow-only lock regeneration and remain visible for a separate
-dependency-lifecycle review; this review does not claim the complete lock is
-vulnerability-free.
+The image build runs `pip3 check` and asserts all five installed package
+versions, including Deep Agents Code itself, before publishing. The complete
+point-in-time audit now reports only two duplicate database records for
+`setuptools==82.0.1`; that record is outside the Critical/High remediation
+scope. This review does not claim the complete lock is vulnerability-free.
 
 ## Managed `fetch_url` Proxy Adapter
 

--- a/agents/langchain-deepagents-code/requirements.in
+++ b/agents/langchain-deepagents-code/requirements.in
@@ -1,8 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-uv==0.11.15
+uv==0.11.33
 deepagents-code[nvidia,openrouter]==0.1.34
 nemo-relay[langgraph]==0.4.0
 # Fix the image parser advisories reported against the transitive 12.2.0 pin.
 pillow==12.3.0
+# Keep the managed MCP transport on the first release with Host/Origin validation.
+mcp==1.28.1
+# Fix the transitive ASN.1 decoder resource-exhaustion advisories.
+pyasn1==0.6.4

--- a/agents/langchain-deepagents-code/requirements.lock
+++ b/agents/langchain-deepagents-code/requirements.lock
@@ -1311,10 +1311,11 @@ markdownify==1.2.2 \
     --hash=sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a \
     --hash=sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09
     # via deepagents-code
-mcp==1.28.0 \
-    --hash=sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2 \
-    --hash=sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4
+mcp==1.28.1 \
+    --hash=sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df \
+    --hash=sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683
     # via
+    #   -r agents/langchain-deepagents-code/requirements.in
     #   deepagents-code
     #   langchain-mcp-adapters
 mdit-py-plugins==0.6.1 \
@@ -1908,10 +1909,12 @@ protobuf==6.33.6 \
     #   grpcio-tools
     #   langgraph-api
     #   opentelemetry-proto
-pyasn1==0.6.3 \
-    --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
-    --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
-    # via pyasn1-modules
+pyasn1==0.6.4 \
+    --hash=sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81 \
+    --hash=sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
+    # via
+    #   -r agents/langchain-deepagents-code/requirements.in
+    #   pyasn1-modules
 pyasn1-modules==0.4.2 \
     --hash=sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a \
     --hash=sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6
@@ -2840,26 +2843,26 @@ uuid-utils==0.16.2 \
     #   langchain-core
     #   langgraph-api
     #   langsmith
-uv==0.11.15 \
-    --hash=sha256:0ed920e896b2fd13a35031707e307e42fbb2681458b967440a17272d86d49137 \
-    --hash=sha256:40ff67e3f8e8a7533781a2e892a534975a93acb83ea35460e64e7b2bf2111774 \
-    --hash=sha256:41d907611f3e6a13262807fd7f0a17849f76285ca80f536f6b3943732bdc6656 \
-    --hash=sha256:49dc6ed70bff00937384f96cdc4b1a4742d18e5504ec2c4a1214dba2dee5687a \
-    --hash=sha256:4f39426a13dee24897aed60c4b98058c66f18bd983885ac5f4a54a04b24fbddf \
-    --hash=sha256:68c1e62d4b78578b90b833553286b65d6a7e327537716441068583ba652ec4f5 \
-    --hash=sha256:755f959ec6a2fd8ccb6ee76ad90ab759d2eb1f4797444078645dd1ee4bca92d6 \
-    --hash=sha256:83b04ab49514a0a761ffedb36a748ee81f87746671e72088e5f32c9585e5f1a9 \
-    --hash=sha256:8e2da3076761086a5b76869c3f38ef0509c836046ef41ddd19485dfd7271dca9 \
-    --hash=sha256:98edf1bdaf82447014852051d93e3ee95012509c567bf057fd117e6bdbd9a807 \
-    --hash=sha256:9accae33619a9166e5c48531deb455d672cfb89f9357a00975e669c76b0bd49f \
-    --hash=sha256:adb9a89352539fdd8f7cd5f9966cf9f94fc5b98e0ccdf5003a04123dc6423bec \
-    --hash=sha256:b6cae61f737be075b90be9e3f07d961072aed7019f4c9b8ed5c5d41c4d6cade3 \
-    --hash=sha256:be8f76d25bcf4c92bb384240ac1bf9aa7f51063d0bdeca4c9cf0ec3ed8b145e0 \
-    --hash=sha256:c0cf52cd6d50bb9e05e2d968f45f80761107e4cbc8d4a26d9758f9d8274aaec1 \
-    --hash=sha256:c6463a299ed7e6b5a800ed6f108af8e1588352629424133ddef7572b0e1e1118 \
-    --hash=sha256:cc3915ab291a1ecaf31de05f5d8bd70d09c66fe9911a53f70d9efa62ff0dbd8a \
-    --hash=sha256:e3b68f8bf1a4568710f77e5bda9182ce7682811d89a8e7468c22460e032b234d \
-    --hash=sha256:f9f4fbbf4fe485522054f3c7496c6e8e932d6436e4200ff3daf718db0b7c7bd5
+uv==0.11.33 \
+    --hash=sha256:2a8506f558e08498c0d80857c356452d14048eddfcc7bc20ec9f201b3011eaaf \
+    --hash=sha256:3242c8bc708b75fb72687c9a24f0e6f47c2004a3d82d32a81b06e17822708c28 \
+    --hash=sha256:36a98c68ba5c3bb59469414f54aaf00bd3134a647ca34509bc53d133ed8e0b5d \
+    --hash=sha256:3cb5b325c58a9ee5febfedf4895e0c48cc7d22d801d1b23a4b8335f16508d0da \
+    --hash=sha256:521229afa69ad5f57127de800120cb2bea1ac729a05a0851aaf920124f8edf66 \
+    --hash=sha256:686ed8c8d9e76eb9259e7f7db627ea836420d9a5e013b169c41398bcd28ee948 \
+    --hash=sha256:70826563c7617efbf7244946354628253e4ea63d72cb1d35b98be4896c4530fd \
+    --hash=sha256:71d00a28beb3924c593ba7ec248263679ae1f7c0f63a8cccc75e7d11ccb2adce \
+    --hash=sha256:8017991a398a55d177c33ecdb29beb33e7b53969921183e4681e3e5b278d73c2 \
+    --hash=sha256:923874411bc0bbf5d1de16cdb14a7800d696d6c6e774eb1b202966243c6d507b \
+    --hash=sha256:94fb388a86cf6c2f2610b427f1bf0897bc0f2771a869da41433e17f7d21a1a41 \
+    --hash=sha256:9542178978b0b6f16a7ae99e55aca039f493a1edb373a15d7993eab80a28615a \
+    --hash=sha256:a4411bf854f5fe3d4b78d37dd2e4b84e0b99fbb0bd185de1511a8515404e04a8 \
+    --hash=sha256:ab9ee61ed9c7c843b52795a96733e109cec831cd3250d73d291bccbb90a81999 \
+    --hash=sha256:ad74bd02a236417df9766b913c2613a7c3db0ef071c4c2390d28e5005be3e4b2 \
+    --hash=sha256:c1ca9b0b51cd89310f87f1fc0bf9d9c6fdb64be516fe3e409817662ec3d9378f \
+    --hash=sha256:d629531a4e8f7cd76d861ec2e0035faef2675036a084d0a5b35dad5025ec62aa \
+    --hash=sha256:e00f371e1affe3fac88f9f1afab31139c8199ecf8df7b1a37554f83629fd7eab \
+    --hash=sha256:f4196584a7f7fbfef3dde1b1a0454c174399bd96071cdfb066c263a798a4524e
     # via -r agents/langchain-deepagents-code/requirements.in
 uvicorn==0.49.0 \
     --hash=sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f \

--- a/docs/security/hermes-0.19.0-dependency-review.md
+++ b/docs/security/hermes-0.19.0-dependency-review.md
@@ -3,7 +3,7 @@
 
 # Hermes 0.19.0 dependency and compatibility review
 
-Review date: 2026-07-29
+Review date: 2026-07-30
 
 ## Decision
 
@@ -16,8 +16,9 @@ Named-profile copies remain inside the raw `profiles` directory capture under th
 The gateway-runtime-metadata, session-preview, Langfuse-placeholder, managed-light-skin, provider-routing, and resumed-one-shot workarounds remain necessary against the target source and retain exact-shape guards.
 
 The selected Python graph is hardened before installation with a reviewed, exact-source patch that updates the published dependency metadata and frozen lock together.
-It selects `cryptography==48.0.1`, `Pillow==12.3.0`, and `starlette==1.3.1`, then verifies those installed versions and the complete environment with `uv pip check`.
+It selects `cryptography==48.0.1`, `mcp==1.28.1`, `Pillow==12.3.0`, `starlette==1.3.1`, and `tornado==6.5.7`, then verifies those installed versions and the complete environment with `uv pip check`.
 The final image also replaces the published `python-multipart==0.0.27` lock resolution with the hash-verified and attested `python-multipart==0.0.32`.
+The base image overlays checksum-pinned Node.js `24.18.1` archives for both supported architectures and installs exact uv `0.11.33`; build-time assertions reject version drift before Hermes is installed.
 
 The source-pin commit must publish a fresh multi-platform Hermes base image before the final Dockerfile can name its immutable digest.
 The PR is not approval-ready until the pinned final image and required live E2E gates pass on the exact PR head.
@@ -33,6 +34,8 @@ The PR is not approval-ready until the pinned final image and required live E2E 
 | Target source commit | `3ef6bbd201263d354fd83ec55b3c306ded2eb72a` |
 | Target source archive SHA-256 | `285f3fc134ff466a90065e1517801a68993733b807158ee8f32aa01613786990` |
 | Target npm cross-check integrity | `sha512-+oVKG3lXbk2kEP+J6BXZjtmSBSaFfczIdOWQ9CUSTdTqq2uyHbk4p+kPyZ6MeGs56JU5qXzMNbqGKRVOQRGC1A==` |
+| Target Node.js release | `24.18.1` |
+| Target uv release | `0.11.33` |
 | Target PyPI wheel SHA-256 | `bd0bac012aee38a60894781f4597dc29ee7bedb3448540249921f10d3bef327f` |
 | Target PyPI source distribution SHA-256 | `ac986bede64a2785436676c0ea084ec586574f8cb00a9d047e095b435d3e21c0` |
 | Target publish date | `2026-07-20` |
@@ -56,7 +59,7 @@ The `hermes-agent` npm package is published from a different bridge repository a
 
 The complete adjacent range contains 2,399 source commits.
 The upstream release-note estimate is not used as the audit boundary.
-Python remains `>=3.11,<3.14`, and the JavaScript runtime remains Node `>=20`, so NemoClaw's Python 3.13 and Node 22 image floors remain compatible.
+Python remains `>=3.11,<3.14`, and the JavaScript runtime remains Node.js `>=20`, so NemoClaw's Python 3.13 and checksum-pinned Node.js 24.18.1 runtime remain compatible.
 
 ## Semantic migration and retained workarounds
 
@@ -152,21 +155,18 @@ The override clears `GHSA-5rvq-cxj2-64vf`, `GHSA-6jv3-5f52-599m`, and `GHSA-v9pg
 A Python 3.13 FastAPI `TestClient` probe covered ordinary forms, file upload, and dense CRLF input with the replacement parser.
 
 The source patch changes the published constraints and `uv.lock` as one transaction rather than overlaying packages after `uv sync`.
-In addition to the three direct selections, the resolver necessarily moves `alibabacloud-tea-openapi` from `0.4.4` to `0.4.5`, `darabonba-core` from `1.0.5` to `1.0.8`, and adds `websocket-client==1.9.0`.
+In addition to the five direct selections, the resolver necessarily moves `alibabacloud-tea-openapi` from `0.4.4` to `0.4.5`, `darabonba-core` from `1.0.5` to `1.0.8`, and adds `websocket-client==1.9.0`.
 The changed packages remain under Apache-2.0, BSD-3-Clause, MIT-CMU, or compatible dual-license terms; no restrictive license enters the selected graph.
 
-The 2026-07-29 point-in-time audit reports no advisory for `cryptography==48.0.1`, `Pillow==12.3.0`, or `starlette==1.3.1`.
-The exported patched lock still reports 14 records in seven other packages, but three records are for the published `python-multipart==0.0.27` resolution that the final image already replaces with `0.0.32`, for which the same point-in-time audit reports no advisories.
-The effective image therefore retains 11 newly published records in six unrelated packages: `click==8.3.1`, `mcp==1.26.0`, `pydantic-settings==2.13.1`, `Pygments==2.19.2`, `PyNaCl==1.5.0`, and `tornado==6.5.5`.
-Those records are not introduced by this targeted remediation and remain visible for a separate dependency-lifecycle review; this review does not describe the complete image as vulnerability-free.
+The 2026-07-30 point-in-time audit reports no advisory for `cryptography==48.0.1`, `mcp==1.28.1`, `Pillow==12.3.0`, `starlette==1.3.1`, or `tornado==6.5.7`.
+The exported patched lock still contains lower-severity records in unrelated packages and records for the published `python-multipart==0.0.27` resolution that the final image replaces with `0.0.32`.
+Those records are not introduced by this targeted Critical and High remediation and remain visible for a separate dependency-lifecycle review; this review does not describe the complete image as vulnerability-free.
 
 Compatibility evidence covers all 97 upstream image-routing tests with Pillow `12.3.0`, plus a real FastAPI `0.133.1`, Starlette `1.3.1`, and multipart `0.0.32` form and upload `TestClient` smoke.
 The image build additionally requires the frozen environment to remain consistent and asserts the exact installed versions before continuing.
 
-The remaining high records have evidence-backed exclusions from currently enabled Hermes paths.
-Hermes-owned MCP servers use stdio and do not enable authenticated stateful HTTP, custom WebSocket servers, or MCP tasks.
-Telegram uses HTTPX outbound requests and polling by default rather than Tornado's affected HTTP client and decompression paths.
-No Hermes call to `click.edit()` or PKCS#7 and S/MIME verification was found.
+The remaining audit records do not meet the Critical or High remediation threshold.
+They stay recorded rather than being described as fixed or excluded.
 
 The final root JavaScript runtime graph remains `agent-browser@0.26.0` plus the existing Streamdown tree and reports zero production audit findings.
 The TUI and web workspaces retain unchanged high package-level findings in build-only dependencies whose `node_modules` directories are deleted after compilation.
@@ -196,7 +196,7 @@ Artifact scanning must therefore inspect the assembled image and record the down
 | `HERMES-7` | High | Test and runtime-proof | The target's `mcp__server__tool` names are compatible by source inspection, while managed-tool discovery and invocation remain a live E2E gate. |
 | `HERMES-8` | High | Guard and runtime-proof | Optional upstream secret sources stay disabled, `--safe-mode` does not broaden the generated environment allowlist, and the live environment boundary must reject raw credentials. |
 | `HERMES-9` | High | Pin and test | The selected Python delta adds no advisory regression, and the affected multipart parser is replaced with attested `0.0.32` plus hash and runtime probes. |
-| `HERMES-10` | High | Pin and test | The exact-source patch updates Hermes metadata and its frozen lock together, selects `cryptography==48.0.1`, `Pillow==12.3.0`, and `starlette==1.3.1`, and fails the image build on dependency inconsistency or installed-version drift. |
+| `HERMES-10` | High | Pin and test | The exact-source patch updates Hermes metadata and its frozen lock together, selects `cryptography==48.0.1`, `mcp==1.28.1`, `Pillow==12.3.0`, `starlette==1.3.1`, and `tornado==6.5.7`, and fails the image build on dependency inconsistency or installed-version drift. The base image separately checksum-pins Node.js `24.18.1` and asserts uv `0.11.33`. |
 | `HERMES-11` | High | Migrate, test, and runtime-proof | Root npm audit reports zero production findings and the WhatsApp bridge removes its current critical, high, and medium advisory entries, while both architectures still require native bridge and message-path evidence. |
 | `HERMES-12` | High | Pin and runtime-proof | Trusted workflow run `30411365314` published the exact source commit as amd64 and arm64 manifests under OCI index `sha256:c4aee5c9b087840da6e1eb2127fef9f4a2eab0862992008d1741dc09f632422e`. The final Dockerfile pins that digest. Before the cron ledger relocation, the pinned arm64 final image passed all 62 BuildKit steps, including installed-version, patch, config, and cross-identity SQLite probes. The exact PR head must build the three added relocation layers and changed cron probe before protected runtime E2E. |
 | `HERMES-13` | Medium | Document bounded residual | Static `state_files` entries online-back up the default profile only. Cron or Discord ledgers created by a process launched under `profiles/<name>` remain in the raw `profiles` tar capture and can be inconsistent during a concurrent snapshot. Dynamic profile-local SQLite discovery is generic snapshot work outside this upgrade PR. |

--- a/scripts/upgrade-bundled-npm.mts
+++ b/scripts/upgrade-bundled-npm.mts
@@ -33,7 +33,7 @@ export const REVIEWED_NPM_PACKAGES = {
   tar: "7.5.19",
 } as const;
 
-const REPLACEABLE_NPM_VERSIONS = new Set(["10.9.8", "11.13.0"]);
+const REPLACEABLE_NPM_VERSIONS = new Set(["10.9.8", "11.13.0", "11.16.0"]);
 
 type JsonRecord = Record<string, unknown>;
 

--- a/test/hermes-dependency-review.test.ts
+++ b/test/hermes-dependency-review.test.ts
@@ -87,13 +87,23 @@ describe("Hermes 0.19.0 dependency review", () => {
       "git -C /opt/hermes apply --check /tmp/hermes-security-dependencies.patch",
     );
     expect(dockerfileBase).toContain("uv pip check --python /opt/hermes/.venv/bin/python");
-    for (const selection of ['"cryptography==48.0.1"', '"Pillow==12.3.0"', '"starlette==1.3.1"']) {
+    expect(arg("NODE_VERSION")).toBe("24.18.1");
+    expect(arg("UV_VERSION")).toBe("0.11.33");
+    for (const selection of [
+      '"cryptography==48.0.1"',
+      '"mcp==1.28.1"',
+      '"Pillow==12.3.0"',
+      '"starlette==1.3.1"',
+      '"tornado==6.5.7"',
+    ]) {
       expect(securityDependenciesPatch).toContain(selection);
     }
     for (const installedVersion of [
       "'cryptography': '48.0.1'",
+      "'mcp': '1.28.1'",
       "'pillow': '12.3.0'",
       "'starlette': '1.3.1'",
+      "'tornado': '6.5.7'",
     ]) {
       expect(dockerfileBase).toContain(installedVersion);
     }
@@ -108,8 +118,11 @@ describe("Hermes 0.19.0 dependency review", () => {
       expect(review).toContain(advisory);
     }
     expect(review).toContain("`cryptography==48.0.1`");
+    expect(review).toContain("`mcp==1.28.1`");
     expect(review).toContain("`Pillow==12.3.0`");
     expect(review).toContain("`starlette==1.3.1`");
-    expect(review).toContain("11 newly published records in six unrelated packages");
+    expect(review).toContain("`tornado==6.5.7`");
+    expect(review).toContain("checksum-pinned Node.js `24.18.1`");
+    expect(review).toContain("exact uv `0.11.33`");
   });
 });

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -1023,10 +1023,21 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(review).toContain(
       "uv tool run --python 3.13 pip-audit -r agents/langchain-deepagents-code/requirements.lock --progress-spinner off --disable-pip",
     );
-    expect(review).toContain("Targeted audit result: `Pillow 12.3.0 has no known vulnerabilities`");
-    expect(review).toContain("Complete-lock audit result: `6 records in 3 unrelated packages`");
+    expect(review).toContain(
+      "Targeted audit result: `uv 0.11.33, MCP 1.28.1, Pillow 12.3.0, and pyasn1 0.6.4 have no known vulnerabilities`",
+    );
+    expect(review).toContain(
+      "Complete-lock audit result: `2 duplicate records in 1 unrelated package`",
+    );
+    expect(review).toContain("Deep Agents Code `0.1.45` and later");
+    expect(review).toContain("semantic migration to `>=0.1.45`");
+    expect(requirementsLock).toContain("uv==0.11.33");
+    expect(requirementsLock).toContain("mcp==1.28.1");
     expect(requirementsLock).toContain("pillow==12.3.0");
-    expect(readAgentFile("Dockerfile.base")).toContain("assert version('pillow') == '12.3.0'");
+    expect(requirementsLock).toContain("pyasn1==0.6.4");
+    expect(readAgentFile("Dockerfile.base")).toContain(
+      "'mcp': '1.28.1', 'pillow': '12.3.0', 'pyasn1': '0.6.4', 'uv': '0.11.33'",
+    );
     expect(review).toContain(`Adapter module SHA-256: \`${sha256(adapterModule)}\``);
     expect(review).toContain(`Adapter project metadata SHA-256: \`${sha256(adapterMetadata)}\``);
     expect(review).toContain("Adapter dependency audit result: `No known vulnerabilities found`");

--- a/test/patch-bundled-npm-tar.test.ts
+++ b/test/patch-bundled-npm-tar.test.ts
@@ -28,7 +28,7 @@ function writeJson(file: string, value: object): void {
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function fixture(npmVersion: "10.9.7" | "11.13.0", tarVersion: string) {
+function fixture(npmVersion: "10.9.7" | "11.13.0" | "11.16.0", tarVersion: string) {
   const root = temporaryDirectory();
   const npmRoot = path.join(root, "npm");
   const replacementRoot = path.join(root, "replacement");
@@ -61,7 +61,8 @@ afterEach(() => {
 describe("npm bundled node-tar remediation", () => {
   it.each([
     ["Node 22 npm", "10.9.7", "7.5.11"],
-    ["Node 24 npm", "11.13.0", "7.5.13"],
+    ["Node.js 24.16 npm", "11.13.0", "7.5.13"],
+    ["Node.js 24.18 npm", "11.16.0", "7.5.15"],
   ] as const)("replaces the complete affected tree for %s", (_label, npmVersion, tarVersion) => {
     const target = fixture(npmVersion, tarVersion);
 

--- a/test/upgrade-bundled-npm.test.ts
+++ b/test/upgrade-bundled-npm.test.ts
@@ -32,7 +32,7 @@ function writePackage(root: string, location: string, name: string, version: str
   writeJson(path.join(root, "node_modules", location, "package.json"), { name, version });
 }
 
-function affectedNpm(version: "10.9.8" | "11.13.0"): string {
+function affectedNpm(version: "10.9.8" | "11.13.0" | "11.16.0"): string {
   const root = path.join(temporaryDirectory(), "npm");
   writeJson(path.join(root, "package.json"), { name: "npm", version });
   writePackage(root, "brace-expansion", "brace-expansion", "2.0.2");
@@ -93,6 +93,7 @@ describe("reviewed bundled npm upgrade", () => {
   it.each([
     "10.9.8",
     "11.13.0",
+    "11.16.0",
   ] as const)("replaces npm %s before running npm or npx", (version) => {
     const npmRoot = affectedNpm(version);
     const replacementRoot = reviewedNpm();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Updates the existing Hermes and Deep Agents Code managed base images to dependency versions that contain public security fixes. Hermes now pins Node.js 24.18.1, uv 0.11.33, MCP 1.28.1, and Tornado 6.5.7; Deep Agents Code retains its integration-compatible 0.1.34 release with hash-locked fixed transitive dependencies.

## Changes

- Checksum-pins the official Node.js 24.18.1 archives for amd64 and arm64, and updates the bundled npm remediation contract for npm 11.16.0.
- Applies an exact-source Hermes metadata and frozen-lock update for MCP 1.28.1 and Tornado 6.5.7, with dependency consistency and installed-version assertions.
- Keeps the current Deep Agents Code 0.1.34 integration contract while pinning uv 0.11.33, MCP 1.28.1, Pillow 12.3.0, and pyasn1 0.6.4 with hashes. Moving to Deep Agents Code 0.1.45 or later requires a separately validated hooks migration; the image contract test protects this temporary compatibility requirement.
- Updates the Hermes and Deep Agents Code dependency review records.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Security checklist passed for the exact PR diff; archive checksums, lock hashes, public dependency audits, installed-version assertions, gitleaks, and hadolint passed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/security/hermes-0.19.0-dependency-review.md`; `agents/langchain-deepagents-code/dependency-review.md`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4eb2cafa5 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Focused Hermes, Deep Agents Code image, bundled npm, and patch tests passed (50 tests); affected subsets passed again after final edits (24 tests and 7 tests).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated dependency versions to address reported vulnerabilities.
  * Added stricter package and runtime version verification.

* **Reliability**
  * Pinned Node.js 24.18.1 and uv 0.11.33 with checksum and version checks.
  * Improved reproducibility of Hermes and Deep Agents Code environments.

* **Documentation**
  * Refreshed dependency reviews, audit records, compatibility details, and security notes.

* **Tests**
  * Expanded validation for dependency pins, runtime versions, and npm upgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->