### PR TITLE
docs: update v0.0.98 release entry

### DIFF
--- a/docs/changelog/2026-07-29.mdx
+++ b/docs/changelog/2026-07-29.mdx
@@ -29,7 +29,9 @@ It also repairs post-reboot delivery recovery, OpenShell-preserving uninstall, m
 - Messaging credential and shared-resource conflicts now stop onboarding, rebuild, and `channels add` for every channel.
   The explicit `channels add <channel> --force` flag remains the only conflict bypass and accepts the duplicate-consumer or shared-resource risk.
   For more information, refer to [Manage Messaging Channels](/user-guide/openclaw/manage-sandboxes/messaging-channels/manage-messaging-channels).
-- Hermes sandbox images now pin reviewed versions of `cryptography`, `Pillow`, and `starlette`.
+- OpenClaw, Hermes, and Deep Agents Code sandbox images now use reviewed, checksum-pinned Perl 5.44.0 packages.
+  Their base-image publisher creates multi-platform tags only after the native `linux/amd64` and `linux/arm64` digests pass.
+  Hermes sandbox images now pin reviewed versions of `cryptography`, `Pillow`, and `starlette`.
   Deep Agents Code sandbox images now pin a reviewed `Pillow` version.
   Hermes images also exclude upstream test sources from the published runtime filesystem, and image builds fail when dependency or filesystem identity drifts.
 - Gateway startup and Docker pulls now limit retained subprocess diagnostics.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Update the canonical NemoClaw v0.0.98 release entry with the managed-image security remediation that merged after the original release documentation.
The entry now records reviewed Perl 5.44.0 packages across OpenClaw, Hermes, and Deep Agents Code images and the native multi-platform publication check.

## Changes

- Update `docs/changelog/2026-07-29.mdx` under the existing `## v0.0.98` heading.
- Record the checksum-pinned Perl 5.44.0 packages and native `linux/amd64` and `linux/arm64` digest checks from [#7864](https://github.com/NVIDIA/NemoClaw/pull/7864).
- Confirm that the other post-entry merges, [#7868](https://github.com/NVIDIA/NemoClaw/pull/7868) and [#7866](https://github.com/NVIDIA/NemoClaw/pull/7866), change E2E orchestration or tests without changing user-facing behavior.

### Source Summary

- [#7864](https://github.com/NVIDIA/NemoClaw/pull/7864) -> `docs/changelog/2026-07-29.mdx`: Record the reviewed Perl 5.44.0 packages and native multi-platform publication checks for managed OpenClaw, Hermes, and Deep Agents Code images.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The merged source PR includes security-package, runtime, and publication tests. `test/changelog-docs.test.ts` validates the release-entry structure.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `blocked`
- Evidence: This side-conversation host does not permit subagents. The primary author reviewed `docs/changelog/2026-07-29.mdx` against `WRITING.md`, the controlled word list, and `docs/CONTRIBUTING.md`. The changelog contract passed 6 tests, and the docs build completed with 0 errors and 2 existing Fern warnings.
- Agent: Codex Desktop side conversation
<!-- docs-review-head-sha: 8e92d9681 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable. `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run test/changelog-docs.test.ts` passed 6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run for this documentation-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — The build completed with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — No new page was added.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v0.0.98 changelog with expanded sandbox image security and provenance details.
  * Documented checksum-pinned Perl packages and reviewed dependency versions for supported sandbox images.
  * Clarified that multi-platform image tags are published only after architecture-specific digest validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->