### PR TITLE
test(e2e): synchronize fixture request proofs

### DIFF
--- a/test/e2e/live/device-auth-health.test.ts
+++ b/test/e2e/live/device-auth-health.test.ts
@@ -130,17 +130,24 @@ test("device auth health probes treat 401 as live instead of offline (#2342)", {
     },
   );
   const authenticatedRequests = inference.requests().slice(authenticatedRequestOffset);
-  await artifacts.writeJson("phase-1-explicit-authenticated-inference-requests.json", {
-    phase: "onboard device-auth OpenClaw sandbox",
-    requests: authenticatedRequests,
+  const authenticatedArtifact = "phase-1-explicit-authenticated-inference-requests.json";
+  const authenticatedPhase = "onboard device-auth OpenClaw sandbox";
+  const authenticatedRequestEvidence = authenticatedRequests
+    .slice(0, 20)
+    .map(({ auth, method, model, path }) => ({ auth, method, model, path }));
+  await artifacts.writeJson(authenticatedArtifact, {
+    phase: authenticatedPhase,
+    requestCount: authenticatedRequests.length,
+    requests: authenticatedRequestEvidence,
+    truncated: authenticatedRequests.length > authenticatedRequestEvidence.length,
   });
   expect(
     authenticatedProbe.exitCode,
-    `explicit authenticated inference failed during the onboard verification phase; observed requests=${JSON.stringify(authenticatedRequests)}; ${resultText(authenticatedProbe)}`,
+    `${authenticatedPhase}: explicit authenticated inference failed; see ${authenticatedArtifact}`,
   ).toBe(0);
   expect(
     authenticatedRequests,
-    `the explicit onboard verification probe did not reach the authenticated fixture; observed requests=${JSON.stringify(authenticatedRequests)}`,
+    `${authenticatedPhase}: explicit verification probe did not reach the authenticated fixture; see ${authenticatedArtifact}`,
   ).toContainEqual(
     expect.objectContaining({
       auth: "ok",

--- a/test/e2e/live/device-auth-health.test.ts
+++ b/test/e2e/live/device-auth-health.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { resultText } from "../fixtures/clients/index.ts";
+import { resultText, shellQuote } from "../fixtures/clients/index.ts";
 import { trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
@@ -74,7 +74,7 @@ test("device auth health probes treat 401 as live instead of offline (#2342)", {
     dashboardPort: DASHBOARD_PORT,
     contracts: [
       "onboard succeeds with device auth enabled",
-      "onboard authenticates to the fixture inference endpoint",
+      "the onboarded inference route authenticates to the fixture endpoint",
       "/health is reachable from inside the sandbox",
       "the authenticated dashboard root may return 401 without being treated as offline",
       "nemoclaw status reports the gateway as live, not Health Offline",
@@ -107,9 +107,44 @@ test("device auth health probes treat 401 as live instead of offline (#2342)", {
   progress.phase("onboard device-auth OpenClaw sandbox");
   const install = await installDeviceAuthSandbox(host, inferenceConfig, installLog);
   expect(install.exitCode, resultText(install)).toBe(0);
-  expect(inference.requests()).toContainEqual(
+
+  // Ignore incidental onboarding traffic. The fixture appends its ledger row
+  // before responding, so this awaited POST is the publication barrier for the
+  // requests sliced from this offset.
+  const authenticatedRequestOffset = inference.requests().length;
+  const authenticatedProbe = await sandbox.execShell(
+    SANDBOX_NAME,
+    trustedSandboxShellScript(
+      `curl -fsS --max-time 60 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' --data ${shellQuote(
+        JSON.stringify({
+          model: INFERENCE_MODEL,
+          messages: [{ role: "user", content: "reply with OK" }],
+          max_tokens: 8,
+        }),
+      )} >/dev/null`,
+    ),
+    {
+      artifactName: "phase-1-explicit-authenticated-inference-post",
+      env: commandEnv(),
+      timeoutMs: 90_000,
+    },
+  );
+  const authenticatedRequests = inference.requests().slice(authenticatedRequestOffset);
+  await artifacts.writeJson("phase-1-explicit-authenticated-inference-requests.json", {
+    phase: "onboard device-auth OpenClaw sandbox",
+    requests: authenticatedRequests,
+  });
+  expect(
+    authenticatedProbe.exitCode,
+    `explicit authenticated inference failed during the onboard verification phase; observed requests=${JSON.stringify(authenticatedRequests)}; ${resultText(authenticatedProbe)}`,
+  ).toBe(0);
+  expect(
+    authenticatedRequests,
+    `the explicit onboard verification probe did not reach the authenticated fixture; observed requests=${JSON.stringify(authenticatedRequests)}`,
+  ).toContainEqual(
     expect.objectContaining({
       auth: "ok",
+      method: "POST",
       model: INFERENCE_MODEL,
       path: "/v1/chat/completions",
     }),

--- a/test/e2e/live/openclaw-inference-switch.test.ts
+++ b/test/e2e/live/openclaw-inference-switch.test.ts
@@ -136,17 +136,53 @@ interface MockAnthropicProvider {
   close(): Promise<void>;
 }
 
-function expectMockBaselineAuthentication(
+async function proveMockBaselineAuthentication(
   baseline: Pick<FakeOpenAiCompatibleServer, "requests"> | undefined,
-): void {
+  sandbox: SandboxClient,
+  home: string,
+  artifacts: { writeJson(path: string, value: unknown): Promise<string> },
+): Promise<void> {
+  if (!baseline) {
+    expect(baseline).toBeUndefined();
+    return;
+  }
+  // Ignore incidental onboarding traffic. The fixture appends its ledger row
+  // before responding, so this awaited POST is the publication barrier for the
+  // requests sliced from this offset.
+  const requestOffset = baseline.requests().length;
+  const payload = {
+    model: MOCK_BASELINE_MODEL,
+    messages: [{ role: "user", content: "reply with OK" }],
+    max_tokens: 8,
+  };
+  const probe = await sandboxShell(
+    sandbox,
+    home,
+    `curl -fsS --max-time 60 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' --data ${shellQuote(JSON.stringify(payload))} >/dev/null`,
+    {
+      artifactName: "baseline-explicit-authenticated-inference-post",
+      timeoutMs: 90_000,
+    },
+  );
+  const requests = baseline.requests().slice(requestOffset);
+  await artifacts.writeJson("baseline-explicit-authenticated-inference-requests.json", {
+    phase: "install and onboard baseline OpenClaw",
+    requests,
+  });
+  expect(
+    probe.exitCode,
+    `explicit baseline inference failed during the install verification phase; observed requests=${JSON.stringify(requests)}; ${resultText(probe)}`,
+  ).toBe(0);
   const expectedRequest = expect.objectContaining({
     auth: "ok",
+    method: "POST",
     model: MOCK_BASELINE_MODEL,
     path: "/v1/chat/completions",
   });
-  baseline
-    ? expect(baseline.requests()).toContainEqual(expectedRequest)
-    : expect(baseline).toBeUndefined();
+  expect(
+    requests,
+    `the explicit baseline verification probe did not reach the authenticated fixture; observed requests=${JSON.stringify(requests)}`,
+  ).toContainEqual(expectedRequest);
 }
 
 function stripAnsi(value: string): string {
@@ -895,6 +931,7 @@ test("openclaw-inference-switch: switches route and preserves live OpenClaw beha
     contracts: [
       "Docker is running and an authenticated compatible baseline endpoint is staged",
       "install.sh --non-interactive onboards an OpenClaw sandbox",
+      "when selected, the mock baseline route completes one explicit authenticated fixture request",
       "nemoclaw inference set switches the running sandbox route",
       "OpenClaw gateway is supervisor-restarted only when the inference API family changes",
       "OpenShell route points at the switched provider/model",
@@ -1008,7 +1045,7 @@ test("openclaw-inference-switch: switches route and preserves live OpenClaw beha
     skip("NVIDIA endpoint validation was unavailable/rate-limited during onboarding");
   }
   expect(install.exitCode, installText).toBe(0);
-  expectMockBaselineAuthentication(baselineProvider);
+  await proveMockBaselineAuthentication(baselineProvider, sandbox, home, artifacts);
 
   progress.phase("prepare the switched provider and endpoint");
   const publicProvider = publicApiKey

--- a/test/e2e/live/openclaw-inference-switch.test.ts
+++ b/test/e2e/live/openclaw-inference-switch.test.ts
@@ -172,14 +172,20 @@ async function proveSelectedMockBaselineAuthentication(
     },
   );
   const requests = baseline.requests().slice(requestOffset);
-  await artifacts.writeJson("baseline-explicit-authenticated-inference-requests.json", {
-    phase: "install and onboard baseline OpenClaw",
-    requests,
+  const artifactName = "baseline-explicit-authenticated-inference-requests.json";
+  const phase = "install and onboard baseline OpenClaw";
+  const requestEvidence = requests
+    .slice(0, 20)
+    .map(({ auth, method, model, path }) => ({ auth, method, model, path }));
+  await artifacts.writeJson(artifactName, {
+    phase,
+    requestCount: requests.length,
+    requests: requestEvidence,
+    truncated: requests.length > requestEvidence.length,
   });
-  expect(
-    probe.exitCode,
-    `explicit baseline inference failed during the install verification phase; observed requests=${JSON.stringify(requests)}; ${resultText(probe)}`,
-  ).toBe(0);
+  expect(probe.exitCode, `${phase}: explicit baseline inference failed; see ${artifactName}`).toBe(
+    0,
+  );
   const expectedRequest = expect.objectContaining({
     auth: "ok",
     method: "POST",
@@ -188,7 +194,7 @@ async function proveSelectedMockBaselineAuthentication(
   });
   expect(
     requests,
-    `the explicit baseline verification probe did not reach the authenticated fixture; observed requests=${JSON.stringify(requests)}`,
+    `${phase}: explicit verification probe did not reach the authenticated fixture; see ${artifactName}`,
   ).toContainEqual(expectedRequest);
 }
 

--- a/test/e2e/live/openclaw-inference-switch.test.ts
+++ b/test/e2e/live/openclaw-inference-switch.test.ts
@@ -136,16 +136,23 @@ interface MockAnthropicProvider {
   close(): Promise<void>;
 }
 
-async function proveMockBaselineAuthentication(
+function proveMockBaselineAuthentication(
   baseline: Pick<FakeOpenAiCompatibleServer, "requests"> | undefined,
   sandbox: SandboxClient,
   home: string,
   artifacts: { writeJson(path: string, value: unknown): Promise<string> },
 ): Promise<void> {
-  if (!baseline) {
-    expect(baseline).toBeUndefined();
-    return;
-  }
+  return baseline
+    ? proveSelectedMockBaselineAuthentication(baseline, sandbox, home, artifacts)
+    : Promise.resolve(expect(baseline).toBeUndefined());
+}
+
+async function proveSelectedMockBaselineAuthentication(
+  baseline: Pick<FakeOpenAiCompatibleServer, "requests">,
+  sandbox: SandboxClient,
+  home: string,
+  artifacts: { writeJson(path: string, value: unknown): Promise<string> },
+): Promise<void> {
   // Ignore incidental onboarding traffic. The fixture appends its ledger row
   // before responding, so this awaited POST is the publication barrier for the
   // requests sliced from this offset.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The device-auth and inference-switch live E2E targets now create and await the authenticated inference request that each test proves before reading the request ledger. Assertions inspect only rows produced after that phase begins, and the new evidence artifacts retain at most 20 redacted request projections. This removes dependence on incidental startup traffic and keeps failure diagnostics content-free.

## Related Issue
Fixes #8002

## Changes
- Capture a ledger offset immediately before each request-proof phase.
- Send and await an authenticated `/v1/chat/completions` request through `inference.local`.
- Assert only the new ledger slice and record its phase, count, truncation state, and bounded `auth`/`method`/`model`/`path` projection.
- Keep the inference-switch expectation scoped to mock-baseline selections.
- Product scope is approved for this test-only reliability fix. It changes no supported product surface, ownership, lifecycle, compatibility contract, or production security boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes live E2E fixture orchestration and evidence only. It does not change a user-facing API, CLI, configuration, workflow, default, error, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: A nine-category security review of exact head `dcceb35094b1a2b3334f469bf71e5d2e7ca05989` against base `57f73a509cd7e950e01af1423b2514ef352bec82` passed all categories. The tests use fixed fixture values, quote the JSON payload, keep provider credentials in the existing managed route, cap evidence at 20 projected rows, and publish through the canonical redacting artifact sink. No production authentication, authorization, network-policy, or sandbox boundary changes. CodeRabbit confirmed and resolved its diagnostic-data finding, and the exact-head PR Review Advisor reports no blocking findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The complete diff against upstream/main changes only live E2E fixture proof orchestration, bounded credential-free request-evidence artifacts, assertion diagnostics, comments, and test contract wording. It does not change a user-facing API, CLI, configuration, workflow, default, error, or supported product behavior. Changed explanatory text was reviewed against the NemoClaw writing and documentation rules.
- Agent: Codex Desktop
<!-- docs-review-head-sha: dcceb3509 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact head `dcceb35094b1a2b3334f469bf71e5d2e7ca05989`, base `57f73a509cd7e950e01af1423b2514ef352bec82`, diff SHA-256 `880192aa008776938c09665b83990d3bdfca958ea7a5be6b77171842a56b5128`: Biome passed; semantic E2E phase coverage passed for 114 tests across 71 files; focused helper tests passed 6/6; Vitest project membership passed for 1,956 files across seven projects; the touched inference-switch file remains at 41 conditionals; CLI build and type-check passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this two-file live E2E fixture synchronization. Exact-head required CI and trusted E2E provide the broad repository evidence.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
