### PR TITLE
fix(hermes): accept uv version metadata

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -412,7 +412,9 @@ RUN printf '%s\n' \
 # skip rather than doing a nondeterministic dependency resolve during image
 # build.
 RUN pip3 install --no-cache-dir --break-system-packages "uv==${UV_VERSION}" \
-    && test "$(uv --version)" = "uv ${UV_VERSION}"
+    && uv_version_output="$(uv --version)" \
+    && uv_version="${uv_version_output#uv }" \
+    && test "${uv_version%% *}" = "${UV_VERSION}"
 # Upstream tests are not part of the production runtime and can contain
 # intentionally hostile security-test fixtures. Remove them in the extraction
 # RUN so their bytes never enter a published image layer.

--- a/test/hermes-dependency-review.test.ts
+++ b/test/hermes-dependency-review.test.ts
@@ -33,7 +33,7 @@ function arg(name: string): string {
   return match?.[1] ?? "";
 }
 
-function uvVersionCheckStatus(output: string): number | null {
+function uvVersionCheckStatus(output: string, expectedVersion: string): number | null {
   const script = [
     'uv() { printf "%s\\n" "$UV_OUTPUT"; }',
     'uv_version_output="$(uv --version)"',
@@ -41,7 +41,7 @@ function uvVersionCheckStatus(output: string): number | null {
     'test "${uv_version%% *}" = "${UV_VERSION}"',
   ].join("\n");
   return spawnSync("/bin/sh", ["-c", script], {
-    env: { ...process.env, UV_OUTPUT: output, UV_VERSION: "0.11.33" },
+    env: { ...process.env, UV_OUTPUT: output, UV_VERSION: expectedVersion },
   }).status;
 }
 
@@ -93,10 +93,19 @@ describe("Hermes 0.19.0 dependency review", () => {
   });
 
   it("accepts uv build metadata and rejects a different semantic version", () => {
+    const expectedVersion = arg("UV_VERSION");
+    const differentVersion = expectedVersion.replace(/\d+$/u, (patch) =>
+      String(Number.parseInt(patch, 10) + 1),
+    );
     expect(
-      uvVersionCheckStatus("uv 0.11.33 (fece32fc5 2026-07-28 aarch64-unknown-linux-gnu)"),
+      uvVersionCheckStatus(
+        `uv ${expectedVersion} (fece32fc5 2026-07-28 aarch64-unknown-linux-gnu)`,
+        expectedVersion,
+      ),
     ).toBe(0);
-    expect(uvVersionCheckStatus("uv 0.11.32 (different build metadata)")).not.toBe(0);
+    expect(
+      uvVersionCheckStatus(`uv ${differentVersion} (different build metadata)`, expectedVersion),
+    ).toBe(1);
   });
 
   it("ships the reviewed Python dependency remediations and records residual debt", () => {

--- a/test/hermes-dependency-review.test.ts
+++ b/test/hermes-dependency-review.test.ts
@@ -34,11 +34,27 @@ function arg(name: string): string {
 }
 
 function uvVersionCheckStatus(output: string, expectedVersion: string): number | null {
+  const dockerfileLines = dockerfileBase.split("\n");
+  const installIndex = dockerfileLines.findIndex(
+    (line) => line.startsWith("RUN pip3 install ") && line.includes('"uv==${UV_VERSION}"'),
+  );
+  expect(installIndex, "Missing Dockerfile uv install command").toBeGreaterThanOrEqual(0);
+
+  const commandLines: string[] = [];
+  for (let index = installIndex; index < dockerfileLines.length; index += 1) {
+    const line = dockerfileLines[index] ?? "";
+    commandLines.push(line);
+    if (!line.endsWith("\\")) {
+      break;
+    }
+  }
+  const versionCheckLines = commandLines.slice(1);
+  expect(versionCheckLines, "Missing Dockerfile uv version check").not.toHaveLength(0);
+
   const script = [
     'uv() { printf "%s\\n" "$UV_OUTPUT"; }',
-    'uv_version_output="$(uv --version)"',
-    'uv_version="${uv_version_output#uv }"',
-    'test "${uv_version%% *}" = "${UV_VERSION}"',
+    "set -e",
+    ...versionCheckLines.map((line) => line.replace(/^\s*&&\s*/u, "").replace(/\s*\\$/u, "")),
   ].join("\n");
   return spawnSync("/bin/sh", ["-c", script], {
     env: { ...process.env, UV_OUTPUT: output, UV_VERSION: expectedVersion },
@@ -118,10 +134,6 @@ describe("Hermes 0.19.0 dependency review", () => {
     expect(dockerfileBase).toContain("uv pip check --python /opt/hermes/.venv/bin/python");
     expect(arg("NODE_VERSION")).toBe("24.18.1");
     expect(arg("UV_VERSION")).toBe("0.11.33");
-    expect(dockerfileBase).toContain('uv_version_output="$(uv --version)"');
-    expect(dockerfileBase).toContain('uv_version="${uv_version_output#uv }"');
-    expect(dockerfileBase).toContain('test "${uv_version%% *}" = "${UV_VERSION}"');
-    expect(dockerfileBase).not.toContain('test "$(uv --version)" = "uv ${UV_VERSION}"');
     for (const selection of [
       '"cryptography==48.0.1"',
       '"mcp==1.28.1"',

--- a/test/hermes-dependency-review.test.ts
+++ b/test/hermes-dependency-review.test.ts
@@ -40,15 +40,9 @@ function uvVersionCheckStatus(output: string, expectedVersion: string): number |
   );
   expect(installIndex, "Missing Dockerfile uv install command").toBeGreaterThanOrEqual(0);
 
-  const commandLines: string[] = [];
-  for (let index = installIndex; index < dockerfileLines.length; index += 1) {
-    const line = dockerfileLines[index] ?? "";
-    commandLines.push(line);
-    if (!line.endsWith("\\")) {
-      break;
-    }
-  }
-  const versionCheckLines = commandLines.slice(1);
+  const commandLines = dockerfileLines.slice(installIndex);
+  const commandEndIndex = commandLines.findIndex((line) => !line.endsWith("\\"));
+  const versionCheckLines = commandLines.slice(1, commandEndIndex + 1);
   expect(versionCheckLines, "Missing Dockerfile uv version check").not.toHaveLength(0);
 
   const script = [

--- a/test/hermes-dependency-review.test.ts
+++ b/test/hermes-dependency-review.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -30,6 +31,18 @@ function arg(name: string): string {
   const match = dockerfileBase.match(new RegExp(`^ARG ${name}=(.+)$`, "mu"));
   expect(match, `Missing Dockerfile ARG ${name}`).not.toBeNull();
   return match?.[1] ?? "";
+}
+
+function uvVersionCheckStatus(output: string): number | null {
+  const script = [
+    'uv() { printf "%s\\n" "$UV_OUTPUT"; }',
+    'uv_version_output="$(uv --version)"',
+    'uv_version="${uv_version_output#uv }"',
+    'test "${uv_version%% *}" = "${UV_VERSION}"',
+  ].join("\n");
+  return spawnSync("/bin/sh", ["-c", script], {
+    env: { ...process.env, UV_OUTPUT: output, UV_VERSION: "0.11.33" },
+  }).status;
 }
 
 describe("Hermes 0.19.0 dependency review", () => {
@@ -79,6 +92,13 @@ describe("Hermes 0.19.0 dependency review", () => {
     }
   });
 
+  it("accepts uv build metadata and rejects a different semantic version", () => {
+    expect(
+      uvVersionCheckStatus("uv 0.11.33 (fece32fc5 2026-07-28 aarch64-unknown-linux-gnu)"),
+    ).toBe(0);
+    expect(uvVersionCheckStatus("uv 0.11.32 (different build metadata)")).not.toBe(0);
+  });
+
   it("ships the reviewed Python dependency remediations and records residual debt", () => {
     expect(dockerfileBase).toContain(
       "COPY agents/hermes/security-dependencies.patch /tmp/hermes-security-dependencies.patch",
@@ -89,6 +109,10 @@ describe("Hermes 0.19.0 dependency review", () => {
     expect(dockerfileBase).toContain("uv pip check --python /opt/hermes/.venv/bin/python");
     expect(arg("NODE_VERSION")).toBe("24.18.1");
     expect(arg("UV_VERSION")).toBe("0.11.33");
+    expect(dockerfileBase).toContain('uv_version_output="$(uv --version)"');
+    expect(dockerfileBase).toContain('uv_version="${uv_version_output#uv }"');
+    expect(dockerfileBase).toContain('test "${uv_version%% *}" = "${UV_VERSION}"');
+    expect(dockerfileBase).not.toContain('test "$(uv --version)" = "uv ${UV_VERSION}"');
     for (const selection of [
       '"cryptography==48.0.1"',
       '"mcp==1.28.1"',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fixes the Hermes base-image build after uv `0.11.33` added build metadata to its version output. The build now verifies the exact semantic version and permits the metadata suffix.

## Changes

- Parse the semantic-version token from `uv --version` instead of comparing the complete output.
- Add a regression test that accepts uv `0.11.33` with build metadata and rejects uv `0.11.32`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change only corrects a build-time version assertion. It does not change an installed version or user-visible behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The assertion still rejects any semantic version other than the checksum-reviewed uv `0.11.33`; the regression test covers accepted metadata and a rejected version.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The Dockerfile fix only accepts build metadata from the pinned uv version output. The regression test executes the Dockerfile fragment directly, accepts the pinned version with metadata, and rejects a different version. The maintainer follow-ups change only test implementation; no user-visible surface changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1809aa6ca -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/hermes-dependency-review.test.ts` passed all 5 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
