### PR TITLE
fix(cli): restore fresh onboarding device pairing

### DIFF
--- a/scripts/patch-openclaw-device-self-approval.mts
+++ b/scripts/patch-openclaw-device-self-approval.mts
@@ -90,9 +90,11 @@ const CALL_OMIT_IDENTITY_TARGET = [
   "function shouldOmitDeviceIdentityForGatewayCall(params) {",
   "\tconst mode = params.opts.mode ?? GATEWAY_CLIENT_MODES.CLI;",
 ].join("\n");
+const CALL_OMIT_IDENTITY_LEGACY_FORCE_LINE = `\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") return false; // ${CALL_FORCE_IDENTITY_MARKER} (#4462)`;
+const CALL_OMIT_IDENTITY_MODE_LINE = `\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1" || process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1") return false; // ${CALL_FORCE_IDENTITY_MARKER} (#4462)`;
 const CALL_OMIT_IDENTITY_REPLACEMENT = [
   "function shouldOmitDeviceIdentityForGatewayCall(params) {",
-  `\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") return false; // ${CALL_FORCE_IDENTITY_MARKER} (#4462)`,
+  CALL_OMIT_IDENTITY_MODE_LINE,
   "\tconst mode = params.opts.mode ?? GATEWAY_CLIENT_MODES.CLI;",
 ].join("\n");
 const CALL_STORED_IDENTITY_TARGET =
@@ -114,9 +116,13 @@ const CALL_IDENTITY_RESOLVER_TARGET = [
   "\t}",
   "}",
 ].join("\n");
+const CALL_IDENTITY_RESOLVER_LEGACY_FORCE_LINE =
+  '\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") {';
+const CALL_IDENTITY_RESOLVER_MODE_LINE =
+  '\tif (process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1") {';
 const CALL_IDENTITY_RESOLVER_REPLACEMENT = [
   "function resolveDeviceIdentityForGatewayCall() {",
-  '\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") {',
+  CALL_IDENTITY_RESOLVER_MODE_LINE,
   "\t\tconst nemoclawExpectedDeviceId = normalizeOptionalString(process.env.NEMOCLAW_OPENCLAW_EXPECTED_DEVICE_ID);",
   '\t\tif (!nemoclawExpectedDeviceId) throw new Error("forced pairing expected device identity is unavailable");',
   "\t\tlet nemoclawDeviceIdentity;",
@@ -155,6 +161,10 @@ const DEVICE_IDENTITY_LOAD_TARGET = [
   "function loadOrCreateDeviceIdentity(filePath = resolveDefaultIdentityPath()) {",
   "\ttry {",
 ].join("\n");
+const DEVICE_IDENTITY_LOAD_LEGACY_FORCE_LINE =
+  '\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") return loadNemoClawForcedDeviceIdentity();';
+const DEVICE_IDENTITY_LOAD_MODE_LINE =
+  '\tif (process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1") return loadNemoClawForcedDeviceIdentity();';
 const DEVICE_IDENTITY_LOAD_REPLACEMENT = [
   "function resolveNemoClawCanonicalIdentityDescriptor() {",
   "\tconst nemoclawRawDescriptor = process.env.NEMOCLAW_OPENCLAW_IDENTITY_FD;",
@@ -187,7 +197,7 @@ const DEVICE_IDENTITY_LOAD_REPLACEMENT = [
   `\treturn nemoclawNormalizedIdentity.identity; // ${DEVICE_IDENTITY_FD_MARKER} (#4462)`,
   "}",
   "function loadOrCreateDeviceIdentity(filePath) {",
-  '\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") return loadNemoClawForcedDeviceIdentity();',
+  DEVICE_IDENTITY_LOAD_MODE_LINE,
   "\tif (filePath === void 0) filePath = resolveDefaultIdentityPath();",
   "\ttry {",
 ].join("\n");
@@ -488,7 +498,7 @@ const CLI_CONTEXT_TARGET = [
 ].join("\n");
 const CLI_CONTEXT_REPLACEMENT = [
   "async function resolveApprovePairingGatewayContext(opts, requestId) {",
-  '\tconst nemoclawPairedTokenRequested = process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1";',
+  '\tconst nemoclawPairedTokenRequested = process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1";',
   "\tlet nemoclawLocalStoredAuthCandidate = false;",
   "\tlet nemoclawLocalPairedTokenContext = null;",
   "\tlet nemoclawLocalPairedToken;",
@@ -1100,6 +1110,18 @@ const FILE_SPECS: FileSpec[] = [
     },
     patch(source, file) {
       if (source.includes(DEVICE_IDENTITY_FD_MARKER)) {
+        if (source.includes(DEVICE_IDENTITY_LOAD_LEGACY_FORCE_LINE)) {
+          const result = replaceExactlyOnce(
+            source,
+            DEVICE_IDENTITY_LOAD_LEGACY_FORCE_LINE,
+            DEVICE_IDENTITY_LOAD_MODE_LINE,
+            "restored-clone device-identity mode target",
+            file,
+          );
+          return result.error
+            ? { source, status: "no-match", error: result.error }
+            : { source: result.source, status: "would-apply" };
+        }
         return { source, status: "already-applied" };
       }
       const result = replaceExactlyOnce(
@@ -1135,7 +1157,17 @@ const FILE_SPECS: FileSpec[] = [
     patch(source, file) {
       let result: ReplacementResult = { source };
       let changed = false;
-      if (!result.source.includes(CALL_FORCE_IDENTITY_MARKER)) {
+      if (result.source.includes(CALL_OMIT_IDENTITY_LEGACY_FORCE_LINE)) {
+        result = replaceExactlyOnce(
+          result.source,
+          CALL_OMIT_IDENTITY_LEGACY_FORCE_LINE,
+          CALL_OMIT_IDENTITY_MODE_LINE,
+          "restored-clone gateway call device-identity mode target",
+          file,
+        );
+        if (result.error) return { source, status: "no-match", error: result.error };
+        changed = true;
+      } else if (!result.source.includes(CALL_FORCE_IDENTITY_MARKER)) {
         result = replaceExactlyOnce(
           result.source,
           CALL_OMIT_IDENTITY_TARGET,
@@ -1157,7 +1189,20 @@ const FILE_SPECS: FileSpec[] = [
         if (result.error) return { source, status: "no-match", error: result.error };
         changed = true;
       }
-      if (!result.source.includes(CALL_EXPECTED_IDENTITY_MARKER)) {
+      if (
+        result.source.includes(CALL_EXPECTED_IDENTITY_MARKER) &&
+        result.source.includes(CALL_IDENTITY_RESOLVER_LEGACY_FORCE_LINE)
+      ) {
+        result = replaceExactlyOnce(
+          result.source,
+          CALL_IDENTITY_RESOLVER_LEGACY_FORCE_LINE,
+          CALL_IDENTITY_RESOLVER_MODE_LINE,
+          "restored-clone gateway call expected identity mode target",
+          file,
+        );
+        if (result.error) return { source, status: "no-match", error: result.error };
+        changed = true;
+      } else if (!result.source.includes(CALL_EXPECTED_IDENTITY_MARKER)) {
         result = replaceExactlyOnce(
           result.source,
           CALL_IDENTITY_RESOLVER_TARGET,
@@ -1200,6 +1245,20 @@ const FILE_SPECS: FileSpec[] = [
       );
       if (appliedMarkerCounts.some((count) => count > 0)) {
         if (appliedMarkerCounts.every((count) => count === 1)) {
+          const legacyModeLine =
+            '\tconst nemoclawPairedTokenRequested = process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1";';
+          if (source.includes(legacyModeLine)) {
+            const result = replaceExactlyOnce(
+              source,
+              legacyModeLine,
+              '\tconst nemoclawPairedTokenRequested = process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1";',
+              "restored-clone paired-token mode target",
+              file,
+            );
+            return result.error
+              ? { source, status: "no-match", error: result.error }
+              : { source: result.source, status: "would-apply" };
+          }
           return { source, status: "already-applied" };
         }
         return {

--- a/src/lib/actions/sandbox/auto-pair-approval-script.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval-script.test.ts
@@ -38,6 +38,7 @@ describe("buildAutoPairApprovalScript (#4263/#4616)", () => {
 
     expect(ordinary).not.toContain("local_identity_public_key");
     expect(ordinary).not.toContain("NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING");
+    expect(ordinary).not.toContain("NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING");
     expect(ordinary).not.toContain("load_clone_local_pending");
     expect(ordinary).not.toContain("open_clone_state_root");
     expect(ordinary).not.toContain("pass_fds=");
@@ -45,7 +46,16 @@ describe("buildAutoPairApprovalScript (#4263/#4616)", () => {
     expect(ordinary).not.toContain("OPENCLAW_NO_RESPAWN");
     expect(restoredClone).toContain("local_identity_public_key");
     expect(restoredClone).toContain(
+      "approve_env.pop('NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING', None)",
+    );
+    expect(restoredClone).toContain(
       "approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)",
+    );
+    expect(restoredClone).not.toContain(
+      "approve_env['NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING'] = '1'",
+    );
+    expect(restoredClone).toContain(
+      "approve_env['NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING'] = '1'",
     );
     expect(restoredClone).not.toContain("'devices', 'list', '--json'");
     expect(restoredClone).toContain("'pending.json'");

--- a/src/lib/actions/sandbox/auto-pair-approval-script.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval-script.test.ts
@@ -68,9 +68,7 @@ describe("buildAutoPairApprovalScript (#4263/#4616)", () => {
     expect(restoredClone).toContain("dir_fd=clone_state_dir_fd");
     expect(restoredClone).toContain("clone_devices_dir_fd,");
     expect(restoredClone).toContain("clone_identity_dir_fd,");
-    expect(restoredClone).toContain("metadata.st_nlink > 1");
-    expect(restoredClone).toContain("metadata.st_nlink == 0");
-    expect(restoredClone).toContain("for attempt in range(3)");
+    expect(restoredClone).toContain("metadata.st_nlink != 1");
     expect(restoredClone).toContain("pass_fds=approval_pass_fds");
     expect(restoredClone).toContain("approve_env['NODE_DISABLE_COMPILE_CACHE'] = '1'");
     expect(restoredClone).toContain("approve_env['OPENCLAW_NO_RESPAWN'] = '1'");

--- a/src/lib/actions/sandbox/auto-pair-approval-script.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval-script.test.ts
@@ -68,7 +68,9 @@ describe("buildAutoPairApprovalScript (#4263/#4616)", () => {
     expect(restoredClone).toContain("dir_fd=clone_state_dir_fd");
     expect(restoredClone).toContain("clone_devices_dir_fd,");
     expect(restoredClone).toContain("clone_identity_dir_fd,");
-    expect(restoredClone).toContain("metadata.st_nlink != 1");
+    expect(restoredClone).toContain("metadata.st_nlink > 1");
+    expect(restoredClone).toContain("metadata.st_nlink == 0");
+    expect(restoredClone).toContain("for attempt in range(3)");
     expect(restoredClone).toContain("pass_fds=approval_pass_fds");
     expect(restoredClone).toContain("approve_env['NODE_DISABLE_COMPILE_CACHE'] = '1'");
     expect(restoredClone).toContain("approve_env['OPENCLAW_NO_RESPAWN'] = '1'");

--- a/src/lib/actions/sandbox/auto-pair-approval.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.test.ts
@@ -365,7 +365,6 @@ process.exit(2);
       );
       const devicesRaceBackup = path.join(stateDir, "devices-before-race");
       const transientRaceMarker = path.join(tmpDir, "transient-devices-race.marker");
-      const entryReplaceMarker = path.join(tmpDir, "entry-replace-race.marker");
       const transientRacePolicy = `${policy}
 import os as _nemoclaw_test_os
 _nemoclaw_test_original_open = _nemoclaw_test_os.open
@@ -473,31 +472,21 @@ _nemoclaw_test_subprocess.run = _nemoclaw_test_race_child
           budget: { maxApprovals: 1 },
         },
       );
-      const descriptorOpenNeedle =
-        "            fd = os.open(entry_name, clone_file_flags, dir_fd=directory_fd)";
-      const descriptorMetadataNeedle = "            metadata = os.fstat(fd)";
-      const entryReplaceRaceScript = script.replace(
-        descriptorMetadataNeedle,
-        `            if os.environ.get('NEMOCLAW_TEST_ENTRY_REPLACE_RACE') == '1' and entry_name == 'pending.json' and not os.path.exists(${JSON.stringify(entryReplaceMarker)}):
-                replacement_contents = os.read(fd, 1048577)
-                os.lseek(fd, 0, os.SEEK_SET)
-                os.unlink(entry_name, dir_fd=directory_fd)
-                replacement_fd = os.open(entry_name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=directory_fd)
-                os.write(replacement_fd, replacement_contents)
-                os.close(replacement_fd)
-                marker_fd = os.open(${JSON.stringify(entryReplaceMarker)}, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
-                os.close(marker_fd)
-${descriptorMetadataNeedle}`,
-      );
-      expect(entryReplaceRaceScript.includes("NEMOCLAW_TEST_ENTRY_REPLACE_RACE")).toBe(true);
+      const persistentRaceNeedle =
+        "    fd = os.open(entry_name, clone_file_flags, dir_fd=directory_fd)";
       const persistentDevicesRaceScript = script.replace(
-        descriptorOpenNeedle,
-        `            if os.environ.get('NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE') == '1' and directory_name == 'devices':
-                os.rename(${JSON.stringify(devicesDir)}, ${JSON.stringify(devicesRaceBackup)})
-                os.symlink(${JSON.stringify(primaryDevicesDir)}, ${JSON.stringify(devicesDir)})
-${descriptorOpenNeedle}`,
+        persistentRaceNeedle,
+        `    if (
+        os.environ.get('NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE') == '1'
+        and directory_name == 'devices'
+    ):
+        os.rename(${JSON.stringify(devicesDir)}, ${JSON.stringify(devicesRaceBackup)})
+        os.symlink(${JSON.stringify(primaryDevicesDir)}, ${JSON.stringify(devicesDir)})
+${persistentRaceNeedle}`,
       );
-      expect(persistentDevicesRaceScript).toContain("NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE");
+      expect(persistentDevicesRaceScript.includes("NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE")).toBe(
+        true,
+      );
       const execute = (
         failApproval = false,
         gatewayToken = "secret-token",
@@ -505,19 +494,17 @@ ${descriptorOpenNeedle}`,
         watcherRace = false,
         invalidWatcherState = false,
         timeoutAfterCommit = false,
-        devicesRace: "child-entry" | "entry-replace" | "none" | "persistent" | "transient" = "none",
+        devicesRace: "child-entry" | "none" | "persistent" | "transient" = "none",
       ) => {
         const approvalScript = timeoutAfterCommit
           ? timeoutScript
           : devicesRace === "child-entry"
             ? childEntryRaceScript
-            : devicesRace === "entry-replace"
-              ? entryReplaceRaceScript
-              : devicesRace === "persistent"
-                ? persistentDevicesRaceScript
-                : devicesRace === "transient"
-                  ? transientDevicesRaceScript
-                  : script;
+            : devicesRace === "persistent"
+              ? persistentDevicesRaceScript
+              : devicesRace === "transient"
+                ? transientDevicesRaceScript
+                : script;
         return spawnSync("sh", {
           encoding: "utf-8",
           input: approvalScript,
@@ -529,7 +516,6 @@ ${descriptorOpenNeedle}`,
             NEMOCLAW_APPROVE_WATCHER_RACE_INVALID: invalidWatcherState ? "1" : "0",
             NEMOCLAW_APPROVE_TIMEOUT_AFTER_COMMIT: timeoutAfterCommit ? "1" : "0",
             NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE: devicesRace === "persistent" ? "1" : "0",
-            NEMOCLAW_TEST_ENTRY_REPLACE_RACE: devicesRace === "entry-replace" ? "1" : "0",
             NEMOCLAW_TEST_TRANSIENT_DEVICES_RACE: devicesRace === "transient" ? "1" : "0",
             NEMOCLAW_TEST_CHILD_ENTRY_RACE: devicesRace === "child-entry" ? "1" : "0",
             NEMOCLAW_TEST_CLONE_STATE_DIR: stateDir,
@@ -556,7 +542,7 @@ ${descriptorOpenNeedle}`,
           pendingById?: Record<string, unknown>;
           pairedById?: Record<string, unknown>;
           clientAuth?: "matching" | "missing" | "primary-symlink" | "stale";
-          devicesRace?: "child-entry" | "entry-replace" | "persistent" | "transient";
+          devicesRace?: "child-entry" | "persistent" | "transient";
         } = {},
       ) => {
         const pendingById =
@@ -1118,19 +1104,6 @@ ${descriptorOpenNeedle}`,
         [privatePrimaryRaceRequest.requestId]: privatePrimaryRaceRequest,
       });
       fs.writeFileSync(path.join(primaryDevicesDir, "pending.json"), primaryRacePending);
-
-      resetLogs();
-      fs.rmSync(entryReplaceMarker, { force: true });
-      const entryReplaceRace = run([foreignRequest, repairRequest], {
-        clientAuth: "missing",
-        devicesRace: "entry-replace",
-        pairedById: { [deviceId]: pairedDevice },
-      });
-      expect(parseAutoPairApprovalReceipt(entryReplaceRace.stdout)).toBe("approved-one");
-      expect(fs.existsSync(entryReplaceMarker)).toBe(true);
-      expect(readApproveCalls()).toHaveLength(1);
-      expect(readApprovals()).toEqual(["clone-write-upgrade"]);
-      expect(entryReplaceRace.stderr).toBe("");
 
       resetLogs();
       fs.rmSync(transientRaceMarker, { force: true });

--- a/src/lib/actions/sandbox/auto-pair-approval.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.test.ts
@@ -365,6 +365,7 @@ process.exit(2);
       );
       const devicesRaceBackup = path.join(stateDir, "devices-before-race");
       const transientRaceMarker = path.join(tmpDir, "transient-devices-race.marker");
+      const entryReplaceMarker = path.join(tmpDir, "entry-replace-race.marker");
       const transientRacePolicy = `${policy}
 import os as _nemoclaw_test_os
 _nemoclaw_test_original_open = _nemoclaw_test_os.open
@@ -472,21 +473,31 @@ _nemoclaw_test_subprocess.run = _nemoclaw_test_race_child
           budget: { maxApprovals: 1 },
         },
       );
-      const persistentRaceNeedle =
-        "    fd = os.open(entry_name, clone_file_flags, dir_fd=directory_fd)";
+      const descriptorOpenNeedle =
+        "            fd = os.open(entry_name, clone_file_flags, dir_fd=directory_fd)";
+      const descriptorMetadataNeedle = "            metadata = os.fstat(fd)";
+      const entryReplaceRaceScript = script.replace(
+        descriptorMetadataNeedle,
+        `            if os.environ.get('NEMOCLAW_TEST_ENTRY_REPLACE_RACE') == '1' and entry_name == 'pending.json' and not os.path.exists(${JSON.stringify(entryReplaceMarker)}):
+                replacement_contents = os.read(fd, 1048577)
+                os.lseek(fd, 0, os.SEEK_SET)
+                os.unlink(entry_name, dir_fd=directory_fd)
+                replacement_fd = os.open(entry_name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=directory_fd)
+                os.write(replacement_fd, replacement_contents)
+                os.close(replacement_fd)
+                marker_fd = os.open(${JSON.stringify(entryReplaceMarker)}, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+                os.close(marker_fd)
+${descriptorMetadataNeedle}`,
+      );
+      expect(entryReplaceRaceScript.includes("NEMOCLAW_TEST_ENTRY_REPLACE_RACE")).toBe(true);
       const persistentDevicesRaceScript = script.replace(
-        persistentRaceNeedle,
-        `    if (
-        os.environ.get('NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE') == '1'
-        and directory_name == 'devices'
-    ):
-        os.rename(${JSON.stringify(devicesDir)}, ${JSON.stringify(devicesRaceBackup)})
-        os.symlink(${JSON.stringify(primaryDevicesDir)}, ${JSON.stringify(devicesDir)})
-${persistentRaceNeedle}`,
+        descriptorOpenNeedle,
+        `            if os.environ.get('NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE') == '1' and directory_name == 'devices':
+                os.rename(${JSON.stringify(devicesDir)}, ${JSON.stringify(devicesRaceBackup)})
+                os.symlink(${JSON.stringify(primaryDevicesDir)}, ${JSON.stringify(devicesDir)})
+${descriptorOpenNeedle}`,
       );
-      expect(persistentDevicesRaceScript.includes("NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE")).toBe(
-        true,
-      );
+      expect(persistentDevicesRaceScript).toContain("NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE");
       const execute = (
         failApproval = false,
         gatewayToken = "secret-token",
@@ -494,17 +505,19 @@ ${persistentRaceNeedle}`,
         watcherRace = false,
         invalidWatcherState = false,
         timeoutAfterCommit = false,
-        devicesRace: "child-entry" | "none" | "persistent" | "transient" = "none",
+        devicesRace: "child-entry" | "entry-replace" | "none" | "persistent" | "transient" = "none",
       ) => {
         const approvalScript = timeoutAfterCommit
           ? timeoutScript
           : devicesRace === "child-entry"
             ? childEntryRaceScript
-            : devicesRace === "persistent"
-              ? persistentDevicesRaceScript
-              : devicesRace === "transient"
-                ? transientDevicesRaceScript
-                : script;
+            : devicesRace === "entry-replace"
+              ? entryReplaceRaceScript
+              : devicesRace === "persistent"
+                ? persistentDevicesRaceScript
+                : devicesRace === "transient"
+                  ? transientDevicesRaceScript
+                  : script;
         return spawnSync("sh", {
           encoding: "utf-8",
           input: approvalScript,
@@ -516,6 +529,7 @@ ${persistentRaceNeedle}`,
             NEMOCLAW_APPROVE_WATCHER_RACE_INVALID: invalidWatcherState ? "1" : "0",
             NEMOCLAW_APPROVE_TIMEOUT_AFTER_COMMIT: timeoutAfterCommit ? "1" : "0",
             NEMOCLAW_TEST_PERSISTENT_DEVICES_RACE: devicesRace === "persistent" ? "1" : "0",
+            NEMOCLAW_TEST_ENTRY_REPLACE_RACE: devicesRace === "entry-replace" ? "1" : "0",
             NEMOCLAW_TEST_TRANSIENT_DEVICES_RACE: devicesRace === "transient" ? "1" : "0",
             NEMOCLAW_TEST_CHILD_ENTRY_RACE: devicesRace === "child-entry" ? "1" : "0",
             NEMOCLAW_TEST_CLONE_STATE_DIR: stateDir,
@@ -542,7 +556,7 @@ ${persistentRaceNeedle}`,
           pendingById?: Record<string, unknown>;
           pairedById?: Record<string, unknown>;
           clientAuth?: "matching" | "missing" | "primary-symlink" | "stale";
-          devicesRace?: "child-entry" | "persistent" | "transient";
+          devicesRace?: "child-entry" | "entry-replace" | "persistent" | "transient";
         } = {},
       ) => {
         const pendingById =
@@ -1104,6 +1118,19 @@ ${persistentRaceNeedle}`,
         [privatePrimaryRaceRequest.requestId]: privatePrimaryRaceRequest,
       });
       fs.writeFileSync(path.join(primaryDevicesDir, "pending.json"), primaryRacePending);
+
+      resetLogs();
+      fs.rmSync(entryReplaceMarker, { force: true });
+      const entryReplaceRace = run([foreignRequest, repairRequest], {
+        clientAuth: "missing",
+        devicesRace: "entry-replace",
+        pairedById: { [deviceId]: pairedDevice },
+      });
+      expect(parseAutoPairApprovalReceipt(entryReplaceRace.stdout)).toBe("approved-one");
+      expect(fs.existsSync(entryReplaceMarker)).toBe(true);
+      expect(readApproveCalls()).toHaveLength(1);
+      expect(readApprovals()).toEqual(["clone-write-upgrade"]);
+      expect(entryReplaceRace.stderr).toBe("");
 
       resetLogs();
       fs.rmSync(transientRaceMarker, { force: true });

--- a/src/lib/actions/sandbox/auto-pair-approval.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.test.ts
@@ -189,7 +189,7 @@ if (args[0] === "devices" && args[1] === "approve") {
     process.stderr.write("raw approval output must stay private\\n");
     process.exit(1);
   }
-  const forced = process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1";
+  const forced = process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1";
   const stateDir = process.env.OPENCLAW_STATE_DIR;
   const expectedCloneStateDir = process.env.NEMOCLAW_TEST_CLONE_STATE_DIR;
   const cloneStateBackup = process.env.NEMOCLAW_TEST_CLONE_STATE_BACKUP;
@@ -250,7 +250,8 @@ if (args[0] === "devices" && args[1] === "approve") {
     !process.env.OPENCLAW_GATEWAY_URL &&
     !process.env.OPENCLAW_GATEWAY_PORT &&
     process.env.OPENCLAW_GATEWAY_TOKEN === "secret-token" &&
-    !process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING;
+    !process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING &&
+    !process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING;
   const pairedTokenOnly =
     process.env.OPENCLAW_GATEWAY_URL === "ws://127.0.0.1:18789" &&
     process.env.NEMOCLAW_OPENCLAW_PINNED_GATEWAY_URL ===
@@ -258,6 +259,7 @@ if (args[0] === "devices" && args[1] === "approve") {
     !process.env.OPENCLAW_GATEWAY_PORT &&
     !process.env.OPENCLAW_GATEWAY_PASSWORD &&
     !process.env.OPENCLAW_GATEWAY_TOKEN &&
+    !process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING &&
     Boolean(pairedOperator?.token) &&
     forced &&
     process.env.NODE_DISABLE_COMPILE_CACHE === "1" &&
@@ -272,7 +274,8 @@ if (args[0] === "devices" && args[1] === "approve") {
     !process.env.OPENCLAW_GATEWAY_URL &&
     !process.env.OPENCLAW_GATEWAY_PORT &&
     !process.env.OPENCLAW_GATEWAY_TOKEN &&
-    !process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING;
+    !process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING &&
+    !process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING;
   const expectedAuthMode = hasPairedBaseline
     ? exactPairingBaseline && boundedWriteUpgrade
       ? pairedTokenOnly
@@ -315,7 +318,7 @@ if (args[0] === "devices" && args[1] === "approve") {
         : pairedTokenOnly
           ? "clone-paired-token"
           : "stored-device-auth",
-      process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1" ? "forced" : "ordinary",
+      forced ? "forced" : "ordinary",
       forced
         ? forcedStatePinned
           ? "clone-state-fd"
@@ -518,6 +521,7 @@ ${persistentRaceNeedle}`,
             NEMOCLAW_TEST_CLONE_STATE_DIR: stateDir,
             NEMOCLAW_TEST_CLONE_STATE_BACKUP: stateRaceBackup,
             NEMOCLAW_PRIMARY_STATE_DIR: primaryStateDir,
+            NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING: "1",
             OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
             OPENCLAW_GATEWAY_PORT: gatewayPort,
             OPENCLAW_GATEWAY_TOKEN: gatewayToken,

--- a/src/lib/actions/sandbox/auto-pair-approval.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.ts
@@ -298,13 +298,14 @@ def exit_with_receipt(receipt):
     ? `
 # SOURCE_OF_TRUTH_REVIEW (restored-clone local pending selection):
 # Invalid state: after snapshot restore restarts the clone gateway, the bounded
-# warm-up asks for operator.write while the clone's paired baseline still has
-# only operator.pairing. OpenClaw creates the pending transition, and that same
-# transition gates the devices list this one-shot approval pass would need.
-# Creation point: establishRestoredSandboxGatewayPairing runs
-# runSandboxScopeWarmupRun immediately before this approval. Restore preserves
-# the clone-owned identity and pairing-only server record, while its client-auth
-# store cannot converge on the rotated token until canonical approval finishes.
+# warm-up asks for operator.write. When the clone's paired baseline lacks that
+# scope, OpenClaw creates the pending transition, and that same transition gates
+# the devices list this one-shot approval pass would need.
+# Creation point: establishRestoredSandboxGatewayPairing runs the direct
+# restored-clone gateway warm-up immediately before this approval. Restore
+# preserves the clone-owned identity and server pairing record, while its client
+# auth store cannot converge on a rotated token until canonical approval
+# finishes.
 # Source boundary: read only the clone-local pending map, validate one exact
 # request below, and delegate the write to OpenClaw's canonical devices approve
 # command. OpenClaw 2026.7.1 has no authenticated bootstrap/list API that can

--- a/src/lib/actions/sandbox/auto-pair-approval.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.ts
@@ -315,7 +315,6 @@ def exit_with_receipt(receipt):
 # Removal condition: delete this path when the pinned OpenClaw release exposes
 # that bootstrap/list API for an unpaired clone.
 import stat
-import time
 
 state_dir = os.environ.get('OPENCLAW_STATE_DIR') or '/sandbox/.openclaw'
 if not os.path.isabs(state_dir):
@@ -405,36 +404,20 @@ def open_clone_json_descriptor(directory_fd, directory_name, entry_name):
         or os.sep in entry_name
     ):
         raise OSError('unsafe clone state entry')
-    # OpenClaw publishes these files with atomic replacement. Retry only a
-    # missing or already-unlinked entry while the pinned directory is current.
-    for attempt in range(3):
-        try:
-            fd = os.open(entry_name, clone_file_flags, dir_fd=directory_fd)
-        except FileNotFoundError:
-            if attempt == 2 or not clone_directory_is_current(directory_name, directory_fd):
-                raise
-            time.sleep(0.05)
-            continue
-        try:
-            metadata = os.fstat(fd)
-            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink > 1:
-                raise OSError('clone state entry is not a single regular file')
-            if metadata.st_nlink == 0:
-                raise FileNotFoundError('clone state entry was replaced')
-            with os.fdopen(os.dup(fd), encoding='utf-8') as handle:
-                parsed = json.load(handle)
-            os.lseek(fd, 0, os.SEEK_SET)
-            if not clone_directory_is_current(directory_name, directory_fd):
-                raise OSError('clone state directory changed')
-            return parsed, fd
-        except FileNotFoundError:
-            os.close(fd)
-            if attempt == 2 or not clone_directory_is_current(directory_name, directory_fd):
-                raise
-            time.sleep(0.05)
-        except Exception:
-            os.close(fd)
-            raise
+    fd = os.open(entry_name, clone_file_flags, dir_fd=directory_fd)
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise OSError('clone state entry is not a single regular file')
+        with os.fdopen(os.dup(fd), encoding='utf-8') as handle:
+            parsed = json.load(handle)
+        os.lseek(fd, 0, os.SEEK_SET)
+        if not clone_directory_is_current(directory_name, directory_fd):
+            raise OSError('clone state directory changed')
+        return parsed, fd
+    except Exception:
+        os.close(fd)
+        raise
 
 def read_clone_json(directory_fd, directory_name, entry_name):
     parsed, fd = open_clone_json_descriptor(directory_fd, directory_name, entry_name)

--- a/src/lib/actions/sandbox/auto-pair-approval.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.ts
@@ -221,7 +221,8 @@ def exit_with_receipt(receipt):
         approve_env['OPENCLAW_GATEWAY_URL'] = pinned_gateway_url
         approve_env['NODE_DISABLE_COMPILE_CACHE'] = '1'
         approve_env['OPENCLAW_NO_RESPAWN'] = '1'
-        approve_env['NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING'] = '1'
+        approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)
+        approve_env['NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING'] = '1'
         approve_env['NEMOCLAW_OPENCLAW_PINNED_GATEWAY_URL'] = pinned_gateway_url
         approve_env['NEMOCLAW_OPENCLAW_EXPECTED_DEVICE_ID'] = local_device_id
         approve_env['NEMOCLAW_OPENCLAW_PENDING_FD'] = str(clone_pending_snapshot_fd)
@@ -234,13 +235,15 @@ def exit_with_receipt(receipt):
             clone_identity_snapshot_fd,
         )
     else:
-        approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)`
+        approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)
+        approve_env.pop('NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING', None)`
     : "approve_env = gateway_approval_env(os.environ)";
   const pairedTokenSuccess = options.localDeviceOnly
     ? `            if local_approval_auth_mode == 'paired-token':
                 previous_approval_token = local_paired_operator_token
                 approve_env.pop('OPENCLAW_GATEWAY_TOKEN', None)
                 approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)
+                approve_env.pop('NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING', None)
                 local_paired_operator_token = ''
                 if not sync_approved_clone_device_auth(device, previous_approval_token):
                     ${exitWithReceipt("approve-failed")}
@@ -255,6 +258,7 @@ def exit_with_receipt(receipt):
             previous_approval_token = local_paired_operator_token
             approve_env.pop('OPENCLAW_GATEWAY_TOKEN', None)
             approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)
+            approve_env.pop('NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING', None)
             local_paired_operator_token = ''
             if not sync_approved_clone_device_auth(device, previous_approval_token):
                 ${exitWithReceipt("approve-failed")}
@@ -272,6 +276,7 @@ def exit_with_receipt(receipt):
         previous_approval_token = local_paired_operator_token
         approve_env.pop('OPENCLAW_GATEWAY_TOKEN', None)
         approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)
+        approve_env.pop('NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING', None)
         local_paired_operator_token = ''
         observe_deadline = time.monotonic() + ${AUTO_PAIR_POST_TIMEOUT_OBSERVE_S}
         while not sync_approved_clone_device_auth(device, previous_approval_token):

--- a/src/lib/actions/sandbox/auto-pair-approval.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.ts
@@ -315,6 +315,7 @@ def exit_with_receipt(receipt):
 # Removal condition: delete this path when the pinned OpenClaw release exposes
 # that bootstrap/list API for an unpaired clone.
 import stat
+import time
 
 state_dir = os.environ.get('OPENCLAW_STATE_DIR') or '/sandbox/.openclaw'
 if not os.path.isabs(state_dir):
@@ -404,20 +405,36 @@ def open_clone_json_descriptor(directory_fd, directory_name, entry_name):
         or os.sep in entry_name
     ):
         raise OSError('unsafe clone state entry')
-    fd = os.open(entry_name, clone_file_flags, dir_fd=directory_fd)
-    try:
-        metadata = os.fstat(fd)
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
-            raise OSError('clone state entry is not a single regular file')
-        with os.fdopen(os.dup(fd), encoding='utf-8') as handle:
-            parsed = json.load(handle)
-        os.lseek(fd, 0, os.SEEK_SET)
-        if not clone_directory_is_current(directory_name, directory_fd):
-            raise OSError('clone state directory changed')
-        return parsed, fd
-    except Exception:
-        os.close(fd)
-        raise
+    # OpenClaw publishes these files with atomic replacement. Retry only a
+    # missing or already-unlinked entry while the pinned directory is current.
+    for attempt in range(3):
+        try:
+            fd = os.open(entry_name, clone_file_flags, dir_fd=directory_fd)
+        except FileNotFoundError:
+            if attempt == 2 or not clone_directory_is_current(directory_name, directory_fd):
+                raise
+            time.sleep(0.05)
+            continue
+        try:
+            metadata = os.fstat(fd)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink > 1:
+                raise OSError('clone state entry is not a single regular file')
+            if metadata.st_nlink == 0:
+                raise FileNotFoundError('clone state entry was replaced')
+            with os.fdopen(os.dup(fd), encoding='utf-8') as handle:
+                parsed = json.load(handle)
+            os.lseek(fd, 0, os.SEEK_SET)
+            if not clone_directory_is_current(directory_name, directory_fd):
+                raise OSError('clone state directory changed')
+            return parsed, fd
+        except FileNotFoundError:
+            os.close(fd)
+            if attempt == 2 or not clone_directory_is_current(directory_name, directory_fd):
+                raise
+            time.sleep(0.05)
+        except Exception:
+            os.close(fd)
+            raise
 
 def read_clone_json(directory_fd, directory_name, entry_name):
     parsed, fd = open_clone_json_descriptor(directory_fd, directory_name, entry_name)

--- a/src/lib/actions/sandbox/auto-pair-warmup.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-warmup.test.ts
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { RESTORED_CLONE_WARMUP_SCRIPT, WARMUP_SCRIPT, WARMUP_TIMEOUT_MS } from "./auto-pair-warmup";
@@ -88,6 +91,58 @@ describe("warm-up tags its throwaway session for user-facing filters (#5511)", (
       timeout: 10_000,
     });
     expect(result.status, result.stderr).toBe(0);
+  });
+
+  itWithSh("uses clone device auth after sourcing restored-clone routing (#7834)", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-clone-warmup-"));
+    const binDir = path.join(fixtureRoot, "bin");
+    const proxyEnv = path.join(fixtureRoot, "proxy-env.sh");
+    const callLog = path.join(fixtureRoot, "call.log");
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(
+      proxyEnv,
+      [
+        "export OPENCLAW_GATEWAY_TOKEN=shared-token",
+        "export OPENCLAW_GATEWAY_PASSWORD=shared-password",
+        "export OPENCLAW_GATEWAY_PORT=18789",
+        "",
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(binDir, "openclaw"),
+      [
+        "#!/bin/sh",
+        "{",
+        "  printf 'token=%s\\n' \"${OPENCLAW_GATEWAY_TOKEN-unset}\"",
+        "  printf 'password=%s\\n' \"${OPENCLAW_GATEWAY_PASSWORD-unset}\"",
+        "  printf 'port=%s\\n' \"${OPENCLAW_GATEWAY_PORT-unset}\"",
+        "  printf 'force=%s\\n' \"${NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING-unset}\"",
+        "  printf 'argv=%s\\n' \"$*\"",
+        '} > "$NEMOCLAW_TEST_CALL_LOG"',
+        "exit 23",
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+
+    try {
+      const script = RESTORED_CLONE_WARMUP_SCRIPT.replace("/tmp/nemoclaw-proxy-env.sh", proxyEnv);
+      const result = spawnSync("sh", ["-c", script], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          NEMOCLAW_TEST_CALL_LOG: callLog,
+          PATH: `${binDir}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+        },
+        timeout: 10_000,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(fs.readFileSync(callLog, "utf8")).toMatch(
+        /^token=unset\npassword=unset\nport=18789\nforce=1\nargv=gateway call sessions\.create --params \{"key":"agent:main:nemoclaw-onboard-warmup-\d+-\d+","agentId":"main"\} --json\n$/,
+      );
+    } finally {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   it("forces device pairing only for the provoke command on OpenClaw 2026.7.1", () => {

--- a/src/lib/actions/sandbox/auto-pair-warmup.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-warmup.test.ts
@@ -4,8 +4,11 @@
 import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
-import { WARMUP_SCRIPT, WARMUP_TIMEOUT_MS } from "./auto-pair-warmup";
+import { RESTORED_CLONE_WARMUP_SCRIPT, WARMUP_SCRIPT, WARMUP_TIMEOUT_MS } from "./auto-pair-warmup";
 import { WARMUP_SESSION_ID_PREFIX } from "./warmup-session";
+
+const shAvailable = spawnSync("sh", ["-c", "exit 0"], { encoding: "utf-8" }).status === 0;
+const itWithSh = shAvailable ? it : it.skip;
 
 // NOTE on coverage shape (#4504-v2): `runSandboxScopeWarmupRun` is not exercised
 // in-process here. Like its sibling `runSandboxAutoPairApprovalPass`, the leaf
@@ -49,9 +52,6 @@ describe("warm-up payload uses native multiline OpenShell exec in v2 (#4504)", (
     expect(WARMUP_SCRIPT).not.toContain("mktemp");
   });
 
-  const shAvailable = spawnSync("sh", ["-c", "exit 0"], { encoding: "utf-8" }).status === 0;
-  const itWithSh = shAvailable ? it : it.skip;
-
   itWithSh("runs a multiline warm-up-shaped payload and preserves its exit-0 status", () => {
     // Mirror the real warm-up: the provoke command itself may "fail" (the agent
     // falls back to embedded mode), but `|| true` + trailing `exit 0` mean the
@@ -68,6 +68,26 @@ describe("warm-up tags its throwaway session for user-facing filters (#5511)", (
   it("tags the provoke session with the shared warm-up prefix", () => {
     expect(WARMUP_SESSION_ID_PREFIX).toBe("nemoclaw-onboard-warmup-");
     expect(WARMUP_SCRIPT).toContain(`--session-id "${WARMUP_SESSION_ID_PREFIX}$$-$(date +%s)"`);
+  });
+
+  it("uses a direct write-scope gateway call for restored clones (#7834)", () => {
+    expect(RESTORED_CLONE_WARMUP_SCRIPT).toContain(
+      'openclaw gateway call sessions.create --params "$params" --json',
+    );
+    expect(RESTORED_CLONE_WARMUP_SCRIPT).toContain(
+      `session_key="agent:main:${WARMUP_SESSION_ID_PREFIX}$$-$(date +%s)"`,
+    );
+    expect(RESTORED_CLONE_WARMUP_SCRIPT).toContain("NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING=1");
+    expect(RESTORED_CLONE_WARMUP_SCRIPT).not.toContain("openclaw agent");
+  });
+
+  itWithSh("keeps the restored-clone warm-up valid POSIX shell (#7834)", () => {
+    const result = spawnSync("sh", ["-n"], {
+      encoding: "utf-8",
+      input: RESTORED_CLONE_WARMUP_SCRIPT,
+      timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(0);
   });
 
   it("forces device pairing only for the provoke command on OpenClaw 2026.7.1", () => {

--- a/src/lib/actions/sandbox/auto-pair-warmup.ts
+++ b/src/lib/actions/sandbox/auto-pair-warmup.ts
@@ -39,11 +39,11 @@ import { spawnSync } from "node:child_process";
 import { ROOT } from "../../state/paths";
 import { WARMUP_SESSION_ID_PREFIX } from "./warmup-session";
 
-// Outer spawnSync cap (ms) for the throwaway warm-up agent run. The `-m`
+// Outer spawnSync cap (ms) for a throwaway warm-up call. The onboard `-m`
 // one-shot prompt ("ping") returns fast even when it falls back to embedded
 // mode, so 30s comfortably covers gateway-connect + scope-upgrade request, the
-// bounded pending-upgrade poll below, plus shell/agent startup, while never
-// letting a wedged sandbox block onboard.
+// bounded pending-upgrade poll below, plus shell/CLI startup, while never
+// letting a wedged sandbox block onboard or restore.
 export const WARMUP_TIMEOUT_MS = 30_000;
 
 // Bounded in-sandbox poll for the pending scope upgrade after the provoke run.
@@ -128,13 +128,23 @@ done
 exit 0
 `;
 
-/**
- * Run the bounded, throwaway scope-upgrade warm-up inside the named sandbox via
- * `openshell sandbox exec`. All failure modes (timeout, sandbox-exec errors,
- * missing openclaw, gateway unreachable) are swallowed: this is best-effort and
- * must never throw — onboard finalization must not be blocked.
- */
-export function runSandboxScopeWarmupRun(sandboxName: string): void {
+// A restored clone must publish its write-scope request before the strict
+// local-state approval pass from #7834. Use a direct gateway call here: unlike
+// `openclaw agent`, this command cannot silently continue in embedded mode.
+// When the clone is already fully paired, the call creates only a tagged empty
+// warm-up session, matching the existing user-facing session filter contract.
+export const RESTORED_CLONE_WARMUP_SCRIPT = `
+PROXY_ENV=/tmp/nemoclaw-proxy-env.sh
+[ -r "$PROXY_ENV" ] && . "$PROXY_ENV"
+command -v openclaw >/dev/null 2>&1 || exit 0
+session_key="agent:main:${WARMUP_SESSION_ID_PREFIX}$$-$(date +%s)"
+params="$(printf '{"key":"%s","agentId":"main"}' "$session_key")"
+NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING=1 \\
+  openclaw gateway call sessions.create --params "$params" --json >/dev/null 2>&1 || true
+exit 0
+`;
+
+function runSandboxWarmupScript(sandboxName: string, script: string): void {
   // Lazy require: `adapters/openshell/resolve` pulls in `runner`, whose
   // load-time `require("./platform")` cannot be resolved by the Vitest TS
   // loader. Importing it here keeps this module unit-testable in-process.
@@ -149,7 +159,7 @@ export function runSandboxScopeWarmupRun(sandboxName: string): void {
     if (!openshellBinary) return;
     spawnSync(
       openshellBinary,
-      ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", WARMUP_SCRIPT],
+      ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", script],
       {
         cwd: ROOT,
         env: process.env,
@@ -158,6 +168,21 @@ export function runSandboxScopeWarmupRun(sandboxName: string): void {
       },
     );
   } catch {
-    /* defense-in-depth — never throw from the onboard finalization path */
+    /* defense-in-depth — never throw from a warm-up path */
   }
+}
+
+/**
+ * Run the bounded, throwaway scope-upgrade warm-up inside the named sandbox via
+ * `openshell sandbox exec`. All failure modes (timeout, sandbox-exec errors,
+ * missing openclaw, gateway unreachable) are swallowed: this is best-effort and
+ * must never throw — onboard finalization must not be blocked.
+ */
+export function runSandboxScopeWarmupRun(sandboxName: string): void {
+  runSandboxWarmupScript(sandboxName, WARMUP_SCRIPT);
+}
+
+/** Publish a restored clone's write-scope request without an embedded fallback. */
+export function runRestoredSandboxScopeWarmupRun(sandboxName: string): void {
+  runSandboxWarmupScript(sandboxName, RESTORED_CLONE_WARMUP_SCRIPT);
 }

--- a/src/lib/actions/sandbox/auto-pair-warmup.ts
+++ b/src/lib/actions/sandbox/auto-pair-warmup.ts
@@ -131,12 +131,16 @@ exit 0
 // A restored clone must publish its write-scope request before the strict
 // local-state approval pass from #7834. Use a direct gateway call here: unlike
 // `openclaw agent`, this command cannot silently continue in embedded mode.
+// The runtime env carries shared gateway auth for owned admin RPCs; remove it
+// before this ordinary CLI call so OpenClaw uses the clone's stored device
+// credential and publishes the exact write-scope upgrade request.
 // When the clone is already fully paired, the call creates only a tagged empty
 // warm-up session, matching the existing user-facing session filter contract.
 export const RESTORED_CLONE_WARMUP_SCRIPT = `
 PROXY_ENV=/tmp/nemoclaw-proxy-env.sh
 [ -r "$PROXY_ENV" ] && . "$PROXY_ENV"
 command -v openclaw >/dev/null 2>&1 || exit 0
+unset OPENCLAW_GATEWAY_TOKEN OPENCLAW_GATEWAY_PASSWORD || exit 0
 session_key="agent:main:${WARMUP_SESSION_ID_PREFIX}$$-$(date +%s)"
 params="$(printf '{"key":"%s","agentId":"main"}' "$session_key")"
 NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING=1 \\

--- a/src/lib/actions/sandbox/restore-gateway-pairing.test.ts
+++ b/src/lib/actions/sandbox/restore-gateway-pairing.test.ts
@@ -65,48 +65,6 @@ describe("establishRestoredSandboxGatewayPairing", () => {
     expect(verifyGatewayPairing).toHaveBeenCalledOnce();
   });
 
-  it("approves once more when the first verifier exposes the clone scope upgrade (#7834)", async () => {
-    const order: string[] = [];
-    const restartRestoredSandboxGateway = vi.fn(() => order.push("restart"));
-    const warmupScopeUpgrade = vi.fn(() => order.push("warmup"));
-    let approvalAttempt = 0;
-    const approveRestoredClonePairing = vi.fn(() => {
-      order.push("approve");
-      approvalAttempt += 1;
-      return approvalAttempt === 1 ? ("list-failed" as const) : ("approved-one" as const);
-    });
-    let verificationAttempt = 0;
-    const verifyGatewayPairing = vi.fn(() => {
-      order.push("verify");
-      verificationAttempt += 1;
-      return verificationAttempt === 1
-        ? ({ ok: false, failureLayer: "scope-upgrade-pending" } as const)
-        : ({ ok: true } as const);
-    });
-
-    await establishRestoredSandboxGatewayPairing("beta", {
-      restartRestoredSandboxGateway,
-      warmupScopeUpgrade,
-      approveRestoredClonePairing,
-      verifyGatewayPairing,
-    });
-
-    expect(restartRestoredSandboxGateway).toHaveBeenCalledTimes(3);
-    expect(warmupScopeUpgrade).toHaveBeenCalledOnce();
-    expect(approveRestoredClonePairing).toHaveBeenCalledTimes(2);
-    expect(verifyGatewayPairing).toHaveBeenCalledTimes(2);
-    expect(order).toEqual([
-      "restart",
-      "warmup",
-      "approve",
-      "restart",
-      "verify",
-      "approve",
-      "restart",
-      "verify",
-    ]);
-  });
-
   it("fails before pairing when the restored gateway cannot restart (#7431)", async () => {
     const warmupScopeUpgrade = vi.fn();
     const approveRestoredClonePairing = vi.fn();

--- a/src/lib/actions/sandbox/restore-gateway-pairing.test.ts
+++ b/src/lib/actions/sandbox/restore-gateway-pairing.test.ts
@@ -65,6 +65,48 @@ describe("establishRestoredSandboxGatewayPairing", () => {
     expect(verifyGatewayPairing).toHaveBeenCalledOnce();
   });
 
+  it("approves once more when the first verifier exposes the clone scope upgrade (#7834)", async () => {
+    const order: string[] = [];
+    const restartRestoredSandboxGateway = vi.fn(() => order.push("restart"));
+    const warmupScopeUpgrade = vi.fn(() => order.push("warmup"));
+    let approvalAttempt = 0;
+    const approveRestoredClonePairing = vi.fn(() => {
+      order.push("approve");
+      approvalAttempt += 1;
+      return approvalAttempt === 1 ? ("list-failed" as const) : ("approved-one" as const);
+    });
+    let verificationAttempt = 0;
+    const verifyGatewayPairing = vi.fn(() => {
+      order.push("verify");
+      verificationAttempt += 1;
+      return verificationAttempt === 1
+        ? ({ ok: false, failureLayer: "scope-upgrade-pending" } as const)
+        : ({ ok: true } as const);
+    });
+
+    await establishRestoredSandboxGatewayPairing("beta", {
+      restartRestoredSandboxGateway,
+      warmupScopeUpgrade,
+      approveRestoredClonePairing,
+      verifyGatewayPairing,
+    });
+
+    expect(restartRestoredSandboxGateway).toHaveBeenCalledTimes(3);
+    expect(warmupScopeUpgrade).toHaveBeenCalledOnce();
+    expect(approveRestoredClonePairing).toHaveBeenCalledTimes(2);
+    expect(verifyGatewayPairing).toHaveBeenCalledTimes(2);
+    expect(order).toEqual([
+      "restart",
+      "warmup",
+      "approve",
+      "restart",
+      "verify",
+      "approve",
+      "restart",
+      "verify",
+    ]);
+  });
+
   it("fails before pairing when the restored gateway cannot restart (#7431)", async () => {
     const warmupScopeUpgrade = vi.fn();
     const approveRestoredClonePairing = vi.fn();
@@ -193,6 +235,31 @@ describe("establishRestoredSandboxGatewayPairing", () => {
       }),
     ).rejects.toThrow(
       "authenticated gateway verification run failed (scope-upgrade-pending; approval=approve-failed)",
+    );
+    expect(restartRestoredSandboxGateway).toHaveBeenCalledTimes(2);
+    expect(warmupScopeUpgrade).toHaveBeenCalledOnce();
+    expect(approveRestoredClonePairing).toHaveBeenCalledOnce();
+    expect(verifyGatewayPairing).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry a different verification failure after an unreadable approval list (#7834)", async () => {
+    const restartRestoredSandboxGateway = vi.fn();
+    const warmupScopeUpgrade = vi.fn();
+    const approveRestoredClonePairing = vi.fn(() => "list-failed" as const);
+    const verifyGatewayPairing = vi.fn(() => ({
+      ok: false as const,
+      failureLayer: "device-pairing-required" as const,
+    }));
+
+    await expect(
+      establishRestoredSandboxGatewayPairing("beta", {
+        restartRestoredSandboxGateway,
+        warmupScopeUpgrade,
+        approveRestoredClonePairing,
+        verifyGatewayPairing,
+      }),
+    ).rejects.toThrow(
+      "authenticated gateway verification run failed (device-pairing-required; approval=list-failed)",
     );
     expect(restartRestoredSandboxGateway).toHaveBeenCalledTimes(2);
     expect(warmupScopeUpgrade).toHaveBeenCalledOnce();

--- a/src/lib/actions/sandbox/restore-gateway-pairing.ts
+++ b/src/lib/actions/sandbox/restore-gateway-pairing.ts
@@ -134,16 +134,26 @@ export async function establishRestoredSandboxGatewayPairing(
   targetSandbox: string,
   deps: RestoreGatewayPairingDeps = defaultRestoreGatewayPairingDeps(),
 ): Promise<void> {
-  // Deliberately do not retry this authorization sequence internally. A fixed
-  // failure lets the caller retry the restore command as a new bounded attempt.
   try {
     deps.restartRestoredSandboxGateway(targetSandbox);
     deps.warmupScopeUpgrade(targetSandbox);
-    const approvalReceipt = deps.approveRestoredClonePairing(targetSandbox) ?? "exec-failed";
-    // Publish the clone's approved pairing transition before the one ordinary
+    let approvalReceipt = deps.approveRestoredClonePairing(targetSandbox) ?? "exec-failed";
+    // Publish the clone's approved pairing transition before an ordinary
     // authenticated verifier. The verifier alone decides success.
     deps.restartRestoredSandboxGateway(targetSandbox);
-    const verification = deps.verifyGatewayPairing(targetSandbox);
+    let verification = deps.verifyGatewayPairing(targetSandbox);
+    if (
+      approvalReceipt === "list-failed" &&
+      !verification.ok &&
+      verification.failureLayer === "scope-upgrade-pending"
+    ) {
+      // The verifier can be the first call that publishes the restored clone's
+      // scope-upgrade request. Repeat only the strict local approval and
+      // ordinary verification for that observed sequence.
+      approvalReceipt = deps.approveRestoredClonePairing(targetSandbox) ?? "exec-failed";
+      deps.restartRestoredSandboxGateway(targetSandbox);
+      verification = deps.verifyGatewayPairing(targetSandbox);
+    }
     if (!verification.ok) {
       throw new RestoreGatewayPairingClassifiedError(
         `the authenticated gateway verification run failed (${verification.failureLayer}; approval=${approvalReceipt})`,

--- a/src/lib/actions/sandbox/restore-gateway-pairing.ts
+++ b/src/lib/actions/sandbox/restore-gateway-pairing.ts
@@ -123,7 +123,7 @@ function defaultRestoreGatewayPairingDeps(): RestoreGatewayPairingDeps {
   const warmup: typeof import("./auto-pair-warmup") = require("./auto-pair-warmup");
   return {
     restartRestoredSandboxGateway,
-    warmupScopeUpgrade: warmup.runSandboxScopeWarmupRun,
+    warmupScopeUpgrade: warmup.runRestoredSandboxScopeWarmupRun,
     approveRestoredClonePairing,
     verifyGatewayPairing: (sandboxName) =>
       verifyRestoredSandboxGatewayPairing(sandboxName, WARMUP_SESSION_ID_PREFIX),
@@ -134,26 +134,16 @@ export async function establishRestoredSandboxGatewayPairing(
   targetSandbox: string,
   deps: RestoreGatewayPairingDeps = defaultRestoreGatewayPairingDeps(),
 ): Promise<void> {
+  // Deliberately do not retry this authorization sequence internally. A fixed
+  // failure lets the caller retry the restore command as a new bounded attempt.
   try {
     deps.restartRestoredSandboxGateway(targetSandbox);
     deps.warmupScopeUpgrade(targetSandbox);
-    let approvalReceipt = deps.approveRestoredClonePairing(targetSandbox) ?? "exec-failed";
+    const approvalReceipt = deps.approveRestoredClonePairing(targetSandbox) ?? "exec-failed";
     // Publish the clone's approved pairing transition before an ordinary
     // authenticated verifier. The verifier alone decides success.
     deps.restartRestoredSandboxGateway(targetSandbox);
-    let verification = deps.verifyGatewayPairing(targetSandbox);
-    if (
-      approvalReceipt === "list-failed" &&
-      !verification.ok &&
-      verification.failureLayer === "scope-upgrade-pending"
-    ) {
-      // The verifier can be the first call that publishes the restored clone's
-      // scope-upgrade request. Repeat only the strict local approval and
-      // ordinary verification for that observed sequence.
-      approvalReceipt = deps.approveRestoredClonePairing(targetSandbox) ?? "exec-failed";
-      deps.restartRestoredSandboxGateway(targetSandbox);
-      verification = deps.verifyGatewayPairing(targetSandbox);
-    }
+    const verification = deps.verifyGatewayPairing(targetSandbox);
     if (!verification.ok) {
       throw new RestoreGatewayPairingClassifiedError(
         `the authenticated gateway verification run failed (${verification.failureLayer}; approval=${approvalReceipt})`,

--- a/test/e2e/live/issue-4462-scope-upgrade-approval.test.ts
+++ b/test/e2e/live/issue-4462-scope-upgrade-approval.test.ts
@@ -1224,6 +1224,7 @@ test("keeps issue 4462 scope-upgrade approval on the gateway path without an adm
     sandboxName: SANDBOX_NAME,
     contracts: [
       "install.sh creates a real OpenClaw sandbox",
+      "fresh onboarding pairs one CLI identity and leaves no request pending for that device",
       "the exact first three host-side nemoclaw sandbox exec openclaw agent turns from issue 4504 stay on the gateway path",
       "the issue 5324 nemoclaw <name> exec transport reaches the local OpenClaw CLI pairing path",
       "the prepared connect shell keeps the injected gateway URL private while retaining port and token",

--- a/test/helpers/openclaw-device-self-approval-patch-harness.ts
+++ b/test/helpers/openclaw-device-self-approval-patch-harness.ts
@@ -76,7 +76,7 @@ function setForceDevicePairing(value) {
 }
 function setForcedDeviceIdentity(identity, expectedDeviceId) {
   forcedDeviceIdentity = identity;
-  process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING = "1";
+  process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING = "1";
   if (expectedDeviceId === undefined) delete process.env.NEMOCLAW_OPENCLAW_EXPECTED_DEVICE_ID;
   else process.env.NEMOCLAW_OPENCLAW_EXPECTED_DEVICE_ID = expectedDeviceId;
 }
@@ -136,7 +136,7 @@ function setPairingLists(localList, liveList = localList) {
   pairingList = liveList;
 }
 function setPairedTokenEnvironment(overrides = {}) {
-  process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING = "1";
+  process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING = "1";
   descriptorFiles.clear();
   descriptorReads.length = 0;
   const pendingFd = Object.hasOwn(overrides, "pendingFd") ? overrides.pendingFd : "41";
@@ -178,7 +178,7 @@ async function callGateway(options) {
   gatewayCalls.push({
     ...options,
     credentialSource: options.token ? "option" : process.env.OPENCLAW_GATEWAY_TOKEN ? "environment" : "none",
-    signedIdentityForced: process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1",
+    signedIdentityForced: process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1" || process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1",
     cliArgUrl: options.cliArgUrl,
     cliArgToken: options.cliArgToken,
     cliArgPassword: options.cliArgPassword
@@ -393,7 +393,7 @@ function loadOrCreateDeviceIdentity(filePath = resolveDefaultIdentityPath()) {
   }
 }
 function setForcedIdentityDescriptor(fd, value) {
-  process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING = "1";
+  process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING = "1";
   if (fd === undefined) delete process.env.NEMOCLAW_OPENCLAW_IDENTITY_FD;
   else process.env.NEMOCLAW_OPENCLAW_IDENTITY_FD = fd;
   descriptorFiles.clear();
@@ -403,7 +403,7 @@ function setForcedIdentityDescriptor(fd, value) {
   }
 }
 function clearForcedIdentityDescriptor() {
-  delete process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING;
+  delete process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING;
   delete process.env.NEMOCLAW_OPENCLAW_IDENTITY_FD;
 }
 function identityStats() {

--- a/test/helpers/openclaw-real-device-self-approval-proof.ts
+++ b/test/helpers/openclaw-real-device-self-approval-proof.ts
@@ -1034,6 +1034,8 @@ fs.statSync = function nemoclawProofStatSync(candidate, ...args) {
       '[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ] || exit 97',
       '[ -z "${OPENCLAW_GATEWAY_PASSWORD:-}" ] || exit 97',
       '[ -z "${OPENCLAW_GATEWAY_PORT:-}" ] || exit 97',
+      '[ -z "${NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING:-}" ] || exit 97',
+      '[ "$NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING" = "1" ] || exit 97',
       '[ "$OPENCLAW_GATEWAY_URL" = "ws://127.0.0.1:$NEMOCLAW_PROOF_GATEWAY_PORT" ] || exit 97',
       'case "${OPENCLAW_STATE_DIR:-}" in /proc/self/fd/*) state_descriptor=${OPENCLAW_STATE_DIR##*/} ;; *) exit 97 ;; esac',
       'case "$state_descriptor" in ""|*[!0-9]*) exit 97 ;; esac',

--- a/test/openclaw-device-self-approval-patch-upgrade.test.ts
+++ b/test/openclaw-device-self-approval-patch-upgrade.test.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { runPatch, writeFixtureDist } from "./helpers/openclaw-device-self-approval-patch-harness";
+
+describe("OpenClaw device self-approval patch upgrades (#4462)", () => {
+  it("migrates the restored-clone mode from the force flag", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-device-clone-mode-upgrade-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist);
+    writeFixtureDist(dist);
+    try {
+      expect(runPatch(dist).status).toBe(0);
+      const legacyReplacements = new Map([
+        [
+          "call-fixture.js",
+          [
+            [
+              '\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1" || process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1") return false;',
+              '\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") return false;',
+            ],
+            [
+              '\tif (process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1") {',
+              '\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") {',
+            ],
+          ],
+        ],
+        [
+          "device-identity-fixture.js",
+          [
+            [
+              '\tif (process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1") return loadNemoClawForcedDeviceIdentity();',
+              '\tif (process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1") return loadNemoClawForcedDeviceIdentity();',
+            ],
+          ],
+        ],
+        [
+          "devices-cli.runtime-fixture.js",
+          [
+            [
+              '\tconst nemoclawPairedTokenRequested = process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1";',
+              '\tconst nemoclawPairedTokenRequested = process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1";',
+            ],
+          ],
+        ],
+      ]);
+      for (const [name, replacements] of legacyReplacements) {
+        const file = path.join(dist, name);
+        let source = fs.readFileSync(file, "utf8");
+        for (const [current, legacy] of replacements) {
+          expect(source).toContain(current);
+          source = source.replace(current, legacy);
+        }
+        fs.writeFileSync(file, source);
+      }
+
+      expect(runPatch(dist).status).toBe(0);
+
+      const callSource = fs.readFileSync(path.join(dist, "call-fixture.js"), "utf8");
+      expect(callSource).toContain(
+        'process.env.NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING === "1" || process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1"',
+      );
+      expect(callSource).toContain(
+        'if (process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1") {',
+      );
+      expect(fs.readFileSync(path.join(dist, "device-identity-fixture.js"), "utf8")).toContain(
+        'if (process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1") return loadNemoClawForcedDeviceIdentity();',
+      );
+      expect(fs.readFileSync(path.join(dist, "devices-cli.runtime-fixture.js"), "utf8")).toContain(
+        'const nemoclawPairedTokenRequested = process.env.NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING === "1";',
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/openclaw-device-self-approval-patch.test.ts
+++ b/test/openclaw-device-self-approval-patch.test.ts
@@ -334,6 +334,32 @@ describe("OpenClaw bounded device self-approval patch (#4462)", () => {
     }
   });
 
+  it("keeps ordinary forced pairing on the default identity path", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-device-ordinary-identity-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist);
+    writeFixtureDist(dist);
+    try {
+      expect(runPatch(dist).status).toBe(0);
+      const source = fs.readFileSync(path.join(dist, "call-fixture.js"), "utf8");
+      const runtime = runFixture<{
+        setForceDevicePairing(value: boolean): void;
+        resolveDeviceIdentityForGatewayCall(): { deviceId: string };
+        getDeviceIdentityLoadCount(): number;
+      }>(
+        source,
+        "({ setForceDevicePairing, resolveDeviceIdentityForGatewayCall, getDeviceIdentityLoadCount })",
+      );
+
+      runtime.setForceDevicePairing(true);
+
+      expect(runtime.resolveDeviceIdentityForGatewayCall()).toEqual({ deviceId: "device-1" });
+      expect(runtime.getDeviceIdentityLoadCount()).toBe(1);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("reads the forced identity descriptor from position zero without creating or migrating", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-device-identity-fd-"));
     const dist = path.join(tmp, "dist");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The restored-clone pairing path from #7834 made ordinary force pairing require clone descriptors, so fresh onboarding could finish without pairing its CLI device. The restored-clone warm-up could also return before OpenClaw published its pending scope request. This PR separates the two identity modes and publishes one write-scoped request before #7834's one-shot approval. The restored-clone provoke command removes runtime shared auth so OpenClaw uses the clone's stored device credential to publish that request.

## Related Issue

Regression follow-up to #7834.

## Changes

- Add the internal `NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING` mode for the restored-clone approval child. Ordinary force pairing continues to use the default device identity.
- Migrate OpenClaw runtimes that contain the #7834 force-pairing patches. Exact-literal migration tests protect the supported legacy patch shapes.
- Tolerate atomic replacement of OpenClaw pairing-state files while retaining descriptor-backed validation.
- Add fresh-onboarding regressions and map the pairing invariant to `issue-4462-scope-upgrade-approval` for deterministic E2E selection.
- Publish the restored clone's `operator.write` pairing request with `gateway call sessions.create` before approval. Remove shared gateway credentials only from that provoke child so OpenClaw uses the clone's stored device credential. The coordinator then uses #7834's one strict approval and authenticated verification; it does not add an approval retry or broader scope.

## Requested Live E2E

- Target: `snapshot-commands`
- Reason: This target exercises cross-sandbox restore and previously returned `restored-pairing-unverified` after the strict approval could not list a pending request.
- Acceptance: The targeted clone restore returns `restored`, verifies gateway pairing, and completes the no-leak lifecycle.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This repairs the implementation of the documented restore and onboarding contracts. It does not change a public command, configuration, default, output, procedure, or supported surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex CLI reviewed all nine security categories at head `4979e10b1` and reported PASS with no findings. Ordinary pairing cannot enter the descriptor-backed clone path. Restored-clone pairing still requires the expected device identity, pinned loopback URL, descriptor-backed state, exact pairing transition, and scoped token. The warm-up removes shared credentials from the provoke child, can publish a request, but cannot approve it. The strict approval and authenticated verifier remain the authorization and success conditions.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independently reviewed the completed diff at head `4979e10b1c4de760f1c39bad69a260f77aa181a0` against `AGENTS.md` blob `c052d60aa2b486bac1235643a56c2d2b1e5c13d5`. No findings. Removing shared gateway credentials from this internal provoke child does not change the CLI, configuration, defaults, output, recovery procedure, or supported behavior. Existing restore documentation remains accurate. The reviewer examined 35 focused restore/approval tests, 10 changed tests, CLI typecheck, Biome, and normal hooks.
- Agent: Codex CLI documentation-writer subagent
<!-- docs-review-head-sha: 4979e10b1c4de760f1c39bad69a260f77aa181a0 -->
<!-- docs-review-agents-blob-sha: c052d60aa2b486bac1235643a56c2d2b1e5c13d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli` for the six restored-pairing warm-up/approval suites passed 35 tests; `npm run test:changed` passed 10 tests; the focused OpenClaw patch integration run on the preceding PR head passed 71 tests with one opt-in real-distribution test skipped; `npm run typecheck:cli`, Biome, and normal pre-commit/commit-msg/pre-push hooks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: An earlier `npm test` run reached the 20-minute local bound after failures in untouched host/runtime-dependent gateway, Docker, Hermes image, package-link, and E2E workflow tests. No maintainer waiver is claimed. The changed suites and normal hooks pass, and CI remains authoritative.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated restored-clone pairing support for device identity loading, paired-token selection, and upgrade flows.
  * Preserved compatibility with existing forced-pairing behavior.

* **Bug Fixes**
  * Improved handling of restored pairing state during failures, retries, and patch upgrades.
  * Increased resilience when device metadata files are replaced during approval.
  * Added recovery for pending scope-upgrade pairing approvals.
  * Ensured fresh onboarding pairs exactly one CLI identity without pending requests.

* **Tests**
  * Added regression coverage for restored-clone pairing, identity resolution, token selection, upgrades, retries, and concurrent file replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
