### PR TITLE
fix(onboard): enforce cron inference readiness budget

### DIFF
--- a/src/lib/verify-deployment.test.ts
+++ b/src/lib/verify-deployment.test.ts
@@ -533,6 +533,21 @@ describe("verifyDeployment", () => {
     expect(result.verification.inferenceRouteWorking).toBe(true);
   });
 
+  it("keeps the inference route reachability probe below the OpenClaw cron preflight timeout", async () => {
+    const scripts: string[] = [];
+    const deps = makeDeps({
+      executeSandboxCommand: (_name: string, script: string) => {
+        scripts.push(script);
+        return { status: 0, stdout: "200", stderr: "" };
+      },
+    });
+
+    await verifyDeployment("my-sandbox", chain, deps, NO_RETRY);
+
+    const inferenceProbe = scripts.find((script) => script.includes("inference.local"));
+    expect(inferenceProbe).toContain("--max-time 2 ");
+  });
+
   it("retries the gateway probe and recovers when the gateway comes up late (#3563)", async () => {
     let gatewayCalls = 0;
     const deps = makeDeps({

--- a/src/lib/verify-deployment.ts
+++ b/src/lib/verify-deployment.ts
@@ -132,6 +132,9 @@ export interface VerifyDeploymentOptions {
 }
 
 const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [1000, 2000, 5000, 7000, 10000];
+// OpenClaw cron stops its provider preflight after 2.5 seconds. Require a
+// response within 2 seconds so onboarding leaves time for client overhead.
+const INFERENCE_ROUTE_REACHABILITY_MAX_SECONDS = 2;
 
 function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -220,7 +223,7 @@ function probeInferenceRouteOnce(
   deps: VerifyDeploymentDeps,
 ): { status: InferenceRouteStatus; detail: string } {
   const script =
-    `HTTP_CODE=$(curl -so /dev/null -w '%{http_code}' --max-time 5 ` +
+    `HTTP_CODE=$(curl -so /dev/null -w '%{http_code}' --max-time ${INFERENCE_ROUTE_REACHABILITY_MAX_SECONDS} ` +
     `https://inference.local/v1/models 2>/dev/null || echo 000); echo $HTTP_CODE`;
   const result = deps.executeSandboxCommand(sandboxName, script);
   if (!result) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Onboarding now requires `inference.local` to respond within two seconds before it reports deployment verification success. The previous five-second probe could pass while OpenClaw cron's 2.5-second provider preflight still timed out immediately after fresh sandbox creation.

## Changes

- Reduce the existing in-sandbox `/v1/models` reachability probe from five seconds to two seconds.
- Preserve the existing bounded retries so fresh sandbox routes can settle before onboarding reports success.
- Add a regression test that binds the reachability probe to a budget below the OpenClaw cron timeout.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change tightens an internal verification threshold. It changes no command, configuration, output, documented workflow, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the nine-category security review on PR #8046. No findings; the change only reduces an existing bounded reachability deadline and does not alter credentials, authorization, SSRF handling, network policy, or command construction.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The review confirmed that this internal reachability threshold changes no command, configuration, output, documented workflow, or supported behavior. Changed comments and test titles follow the writing guide and controlled claim ladder.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 64d5e21c2 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/verify-deployment.test.ts` passed 41/41; scoped Biome checks and `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment verification now checks inference-route reachability within two seconds, reducing delays when a route is unavailable.
* **Tests**
  * Added coverage to ensure the inference-route probe uses the updated timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->