### PR TITLE
feat(runtime): qualify Podman inference commands

### DIFF
--- a/src/lib/adapters/container-engine.ts
+++ b/src/lib/adapters/container-engine.ts
@@ -8,6 +8,7 @@ import { buildSubprocessEnv } from "../subprocess-env";
 
 export type ContainerEngineOperationScope =
   | "host-doctor"
+  | "host-local-inference"
   | "gateway-inspection"
   | "managed-bootstrap"
   | "sandbox-lifecycle"

--- a/src/lib/adapters/podman/index.ts
+++ b/src/lib/adapters/podman/index.ts
@@ -15,7 +15,11 @@ import {
 } from "./socket-authority";
 
 export interface PodmanContainerEngineOptions {
-  readonly operation: "host-doctor" | "managed-bootstrap" | "sandbox-lifecycle";
+  readonly operation:
+    | "host-doctor"
+    | "host-local-inference"
+    | "managed-bootstrap"
+    | "sandbox-lifecycle";
   readonly socketAuthority: PodmanSocketAuthority;
   readonly executable?: string;
   readonly capture?: ContainerEngineCommandCapture;

--- a/src/lib/onboard/runtime-provider/contract.ts
+++ b/src/lib/onboard/runtime-provider/contract.ts
@@ -29,6 +29,7 @@ export type RuntimeProviderMutationOperation =
   | "workload-cleanup";
 export type RuntimeProviderContainerEngineOperation =
   | "host-doctor"
+  | "host-local-inference"
   | "gateway-inspection"
   | "sandbox-lifecycle"
   | "workload-cleanup";

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.test.ts
@@ -86,6 +86,25 @@ describe("persisted engine authority", () => {
     expect(fs.readFileSync(target, "utf8")).toBe(serializePersistedEngineAuthority(authority));
   });
 
+  it("persists a host-local inference engine independently of lifecycle authority", () => {
+    const store = createFilePersistedEngineAuthorityStore(temporaryRoot());
+    const inference = createPersistedEngineAuthority(
+      "mxc",
+      engine("host-local-inference"),
+      BINDING_SHA256,
+    );
+    const lifecycle = createPersistedEngineAuthority(
+      "mxc",
+      engine("sandbox-lifecycle"),
+      BINDING_SHA256,
+    );
+
+    expect(store.record(inference)).toEqual(inference);
+    expect(store.record(lifecycle)).toEqual(lifecycle);
+    expect(store.load("host-local-inference")).toEqual(inference);
+    expect(store.load("sandbox-lifecycle")).toEqual(lifecycle);
+  });
+
   it.each([
     {
       label: "provider",

--- a/src/lib/onboard/runtime-provider/persisted-engine-authority.ts
+++ b/src/lib/onboard/runtime-provider/persisted-engine-authority.ts
@@ -22,6 +22,7 @@ const AUTHORITY_ID = /^[a-z][a-z0-9-]{0,62}:[A-Za-z0-9._:-]{1,255}$/u;
 const SHA256 = /^[a-f0-9]{64}$/u;
 const OPERATIONS = new Set<ContainerEngineOperationScope>([
   "host-doctor",
+  "host-local-inference",
   "gateway-inspection",
   "managed-bootstrap",
   "sandbox-lifecycle",

--- a/src/lib/onboard/runtime-provider/podman-gpu.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-gpu.test.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeNvidiaCdiDevice,
+  normalizePodmanCdiInventory,
+  qualifyPodmanGpuAttachments,
+} from "./podman-gpu";
+
+describe("Podman GPU attachment authority", () => {
+  it.each([
+    ["all", "nvidia.com/gpu=all"],
+    ["0", "nvidia.com/gpu=0"],
+    ["1:0", "nvidia.com/gpu=1:0"],
+    ["GPU-deadbeef", "nvidia.com/gpu=GPU-deadbeef"],
+    ["nvidia.com/gpu=MIG-deadbeef", "nvidia.com/gpu=MIG-deadbeef"],
+    [
+      "MIG-GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/1/0",
+      "nvidia.com/gpu=MIG-GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/1/0",
+    ],
+  ])("normalizes %s to canonical NVIDIA CDI identity", (requested, expected) => {
+    expect(normalizeNvidiaCdiDevice(requested)).toBe(expected);
+  });
+
+  it("qualifies only exact devices advertised by the injected endpoint", () => {
+    const attachments = qualifyPodmanGpuAttachments(
+      ["nvidia.com/gpu=all", "nvidia.com/gpu=0", "nvidia.com/gpu=GPU-deadbeef"],
+      ["0", "GPU-deadbeef"],
+    );
+
+    expect(attachments).toEqual([
+      { kind: "cdi", device: "nvidia.com/gpu=0" },
+      { kind: "cdi", device: "nvidia.com/gpu=GPU-deadbeef" },
+    ]);
+    expect(Object.isFrozen(attachments)).toBe(true);
+    expect(Object.isFrozen(attachments[0])).toBe(true);
+  });
+
+  it("fails closed for missing, duplicate, raw, and malformed devices", () => {
+    expect(() => qualifyPodmanGpuAttachments([], ["all"])).toThrow("does not advertise");
+    expect(() =>
+      qualifyPodmanGpuAttachments(["nvidia.com/gpu=0"], ["0", "nvidia.com/gpu=0"]),
+    ).toThrow("duplicate NVIDIA CDI device");
+    expect(() => normalizeNvidiaCdiDevice("/dev/nvidia0")).toThrow("safe NVIDIA CDI name");
+    expect(() => normalizePodmanCdiInventory(["all", "nvidia.com/gpu=all"])).toThrow(
+      "duplicate NVIDIA device",
+    );
+  });
+});

--- a/src/lib/onboard/runtime-provider/podman-gpu.ts
+++ b/src/lib/onboard/runtime-provider/podman-gpu.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const NVIDIA_CDI_PREFIX = "nvidia.com/gpu=";
+const CDI_DEVICE_NAME = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,255}$/u;
+const LEGACY_MIG_DEVICE_NAME = /^MIG-GPU-[A-Za-z0-9-]+\/[0-9]+\/[0-9]+$/u;
+
+export interface PodmanGpuAttachment {
+  readonly kind: "cdi";
+  readonly device: string;
+}
+
+/**
+ * Normalize one NVIDIA CDI device identity without consulting host state.
+ * Availability is proved separately against the exact Podman endpoint's
+ * qualified inventory.
+ */
+export function normalizeNvidiaCdiDevice(requestedDevice: string): string {
+  const requested = requestedDevice.trim();
+  const device = requested.startsWith(NVIDIA_CDI_PREFIX)
+    ? requested
+    : `${NVIDIA_CDI_PREFIX}${requested}`;
+  const name = device.slice(NVIDIA_CDI_PREFIX.length);
+  if (!CDI_DEVICE_NAME.test(name) && !LEGACY_MIG_DEVICE_NAME.test(name)) {
+    throw new Error(
+      "Podman GPU device must be a safe NVIDIA CDI name such as 'all', '0', '1:0', 'GPU-...', or 'MIG-...'.",
+    );
+  }
+  return device;
+}
+
+export function normalizePodmanCdiInventory(devices: readonly string[]): readonly string[] {
+  if (!Array.isArray(devices) || devices.length > 256) {
+    throw new Error("Podman CDI inventory is invalid or exceeds its device limit.");
+  }
+  const normalized = devices.map(normalizeNvidiaCdiDevice).sort();
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error("Podman CDI inventory contains a duplicate NVIDIA device.");
+  }
+  return Object.freeze(normalized);
+}
+
+export function qualifyPodmanGpuAttachments(
+  availableDevices: readonly string[],
+  requestedDevices: readonly string[] = ["all"],
+): readonly PodmanGpuAttachment[] {
+  const available = new Set(normalizePodmanCdiInventory(availableDevices));
+  if (!Array.isArray(requestedDevices) || requestedDevices.length === 0) {
+    throw new Error("Podman GPU attachment requires at least one NVIDIA CDI device.");
+  }
+  const requested = requestedDevices.map(normalizeNvidiaCdiDevice);
+  if (new Set(requested).size !== requested.length) {
+    throw new Error("Podman GPU attachment contains a duplicate NVIDIA CDI device.");
+  }
+  for (const device of requested) {
+    if (!available.has(device)) {
+      throw new Error(
+        `Rootless Podman does not advertise the requested CDI device '${device}'. Refresh the NVIDIA CDI specification and retry.`,
+      );
+    }
+  }
+  return Object.freeze(requested.map((device) => Object.freeze({ kind: "cdi" as const, device })));
+}

--- a/src/lib/onboard/runtime-provider/podman-inference-args.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-inference-args.test.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { translatePodmanLocalInferenceArgs } from "./podman-inference-args";
+
+const CDI_DEVICES = [
+  "nvidia.com/gpu=all",
+  "nvidia.com/gpu=0",
+  "nvidia.com/gpu=1:0",
+  "nvidia.com/gpu=2",
+  "nvidia.com/gpu=GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "nvidia.com/gpu=MIG-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "nvidia.com/gpu=MIG-GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/1/0",
+] as const;
+
+describe("Podman local inference command translation", () => {
+  it.each([
+    ["all", ["nvidia.com/gpu=all"]],
+    ["device=0", ["nvidia.com/gpu=0"]],
+    ["device=1:0", ["nvidia.com/gpu=1:0"]],
+    [
+      "device=GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      ["nvidia.com/gpu=GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
+    ],
+    [
+      "device=MIG-GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/1/0",
+      ["nvidia.com/gpu=MIG-GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/1/0"],
+    ],
+    ['"device=0,2"', ["nvidia.com/gpu=0", "nvidia.com/gpu=2"]],
+  ])("preserves Docker selector %s as exact CDI devices", (selector, devices) => {
+    const translated = translatePodmanLocalInferenceArgs(
+      ["run", "--gpus", selector, "image"],
+      CDI_DEVICES,
+    );
+    expect(translated.filter((value) => value.startsWith("nvidia.com/gpu="))).toEqual(devices);
+    expect(translated.filter((value) => value === "--device")).toHaveLength(devices.length);
+    expect(translated).not.toContain("--gpus");
+  });
+
+  it("translates the NIM and vLLM subset without Docker name-filter leakage", () => {
+    expect(
+      translatePodmanLocalInferenceArgs(
+        ["run", "--gpus=all", "--filter", "name=^/nemoclaw-vllm$"],
+        CDI_DEVICES,
+      ),
+    ).toEqual(["run", "--device", "nvidia.com/gpu=all", "--filter", "name=^nemoclaw-vllm$"]);
+    expect(
+      translatePodmanLocalInferenceArgs(["run", "--device=nvidia.com/gpu=0", "image"], CDI_DEVICES),
+    ).toEqual(["run", "--device", "nvidia.com/gpu=0", "image"]);
+  });
+
+  it("fails closed instead of dropping unsupported Docker GPU modes", () => {
+    expect(() =>
+      translatePodmanLocalInferenceArgs(
+        ["run", "--gpus", "capabilities=compute", "image"],
+        CDI_DEVICES,
+      ),
+    ).toThrow("cannot translate Docker GPU selector");
+    expect(() =>
+      translatePodmanLocalInferenceArgs(["run", "--gpus", "device=0,0"], CDI_DEVICES),
+    ).toThrow("duplicate NVIDIA CDI device");
+    expect(() =>
+      translatePodmanLocalInferenceArgs(["run", "--runtime", "nvidia"], CDI_DEVICES),
+    ).toThrow("refuses Docker's NVIDIA runtime mode");
+    expect(() =>
+      translatePodmanLocalInferenceArgs(["run", "--device", "/dev/nvidia0"], CDI_DEVICES),
+    ).toThrow("refuses raw NVIDIA device paths");
+    expect(() =>
+      translatePodmanLocalInferenceArgs(["run", "--gpus", "device=9"], CDI_DEVICES),
+    ).toThrow("does not advertise");
+  });
+});

--- a/src/lib/onboard/runtime-provider/podman-inference-args.ts
+++ b/src/lib/onboard/runtime-provider/podman-inference-args.ts
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { qualifyPodmanGpuAttachments } from "./podman-gpu";
+
+const MAX_ARGUMENTS = 512;
+const MAX_ARGUMENT_BYTES = 16 * 1024;
+
+function exactArgument(value: unknown, index: number): string {
+  if (
+    typeof value !== "string" ||
+    value.includes("\0") ||
+    Buffer.byteLength(value, "utf8") > MAX_ARGUMENT_BYTES
+  ) {
+    throw new Error(`Podman local inference argument ${String(index)} is invalid.`);
+  }
+  return value;
+}
+
+function stripExactDoubleQuotes(raw: string): string {
+  const trimmed = raw.trim();
+  const startsQuoted = trimmed.startsWith('"');
+  const endsQuoted = trimmed.endsWith('"');
+  if (startsQuoted !== endsQuoted || (startsQuoted && trimmed.length < 2)) {
+    throw new Error(`Podman local inference cannot translate Docker GPU selector '${raw}' to CDI.`);
+  }
+  return startsQuoted ? trimmed.slice(1, -1) : trimmed;
+}
+
+function translatedGpuDevices(selector: string, availableCdiDevices: readonly string[]): string[] {
+  const normalized = stripExactDoubleQuotes(selector);
+  const requested =
+    normalized === "all"
+      ? ["all"]
+      : normalized.startsWith("device=")
+        ? normalized.slice("device=".length).split(",")
+        : [];
+  if (requested.length === 0 || requested.some((device) => device.trim() === "")) {
+    throw new Error(
+      `Podman local inference cannot translate Docker GPU selector '${selector}' to CDI.`,
+    );
+  }
+  return qualifyPodmanGpuAttachments(
+    availableCdiDevices,
+    requested.map((device) => device.trim()),
+  ).map((attachment) => attachment.device);
+}
+
+function appendGpuDevices(target: string[], devices: readonly string[]): void {
+  for (const device of devices) target.push("--device", device);
+}
+
+/**
+ * Translate the bounded Docker-compatible argument subset emitted by the
+ * existing NIM and vLLM launchers. NVIDIA GPU selection becomes exact CDI
+ * attachment; Docker-only runtime and raw-device modes fail closed.
+ */
+export function translatePodmanLocalInferenceArgs(
+  args: readonly string[],
+  availableCdiDevices: readonly string[],
+): readonly string[] {
+  if (!Array.isArray(args) || args.length > MAX_ARGUMENTS) {
+    throw new Error("Podman local inference has too many command arguments.");
+  }
+  const source = args.map(exactArgument);
+  const translated: string[] = [];
+  for (let index = 0; index < source.length; index += 1) {
+    const value = source[index] ?? "";
+    if (value === "--gpus") {
+      const selector = source[index + 1];
+      if (selector === undefined) {
+        throw new Error("Podman local inference requires a GPU selector value.");
+      }
+      appendGpuDevices(translated, translatedGpuDevices(selector, availableCdiDevices));
+      index += 1;
+      continue;
+    }
+    if (value.startsWith("--gpus=")) {
+      appendGpuDevices(
+        translated,
+        translatedGpuDevices(value.slice("--gpus=".length), availableCdiDevices),
+      );
+      continue;
+    }
+    if (
+      (value === "--runtime" && source[index + 1]?.toLowerCase() === "nvidia") ||
+      value.toLowerCase() === "--runtime=nvidia"
+    ) {
+      throw new Error(
+        "Podman local inference refuses Docker's NVIDIA runtime mode; an exact CDI device is required.",
+      );
+    }
+    if (value === "--device") {
+      const device = source[index + 1];
+      if (device === undefined) {
+        throw new Error("Podman local inference requires a --device value.");
+      }
+      if (/^\/dev\/nvidia/u.test(device)) {
+        throw new Error(
+          "Podman local inference refuses raw NVIDIA device paths; an exact CDI device is required.",
+        );
+      }
+      if (device.startsWith("nvidia.com/gpu=")) {
+        appendGpuDevices(translated, translatedGpuDevices(`device=${device}`, availableCdiDevices));
+        index += 1;
+        continue;
+      }
+    }
+    if (value.startsWith("--device=/dev/nvidia")) {
+      throw new Error(
+        "Podman local inference refuses raw NVIDIA device paths; an exact CDI device is required.",
+      );
+    }
+    if (value.startsWith("--device=nvidia.com/gpu=")) {
+      appendGpuDevices(
+        translated,
+        translatedGpuDevices(`device=${value.slice("--device=".length)}`, availableCdiDevices),
+      );
+      continue;
+    }
+    if (value.startsWith("name=^/") && value.endsWith("$")) {
+      translated.push(`name=^${value.slice("name=^/".length)}`);
+      continue;
+    }
+    translated.push(value);
+  }
+  return Object.freeze(translated);
+}

--- a/src/lib/onboard/runtime-provider/podman-preflight.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-preflight.test.ts
@@ -142,6 +142,13 @@ describe("Podman host preflight", () => {
         additionalCdiDevices: ["all"],
       }),
     ).toThrow("duplicate NVIDIA device");
+    expect(() =>
+      qualifyPodmanHost(engine(), {
+        platform: "linux",
+        architecture: "x64",
+        additionalCdiDevices: ["nvidia.com/gpu=0"],
+      }),
+    ).toThrow("duplicate NVIDIA device");
   });
 
   it("rejects an API service architecture that differs from the host", () => {

--- a/src/lib/onboard/runtime-provider/podman-preflight.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-preflight.test.ts
@@ -18,6 +18,7 @@ const INFO = JSON.stringify({
     cgroupVersion: "v2",
     networkBackend: "netavark",
     security: { rootless: true },
+    cdi: { devices: ["nvidia.com/gpu=all", "nvidia.com/gpu=0"] },
   },
 });
 
@@ -80,6 +81,7 @@ describe("Podman host preflight", () => {
 
     expect(qualifyPodmanHost(runtime, { platform: "linux", architecture: "x64" })).toEqual({
       providerId: "podman",
+      authorityId: "test:podman-socket",
       clientVersion: "5.6.2",
       serverVersion: "5.6.2",
       rootless: true,
@@ -87,6 +89,7 @@ describe("Podman host preflight", () => {
       os: "linux",
       architecture: "amd64",
       networkBackend: "netavark",
+      cdiDevices: ["nvidia.com/gpu=0", "nvidia.com/gpu=all"],
     });
     expect(runtime.capture).toHaveBeenCalledWith(["info", "--format", "json"], 15_000);
     expect(runtime.capture).toHaveBeenCalledWith(["version", "--format", "json"], 10_000);
@@ -109,6 +112,36 @@ describe("Podman host preflight", () => {
     expect(
       qualifyPodmanHost(engine({ info }), { platform: "linux", architecture: "arm64" }),
     ).toMatchObject({ architecture: "arm64" });
+  });
+
+  it("combines endpoint-reported and separately qualified CDI inventories", () => {
+    expect(
+      qualifyPodmanHost(engine(), {
+        platform: "linux",
+        architecture: "x64",
+        additionalCdiDevices: ["nvidia.com/gpu=GPU-deadbeef"],
+      }),
+    ).toMatchObject({
+      authorityId: "test:podman-socket",
+      cdiDevices: ["nvidia.com/gpu=0", "nvidia.com/gpu=GPU-deadbeef", "nvidia.com/gpu=all"],
+    });
+  });
+
+  it("rejects malformed or duplicate qualified CDI inventory", () => {
+    expect(() =>
+      qualifyPodmanHost(engine(), {
+        platform: "linux",
+        architecture: "x64",
+        additionalCdiDevices: ["/dev/nvidia0"],
+      }),
+    ).toThrow("safe NVIDIA CDI name");
+    expect(() =>
+      qualifyPodmanHost(engine(), {
+        platform: "linux",
+        architecture: "x64",
+        additionalCdiDevices: ["all"],
+      }),
+    ).toThrow("duplicate NVIDIA device");
   });
 
   it("rejects an API service architecture that differs from the host", () => {

--- a/src/lib/onboard/runtime-provider/podman-preflight.ts
+++ b/src/lib/onboard/runtime-provider/podman-preflight.ts
@@ -117,9 +117,9 @@ function normalizeArchitecture(value: string): "amd64" | "arm64" | null {
   return null;
 }
 
-function collectNvidiaCdiDevices(value: unknown, devices: Set<string>): void {
+function collectNvidiaCdiDevices(value: unknown, devices: string[]): void {
   if (typeof value === "string") {
-    if (value.startsWith("nvidia.com/gpu=")) devices.add(value);
+    if (value.startsWith("nvidia.com/gpu=")) devices.push(value);
     return;
   }
   if (Array.isArray(value)) {
@@ -129,7 +129,7 @@ function collectNvidiaCdiDevices(value: unknown, devices: Set<string>): void {
   const source = record(value);
   if (!source) return;
   for (const [key, entry] of Object.entries(source)) {
-    if (key.startsWith("nvidia.com/gpu=")) devices.add(key);
+    if (key.startsWith("nvidia.com/gpu=")) devices.push(key);
     collectNvidiaCdiDevices(entry, devices);
   }
 }
@@ -242,10 +242,10 @@ export function qualifyPodmanHost(
   }
   requireSubordinateIdMappings(engine);
 
-  const cdiDevices = new Set<string>();
+  const cdiDevices: string[] = [];
   collectNvidiaCdiDevices(host, cdiDevices);
-  for (const device of options.additionalCdiDevices ?? []) cdiDevices.add(device);
-  const qualifiedCdiDevices = normalizePodmanCdiInventory([...cdiDevices]);
+  cdiDevices.push(...(options.additionalCdiDevices ?? []));
+  const qualifiedCdiDevices = normalizePodmanCdiInventory(cdiDevices);
 
   return Object.freeze({
     providerId: "podman",

--- a/src/lib/onboard/runtime-provider/podman-preflight.ts
+++ b/src/lib/onboard/runtime-provider/podman-preflight.ts
@@ -6,11 +6,14 @@ import type {
   ContainerEngineCommandResult,
 } from "../../adapters/container-engine";
 import type { RuntimeProviderDoctorCheck } from "./contract";
+import { normalizePodmanCdiInventory } from "./podman-gpu";
 
 export const MINIMUM_PODMAN_VERSION = "5.0.0";
 
 export interface PodmanHostPreflightReceipt {
   readonly providerId: "podman";
+  /** Exact endpoint identity of the operation-scoped engine that produced this receipt. */
+  readonly authorityId: string;
   readonly clientVersion: string;
   readonly serverVersion: string;
   readonly rootless: true;
@@ -18,11 +21,14 @@ export interface PodmanHostPreflightReceipt {
   readonly os: "linux";
   readonly architecture: "amd64" | "arm64";
   readonly networkBackend: string;
+  readonly cdiDevices: readonly string[];
 }
 
 export interface PodmanHostPreflightOptions {
   readonly platform?: NodeJS.Platform;
   readonly architecture?: NodeJS.Architecture;
+  /** Additional devices from a separately qualified NVIDIA CDI inventory adapter. */
+  readonly additionalCdiDevices?: readonly string[];
 }
 
 export class PodmanHostPreflightError extends Error {
@@ -109,6 +115,23 @@ function normalizeArchitecture(value: string): "amd64" | "arm64" | null {
   if (value === "amd64" || value === "x86_64") return "amd64";
   if (value === "arm64" || value === "aarch64") return "arm64";
   return null;
+}
+
+function collectNvidiaCdiDevices(value: unknown, devices: Set<string>): void {
+  if (typeof value === "string") {
+    if (value.startsWith("nvidia.com/gpu=")) devices.add(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectNvidiaCdiDevices(entry, devices);
+    return;
+  }
+  const source = record(value);
+  if (!source) return;
+  for (const [key, entry] of Object.entries(source)) {
+    if (key.startsWith("nvidia.com/gpu=")) devices.add(key);
+    collectNvidiaCdiDevices(entry, devices);
+  }
 }
 
 function hasSubordinateIdMapping(output: string): boolean {
@@ -219,8 +242,14 @@ export function qualifyPodmanHost(
   }
   requireSubordinateIdMappings(engine);
 
+  const cdiDevices = new Set<string>();
+  collectNvidiaCdiDevices(host, cdiDevices);
+  for (const device of options.additionalCdiDevices ?? []) cdiDevices.add(device);
+  const qualifiedCdiDevices = normalizePodmanCdiInventory([...cdiDevices]);
+
   return Object.freeze({
     providerId: "podman",
+    authorityId: engine.authorityId,
     clientVersion,
     serverVersion,
     rootless: true,
@@ -228,6 +257,7 @@ export function qualifyPodmanHost(
     os: "linux",
     architecture: normalizedArchitecture,
     networkBackend: textField(host, "networkBackend", "NetworkBackend") || "unknown",
+    cdiDevices: qualifiedCdiDevices,
   });
 }
 

--- a/src/lib/onboard/runtime-provider/registry.ts
+++ b/src/lib/onboard/runtime-provider/registry.ts
@@ -66,6 +66,7 @@ const MUTATION_OPERATIONS = new Set<RuntimeProviderMutationOperation>([
 ]);
 const CONTAINER_ENGINE_OPERATIONS = new Set<RuntimeProviderContainerEngineOperation>([
   "host-doctor",
+  "host-local-inference",
   "gateway-inspection",
   "sandbox-lifecycle",
   "workload-cleanup",

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -167,6 +167,7 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/runtime-provider/docker.ts",
       "src/lib/onboard/runtime-provider/persisted-engine-authority.ts",
       "src/lib/onboard/runtime-provider/persisted-engine-lifecycle.ts",
+      "src/lib/onboard/runtime-provider/podman-gpu.ts",
       "src/lib/onboard/runtime-provider/podman-lifecycle.ts",
       "src/lib/onboard/runtime-provider/podman-preflight.ts",
       "src/lib/onboard/runtime-provider/podman.ts",

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -168,6 +168,7 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/runtime-provider/persisted-engine-authority.ts",
       "src/lib/onboard/runtime-provider/persisted-engine-lifecycle.ts",
       "src/lib/onboard/runtime-provider/podman-gpu.ts",
+      "src/lib/onboard/runtime-provider/podman-inference-args.ts",
       "src/lib/onboard/runtime-provider/podman-lifecycle.ts",
       "src/lib/onboard/runtime-provider/podman-preflight.ts",
       "src/lib/onboard/runtime-provider/podman.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR adds the dormant Podman GPU-qualification and inference-command translation boundary for the incremental runtime stack in #7744. It does not register Podman for production selection or advertise user-visible Podman support.

## Changes

- Add an operation-scoped `host-local-inference` engine contract so runtime providers can request GPU-qualified execution without a Podman switch in central orchestration. Provider contract and source-shape tests protect this boundary.
- Record the exact Podman authority and qualified CDI device inventory during preflight. Qualification now preserves the raw inventory through validation and fails closed on both exact and normalization-equivalent duplicate device identities before any deduplication can hide them.
- Translate Docker-compatible inference GPU arguments into Podman CDI device arguments. Unit tests cover `all`, indexed GPUs, GPU UUIDs, MIG devices, container-name filters, and fail-closed rejection of unsupported NVIDIA runtime, duplicate, unqualified, or raw-device options.
- Keep the new path dormant. Production provider selection, agent behavior, Docker behavior, and Kubernetes behavior do not change in this slice.

## Advisor disposition

- The duplicate-CDI fail-closed finding is fixed at exact head `e74e262c2`; the denial test supplies the same canonical CDI identity from both endpoint inventory and the separately qualified inventory and proves qualification rejects it.
- The dormant-translator suggestion is intentionally not applied in this slice. Epic #7744 defines this review unit as the inert GPU/translation contract; stacked PR #8061 supplies its named, operation-scoped host-local inference provider consumer. Production activation remains owned by the later qualification slice after every agent, GPU/local inference path, recovery path, and protected E2E pass. Removing the contract here or adding a central Podman switch would defeat that incremental, pluggable stack design.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This slice adds an internal, dormant provider contract and does not activate or document a supported surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent exact-head review verified fail-closed CDI identity, endpoint authority, provider-neutral operation scope, and dormant production selection.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Advisor Disposition

- Earlier PRA-1, which found duplicate CDI identities lost before normalization, is resolved by d4622df35. Endpoint-reported and additional identities now remain in one raw array until normalizePodmanCdiInventory rejects normalized duplicates; the focused test covers both prefixed and shorthand collisions.
- Earlier PRA-2, now published as the PRA-1 dormant-consumer suggestion, is explicitly retained for the maintainer-approved incremental stack. Wiring production here would violate the dormant review thesis for this slice and bypass the receipt authority that lands in #8060. Stacked #8061 is the named production-bound provider consumer and adds provider-level contract tests for qualified CDI devices. Current central selection still excludes Podman, and the source-shape test rejects Podman switches in central orchestration.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independent review of the exact 13-file slice at e74e262c28f514bc9e782b157c2c2549a710ad8c against base baa495a5e9ac6c09508c0acac649ed08a7059f1b, WRITING.md, the controlled word list, and docs/CONTRIBUTING.md found no documentation update required. CURRENT_RUNTIME_PROVIDER_BUNDLES still contains only Docker and Kubernetes, the Podman provider still reports hostLocalInference false, and user-visible Podman support remains inactive. The duplicate-CDI repair collects endpoint and additional device identities before normalization and rejects normalized duplicates. Stable patch ID 681a1e01ee7d6328fef26c359ef7b75b88301c9e and binary diff SHA-256 4fc440a2a439e604553eb24aba928dbd507ec5558cfa8d31383795c49eb4098d bind the receipt. CLI build and typecheck, 97 focused CLI tests, 2 source-shape tests, repository checks, and git diff --check passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e74e262c2 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this slice remains dormant and protected runtime qualification is owned by the activation slice.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: At exact head e74e262c28f514bc9e782b157c2c2549a710ad8c on base baa495a5e9ac6c09508c0acac649ed08a7059f1b, six focused CLI files passed 97 tests; the runtime-provider source-shape file passed 2 tests; npm run build:cli, npm run typecheck:cli, npm run checks:repository, and git diff --check passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Exact-head CI and protected E2E are running.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


