### PR TITLE
test(e2e): model boot restart before recovery

### DIFF
--- a/test/e2e/fixtures/phases/lifecycle.ts
+++ b/test/e2e/fixtures/phases/lifecycle.ts
@@ -36,7 +36,6 @@ const STATUS_TIMEOUT_MS = 5 * 60_000;
 const REBUILD_TIMEOUT_MS = 20 * 60_000;
 const SANDBOX_READY_ATTEMPTS = 30;
 const SANDBOX_READY_DELAY_MS = 5_000;
-const STOPPED_SANDBOX_STATUS = "Failure layer: sandbox_container_stopped";
 const USER_SERVICE_UNAVAILABLE_EXIT = 75;
 const NEMOCLAW_OPENSHELL_GATEWAY_USER_SERVICE_MARKER_LINE =
   "# NEMOCLAW_MANAGED_OPENSHELL_GATEWAY=1";
@@ -285,6 +284,14 @@ export class LifecyclePhaseFixture {
     instance: NemoClawInstance | string,
     options: SandboxReadyAfterRebuildOptions = {},
   ): Promise<ShellProbeResult> {
+    return await this.waitForSandboxReady(instance, options, "after rebuild");
+  }
+
+  private async waitForSandboxReady(
+    instance: NemoClawInstance | string,
+    options: SandboxReadyAfterRebuildOptions,
+    transition: "after rebuild" | "after the boot restart",
+  ): Promise<ShellProbeResult> {
     const sandboxName = instanceName(instance);
     const attempts = options.attempts ?? SANDBOX_READY_ATTEMPTS;
     const delayMs = options.delayMs ?? SANDBOX_READY_DELAY_MS;
@@ -304,7 +311,7 @@ export class LifecyclePhaseFixture {
     }
     const detail = last ? `${last.stdout}\n${last.stderr}`.trim() : "no probe result";
     throw new Error(
-      `sandbox ${sandboxName} did not become Ready after rebuild within ${attempts} attempts: ${detail}`,
+      `sandbox ${sandboxName} did not become Ready ${transition} within ${attempts} attempts: ${detail}`,
     );
   }
 
@@ -347,17 +354,18 @@ export class LifecyclePhaseFixture {
    *      `openshell-gateway` service or the marked
    *      `nemoclaw-openshell-gateway` service.
    *
-   *   2. Invoke `nemoclaw <name> status` — the user-visible action
+   *   2. Model the Docker daemon's boot-owned container restart. Wait until
+   *      the OpenShell gateway reports the preserved sandbox Ready.
+   *
+   *   3. Invoke `nemoclaw <name> status` — the user-visible action
    *      that documented the regression in #4423. On unfixed `main`
    *      the destructive `missing` branch in `status.ts` wipes the
-   *      registry entry. The Docker-driver recovery helper restarts the
-   *      labeled container before stale-removal can fire. The preceding gateway restart must
-   *      make `openshell status` report the named gateway connected
-   *      without running `nemoclaw onboard --resume`.
+   *      registry entry. Status must also restore the OpenClaw gateway
+   *      and host forward before it exits successfully.
    *
-   *   Status must exit zero to prove that the restored sandbox delivery
-   *   path is ready. The state-validation phase that follows additionally
-   *   verifies preservation via the
+   *   The final status must exit zero to verify the restored sandbox
+   *   delivery path. The state-validation phase that follows additionally
+   *   verifies preservation through the
    *   `local-registry-entry-present` and `docker-sandbox-container-present`
    *   probes.
    *
@@ -390,6 +398,7 @@ export class LifecyclePhaseFixture {
       );
     }
     const originalName = containerNames[0];
+    let bootContainerName = originalName;
 
     const stop = await this.host.command("docker", ["stop", originalName], {
       artifactName: `lifecycle-post-reboot-docker-stop-${originalName}`,
@@ -418,6 +427,7 @@ export class LifecyclePhaseFixture {
         id: `docker-rename:${originalName}->${backupName}`,
         results: [rename],
       });
+      bootContainerName = backupName;
       this.cleanup.add(`lifecycle.docker-rename-back:${backupName}`, async () => {
         await this.host.command("docker", ["rename", backupName, originalName], {
           artifactName: `lifecycle-cleanup-docker-rename-back-${backupName}`,
@@ -439,47 +449,45 @@ export class LifecyclePhaseFixture {
     await this.waitForGatewayConnected();
     steps.push({ id: "gateway-connected:nemoclaw", results: [] });
 
-    // Final step: drive the user-visible action that exposed #4423.
-    // We invoke status through the host CLI client so artifacts are
-    // captured and the command goes through the same
-    // shellProbe/redaction layer the rest of the fixture code uses.
-    // OpenShell can report the gateway as connected before it starts the
-    // preserved sandbox container. Retry only that observed transition.
-    // Other status failures remain terminal.
-    const statusResult = await this.waitForPostRebootSandboxStatus(instance.sandboxName);
+    // `docker stop` suppresses Docker restart-policy handling until the
+    // daemon restarts. Start the same container here to model that boot-owned
+    // transition without restarting the GitHub-hosted runner's Docker daemon.
+    const bootStart = await this.host.command("docker", ["start", bootContainerName], {
+      artifactName: `lifecycle-post-reboot-docker-start-${bootContainerName}`,
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: DOCKER_PROBE_TIMEOUT_MS,
+    });
+    assertExitZero(bootStart, `docker start ${bootContainerName}`);
+    steps.push({
+      id: `docker-boot-start:${bootContainerName}`,
+      results: [bootStart],
+    });
+
+    const ready = await this.waitForSandboxReady(
+      instance,
+      {
+        artifactNamePrefix: `lifecycle-post-reboot-ready-${instance.sandboxName}`,
+      },
+      "after the boot restart",
+    );
+    steps.push({
+      id: `sandbox-ready-after-boot:${instance.sandboxName}`,
+      results: [ready],
+    });
+
+    // `nemoclaw <name> status` owns the post-reboot delivery-chain recovery.
+    // It must restore OpenClaw and the host forward without invoking `nemoclaw <name> start`.
+    const statusResult = await this.host.expectStatus(instance.sandboxName, {
+      artifactName: `lifecycle-post-reboot-nemoclaw-status-${instance.sandboxName}`,
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: STATUS_TIMEOUT_MS,
+    });
     steps.push({
       id: `nemoclaw-status:${instance.sandboxName}`,
       results: [statusResult],
     });
 
     return { profile: "post-reboot-recovery", steps };
-  }
-
-  private async waitForPostRebootSandboxStatus(sandboxName: string): Promise<ShellProbeResult> {
-    let last: ShellProbeResult | undefined;
-    const deadlineMs = Date.now() + STATUS_TIMEOUT_MS;
-    for (let attempt = 1; attempt <= SANDBOX_READY_ATTEMPTS; attempt += 1) {
-      const remainingMs = deadlineMs - Date.now();
-      if (remainingMs <= 0) break;
-      last = await this.host.nemoclaw([sandboxName, "status"], {
-        artifactName:
-          `lifecycle-post-reboot-nemoclaw-status-${sandboxName}-` +
-          `attempt-${String(attempt).padStart(2, "0")}`,
-        env: buildAvailabilityProbeEnv(),
-        timeoutMs: Math.min(60_000, remainingMs),
-      });
-      if (last.exitCode === 0) return last;
-      const detail = `${last.stdout}\n${last.stderr}`;
-      if (!detail.includes(STOPPED_SANDBOX_STATUS)) {
-        assertExitZero(last, `nemoclaw ${sandboxName} status`);
-      }
-      if (attempt < SANDBOX_READY_ATTEMPTS && Date.now() < deadlineMs) {
-        await sleep(Math.min(SANDBOX_READY_DELAY_MS, deadlineMs - Date.now()));
-      }
-    }
-    if (!last) throw new Error(`nemoclaw ${sandboxName} status did not run before its deadline`);
-    assertExitZero(last, `nemoclaw ${sandboxName} status`);
-    return last;
   }
 
   private async ensureOpenShellGatewayUserService(): Promise<UserServiceStageResult> {

--- a/test/e2e/support/e2e-phase-lifecycle.test.ts
+++ b/test/e2e/support/e2e-phase-lifecycle.test.ts
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 import {
   type CommandRunner,
@@ -126,10 +126,6 @@ function restoreEnv(name: string, value: string | undefined): void {
   Object.assign(process.env, value === undefined ? {} : { [name]: value });
 }
 
-afterEach(() => {
-  vi.useRealTimers();
-});
-
 describe("LifecyclePhaseFixture.preparePostReboot", () => {
   it("installs OpenShell and stages the gateway user service when openshell-gateway is unavailable", async () => {
     const runner = new FakeRunner();
@@ -172,6 +168,8 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
     runner.enqueue(shellResult(0)); // container stop
     runner.enqueue(shellResult(0)); // user service restart
     runner.enqueue(shellResult(0, "Connected to nemoclaw\n")); // openshell status
+    runner.enqueue(shellResult(0)); // boot-owned docker start
+    runner.enqueue(shellResult(0, "NAME  PHASE\ne2e-ubuntu-repo-cloud-openclaw  Ready\n"));
     runner.enqueue(shellResult(0)); // status proves recovered delivery readiness
 
     const result = await prepared.simulate("post-reboot-recovery", instance());
@@ -181,6 +179,8 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
       "docker-stop:openshell-cluster-e2e-ubuntu-repo-cloud-openclaw",
       "gateway-restart:user-service",
       "gateway-connected:nemoclaw",
+      "docker-boot-start:openshell-cluster-e2e-ubuntu-repo-cloud-openclaw",
+      "sandbox-ready-after-boot:e2e-ubuntu-repo-cloud-openclaw",
       "nemoclaw-status:e2e-ubuntu-repo-cloud-openclaw",
     ]);
     expect(runner.calls.map((call) => `${call.command} ${call.args.join(" ")}`)).toEqual([
@@ -194,6 +194,8 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
       expect.stringContaining("sh -lc cid="),
       expect.stringContaining('systemctl --user cat "$service"'),
       "openshell status",
+      "docker start openshell-cluster-e2e-ubuntu-repo-cloud-openclaw",
+      "openshell sandbox list",
       "nemoclaw e2e-ubuntu-repo-cloud-openclaw status",
     ]);
     expect(cleanup.calls.map((call) => call.name)).toEqual([
@@ -214,6 +216,8 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
     runner.enqueue(shellResult(0)); // container stop
     runner.enqueue(shellResult(0)); // user service restart
     runner.enqueue(shellResult(0, "Connected to nemoclaw\n")); // openshell status
+    runner.enqueue(shellResult(0)); // boot-owned docker start
+    runner.enqueue(shellResult(0, "NAME  PHASE\ne2e-ubuntu-repo-cloud-openclaw  Ready\n"));
     runner.enqueue(shellResult(1, "Removed stale local registry entry.\n")); // status non-zero
 
     await expect(prepared.simulate("post-reboot-recovery", instance())).rejects.toThrow(
@@ -221,8 +225,7 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
     );
   });
 
-  it("retries the stopped-container status until the sandbox starts", async () => {
-    vi.useFakeTimers();
+  it("models the boot-owned container restart before checking status", async () => {
     const runner = new FakeRunner();
     const cleanup = new FakeCleanup();
     const prepared = await preparedPostRebootFixture(runner, cleanup);
@@ -234,26 +237,32 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (stop-original)", 
     runner.enqueue(shellResult(0)); // container stop
     runner.enqueue(shellResult(0)); // user service restart
     runner.enqueue(shellResult(0, "Connected to nemoclaw\n")); // openshell status
-    runner.enqueue(
-      shellResult(
-        1,
-        "Failure layer: sandbox_container_stopped — sandbox container exists but is not running.",
-      ),
-    );
-    runner.enqueue(shellResult(0)); // status after OpenShell starts the container
+    runner.enqueue(shellResult(0)); // boot-owned docker start
+    runner.enqueue(shellResult(0, "NAME  PHASE\ne2e-ubuntu-repo-cloud-openclaw  Ready\n"));
+    runner.enqueue(shellResult(0)); // status restores the delivery chain
 
-    const simulation = prepared.simulate("post-reboot-recovery", instance());
-    await vi.advanceTimersByTimeAsync(5_000);
-    const result = await simulation;
+    const result = await prepared.simulate("post-reboot-recovery", instance());
 
-    expect(result.steps.at(-1)?.results[0]?.exitCode).toBe(0);
     expect(
-      runner.calls.filter(
-        (call) =>
-          call.command === "nemoclaw" &&
-          call.args.join(" ") === "e2e-ubuntu-repo-cloud-openclaw status",
-      ),
-    ).toHaveLength(2);
+      runner.calls
+        .map((call) => `${call.command} ${call.args.join(" ")}`)
+        .filter(
+          (call) =>
+            call === "docker start container-1" ||
+            call === "openshell sandbox list" ||
+            call === "nemoclaw e2e-ubuntu-repo-cloud-openclaw status",
+        ),
+    ).toEqual([
+      "docker start container-1",
+      "openshell sandbox list",
+      "nemoclaw e2e-ubuntu-repo-cloud-openclaw status",
+    ]);
+    expect(result.steps.slice(-3).map((step) => step.id)).toEqual([
+      "docker-boot-start:container-1",
+      "sandbox-ready-after-boot:e2e-ubuntu-repo-cloud-openclaw",
+      "nemoclaw-status:e2e-ubuntu-repo-cloud-openclaw",
+    ]);
+    expect(result.steps.at(-1)?.results[0]?.exitCode).toBe(0);
   });
 
   it("fails when no Docker container carries the OpenShell sandbox-name label", async () => {
@@ -314,6 +323,8 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (rename-to-gpu-bac
     runner.enqueue(shellResult(0)); // container stop
     runner.enqueue(shellResult(0)); // user service restart
     runner.enqueue(shellResult(0, "Connected to nemoclaw\n")); // openshell status
+    runner.enqueue(shellResult(0)); // boot-owned docker start
+    runner.enqueue(shellResult(0, "NAME  PHASE\ne2e-x  Ready\n"));
     runner.enqueue(shellResult(0)); // status proves recovered delivery readiness
 
     const result = await prepared.simulate(
@@ -331,6 +342,12 @@ describe("LifecyclePhaseFixture.simulate post-reboot-recovery (rename-to-gpu-bac
     expect(renameCall).toBeTruthy();
     expect(renameCall!.args[1]).toBe("openshell-cluster-e2e-x");
     expect(renameCall!.args[2]).toMatch(/^openshell-cluster-e2e-x-nemoclaw-gpu-backup-\d+$/);
+    expect(runner.calls).toContainEqual(
+      expect.objectContaining({
+        command: "docker",
+        args: ["start", renameCall!.args[2]],
+      }),
+    );
 
     // Cleanup queue now has both docker-start and docker-rename-back.
     expect(cleanup.calls.map((call) => call.name.split(":")[0])).toEqual([


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The post-reboot E2E fixture now models the boot-owned restart of the preserved OpenShell container before checking recovery. The previous fixture retried `nemoclaw <name> status` against a stopped container even though no actor could start it, so the lane failed deterministically instead of testing automatic post-reboot recovery.

## Changes

- Start the preserved Docker container at the simulated reboot boundary and wait for the exact OpenShell sandbox to report `Ready`.
- Invoke `nemoclaw <name> status` once after the boot transition so status remains responsible for restoring OpenClaw, host forwarding, and the delivery path.
- Add focused coverage for command ordering and for starting the renamed preserved container in the GPU-backup scenario.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the E2E fixture's reboot simulation and support coverage. It does not change a product command, configuration, output, default, error, or supported user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed E2E-only scope. The fixture starts the already identified preserved container; it does not change product sandbox lifecycle, command construction, credentials, or policy.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The review confirmed exact command and lifecycle terminology in `test/e2e/fixtures/phases/lifecycle.ts` and behavior-oriented coverage in `test/e2e/support/e2e-phase-lifecycle.test.ts`. No user-visible product surface changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 95165659 -->
<!-- docs-review-agents-blob-sha: 3dd7c242 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/e2e-phase-lifecycle.test.ts` passed 23/23; `npm run test:e2e-phases:check` passed with 114 tests across 71 files; CLI and plugin builds passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Aggregate `e2e-support` reached 1,888 passing tests; two Linux/systemd fixture cases are incompatible with the macOS login-shell harness and one unrelated Hermes swap test timed out. The changed lifecycle suite is green; Linux CI is the authoritative broad gate.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated lifecycle recovery coverage to reflect Docker-managed container startup after reboot.
  * Added verification for sandbox readiness during stop-and-restart and rename-and-restart scenarios.
  * Added failure and readiness checks for post-reboot recovery.
  * Replaced timer-based status retry coverage with direct boot-restart readiness validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->