### PR TITLE
fix(images): ignore BuildKit telemetry in dcode probe

### DIFF
--- a/agents/langchain-deepagents-code/Dockerfile
+++ b/agents/langchain-deepagents-code/Dockerfile
@@ -145,6 +145,7 @@ RUN install -d -m 0755 /usr/local/share/nemoclaw \
     && printf '%s\n' "$NEMOCLAW_DCODE_AUTO_APPROVAL" > /usr/local/share/nemoclaw/dcode-auto-approval \
     && chown root:root /usr/local/share/nemoclaw/dcode-proxy-host /usr/local/share/nemoclaw/dcode-proxy-port /usr/local/share/nemoclaw/dcode-inference-base-url /usr/local/share/nemoclaw/dcode-auto-approval \
     && chmod 0444 /usr/local/share/nemoclaw/dcode-proxy-host /usr/local/share/nemoclaw/dcode-proxy-port /usr/local/share/nemoclaw/dcode-inference-base-url /usr/local/share/nemoclaw/dcode-auto-approval \
+    && unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT \
     && empty_prompt_log="$(mktemp)" \
     && if timeout 10 /usr/local/bin/dcode -n "" >"$empty_prompt_log" 2>&1; then empty_prompt_status=0; else empty_prompt_status=$?; fi \
     && test "$empty_prompt_status" -eq 2 \

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -355,6 +355,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
       "test ! -L /usr/local/lib/nemoclaw/dcode-managed-exec",
       `test "$(stat -c '%u:%g:%a' /usr/local/lib/nemoclaw/dcode-managed-exec)" = "0:0:755"`,
       "cmp -s /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/lib/nemoclaw/dcode-managed-exec",
+      "unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
       "/usr/local/lib/nemoclaw/dcode-managed-exec /usr/bin/true",
       "/opt/venv/bin/pip3 install --no-index --no-cache-dir --no-deps --no-build-isolation /opt/nemoclaw-deepagents-profile-plugin",
       "find /opt/nemoclaw-deepagents-profile-plugin -type f -print | LC_ALL=C sort",
@@ -363,6 +364,9 @@ describe("LangChain Deep Agents Code image contracts", () => {
     ]) {
       expect(dockerfile).toContain(s);
     }
+    expect(dockerfile.indexOf("unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")).toBeLessThan(
+      dockerfile.indexOf('/usr/local/bin/dcode -n ""'),
+    );
     expect(
       dockerfile
         .split("\n")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The complete managed-image publication failed because BuildKit injected an OpenTelemetry endpoint into Dockerfile probe steps. Remove that build-only value before the probes run, while keeping the shipped runtime secret rejection unchanged.

## Changes

- Remove `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` from the build-time Deep Agents Code probe environment.
- Verify that the removal occurs before the managed launcher probe.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change affects only Dockerfile probe execution under BuildKit. It does not change the shipped runtime, configuration, or user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The runtime secret rejection remains unchanged. The exact failing buildx driver and the focused image contract test verify the scoped build-time removal.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change affects only BuildKit probe execution. The shipped runtime, configuration, interface, and user workflow do not change.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1db90ad37 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/langchain-deepagents-code-image.test.ts` passed 20 tests. The exact arm64 managed image also built with buildx's `docker-container` driver from the immutable attempt-3 base digest.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new docs only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Deep Agents Code image startup behavior by preventing unintended trace exporter configuration from affecting its non-interactive initialization.
  * Ensured initialization proceeds in the correct order for more reliable startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->