### PR TITLE
ci(e2e): tier retained gateway upgrade coverage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4316,6 +4316,8 @@ jobs:
         include:
           - id: v0.0.36-x86_64
             runner: ubuntu-latest
+            execution_tier: weekly-release
+            unique_boundary: "oldest-supported OpenShell/NemoClaw gateway migration baseline"
             shard: v0-0-36-x86-64
             nemoclaw_ref: v0.0.36
             nemoclaw_commit: "3351fbdd4eb7d9b80ec471545083956327da2b10"
@@ -4325,6 +4327,8 @@ jobs:
             openclaw_version: 2026.4.24
           - id: v0.0.55-x86_64
             runner: ubuntu-latest
+            execution_tier: weekly-release
+            unique_boundary: "OpenShell 0.0.44 gateway migration on x86_64"
             shard: v0-0-55-x86-64
             nemoclaw_ref: v0.0.55
             nemoclaw_commit: "95d483fe2b6569d68e59493c60f19df09a068e8f"
@@ -4334,6 +4338,8 @@ jobs:
             openclaw_version: 2026.5.22
           - id: v0.0.55-aarch64
             runner: ubuntu-24.04-arm
+            execution_tier: weekly-release
+            unique_boundary: "OpenShell 0.0.44 gateway migration on arm64"
             shard: v0-0-55-aarch64
             nemoclaw_ref: v0.0.55
             nemoclaw_commit: "95d483fe2b6569d68e59493c60f19df09a068e8f"
@@ -4343,6 +4349,8 @@ jobs:
             openclaw_version: 2026.5.22
           - id: v0.0.74-x86_64
             runner: ubuntu-latest
+            execution_tier: weekly-release
+            unique_boundary: "immediate-predecessor OpenShell 0.0.72 gateway migration"
             shard: v0-0-74-x86-64
             nemoclaw_ref: v0.0.74
             nemoclaw_commit: "3a05b54e8ec3e1d5550ec5c728de54af872bffe3"
@@ -4352,6 +4360,8 @@ jobs:
             openclaw_version: 2026.5.27
           - id: v0.0.89-x86_64
             runner: ubuntu-latest
+            execution_tier: nightly
+            unique_boundary: "current OpenClaw state-upgrade gateway migration"
             shard: v0-0-89-x86-64
             nemoclaw_ref: v0.0.89
             nemoclaw_commit: "1143aa5cce77f3bad1b3b5588bd7fddbe438237e"
@@ -4379,6 +4389,8 @@ jobs:
       NEMOCLAW_OLD_OPENCLAW_VERSION: ${{ matrix.openclaw_version }}
       NEMOCLAW_CURRENT_OPENCLAW_VERSION: ${{ matrix.current_openclaw_version }}
       NEMOCLAW_OPENCLAW_STATE_UPGRADE_PROOF: ${{ matrix.openclaw_state_upgrade }}
+      NEMOCLAW_GATEWAY_UPGRADE_EXECUTION_TIER: ${{ matrix.execution_tier }}
+      NEMOCLAW_GATEWAY_UPGRADE_UNIQUE_BOUNDARY: ${{ matrix.unique_boundary }}
       OPENSHELL_GATEWAY: "nemoclaw"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -4389,15 +4401,72 @@ jobs:
 
       - *dockerhub-auth
 
+      - id: gateway_upgrade_tier
+        name: Classify OpenShell gateway upgrade coverage tier
+        env:
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          EXECUTION_TIER: ${{ matrix.execution_tier }}
+          INCLUDE_STAGING_BREV_LAUNCHABLE: ${{ inputs.include_staging_brev_launchable && '1' || '0' }}
+          JOBS: ${{ inputs.jobs }}
+          MATRIX_ID: ${{ matrix.id }}
+          TARGETS: ${{ inputs.targets }}
+          UNIQUE_BOUNDARY: ${{ matrix.unique_boundary }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          selected=0
+          case ",${JOBS}," in
+            *,openshell-gateway-upgrade,*) selected=1 ;;
+          esac
+          case ",${TARGETS}," in
+            *,openshell-gateway-upgrade,*) selected=1 ;;
+          esac
+
+          day_of_week="$(date -u +%u)"
+          reason="skipped-by-tier"
+          run=0
+          if [[ "${selected}" == "1" ]]; then
+            run=1
+            reason="explicit-selection"
+          elif [[ "${EXECUTION_TIER}" == "nightly" ]]; then
+            run=1
+            reason="nightly-canonical"
+          elif [[ "${EVENT_NAME}" == "schedule" && "${day_of_week}" == "7" ]]; then
+            run=1
+            reason="weekly-retained"
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" && -z "${CHECKOUT_SHA}" && "${INCLUDE_STAGING_BREV_LAUNCHABLE}" == "1" ]]; then
+            run=1
+            reason="release-qualification"
+          fi
+
+          printf 'run=%s\n' "${run}" >> "${GITHUB_OUTPUT}"
+          printf 'reason=%s\n' "${reason}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "### OpenShell gateway upgrade tier"
+            echo ""
+            echo "- Row: \`${MATRIX_ID}\`"
+            echo "- Tier: \`${EXECUTION_TIER}\`"
+            echo "- Boundary: ${UNIQUE_BOUNDARY}"
+            echo "- Decision: \`${reason}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          if [[ "${run}" != "1" ]]; then
+            echo "skipped-by-tier: ${MATRIX_ID} is retained for ${EXECUTION_TIER} coverage and not selected for this run"
+          fi
+
       - name: Prepare E2E workspace
+        if: ${{ steps.gateway_upgrade_tier.outputs.run == '1' }}
         uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@f6304bc25fc35bfaa441c8c2fbfee38f72805a75
 
       - name: Run OpenShell gateway upgrade live Vitest test
+        if: ${{ steps.gateway_upgrade_tier.outputs.run == '1' }}
         # Keep the original v0.0.36 fixture on x86_64 and validate the exact
         # v0.0.55/OpenShell 0.0.44 regression shape on x86_64 and arm64, plus
         # the immediate v0.0.74/OpenShell 0.0.72 predecessor to this bump. The
         # v0.0.89 row proves OpenClaw 2026.6.10 state survives the 2026.7.1
-        # migration without crossing the OpenShell secret boundary.
+        # migration without crossing the OpenShell secret boundary. The matrix
+        # keeps every retained row directly selectable while only the current
+        # state-upgrade row runs in the ordinary nightly tier.
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -4405,8 +4474,15 @@ jobs:
           export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
           npx tsx tools/e2e/live-vitest-invocation.mts run --test-path test/e2e/live/openshell-gateway-upgrade.test.ts
 
+      - name: Record skipped OpenShell gateway upgrade row
+        if: ${{ steps.gateway_upgrade_tier.outputs.run != '1' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "skipped-by-tier: retained ${NEMOCLAW_GATEWAY_UPGRADE_EXECUTION_TIER} row ${NEMOCLAW_E2E_SHARD} was not selected for this run"
+
       - name: Upload OpenShell gateway upgrade artifacts
-        if: always()
+        if: ${{ always() && steps.gateway_upgrade_tier.outputs.run == '1' }}
         uses: NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@7768e15eb90d3ee2d33432f481dfe8747e4f6d57
         with:
           name: e2e-openshell-gateway-upgrade-${{ matrix.id }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4407,6 +4407,9 @@ jobs:
           CHECKOUT_SHA: ${{ inputs.checkout_sha }}
           EVENT_NAME: ${{ github.event_name }}
           EXECUTION_TIER: ${{ matrix.execution_tier }}
+          GATEWAY_UPGRADE_NIGHTLY_ROWS: "1"
+          GATEWAY_UPGRADE_RETAINED_ROWS: "5"
+          GATEWAY_UPGRADE_ROW_TIMEOUT_MINUTES: "70"
           INCLUDE_STAGING_BREV_LAUNCHABLE: ${{ inputs.include_staging_brev_launchable && '1' || '0' }}
           JOBS: ${{ inputs.jobs }}
           MATRIX_ID: ${{ matrix.id }}
@@ -4440,6 +4443,19 @@ jobs:
             reason="release-qualification"
           fi
 
+          baseline_nightly_runner_minutes=$((GATEWAY_UPGRADE_RETAINED_ROWS * GATEWAY_UPGRADE_ROW_TIMEOUT_MINUTES))
+          tiered_nightly_runner_minutes=$((GATEWAY_UPGRADE_NIGHTLY_ROWS * GATEWAY_UPGRADE_ROW_TIMEOUT_MINUTES))
+          expected_nightly_runner_minute_reduction=$((baseline_nightly_runner_minutes - tiered_nightly_runner_minutes))
+          expected_nightly_runner_minute_reduction_percent=$((expected_nightly_runner_minute_reduction * 100 / baseline_nightly_runner_minutes))
+          observed_nightly_runner_minute_reduction=0
+          if [[ "${EVENT_NAME}" == "schedule" && "${day_of_week}" != "7" && "${run}" != "1" ]]; then
+            observed_nightly_runner_minute_reduction="${GATEWAY_UPGRADE_ROW_TIMEOUT_MINUTES}"
+          fi
+
+          printf 'baseline_nightly_runner_minutes=%s\n' "${baseline_nightly_runner_minutes}" >> "${GITHUB_OUTPUT}"
+          printf 'tiered_nightly_runner_minutes=%s\n' "${tiered_nightly_runner_minutes}" >> "${GITHUB_OUTPUT}"
+          printf 'expected_nightly_runner_minute_reduction=%s\n' "${expected_nightly_runner_minute_reduction}" >> "${GITHUB_OUTPUT}"
+          printf 'observed_nightly_runner_minute_reduction=%s\n' "${observed_nightly_runner_minute_reduction}" >> "${GITHUB_OUTPUT}"
           printf 'run=%s\n' "${run}" >> "${GITHUB_OUTPUT}"
           printf 'reason=%s\n' "${reason}" >> "${GITHUB_OUTPUT}"
           {
@@ -4449,6 +4465,10 @@ jobs:
             echo "- Tier: \`${EXECUTION_TIER}\`"
             echo "- Boundary: ${UNIQUE_BOUNDARY}"
             echo "- Decision: \`${reason}\`"
+            echo "- Baseline nightly runner budget: \`${baseline_nightly_runner_minutes}\` max runner-minutes"
+            echo "- Tiered nightly runner budget: \`${tiered_nightly_runner_minutes}\` max runner-minutes"
+            echo "- Expected nightly runner-minute reduction: \`${expected_nightly_runner_minute_reduction}\` max runner-minutes (${expected_nightly_runner_minute_reduction_percent}%)"
+            echo "- Observed nightly runner-minute reduction for this row: \`${observed_nightly_runner_minute_reduction}\` max runner-minutes"
           } >> "${GITHUB_STEP_SUMMARY}"
           if [[ "${run}" != "1" ]]; then
             echo "skipped-by-tier: ${MATRIX_ID} is retained for ${EXECUTION_TIER} coverage and not selected for this run"

--- a/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
@@ -23,6 +23,84 @@ import {
   validateLegacyGatewayUpgradeFixture,
 } from "../live/openshell-gateway-upgrade-helpers.ts";
 
+type GatewayTierScenario = {
+  checkoutSha?: string;
+  eventName: string;
+  executionTier: string;
+  includeStagingBrevLaunchable?: "0" | "1";
+  jobs?: string;
+  matrixId?: string;
+  targets?: string;
+  uniqueBoundary?: string;
+  weekday: string;
+};
+
+function runGatewayTierClassifier(scenario: GatewayTierScenario): Record<string, string> {
+  const workflow = readOpenShellGatewayUpgradeWorkflow();
+  const job = (workflow.jobs as Record<string, Record<string, unknown>>)[
+    "openshell-gateway-upgrade"
+  ];
+  const steps = job.steps as Array<Record<string, unknown>>;
+  const classify = steps.find(
+    (step) => step.name === "Classify OpenShell gateway upgrade coverage tier",
+  );
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-tier-"));
+  const fakeDate = path.join(tempDir, "date");
+  const outputPath = path.join(tempDir, "github-output");
+  const summaryPath = path.join(tempDir, "summary.md");
+  fs.writeFileSync(
+    fakeDate,
+    [
+      "#!/usr/bin/env bash",
+      'if [[ "${1:-}" == "-u" && "${2:-}" == "+%u" ]]; then',
+      '  printf "%s\\n" "${FAKE_DAY_OF_WEEK}"',
+      "else",
+      '  /bin/date "$@"',
+      "fi",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  try {
+    const result = spawnSync("bash", ["-c", String(classify?.run)], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CHECKOUT_SHA: scenario.checkoutSha ?? "",
+        EVENT_NAME: scenario.eventName,
+        EXECUTION_TIER: scenario.executionTier,
+        FAKE_DAY_OF_WEEK: scenario.weekday,
+        GATEWAY_UPGRADE_NIGHTLY_ROWS: "1",
+        GATEWAY_UPGRADE_RETAINED_ROWS: "5",
+        GATEWAY_UPGRADE_ROW_TIMEOUT_MINUTES: "70",
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_STEP_SUMMARY: summaryPath,
+        INCLUDE_STAGING_BREV_LAUNCHABLE: scenario.includeStagingBrevLaunchable ?? "0",
+        JOBS: scenario.jobs ?? "",
+        MATRIX_ID: scenario.matrixId ?? "v0.0.55-x86_64",
+        PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+        TARGETS: scenario.targets ?? "",
+        UNIQUE_BOUNDARY: scenario.uniqueBoundary ?? "OpenShell 0.0.44 gateway migration on x86_64",
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const outputs = Object.fromEntries(
+      fs
+        .readFileSync(outputPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const [key, ...value] = line.split("=");
+          return [key, value.join("=")];
+        }),
+    );
+    outputs.summary = fs.readFileSync(summaryPath, "utf8");
+    return outputs;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 describe("OpenShell gateway upgrade workflow boundary", () => {
   it("pins architecture and immediate-predecessor fixtures to the canonical live test (#6114)", () => {
     const workflow = readOpenShellGatewayUpgradeWorkflow();
@@ -113,6 +191,9 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
         CHECKOUT_SHA: "${{ inputs.checkout_sha }}",
         EVENT_NAME: "${{ github.event_name }}",
         EXECUTION_TIER: "${{ matrix.execution_tier }}",
+        GATEWAY_UPGRADE_NIGHTLY_ROWS: "1",
+        GATEWAY_UPGRADE_RETAINED_ROWS: "5",
+        GATEWAY_UPGRADE_ROW_TIMEOUT_MINUTES: "70",
         INCLUDE_STAGING_BREV_LAUNCHABLE:
           "${{ inputs.include_staging_brev_launchable && '1' || '0' }}",
         JOBS: "${{ inputs.jobs }}",
@@ -128,6 +209,10 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
     expect(classifyRun).toContain("weekly-retained");
     expect(classifyRun).toContain("release-qualification");
     expect(classifyRun).toContain("skipped-by-tier");
+    expect(classifyRun).toContain("expected_nightly_runner_minute_reduction");
+    expect(classifyRun).toContain("observed_nightly_runner_minute_reduction");
+    expect(classifyRun).toContain("Expected nightly runner-minute reduction");
+    expect(classifyRun).toContain("Observed nightly runner-minute reduction");
     expect(classifyRun).toContain("GITHUB_STEP_SUMMARY");
 
     expect(steps.find((step) => step.name === "Prepare E2E workspace")?.if).toBe(
@@ -144,6 +229,72 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
     );
     expect(skipped?.if).toBe("${{ steps.gateway_upgrade_tier.outputs.run != '1' }}");
     expect(String(skipped?.run)).toContain("skipped-by-tier");
+  });
+
+  it.each([
+    {
+      expected: { observed: "0", reason: "explicit-selection", run: "1" },
+      name: "explicit jobs selection",
+      scenario: {
+        eventName: "workflow_dispatch",
+        executionTier: "weekly-release",
+        includeStagingBrevLaunchable: "1",
+        jobs: "openshell-gateway-upgrade",
+        weekday: "7",
+      },
+    },
+    {
+      expected: { observed: "0", reason: "explicit-selection", run: "1" },
+      name: "explicit targets selection",
+      scenario: {
+        eventName: "workflow_dispatch",
+        executionTier: "weekly-release",
+        targets: "openshell-gateway-upgrade",
+        weekday: "1",
+      },
+    },
+    {
+      expected: { observed: "0", reason: "nightly-canonical", run: "1" },
+      name: "nightly canonical row",
+      scenario: { eventName: "schedule", executionTier: "nightly", weekday: "1" },
+    },
+    {
+      expected: { observed: "0", reason: "weekly-retained", run: "1" },
+      name: "Sunday retained row",
+      scenario: { eventName: "schedule", executionTier: "weekly-release", weekday: "7" },
+    },
+    {
+      expected: { observed: "70", reason: "skipped-by-tier", run: "0" },
+      name: "non-Sunday retained row",
+      scenario: { eventName: "schedule", executionTier: "weekly-release", weekday: "1" },
+    },
+    {
+      expected: { observed: "0", reason: "release-qualification", run: "1" },
+      name: "release qualification",
+      scenario: {
+        eventName: "workflow_dispatch",
+        executionTier: "weekly-release",
+        includeStagingBrevLaunchable: "1",
+        weekday: "1",
+      },
+    },
+  ])("classifies $name gateway upgrade tier decisions (#7920)", ({ expected, scenario }) => {
+    const outputs = runGatewayTierClassifier(scenario as GatewayTierScenario);
+
+    expect(outputs).toMatchObject({
+      baseline_nightly_runner_minutes: "350",
+      expected_nightly_runner_minute_reduction: "280",
+      observed_nightly_runner_minute_reduction: expected.observed,
+      reason: expected.reason,
+      run: expected.run,
+      tiered_nightly_runner_minutes: "70",
+    });
+    expect(outputs.summary).toContain(
+      "Expected nightly runner-minute reduction: `280` max runner-minutes (80%)",
+    );
+    expect(outputs.summary).toContain(
+      `Observed nightly runner-minute reduction for this row: \`${expected.observed}\` max runner-minutes`,
+    );
   });
 
   it("freshens only the retryable old fixture install", () => {

--- a/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
@@ -254,6 +254,17 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
       },
     },
     {
+      expected: { observed: "0", reason: "explicit-selection", run: "1" },
+      name: "owning-file PR selection",
+      scenario: {
+        checkoutSha: "candidate-sha",
+        eventName: "workflow_dispatch",
+        executionTier: "weekly-release",
+        jobs: "openshell-gateway-upgrade",
+        weekday: "1",
+      },
+    },
+    {
       expected: { observed: "0", reason: "nightly-canonical", run: "1" },
       name: "nightly canonical row",
       scenario: { eventName: "schedule", executionTier: "nightly", weekday: "1" },

--- a/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
@@ -63,6 +63,89 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
     );
   });
 
+  it("documents retained gateway upgrade execution tiers (#7920)", () => {
+    const workflow = readOpenShellGatewayUpgradeWorkflow();
+    const job = (workflow.jobs as Record<string, Record<string, unknown>>)[
+      "openshell-gateway-upgrade"
+    ];
+    const strategy = job.strategy as Record<string, Record<string, unknown>>;
+    const fixtures = strategy.matrix.include as Array<Record<string, unknown>>;
+    expect(
+      fixtures.map((fixture) => ({
+        execution_tier: fixture.execution_tier,
+        id: fixture.id,
+        unique_boundary: fixture.unique_boundary,
+      })),
+    ).toEqual([
+      {
+        execution_tier: "weekly-release",
+        id: "v0.0.36-x86_64",
+        unique_boundary: "oldest-supported OpenShell/NemoClaw gateway migration baseline",
+      },
+      {
+        execution_tier: "weekly-release",
+        id: "v0.0.55-x86_64",
+        unique_boundary: "OpenShell 0.0.44 gateway migration on x86_64",
+      },
+      {
+        execution_tier: "weekly-release",
+        id: "v0.0.55-aarch64",
+        unique_boundary: "OpenShell 0.0.44 gateway migration on arm64",
+      },
+      {
+        execution_tier: "weekly-release",
+        id: "v0.0.74-x86_64",
+        unique_boundary: "immediate-predecessor OpenShell 0.0.72 gateway migration",
+      },
+      {
+        execution_tier: "nightly",
+        id: "v0.0.89-x86_64",
+        unique_boundary: "current OpenClaw state-upgrade gateway migration",
+      },
+    ]);
+
+    const steps = job.steps as Array<Record<string, unknown>>;
+    const classify = steps.find(
+      (step) => step.name === "Classify OpenShell gateway upgrade coverage tier",
+    );
+    expect(classify).toMatchObject({
+      env: expect.objectContaining({
+        CHECKOUT_SHA: "${{ inputs.checkout_sha }}",
+        EVENT_NAME: "${{ github.event_name }}",
+        EXECUTION_TIER: "${{ matrix.execution_tier }}",
+        INCLUDE_STAGING_BREV_LAUNCHABLE:
+          "${{ inputs.include_staging_brev_launchable && '1' || '0' }}",
+        JOBS: "${{ inputs.jobs }}",
+        MATRIX_ID: "${{ matrix.id }}",
+        TARGETS: "${{ inputs.targets }}",
+        UNIQUE_BOUNDARY: "${{ matrix.unique_boundary }}",
+      }),
+      id: "gateway_upgrade_tier",
+    });
+    const classifyRun = String(classify?.run);
+    expect(classifyRun).toContain("date -u +%u");
+    expect(classifyRun).toContain("explicit-selection");
+    expect(classifyRun).toContain("weekly-retained");
+    expect(classifyRun).toContain("release-qualification");
+    expect(classifyRun).toContain("skipped-by-tier");
+    expect(classifyRun).toContain("GITHUB_STEP_SUMMARY");
+
+    expect(steps.find((step) => step.name === "Prepare E2E workspace")?.if).toBe(
+      "${{ steps.gateway_upgrade_tier.outputs.run == '1' }}",
+    );
+    expect(
+      steps.find((step) => step.name === "Run OpenShell gateway upgrade live Vitest test")?.if,
+    ).toBe("${{ steps.gateway_upgrade_tier.outputs.run == '1' }}");
+    expect(
+      steps.find((step) => step.name === "Upload OpenShell gateway upgrade artifacts")?.if,
+    ).toBe("${{ always() && steps.gateway_upgrade_tier.outputs.run == '1' }}");
+    const skipped = steps.find(
+      (step) => step.name === "Record skipped OpenShell gateway upgrade row",
+    );
+    expect(skipped?.if).toBe("${{ steps.gateway_upgrade_tier.outputs.run != '1' }}");
+    expect(String(skipped?.run)).toContain("skipped-by-tier");
+  });
+
   it("freshens only the retryable old fixture install", () => {
     expect(oldGatewayUpgradeInstallerArgs("old-install.sh")).toEqual([
       "old-install.sh",

--- a/tools/e2e/openshell-gateway-upgrade-workflow-boundary.mts
+++ b/tools/e2e/openshell-gateway-upgrade-workflow-boundary.mts
@@ -229,6 +229,9 @@ export function validateOpenShellGatewayUpgradeWorkflow(workflow: WorkflowRecord
     CHECKOUT_SHA: "${{ inputs.checkout_sha }}",
     EVENT_NAME: "${{ github.event_name }}",
     EXECUTION_TIER: "${{ matrix.execution_tier }}",
+    GATEWAY_UPGRADE_NIGHTLY_ROWS: "1",
+    GATEWAY_UPGRADE_RETAINED_ROWS: "5",
+    GATEWAY_UPGRADE_ROW_TIMEOUT_MINUTES: "70",
     INCLUDE_STAGING_BREV_LAUNCHABLE: "${{ inputs.include_staging_brev_launchable && '1' || '0' }}",
     JOBS: "${{ inputs.jobs }}",
     MATRIX_ID: "${{ matrix.id }}",
@@ -248,6 +251,10 @@ export function validateOpenShellGatewayUpgradeWorkflow(workflow: WorkflowRecord
     "weekly-retained",
     "release-qualification",
     "skipped-by-tier",
+    "expected_nightly_runner_minute_reduction",
+    "observed_nightly_runner_minute_reduction",
+    "Expected nightly runner-minute reduction",
+    "Observed nightly runner-minute reduction",
     "GITHUB_STEP_SUMMARY",
   ]) {
     requireRunContains(errors, classify, CLASSIFY_STEP_NAME, fragment);

--- a/tools/e2e/openshell-gateway-upgrade-workflow-boundary.mts
+++ b/tools/e2e/openshell-gateway-upgrade-workflow-boundary.mts
@@ -10,7 +10,12 @@ import YAML from "yaml";
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_WORKFLOW_PATH = join(REPO_ROOT, ".github", "workflows", "e2e.yaml");
 const JOB_NAME = "openshell-gateway-upgrade";
+const CLASSIFY_STEP_NAME = "Classify OpenShell gateway upgrade coverage tier";
+const PREPARE_STEP_NAME = "Prepare E2E workspace";
 const RUN_STEP_NAME = "Run OpenShell gateway upgrade live Vitest test";
+const SKIP_STEP_NAME = "Record skipped OpenShell gateway upgrade row";
+const UPLOAD_STEP_NAME = "Upload OpenShell gateway upgrade artifacts";
+const GATEWAY_TIER_RUN_GATE = "${{ steps.gateway_upgrade_tier.outputs.run == '1' }}";
 const RUN_COMMAND =
   "npx tsx tools/e2e/live-vitest-invocation.mts run --test-path test/e2e/live/openshell-gateway-upgrade.test.ts";
 
@@ -21,6 +26,8 @@ const EXPECTED_V055_FIXTURES: WorkflowRecord[] = [
   {
     id: "v0.0.55-x86_64",
     runner: "ubuntu-latest",
+    execution_tier: "weekly-release",
+    unique_boundary: "OpenShell 0.0.44 gateway migration on x86_64",
     shard: "v0-0-55-x86-64",
     nemoclaw_ref: "v0.0.55",
     nemoclaw_commit: "95d483fe2b6569d68e59493c60f19df09a068e8f",
@@ -33,6 +40,8 @@ const EXPECTED_V055_FIXTURES: WorkflowRecord[] = [
   {
     id: "v0.0.55-aarch64",
     runner: "ubuntu-24.04-arm",
+    execution_tier: "weekly-release",
+    unique_boundary: "OpenShell 0.0.44 gateway migration on arm64",
     shard: "v0-0-55-aarch64",
     nemoclaw_ref: "v0.0.55",
     nemoclaw_commit: "95d483fe2b6569d68e59493c60f19df09a068e8f",
@@ -47,6 +56,8 @@ const EXPECTED_V055_FIXTURES: WorkflowRecord[] = [
 const EXPECTED_V074_FIXTURE: WorkflowRecord = {
   id: "v0.0.74-x86_64",
   runner: "ubuntu-latest",
+  execution_tier: "weekly-release",
+  unique_boundary: "immediate-predecessor OpenShell 0.0.72 gateway migration",
   shard: "v0-0-74-x86-64",
   nemoclaw_ref: "v0.0.74",
   nemoclaw_commit: "3a05b54e8ec3e1d5550ec5c728de54af872bffe3",
@@ -60,6 +71,8 @@ const EXPECTED_V074_FIXTURE: WorkflowRecord = {
 const EXPECTED_V089_FIXTURE: WorkflowRecord = {
   id: "v0.0.89-x86_64",
   runner: "ubuntu-latest",
+  execution_tier: "nightly",
+  unique_boundary: "current OpenClaw state-upgrade gateway migration",
   shard: "v0-0-89-x86-64",
   nemoclaw_ref: "v0.0.89",
   nemoclaw_commit: "1143aa5cce77f3bad1b3b5588bd7fddbe438237e",
@@ -72,40 +85,92 @@ const EXPECTED_V089_FIXTURE: WorkflowRecord = {
   openclaw_state_upgrade: "1",
 };
 
+const EXPECTED_FIXTURE_TIERS: WorkflowRecord[] = [
+  {
+    execution_tier: "weekly-release",
+    id: "v0.0.36-x86_64",
+    unique_boundary: "oldest-supported OpenShell/NemoClaw gateway migration baseline",
+  },
+  {
+    execution_tier: "weekly-release",
+    id: "v0.0.55-x86_64",
+    unique_boundary: "OpenShell 0.0.44 gateway migration on x86_64",
+  },
+  {
+    execution_tier: "weekly-release",
+    id: "v0.0.55-aarch64",
+    unique_boundary: "OpenShell 0.0.44 gateway migration on arm64",
+  },
+  {
+    execution_tier: "weekly-release",
+    id: "v0.0.74-x86_64",
+    unique_boundary: "immediate-predecessor OpenShell 0.0.72 gateway migration",
+  },
+  {
+    execution_tier: "nightly",
+    id: "v0.0.89-x86_64",
+    unique_boundary: "current OpenClaw state-upgrade gateway migration",
+  },
+];
+
 function record(value: unknown): WorkflowRecord {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as WorkflowRecord)
     : {};
 }
 
+function gatewayFixtures(job: WorkflowRecord): WorkflowRecord[] {
+  const include = record(record(job.strategy).matrix).include;
+  return Array.isArray(include) ? include.map(record) : [];
+}
+
 function jobSteps(job: WorkflowRecord): WorkflowStep[] {
   return Array.isArray(job.steps) ? (job.steps as WorkflowStep[]) : [];
 }
 
+function findStep(job: WorkflowRecord, name: string): WorkflowStep {
+  return jobSteps(job).find((step) => step.name === name) ?? {};
+}
+
+function fixtureTiers(job: WorkflowRecord): WorkflowRecord[] {
+  return gatewayFixtures(job).map((fixture) => ({
+    execution_tier: fixture.execution_tier,
+    id: fixture.id,
+    unique_boundary: fixture.unique_boundary,
+  }));
+}
+
 function v055Fixtures(job: WorkflowRecord): WorkflowRecord[] {
-  const include = record(record(job.strategy).matrix).include;
-  return Array.isArray(include)
-    ? include.map(record).filter((fixture) => fixture.nemoclaw_ref === "v0.0.55")
-    : [];
+  return gatewayFixtures(job).filter((fixture) => fixture.nemoclaw_ref === "v0.0.55");
 }
 
 function v074Fixture(job: WorkflowRecord): WorkflowRecord {
-  const include = record(record(job.strategy).matrix).include;
-  return Array.isArray(include)
-    ? (include.map(record).find((fixture) => fixture.nemoclaw_ref === "v0.0.74") ?? {})
-    : {};
+  return gatewayFixtures(job).find((fixture) => fixture.nemoclaw_ref === "v0.0.74") ?? {};
 }
 
 function v089Fixture(job: WorkflowRecord): WorkflowRecord {
-  const include = record(record(job.strategy).matrix).include;
-  return Array.isArray(include)
-    ? (include.map(record).find((fixture) => fixture.nemoclaw_ref === "v0.0.89") ?? {})
-    : {};
+  return gatewayFixtures(job).find((fixture) => fixture.nemoclaw_ref === "v0.0.89") ?? {};
 }
 
-function requireRunContains(errors: string[], step: WorkflowStep, fragment: string): void {
+function requireRunContains(
+  errors: string[],
+  step: WorkflowStep,
+  stepName: string,
+  fragment: string,
+): void {
   if (!step.run?.includes(fragment)) {
-    errors.push(`${JOB_NAME} step '${RUN_STEP_NAME}' must run: ${fragment}`);
+    errors.push(`${JOB_NAME} step '${stepName}' must run: ${fragment}`);
+  }
+}
+
+function requireStepIf(
+  errors: string[],
+  step: WorkflowStep,
+  stepName: string,
+  expectedIf: string,
+): void {
+  if (step.if !== expectedIf) {
+    errors.push(`${JOB_NAME} step '${stepName}' must be gated by: ${expectedIf}`);
   }
 }
 
@@ -121,6 +186,11 @@ export function validateOpenShellGatewayUpgradeWorkflow(workflow: WorkflowRecord
 
   if (job["runs-on"] !== "${{ matrix.runner }}") {
     errors.push(`${JOB_NAME} must run on \${{ matrix.runner }}`);
+  }
+  if (!isDeepStrictEqual(fixtureTiers(job), EXPECTED_FIXTURE_TIERS)) {
+    errors.push(
+      `${JOB_NAME} matrix must document retained fixture execution tiers and unique boundaries`,
+    );
   }
   if (!isDeepStrictEqual(v055Fixtures(job), EXPECTED_V055_FIXTURES)) {
     errors.push(`${JOB_NAME} v0.0.55 matrix must pin x86_64 and arm64 upgrade fixtures`);
@@ -141,9 +211,68 @@ export function validateOpenShellGatewayUpgradeWorkflow(workflow: WorkflowRecord
   if (env.NEMOCLAW_OPENCLAW_STATE_UPGRADE_PROOF !== "${{ matrix.openclaw_state_upgrade }}") {
     errors.push(`${JOB_NAME} must bind the OpenClaw state-upgrade proof flag from its fixture`);
   }
+  if (env.NEMOCLAW_GATEWAY_UPGRADE_EXECUTION_TIER !== "${{ matrix.execution_tier }}") {
+    errors.push(`${JOB_NAME} must bind the gateway upgrade execution tier from its fixture`);
+  }
+  if (env.NEMOCLAW_GATEWAY_UPGRADE_UNIQUE_BOUNDARY !== "${{ matrix.unique_boundary }}") {
+    errors.push(`${JOB_NAME} must bind the gateway upgrade unique boundary from its fixture`);
+  }
 
-  const run = jobSteps(job).find((step) => step.name === RUN_STEP_NAME) ?? {};
-  requireRunContains(errors, run, RUN_COMMAND);
+  const classify = findStep(job, CLASSIFY_STEP_NAME);
+  if (classify.id !== "gateway_upgrade_tier") {
+    errors.push(
+      `${JOB_NAME} step '${CLASSIFY_STEP_NAME}' must expose gateway_upgrade_tier outputs`,
+    );
+  }
+  const classifyEnv = record(classify.env);
+  const expectedClassifyEnv: WorkflowRecord = {
+    CHECKOUT_SHA: "${{ inputs.checkout_sha }}",
+    EVENT_NAME: "${{ github.event_name }}",
+    EXECUTION_TIER: "${{ matrix.execution_tier }}",
+    INCLUDE_STAGING_BREV_LAUNCHABLE: "${{ inputs.include_staging_brev_launchable && '1' || '0' }}",
+    JOBS: "${{ inputs.jobs }}",
+    MATRIX_ID: "${{ matrix.id }}",
+    TARGETS: "${{ inputs.targets }}",
+    UNIQUE_BOUNDARY: "${{ matrix.unique_boundary }}",
+  };
+  for (const [key, expected] of Object.entries(expectedClassifyEnv)) {
+    if (classifyEnv[key] !== expected) {
+      errors.push(
+        `${JOB_NAME} step '${CLASSIFY_STEP_NAME}' must bind ${key} from workflow context`,
+      );
+    }
+  }
+  for (const fragment of [
+    "date -u +%u",
+    "explicit-selection",
+    "weekly-retained",
+    "release-qualification",
+    "skipped-by-tier",
+    "GITHUB_STEP_SUMMARY",
+  ]) {
+    requireRunContains(errors, classify, CLASSIFY_STEP_NAME, fragment);
+  }
+
+  requireStepIf(errors, findStep(job, PREPARE_STEP_NAME), PREPARE_STEP_NAME, GATEWAY_TIER_RUN_GATE);
+  const run = findStep(job, RUN_STEP_NAME);
+  requireStepIf(errors, run, RUN_STEP_NAME, GATEWAY_TIER_RUN_GATE);
+  requireRunContains(errors, run, RUN_STEP_NAME, RUN_COMMAND);
+
+  const skipped = findStep(job, SKIP_STEP_NAME);
+  requireStepIf(
+    errors,
+    skipped,
+    SKIP_STEP_NAME,
+    "${{ steps.gateway_upgrade_tier.outputs.run != '1' }}",
+  );
+  requireRunContains(errors, skipped, SKIP_STEP_NAME, "skipped-by-tier");
+
+  requireStepIf(
+    errors,
+    findStep(job, UPLOAD_STEP_NAME),
+    UPLOAD_STEP_NAME,
+    "${{ always() && steps.gateway_upgrade_tier.outputs.run == '1' }}",
+  );
 
   return errors;
 }

--- a/tools/e2e/prepare-e2e-workflow-boundary.mts
+++ b/tools/e2e/prepare-e2e-workflow-boundary.mts
@@ -23,6 +23,9 @@ export const PREPARE_E2E_STEP = "Prepare E2E workspace";
 const CHECKOUT_LOCAL_PREPARE_E2E_ACTION = "./.github/actions/prepare-e2e";
 const PREINSTALLED_E2E_JOBS = new Set(["staging-brev-launchable"]);
 const RETIRED_SELECTOR_COMPATIBILITY_JOB = "retired-selector-compatibility";
+const PREPARE_CALLER_CONDITIONS = new Map([
+  ["openshell-gateway-upgrade", "${{ steps.gateway_upgrade_tier.outputs.run == '1' }}"],
+]);
 
 const NO_BUILD_JOBS = new Set([
   "generate-matrix",
@@ -158,7 +161,16 @@ export function validatePrepareE2eInvocations(workflow: WorkflowRecord): string[
     if (!shouldBuild && !isDeepStrictEqual(withInputs, { "build-cli": "false" })) {
       errors.push(`${jobName} prepare-e2e must set build-cli to false`);
     }
+    const callerCondition = PREPARE_CALLER_CONDITIONS.get(jobName);
     const allowedKeys = shouldBuild ? ["name", "uses"] : ["name", "uses", "with"];
+    if (callerCondition !== undefined) {
+      allowedKeys.push("if");
+      if (prepare.if !== callerCondition) {
+        errors.push(
+          `${jobName} prepare-e2e invocation must remain gated by its reviewed caller condition`,
+        );
+      }
+    }
     if (!isDeepStrictEqual(Object.keys(prepare).sort(), allowedKeys.sort())) {
       errors.push(`${jobName} prepare-e2e invocation must not override its canonical contract`);
     }

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -249,6 +249,7 @@ const EXPLICIT_CALLER_CONDITIONS = new Map<string, string>([
   ["mcp-bridge-dev", MCP_SCANNED_UPLOAD_CONDITION],
   ["openshell-credential-generation-window", CREDENTIAL_WINDOW_SCANNED_UPLOAD_CONDITION],
   ["openshell-gateway-auth-contract", GATEWAY_AUTH_SCANNED_UPLOAD_CONDITION],
+  ["openshell-gateway-upgrade", "${{ always() && steps.gateway_upgrade_tier.outputs.run == '1' }}"],
 ]);
 
 const EXPECTED_ACTION_INPUTS = {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Tiers the retained OpenShell gateway upgrade rows so ordinary scheduled runs keep the
current state-upgrade migration row while preserving historical and architecture
coverage for weekly, release-qualification, and explicit maintainer dispatch runs.
The change stays inside the existing `openshell-gateway-upgrade` job and does not
change gateway product behavior.

## Related Issue

Fixes #7920

## Changes

- Add `execution_tier` and `unique_boundary` metadata to each retained gateway
  upgrade matrix row.
- Run the current `v0.0.89-x86_64` state-upgrade row in the ordinary nightly tier.
- Retain the older and architecture-specific rows for explicit selection, weekly
  scheduled coverage, and release qualification.
- Gate prepare, live execution, and artifact upload through the row classifier so
  skipped rows are reported as `skipped-by-tier` instead of looking like failures.
- Extend the existing workflow-boundary tests to protect the retained row inventory,
  tier metadata, classifier, and reviewed prepare/upload caller gates.

Expected runner-minute reduction: ordinary scheduled Monday-Saturday runs now execute
1 of 5 retained gateway upgrade rows; weekly, release-qualification, and explicit
selection paths still execute the retained historical and architecture rows.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal E2E workflow row
  selection and workflow-boundary tests only. It does not change user-facing docs,
  CLI commands, configuration, or product runtime behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding,
  inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded —
  reviewer/approval link/justification: Reviewed against #7912 and #7920. The
  change does not delete retained assertions, add a new workflow lane, or alter
  gateway product behavior. Explicit selection, weekly retained coverage, and
  release qualification still run the historical and architecture rows.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name,
  approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed `origin/main...HEAD`; the diff changes only E2E workflow
  tiering and boundary-test files for `openshell-gateway-upgrade`, with no changes
  to Fern docs, README user guidance, CLI commands, configuration options,
  install/runtime behavior, or public workflow inputs. No user-facing documentation
  paths need updates.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 032e419aa -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as
  `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or
  `npm run validate:pr` passed after refreshing `origin/main` when hooks were
  skipped or unavailable — `npm run validate:pr` passed for `032e419aa`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked
  not applicable above — `npx vitest run --project e2e-support
  test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts` passed 7
  tests; focused workflow/report/planner checks passed 122 tests; `npm run
  test:changed` passed 327 tests; `npm run test:e2e-phases:check` validated 114
  semantic E2E phase plans.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness
  changes; `npm run check` for repo-wide validation/coverage changes — not
  applicable to this focused workflow-tiering change; targeted workflow checks and
  `npm run validate:pr` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Disclosure: This PR was prepared with AI assistance under human direction and
review.

---
Signed-off-by: ScarabSystems <scarab.systems@yahoo.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tier-based selection for gateway upgrade checks across scheduled, nightly, staging, and explicitly selected runs.
  * Added clear reporting for selected and skipped upgrade tiers.
  * Limited workspace preparation, test execution, and artifact uploads to applicable tiers.

* **Tests**
  * Added end-to-end coverage for tier boundaries, selection logic, conditional execution, and skipped-tier reporting.
  * Expanded workflow validation for execution conditions and environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->