### PR TITLE
fix(onboard): reuse DNS-pinned endpoint validation

### DIFF
--- a/docs/changelog/2026-07-31.mdx
+++ b/docs/changelog/2026-07-31.mdx
@@ -22,6 +22,9 @@ It also improves onboarding recovery, lifecycle cleanup, Hermes image builds, ru
   Recovery binds the source, replacement, registry generation, and OpenShell gateway, then continues the recorded operation or fails closed when those identities drift.
   For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
 - Compatible-endpoint onboarding now limits the Responses API streaming-event probe to 5 seconds while preserving the Chat Completions API fallback.
+  Onboarding reuses a successful Chat Completions validation result instead of sending the immediate host-side validation request when the public endpoint, model, authentication mode, and request requirements match.
+  The validated IP address set must also match, so onboarding sends another validation request after the DNS pin changes.
+  NemoClaw still sends a separate validation request for an operator-trusted private endpoint.
   Host interruptions during an active onboarding step produce the existing resumable recovery path instead of an invalid state transition.
   DGX Station Express also preserves its owner-only resume receipt when automatic dual-Station discovery selects the single-Station fallback.
   For more information, refer to [Choose a Compatible Inference API](/user-guide/openclaw/inference/custom-endpoints/choose-compatible-inference-api), [Quickstart](/user-guide/openclaw/get-started/quickstart), and [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).

--- a/src/lib/inference/probe-http-helpers.ts
+++ b/src/lib/inference/probe-http-helpers.ts
@@ -108,9 +108,9 @@ export function getValidationProbeCurlArgs(opts?: ValidationProbeOptions): strin
   );
 }
 
-// The calibrated inference phase has 5 seconds of headroom above its observed
-// p95. Keep a stalled stream inside that headroom so it cannot consume the
-// complete 6-second phase budget before Chat Completions fallback. See #7792.
+// The calibrated provider-selection phase has 5 seconds of headroom above its
+// p95. Limit the streaming-specific wait to that headroom. The complete probe
+// remains subject to the 8-second provider-selection phase budget. See #7792.
 export const STREAMING_EVENT_PROBE_MAX_SECONDS = 5;
 
 // Cap the streaming probe's --max-time only (min, never lengthen); connect-timeout

--- a/src/lib/onboard/inference-capability-cache.test.ts
+++ b/src/lib/onboard/inference-capability-cache.test.ts
@@ -38,11 +38,36 @@ describe("OnboardInferenceCapabilityCache", () => {
         endpointUrl: "https://api.example.test/v1?key=x",
       }),
     ).toBe(false);
-    expect(
-      cache.rememberCompletedOpenAiChat({ ...input, pinnedAddresses: ["93.184.216.34"] }),
-    ).toBe(false);
+    expect(cache.rememberCompletedOpenAiChat({ ...input, extraHeaders: ["X-Test: value"] })).toBe(
+      false,
+    );
 
     cache.invalidate();
     expect(cache.takeCompletedOpenAiChat(input)).toBe(false);
+  });
+
+  it("reuses a DNS-pinned validation result only for the same approved IP address set", () => {
+    const cache = new OnboardInferenceCapabilityCache();
+    const input = {
+      endpointUrl: "https://api.example.test/v1",
+      model: "model-a",
+      pinnedAddresses: ["2606:4700:4700::1111", "93.184.216.34"],
+    };
+
+    expect(cache.rememberCompletedOpenAiChat(input)).toBe(true);
+    expect(
+      cache.takeCompletedOpenAiChat({
+        ...input,
+        pinnedAddresses: ["93.184.216.34", "2606:4700:4700::1111", "93.184.216.34"],
+      }),
+    ).toBe(true);
+
+    expect(cache.rememberCompletedOpenAiChat(input)).toBe(true);
+    expect(cache.takeCompletedOpenAiChat({ ...input, pinnedAddresses: ["93.184.216.35"] })).toBe(
+      false,
+    );
+    expect(
+      cache.rememberCompletedOpenAiChat({ ...input, pinnedAddresses: ["not-an-ip-address"] }),
+    ).toBe(false);
   });
 });

--- a/src/lib/onboard/inference-capability-cache.ts
+++ b/src/lib/onboard/inference-capability-cache.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isIP } from "node:net";
+
 import type { TrustedPrivateEndpointCapability } from "../inference/endpoint-ssrf-preflight";
 
 type OpenAiChatCapabilityInput = {
@@ -16,8 +18,12 @@ type OpenAiChatCapabilityInput = {
 function capabilityKey(input: OpenAiChatCapabilityInput): string | null {
   // Query strings, embedded URL credentials, and custom headers can carry
   // credentials. Do not retain either those values or a derived identifier.
-  if (input.extraHeaders?.length || input.pinnedAddresses?.length || input.trustedPrivateCapability)
-    return null;
+  // Operator-trusted private endpoints must repeat the validation request because
+  // their access depends on a non-forgeable capability at the curl boundary.
+  if (input.extraHeaders?.length || input.trustedPrivateCapability) return null;
+
+  const pinnedAddresses = [...new Set(input.pinnedAddresses ?? [])].sort();
+  if (pinnedAddresses.some((address) => isIP(address) === 0)) return null;
 
   let endpoint: URL;
   try {
@@ -42,14 +48,18 @@ function capabilityKey(input: OpenAiChatCapabilityInput): string | null {
     endpoint: endpoint.toString(),
     authMode: input.authMode ?? "bearer",
     model,
+    pinnedAddresses,
     requireChatCompletionsToolCalling: input.requireChatCompletionsToolCalling === true,
   });
 }
 
 /**
- * One onboarding invocation may validate a selected Chat Completions route and
- * then immediately run the same host-side smoke check. This cache is strictly
- * in-memory, one-shot, and refuses credential-bearing or pinned paths.
+ * One onboarding invocation may validate a selected endpoint with a Chat
+ * Completions request and would otherwise send the same host-side validation
+ * request immediately. This cache is in-memory and one-shot. Public DNS-pinned
+ * endpoints bind the exact approved IP address set into the receipt.
+ * Credential-bearing inputs and operator-trusted private endpoints remain
+ * non-cacheable.
  */
 export class OnboardInferenceCapabilityCache {
   readonly #entries = new Set<string>();

--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -203,6 +203,7 @@ describe("inference selection validation", () => {
     vi.stubEnv("NEMOCLAW_TRUSTED_PRIVATE_INFERENCE_HOSTS", "llm.corp.example");
     const probeOpenAiLikeEndpoint = vi.fn(() => ({ ok: true, api: "openai-completions" }));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const capabilityCache = new OnboardInferenceCapabilityCache();
     const helpers = createInferenceSelectionValidationHelpers({
       isNonInteractive: () => false,
       agentProductName: () => "OpenClaw",
@@ -218,6 +219,8 @@ describe("inference selection validation", () => {
         "https://llm.corp.example/v1",
         "model-a",
         "COMPATIBLE_API_KEY",
+        null,
+        capabilityCache,
       );
       expect(result).toMatchObject({
         ok: true,
@@ -225,6 +228,15 @@ describe("inference selection validation", () => {
         pinnedAddresses: ["10.0.0.8"],
       });
       expect(result.ok && result.trustedPrivateCapability?.addresses).toEqual(["10.0.0.8"]);
+      expect(
+        result.ok &&
+          capabilityCache.takeCompletedOpenAiChat({
+            endpointUrl: "https://llm.corp.example/v1",
+            model: "model-a",
+            pinnedAddresses: result.pinnedAddresses,
+            trustedPrivateCapability: result.trustedPrivateCapability,
+          }),
+      ).toBe(false);
       expect(probeOpenAiLikeEndpoint).toHaveBeenCalledWith(
         "https://llm.corp.example/v1",
         "model-a",
@@ -461,6 +473,7 @@ describe("inference selection validation", () => {
 
   it("probes a custom endpoint that resolves to a public address (#6293)", async () => {
     const probeOpenAiLikeEndpoint = vi.fn(() => ({ ok: true, api: "openai-completions" }));
+    const capabilityCache = new OnboardInferenceCapabilityCache();
     const helpers = createInferenceSelectionValidationHelpers({
       isNonInteractive: () => false,
       agentProductName: () => "OpenClaw",
@@ -470,19 +483,27 @@ describe("inference selection validation", () => {
       resolveEndpointHost: async () => [{ address: "93.184.216.34", family: 4 }],
     });
 
-    await expect(
-      helpers.validateCustomOpenAiLikeSelection(
-        "Custom endpoint",
-        "https://vllm.public.test/v1",
-        "model-a",
-        "COMPATIBLE_API_KEY",
-      ),
-    ).resolves.toEqual({
+    const result = await helpers.validateCustomOpenAiLikeSelection(
+      "Custom endpoint",
+      "https://vllm.public.test/v1",
+      "model-a",
+      "COMPATIBLE_API_KEY",
+      null,
+      capabilityCache,
+    );
+    expect(result).toEqual({
       ok: true,
       api: "openai-completions",
       pinnedAddresses: ["93.184.216.34"],
     });
     expect(probeOpenAiLikeEndpoint).toHaveBeenCalled();
+    expect(
+      capabilityCache.takeCompletedOpenAiChat({
+        endpointUrl: "https://vllm.public.test/v1",
+        model: "model-a",
+        pinnedAddresses: ["93.184.216.34"],
+      }),
+    ).toBe(true);
   });
 
   it("requests streaming validation for OpenClaw custom Anthropic endpoints (#6289)", async () => {

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -111,6 +111,7 @@ export interface InferenceSelectionValidationHelpers {
     model: string,
     credentialEnv: string,
     helpUrl?: string | null,
+    capabilityCache?: OnboardInferenceCapabilityCache,
   ): Promise<EndpointValidationResult>;
   validateCustomAnthropicSelection(
     label: string,
@@ -305,6 +306,8 @@ export function createInferenceSelectionValidationHelpers(
         authMode: probeOptions.authMode,
         requireChatCompletionsToolCalling: probeOptions.requireChatCompletionsToolCalling,
         extraHeaders: probeOptions.extraHeaders,
+        pinnedAddresses: probeOptions.pinnedAddresses,
+        trustedPrivateCapability: probeOptions.trustedPrivateCapability,
       });
     }
     return { ok: true, api };
@@ -347,6 +350,7 @@ export function createInferenceSelectionValidationHelpers(
     model: string,
     credentialEnv: string,
     helpUrl: string | null = null,
+    capabilityCache?: OnboardInferenceCapabilityCache,
   ): Promise<EndpointValidationResult> {
     const preflight = await preflightCustomEndpointOrFail(
       label,
@@ -376,9 +380,18 @@ export function createInferenceSelectionValidationHelpers(
           `  ${probe.label} available — ${deps.agentProductName()} will use ${probe.api}.`,
         );
       }
+      const api = probe.api ?? "openai-completions";
+      if (api === "openai-completions" && probe.validated !== false) {
+        capabilityCache?.rememberCompletedOpenAiChat({
+          endpointUrl,
+          model,
+          pinnedAddresses,
+          trustedPrivateCapability,
+        });
+      }
       return {
         ok: true,
-        api: probe.api ?? "openai-completions",
+        api,
         pinnedAddresses,
         ...(trustedPrivateCapability ? { trustedPrivateCapability } : {}),
       };

--- a/src/lib/onboard/setup-nim-selection.test.ts
+++ b/src/lib/onboard/setup-nim-selection.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 
 import { requireValue } from "../core/require-value";
+import { OnboardInferenceCapabilityCache } from "./inference-capability-cache";
 import {
   applyCloudFallbackSelection,
   clearNimContainerBeforeRetry,
@@ -125,7 +126,10 @@ describe("createRemoteModelValidator", () => {
     state.provider = "openai-compatible";
     state.endpointUrl = "https://compatible.example/v1";
     state.model = "model-a";
+    const capabilityCache = new OnboardInferenceCapabilityCache();
+    state.inferenceCapabilityCache = capabilityCache;
     let calledEndpoint: string | null = null;
+    let receivedCapabilityCache: OnboardInferenceCapabilityCache | undefined;
     let configuredReasoning = false;
     const logLines: string[] = [];
     const { validateSelectedRemoteModel } = createRemoteModelValidator({
@@ -136,8 +140,16 @@ describe("createRemoteModelValidator", () => {
         return value;
       },
       isBackToSelection: (_value): _value is never => false,
-      validateCustomOpenAiLikeSelection: async (_label, endpointUrl) => {
+      validateCustomOpenAiLikeSelection: async (
+        _label,
+        endpointUrl,
+        _model,
+        _credentialEnv,
+        _helpUrl,
+        selectedCapabilityCache,
+      ) => {
         calledEndpoint = endpointUrl;
+        receivedCapabilityCache = selectedCapabilityCache;
         return { ok: true, api: "responses" };
       },
       validateCustomAnthropicSelection: async () => ({ ok: false, retry: "selection" }),
@@ -166,6 +178,7 @@ describe("createRemoteModelValidator", () => {
 
     assert.equal(result, "selected");
     assert.equal(calledEndpoint, "https://compatible.example/v1");
+    assert.equal(receivedCapabilityCache, capabilityCache);
     assert.equal(state.preferredInferenceApi, "openai-completions");
     assert.equal(state.compatibleEndpointReasoning, "true");
     assert.equal(configuredReasoning, true);

--- a/src/lib/onboard/setup-nim-selection.ts
+++ b/src/lib/onboard/setup-nim-selection.ts
@@ -161,6 +161,7 @@ type RemoteModelValidatorDeps = {
     model: string,
     credentialEnv: string,
     helpUrl: string | null,
+    capabilityCache?: OnboardInferenceCapabilityCache,
   ) => Promise<ValidationResult>;
   validateCustomAnthropicSelection: (
     label: string,
@@ -260,6 +261,7 @@ export function createRemoteModelValidator(deps: RemoteModelValidatorDeps): {
           selectedModel,
           selectedCredentialEnv,
           remoteConfig.helpUrl,
+          state.inferenceCapabilityCache,
         );
         if (validation.ok) {
           if (validation.pinnedAddresses)

--- a/test/helpers/onboard-smoke-verifier-harness.ts
+++ b/test/helpers/onboard-smoke-verifier-harness.ts
@@ -12,6 +12,7 @@ type VerifyOnboardSmokeInvocation = {
   endpointUrl?: string;
   forceOpenAiLike?: boolean;
   model?: string;
+  pinnedAddresses?: string[];
   provider?: string;
 };
 
@@ -109,6 +110,7 @@ console.log = (...args) => calls.push(["log", args.join(" ")]);
         model: effectiveInvocation.model,
         authMode: getProbeAuthMode(effectiveInvocation.provider),
         extraHeaders: getProbeExtraHeaders(effectiveInvocation.provider),
+        pinnedAddresses: effectiveInvocation.pinnedAddresses,
       });
       if (!primed) throw new Error("failed to prime selected Chat Completions capability");
     }

--- a/test/onboard-smoke-verifier.test.ts
+++ b/test/onboard-smoke-verifier.test.ts
@@ -56,6 +56,25 @@ describe("Hermes onboard smoke verification", () => {
     ]);
   });
 
+  it("reuses a matching DNS-pinned Chat Completions validation without another request", async () => {
+    const calls = await runVerifyOnboardSmokeHarness([
+      {
+        credentialEnv: "NOUS_API_KEY",
+        endpointUrl: "https://pinned.example/v1",
+        model: "pinned/model",
+        pinnedAddresses: ["93.184.216.34"],
+        provider: "hermes-provider",
+        selectedChatCapability: true,
+      },
+    ]);
+
+    expect(calls.filter((call) => call[0] === "runCurlProbe")).toHaveLength(0);
+    expect(calls).toContainEqual([
+      "log",
+      "  ✓ Reusing selected Chat Completions validation: hermes-provider / pinned/model",
+    ]);
+  });
+
   it("fails when the selected capability cannot be safely cached", async () => {
     await expect(
       runVerifyOnboardSmokeHarness([


### PR DESCRIPTION
## Summary

Compatible-endpoint onboarding now reuses the successful public DNS-pinned Chat Completions validation result instead of sending the immediate duplicate validation request. The one-shot receipt remains bound to the exact endpoint, model, authentication mode, request requirements, and approved IP address set; operator-trusted private endpoints remain non-cacheable.

## Changes

- Carry the existing onboarding capability cache through custom OpenAI-compatible endpoint selection.
- Bind public DNS-pinned validation receipts to a normalized exact IP address set, and reject malformed pins or operator-trusted private capabilities.
- Keep the initial DNS-backed SSRF preflight and pinned validation request unchanged; only the immediate duplicate request is removed.
- Correct the streaming-probe comment to identify the 8-second provider-selection phase contract. The 5-second streaming deadline and all E2E phase budgets remain unchanged.
- Add focused source and integration regression coverage for exact-pin reuse, pin mismatch, invalid pins, private-endpoint refusal, cache propagation, and absence of the duplicate curl request.
- Update the v0.0.100 release entry with the user-visible validation behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the nine-category security review. No findings; the initial SSRF preflight remains required, the receipt binds the exact approved IP address set, and operator-trusted private capabilities remain non-cacheable.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-07-31.mdx`; terminology, release meaning, source comments, and test titles reviewed; changelog tests and docs build passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7ce0379 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 40 CLI tests and 5 integration tests passed; `npm run typecheck:cli` and scoped Biome checks passed; 6 changelog tests and `npm run docs` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Faster compatible-endpoint onboarding by reusing successful validation results when endpoint, model, and validated IP addresses match.
  * DNS-pinned endpoints now support safe validation reuse, including equivalent address sets regardless of order or duplicates.
* **Bug Fixes**
  * Prevented cached validation from being reused when headers, IP addresses, or endpoint trust settings differ.
  * DNS changes now trigger fresh validation, improving endpoint security and reliability.
  * Responses API probing is capped at five seconds during onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->