### PR TITLE
fix(shields): clean up permissive runtime temp dir on failed shields down (#7964)

### DIFF
--- a/src/lib/shields/flow.test.ts
+++ b/src/lib/shields/flow.test.ts
@@ -61,6 +61,7 @@ type HarnessOptions = {
     send: () => boolean;
     kill: () => boolean;
   };
+  livePolicyYaml?: string;
   run?: (cmd: unknown) => { status: number };
 };
 
@@ -90,7 +91,9 @@ function createHarness(options: HarnessOptions = {}): ShieldsHarness {
   let openClawPosture: "locked" | "mutable" = "mutable";
 
   vi.spyOn(runner, "validateName").mockImplementation((name: unknown) => String(name));
-  vi.spyOn(runner, "runCapture").mockReturnValue("version: 1\nnetwork_policies:\n  test: {}\n");
+  vi.spyOn(runner, "runCapture").mockReturnValue(
+    options.livePolicyYaml ?? "version: 1\nnetwork_policies:\n  test: {}\n",
+  );
   const runSpy = vi.spyOn(runner, "run").mockImplementation((cmd: unknown) => {
     return options.run ? options.run(cmd) : { status: 0 };
   });
@@ -872,6 +875,36 @@ describe("shields command flow", () => {
       snapshotPath: expect.stringContaining("policy-snapshot-"),
     });
     expect(fs.existsSync(path.join(stateDir, "shields-timer-openclaw.json"))).toBe(true);
+  });
+
+  it("shields down removes the permissive runtime temp directory when the auto-restore timer fails (#7964)", () => {
+    const tempRoot = os.tmpdir();
+    const permissiveRuntimeDirs = () =>
+      fs.readdirSync(tempRoot).filter((name) => name.startsWith("nemoclaw-permissive-runtime-"));
+    const before = permissiveRuntimeDirs();
+    // A real `openshell policy get --base` carries filesystem_policy paths, so the
+    // permissive merge writes a temp policy file instead of returning the static
+    // base path. That is the state that makes the leak reachable.
+    const harness = createHarness({
+      livePolicyYaml:
+        "version: 1\nfilesystem_policy:\n  read_write:\n    - /proc\n  read_only:\n    - /opt/hermes\n",
+      fork: () => ({
+        pid: 0,
+        disconnect: vi.fn(),
+        unref: vi.fn(),
+        send: vi.fn(() => true),
+        kill: vi.fn(() => true),
+      }),
+    });
+
+    expect(() =>
+      harness.shieldsDown("openclaw", {
+        timeout: "5m",
+        reason: "temp cleanup coverage",
+        throwOnError: true,
+      }),
+    ).toThrow("Cannot start auto-restore timer");
+    expect(permissiveRuntimeDirs()).toEqual(before);
   });
 
   it("shieldsUp refuses to mark lockdown active when the saved restrictive policy snapshot is missing", () => {

--- a/src/lib/shields/flow.test.ts
+++ b/src/lib/shields/flow.test.ts
@@ -882,19 +882,27 @@ describe("shields command flow", () => {
     const permissiveRuntimeDirs = () =>
       fs.readdirSync(tempRoot).filter((name) => name.startsWith("nemoclaw-permissive-runtime-"));
     const before = permissiveRuntimeDirs();
+    // shieldsDown builds the temp policy before it forks the auto-restore timer,
+    // so the fork mock observes the runtime-policy directory mid-transition. That
+    // proves the test exercises real temp-policy creation, not only the absence
+    // of a leak.
+    let runtimeDirsDuringFork: string[] = [];
     // A real `openshell policy get --base` carries filesystem_policy paths, so the
     // permissive merge writes a temp policy file instead of returning the static
     // base path. That is the state that makes the leak reachable.
     const harness = createHarness({
       livePolicyYaml:
         "version: 1\nfilesystem_policy:\n  read_write:\n    - /proc\n  read_only:\n    - /opt/hermes\n",
-      fork: () => ({
-        pid: 0,
-        disconnect: vi.fn(),
-        unref: vi.fn(),
-        send: vi.fn(() => true),
-        kill: vi.fn(() => true),
-      }),
+      fork: () => {
+        runtimeDirsDuringFork = permissiveRuntimeDirs();
+        return {
+          pid: 0,
+          disconnect: vi.fn(),
+          unref: vi.fn(),
+          send: vi.fn(() => true),
+          kill: vi.fn(() => true),
+        };
+      },
     });
 
     expect(() =>
@@ -904,6 +912,9 @@ describe("shields command flow", () => {
         throwOnError: true,
       }),
     ).toThrow("Cannot start auto-restore timer");
+    // One runtime-policy directory existed during the transition, and none
+    // remains after the failed shields down.
+    expect(runtimeDirsDuringFork.length).toBe(before.length + 1);
     expect(permissiveRuntimeDirs()).toEqual(before);
   });
 

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -2674,6 +2674,17 @@ function shieldsDownWithoutHostLock(sandboxName: string, opts: ShieldsDownOpts =
     return failShieldsCommand(`Unknown policy "${policyName}"`, opts.throwOnError);
   }
 
+  // Every exit after the permissive merge builds a temp policy directory must
+  // remove it. The apply below has always cleaned up, but the timer-failure
+  // and saveShieldsState-failure early exits between here and there historically
+  // leaked one 0700 nemoclaw-permissive-runtime-* directory per failed
+  // attempt. Route all three exits through one cleanup. See #7964.
+  const cleanupRuntimePolicyFile = () => {
+    if (policyFileIsTemp) {
+      cleanupTempDir(policyFile, "nemoclaw-permissive-runtime");
+    }
+  };
+
   const now = new Date().toISOString();
   let transition: ShieldsDownTransition | null = null;
 
@@ -2762,6 +2773,7 @@ function shieldsDownWithoutHostLock(sandboxName: string, opts: ShieldsDownOpts =
       }
       clearTimerMarker(sandboxName);
       clearShieldsDownTransition(sandboxName, processToken);
+      cleanupRuntimePolicyFile();
       const message = err instanceof Error ? err.message : String(err);
       console.error(`  Cannot start auto-restore timer: ${message}`);
       return failShieldsCommand(`Cannot start auto-restore timer: ${message}`, opts.throwOnError);
@@ -2782,6 +2794,7 @@ function shieldsDownWithoutHostLock(sandboxName: string, opts: ShieldsDownOpts =
       clearShieldsDownTransition(sandboxName, transition.processToken);
       killTimer(sandboxName);
     }
+    cleanupRuntimePolicyFile();
     throw error;
   }
 
@@ -2789,9 +2802,7 @@ function shieldsDownWithoutHostLock(sandboxName: string, opts: ShieldsDownOpts =
   try {
     run(buildPolicySetCommand(policyFile, sandboxName));
   } finally {
-    if (policyFileIsTemp) {
-      cleanupTempDir(policyFile, "nemoclaw-permissive-runtime");
-    }
+    cleanupRuntimePolicyFile();
   }
 
   // 2b. Return config to default mutable state.


### PR DESCRIPTION
## Summary

`nemoclaw <sandbox> shields down` leaked a `0700` temporary directory into the
system temp directory whenever the transition failed partway through.

`shieldsDown` builds the merged permissive policy into a `mkdtemp` directory, but
only the policy-apply `try`/`finally` removed it. Two early exits sit between the
build and that apply, and both skipped cleanup:

1. the auto-restore timer failure (`Cannot start auto-restore timer: …`), and
2. the `saveShieldsState` failure (rethrow).

Each failed transition therefore leaked one `nemoclaw-permissive-runtime-*`
directory holding the merged permissive policy YAML. The merge runs on
effectively every real `shields down`, because a live `openshell policy get
--base` always carries `filesystem_policy.read_only`/`read_write` entries.

Fixes #7964.

## Changes

- `src/lib/shields/index.ts`: route all three exits (timer failure,
  `saveShieldsState` failure, and the existing apply `finally`) through a single
  `cleanupRuntimePolicyFile()` closure, so a failed `shields down` leaves nothing
  behind.
- `src/lib/shields/flow.test.ts`: add a regression test that drives the real
  `shieldsDown` timer-failure path with a live policy carrying
  `filesystem_policy` paths (so the permissive merge writes a temp file, matching
  production) and asserts no `nemoclaw-permissive-runtime-*` directory remains.
  A new `livePolicyYaml` harness option supplies that live policy.

## Verification

Run on the Ubuntu host (`npm ci` + plugin build, Node 22), against a clean clone
of this branch:

- **With the fix**: `npx vitest run --project cli src/lib/shields/flow.test.ts -t "removes the permissive runtime temp directory"` → **1 passed**.
- **Reverting only the source fix, keeping the new test**: same command →
  **1 failed** with `AssertionError: expected [ Array(1) ] to deeply equal []`
  and a leftover `nemoclaw-permissive-runtime-*` directory.

The second run confirms the test exercises the real `shieldsDown` code path (not
hand-built internal state) and reproduces the reported leak; the first confirms
the fix removes it.

## Documentation

No user-visible surface changes (no CLI, config, output, or documented behavior
change). Behavior is corrected to match the already-documented contract that a
failed `shields down` leaves nothing behind. No docs update required.

Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup of temporary runtime policy files when automatic restoration fails to start.
  * Ensured temporary permissive-policy directories are removed after state-save failures and policy-application completion.
  * Improved cleanup reliability across policy restoration outcomes, preventing temporary files from being left behind.
  * Added regression coverage for cleanup during failed timer startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->