### PR TITLE
ci(advisor): preserve E2E lane disagreements

### DIFF
--- a/test/pr-review-advisor-comment-cli.test.ts
+++ b/test/pr-review-advisor-comment-cli.test.ts
@@ -176,6 +176,10 @@ describe("PR review advisor comment CLI", () => {
       partial: false,
       confidence: "high",
       counts: { blockers: 1, warnings: 1, suggestions: 1 },
+      e2e: {
+        recommended: [{ id: "security-posture" }],
+        optional: [],
+      },
     });
     expect(completed.fingerprints?.findings).toMatch(/^[0-9a-f]{64}$/u);
     expect(completed.fingerprints?.e2e).toMatch(/^[0-9a-f]{64}$/u);
@@ -280,7 +284,7 @@ describe("PR review advisor comment CLI", () => {
     }
   });
 
-  it("renders sanitized model-lane status and structural disagreement only", () => {
+  it("renders sanitized model-lane status and visible E2E disagreements (#8016)", () => {
     const result = {
       version: 1,
       headSha: "a".repeat(40),
@@ -316,7 +320,24 @@ describe("PR review advisor comment CLI", () => {
       summary: { confidence: "low", oneLine: "do not publish this summary" },
       findings: [{ severity: "warning", title: "do not publish this finding" }],
       e2e: {
-        coverage: { requiredTests: [{ id: "security-posture" }], optionalTests: [] },
+        coverage: {
+          requiredTests: [
+            {
+              id: "full-e2e",
+              reason: "Cover the shipped startup chain. @team </details>",
+            },
+          ],
+          optionalTests: [
+            {
+              id: "full-e2e",
+              reason: "do not publish a duplicate selector",
+            },
+            {
+              id: "not-allowlisted",
+              reason: "do not publish an unknown selector",
+            },
+          ],
+        },
         targets: { required: [], optional: [] },
       },
     };
@@ -343,8 +364,22 @@ describe("PR review advisor comment CLI", () => {
     expect(comment).toContain("severity counts match");
     expect(comment).not.toContain("do not publish this summary");
     expect(comment).not.toContain("do not publish this finding");
+    expect(comment).toContain(
+      "<summary>1 additional E2E selection from the second opinion</summary>",
+    );
+    expect(comment).toContain(
+      "<code>full-e2e</code>: The completed second-opinion lane identified E2E coverage that the primary lane omitted.",
+    );
+    expect(comment).not.toContain("Cover the shipped startup chain");
+    expect(comment).not.toContain("do not publish a duplicate selector");
+    expect(comment).not.toContain("not-allowlisted");
+    expect(comment).not.toContain("do not publish an unknown selector");
+    expect(comment).toContain(
+      "Second-opinion E2E selections are advisory. They do not change the primary assessment or E2E / PR Gate.",
+    );
     expect(comment).toContain("<summary>1 optional E2E recommendation</summary>");
     expect(comment.match(/<code>vllm-docker-storage<\/code>/gu)).toHaveLength(1);
+    expect(comment.match(/<code>full-e2e<\/code>/gu)).toHaveLength(1);
 
     const partialComment = buildComment({
       summary: "# ignored\n",
@@ -365,5 +400,6 @@ describe("PR review advisor comment CLI", () => {
     expect(partialComment).not.toContain("do not publish this provider failure");
     expect(partialComment).not.toContain("do not publish this summary");
     expect(partialComment).not.toContain("do not publish this finding");
+    expect(partialComment).not.toContain("full-e2e");
   });
 });

--- a/test/pr-review-advisor-comment-cli.test.ts
+++ b/test/pr-review-advisor-comment-cli.test.ts
@@ -381,6 +381,53 @@ describe("PR review advisor comment CLI", () => {
     expect(comment.match(/<code>vllm-docker-storage<\/code>/gu)).toHaveLength(1);
     expect(comment.match(/<code>full-e2e<\/code>/gu)).toHaveLength(1);
 
+    const completedPartialComment = buildComment({
+      summary: "# ignored\n",
+      result,
+      lanes: {
+        primary,
+        secondOpinion: { ...secondOpinion, partial: true },
+      },
+    });
+    expect(completedPartialComment).not.toContain(
+      "additional E2E selection from the second opinion",
+    );
+    expect(completedPartialComment).not.toContain("<code>full-e2e</code>");
+
+    const malformedSecondOpinionResult = {
+      ...secondOpinionResult,
+      e2e: {
+        coverage: {
+          requiredTests: [null, "invalid", { id: "full-e2e", reason: "valid coverage" }],
+          optionalTests: [],
+        },
+        targets: {
+          required: [
+            null,
+            "invalid",
+            {
+              id: "security-posture",
+              workflow: "e2e.yaml",
+              selectorType: "job",
+              required: true,
+              reason: "valid target",
+            },
+          ],
+          optional: [],
+        },
+      },
+    };
+    expect(
+      normalizeAdvisorLaneReport(
+        malformedSecondOpinionResult,
+        malformedSecondOpinionResult,
+        result.headSha,
+      ).e2e,
+    ).toEqual({
+      recommended: [{ id: "security-posture" }, { id: "full-e2e" }],
+      optional: [],
+    });
+
     const partialComment = buildComment({
       summary: "# ignored\n",
       result,

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -27,7 +27,7 @@ describe("deterministic PR risk plan", () => {
     const second = plan("src/lib/onboard.ts", "src/lib/state/registry.ts");
 
     expect(first).toEqual(second);
-    expect(first.version).toBe(9);
+    expect(first.version).toBe(10);
     expect(first.headSha).toBe(HEAD_SHA);
     expect(first.planHash).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.changedFiles).toEqual(["src/lib/onboard.ts", "src/lib/state/registry.ts"]);
@@ -82,6 +82,39 @@ describe("deterministic PR risk plan", () => {
     expect(riskPlanRequiredJobIds(result)).toEqual(["token-rotation"]);
     expect(result.families.map((family) => family.id)).toEqual(["focused-e2e"]);
     expect(result.planHash).not.toBe(withoutFocusedSelection.planHash);
+  });
+
+  it("selects startup and auth E2E for managed startup delivery changes (#8016)", () => {
+    const changedFiles = [
+      "scripts/lib/entrypoint-env-wrapper.sh",
+      "src/lib/onboard/managed-startup/agent-environment.ts",
+      "src/lib/onboard/sandbox-create-launch.ts",
+    ];
+    const result = plan(...changedFiles);
+    const adjacentOnboardChange = plan("src/lib/onboard/provider-selection.ts");
+
+    expect(result.families).toContainEqual(
+      expect.objectContaining({
+        id: "focused-e2e",
+        matchedFiles: changedFiles,
+        requiredJobs: [
+          "device-auth-health",
+          "issue-4462-scope-upgrade-approval",
+          "openclaw-inference-switch",
+        ],
+      }),
+    );
+    expect(riskPlanRequiredJobIds(result)).toEqual(
+      expect.arrayContaining([
+        "device-auth-health",
+        "issue-4462-scope-upgrade-approval",
+        "openclaw-inference-switch",
+      ]),
+    );
+    expect(riskPlanRequiredJobIds(adjacentOnboardChange)).toEqual([
+      "onboard-repair",
+      "onboard-resume",
+    ]);
   });
 
   it("leaves E2E support-only changes in the fast e2e-support project (#7921)", () => {

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -3,7 +3,7 @@
 
 import { createHash } from "node:crypto";
 
-export const RISK_PLAN_VERSION = 9 as const;
+export const RISK_PLAN_VERSION = 10 as const;
 
 export const PR_E2E_TYPED_TARGET_IDS = [
   "ubuntu-repo-cloud-langchain-deepagents-code",
@@ -20,6 +20,11 @@ const POST_REBOOT_DELIVERY_RUNTIME_FILES = new Set([
   "src/lib/onboard/docker-startup-command-agent.ts",
   "src/lib/onboard/sandbox-create-step.ts",
 ]);
+const MANAGED_STARTUP_E2E_JOB_IDS = [
+  "device-auth-health",
+  "issue-4462-scope-upgrade-approval",
+  "openclaw-inference-switch",
+] as const;
 
 export type RiskTier = 0 | 1 | 2 | 3;
 export type RiskFamilyId =
@@ -155,6 +160,22 @@ export function focusedPrE2eTargetsForChangedFiles(
         ]
       : []),
   ];
+}
+
+export function focusedPrE2eJobsForChangedFiles(
+  changedFiles: readonly string[],
+): TrustedFocusedE2eJob[] {
+  const matchedFiles = stableUnique(
+    changedFiles.filter(
+      (file) =>
+        (file.startsWith("src/lib/onboard/managed-startup/") ||
+          file === "src/lib/onboard/sandbox-create-launch.ts" ||
+          file === "scripts/lib/entrypoint-env-wrapper.sh") &&
+        isRuntimeRelevant(file),
+    ),
+  );
+  if (matchedFiles.length === 0) return [];
+  return MANAGED_STARTUP_E2E_JOB_IDS.map((id) => ({ id, matchedFiles }));
 }
 
 export const RISK_RULES: readonly RiskRule[] = [
@@ -393,7 +414,10 @@ export function buildRiskPlan(options: {
 }): RiskPlan {
   const changedFiles = stableUnique(options.changedFiles);
   const runtimeFiles = changedFiles.filter(isRuntimeRelevant);
-  const focusedE2eJobs = normalizeFocusedE2eJobs(options.focusedE2eJobs ?? [], changedFiles);
+  const focusedE2eJobs = normalizeFocusedE2eJobs(
+    [...focusedPrE2eJobsForChangedFiles(changedFiles), ...(options.focusedE2eJobs ?? [])],
+    changedFiles,
+  );
   const focusedLiveFiles = new Set(focusedE2eJobs.flatMap((selection) => selection.matchedFiles));
   const staticFamilies: RiskPlanFamily[] = RISK_RULES.flatMap((rule) => {
     const matchedFiles = runtimeFiles.filter(

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -45,7 +45,15 @@ It intentionally does not report GitHub mergeability, branch protection, CI stat
 14. Retries transient provider failures such as HTTP 429 within the same session using one bounded exponential-backoff layer. GPT waits 6s, 12s, 24s, and 48s; Nemotron waits 9s, 18s, 36s, and 72s so parallel lanes do not retry in lockstep. The workflow still publishes the primary comment and lane artifacts after an incomplete analysis. An incomplete primary review fails its outcome step; the artifact-only evaluation lane does not affect the workflow result.
 15. Validates and repairs the draft synthesis in the final turn of the same session. If that turn fails or emits malformed output, the runner preserves a schema-valid canonical draft with a limitation; a post-validation ledger mismatch still fails closed.
 16. Writes artifacts under the model-specific artifact directory in the writable runtime subtree, downloads them to the trusted host, and uploads them from the read-only analysis job. Example directories are `artifacts/pr-review-advisor/` and `artifacts/pr-review-advisor-nemotron-ultra/`.
-17. Uses a separate publisher job with no model credential or untrusted worktree. It validates the primary artifact and live PR head/base, then posts or updates one combined sticky PR comment marked by `<!-- nemoclaw-pr-review-advisor -->`. The evaluation lane does not publish another review. Previous sticky-comment ingestion is disabled for both lanes.
+17. Uses a separate publisher job with no model credential or untrusted worktree.
+    It validates the primary artifact and live PR head/base.
+    It then posts or updates one combined sticky PR comment marked by `<!-- nemoclaw-pr-review-advisor -->`.
+    The primary lane remains authoritative for the assessment and recommended E2E guidance.
+    When the completed second-opinion lane includes a trusted E2E selector that the primary lane omits, the publisher shows an optional disagreement.
+    The disagreement includes the selector and a publisher-authored coverage-gap reason in the same comment.
+    A missing, malformed, or incomplete second-opinion result cannot suppress the primary result.
+    The evaluation lane does not publish another review.
+    Previous sticky-comment ingestion is disabled for both lanes.
 
 The ordered stage array in `buildPromptTurns` is the source of truth for stage order, evidence, and
 prompt text. Runtime numbering and prompt artifact names derive from that array, so adding or
@@ -99,6 +107,18 @@ Authors and coding agents should follow the shared [PR CI and Review Follow-Up](
   invariant and required job for missing evidence. The trusted E2E normalizer restores any listed
   job that the model omits or downgrades. The PR E2E controller separately dispatches every listed
   job without consuming the advisor's normalized result.
+
+Risk plan version 10 maps runtime changes from these paths to the `focused-e2e` family:
+
+- `src/lib/onboard/managed-startup/**`.
+- `src/lib/onboard/sandbox-create-launch.ts`.
+- `scripts/lib/entrypoint-env-wrapper.sh`.
+
+Each match selects these focused E2E jobs:
+
+- `device-auth-health`.
+- `issue-4462-scope-upgrade-approval`.
+- `openclaw-inference-switch`.
 
 ## Required secret
 
@@ -170,6 +190,9 @@ reports how many more IDs exist. The trusted normalizer
 restores deterministic requirements before model selections, retains only allowlisted coverage IDs
 and supported selector tuples, and replaces model-authored reasons with trusted
 reasons. It discards free-form E2E domains, new-test recommendations, and no-selection explanations.
+The publisher compares the completed lanes after this normalization. It lists trusted
+second-opinion-only selectors with a publisher-authored coverage-gap reason as optional
+disagreements without adding them to the primary lane's recommended E2E guidance.
 For a changed credential-free test, the normalizer also records structured head evidence only
 after the trusted module-tag parser accepts the source; model-provided evidence is overwritten. The
 trusted publisher independently repeats the ID and tuple checks, verifies that evidence against the

--- a/tools/pr-review-advisor/comment.mts
+++ b/tools/pr-review-advisor/comment.mts
@@ -492,6 +492,8 @@ function renderSecondOpinionE2eRecommendations(
   if (
     primary.status !== "completed" ||
     secondOpinion.status !== "completed" ||
+    primary.partial ||
+    secondOpinion.partial ||
     !primary.e2e ||
     !secondOpinion.e2e
   ) {
@@ -593,29 +595,22 @@ function renderE2eDetails(result?: ReviewAdvisorResult): string {
 }
 
 function trustedCoverageIds(
-  items: Array<{ id?: string; reason?: string }> | undefined,
+  items: unknown[] | undefined,
   inventory: TrustedE2eRecommendationInventory,
 ): string[] {
   const allowedIds = new Set([...inventory.allowedJobIds, ...inventory.liveSupportedTargetIds]);
   const seen = new Set<string>();
   return (items ?? []).flatMap((item) => {
+    if (!isRecord(item)) return [];
     const id = item.id;
-    if (!id || !allowedIds.has(id) || seen.has(id)) return [];
+    if (typeof id !== "string" || !allowedIds.has(id) || seen.has(id)) return [];
     seen.add(id);
     return [id];
   });
 }
 
 function trustedTargetIds(
-  items:
-    | Array<{
-        id?: string;
-        workflow?: string;
-        selectorType?: string;
-        required?: boolean;
-        reason?: string;
-      }>
-    | undefined,
+  items: unknown[] | undefined,
   required: boolean,
   inventory: TrustedE2eRecommendationInventory,
   changedCredentialFreeJobIds: ReadonlySet<string>,
@@ -624,9 +619,15 @@ function trustedTargetIds(
   const allowedTargets = new Set(inventory.liveSupportedTargetIds);
   const seen = new Set<string>();
   return (items ?? []).flatMap((item) => {
+    if (!isRecord(item)) return [];
     const id = item.id;
     const selectorType = item.selectorType;
-    if (!id || item.workflow !== inventory.workflow || item.required !== required) return [];
+    if (
+      typeof id !== "string" ||
+      item.workflow !== inventory.workflow ||
+      item.required !== required
+    )
+      return [];
     const trustedTuple =
       (selectorType === "all" && id === inventory.fanoutId) ||
       (selectorType === "job" && (allowedJobs.has(id) || changedCredentialFreeJobIds.has(id))) ||
@@ -751,16 +752,8 @@ function trustedLaneE2eRecommendations(result: ReviewAdvisorResult): LaneE2eReco
 }
 
 function trustedLaneE2eTier(
-  coverageItems: Array<{ id?: string; reason?: string }> | undefined,
-  targetItems:
-    | Array<{
-        id?: string;
-        workflow?: string;
-        selectorType?: string;
-        required?: boolean;
-        reason?: string;
-      }>
-    | undefined,
+  coverageItems: unknown[] | undefined,
+  targetItems: unknown[] | undefined,
   required: boolean,
   inventory: TrustedE2eRecommendationInventory,
   changedCredentialFreeJobIds: ReadonlySet<string>,

--- a/tools/pr-review-advisor/comment.mts
+++ b/tools/pr-review-advisor/comment.mts
@@ -120,12 +120,22 @@ type LaneFingerprints = {
   e2e: string;
 };
 
+type LaneE2eRecommendation = {
+  id: string;
+};
+
+type LaneE2eRecommendations = {
+  recommended: LaneE2eRecommendation[];
+  optional: LaneE2eRecommendation[];
+};
+
 export type AdvisorLaneReport = {
   status: "completed" | "failed" | "skipped" | "unavailable";
   partial: boolean;
   counts?: FindingCounts;
   confidence?: "low" | "medium" | "high";
   fingerprints?: LaneFingerprints;
+  e2e?: LaneE2eRecommendations;
 };
 
 export type AdvisorLaneReports = {
@@ -415,9 +425,10 @@ function renderAdvisorLanes(lanes?: AdvisorLaneReports): string {
   ];
   const comparison = renderLaneComparison(lanes.primary, lanes.secondOpinion);
   if (comparison) lines.push(`- **Model comparison:** ${comparison}`);
+  lines.push(...renderSecondOpinionE2eRecommendations(lanes.primary, lanes.secondOpinion));
   lines.push(
     "",
-    "_Nemotron output stays in workflow artifacts and does not change the assessment above._",
+    "_Second-opinion E2E selections are advisory. They do not change the primary assessment or E2E / PR Gate._",
     "",
   );
   return `${lines.join("\n")}\n`;
@@ -472,6 +483,52 @@ function renderLaneComparison(
     ? "severity counts match"
     : `Nemotron reported ${differences.join(", ")}`;
   return `${findingComparison}; ${e2eComparison}; ${countComparison}.`;
+}
+
+function renderSecondOpinionE2eRecommendations(
+  primary: AdvisorLaneReport,
+  secondOpinion: AdvisorLaneReport,
+): string[] {
+  if (
+    primary.status !== "completed" ||
+    secondOpinion.status !== "completed" ||
+    !primary.e2e ||
+    !secondOpinion.e2e
+  ) {
+    return [];
+  }
+
+  const primaryIds = new Set(
+    [...primary.e2e.recommended, ...primary.e2e.optional].map(({ id }) => id),
+  );
+  const additionalIds = new Set<string>();
+  const additional = [...secondOpinion.e2e.recommended, ...secondOpinion.e2e.optional].filter(
+    ({ id }) => {
+      if (primaryIds.has(id) || additionalIds.has(id)) return false;
+      additionalIds.add(id);
+      return true;
+    },
+  );
+  if (additional.length === 0) return [];
+
+  const lines = [
+    "",
+    "<details>",
+    `<summary>${compactCount(additional.length, "additional E2E selection")} from the second opinion</summary>`,
+    "",
+    "_Advisory only. The primary lane did not select these E2E jobs or targets._",
+    "",
+  ];
+  for (const recommendation of additional.slice(0, E2E_RENDER_LIMIT)) {
+    lines.push(
+      `- <code>${escapeLocationHtml(recommendation.id)}</code>: The completed second-opinion lane identified E2E coverage that the primary lane omitted.`,
+    );
+  }
+  if (additional.length > E2E_RENDER_LIMIT) {
+    lines.push(`- _${additional.length - E2E_RENDER_LIMIT} more._`);
+  }
+  lines.push("", "</details>");
+  return lines;
 }
 
 function countDifference(difference: number, label: string): string {
@@ -633,6 +690,7 @@ function trustedLaneStructure(
       counts: FindingCounts;
       confidence?: "low" | "medium" | "high";
       fingerprints: LaneFingerprints;
+      e2e: LaneE2eRecommendations;
     }
   | undefined {
   if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.findings)) return undefined;
@@ -646,9 +704,11 @@ function trustedLaneStructure(
   }
   const summary = isRecord(value.summary) ? value.summary : undefined;
   const confidence = trustedLaneConfidence(summary?.confidence);
+  const e2e = trustedLaneE2eRecommendations(value as ReviewAdvisorResult);
   return {
     counts,
     ...(confidence ? { confidence } : {}),
+    e2e,
     fingerprints: {
       findings: opaqueFingerprint(normalizedFindingRecords(value.findings)),
       e2e: opaqueFingerprint(e2eDecisionSets(value.e2e)),
@@ -665,6 +725,51 @@ function normalizedFindingRecords(value: unknown[]): unknown[] {
 
 function trustedLaneConfidence(value: unknown): "low" | "medium" | "high" | undefined {
   return value === "low" || value === "medium" || value === "high" ? value : undefined;
+}
+
+function trustedLaneE2eRecommendations(result: ReviewAdvisorResult): LaneE2eRecommendations {
+  const inventory = commentE2eInventory();
+  const changedCredentialFreeJobIds = trustedChangedCredentialFreeJobIds(result);
+  const coverage = result.e2e?.coverage;
+  const targets = result.e2e?.targets;
+  return {
+    recommended: trustedLaneE2eTier(
+      Array.isArray(coverage?.requiredTests) ? coverage.requiredTests : undefined,
+      Array.isArray(targets?.required) ? targets.required : undefined,
+      true,
+      inventory,
+      changedCredentialFreeJobIds,
+    ),
+    optional: trustedLaneE2eTier(
+      Array.isArray(coverage?.optionalTests) ? coverage.optionalTests : undefined,
+      Array.isArray(targets?.optional) ? targets.optional : undefined,
+      false,
+      inventory,
+      changedCredentialFreeJobIds,
+    ),
+  };
+}
+
+function trustedLaneE2eTier(
+  coverageItems: Array<{ id?: string; reason?: string }> | undefined,
+  targetItems:
+    | Array<{
+        id?: string;
+        workflow?: string;
+        selectorType?: string;
+        required?: boolean;
+        reason?: string;
+      }>
+    | undefined,
+  required: boolean,
+  inventory: TrustedE2eRecommendationInventory,
+  changedCredentialFreeJobIds: ReadonlySet<string>,
+): LaneE2eRecommendation[] {
+  const ids = uniqueE2eIds([
+    ...trustedTargetIds(targetItems, required, inventory, changedCredentialFreeJobIds),
+    ...trustedCoverageIds(coverageItems, inventory),
+  ]);
+  return ids.map((id) => ({ id }));
 }
 
 function e2eDecisionSets(value: unknown): Record<string, string[]> {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The PR Review Advisor now shows trusted E2E selections that only the completed second-opinion lane selected.
The primary assessment and E2E guidance remain authoritative, while managed-startup delivery changes receive the focused startup and authentication E2E floor identified after v0.0.99.

## Related Issue

Fixes #8016

## Changes

- Publish allowlisted second-opinion-only E2E identifiers with a publisher-authored coverage-gap reason.
- Keep incomplete lanes, unknown selectors, duplicate selectors, and artifact-authored reasons out of the published disagreement.
- Update risk plan version 10 to select `device-auth-health`, `issue-4462-scope-upgrade-approval`, and `openclaw-inference-switch` for managed-startup delivery paths.
- Add regression tests for the comment boundary and the focused risk-plan mapping.
- Document the publication and managed-startup selection contracts in `tools/pr-review-advisor/README.md`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible and hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `tools/pr-review-advisor/README.md`; focused integration tests passed 77/77; `npm run docs` passed with 0 errors and 2 Fern warnings; `git diff --check` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 3c9e570e7 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable; this change does not modify `scripts/prepare-dgx-station-host.sh`.
- Supporting evidence: Not applicable.

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/pr-review-advisor-comment-cli.test.ts test/pr-risk-plan.test.ts` passed 77 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; focused advisor and risk-plan tests cover the changed behavior.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR review guidance now includes trusted, focused E2E test recommendations.
  * Second-opinion E2E selections that differ from primary recommendations appear as advisory suggestions.
  * Runtime-related managed startup changes automatically select relevant focused E2E checks.
* **Bug Fixes**
  * Improved validation filters unknown, duplicate, malformed, or untrusted test selections.
  * Partial second-opinion results no longer produce misleading E2E output.
* **Documentation**
  * Updated publisher guidance covers artifact validation, live reference checks, and E2E recommendation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->