### PR TITLE
feat(runtime): persist container engine authority

### DIFF
--- a/src/lib/onboard/managed-bootstrap/README.md
+++ b/src/lib/onboard/managed-bootstrap/README.md
@@ -86,3 +86,11 @@ the direct root-stdin and hold contract without advertising buildless support.
 No production provider invokes the trampoline yet. Until the later provider
 activation and protected E2E slices pass, every production runtime provider
 keeps bootstrap unsupported.
+
+The next dormant lifecycle boundary persists only an operation-scoped provider,
+engine, endpoint-authority, and non-secret binding digest. A freshly qualified
+injected engine must match that immutable record exactly before later lifecycle
+recovery work can use it. The record does not persist an executable, endpoint,
+environment, or credential, does not activate an engine, and has no production
+consumer yet. Its contract is provider-neutral; tests use an MXC-style engine
+to ensure central persistence does not gain a Podman-specific selection branch.

--- a/src/lib/onboard/managed-bootstrap/README.md
+++ b/src/lib/onboard/managed-bootstrap/README.md
@@ -87,10 +87,11 @@ No production provider invokes the trampoline yet. Until the later provider
 activation and protected E2E slices pass, every production runtime provider
 keeps bootstrap unsupported.
 
-The next dormant lifecycle boundary persists only an operation-scoped provider,
-engine, endpoint-authority, and non-secret binding digest. A freshly qualified
-injected engine must match that immutable record exactly before later lifecycle
-recovery work can use it. The record does not persist an executable, endpoint,
-environment, or credential, does not activate an engine, and has no production
-consumer yet. Its contract is provider-neutral; tests use an MXC-style engine
-to ensure central persistence does not gain a Podman-specific selection branch.
+The dormant persisted-engine-authority boundary supports future snapshot,
+rebuild, restore, and recovery work by recording only an operation-scoped
+provider, engine, endpoint-authority, and non-secret binding digest. It adds an
+exact matcher for a freshly provider-qualified injected engine, but no
+production lifecycle calls that matcher yet. The record does not persist an
+executable, endpoint, environment, or credential and does not activate an
+engine. Its contract is provider-neutral; tests use an MXC-style engine to
+ensure central persistence does not gain a Podman-specific selection branch.

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  type ContainerEngineOperationScope,
+  createContainerEngineCommand,
+} from "../../adapters/container-engine";
+import {
+  createFilePersistedEngineAuthorityStore,
+  createPersistedEngineAuthority,
+  normalizePersistedEngineAuthority,
+  parsePersistedEngineAuthority,
+  PERSISTED_ENGINE_AUTHORITY_DIRECTORY,
+  persistedEngineAuthorityPath,
+  requirePersistedEngineAuthority,
+  serializePersistedEngineAuthority,
+} from "./persisted-engine-authority";
+
+const BINDING_SHA256 = "1".repeat(64);
+const roots: string[] = [];
+
+function temporaryRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-engine-authority-"));
+  roots.push(root);
+  return root;
+}
+
+function engine(
+  operation: ContainerEngineOperationScope = "sandbox-lifecycle",
+  authorityId = `mxc-endpoint:${"2".repeat(64)}`,
+) {
+  return createContainerEngineCommand({
+    operation,
+    engineId: "mxc",
+    displayName: "MXC test engine",
+    authorityId,
+    executable: "mxcctl",
+    endpointArgs: ["--endpoint", "unix:///run/mxc/runtime.sock"],
+    capture: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
+});
+
+describe("persisted engine authority", () => {
+  it("round-trips an MXC-style provider without a Podman-specific switch", () => {
+    const qualified = engine();
+    const authority = createPersistedEngineAuthority("mxc", qualified, BINDING_SHA256);
+    const serialized = serializePersistedEngineAuthority(authority);
+
+    expect(parsePersistedEngineAuthority(serialized)).toEqual(authority);
+    expect(requirePersistedEngineAuthority(authority, "mxc", qualified, BINDING_SHA256)).toEqual(
+      authority,
+    );
+    expect(authority).toEqual({
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "sandbox-lifecycle",
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+    });
+  });
+
+  it("persists one private canonical record and accepts an exact retry", () => {
+    const root = temporaryRoot();
+    const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    const store = createFilePersistedEngineAuthorityStore(root);
+
+    expect(store.record(authority)).toEqual(authority);
+    expect(store.record(authority)).toEqual(authority);
+    expect(store.load("sandbox-lifecycle")).toEqual(authority);
+
+    const directory = path.join(root, PERSISTED_ENGINE_AUTHORITY_DIRECTORY);
+    const target = persistedEngineAuthorityPath(root, "sandbox-lifecycle");
+    expect(fs.statSync(directory).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+    expect(fs.readFileSync(target, "utf8")).toBe(serializePersistedEngineAuthority(authority));
+  });
+
+  it.each([
+    {
+      label: "provider",
+      providerId: "other",
+      operation: "sandbox-lifecycle" as const,
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+      message: "provider does not match",
+    },
+    {
+      label: "operation",
+      providerId: "mxc",
+      operation: "workload-cleanup" as const,
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+      message: "operation does not match",
+    },
+    {
+      label: "engine",
+      providerId: "mxc",
+      operation: "sandbox-lifecycle" as const,
+      engineId: "other",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+      message: "identity does not match",
+    },
+    {
+      label: "endpoint authority",
+      providerId: "mxc",
+      operation: "sandbox-lifecycle" as const,
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"3".repeat(64)}`,
+      bindingSha256: BINDING_SHA256,
+      message: "endpoint does not match",
+    },
+    {
+      label: "binding",
+      providerId: "mxc",
+      operation: "sandbox-lifecycle" as const,
+      engineId: "mxc",
+      authorityId: `mxc-endpoint:${"2".repeat(64)}`,
+      bindingSha256: "4".repeat(64),
+      message: "binding does not match",
+    },
+  ])("fails closed when qualified $label differs", (candidate) => {
+    const persisted = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    const qualified = createContainerEngineCommand({
+      operation: candidate.operation,
+      engineId: candidate.engineId,
+      displayName: "candidate",
+      authorityId: candidate.authorityId,
+      executable: "mxcctl",
+      capture: () => ({ status: 0, stdout: "", stderr: "" }),
+    });
+
+    expect(() =>
+      requirePersistedEngineAuthority(
+        persisted,
+        candidate.providerId,
+        qualified,
+        candidate.bindingSha256,
+      ),
+    ).toThrow(candidate.message);
+  });
+
+  it("rejects malformed, extended, and noncanonical records", () => {
+    const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    expect(() => normalizePersistedEngineAuthority({ ...authority, extra: true })).toThrow(
+      "schema is unsupported",
+    );
+    expect(() =>
+      normalizePersistedEngineAuthority({ ...authority, authorityId: "not-an-authority" }),
+    ).toThrow("endpoint authority identity is malformed");
+    expect(() => parsePersistedEngineAuthority(JSON.stringify(authority))).toThrow("not canonical");
+    expect(() =>
+      parsePersistedEngineAuthority(`{\"value\":\"${"x".repeat(17 * 1024)}\"}\n`),
+    ).toThrow("too large");
+  });
+
+  it("rejects a conflicting record for the same operation", () => {
+    const store = createFilePersistedEngineAuthorityStore(temporaryRoot());
+    const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    store.record(authority);
+
+    expect(() =>
+      store.record(
+        createPersistedEngineAuthority(
+          "mxc",
+          engine("sandbox-lifecycle", `mxc-endpoint:${"5".repeat(64)}`),
+          BINDING_SHA256,
+        ),
+      ),
+    ).toThrow("already exists for 'sandbox-lifecycle'");
+    expect(store.load("sandbox-lifecycle")).toEqual(authority);
+  });
+
+  it("rejects a symlink or shared-permission authority file", () => {
+    const root = temporaryRoot();
+    const store = createFilePersistedEngineAuthorityStore(root);
+    const target = persistedEngineAuthorityPath(root, "sandbox-lifecycle");
+    const outside = path.join(root, "outside.json");
+    const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
+    fs.writeFileSync(outside, serializePersistedEngineAuthority(authority), { mode: 0o600 });
+    fs.symlinkSync(outside, target);
+    expect(() => store.load("sandbox-lifecycle")).toThrow("must not be a symbolic link");
+
+    fs.unlinkSync(target);
+    fs.writeFileSync(target, serializePersistedEngineAuthority(authority), { mode: 0o644 });
+    expect(() => store.load("sandbox-lifecycle")).toThrow("failed ownership, mode, link, or size");
+  });
+});

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
@@ -15,8 +15,8 @@ import {
   createFilePersistedEngineAuthorityStore,
   createPersistedEngineAuthority,
   normalizePersistedEngineAuthority,
-  parsePersistedEngineAuthority,
   PERSISTED_ENGINE_AUTHORITY_DIRECTORY,
+  parsePersistedEngineAuthority,
   persistedEngineAuthorityPath,
   requirePersistedEngineAuthority,
   serializePersistedEngineAuthority,
@@ -82,8 +82,15 @@ describe("persisted engine authority", () => {
     const directory = path.join(root, PERSISTED_ENGINE_AUTHORITY_DIRECTORY);
     const target = persistedEngineAuthorityPath(root, "sandbox-lifecycle");
     expect(fs.statSync(directory).mode & 0o777).toBe(0o700);
-    expect(fs.statSync(target).mode & 0o777).toBe(0o600);
-    expect(fs.readFileSync(target, "utf8")).toBe(serializePersistedEngineAuthority(authority));
+    const descriptor = fs.openSync(target, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    try {
+      expect(fs.fstatSync(descriptor).mode & 0o777).toBe(0o600);
+      expect(fs.readFileSync(descriptor, "utf8")).toBe(
+        serializePersistedEngineAuthority(authority),
+      );
+    } finally {
+      fs.closeSync(descriptor);
+    }
   });
 
   it.each([

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
@@ -70,7 +70,7 @@ describe("persisted engine authority", () => {
     });
   });
 
-  it("persists one private canonical record and accepts an exact retry", () => {
+  it("writes one private canonical record and accepts an exact retry", () => {
     const root = temporaryRoot();
     const authority = createPersistedEngineAuthority("mxc", engine(), BINDING_SHA256);
     const store = createFilePersistedEngineAuthorityStore(root);

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.ts
@@ -141,8 +141,9 @@ export function createPersistedEngineAuthority(
 }
 
 /**
- * Require a freshly provider-qualified engine to match durable identity before
- * a later slice is allowed to perform any lifecycle or destructive mutation.
+ * Reject a freshly provider-qualified engine unless it matches the recorded
+ * identity. Callers must perform this check before lifecycle or destructive
+ * mutation.
  */
 export function requirePersistedEngineAuthority(
   persisted: PersistedEngineAuthority,

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.ts
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import type {
+  ContainerEngine,
+  ContainerEngineOperationScope,
+} from "../../adapters/container-engine";
+
+export const PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION = 1 as const;
+export const PERSISTED_ENGINE_AUTHORITY_DIRECTORY = "runtime-provider-authority";
+
+const DIRECTORY_MODE = 0o700;
+const FILE_MODE = 0o600;
+const MAX_RECORD_BYTES = 16 * 1024;
+const PROVIDER_ID = /^[a-z][a-z0-9-]{0,62}$/u;
+const ENGINE_ID = /^[a-z][a-z0-9-]{0,62}$/u;
+const AUTHORITY_ID = /^[a-z][a-z0-9-]{0,62}:[A-Za-z0-9._:-]{1,255}$/u;
+const SHA256 = /^[a-f0-9]{64}$/u;
+const OPERATIONS = new Set<ContainerEngineOperationScope>([
+  "host-doctor",
+  "gateway-inspection",
+  "managed-bootstrap",
+  "sandbox-lifecycle",
+  "workload-cleanup",
+]);
+
+/**
+ * Immutable, provider-neutral identity for one qualified container-engine
+ * operation. The record carries no executable, endpoint, environment, or
+ * credential material; those remain owned by the provider that reconstructs
+ * and qualifies the injected ContainerEngine.
+ */
+export interface PersistedEngineAuthority {
+  readonly schemaVersion: typeof PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION;
+  readonly providerId: string;
+  readonly operation: ContainerEngineOperationScope;
+  readonly engineId: string;
+  readonly authorityId: string;
+  readonly bindingSha256: string;
+}
+
+export interface PersistedEngineAuthorityStore {
+  readonly load: (operation: ContainerEngineOperationScope) => PersistedEngineAuthority | null;
+  /** Write once, or prove an existing record is byte-for-byte identical. */
+  readonly record: (authority: PersistedEngineAuthority) => PersistedEngineAuthority;
+}
+
+function fail(message: string): never {
+  throw new Error(`Persisted engine authority is invalid: ${message}`);
+}
+
+function exactIdentity(value: unknown, pattern: RegExp, label: string): string {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    fail(`${label} is malformed`);
+  }
+  return value;
+}
+
+function exactOperation(value: unknown): ContainerEngineOperationScope {
+  if (typeof value !== "string" || !OPERATIONS.has(value as ContainerEngineOperationScope)) {
+    fail("operation is unsupported");
+  }
+  return value as ContainerEngineOperationScope;
+}
+
+export function normalizePersistedEngineAuthority(value: unknown): PersistedEngineAuthority {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail("record must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  const expectedKeys = [
+    "authorityId",
+    "bindingSha256",
+    "engineId",
+    "operation",
+    "providerId",
+    "schemaVersion",
+  ];
+  if (
+    Object.keys(record).sort().join(",") !== expectedKeys.join(",") ||
+    record.schemaVersion !== PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION
+  ) {
+    fail("record schema is unsupported");
+  }
+  return Object.freeze({
+    schemaVersion: PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION,
+    providerId: exactIdentity(record.providerId, PROVIDER_ID, "provider identity"),
+    operation: exactOperation(record.operation),
+    engineId: exactIdentity(record.engineId, ENGINE_ID, "engine identity"),
+    authorityId: exactIdentity(record.authorityId, AUTHORITY_ID, "endpoint authority identity"),
+    bindingSha256: exactIdentity(record.bindingSha256, SHA256, "binding digest"),
+  });
+}
+
+export function serializePersistedEngineAuthority(authority: PersistedEngineAuthority): string {
+  const serialized = `${JSON.stringify(normalizePersistedEngineAuthority(authority))}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MAX_RECORD_BYTES) {
+    fail("serialized record exceeds its bounded transport");
+  }
+  return serialized;
+}
+
+export function parsePersistedEngineAuthority(serialized: string): PersistedEngineAuthority {
+  if (
+    serialized.length === 0 ||
+    serialized.includes("\0") ||
+    Buffer.byteLength(serialized, "utf8") > MAX_RECORD_BYTES
+  ) {
+    fail("serialized record is empty or too large");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    fail("serialized record is not valid JSON");
+  }
+  const authority = normalizePersistedEngineAuthority(parsed);
+  if (serializePersistedEngineAuthority(authority) !== serialized) {
+    fail("serialized record is not canonical");
+  }
+  return authority;
+}
+
+export function createPersistedEngineAuthority(
+  providerId: string,
+  engine: ContainerEngine,
+  bindingSha256: string,
+): PersistedEngineAuthority {
+  return normalizePersistedEngineAuthority({
+    schemaVersion: PERSISTED_ENGINE_AUTHORITY_SCHEMA_VERSION,
+    providerId,
+    operation: engine.operation,
+    engineId: engine.engineId,
+    authorityId: engine.authorityId,
+    bindingSha256,
+  });
+}
+
+/**
+ * Require a freshly provider-qualified engine to match durable identity before
+ * a later slice is allowed to perform any lifecycle or destructive mutation.
+ */
+export function requirePersistedEngineAuthority(
+  persisted: PersistedEngineAuthority,
+  providerId: string,
+  engine: ContainerEngine,
+  bindingSha256: string,
+): PersistedEngineAuthority {
+  const authority = normalizePersistedEngineAuthority(persisted);
+  const qualified = createPersistedEngineAuthority(providerId, engine, bindingSha256);
+  if (authority.providerId !== qualified.providerId) {
+    throw new Error("Qualified runtime provider does not match persisted engine authority.");
+  }
+  if (authority.operation !== qualified.operation) {
+    throw new Error("Qualified container-engine operation does not match persisted authority.");
+  }
+  if (authority.engineId !== qualified.engineId) {
+    throw new Error("Qualified container-engine identity does not match persisted authority.");
+  }
+  if (authority.authorityId !== qualified.authorityId) {
+    throw new Error("Qualified container endpoint does not match persisted authority.");
+  }
+  if (authority.bindingSha256 !== qualified.bindingSha256) {
+    throw new Error("Qualified runtime binding does not match persisted engine authority.");
+  }
+  return authority;
+}
+
+function operationFileName(operation: ContainerEngineOperationScope): string {
+  return `${exactOperation(operation)}.json`;
+}
+
+export function persistedEngineAuthorityPath(
+  stateDir: string,
+  operation: ContainerEngineOperationScope,
+): string {
+  return path.join(stateDir, PERSISTED_ENGINE_AUTHORITY_DIRECTORY, operationFileName(operation));
+}
+
+function currentUid(fallback: number | bigint): bigint {
+  return BigInt(typeof process.getuid === "function" ? process.getuid() : fallback);
+}
+
+function requirePrivateDirectory(directory: string): void {
+  fs.mkdirSync(directory, { recursive: true, mode: DIRECTORY_MODE });
+  const metadata = fs.lstatSync(directory);
+  if (
+    !metadata.isDirectory() ||
+    metadata.isSymbolicLink() ||
+    BigInt(metadata.uid) !== currentUid(metadata.uid) ||
+    (metadata.mode & 0o077) !== 0
+  ) {
+    fail("authority directory must be a private real directory owned by the current user");
+  }
+}
+
+function sameStableMetadata(left: fs.BigIntStats, right: fs.BigIntStats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.nlink === right.nlink &&
+    left.uid === right.uid &&
+    left.gid === right.gid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function readPrivateRecord(target: string): string | null {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") {
+    fail("O_NOFOLLOW is unavailable for persisted authority reads");
+  }
+  const nonblock = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(target, fs.constants.O_RDONLY | noFollow | nonblock);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    if (code === "ELOOP") fail("authority file must not be a symbolic link");
+    throw error;
+  }
+  try {
+    const before = fs.fstatSync(descriptor, { bigint: true });
+    if (
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      before.uid !== currentUid(before.uid) ||
+      (before.mode & 0o077n) !== 0n ||
+      before.size <= 0n ||
+      before.size > BigInt(MAX_RECORD_BYTES)
+    ) {
+      fail("authority file failed ownership, mode, link, or size checks");
+    }
+    const contents = Buffer.alloc(Number(before.size));
+    let offset = 0;
+    while (offset < contents.length) {
+      const count = fs.readSync(descriptor, contents, offset, contents.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const overflow = Buffer.alloc(1);
+    const overflowCount = fs.readSync(descriptor, overflow, 0, 1, offset);
+    const after = fs.fstatSync(descriptor, { bigint: true });
+    if (offset !== contents.length || overflowCount !== 0 || !sameStableMetadata(before, after)) {
+      fail("authority file changed during its stable read");
+    }
+    return contents.toString("utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function fsyncDirectory(directory: string): void {
+  const descriptor = fs.openSync(directory, "r");
+  try {
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function writeExclusiveRecord(directory: string, target: string, serialized: string): boolean {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") {
+    fail("O_NOFOLLOW is unavailable for persisted authority writes");
+  }
+  const temporary = path.join(directory, `.${path.basename(target)}.${randomUUID()}.tmp`);
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(
+      temporary,
+      fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY | noFollow,
+      FILE_MODE,
+    );
+    fs.writeFileSync(descriptor, serialized, { encoding: "utf8" });
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = null;
+    try {
+      fs.linkSync(temporary, target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+      throw error;
+    }
+    fs.unlinkSync(temporary);
+    fsyncDirectory(directory);
+    return true;
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+export function createFilePersistedEngineAuthorityStore(
+  stateDir: string,
+): PersistedEngineAuthorityStore {
+  const directory = path.join(stateDir, PERSISTED_ENGINE_AUTHORITY_DIRECTORY);
+  requirePrivateDirectory(directory);
+  const load = (operation: ContainerEngineOperationScope): PersistedEngineAuthority | null => {
+    requirePrivateDirectory(directory);
+    const serialized = readPrivateRecord(path.join(directory, operationFileName(operation)));
+    return serialized === null ? null : parsePersistedEngineAuthority(serialized);
+  };
+  return Object.freeze({
+    load,
+    record(authority: PersistedEngineAuthority) {
+      const normalized = normalizePersistedEngineAuthority(authority);
+      const serialized = serializePersistedEngineAuthority(normalized);
+      const target = path.join(directory, operationFileName(normalized.operation));
+      const existing = load(normalized.operation);
+      if (existing !== null) {
+        if (serializePersistedEngineAuthority(existing) === serialized) return existing;
+        throw new Error(`Persisted engine authority already exists for '${normalized.operation}'.`);
+      }
+      if (writeExclusiveRecord(directory, target, serialized)) return normalized;
+      const raced = load(normalized.operation);
+      if (raced !== null && serializePersistedEngineAuthority(raced) === serialized) return raced;
+      throw new Error(`Persisted engine authority already exists for '${normalized.operation}'.`);
+    },
+  });
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add a dormant, provider-neutral persistence contract for future snapshot, rebuild, restore, and recovery paths. These paths must compare a freshly provider-qualified container engine with its exact authority record before mutation. This slice adds the identity record and matcher only; no production lifecycle calls it, and it does not select, reconstruct, or activate Podman or any other runtime.

## Related Issue

Related to #7744.

## Changes

- Add a canonical versioned authority record binding one provider, operation scope, engine identity, endpoint-authority identity, and non-secret runtime binding digest.
- Add a private atomic store with write-once/idempotent semantics, stable metadata checks, bounded canonical parsing, and fail-closed symlink, ownership, permission, and conflict handling.
- Verify stored-file mode and canonical bytes through one `O_NOFOLLOW` descriptor in tests, avoiding a path-based check/use race.
- Add an exact matcher for a freshly provider-qualified injected engine; no production lifecycle calls the matcher in this slice.
- Exercise the contract with an MXC-style engine and keep production provider selection unchanged; source-shape coverage prevents the persistence boundary from importing managed-bootstrap implementations.
- Document the dormant ownership and deferred activation boundary in the internal managed-bootstrap map.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This slice is internal and dormant; its ownership and activation boundary is recorded in the internal managed-bootstrap README.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed inert slice in #7744; exact identity, filesystem, canonicalization, retry, and drift boundaries have focused adversarial tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `src/lib/onboard/managed-bootstrap/README.md`, changed source comments, test titles, source-shape wording, and the PR description at exact head `269de66e5`; all prior wording findings are resolved, and `git diff --check` passed. The append-only parent refresh to `ae30b0694` preserves the exact reviewed slice diff and changes no reviewed documentation.
- Agent: Codex Desktop
- Qualification carry-forward: Exact head a2ae17e4291d47061b1fc2ed075d8d6afca2140c on base 03f5a3d149a3320a9110c3219f84e51607a20ac5 preserves the byte-identical previously reviewed slice diff (stable patch ID 1eecb90d9b155b37b64b93c8d9c31feeb6b611d2; binary diff SHA-256 1c1968117fe5fae4894da9d74030aa39d6a6be8e8ae525c2ff2e7c594404efb6), and its source and documentation tree is unchanged from reviewed head 0fde3f9f5fb3709fe353460f5ffdd50d8430cbeb.
<!-- docs-review-head-sha: a2ae17e42 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- Qualification-only exact head/base: a2ae17e4291d47061b1fc2ed075d8d6afca2140c / 03f5a3d149a3320a9110c3219f84e51607a20ac5; signed-DCO append-only cascade, stable-patch proof, byte-identical slice diff, final-tree equality, and normal pre-push hooks passed.
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts` (10 passed); `npx vitest run --project integration test/runtime-provider-source-shape.test.ts` (2 passed); CLI build and typecheck passed at exact implementation head `b403f7a68`; the exact head `269de66e5` reran the authority suite after the same-descriptor CodeQL repair; source-shape, Biome, diff-check, and normal push hooks pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

