### PR TITLE
test(e2e): bracket Hermes MCP route removal

### DIFF
--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -415,6 +415,7 @@ async function assertConcurrentAddSerialized(
     mcpUrl: string;
     expectedAdapter: McpAdapter;
     artifactPrefix: string;
+    remainingServerName?: string;
   },
 ): Promise<void> {
   cleanup.add(`remove ${options.artifactPrefix} concurrent MCP bridge`, () =>
@@ -508,7 +509,11 @@ async function assertConcurrentAddSerialized(
     timeoutMs: 60_000,
   });
   expectExitZero(list, `${options.artifactPrefix} lists after concurrent bridge removal`);
-  expect(JSON.parse(list.stdout).bridges).toEqual([]);
+  expect(JSON.parse(list.stdout).bridges).toEqual(
+    options.remainingServerName
+      ? [expect.objectContaining({ server: options.remainingServerName })]
+      : [],
+  );
 }
 
 async function expectMcpCliFailure(
@@ -1200,13 +1205,6 @@ mcpBridgeShardTest("hermes")(
     );
 
     progress.phase("configure and inspect the Hermes MCP bridge");
-    await assertConcurrentAddSerialized(host, cleanup, {
-      sandboxName: HERMES_SANDBOX_NAME,
-      mcpUrl,
-      expectedAdapter: "hermes-config",
-      artifactPrefix: "hermes",
-    });
-
     const initialDiscoveryOffset = fakeMcp.requests.length;
     const providerName = await addBridgeAndReadStatus(host, {
       sandboxName: HERMES_SANDBOX_NAME,
@@ -1263,6 +1261,13 @@ mcpBridgeShardTest("hermes")(
       secretPaths: ["/sandbox/.hermes"],
     });
     await assertHermesToolCall("hermes-real-mcp-tool-call-after-dns-rebinding-remove");
+    await assertConcurrentAddSerialized(host, cleanup, {
+      sandboxName: HERMES_SANDBOX_NAME,
+      mcpUrl,
+      expectedAdapter: "hermes-config",
+      artifactPrefix: "hermes",
+      remainingServerName: SERVER_NAME,
+    });
     const survivingDiscoveryOffset = fakeMcp.requests.length;
     await restartBridgeWithoutHostSecret(host, HERMES_SANDBOX_NAME, "hermes");
     await assertHermesToolCall("hermes-real-mcp-tool-call-after-rediscovery-restart");

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -187,6 +187,7 @@ async function assertAdapterDnsRebindingDenied(
   options: {
     adapter: McpDnsRebindingAdapter;
     artifactPrefix: string;
+    beforeRemove?: () => Promise<void>;
     sandboxName: string;
     secretPaths: string[];
   },
@@ -316,6 +317,7 @@ async function assertAdapterDnsRebindingDenied(
   ).toHaveLength(0);
   // Restore before removal can reload policy and restart the sandbox.
   await restoreDnsRebindingHostsFixture(host, options.sandboxName, hostsFixture);
+  await options.beforeRemove?.();
   const remove = await host.nemoclaw([options.sandboxName, "mcp", "remove", REBIND_SERVER_NAME], {
     artifactName: `${options.artifactPrefix}-mcp-dns-rebinding-remove`,
     env: buildAvailabilityProbeEnv(),
@@ -1170,6 +1172,13 @@ mcpBridgeShardTest("hermes")(
       challenge: TOOL_CHALLENGE,
       resultToken: hermesResult,
     });
+    const assertHermesToolCall = (artifactName: string) =>
+      assertRealAdapterToolCall(sandbox, fakeMcp, {
+        agent: "hermes",
+        sandboxName: HERMES_SANDBOX_NAME,
+        resultToken: hermesResult,
+        artifactName,
+      });
     cleanup.add("stop fake Hermes MCP HTTPS server", () => fakeMcp.close());
     const fakeMcpTunnel = await startPublicMcpHttpsTunnel({
       cleanup,
@@ -1247,17 +1256,16 @@ mcpBridgeShardTest("hermes")(
     await assertAdapterDnsRebindingDenied(host, sandbox, cleanup, {
       adapter: "hermes-config",
       artifactPrefix: "hermes",
+      beforeRemove: async () => {
+        await assertHermesToolCall("hermes-real-mcp-tool-call-before-dns-rebinding-remove");
+      },
       sandboxName: HERMES_SANDBOX_NAME,
       secretPaths: ["/sandbox/.hermes"],
     });
+    await assertHermesToolCall("hermes-real-mcp-tool-call-after-dns-rebinding-remove");
     const survivingDiscoveryOffset = fakeMcp.requests.length;
     await restartBridgeWithoutHostSecret(host, HERMES_SANDBOX_NAME, "hermes");
-    await assertRealAdapterToolCall(sandbox, fakeMcp, {
-      agent: "hermes",
-      sandboxName: HERMES_SANDBOX_NAME,
-      resultToken: hermesResult,
-      artifactName: "hermes-real-mcp-tool-call-after-rediscovery-restart",
-    });
+    await assertHermesToolCall("hermes-real-mcp-tool-call-after-rediscovery-restart");
     await assertAuthenticatedMcpRediscovery(survivingMcp, survivingDiscoveryOffset);
     fakeMcp.setSecret(ROTATED_HOST_SECRET);
     await rotateBridgeCredential(host, HERMES_SANDBOX_NAME, "hermes");

--- a/test/e2e/support/mcp-bridge-sandbox.test.ts
+++ b/test/e2e/support/mcp-bridge-sandbox.test.ts
@@ -317,26 +317,38 @@ network_policies:
     expect(source).toContain(").toHaveLength(0);");
   });
 
-  it("captures the Hermes rediscovery offset after route removal and before restart", () => {
+  it("brackets Hermes route removal with surviving MCP tool calls", () => {
     const source = fs.readFileSync("test/e2e/live/mcp-bridge.test.ts", "utf8");
     const denialProof = source.indexOf("rebound request must not reach the upstream MCP server");
     const restore = source.indexOf("await restoreDnsRebindingHostsFixture", denialProof);
+    const beforeRemove = source.indexOf("await options.beforeRemove?.()", restore);
     const remove = source.indexOf("const remove = await host.nemoclaw", denialProof);
     const hermesTest = source.indexOf('mcpBridgeShardTest("hermes")');
     const rebinding = source.indexOf("await assertAdapterDnsRebindingDenied", hermesTest);
-    const offset = source.indexOf(
-      "const survivingDiscoveryOffset = fakeMcp.requests.length",
+    const beforeRemoveToolCall = source.indexOf(
+      "hermes-real-mcp-tool-call-before-dns-rebinding-remove",
       rebinding,
     );
+    const afterRemoveToolCall = source.indexOf(
+      "hermes-real-mcp-tool-call-after-dns-rebinding-remove",
+      beforeRemoveToolCall,
+    );
+    const offset = source.indexOf(
+      "const survivingDiscoveryOffset = fakeMcp.requests.length",
+      afterRemoveToolCall,
+    );
     const restart = source.indexOf("await restartBridgeWithoutHostSecret", offset);
-    const toolCall = source.indexOf("await assertRealAdapterToolCall", restart);
+    const toolCall = source.indexOf("hermes-real-mcp-tool-call-after-rediscovery-restart", restart);
     const rediscovery = source.indexOf("await assertAuthenticatedMcpRediscovery", toolCall);
 
     expect(denialProof).toBeGreaterThanOrEqual(0);
     expect(restore).toBeGreaterThan(denialProof);
-    expect(remove).toBeGreaterThan(restore);
+    expect(beforeRemove).toBeGreaterThan(restore);
+    expect(remove).toBeGreaterThan(beforeRemove);
     expect(rebinding).toBeGreaterThan(hermesTest);
-    expect(offset).toBeGreaterThan(rebinding);
+    expect(beforeRemoveToolCall).toBeGreaterThan(rebinding);
+    expect(afterRemoveToolCall).toBeGreaterThan(beforeRemoveToolCall);
+    expect(offset).toBeGreaterThan(afterRemoveToolCall);
     expect(restart).toBeGreaterThan(offset);
     expect(toolCall).toBeGreaterThan(restart);
     expect(rediscovery).toBeGreaterThan(toolCall);

--- a/test/e2e/support/mcp-bridge-sandbox.test.ts
+++ b/test/e2e/support/mcp-bridge-sandbox.test.ts
@@ -333,6 +333,10 @@ network_policies:
       "hermes-real-mcp-tool-call-after-dns-rebinding-remove",
       beforeRemoveToolCall,
     );
+    const concurrencyStress = source.indexOf(
+      "await assertConcurrentAddSerialized",
+      afterRemoveToolCall,
+    );
     const offset = source.indexOf(
       "const survivingDiscoveryOffset = fakeMcp.requests.length",
       afterRemoveToolCall,
@@ -348,7 +352,8 @@ network_policies:
     expect(rebinding).toBeGreaterThan(hermesTest);
     expect(beforeRemoveToolCall).toBeGreaterThan(rebinding);
     expect(afterRemoveToolCall).toBeGreaterThan(beforeRemoveToolCall);
-    expect(offset).toBeGreaterThan(afterRemoveToolCall);
+    expect(concurrencyStress).toBeGreaterThan(afterRemoveToolCall);
+    expect(offset).toBeGreaterThan(concurrencyStress);
     expect(restart).toBeGreaterThan(offset);
     expect(toolCall).toBeGreaterThan(restart);
     expect(rediscovery).toBeGreaterThan(toolCall);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This diagnostic change brackets removal of the DNS-rebinding MCP server with Hermes tool calls to the surviving server. The live E2E can now distinguish a failure that exists before removal from one introduced by the remove-triggered reload.

## Changes

- Call the surviving Hermes MCP tool immediately before removing the DNS-rebinding server.
- Call the same tool after removal and before the existing explicit restart.
- Run the unrelated concurrent-add stress after those probes so its same-host remove/add cycle cannot contaminate the diagnostic.
- Add an E2E-support source contract that preserves the runtime order around removal.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change adds diagnostic live E2E ordering and does not change user-visible behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `blocked`
- Evidence: This side-conversation host cannot run the required independent documentation writer. The test-only change does not require a documentation update.
- Agent: Codex Desktop
<!-- docs-review-head-sha: c20b34fe0 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec -- vitest run --project e2e-support test/e2e/support/mcp-bridge-sandbox.test.ts` — 14 passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
