### PR TITLE
fix(rebuild): persist replacement lifecycle proof

### DIFF
--- a/src/lib/state/registry-normalization.test.ts
+++ b/src/lib/state/registry-normalization.test.ts
@@ -119,6 +119,25 @@ describe("sandbox registry normalization", () => {
     expect(persisted.defaultSandbox).toBeNull();
     expect(persisted.defaultSelectionRevision).toBe(1);
   });
+
+  it("round-trips the lifecycle proof used to retire a replaced workload", async () => {
+    const registry = await loadRegistryWith({});
+    const lifecycleGeneration = "22222222-2222-4222-8222-222222222222";
+    const lifecycleLiveIdentityFingerprint = "d".repeat(64);
+
+    registry.registerSandbox({
+      name: "replacement",
+      lifecycleGeneration,
+      lifecycleLiveIdentityFingerprint,
+    });
+
+    vi.resetModules();
+    const reloadedRegistry = await import("./registry");
+    expect(reloadedRegistry.getSandbox("replacement")).toMatchObject({
+      lifecycleGeneration,
+      lifecycleLiveIdentityFingerprint,
+    });
+  });
 });
 
 describe("baseline exclusion normalization (#7178)", () => {

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -165,6 +165,8 @@ export function registerSandbox(entry: SandboxEntry): void {
           : null,
       imageTag: entry.imageTag || null,
       workload: cloneSandboxWorkloadReceipt(entry.workload),
+      lifecycleGeneration: entry.lifecycleGeneration,
+      lifecycleLiveIdentityFingerprint: entry.lifecycleLiveIdentityFingerprint,
       messaging: cloneSandboxMessagingState(entry.messaging),
       mcp: normalizeSandboxMcpState(entry.mcp),
       hermesToolGateways:


### PR DESCRIPTION
## Summary

Sandbox registration discarded the lifecycle proof after a same-name rebuild. This change persists that proof so cleanup can verify the replacement identity and remove the obsolete owned image.

## Changes

- Persist `lifecycleGeneration` and `lifecycleLiveIdentityFingerprint` in `registerSandbox`.
- Add a regression test that registers a sandbox, reloads the registry from disk, and verifies both fields.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This internal registry fix restores the documented rebuild cleanup behavior without changing a user-visible contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer security review passed on `411b06be`; the change preserves the existing fail-closed replacement identity checks.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The existing v0.0.100 release entry already describes transactional replacement and lifecycle cleanup. This change restores that behavior across the registry save-and-reload boundary.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 411b06be -->
<!-- docs-review-agents-blob-sha: 3dd7c242 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: The six-file lifecycle suite passed 113 tests across registration, registry reload, recreate journals, handler cleanup, and provider image removal.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
