### PR TITLE
feat(runtime): route host-local inference

### DIFF
--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -28,6 +28,7 @@ import type {
   createProviderRecoveryReceiptLedger,
   ProviderRecoveryReceipt,
 } from "../../rebuild-route-handoff";
+import type { HostLocalInferenceStartupRequest } from "../../runtime-provider/host-local-inference-routing";
 import { withInferenceTrace, withProviderSelectionTrace } from "../../tracing";
 import { advanceTo, type OnboardStateTransitionResult, retryTo } from "../result";
 import { createRecovery, type RecoveryAuthority } from "./provider-inference-recovery";
@@ -65,6 +66,8 @@ export interface ProviderInferenceSetupOptions {
   reservationSessionId?: string;
   /** Recheck recorded-route ownership after acquiring route mutation locks. */
   isRecordedProviderRecoveryAuthorized?: () => boolean;
+  /** Dormant provider-owned startup request used by pluggable local runtimes. */
+  hostLocalInference?: HostLocalInferenceStartupRequest;
 }
 
 export interface ProviderSelectionResult {

--- a/src/lib/onboard/runtime-provider/host-local-inference-routing.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-routing.test.ts
@@ -40,6 +40,7 @@ function receipt(service: "ollama" | "nim" | "vllm"): HostLocalInferenceReceipt 
             runtimeId: `mxc-runtime:${service}`,
             name: `nemoclaw-${service}`,
             imageRef: MANAGED_IMAGE,
+            probeImageRef: PROBE_IMAGE,
             specSha256: "e".repeat(64),
             gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
           },

--- a/src/lib/onboard/runtime-provider/host-local-inference-routing.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-routing.test.ts
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { HostLocalInferenceReceipt, HostLocalInferenceRuntime } from "./host-local-inference";
+import {
+  HOST_LOCAL_INFERENCE_APPLICATIONS,
+  hostLocalInferenceApplicationBaseUrl,
+  prepareHostLocalInferenceStartup,
+} from "./host-local-inference-routing";
+
+const AUTHORITY_ID = `mxc-endpoint:${"a".repeat(64)}`;
+const PROBE_IMAGE = `quay.io/curl/curl@sha256:${"b".repeat(64)}`;
+const MANAGED_IMAGE = `nvcr.io/nvidia/inference@sha256:${"c".repeat(64)}`;
+
+function receipt(service: "ollama" | "nim" | "vllm"): HostLocalInferenceReceipt {
+  return {
+    schemaVersion: 1,
+    providerId: "mxc",
+    service,
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "host-local-inference",
+      engineId: "mxc",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: "d".repeat(64),
+    },
+    endpoint: {
+      host: "mxc-provider-native.internal",
+      port: service === "ollama" ? 11434 : service === "nim" ? 8001 : 8000,
+      networkName: "mxc-runtime-network",
+    },
+    runtime:
+      service === "ollama"
+        ? { kind: "host", probeImageRef: PROBE_IMAGE }
+        : {
+            kind: "container",
+            runtimeId: `mxc-runtime:${service}`,
+            name: `nemoclaw-${service}`,
+            imageRef: MANAGED_IMAGE,
+            specSha256: "e".repeat(64),
+            gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
+          },
+  };
+}
+
+function runtime(): HostLocalInferenceRuntime {
+  return {
+    providerId: "mxc",
+    authorityId: AUTHORITY_ID,
+    services: ["ollama", "nim", "vllm"],
+    translateContainerArgs: (args) => args,
+    qualifyOllama: vi.fn(() => receipt("ollama")),
+    startManaged: vi.fn((input) => receipt(input.service)),
+    inspectManaged: vi.fn((value) => ({ running: true, receipt: value })),
+    stopManaged: vi.fn((value) => ({ running: false, receipt: value })),
+    preserveForRebuild: vi.fn((value) => value),
+  };
+}
+
+const endpoint = {
+  networkName: "mxc-runtime-network",
+  hostPort: 11434,
+  probeImageRef: PROBE_IMAGE,
+} as const;
+
+const managed = (service: "nim" | "vllm") => ({
+  service,
+  containerName: `nemoclaw-${service}`,
+  containerPort: 8000,
+  imageRef: MANAGED_IMAGE,
+  gpuDevices: ["nvidia.com/gpu=all"],
+  networkName: "mxc-runtime-network",
+  hostPort: service === "nim" ? 8001 : 8000,
+  probeImageRef: PROBE_IMAGE,
+});
+
+describe("provider-neutral host-local inference startup routing", () => {
+  it.each([
+    ["ollama", "ollama-local", "http://host.openshell.internal:11434/v1"],
+    ["nim", "vllm-local", "http://host.openshell.internal:8001/v1"],
+    ["vllm", "vllm-local", "http://host.openshell.internal:8000/v1"],
+  ] as const)("starts %s without exposing the provider-native host", (service, provider, baseUrl) => {
+    const providerRuntime = runtime();
+    const route = prepareHostLocalInferenceStartup(
+      providerRuntime,
+      service === "ollama" ? { service, endpoint } : { service, managed: managed(service) },
+    );
+
+    expect(route.gatewayProvider).toBe(provider);
+    expect(route.gatewayProviderBaseUrl).toBe(baseUrl);
+    expect(route.gatewayProviderBaseUrl).not.toContain("mxc-provider-native.internal");
+    expect(route.applicationBaseUrl).toBe("https://inference.local/v1");
+  });
+
+  it("presents the same inference.local route to every supported application", () => {
+    const route = prepareHostLocalInferenceStartup(runtime(), {
+      service: "vllm",
+      managed: managed("vllm"),
+    });
+
+    expect(
+      HOST_LOCAL_INFERENCE_APPLICATIONS.map((application) =>
+        hostLocalInferenceApplicationBaseUrl(application, route),
+      ),
+    ).toEqual([
+      "https://inference.local/v1",
+      "https://inference.local/v1",
+      "https://inference.local/v1",
+    ]);
+  });
+
+  it("fails closed on service and runtime authority drift", () => {
+    const providerRuntime = runtime();
+    expect(() =>
+      prepareHostLocalInferenceStartup(providerRuntime, {
+        service: "nim",
+        managed: managed("vllm"),
+      }),
+    ).toThrow("service identity is inconsistent");
+
+    const drifted = runtime();
+    drifted.startManaged = vi.fn(() => ({
+      ...receipt("vllm"),
+      engineAuthority: {
+        ...receipt("vllm").engineAuthority,
+        authorityId: `other-endpoint:${"f".repeat(64)}`,
+      },
+    }));
+    expect(() =>
+      prepareHostLocalInferenceStartup(drifted, {
+        service: "vllm",
+        managed: managed("vllm"),
+      }),
+    ).toThrow("different runtime authority");
+  });
+});

--- a/src/lib/onboard/runtime-provider/host-local-inference-routing.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-routing.ts
@@ -35,7 +35,7 @@ export interface HostLocalInferenceStartupRoute {
   readonly gatewayProvider: "ollama-local" | "vllm-local";
   /** Provider registration target visible inside the OpenShell gateway. */
   readonly gatewayProviderBaseUrl: string;
-  /** Stable application route shared by OpenClaw, Hermes, and Deep Agents Code. */
+  /** Stable inference route shared by OpenClaw, Hermes, and Deep Agents Code. */
   readonly applicationBaseUrl: typeof HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL;
 }
 

--- a/src/lib/onboard/runtime-provider/host-local-inference-routing.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-routing.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type HostLocalInferenceEndpointInput,
+  type HostLocalInferenceReceipt,
+  type HostLocalInferenceRuntime,
+  type HostLocalManagedInferenceInput,
+  normalizeHostLocalInferenceReceipt,
+} from "./host-local-inference";
+
+export const HOST_LOCAL_INFERENCE_SANDBOX_HOST = "host.openshell.internal" as const;
+export const HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL = "https://inference.local/v1" as const;
+
+export const HOST_LOCAL_INFERENCE_APPLICATIONS = [
+  "openclaw",
+  "hermes",
+  "langchain-deepagents-code",
+] as const;
+
+export type HostLocalInferenceApplication = (typeof HOST_LOCAL_INFERENCE_APPLICATIONS)[number];
+
+export type HostLocalInferenceStartupRequest =
+  | {
+      readonly service: "ollama";
+      readonly endpoint: HostLocalInferenceEndpointInput;
+    }
+  | {
+      readonly service: "nim" | "vllm";
+      readonly managed: HostLocalManagedInferenceInput;
+    };
+
+export interface HostLocalInferenceStartupRoute {
+  readonly receipt: HostLocalInferenceReceipt;
+  readonly gatewayProvider: "ollama-local" | "vllm-local";
+  /** Provider registration target visible inside the OpenShell gateway. */
+  readonly gatewayProviderBaseUrl: string;
+  /** Stable application route shared by OpenClaw, Hermes, and Deep Agents Code. */
+  readonly applicationBaseUrl: typeof HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL;
+}
+
+function normalizeStartupReceipt(
+  runtime: HostLocalInferenceRuntime,
+  service: HostLocalInferenceStartupRequest["service"],
+  receipt: HostLocalInferenceReceipt,
+): HostLocalInferenceReceipt {
+  const normalized = normalizeHostLocalInferenceReceipt(receipt);
+  if (
+    normalized.providerId !== runtime.providerId ||
+    normalized.engineAuthority.authorityId !== runtime.authorityId ||
+    normalized.service !== service
+  ) {
+    throw new Error("Host-local inference startup returned a different runtime authority.");
+  }
+  return normalized;
+}
+
+function providerBaseUrl(receipt: HostLocalInferenceReceipt): string {
+  // The provider-native receipt host proves reachability from its own engine
+  // network. It is deliberately not exposed to central orchestration. Every
+  // application reaches the gateway through OpenShell's canonical host alias.
+  return `http://${HOST_LOCAL_INFERENCE_SANDBOX_HOST}:${String(receipt.endpoint.port)}/v1`;
+}
+
+export function prepareHostLocalInferenceStartup(
+  runtime: HostLocalInferenceRuntime,
+  request: HostLocalInferenceStartupRequest,
+): HostLocalInferenceStartupRoute {
+  if (!runtime.services.includes(request.service)) {
+    throw new Error(
+      `Runtime provider '${runtime.providerId}' does not support host-local ${request.service}.`,
+    );
+  }
+  let rawReceipt: HostLocalInferenceReceipt;
+  if (request.service === "ollama") {
+    rawReceipt = runtime.qualifyOllama(request.endpoint);
+  } else {
+    if (request.managed.service !== request.service) {
+      throw new Error("Managed host-local inference service identity is inconsistent.");
+    }
+    rawReceipt = runtime.startManaged(request.managed);
+  }
+  const receipt = normalizeStartupReceipt(runtime, request.service, rawReceipt);
+  return Object.freeze({
+    receipt,
+    gatewayProvider: request.service === "ollama" ? "ollama-local" : "vllm-local",
+    gatewayProviderBaseUrl: providerBaseUrl(receipt),
+    applicationBaseUrl: HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL,
+  });
+}
+
+export function hostLocalInferenceApplicationBaseUrl(
+  application: HostLocalInferenceApplication,
+  route: HostLocalInferenceStartupRoute,
+): typeof HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL {
+  if (!HOST_LOCAL_INFERENCE_APPLICATIONS.includes(application)) {
+    throw new Error(`Unsupported host-local inference application '${String(application)}'.`);
+  }
+  return route.applicationBaseUrl;
+}

--- a/src/lib/onboard/setup-inference.ts
+++ b/src/lib/onboard/setup-inference.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isBedrockRuntimeEndpoint } from "../inference/bedrock-runtime";
 import { canonicalEndpoint } from "../core/url-utils";
+import { isBedrockRuntimeEndpoint } from "../inference/bedrock-runtime";
 import {
   assertEndpointResolvesPublic,
   type EndpointDnsLookupFn,
@@ -37,6 +37,7 @@ function matchesOnboardEndpoint(
   const selected = canonicalEndpoint(endpointUrl, flavor);
   return selected !== null && selected === canonicalEndpoint(onboardEndpointUrl, flavor);
 }
+
 import type {
   CommonDeps,
   HermesDeps,
@@ -49,6 +50,11 @@ import type {
 import * as inferenceProviders from "./inference-providers";
 import { createLocalInferenceRouteApplier } from "./local-inference-route";
 import type { ProviderInferenceSetupOptions } from "./machine/handlers/provider-inference";
+import type { HostLocalInferenceRuntime } from "./runtime-provider/host-local-inference";
+import {
+  type HostLocalInferenceStartupRoute,
+  prepareHostLocalInferenceStartup,
+} from "./runtime-provider/host-local-inference-routing";
 
 type ProviderBranchDeps = Pick<
   CommonDeps,
@@ -119,6 +125,7 @@ export type SetupInferenceDeps = ProviderBranchDeps & {
   localInferenceTimeoutSecs: number;
   vllmLocalCredentialEnv: string;
   getManagedVllmProviderBinding?: () => { baseUrl: string; apiKey: string } | null;
+  resolveHostLocalInferenceRuntime?: (sandboxName: string) => HostLocalInferenceRuntime | null;
   ollamaProxyCredentialEnv: string;
   isRoutedInferenceProvider: (provider: string) => boolean;
   applyLocalInferenceRoute?: VllmDeps["applyLocalInferenceRoute"];
@@ -215,6 +222,35 @@ function resolveLocalInferenceRouteApplier(
       exitProcess: deps.exitProcess,
     })
   );
+}
+
+function resolveHostLocalInferenceRoute(
+  deps: SetupInferenceDeps,
+  sandboxName: string | null,
+  provider: string,
+  request: NonNullable<ProviderInferenceSetupOptions["hostLocalInference"]>,
+): HostLocalInferenceStartupRoute {
+  const expectedProvider = request.service === "ollama" ? "ollama-local" : "vllm-local";
+  if (expectedProvider !== provider) {
+    throw new Error(`Host-local ${request.service} cannot configure provider '${provider}'.`);
+  }
+  if (!sandboxName || !deps.resolveHostLocalInferenceRuntime) {
+    throw new Error("Host-local inference requires a sandbox-bound runtime provider.");
+  }
+  const runtime = deps.resolveHostLocalInferenceRuntime(sandboxName);
+  if (!runtime) throw new Error(`Sandbox '${sandboxName}' has no host-local inference runtime.`);
+  let route: HostLocalInferenceStartupRoute;
+  try {
+    route = prepareHostLocalInferenceStartup(runtime, request);
+  } catch (error) {
+    throw new Error(
+      `Host-local inference startup failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (route.gatewayProvider !== provider) {
+    throw new Error("Host-local inference route provider normalization failed.");
+  }
+  return route;
 }
 
 export type SetupInference = (
@@ -364,6 +400,21 @@ export function createSetupInference(
           log: deps.log,
         } satisfies CommonDeps;
 
+        let hostLocalRoute: HostLocalInferenceStartupRoute | null = null;
+        if (options.hostLocalInference) {
+          try {
+            hostLocalRoute = resolveHostLocalInferenceRoute(
+              deps,
+              sandboxName,
+              provider,
+              options.hostLocalInference,
+            );
+          } catch (error) {
+            deps.error(`  ${error instanceof Error ? error.message : String(error)}`);
+            return deps.exitProcess(1);
+          }
+        }
+
         if (provider === deps.hermesProviderAuth.HERMES_PROVIDER_NAME) {
           return inferenceProviders.setupHermesProviderInference(
             {
@@ -432,17 +483,22 @@ export function createSetupInference(
             { model, provider },
             {
               ...commonDeps,
-              validateLocalProvider: deps.validateLocalProvider,
+              validateLocalProvider: hostLocalRoute
+                ? () => ({ ok: true as const })
+                : deps.validateLocalProvider,
               getLocalProviderHealthCheck: deps.getLocalProviderHealthCheck,
-              getLocalProviderBaseUrl: deps.getLocalProviderBaseUrl,
+              getLocalProviderBaseUrl: hostLocalRoute
+                ? () => hostLocalRoute.gatewayProviderBaseUrl
+                : deps.getLocalProviderBaseUrl,
               applyLocalInferenceRoute: resolveLocalInferenceRouteApplier(
                 deps,
                 runGatewayOpenshell,
               ),
               run: deps.run,
               VLLM_LOCAL_CREDENTIAL_ENV: deps.vllmLocalCredentialEnv,
-              getManagedVllmProviderBinding:
-                deps.getManagedVllmProviderBinding ?? getManagedDualStationVllmProviderBinding,
+              getManagedVllmProviderBinding: hostLocalRoute
+                ? () => null
+                : (deps.getManagedVllmProviderBinding ?? getManagedDualStationVllmProviderBinding),
             },
           );
           if (outcome.done) return outcome.result;
@@ -451,15 +507,21 @@ export function createSetupInference(
             { model, provider, allowToolsIncompatible: options.allowToolsIncompatible === true },
             {
               ...commonDeps,
-              validateLocalProvider: deps.validateLocalProvider,
-              getLocalProviderBaseUrl: deps.getLocalProviderBaseUrl,
+              validateLocalProvider: hostLocalRoute
+                ? () => ({ ok: true as const })
+                : deps.validateLocalProvider,
+              getLocalProviderBaseUrl: hostLocalRoute
+                ? () => hostLocalRoute.gatewayProviderBaseUrl
+                : deps.getLocalProviderBaseUrl,
               applyLocalInferenceRoute: resolveLocalInferenceRouteApplier(
                 deps,
                 runGatewayOpenshell,
               ),
               getOllamaWarmupCommand: deps.getOllamaWarmupCommand,
               run: deps.run,
-              shouldFrontOllamaWithProxy: deps.shouldFrontOllamaWithProxy,
+              shouldFrontOllamaWithProxy: hostLocalRoute
+                ? () => false
+                : deps.shouldFrontOllamaWithProxy,
               ensureOllamaAuthProxy: deps.ensureOllamaAuthProxy,
               isProxyHealthy: deps.isProxyHealthy,
               getOllamaProxyToken: deps.getOllamaProxyToken,

--- a/test/onboard-host-local-inference-routing.test.ts
+++ b/test/onboard-host-local-inference-routing.test.ts
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  HostLocalInferenceReceipt,
+  HostLocalInferenceRuntime,
+} from "../src/lib/onboard/runtime-provider/host-local-inference.js";
+import { createSetupInference } from "../src/lib/onboard/setup-inference.js";
+import { createDirectSetupInferenceHarnessFactory } from "./support/setup-inference-test-harness.js";
+
+const createHarness = createDirectSetupInferenceHarnessFactory((overrides) =>
+  createSetupInference({
+    hermesProviderAuth: { HERMES_PROVIDER_NAME: "hermes-provider" },
+    getOllamaWarmupCommand: () => ["true"],
+    ollamaProxyCredentialEnv: "NEMOCLAW_OLLAMA_PROXY_TOKEN",
+    vllmLocalCredentialEnv: "NEMOCLAW_VLLM_LOCAL_API_KEY",
+    withGatewayRouteMutationLock: async <T>(
+      _gatewayName: string,
+      operation: () => Promise<T> | T,
+    ) => await operation(),
+    withSandboxMutationLock: async <T>(_sandboxName: string, operation: () => Promise<T> | T) =>
+      await operation(),
+    ...overrides,
+  } as never),
+);
+const AUTHORITY_ID = "mxc:host-local-authority";
+const PROBE_IMAGE = `quay.io/curl/curl@sha256:${"a".repeat(64)}`;
+const MANAGED_IMAGE = `nvcr.io/nvidia/vllm@sha256:${"b".repeat(64)}`;
+
+function runtime(): HostLocalInferenceRuntime {
+  return {
+    providerId: "mxc",
+    authorityId: AUTHORITY_ID,
+    services: ["ollama", "nim", "vllm"],
+    translateContainerArgs: (args) => args,
+    qualifyOllama: vi.fn(
+      (): HostLocalInferenceReceipt => ({
+        schemaVersion: 1,
+        providerId: "mxc",
+        service: "ollama",
+        engineAuthority: {
+          schemaVersion: 1,
+          providerId: "mxc",
+          operation: "host-local-inference",
+          engineId: "mxc",
+          authorityId: AUTHORITY_ID,
+          bindingSha256: "c".repeat(64),
+        },
+        endpoint: { host: "mxc.internal", port: 11434, networkName: "mxc-network" },
+        runtime: { kind: "host", probeImageRef: PROBE_IMAGE },
+      }),
+    ),
+    startManaged: vi.fn(() => {
+      throw new Error("not used");
+    }),
+    inspectManaged: vi.fn((receipt) => ({ running: true, receipt })),
+    stopManaged: vi.fn((receipt) => ({ running: false, receipt })),
+    preserveForRebuild: vi.fn((receipt) => receipt),
+  };
+}
+
+describe("setupInference host-local runtime integration", () => {
+  it.each([
+    "openclaw",
+    "hermes",
+    "langchain-deepagents-code",
+  ] as const)("routes %s through the canonical all-agent inference boundary", async (application) => {
+    const providerRuntime = runtime();
+    const harness = createHarness({
+      overrides: {
+        resolveHostLocalInferenceRuntime: vi.fn(() => providerRuntime),
+      },
+    });
+
+    await expect(
+      harness.setupInference(
+        `${application}-sandbox`,
+        "qwen3.5:9b",
+        "ollama-local",
+        null,
+        null,
+        null,
+        [],
+        {
+          hostLocalInference: {
+            service: "ollama",
+            endpoint: {
+              networkName: "mxc-network",
+              hostPort: 11434,
+              probeImageRef: PROBE_IMAGE,
+            },
+          },
+        },
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    expect(providerRuntime.qualifyOllama).toHaveBeenCalledOnce();
+    const providerMutation = harness.commands
+      .map(({ command }) => command)
+      .find((command) => command.startsWith("provider update -g nemoclaw ollama-local"));
+    expect(providerMutation).toContain(
+      "--credential NEMOCLAW_OLLAMA_PROXY_TOKEN --config OPENAI_BASE_URL=http://host.openshell.internal:11434/v1",
+    );
+    expect(harness.commands.join("\n")).not.toContain("mxc.internal");
+    expect(harness.verifyInferenceRoute).toHaveBeenCalledWith(
+      "nemoclaw",
+      "ollama-local",
+      "qwen3.5:9b",
+    );
+  });
+
+  it("fails before gateway mutation when the selected provider does not match the startup service", async () => {
+    const providerRuntime = runtime();
+    const harness = createHarness({
+      overrides: { resolveHostLocalInferenceRuntime: () => providerRuntime },
+    });
+
+    await expect(
+      harness.setupInference("sandbox-a", "model-a", "vllm-local", null, null, null, [], {
+        hostLocalInference: {
+          service: "ollama",
+          endpoint: {
+            networkName: "mxc-network",
+            hostPort: 11434,
+            probeImageRef: PROBE_IMAGE,
+          },
+        },
+      }),
+    ).rejects.toThrow("EXIT_CALLED:1");
+
+    expect(providerRuntime.qualifyOllama).not.toHaveBeenCalled();
+    expect(harness.commands).toEqual([]);
+    expect(harness.errors).toContain("  Host-local ollama cannot configure provider 'vllm-local'.");
+  });
+
+  it("starts a provider-owned managed vLLM input before registering the canonical route", async () => {
+    const providerRuntime = runtime();
+    providerRuntime.startManaged = vi.fn(
+      (): HostLocalInferenceReceipt => ({
+        schemaVersion: 1,
+        providerId: "mxc",
+        service: "vllm",
+        engineAuthority: {
+          schemaVersion: 1,
+          providerId: "mxc",
+          operation: "host-local-inference",
+          engineId: "mxc",
+          authorityId: AUTHORITY_ID,
+          bindingSha256: "c".repeat(64),
+        },
+        endpoint: { host: "mxc.internal", port: 8000, networkName: "mxc-network" },
+        runtime: {
+          kind: "container",
+          runtimeId: "mxc-runtime:vllm",
+          name: "nemoclaw-vllm",
+          imageRef: MANAGED_IMAGE,
+          specSha256: "d".repeat(64),
+          gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
+        },
+      }),
+    );
+    const harness = createHarness({
+      overrides: { resolveHostLocalInferenceRuntime: () => providerRuntime },
+    });
+
+    await expect(
+      harness.setupInference("sandbox-a", "model-a", "vllm-local", null, null, null, [], {
+        hostLocalInference: {
+          service: "vllm",
+          managed: {
+            service: "vllm",
+            containerName: "nemoclaw-vllm",
+            containerPort: 8000,
+            imageRef: MANAGED_IMAGE,
+            gpuDevices: ["nvidia.com/gpu=all"],
+            networkName: "mxc-network",
+            hostPort: 8000,
+            probeImageRef: PROBE_IMAGE,
+          },
+        },
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(providerRuntime.startManaged).toHaveBeenCalledOnce();
+    const providerMutation = harness.commands
+      .map(({ command }) => command)
+      .find((command) => command.startsWith("provider update -g nemoclaw vllm-local"));
+    expect(providerMutation).toContain(
+      "--credential NEMOCLAW_VLLM_LOCAL_API_KEY --config OPENAI_BASE_URL=http://host.openshell.internal:8000/v1",
+    );
+  });
+});

--- a/test/onboard-host-local-inference-routing.test.ts
+++ b/test/onboard-host-local-inference-routing.test.ts
@@ -155,6 +155,7 @@ describe("setupInference host-local runtime integration", () => {
           runtimeId: "mxc-runtime:vllm",
           name: "nemoclaw-vllm",
           imageRef: MANAGED_IMAGE,
+          probeImageRef: PROBE_IMAGE,
           specSha256: "d".repeat(64),
           gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
         },

--- a/test/onboard-host-local-inference-routing.test.ts
+++ b/test/onboard-host-local-inference-routing.test.ts
@@ -7,7 +7,10 @@ import type {
   HostLocalInferenceRuntime,
 } from "../src/lib/onboard/runtime-provider/host-local-inference.js";
 import { createSetupInference } from "../src/lib/onboard/setup-inference.js";
-import { createDirectSetupInferenceHarnessFactory } from "./support/setup-inference-test-harness.js";
+import {
+  createDirectCommandRouter,
+  createDirectSetupInferenceHarnessFactory,
+} from "./support/setup-inference-test-harness.js";
 
 const createHarness = createDirectSetupInferenceHarnessFactory((overrides) =>
   createSetupInference({
@@ -57,6 +60,48 @@ function runtime(): HostLocalInferenceRuntime {
     inspectManaged: vi.fn((receipt) => ({ running: true, receipt })),
     stopManaged: vi.fn((receipt) => ({ running: false, receipt })),
     preserveForRebuild: vi.fn((receipt) => receipt),
+  };
+}
+
+function managedVllmReceipt(): HostLocalInferenceReceipt {
+  return {
+    schemaVersion: 1,
+    providerId: "mxc",
+    service: "vllm",
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "host-local-inference",
+      engineId: "mxc",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: "c".repeat(64),
+    },
+    endpoint: { host: "mxc.internal", port: 8000, networkName: "mxc-network" },
+    runtime: {
+      kind: "container",
+      runtimeId: "mxc-runtime:vllm",
+      name: "nemoclaw-vllm",
+      imageRef: MANAGED_IMAGE,
+      probeImageRef: PROBE_IMAGE,
+      specSha256: "d".repeat(64),
+      gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
+    },
+  };
+}
+
+function managedVllmRequest() {
+  return {
+    service: "vllm" as const,
+    managed: {
+      service: "vllm" as const,
+      containerName: "nemoclaw-vllm",
+      containerPort: 8000,
+      imageRef: MANAGED_IMAGE,
+      gpuDevices: ["nvidia.com/gpu=all"],
+      networkName: "mxc-network",
+      hostPort: 8000,
+      probeImageRef: PROBE_IMAGE,
+    },
   };
 }
 
@@ -136,50 +181,14 @@ describe("setupInference host-local runtime integration", () => {
 
   it("starts a provider-owned managed vLLM input before registering the canonical route", async () => {
     const providerRuntime = runtime();
-    providerRuntime.startManaged = vi.fn(
-      (): HostLocalInferenceReceipt => ({
-        schemaVersion: 1,
-        providerId: "mxc",
-        service: "vllm",
-        engineAuthority: {
-          schemaVersion: 1,
-          providerId: "mxc",
-          operation: "host-local-inference",
-          engineId: "mxc",
-          authorityId: AUTHORITY_ID,
-          bindingSha256: "c".repeat(64),
-        },
-        endpoint: { host: "mxc.internal", port: 8000, networkName: "mxc-network" },
-        runtime: {
-          kind: "container",
-          runtimeId: "mxc-runtime:vllm",
-          name: "nemoclaw-vllm",
-          imageRef: MANAGED_IMAGE,
-          probeImageRef: PROBE_IMAGE,
-          specSha256: "d".repeat(64),
-          gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
-        },
-      }),
-    );
+    providerRuntime.startManaged = vi.fn(() => managedVllmReceipt());
     const harness = createHarness({
       overrides: { resolveHostLocalInferenceRuntime: () => providerRuntime },
     });
 
     await expect(
       harness.setupInference("sandbox-a", "model-a", "vllm-local", null, null, null, [], {
-        hostLocalInference: {
-          service: "vllm",
-          managed: {
-            service: "vllm",
-            containerName: "nemoclaw-vllm",
-            containerPort: 8000,
-            imageRef: MANAGED_IMAGE,
-            gpuDevices: ["nvidia.com/gpu=all"],
-            networkName: "mxc-network",
-            hostPort: 8000,
-            probeImageRef: PROBE_IMAGE,
-          },
-        },
+        hostLocalInference: managedVllmRequest(),
       }),
     ).resolves.toEqual({ ok: true });
 
@@ -189,6 +198,41 @@ describe("setupInference host-local runtime integration", () => {
       .find((command) => command.startsWith("provider update -g nemoclaw vllm-local"));
     expect(providerMutation).toContain(
       "--credential NEMOCLAW_VLLM_LOCAL_API_KEY --config OPENAI_BASE_URL=http://host.openshell.internal:8000/v1",
+    );
+  });
+
+  it("retries exact managed startup after provider registration failure without duplicate reservation", async () => {
+    const receipt = managedVllmReceipt();
+    const providerRuntime = runtime();
+    providerRuntime.startManaged = vi.fn(() => receipt);
+    const router = createDirectCommandRouter([
+      {
+        name: "provider-upsert",
+        matches: (command) => command.startsWith("provider update -g nemoclaw vllm-local"),
+        results: [{ status: 1, stderr: "injected provider registration failure" }, { status: 0 }],
+      },
+    ]);
+    const harness = createHarness({
+      runOpenshell: router.runOpenshell,
+      overrides: { resolveHostLocalInferenceRuntime: () => providerRuntime },
+    });
+    const setup = () =>
+      harness.setupInference("sandbox-a", "model-a", "vllm-local", null, null, null, [], {
+        hostLocalInference: managedVllmRequest(),
+      });
+
+    await expect(setup()).rejects.toThrow("EXIT_CALLED:1");
+    expect(harness.updateSandbox).not.toHaveBeenCalled();
+
+    await expect(setup()).resolves.toEqual({ ok: true });
+    expect(providerRuntime.startManaged).toHaveBeenCalledTimes(2);
+    expect(providerRuntime.startManaged).toHaveNthReturnedWith(1, receipt);
+    expect(providerRuntime.startManaged).toHaveNthReturnedWith(2, receipt);
+    expect(router.callCount("provider-upsert")).toBe(2);
+    expect(harness.updateSandbox).toHaveBeenCalledOnce();
+    expect(harness.updateSandbox).toHaveBeenCalledWith(
+      "sandbox-a",
+      expect.objectContaining({ model: "model-a", provider: "vllm-local" }),
     );
   });
 });

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -165,6 +165,7 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/runtime-provider/contract.ts",
       "src/lib/onboard/runtime-provider/current.ts",
       "src/lib/onboard/runtime-provider/docker.ts",
+      "src/lib/onboard/runtime-provider/host-local-inference-routing.ts",
       "src/lib/onboard/runtime-provider/host-local-inference.ts",
       "src/lib/onboard/runtime-provider/persisted-engine-authority.ts",
       "src/lib/onboard/runtime-provider/persisted-engine-lifecycle.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR connects the dormant host-local inference runtime contract to the provider-neutral onboarding and application-routing boundary. Ollama, NIM, and vLLM remain injected capabilities; no central Podman switch or production activation is added.

## Changes

- Add provider-neutral startup requests and route results for host Ollama and managed NIM/vLLM.
- Bind returned receipts to the injected provider and exact runtime authority.
- Translate provider-native endpoints to the canonical gateway registration host while keeping `https://inference.local/v1` identical for OpenClaw, Hermes, and Deep Agents Code.
- Reject provider, service, and authority mismatch before runtime or gateway mutation.
- Carry immutable managed probe-image authority through routing fixtures.
- Prove retry after provider-registration failure reuses exact managed ownership and publishes one final route reservation.
- Keep the resolver dormant until later activation and protected qualification slices.

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs not applicable: no supported runtime surface is activated
- [x] Sensitive paths changed
- [ ] Exact-head advisor, CI, and protected E2E refresh completed

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: pending exact-head refresh
- Evidence: review requested for exact head `b588f8b468c8a6982efff82dd57790325176e5dc`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b588f8b468c8a6982efff82dd57790325176e5dc -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## Verification

- [x] Signed commits and DCO
- [x] Focused provider/routing suite: 5 files, 40 tests passed
- [x] CLI typecheck, repository checks, growth guard, and normal commit/push hooks passed
- [ ] Exact-head GitHub qualification is running

Exact head: `b588f8b468c8a6982efff82dd57790325176e5dc`.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
