### PR TITLE
feat(runtime): start exact Podman image bootstrap

### DIFF
--- a/src/lib/onboard/lifecycle-contracts.md
+++ b/src/lib/onboard/lifecycle-contracts.md
@@ -181,11 +181,37 @@ replacement startup fail closed. The caller keeps the watcher lease stopped
 throughout and owns its later release.
 
 This slice neither starts the replacement nor changes registry, agent state,
-or user-visible runtime selection. Commit, all-agent bootstrap, durable resume,
-and activation remain separate work in epic
+or user-visible runtime selection. Commit, durable resume, and activation
+remain separate work in epic
 [#7744](https://github.com/NVIDIA/NemoClaw/issues/7744). Journal and exact
 rollback behavior is covered by `podman-bootstrap-journal.test.ts` and
 `podman-bootstrap-replacement.test.ts`.
+
+## Dormant Podman image-owned bootstrap transaction
+
+`startPodmanBootstrapImageTransaction` is the internal, unregistered
+continuation of the exact prepared replacement. It requires the
+`PodmanBootstrapPreparedReplacement`, the same authority-bound engine and
+journal store, and the same stopped-watcher lease. Before request staging and
+around each mutation, it reloads the journal and requires the exact
+`original-stopped` phase. Stable inspections revalidate the full runtime ID,
+immutable image ID, staging name, state-volume name and mountpoint, and
+writable state-volume mount.
+
+The transaction stages one root-apply envelope for the selected agent from a
+mode-`0400` host temporary file into the stopped replacement. It does not use
+`container exec` or a `--user` override. It then starts that exact replacement.
+`awaitPodmanBootstrapImageTransaction` retains the same journal, engine,
+watcher, runtime, and volume authority while polling. It accepts only a
+bounded, stable mode-`0444` completion that authenticates the selected agent,
+bootstrap identity, and managed-startup profile.
+
+When staging, startup, or completion fails after the original stop, this slice
+does not compensate. In the unresolved state, the original is stopped, the
+replacement may remain running, the journal remains in `original-stopped`, and
+the watcher remains stopped. Later slices own compensation, durable resume,
+commit, watcher release, and user-visible activation. Coverage is in
+`podman-image-transaction.test.ts`.
 
 ## Durable resumed recreate journal
 

--- a/src/lib/onboard/managed-bootstrap/README.md
+++ b/src/lib/onboard/managed-bootstrap/README.md
@@ -86,3 +86,12 @@ the direct root-stdin and hold contract without advertising buildless support.
 No production provider invokes the trampoline yet. Until the later provider
 activation and protected E2E slices pass, every production runtime provider
 keeps bootstrap unsupported.
+
+The dormant persisted-engine-authority boundary supports future snapshot,
+rebuild, restore, and recovery work by recording only an operation-scoped
+provider, engine, endpoint-authority, and non-secret binding digest. It adds an
+exact matcher for a freshly provider-qualified injected engine, but no
+production lifecycle calls that matcher yet. The record does not persist an
+executable, endpoint, environment, or credential and does not activate an
+engine. Its contract is provider-neutral; tests use an MXC-style engine to
+ensure central persistence does not gain a Podman-specific selection branch.

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
@@ -1,0 +1,356 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import type { ContainerEngineCommandResult } from "../../adapters/container-engine";
+import {
+  encodeManagedStartupProfile,
+  MANAGED_STARTUP_AGENTS,
+  type ManagedStartupAgent,
+} from "../managed-startup/profile";
+import { createManagedStartupRootApplyRequest } from "../managed-startup/root-apply";
+import {
+  parseManagedBootstrapEnvelope,
+  serializeManagedBootstrapImageCompletion,
+} from "./envelope";
+import {
+  awaitPodmanBootstrapImageTransaction,
+  startPodmanBootstrapImageTransaction,
+} from "./podman-image-transaction";
+import type { PodmanGatewayWatcherLease } from "./podman-watcher-lease";
+
+const RUNTIME_ID = "1".repeat(64);
+const IMAGE_ID = `sha256:${"2".repeat(64)}`;
+const BOOTSTRAP_IDENTITY = "3".repeat(64);
+const AUTHORITY_ID = `podman-sha256:${"4".repeat(64)}`;
+const LEASE_ID = "01234567-89ab-4cde-8fab-0123456789ab";
+
+function requestFor(agent: ManagedStartupAgent) {
+  return createManagedStartupRootApplyRequest({
+    agent,
+    encodedProfile: encodeManagedStartupProfile(managedStartupE2eProfile(agent, false, false)),
+  });
+}
+
+function result(
+  overrides: Partial<ContainerEngineCommandResult> = {},
+): ContainerEngineCommandResult {
+  return { status: 0, stdout: "", stderr: "", ...overrides };
+}
+
+function watcherLease(): PodmanGatewayWatcherLease {
+  return {
+    record: {
+      schemaVersion: 1,
+      leaseId: LEASE_ID,
+      phase: "stopped",
+      gatewayName: "gateway",
+      gatewayPort: 8080,
+      launchIdentity: "launch-1",
+      ownerIdentity: "owner-1",
+      ownerKind: "managed-service",
+      pid: 42,
+      processStartIdentity: "pid-start-1",
+    },
+    assertStillStopped: vi.fn(),
+    resumeAndProve: vi.fn(),
+  };
+}
+
+interface HarnessOptions {
+  readonly completionAgent?: ManagedStartupAgent;
+  readonly completionMode?: number;
+  readonly completionUnavailableCount?: number;
+  readonly inspectImage?: string;
+  readonly inspectRuntimeId?: string;
+  readonly startsRunning?: boolean;
+}
+
+function harness(agent: ManagedStartupAgent, options: HarnessOptions = {}) {
+  const request = requestFor(agent);
+  const commands: string[][] = [];
+  const timeouts: number[] = [];
+  let running = options.startsRunning ?? false;
+  let completionAttempts = 0;
+  let stagedEnvelope = "";
+  const capture = vi.fn(
+    (args: readonly string[], timeoutMs = 15_000): ContainerEngineCommandResult => {
+      commands.push([...args]);
+      timeouts.push(timeoutMs);
+      if (args[0] === "container" && args[1] === "inspect") {
+        return result({
+          stdout: JSON.stringify([
+            {
+              Id: options.inspectRuntimeId ?? RUNTIME_ID,
+              Image: options.inspectImage ?? IMAGE_ID,
+              State: { Dead: false, Paused: false, Restarting: false, Running: running },
+            },
+          ]),
+        });
+      }
+      if (args[0] === "container" && args[1] === "start") {
+        running = true;
+        return result({ stdout: RUNTIME_ID });
+      }
+      if (args[0] === "container" && args[1] === "cp") {
+        const source = args[2] as string;
+        const destination = args[3] as string;
+        if (!source.startsWith(`${RUNTIME_ID}:`)) {
+          stagedEnvelope = fs.readFileSync(source, "utf8");
+          return result();
+        }
+        completionAttempts += 1;
+        if (completionAttempts <= (options.completionUnavailableCount ?? 0)) {
+          return result({ status: 1, stderr: "completion not found" });
+        }
+        fs.writeFileSync(
+          destination,
+          serializeManagedBootstrapImageCompletion({
+            agent: options.completionAgent ?? agent,
+            bootstrapIdentity: BOOTSTRAP_IDENTITY,
+            profileFingerprint: request.profileFingerprint,
+            transactionPending: true,
+          }),
+          { flag: "wx", mode: options.completionMode ?? 0o444 },
+        );
+        fs.chmodSync(destination, options.completionMode ?? 0o444);
+        return result();
+      }
+      return result({ status: 127, stderr: "unexpected command" });
+    },
+  );
+  const engine = {
+    operation: "managed-bootstrap" as const,
+    engineId: "podman",
+    displayName: "Podman",
+    authorityId: AUTHORITY_ID,
+    capture,
+    captureHost: vi.fn(),
+  };
+  const watcher = watcherLease();
+  return {
+    commands,
+    completionAttempts: () => completionAttempts,
+    engine,
+    request,
+    stagedEnvelope: () => stagedEnvelope,
+    timeouts,
+    watcher,
+  };
+}
+
+function startInput(agent: ManagedStartupAgent, fake: ReturnType<typeof harness>) {
+  return {
+    agent,
+    bootstrapIdentity: BOOTSTRAP_IDENTITY,
+    engine: fake.engine,
+    profileFingerprint: fake.request.profileFingerprint,
+    replacementImageContentId: IMAGE_ID,
+    replacementRuntimeId: RUNTIME_ID,
+    request: fake.request,
+    watcherLease: fake.watcher,
+  } as const;
+}
+
+describe("Podman image-owned bootstrap transaction", () => {
+  it.each(
+    MANAGED_STARTUP_AGENTS,
+  )("stages, starts, and authenticates one protected %s completion without exec", (agent) => {
+    const fake = harness(agent);
+    const transaction = startPodmanBootstrapImageTransaction(startInput(agent, fake), {
+      now: () => new Date("2026-08-01T12:00:00.000Z"),
+    });
+    const completion = awaitPodmanBootstrapImageTransaction(
+      {
+        engine: fake.engine,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 30,
+      },
+      { now: () => new Date("2026-08-01T12:00:01.000Z") },
+    );
+
+    expect(parseManagedBootstrapEnvelope(fake.stagedEnvelope())).toEqual({
+      schemaVersion: 1,
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      rootApplyRequest: fake.request,
+    });
+    expect(transaction).toMatchObject({
+      agent,
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      engineAuthorityId: AUTHORITY_ID,
+      replacementRuntimeId: RUNTIME_ID,
+      replacementImageContentId: IMAGE_ID,
+      watcherLeaseId: LEASE_ID,
+    });
+    expect(completion).toMatchObject({
+      agent,
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      engineAuthorityId: AUTHORITY_ID,
+      profileFingerprint: fake.request.profileFingerprint,
+      replacementRuntimeId: RUNTIME_ID,
+      replacementImageContentId: IMAGE_ID,
+      transactionPending: true,
+      watcherLeaseId: LEASE_ID,
+    });
+    expect(fake.commands).toContainEqual(["container", "start", RUNTIME_ID]);
+    expect(fake.commands).toContainEqual([
+      "container",
+      "cp",
+      `${RUNTIME_ID}:/run/nemoclaw/managed-bootstrap-completion.json`,
+      expect.any(String),
+    ]);
+    expect(fake.commands.every((command) => !command.includes("exec"))).toBe(true);
+    expect(fake.commands.every((command) => !command.includes("--user"))).toBe(true);
+    expect(fake.watcher.assertStillStopped).toHaveBeenCalled();
+  });
+
+  it("retries an unpublished completion while retaining the stopped watcher lease", () => {
+    const fake = harness("openclaw", { completionUnavailableCount: 1 });
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+    let milliseconds = 0;
+    const completion = awaitPodmanBootstrapImageTransaction(
+      {
+        engine: fake.engine,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      },
+      {
+        now: () => new Date(milliseconds),
+        pollIntervalMs: 25,
+        sleep: (duration) => {
+          milliseconds += duration;
+        },
+      },
+    );
+
+    expect(completion.agent).toBe("openclaw");
+    expect(fake.completionAttempts()).toBe(2);
+  });
+
+  it("rejects a root request belonging to another agent before any container mutation", () => {
+    const fake = harness("openclaw");
+
+    expect(() =>
+      startPodmanBootstrapImageTransaction({
+        ...startInput("openclaw", fake),
+        request: requestFor("hermes"),
+      }),
+    ).toThrow("root request does not match");
+    expect(fake.commands).toEqual([]);
+  });
+
+  it("rejects a replacement that was already running before request staging", () => {
+    const fake = harness("hermes", { startsRunning: true });
+
+    expect(() => startPodmanBootstrapImageTransaction(startInput("hermes", fake))).toThrow(
+      "not stably stopped",
+    );
+    expect(fake.commands.some((command) => command[1] === "cp")).toBe(false);
+  });
+
+  it("rejects runtime and image drift before request staging", () => {
+    const runtimeDrift = harness("openclaw", { inspectRuntimeId: "5".repeat(64) });
+    const imageDrift = harness("openclaw", { inspectImage: `sha256:${"6".repeat(64)}` });
+
+    expect(() =>
+      startPodmanBootstrapImageTransaction(startInput("openclaw", runtimeDrift)),
+    ).toThrow("runtime or image identity changed");
+    expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", imageDrift))).toThrow(
+      "runtime or image identity changed",
+    );
+  });
+
+  it("rejects a copied completion that is not protected mode 0444", () => {
+    const fake = harness("langchain-deepagents-code", { completionMode: 0o600 });
+    const transaction = startPodmanBootstrapImageTransaction(
+      startInput("langchain-deepagents-code", fake),
+    );
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: fake.engine,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("protected bounded 0444 file");
+  });
+
+  it("rejects completion from another agent", () => {
+    const fake = harness("openclaw", { completionAgent: "hermes" });
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: fake.engine,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("does not match its exact transaction authority");
+  });
+
+  it("rejects endpoint-authority or watcher-lease drift before polling", () => {
+    const fake = harness("openclaw");
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+    const commandsBefore = fake.commands.length;
+    const differentEngine = {
+      ...fake.engine,
+      authorityId: `podman-sha256:${"7".repeat(64)}`,
+    };
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: differentEngine,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("exact Podman managed-bootstrap engine authority");
+    expect(fake.commands).toHaveLength(commandsBefore);
+
+    const differentLease = watcherLease();
+    Object.defineProperty(differentLease.record, "leaseId", {
+      configurable: true,
+      value: "fedcba98-7654-4abc-9def-fedcba987654",
+    });
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: fake.engine,
+        watcherLease: differentLease,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("exact stopped OpenShell watcher lease");
+  });
+
+  it("times out deterministically when the protected completion never appears", () => {
+    const fake = harness("hermes", { completionUnavailableCount: 100 });
+    const transaction = startPodmanBootstrapImageTransaction(startInput("hermes", fake));
+    let milliseconds = 0;
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction(
+        {
+          engine: fake.engine,
+          watcherLease: fake.watcher,
+          transaction,
+          timeoutSecs: 1,
+        },
+        {
+          now: () => new Date(milliseconds),
+          pollIntervalMs: 500,
+          sleep: (duration) => {
+            milliseconds += duration;
+          },
+        },
+      ),
+    ).toThrow("not published before timeout");
+    expect(fake.completionAttempts()).toBe(3);
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
@@ -468,7 +468,7 @@ describe("Podman image-owned bootstrap transaction", () => {
     ).toThrow("does not match its exact transaction authority");
   });
 
-  it("rejects endpoint-authority or watcher-lease drift before polling", () => {
+  it("rejects engine-authority or watcher-lease drift before polling", () => {
     const fake = harness("openclaw");
     const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
     const commandsBefore = fake.commands.length;

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
@@ -119,6 +119,7 @@ interface HarnessOptions {
   readonly inspectName?: string;
   readonly inspectRuntimeId?: string;
   readonly inspectStateVolumeMountpoint?: string;
+  readonly inspectStateVolumeMode?: string;
   readonly inspectStateVolumeName?: string;
   readonly journal?: PodmanBootstrapJournal | null;
   readonly startsRunning?: boolean;
@@ -144,7 +145,7 @@ function harness(agent: ManagedStartupAgent, options: HarnessOptions = {}) {
             {
               Destination: PODMAN_BOOTSTRAP_STATE_DIRECTORY,
               Driver: "local",
-              Mode: "z",
+              Mode: options.inspectStateVolumeMode ?? "z",
               Name: options.inspectStateVolumeName ?? STATE_VOLUME_NAME,
               Options: ["rw"],
               Propagation: "",
@@ -422,6 +423,15 @@ describe("Podman image-owned bootstrap transaction", () => {
       /replacement (runtime, image, or name identity|state-volume authority) changed/u,
     );
     expect(fake.commands.every((command) => command[1] !== "cp")).toBe(true);
+  });
+
+  it("accepts an empty non-authoritative Podman state-volume mount mode", () => {
+    const fake = harness("openclaw", { inspectStateVolumeMode: "" });
+
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+
+    expect(transaction.replacementStateVolumeName).toBe(STATE_VOLUME_NAME);
+    expect(fake.commands).toContainEqual(["container", "start", RUNTIME_ID]);
   });
 
   it("rejects a copied completion that is not protected mode 0444", () => {

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
@@ -16,6 +16,12 @@ import {
   parseManagedBootstrapEnvelope,
   serializeManagedBootstrapImageCompletion,
 } from "./envelope";
+import type { PodmanBootstrapJournal } from "./podman-bootstrap-journal";
+import {
+  PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+  PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+  type PodmanBootstrapPreparedReplacement,
+} from "./podman-bootstrap-replacement";
 import {
   awaitPodmanBootstrapImageTransaction,
   startPodmanBootstrapImageTransaction,
@@ -23,10 +29,15 @@ import {
 import type { PodmanGatewayWatcherLease } from "./podman-watcher-lease";
 
 const RUNTIME_ID = "1".repeat(64);
+const ORIGINAL_RUNTIME_ID = "0".repeat(64);
 const IMAGE_ID = `sha256:${"2".repeat(64)}`;
 const BOOTSTRAP_IDENTITY = "3".repeat(64);
 const AUTHORITY_ID = `podman-sha256:${"4".repeat(64)}`;
 const LEASE_ID = "01234567-89ab-4cde-8fab-0123456789ab";
+const SPEC_FINGERPRINT = "5".repeat(64);
+const STAGING_NAME = "sandbox-nemoclaw-bootstrap-333333333333";
+const STATE_VOLUME_NAME = "sandbox-nemoclaw-state-333333333333";
+const STATE_VOLUME_MOUNTPOINT = "/var/lib/containers/storage/volumes/state/_data";
 
 function requestFor(agent: ManagedStartupAgent) {
   return createManagedStartupRootApplyRequest({
@@ -60,17 +71,63 @@ function watcherLease(): PodmanGatewayWatcherLease {
   };
 }
 
+function journal(overrides: Partial<PodmanBootstrapJournal> = {}): PodmanBootstrapJournal {
+  return {
+    schemaVersion: 1,
+    phase: "original-stopped",
+    bootstrapIdentity: BOOTSTRAP_IDENTITY,
+    engineAuthorityId: AUTHORITY_ID,
+    watcherLeaseId: LEASE_ID,
+    sandboxName: "sandbox",
+    sandboxId: "sandbox-id",
+    originalRuntimeId: ORIGINAL_RUNTIME_ID,
+    originalContainerName: "sandbox-original",
+    originalImageContentId: `sha256:${"6".repeat(64)}`,
+    originalSpecFingerprint: "7".repeat(64),
+    replacementStateVolumeName: STATE_VOLUME_NAME,
+    replacementStateVolumeMountpoint: STATE_VOLUME_MOUNTPOINT,
+    replacementRuntimeId: RUNTIME_ID,
+    replacementStagingName: STAGING_NAME,
+    replacementImageContentId: IMAGE_ID,
+    replacementSpecFingerprint: SPEC_FINGERPRINT,
+    ...overrides,
+  };
+}
+
+function preparedReplacement(
+  durableJournal: PodmanBootstrapJournal = journal(),
+): PodmanBootstrapPreparedReplacement {
+  return {
+    schemaVersion: PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+    bootstrapIdentity: durableJournal.bootstrapIdentity,
+    originalRuntimeId: durableJournal.originalRuntimeId,
+    replacementRuntimeId: durableJournal.replacementRuntimeId as string,
+    replacementStagingName: durableJournal.replacementStagingName,
+    replacementStateVolumeName: durableJournal.replacementStateVolumeName,
+    replacementStateVolumeMountpoint: durableJournal.replacementStateVolumeMountpoint as string,
+    replacementImageContentId: durableJournal.replacementImageContentId,
+    replacementSpecFingerprint: durableJournal.replacementSpecFingerprint,
+    journal: durableJournal,
+  };
+}
+
 interface HarnessOptions {
   readonly completionAgent?: ManagedStartupAgent;
   readonly completionMode?: number;
   readonly completionUnavailableCount?: number;
   readonly inspectImage?: string;
+  readonly inspectName?: string;
   readonly inspectRuntimeId?: string;
+  readonly inspectStateVolumeMountpoint?: string;
+  readonly inspectStateVolumeName?: string;
+  readonly journal?: PodmanBootstrapJournal | null;
   readonly startsRunning?: boolean;
 }
 
 function harness(agent: ManagedStartupAgent, options: HarnessOptions = {}) {
   const request = requestFor(agent);
+  const prepared = preparedReplacement();
+  const durableJournal = options.journal === undefined ? prepared.journal : options.journal;
   const commands: string[][] = [];
   const timeouts: number[] = [];
   let running = options.startsRunning ?? false;
@@ -82,6 +139,20 @@ function harness(agent: ManagedStartupAgent, options: HarnessOptions = {}) {
         {
           Id: options.inspectRuntimeId ?? RUNTIME_ID,
           Image: options.inspectImage ?? IMAGE_ID,
+          Name: options.inspectName ?? STAGING_NAME,
+          Mounts: [
+            {
+              Destination: PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+              Driver: "local",
+              Mode: "z",
+              Name: options.inspectStateVolumeName ?? STATE_VOLUME_NAME,
+              Options: ["rw"],
+              Propagation: "",
+              RW: true,
+              Source: options.inspectStateVolumeMountpoint ?? STATE_VOLUME_MOUNTPOINT,
+              Type: "volume",
+            },
+          ],
           State: { Dead: false, Paused: false, Restarting: false, Running: running },
         },
       ]),
@@ -146,11 +217,14 @@ function harness(agent: ManagedStartupAgent, options: HarnessOptions = {}) {
     capture,
     captureHost: vi.fn(),
   };
+  const journalStore = { load: vi.fn(() => durableJournal) };
   const watcher = watcherLease();
   return {
     commands,
     completionAttempts: () => completionAttempts,
     engine,
+    journalStore,
+    prepared,
     request,
     stagedEnvelope: () => stagedEnvelope,
     timeouts,
@@ -161,11 +235,10 @@ function harness(agent: ManagedStartupAgent, options: HarnessOptions = {}) {
 function startInput(agent: ManagedStartupAgent, fake: ReturnType<typeof harness>) {
   return {
     agent,
-    bootstrapIdentity: BOOTSTRAP_IDENTITY,
     engine: fake.engine,
+    journalStore: fake.journalStore,
+    prepared: fake.prepared,
     profileFingerprint: fake.request.profileFingerprint,
-    replacementImageContentId: IMAGE_ID,
-    replacementRuntimeId: RUNTIME_ID,
     request: fake.request,
     watcherLease: fake.watcher,
   } as const;
@@ -182,6 +255,8 @@ describe("Podman image-owned bootstrap transaction", () => {
     const completion = awaitPodmanBootstrapImageTransaction(
       {
         engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
         watcherLease: fake.watcher,
         transaction,
         timeoutSecs: 30,
@@ -198,17 +273,27 @@ describe("Podman image-owned bootstrap transaction", () => {
       agent,
       bootstrapIdentity: BOOTSTRAP_IDENTITY,
       engineAuthorityId: AUTHORITY_ID,
+      originalRuntimeId: ORIGINAL_RUNTIME_ID,
       replacementRuntimeId: RUNTIME_ID,
       replacementImageContentId: IMAGE_ID,
+      replacementSpecFingerprint: SPEC_FINGERPRINT,
+      replacementStagingName: STAGING_NAME,
+      replacementStateVolumeMountpoint: STATE_VOLUME_MOUNTPOINT,
+      replacementStateVolumeName: STATE_VOLUME_NAME,
       watcherLeaseId: LEASE_ID,
     });
     expect(completion).toMatchObject({
       agent,
       bootstrapIdentity: BOOTSTRAP_IDENTITY,
       engineAuthorityId: AUTHORITY_ID,
+      originalRuntimeId: ORIGINAL_RUNTIME_ID,
       profileFingerprint: fake.request.profileFingerprint,
       replacementRuntimeId: RUNTIME_ID,
       replacementImageContentId: IMAGE_ID,
+      replacementSpecFingerprint: SPEC_FINGERPRINT,
+      replacementStagingName: STAGING_NAME,
+      replacementStateVolumeMountpoint: STATE_VOLUME_MOUNTPOINT,
+      replacementStateVolumeName: STATE_VOLUME_NAME,
       transactionPending: true,
       watcherLeaseId: LEASE_ID,
     });
@@ -231,6 +316,8 @@ describe("Podman image-owned bootstrap transaction", () => {
     const completion = awaitPodmanBootstrapImageTransaction(
       {
         engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
         watcherLease: fake.watcher,
         transaction,
         timeoutSecs: 1,
@@ -248,6 +335,23 @@ describe("Podman image-owned bootstrap transaction", () => {
     expect(fake.completionAttempts()).toBe(2);
   });
 
+  it("rejects a durable journal lost after replacement startup", () => {
+    const fake = harness("openclaw");
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+    fake.journalStore.load.mockReturnValue(null);
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("durable prepared-replacement journal is unavailable");
+  });
+
   it("rejects a root request belonging to another agent before any container mutation", () => {
     const fake = harness("openclaw");
 
@@ -257,6 +361,32 @@ describe("Podman image-owned bootstrap transaction", () => {
         request: requestFor("hermes"),
       }),
     ).toThrow("root request does not match");
+    expect(fake.commands).toEqual([]);
+  });
+
+  it("rejects a lost durable replacement journal before request staging", () => {
+    const fake = harness("openclaw", { journal: null });
+
+    expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", fake))).toThrow(
+      "durable prepared-replacement journal is unavailable",
+    );
+    expect(fake.commands).toEqual([]);
+  });
+
+  it.each([
+    ["phase", { phase: "replacement-created" as const }],
+    ["engine authority", { engineAuthorityId: `podman-sha256:${"8".repeat(64)}` }],
+    ["watcher lease", { watcherLeaseId: "fedcba98-7654-4abc-9def-fedcba987654" }],
+    ["replacement runtime", { replacementRuntimeId: "9".repeat(64) }],
+    ["replacement image", { replacementImageContentId: `sha256:${"a".repeat(64)}` }],
+    ["replacement name", { replacementStagingName: "different-staging-name" }],
+    ["state volume", { replacementStateVolumeName: "different-state-volume" }],
+  ])("rejects durable %s drift before request staging", (_label, overrides) => {
+    const fake = harness("openclaw", { journal: journal(overrides) });
+
+    expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", fake))).toThrow(
+      "exact original-stopped authority",
+    );
     expect(fake.commands).toEqual([]);
   });
 
@@ -275,10 +405,23 @@ describe("Podman image-owned bootstrap transaction", () => {
 
     expect(() =>
       startPodmanBootstrapImageTransaction(startInput("openclaw", runtimeDrift)),
-    ).toThrow("runtime or image identity changed");
+    ).toThrow("runtime, image, or name identity changed");
     expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", imageDrift))).toThrow(
-      "runtime or image identity changed",
+      "runtime, image, or name identity changed",
     );
+  });
+
+  it.each([
+    ["replacement name", { inspectName: "different-staging-name" }],
+    ["state-volume name", { inspectStateVolumeName: "different-state-volume" }],
+    ["state-volume mountpoint", { inspectStateVolumeMountpoint: "/different/mountpoint" }],
+  ])("rejects live %s drift before request staging", (_label, options) => {
+    const fake = harness("openclaw", options);
+
+    expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", fake))).toThrow(
+      /replacement (runtime, image, or name identity|state-volume authority) changed/u,
+    );
+    expect(fake.commands.every((command) => command[1] !== "cp")).toBe(true);
   });
 
   it("rejects a copied completion that is not protected mode 0444", () => {
@@ -290,6 +433,8 @@ describe("Podman image-owned bootstrap transaction", () => {
     expect(() =>
       awaitPodmanBootstrapImageTransaction({
         engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
         watcherLease: fake.watcher,
         transaction,
         timeoutSecs: 1,
@@ -304,6 +449,8 @@ describe("Podman image-owned bootstrap transaction", () => {
     expect(() =>
       awaitPodmanBootstrapImageTransaction({
         engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
         watcherLease: fake.watcher,
         transaction,
         timeoutSecs: 1,
@@ -323,6 +470,8 @@ describe("Podman image-owned bootstrap transaction", () => {
     expect(() =>
       awaitPodmanBootstrapImageTransaction({
         engine: differentEngine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
         watcherLease: fake.watcher,
         transaction,
         timeoutSecs: 1,
@@ -338,6 +487,8 @@ describe("Podman image-owned bootstrap transaction", () => {
     expect(() =>
       awaitPodmanBootstrapImageTransaction({
         engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
         watcherLease: differentLease,
         transaction,
         timeoutSecs: 1,
@@ -354,6 +505,8 @@ describe("Podman image-owned bootstrap transaction", () => {
       awaitPodmanBootstrapImageTransaction(
         {
           engine: fake.engine,
+          journalStore: fake.journalStore,
+          prepared: fake.prepared,
           watcherLease: fake.watcher,
           transaction,
           timeoutSecs: 1,

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
@@ -76,50 +76,66 @@ function harness(agent: ManagedStartupAgent, options: HarnessOptions = {}) {
   let running = options.startsRunning ?? false;
   let completionAttempts = 0;
   let stagedEnvelope = "";
+  const inspect = (): ContainerEngineCommandResult =>
+    result({
+      stdout: JSON.stringify([
+        {
+          Id: options.inspectRuntimeId ?? RUNTIME_ID,
+          Image: options.inspectImage ?? IMAGE_ID,
+          State: { Dead: false, Paused: false, Restarting: false, Running: running },
+        },
+      ]),
+    });
+  const start = (): ContainerEngineCommandResult => {
+    running = true;
+    return result({ stdout: RUNTIME_ID });
+  };
+  const stageEnvelope = (source: string): ContainerEngineCommandResult => {
+    stagedEnvelope = fs.readFileSync(source, "utf8");
+    return result();
+  };
+  const publishCompletion = (destination: string): ContainerEngineCommandResult => {
+    fs.writeFileSync(
+      destination,
+      serializeManagedBootstrapImageCompletion({
+        agent: options.completionAgent ?? agent,
+        bootstrapIdentity: BOOTSTRAP_IDENTITY,
+        profileFingerprint: request.profileFingerprint,
+        transactionPending: true,
+      }),
+      { flag: "wx", mode: options.completionMode ?? 0o444 },
+    );
+    fs.chmodSync(destination, options.completionMode ?? 0o444);
+    return result();
+  };
+  const copyCompletion = (destination: string): ContainerEngineCommandResult => {
+    completionAttempts += 1;
+    return completionAttempts <= (options.completionUnavailableCount ?? 0)
+      ? result({ status: 1, stderr: "completion not found" })
+      : publishCompletion(destination);
+  };
+  const copy = (args: readonly string[]): ContainerEngineCommandResult => {
+    const source = args[2] as string;
+    const destination = args[3] as string;
+    return source.startsWith(`${RUNTIME_ID}:`)
+      ? copyCompletion(destination)
+      : stageEnvelope(source);
+  };
+  const handlers: Readonly<
+    Record<string, (args: readonly string[]) => ContainerEngineCommandResult>
+  > = {
+    "container cp": copy,
+    "container inspect": inspect,
+    "container start": start,
+  };
   const capture = vi.fn(
     (args: readonly string[], timeoutMs = 15_000): ContainerEngineCommandResult => {
       commands.push([...args]);
       timeouts.push(timeoutMs);
-      if (args[0] === "container" && args[1] === "inspect") {
-        return result({
-          stdout: JSON.stringify([
-            {
-              Id: options.inspectRuntimeId ?? RUNTIME_ID,
-              Image: options.inspectImage ?? IMAGE_ID,
-              State: { Dead: false, Paused: false, Restarting: false, Running: running },
-            },
-          ]),
-        });
-      }
-      if (args[0] === "container" && args[1] === "start") {
-        running = true;
-        return result({ stdout: RUNTIME_ID });
-      }
-      if (args[0] === "container" && args[1] === "cp") {
-        const source = args[2] as string;
-        const destination = args[3] as string;
-        if (!source.startsWith(`${RUNTIME_ID}:`)) {
-          stagedEnvelope = fs.readFileSync(source, "utf8");
-          return result();
-        }
-        completionAttempts += 1;
-        if (completionAttempts <= (options.completionUnavailableCount ?? 0)) {
-          return result({ status: 1, stderr: "completion not found" });
-        }
-        fs.writeFileSync(
-          destination,
-          serializeManagedBootstrapImageCompletion({
-            agent: options.completionAgent ?? agent,
-            bootstrapIdentity: BOOTSTRAP_IDENTITY,
-            profileFingerprint: request.profileFingerprint,
-            transactionPending: true,
-          }),
-          { flag: "wx", mode: options.completionMode ?? 0o444 },
-        );
-        fs.chmodSync(destination, options.completionMode ?? 0o444);
-        return result();
-      }
-      return result({ status: 127, stderr: "unexpected command" });
+      return (
+        handlers[`${args[0] ?? ""} ${args[1] ?? ""}`]?.(args) ??
+        result({ status: 127, stderr: "unexpected command" })
+      );
     },
   );
   const engine = {

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
@@ -294,7 +294,6 @@ function exactStateVolume(
     mount.Driver !== "local" ||
     mount.RW !== true ||
     !["", "rprivate"].includes(propagation) ||
-    !modeTokens.has("z") ||
     modeTokens.has("Z") ||
     modeTokens.has("ro") ||
     options.some((option) => option === "ro" || option === "readonly")

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
@@ -1,0 +1,499 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+
+import type {
+  ContainerEngine,
+  ContainerEngineCommandResult,
+} from "../../adapters/container-engine";
+import { MANAGED_STARTUP_AGENTS, type ManagedStartupAgent } from "../managed-startup/profile";
+import type { ManagedStartupRootApplyRequest } from "../managed-startup/root-apply";
+import { cleanupTempDir, secureTempFile } from "../temp-files";
+import {
+  MANAGED_BOOTSTRAP_COMPLETION_FILE,
+  MANAGED_BOOTSTRAP_COMPLETION_MAX_BYTES,
+  MANAGED_BOOTSTRAP_REQUEST_FILE,
+  type ManagedBootstrapImageCompletion,
+  parseManagedBootstrapImageCompletion,
+  serializeManagedBootstrapEnvelope,
+} from "./envelope";
+import type { PodmanGatewayWatcherLease } from "./podman-watcher-lease";
+
+export const PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION = 1 as const;
+
+const REQUEST_TEMP_PREFIX = "nemoclaw-podman-bootstrap-request";
+const COMPLETION_TEMP_PREFIX = "nemoclaw-podman-bootstrap-completion";
+const FULL_RUNTIME_ID = /^[a-f0-9]{64}$/u;
+const IMAGE_CONTENT_ID = /^sha256:[a-f0-9]{64}$/u;
+const SHA256 = /^[a-f0-9]{64}$/u;
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+const DEFAULT_START_TIMEOUT_MS = 90_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+const MAX_TIMEOUT_SECONDS = 3_600;
+
+type BootstrapEngine = ContainerEngine & { readonly authorityId: string };
+
+export interface PodmanBootstrapImageTransactionInput {
+  readonly engine: BootstrapEngine;
+  readonly watcherLease: PodmanGatewayWatcherLease;
+  readonly agent: ManagedStartupAgent;
+  readonly bootstrapIdentity: string;
+  readonly profileFingerprint: string;
+  readonly replacementRuntimeId: string;
+  readonly replacementImageContentId: string;
+  readonly request: ManagedStartupRootApplyRequest;
+}
+
+export interface PodmanBootstrapImageTransaction {
+  readonly schemaVersion: typeof PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION;
+  readonly agent: ManagedStartupAgent;
+  readonly bootstrapIdentity: string;
+  readonly engineAuthorityId: string;
+  readonly profileFingerprint: string;
+  readonly replacementRuntimeId: string;
+  readonly replacementImageContentId: string;
+  readonly watcherLeaseId: string;
+  readonly startedAt: string;
+}
+
+export interface PodmanBootstrapImageTransactionCompletion extends ManagedBootstrapImageCompletion {
+  readonly engineAuthorityId: string;
+  readonly replacementRuntimeId: string;
+  readonly replacementImageContentId: string;
+  readonly watcherLeaseId: string;
+  readonly completedAt: string;
+}
+
+export interface PodmanBootstrapImageTransactionDeps {
+  readonly now?: () => Date;
+  readonly sleep?: (milliseconds: number) => void;
+  readonly pollIntervalMs?: number;
+}
+
+interface ExactPodmanContainerState {
+  readonly imageContentId: string;
+  readonly runtimeId: string;
+  readonly running: boolean;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function fail(message: string): never {
+  throw new Error(`Podman managed bootstrap image transaction failed: ${message}`);
+}
+
+function exactEngine(engine: BootstrapEngine, expectedAuthorityId?: string): BootstrapEngine {
+  if (
+    engine.engineId !== "podman" ||
+    engine.operation !== "managed-bootstrap" ||
+    typeof engine.authorityId !== "string" ||
+    !/^podman-sha256:[a-f0-9]{64}$/u.test(engine.authorityId) ||
+    (expectedAuthorityId !== undefined && engine.authorityId !== expectedAuthorityId)
+  ) {
+    fail("the exact Podman managed-bootstrap engine authority is unavailable");
+  }
+  return engine;
+}
+
+function exactAgent(value: string): ManagedStartupAgent {
+  if ((MANAGED_STARTUP_AGENTS as readonly string[]).includes(value)) {
+    return value as ManagedStartupAgent;
+  }
+  return fail("the managed agent is unsupported");
+}
+
+function exactSha256(value: string, label: string): string {
+  if (!SHA256.test(value)) fail(`${label} must be lowercase SHA-256`);
+  return value;
+}
+
+function exactRuntimeId(value: string): string {
+  if (!FULL_RUNTIME_ID.test(value)) fail("replacement runtime ID must be a full lowercase ID");
+  return value;
+}
+
+function exactImageContentId(value: string): string {
+  if (!IMAGE_CONTENT_ID.test(value)) {
+    fail("replacement image identity must be one immutable content ID");
+  }
+  return value;
+}
+
+function exactWatcherLease(lease: PodmanGatewayWatcherLease, expectedLeaseId?: string): void {
+  if (
+    !lease ||
+    typeof lease !== "object" ||
+    lease.record?.phase !== "stopped" ||
+    (expectedLeaseId !== undefined && lease.record.leaseId !== expectedLeaseId)
+  ) {
+    fail("the exact stopped OpenShell watcher lease is unavailable");
+  }
+  lease.assertStillStopped();
+}
+
+function commandFailure(result: ContainerEngineCommandResult, action: string): never {
+  const detail = result.error?.message.trim().slice(0, 400);
+  fail(`${action} returned status ${String(result.status)}${detail ? `: ${detail}` : ""}`);
+}
+
+function capture(
+  engine: BootstrapEngine,
+  args: readonly string[],
+  action: string,
+  timeoutMs = DEFAULT_COMMAND_TIMEOUT_MS,
+): ContainerEngineCommandResult {
+  const result = engine.capture(args, timeoutMs);
+  if (result.status !== 0) commandFailure(result, action);
+  return result;
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value as JsonRecord;
+}
+
+function normalizedRuntimeId(value: unknown, label: string): string {
+  if (typeof value !== "string") fail(`${label} is missing`);
+  const match = /^(?:sha256:)?([a-f0-9]{64})$/u.exec(value);
+  if (!match?.[1]) fail(`${label} must be one full immutable ID`);
+  return match[1];
+}
+
+function parseInspect(
+  text: string,
+  expectedRuntimeId: string,
+  expectedImageContentId: string,
+): ExactPodmanContainerState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return fail("Podman inspect returned unreadable JSON");
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 1) {
+    return fail("Podman inspect did not return exactly one replacement");
+  }
+  const inspect = record(parsed[0], "Podman replacement inspect");
+  const runtimeId = normalizedRuntimeId(inspect.Id, "Podman replacement runtime ID");
+  const imageContentId = `sha256:${normalizedRuntimeId(
+    inspect.Image,
+    "Podman replacement image content ID",
+  )}`;
+  if (runtimeId !== expectedRuntimeId || imageContentId !== expectedImageContentId) {
+    return fail("the exact replacement runtime or image identity changed");
+  }
+  const state = record(inspect.State, "Podman replacement state");
+  if (
+    typeof state.Running !== "boolean" ||
+    (state.Paused !== undefined && typeof state.Paused !== "boolean") ||
+    (state.Restarting !== undefined && typeof state.Restarting !== "boolean") ||
+    (state.Dead !== undefined && typeof state.Dead !== "boolean") ||
+    state.Paused === true ||
+    state.Restarting === true ||
+    state.Dead === true
+  ) {
+    return fail("the exact replacement is not in a stable running or stopped state");
+  }
+  return Object.freeze({ imageContentId, runtimeId, running: state.Running });
+}
+
+function inspectExact(
+  engine: BootstrapEngine,
+  runtimeId: string,
+  imageContentId: string,
+): ExactPodmanContainerState {
+  return parseInspect(
+    capture(engine, ["container", "inspect", runtimeId], "exact replacement inspection").stdout,
+    runtimeId,
+    imageContentId,
+  );
+}
+
+function sameState(left: ExactPodmanContainerState, right: ExactPodmanContainerState): boolean {
+  return (
+    left.runtimeId === right.runtimeId &&
+    left.imageContentId === right.imageContentId &&
+    left.running === right.running
+  );
+}
+
+function inspectStable(
+  engine: BootstrapEngine,
+  runtimeId: string,
+  imageContentId: string,
+  expectedRunning: boolean,
+): ExactPodmanContainerState {
+  const first = inspectExact(engine, runtimeId, imageContentId);
+  const second = inspectExact(engine, runtimeId, imageContentId);
+  if (!sameState(first, second) || second.running !== expectedRunning) {
+    fail(`the exact replacement is not stably ${expectedRunning ? "running" : "stopped"}`);
+  }
+  return second;
+}
+
+function writeProtectedEnvelope(input: PodmanBootstrapImageTransactionInput): string {
+  const file = secureTempFile(REQUEST_TEMP_PREFIX, ".json");
+  try {
+    fs.writeFileSync(
+      file,
+      serializeManagedBootstrapEnvelope({
+        bootstrapIdentity: input.bootstrapIdentity,
+        rootApplyRequest: input.request,
+      }),
+      { encoding: "utf8", flag: "wx", mode: 0o400 },
+    );
+    fs.chmodSync(file, 0o400);
+    const stat = fs.lstatSync(file);
+    if (
+      !stat.isFile() ||
+      stat.isSymbolicLink() ||
+      stat.nlink !== 1 ||
+      (stat.mode & 0o777) !== 0o400
+    ) {
+      fail("the root request source is not one protected 0400 file");
+    }
+    return file;
+  } catch (error) {
+    cleanupTempDir(file, REQUEST_TEMP_PREFIX);
+    throw error;
+  }
+}
+
+function stageProtectedEnvelope(input: PodmanBootstrapImageTransactionInput): void {
+  const file = writeProtectedEnvelope(input);
+  try {
+    capture(
+      input.engine,
+      ["container", "cp", file, `${input.replacementRuntimeId}:${MANAGED_BOOTSTRAP_REQUEST_FILE}`],
+      "protected root request staging",
+    );
+  } finally {
+    cleanupTempDir(file, REQUEST_TEMP_PREFIX);
+  }
+}
+
+function sameStableMetadata(left: fs.BigIntStats, right: fs.BigIntStats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.nlink === right.nlink &&
+    left.uid === right.uid &&
+    left.gid === right.gid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function readProtectedCompletion(file: string): ManagedBootstrapImageCompletion {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") fail("O_NOFOLLOW is unavailable for completion reads");
+  const nonblock = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(file, fs.constants.O_RDONLY | noFollow | nonblock);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      return fail("the copied completion ownership boundary is invalid");
+    }
+    throw error;
+  }
+  try {
+    const before = fs.fstatSync(descriptor, { bigint: true });
+    if (
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      Number(before.mode & 0o777n) !== 0o444 ||
+      before.size < 1n ||
+      before.size > BigInt(MANAGED_BOOTSTRAP_COMPLETION_MAX_BYTES)
+    ) {
+      return fail("the image completion is not one protected bounded 0444 file");
+    }
+    const bytes = Buffer.alloc(Number(before.size));
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = fs.readSync(descriptor, bytes, offset, bytes.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const overflow = Buffer.alloc(1);
+    const overflowCount = fs.readSync(descriptor, overflow, 0, 1, offset);
+    const after = fs.fstatSync(descriptor, { bigint: true });
+    if (offset !== bytes.length || overflowCount !== 0 || !sameStableMetadata(before, after)) {
+      return fail("the image completion changed during its stable read");
+    }
+    return parseManagedBootstrapImageCompletion(bytes.toString("utf8"));
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function tryCopyCompletion(
+  engine: BootstrapEngine,
+  runtimeId: string,
+): { readonly completion: ManagedBootstrapImageCompletion | null; readonly status: number } {
+  const file = secureTempFile(COMPLETION_TEMP_PREFIX, ".json");
+  try {
+    const result = engine.capture(
+      ["container", "cp", `${runtimeId}:${MANAGED_BOOTSTRAP_COMPLETION_FILE}`, file],
+      DEFAULT_COMMAND_TIMEOUT_MS,
+    );
+    if (result.status !== 0) return { completion: null, status: result.status };
+    return { completion: readProtectedCompletion(file), status: result.status };
+  } finally {
+    cleanupTempDir(file, COMPLETION_TEMP_PREFIX);
+  }
+}
+
+function defaultSleep(milliseconds: number): void {
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function timeoutMilliseconds(timeoutSecs: number): number {
+  if (!Number.isSafeInteger(timeoutSecs) || timeoutSecs < 1 || timeoutSecs > MAX_TIMEOUT_SECONDS) {
+    fail(`completion timeout must be an integer from 1 to ${String(MAX_TIMEOUT_SECONDS)} seconds`);
+  }
+  return timeoutSecs * 1_000;
+}
+
+function pollInterval(deps: PodmanBootstrapImageTransactionDeps): number {
+  const value = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  if (!Number.isSafeInteger(value) || value < 1 || value > 10_000) {
+    fail("completion polling interval must be an integer from 1 to 10000 milliseconds");
+  }
+  return value;
+}
+
+function assertInput(input: PodmanBootstrapImageTransactionInput): void {
+  exactEngine(input.engine);
+  exactWatcherLease(input.watcherLease);
+  exactAgent(input.agent);
+  exactSha256(input.bootstrapIdentity, "bootstrap identity");
+  exactSha256(input.profileFingerprint, "profile fingerprint");
+  exactRuntimeId(input.replacementRuntimeId);
+  exactImageContentId(input.replacementImageContentId);
+  if (
+    input.request.agent !== input.agent ||
+    input.request.profileFingerprint !== input.profileFingerprint
+  ) {
+    fail("the root request does not match its exact agent and profile authority");
+  }
+}
+
+/**
+ * Stage one identity-bound request into the stopped writable layer, then start
+ * that exact replacement. The image-owned trampoline remains the only root
+ * application boundary; this host path never enters a container process.
+ */
+export function startPodmanBootstrapImageTransaction(
+  input: PodmanBootstrapImageTransactionInput,
+  deps: Pick<PodmanBootstrapImageTransactionDeps, "now"> = {},
+): PodmanBootstrapImageTransaction {
+  assertInput(input);
+  inspectStable(input.engine, input.replacementRuntimeId, input.replacementImageContentId, false);
+  exactWatcherLease(input.watcherLease);
+  stageProtectedEnvelope(input);
+  exactWatcherLease(input.watcherLease);
+  inspectStable(input.engine, input.replacementRuntimeId, input.replacementImageContentId, false);
+  capture(
+    input.engine,
+    ["container", "start", input.replacementRuntimeId],
+    "exact replacement start",
+    DEFAULT_START_TIMEOUT_MS,
+  );
+  exactWatcherLease(input.watcherLease);
+  inspectStable(input.engine, input.replacementRuntimeId, input.replacementImageContentId, true);
+  exactWatcherLease(input.watcherLease);
+  return Object.freeze({
+    schemaVersion: PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION,
+    agent: input.agent,
+    bootstrapIdentity: input.bootstrapIdentity,
+    engineAuthorityId: input.engine.authorityId,
+    profileFingerprint: input.profileFingerprint,
+    replacementRuntimeId: input.replacementRuntimeId,
+    replacementImageContentId: input.replacementImageContentId,
+    watcherLeaseId: input.watcherLease.record.leaseId,
+    startedAt: (deps.now ?? (() => new Date()))().toISOString(),
+  });
+}
+
+/** Poll one protected image-owned completion while the exact watcher stays stopped. */
+export function awaitPodmanBootstrapImageTransaction(
+  input: {
+    readonly engine: BootstrapEngine;
+    readonly watcherLease: PodmanGatewayWatcherLease;
+    readonly transaction: PodmanBootstrapImageTransaction;
+    readonly timeoutSecs: number;
+  },
+  deps: PodmanBootstrapImageTransactionDeps = {},
+): PodmanBootstrapImageTransactionCompletion {
+  const transaction = input.transaction;
+  if (
+    transaction.schemaVersion !== PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION ||
+    exactAgent(transaction.agent) !== transaction.agent
+  ) {
+    return fail("the started transaction receipt is invalid");
+  }
+  exactEngine(input.engine, transaction.engineAuthorityId);
+  exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
+  exactSha256(transaction.bootstrapIdentity, "bootstrap identity");
+  exactSha256(transaction.profileFingerprint, "profile fingerprint");
+  exactRuntimeId(transaction.replacementRuntimeId);
+  exactImageContentId(transaction.replacementImageContentId);
+  const timeoutMs = timeoutMilliseconds(input.timeoutSecs);
+  const intervalMs = pollInterval(deps);
+  const now = deps.now ?? (() => new Date());
+  const sleep = deps.sleep ?? defaultSleep;
+  const deadline = now().getTime() + timeoutMs;
+  let lastCopyStatus: number | null = null;
+
+  while (true) {
+    exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
+    inspectStable(
+      input.engine,
+      transaction.replacementRuntimeId,
+      transaction.replacementImageContentId,
+      true,
+    );
+    const copied = tryCopyCompletion(input.engine, transaction.replacementRuntimeId);
+    lastCopyStatus = copied.status;
+    if (copied.completion) {
+      const completion = copied.completion;
+      if (
+        completion.agent !== transaction.agent ||
+        completion.bootstrapIdentity !== transaction.bootstrapIdentity ||
+        completion.profileFingerprint !== transaction.profileFingerprint
+      ) {
+        return fail("the image completion does not match its exact transaction authority");
+      }
+      inspectStable(
+        input.engine,
+        transaction.replacementRuntimeId,
+        transaction.replacementImageContentId,
+        true,
+      );
+      exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
+      return Object.freeze({
+        ...completion,
+        engineAuthorityId: transaction.engineAuthorityId,
+        replacementRuntimeId: transaction.replacementRuntimeId,
+        replacementImageContentId: transaction.replacementImageContentId,
+        watcherLeaseId: transaction.watcherLeaseId,
+        completedAt: now().toISOString(),
+      });
+    }
+    if (now().getTime() >= deadline) {
+      return fail(
+        `protected image completion was not published before timeout (last copy status ${String(
+          lastCopyStatus,
+        )})`,
+      );
+    }
+    sleep(intervalMs);
+  }
+}

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import path from "node:path";
 
 import type {
   ContainerEngine,
@@ -18,6 +19,16 @@ import {
   parseManagedBootstrapImageCompletion,
   serializeManagedBootstrapEnvelope,
 } from "./envelope";
+import {
+  normalizePodmanBootstrapJournal,
+  type PodmanBootstrapJournal,
+  type PodmanBootstrapJournalStore,
+} from "./podman-bootstrap-journal";
+import {
+  PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+  PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+  type PodmanBootstrapPreparedReplacement,
+} from "./podman-bootstrap-replacement";
 import type { PodmanGatewayWatcherLease } from "./podman-watcher-lease";
 
 export const PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION = 1 as const;
@@ -27,6 +38,7 @@ const COMPLETION_TEMP_PREFIX = "nemoclaw-podman-bootstrap-completion";
 const FULL_RUNTIME_ID = /^[a-f0-9]{64}$/u;
 const IMAGE_CONTENT_ID = /^sha256:[a-f0-9]{64}$/u;
 const SHA256 = /^[a-f0-9]{64}$/u;
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,252}$/u;
 const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
 const DEFAULT_START_TIMEOUT_MS = 90_000;
 const DEFAULT_POLL_INTERVAL_MS = 250;
@@ -36,12 +48,11 @@ type BootstrapEngine = ContainerEngine & { readonly authorityId: string };
 
 export interface PodmanBootstrapImageTransactionInput {
   readonly engine: BootstrapEngine;
+  readonly journalStore: Pick<PodmanBootstrapJournalStore, "load">;
   readonly watcherLease: PodmanGatewayWatcherLease;
   readonly agent: ManagedStartupAgent;
-  readonly bootstrapIdentity: string;
+  readonly prepared: PodmanBootstrapPreparedReplacement;
   readonly profileFingerprint: string;
-  readonly replacementRuntimeId: string;
-  readonly replacementImageContentId: string;
   readonly request: ManagedStartupRootApplyRequest;
 }
 
@@ -50,17 +61,27 @@ export interface PodmanBootstrapImageTransaction {
   readonly agent: ManagedStartupAgent;
   readonly bootstrapIdentity: string;
   readonly engineAuthorityId: string;
+  readonly originalRuntimeId: string;
   readonly profileFingerprint: string;
   readonly replacementRuntimeId: string;
+  readonly replacementStagingName: string;
+  readonly replacementStateVolumeName: string;
+  readonly replacementStateVolumeMountpoint: string;
   readonly replacementImageContentId: string;
+  readonly replacementSpecFingerprint: string;
   readonly watcherLeaseId: string;
   readonly startedAt: string;
 }
 
 export interface PodmanBootstrapImageTransactionCompletion extends ManagedBootstrapImageCompletion {
   readonly engineAuthorityId: string;
+  readonly originalRuntimeId: string;
   readonly replacementRuntimeId: string;
+  readonly replacementStagingName: string;
+  readonly replacementStateVolumeName: string;
+  readonly replacementStateVolumeMountpoint: string;
   readonly replacementImageContentId: string;
+  readonly replacementSpecFingerprint: string;
   readonly watcherLeaseId: string;
   readonly completedAt: string;
 }
@@ -73,8 +94,11 @@ export interface PodmanBootstrapImageTransactionDeps {
 
 interface ExactPodmanContainerState {
   readonly imageContentId: string;
+  readonly name: string;
   readonly runtimeId: string;
   readonly running: boolean;
+  readonly stateVolumeMountpoint: string;
+  readonly stateVolumeName: string;
 }
 
 type JsonRecord = Record<string, unknown>;
@@ -120,6 +144,70 @@ function exactImageContentId(value: string): string {
   return value;
 }
 
+function exactName(value: string, label: string): string {
+  if (!SAFE_NAME.test(value)) fail(`${label} must be one exact Podman name`);
+  return value;
+}
+
+function exactMountpoint(value: string): string {
+  if (
+    !path.isAbsolute(value) ||
+    path.normalize(value) !== value ||
+    value === path.parse(value).root
+  ) {
+    fail("replacement state-volume mountpoint must be one normalized non-root absolute path");
+  }
+  return value;
+}
+
+function sameJournal(left: PodmanBootstrapJournal, right: PodmanBootstrapJournal): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function exactPreparedAuthority(
+  input: Pick<
+    PodmanBootstrapImageTransactionInput,
+    "engine" | "journalStore" | "prepared" | "watcherLease"
+  >,
+): PodmanBootstrapPreparedReplacement {
+  const prepared = input.prepared;
+  if (
+    !prepared ||
+    typeof prepared !== "object" ||
+    prepared.schemaVersion !== PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION
+  ) {
+    return fail("the prepared replacement authority is invalid");
+  }
+  exactSha256(prepared.bootstrapIdentity, "bootstrap identity");
+  exactRuntimeId(prepared.originalRuntimeId);
+  exactRuntimeId(prepared.replacementRuntimeId);
+  exactImageContentId(prepared.replacementImageContentId);
+  exactSha256(prepared.replacementSpecFingerprint, "replacement specification fingerprint");
+  exactName(prepared.replacementStagingName, "replacement staging name");
+  exactName(prepared.replacementStateVolumeName, "replacement state-volume name");
+  exactMountpoint(prepared.replacementStateVolumeMountpoint);
+  const expectedJournal = normalizePodmanBootstrapJournal(prepared.journal);
+  const loaded = input.journalStore.load(prepared.bootstrapIdentity);
+  if (!loaded) return fail("the durable prepared-replacement journal is unavailable");
+  const journal = normalizePodmanBootstrapJournal(loaded);
+  if (
+    journal.phase !== "original-stopped" ||
+    !sameJournal(journal, expectedJournal) ||
+    journal.engineAuthorityId !== input.engine.authorityId ||
+    journal.watcherLeaseId !== input.watcherLease.record.leaseId ||
+    journal.originalRuntimeId !== prepared.originalRuntimeId ||
+    journal.replacementRuntimeId !== prepared.replacementRuntimeId ||
+    journal.replacementStagingName !== prepared.replacementStagingName ||
+    journal.replacementStateVolumeName !== prepared.replacementStateVolumeName ||
+    journal.replacementStateVolumeMountpoint !== prepared.replacementStateVolumeMountpoint ||
+    journal.replacementImageContentId !== prepared.replacementImageContentId ||
+    journal.replacementSpecFingerprint !== prepared.replacementSpecFingerprint
+  ) {
+    return fail("the prepared replacement does not match its exact original-stopped authority");
+  }
+  return prepared;
+}
+
 function exactWatcherLease(lease: PodmanGatewayWatcherLease, expectedLeaseId?: string): void {
   if (
     !lease ||
@@ -162,10 +250,66 @@ function normalizedRuntimeId(value: unknown, label: string): string {
   return match[1];
 }
 
+function exactString(value: unknown, label: string, allowEmpty = false): string {
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+    return fail(`${label} must be one exact string`);
+  }
+  return value;
+}
+
+function exactStringArray(value: unknown, label: string): readonly string[] {
+  if (value === undefined || value === null) return Object.freeze([]);
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    return fail(`${label} must be an array of strings`);
+  }
+  return Object.freeze([...(value as string[])]);
+}
+
+function exactStateVolume(
+  inspect: JsonRecord,
+  prepared: PodmanBootstrapPreparedReplacement,
+): Pick<ExactPodmanContainerState, "stateVolumeMountpoint" | "stateVolumeName"> {
+  if (!Array.isArray(inspect.Mounts)) {
+    return fail("Podman replacement inspect Mounts must be an array");
+  }
+  const mounts = inspect.Mounts.map((entry, index) =>
+    record(entry, `Podman replacement mount ${String(index)}`),
+  ).filter((entry) => entry.Destination === PODMAN_BOOTSTRAP_STATE_DIRECTORY);
+  if (mounts.length !== 1) {
+    return fail("the exact replacement state-volume mount is unavailable");
+  }
+  const mount = mounts[0] as JsonRecord;
+  const mode = exactString(mount.Mode, "Podman replacement state-volume mode", true);
+  const options = exactStringArray(mount.Options, "Podman replacement state-volume options");
+  const propagation = exactString(
+    mount.Propagation,
+    "Podman replacement state-volume propagation",
+    true,
+  );
+  const modeTokens = new Set(mode.split(",").filter(Boolean));
+  if (
+    mount.Type !== "volume" ||
+    mount.Name !== prepared.replacementStateVolumeName ||
+    mount.Source !== prepared.replacementStateVolumeMountpoint ||
+    mount.Driver !== "local" ||
+    mount.RW !== true ||
+    !["", "rprivate"].includes(propagation) ||
+    !modeTokens.has("z") ||
+    modeTokens.has("Z") ||
+    modeTokens.has("ro") ||
+    options.some((option) => option === "ro" || option === "readonly")
+  ) {
+    return fail("the exact replacement state-volume authority changed");
+  }
+  return Object.freeze({
+    stateVolumeMountpoint: prepared.replacementStateVolumeMountpoint,
+    stateVolumeName: prepared.replacementStateVolumeName,
+  });
+}
+
 function parseInspect(
   text: string,
-  expectedRuntimeId: string,
-  expectedImageContentId: string,
+  prepared: PodmanBootstrapPreparedReplacement,
 ): ExactPodmanContainerState {
   let parsed: unknown;
   try {
@@ -182,9 +326,15 @@ function parseInspect(
     inspect.Image,
     "Podman replacement image content ID",
   )}`;
-  if (runtimeId !== expectedRuntimeId || imageContentId !== expectedImageContentId) {
-    return fail("the exact replacement runtime or image identity changed");
+  const name = exactString(inspect.Name, "Podman replacement name");
+  if (
+    runtimeId !== prepared.replacementRuntimeId ||
+    imageContentId !== prepared.replacementImageContentId ||
+    name !== prepared.replacementStagingName
+  ) {
+    return fail("the exact replacement runtime, image, or name identity changed");
   }
+  const stateVolume = exactStateVolume(inspect, prepared);
   const state = record(inspect.State, "Podman replacement state");
   if (
     typeof state.Running !== "boolean" ||
@@ -197,18 +347,20 @@ function parseInspect(
   ) {
     return fail("the exact replacement is not in a stable running or stopped state");
   }
-  return Object.freeze({ imageContentId, runtimeId, running: state.Running });
+  return Object.freeze({ imageContentId, name, runtimeId, running: state.Running, ...stateVolume });
 }
 
 function inspectExact(
   engine: BootstrapEngine,
-  runtimeId: string,
-  imageContentId: string,
+  prepared: PodmanBootstrapPreparedReplacement,
 ): ExactPodmanContainerState {
   return parseInspect(
-    capture(engine, ["container", "inspect", runtimeId], "exact replacement inspection").stdout,
-    runtimeId,
-    imageContentId,
+    capture(
+      engine,
+      ["container", "inspect", prepared.replacementRuntimeId],
+      "exact replacement inspection",
+    ).stdout,
+    prepared,
   );
 }
 
@@ -216,31 +368,36 @@ function sameState(left: ExactPodmanContainerState, right: ExactPodmanContainerS
   return (
     left.runtimeId === right.runtimeId &&
     left.imageContentId === right.imageContentId &&
-    left.running === right.running
+    left.name === right.name &&
+    left.running === right.running &&
+    left.stateVolumeMountpoint === right.stateVolumeMountpoint &&
+    left.stateVolumeName === right.stateVolumeName
   );
 }
 
 function inspectStable(
   engine: BootstrapEngine,
-  runtimeId: string,
-  imageContentId: string,
+  prepared: PodmanBootstrapPreparedReplacement,
   expectedRunning: boolean,
 ): ExactPodmanContainerState {
-  const first = inspectExact(engine, runtimeId, imageContentId);
-  const second = inspectExact(engine, runtimeId, imageContentId);
+  const first = inspectExact(engine, prepared);
+  const second = inspectExact(engine, prepared);
   if (!sameState(first, second) || second.running !== expectedRunning) {
     fail(`the exact replacement is not stably ${expectedRunning ? "running" : "stopped"}`);
   }
   return second;
 }
 
-function writeProtectedEnvelope(input: PodmanBootstrapImageTransactionInput): string {
+function writeProtectedEnvelope(
+  input: PodmanBootstrapImageTransactionInput,
+  prepared: PodmanBootstrapPreparedReplacement,
+): string {
   const file = secureTempFile(REQUEST_TEMP_PREFIX, ".json");
   try {
     fs.writeFileSync(
       file,
       serializeManagedBootstrapEnvelope({
-        bootstrapIdentity: input.bootstrapIdentity,
+        bootstrapIdentity: prepared.bootstrapIdentity,
         rootApplyRequest: input.request,
       }),
       { encoding: "utf8", flag: "wx", mode: 0o400 },
@@ -262,12 +419,20 @@ function writeProtectedEnvelope(input: PodmanBootstrapImageTransactionInput): st
   }
 }
 
-function stageProtectedEnvelope(input: PodmanBootstrapImageTransactionInput): void {
-  const file = writeProtectedEnvelope(input);
+function stageProtectedEnvelope(
+  input: PodmanBootstrapImageTransactionInput,
+  prepared: PodmanBootstrapPreparedReplacement,
+): void {
+  const file = writeProtectedEnvelope(input, prepared);
   try {
     capture(
       input.engine,
-      ["container", "cp", file, `${input.replacementRuntimeId}:${MANAGED_BOOTSTRAP_REQUEST_FILE}`],
+      [
+        "container",
+        "cp",
+        file,
+        `${prepared.replacementRuntimeId}:${MANAGED_BOOTSTRAP_REQUEST_FILE}`,
+      ],
       "protected root request staging",
     );
   } finally {
@@ -369,20 +534,20 @@ function pollInterval(deps: PodmanBootstrapImageTransactionDeps): number {
   return value;
 }
 
-function assertInput(input: PodmanBootstrapImageTransactionInput): void {
+function assertInput(
+  input: PodmanBootstrapImageTransactionInput,
+): PodmanBootstrapPreparedReplacement {
   exactEngine(input.engine);
   exactWatcherLease(input.watcherLease);
   exactAgent(input.agent);
-  exactSha256(input.bootstrapIdentity, "bootstrap identity");
   exactSha256(input.profileFingerprint, "profile fingerprint");
-  exactRuntimeId(input.replacementRuntimeId);
-  exactImageContentId(input.replacementImageContentId);
   if (
     input.request.agent !== input.agent ||
     input.request.profileFingerprint !== input.profileFingerprint
   ) {
     fail("the root request does not match its exact agent and profile authority");
   }
+  return exactPreparedAuthority(input);
 }
 
 /**
@@ -394,29 +559,38 @@ export function startPodmanBootstrapImageTransaction(
   input: PodmanBootstrapImageTransactionInput,
   deps: Pick<PodmanBootstrapImageTransactionDeps, "now"> = {},
 ): PodmanBootstrapImageTransaction {
-  assertInput(input);
-  inspectStable(input.engine, input.replacementRuntimeId, input.replacementImageContentId, false);
+  const prepared = assertInput(input);
+  inspectStable(input.engine, prepared, false);
   exactWatcherLease(input.watcherLease);
-  stageProtectedEnvelope(input);
+  exactPreparedAuthority(input);
+  stageProtectedEnvelope(input, prepared);
   exactWatcherLease(input.watcherLease);
-  inspectStable(input.engine, input.replacementRuntimeId, input.replacementImageContentId, false);
+  exactPreparedAuthority(input);
+  inspectStable(input.engine, prepared, false);
   capture(
     input.engine,
-    ["container", "start", input.replacementRuntimeId],
+    ["container", "start", prepared.replacementRuntimeId],
     "exact replacement start",
     DEFAULT_START_TIMEOUT_MS,
   );
   exactWatcherLease(input.watcherLease);
-  inspectStable(input.engine, input.replacementRuntimeId, input.replacementImageContentId, true);
+  exactPreparedAuthority(input);
+  inspectStable(input.engine, prepared, true);
   exactWatcherLease(input.watcherLease);
+  exactPreparedAuthority(input);
   return Object.freeze({
     schemaVersion: PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION,
     agent: input.agent,
-    bootstrapIdentity: input.bootstrapIdentity,
+    bootstrapIdentity: prepared.bootstrapIdentity,
     engineAuthorityId: input.engine.authorityId,
+    originalRuntimeId: prepared.originalRuntimeId,
     profileFingerprint: input.profileFingerprint,
-    replacementRuntimeId: input.replacementRuntimeId,
-    replacementImageContentId: input.replacementImageContentId,
+    replacementRuntimeId: prepared.replacementRuntimeId,
+    replacementStagingName: prepared.replacementStagingName,
+    replacementStateVolumeName: prepared.replacementStateVolumeName,
+    replacementStateVolumeMountpoint: prepared.replacementStateVolumeMountpoint,
+    replacementImageContentId: prepared.replacementImageContentId,
+    replacementSpecFingerprint: prepared.replacementSpecFingerprint,
     watcherLeaseId: input.watcherLease.record.leaseId,
     startedAt: (deps.now ?? (() => new Date()))().toISOString(),
   });
@@ -426,6 +600,8 @@ export function startPodmanBootstrapImageTransaction(
 export function awaitPodmanBootstrapImageTransaction(
   input: {
     readonly engine: BootstrapEngine;
+    readonly journalStore: Pick<PodmanBootstrapJournalStore, "load">;
+    readonly prepared: PodmanBootstrapPreparedReplacement;
     readonly watcherLease: PodmanGatewayWatcherLease;
     readonly transaction: PodmanBootstrapImageTransaction;
     readonly timeoutSecs: number;
@@ -443,8 +619,26 @@ export function awaitPodmanBootstrapImageTransaction(
   exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
   exactSha256(transaction.bootstrapIdentity, "bootstrap identity");
   exactSha256(transaction.profileFingerprint, "profile fingerprint");
+  exactRuntimeId(transaction.originalRuntimeId);
   exactRuntimeId(transaction.replacementRuntimeId);
+  exactName(transaction.replacementStagingName, "replacement staging name");
+  exactName(transaction.replacementStateVolumeName, "replacement state-volume name");
+  exactMountpoint(transaction.replacementStateVolumeMountpoint);
   exactImageContentId(transaction.replacementImageContentId);
+  exactSha256(transaction.replacementSpecFingerprint, "replacement specification fingerprint");
+  const prepared = exactPreparedAuthority(input);
+  if (
+    transaction.bootstrapIdentity !== prepared.bootstrapIdentity ||
+    transaction.originalRuntimeId !== prepared.originalRuntimeId ||
+    transaction.replacementRuntimeId !== prepared.replacementRuntimeId ||
+    transaction.replacementStagingName !== prepared.replacementStagingName ||
+    transaction.replacementStateVolumeName !== prepared.replacementStateVolumeName ||
+    transaction.replacementStateVolumeMountpoint !== prepared.replacementStateVolumeMountpoint ||
+    transaction.replacementImageContentId !== prepared.replacementImageContentId ||
+    transaction.replacementSpecFingerprint !== prepared.replacementSpecFingerprint
+  ) {
+    return fail("the started transaction does not match its prepared replacement authority");
+  }
   const timeoutMs = timeoutMilliseconds(input.timeoutSecs);
   const intervalMs = pollInterval(deps);
   const now = deps.now ?? (() => new Date());
@@ -454,12 +648,8 @@ export function awaitPodmanBootstrapImageTransaction(
 
   while (true) {
     exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
-    inspectStable(
-      input.engine,
-      transaction.replacementRuntimeId,
-      transaction.replacementImageContentId,
-      true,
-    );
+    exactPreparedAuthority(input);
+    inspectStable(input.engine, prepared, true);
     const copied = tryCopyCompletion(input.engine, transaction.replacementRuntimeId);
     lastCopyStatus = copied.status;
     if (copied.completion) {
@@ -471,18 +661,19 @@ export function awaitPodmanBootstrapImageTransaction(
       ) {
         return fail("the image completion does not match its exact transaction authority");
       }
-      inspectStable(
-        input.engine,
-        transaction.replacementRuntimeId,
-        transaction.replacementImageContentId,
-        true,
-      );
+      inspectStable(input.engine, prepared, true);
       exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
+      exactPreparedAuthority(input);
       return Object.freeze({
         ...completion,
         engineAuthorityId: transaction.engineAuthorityId,
+        originalRuntimeId: transaction.originalRuntimeId,
         replacementRuntimeId: transaction.replacementRuntimeId,
+        replacementStagingName: transaction.replacementStagingName,
+        replacementStateVolumeName: transaction.replacementStateVolumeName,
+        replacementStateVolumeMountpoint: transaction.replacementStateVolumeMountpoint,
         replacementImageContentId: transaction.replacementImageContentId,
+        replacementSpecFingerprint: transaction.replacementSpecFingerprint,
         watcherLeaseId: transaction.watcherLeaseId,
         completedAt: now().toISOString(),
       });

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  type ContainerEngineOperationScope,
+  createContainerEngineCommand,
+} from "../../adapters/container-engine";
+import {
+  createFilePersistedEngineAuthorityStore,
+  createPersistedEngineAuthority,
+  normalizePersistedEngineAuthority,
+  PERSISTED_ENGINE_AUTHORITY_DIRECTORY,
+  parsePersistedEngineAuthority,
+  persistedEngineAuthorityPath,
+  requirePersistedEngineAuthority,
+  serializePersistedEngineAuthority,
+} from "./persisted-engine-authority";
+
+const BINDING_SHA256 = "1".repeat(64);
+const roots: string[] = [];
+
+function temporaryRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-engine-authority-"));
+  roots.push(root);
+  return root;
+}
+
+function engine(
+  operation: ContainerEngineOperationScope = "sandbox-lifecycle",
+  authorityId = `mxc-endpoint:${"2".repeat(64)}`,
+) {
+  return createContainerEngineCommand({
+    operation,
+    engineId: "mxc",
+    displayName: "MXC test engine",
+    authorityId,
+    executable: "mxcctl",
+    endpointArgs: ["--endpoint", "unix:///run/mxc/runtime.sock"],
+    capture: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
+});
+
+describe("persisted engine authority", () => {
+  it("round-trips an MXC-style provider without a Podman-specific switch", () => {
+    const qualified = engine();
+    const authority = createPersistedEngineAuthority("mxc", qualified, BINDING_SHA256);
+    const serialized = serializePersistedEngineAuthority(authority);
+
+    expect(parsePersistedEngineAuthority(serialized)).toEqual(authority);
+    expect(requirePersistedEngineAuthority(authority, "mxc", qualified, BINDING_SHA256)).toEqual(
+      authority,
+    );
+    expect(authority).toEqual({
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "sandbox-lifecycle",
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+    });
+  });
+
+  it("writes one private canonical record and accepts an exact retry", () => {
+    const root = temporaryRoot();
+    const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    const store = createFilePersistedEngineAuthorityStore(root);
+
+    expect(store.record(authority)).toEqual(authority);
+    expect(store.record(authority)).toEqual(authority);
+    expect(store.load("sandbox-lifecycle")).toEqual(authority);
+
+    const directory = path.join(root, PERSISTED_ENGINE_AUTHORITY_DIRECTORY);
+    const target = persistedEngineAuthorityPath(root, "sandbox-lifecycle");
+    expect(fs.statSync(directory).mode & 0o777).toBe(0o700);
+    const descriptor = fs.openSync(target, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    try {
+      expect(fs.fstatSync(descriptor).mode & 0o777).toBe(0o600);
+      expect(fs.readFileSync(descriptor, "utf8")).toBe(
+        serializePersistedEngineAuthority(authority),
+      );
+    } finally {
+      fs.closeSync(descriptor);
+    }
+  });
+
+  it.each([
+    {
+      label: "provider",
+      providerId: "other",
+      operation: "sandbox-lifecycle" as const,
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+      message: "provider does not match",
+    },
+    {
+      label: "operation",
+      providerId: "mxc",
+      operation: "workload-cleanup" as const,
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+      message: "operation does not match",
+    },
+    {
+      label: "engine",
+      providerId: "mxc",
+      operation: "sandbox-lifecycle" as const,
+      engineId: "other",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+      message: "identity does not match",
+    },
+    {
+      label: "endpoint authority",
+      providerId: "mxc",
+      operation: "sandbox-lifecycle" as const,
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"3".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+      message: "endpoint does not match",
+    },
+    {
+      label: "binding",
+      providerId: "mxc",
+      operation: "sandbox-lifecycle" as const,
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: "4".repeat(64),
+      message: "binding does not match",
+    },
+  ])("fails closed when qualified $label differs", (candidate) => {
+    const persisted = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    const qualified = createContainerEngineCommand({
+      operation: candidate.operation,
+      engineId: candidate.engineId,
+      displayName: "candidate",
+      authorityId: candidate.authorityId,
+      executable: "mxcctl",
+      capture: () => ({ status: 0, stdout: "", stderr: "" }),
+    });
+
+    expect(() =>
+      requirePersistedEngineAuthority(
+        persisted,
+        candidate.providerId,
+        qualified,
+        candidate.bindingSha256,
+      ),
+    ).toThrow(candidate.message);
+  });
+
+  it("rejects malformed, extended, and noncanonical records", () => {
+    const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    expect(() => normalizePersistedEngineAuthority({ ...authority, extra: true })).toThrow(
+      "schema is unsupported",
+    );
+    expect(() =>
+      normalizePersistedEngineAuthority({ ...authority, authorityId: "not-an-authority" }),
+    ).toThrow("endpoint authority identity is malformed");
+    expect(() => parsePersistedEngineAuthority(JSON.stringify(authority))).toThrow("not canonical");
+    expect(() =>
+      parsePersistedEngineAuthority(`{\"value\":\"${"x".repeat(17 * 1024)}\"}\n`),
+    ).toThrow("too large");
+  });
+
+  it("rejects a conflicting record for the same operation", () => {
+    const store = createFilePersistedEngineAuthorityStore(temporaryRoot());
+    const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    store.record(authority);
+
+    expect(() =>
+      store.record(
+        createPersistedEngineAuthority(
+          "mxc",
+          engine("sandbox-lifecycle", `mxc-endpoint:${"5".repeat(64)}`),
+          BINDING_SHA256,
+        ),
+      ),
+    ).toThrow("already exists for 'sandbox-lifecycle'");
+    expect(store.load("sandbox-lifecycle")).toEqual(authority);
+  });
+
+  it("rejects a symlink or shared-permission authority file", () => {
+    const root = temporaryRoot();
+    const store = createFilePersistedEngineAuthorityStore(root);
+    const target = persistedEngineAuthorityPath(root, "sandbox-lifecycle");
+    const outside = path.join(root, "outside.json");
+    const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    fs.writeFileSync(outside, serializePersistedEngineAuthority(authority), { mode: 0o600 });
+    fs.symlinkSync(outside, target);
+    expect(() => store.load("sandbox-lifecycle")).toThrow("must not be a symbolic link");
+
+    fs.unlinkSync(target);
+    fs.writeFileSync(target, serializePersistedEngineAuthority(authority), { mode: 0o644 });
+    expect(() => store.load("sandbox-lifecycle")).toThrow("failed ownership, mode, link, or size");
+  });
+});

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.ts
@@ -1,0 +1,330 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import type {
+  ContainerEngine,
+  ContainerEngineOperationScope,
+} from "../../adapters/container-engine";
+
+export const PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION = 1 as const;
+export const PERSISTED_ENGINE_AUTHORITY_DIRECTORY = "runtime-provider-authority";
+
+const DIRECTORY_MODE = 0o700;
+const FILE_MODE = 0o600;
+const MAX_RECORD_BYTES = 16 * 1024;
+const PROVIDER_ID = /^[a-z][a-z0-9-]{0,62}$/u;
+const ENGINE_ID = /^[a-z][a-z0-9-]{0,62}$/u;
+const AUTHORITY_ID = /^[a-z][a-z0-9-]{0,62}:[A-Za-z0-9._:-]{1,255}$/u;
+const SHA256 = /^[a-f0-9]{64}$/u;
+const OPERATIONS = new Set<ContainerEngineOperationScope>([
+  "host-doctor",
+  "gateway-inspection",
+  "managed-bootstrap",
+  "sandbox-lifecycle",
+  "workload-cleanup",
+]);
+
+/**
+ * Immutable, provider-neutral identity for one qualified container-engine
+ * operation. The record carries no executable, endpoint, environment, or
+ * credential material; those remain owned by the provider that reconstructs
+ * and qualifies the injected ContainerEngine.
+ */
+export interface PersistedEngineAuthority {
+  readonly schemaVersion: typeof PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION;
+  readonly providerId: string;
+  readonly operation: ContainerEngineOperationScope;
+  readonly engineId: string;
+  readonly authorityId: string;
+  readonly bindingSha256: string;
+}
+
+export interface PersistedEngineAuthorityStore {
+  readonly load: (operation: ContainerEngineOperationScope) => PersistedEngineAuthority | null;
+  /** Write once, or prove an existing record is byte-for-byte identical. */
+  readonly record: (authority: PersistedEngineAuthority) => PersistedEngineAuthority;
+}
+
+function fail(message: string): never {
+  throw new Error(`Persisted engine authority is invalid: ${message}`);
+}
+
+function exactIdentity(value: unknown, pattern: RegExp, label: string): string {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    fail(`${label} is malformed`);
+  }
+  return value;
+}
+
+function exactOperation(value: unknown): ContainerEngineOperationScope {
+  if (typeof value !== "string" || !OPERATIONS.has(value as ContainerEngineOperationScope)) {
+    fail("operation is unsupported");
+  }
+  return value as ContainerEngineOperationScope;
+}
+
+export function normalizePersistedEngineAuthority(value: unknown): PersistedEngineAuthority {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail("record must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  const expectedKeys = [
+    "authorityId",
+    "bindingSha256",
+    "engineId",
+    "operation",
+    "providerId",
+    "schemaVersion",
+  ];
+  if (
+    Object.keys(record).sort().join(",") !== expectedKeys.join(",") ||
+    record.schemaVersion !== PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION
+  ) {
+    fail("record schema is unsupported");
+  }
+  return Object.freeze({
+    schemaVersion: PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION,
+    providerId: exactIdentity(record.providerId, PROVIDER_ID, "provider identity"),
+    operation: exactOperation(record.operation),
+    engineId: exactIdentity(record.engineId, ENGINE_ID, "engine identity"),
+    authorityId: exactIdentity(record.authorityId, AUTHORITY_ID, "endpoint authority identity"),
+    bindingSha256: exactIdentity(record.bindingSha256, SHA256, "binding digest"),
+  });
+}
+
+export function serializePersistedEngineAuthority(authority: PersistedEngineAuthority): string {
+  const serialized = `${JSON.stringify(normalizePersistedEngineAuthority(authority))}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MAX_RECORD_BYTES) {
+    fail("serialized record exceeds its bounded transport");
+  }
+  return serialized;
+}
+
+export function parsePersistedEngineAuthority(serialized: string): PersistedEngineAuthority {
+  if (
+    serialized.length === 0 ||
+    serialized.includes("\0") ||
+    Buffer.byteLength(serialized, "utf8") > MAX_RECORD_BYTES
+  ) {
+    fail("serialized record is empty or too large");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    fail("serialized record is not valid JSON");
+  }
+  const authority = normalizePersistedEngineAuthority(parsed);
+  if (serializePersistedEngineAuthority(authority) !== serialized) {
+    fail("serialized record is not canonical");
+  }
+  return authority;
+}
+
+export function createPersistedEngineAuthority(
+  providerId: string,
+  engine: ContainerEngine,
+  bindingSha256: string,
+): PersistedEngineAuthority {
+  return normalizePersistedEngineAuthority({
+    schemaVersion: PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION,
+    providerId,
+    operation: engine.operation,
+    engineId: engine.engineId,
+    authorityId: engine.authorityId,
+    bindingSha256,
+  });
+}
+
+/**
+ * Reject a freshly provider-qualified engine unless it matches the recorded
+ * identity. Callers must perform this check before lifecycle or destructive
+ * mutation.
+ */
+export function requirePersistedEngineAuthority(
+  persisted: PersistedEngineAuthority,
+  providerId: string,
+  engine: ContainerEngine,
+  bindingSha256: string,
+): PersistedEngineAuthority {
+  const authority = normalizePersistedEngineAuthority(persisted);
+  const qualified = createPersistedEngineAuthority(providerId, engine, bindingSha256);
+  if (authority.providerId !== qualified.providerId) {
+    throw new Error("Qualified runtime provider does not match persisted engine authority.");
+  }
+  if (authority.operation !== qualified.operation) {
+    throw new Error("Qualified container-engine operation does not match persisted authority.");
+  }
+  if (authority.engineId !== qualified.engineId) {
+    throw new Error("Qualified container-engine identity does not match persisted authority.");
+  }
+  if (authority.authorityId !== qualified.authorityId) {
+    throw new Error("Qualified container endpoint does not match persisted authority.");
+  }
+  if (authority.bindingSha256 !== qualified.bindingSha256) {
+    throw new Error("Qualified runtime binding does not match persisted engine authority.");
+  }
+  return authority;
+}
+
+function operationFileName(operation: ContainerEngineOperationScope): string {
+  return `${exactOperation(operation)}.json`;
+}
+
+export function persistedEngineAuthorityPath(
+  stateDir: string,
+  operation: ContainerEngineOperationScope,
+): string {
+  return path.join(stateDir, PERSISTED_ENGINE_AUTHORITY_DIRECTORY, operationFileName(operation));
+}
+
+function currentUid(fallback: number | bigint): bigint {
+  return BigInt(typeof process.getuid === "function" ? process.getuid() : fallback);
+}
+
+function requirePrivateDirectory(directory: string): void {
+  fs.mkdirSync(directory, { recursive: true, mode: DIRECTORY_MODE });
+  const metadata = fs.lstatSync(directory);
+  if (
+    !metadata.isDirectory() ||
+    metadata.isSymbolicLink() ||
+    BigInt(metadata.uid) !== currentUid(metadata.uid) ||
+    (metadata.mode & 0o077) !== 0
+  ) {
+    fail("authority directory must be a private real directory owned by the current user");
+  }
+}
+
+function sameStableMetadata(left: fs.BigIntStats, right: fs.BigIntStats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.nlink === right.nlink &&
+    left.uid === right.uid &&
+    left.gid === right.gid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function readPrivateRecord(target: string): string | null {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") {
+    fail("O_NOFOLLOW is unavailable for persisted authority reads");
+  }
+  const nonblock = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(target, fs.constants.O_RDONLY | noFollow | nonblock);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    if (code === "ELOOP") fail("authority file must not be a symbolic link");
+    throw error;
+  }
+  try {
+    const before = fs.fstatSync(descriptor, { bigint: true });
+    if (
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      before.uid !== currentUid(before.uid) ||
+      (before.mode & 0o077n) !== 0n ||
+      before.size <= 0n ||
+      before.size > BigInt(MAX_RECORD_BYTES)
+    ) {
+      fail("authority file failed ownership, mode, link, or size checks");
+    }
+    const contents = Buffer.alloc(Number(before.size));
+    let offset = 0;
+    while (offset < contents.length) {
+      const count = fs.readSync(descriptor, contents, offset, contents.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const overflow = Buffer.alloc(1);
+    const overflowCount = fs.readSync(descriptor, overflow, 0, 1, offset);
+    const after = fs.fstatSync(descriptor, { bigint: true });
+    if (offset !== contents.length || overflowCount !== 0 || !sameStableMetadata(before, after)) {
+      fail("authority file changed during its stable read");
+    }
+    return contents.toString("utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function fsyncDirectory(directory: string): void {
+  const descriptor = fs.openSync(directory, "r");
+  try {
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function writeExclusiveRecord(directory: string, target: string, serialized: string): boolean {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") {
+    fail("O_NOFOLLOW is unavailable for persisted authority writes");
+  }
+  const temporary = path.join(directory, `.${path.basename(target)}.${randomUUID()}.tmp`);
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(
+      temporary,
+      fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY | noFollow,
+      FILE_MODE,
+    );
+    fs.writeFileSync(descriptor, serialized, { encoding: "utf8" });
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = null;
+    try {
+      fs.linkSync(temporary, target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+      throw error;
+    }
+    fs.unlinkSync(temporary);
+    fsyncDirectory(directory);
+    return true;
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+export function createFilePersistedEngineAuthorityStore(
+  stateDir: string,
+): PersistedEngineAuthorityStore {
+  const directory = path.join(stateDir, PERSISTED_ENGINE_AUTHORITY_DIRECTORY);
+  requirePrivateDirectory(directory);
+  const load = (operation: ContainerEngineOperationScope): PersistedEngineAuthority | null => {
+    requirePrivateDirectory(directory);
+    const serialized = readPrivateRecord(path.join(directory, operationFileName(operation)));
+    return serialized === null ? null : parsePersistedEngineAuthority(serialized);
+  };
+  return Object.freeze({
+    load,
+    record(authority: PersistedEngineAuthority) {
+      const normalized = normalizePersistedEngineAuthority(authority);
+      const serialized = serializePersistedEngineAuthority(normalized);
+      const target = path.join(directory, operationFileName(normalized.operation));
+      const existing = load(normalized.operation);
+      if (existing !== null) {
+        if (serializePersistedEngineAuthority(existing) === serialized) return existing;
+        throw new Error(`Persisted engine authority already exists for '${normalized.operation}'.`);
+      }
+      if (writeExclusiveRecord(directory, target, serialized)) return normalized;
+      const raced = load(normalized.operation);
+      if (raced !== null && serializePersistedEngineAuthority(raced) === serialized) return raced;
+      throw new Error(`Persisted engine authority already exists for '${normalized.operation}'.`);
+    },
+  });
+}

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -82,6 +82,10 @@ describe("runtime provider central source boundary", () => {
       join(repoRoot, "src/lib/onboard/runtime-provider/docker.ts"),
       "utf8",
     );
+    const persistedEngineAuthority = readFileSync(
+      join(repoRoot, "src/lib/onboard/runtime-provider/persisted-engine-authority.ts"),
+      "utf8",
+    );
     const productionPaths = trackedPaths(
       "src/lib/onboard.ts",
       "src/lib/onboard",
@@ -127,7 +131,13 @@ describe("runtime provider central source boundary", () => {
     const bootstrapProtocol = bootstrapProtocolPaths.map(read);
     const activationSources = activationPaths.map(read);
     const providerImplementationSources = providerPaths
-      .filter((path) => path !== "src/lib/onboard/runtime-provider/contract.ts")
+      .filter(
+        (path) =>
+          ![
+            "src/lib/onboard/runtime-provider/contract.ts",
+            "src/lib/onboard/runtime-provider/persisted-engine-authority.ts",
+          ].includes(path),
+      )
       .map(read);
     const packagingSources = packagingPaths.map((path) => [path, read(path)] as const);
     const packagedBootstrapAsset =
@@ -155,6 +165,7 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/runtime-provider/contract.ts",
       "src/lib/onboard/runtime-provider/current.ts",
       "src/lib/onboard/runtime-provider/docker.ts",
+      "src/lib/onboard/runtime-provider/persisted-engine-authority.ts",
       "src/lib/onboard/runtime-provider/podman-lifecycle.ts",
       "src/lib/onboard/runtime-provider/podman-preflight.ts",
       "src/lib/onboard/runtime-provider/podman.ts",
@@ -184,6 +195,9 @@ describe("runtime provider central source boundary", () => {
       /(?:from\s+["'][^"']*managed-bootstrap|require\([^)]*managed-bootstrap)/u,
     );
     expect(providerImplementationSources.join("\n")).not.toMatch(/managed-bootstrap/iu);
+    expect(persistedEngineAuthority).not.toMatch(
+      /(?:from\s+["'][^"']*managed-bootstrap|require\([^)]*managed-bootstrap)/u,
+    );
     expect(dockerProvider.match(/bootstrap:\s*unsupported\(/gu)).toHaveLength(2);
     expect(
       packagingSources

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -146,6 +146,7 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/managed-bootstrap/podman-bootstrap-journal.ts",
       "src/lib/onboard/managed-bootstrap/podman-bootstrap-replacement.ts",
       "src/lib/onboard/managed-bootstrap/podman-held-workload.ts",
+      "src/lib/onboard/managed-bootstrap/podman-image-transaction.ts",
       "src/lib/onboard/managed-bootstrap/podman-watcher-lease.ts",
       "src/lib/onboard/managed-bootstrap/runtime-create.ts",
     ]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds a dormant Podman image-bootstrap transaction that accepts only the exact prepared replacement authority from the preceding stack slice. It stages one protected request for the selected agent, starts the exact replacement without `exec` or a user override, and authenticates the image-owned completion while the stopped watcher and durable journal remain authoritative. This PR does not activate Podman as a user-visible runtime.

## Related Issue

Part of #7744.

## Changes

- Bind startup to `PodmanBootstrapPreparedReplacement` and the exact durable `original-stopped` journal.
- Re-prove engine, watcher lease, runtime, image, staging name, state volume, mountpoint, and specification authority before staging, starting, polling, and accepting completion.
- Stage one protected root-apply envelope and authenticate protected completion receipts for OpenClaw, Hermes, and LangChain Deep Agents Code.
- Keep the transaction internal and dormant so central orchestration gains no Podman-specific activation switch.
- Add drift, lost-journal, retry, timeout, file-mode, all-agent, and source-shape tests.
- Document the exact image-transaction authority and its unresolved post-failure state.

The internal transaction is required by #7744 to connect the prepared replacement to the image-owned root-application boundary. A direct central-orchestration change would bypass the pluggable runtime boundary. `podman-image-transaction.test.ts` protects this contract.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed incremental runtime design in #7744; exact authority, drift, protected-file, and unresolved-failure behavior have focused tests and lifecycle documentation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `src/lib/onboard/lifecycle-contracts.md` documents exact prerequisites, revalidation, the selected-agent request, protected completion, and the unresolved post-failure state. The review also corrected the engine-authority test title and PR terminology. The append-only parent refresh to `5250328ca` preserves the exact reviewed slice diff and changes no reviewed documentation.
- Agent: Codex Desktop
- Qualification carry-forward: Exact head 03f5a3d149a3320a9110c3219f84e51607a20ac5 on base e7241966521068fa2ee198f90247b19f44a5673d preserves the byte-identical previously reviewed slice diff (stable patch ID 3c5a755831318334c0870a037f138765d986ae3f; binary diff SHA-256 0196f405c488cd2a352863938fd6da21cdbdc04098fe019863834e84009d8f66), and its source and documentation tree is unchanged from reviewed head 0f125e06e8224a6d94c90a00a1c324f82188ff0f.
<!-- docs-review-head-sha: 03f5a3d14 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- Qualification-only exact head/base: 03f5a3d149a3320a9110c3219f84e51607a20ac5 / e7241966521068fa2ee198f90247b19f44a5673d; signed-DCO append-only cascade, stable-patch proof, byte-identical slice diff, final-tree equality, and normal pre-push hooks passed.
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts src/lib/onboard/managed-bootstrap/podman-bootstrap-replacement.test.ts src/lib/onboard/managed-bootstrap/podman-bootstrap-journal.test.ts src/lib/onboard/managed-bootstrap/podman-watcher-lease.test.ts src/lib/onboard/managed-bootstrap/podman-held-workload.test.ts` passed 73/73; `npx vitest run --project integration test/runtime-provider-source-shape.test.ts` passed 2/2; CLI typecheck and pre-push checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

