### PR TITLE
feat(onboard): add managed shared-state transactions

### DIFF
--- a/src/lib/onboard/managed-startup-image-runtime.test.ts
+++ b/src/lib/onboard/managed-startup-image-runtime.test.ts
@@ -20,14 +20,18 @@ import { mapManagedStartupProfileToAgentEnvironment } from "./managed-startup/ag
 import {
   applyManagedStartupCommandEnvironmentPlan,
   applyManagedStartupImageProfile,
+  applyManagedStartupRootRequest,
   buildManagedStartupImageActionPlan,
+  MANAGED_STARTUP_COMPLETION_FILE,
   MANAGED_STARTUP_MERGED_CA_FILE,
   MANAGED_STARTUP_PROFILE_ENV,
   MANAGED_STARTUP_RUNTIME_ENV_FILE,
   type ManagedStartupImageActionPlanInput,
   normalizeHermesManagedConfigDescriptor,
   readStableRegularFile,
+  serializeManagedStartupCompletionMarker,
   serializeManagedStartupRuntimeEnvironment,
+  verifyManagedStartupImageCompletion,
 } from "./managed-startup/image-runtime";
 import {
   encodeManagedStartupProfile,
@@ -35,8 +39,10 @@ import {
   MANAGED_STARTUP_AGENTS,
   type ManagedStartupAgent,
   type ManagedStartupDashboard,
+  type ManagedStartupProfile,
   validateManagedStartupProfile,
 } from "./managed-startup/profile";
+import { createManagedStartupRootApplyRequest } from "./managed-startup/root-apply";
 
 function dashboard(agent: ManagedStartupAgent): ManagedStartupDashboard {
   switch (agent) {
@@ -323,7 +329,10 @@ describe("managed startup image runtime", () => {
       "/var/lib",
       "/var/lib/nemoclaw",
     ]);
-    let runtimeFileWritten = false;
+    const files = new Map<string, Buffer>();
+    const descriptorTargets = new Map<number, string>();
+    const pendingFiles = new Map<string, Buffer>();
+    let nextDescriptor = 91;
     const stat = (kind: "directory" | "file", mode: number) =>
       ({
         gid: 0,
@@ -334,31 +343,88 @@ describe("managed startup image runtime", () => {
         nlink: 1,
         uid: 0,
       }) as fs.Stats;
+    const bigFileStat = (bytes: Buffer) =>
+      ({
+        ctimeNs: 1n,
+        dev: 1n,
+        gid: 0n,
+        ino: 2n,
+        isFile: () => true,
+        mode: 0o100444n,
+        mtimeNs: 1n,
+        nlink: 1n,
+        size: BigInt(bytes.length),
+        uid: 0n,
+      }) as fs.BigIntStats;
     const missing = () => Object.assign(new Error("missing"), { code: "ENOENT" });
 
     vi.spyOn(process, "geteuid").mockReturnValue(0);
     vi.spyOn(fs, "lstatSync").mockImplementation(((target: fs.PathLike) => {
       const resolved = String(target);
       if (directories.has(resolved)) return stat("directory", 0o755);
-      if (resolved === MANAGED_STARTUP_RUNTIME_ENV_FILE && runtimeFileWritten) {
-        return stat("file", 0o400);
-      }
+      if (files.has(resolved)) return stat("file", 0o444);
       throw missing();
     }) as typeof fs.lstatSync);
     vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
     vi.spyOn(fs, "chownSync").mockImplementation(() => undefined);
     vi.spyOn(fs, "chmodSync").mockImplementation(() => undefined);
     vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    vi.spyOn(fs, "openSync").mockReturnValue(91);
+    vi.spyOn(fs, "openSync").mockImplementation(((target: fs.PathLike) => {
+      const resolved = String(target);
+      if (
+        (resolved === MANAGED_STARTUP_RUNTIME_ENV_FILE ||
+          resolved === MANAGED_STARTUP_COMPLETION_FILE) &&
+        !files.has(resolved)
+      ) {
+        throw missing();
+      }
+      const descriptor = nextDescriptor;
+      nextDescriptor += 1;
+      descriptorTargets.set(descriptor, resolved);
+      return descriptor;
+    }) as typeof fs.openSync);
+    vi.spyOn(fs, "fstatSync").mockImplementation(((descriptor: number) => {
+      const target = descriptorTargets.get(descriptor);
+      const bytes = target === undefined ? undefined : files.get(target);
+      if (bytes === undefined) throw missing();
+      return bigFileStat(bytes);
+    }) as typeof fs.fstatSync);
+    vi.spyOn(fs, "readSync").mockImplementation(((
+      descriptor: number,
+      buffer: NodeJS.ArrayBufferView,
+      offset: number,
+      length: number,
+      position: number | null,
+    ) => {
+      const target = descriptorTargets.get(descriptor);
+      const bytes = target === undefined ? undefined : files.get(target);
+      if (bytes === undefined) throw missing();
+      const start = position ?? 0;
+      const count = Math.min(length, Math.max(0, bytes.length - start));
+      bytes.copy(buffer as Buffer, offset, start, start + count);
+      return count;
+    }) as typeof fs.readSync);
     vi.spyOn(fs, "fchownSync").mockImplementation(() => undefined);
     vi.spyOn(fs, "writeFileSync").mockImplementation(((target: fs.PathOrFileDescriptor, value) => {
-      if (target === 91) runtimeWrites.push(String(value));
+      if (typeof target !== "number") return;
+      const resolved = descriptorTargets.get(target);
+      if (resolved === undefined) throw missing();
+      pendingFiles.set(
+        resolved,
+        Buffer.isBuffer(value) ? Buffer.from(value) : Buffer.from(String(value), "utf8"),
+      );
     }) as typeof fs.writeFileSync);
     vi.spyOn(fs, "fchmodSync").mockImplementation(() => undefined);
     vi.spyOn(fs, "fsyncSync").mockImplementation(() => undefined);
     vi.spyOn(fs, "closeSync").mockImplementation(() => undefined);
-    vi.spyOn(fs, "renameSync").mockImplementation((_source, target) => {
-      if (String(target) === MANAGED_STARTUP_RUNTIME_ENV_FILE) runtimeFileWritten = true;
+    vi.spyOn(fs, "renameSync").mockImplementation((source, target) => {
+      const pending = pendingFiles.get(String(source));
+      if (pending === undefined) throw missing();
+      files.set(String(target), pending);
+      pendingFiles.delete(String(source));
+      if (String(target) === MANAGED_STARTUP_RUNTIME_ENV_FILE) {
+        runtimeWrites.push(pending.toString("utf8"));
+      }
     });
     vi.spyOn(fs, "unlinkSync").mockImplementation(() => {
       throw missing();
@@ -367,14 +433,16 @@ describe("managed startup image runtime", () => {
 
   it("rejects invalid OpenClaw launch controls before filesystem or coordinator mutation", async () => {
     const profile = managedStartupE2eProfile("openclaw");
+    const request = createManagedStartupRootApplyRequest({
+      agent: profile.agent,
+      encodedProfile: encodeManagedStartupProfile(profile),
+    });
     const lstat = vi.spyOn(fs, "lstatSync");
     vi.spyOn(process, "geteuid").mockReturnValue(0);
 
     await expect(
-      applyManagedStartupImageProfile("openclaw", {
-        NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION: "1",
+      applyManagedStartupRootRequest(request, {
         NEMOCLAW_AUTO_PAIR_FAST_REENTRY_INTERVAL_SECS: "NaN",
-        [MANAGED_STARTUP_PROFILE_ENV]: encodeManagedStartupProfile(profile),
       }),
     ).rejects.toThrow(/finite positive seconds/u);
     expect(lstat).not.toHaveBeenCalled();
@@ -406,20 +474,69 @@ describe("managed startup image runtime", () => {
       NEMOCLAW_AUTO_PAIR_FAST_REENTRY_POLLS: "3",
       [MANAGED_STARTUP_PROFILE_ENV]: encodedProfile,
     });
-    const second = await applyManagedStartupImageProfile("openclaw", {
-      NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION: "1",
-      NEMOCLAW_AUTO_PAIR_FAST_REENTRY_POLLS: "5",
-      [MANAGED_STARTUP_PROFILE_ENV]: encodedProfile,
-    });
+    const second = await applyManagedStartupRootRequest(
+      createManagedStartupRootApplyRequest({
+        agent: profile.agent,
+        encodedProfile,
+      }),
+      {
+        NEMOCLAW_AUTO_PAIR_FAST_REENTRY_POLLS: "5",
+      },
+    );
 
     expect(first).toMatchObject({ adapterApplied: false, fingerprint });
-    expect(second).toMatchObject({ adapterApplied: false, fingerprint });
+    expect(second).toMatchObject({
+      adapterApplied: false,
+      fingerprint,
+      transactionPending: false,
+    });
     expect(runtimeWrites).toHaveLength(2);
     expect(runtimeWrites[0]).toContain("export NEMOCLAW_AUTO_PAIR_FAST_REENTRY_POLLS='3'");
     expect(runtimeWrites[1]).toContain("export NEMOCLAW_AUTO_PAIR_FAST_REENTRY_POLLS='5'");
     expect(coordinatorMock.coordinateManagedStartupApplication).toHaveBeenCalledTimes(2);
   });
 
+  function writeCompletionFixture(
+    profile: ManagedStartupProfile,
+    corporateCaMerged = false,
+  ): {
+    readonly agent: ManagedStartupAgent;
+    readonly completionFile: string;
+    readonly fingerprint: string;
+    readonly runtimeEnvironmentFile: string;
+  } {
+    const mapped = mapManagedStartupProfileToAgentEnvironment(profile);
+    const runtimeEnvironment = serializeManagedStartupRuntimeEnvironment(
+      mapped.runtimeEnvironment,
+      corporateCaMerged,
+      mapped.configurationEnvironment,
+    );
+    const fingerprint = fingerprintManagedStartupProfile(profile);
+    const completionFile = path.join(temporaryDirectory(), "managed-startup-complete.json");
+    const runtimeEnvironmentFile = path.join(temporaryDirectory(), "managed-startup-runtime.env");
+    fs.writeFileSync(runtimeEnvironmentFile, runtimeEnvironment, { mode: 0o444 });
+    fs.chmodSync(runtimeEnvironmentFile, 0o444);
+    fs.writeFileSync(
+      completionFile,
+      serializeManagedStartupCompletionMarker({
+        schemaVersion: 1,
+        agent: profile.agent,
+        profileFingerprint: fingerprint,
+        runtimeEnvironmentSha256: createHash("sha256")
+          .update(runtimeEnvironment, "utf8")
+          .digest("hex"),
+        corporateCaMerged,
+      }),
+      { mode: 0o444 },
+    );
+    fs.chmodSync(completionFile, 0o444);
+    return {
+      agent: profile.agent,
+      completionFile,
+      fingerprint,
+      runtimeEnvironmentFile,
+    };
+  }
   it.each(
     MANAGED_STARTUP_AGENTS,
   )("maps the complete %s profile into the reviewed image command contract", (agent) => {
@@ -447,6 +564,74 @@ describe("managed startup image runtime", () => {
     expect(fingerprintManagedStartupProfile(same)).toBe(fingerprintManagedStartupProfile(initial));
     expect(fingerprintManagedStartupProfile(changed)).not.toBe(
       fingerprintManagedStartupProfile(initial),
+    );
+  });
+
+  it.each(
+    MANAGED_STARTUP_AGENTS,
+  )("accepts the root completion marker and exact runtime handoff for %s", (agent) => {
+    const fixture = writeCompletionFixture(managedStartupE2eProfile(agent));
+    mockDescriptorOwnership(0n, 0n);
+    expect(
+      verifyManagedStartupImageCompletion(
+        agent,
+        fixture.fingerprint,
+        fixture.completionFile,
+        fixture.runtimeEnvironmentFile,
+      ),
+    ).toEqual({ agent, fingerprint: fixture.fingerprint });
+  });
+
+  it("rejects a changed profile against the root completion fingerprint", () => {
+    const initial = writeCompletionFixture(managedStartupE2eProfile("openclaw"));
+    const changedProfile = managedStartupE2eProfile("openclaw", true);
+    mockDescriptorOwnership(0n, 0n);
+    expect(() =>
+      verifyManagedStartupImageCompletion(
+        "openclaw",
+        fingerprintManagedStartupProfile(changedProfile),
+        initial.completionFile,
+        initial.runtimeEnvironmentFile,
+      ),
+    ).toThrow(/completion marker does not match the requested profile/u);
+  });
+
+  it("rejects runtime handoff drift after a matching completion", () => {
+    const fixture = writeCompletionFixture(managedStartupE2eProfile("hermes"));
+    mockDescriptorOwnership(0n, 0n);
+    fs.chmodSync(fixture.runtimeEnvironmentFile, 0o644);
+    fs.appendFileSync(fixture.runtimeEnvironmentFile, "export NEMOCLAW_MODEL='tampered/model'\n");
+    fs.chmodSync(fixture.runtimeEnvironmentFile, 0o444);
+
+    expect(() =>
+      verifyManagedStartupImageCompletion(
+        "hermes",
+        fixture.fingerprint,
+        fixture.completionFile,
+        fixture.runtimeEnvironmentFile,
+      ),
+    ).toThrow(/runtime environment digest mismatch/u);
+  });
+
+  it("accepts merged CA paths without putting the CA payload in the readable handoff", () => {
+    const fixture = writeCompletionFixture(
+      managedStartupE2eProfile("langchain-deepagents-code", false, true),
+      true,
+    );
+    mockDescriptorOwnership(0n, 0n);
+    expect(
+      verifyManagedStartupImageCompletion(
+        "langchain-deepagents-code",
+        fixture.fingerprint,
+        fixture.completionFile,
+        fixture.runtimeEnvironmentFile,
+      ),
+    ).toEqual({
+      agent: "langchain-deepagents-code",
+      fingerprint: fixture.fingerprint,
+    });
+    expect(fs.readFileSync(fixture.runtimeEnvironmentFile, "utf8")).not.toContain(
+      "NEMOCLAW_CORPORATE_CA_B64",
     );
   });
 

--- a/src/lib/onboard/managed-startup-root-apply.test.ts
+++ b/src/lib/onboard/managed-startup-root-apply.test.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MANAGED_STARTUP_E2E_CORPORATE_CA_PEM,
+  managedStartupE2eProfile,
+} from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import { encodeManagedStartupProfile } from "./managed-startup/profile";
+import {
+  createManagedStartupRootApplyRequest,
+  MANAGED_STARTUP_ROOT_APPLY_MAX_BYTES,
+  parseManagedStartupRootApplyRequest,
+  serializeManagedStartupRootApplyRequest,
+} from "./managed-startup/root-apply";
+
+function requestFor(
+  agent: "openclaw" | "hermes" | "langchain-deepagents-code",
+  withCorporateCa = false,
+) {
+  return createManagedStartupRootApplyRequest({
+    agent,
+    encodedProfile: encodeManagedStartupProfile(
+      managedStartupE2eProfile(agent, false, withCorporateCa),
+    ),
+    ...(withCorporateCa
+      ? { corporateCaB64: Buffer.from(MANAGED_STARTUP_E2E_CORPORATE_CA_PEM).toString("base64") }
+      : {}),
+  });
+}
+
+describe("managed startup root-application envelope", () => {
+  it.each([
+    "openclaw",
+    "hermes",
+    "langchain-deepagents-code",
+  ] as const)("round-trips one canonical bounded %s request", (agent) => {
+    const request = requestFor(agent, true);
+    const serialized = serializeManagedStartupRootApplyRequest(request);
+
+    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThan(
+      MANAGED_STARTUP_ROOT_APPLY_MAX_BYTES,
+    );
+    expect(parseManagedStartupRootApplyRequest(serialized)).toEqual(request);
+  });
+
+  it("rejects non-canonical JSON and unknown fields", () => {
+    const request = requestFor("openclaw");
+    const reordered = `${JSON.stringify({
+      schemaVersion: request.schemaVersion,
+      profileFingerprint: request.profileFingerprint,
+      encodedProfile: request.encodedProfile,
+      corporateCaB64: request.corporateCaB64,
+      agent: request.agent,
+    })}\n`;
+    const withUnknownField = `${JSON.stringify({
+      ...JSON.parse(serializeManagedStartupRootApplyRequest(request)),
+      surprise: true,
+    })}\n`;
+
+    expect(() => parseManagedStartupRootApplyRequest(reordered)).toThrow(/not canonical/u);
+    expect(() => parseManagedStartupRootApplyRequest(withUnknownField)).toThrow(/invalid schema/u);
+  });
+
+  it("rejects a tampered profile fingerprint", () => {
+    const request = requestFor("hermes");
+    const parsed = JSON.parse(serializeManagedStartupRootApplyRequest(request)) as Record<
+      string,
+      unknown
+    >;
+    parsed.profileFingerprint = "f".repeat(64);
+
+    expect(() => parseManagedStartupRootApplyRequest(`${JSON.stringify(parsed)}\n`)).toThrow(
+      /fingerprint does not match/u,
+    );
+  });
+
+  it("rejects a canonical CA payload that does not match the profile digest", () => {
+    const profile = managedStartupE2eProfile("langchain-deepagents-code", false, true);
+
+    expect(() =>
+      createManagedStartupRootApplyRequest({
+        agent: profile.agent,
+        encodedProfile: encodeManagedStartupProfile(profile),
+        corporateCaB64: Buffer.from("different-ca").toString("base64"),
+      }),
+    ).toThrow(/does not match the profile digest/u);
+  });
+
+  it("rejects an oversized serialized transport before parsing JSON", () => {
+    expect(() =>
+      parseManagedStartupRootApplyRequest("x".repeat(MANAGED_STARTUP_ROOT_APPLY_MAX_BYTES + 1)),
+    ).toThrow(/empty or too large/u);
+  });
+});

--- a/src/lib/onboard/managed-startup-shared-state-transaction.test.ts
+++ b/src/lib/onboard/managed-startup-shared-state-transaction.test.ts
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import type { SandboxMessagingPlan } from "../messaging/manifest";
+import type { ManagedStartupAgent, ManagedStartupProfile } from "./managed-startup/profile";
+import {
+  beginManagedStartupSharedStateTransaction,
+  commitManagedStartupSharedStateTransaction,
+  type ManagedStartupSharedTransactionOptions,
+  rollbackManagedStartupSharedStateTransaction,
+} from "./managed-startup/shared-state-transaction";
+
+function mode(target: string): number {
+  return fs.lstatSync(target).mode & 0o7777;
+}
+
+function unavailableIdentity(name: string): never {
+  throw new Error(`effective ${name} is unavailable`);
+}
+
+function effectiveUid(): number {
+  return process.geteuid?.() ?? unavailableIdentity("uid");
+}
+
+function effectiveGid(): number {
+  return process.getegid?.() ?? unavailableIdentity("gid");
+}
+
+describe("managed startup shared-state transaction", () => {
+  let temporaryRoot = "";
+  let sandboxRoot = "";
+  let transactionDirectory = "";
+  let options: ManagedStartupSharedTransactionOptions;
+
+  beforeEach(() => {
+    temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-shared-transaction-"));
+    sandboxRoot = path.join(temporaryRoot, "sandbox");
+    const transactionParent = path.join(temporaryRoot, "root-state");
+    transactionDirectory = path.join(transactionParent, "transaction");
+    fs.mkdirSync(sandboxRoot, { mode: 0o755 });
+    fs.mkdirSync(transactionParent, { mode: 0o755 });
+    fs.chmodSync(transactionParent, 0o755);
+    options = {
+      sandboxRoot,
+      transactionDirectory,
+      trustedUid: effectiveUid(),
+      trustedGid: effectiveGid(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(temporaryRoot, { force: true, recursive: true });
+  });
+
+  function agentRoot(agent: ManagedStartupAgent): string {
+    return path.join(
+      sandboxRoot,
+      agent === "openclaw" ? ".openclaw" : agent === "hermes" ? ".hermes" : ".deepagents",
+    );
+  }
+
+  it.each([
+    "openclaw",
+    "hermes",
+    "langchain-deepagents-code",
+  ] as const)("restores exact %s bytes, ownership, modes, and absence receipts", (agent) => {
+    const root = agentRoot(agent);
+    fs.mkdirSync(root, { mode: 0o750 });
+    fs.chmodSync(root, 0o750);
+    const originalFiles =
+      agent === "openclaw"
+        ? [["openclaw.json", "openclaw-original\n", 0o640] as const]
+        : agent === "hermes"
+          ? [
+              ["config.yaml", "hermes-original\n", 0o640] as const,
+              [".env", "TOKEN=original\n", 0o600] as const,
+            ]
+          : [["config.toml", "dcode-original\n", 0o660] as const];
+    for (const [name, contents, fileMode] of originalFiles) {
+      const target = path.join(root, name);
+      fs.writeFileSync(target, contents);
+      fs.chmodSync(target, fileMode);
+    }
+
+    beginManagedStartupSharedStateTransaction(managedStartupE2eProfile(agent), options);
+    for (const [name] of originalFiles) {
+      const target = path.join(root, name);
+      fs.writeFileSync(target, "changed\n");
+      fs.chmodSync(target, 0o600);
+    }
+    const createManagedDrift: Record<ManagedStartupAgent, () => void> = {
+      openclaw: () => fs.writeFileSync(path.join(root, ".config-hash"), "new\n"),
+      hermes: () => fs.writeFileSync(path.join(root, ".config-hash"), "new\n"),
+      "langchain-deepagents-code": () => {
+        fs.mkdirSync(path.join(root, ".state"));
+        fs.mkdirSync(path.join(root, "skills"));
+      },
+    };
+    createManagedDrift[agent]();
+
+    expect(rollbackManagedStartupSharedStateTransaction(agent, options)).toBe(true);
+    for (const [name, contents, fileMode] of originalFiles) {
+      const target = path.join(root, name);
+      expect(fs.readFileSync(target, "utf8")).toBe(contents);
+      expect(mode(target)).toBe(fileMode);
+      expect(fs.lstatSync(target).uid).toBe(effectiveUid());
+      expect(fs.lstatSync(target).gid).toBe(effectiveGid());
+    }
+    expect(mode(root)).toBe(0o750);
+    const absentManagedPaths: Record<ManagedStartupAgent, readonly string[]> = {
+      openclaw: [".config-hash"],
+      hermes: [".config-hash"],
+      "langchain-deepagents-code": [".state", "skills"],
+    };
+    for (const relativePath of absentManagedPaths[agent]) {
+      expect(fs.existsSync(path.join(root, relativePath))).toBe(false);
+    }
+    expect(fs.existsSync(transactionDirectory)).toBe(false);
+  });
+
+  it("tracks only active post-install messaging outputs and leaves disabled targets alone", () => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, "openclaw.json"), "{}\n");
+    const plan: SandboxMessagingPlan = {
+      schemaVersion: 1,
+      sandboxName: "managed",
+      agent: "openclaw",
+      workflow: "onboard",
+      channels: [
+        {
+          channelId: "wechat",
+          displayName: "WeChat",
+          authMode: "host-qr",
+          active: true,
+          selected: true,
+          configured: true,
+          disabled: false,
+          inputs: [],
+          hooks: [
+            {
+              channelId: "wechat",
+              id: "seed",
+              phase: "post-agent-install",
+              handler: "wechat.seedOpenClawAccount",
+            },
+          ],
+        },
+        {
+          channelId: "telegram",
+          displayName: "Telegram",
+          authMode: "token-paste",
+          active: false,
+          selected: true,
+          configured: true,
+          disabled: true,
+          inputs: [],
+          hooks: [],
+        },
+      ],
+      disabledChannels: ["telegram"],
+      credentialBindings: [],
+      networkPolicy: { presets: [], entries: [] },
+      agentRender: [
+        {
+          channelId: "wechat",
+          agent: "openclaw",
+          target: "~/.openclaw/active-render.json",
+          kind: "json-fragment",
+          path: "channels.wechat",
+          value: { enabled: true },
+          templateRefs: [],
+        },
+        {
+          channelId: "telegram",
+          agent: "openclaw",
+          target: "~/.openclaw/disabled-render.json",
+          kind: "json-fragment",
+          path: "channels.telegram",
+          value: { enabled: true },
+          templateRefs: [],
+        },
+      ],
+      buildSteps: [
+        {
+          channelId: "wechat",
+          kind: "build-file",
+          hookId: "seed",
+          outputId: "accounts",
+          required: true,
+          value: {
+            path: "openclaw-weixin/accounts.json",
+            content: ["primary"],
+          },
+        },
+        {
+          channelId: "telegram",
+          kind: "build-file",
+          outputId: "disabled",
+          required: true,
+          value: { path: "disabled/new.json", content: {} },
+        },
+      ],
+      stateUpdates: [],
+      healthChecks: [],
+    };
+    const profile = {
+      ...managedStartupE2eProfile("openclaw"),
+      messaging: { plan: plan as unknown as ManagedStartupProfile["messaging"]["plan"] },
+    };
+    beginManagedStartupSharedStateTransaction(profile, options);
+
+    fs.writeFileSync(path.join(root, "active-render.json"), "active\n");
+    fs.mkdirSync(path.join(root, "openclaw-weixin"));
+    fs.writeFileSync(path.join(root, "openclaw-weixin", "accounts.json"), "active\n");
+    fs.writeFileSync(path.join(root, "disabled-render.json"), "keep\n");
+    fs.mkdirSync(path.join(root, "disabled"));
+    fs.writeFileSync(path.join(root, "disabled", "new.json"), "keep\n");
+
+    expect(rollbackManagedStartupSharedStateTransaction("openclaw", options)).toBe(true);
+    expect(fs.existsSync(path.join(root, "active-render.json"))).toBe(false);
+    expect(fs.existsSync(path.join(root, "openclaw-weixin"))).toBe(false);
+    expect(fs.readFileSync(path.join(root, "disabled-render.json"), "utf8")).toBe("keep\n");
+    expect(fs.readFileSync(path.join(root, "disabled", "new.json"), "utf8")).toBe("keep\n");
+  });
+
+  it("commits applied output while removing its private backups", () => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root);
+    const config = path.join(root, "openclaw.json");
+    fs.writeFileSync(config, "before\n");
+    beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), options);
+    fs.writeFileSync(config, "after\n");
+
+    expect(commitManagedStartupSharedStateTransaction("openclaw", options)).toBe(true);
+    expect(fs.readFileSync(config, "utf8")).toBe("after\n");
+    expect(fs.existsSync(transactionDirectory)).toBe(false);
+    expect(commitManagedStartupSharedStateTransaction("openclaw", options)).toBe(false);
+  });
+
+  it("resumes the same pending profile idempotently and rejects profile drift", () => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, "openclaw.json"), "{}\n");
+    const profile = managedStartupE2eProfile("openclaw");
+    expect(beginManagedStartupSharedStateTransaction(profile, options)).toBe(true);
+    expect(beginManagedStartupSharedStateTransaction(profile, options)).toBe(false);
+    expect(() =>
+      beginManagedStartupSharedStateTransaction(
+        managedStartupE2eProfile("openclaw", true),
+        options,
+      ),
+    ).toThrow(/belongs to a different profile/u);
+    expect(rollbackManagedStartupSharedStateTransaction("openclaw", options)).toBe(true);
+  });
+
+  it("rejects planted target and ancestor symlinks before creating a receipt", () => {
+    const outside = path.join(temporaryRoot, "outside");
+    fs.mkdirSync(outside);
+    const root = agentRoot("openclaw");
+    fs.symlinkSync(outside, root);
+    expect(() =>
+      beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), options),
+    ).toThrow(/ancestor is unsafe/u);
+    expect(fs.existsSync(transactionDirectory)).toBe(false);
+
+    fs.unlinkSync(root);
+    fs.mkdirSync(root);
+    const outsideConfig = path.join(outside, "openclaw.json");
+    fs.writeFileSync(outsideConfig, "outside\n");
+    fs.symlinkSync(outsideConfig, path.join(root, "openclaw.json"));
+    expect(() =>
+      beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), options),
+    ).toThrow(/not a safe regular file/u);
+    expect(fs.readFileSync(outsideConfig, "utf8")).toBe("outside\n");
+    expect(fs.existsSync(transactionDirectory)).toBe(false);
+  });
+
+  it("does not rewrite unchanged shield-like files or directory metadata", () => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root, { mode: 0o755 });
+    const config = path.join(root, "openclaw.json");
+    fs.writeFileSync(config, "shielded\n");
+    fs.chmodSync(config, 0o444);
+    beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), options);
+    const rename = vi.spyOn(fs, "renameSync");
+    const chown = vi.spyOn(fs, "chownSync");
+
+    expect(rollbackManagedStartupSharedStateTransaction("openclaw", options)).toBe(true);
+    expect(rename).not.toHaveBeenCalled();
+    expect(chown).not.toHaveBeenCalled();
+    expect(fs.readFileSync(config, "utf8")).toBe("shielded\n");
+    expect(mode(config)).toBe(0o444);
+  });
+
+  it("refuses to operate on a pending transaction for a different agent", () => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, "openclaw.json"), "{}\n");
+    beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), options);
+    expect(() => rollbackManagedStartupSharedStateTransaction("hermes", options)).toThrow(
+      /targets openclaw, expected hermes/u,
+    );
+    expect(fs.existsSync(transactionDirectory)).toBe(true);
+    expect(rollbackManagedStartupSharedStateTransaction("openclaw", options)).toBe(true);
+  });
+
+  it("rejects an oversized managed output before creating a receipt", () => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root);
+    const config = path.join(root, "openclaw.json");
+    fs.writeFileSync(config, "");
+    fs.truncateSync(config, 8 * 1024 * 1024 + 1);
+
+    expect(() =>
+      beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), options),
+    ).toThrow(/unsafe or oversized/u);
+    expect(fs.existsSync(transactionDirectory)).toBe(false);
+  });
+});

--- a/src/lib/onboard/managed-startup/docker-root-apply.test.ts
+++ b/src/lib/onboard/managed-startup/docker-root-apply.test.ts
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import {
+  applyDockerManagedStartupRootRequest,
+  getDockerManagedStartupFailureTransaction,
+} from "./docker-root-apply";
+import { encodeManagedStartupProfile } from "./profile";
+import {
+  createManagedStartupRootApplyRequest,
+  parseManagedStartupRootApplyRequest,
+} from "./root-apply";
+import { MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY } from "./shared-state-transaction";
+
+const CONTAINER_ID = "b".repeat(64);
+const IMAGE_ID = `sha256:${"c".repeat(64)}`;
+
+function requestFor(agent: "openclaw" | "hermes" | "langchain-deepagents-code") {
+  return createManagedStartupRootApplyRequest({
+    agent,
+    encodedProfile: encodeManagedStartupProfile(managedStartupE2eProfile(agent)),
+  });
+}
+
+function stableInspect(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify([
+    {
+      Id: CONTAINER_ID,
+      Image: IMAGE_ID,
+      State: {
+        Running: true,
+        Paused: false,
+        Restarting: false,
+        Dead: false,
+      },
+      ...overrides,
+    },
+  ]);
+}
+
+function successfulSpawnResult() {
+  return {
+    status: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    output: [null, "", ""],
+    pid: 1,
+    error: undefined,
+  };
+}
+
+describe("Docker managed-startup root applicator", () => {
+  it.each([
+    "openclaw",
+    "hermes",
+    "langchain-deepagents-code",
+  ] as const)("pins exact container/image identity and uses fixed root stdin for %s", (agent) => {
+    const request = requestFor(agent);
+    const dockerCapture = vi.fn(() => stableInspect());
+    const dockerSpawnSync = vi.fn(() => successfulSpawnResult());
+
+    expect(
+      applyDockerManagedStartupRootRequest(
+        { containerId: CONTAINER_ID, request },
+        { dockerCapture, dockerSpawnSync, environment: {} },
+      ),
+    ).toEqual({ agent, containerId: CONTAINER_ID, image: IMAGE_ID });
+
+    expect(dockerCapture).toHaveBeenCalledWith(["inspect", "--type", "container", CONTAINER_ID], {
+      ignoreError: false,
+      timeout: 30_000,
+    });
+    expect(dockerSpawnSync).toHaveBeenCalledTimes(2);
+    const [argv, options] = dockerSpawnSync.mock.calls[0] as unknown as [
+      string[],
+      { input: string; timeout: number; encoding: string },
+    ];
+    expect(argv).toEqual([
+      "exec",
+      "--interactive",
+      "--user",
+      "0:0",
+      "--workdir",
+      "/",
+      CONTAINER_ID,
+      "/usr/bin/env",
+      "-i",
+      "HOME=/root",
+      "LANG=C.UTF-8",
+      "LC_ALL=C.UTF-8",
+      "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1",
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "/usr/local/bin/node",
+      "/usr/local/lib/nemoclaw/managed-startup-image-runtime.cjs",
+      "--apply-root-stdin",
+      "--agent",
+      agent,
+    ]);
+    expect(argv.join(" ")).not.toContain(request.encodedProfile);
+    expect(parseManagedStartupRootApplyRequest(options.input)).toEqual(request);
+    expect(options).toMatchObject({ encoding: "utf8", timeout: 300_000 });
+    expect(dockerSpawnSync.mock.calls[1]).toEqual([
+      [
+        "exec",
+        "--user",
+        "0:0",
+        "--workdir",
+        "/",
+        CONTAINER_ID,
+        "/usr/bin/env",
+        "-i",
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "/bin/sh",
+        "-c",
+        'if [ -d "$1" ] && [ ! -L "$1" ]; then exit 0; fi; if [ ! -e "$1" ] && [ ! -L "$1" ]; then exit 1; fi; exit 2',
+        "nemoclaw-transaction-probe",
+        MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY,
+      ],
+      { encoding: "utf8", timeout: 30_000 },
+    ]);
+  });
+
+  it("forwards only allowlisted application-runtime controls through the clean root exec", () => {
+    const dockerSpawnSync = vi.fn(() => successfulSpawnResult());
+
+    applyDockerManagedStartupRootRequest(
+      { containerId: CONTAINER_ID, request: requestFor("openclaw") },
+      {
+        dockerCapture: vi.fn(() => stableInspect()),
+        dockerSpawnSync,
+        environment: {
+          NEMOCLAW_AUTO_PAIR_FAST_REENTRY_INTERVAL_SECS: " 0.25 ",
+          NEMOCLAW_AUTO_PAIR_FAST_REENTRY_POLLS: "03",
+          NEMOCLAW_NOT_AN_APPLICATION_RUNTIME_INPUT: "must-not-cross",
+        },
+      },
+    );
+
+    const [argv] = dockerSpawnSync.mock.calls[0] as unknown as [string[]];
+    expect(argv).toContain("NEMOCLAW_AUTO_PAIR_FAST_REENTRY_INTERVAL_SECS= 0.25 ");
+    expect(argv).toContain("NEMOCLAW_AUTO_PAIR_FAST_REENTRY_POLLS=03");
+    expect(argv.join("\n")).not.toContain("NEMOCLAW_NOT_AN_APPLICATION_RUNTIME_INPUT");
+  });
+
+  it("retries one lost acknowledgement with the identical pinned command and payload", () => {
+    const request = requestFor("openclaw");
+    const dockerSpawnSync = vi
+      .fn()
+      .mockReturnValueOnce({ ...successfulSpawnResult(), status: 1, stderr: "lost ack" })
+      .mockReturnValueOnce(successfulSpawnResult())
+      .mockReturnValueOnce(successfulSpawnResult());
+
+    applyDockerManagedStartupRootRequest(
+      { containerId: CONTAINER_ID, request },
+      { dockerCapture: vi.fn(() => stableInspect()), dockerSpawnSync },
+    );
+
+    expect(dockerSpawnSync).toHaveBeenCalledTimes(3);
+    expect(dockerSpawnSync.mock.calls[1]).toEqual(dockerSpawnSync.mock.calls[0]);
+  });
+
+  it("returns no pending transaction when the same profile was already finalized", () => {
+    const request = requestFor("openclaw");
+    const dockerSpawnSync = vi
+      .fn()
+      .mockReturnValueOnce(successfulSpawnResult())
+      .mockReturnValueOnce({ ...successfulSpawnResult(), status: 1 });
+
+    expect(
+      applyDockerManagedStartupRootRequest(
+        { containerId: CONTAINER_ID, request },
+        { dockerCapture: vi.fn(() => stableInspect()), dockerSpawnSync },
+      ),
+    ).toBeNull();
+    expect(dockerSpawnSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails with rollback context when transaction state cannot be verified", () => {
+    const request = requestFor("hermes");
+    const dockerSpawnSync = vi
+      .fn()
+      .mockReturnValueOnce(successfulSpawnResult())
+      .mockReturnValueOnce({
+        ...successfulSpawnResult(),
+        status: null,
+        error: new Error("probe unavailable"),
+      });
+
+    let failure: unknown;
+    try {
+      applyDockerManagedStartupRootRequest(
+        { containerId: CONTAINER_ID, request },
+        { dockerCapture: vi.fn(() => stableInspect()), dockerSpawnSync },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining("transaction state could not be verified"),
+      }),
+    );
+    expect(getDockerManagedStartupFailureTransaction(failure)).toEqual({
+      agent: "hermes",
+      containerId: CONTAINER_ID,
+      image: IMAGE_ID,
+    });
+  });
+
+  it("attaches the pinned transaction when both idempotent attempts fail", () => {
+    const request = requestFor("hermes");
+    const dockerSpawnSync = vi.fn(() => ({
+      ...successfulSpawnResult(),
+      status: 1,
+      stderr: "exec failed",
+    }));
+
+    let failure: unknown;
+    try {
+      applyDockerManagedStartupRootRequest(
+        { containerId: CONTAINER_ID, request },
+        { dockerCapture: vi.fn(() => stableInspect()), dockerSpawnSync },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toEqual(
+      expect.objectContaining({ message: expect.stringContaining("exec failed") }),
+    );
+    expect(getDockerManagedStartupFailureTransaction(failure)).toEqual({
+      agent: "hermes",
+      containerId: CONTAINER_ID,
+      image: IMAGE_ID,
+    });
+    expect(dockerSpawnSync).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      label: "changed exact identity",
+      containerId: CONTAINER_ID,
+      inspect: stableInspect({ Id: "d".repeat(64) }),
+      error: /identity changed/u,
+    },
+    {
+      label: "mutable image identity",
+      containerId: CONTAINER_ID,
+      inspect: stableInspect({ Image: "registry.example/image:latest" }),
+      error: /immutable image identity/u,
+    },
+    {
+      label: "unstable running state",
+      containerId: CONTAINER_ID,
+      inspect: stableInspect({
+        State: { Running: true, Paused: false, Restarting: true, Dead: false },
+      }),
+      error: /not stably running/u,
+    },
+    {
+      label: "short caller identity",
+      containerId: "b".repeat(12),
+      inspect: stableInspect(),
+      error: /full lowercase Docker container ID/u,
+    },
+  ])("rejects $label before root exec", ({ containerId, inspect, error }) => {
+    const dockerSpawnSync = vi.fn();
+
+    expect(() =>
+      applyDockerManagedStartupRootRequest(
+        { containerId, request: requestFor("openclaw") },
+        { dockerCapture: vi.fn(() => inspect), dockerSpawnSync },
+      ),
+    ).toThrow(error);
+    expect(dockerSpawnSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/managed-startup/docker-root-apply.ts
+++ b/src/lib/onboard/managed-startup/docker-root-apply.ts
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { dockerSpawnSync } from "../../adapters/docker/exec";
+import { dockerCapture } from "../../adapters/docker/run";
+import { isImmutableDockerImageId } from "../openshell-docker-sandbox-containers";
+import { MANAGED_STARTUP_RUNTIME_EXECUTABLE } from "./image-runtime";
+import {
+  type ManagedStartupRootApplyRequest,
+  selectManagedStartupApplicationRuntimeEnvironment,
+  serializeManagedStartupRootApplyRequest,
+} from "./root-apply";
+import { MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY } from "./shared-state-transaction";
+
+const FULL_CONTAINER_ID_RE = /^[a-f0-9]{64}$/u;
+const ROOT_APPLY_TIMEOUT_MS = 300_000;
+const FIXED_ROOT_ENV = [
+  "HOME=/root",
+  "LANG=C.UTF-8",
+  "LC_ALL=C.UTF-8",
+  "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1",
+  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+] as const;
+
+interface DockerManagedStartupInspect {
+  readonly Id?: string;
+  readonly Image?: string;
+  readonly State?: {
+    readonly Running?: boolean;
+    readonly Paused?: boolean;
+    readonly Restarting?: boolean;
+    readonly Dead?: boolean;
+  } | null;
+}
+
+export interface DockerManagedStartupTransaction {
+  readonly agent: ManagedStartupRootApplyRequest["agent"];
+  readonly containerId: string;
+  readonly image: string;
+}
+
+export interface DockerManagedStartupRootApplyDeps {
+  readonly dockerCapture?: typeof dockerCapture;
+  readonly dockerSpawnSync?: typeof dockerSpawnSync;
+  readonly environment?: Readonly<NodeJS.ProcessEnv>;
+}
+
+export function getDockerManagedStartupFailureTransaction(
+  error: unknown,
+): DockerManagedStartupTransaction | null {
+  if (typeof error === "object" && error !== null && "managedStartupTransaction" in error) {
+    return (
+      (error as { managedStartupTransaction?: DockerManagedStartupTransaction })
+        .managedStartupTransaction ?? null
+    );
+  }
+  return null;
+}
+
+function commandDetail(result: {
+  readonly status?: number | null;
+  readonly stdout?: string | Buffer | null;
+  readonly stderr?: string | Buffer | null;
+  readonly error?: Error | null;
+}): string {
+  return `${String(result.stderr ?? "")} ${String(result.stdout ?? "")} ${String(
+    result.error?.message ?? "",
+  )}`
+    .trim()
+    .slice(-1200);
+}
+
+function inspectExactContainer(
+  containerId: string,
+  capture: typeof dockerCapture,
+): { readonly containerId: string; readonly image: string } {
+  if (!FULL_CONTAINER_ID_RE.test(containerId)) {
+    throw new Error("Managed startup requires one full lowercase Docker container ID.");
+  }
+  const output = capture(["inspect", "--type", "container", containerId], {
+    ignoreError: false,
+    timeout: 30_000,
+  });
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    throw new Error("Docker returned malformed inspect output for the managed-startup container.");
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 1) {
+    throw new Error("Docker inspect did not resolve exactly one managed-startup container.");
+  }
+  const inspect = parsed[0] as DockerManagedStartupInspect;
+  const exactId = String(inspect.Id ?? "").toLowerCase();
+  const image = String(inspect.Image ?? "").toLowerCase();
+  if (exactId !== containerId) {
+    throw new Error("Managed-startup container identity changed before root application.");
+  }
+  if (!isImmutableDockerImageId(image)) {
+    throw new Error("Managed-startup container does not have an immutable image identity.");
+  }
+  if (
+    inspect.State?.Running !== true ||
+    inspect.State.Paused === true ||
+    inspect.State.Restarting === true ||
+    inspect.State.Dead === true
+  ) {
+    throw new Error("Managed-startup container is not stably running for root application.");
+  }
+  return { containerId: exactId, image };
+}
+
+export function applyDockerManagedStartupRootRequest(
+  input: {
+    readonly containerId: string;
+    readonly request: ManagedStartupRootApplyRequest;
+  },
+  deps: DockerManagedStartupRootApplyDeps = {},
+): DockerManagedStartupTransaction | null {
+  const capture = deps.dockerCapture ?? dockerCapture;
+  const spawn = deps.dockerSpawnSync ?? dockerSpawnSync;
+  const pinned = inspectExactContainer(input.containerId, capture);
+  const transaction = {
+    agent: input.request.agent,
+    containerId: pinned.containerId,
+    image: pinned.image,
+  } satisfies DockerManagedStartupTransaction;
+  const payload = serializeManagedStartupRootApplyRequest(input.request);
+  const applicationRuntimeEnvironment = Object.entries(
+    selectManagedStartupApplicationRuntimeEnvironment(deps.environment ?? process.env),
+  ).map(([name, value]) => `${name}=${value}`);
+  const argv = [
+    "exec",
+    "--interactive",
+    "--user",
+    "0:0",
+    "--workdir",
+    "/",
+    pinned.containerId,
+    "/usr/bin/env",
+    "-i",
+    ...FIXED_ROOT_ENV,
+    ...applicationRuntimeEnvironment,
+    "/usr/local/bin/node",
+    MANAGED_STARTUP_RUNTIME_EXECUTABLE,
+    "--apply-root-stdin",
+    "--agent",
+    input.request.agent,
+  ];
+  const receiptProbeArgv = [
+    "exec",
+    "--user",
+    "0:0",
+    "--workdir",
+    "/",
+    pinned.containerId,
+    "/usr/bin/env",
+    "-i",
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "/bin/sh",
+    "-c",
+    'if [ -d "$1" ] && [ ! -L "$1" ]; then exit 0; fi; if [ ! -e "$1" ] && [ ! -L "$1" ]; then exit 1; fi; exit 2',
+    "nemoclaw-transaction-probe",
+    MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY,
+  ];
+
+  let lastFailure = "";
+  // The image-side coordinator and transaction are idempotent. One retry
+  // reconciles the only ambiguous case: Docker lost the first exec
+  // acknowledgement after the completion marker was already published.
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = spawn(argv, {
+      encoding: "utf8",
+      input: payload,
+      timeout: ROOT_APPLY_TIMEOUT_MS,
+    });
+    if (result.status === 0) {
+      const receiptProbe = spawn(receiptProbeArgv, {
+        encoding: "utf8",
+        timeout: 30_000,
+      });
+      if (receiptProbe.status === 0) return transaction;
+      if (receiptProbe.status === 1) return null;
+      const receiptProbeDetail = commandDetail(receiptProbe);
+      const error = new Error(
+        `Managed startup root application completed, but transaction state could not be verified in exact container ${pinned.containerId.slice(0, 12)}${
+          receiptProbeDetail ? `: ${receiptProbeDetail}` : ""
+        }`,
+      );
+      (
+        error as Error & {
+          managedStartupTransaction?: DockerManagedStartupTransaction;
+        }
+      ).managedStartupTransaction = transaction;
+      throw error;
+    }
+    lastFailure = commandDetail(result);
+  }
+  const error = new Error(
+    `Managed startup root application failed in exact container ${pinned.containerId.slice(0, 12)}${
+      lastFailure ? `: ${lastFailure}` : ""
+    }`,
+  );
+  (
+    error as Error & {
+      managedStartupTransaction?: DockerManagedStartupTransaction;
+    }
+  ).managedStartupTransaction = transaction;
+  throw error;
+}

--- a/src/lib/onboard/managed-startup/docker-shared-state.test.ts
+++ b/src/lib/onboard/managed-startup/docker-shared-state.test.ts
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DockerGpuPatchResult } from "../docker-gpu-patch-types";
+import type { DockerManagedStartupTransaction } from "./docker-root-apply";
+import { finalizeDockerManagedStartupSharedState } from "./docker-shared-state";
+import { MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY } from "./shared-state-transaction";
+
+const IMMUTABLE_IMAGE = `sha256:${"a".repeat(64)}`;
+
+function result(): DockerGpuPatchResult {
+  return {
+    applied: true,
+    oldContainerId: "old",
+    newContainerId: "new",
+    originalName: "openshell-alpha",
+    backupContainerName: "openshell-alpha-backup",
+    mode: {
+      kind: "startup-command",
+      label: "restart-safe startup command",
+      device: "",
+      args: [],
+    },
+    backupRemoved: false,
+  };
+}
+
+function transaction(): DockerManagedStartupTransaction {
+  return {
+    agent: "openclaw",
+    containerId: "new",
+    image: IMMUTABLE_IMAGE,
+  };
+}
+
+function removeReceiptParents(...receiptPaths: readonly string[]): void {
+  for (const receiptPath of receiptPaths.filter((candidate) => candidate.length > 0)) {
+    fs.rmSync(path.dirname(receiptPath), { force: true, recursive: true });
+  }
+}
+
+describe("Docker managed-startup shared-state finalization", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("copies the bounded receipt before commit and removes the host copy on success", () => {
+    const calls: string[] = [];
+    let receiptPath = "";
+    const dockerRun = vi
+      .fn()
+      .mockImplementationOnce((args: readonly string[]) => {
+        calls.push("copy");
+        receiptPath = String(args[2]);
+        expect(args[1]).toBe(`new:${MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY}`);
+        return { status: 0 };
+      })
+      .mockImplementationOnce((args: readonly string[]) => {
+        calls.push("commit");
+        expect(args).toEqual([
+          "exec",
+          "--user",
+          "0:0",
+          "--env",
+          "NODE_OPTIONS=",
+          "--env",
+          "NODE_PATH=",
+          "--env",
+          "BASH_ENV=",
+          "--env",
+          "ENV=",
+          "new",
+          "/usr/bin/env",
+          "-i",
+          "HOME=/root",
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "/usr/local/bin/node",
+          "/usr/local/lib/nemoclaw/managed-startup-image-runtime.cjs",
+          "--commit-shared-state-transaction",
+          "--agent",
+          "openclaw",
+        ]);
+        return { status: 0 };
+      });
+    const dockerStop = vi.fn();
+
+    expect(
+      finalizeDockerManagedStartupSharedState(
+        { transaction: transaction(), patchResult: result(), supervisorReady: true },
+        { dockerRun, dockerStop },
+      ),
+    ).toEqual({ supervisorReady: true, failure: null });
+    expect(calls).toEqual(["copy", "commit"]);
+    expect(dockerStop).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.dirname(receiptPath))).toBe(false);
+  });
+
+  it("uses the preserved pre-commit receipt after a lost commit acknowledgement", () => {
+    const calls: string[] = [];
+    let receiptPath = "";
+    const dockerRun = vi
+      .fn()
+      .mockImplementationOnce((args: readonly string[]) => {
+        calls.push("copy");
+        receiptPath = String(args[2]);
+        return { status: 0 };
+      })
+      .mockImplementationOnce(() => {
+        calls.push("commit-lost-ack");
+        return { status: 1, stderr: "daemon acknowledgement lost" };
+      })
+      .mockImplementationOnce((args: readonly string[]) => {
+        calls.push("rollback-helper");
+        expect(args).toEqual([
+          "run",
+          "--rm",
+          "--pull",
+          "never",
+          "--network",
+          "none",
+          "--read-only",
+          "--user",
+          "0:0",
+          "--security-opt",
+          "no-new-privileges",
+          "--cap-drop",
+          "ALL",
+          "--cap-add",
+          "CHOWN",
+          "--cap-add",
+          "DAC_OVERRIDE",
+          "--cap-add",
+          "FOWNER",
+          "--env",
+          "NODE_OPTIONS=",
+          "--env",
+          "NODE_PATH=",
+          "--env",
+          "BASH_ENV=",
+          "--env",
+          "ENV=",
+          "--volumes-from",
+          "new",
+          "--mount",
+          expect.stringMatching(
+            /^type=bind,src=.+,dst=\/run\/nemoclaw\/managed-startup-shared-rollback-receipt-v1,readonly$/u,
+          ),
+          "--entrypoint",
+          "/usr/local/bin/node",
+          IMMUTABLE_IMAGE,
+          "/usr/local/lib/nemoclaw/managed-startup-image-runtime.cjs",
+          "--rollback-shared-state-transaction",
+          "--agent",
+          "openclaw",
+          "--read-only-receipt",
+        ]);
+        return { status: 0 };
+      });
+    const dockerStop = vi.fn(() => {
+      calls.push("stop");
+      return { status: 0 };
+    });
+
+    const outcome = finalizeDockerManagedStartupSharedState(
+      { transaction: transaction(), patchResult: result(), supervisorReady: true },
+      { dockerRun, dockerStop },
+    );
+    expect(outcome.supervisorReady).toBe(false);
+    expect(outcome.failure?.message).toContain("commit failed");
+    expect(calls).toEqual(["copy", "commit-lost-ack", "stop", "rollback-helper"]);
+    expect(fs.existsSync(path.dirname(receiptPath))).toBe(false);
+  });
+
+  it("uses unique receipt paths and treats already-completed cleanup idempotently", () => {
+    const receiptPaths: string[] = [];
+    const copyReceipt = (args: readonly string[]) => {
+      expect(args[0]).toBe("cp");
+      const receiptPath = String(args[2]);
+      receiptPaths.push(receiptPath);
+      return { status: 0 };
+    };
+    const completeCommit = (args: readonly string[]) => {
+      expect(args[0]).toBe("exec");
+      removeReceiptParents(receiptPaths.at(-1)!);
+      return { status: 0 };
+    };
+    const dockerRun = vi
+      .fn()
+      .mockImplementationOnce(copyReceipt)
+      .mockImplementationOnce(completeCommit)
+      .mockImplementationOnce(copyReceipt)
+      .mockImplementationOnce(completeCommit);
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect(
+        finalizeDockerManagedStartupSharedState(
+          { transaction: transaction(), patchResult: result(), supervisorReady: true },
+          { dockerRun },
+        ),
+      ).toEqual({ supervisorReady: true, failure: null });
+    }
+    expect(new Set(receiptPaths).size).toBe(2);
+    expect(receiptPaths.every((receiptPath) => !fs.existsSync(path.dirname(receiptPath)))).toBe(
+      true,
+    );
+  });
+
+  it("quiesces a failed supervisor before copying and replaying the receipt", () => {
+    const calls: string[] = [];
+    const dockerStop = vi.fn(() => {
+      calls.push("stop");
+      return { status: 0 };
+    });
+    const dockerRun = vi.fn((args: readonly string[]) => {
+      calls.push(args[0] === "cp" ? "copy" : "rollback-helper");
+      return { status: 0 };
+    });
+
+    expect(
+      finalizeDockerManagedStartupSharedState(
+        { transaction: transaction(), patchResult: result(), supervisorReady: false },
+        { dockerRun, dockerStop },
+      ),
+    ).toEqual({ supervisorReady: false, failure: null });
+    expect(calls).toEqual(["stop", "copy", "rollback-helper"]);
+  });
+
+  it("stops a live workload when pre-commit receipt preservation fails", () => {
+    const dockerRun = vi.fn(() => ({ status: 1, stderr: "copy failed" }));
+    const dockerStop = vi.fn(() => ({ status: 0 }));
+
+    expect(() =>
+      finalizeDockerManagedStartupSharedState(
+        { transaction: transaction(), patchResult: result(), supervisorReady: true },
+        { dockerRun, dockerStop },
+      ),
+    ).toThrow(/Could not copy/u);
+    expect(dockerStop).toHaveBeenCalledOnce();
+    expect(dockerRun).toHaveBeenCalledOnce();
+  });
+
+  it("fails before container rollback when the immutable helper cannot verify restoration", () => {
+    const dockerStop = vi.fn(() => ({ status: 0 }));
+    let receiptPath = "";
+    const dockerRun = vi
+      .fn()
+      .mockImplementationOnce((args: readonly string[]) => {
+        receiptPath = String(args[2]);
+        return { status: 0 };
+      })
+      .mockImplementationOnce(() => ({
+        status: 1,
+        stderr: "receipt verification failed",
+      }));
+
+    try {
+      expect(() =>
+        finalizeDockerManagedStartupSharedState(
+          { transaction: transaction(), patchResult: result(), supervisorReady: false },
+          { dockerRun, dockerStop },
+        ),
+      ).toThrow(/could not restore and verify/u);
+      expect(dockerStop).toHaveBeenCalledOnce();
+      expect(fs.existsSync(path.dirname(receiptPath))).toBe(true);
+    } finally {
+      removeReceiptParents(receiptPath);
+    }
+  });
+
+  it("is a no-op for non-managed container patches", () => {
+    const dockerRun = vi.fn();
+    const dockerStop = vi.fn();
+    expect(
+      finalizeDockerManagedStartupSharedState(
+        { transaction: null, patchResult: result(), supervisorReady: true },
+        { dockerRun, dockerStop },
+      ),
+    ).toEqual({ supervisorReady: true, failure: null });
+    expect(dockerRun).not.toHaveBeenCalled();
+    expect(dockerStop).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/managed-startup/docker-shared-state.ts
+++ b/src/lib/onboard/managed-startup/docker-shared-state.ts
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  dockerRm as defaultDockerRm,
+  dockerStop as defaultDockerStop,
+} from "../../adapters/docker/container";
+import { dockerRun as defaultDockerRun } from "../../adapters/docker/run";
+import { hasZeroDockerExitStatus } from "../docker-command-result";
+import {
+  DOCKER_GPU_PATCH_STOP_TIMEOUT_MS,
+  DOCKER_GPU_PATCH_TIMEOUT_MS,
+} from "../docker-gpu-patch-constants";
+import type { DockerGpuPatchDeps, DockerGpuPatchResult } from "../docker-gpu-patch-types";
+import { cleanupTempDir, secureTempFile } from "../temp-files";
+import type { DockerManagedStartupTransaction } from "./docker-root-apply";
+import { MANAGED_STARTUP_RUNTIME_EXECUTABLE } from "./image-runtime";
+import {
+  MANAGED_STARTUP_SHARED_ROLLBACK_RECEIPT_DIRECTORY,
+  MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY,
+} from "./shared-state-transaction";
+
+const RECEIPT_TEMP_PREFIX = "nemoclaw-managed-startup-receipt";
+const NEUTRALIZED_PROCESS_INJECTION_ENV = [
+  "--env",
+  "NODE_OPTIONS=",
+  "--env",
+  "NODE_PATH=",
+  "--env",
+  "BASH_ENV=",
+  "--env",
+  "ENV=",
+] as const;
+
+export interface DockerManagedStartupSharedStateOutcome {
+  /**
+   * True only when the new supervisor is still eligible for successful
+   * container cutover. A commit failure forces shared-state rollback first.
+   */
+  readonly supervisorReady: boolean;
+  /** Original commit failure after a successful shared-state rollback. */
+  readonly failure: Error | null;
+}
+
+function commandDetail(result: {
+  readonly stderr?: string | Buffer | null;
+  readonly stdout?: string | Buffer | null;
+  readonly error?: Error | null;
+}): string {
+  return `${String(result.stderr ?? "")} ${String(result.stdout ?? "")} ${String(
+    result.error?.message ?? "",
+  )}`
+    .trim()
+    .slice(-800);
+}
+
+function cleanupReceiptBestEffort(receiptPath: string): void {
+  try {
+    cleanupTempDir(receiptPath, RECEIPT_TEMP_PREFIX);
+  } catch (error) {
+    console.warn(
+      `  ⚠ Managed-startup shared state is finalized, but its protected host receipt could not be removed (${receiptPath}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+function transactionCommand(action: "commit" | "rollback", agent: string): string[] {
+  return [
+    MANAGED_STARTUP_RUNTIME_EXECUTABLE,
+    `--${action}-shared-state-transaction`,
+    "--agent",
+    agent,
+  ];
+}
+
+const DOCKER_MUTATION_OPTIONS = {
+  ignoreError: true,
+  suppressOutput: true,
+  timeout: DOCKER_GPU_PATCH_TIMEOUT_MS,
+} as const;
+
+function quiesceManagedStartupContainer(
+  transaction: DockerManagedStartupTransaction,
+  deps: DockerGpuPatchDeps,
+): void {
+  const dockerStop = deps.dockerStop ?? defaultDockerStop;
+  const stopped = dockerStop(transaction.containerId, {
+    ...DOCKER_MUTATION_OPTIONS,
+    timeout: DOCKER_GPU_PATCH_STOP_TIMEOUT_MS,
+  });
+  if (!hasZeroDockerExitStatus(stopped)) {
+    throw new Error(
+      `Could not quiesce the failed managed-startup container before shared-state rollback: ${commandDetail(stopped)}`,
+    );
+  }
+}
+
+function copyManagedStartupReceipt(
+  transaction: DockerManagedStartupTransaction,
+  deps: DockerGpuPatchDeps,
+): string {
+  const dockerRun = deps.dockerRun ?? defaultDockerRun;
+  const receiptPath = secureTempFile(RECEIPT_TEMP_PREFIX);
+  try {
+    const copy = dockerRun(
+      [
+        "cp",
+        `${transaction.containerId}:${MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY}`,
+        receiptPath,
+      ],
+      DOCKER_MUTATION_OPTIONS,
+    );
+    if (!hasZeroDockerExitStatus(copy)) {
+      throw new Error(
+        `Could not copy the managed-startup rollback receipt from the failed container: ${commandDetail(copy)}`,
+      );
+    }
+    if (receiptPath.includes(",") || /[\r\n\0]/u.test(receiptPath)) {
+      throw new Error("Managed-startup rollback receipt path is unsafe for a Docker bind mount");
+    }
+    return receiptPath;
+  } catch (error) {
+    cleanupReceiptBestEffort(receiptPath);
+    throw error;
+  }
+}
+
+function rollbackManagedStartupSharedState(
+  transaction: DockerManagedStartupTransaction,
+  receiptPath: string,
+  deps: DockerGpuPatchDeps,
+): void {
+  const dockerRun = deps.dockerRun ?? defaultDockerRun;
+  let restored = false;
+  try {
+    const helper = dockerRun(
+      [
+        "run",
+        "--rm",
+        "--pull",
+        "never",
+        "--network",
+        "none",
+        "--read-only",
+        "--user",
+        "0:0",
+        "--security-opt",
+        "no-new-privileges",
+        "--cap-drop",
+        "ALL",
+        "--cap-add",
+        "CHOWN",
+        "--cap-add",
+        "DAC_OVERRIDE",
+        "--cap-add",
+        "FOWNER",
+        ...NEUTRALIZED_PROCESS_INJECTION_ENV,
+        "--volumes-from",
+        transaction.containerId,
+        "--mount",
+        `type=bind,src=${receiptPath},dst=${MANAGED_STARTUP_SHARED_ROLLBACK_RECEIPT_DIRECTORY},readonly`,
+        "--entrypoint",
+        "/usr/local/bin/node",
+        transaction.image,
+        ...transactionCommand("rollback", transaction.agent),
+        "--read-only-receipt",
+      ],
+      DOCKER_MUTATION_OPTIONS,
+    );
+    if (!hasZeroDockerExitStatus(helper)) {
+      throw new Error(
+        `Immutable managed-startup helper could not restore and verify shared state: ${commandDetail(helper)}. ` +
+          `Protected receipt retained at ${receiptPath}`,
+      );
+    }
+    restored = true;
+  } finally {
+    if (restored) {
+      cleanupReceiptBestEffort(receiptPath);
+    }
+  }
+}
+
+function removeFailedUnbackedContainer(
+  transaction: DockerManagedStartupTransaction,
+  deps: DockerGpuPatchDeps,
+): void {
+  const dockerRm = deps.dockerRm ?? defaultDockerRm;
+  const removed = dockerRm(transaction.containerId, DOCKER_MUTATION_OPTIONS);
+  if (!hasZeroDockerExitStatus(removed)) {
+    throw new Error(
+      `Could not remove the failed managed-startup container after shared-state rollback: ${commandDetail(removed)}`,
+    );
+  }
+}
+
+/**
+ * Finalize the shared-state half of managed container cutover before generic
+ * backup removal or rollback. A shared-state rollback failure deliberately
+ * throws so callers cannot remove the new container or restart the old one
+ * while `/sandbox` remains partially applied.
+ */
+export function finalizeDockerManagedStartupSharedState(
+  input: {
+    readonly transaction: DockerManagedStartupTransaction | null;
+    readonly patchResult?: DockerGpuPatchResult | null;
+    readonly supervisorReady: boolean;
+  },
+  deps: DockerGpuPatchDeps = {},
+): DockerManagedStartupSharedStateOutcome {
+  const transaction = input.transaction;
+  if (!transaction) {
+    return { supervisorReady: input.supervisorReady, failure: null };
+  }
+  const dockerRun = deps.dockerRun ?? defaultDockerRun;
+  if (input.supervisorReady) {
+    // Preserve a verified rollback source before commit deletes the
+    // container-local receipt. If Docker loses the exec acknowledgement after
+    // deletion, this copy still makes the cutover reversible.
+    let receiptPath: string;
+    try {
+      receiptPath = copyManagedStartupReceipt(transaction, deps);
+    } catch (error) {
+      try {
+        quiesceManagedStartupContainer(transaction, deps);
+      } catch (stopError) {
+        throw new Error(
+          `Managed-startup receipt preservation failed and the new workload could not be quiesced: ${
+            error instanceof Error ? error.message : String(error)
+          }; ${stopError instanceof Error ? stopError.message : String(stopError)}`,
+        );
+      }
+      throw error;
+    }
+    const commit = dockerRun(
+      [
+        "exec",
+        "--user",
+        "0:0",
+        ...NEUTRALIZED_PROCESS_INJECTION_ENV,
+        transaction.containerId,
+        "/usr/bin/env",
+        "-i",
+        "HOME=/root",
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "/usr/local/bin/node",
+        ...transactionCommand("commit", transaction.agent),
+      ],
+      DOCKER_MUTATION_OPTIONS,
+    );
+    if (hasZeroDockerExitStatus(commit)) {
+      cleanupReceiptBestEffort(receiptPath);
+      return { supervisorReady: true, failure: null };
+    }
+    const failure = new Error(
+      `OpenShell supervisor reconnected, but managed shared-state commit failed: ${commandDetail(commit)}`,
+    );
+    quiesceManagedStartupContainer(transaction, deps);
+    rollbackManagedStartupSharedState(transaction, receiptPath, deps);
+    if (!input.patchResult) removeFailedUnbackedContainer(transaction, deps);
+    return { supervisorReady: false, failure };
+  }
+
+  quiesceManagedStartupContainer(transaction, deps);
+  const receiptPath = copyManagedStartupReceipt(transaction, deps);
+  rollbackManagedStartupSharedState(transaction, receiptPath, deps);
+  if (!input.patchResult) removeFailedUnbackedContainer(transaction, deps);
+  return { supervisorReady: false, failure: null };
+}

--- a/src/lib/onboard/managed-startup/image-runtime.ts
+++ b/src/lib/onboard/managed-startup/image-runtime.ts
@@ -19,10 +19,24 @@ import {
 } from "./coordinator";
 import {
   decodeManagedStartupProfile,
+  fingerprintManagedStartupProfile,
   MANAGED_STARTUP_AGENTS,
   type ManagedStartupAgent,
   type ManagedStartupDashboard,
+  type ManagedStartupProfile,
 } from "./profile";
+import {
+  MANAGED_STARTUP_ROOT_APPLY_MAX_BYTES,
+  type ManagedStartupRootApplyRequest,
+  parseManagedStartupRootApplyRequest,
+  selectManagedStartupApplicationRuntimeEnvironment,
+} from "./root-apply";
+import {
+  beginManagedStartupSharedStateTransaction,
+  commitManagedStartupSharedStateTransaction,
+  MANAGED_STARTUP_SHARED_ROLLBACK_RECEIPT_DIRECTORY,
+  rollbackManagedStartupSharedStateTransaction,
+} from "./shared-state-transaction";
 import { MANAGED_STARTUP_CA_ENV, MANAGED_STARTUP_PROFILE_ENV } from "./transport";
 
 export { MANAGED_STARTUP_CA_ENV, MANAGED_STARTUP_PROFILE_ENV } from "./transport";
@@ -30,6 +44,7 @@ export const MANAGED_STARTUP_RUNTIME_ENV_FILE = "/run/nemoclaw/managed-startup-r
 export const MANAGED_STARTUP_RUNTIME_EXECUTABLE =
   "/usr/local/lib/nemoclaw/managed-startup-image-runtime.cjs";
 export const MANAGED_STARTUP_MERGED_CA_FILE = "/run/nemoclaw/managed-startup-ca-bundle.pem";
+export const MANAGED_STARTUP_COMPLETION_FILE = "/run/nemoclaw/managed-startup-complete.json";
 
 const MANAGED_STARTUP_CORPORATE_CA_FILE = "/usr/local/share/nemoclaw/corporate-ca.pem";
 const MESSAGING_RUNTIME_PLAN_FILE = "/usr/local/share/nemoclaw/messaging-runtime-plan.json";
@@ -43,6 +58,9 @@ const HERMES_MANAGED_CONFIG_FILES = [
 ] as const;
 const FIXED_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const SHA256_RE = /^[a-f0-9]{64}$/u;
+const MANAGED_STARTUP_COMPLETION_SCHEMA_VERSION = 1;
+const MAX_MANAGED_STARTUP_COMPLETION_BYTES = 4096;
+const MAX_MANAGED_STARTUP_RUNTIME_ENVIRONMENT_BYTES = 512 * 1024;
 
 export type ManagedStartupImageIdentity = "root" | "sandbox";
 export type ManagedStartupMessagingAgent = "openclaw" | "hermes";
@@ -108,6 +126,18 @@ export interface ManagedStartupImageApplyResult {
   readonly adapterApplied: boolean;
   readonly fingerprint: string;
   readonly runtimeEnvironmentFile: string;
+}
+
+export interface ManagedStartupRootApplyResult extends ManagedStartupImageApplyResult {
+  readonly transactionPending: boolean;
+}
+
+export interface ManagedStartupCompletionMarker {
+  readonly schemaVersion: typeof MANAGED_STARTUP_COMPLETION_SCHEMA_VERSION;
+  readonly agent: ManagedStartupAgent;
+  readonly profileFingerprint: string;
+  readonly runtimeEnvironmentSha256: string;
+  readonly corporateCaMerged: boolean;
 }
 
 export class ManagedStartupImageActionPlanError extends Error {
@@ -213,6 +243,24 @@ function exactAgent(value: string): ManagedStartupAgent {
     return value as ManagedStartupAgent;
   }
   return fail(`unsupported agent ${JSON.stringify(value)}`);
+}
+
+function managedTransactionProfile(
+  expectedAgentInput: string,
+  env: Environment = process.env,
+): ManagedStartupProfile {
+  requireRoot();
+  const expectedAgent = exactAgent(expectedAgentInput);
+  if (env.NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION !== "1") {
+    fail("shared-state transactions require a complete managed image");
+  }
+  const encodedProfile = env[MANAGED_STARTUP_PROFILE_ENV];
+  if (!encodedProfile) fail(`${MANAGED_STARTUP_PROFILE_ENV} is required`);
+  const profile = decodeManagedStartupProfile(encodedProfile);
+  if (profile.agent !== expectedAgent) {
+    fail(`shared-state transaction profile targets ${profile.agent}, expected ${expectedAgent}`);
+  }
+  return profile;
 }
 
 function requireRoot(): void {
@@ -993,6 +1041,28 @@ export function serializeManagedStartupRuntimeEnvironment(
     unsetEnvironment: [],
   },
 ): string {
+  const { output, unsetNames } = materializeManagedStartupRuntimeEnvironment(
+    environment,
+    corporateCaMerged,
+    configurationEnvironment,
+    applicationRuntime,
+  );
+  const unsetLines = unsetNames.map((name) => `unset ${name}`);
+  const exportLines = Object.entries(output)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, value]) => `export ${name}=${shellSingleQuote(value)}`);
+  return `${[...unsetLines, ...exportLines].join("\n")}\n`;
+}
+
+function materializeManagedStartupRuntimeEnvironment(
+  environment: Readonly<Record<string, string>>,
+  corporateCaMerged: boolean,
+  configurationEnvironment: Readonly<Record<string, string>> = {},
+  applicationRuntime: ManagedStartupApplicationRuntimePlan = {
+    exportEnvironment: {},
+    unsetEnvironment: [],
+  },
+): { output: Record<string, string>; unsetNames: string[] } {
   const validatedApplicationRuntime =
     validateManagedStartupApplicationRuntimePlan(applicationRuntime);
   const output: Record<string, string> = {
@@ -1012,6 +1082,11 @@ export function serializeManagedStartupRuntimeEnvironment(
     }
     output._NEMOCLAW_CORPORATE_CA_MERGED = "1";
   }
+  for (const name of [...Object.keys(configurationEnvironment), ...Object.keys(output)]) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name)) {
+      fail(`invalid runtime environment key ${JSON.stringify(name)}`);
+    }
+  }
   const unsetNames = new Set([
     ...Object.keys(configurationEnvironment).filter((name) => !Object.hasOwn(output, name)),
     ...validatedApplicationRuntime.unsetEnvironment,
@@ -1021,21 +1096,146 @@ export function serializeManagedStartupRuntimeEnvironment(
       fail(`runtime environment cannot both export and unset ${name}`);
     }
   }
-  const unsetLines = [...unsetNames].sort().map((name) => {
+  for (const name of unsetNames) {
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name)) {
       fail(`invalid runtime environment key ${JSON.stringify(name)}`);
     }
-    return `unset ${name}`;
-  });
-  const exportLines = Object.entries(output)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([name, value]) => {
-      if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name)) {
-        fail(`invalid runtime environment key ${JSON.stringify(name)}`);
+  }
+  return { output, unsetNames: [...unsetNames].sort() };
+}
+
+export function serializeManagedStartupCompletionMarker(
+  marker: ManagedStartupCompletionMarker,
+): string {
+  if (
+    marker.schemaVersion !== MANAGED_STARTUP_COMPLETION_SCHEMA_VERSION ||
+    !(MANAGED_STARTUP_AGENTS as readonly string[]).includes(marker.agent) ||
+    !SHA256_RE.test(marker.profileFingerprint) ||
+    !SHA256_RE.test(marker.runtimeEnvironmentSha256) ||
+    typeof marker.corporateCaMerged !== "boolean"
+  ) {
+    fail("managed startup completion marker is invalid");
+  }
+  return `${JSON.stringify({
+    agent: marker.agent,
+    corporateCaMerged: marker.corporateCaMerged,
+    profileFingerprint: marker.profileFingerprint,
+    runtimeEnvironmentSha256: marker.runtimeEnvironmentSha256,
+    schemaVersion: marker.schemaVersion,
+  })}\n`;
+}
+
+function parseManagedStartupCompletionMarker(text: string): ManagedStartupCompletionMarker {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    fail("managed startup completion marker is not valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    fail("managed startup completion marker must be an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  const expectedKeys = [
+    "agent",
+    "corporateCaMerged",
+    "profileFingerprint",
+    "runtimeEnvironmentSha256",
+    "schemaVersion",
+  ];
+  if (
+    Object.keys(record).sort().join(",") !== expectedKeys.sort().join(",") ||
+    record.schemaVersion !== MANAGED_STARTUP_COMPLETION_SCHEMA_VERSION ||
+    typeof record.agent !== "string" ||
+    !(MANAGED_STARTUP_AGENTS as readonly string[]).includes(record.agent) ||
+    typeof record.profileFingerprint !== "string" ||
+    !SHA256_RE.test(record.profileFingerprint) ||
+    typeof record.runtimeEnvironmentSha256 !== "string" ||
+    !SHA256_RE.test(record.runtimeEnvironmentSha256) ||
+    typeof record.corporateCaMerged !== "boolean"
+  ) {
+    fail("managed startup completion marker has an invalid schema");
+  }
+  const marker = {
+    schemaVersion: MANAGED_STARTUP_COMPLETION_SCHEMA_VERSION,
+    agent: record.agent as ManagedStartupAgent,
+    profileFingerprint: record.profileFingerprint,
+    runtimeEnvironmentSha256: record.runtimeEnvironmentSha256,
+    corporateCaMerged: record.corporateCaMerged,
+  } as const;
+  if (serializeManagedStartupCompletionMarker(marker) !== text) {
+    fail("managed startup completion marker is not canonical");
+  }
+  return marker;
+}
+
+export function verifyManagedStartupImageCompletion(
+  expectedAgentInput: string,
+  expectedFingerprint: string,
+  completionFile: string = MANAGED_STARTUP_COMPLETION_FILE,
+  runtimeEnvironmentFile: string = MANAGED_STARTUP_RUNTIME_ENV_FILE,
+): { readonly agent: ManagedStartupAgent; readonly fingerprint: string } {
+  const expectedAgent = exactAgent(expectedAgentInput);
+  if (!SHA256_RE.test(expectedFingerprint)) {
+    fail("startup completion expected profile fingerprint is invalid");
+  }
+  const { bytes, stat } = readStableRegularFileSnapshot(
+    completionFile,
+    MAX_MANAGED_STARTUP_COMPLETION_BYTES,
+  );
+  if (
+    stat.nlink !== 1n ||
+    stat.uid !== 0n ||
+    stat.gid !== 0n ||
+    Number(stat.mode & 0o777n) !== 0o444
+  ) {
+    fail("managed startup completion marker must be root:root mode 0444");
+  }
+  const marker = parseManagedStartupCompletionMarker(bytes.toString("utf8"));
+  if (marker.agent !== expectedAgent || marker.profileFingerprint !== expectedFingerprint) {
+    fail("managed startup completion marker does not match the requested profile");
+  }
+  const runtimeEnvironment = readStableRegularFileSnapshot(
+    runtimeEnvironmentFile,
+    MAX_MANAGED_STARTUP_RUNTIME_ENVIRONMENT_BYTES,
+  );
+  if (
+    runtimeEnvironment.stat.nlink !== 1n ||
+    runtimeEnvironment.stat.uid !== 0n ||
+    runtimeEnvironment.stat.gid !== 0n ||
+    Number(runtimeEnvironment.stat.mode & 0o777n) !== 0o444
+  ) {
+    fail("managed startup runtime environment must be root:root mode 0444");
+  }
+  const runtimeEnvironmentSha256 = createHash("sha256")
+    .update(runtimeEnvironment.bytes)
+    .digest("hex");
+  if (runtimeEnvironmentSha256 !== marker.runtimeEnvironmentSha256) {
+    fail("managed startup completion marker runtime environment digest mismatch");
+  }
+  return { agent: expectedAgent, fingerprint: expectedFingerprint };
+}
+
+export function waitForManagedStartupImageCompletion(
+  expectedAgentInput: string,
+  expectedFingerprint: string,
+  timeoutSeconds = 600,
+): { readonly agent: ManagedStartupAgent; readonly fingerprint: string } {
+  if (!Number.isSafeInteger(timeoutSeconds) || timeoutSeconds < 1 || timeoutSeconds > 3600) {
+    fail("startup completion wait timeout must be an integer from 1 to 3600 seconds");
+  }
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (true) {
+    try {
+      return verifyManagedStartupImageCompletion(expectedAgentInput, expectedFingerprint);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      if (Date.now() >= deadline) {
+        fail(`startup completion was not published within ${String(timeoutSeconds)} seconds`);
       }
-      return `export ${name}=${shellSingleQuote(value)}`;
-    });
-  return `${[...unsetLines, ...exportLines].join("\n")}\n`;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+    }
+  }
 }
 
 function applyAdapter(
@@ -1168,15 +1368,29 @@ export async function applyManagedStartupImageProfile(
     }
     corporateCaMerged = mergeCorporateCa(result.application.corporateCaPath);
   }
+  const runtimeEnvironment = serializeManagedStartupRuntimeEnvironment(
+    mapped.runtimeEnvironment,
+    corporateCaMerged,
+    mapped.configurationEnvironment,
+    mapped.applicationRuntime,
+  );
+  // This handoff is intentionally readable by the sandbox account only after
+  // the root-owned completion marker authenticates its exact digest. It
+  // contains the secret-free mapped profile environment, never provider
+  // credentials or the raw corporate-CA transport.
+  atomicWriteRootFile(MANAGED_STARTUP_RUNTIME_ENV_FILE, runtimeEnvironment, 0o444);
   atomicWriteRootFile(
-    MANAGED_STARTUP_RUNTIME_ENV_FILE,
-    serializeManagedStartupRuntimeEnvironment(
-      mapped.runtimeEnvironment,
+    MANAGED_STARTUP_COMPLETION_FILE,
+    serializeManagedStartupCompletionMarker({
+      schemaVersion: MANAGED_STARTUP_COMPLETION_SCHEMA_VERSION,
+      agent: expectedAgent,
+      profileFingerprint: result.application.fingerprint,
+      runtimeEnvironmentSha256: createHash("sha256")
+        .update(runtimeEnvironment, "utf8")
+        .digest("hex"),
       corporateCaMerged,
-      mapped.configurationEnvironment,
-      mapped.applicationRuntime,
-    ),
-    0o400,
+    }),
+    0o444,
   );
   return {
     agent: expectedAgent,
@@ -1184,6 +1398,72 @@ export async function applyManagedStartupImageProfile(
     fingerprint: result.application.fingerprint,
     runtimeEnvironmentFile: MANAGED_STARTUP_RUNTIME_ENV_FILE,
   };
+}
+
+function completionAlreadyPublished(request: ManagedStartupRootApplyRequest): boolean {
+  try {
+    verifyManagedStartupImageCompletion(request.agent, request.profileFingerprint);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export async function applyManagedStartupRootRequest(
+  request: ManagedStartupRootApplyRequest,
+  env: Environment = process.env,
+): Promise<ManagedStartupRootApplyResult> {
+  requireRoot();
+  const profile = decodeManagedStartupProfile(request.encodedProfile);
+  if (
+    profile.agent !== request.agent ||
+    fingerprintManagedStartupProfile(profile) !== request.profileFingerprint
+  ) {
+    fail("root application request identity does not match its profile");
+  }
+  const imageEnvironment = {
+    HOME: "/root",
+    PATH: FIXED_PATH,
+    NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION: "1",
+    ...selectManagedStartupApplicationRuntimeEnvironment(env),
+    [MANAGED_STARTUP_PROFILE_ENV]: request.encodedProfile,
+    ...(request.corporateCaB64 === null
+      ? {}
+      : { [MANAGED_STARTUP_CA_ENV]: request.corporateCaB64 }),
+  };
+  // Validate launch controls before completion inspection or transaction
+  // mutation. A completed same-profile replay must still be allowed to refresh
+  // these non-fingerprinted application-runtime values.
+  mapManagedStartupProfileToAgentEnvironment(profile, imageEnvironment);
+  const alreadyPublished = completionAlreadyPublished(request);
+  if (!alreadyPublished) {
+    ensureRootOwnedDirectory(ROOT_STATE_PARENT);
+    beginManagedStartupSharedStateTransaction(profile);
+  }
+  const result = await applyManagedStartupImageProfile(request.agent, imageEnvironment);
+  return { ...result, transactionPending: !alreadyPublished };
+}
+
+function readBoundedRootApplyStdin(): string {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  while (true) {
+    const chunk = Buffer.alloc(16 * 1024);
+    const read = fs.readSync(0, chunk, 0, chunk.length, null);
+    if (read === 0) break;
+    total += read;
+    if (total > MANAGED_STARTUP_ROOT_APPLY_MAX_BYTES) {
+      fail("root application stdin exceeds its bounded transport");
+    }
+    chunks.push(chunk.subarray(0, read));
+  }
+  const bytes = Buffer.concat(chunks, total);
+  const text = bytes.toString("utf8");
+  if (text.includes("\0") || !Buffer.from(text, "utf8").equals(bytes)) {
+    fail("root application stdin must be valid UTF-8 without NUL bytes");
+  }
+  return text;
 }
 
 function writeSandboxFileAtomically(target: string, contents: string, mode: number): void {
@@ -1250,10 +1530,20 @@ function internalWriteHermesCompatHash(): void {
   writeSandboxFileAtomically("/sandbox/.hermes/.config-hash", decoded.toString("utf8"), 0o640);
 }
 
-function readCliAgent(argv: readonly string[]): string {
+function readCliAgent(argv: readonly string[], expectedLength = 2): string {
   const index = argv.indexOf("--agent");
-  if (index < 0 || index + 1 >= argv.length || argv.length !== 2) {
-    fail("usage: managed-startup-image-runtime --agent <agent>");
+  if (index < 0 || index + 1 >= argv.length || argv.length !== expectedLength) {
+    fail(
+      "usage: managed-startup-image-runtime [--apply-root-stdin|--wait-for-completion|--verify-completion|--begin-shared-state-transaction|--commit-shared-state-transaction] --agent <agent>",
+    );
+  }
+  return argv[index + 1] as string;
+}
+
+function readCliFingerprint(argv: readonly string[]): string {
+  const index = argv.indexOf("--profile-fingerprint");
+  if (index < 0 || index + 1 >= argv.length) {
+    fail("managed startup profile fingerprint argument is missing");
   }
   return argv[index + 1] as string;
 }
@@ -1265,6 +1555,66 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
   }
   if (argv.length === 1 && argv[0] === "--internal-write-hermes-compat-hash") {
     internalWriteHermesCompatHash();
+    return;
+  }
+  if (argv.length === 3 && argv[0] === "--apply-root-stdin") {
+    const expectedAgent = exactAgent(readCliAgent(argv, 3));
+    const request = parseManagedStartupRootApplyRequest(readBoundedRootApplyStdin());
+    if (request.agent !== expectedAgent) {
+      fail(`root application request targets ${request.agent}, expected ${expectedAgent}`);
+    }
+    const result = await applyManagedStartupRootRequest(request);
+    console.log(
+      result.transactionPending
+        ? `[managed-startup] applied ${result.agent} profile ${result.fingerprint}; transaction pending`
+        : `[managed-startup] ${result.agent} profile ${result.fingerprint} was already complete`,
+    );
+    return;
+  }
+  if (
+    argv.length === 5 &&
+    (argv[0] === "--verify-completion" || argv[0] === "--wait-for-completion")
+  ) {
+    const agent = readCliAgent(argv, 5);
+    const fingerprint = readCliFingerprint(argv);
+    const result =
+      argv[0] === "--wait-for-completion"
+        ? waitForManagedStartupImageCompletion(agent, fingerprint)
+        : verifyManagedStartupImageCompletion(agent, fingerprint);
+    console.log(
+      `[managed-startup] verified ${result.agent} profile ${result.fingerprint} completion`,
+    );
+    return;
+  }
+  if (argv.length === 3 && argv[0] === "--begin-shared-state-transaction") {
+    const profile = managedTransactionProfile(readCliAgent(argv, 3));
+    ensureRootOwnedDirectory(ROOT_STATE_PARENT);
+    const created = beginManagedStartupSharedStateTransaction(profile);
+    process.stdout.write(created ? "created\n" : "pending\n");
+    return;
+  }
+  if (
+    argv.length === 4 &&
+    argv[0] === "--rollback-shared-state-transaction" &&
+    argv[3] === "--read-only-receipt"
+  ) {
+    requireRoot();
+    const agent = exactAgent(readCliAgent(argv, 4));
+    const rolledBack = rollbackManagedStartupSharedStateTransaction(agent, {
+      transactionDirectory: MANAGED_STARTUP_SHARED_ROLLBACK_RECEIPT_DIRECTORY,
+      readOnlyReceipt: true,
+    });
+    if (!rolledBack) fail("read-only shared-state rollback receipt is missing");
+    console.log(`[managed-startup] verified and restored ${agent} shared state`);
+    return;
+  }
+  if (argv.length === 3 && argv[0] === "--commit-shared-state-transaction") {
+    requireRoot();
+    const agent = exactAgent(readCliAgent(argv, 3));
+    if (!commitManagedStartupSharedStateTransaction(agent)) {
+      fail("managed startup transaction is missing at commit");
+    }
+    console.log(`[managed-startup] committed ${agent} shared state`);
     return;
   }
   const result = await applyManagedStartupImageProfile(readCliAgent(argv));

--- a/src/lib/onboard/managed-startup/root-apply.ts
+++ b/src/lib/onboard/managed-startup/root-apply.ts
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import {
+  decodeManagedStartupProfile,
+  fingerprintManagedStartupProfile,
+  MANAGED_STARTUP_AGENTS,
+  MANAGED_STARTUP_PROFILE_DEFERRED_RUNTIME_INPUTS,
+  MANAGED_STARTUP_PROFILE_MAX_ENCODED_BYTES,
+  type ManagedStartupAgent,
+} from "./profile";
+
+export const MANAGED_STARTUP_ROOT_APPLY_SCHEMA_VERSION = 1 as const;
+
+// One canonical profile (64 KiB decoded), one bounded corporate CA bundle
+// (128 KiB decoded), and a small fixed JSON envelope.
+export const MANAGED_STARTUP_ROOT_APPLY_MAX_BYTES = 320 * 1024;
+
+const MAX_CORPORATE_CA_ENCODED_BYTES = 4 * Math.ceil((128 * 1024) / 3);
+const SHA256_RE = /^[a-f0-9]{64}$/u;
+const STANDARD_BASE64_RE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u;
+
+export const MANAGED_STARTUP_APPLICATION_RUNTIME_ENV_KEYS = Object.freeze(
+  MANAGED_STARTUP_PROFILE_DEFERRED_RUNTIME_INPUTS.openclaw
+    .filter(
+      ({ admission, owner }) =>
+        admission === "managed-launch-forwarded" && owner === "application-environment",
+    )
+    .map(({ input }) => input),
+);
+
+export function selectManagedStartupApplicationRuntimeEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+): Readonly<Record<string, string>> {
+  const selected: Record<string, string> = {};
+  for (const name of MANAGED_STARTUP_APPLICATION_RUNTIME_ENV_KEYS) {
+    const value = environment[name];
+    if (value !== undefined) selected[name] = value;
+  }
+  return Object.freeze(selected);
+}
+
+export interface ManagedStartupRootApplyRequest {
+  readonly schemaVersion: typeof MANAGED_STARTUP_ROOT_APPLY_SCHEMA_VERSION;
+  readonly agent: ManagedStartupAgent;
+  readonly encodedProfile: string;
+  readonly profileFingerprint: string;
+  readonly corporateCaB64: string | null;
+}
+
+function fail(message: string): never {
+  throw new Error(`Managed startup root application request is invalid: ${message}`);
+}
+
+function exactAgent(value: unknown): ManagedStartupAgent {
+  if (typeof value === "string" && (MANAGED_STARTUP_AGENTS as readonly string[]).includes(value)) {
+    return value as ManagedStartupAgent;
+  }
+  return fail("agent is unsupported");
+}
+
+export function createManagedStartupRootApplyRequest(input: {
+  readonly agent: ManagedStartupAgent;
+  readonly encodedProfile: string;
+  readonly corporateCaB64?: string;
+}): ManagedStartupRootApplyRequest {
+  const agent = exactAgent(input.agent);
+  if (
+    input.encodedProfile.length === 0 ||
+    input.encodedProfile.length > MANAGED_STARTUP_PROFILE_MAX_ENCODED_BYTES
+  ) {
+    fail("encoded profile exceeds its bounded transport");
+  }
+  const profile = decodeManagedStartupProfile(input.encodedProfile);
+  if (profile.agent !== agent) {
+    fail(`profile targets ${profile.agent}, expected ${agent}`);
+  }
+  const corporateCaB64 = input.corporateCaB64 ?? null;
+  if (
+    corporateCaB64 !== null &&
+    (corporateCaB64.length === 0 ||
+      corporateCaB64.length > MAX_CORPORATE_CA_ENCODED_BYTES ||
+      !STANDARD_BASE64_RE.test(corporateCaB64) ||
+      Buffer.from(corporateCaB64, "base64").toString("base64") !== corporateCaB64)
+  ) {
+    fail("corporate CA is not canonical bounded base64");
+  }
+  if ((profile.corporateCa.bundleSha256 !== null) !== (corporateCaB64 !== null)) {
+    fail("corporate CA transport does not match the profile");
+  }
+  if (
+    corporateCaB64 !== null &&
+    createHash("sha256").update(Buffer.from(corporateCaB64, "base64")).digest("hex") !==
+      profile.corporateCa.bundleSha256
+  ) {
+    fail("corporate CA does not match the profile digest");
+  }
+  return Object.freeze({
+    schemaVersion: MANAGED_STARTUP_ROOT_APPLY_SCHEMA_VERSION,
+    agent,
+    encodedProfile: input.encodedProfile,
+    profileFingerprint: fingerprintManagedStartupProfile(profile),
+    corporateCaB64,
+  });
+}
+
+export function serializeManagedStartupRootApplyRequest(
+  request: ManagedStartupRootApplyRequest,
+): string {
+  const normalized = createManagedStartupRootApplyRequest({
+    agent: request.agent,
+    encodedProfile: request.encodedProfile,
+    ...(request.corporateCaB64 === null ? {} : { corporateCaB64: request.corporateCaB64 }),
+  });
+  if (
+    request.schemaVersion !== MANAGED_STARTUP_ROOT_APPLY_SCHEMA_VERSION ||
+    request.profileFingerprint !== normalized.profileFingerprint ||
+    !SHA256_RE.test(request.profileFingerprint)
+  ) {
+    fail("schema version or profile fingerprint is invalid");
+  }
+  const serialized = `${JSON.stringify({
+    agent: normalized.agent,
+    corporateCaB64: normalized.corporateCaB64,
+    encodedProfile: normalized.encodedProfile,
+    profileFingerprint: normalized.profileFingerprint,
+    schemaVersion: normalized.schemaVersion,
+  })}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MANAGED_STARTUP_ROOT_APPLY_MAX_BYTES) {
+    fail("serialized request exceeds its bounded transport");
+  }
+  return serialized;
+}
+
+export function parseManagedStartupRootApplyRequest(text: string): ManagedStartupRootApplyRequest {
+  if (text.length === 0 || Buffer.byteLength(text, "utf8") > MANAGED_STARTUP_ROOT_APPLY_MAX_BYTES) {
+    fail("serialized request is empty or too large");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    fail("serialized request is not valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    fail("serialized request must be an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  const expectedKeys = [
+    "agent",
+    "corporateCaB64",
+    "encodedProfile",
+    "profileFingerprint",
+    "schemaVersion",
+  ];
+  if (
+    Object.keys(record).sort().join(",") !== expectedKeys.sort().join(",") ||
+    record.schemaVersion !== MANAGED_STARTUP_ROOT_APPLY_SCHEMA_VERSION ||
+    typeof record.encodedProfile !== "string" ||
+    typeof record.profileFingerprint !== "string" ||
+    (record.corporateCaB64 !== null && typeof record.corporateCaB64 !== "string")
+  ) {
+    fail("serialized request has an invalid schema");
+  }
+  const request = createManagedStartupRootApplyRequest({
+    agent: exactAgent(record.agent),
+    encodedProfile: record.encodedProfile,
+    ...(record.corporateCaB64 === null ? {} : { corporateCaB64: record.corporateCaB64 as string }),
+  });
+  if (
+    record.profileFingerprint !== request.profileFingerprint ||
+    !SHA256_RE.test(record.profileFingerprint)
+  ) {
+    fail("profile fingerprint does not match the encoded profile");
+  }
+  if (serializeManagedStartupRootApplyRequest(request) !== text) {
+    fail("serialized request is not canonical");
+  }
+  return request;
+}

--- a/src/lib/onboard/managed-startup/shared-state-transaction.ts
+++ b/src/lib/onboard/managed-startup/shared-state-transaction.ts
@@ -1,0 +1,1025 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash, randomBytes } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { parseSandboxMessagingPlan } from "../../messaging/plan-validation";
+import {
+  selectEnabledMessagingAgentRender,
+  selectEnabledPostAgentInstallBuildFiles,
+} from "../../messaging/post-agent-install-selection";
+import {
+  fingerprintManagedStartupProfile,
+  type ManagedStartupAgent,
+  type ManagedStartupProfile,
+} from "./profile";
+
+const TRANSACTION_SCHEMA_VERSION = 1;
+const MAX_TRANSACTION_FILES = 128;
+const MAX_TRANSACTION_FILE_BYTES = 8 * 1024 * 1024;
+const MAX_TRANSACTION_TOTAL_BYTES = 32 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 256 * 1024;
+const TRANSACTION_PARENT_DIRECTORY_MODE = 0o755;
+const TRANSACTION_DIRECTORY_MODE = 0o700;
+const TRANSACTION_FILE_MODE = 0o400;
+
+export const MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY =
+  "/var/lib/nemoclaw/managed-startup-shared-state-transaction-v1";
+export const MANAGED_STARTUP_SHARED_ROLLBACK_RECEIPT_DIRECTORY =
+  "/run/nemoclaw/managed-startup-shared-rollback-receipt-v1";
+
+interface FilePresentReceipt {
+  readonly path: string;
+  readonly state: "file";
+  readonly backup: string;
+  readonly sha256: string;
+  readonly size: number;
+  readonly uid: number;
+  readonly gid: number;
+  readonly mode: number;
+}
+
+interface FileAbsentReceipt {
+  readonly path: string;
+  readonly state: "absent";
+}
+
+type FileReceipt = FilePresentReceipt | FileAbsentReceipt;
+
+interface DirectoryPresentReceipt {
+  readonly path: string;
+  readonly state: "directory";
+  readonly uid: number;
+  readonly gid: number;
+  readonly mode: number;
+}
+
+interface DirectoryAbsentReceipt {
+  readonly path: string;
+  readonly state: "absent";
+}
+
+type DirectoryReceipt = DirectoryPresentReceipt | DirectoryAbsentReceipt;
+
+interface TransactionManifest {
+  readonly schemaVersion: typeof TRANSACTION_SCHEMA_VERSION;
+  readonly agent: ManagedStartupAgent;
+  readonly profileFingerprint: string;
+  readonly files: readonly FileReceipt[];
+  readonly directories: readonly DirectoryReceipt[];
+}
+
+export interface ManagedStartupSharedTransactionOptions {
+  readonly sandboxRoot?: string;
+  readonly transactionDirectory?: string;
+  /** Test seam. Production always retains the root:root defaults. */
+  readonly trustedUid?: number;
+  /** Test seam. Production always retains the root:root defaults. */
+  readonly trustedGid?: number;
+  /**
+   * Rollback-helper seam. The host copy is mounted read-only at a fixed path,
+   * so ownership may reflect the Docker CLI user instead of container root.
+   */
+  readonly readOnlyReceipt?: boolean;
+}
+
+interface ResolvedOptions {
+  readonly sandboxRoot: string;
+  readonly transactionParentDirectory: string;
+  readonly transactionDirectory: string;
+  readonly backupDirectory: string;
+  readonly manifestFile: string;
+  readonly trustedUid: number;
+  readonly trustedGid: number;
+  readonly readOnlyReceipt: boolean;
+}
+
+interface StableFile {
+  readonly bytes: Buffer;
+  readonly stat: fs.BigIntStats;
+}
+
+function fail(message: string): never {
+  throw new Error(`Managed startup shared-state transaction failed: ${message}`);
+}
+
+function resolveOptions(options: ManagedStartupSharedTransactionOptions = {}): ResolvedOptions {
+  const sandboxRoot = path.resolve(options.sandboxRoot ?? "/sandbox");
+  const transactionDirectory = path.resolve(
+    options.transactionDirectory ?? MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY,
+  );
+  if (
+    transactionDirectory === sandboxRoot ||
+    transactionDirectory.startsWith(`${sandboxRoot}${path.sep}`)
+  ) {
+    fail("transaction receipts must not be stored in sandbox-shared state");
+  }
+  return {
+    sandboxRoot,
+    transactionParentDirectory: path.dirname(transactionDirectory),
+    transactionDirectory,
+    backupDirectory: path.join(transactionDirectory, "backups"),
+    manifestFile: path.join(transactionDirectory, "manifest.json"),
+    trustedUid: options.trustedUid ?? 0,
+    trustedGid: options.trustedGid ?? 0,
+    readOnlyReceipt: options.readOnlyReceipt ?? false,
+  };
+}
+
+function modeOf(stat: fs.Stats | fs.BigIntStats): number {
+  if (typeof stat.mode === "bigint") {
+    return Number(stat.mode & 0o7777n);
+  }
+  return stat.mode & 0o7777;
+}
+
+function requireTransactionIdentity(options: ResolvedOptions): void {
+  const expectedUid = options.readOnlyReceipt ? 0 : options.trustedUid;
+  const expectedGid = options.readOnlyReceipt ? 0 : options.trustedGid;
+  if (process.geteuid?.() !== expectedUid || process.getegid?.() !== expectedGid) {
+    fail("transaction control requires the trusted effective identity");
+  }
+}
+
+function pathExistsNoFollow(target: string): boolean {
+  try {
+    fs.lstatSync(target);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    fail(`could not inspect ${target}`);
+  }
+}
+
+function requireDirectory(
+  target: string,
+  options: ResolvedOptions,
+  expectedMode: number | null = null,
+): fs.Stats {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch {
+    fail(`required directory is missing: ${target}`);
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    fail(`required directory is unsafe: ${target}`);
+  }
+  if (
+    expectedMode !== null &&
+    (stat.uid !== options.trustedUid ||
+      stat.gid !== options.trustedGid ||
+      modeOf(stat) !== expectedMode)
+  ) {
+    fail(
+      `${target} must be ${options.trustedUid}:${options.trustedGid} mode ${expectedMode.toString(8)}`,
+    );
+  }
+  return stat;
+}
+
+function requireTransactionBoundaries(options: ResolvedOptions): void {
+  requireDirectory(options.sandboxRoot, options);
+  requireDirectory(options.transactionParentDirectory, options, TRANSACTION_PARENT_DIRECTORY_MODE);
+}
+
+function sameStableMetadata(left: fs.BigIntStats, right: fs.BigIntStats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.nlink === right.nlink &&
+    left.uid === right.uid &&
+    left.gid === right.gid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function readStableFile(target: string, maxBytes: number): StableFile {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") fail("O_NOFOLLOW is unavailable");
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(target, fs.constants.O_RDONLY | noFollow);
+  } catch {
+    fail(`could not safely open ${target}`);
+  }
+  try {
+    const before = fs.fstatSync(descriptor, { bigint: true });
+    if (
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      before.size < 0n ||
+      before.size > BigInt(maxBytes)
+    ) {
+      fail(`refusing unsafe or oversized transaction file ${target}`);
+    }
+    const bytes = Buffer.alloc(Number(before.size));
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = fs.readSync(descriptor, bytes, offset, bytes.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const overflow = Buffer.alloc(1);
+    const overflowCount = fs.readSync(descriptor, overflow, 0, 1, offset);
+    const after = fs.fstatSync(descriptor, { bigint: true });
+    if (offset !== bytes.length || overflowCount !== 0 || !sameStableMetadata(before, after)) {
+      fail(`${target} changed while it was captured`);
+    }
+    return { bytes, stat: before };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function safeRelativePath(value: string): string {
+  if (
+    value.length === 0 ||
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    /[\0-\x1f\x7f]/u.test(value)
+  ) {
+    fail(`unsafe transaction path ${JSON.stringify(value)}`);
+  }
+  const segments = value.split("/");
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    fail(`unsafe transaction path ${JSON.stringify(value)}`);
+  }
+  return segments.join("/");
+}
+
+function absoluteTarget(relativePath: string, options: ResolvedOptions): string {
+  const safe = safeRelativePath(relativePath);
+  const target = path.resolve(options.sandboxRoot, safe);
+  if (!target.startsWith(`${options.sandboxRoot}${path.sep}`)) {
+    fail(`transaction target escapes the sandbox root: ${relativePath}`);
+  }
+  return target;
+}
+
+function relativeTarget(target: string, options: ResolvedOptions): string {
+  return safeRelativePath(path.relative(options.sandboxRoot, target));
+}
+
+function validateExistingAncestors(target: string, options: ResolvedOptions): void {
+  const relative = relativeTarget(target, options);
+  const sandboxStat = requireDirectory(options.sandboxRoot, options);
+  let current = options.sandboxRoot;
+  const segments = relative.split("/").slice(0, -1);
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      fail(`could not inspect transaction path ancestor ${current}`);
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      fail(`transaction path ancestor is unsafe: ${current}`);
+    }
+    if (stat.dev !== sandboxStat.dev) {
+      fail(`transaction path crosses a nested filesystem mount: ${current}`);
+    }
+  }
+}
+
+function agentRoot(agent: ManagedStartupAgent, sandboxRoot: string): string {
+  switch (agent) {
+    case "openclaw":
+      return path.join(sandboxRoot, ".openclaw");
+    case "hermes":
+      return path.join(sandboxRoot, ".hermes");
+    case "langchain-deepagents-code":
+      return path.join(sandboxRoot, ".deepagents");
+  }
+}
+
+function resolveUnderAgentRoot(root: string, relativePath: string): string {
+  const safe = safeRelativePath(relativePath);
+  const target = path.resolve(root, safe);
+  if (!target.startsWith(`${root}${path.sep}`)) {
+    fail(`managed output escapes the agent root: ${relativePath}`);
+  }
+  return target;
+}
+
+function renderTarget(root: string, agent: ManagedStartupAgent, target: string): string {
+  if (agent === "openclaw" && target === "openclaw.json") {
+    return path.join(root, "openclaw.json");
+  }
+  const prefix = agent === "openclaw" ? "~/.openclaw/" : agent === "hermes" ? "~/.hermes/" : null;
+  if (!prefix || !target.startsWith(prefix)) {
+    fail(`unsupported managed messaging render target ${JSON.stringify(target)}`);
+  }
+  return resolveUnderAgentRoot(root, target.slice(prefix.length));
+}
+
+function managedOutputTargets(
+  profile: ManagedStartupProfile,
+  options: ResolvedOptions,
+): { readonly files: string[]; readonly directories: string[] } {
+  const root = agentRoot(profile.agent, options.sandboxRoot);
+  const files = new Set<string>();
+  const directories = new Set<string>([root]);
+  switch (profile.agent) {
+    case "openclaw":
+      files.add(path.join(root, "openclaw.json"));
+      files.add(path.join(root, ".config-hash"));
+      break;
+    case "hermes":
+      files.add(path.join(root, "config.yaml"));
+      files.add(path.join(root, ".env"));
+      files.add(path.join(root, ".config-hash"));
+      break;
+    case "langchain-deepagents-code":
+      files.add(path.join(root, "config.toml"));
+      directories.add(path.join(root, ".state"));
+      directories.add(path.join(root, "skills"));
+      break;
+  }
+
+  if (profile.messaging.plan !== null) {
+    const plan = parseSandboxMessagingPlan(profile.messaging.plan, { agent: profile.agent });
+    if (!plan) fail("managed messaging plan is invalid");
+    for (const render of selectEnabledMessagingAgentRender(plan)) {
+      if (typeof render.target !== "string") continue;
+      files.add(renderTarget(root, profile.agent, render.target));
+    }
+    for (const step of selectEnabledPostAgentInstallBuildFiles(plan)) {
+      if (typeof step.value !== "object" || step.value === null) {
+        continue;
+      }
+      const outputPath = (step.value as Record<string, unknown>).path;
+      if (typeof outputPath === "string") {
+        files.add(resolveUnderAgentRoot(root, outputPath));
+      }
+    }
+  }
+
+  for (const file of files) {
+    let parent = path.dirname(file);
+    while (parent !== options.sandboxRoot && parent.startsWith(`${root}${path.sep}`)) {
+      directories.add(parent);
+      if (parent === root) break;
+      parent = path.dirname(parent);
+    }
+  }
+  return {
+    files: [...files].sort(),
+    directories: [...directories].sort(
+      (left, right) => left.split(path.sep).length - right.split(path.sep).length,
+    ),
+  };
+}
+
+function snapshotFile(
+  target: string,
+  index: number,
+  options: ResolvedOptions,
+): { readonly receipt: FileReceipt; readonly bytes: Buffer | null } {
+  validateExistingAncestors(target, options);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        receipt: { path: relativeTarget(target, options), state: "absent" },
+        bytes: null,
+      };
+    }
+    fail(`could not inspect managed output ${target}`);
+  }
+  if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
+    fail(`managed output is not a safe regular file: ${target}`);
+  }
+  if (stat.dev !== requireDirectory(options.sandboxRoot, options).dev) {
+    fail(`managed output crosses a nested filesystem mount: ${target}`);
+  }
+  const stable = readStableFile(target, MAX_TRANSACTION_FILE_BYTES);
+  const size = Number(stable.stat.size);
+  const backup = `${String(index).padStart(3, "0")}.bin`;
+  return {
+    receipt: {
+      path: relativeTarget(target, options),
+      state: "file",
+      backup,
+      sha256: createHash("sha256").update(stable.bytes).digest("hex"),
+      size,
+      uid: Number(stable.stat.uid),
+      gid: Number(stable.stat.gid),
+      mode: Number(stable.stat.mode & 0o7777n),
+    },
+    bytes: stable.bytes,
+  };
+}
+
+function snapshotDirectory(target: string, options: ResolvedOptions): DirectoryReceipt {
+  validateExistingAncestors(path.join(target, ".receipt"), options);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { path: relativeTarget(target, options), state: "absent" };
+    }
+    fail(`could not inspect managed output directory ${target}`);
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    fail(`managed output directory is unsafe: ${target}`);
+  }
+  if (stat.dev !== requireDirectory(options.sandboxRoot, options).dev) {
+    fail(`managed output directory crosses a nested filesystem mount: ${target}`);
+  }
+  return {
+    path: relativeTarget(target, options),
+    state: "directory",
+    uid: stat.uid,
+    gid: stat.gid,
+    mode: modeOf(stat),
+  };
+}
+
+function atomicWriteTrustedFile(
+  target: string,
+  contents: string | Buffer,
+  mode: number,
+  uid: number,
+  gid: number,
+): void {
+  const parent = path.dirname(target);
+  const temporary = path.join(
+    parent,
+    `.${path.basename(target)}.${randomBytes(12).toString("hex")}`,
+  );
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(
+      temporary,
+      fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    fs.writeFileSync(descriptor, contents);
+    fs.fchownSync(descriptor, uid, gid);
+    fs.fchmodSync(descriptor, mode);
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.renameSync(temporary, target);
+  } catch (error) {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    try {
+      fs.unlinkSync(temporary);
+    } catch {
+      // Preserve the primary failure.
+    }
+    fail(`could not atomically write ${target}: ${(error as Error).message}`);
+  }
+}
+
+function canonicalManifest(manifest: TransactionManifest): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function requireExactKeys(record: Record<string, unknown>, keys: readonly string[]): void {
+  if (Object.keys(record).sort().join(",") !== [...keys].sort().join(",")) {
+    fail("transaction manifest contains unexpected fields");
+  }
+}
+
+function safeMetadata(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function parseManifest(text: string): TransactionManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    fail("transaction manifest is not valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    fail("transaction manifest must be an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  requireExactKeys(record, [
+    "agent",
+    "directories",
+    "files",
+    "profileFingerprint",
+    "schemaVersion",
+  ]);
+  if (
+    record.schemaVersion !== TRANSACTION_SCHEMA_VERSION ||
+    !["openclaw", "hermes", "langchain-deepagents-code"].includes(String(record.agent)) ||
+    typeof record.profileFingerprint !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(record.profileFingerprint) ||
+    !Array.isArray(record.files) ||
+    !Array.isArray(record.directories) ||
+    record.files.length > MAX_TRANSACTION_FILES ||
+    record.directories.length > MAX_TRANSACTION_FILES * 4
+  ) {
+    fail("transaction manifest has an invalid envelope");
+  }
+  const files = record.files.map((value): FileReceipt => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return fail("transaction file receipt must be an object");
+    }
+    const receipt = value as Record<string, unknown>;
+    if (typeof receipt.path !== "string") {
+      return fail("transaction file receipt path must be a string");
+    }
+    const receiptPath = safeRelativePath(receipt.path);
+    if (receipt.state === "absent") {
+      requireExactKeys(receipt, ["path", "state"]);
+      return { path: receiptPath, state: "absent" };
+    }
+    requireExactKeys(receipt, ["backup", "gid", "mode", "path", "sha256", "size", "state", "uid"]);
+    if (
+      receipt.state !== "file" ||
+      typeof receipt.backup !== "string" ||
+      !/^[0-9]{3}\.bin$/u.test(receipt.backup) ||
+      typeof receipt.sha256 !== "string" ||
+      !/^[a-f0-9]{64}$/u.test(receipt.sha256) ||
+      !safeMetadata(receipt.size) ||
+      (receipt.size as number) > MAX_TRANSACTION_FILE_BYTES ||
+      !safeMetadata(receipt.uid) ||
+      !safeMetadata(receipt.gid) ||
+      !safeMetadata(receipt.mode) ||
+      (receipt.mode as number) > 0o7777
+    ) {
+      return fail("transaction file receipt is invalid");
+    }
+    return {
+      path: receiptPath,
+      state: "file",
+      backup: receipt.backup,
+      sha256: receipt.sha256,
+      size: receipt.size as number,
+      uid: receipt.uid as number,
+      gid: receipt.gid as number,
+      mode: receipt.mode as number,
+    };
+  });
+  const directories = record.directories.map((value): DirectoryReceipt => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return fail("transaction directory receipt must be an object");
+    }
+    const receipt = value as Record<string, unknown>;
+    if (typeof receipt.path !== "string") {
+      return fail("transaction directory receipt path must be a string");
+    }
+    const receiptPath = safeRelativePath(receipt.path);
+    if (receipt.state === "absent") {
+      requireExactKeys(receipt, ["path", "state"]);
+      return { path: receiptPath, state: "absent" };
+    }
+    requireExactKeys(receipt, ["gid", "mode", "path", "state", "uid"]);
+    if (
+      receipt.state !== "directory" ||
+      !safeMetadata(receipt.uid) ||
+      !safeMetadata(receipt.gid) ||
+      !safeMetadata(receipt.mode) ||
+      (receipt.mode as number) > 0o7777
+    ) {
+      return fail("transaction directory receipt is invalid");
+    }
+    return {
+      path: receiptPath,
+      state: "directory",
+      uid: receipt.uid as number,
+      gid: receipt.gid as number,
+      mode: receipt.mode as number,
+    };
+  });
+  const filePaths = files.map((receipt) => receipt.path);
+  const directoryPaths = directories.map((receipt) => receipt.path);
+  const backupNames = files
+    .filter((receipt): receipt is FilePresentReceipt => receipt.state === "file")
+    .map((receipt) => receipt.backup);
+  if (
+    new Set(filePaths).size !== filePaths.length ||
+    new Set(directoryPaths).size !== directoryPaths.length ||
+    new Set(backupNames).size !== backupNames.length
+  ) {
+    fail("transaction manifest contains duplicate receipts");
+  }
+  const manifest: TransactionManifest = {
+    schemaVersion: TRANSACTION_SCHEMA_VERSION,
+    agent: record.agent as ManagedStartupAgent,
+    profileFingerprint: record.profileFingerprint,
+    files,
+    directories,
+  };
+  if (canonicalManifest(manifest) !== text) {
+    fail("transaction manifest is not canonical");
+  }
+  return manifest;
+}
+
+function requireTrustedTransactionPath(
+  target: string,
+  mode: number,
+  options: ResolvedOptions,
+): void {
+  const stat = fs.lstatSync(target);
+  if (
+    stat.isSymbolicLink() ||
+    (mode === TRANSACTION_DIRECTORY_MODE ? !stat.isDirectory() : !stat.isFile()) ||
+    (!options.readOnlyReceipt &&
+      (stat.uid !== options.trustedUid || stat.gid !== options.trustedGid)) ||
+    modeOf(stat) !== mode
+  ) {
+    fail(`transaction artifact has unsafe metadata: ${target}`);
+  }
+}
+
+function requireReadOnlyReceiptMount(options: ResolvedOptions): void {
+  if (!options.readOnlyReceipt) return;
+  const probe = path.join(options.transactionDirectory, ".nemoclaw-write-probe");
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(
+      probe,
+      fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.unlinkSync(probe);
+  } catch (error) {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    if ((error as NodeJS.ErrnoException).code === "EROFS") return;
+    fail("rollback receipt must be mounted on a read-only filesystem");
+  }
+  fail("rollback receipt mount is writable");
+}
+
+function loadManifest(options: ResolvedOptions): TransactionManifest | null {
+  requireTransactionBoundaries(options);
+  if (!pathExistsNoFollow(options.transactionDirectory)) return null;
+  requireTrustedTransactionPath(options.transactionDirectory, TRANSACTION_DIRECTORY_MODE, options);
+  requireReadOnlyReceiptMount(options);
+  requireTrustedTransactionPath(options.backupDirectory, TRANSACTION_DIRECTORY_MODE, options);
+  requireTrustedTransactionPath(options.manifestFile, TRANSACTION_FILE_MODE, options);
+  const stable = readStableFile(options.manifestFile, MAX_MANIFEST_BYTES);
+  if (
+    (!options.readOnlyReceipt &&
+      (Number(stable.stat.uid) !== options.trustedUid ||
+        Number(stable.stat.gid) !== options.trustedGid)) ||
+    Number(stable.stat.mode & 0o7777n) !== TRANSACTION_FILE_MODE
+  ) {
+    fail("transaction manifest ownership changed while it was read");
+  }
+  return parseManifest(stable.bytes.toString("utf8"));
+}
+
+function verifyBackup(receipt: FilePresentReceipt, options: ResolvedOptions): Buffer {
+  const backupPath = path.join(options.backupDirectory, receipt.backup);
+  requireTrustedTransactionPath(backupPath, TRANSACTION_FILE_MODE, options);
+  const stable = readStableFile(backupPath, MAX_TRANSACTION_FILE_BYTES);
+  const digest = createHash("sha256").update(stable.bytes).digest("hex");
+  if (stable.bytes.length !== receipt.size || digest !== receipt.sha256) {
+    fail(`transaction backup does not match its receipt: ${receipt.path}`);
+  }
+  return stable.bytes;
+}
+
+function verifyAllBackups(
+  receipts: readonly FileReceipt[],
+  options: ResolvedOptions,
+): ReadonlyMap<string, Buffer> {
+  const backups = new Map<string, Buffer>();
+  for (const receipt of receipts) {
+    if (receipt.state === "file") {
+      backups.set(receipt.path, verifyBackup(receipt, options));
+    }
+  }
+  return backups;
+}
+
+function fileMatchesReceipt(target: string, receipt: FilePresentReceipt): boolean {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    fail(`could not inspect managed output ${target}`);
+  }
+  if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) return false;
+  const stable = readStableFile(target, MAX_TRANSACTION_FILE_BYTES);
+  return (
+    stable.bytes.length === receipt.size &&
+    createHash("sha256").update(stable.bytes).digest("hex") === receipt.sha256 &&
+    Number(stable.stat.uid) === receipt.uid &&
+    Number(stable.stat.gid) === receipt.gid &&
+    Number(stable.stat.mode & 0o7777n) === receipt.mode
+  );
+}
+
+function directoryMatchesReceipt(target: string, receipt: DirectoryPresentReceipt): boolean {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    fail(`could not inspect managed output directory ${target}`);
+  }
+  return (
+    !stat.isSymbolicLink() &&
+    stat.isDirectory() &&
+    stat.uid === receipt.uid &&
+    stat.gid === receipt.gid &&
+    modeOf(stat) === receipt.mode
+  );
+}
+
+function removeTransactionDirectory(options: ResolvedOptions): void {
+  requireTrustedTransactionPath(options.transactionDirectory, TRANSACTION_DIRECTORY_MODE, options);
+  fs.rmSync(options.transactionDirectory, { force: false, recursive: true });
+  if (pathExistsNoFollow(options.transactionDirectory)) {
+    fail("transaction directory remained after cleanup");
+  }
+}
+
+export function beginManagedStartupSharedStateTransaction(
+  profile: ManagedStartupProfile,
+  inputOptions: ManagedStartupSharedTransactionOptions = {},
+): boolean {
+  const options = resolveOptions(inputOptions);
+  requireTransactionIdentity(options);
+  if (options.readOnlyReceipt) {
+    fail("cannot begin a transaction from a read-only rollback receipt");
+  }
+  requireTransactionBoundaries(options);
+  const profileFingerprint = fingerprintManagedStartupProfile(profile);
+  const pending = loadManifest(options);
+  if (pending) {
+    if (pending.agent !== profile.agent || pending.profileFingerprint !== profileFingerprint) {
+      fail("a pending managed startup transaction belongs to a different profile");
+    }
+    verifyAllBackups(pending.files, options);
+    return false;
+  }
+  const targets = managedOutputTargets(profile, options);
+  if (targets.files.length > MAX_TRANSACTION_FILES) {
+    fail("managed startup transaction has too many file targets");
+  }
+  const snapshots = targets.files.map((target, index) => snapshotFile(target, index, options));
+  const totalBytes = snapshots.reduce((sum, snapshot) => sum + (snapshot.bytes?.length ?? 0), 0);
+  if (totalBytes > MAX_TRANSACTION_TOTAL_BYTES) {
+    fail("managed startup transaction backup exceeds the total size limit");
+  }
+  const directories = targets.directories.map((target) => snapshotDirectory(target, options));
+  const manifest: TransactionManifest = {
+    schemaVersion: TRANSACTION_SCHEMA_VERSION,
+    agent: profile.agent,
+    profileFingerprint,
+    files: snapshots.map(({ receipt }) => receipt),
+    directories,
+  };
+
+  let createdTransactionIdentity:
+    | { readonly dev: bigint; readonly ino: bigint; readonly uid: bigint; readonly gid: bigint }
+    | undefined;
+  try {
+    fs.mkdirSync(options.transactionDirectory, { mode: TRANSACTION_DIRECTORY_MODE });
+    const created = fs.lstatSync(options.transactionDirectory, { bigint: true });
+    if (!created.isDirectory() || created.isSymbolicLink()) {
+      fail("new transaction path is not a directory");
+    }
+    createdTransactionIdentity = {
+      dev: created.dev,
+      ino: created.ino,
+      uid: created.uid,
+      gid: created.gid,
+    };
+    fs.chownSync(options.transactionDirectory, options.trustedUid, options.trustedGid);
+    fs.chmodSync(options.transactionDirectory, TRANSACTION_DIRECTORY_MODE);
+    fs.mkdirSync(options.backupDirectory, { mode: TRANSACTION_DIRECTORY_MODE });
+    fs.chownSync(options.backupDirectory, options.trustedUid, options.trustedGid);
+    fs.chmodSync(options.backupDirectory, TRANSACTION_DIRECTORY_MODE);
+    for (const snapshot of snapshots) {
+      if (snapshot.receipt.state !== "file" || snapshot.bytes === null) continue;
+      atomicWriteTrustedFile(
+        path.join(options.backupDirectory, snapshot.receipt.backup),
+        snapshot.bytes,
+        TRANSACTION_FILE_MODE,
+        options.trustedUid,
+        options.trustedGid,
+      );
+    }
+    atomicWriteTrustedFile(
+      options.manifestFile,
+      canonicalManifest(manifest),
+      TRANSACTION_FILE_MODE,
+      options.trustedUid,
+      options.trustedGid,
+    );
+    loadManifest(options);
+  } catch (error) {
+    try {
+      if (createdTransactionIdentity && pathExistsNoFollow(options.transactionDirectory)) {
+        const current = fs.lstatSync(options.transactionDirectory, { bigint: true });
+        if (
+          !current.isSymbolicLink() &&
+          current.isDirectory() &&
+          current.dev === createdTransactionIdentity.dev &&
+          current.ino === createdTransactionIdentity.ino &&
+          current.uid === createdTransactionIdentity.uid &&
+          current.gid === createdTransactionIdentity.gid
+        ) {
+          fs.chmodSync(options.transactionDirectory, TRANSACTION_DIRECTORY_MODE);
+          fs.chownSync(options.transactionDirectory, options.trustedUid, options.trustedGid);
+        }
+        requireTrustedTransactionPath(
+          options.transactionDirectory,
+          TRANSACTION_DIRECTORY_MODE,
+          options,
+        );
+        fs.rmSync(options.transactionDirectory, { force: true, recursive: true });
+      }
+    } catch {
+      // Preserve the primary transaction preparation failure.
+    }
+    throw error;
+  }
+  return true;
+}
+
+function ensureOriginalDirectories(
+  receipts: readonly DirectoryReceipt[],
+  options: ResolvedOptions,
+): void {
+  for (const receipt of receipts) {
+    if (receipt.state !== "directory") continue;
+    const target = absoluteTarget(receipt.path, options);
+    validateExistingAncestors(path.join(target, ".restore"), options);
+    let stat: fs.Stats | null = null;
+    try {
+      stat = fs.lstatSync(target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        fail(`could not inspect restore directory ${target}`);
+      }
+    }
+    if (stat && (stat.isSymbolicLink() || !stat.isDirectory())) {
+      fail(`restore directory is unsafe: ${target}`);
+    }
+    if (stat && directoryMatchesReceipt(target, receipt)) continue;
+    if (!stat) fs.mkdirSync(target, { mode: receipt.mode });
+    fs.chownSync(target, receipt.uid, receipt.gid);
+    fs.chmodSync(target, receipt.mode);
+  }
+}
+
+function restoreFiles(
+  receipts: readonly FileReceipt[],
+  backups: ReadonlyMap<string, Buffer>,
+  options: ResolvedOptions,
+): void {
+  for (const receipt of receipts) {
+    const target = absoluteTarget(receipt.path, options);
+    validateExistingAncestors(target, options);
+    if (receipt.state === "absent") {
+      let stat: fs.Stats;
+      try {
+        stat = fs.lstatSync(target);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        fail(`could not inspect new managed output ${target}`);
+      }
+      if (stat.isDirectory()) {
+        fail(`new managed output unexpectedly became a directory: ${target}`);
+      }
+      fs.unlinkSync(target);
+      continue;
+    }
+    if (fileMatchesReceipt(target, receipt)) continue;
+    const bytes = backups.get(receipt.path);
+    if (!bytes) fail(`verified transaction backup is missing: ${receipt.path}`);
+    let current: fs.Stats | null = null;
+    try {
+      current = fs.lstatSync(target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        fail(`could not inspect managed output before restore: ${target}`);
+      }
+    }
+    if (current?.isDirectory()) {
+      fail(`managed output unexpectedly became a directory: ${target}`);
+    }
+    atomicWriteTrustedFile(target, bytes, receipt.mode, receipt.uid, receipt.gid);
+  }
+}
+
+function restoreDirectoryMetadata(
+  receipts: readonly DirectoryReceipt[],
+  options: ResolvedOptions,
+): void {
+  for (const receipt of [...receipts].reverse()) {
+    const target = absoluteTarget(receipt.path, options);
+    if (receipt.state === "absent") {
+      try {
+        fs.rmdirSync(target);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        fail(`could not remove newly created managed directory ${target}`);
+      }
+      continue;
+    }
+    if (directoryMatchesReceipt(target, receipt)) continue;
+    const stat = fs.lstatSync(target);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      fail(`managed directory changed type during restore: ${target}`);
+    }
+    fs.chownSync(target, receipt.uid, receipt.gid);
+    fs.chmodSync(target, receipt.mode);
+  }
+}
+
+function verifyRestoration(manifest: TransactionManifest, options: ResolvedOptions): void {
+  for (const receipt of manifest.files) {
+    const target = absoluteTarget(receipt.path, options);
+    if (receipt.state === "absent") {
+      if (pathExistsNoFollow(target)) {
+        fail(`new managed output remained after rollback: ${target}`);
+      }
+      continue;
+    }
+    const stable = readStableFile(target, MAX_TRANSACTION_FILE_BYTES);
+    if (
+      stable.bytes.length !== receipt.size ||
+      createHash("sha256").update(stable.bytes).digest("hex") !== receipt.sha256 ||
+      Number(stable.stat.uid) !== receipt.uid ||
+      Number(stable.stat.gid) !== receipt.gid ||
+      Number(stable.stat.mode & 0o7777n) !== receipt.mode
+    ) {
+      fail(`managed output was not restored exactly: ${target}`);
+    }
+  }
+  for (const receipt of manifest.directories) {
+    const target = absoluteTarget(receipt.path, options);
+    if (receipt.state === "absent") {
+      if (pathExistsNoFollow(target)) {
+        fail(`new managed directory remained after rollback: ${target}`);
+      }
+      continue;
+    }
+    const stat = fs.lstatSync(target);
+    if (
+      stat.isSymbolicLink() ||
+      !stat.isDirectory() ||
+      stat.uid !== receipt.uid ||
+      stat.gid !== receipt.gid ||
+      modeOf(stat) !== receipt.mode
+    ) {
+      fail(`managed directory metadata was not restored exactly: ${target}`);
+    }
+  }
+}
+
+export function rollbackManagedStartupSharedStateTransaction(
+  expectedAgent: ManagedStartupAgent,
+  inputOptions: ManagedStartupSharedTransactionOptions = {},
+): boolean {
+  const options = resolveOptions(inputOptions);
+  requireTransactionIdentity(options);
+  const manifest = loadManifest(options);
+  if (!manifest) return false;
+  if (manifest.agent !== expectedAgent) {
+    fail(`pending transaction targets ${manifest.agent}, expected ${expectedAgent}`);
+  }
+  const backups = verifyAllBackups(manifest.files, options);
+  ensureOriginalDirectories(manifest.directories, options);
+  restoreFiles(manifest.files, backups, options);
+  restoreDirectoryMetadata(manifest.directories, options);
+  verifyRestoration(manifest, options);
+  if (!options.readOnlyReceipt) {
+    removeTransactionDirectory(options);
+  }
+  return true;
+}
+
+export function commitManagedStartupSharedStateTransaction(
+  expectedAgent: ManagedStartupAgent,
+  inputOptions: ManagedStartupSharedTransactionOptions = {},
+): boolean {
+  const options = resolveOptions(inputOptions);
+  requireTransactionIdentity(options);
+  if (options.readOnlyReceipt) {
+    fail("cannot commit a read-only rollback receipt");
+  }
+  const manifest = loadManifest(options);
+  if (!manifest) return false;
+  if (manifest.agent !== expectedAgent) {
+    fail(`pending transaction targets ${manifest.agent}, expected ${expectedAgent}`);
+  }
+  removeTransactionDirectory(options);
+  return true;
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds root-owned, transactional managed shared-state application and the first Docker adapter. The slice applies and rolls back validated OpenClaw, Hermes, and LangChain Deep Agents Code state atomically while keeping production buildless activation and durable crash recovery in later review units.

## Related Issue

Part of #7744

## Changes

- Define the managed shared-state transaction contract, ownership/mode checks, commit receipt, and idempotent rollback.
- Add Docker staging and root-apply adapters that execute with `env -i`.
- Forward only the six allowlisted OpenClaw scheduler controls through the clean root path.
- Validate application controls before completion-file inspection or filesystem/transaction mutation.
- Refresh a verified same-profile runtime and completion digest without starting a duplicate shared-state transaction.
- Cover OpenClaw, Hermes, and DCode transaction, replay, ownership, mode, cleanup, and failure behavior.
- Intentionally expose no production cutover caller in this slice. PR3.10 owns the transactional bootstrap/cutover integration after the driver-neutral lifecycle exists; PR3.12 owns restart-spanning persistence; PR3.15 owns production activation. Wiring these primitives directly into current onboarding here would create the partial runtime activation prohibited by #7744.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This transaction layer remains dormant and does not change a supported CLI, configuration, runtime selection, workflow, or support statement.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-diff and independent P1/P2 reviews covered clean-exec forwarding, pre-mutation validation, same-profile replay, ownership/mode enforcement, atomic commit, and rollback. The absence of a production caller is required by this review boundary: PR3.10 integrates cutover only after PR3.6–3.9 establish lifecycle parity, and PR3.15 activates the complete all-agent path. No P1/P2 remains inside this slice.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The exact ten-file diff (`+3,251/-37`) adds dormant transaction/adaptor internals and tests only. Durable recovery and user-visible activation remain explicitly deferred.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b1726a676 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- Exact validated head/base: `b1726a676da10e26e08e045432698f0f1dfa1407` / `3f3bdbbde388cfb3e984e5a627bebc29cab8c606`
- Review budget: 10 files, `+3,251/-37`; no documentation paths.
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 87 slice-focused tests and 290 cross-slice regression tests passed; CLI and plugin builds passed; `npm run validate:pr` passed; `git diff --check` is clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Exact-head required CI is the broad gate for this dormant transaction slice.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Stack

- Base: PR3.4b branch `feat/buildless-managed-image-application` at `3f3bdbbde388cfb3e984e5a627bebc29cab8c606`
- This slice: PR3.5 branch `feat/buildless-shared-state-transactions` at `b1726a676da10e26e08e045432698f0f1dfa1407`
- Next: PR3.6 introduces the driver-neutral lifecycle and sandbox-action parity. It is not part of this review diff.
- Buildless support remains disabled until every supported agent and required qualification gate passes.

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure managed-startup application for Docker-based environments.
  - Added completion verification and recovery support for startup operations.
  - Added transactional shared-state handling with rollback and commit workflows.
  - Added validation for profiles, runtime settings, corporate certificates, file integrity, permissions, and process identity.
  - Added protection against tampered, oversized, malformed, or non-canonical startup data.

- **Tests**
  - Expanded coverage for successful operations, retries, recovery, rollback, idempotency, and security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->