### PR TITLE
docs: add v0.0.100 release entry

### DIFF
--- a/docs/changelog/2026-07-31.mdx
+++ b/docs/changelog/2026-07-31.mdx
@@ -1,0 +1,47 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.100
+
+NemoClaw v0.0.100 strengthens restored OpenClaw pairing, transactional sandbox replacement, managed Deep Agents Code, and host readiness provenance.
+It also improves onboarding recovery, lifecycle cleanup, Hermes image builds, runtime diagnostics, documentation, and trusted end-to-end (E2E) evidence.
+
+- OpenClaw cross-sandbox restore now uses descriptor-pinned clone pairing, while fresh onboarding continues to use generated pairing identity.
+  A restored clone can perform one bounded scope-upgrade recovery and tolerate a brief pending-request publication interval.
+  Unsafe filesystem shapes, persistent malformed state, and mismatched identities still fail closed.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots).
+- Managed Model Context Protocol (MCP) startup for Deep Agents Code now works when OpenShell seccomp denies `memfd_create` and workspace-backed `/tmp` rejects `O_TMPFILE`.
+  The Deep Agents Code sandbox receives a 1 MiB private tmpfs with verified mount options, and the managed runtime keeps its anonymous descriptor and integrity checks.
+  For more information, refer to [Run LangChain Deep Agents Code](/user-guide/deepagents/manage-sandboxes/operate-sandboxes/run-deep-agents-code).
+- Managed Deep Agents Code requests now apply the recorded compatible-endpoint reasoning effort at runtime.
+  Recovered onboarding and sandbox recreation also preserve recorded reasoning mode and effort instead of accepting unrelated ambient values.
+  For more information, refer to [Quickstart with Deep Agents](/user-guide/deepagents/get-started/quickstart) and [Configure Model Capabilities](/user-guide/openclaw/inference/manage-inference/configure-model-capabilities).
+- `rebuild` and same-name onboarding replacement now record a transaction before the first destructive mutation.
+  Recovery binds the source, replacement, registry generation, and OpenShell gateway, then continues the recorded operation or fails closed when those identities drift.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Compatible-endpoint onboarding now limits the Responses API streaming-event probe to 12 seconds while preserving the Chat Completions API fallback.
+  Host interruptions during an active onboarding step produce the existing resumable recovery path instead of an invalid state transition.
+  DGX Station Express also preserves its owner-only resume receipt when automatic dual-Station discovery selects the single-Station fallback.
+  For more information, refer to [Choose a Compatible Inference API](/user-guide/openclaw/inference/custom-endpoints/choose-compatible-inference-api), [Quickstart](/user-guide/openclaw/get-started/quickstart), and [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).
+- `nemoclaw status` now reads terminal-runtime out-of-memory counters through a bounded host-side Docker probe, so a recorded kill produces degraded status and rebuild guidance.
+  Destroying the final sandbox now stops a packaged OpenShell gateway service and refuses cleanup when the service remains active.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- `shields down` now succeeds without changing state when an OpenClaw configuration already has the exact mutable posture.
+  Cloudflare Tunnel cleanup verifies that the recorded process still belongs to `cloudflared` before each signal and removes a stale PID file without signaling an unrelated process.
+  For more information, refer to [Understand Runtime Changes](/user-guide/openclaw/manage-sandboxes/configure-sandboxes/understand-runtime-changes) and [Run Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/run-sandboxes).
+- Managed Hermes image probes now run through a checked-in Python runner, so OpenShell gateways that use Docker's legacy builder enforce the same image assertions as BuildKit.
+  For more information, refer to [Install Hermes Plugins](/user-guide/hermes/manage-sandboxes/install-hermes-plugins).
+- `nemoclaw host probe` schema `1.1.0` now identifies the exact compiled CLI version and immutable source revision for every readiness result.
+  Consumers can reject stale or mismatched readiness producers before they use host evidence.
+  For more information, refer to [System Readiness](/user-guide/openclaw/reference/system-readiness).
+- Provider-neutral runtime bundles now enforce provider, workload, ownership, and registry contracts for the existing Docker and Kubernetes paths.
+  Root-owned managed shared-state transactions enforce atomic application and rollback contracts but remain inactive in production onboarding.
+  Neither foundation activates a new runtime provider or adds a CLI, configuration, default, or support claim.
+- Documentation now includes a focused Deep Agents Code operation page, publishes the agentic-documentation guide in every guide variant, and uses host capability detection for optional NVIDIA DORI routing.
+  It also adds missing recovery, memory-search, and two-DGX Station verification guidance identified by post-tag documentation audits.
+  For more information, refer to [Run LangChain Deep Agents Code](/user-guide/deepagents/manage-sandboxes/operate-sandboxes/run-deep-agents-code) and [Engineer Documentation for AI Agents](/user-guide/openclaw/resources/engineer-agentic-documentation).
+- Trusted E2E now binds request proofs to explicit authenticated phases, keeps calibration ancestry durable after evidence-source PR refs disappear, and validates coupled MCP credential evidence.
+  Recovery repetition moved into deterministic integration tests, while the retained live test verifies one exact replacement process and connect-driven recovery.
+  The PR Review Advisor now preserves validated second-opinion lane disagreements and rejects malformed E2E collections.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the canonical dated changelog entry for `v0.0.100` so the maintainer release plan can verify the pre-tag documentation prerequisite. The entry summarizes the user-facing changes merged since `v0.0.99` and links to the relevant guides.

## Changes

- Add `docs/changelog/2026-07-31.mdx` with the exact `## v0.0.100` heading.
- Cover restored OpenClaw pairing, transactional replacement, Deep Agents Code, onboarding recovery, lifecycle cleanup, Hermes builds, host provenance, documentation, and trusted E2E evidence.
- Distinguish active Docker and Kubernetes runtime-bundle enforcement from the still-inactive managed shared-state transaction foundation.

## Source Coverage

The release entry maps the doc-impacting merged PRs in the `v0.0.99..main` release range to `docs/changelog/2026-07-31.mdx`: #8021, #8024, #7973, #8028, #7947, #7788, #7884, #8023, #7969, #8020, #7989, #8000, #7907, #7942, #7567, #8013, #7955, #8017, #8014, #8015, #7629, #7644, #7821, #7971, and #7991.

PR #7974 was reviewed after the final rebase and excluded because it changes internal maintainer-skill attribution policy and tests only; it does not change a user-facing product or documentation surface.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the changelog contract test validates the dated entry, version heading, SPDX form, and route constraints.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-07-31.mdx`; exact-head review passed for `6093f44f`; writing rules and documentation style reviewed; `npx vitest run test/changelog-docs.test.ts` passed 6/6; `npm run docs` passed with zero Fern errors and two generic Fern upgrade notices.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6093f44f -->
<!-- docs-review-agents-blob-sha: 3dd7c242 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host script changed.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6/6 at `6093f44f`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to a dated prose-only release entry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — validation passed with zero errors; Fern emitted two generic upgrade notices.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — the changelog entry has the required parser-safe MDX SPDX header; dated changelog entries intentionally do not use page frontmatter.

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.100.
  * Documented improvements to restore pairing, sandbox replacement, onboarding recovery, lifecycle cleanup, runtime handling, build support, host readiness, and end-to-end validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->