### PR TITLE
test(readiness): provide Station fixture source revision

### DIFF
--- a/test/host-readiness-station-release-marker.test.ts
+++ b/test/host-readiness-station-release-marker.test.ts
@@ -11,6 +11,7 @@ import { assessHost } from "../src/lib/onboard/preflight";
 import { createHostReadinessReport } from "../src/lib/readiness/host";
 
 const NOW = new Date("2026-07-30T12:00:00Z");
+const SOURCE_REVISION = "a".repeat(40);
 const DOCKER_INFO = JSON.stringify({
   CgroupVersion: "2",
   Driver: "overlay2",
@@ -71,7 +72,7 @@ function createStationFixture(marker: "regular-file" | "symbolic-link"): string 
 
 function reportForStationHost(root: string) {
   return createHostReadinessReport(
-    { nemoclawVersion: "0.0.0-test", now: () => NOW },
+    { nemoclawVersion: "0.0.0-test", sourceRevision: SOURCE_REVISION, now: () => NOW },
     {
       architecture: "arm64",
       assess: () =>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The DGX Station readiness fixture now supplies the immutable source revision required by the readiness producer-identity contract. This restores CLI type-checking on `main` after #7821 made `sourceRevision` required.

## Related Issue

Follow-up to #7821

## Changes

- Add one stable 40-character source revision to the Station readiness fixture.
- Pass that revision to `createHostReadinessReport`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change updates one test fixture to satisfy the existing readiness producer-identity contract. It does not change supported behavior, the public schema, or user procedures.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `test/host-readiness-station-release-marker.test.ts` now supplies the required stable 40-hex source revision to the existing readiness fixture. This restores test compatibility with the existing producer-identity contract and does not change user-visible behavior, supported behavior, test titles, or comments. Focused integration tests passed 2/2, CLI typecheck passed, and `npm run validate:pr` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: db91d49ad -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/host-readiness-station-release-marker.test.ts` passed 2/2 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated host readiness reporting tests to include a source revision value when generating reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->