### PR TITLE
fix(recover): restore managed OpenClaw config mode

### DIFF
--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -1295,10 +1295,12 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
         initialManagedHealthPassed: recovery.kind === "managed",
         requireManagedProbe: recovery.kind === "relaunched",
         timeoutSeconds: gatewayRecoveryTimeoutSeconds(recoveryAgent),
-        managedProbeImpl: (name) =>
-          confirmRecoveredSandboxGatewayManaged(name, {
-            requestGatewaySupervisorActionImpl: requestManagedProbe,
-          }),
+        managedProbeImpl: relaunch
+          ? () => confirmRelaunchedManagedHealth?.(210000) ?? null
+          : (name) =>
+              confirmRecoveredSandboxGatewayManaged(name, {
+                requestGatewaySupervisorActionImpl: requestManagedProbe,
+              }),
       });
     } catch (error) {
       try {
@@ -1334,6 +1336,16 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
         );
       }
       onRecoveryFailureLayer?.(managedRecoveryFailureLayer);
+      if (relaunchedManagedHealthFailureDetail) {
+        return {
+          checked: true,
+          wasRunning: false,
+          recovered: false,
+          forwardRecovered: false,
+          forwardRecoveryFailed: true,
+          forwardRecoveryFailureDetail: `the recreated sandbox failed the managed health guard while waiting for its gateway. Managed health result: ${relaunchedManagedHealthFailureDetail}`,
+        };
+      }
       return { checked: true, wasRunning: false, recovered: false, forwardRecovered: false };
     }
     if (relaunch) {

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -688,6 +688,7 @@ type RecreatedSandboxOpenShellReadyOptions = {
 function recreatedSandboxOpenShellReadinessFailureDetail(
   failure: RecreatedSandboxOpenShellReadinessFailure,
   openshellError?: string,
+  managedHealthFailureDetail?: string,
 ): string {
   const detail = (() => {
     switch (failure) {
@@ -699,7 +700,13 @@ function recreatedSandboxOpenShellReadinessFailureDetail(
         return "the recreated sandbox did not become ready in OpenShell, so the primary dashboard/API host forward was not started";
     }
   })();
-  return openshellError ? `${detail} Last OpenShell readiness error: ${openshellError}` : detail;
+  const managedHealthResult = managedHealthFailureDetail
+    ? ` Managed health result: ${managedHealthFailureDetail}`
+    : "";
+  const openshellResult = openshellError
+    ? ` Last OpenShell readiness error: ${openshellError}`
+    : "";
+  return `${detail}${managedHealthResult}${openshellResult}`;
 }
 
 // Default seconds to wait for OpenShell to re-register a recreated sandbox as
@@ -1249,17 +1256,29 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
           requestPinnedGatewaySupervisorAction(name, action, timeout, relaunch.containerId)
       : requestGatewaySupervisorAction;
     let relaunchedIdentityRejected = false;
+    let relaunchedManagedHealthFailureDetail: string | null = null;
     const confirmRelaunchedManagedHealth = relaunch
       ? (timeout = OPENSHELL_PROBE_TIMEOUT_MS) => {
+          let probeResult: SandboxCommandResult | null = null;
           try {
             const confirmed = confirmRecoveredSandboxGatewayManaged(sandboxName, {
-              requestGatewaySupervisorActionImpl: (name, action) =>
-                requestManagedProbe(name, action, timeout),
+              requestGatewaySupervisorActionImpl: (name, action) => {
+                probeResult = requestManagedProbe(name, action, timeout);
+                return probeResult;
+              },
             });
-            if (confirmed === false) relaunchedIdentityRejected = true;
+            if (confirmed === false) {
+              relaunchedIdentityRejected = true;
+              const failure = classifyGatewayRestartFailure(probeResult);
+              relaunchedManagedHealthFailureDetail = `${failure.layer}: ${failure.detail}`;
+            } else if (confirmed === true) {
+              relaunchedManagedHealthFailureDetail = null;
+            }
             return confirmed;
           } catch {
             relaunchedIdentityRejected = true;
+            relaunchedManagedHealthFailureDetail =
+              "the pinned replacement sandbox identity changed during the managed probe";
             return false;
           }
         }
@@ -1380,6 +1399,9 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
             : recreatedSandboxOpenShellReadinessFailureDetail(
                 readiness.failure,
                 "openshellError" in readiness ? readiness.openshellError : undefined,
+                readiness.failure === "managed-health-definitive-failure"
+                  ? (relaunchedManagedHealthFailureDetail ?? undefined)
+                  : undefined,
               );
         })()
       : null;

--- a/src/lib/state/state-file-restore-mode.test.ts
+++ b/src/lib/state/state-file-restore-mode.test.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildStateFileRestoreCommand } from "./state-file-restore";
+
+const STATE_FILE = { path: "openclaw.json", strategy: "copy" } as const;
+const fixtures: string[] = [];
+
+function runRestore(refreshOpenClawConfigHash: boolean): {
+  configPath: string;
+  stateDir: string;
+} {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-state-file-mode-"));
+  fixtures.push(fixture);
+  const stateDir = path.join(fixture, ".openclaw");
+  fs.mkdirSync(stateDir);
+  const command = buildStateFileRestoreCommand(stateDir, STATE_FILE, refreshOpenClawConfigHash);
+  const result = spawnSync("bash", ["-c", command], {
+    input: Buffer.from('{"gateway":{"mode":"local"}}\n'),
+  });
+  expect(result.status, result.stderr.toString()).toBe(0);
+  return { configPath: path.join(stateDir, STATE_FILE.path), stateDir };
+}
+
+function mode(filePath: string): number {
+  return fs.statSync(filePath).mode & 0o777;
+}
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) {
+    fs.rmSync(fixture, { force: true, recursive: true });
+  }
+});
+
+describe("state-file restore modes", () => {
+  it("restores an OpenClaw config with the mutable managed-guard mode", () => {
+    const { configPath, stateDir } = runRestore(true);
+
+    expect(mode(configPath)).toBe(0o660);
+    expect(mode(`${configPath}.last-good`)).toBe(0o660);
+    expect(mode(path.join(stateDir, ".config-hash"))).toBe(0o660);
+  });
+
+  it("keeps the restricted mode for ordinary copied state files", () => {
+    const { configPath } = runRestore(false);
+
+    expect(mode(configPath)).toBe(0o640);
+  });
+});

--- a/src/lib/state/state-file-restore.ts
+++ b/src/lib/state/state-file-restore.ts
@@ -97,7 +97,12 @@ export function buildStateFileRestoreCommand(
     'tmp="$(mktemp "${parent}/.nemoclaw-restore.XXXXXX")"',
     'trap \'rm -f "$tmp" "${anchor_tmp:-}"\' EXIT',
     'cat > "$tmp"',
-    'chmod 640 "$tmp"',
+    // The managed OpenClaw restart preflight accepts only the exact mutable
+    // sandbox:sandbox 0660 configuration posture. Apply that mode to the
+    // staged inode before the atomic swap so the gateway and its trusted
+    // controller never observe the restored config with the generic 0640
+    // state-file mode.
+    refreshOpenClawConfigHash ? 'chmod 660 "$tmp"' : 'chmod 640 "$tmp"',
   ];
 
   if (refreshOpenClawConfigHash) {

--- a/test/e2e/live/gateway-guard-legacy-keepalive-fixture.ts
+++ b/test/e2e/live/gateway-guard-legacy-keepalive-fixture.ts
@@ -4,12 +4,17 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import * as startupCommandPatch from "../../../src/lib/onboard/docker-startup-command-patch.ts";
+import * as startupCommandPatchNamespace from "../../../src/lib/onboard/docker-startup-command-patch.ts";
 import { redactString } from "../fixtures/redaction.ts";
 
 const LEGACY_KEEPALIVE_COMMAND = ["sleep", "infinity"] as const;
 const DEFAULT_RECREATE_TIMEOUT_SECS = 180;
 const DOCKER_CONTAINER_ID_PATTERN = /^[0-9a-f]{64}$/i;
+const startupCommandPatch = (
+  "default" in startupCommandPatchNamespace
+    ? startupCommandPatchNamespace.default
+    : startupCommandPatchNamespace
+) as typeof import("../../../src/lib/onboard/docker-startup-command-patch.ts");
 const { recreateOpenShellDockerSandboxWithStartupCommand } = startupCommandPatch;
 
 type StartupCommandRecreate = typeof recreateOpenShellDockerSandboxWithStartupCommand;

--- a/test/e2e/live/gateway-guard-legacy-keepalive-fixture.ts
+++ b/test/e2e/live/gateway-guard-legacy-keepalive-fixture.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import * as startupCommandPatch from "../../../src/lib/onboard/docker-startup-command-patch.ts";
+import { redactString } from "../fixtures/redaction.ts";
+
+const LEGACY_KEEPALIVE_COMMAND = ["sleep", "infinity"] as const;
+const DEFAULT_RECREATE_TIMEOUT_SECS = 180;
+const DOCKER_CONTAINER_ID_PATTERN = /^[0-9a-f]{64}$/i;
+const { recreateOpenShellDockerSandboxWithStartupCommand } = startupCommandPatch;
+
+type StartupCommandRecreate = typeof recreateOpenShellDockerSandboxWithStartupCommand;
+
+export type LegacyKeepaliveFixtureOptions = {
+  sandboxName: string;
+  expectedContainerId: string;
+  timeoutSecs?: number;
+};
+
+export type LegacyKeepaliveFixtureDeps = {
+  recreate: StartupCommandRecreate;
+};
+
+const defaultDeps: LegacyKeepaliveFixtureDeps = {
+  recreate: recreateOpenShellDockerSandboxWithStartupCommand,
+};
+
+function requireFixtureInput(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+export function createLegacyKeepaliveFixture(
+  options: LegacyKeepaliveFixtureOptions,
+  deps: LegacyKeepaliveFixtureDeps = defaultDeps,
+): ReturnType<StartupCommandRecreate> {
+  requireFixtureInput(options.sandboxName.trim() !== "", "sandbox name is required");
+  requireFixtureInput(
+    DOCKER_CONTAINER_ID_PATTERN.test(options.expectedContainerId),
+    "expected container ID must be a full Docker container ID",
+  );
+
+  const result = deps.recreate({
+    sandboxName: options.sandboxName,
+    expectedOldContainerId: options.expectedContainerId,
+    openshellSandboxCommand: LEGACY_KEEPALIVE_COMMAND,
+    timeoutSecs: options.timeoutSecs ?? DEFAULT_RECREATE_TIMEOUT_SECS,
+  });
+
+  requireFixtureInput(
+    result.oldContainerId === options.expectedContainerId,
+    "legacy keepalive recreation changed an unpinned container",
+  );
+  requireFixtureInput(
+    result.mode.kind === "startup-command",
+    "legacy keepalive recreation did not use startup-command mode",
+  );
+  requireFixtureInput(
+    result.newContainerId !== result.oldContainerId,
+    "legacy keepalive recreation did not replace the container",
+  );
+  requireFixtureInput(
+    result.backupRemoved,
+    "legacy keepalive recreation left the original container backup in place",
+  );
+  return result;
+}
+
+function main(): void {
+  const [sandboxName, expectedContainerId, ...extraArgs] = process.argv.slice(2);
+  requireFixtureInput(
+    sandboxName !== undefined && expectedContainerId !== undefined && extraArgs.length === 0,
+    "usage: gateway-guard-legacy-keepalive-fixture <sandbox-name> <container-id>",
+  );
+  const result = createLegacyKeepaliveFixture({ sandboxName, expectedContainerId });
+  process.stdout.write(
+    `${JSON.stringify({
+      oldContainerId: result.oldContainerId,
+      newContainerId: result.newContainerId,
+      startupCommand: LEGACY_KEEPALIVE_COMMAND.join(" "),
+    })}\n`,
+  );
+}
+
+const invokedAsScript =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (invokedAsScript) {
+  try {
+    main();
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${redactString(detail)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/test/e2e/live/gateway-guard-recovery.test.ts
+++ b/test/e2e/live/gateway-guard-recovery.test.ts
@@ -42,6 +42,8 @@
  * #2701 guard-chain assertion.
  */
 
+import { fileURLToPath } from "node:url";
+
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { resultText } from "../fixtures/clients/command.ts";
@@ -60,6 +62,9 @@ import { ubuntuRepoDocker } from "../registry/matrix.ts";
 const ENVIRONMENT = ubuntuRepoDocker("cloud-openclaw");
 
 const SANDBOX_NAME = "e2e-2701";
+const LEGACY_KEEPALIVE_FIXTURE = fileURLToPath(
+  new URL("./gateway-guard-legacy-keepalive-fixture.ts", import.meta.url),
+);
 
 const STARTUP_COMMAND_INSPECT_SCRIPT = String.raw`
 const { spawnSync } = require("node:child_process");
@@ -147,7 +152,7 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
       "wipe guard chain and gateway tree",
       "recover gateway through connect probe",
       "validate recovered guard and stable PID",
-      "restart legacy Docker sandbox",
+      "recreate and restart sandbox container with legacy keepalive",
       "recover managed supervisor and inference",
     ],
   },
@@ -282,22 +287,37 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
 
   expect(stablePid).toBeGreaterThan(0);
 
-  progress.phase("restart legacy Docker sandbox");
+  progress.phase("recreate and restart sandbox container with legacy keepalive");
   // ── Assert #6635 legacy Docker restart recovery ────────────────
-  // Fresh non-GPU OpenClaw containers on this OpenShell floor still carry the
-  // legacy keepalive. Restarting the container therefore kills the initial
-  // OpenShell workload session and deterministically leaves no managed
-  // supervisor. Recovery must upgrade that container through the host-side
-  // transaction and commit only after managed control accepts the new tree.
-  const originalContainerId = await findSandboxContainer(host, "legacy-restart-container-before");
+  // Current onboarding persists nemoclaw-start. Recreate the sandbox container
+  // with the exact legacy keepalive before restarting it so this target
+  // continues to prove the compatibility migration rather than asserting
+  // stale defaults.
+  const modernContainerId = await findSandboxContainer(host, "legacy-restart-modern-container");
   expect(
-    await inspectStartupCommand(host, originalContainerId, "legacy-restart-command-before"),
-  ).toBe("sleep infinity");
+    await inspectStartupCommand(host, modernContainerId, "legacy-restart-modern-command"),
+  ).toMatch(/(?:^| )nemoclaw-start$/);
   await host.cleanupForward(18789, {
     artifactName: "legacy-restart-stop-dashboard-forward",
     env: buildAvailabilityProbeEnv(),
   });
-  const restart = await host.command("docker", ["restart", originalContainerId], {
+  const createLegacyKeepalive = await host.command(
+    "npx",
+    ["--no-install", "tsx", LEGACY_KEEPALIVE_FIXTURE, instance.sandboxName, modernContainerId],
+    {
+      artifactName: "legacy-restart-create-keepalive",
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 240_000,
+    },
+  );
+  expect(createLegacyKeepalive.exitCode, resultText(createLegacyKeepalive)).toBe(0);
+
+  const legacyContainerId = await findSandboxContainer(host, "legacy-restart-legacy-container");
+  expect(legacyContainerId).not.toBe(modernContainerId);
+  expect(
+    await inspectStartupCommand(host, legacyContainerId, "legacy-restart-legacy-command"),
+  ).toBe("sleep infinity");
+  const restart = await host.command("docker", ["restart", legacyContainerId], {
     artifactName: "legacy-restart-docker-restart",
     env: buildAvailabilityProbeEnv(),
     timeoutMs: 120_000,
@@ -321,7 +341,7 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
   expect(resultText(trustedRecovery)).toContain("Probe complete: recovered OpenClaw gateway");
 
   const recoveredContainerId = await findSandboxContainer(host, "legacy-restart-container-after");
-  expect(recoveredContainerId).not.toBe(originalContainerId);
+  expect(recoveredContainerId).not.toBe(legacyContainerId);
   const recoveredStartupCommand = await inspectStartupCommand(
     host,
     recoveredContainerId,

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -71,6 +71,7 @@
         "src/lib/sandbox/privileged-exec.test.ts",
         "test/managed-gateway-control.test.ts",
         "test/nemoclaw-start-guard-recovery.test.ts",
+        "test/e2e/support/gateway-guard-legacy-keepalive-fixture.test.ts",
         "test/process-recovery-supervisor-relaunch.test.ts"
       ]
     },

--- a/test/e2e/support/gateway-guard-legacy-keepalive-fixture.test.ts
+++ b/test/e2e/support/gateway-guard-legacy-keepalive-fixture.test.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createLegacyKeepaliveFixture,
+  type LegacyKeepaliveFixtureDeps,
+} from "../live/gateway-guard-legacy-keepalive-fixture.ts";
+
+const OLD_CONTAINER_ID = "a".repeat(64);
+const NEW_CONTAINER_ID = "b".repeat(64);
+
+function successfulResult() {
+  return {
+    applied: true as const,
+    oldContainerId: OLD_CONTAINER_ID,
+    newContainerId: NEW_CONTAINER_ID,
+    originalName: "openshell-e2e-2701",
+    backupContainerName: "openshell-e2e-2701-nemoclaw-gpu-backup-1",
+    mode: {
+      kind: "startup-command" as const,
+      label: "startup command",
+      device: "",
+      args: [],
+    },
+    backupRemoved: true,
+  };
+}
+
+describe("gateway guard legacy keepalive fixture", () => {
+  it("recreates only the pinned sandbox container with the legacy startup command", () => {
+    const recreate = vi.fn(() => successfulResult());
+
+    const result = createLegacyKeepaliveFixture(
+      {
+        sandboxName: "e2e-2701",
+        expectedContainerId: OLD_CONTAINER_ID,
+      },
+      { recreate },
+    );
+
+    expect(result.newContainerId).toBe(NEW_CONTAINER_ID);
+    expect(recreate).toHaveBeenCalledOnce();
+    expect(recreate).toHaveBeenCalledWith({
+      sandboxName: "e2e-2701",
+      expectedOldContainerId: OLD_CONTAINER_ID,
+      openshellSandboxCommand: ["sleep", "infinity"],
+      timeoutSecs: 180,
+    });
+  });
+
+  it.each([
+    {
+      name: "an unremoved backup",
+      result: { ...successfulResult(), backupRemoved: false },
+      error: "left the original container backup in place",
+    },
+    {
+      name: "a replacement with the wrong mode",
+      result: {
+        ...successfulResult(),
+        mode: { ...successfulResult().mode, kind: "cdi" as const },
+      },
+      error: "did not use startup-command mode",
+    },
+    {
+      name: "an unchanged container identity",
+      result: { ...successfulResult(), newContainerId: OLD_CONTAINER_ID },
+      error: "did not replace the container",
+    },
+  ])("fails closed for $name", ({ result, error }) => {
+    const recreate = vi.fn(() => result) as LegacyKeepaliveFixtureDeps["recreate"];
+
+    expect(() =>
+      createLegacyKeepaliveFixture(
+        {
+          sandboxName: "e2e-2701",
+          expectedContainerId: OLD_CONTAINER_ID,
+        },
+        { recreate },
+      ),
+    ).toThrow(error);
+  });
+
+  it("rejects an abbreviated container ID before recreation", () => {
+    const recreate = vi.fn(() => successfulResult());
+
+    expect(() =>
+      createLegacyKeepaliveFixture(
+        {
+          sandboxName: "e2e-2701",
+          expectedContainerId: "abc123",
+        },
+        { recreate },
+      ),
+    ).toThrow("expected container ID must be a full Docker container ID");
+    expect(recreate).not.toHaveBeenCalled();
+  });
+});

--- a/test/e2e/support/gateway-guard-legacy-keepalive-fixture.test.ts
+++ b/test/e2e/support/gateway-guard-legacy-keepalive-fixture.test.ts
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -10,6 +13,9 @@ import {
 
 const OLD_CONTAINER_ID = "a".repeat(64);
 const NEW_CONTAINER_ID = "b".repeat(64);
+const FIXTURE_PATH = fileURLToPath(
+  new URL("../live/gateway-guard-legacy-keepalive-fixture.ts", import.meta.url),
+);
 
 function successfulResult() {
   return {
@@ -96,5 +102,19 @@ describe("gateway guard legacy keepalive fixture", () => {
       ),
     ).toThrow("expected container ID must be a full Docker container ID");
     expect(recreate).not.toHaveBeenCalled();
+  });
+
+  it("loads the real recreation dependency through the standalone tsx entrypoint", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", FIXTURE_PATH, "fixture-import-probe", "f".repeat(64)],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Could not find OpenShell Docker container for sandbox 'fixture-import-probe'.",
+    );
+    expect(result.stderr).not.toContain("deps.recreate is not a function");
   });
 });

--- a/test/process-recovery-supervisor-relaunch.test.ts
+++ b/test/process-recovery-supervisor-relaunch.test.ts
@@ -527,7 +527,7 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
       .mockReturnValue({
         status: 1,
         stdout: "",
-        stderr: "SUPERVISOR_UNAVAILABLE",
+        stderr: "GATEWAY_UNSAFE_CONFIG_PATH",
       });
     const captureOpenshell = vi.spyOn(openshellRuntime, "captureOpenshell");
 
@@ -547,6 +547,9 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
       forwardRecoveryFailed: true,
       forwardRecoveryFailureDetail: expect.stringContaining("failed the managed health guard"),
     });
+    expect(result.forwardRecoveryFailureDetail).toContain(
+      "unsafe config path: GATEWAY_UNSAFE_CONFIG_PATH",
+    );
     expect(finalize).toHaveBeenCalledWith(true);
     expect(captureOpenshell).not.toHaveBeenCalled();
   });

--- a/test/process-recovery-supervisor-relaunch.test.ts
+++ b/test/process-recovery-supervisor-relaunch.test.ts
@@ -173,6 +173,52 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
     expect(finalize).toHaveBeenCalledWith(false);
   });
 
+  it("reports a managed health failure during the recreated gateway wait", () => {
+    mockOpenClawSandbox("wait-failed-box");
+    setImmediateRecoveryPolling();
+    const finalize = vi.fn(() => ({ backupRemoved: false, rolledBack: true }));
+    const relaunchManagedSupervisorSessionImpl = vi.fn(() => ({
+      containerId: "replacement-container-id",
+      finalize,
+    }));
+    const requestGatewaySupervisorAction = vi.fn(() => ({
+      status: 1,
+      stdout: "",
+      stderr: "SUPERVISOR_NOT_RUNNING",
+    }));
+    const requestPinnedGatewaySupervisorAction = vi.fn(() => ({
+      status: 1,
+      stdout: "",
+      stderr: "GATEWAY_UNSAFE_CONFIG_PATH",
+    }));
+
+    const result = checkAndRecoverSandboxProcesses("wait-failed-box", {
+      quiet: true,
+      isSandboxGatewayRunningImpl: () => false,
+      requestGatewaySupervisorAction,
+      requestPinnedGatewaySupervisorAction,
+      relaunchManagedSupervisorSessionImpl,
+    });
+
+    expect(result).toMatchObject({
+      checked: true,
+      wasRunning: false,
+      recovered: false,
+      forwardRecovered: false,
+      forwardRecoveryFailed: true,
+      forwardRecoveryFailureDetail: expect.stringContaining(
+        "unsafe config path: GATEWAY_UNSAFE_CONFIG_PATH",
+      ),
+    });
+    expect(requestPinnedGatewaySupervisorAction).toHaveBeenCalledWith(
+      "wait-failed-box",
+      "probe",
+      210000,
+      "replacement-container-id",
+    );
+    expect(finalize).toHaveBeenCalledWith(false);
+  });
+
   it("commits only after managed health accepts the recreated supervisor", () => {
     mockOpenClawSandbox("recovered-box");
     setImmediateRecoveryPolling();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Sandbox recovery restored managed `openclaw.json` through the generic state-file path at mode `0640`, so the trusted restart preflight rejected the recreated sandbox even though its gateway process and HTTP endpoint were healthy. This change restores managed OpenClaw configuration at the required `0660` mode and preserves the classified managed-health failure detail when recovery still fails. The live regression target now deliberately recreates a legacy keepalive container because current onboarding correctly persists `nemoclaw-start`.

## Changes

- Restore managed `openclaw.json`, `.last-good`, and `.config-hash` files at mode `0660` while retaining mode `0640` for ordinary copied state files.
- Include the sanitized managed-controller failure layer and detail in recreated-sandbox recovery diagnostics.
- Add behavior tests for restored file modes and the exact `GATEWAY_UNSAFE_CONFIG_PATH` recovery failure.
- Validate the current persisted `nemoclaw-start` restart path, then recreate only the identity-pinned sandbox container with `sleep infinity` and prove the legacy migration, with fail-closed fixture coverage, standalone `tsx` loader coverage, and mock/live parity mapping.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing recovery and host-state documentation already specifies transactional restoration, the mutable `660 sandbox:sandbox` posture, final managed-health checks, and the unsafe-config-path failure layer. The E2E follow-up changes only internal test setup.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer approval: https://github.com/NVIDIA/NemoClaw/pull/7972#pullrequestreview-4826037365. Later commits change only E2E coverage and merge history; GitHub retains the approved review decision on the final head.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact committed diff reviewed through the target-specific recovery fixture. The final merge resolution preserves distinct, accurately named modern restart and legacy keepalive migration coverage. The change restores documented recovery behavior and updates only internal E2E setup without changing a command, configuration, workflow, default, error, or supported surface.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 25f1cdbb135eaadc539060a0d7a0a0240e7d2e1d -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every published commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Validation passed for CLI recovery (28/28), integration recovery (29/29), combined fixture/lifecycle E2E support (29/29), mock/live parity (9/9), semantic E2E phases (114 tests across 71 files), CLI type-check, project membership, repository checks, imports, titles, test size, source shape, Biome, and diff checks. `test:changed` passed 412 tests with 7 skipped but hit three known macOS `systemctl --user` failures inherited from merged #7975; focused lifecycle coverage passed. Exact run 30610342220 selected `gateway-guard-recovery` and exposed a standalone `tsx` import failure before legacy recreation; commit `0f47a7b78` fixes that fixture failure. Merge commit `6da6b0de9` resolves current `main` by retaining both modern and legacy routes; `25f1cdbb1` includes the concurrent automated conflict-resolution history without changing the reviewed tree. Exact-head run https://github.com/NVIDIA/NemoClaw/actions/runs/30612753934 passed the full selected matrix; `gateway-guard-recovery` passed all 10 phases, including persisted-startup recovery and legacy keepalive recreation/recovery.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this narrow recovery fix and target-specific E2E fixture; the affected suites and diff-scoped validation passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recovery diagnostics now include managed health-check failures, unsafe configuration paths, and identity changes detected during probing.
  - Improved readiness reporting and rollback behavior after gateway relaunches or sandbox recreation.
  - Managed configuration restores now apply the correct permissions to configuration, backup, and hash files.

- **Tests**
  - Added coverage for restore-file permissions, managed health failures, rollback behavior, and recovery diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
