### PR TITLE
fix(runtime): close prior review debt

### DIFF
--- a/src/lib/messaging/applier/plan-filter.ts
+++ b/src/lib/messaging/applier/plan-filter.ts
@@ -1,31 +1,44 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type {
-  MessagingChannelId,
-  SandboxMessagingChannelPlan,
-  SandboxMessagingPlan,
-} from "../manifest";
+import type { MessagingChannelId, SandboxMessagingChannelPlan } from "../manifest";
 
-export function enabledPlanChannels(plan: SandboxMessagingPlan): SandboxMessagingChannelPlan[] {
+export type EnabledPlanChannel = Pick<SandboxMessagingChannelPlan, "channelId"> &
+  Partial<Pick<SandboxMessagingChannelPlan, "active" | "disabled">>;
+
+export interface EnabledPlanSelection<Channel extends EnabledPlanChannel = EnabledPlanChannel> {
+  readonly channels: readonly Channel[];
+  readonly disabledChannels?: readonly MessagingChannelId[];
+}
+
+export function normalizeMessagingChannelId(channelId: MessagingChannelId): MessagingChannelId {
+  return channelId.trim().toLowerCase();
+}
+
+export function enabledPlanChannels<Channel extends EnabledPlanChannel>(
+  plan: EnabledPlanSelection<Channel>,
+): Channel[] {
   const disabled = disabledPlanChannelIds(plan);
-  return plan.channels.filter(
-    (channel) => channel.active && !channel.disabled && !disabled.has(channel.channelId),
+  return plan.channels.filter((channel) => {
+    const channelId = normalizeMessagingChannelId(channel.channelId);
+    return channelId.length > 0 && channel.active && !channel.disabled && !disabled.has(channelId);
+  });
+}
+
+export function enabledPlanChannelIds(plan: EnabledPlanSelection): Set<MessagingChannelId> {
+  return new Set(
+    enabledPlanChannels(plan).map((channel) => normalizeMessagingChannelId(channel.channelId)),
   );
 }
 
-export function enabledPlanChannelIds(plan: SandboxMessagingPlan): Set<MessagingChannelId> {
-  return new Set(enabledPlanChannels(plan).map((channel) => channel.channelId));
-}
-
 export function filterEnabledPlanEntries<T extends { readonly channelId: MessagingChannelId }>(
-  plan: SandboxMessagingPlan,
+  plan: EnabledPlanSelection,
   entries: readonly T[],
 ): T[] {
   const enabled = enabledPlanChannelIds(plan);
-  return entries.filter((entry) => enabled.has(entry.channelId));
+  return entries.filter((entry) => enabled.has(normalizeMessagingChannelId(entry.channelId)));
 }
 
-function disabledPlanChannelIds(plan: SandboxMessagingPlan): Set<MessagingChannelId> {
-  return new Set(plan.disabledChannels);
+function disabledPlanChannelIds(plan: EnabledPlanSelection): Set<MessagingChannelId> {
+  return new Set((plan.disabledChannels ?? []).map(normalizeMessagingChannelId).filter(Boolean));
 }

--- a/src/lib/messaging/applier/plan-filter.ts
+++ b/src/lib/messaging/applier/plan-filter.ts
@@ -1,44 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { MessagingChannelId, SandboxMessagingChannelPlan } from "../manifest";
-
-export type EnabledPlanChannel = Pick<SandboxMessagingChannelPlan, "channelId"> &
-  Partial<Pick<SandboxMessagingChannelPlan, "active" | "disabled">>;
-
-export interface EnabledPlanSelection<Channel extends EnabledPlanChannel = EnabledPlanChannel> {
-  readonly channels: readonly Channel[];
-  readonly disabledChannels?: readonly MessagingChannelId[];
-}
-
-export function normalizeMessagingChannelId(channelId: MessagingChannelId): MessagingChannelId {
-  return channelId.trim().toLowerCase();
-}
-
-export function enabledPlanChannels<Channel extends EnabledPlanChannel>(
-  plan: EnabledPlanSelection<Channel>,
-): Channel[] {
-  const disabled = disabledPlanChannelIds(plan);
-  return plan.channels.filter((channel) => {
-    const channelId = normalizeMessagingChannelId(channel.channelId);
-    return channelId.length > 0 && channel.active && !channel.disabled && !disabled.has(channelId);
-  });
-}
-
-export function enabledPlanChannelIds(plan: EnabledPlanSelection): Set<MessagingChannelId> {
-  return new Set(
-    enabledPlanChannels(plan).map((channel) => normalizeMessagingChannelId(channel.channelId)),
-  );
-}
-
-export function filterEnabledPlanEntries<T extends { readonly channelId: MessagingChannelId }>(
-  plan: EnabledPlanSelection,
-  entries: readonly T[],
-): T[] {
-  const enabled = enabledPlanChannelIds(plan);
-  return entries.filter((entry) => enabled.has(normalizeMessagingChannelId(entry.channelId)));
-}
-
-function disabledPlanChannelIds(plan: EnabledPlanSelection): Set<MessagingChannelId> {
-  return new Set((plan.disabledChannels ?? []).map(normalizeMessagingChannelId).filter(Boolean));
-}
+export {
+  type EnabledPlanChannel,
+  type EnabledPlanSelection,
+  enabledPlanChannelIds,
+  enabledPlanChannels,
+  filterEnabledPlanEntries,
+  normalizeMessagingChannelId,
+} from "../post-agent-install-selection";

--- a/src/lib/messaging/plan-validation.test.ts
+++ b/src/lib/messaging/plan-validation.test.ts
@@ -237,6 +237,16 @@ describe("parseSandboxMessagingPlan", () => {
         makePlan({ channels: [makePlan().channels[0], makePlan().channels[0]] }),
       ),
     ).toBeNull();
+    expect(
+      parseSandboxMessagingPlan(
+        makePlan({
+          channels: [
+            makePlan().channels[0],
+            { ...makePlan().channels[0], channelId: " TELEGRAM " },
+          ],
+        }),
+      ),
+    ).toBeNull();
   });
 
   it("rejects any persisted channel when supportedChannelIds: [] is passed (deny-all)", () => {

--- a/src/lib/messaging/plan-validation.test.ts
+++ b/src/lib/messaging/plan-validation.test.ts
@@ -249,6 +249,98 @@ describe("parseSandboxMessagingPlan", () => {
     ).toBeNull();
   });
 
+  it("rejects a lone noncanonical channel id even when related ids are canonical", () => {
+    const source = makePlan();
+    expect(
+      parseSandboxMessagingPlan(
+        makePlan({
+          channels: [{ ...source.channels[0], channelId: " Telegram " }],
+          disabledChannels: ["telegram"],
+          credentialBindings: [
+            {
+              channelId: "telegram",
+              credentialId: "telegramBotToken",
+              sourceInput: "botToken",
+              providerName: "sb-telegram-bridge",
+              providerEnvKey: "TELEGRAM_BOT_TOKEN",
+              placeholder: "openshell:resolve:env:TELEGRAM_BOT_TOKEN",
+              credentialAvailable: true,
+            },
+          ],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["disabledChannels", { disabledChannels: [" Telegram "] }],
+    ["credentialBindings", { credentialBindings: [{ channelId: "Telegram" }] }],
+    [
+      "networkPolicy.entries",
+      { networkPolicy: { presets: [], entries: [{ channelId: "Telegram" }] } },
+    ],
+    ["agentRender", { agentRender: [{ channelId: "Telegram" }] }],
+    ["buildSteps", { buildSteps: [{ channelId: "Telegram" }] }],
+    ["stateUpdates", { stateUpdates: [{ channelId: "Telegram" }] }],
+    ["healthChecks", { healthChecks: [{ channelId: "Telegram" }] }],
+    [
+      "runtimeSetup.nodePreloads",
+      {
+        runtimeSetup: {
+          nodePreloads: [{ channelId: "Telegram" }],
+          envAliases: [],
+          secretScans: [],
+        },
+      },
+    ],
+    [
+      "runtimeSetup.envAliases",
+      {
+        runtimeSetup: {
+          nodePreloads: [],
+          envAliases: [{ channelId: "Telegram" }],
+          secretScans: [],
+        },
+      },
+    ],
+    [
+      "runtimeSetup.secretScans",
+      {
+        runtimeSetup: {
+          nodePreloads: [],
+          envAliases: [],
+          secretScans: [{ channelId: "Telegram" }],
+        },
+      },
+    ],
+  ])("rejects noncanonical channel references in %s", (_field, overrides) => {
+    expect(parseSandboxMessagingPlan({ ...makePlan(), ...overrides })).toBeNull();
+  });
+
+  it.each([
+    ["input", { inputs: [{ inputId: "token", channelId: "Telegram" }] }],
+    ["hook", { hooks: [{ channelId: "Telegram" }] }],
+    [
+      "host forward",
+      {
+        hostForward: {
+          channelId: "Telegram",
+          port: 3978,
+          label: "Telegram webhook",
+        },
+      },
+    ],
+  ])("rejects a noncanonical nested %s channel reference", (_field, channelOverrides) => {
+    const channel = makePlan().channels[0];
+    expect(
+      parseSandboxMessagingPlan(
+        makePlan({
+          channels: [{ ...channel, ...channelOverrides }] as SandboxMessagingPlan["channels"],
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it("rejects any persisted channel when supportedChannelIds: [] is passed (deny-all)", () => {
     expect(parseSandboxMessagingPlan(makePlan(), { supportedChannelIds: [] })).toBeNull();
   });

--- a/src/lib/messaging/plan-validation.ts
+++ b/src/lib/messaging/plan-validation.ts
@@ -13,6 +13,7 @@ import {
   type MaybeCompactMessagingPlan,
   normalizePersistedSandboxMessagingPlanShape,
 } from "./persistence";
+import { normalizeMessagingChannelId } from "./post-agent-install-selection";
 
 export interface SandboxMessagingPlanParseOptions {
   sandboxName?: string | null;
@@ -49,7 +50,8 @@ export function parseSandboxMessagingPlan(
   const supported = Array.isArray(options.supportedChannelIds)
     ? new Set(options.supportedChannelIds)
     : null;
-  for (const [index, channel] of value.channels.entries()) {
+  const normalizedChannelIds = new Set<string>();
+  for (const channel of value.channels) {
     if (!isObjectRecord(channel) || typeof channel.channelId !== "string") return null;
     if (Object.hasOwn(channel, "configured") && typeof channel.configured !== "boolean") {
       return null;
@@ -69,13 +71,9 @@ export function parseSandboxMessagingPlan(
       return null;
     }
     if (supported && !supported.has(channel.channelId)) return null;
-    if (
-      value.channels.findIndex(
-        (candidate) => isObjectRecord(candidate) && candidate.channelId === channel.channelId,
-      ) !== index
-    ) {
-      return null;
-    }
+    const normalizedChannelId = normalizeMessagingChannelId(channel.channelId);
+    if (!normalizedChannelId || normalizedChannelIds.has(normalizedChannelId)) return null;
+    normalizedChannelIds.add(normalizedChannelId);
   }
   if (!value.disabledChannels.every((channelId) => typeof channelId === "string")) return null;
 

--- a/src/lib/messaging/plan-validation.ts
+++ b/src/lib/messaging/plan-validation.ts
@@ -53,6 +53,14 @@ export function parseSandboxMessagingPlan(
   const normalizedChannelIds = new Set<string>();
   for (const channel of value.channels) {
     if (!isObjectRecord(channel) || typeof channel.channelId !== "string") return null;
+    const normalizedChannelId = normalizeMessagingChannelId(channel.channelId);
+    if (
+      !normalizedChannelId ||
+      normalizedChannelId !== channel.channelId ||
+      normalizedChannelIds.has(normalizedChannelId)
+    ) {
+      return null;
+    }
     if (Object.hasOwn(channel, "configured") && typeof channel.configured !== "boolean") {
       return null;
     }
@@ -63,19 +71,47 @@ export function parseSandboxMessagingPlan(
     if (Object.hasOwn(channel, "hooks") && !Array.isArray(channel.hooks)) return null;
     if (
       Array.isArray(channel.inputs) &&
-      channel.inputs.some((input) => !isObjectRecord(input) || typeof input.inputId !== "string")
+      channel.inputs.some(
+        (input) =>
+          !isObjectRecord(input) ||
+          typeof input.inputId !== "string" ||
+          (Object.hasOwn(input, "channelId") && input.channelId !== normalizedChannelId),
+      )
     ) {
       return null;
     }
-    if (Array.isArray(channel.hooks) && channel.hooks.some((hook) => !isObjectRecord(hook))) {
+    if (
+      Array.isArray(channel.hooks) &&
+      channel.hooks.some(
+        (hook) =>
+          !isObjectRecord(hook) ||
+          (Object.hasOwn(hook, "channelId") && hook.channelId !== normalizedChannelId),
+      )
+    ) {
+      return null;
+    }
+    if (
+      Object.hasOwn(channel, "hostForward") &&
+      isObjectRecord(channel.hostForward) &&
+      channel.hostForward.channelId !== normalizedChannelId
+    ) {
       return null;
     }
     if (supported && !supported.has(channel.channelId)) return null;
-    const normalizedChannelId = normalizeMessagingChannelId(channel.channelId);
-    if (!normalizedChannelId || normalizedChannelIds.has(normalizedChannelId)) return null;
     normalizedChannelIds.add(normalizedChannelId);
   }
-  if (!value.disabledChannels.every((channelId) => typeof channelId === "string")) return null;
+  if (!value.disabledChannels.every(isCanonicalMessagingChannelId)) return null;
+  if (
+    !hasCanonicalChannelReferences(value.credentialBindings) ||
+    !hasCanonicalChannelReferences(value.agentRender) ||
+    !hasCanonicalChannelReferences(value.buildSteps) ||
+    !hasCanonicalChannelReferences(value.stateUpdates) ||
+    !hasCanonicalChannelReferences(value.healthChecks) ||
+    !hasCanonicalNetworkPolicyReferences(value.networkPolicy) ||
+    !hasCanonicalRuntimeSetupReferences(value.runtimeSetup)
+  ) {
+    return null;
+  }
 
   return cloneSandboxMessagingPlan(
     normalizePersistedSandboxMessagingPlanShape(value as MaybeCompactMessagingPlan),
@@ -188,5 +224,34 @@ function isRuntimeSetup(value: unknown): boolean {
     value.nodePreloads.every(isObjectRecord) &&
     value.envAliases.every(isObjectRecord) &&
     value.secretScans.every(isObjectRecord)
+  );
+}
+
+function isCanonicalMessagingChannelId(value: unknown): value is string {
+  return (
+    typeof value === "string" && value.length > 0 && normalizeMessagingChannelId(value) === value
+  );
+}
+
+function hasCanonicalChannelReferences(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (Array.isArray(value) &&
+      value.every(
+        (entry) => isObjectRecord(entry) && isCanonicalMessagingChannelId(entry.channelId),
+      ))
+  );
+}
+
+function hasCanonicalNetworkPolicyReferences(value: unknown): boolean {
+  if (!isObjectRecord(value) || !Object.hasOwn(value, "entries")) return true;
+  return hasCanonicalChannelReferences(value.entries);
+}
+
+function hasCanonicalRuntimeSetupReferences(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!isObjectRecord(value)) return false;
+  return ["nodePreloads", "envAliases", "secretScans"].every((field) =>
+    hasCanonicalChannelReferences(value[field]),
   );
 }

--- a/src/lib/messaging/post-agent-install-selection.test.ts
+++ b/src/lib/messaging/post-agent-install-selection.test.ts
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { filterEnabledPlanEntries } from "./applier/plan-filter";
+import type {
+  SandboxMessagingAgentRenderPlan,
+  SandboxMessagingBuildStepPlan,
+  SandboxMessagingChannelPlan,
+  SandboxMessagingPlan,
+} from "./manifest";
+import {
+  selectActiveMessagingChannelIds,
+  selectEnabledMessagingAgentRender,
+  selectEnabledPostAgentInstallBuildFiles,
+} from "./post-agent-install-selection";
+
+function channel(
+  channelId: string,
+  hooks: SandboxMessagingChannelPlan["hooks"] = [],
+): SandboxMessagingChannelPlan {
+  return {
+    channelId,
+    displayName: channelId,
+    authMode: "none",
+    active: true,
+    selected: true,
+    configured: true,
+    disabled: false,
+    inputs: [],
+    hooks,
+  };
+}
+
+function plan(overrides: Partial<SandboxMessagingPlan> = {}): SandboxMessagingPlan {
+  return {
+    schemaVersion: 1,
+    sandboxName: "selection-test",
+    agent: "openclaw",
+    workflow: "onboard",
+    channels: [],
+    disabledChannels: [],
+    credentialBindings: [],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
+    ...overrides,
+  };
+}
+
+function render(channelId: string): SandboxMessagingAgentRenderPlan {
+  return {
+    channelId,
+    kind: "json-fragment",
+    agent: "openclaw",
+    target: "/sandbox/.openclaw/openclaw.json",
+    path: "channels.telegram.enabled",
+    value: true,
+    templateRefs: [],
+  };
+}
+
+function buildFile(
+  channelId: string,
+  outputId: string,
+  hookId?: string,
+): SandboxMessagingBuildStepPlan {
+  return {
+    channelId,
+    kind: "build-file",
+    hookId,
+    outputId,
+    required: true,
+    value: "fixture",
+  };
+}
+
+describe("post-agent-install messaging selection", () => {
+  it("uses the shared enabled-channel contract and preserves canonical ordering", () => {
+    const selection = plan({
+      channels: [channel(" Discord "), channel(" TeLeGrAm "), channel("DISCORD")],
+      disabledChannels: [" telegram "],
+    });
+
+    expect(selectActiveMessagingChannelIds(selection)).toEqual(["discord"]);
+    expect(
+      filterEnabledPlanEntries(selection, [
+        { channelId: "DISCORD", value: "kept" },
+        { channelId: "telegram", value: "disabled" },
+      ]),
+    ).toEqual([{ channelId: "DISCORD", value: "kept" }]);
+  });
+
+  it("matches normalized channel ids across channels, render entries, and build steps", () => {
+    const selection = plan({
+      channels: [
+        channel(" Telegram ", [
+          {
+            channelId: " Telegram ",
+            id: "post-install",
+            phase: "post-agent-install",
+            handler: "telegram.post-install",
+          },
+          {
+            channelId: " Telegram ",
+            id: "render-only",
+            phase: "render",
+            handler: "telegram.render",
+          },
+        ]),
+      ],
+      agentRender: [render("TELEGRAM"), render("discord")],
+      buildSteps: [
+        buildFile("telegram", "post-install-file", "post-install"),
+        buildFile(" TELEGRAM ", "render-file", "render-only"),
+        buildFile("discord", "unrelated-file"),
+      ],
+    });
+
+    expect(selectEnabledMessagingAgentRender(selection).map(({ channelId }) => channelId)).toEqual([
+      "TELEGRAM",
+    ]);
+    expect(
+      selectEnabledPostAgentInstallBuildFiles(selection).map(({ outputId }) => outputId),
+    ).toEqual(["post-install-file"]);
+  });
+});

--- a/src/lib/messaging/post-agent-install-selection.test.ts
+++ b/src/lib/messaging/post-agent-install-selection.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+
 import { describe, expect, it } from "vitest";
 import { filterEnabledPlanEntries } from "./applier/plan-filter";
 import type {
@@ -78,6 +80,22 @@ function buildFile(
 }
 
 describe("post-agent-install messaging selection", () => {
+  it("loads through Node's direct TypeScript ESM path used by image builds", () => {
+    const moduleUrl = new URL("./post-agent-install-selection.ts", import.meta.url).href;
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--experimental-strip-types",
+        "--input-type=module",
+        "--eval",
+        `import(${JSON.stringify(moduleUrl)})`,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect({ status: result.status, signal: result.signal }).toEqual({ status: 0, signal: null });
+  });
+
   it("uses the shared enabled-channel contract and preserves canonical ordering", () => {
     const selection = plan({
       channels: [channel(" Discord "), channel(" TeLeGrAm "), channel("DISCORD")],

--- a/src/lib/messaging/post-agent-install-selection.test.ts
+++ b/src/lib/messaging/post-agent-install-selection.test.ts
@@ -170,4 +170,22 @@ describe("post-agent-install messaging selection", () => {
 
     expect(selectEnabledPostAgentInstallBuildFiles(selection)).toEqual([]);
   });
+
+  it("fails closed when a build step references a missing hook", () => {
+    const selection = plan({
+      channels: [
+        channel("telegram", [
+          {
+            channelId: "telegram",
+            id: "post-install",
+            phase: "post-agent-install",
+            handler: "telegram.post-install",
+          },
+        ]),
+      ],
+      buildSteps: [buildFile("telegram", "stale-hook-file", "missing-hook")],
+    });
+
+    expect(selectEnabledPostAgentInstallBuildFiles(selection)).toEqual([]);
+  });
 });

--- a/src/lib/messaging/post-agent-install-selection.test.ts
+++ b/src/lib/messaging/post-agent-install-selection.test.ts
@@ -144,4 +144,30 @@ describe("post-agent-install messaging selection", () => {
       selectEnabledPostAgentInstallBuildFiles(selection).map(({ outputId }) => outputId),
     ).toEqual(["post-install-file"]);
   });
+
+  it("fails closed instead of selecting a hook phase from ambiguous normalized ids", () => {
+    const selection = plan({
+      channels: [
+        channel("telegram", [
+          {
+            channelId: "telegram",
+            id: "shared-hook",
+            phase: "post-agent-install",
+            handler: "telegram.post-install",
+          },
+        ]),
+        channel(" TELEGRAM ", [
+          {
+            channelId: " TELEGRAM ",
+            id: "shared-hook",
+            phase: "render",
+            handler: "telegram.render",
+          },
+        ]),
+      ],
+      buildSteps: [buildFile("TELEGRAM", "ambiguous-file", "shared-hook")],
+    });
+
+    expect(selectEnabledPostAgentInstallBuildFiles(selection)).toEqual([]);
+  });
 });

--- a/src/lib/messaging/post-agent-install-selection.ts
+++ b/src/lib/messaging/post-agent-install-selection.ts
@@ -106,7 +106,7 @@ export function selectEnabledPostAgentInstallBuildFiles<
       (channel) => normalizeMessagingChannelId(channel.channelId) === channelId,
     );
     if (matchingChannels.length !== 1) return false;
-    const hookPhase = matchingChannels[0]?.hooks?.find((hook) => hook.id === step.hookId)?.phase;
-    return hookPhase === undefined || hookPhase === "post-agent-install";
+    const matchedHook = matchingChannels[0]?.hooks?.find((hook) => hook.id === step.hookId);
+    return matchedHook !== undefined && matchedHook.phase === "post-agent-install";
   });
 }

--- a/src/lib/messaging/post-agent-install-selection.ts
+++ b/src/lib/messaging/post-agent-install-selection.ts
@@ -1,76 +1,76 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-interface SelectionHook {
-  readonly id: string;
-  readonly phase: string;
-}
+import {
+  type EnabledPlanChannel,
+  type EnabledPlanSelection,
+  enabledPlanChannels,
+  normalizeMessagingChannelId,
+} from "./applier/plan-filter";
+import type {
+  MessagingChannelId,
+  SandboxMessagingAgentRenderPlan,
+  SandboxMessagingBuildStepPlan,
+  SandboxMessagingHookReferencePlan,
+} from "./manifest";
 
-interface SelectionChannel {
-  readonly channelId: string;
-  readonly active?: boolean;
-  readonly disabled?: boolean;
-  readonly hooks?: readonly SelectionHook[];
-}
+type SelectionChannel = EnabledPlanChannel & {
+  readonly hooks?: readonly (Pick<SandboxMessagingHookReferencePlan, "id"> & {
+    readonly phase: string;
+  })[];
+};
 
-interface SelectionPlanBase {
-  readonly channels: readonly SelectionChannel[];
-}
+type SelectionRender = Pick<SandboxMessagingAgentRenderPlan, "agent" | "channelId">;
+
+type SelectionBuildStep = Pick<SandboxMessagingBuildStepPlan, "channelId" | "kind" | "hookId">;
 
 /**
  * Canonical active-channel selection for the image applier. Each selection
  * consumer must resolve the same active channels and mutable outputs.
  */
-export function selectActiveMessagingChannelIds(plan: SelectionPlanBase): string[] {
+export function selectActiveMessagingChannelIds<Channel extends EnabledPlanChannel>(
+  plan: EnabledPlanSelection<Channel>,
+): MessagingChannelId[] {
   const seen = new Set<string>();
   const channels: string[] = [];
-  for (const item of plan.channels) {
-    const channel = String(item.channelId || "")
-      .trim()
-      .toLowerCase();
+  for (const item of enabledPlanChannels(plan)) {
+    const channel = normalizeMessagingChannelId(item.channelId);
     if (!channel || seen.has(channel)) continue;
-    if (item.active === true && item.disabled !== true) {
-      seen.add(channel);
-      channels.push(channel);
-    }
+    seen.add(channel);
+    channels.push(channel);
   }
   return channels;
 }
 
-export function selectEnabledMessagingAgentRender<
-  Render extends {
-    readonly agent: string;
-    readonly channelId: string;
-  },
->(
-  plan: SelectionPlanBase & {
+export function selectEnabledMessagingAgentRender<Render extends SelectionRender>(
+  plan: EnabledPlanSelection & {
     readonly agent: string;
     readonly agentRender: readonly Render[];
   },
 ): Render[] {
   const active = new Set(selectActiveMessagingChannelIds(plan));
   return plan.agentRender.filter(
-    (render) => render.agent === plan.agent && active.has(render.channelId),
+    (render) =>
+      render.agent === plan.agent && active.has(normalizeMessagingChannelId(render.channelId)),
   );
 }
 
 export function selectEnabledPostAgentInstallBuildFiles<
-  Step extends {
-    readonly channelId: string;
-    readonly kind: string;
-    readonly hookId?: string;
-  },
+  Channel extends SelectionChannel,
+  Step extends SelectionBuildStep,
 >(
-  plan: SelectionPlanBase & {
+  plan: EnabledPlanSelection<Channel> & {
     readonly buildSteps: readonly Step[];
   },
-): Step[] {
+): Array<Step & { readonly kind: "build-file" }> {
   const active = new Set(selectActiveMessagingChannelIds(plan));
-  return plan.buildSteps.filter((step) => {
-    if (!active.has(step.channelId) || step.kind !== "build-file") return false;
+  const channels = enabledPlanChannels(plan);
+  return plan.buildSteps.filter((step): step is Step & { readonly kind: "build-file" } => {
+    const channelId = normalizeMessagingChannelId(step.channelId);
+    if (!active.has(channelId) || step.kind !== "build-file") return false;
     if (!step.hookId) return true;
-    const hookPhase = plan.channels
-      .find((channel) => channel.channelId === step.channelId)
+    const hookPhase = channels
+      .find((channel) => normalizeMessagingChannelId(channel.channelId) === channelId)
       ?.hooks?.find((hook) => hook.id === step.hookId)?.phase;
     return hookPhase === undefined || hookPhase === "post-agent-install";
   });

--- a/src/lib/messaging/post-agent-install-selection.ts
+++ b/src/lib/messaging/post-agent-install-selection.ts
@@ -102,9 +102,11 @@ export function selectEnabledPostAgentInstallBuildFiles<
     const channelId = normalizeMessagingChannelId(step.channelId);
     if (!active.has(channelId) || step.kind !== "build-file") return false;
     if (!step.hookId) return true;
-    const hookPhase = channels
-      .find((channel) => normalizeMessagingChannelId(channel.channelId) === channelId)
-      ?.hooks?.find((hook) => hook.id === step.hookId)?.phase;
+    const matchingChannels = channels.filter(
+      (channel) => normalizeMessagingChannelId(channel.channelId) === channelId,
+    );
+    if (matchingChannels.length !== 1) return false;
+    const hookPhase = matchingChannels[0]?.hooks?.find((hook) => hook.id === step.hookId)?.phase;
     return hookPhase === undefined || hookPhase === "post-agent-install";
   });
 }

--- a/src/lib/messaging/post-agent-install-selection.ts
+++ b/src/lib/messaging/post-agent-install-selection.ts
@@ -1,18 +1,51 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  type EnabledPlanChannel,
-  type EnabledPlanSelection,
-  enabledPlanChannels,
-  normalizeMessagingChannelId,
-} from "./applier/plan-filter";
 import type {
   MessagingChannelId,
   SandboxMessagingAgentRenderPlan,
   SandboxMessagingBuildStepPlan,
+  SandboxMessagingChannelPlan,
   SandboxMessagingHookReferencePlan,
 } from "./manifest";
+
+export type EnabledPlanChannel = Pick<SandboxMessagingChannelPlan, "channelId"> &
+  Partial<Pick<SandboxMessagingChannelPlan, "active" | "disabled">>;
+
+export interface EnabledPlanSelection<Channel extends EnabledPlanChannel = EnabledPlanChannel> {
+  readonly channels: readonly Channel[];
+  readonly disabledChannels?: readonly MessagingChannelId[];
+}
+
+export function normalizeMessagingChannelId(channelId: MessagingChannelId): MessagingChannelId {
+  return channelId.trim().toLowerCase();
+}
+
+export function enabledPlanChannels<Channel extends EnabledPlanChannel>(
+  plan: EnabledPlanSelection<Channel>,
+): Channel[] {
+  const disabled = new Set(
+    (plan.disabledChannels ?? []).map(normalizeMessagingChannelId).filter(Boolean),
+  );
+  return plan.channels.filter((channel) => {
+    const channelId = normalizeMessagingChannelId(channel.channelId);
+    return channelId.length > 0 && channel.active && !channel.disabled && !disabled.has(channelId);
+  });
+}
+
+export function enabledPlanChannelIds(plan: EnabledPlanSelection): Set<MessagingChannelId> {
+  return new Set(
+    enabledPlanChannels(plan).map((channel) => normalizeMessagingChannelId(channel.channelId)),
+  );
+}
+
+export function filterEnabledPlanEntries<T extends { readonly channelId: MessagingChannelId }>(
+  plan: EnabledPlanSelection,
+  entries: readonly T[],
+): T[] {
+  const enabled = enabledPlanChannelIds(plan);
+  return entries.filter((entry) => enabled.has(normalizeMessagingChannelId(entry.channelId)));
+}
 
 type SelectionChannel = EnabledPlanChannel & {
   readonly hooks?: readonly (Pick<SandboxMessagingHookReferencePlan, "id"> & {

--- a/src/lib/onboard/managed-startup/image-runtime.ts
+++ b/src/lib/onboard/managed-startup/image-runtime.ts
@@ -1631,7 +1631,7 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
   );
 }
 
-if (require.main === module) {
+if (typeof require !== "undefined" && typeof module !== "undefined" && require.main === module) {
   main().catch((error: unknown) => {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/test/entrypoint-env-wrapper.test.ts
+++ b/test/entrypoint-env-wrapper.test.ts
@@ -134,8 +134,13 @@ describe("OCI entrypoint env-wrapper normalization", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-env-wrapper-"));
     const fakeBin = path.join(tmpDir, "bin");
     const scriptPath = path.join(tmpDir, "run.sh");
+    const inheritedDashboardPort = process.env.NEMOCLAW_DASHBOARD_PORT;
+    const inheritedChatUiUrl = process.env.CHAT_UI_URL;
 
     function runScenario(setArgs: string, extraEnv: Record<string, string> = {}) {
+      const baseEnv = { ...process.env };
+      delete baseEnv.NEMOCLAW_DASHBOARD_PORT;
+      delete baseEnv.CHAT_UI_URL;
       const script = [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
@@ -156,9 +161,12 @@ describe("OCI entrypoint env-wrapper normalization", () => {
       return spawnSync("bash", [scriptPath], {
         encoding: "utf-8",
         timeout: 5000,
-        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH || ""}`, ...extraEnv },
+        env: { ...baseEnv, PATH: `${fakeBin}:${process.env.PATH || ""}`, ...extraEnv },
       });
     }
+
+    process.env.NEMOCLAW_DASHBOARD_PORT = "19999";
+    process.env.CHAT_UI_URL = "https://ambient.example.test/ui";
 
     try {
       fs.mkdirSync(fakeBin);
@@ -205,6 +213,11 @@ describe("OCI entrypoint env-wrapper normalization", () => {
       expect(baked.stdout).toContain("OPENCLAW_STATE_DIR=/sandbox/.openclaw");
       expect(baked.stdout).toContain("CMD=openclaw agent");
 
+      const defaults = runScenario("set -- nemoclaw-start openclaw agent");
+      expect(defaults.status).toBe(0);
+      expect(defaults.stdout).toContain("CHAT_UI_URL=http://127.0.0.1:18789");
+      expect(defaults.stdout).toContain("PUBLIC_PORT=18789");
+
       const invalidHighPort = runScenario("set -- nemoclaw-start openclaw agent", {
         NEMOCLAW_DASHBOARD_PORT: "70000",
       });
@@ -212,6 +225,16 @@ describe("OCI entrypoint env-wrapper normalization", () => {
       expect(invalidHighPort.stderr).toContain("Invalid NEMOCLAW_DASHBOARD_PORT='70000'");
       expect(invalidHighPort.stderr).toContain("must be an integer between 1024 and 65535");
     } finally {
+      if (inheritedDashboardPort === undefined) {
+        delete process.env.NEMOCLAW_DASHBOARD_PORT;
+      } else {
+        process.env.NEMOCLAW_DASHBOARD_PORT = inheritedDashboardPort;
+      }
+      if (inheritedChatUiUrl === undefined) {
+        delete process.env.CHAT_UI_URL;
+      } else {
+        process.env.CHAT_UI_URL = inheritedChatUiUrl;
+      }
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/test/entrypoint-env-wrapper.test.ts
+++ b/test/entrypoint-env-wrapper.test.ts
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { sliceBlock } from "./helpers/corporate-ca-support";
 
 const HELPER = path.join(import.meta.dirname, "..", "scripts", "lib", "entrypoint-env-wrapper.sh");
@@ -134,9 +134,6 @@ describe("OCI entrypoint env-wrapper normalization", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-env-wrapper-"));
     const fakeBin = path.join(tmpDir, "bin");
     const scriptPath = path.join(tmpDir, "run.sh");
-    const inheritedDashboardPort = process.env.NEMOCLAW_DASHBOARD_PORT;
-    const inheritedChatUiUrl = process.env.CHAT_UI_URL;
-
     function runScenario(setArgs: string, extraEnv: Record<string, string> = {}) {
       const baseEnv = { ...process.env };
       delete baseEnv.NEMOCLAW_DASHBOARD_PORT;
@@ -165,8 +162,8 @@ describe("OCI entrypoint env-wrapper normalization", () => {
       });
     }
 
-    process.env.NEMOCLAW_DASHBOARD_PORT = "19999";
-    process.env.CHAT_UI_URL = "https://ambient.example.test/ui";
+    vi.stubEnv("NEMOCLAW_DASHBOARD_PORT", "19999");
+    vi.stubEnv("CHAT_UI_URL", "https://ambient.example.test/ui");
 
     try {
       fs.mkdirSync(fakeBin);
@@ -225,16 +222,7 @@ describe("OCI entrypoint env-wrapper normalization", () => {
       expect(invalidHighPort.stderr).toContain("Invalid NEMOCLAW_DASHBOARD_PORT='70000'");
       expect(invalidHighPort.stderr).toContain("must be an integer between 1024 and 65535");
     } finally {
-      if (inheritedDashboardPort === undefined) {
-        delete process.env.NEMOCLAW_DASHBOARD_PORT;
-      } else {
-        process.env.NEMOCLAW_DASHBOARD_PORT = inheritedDashboardPort;
-      }
-      if (inheritedChatUiUrl === undefined) {
-        delete process.env.CHAT_UI_URL;
-      } else {
-        process.env.CHAT_UI_URL = inheritedChatUiUrl;
-      }
+      vi.unstubAllEnvs();
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Closes the five still-valid unresolved CodeRabbit findings from the lower buildless stack and the same-surface advisor findings found during exact-head qualification without rewriting its green heads. Managed messaging selection now honors disabled channels through one normalized shared contract, the image-runtime entry guard is safe under ESM test imports, and dashboard-port tests are hermetic against ambient host values.

## Related Issue

Part of #7744

## Changes

- Normalize channel identifiers once in the shared enabled-plan helper, including disabled-channel and entry comparisons, while preserving declared channel order.
- Make post-agent-install render and build-file selection consume that shared helper and normalize both sides of render, step, channel, and hook comparisons; keep the direct image-build module self-contained and regression-test Node’s TypeScript ESM import path.
- Guard the CommonJS direct-entry check when the managed image runtime is imported through Vitest's ESM runner.
- Strip ambient `NEMOCLAW_DASHBOARD_PORT` and `CHAT_UI_URL` from wrapper scenarios before applying explicit test inputs.
- Reject persisted channel IDs that collide after canonical normalization and exclude build files whose hook owner is ambiguous or unresolved.
- Require the canonical lowercase, unpadded identity at the persisted-plan boundary across channels, disabled lists, credentials, policy, render, build, runtime-setup, state, health, and nested channel-owned references.
- Add focused regressions for mixed-case and whitespace channel IDs, disabled channels, canonical ordering, hook phases, ambiguous or missing hook references, and inherited dashboard environment values.
- Keep the slice inert: no runtime registration, buildless activation, Podman selector, workflow, or support claim changes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This corrects internal selection and test-import behavior in dormant buildless scaffolding; it adds no command, configuration, default, runtime selector, workflow, or support claim.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-slice audit verified disabled channels and ambiguous or unresolved hook references fail closed, normalization is symmetric, declared ordering is stable, the entry guard preserves CommonJS execution, and port tests restore the parent environment.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The exact seven-file diff changes internal TypeScript selection/runtime guards and focused tests only; no documentation path or user-visible supported behavior changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 771f48c47 -->
<!-- docs-review-agents-blob-sha: c052d60aa2 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 97 exact-head focused parser, messaging-selection, direct TypeScript ESM import, managed image-runtime, and entrypoint-wrapper tests passed; the branchless-test scan, `build:cli`, `typecheck:cli`, and exact-head `validate:pr` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Exact-head required GitHub CI and protected E2E are the broad gate for this small dormant follow-up; they are running for locally validated head `771f48c47c0aaa1d51511d172fffc691e6c9ac76`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Stack

- Base: PR3.5a #7973 branch `feat/buildless-managed-contract-hardening` at `7d51947c870b8f1de2caa1d33e6e9d6e98d11346`.
- This slice: PR3.5b branch `feat/buildless-coderabbit-debt` at `771f48c47c0aaa1d51511d172fffc691e6c9ac76`.
- Next: PR3.5c introduces the inert runtime-parameterized protected-E2E foundation; it is not part of this review diff.
- Production buildless and Podman support remain disabled until their complete all-agent qualification and activation gates pass.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved messaging-plan validation by detecting duplicate, noncanonical, and mismatched channel references.
  - Ensured disabled channels are consistently excluded from messaging, rendering, and post-install build selections.
  - Prevented ambiguous post-install hook references from being selected.
  - Improved CLI startup compatibility across supported runtime environments.
- **Reliability**
  - Standardized channel handling and validation across nested messaging configurations for more predictable setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

