### PR TITLE
fix(hermes): remove uv build cache metadata

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -1191,6 +1191,7 @@ RUN check_metadata() { \
     && check_absent /root/.npm \
     && check_absent /root/.cache/electron \
     && check_absent /root/.cache/node-gyp \
+    && check_absent /root/.cache/uv \
     && check_absent /sandbox/.cache \
     && check_metadata /scripts/patch-bundled-npm-brace-expansion.mts 'root:root 444' \
     && check_metadata /scripts/patch-bundled-npm-tar.mts 'root:root 444' \

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -523,6 +523,8 @@ RUN set -eu; \
 # differential. Keep this hash-verified downstream override at the first stable
 # release that fixes those issues plus GHSA-v9pg-7xvm-68hf. Re-review the
 # version and both hashes on every Hermes version bump.
+# uv creates a phony .git cache marker even with --no-cache. Remove the cache
+# after the final uv command because the root cache is not used at runtime.
 # hadolint ignore=DL3059
 RUN printf '%s\n' \
         "python-multipart==0.0.32 \\" \
@@ -533,7 +535,8 @@ RUN printf '%s\n' \
         --no-deps --no-cache --require-hashes -r /tmp/multipart-req.txt \
     && rm -f /tmp/multipart-req.txt \
     && /opt/hermes/.venv/bin/python -c \
-        "import multipart; assert multipart.__version__ == '0.0.32', multipart.__version__"
+        "import multipart; assert multipart.__version__ == '0.0.32', multipart.__version__" \
+    && rm -rf /root/.cache/uv
 
 ENV PATH="/usr/local/bin:/opt/hermes/.venv/bin:${PATH}" \
     HERMES_TUI_DIR="/opt/hermes/ui-tui" \
@@ -561,7 +564,7 @@ RUN chmod -R a+rX /opt/hermes/.venv \
 # Gate the exact completed base filesystem before it can be published.
 COPY scripts/checks/node-tar-image-scan.mts /scripts/checks/node-tar-image-scan.mts
 RUN set -eu; \
-    for build_only_path in /opt/hermes/tests /root/.npm /root/.cache/electron /root/.cache/node-gyp; do \
+    for build_only_path in /opt/hermes/tests /root/.npm /root/.cache/electron /root/.cache/node-gyp /root/.cache/uv; do \
         if [ -e "$build_only_path" ] || [ -L "$build_only_path" ]; then \
             echo "ERROR: build-only Hermes path leaked into the base image: $build_only_path" >&2; \
             exit 1; \

--- a/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
+++ b/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
@@ -243,7 +243,7 @@ async function assertBuildOnlyPathsAbsent(probe: DockerProbe, container: string)
     probe,
     container,
     "build-only Hermes paths are present in the runtime image",
-    'for path in /opt/hermes/tests /root/.npm /root/.cache/electron /root/.cache/node-gyp; do test ! -e "$path" && test ! -L "$path"; done',
+    'for path in /opt/hermes/tests /root/.npm /root/.cache/electron /root/.cache/node-gyp /root/.cache/uv; do test ! -e "$path" && test ! -L "$path"; done',
   );
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes image builds can leave uv's build-only root cache in the published image even when uv runs with `--no-cache`. This change removes the cache after the final uv command and makes both image gates reject it.

## Changes

- Remove `/root/.cache/uv` after the final build-time uv command.
- Reject the cache path in the Hermes base-image and final-image gates.
- Verify the cache remains absent in the Hermes live E2E runtime image.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change removes build-only cache metadata and does not change a user-visible surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer security review passed all nine categories with no findings. The change removes a root-owned build cache and adds no input, dependency, credential, or privilege surface.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change removes `/root/.cache/uv` after the final build-time uv command and verifies that the path is absent from the base image, final image, and live E2E runtime image. No user-visible surface changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 22ec39e4a -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:e2e-phases:check` passed for 116 tests across 73 files; `npx vitest run --project integration test/node-tar-dockerfile-contract.test.ts` passed 13/13; Hadolint passed for both changed Dockerfiles.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime image hygiene by preventing temporary `uv` build caches from remaining in published images.
  * Added safeguards to ensure build-only cache paths are removed and cannot appear as symlinks.

* **Tests**
  * Expanded image verification checks to detect unintended `uv` cache remnants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->