### PR TITLE
docs: add v0.0.99 release entry

### DIFF
--- a/docs/changelog/2026-07-30.mdx
+++ b/docs/changelog/2026-07-30.mdx
@@ -1,0 +1,41 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.99
+
+NemoClaw v0.0.99 strengthens snapshot restore, sandbox recovery, shared-route upgrades, Hermes lockdown, and experimental runtime identity.
+It also hardens host readiness, inference health checks, managed images, documentation routing, and release end-to-end (E2E) evidence.
+
+- Snapshot restore can now create a Docker- or VM-driver replacement from a stopped source when the registry records its image and complete inference route.
+  Restored SQLite databases must accept a write transaction, and OpenClaw clone restore waits for bounded managed-supervisor readiness before it applies state.
+  Pairing verification now proves that the restored authenticated session belongs to the clone.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Legacy supervisor recovery now backs up manifest-declared state before it recreates a container and restores that state only after replacement identity and managed health pass.
+  Rebuild recovery manifests publish atomically, OpenClaw onboarding persists the credential-free `nemoclaw-start` command, and recreated managed OpenClaw configuration files regain their required writable mode.
+  Failed recovery preserves the temporary backup and reports host recovery guidance when rollback also fails.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Rebuild now migrates only missing canonical credential environment-variable names for legacy sandboxes that share a gateway route.
+  It revalidates the target and every registered peer immediately before deletion, while explicit credential, model, endpoint, API-family, and gateway conflicts continue to stop the rebuild.
+  For more information, refer to [Use Shared Gateway Routes](/user-guide/openclaw/inference/manage-inference/use-shared-gateway-routes) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Hermes lockdown now keeps `/sandbox/.hermes` at `3770 root:sandbox`, which lets the gateway create runtime state while sealed configuration files remain protected.
+  Gateway restart, recovery, and connect now classify exhausted or refused relaunches as `relaunch quarantined` and direct you to rebuild instead of retrying a deterministic refusal.
+  For more information, refer to [Troubleshooting](/user-guide/hermes/reference/troubleshooting) and the [NemoClaw CLI Commands Reference](/user-guide/hermes/reference/commands).
+- The experimental direct OpenClaw blueprint runner now includes a data-only Microsoft Entra runtime identity reference.
+  The reviewed policy restricts refresh to `login.microsoftonline.com`, bearer delivery to `GET graph.microsoft.com/v1.0/me`, and delegated permission guidance to `User.Read` with `offline_access`.
+  NemoClaw does not package OAuth bootstrap, on-behalf-of exchange, or a production identity middleware service, and normal `nemoclaw onboard` does not enable this component.
+  For more information, refer to [Configure Experimental Runtime Identity](/user-guide/openclaw/reference/configure-runtime-identity).
+- `nemoclaw host probe` now classifies a symlinked DGX Station release marker as unqualified instead of inconclusive, matching the other rejected marker shapes.
+  Local inference adapter health checks now retain at most 64 KiB and fail closed on oversized declared or chunked loopback responses.
+  For more information, refer to [System Readiness](/user-guide/openclaw/reference/system-readiness).
+- Managed Hermes images now pin Node.js 24.18.1, `uv==0.11.33`, `mcp==1.28.1`, and `tornado==6.5.7`.
+  Managed LangChain Deep Agents Code images retain the reviewed 0.1.34 integration contract while pinning `uv==0.11.33`, `mcp==1.28.1`, `Pillow==12.3.0`, and `pyasn1==0.6.4`.
+  Image validation also rejects retained `uv` build cache metadata, ignores build-only BuildKit telemetry during the Deep Agents Code probe, and clears each local platform pull before validating the next architecture.
+- Trusted CI now publishes agent-complete Open Container Initiative images by immutable digest, validates anonymous pulls and runtime contracts, and promotes aliases only after those checks pass.
+  Dormant managed-image selection and startup-profile contracts resolve exact all-agent cohorts and bounded agent-specific startup data without activating buildless onboarding or changing the current `Dockerfile` path.
+- Documentation now keeps provider-switch sections within the applicable OpenClaw and Hermes guide variants, corrects the Omni sub-agent model ID, and generalizes agent-selection guidance.
+  The contributor workflow also separates pre-tag release entries from post-tag Announcements and corrects the NVIDIA DORI installation pin from 0.10.0 to 0.9.0.
+  For more information, refer to [Switch Inference Providers](/user-guide/openclaw/inference/manage-inference/switch-providers) and [Set Up Task-Specific Sub-Agents](/user-guide/openclaw/configure-agents/set-up-sub-agent).
+- Release E2E now preserves command and agent first-turn latency separately, evaluates recurring anomalies within an exact 12-sample cohort, and routes retired rebuild selectors to focused replacement evidence.
+  The credential-generation window runs independently, managed startup recovery covers the persisted startup command, and the standing Brev Launchable waits for the staging image family before deployment.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the canonical July 30 release entry for `v0.0.99` before the release tag is captured.
The entry covers all 37 merged PRs since `v0.0.98` and bounds experimental or dormant work without presenting it as supported behavior.

## Changes

- Adds `docs/changelog/2026-07-30.mdx` with the exact `## v0.0.99` heading, parser-safe MDX SPDX comment, summary, detailed release bullets, and published documentation routes.
- Records user-visible recovery, snapshot, shared-route, Hermes, readiness, inference, image, documentation, and release E2E changes.
- States that the managed-image selection and startup-profile contracts remain dormant and do not activate buildless onboarding.

Source summary:

- [#7972](https://github.com/NVIDIA/NemoClaw/pull/7972) -> `docs/changelog/2026-07-30.mdx`: Records restored managed OpenClaw configuration modes during recovery.
- [#7834](https://github.com/NVIDIA/NemoClaw/pull/7834) -> `docs/changelog/2026-07-30.mdx`: Records clone-bound pairing verification after snapshot restore.
- [#7975](https://github.com/NVIDIA/NemoClaw/pull/7975) -> `docs/changelog/2026-07-30.mdx`: Records managed startup recovery coverage.
- [#7960](https://github.com/NVIDIA/NemoClaw/pull/7960) -> `docs/changelog/2026-07-30.mdx`: Records dormant startup-profile coordination without activating a supported surface.
- [#7856](https://github.com/NVIDIA/NemoClaw/pull/7856) -> `docs/changelog/2026-07-30.mdx`: Records persistence of the credential-free OpenClaw startup command.
- [#7959](https://github.com/NVIDIA/NemoClaw/pull/7959) -> `docs/changelog/2026-07-30.mdx`: Records dormant startup-profile construction without changing onboarding.
- [#7946](https://github.com/NVIDIA/NemoClaw/pull/7946) -> `docs/changelog/2026-07-30.mdx`: Records the internal startup-profile schema and transport contract.
- [#7951](https://github.com/NVIDIA/NemoClaw/pull/7951) -> `docs/changelog/2026-07-30.mdx`: Records platform-pull cleanup before managed-image validation.
- [#7949](https://github.com/NVIDIA/NemoClaw/pull/7949) -> `docs/changelog/2026-07-30.mdx`: Records rejection of retained Hermes `uv` build cache metadata.
- [#7597](https://github.com/NVIDIA/NemoClaw/pull/7597) -> `docs/changelog/2026-07-30.mdx`: Records separate command and agent first-turn latency evidence.
- [#7931](https://github.com/NVIDIA/NemoClaw/pull/7931) -> `docs/changelog/2026-07-30.mdx`: Records focused E2E replacement evidence for retired selectors.
- [#7950](https://github.com/NVIDIA/NemoClaw/pull/7950) -> `docs/changelog/2026-07-30.mdx`: Records exclusion of build-only BuildKit telemetry from the Deep Agents Code probe.
- [#7665](https://github.com/NVIDIA/NemoClaw/pull/7665) -> `docs/changelog/2026-07-30.mdx`: Records consolidated priority 2 E2E coverage.
- [#7911](https://github.com/NVIDIA/NemoClaw/pull/7911) -> `docs/changelog/2026-07-30.mdx`: Records the corrected NVIDIA DORI installation pin.
- [#7934](https://github.com/NVIDIA/NemoClaw/pull/7934) -> `docs/changelog/2026-07-30.mdx`: Records the staging image-family wait before Brev Launchable deployment.
- [#7772](https://github.com/NVIDIA/NemoClaw/pull/7772) -> `docs/changelog/2026-07-30.mdx`: Records dormant managed-image selection contracts without activating buildless onboarding.
- [#7941](https://github.com/NVIDIA/NemoClaw/pull/7941) -> `docs/changelog/2026-07-30.mdx`: Records corrected agent-specific provider and policy guidance.
- [#7819](https://github.com/NVIDIA/NemoClaw/pull/7819) -> `docs/changelog/2026-07-30.mdx`: Records removal of empty Deep Agents Code provider-switch sections.
- [#7932](https://github.com/NVIDIA/NemoClaw/pull/7932) -> `docs/changelog/2026-07-30.mdx`: Records independent credential-generation E2E execution.
- [#7840](https://github.com/NVIDIA/NemoClaw/pull/7840) -> `docs/changelog/2026-07-30.mdx`: Records shared-route preservation and pre-delete peer validation during upgrades.
- [#7874](https://github.com/NVIDIA/NemoClaw/pull/7874) -> `docs/changelog/2026-07-30.mdx`: Records the split between pre-tag release entries and post-tag Announcements.
- [#7876](https://github.com/NVIDIA/NemoClaw/pull/7876) -> `docs/changelog/2026-07-30.mdx`: Records the writable Hermes runtime root within lockdown.
- [#7756](https://github.com/NVIDIA/NemoClaw/pull/7756) -> `docs/changelog/2026-07-30.mdx`: Records validated multi-platform managed-image publication.
- [#7914](https://github.com/NVIDIA/NemoClaw/pull/7914) -> `docs/changelog/2026-07-30.mdx`: Records accepted `uv` version metadata in Hermes image validation.
- [#7686](https://github.com/NVIDIA/NemoClaw/pull/7686) -> `docs/changelog/2026-07-30.mdx`: Records the explicitly experimental Microsoft Entra runtime identity reference.
- [#7869](https://github.com/NVIDIA/NemoClaw/pull/7869) -> `docs/changelog/2026-07-30.mdx`: Records classified gateway relaunch quarantine and rebuild guidance.
- [#7814](https://github.com/NVIDIA/NemoClaw/pull/7814) -> `docs/changelog/2026-07-30.mdx`: Records state restore into replacement sandboxes and SQLite write verification.
- [#7839](https://github.com/NVIDIA/NemoClaw/pull/7839) -> `docs/changelog/2026-07-30.mdx`: Records quieter onboarding test execution without a user-facing behavior claim.
- [#7854](https://github.com/NVIDIA/NemoClaw/pull/7854) -> `docs/changelog/2026-07-30.mdx`: Records generalized agent-selection guidance.
- [#7845](https://github.com/NVIDIA/NemoClaw/pull/7845) -> `docs/changelog/2026-07-30.mdx`: Records isolated CDI test evidence without a user-facing behavior claim.
- [#7843](https://github.com/NVIDIA/NemoClaw/pull/7843) -> `docs/changelog/2026-07-30.mdx`: Records the corrected Omni sub-agent model ID.
- [#7908](https://github.com/NVIDIA/NemoClaw/pull/7908) -> `docs/changelog/2026-07-30.mdx`: Records reviewed Hermes and Deep Agents Code dependency pins.
- [#7887](https://github.com/NVIDIA/NemoClaw/pull/7887) -> `docs/changelog/2026-07-30.mdx`: Records rejection of a symlinked DGX Station release marker.
- [#7747](https://github.com/NVIDIA/NemoClaw/pull/7747) -> `docs/changelog/2026-07-30.mdx`: Records the internal compute-driver separation without a user-facing behavior claim.
- [#7660](https://github.com/NVIDIA/NemoClaw/pull/7660) -> `docs/changelog/2026-07-30.mdx`: Records atomic publication of rebuild recovery manifests.
- [#7661](https://github.com/NVIDIA/NemoClaw/pull/7661) -> `docs/changelog/2026-07-30.mdx`: Records bounded local inference health-response retention.
- [#7654](https://github.com/NVIDIA/NemoClaw/pull/7654) -> `docs/changelog/2026-07-30.mdx`: Records state preservation across supervisor relaunch recovery.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates the dated changelog contract, SPDX comment, version heading, and published routes.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-07-30.mdx`; the documentation-only diff passed review against `WRITING.md`, the controlled word list, and `docs/CONTRIBUTING.md`. The review covered terminology, structure, active voice, release meaning, product-scope boundaries, and link and code presentation. Changelog tests passed 6/6, and the docs build reported 0 errors with 2 pre-existing warnings.
- Agent: Codex CLI
<!-- docs-review-head-sha: 200940f3d -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6/6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this documentation-only release entry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — result: Build passed with 0 errors and 2 pre-existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.99 covering snapshot restoration, sandbox recovery, gateway route upgrades, and Hermes security updates.
  * Documented experimental Microsoft Entra runtime identity support and enhanced readiness checks.
  * Added details on managed image validation, trusted CI image promotion, and end-to-end release evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->