### PR TITLE
ci(e2e): wait for Launchable family update

### DIFF
--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -26,6 +26,7 @@ function fixture(
     deleteFails?: boolean;
     e2eFails?: boolean;
     imageRepositorySha?: string;
+    missingProvisionReceipt?: boolean;
     omitReceiptField?: "imageName" | "imageRepositorySha" | "project";
     provisionImageRepositorySha?: string;
     provisionSha?: string;
@@ -35,6 +36,7 @@ function fixture(
     repoSha?: string;
     runtimeOverrides?: boolean;
     schemaVersion?: number;
+    settleSeconds?: number;
     sourceRepository?: string;
     sourcePath?: string;
   } = {},
@@ -49,6 +51,10 @@ function fixture(
   fs.mkdirSync(workDir);
 
   executable(path.join(bin, "timeout"), '#!/usr/bin/env bash\nshift\nexec "$@"\n');
+  executable(
+    path.join(bin, "sleep"),
+    '#!/usr/bin/env bash\nprintf "sleep %s\\n" "$*" >> "$FAKE_CALLS"\n',
+  );
   executable(
     path.join(bin, "gh"),
     `#!/usr/bin/env bash
@@ -98,16 +104,20 @@ case "$1" in
       '{workspaces:[{id:"ws-1",name:$name,status:"RUNNING",shell_status:$shell,build_status:$build}]}' > "$FAKE_STATE" ;;
   exec)
     case "$3" in
+      *NEMOCLAW_BOOT_IMAGE*)
+        printf 'NEMOCLAW_BOOT_IMAGE=%s\\n' "$FAKE_BOOT_IMAGE"
+        printf '%s\\n' "$INSTANCE_NAME" ;;
       *repo_clean*)
+        [ "$FAKE_MISSING_PROVISION_RECEIPT" != 1 ] || exit 2
         printf 'NEMOCLAW_IDENTITY='
-        jq -cn --arg bootImage "$FAKE_BOOT_IMAGE" --arg sourcePath "$FAKE_SOURCE_PATH" \
-          --arg repo "$FAKE_REPO_SHA" --arg provision "$FAKE_PROVISION_SHA" \
+        jq -cn --arg sourcePath "$FAKE_SOURCE_PATH" --arg repo "$FAKE_REPO_SHA" \
+          --arg provision "$FAKE_PROVISION_SHA" \
           --arg sourceRepository "$FAKE_SOURCE_REPOSITORY" \
           --arg imageRepositorySha "$FAKE_PROVISION_IMAGE_REPOSITORY_SHA" \
           --argjson schemaVersion "$FAKE_SCHEMA_VERSION" --argjson clean "$FAKE_REPO_CLEAN" \
           --argjson overrides "$FAKE_RUNTIME_OVERRIDES" \
-          '{bootImage:$bootImage,schemaVersion:$schemaVersion,sourceRepository:$sourceRepository,
-            sourcePath:$sourcePath,repoSha:$repo,provisionSha:$provision,
+          '{schemaVersion:$schemaVersion,sourceRepository:$sourceRepository,sourcePath:$sourcePath,
+            repoSha:$repo,provisionSha:$provision,
             imageRepositorySha:$imageRepositorySha,repoClean:$clean,runtimeOverrides:$overrides}'
         printf '%s\\n' "$INSTANCE_NAME" ;;
       *) exit 2 ;;
@@ -146,6 +156,7 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     FAKE_DELETE_FAILS: options.deleteFails ? "1" : "0",
     FAKE_E2E_FAILS: options.e2eFails ? "1" : "0",
     FAKE_IMAGE_REPOSITORY_SHA: options.imageRepositorySha ?? "b".repeat(40),
+    FAKE_MISSING_PROVISION_RECEIPT: options.missingProvisionReceipt ? "1" : "0",
     FAKE_OMIT_RECEIPT_FIELD: options.omitReceiptField ?? "",
     FAKE_PROVISION_IMAGE_REPOSITORY_SHA:
       options.provisionImageRepositorySha ?? options.imageRepositorySha ?? "b".repeat(40),
@@ -163,6 +174,7 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     GITHUB_RUN_ATTEMPT: "1",
     GITHUB_RUN_ID: "789",
     INSTANCE_NAME: "nclaw-e2e-test-1",
+    LAUNCHABLE_FAMILY_SETTLE_SECONDS: String(options.settleSeconds ?? 0),
     NVIDIA_INFERENCE_API_KEY: "nvapi-test-value",
     POLL_SECONDS: "0",
     RUNNER_TEMP: root,
@@ -177,11 +189,15 @@ function run(env: NodeJS.ProcessEnv) {
 
 describe("focused staging Brev Launchable lane", () => {
   it("binds the producer run, verifies the clean booted SHA, runs E2E, and deletes (#6943)", () => {
-    const { calls, env, state, workDir } = fixture();
+    const { calls, env, state, workDir } = fixture({ settleSeconds: 7 });
     const result = run(env);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     const commands = fs.readFileSync(calls, "utf8");
     expect(commands.match(/\/dispatches/gu)).toHaveLength(1);
+    expect(commands).toContain("sleep 7");
+    expect(commands.indexOf("sleep 7")).toBeLessThan(
+      commands.indexOf("create nclaw-e2e-test-1 --launchable env-staging123"),
+    );
     expect(commands).toContain("create nclaw-e2e-test-1 --launchable env-staging123");
     expect(commands).toContain("ssh preinstalled full-e2e.test.ts");
     expect(commands).not.toContain("nvapi-test-value");
@@ -240,8 +256,16 @@ describe("focused staging Brev Launchable lane", () => {
     expect(fs.readFileSync(unready.calls, "utf8")).not.toMatch(/brev exec|full-e2e\.test\.ts/u);
     expect(fs.existsSync(unready.state)).toBe(false);
 
+    const wrongImage = fixture({
+      bootImage: "projects/brevdevprod/global/images/wrong-image",
+    });
+    const wrongImageResult = run(wrongImage.env);
+    expect(wrongImageResult.status).not.toBe(0);
+    expect(wrongImageResult.stderr).toContain("booted image does not match the producer handoff");
+    expect(fs.readFileSync(wrongImage.calls, "utf8")).not.toContain("full-e2e.test.ts");
+    expect(fs.existsSync(wrongImage.state)).toBe(false);
+
     for (const boot of [
-      fixture({ bootImage: "projects/brevdevprod/global/images/wrong-image" }),
       fixture({ repoSha: "b".repeat(40) }),
       fixture({ provisionSha: "b".repeat(40) }),
       fixture({ provisionImageRepositorySha: "c".repeat(40) }),
@@ -269,6 +293,21 @@ describe("focused staging Brev Launchable lane", () => {
     expect(fs.existsSync(state)).toBe(false);
     expect(JSON.parse(fs.readFileSync(path.join(workDir, "cleanup.json"), "utf8"))).toMatchObject({
       status: "ABSENT",
+    });
+  });
+
+  it("preserves the booted image when the provision receipt is missing", () => {
+    const { calls, env, state, workDir } = fixture({ missingProvisionReceipt: true });
+    const result = run(env);
+    expect(result.status).not.toBe(0);
+    expect(fs.existsSync(state)).toBe(false);
+    expect(fs.readFileSync(calls, "utf8")).not.toContain("full-e2e.test.ts");
+    expect(
+      JSON.parse(fs.readFileSync(path.join(workDir, "launchable-e2e.json"), "utf8")),
+    ).toMatchObject({
+      candidateSha,
+      boot: { bootImage: "projects/brevdevprod/global/images/nemoclaw-test-image" },
+      fullE2e: "pending",
     });
   });
 

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -36,7 +36,6 @@ function fixture(
     repoSha?: string;
     runtimeOverrides?: boolean;
     schemaVersion?: number;
-    settleSeconds?: number;
     sourceRepository?: string;
     sourcePath?: string;
   } = {},
@@ -174,7 +173,6 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     GITHUB_RUN_ATTEMPT: "1",
     GITHUB_RUN_ID: "789",
     INSTANCE_NAME: "nclaw-e2e-test-1",
-    LAUNCHABLE_FAMILY_SETTLE_SECONDS: String(options.settleSeconds ?? 0),
     NVIDIA_INFERENCE_API_KEY: "nvapi-test-value",
     POLL_SECONDS: "0",
     RUNNER_TEMP: root,
@@ -189,13 +187,13 @@ function run(env: NodeJS.ProcessEnv) {
 
 describe("focused staging Brev Launchable lane", () => {
   it("binds the producer run, verifies the clean booted SHA, runs E2E, and deletes (#6943)", () => {
-    const { calls, env, state, workDir } = fixture({ settleSeconds: 7 });
+    const { calls, env, state, workDir } = fixture();
     const result = run(env);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     const commands = fs.readFileSync(calls, "utf8");
     expect(commands.match(/\/dispatches/gu)).toHaveLength(1);
-    expect(commands).toContain("sleep 7");
-    expect(commands.indexOf("sleep 7")).toBeLessThan(
+    expect(commands).toContain("sleep 300");
+    expect(commands.indexOf("sleep 300")).toBeLessThan(
       commands.indexOf("create nclaw-e2e-test-1 --launchable env-staging123"),
     );
     expect(commands).toContain("create nclaw-e2e-test-1 --launchable env-staging123");

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -153,13 +153,8 @@ rm -rf "$WORK_DIR/handoff"
 
 # The standing Launchable resolves the staging family. Give that reference time to
 # observe the family update before deploying it.
-family_settle_seconds="${LAUNCHABLE_FAMILY_SETTLE_SECONDS:-300}"
-[[ "$family_settle_seconds" =~ ^[0-9]+$ ]] \
-  || die "LAUNCHABLE_FAMILY_SETTLE_SECONDS must be a non-negative integer"
-if [ "$family_settle_seconds" -gt 0 ]; then
-  log "Waiting ${family_settle_seconds}s for the Launchable image family to settle"
-  sleep "$family_settle_seconds"
-fi
+log "Waiting 300s for the Launchable image family to settle"
+sleep 300
 
 # The guest must boot the exact image and contain the exact clean candidate.
 existing="$(workspace)" || die "Brev workspace inventory failed"

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -151,7 +151,17 @@ expected_boot_image="projects/$(jq -er .project "$manifest")/global/images/$(jq 
 image_repository_sha="$(jq -er .imageRepositorySha "$manifest")"
 rm -rf "$WORK_DIR/handoff"
 
-# The standing Launchable resolves the staging family; the guest must contain the exact clean candidate.
+# The standing Launchable resolves the staging family. Give that reference time to
+# observe the family update before deploying it.
+family_settle_seconds="${LAUNCHABLE_FAMILY_SETTLE_SECONDS:-300}"
+[[ "$family_settle_seconds" =~ ^[0-9]+$ ]] \
+  || die "LAUNCHABLE_FAMILY_SETTLE_SECONDS must be a non-negative integer"
+if [ "$family_settle_seconds" -gt 0 ]; then
+  log "Waiting ${family_settle_seconds}s for the Launchable image family to settle"
+  sleep "$family_settle_seconds"
+fi
+
+# The guest must boot the exact image and contain the exact clean candidate.
 existing="$(workspace)" || die "Brev workspace inventory failed"
 [ -z "$existing" ] || die "workspace name already exists"
 cleanup_required=1
@@ -172,12 +182,28 @@ jq -e '.status == "RUNNING" and (.shell_status // .shellStatus) == "READY" and
 workspace_id="$(jq -r '.id // ""' <<<"$ready")"
 log "Workspace $INSTANCE_NAME ($workspace_id) is ready"
 
-# Return the booted image and the baked runtime receipt.
+# Record the booted image before reading the baked runtime receipt so a stale
+# Launchable image remains visible when the receipt is absent.
 # The remote shell expands the single-quoted command.
 # shellcheck disable=SC2016
-identity="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
+boot_image="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
   boot_image=$(curl -fsS --max-time 10 -H "Metadata-Flavor: Google" \
     http://metadata.google.internal/computeMetadata/v1/instance/image)
+  printf "NEMOCLAW_BOOT_IMAGE=%s\n" "$boot_image"' --host \
+  | sed -n 's/^NEMOCLAW_BOOT_IMAGE=//p' | tail -n 1)"
+[ -n "$boot_image" ] || die "booted image identity is missing"
+
+jq -n --arg candidateSha "$CANDIDATE_SHA" --arg producerRun "$producer_run" \
+  --arg bootImage "$boot_image" --arg workspaceName "$INSTANCE_NAME" --arg workspaceId "$workspace_id" \
+  '{candidateSha:$candidateSha,producer:{runId:$producerRun,status:"success"},boot:{bootImage:$bootImage},workspace:{name:$workspaceName,id:$workspaceId},fullE2e:"pending"}' \
+  >"$WORK_DIR/launchable-e2e.json"
+
+[ "$boot_image" = "$expected_boot_image" ] \
+  || die "booted image does not match the producer handoff"
+
+# Return the baked runtime receipt.
+# shellcheck disable=SC2016
+identity="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
   schema_version=$(sudo -n jq -er .schemaVersion /etc/nemoclaw/provision.json)
   source_repository=$(sudo -n jq -er .sourceRepository /etc/nemoclaw/provision.json)
   source_path=$(sudo -n jq -er .sourcePath /etc/nemoclaw/provision.json)
@@ -195,17 +221,15 @@ identity="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
     runtime_overrides=false
   fi
   printf "NEMOCLAW_IDENTITY="
-  jq -cn --arg bootImage "$boot_image" --argjson schemaVersion "$schema_version" \
-    --arg sourceRepository "$source_repository" --arg sourcePath "$source_path" \
+  jq -cn --argjson schemaVersion "$schema_version" --arg sourceRepository "$source_repository" \
+    --arg sourcePath "$source_path" \
     --arg repoSha "$repo_sha" --arg provisionSha "$provision_sha" \
     --arg imageRepositorySha "$image_repository_sha" --argjson repoClean "$repo_clean" \
     --argjson runtimeOverrides "$runtime_overrides" \
-    "{bootImage:\$bootImage,schemaVersion:\$schemaVersion,sourceRepository:\$sourceRepository,sourcePath:\$sourcePath,repoSha:\$repoSha,provisionSha:\$provisionSha,imageRepositorySha:\$imageRepositorySha,repoClean:\$repoClean,runtimeOverrides:\$runtimeOverrides}"' --host \
+    "{schemaVersion:\$schemaVersion,sourceRepository:\$sourceRepository,sourcePath:\$sourcePath,repoSha:\$repoSha,provisionSha:\$provisionSha,imageRepositorySha:\$imageRepositorySha,repoClean:\$repoClean,runtimeOverrides:\$runtimeOverrides}"' --host \
   | sed -n 's/^NEMOCLAW_IDENTITY=//p' | tail -n 1)"
-jq -e --arg sha "$CANDIDATE_SHA" --arg bootImage "$expected_boot_image" \
-  --arg imageRepositorySha "$image_repository_sha" '
-  .bootImage == $bootImage and .schemaVersion == 1 and
-  .sourceRepository == "NVIDIA/NemoClaw" and
+jq -e --arg sha "$CANDIDATE_SHA" --arg imageRepositorySha "$image_repository_sha" '
+  .schemaVersion == 1 and .sourceRepository == "NVIDIA/NemoClaw" and
   .sourcePath == "/opt/nemoclaw-image/NemoClaw" and
   .repoSha == $sha and .provisionSha == $sha and
   .imageRepositorySha == $imageRepositorySha and
@@ -213,10 +237,9 @@ jq -e --arg sha "$CANDIDATE_SHA" --arg bootImage "$expected_boot_image" \
   <<<"$identity" >/dev/null || die "booted image runtime does not match the producer handoff"
 source_path="$(jq -er .sourcePath <<<"$identity")"
 
-jq -n --arg candidateSha "$CANDIDATE_SHA" --arg producerRun "$producer_run" \
-  --argjson boot "$identity" --arg workspaceName "$INSTANCE_NAME" --arg workspaceId "$workspace_id" \
-  '{candidateSha:$candidateSha,producer:{runId:$producerRun,status:"success"},boot:$boot,workspace:{name:$workspaceName,id:$workspaceId},fullE2e:"pending"}' \
-  >"$WORK_DIR/launchable-e2e.json"
+jq --argjson identity "$identity" '.boot += $identity' \
+  "$WORK_DIR/launchable-e2e.json" >"$WORK_DIR/launchable-e2e.tmp"
+mv "$WORK_DIR/launchable-e2e.tmp" "$WORK_DIR/launchable-e2e.json"
 
 # Run the existing suite from the baked checkout; no source copy, install, or rebuild.
 raw_log="${RUNNER_TEMP:-/tmp}/brev-launchable-e2e-${GITHUB_RUN_ID}.raw"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Wait five minutes after the image producer verifies the staging family before deploying the standing Brev Launchable. Record the guest's GCE boot image before reading its provision receipt so a stale-family boot remains diagnosable when that receipt is absent.

## Changes

- Add a fixed 300-second family settle period before `brev create --launchable`.
- Persist the concrete boot image in `launchable-e2e.json` before validating `/etc/nemoclaw/provision.json`.
- Cover settle-before-deploy ordering, wrong-image rejection, missing-receipt evidence, runtime provenance, full E2E, and cleanup.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the protected internal E2E controller; the existing E2E README already describes exact baked-candidate validation through the standing Launchable.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Only the internal Launchable E2E controller and its focused tests changed. Existing E2E documentation already owns the exact-image behavior; comments, logs, errors, and test titles have no blocking terminology findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 13b6f4466 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/brev-launchable-e2e.test.ts` passed 5/5 after the final behavior edit.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging Launchable workflows by waiting for image availability before creating guest workspaces.
  * Enhanced boot image and runtime receipt handling to preserve accurate launch state.
  * When a provision receipt is unavailable, the workflow now fails safely, removes temporary state, and records the run as pending instead of starting full end-to-end validation.

* **Tests**
  * Added coverage for timing, boot image mismatches, and missing provision receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->