### PR TITLE
fix(ci): clear managed image platform pulls

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -811,6 +811,9 @@ jobs:
               DOCKER_CONFIG="$anonymous_config" docker pull \
                 --platform "$platform" \
                 "$cohort_reference"
+              # The classic Docker image store cannot retain two platform
+              # variants under one multi-platform digest reference.
+              docker image rm "$cohort_reference"
             done
           done < <(jq -c '.[]' "$cohort_manifests")
 

--- a/test/helpers/managed-image-publication-barrier.ts
+++ b/test/helpers/managed-image-publication-barrier.ts
@@ -141,6 +141,7 @@ export function runManagedImagePromotion(script: string, failCohortAgent = ""): 
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-promotion-"));
   const bin = path.join(root, "bin");
   const calls = path.join(root, "docker-calls");
+  const pulledReferences = path.join(root, "docker-pulled-references");
   const candidateSet = path.join(root, "candidate-set.json");
   const contracts = path.join(root, "managed-image-contracts");
   const digest = `sha256:${"f".repeat(64)}`;
@@ -163,6 +164,19 @@ export function runManagedImagePromotion(script: string, failCohortAgent = ""): 
     `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >> "$DOCKER_CALLS"
+if [ "$1" = "pull" ]; then
+  reference="\${@: -1}"
+  if grep -Fxq "$reference" "$DOCKER_PULLED_REFERENCES" 2>/dev/null; then
+    printf 'cannot overwrite digest %s\\n' "\${reference##*@}" >&2
+    exit 92
+  fi
+  printf '%s\\n' "$reference" >> "$DOCKER_PULLED_REFERENCES"
+elif [ "$1" = "image" ] && [ "$2" = "rm" ]; then
+  reference="$3"
+  remaining="\${DOCKER_PULLED_REFERENCES}.remaining"
+  grep -Fvx "$reference" "$DOCKER_PULLED_REFERENCES" > "$remaining" || true
+  mv "$remaining" "$DOCKER_PULLED_REFERENCES"
+fi
 if [ -n "\${FAIL_COHORT_AGENT:-}" ] &&
    [[ "$*" == *"imagetools create"* ]] &&
    [[ "$*" == *"/\${FAIL_COHORT_AGENT}-sandbox:cohort-"* ]]; then
@@ -189,6 +203,7 @@ fi
         ...process.env,
         CANDIDATE_SET: candidateSet,
         DOCKER_CALLS: calls,
+        DOCKER_PULLED_REFERENCES: pulledReferences,
         FAIL_COHORT_AGENT: failCohortAgent,
         GITHUB_REPOSITORY: repository,
         GITHUB_RUN_ATTEMPT: runAttempt,

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -572,6 +572,38 @@ describe("complete managed-image publication workflow", () => {
     expect(runPublicationBarrier(barrier.run ?? "").status).toBe(0);
   });
 
+  it("removes each anonymously pulled digest reference before the next platform pull", () => {
+    const promotion = required(
+      step(
+        managedPromoter(readWorkflow("managed-images.yaml")),
+        "Promote validated multi-platform managed image cohort",
+      ).run,
+      "managed image promotion script is missing",
+    );
+    const result = runManagedImagePromotion(promotion);
+    const collision = runManagedImagePromotion(
+      promotion.replace('docker image rm "$cohort_reference"', ":"),
+    );
+    const digest = `sha256:${"f".repeat(64)}`;
+    const anonymousPullCalls = result.calls.filter(
+      (call) => call.startsWith("pull --platform") || call.startsWith("image rm"),
+    );
+    const expectedCalls = [...publicationAgents].sort().flatMap((agent) => {
+      const reference = `ghcr.io/nvidia/nemoclaw/${agent}-sandbox@${digest}`;
+      return [
+        `pull --platform linux/amd64 ${reference}`,
+        `image rm ${reference}`,
+        `pull --platform linux/arm64 ${reference}`,
+        `image rm ${reference}`,
+      ];
+    });
+
+    expect(collision.status).toBe(92);
+    expect(collision.stderr).toContain(`cannot overwrite digest ${digest}`);
+    expect(result.status, result.stderr).toBe(0);
+    expect(anonymousPullCalls).toEqual(expectedCalls);
+  });
+
   it("stages all multi-platform cohort aliases before moving the sole root pointer (#7744)", () => {
     const promotion = required(
       step(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed image publication now removes the local digest reference after each anonymous platform pull. This prevents Docker's classic image store from rejecting the next platform pull with `cannot overwrite digest` while preserving both architecture checks.

## Changes

- Remove each locally pulled digest reference before the next platform pull.
- Make the managed-image promotion harness reproduce the same-digest platform collision.
- Verify the cleanup order for every agent and supported architecture.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change repairs internal GitHub Actions image publication and does not change a user API, CLI, configuration, default, or supported workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The [nine-category security review](https://github.com/NVIDIA/NemoClaw/pull/7953#issuecomment-5137583010) passed with no findings. The change removes only runner-local digest references; registry aliases, credentials, permissions, and authorization are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change affects internal GitHub Actions image publication only. The reviewer found no user documentation requirement or blocking writing findings. The focused Linux integration test passed 12/12 after the final wording change.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f4ae478d3 -->
<!-- docs-review-agents-blob-sha: c052d60aa2b -->

## DGX Station Hardware Evidence

<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Linux `npx vitest run --project integration test/managed-image-publication-workflow.test.ts` passed 12/12 in `node:22-bookworm` with `jq`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-platform image promotion by removing temporary image references before processing the next platform.
  * Prevented conflicting platform variants from being retained in the local Docker image store.

* **Tests**
  * Added coverage confirming correct cleanup order and successful promotion.
  * Added validation for expected failure handling when image references are not removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->