### PR TITLE
fix(e2e): expect coupled MCP credential evidence

### DIFF
--- a/test/pr-e2e-gate-signal-shards.test.ts
+++ b/test/pr-e2e-gate-signal-shards.test.ts
@@ -8,7 +8,7 @@ import {
   PR_E2E_TYPED_TARGET_IDS,
   riskPlanRequiredJobIds,
 } from "../tools/advisors/risk-plan.mts";
-import { expectedSignalShards } from "../tools/e2e/pr-e2e-gate.mts";
+import { expandPrGateJobSelections, expectedSignalShards } from "../tools/e2e/pr-e2e-gate.mts";
 
 const HEAD_SHA = "a".repeat(40);
 const DCODE_TARGET = PR_E2E_TYPED_TARGET_IDS[0];
@@ -50,5 +50,16 @@ describe("PR E2E signal shard policy", () => {
     expect(Object.keys(broadShards)).toHaveLength(13);
     expect(Object.values(broadShards).flat()).toHaveLength(15);
     expect(() => expectedSignalShards(["not-a-workflow-job"])).toThrow(/does not define/u);
+  });
+
+  it("expects the credential window evidence coupled to an MCP bridge selection", () => {
+    expect(expandPrGateJobSelections(["mcp-bridge"])).toEqual([
+      "mcp-bridge",
+      "openshell-credential-generation-window",
+    ]);
+    expect(expectedSignalShards(["mcp-bridge"])).toEqual({
+      "mcp-bridge": ["openclaw", "hermes", "deepagents"],
+      "openshell-credential-generation-window": ["default"],
+    });
   });
 });

--- a/test/pr-e2e-gate-signal-shards.test.ts
+++ b/test/pr-e2e-gate-signal-shards.test.ts
@@ -57,7 +57,14 @@ describe("PR E2E signal shard policy", () => {
       "mcp-bridge",
       "openshell-credential-generation-window",
     ]);
+    expect(
+      expandPrGateJobSelections(["mcp-bridge", "openshell-credential-generation-window"]),
+    ).toEqual(["mcp-bridge", "openshell-credential-generation-window"]);
     expect(expectedSignalShards(["mcp-bridge"])).toEqual({
+      "mcp-bridge": ["openclaw", "hermes", "deepagents"],
+      "openshell-credential-generation-window": ["default"],
+    });
+    expect(expectedSignalShards(["mcp-bridge", "openshell-credential-generation-window"])).toEqual({
       "mcp-bridge": ["openclaw", "hermes", "deepagents"],
       "openshell-credential-generation-window": ["default"],
     });

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -1864,7 +1864,8 @@ export function expectedSignalShards(
   workflowPath = ".github/workflows/e2e.yaml",
   targetIds: readonly string[] = [],
 ): Record<string, string[]> {
-  const selections = [...jobIds, ...targetIds];
+  const expandedJobIds = expandPrGateJobSelections(jobIds);
+  const selections = [...expandedJobIds, ...targetIds];
   if (new Set(selections).size !== selections.length) {
     throw new Error("E2E evidence jobs and targets must be unique");
   }
@@ -1877,7 +1878,7 @@ export function expectedSignalShards(
   const jobs = isObjectRecord(workflow) && isObjectRecord(workflow.jobs) ? workflow.jobs : {};
   const inventory = readFreeStandingJobsInventory(workflowPath);
   const jobShards = Object.fromEntries(
-    jobIds.map((jobId) => {
+    expandedJobIds.map((jobId) => {
       const executionJobId = inventory.targetToJob.get(jobId) ?? jobId;
       if (!isObjectRecord(jobs[executionJobId])) {
         throw new Error(`E2E workflow does not define ${executionJobId} for ${jobId}`);
@@ -1941,6 +1942,14 @@ export function expectedSignalShards(
     ...jobShards,
     ...Object.fromEntries(targetIds.map((targetId) => [targetId, ["default"]])),
   };
+}
+
+export function expandPrGateJobSelections(jobIds: readonly string[]): string[] {
+  const jobs = [...jobIds];
+  if (jobs.includes("mcp-bridge") && !jobs.includes("openshell-credential-generation-window")) {
+    jobs.push("openshell-credential-generation-window");
+  }
+  return jobs;
 }
 
 function validateMainReference(value: unknown): string {
@@ -2550,7 +2559,7 @@ async function dispatchSelectedPrGate(options: {
   expectedCheckTitle: string;
   paths: ControllerPaths;
 }): Promise<void> {
-  const jobs = riskPlanRequiredJobIds(options.plan);
+  const jobs = expandPrGateJobSelections(riskPlanRequiredJobIds(options.plan));
   const targets = riskPlanRequiredTargetIds(options.plan);
   const expectedShards = expectedSignalShards(jobs, E2E_WORKFLOW_PATH, targets);
   const correlationId = randomUUID();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make the trusted PR E2E coordinator account for the credential-window job that the workflow couples to every MCP bridge selection. This prevents successful evidence from being rejected as an unexpected job.

## Related Issue

Prerequisite for #8024.

## Changes

- Expand MCP bridge selections with the coupled credential-window job before dispatch.
- Expect the coupled job's signed evidence during coordinator validation.
- Add a regression test for the exact selection and shard contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the internal trusted PR E2E coordinator and does not change supported product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The change preserves fail-closed SHA, plan, correlation, job, and shard validation and only adds the workflow-defined coupled job.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `tools/e2e/pr-e2e-gate.mts`, `test/pr-e2e-gate-signal-shards.test.ts`
- Agent: Codex Desktop
<!-- docs-review-head-sha: a8e8406c8 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 40 PR-gate tests and 14 MCP workflow-boundary tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
