### PR TITLE
fix(advisor): validate E2E collections

### DIFF
--- a/test/pr-review-advisor-comment-cli.test.ts
+++ b/test/pr-review-advisor-comment-cli.test.ts
@@ -63,6 +63,48 @@ describe("PR review advisor comment CLI", () => {
     expect(comment).toContain("- _1 more._");
   });
 
+  it("ignores malformed E2E collections and selectors outside the trusted inventory", () => {
+    const malformedCollectionsComment = buildComment({
+      summary: "unused",
+      result: {
+        e2e: {
+          coverage: { requiredTests: {}, optionalTests: "full-e2e" },
+          targets: { required: "full-e2e", optional: {} },
+        },
+      } as never,
+    });
+    expect(malformedCollectionsComment).toContain("**Recommended E2E:** _None_");
+    expect(malformedCollectionsComment).not.toContain("<code>full-e2e</code>");
+
+    const selectorTypeComment = buildComment({
+      summary: "unused",
+      result: {
+        e2e: {
+          coverage: { requiredTests: [], optionalTests: [] },
+          targets: {
+            required: [
+              {
+                id: "security-posture",
+                workflow: "e2e.yaml",
+                selectorType: "job",
+                required: true,
+              },
+              {
+                id: "full-e2e",
+                workflow: "e2e.yaml",
+                selectorType: "workflow",
+                required: true,
+              },
+            ],
+            optional: [],
+          },
+        },
+      },
+    });
+    expect(selectorTypeComment).toContain("**Recommended E2E:** <code>security-posture</code>");
+    expect(selectorTypeComment).not.toContain("<code>full-e2e</code>");
+  });
+
   it("validates configurable comment CLI fields and explicit artifacts", () => {
     const tmp = fs.mkdtempSync(path.join(ROOT, ".tmp-pr-advisor-comment-"));
     const defaultSummary = path.join(

--- a/tools/pr-review-advisor/comment.mts
+++ b/tools/pr-review-advisor/comment.mts
@@ -595,12 +595,13 @@ function renderE2eDetails(result?: ReviewAdvisorResult): string {
 }
 
 function trustedCoverageIds(
-  items: unknown[] | undefined,
+  items: unknown,
   inventory: TrustedE2eRecommendationInventory,
 ): string[] {
   const allowedIds = new Set([...inventory.allowedJobIds, ...inventory.liveSupportedTargetIds]);
   const seen = new Set<string>();
-  return (items ?? []).flatMap((item) => {
+  const entries = Array.isArray(items) ? items : [];
+  return entries.flatMap((item) => {
     if (!isRecord(item)) return [];
     const id = item.id;
     if (typeof id !== "string" || !allowedIds.has(id) || seen.has(id)) return [];
@@ -610,20 +611,24 @@ function trustedCoverageIds(
 }
 
 function trustedTargetIds(
-  items: unknown[] | undefined,
+  items: unknown,
   required: boolean,
   inventory: TrustedE2eRecommendationInventory,
   changedCredentialFreeJobIds: ReadonlySet<string>,
 ): string[] {
   const allowedJobs = new Set(inventory.allowedJobIds);
   const allowedTargets = new Set(inventory.liveSupportedTargetIds);
+  const allowedSelectorTypes = new Set<string>(inventory.selectorTypes);
   const seen = new Set<string>();
-  return (items ?? []).flatMap((item) => {
+  const entries = Array.isArray(items) ? items : [];
+  return entries.flatMap((item) => {
     if (!isRecord(item)) return [];
     const id = item.id;
     const selectorType = item.selectorType;
     if (
       typeof id !== "string" ||
+      typeof selectorType !== "string" ||
+      !allowedSelectorTypes.has(selectorType) ||
       item.workflow !== inventory.workflow ||
       item.required !== required
     )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Harden the PR Review Advisor publisher against malformed E2E collections and selector types outside the canonical inventory.
This is the post-merge follow-up to the final CodeRabbit findings on #8017.

## Related Issue

Follow-up to #8017 and #8016.

## Changes

- Treat coverage and target collections as untrusted input and require arrays before iteration.
- Require target selector types to exist in the canonical E2E inventory before tuple validation.
- Add focused positive and negative tests for malformed collections and allowed or excluded selector types.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This validation hardening preserves the trusted selector allowlisting contract documented by #8017 and does not change valid output or UI text.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible and hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put git rev-parse --short HEAD and git rev-parse --short HEAD:AGENTS.md in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-not-needed`
- Evidence: Existing `tools/pr-review-advisor/README.md` documents publisher-side coverage-ID and selector-tuple allowlisting; focused integration tests passed 78/78; CLI type-check, Biome, and `git diff --check` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9a8fd4766 -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable; this change does not modify `scripts/prepare-dgx-station-host.sh`.
- Supporting evidence: Not applicable.

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/pr-review-advisor-comment-cli.test.ts test/pr-risk-plan.test.ts` passed 78 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; focused advisor tests cover the validation boundary.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. -->
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed coverage data to prevent invalid entries from appearing in review comments.
  * Restricted displayed job selectors to trusted, supported values and excluded workflow selectors.
  * Added validation for selector types and input collections before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->