### PR TITLE
test(e2e): keep calibration ancestry durable

### DIFF
--- a/test/onboard-performance-config-schema.test.ts
+++ b/test/onboard-performance-config-schema.test.ts
@@ -574,6 +574,7 @@ describe("full-E2E cold-path calibration", () => {
     expect(startupAdjustment.runs).toHaveLength(5);
     expect(new Set(startupAdjustment.runs.map((run) => run.runId)).size).toBe(5);
     expect(new Set(startupAdjustment.runs.map((run) => run.jobId)).size).toBe(5);
+    expect(new Set(startupAdjustment.runs.map((run) => run.testedSha)).size).toBe(5);
     expect(
       changedInputs(
         startupAdjustment.changeSha,
@@ -587,7 +588,9 @@ describe("full-E2E cold-path calibration", () => {
       expect(run.workflowHeadSha).toMatch(/^[0-9a-f]{40}$/u);
       expect(run.testedSha).toMatch(/^[0-9a-f]{40}$/u);
       expect(gitIsAncestor(startupAdjustment.changeSha, run.workflowHeadSha)).toBe(true);
-      expect(gitIsAncestor(startupAdjustment.changeSha, run.testedSha)).toBe(true);
+      // A tested revision can be a PR merge or head commit that GitHub stops
+      // advertising after the PR closes. The run and job receipts bind that
+      // exact SHA; local ancestry uses the durable workflow head instead.
       expect(
         gitIsAncestor(run.workflowHeadSha, startupAdjustment.runtimeInputsVerifiedThroughSha),
       ).toBe(true);

--- a/test/onboard-performance-config-schema.test.ts
+++ b/test/onboard-performance-config-schema.test.ts
@@ -576,6 +576,15 @@ describe("full-E2E cold-path calibration", () => {
     expect(new Set(startupAdjustment.runs.map((run) => run.jobId)).size).toBe(5);
     expect(new Set(startupAdjustment.runs.map((run) => run.testedSha)).size).toBe(5);
     expect(
+      Object.fromEntries(startupAdjustment.runs.map((run) => [run.runId, run.testedSha])),
+    ).toEqual({
+      30614075121: "387cb08644fe030bb85146255f4b77e3c54697d2",
+      30615995748: "915b25c522d982fc7d40d01e583bc8f15bcf975f",
+      30619965759: "c3106eea0669aa645c0ff6f51adce0badf24477f",
+      30620296004: "f8fb820159c4843a19759efc9b0e28d4aa122440",
+      30620879680: "d1b24c97c348215574fd8c55435a2e8c5e0d86e1",
+    });
+    expect(
       changedInputs(
         startupAdjustment.changeSha,
         startupAdjustment.runtimeInputsVerifiedThroughSha,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Calibration validation now uses only durable workflow revisions for local Git ancestry. Exact tested revisions remain bound to their run and job receipts, but closing an evidence-source PR no longer breaks unrelated CI when its ref disappears.

## Related Issue

Fixes #8022.

## Changes

- Preserve exact `testedSha`, run ID, job ID, and run URL receipt validation and require five distinct tested revisions.
- Keep the restart-safe change ancestor, workflow-head ancestor, unchanged runtime-input boundary, and derived-budget checks.
- Stop resolving PR-only tested commits through the local checkout because GitHub can stop advertising those objects after a PR closes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only deterministic internal calibration validation and no user-facing command, configuration, workflow, default, or error contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head nine-category security and provenance review passed with no findings: https://github.com/NVIDIA/NemoClaw/pull/8023#issuecomment-5146203614
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The changed test comment distinguishes immutable run receipt identity from the durable workflow revision used for local ancestry; no supported product or documentation surface changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a984a48ac -->
<!-- docs-review-agents-blob-sha: c052d60aa -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — fresh worktree reproduced the missing-PR-ref failure before the change; `npx vitest run test/onboard-performance-config-schema.test.ts` passes 14/14 afterward. Repository, project-membership, source-shape, test-size, Biome, and diff checks pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Required PR CI is pending.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded startup calibration coverage to verify five distinct tested revisions and their exact run mappings.
  * Improved ancestry validation by checking the workflow’s head revision while preserving verification of the revision actually tested.
  * Added coverage for cases where the tested revision is no longer advertised by the source control provider, improving confidence in calibration results and recorded verification details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

