### PR TITLE
fix(onboard): fit streaming probe within phase budget

### DIFF
--- a/docs/changelog/2026-07-31.mdx
+++ b/docs/changelog/2026-07-31.mdx
@@ -21,7 +21,7 @@ It also improves onboarding recovery, lifecycle cleanup, Hermes image builds, ru
 - `rebuild` and same-name onboarding replacement now record a transaction before the first destructive mutation.
   Recovery binds the source, replacement, registry generation, and OpenShell gateway, then continues the recorded operation or fails closed when those identities drift.
   For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
-- Compatible-endpoint onboarding now limits the Responses API streaming-event probe to 12 seconds while preserving the Chat Completions API fallback.
+- Compatible-endpoint onboarding now limits the Responses API streaming-event probe to 5 seconds while preserving the Chat Completions API fallback.
   Host interruptions during an active onboarding step produce the existing resumable recovery path instead of an invalid state transition.
   DGX Station Express also preserves its owner-only resume receipt when automatic dual-Station discovery selects the single-Station fallback.
   For more information, refer to [Choose a Compatible Inference API](/user-guide/openclaw/inference/custom-endpoints/choose-compatible-inference-api), [Quickstart](/user-guide/openclaw/get-started/quickstart), and [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).

--- a/docs/inference/understand-provider-validation.mdx
+++ b/docs/inference/understand-provider-validation.mdx
@@ -37,6 +37,7 @@ NemoClaw sends a provider-specific request that exercises the API surface intend
 For an OpenAI-compatible endpoint, the runtime defaults to `/v1/chat/completions` even when the Responses probe succeeds.
 Set `NEMOCLAW_PREFERRED_API=openai-responses` before onboarding to select `/v1/responses` only after the probe verifies the required streaming behavior.
 Set `NEMOCLAW_PREFERRED_API=openai-completions` to skip the Responses probe and validate Chat Completions only.
+The Responses streaming check waits up to 5 seconds for `response.output_text.delta` before onboarding falls back to Chat Completions.
 
 <AgentOnly variant="deepagents">
 

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -4,7 +4,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { captureAuthConfigPath } from "../adapters/http/auth-config-test-helpers";
 import {
@@ -846,6 +846,10 @@ exit 28
 outfile=""
 url=""
 payload=""
+n=$(cat "${HARNESS_COUNTER}")
+n=$((n + 1))
+echo "$n" > "${HARNESS_COUNTER}"
+printf '%s\n' "$@" > "${HARNESS_TMPDIR}/request-$n-args.txt"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -o) outfile="$2"; shift 2 ;;
@@ -854,9 +858,6 @@ while [ "$#" -gt 0 ]; do
     *) url="$1"; shift ;;
   esac
 done
-n=$(cat "${HARNESS_COUNTER}")
-n=$((n + 1))
-echo "$n" > "${HARNESS_COUNTER}"
 if echo "$url" | grep -q '/responses'; then
   if printf '%s' "$payload" | grep -q '"stream":true'; then
     if [ -n "$outfile" ]; then
@@ -889,17 +890,31 @@ fi
 printf '200'
 exit 0
 `;
-    withFakeCurlProbe({ script, dirPrefix: "nemoclaw-stream-fallback-" }, ({ lines }) => {
-      const result = probeOpenAiLikeEndpoint(
-        "https://api.example.com/v1",
-        "test-model",
-        "sk-test",
-        { probeStreaming: true },
-      );
+    vi.stubEnv("NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS", "300");
+    try {
+      withFakeCurlProbe({ script, dirPrefix: "nemoclaw-stream-fallback-" }, ({ lines, tmpDir }) => {
+        const result = probeOpenAiLikeEndpoint(
+          "https://api.example.com/v1",
+          "test-model",
+          "sk-test",
+          { probeStreaming: true },
+        );
 
-      expect(result).toMatchObject({ ok: true, api: "openai-completions" });
-      expect(lines.join("\n")).toMatch(/missing required events/i);
-    });
+        expect(result).toMatchObject({ ok: true, api: "openai-completions" });
+        expect(lines.join("\n")).toMatch(/missing required events/i);
+        expect(fs.readFileSync(path.join(tmpDir, "request-1-args.txt"), "utf8")).toContain(
+          "--max-time\n300\n",
+        );
+        expect(fs.readFileSync(path.join(tmpDir, "request-2-args.txt"), "utf8")).toContain(
+          "--max-time\n5\n",
+        );
+        expect(fs.readFileSync(path.join(tmpDir, "request-3-args.txt"), "utf8")).toContain(
+          "--max-time\n300\n",
+        );
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   // PR #5975 review notes PRA-3 (Standard) and PRA-2 (Required). The unit

--- a/src/lib/inference/openai-validation-session.test.ts
+++ b/src/lib/inference/openai-validation-session.test.ts
@@ -191,11 +191,11 @@ describe("OpenAI validation keepalive sequence", () => {
       );
 
       await initialStarted;
-      await vi.advanceTimersByTimeAsync(12_001);
+      await vi.advanceTimersByTimeAsync(5_001);
       expect(initialResponse).toBeDefined();
       initialResponse!.end('{"output":[{"type":"message"}]}');
       await streamingStarted;
-      await vi.advanceTimersByTimeAsync(12_000);
+      await vi.advanceTimersByTimeAsync(5_000);
 
       await expect(resultPromise).resolves.toMatchObject({
         ok: true,

--- a/src/lib/inference/probe-http-helpers.test.ts
+++ b/src/lib/inference/probe-http-helpers.test.ts
@@ -81,8 +81,9 @@ describe("validation probe curl timing helpers", () => {
       "--connect-timeout",
       "10",
       "--max-time",
-      String(STREAMING_EVENT_PROBE_MAX_SECONDS),
+      "5",
     ]);
+    expect(STREAMING_EVENT_PROBE_MAX_SECONDS).toBe(5);
     // Non-stream standard budget stays at the full 15s for comparison.
     expect(getValidationProbeCurlArgs({ isWsl: false })).toEqual([
       "--connect-timeout",
@@ -98,7 +99,7 @@ describe("validation probe curl timing helpers", () => {
       "--connect-timeout",
       "10",
       "--max-time",
-      String(STREAMING_EVENT_PROBE_MAX_SECONDS),
+      "5",
     ]);
   });
 });

--- a/src/lib/inference/probe-http-helpers.ts
+++ b/src/lib/inference/probe-http-helpers.ts
@@ -108,10 +108,10 @@ export function getValidationProbeCurlArgs(opts?: ValidationProbeOptions): strin
   );
 }
 
-// Dedicated short deadline for the /responses streaming probe. It only needs the
-// first output_text.delta, and its failure falls back to chat completions, so a
-// stalled stream must not spend the full validation budget (up to 60s). See #7792.
-export const STREAMING_EVENT_PROBE_MAX_SECONDS = 12;
+// The calibrated inference phase has 5 seconds of headroom above its observed
+// p95. Keep a stalled stream inside that headroom so it cannot consume the
+// complete 6-second phase budget before Chat Completions fallback. See #7792.
+export const STREAMING_EVENT_PROBE_MAX_SECONDS = 5;
 
 // Cap the streaming probe's --max-time only (min, never lengthen); connect-timeout
 // stays and --max-time bounds the whole call. See #7792.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

Onboarding could spend 12 seconds on a stalled Responses API stream even though the calibrated full-E2E inference-phase budget is 6 seconds. This change limits that probe to the budget's existing 5-second headroom, preserves Chat Completions API fallback, and leaves the E2E budget unchanged.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name the current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- Change the shared curl and native Responses streaming deadline from 12 seconds to 5 seconds. The five calibration samples measured the complete inference phase at 563–805 ms, and the accepted gate adds 5 seconds of minimum headroom for a 6,000 ms cap.
- Extend the curl public-boundary test to prove that a 300-second general validation override produces a 5-second streaming request between unchanged 300-second non-streaming requests.
- Update the native stalled-stream test to prove fallback after the 5-second deadline without shortening the initial Responses request.
- Document the user-visible deadline and correct the v0.0.100 release entry.

No new abstraction, configuration, fallback, migration, compatibility path, or supported surface is added. The existing custom-endpoint onboarding flow and Chat Completions API fallback are the current consumers.

The product root cause was a source deadline introduced after the blocking phase gate without checking the two contracts together. The detection gap was that PR #7884 tested the 12-second value in isolation; the full-E2E run exercised the real stalled-stream path and measured 11,950 ms for the inference phase.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed exact commit `134e9cbf77d43859bbaf84c5d02d3005ac847b5b`. All nine categories pass. The diff changes no credential, input-validation, authorization, dependency, logging, cryptography, configuration, header, policy, or SSRF boundary. Both transports retain authentication, address pinning, and the established Chat Completions API fallback. Focused tests cover the curl and native deadline boundaries.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `docs/inference/understand-provider-validation.mdx` and `docs/changelog/2026-07-31.mdx`, plus changed comments and test titles. Generated OpenClaw, Hermes, and Deep Agents variants render the 5-second deadline. Focused inference tests passed 54 tests with 1 skipped, changelog tests passed 6 tests, the docs build completed with 0 errors and 2 existing warnings, and `git diff --check` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 134e9cbf7 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/inference/probe-http-helpers.test.ts src/lib/inference/onboard-probes.test.ts src/lib/inference/openai-validation-session.test.ts src/lib/inference/openai-validation-session-fallback.test.ts`: 4 files passed, 54 tests passed, 1 skipped. `npx vitest run test/changelog-docs.test.ts`: 1 file and 6 tests passed.
- [ ] Applicable broad gate passed — not applicable; this changes one bounded onboarding deadline, focused regression coverage, and matching documentation. Required CI runs the broader suite.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — the build completed with 0 errors and 2 existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new pages.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Compatible-endpoint onboarding now completes streaming validation after up to 5 seconds instead of 12.
  * Chat Completions fallback remains available when no Responses API streaming event is received.

* **Documentation**
  * Updated validation guidance to reflect the five-second streaming wait and fallback behavior.

* **Tests**
  * Expanded coverage for timeout handling, fallback requests, retries, and configurable validation timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->