### PR TITLE
fix(images): clear platform pull before validation

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -811,6 +811,7 @@ jobs:
               DOCKER_CONFIG="$anonymous_config" docker pull \
                 --platform "$platform" \
                 "$cohort_reference"
+              docker image rm "$cohort_reference" >/dev/null
             done
           done < <(jq -c '.[]' "$cohort_manifests")
 

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -593,9 +593,6 @@ describe("complete managed-image publication workflow", () => {
     const accepted = runManagedImagePromotion(promotion);
     const acceptedCalls = accepted.calls.join("\n");
     const cohortDigest = `sha256:${"f".repeat(64)}`;
-    const pullCleanupCalls = accepted.calls.filter(
-      (call) => call.startsWith("pull ") || call.startsWith("image rm "),
-    );
     const expectedPullCalls = publicationAgents.flatMap((agent) => {
       const reference = `ghcr.io/nvidia/nemoclaw/${agent}-sandbox@${cohortDigest}`;
       return publicationPlatforms.map((platform) => `pull --platform ${platform} ${reference}`);
@@ -608,16 +605,15 @@ describe("complete managed-image publication workflow", () => {
     const rootPointer = acceptedCalls.indexOf(`openclaw-sandbox:${revision}`);
 
     expect(accepted.status, accepted.stderr).toBe(0);
-    expect(pullCleanupCalls).toHaveLength(expectedPullCalls.length * 2);
-    expect(pullCleanupCalls.filter((call) => call.startsWith("pull ")).sort()).toEqual(
+    expect(accepted.calls.filter((call) => call.startsWith("pull ")).sort()).toEqual(
       expectedPullCalls.sort(),
     );
-    for (let index = 0; index < pullCleanupCalls.length; index += 2) {
-      const pull = pullCleanupCalls[index];
-      const cleanup = pullCleanupCalls[index + 1];
-      const reference = pull?.match(/^pull --platform linux\/(?:amd64|arm64) (.+)$/u)?.[1];
+    for (const pull of expectedPullCalls) {
+      const index = accepted.calls.indexOf(pull);
+      const reference = pull.match(/^pull --platform linux\/(?:amd64|arm64) (.+)$/u)?.[1];
       expect(reference).toBeDefined();
-      expect(cleanup).toBe(`image rm ${reference}`);
+      expect(index).toBeGreaterThanOrEqual(0);
+      expect(accepted.calls[index + 1]).toBe(`image rm ${reference}`);
     }
     expect(lastCohortStage).toBeGreaterThanOrEqual(0);
     expect(rootPointer).toBeGreaterThan(lastCohortStage);

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -464,7 +464,6 @@ describe("complete managed-image publication workflow", () => {
     const steps = promoter.steps ?? [];
     const barrier = step(promoter, "Validate complete managed image candidate set");
     const promotion = step(promoter, "Promote validated multi-platform managed image cohort");
-    const promotionRun = promotion.run ?? "";
 
     expect(promoter.needs).toBe("build-and-validate");
     expect(step(promoter, "Download all validated managed image candidates").with).toEqual({
@@ -485,11 +484,6 @@ describe("complete managed-image publication workflow", () => {
       'docker buildx imagetools create --tag "$cohort_alias" "${sources[@]}"',
     );
     expect(promotion.run).toContain(') == ["linux/amd64", "linux/arm64"]');
-    expect(promotionRun).toContain('DOCKER_CONFIG="$anonymous_config" docker pull');
-    expect(promotionRun).toContain('docker image rm "$cohort_reference"');
-    expect(promotionRun.indexOf('docker image rm "$cohort_reference"')).toBeGreaterThan(
-      promotionRun.indexOf('DOCKER_CONFIG="$anonymous_config" docker pull'),
-    );
     expect(promotion.run).toContain(
       'consumer_aliases=("$(jq -r \'.image\' <<<"$openclaw_manifest"):${GITHUB_SHA}")',
     );
@@ -598,6 +592,14 @@ describe("complete managed-image publication workflow", () => {
 
     const accepted = runManagedImagePromotion(promotion);
     const acceptedCalls = accepted.calls.join("\n");
+    const cohortDigest = `sha256:${"f".repeat(64)}`;
+    const pullCleanupCalls = accepted.calls.filter(
+      (call) => call.startsWith("pull ") || call.startsWith("image rm "),
+    );
+    const expectedPullCalls = publicationAgents.flatMap((agent) => {
+      const reference = `ghcr.io/nvidia/nemoclaw/${agent}-sandbox@${cohortDigest}`;
+      return publicationPlatforms.map((platform) => `pull --platform ${platform} ${reference}`);
+    });
     const lastCohortStage = Math.max(
       acceptedCalls.indexOf(`hermes-sandbox:cohort-${cohort}`),
       acceptedCalls.indexOf(`langchain-deepagents-code-sandbox:cohort-${cohort}`),
@@ -606,6 +608,17 @@ describe("complete managed-image publication workflow", () => {
     const rootPointer = acceptedCalls.indexOf(`openclaw-sandbox:${revision}`);
 
     expect(accepted.status, accepted.stderr).toBe(0);
+    expect(pullCleanupCalls).toHaveLength(expectedPullCalls.length * 2);
+    expect(pullCleanupCalls.filter((call) => call.startsWith("pull ")).toSorted()).toEqual(
+      expectedPullCalls.toSorted(),
+    );
+    for (let index = 0; index < pullCleanupCalls.length; index += 2) {
+      const pull = pullCleanupCalls[index];
+      const cleanup = pullCleanupCalls[index + 1];
+      const reference = pull?.match(/^pull --platform linux\/(?:amd64|arm64) (.+)$/u)?.[1];
+      expect(reference).toBeDefined();
+      expect(cleanup).toBe(`image rm ${reference}`);
+    }
     expect(lastCohortStage).toBeGreaterThanOrEqual(0);
     expect(rootPointer).toBeGreaterThan(lastCohortStage);
     expect(acceptedCalls).not.toContain(`hermes-sandbox:${revision}`);

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -609,8 +609,8 @@ describe("complete managed-image publication workflow", () => {
 
     expect(accepted.status, accepted.stderr).toBe(0);
     expect(pullCleanupCalls).toHaveLength(expectedPullCalls.length * 2);
-    expect(pullCleanupCalls.filter((call) => call.startsWith("pull ")).toSorted()).toEqual(
-      expectedPullCalls.toSorted(),
+    expect(pullCleanupCalls.filter((call) => call.startsWith("pull ")).sort()).toEqual(
+      expectedPullCalls.sort(),
     );
     for (let index = 0; index < pullCleanupCalls.length; index += 2) {
       const pull = pullCleanupCalls[index];

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -464,6 +464,7 @@ describe("complete managed-image publication workflow", () => {
     const steps = promoter.steps ?? [];
     const barrier = step(promoter, "Validate complete managed image candidate set");
     const promotion = step(promoter, "Promote validated multi-platform managed image cohort");
+    const promotionRun = promotion.run ?? "";
 
     expect(promoter.needs).toBe("build-and-validate");
     expect(step(promoter, "Download all validated managed image candidates").with).toEqual({
@@ -484,7 +485,11 @@ describe("complete managed-image publication workflow", () => {
       'docker buildx imagetools create --tag "$cohort_alias" "${sources[@]}"',
     );
     expect(promotion.run).toContain(') == ["linux/amd64", "linux/arm64"]');
-    expect(promotion.run).toContain('DOCKER_CONFIG="$anonymous_config" docker pull');
+    expect(promotionRun).toContain('DOCKER_CONFIG="$anonymous_config" docker pull');
+    expect(promotionRun).toContain('docker image rm "$cohort_reference"');
+    expect(promotionRun.indexOf('docker image rm "$cohort_reference"')).toBeGreaterThan(
+      promotionRun.indexOf('DOCKER_CONFIG="$anonymous_config" docker pull'),
+    );
     expect(promotion.run).toContain(
       'consumer_aliases=("$(jq -r \'.image\' <<<"$openclaw_manifest"):${GITHUB_SHA}")',
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed-image promotion now removes each locally pulled platform image before it validates the next architecture. This prevents Docker from rejecting the second platform pull for the same multi-platform digest.

## Changes

- Remove the local cohort image after each anonymous architecture-specific pull.
- Verify that local image removal follows the anonymous pull in the managed-image workflow.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change affects only the local Docker cache used by CI validation. It does not change a managed-image tag, publication contract, interface, or operator procedure.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed `.github/workflows/managed-images.yaml` and `test/managed-image-publication-workflow.test.ts`. The change has no user-facing interface, publication-contract, or operator-procedure effect.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f4ab97473 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/managed-image-publication-workflow.test.ts` passed 11 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved image publication workflow cleanup by automatically removing temporarily pulled images after processing.
  * Helps reduce leftover image data and local storage usage during staged image promotion.

* **Tests**
  * Updated validation to confirm platform-specific images are pulled and removed as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->