### PR TITLE
docs(hermes): fix agent-specific guidance

### DIFF
--- a/docs/inference/switch-providers.mdx
+++ b/docs/inference/switch-providers.mdx
@@ -46,15 +46,27 @@ $$nemoclaw inference set --provider <provider> --model <model> --sandbox <name>
 $$nemoclaw <name> shields up
 ```
 
+</AgentOnly>
+
+<AgentOnly variant="openclaw">
+
 For OpenClaw, NemoClaw updates the provider namespace and selected model in the running configuration.
 Changes within the current API family hot-reload without replacing the gateway process.
 When the API family changes, NemoClaw commits the route and configuration, then restarts only the OpenClaw gateway and verifies its health.
+
+</AgentOnly>
+
+<AgentOnly variant="hermes">
 
 For Hermes, NemoClaw updates `/sandbox/.hermes/config.yaml`, including the model, base URL, API-family mode, and OpenShell proxy API-key placeholder.
 When the dashboard profile exists, NemoClaw also mirrors the route into `/sandbox/.hermes/dashboard-home/config.yaml`; a normal runtime route change does not rebuild or restart Hermes.
 If that dashboard mirror cannot be confirmed, the route and main config remain committed but the command exits nonzero.
 Follow [Hermes dashboard config did not converge](../../reference/troubleshooting#hermes-dashboard-config-did-not-converge) before using Dashboard Chat.
 A missing dashboard profile is treated as disabled and does not fail the switch.
+
+</AgentOnly>
+
+<AgentOnly variant="openclaw,hermes">
 
 If the in-sandbox configuration sync fails after the gateway route changes, NemoClaw keeps the gateway and host registry aligned and prints a rebuild hint.
 Run the rebuild before relying on the running agent.

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -32,14 +32,6 @@ Deep Agents uses strict Landlock compatibility, so sandbox startup fails when Op
 
 </AgentOnly>
 
-<AgentOnly variant="hermes">
-
-<Note>
-Hermes sandboxes use an agent-specific baseline policy in `agents/hermes/policy-additions.yaml` so Hermes runtime binaries can reach the service endpoints they need while keeping the same deny-by-default model.
-</Note>
-
-</AgentOnly>
-
 ### Filesystem
 
 | Path | Access |

--- a/test/agent-variant-docs.test.ts
+++ b/test/agent-variant-docs.test.ts
@@ -292,6 +292,38 @@ import { AgentOnly } from "../_components/AgentGuide";
     expect(deepAgents).not.toContain(namedSandboxSyntax);
   });
 
+  it("excludes OpenClaw gateway behavior from Hermes provider switching (#7902)", () => {
+    const source = readFileSync(
+      new URL("../docs/inference/switch-providers.mdx", import.meta.url),
+      "utf8",
+    );
+    const render = (variant: "openclaw" | "hermes") =>
+      renderAgentVariantPage(source, variant, {
+        sourcePath: "/repo/docs/inference/switch-providers.mdx",
+      });
+    const openclaw = render("openclaw");
+    const hermes = render("hermes");
+    const openClawGatewayBehavior = "restarts only the OpenClaw gateway and verifies its health";
+
+    expect(openclaw).toContain(openClawGatewayBehavior);
+    expect(hermes).not.toContain(openClawGatewayBehavior);
+    expect(hermes).toContain("a normal runtime route change does not rebuild or restart Hermes");
+  });
+
+  it("renders the Hermes baseline-policy explanation once (#7903)", () => {
+    const source = readFileSync(
+      new URL("../docs/reference/network-policies.mdx", import.meta.url),
+      "utf8",
+    );
+    const hermes = renderAgentVariantPage(source, "hermes", {
+      sourcePath: "/repo/docs/reference/network-policies.mdx",
+    });
+    const baselineExplanation =
+      "Hermes sandboxes use an agent-specific baseline policy in `agents/hermes/policy-additions.yaml`";
+
+    expect(hermes.split(baselineExplanation)).toHaveLength(2);
+  });
+
   it("keeps the troubleshooting security review link within each agent guide (#6558)", () => {
     const troubleshooting = readFileSync(
       new URL("../docs/reference/troubleshooting.mdx", import.meta.url),

--- a/test/agent-variant-docs.test.ts
+++ b/test/agent-variant-docs.test.ts
@@ -306,6 +306,12 @@ import { AgentOnly } from "../_components/AgentGuide";
     const openClawGatewayBehavior = "restarts only the OpenClaw gateway and verifies its health";
 
     expect(openclaw).toContain(openClawGatewayBehavior);
+    expect(hermes).not.toContain(
+      "updates the provider namespace and selected model in the running configuration",
+    );
+    expect(hermes).not.toContain(
+      "Changes within the current API family hot-reload without replacing the gateway process",
+    );
     expect(hermes).not.toContain(openClawGatewayBehavior);
     expect(hermes).toContain("a normal runtime route change does not rebuild or restart Hermes");
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes two QA-reported Hermes documentation defects.
The Hermes provider-switch page now excludes OpenClaw gateway behavior, and the Network Policies page no longer repeats the Hermes baseline-policy guidance.

## Related Issue
Fixes #7902.
Fixes #7903.

## Changes
- Scope the OpenClaw and Hermes provider-switch behavior to their respective guide variants.
- Remove the duplicate Hermes baseline-policy callout.
- Add regression tests for both generated Hermes pages.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent documentation writer review passed on `d6eeb445e`; the diff changes agent-specific inference and policy documentation only and does not change runtime behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `docs/inference/switch-providers.mdx` and `docs/reference/network-policies.mdx` against the writing rules and documentation style. The focused regression test passed 17 of 17 tests, and `npm run docs --silent` completed with 0 errors.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d6eeb445e -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/agent-variant-docs.test.ts` passed 17 of 17 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run because the diff changes documentation and focused regression assertions only.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — Fern completed with 0 errors and reported one light-mode accent-color contrast warning in unchanged configuration.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “switch providers at runtime” workflow to show distinct, provider-specific instructions, with shared follow-up guidance applied after.
  * Refined the Hermes “Baseline Policy” section formatting by removing an extra wrapper while keeping the displayed text unchanged.
* **Tests**
  * Added assertions to ensure Hermes docs exclude OpenClaw gateway-behavior phrases and that Hermes-only baseline-policy guidance appears exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->