### PR TITLE
refactor(images): share managed base contract export

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -440,6 +440,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Download platform digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -472,6 +477,7 @@ jobs:
       - name: Create and verify multi-platform manifest
         id: manifest
         env:
+          AGENT: hermes
           IMAGE: ${{ env.REGISTRY }}/nvidia/nemoclaw/hermes-sandbox-base
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
@@ -551,58 +557,16 @@ jobs:
           reference="$IMAGE@$digest"
           docker buildx imagetools inspect "$reference" >/dev/null
 
-          contract_dir="$RUNNER_TEMP/managed-base-contract"
-          mkdir -p "$contract_dir"
-          jq -n \
-            --arg amd64Digest "${platform_digests[linux/amd64]}" \
-            --arg amd64Reference "$IMAGE@${platform_digests[linux/amd64]}" \
-            --arg arm64Digest "${platform_digests[linux/arm64]}" \
-            --arg arm64Reference "$IMAGE@${platform_digests[linux/arm64]}" \
-            --arg digest "$digest" \
-            --arg image "$IMAGE" \
-            --arg reference "$reference" \
-            --arg revision "$GITHUB_SHA" \
-            --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
-            --argjson runId "$GITHUB_RUN_ID" \
-            '{
-              contractVersion: 1,
-              agent: "hermes",
-              image: $image,
-              digest: $digest,
-              reference: $reference,
-              platforms: ["linux/amd64", "linux/arm64"],
-              platformDigests: {
-                "linux/amd64": $amd64Digest,
-                "linux/arm64": $arm64Digest
-              },
-              platformReferences: {
-                "linux/amd64": $amd64Reference,
-                "linux/arm64": $arm64Reference
-              },
-              sourceRevision: $revision,
-              run: {
-                id: $runId,
-                attempt: $runAttempt
-              }
-            }' > "$contract_dir/contract.json"
-          jq -e \
-            '.contractVersion == 1
-             and .agent == "hermes"
-             and (.sourceRevision | test("^[0-9a-f]{40}$"))
-             and (.digest | test("^sha256:[0-9a-f]{64}$"))
-             and .reference == (.image + "@" + .digest)
-             and .platforms == ["linux/amd64", "linux/arm64"]
-             and (.platformDigests | keys | sort) == .platforms
-             and (.platformReferences | keys | sort) == .platforms
-             and ([
-               .platforms[] as $platform
-               | (
-                   (.platformDigests[$platform] | test("^sha256:[0-9a-f]{64}$"))
-                   and .platformReferences[$platform] ==
-                     (.image + "@" + .platformDigests[$platform])
-                 )
-             ] | all)' \
-            "$contract_dir/contract.json" >/dev/null
+          scripts/export-managed-base-image-contract.sh \
+            "$AGENT" \
+            "$IMAGE" \
+            "$digest" \
+            "${platform_digests[linux/amd64]}" \
+            "${platform_digests[linux/arm64]}" \
+            "$GITHUB_SHA" \
+            "$GITHUB_RUN_ID" \
+            "$GITHUB_RUN_ATTEMPT" \
+            "$RUNNER_TEMP/managed-base-contract/contract.json"
           printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
 
       - name: Upload managed base image contract
@@ -620,6 +584,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Download platform digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -652,6 +621,7 @@ jobs:
       - name: Create and verify multi-platform manifest
         id: manifest
         env:
+          AGENT: langchain-deepagents-code
           IMAGE: ${{ env.REGISTRY }}/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
@@ -731,58 +701,16 @@ jobs:
           reference="$IMAGE@$digest"
           docker buildx imagetools inspect "$reference" >/dev/null
 
-          contract_dir="$RUNNER_TEMP/managed-base-contract"
-          mkdir -p "$contract_dir"
-          jq -n \
-            --arg amd64Digest "${platform_digests[linux/amd64]}" \
-            --arg amd64Reference "$IMAGE@${platform_digests[linux/amd64]}" \
-            --arg arm64Digest "${platform_digests[linux/arm64]}" \
-            --arg arm64Reference "$IMAGE@${platform_digests[linux/arm64]}" \
-            --arg digest "$digest" \
-            --arg image "$IMAGE" \
-            --arg reference "$reference" \
-            --arg revision "$GITHUB_SHA" \
-            --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
-            --argjson runId "$GITHUB_RUN_ID" \
-            '{
-              contractVersion: 1,
-              agent: "langchain-deepagents-code",
-              image: $image,
-              digest: $digest,
-              reference: $reference,
-              platforms: ["linux/amd64", "linux/arm64"],
-              platformDigests: {
-                "linux/amd64": $amd64Digest,
-                "linux/arm64": $arm64Digest
-              },
-              platformReferences: {
-                "linux/amd64": $amd64Reference,
-                "linux/arm64": $arm64Reference
-              },
-              sourceRevision: $revision,
-              run: {
-                id: $runId,
-                attempt: $runAttempt
-              }
-            }' > "$contract_dir/contract.json"
-          jq -e \
-            '.contractVersion == 1
-             and .agent == "langchain-deepagents-code"
-             and (.sourceRevision | test("^[0-9a-f]{40}$"))
-             and (.digest | test("^sha256:[0-9a-f]{64}$"))
-             and .reference == (.image + "@" + .digest)
-             and .platforms == ["linux/amd64", "linux/arm64"]
-             and (.platformDigests | keys | sort) == .platforms
-             and (.platformReferences | keys | sort) == .platforms
-             and ([
-               .platforms[] as $platform
-               | (
-                   (.platformDigests[$platform] | test("^sha256:[0-9a-f]{64}$"))
-                   and .platformReferences[$platform] ==
-                     (.image + "@" + .platformDigests[$platform])
-                 )
-             ] | all)' \
-            "$contract_dir/contract.json" >/dev/null
+          scripts/export-managed-base-image-contract.sh \
+            "$AGENT" \
+            "$IMAGE" \
+            "$digest" \
+            "${platform_digests[linux/amd64]}" \
+            "${platform_digests[linux/arm64]}" \
+            "$GITHUB_SHA" \
+            "$GITHUB_RUN_ID" \
+            "$GITHUB_RUN_ATTEMPT" \
+            "$RUNNER_TEMP/managed-base-contract/contract.json"
           printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
 
       - name: Upload managed base image contract
@@ -802,6 +730,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Download platform digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -834,6 +767,7 @@ jobs:
       - name: Create and verify multi-platform manifest
         id: manifest
         env:
+          AGENT: openclaw
           IMAGE: ${{ env.REGISTRY }}/nvidia/nemoclaw/sandbox-base
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
@@ -913,58 +847,16 @@ jobs:
           reference="$IMAGE@$digest"
           docker buildx imagetools inspect "$reference" >/dev/null
 
-          contract_dir="$RUNNER_TEMP/managed-base-contract"
-          mkdir -p "$contract_dir"
-          jq -n \
-            --arg amd64Digest "${platform_digests[linux/amd64]}" \
-            --arg amd64Reference "$IMAGE@${platform_digests[linux/amd64]}" \
-            --arg arm64Digest "${platform_digests[linux/arm64]}" \
-            --arg arm64Reference "$IMAGE@${platform_digests[linux/arm64]}" \
-            --arg digest "$digest" \
-            --arg image "$IMAGE" \
-            --arg reference "$reference" \
-            --arg revision "$GITHUB_SHA" \
-            --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
-            --argjson runId "$GITHUB_RUN_ID" \
-            '{
-              contractVersion: 1,
-              agent: "openclaw",
-              image: $image,
-              digest: $digest,
-              reference: $reference,
-              platforms: ["linux/amd64", "linux/arm64"],
-              platformDigests: {
-                "linux/amd64": $amd64Digest,
-                "linux/arm64": $arm64Digest
-              },
-              platformReferences: {
-                "linux/amd64": $amd64Reference,
-                "linux/arm64": $arm64Reference
-              },
-              sourceRevision: $revision,
-              run: {
-                id: $runId,
-                attempt: $runAttempt
-              }
-            }' > "$contract_dir/contract.json"
-          jq -e \
-            '.contractVersion == 1
-             and .agent == "openclaw"
-             and (.sourceRevision | test("^[0-9a-f]{40}$"))
-             and (.digest | test("^sha256:[0-9a-f]{64}$"))
-             and .reference == (.image + "@" + .digest)
-             and .platforms == ["linux/amd64", "linux/arm64"]
-             and (.platformDigests | keys | sort) == .platforms
-             and (.platformReferences | keys | sort) == .platforms
-             and ([
-               .platforms[] as $platform
-               | (
-                   (.platformDigests[$platform] | test("^sha256:[0-9a-f]{64}$"))
-                   and .platformReferences[$platform] ==
-                     (.image + "@" + .platformDigests[$platform])
-                 )
-             ] | all)' \
-            "$contract_dir/contract.json" >/dev/null
+          scripts/export-managed-base-image-contract.sh \
+            "$AGENT" \
+            "$IMAGE" \
+            "$digest" \
+            "${platform_digests[linux/amd64]}" \
+            "${platform_digests[linux/arm64]}" \
+            "$GITHUB_SHA" \
+            "$GITHUB_RUN_ID" \
+            "$GITHUB_RUN_ATTEMPT" \
+            "$RUNNER_TEMP/managed-base-contract/contract.json"
           printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
 
       - name: Upload managed base image contract

--- a/scripts/export-managed-base-image-contract.sh
+++ b/scripts/export-managed-base-image-contract.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [ "$#" -ne 9 ]; then
+  echo "Usage: $0 AGENT IMAGE DIGEST AMD64_DIGEST ARM64_DIGEST SOURCE_REVISION RUN_ID RUN_ATTEMPT OUTPUT" >&2
+  exit 2
+fi
+
+readonly agent="$1"
+readonly image="$2"
+readonly digest="$3"
+readonly amd64_digest="$4"
+readonly arm64_digest="$5"
+readonly source_revision="$6"
+readonly run_id="$7"
+readonly run_attempt="$8"
+readonly output="$9"
+readonly reference="${image}@${digest}"
+
+mkdir -p "$(dirname -- "$output")"
+jq -n \
+  --arg agent "$agent" \
+  --arg amd64Digest "$amd64_digest" \
+  --arg amd64Reference "$image@$amd64_digest" \
+  --arg arm64Digest "$arm64_digest" \
+  --arg arm64Reference "$image@$arm64_digest" \
+  --arg digest "$digest" \
+  --arg image "$image" \
+  --arg reference "$reference" \
+  --arg revision "$source_revision" \
+  --argjson runAttempt "$run_attempt" \
+  --argjson runId "$run_id" \
+  '{
+    contractVersion: 1,
+    agent: $agent,
+    image: $image,
+    digest: $digest,
+    reference: $reference,
+    platforms: ["linux/amd64", "linux/arm64"],
+    platformDigests: {
+      "linux/amd64": $amd64Digest,
+      "linux/arm64": $arm64Digest
+    },
+    platformReferences: {
+      "linux/amd64": $amd64Reference,
+      "linux/arm64": $arm64Reference
+    },
+    sourceRevision: $revision,
+    run: {
+      id: $runId,
+      attempt: $runAttempt
+    }
+  }' >"$output"
+
+jq -e \
+  --arg agent "$agent" \
+  '.contractVersion == 1
+   and .agent == $agent
+   and (.sourceRevision | test("^[0-9a-f]{40}$"))
+   and (.digest | test("^sha256:[0-9a-f]{64}$"))
+   and .reference == (.image + "@" + .digest)
+   and .platforms == ["linux/amd64", "linux/arm64"]
+   and (.platformDigests | keys | sort) == .platforms
+   and (.platformReferences | keys | sort) == .platforms
+   and ([
+     .platforms[] as $platform
+     | (
+         (.platformDigests[$platform] | test("^sha256:[0-9a-f]{64}$"))
+         and .platformReferences[$platform] ==
+           (.image + "@" + .platformDigests[$platform])
+       )
+   ] | all)' \
+  "$output" >/dev/null

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -446,6 +446,7 @@ describe("base-image publication behavior", () => {
     expect(metadata?.with?.tags).toContain("type=raw,value=latest");
     expect(metadata?.with?.tags).toContain("type=ref,event=tag");
     expect(metadata?.with?.tags).toContain("type=sha,prefix=,format=short");
+    expect(createManifest?.env?.AGENT).toBe("openclaw");
     const openClawManifestScript = createManifest?.run ?? "";
     expect(openClawManifestScript).toContain('"${#digest_files[@]}" -ne 2');
     expect(openClawManifestScript).toContain("^(amd64|arm64)-([0-9a-f]{64})$");
@@ -461,6 +462,7 @@ describe("base-image publication behavior", () => {
       'docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"',
     );
     expect(openClawManifestScript).toContain('"amd64,arm64"');
+    expect(openClawManifestScript).toContain("scripts/export-managed-base-image-contract.sh");
     for (const step of (manifestJob?.steps ?? []).filter((step) => step.uses)) {
       expect(step.uses, step.name).toMatch(FULL_SHA_ACTION);
     }
@@ -470,6 +472,7 @@ describe("base-image publication behavior", () => {
     const publishers = publisherJobs(workflow);
     const imagePublishers = [
       {
+        agent: "hermes",
         platformJobName: "build-hermes-platforms",
         manifestJobName: "build-and-push-hermes",
         manifestName: "Build and push Hermes base image",
@@ -477,6 +480,7 @@ describe("base-image publication behavior", () => {
         image: "${{ env.REGISTRY }}/nvidia/nemoclaw/hermes-sandbox-base",
       },
       {
+        agent: "langchain-deepagents-code",
         platformJobName: "build-dcode-platforms",
         manifestJobName: "build-and-push-dcode",
         manifestName: "Build and push Deep Agents Code base image",
@@ -564,6 +568,7 @@ describe("base-image publication behavior", () => {
       expect(metadata?.with?.tags).toContain("type=raw,value=latest");
       expect(metadata?.with?.tags).toContain("type=ref,event=tag");
       expect(metadata?.with?.tags).toContain("type=sha,prefix=,format=short");
+      expect(createManifest?.env?.AGENT).toBe(imagePublisher.agent);
       expect(createManifest?.env?.IMAGE).toBe(imagePublisher.image);
       const manifestScript = createManifest?.run ?? "";
       expect(manifestScript).toContain('"${#digest_files[@]}" -ne 2');
@@ -578,6 +583,7 @@ describe("base-image publication behavior", () => {
         'docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"',
       );
       expect(manifestScript).toContain('"amd64,arm64"');
+      expect(manifestScript).toContain("scripts/export-managed-base-image-contract.sh");
       for (const step of (manifestJob?.steps ?? []).filter((step) => step.uses)) {
         expect(step.uses, step.name).toMatch(FULL_SHA_ACTION);
       }

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -84,6 +84,15 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     testsToRun: runTests("test/setup-jetson.test.ts"),
   },
   {
+    pattern:
+      /(?:^|\/)(?:\.github\/workflows\/base-image\.yaml|scripts\/export-managed-base-image-contract\.sh)$/,
+    testsToRun: runTests(
+      "test/managed-base-image-contract.test.ts",
+      "test/managed-image-publication-workflow.test.ts",
+      "test/dcode-base-image-workflow.test.ts",
+    ),
+  },
+  {
     pattern: /(?:^|\/)scripts\/e2e\/sanitize-trace-timing\.py$/,
     testsToRun: runTests(
       "test/e2e/support/e2e-scorecard.test.ts",

--- a/test/managed-base-image-contract.test.ts
+++ b/test/managed-base-image-contract.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const exporter = path.join(repoRoot, "scripts", "export-managed-base-image-contract.sh");
+const sourceRevision = "c".repeat(40);
+const digest = `sha256:${"d".repeat(64)}`;
+const amd64Digest = `sha256:${"a".repeat(64)}`;
+const arm64Digest = `sha256:${"b".repeat(64)}`;
+const agents = [
+  {
+    agent: "openclaw",
+    image: "ghcr.io/nvidia/nemoclaw/sandbox-base",
+  },
+  {
+    agent: "hermes",
+    image: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base",
+  },
+  {
+    agent: "langchain-deepagents-code",
+    image: "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
+  },
+] as const;
+
+function exportContract(output: string, agent: string, image: string, amd64 = amd64Digest) {
+  return spawnSync(
+    exporter,
+    [agent, image, digest, amd64, arm64Digest, sourceRevision, "42", "3", output],
+    { encoding: "utf8" },
+  );
+}
+
+describe("managed base image contract exporter", () => {
+  it("binds both native platform digests for every managed agent (#7744)", () => {
+    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-contract-"));
+
+    try {
+      for (const { agent, image } of agents) {
+        const output = path.join(temporaryRoot, agent, "contract.json");
+        const result = exportContract(output, agent, image);
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(JSON.parse(fs.readFileSync(output, "utf8"))).toEqual({
+          contractVersion: 1,
+          agent,
+          image,
+          digest,
+          reference: `${image}@${digest}`,
+          platforms: ["linux/amd64", "linux/arm64"],
+          platformDigests: {
+            "linux/amd64": amd64Digest,
+            "linux/arm64": arm64Digest,
+          },
+          platformReferences: {
+            "linux/amd64": `${image}@${amd64Digest}`,
+            "linux/arm64": `${image}@${arm64Digest}`,
+          },
+          sourceRevision,
+          run: { id: 42, attempt: 3 },
+        });
+      }
+    } finally {
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a platform digest that is not a full SHA-256 value (#7744)", () => {
+    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-contract-"));
+
+    try {
+      const output = path.join(temporaryRoot, "contract.json");
+      const result = exportContract(
+        output,
+        "openclaw",
+        "ghcr.io/nvidia/nemoclaw/sandbox-base",
+        "sha256:bad",
+      );
+
+      expect(result.status).not.toBe(0);
+    } finally {
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -248,10 +248,13 @@ describe("complete managed-image publication workflow", () => {
       );
       const manifest = step(basePublisher, "Create and verify multi-platform manifest");
       expect(manifest.id).toBe("manifest");
+      expect(manifest.env?.AGENT).toBe(expectedPublisher.agent);
       expect(manifest.run).toContain('reference="$IMAGE@$digest"');
       expect(manifest.run).toContain("--format '{{.Manifest.Digest}}'");
-      expect(manifest.run).toContain(`agent: "${expectedPublisher.agent}"`);
-      expect(manifest.run).toContain("platformDigests: {");
+      expect(manifest.run).toContain("scripts/export-managed-base-image-contract.sh");
+      expect(manifest.run).toContain('"${platform_digests[linux/amd64]}"');
+      expect(manifest.run).toContain('"${platform_digests[linux/arm64]}"');
+      expect(step(basePublisher, "Checkout").with?.["persist-credentials"]).toBe(false);
       expect(step(basePublisher, "Upload managed base image contract").with?.name).toBe(
         expectedPublisher.artifact,
       );

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -59,6 +59,8 @@ const OPAQUE_INPUTS = [
   "agents/hermes/mcp-config-transaction.py",
   "test/e2e/lib/ci-compatible-inference.sh",
   "scripts/setup-jetson.sh",
+  ".github/workflows/base-image.yaml",
+  "scripts/export-managed-base-image-contract.sh",
   "scripts/e2e/sanitize-trace-timing.py",
   "test/e2e/manifests/openclaw-nvidia.yaml",
   "test/e2e/docs/parity-inventory.generated.json",
@@ -116,6 +118,16 @@ describe("Vitest opaque-input watch triggers", () => {
       "test/e2e/support/hosted-inference.test.ts",
     ]);
     expect(triggeredBy("scripts/setup-jetson.sh")).toEqual(["test/setup-jetson.test.ts"]);
+    expect(triggeredBy(".github/workflows/base-image.yaml")).toEqual([
+      "test/managed-base-image-contract.test.ts",
+      "test/managed-image-publication-workflow.test.ts",
+      "test/dcode-base-image-workflow.test.ts",
+    ]);
+    expect(triggeredBy("scripts/export-managed-base-image-contract.sh")).toEqual([
+      "test/managed-base-image-contract.test.ts",
+      "test/managed-image-publication-workflow.test.ts",
+      "test/dcode-base-image-workflow.test.ts",
+    ]);
     expect(triggeredBy("scripts/e2e/sanitize-trace-timing.py")).toEqual([
       "test/e2e/support/e2e-scorecard.test.ts",
       "test/e2e/support/sanitize-trace-timing.test.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Centralize the managed base image contract export and validation used by OpenClaw, Hermes, and Deep Agents Code without changing publication behavior. This is PR3.14A2 for #7744 and does not activate buildless or Podman support.

## Related Issue

Related to #7744

## Changes

- Replace three duplicate contract writer and validator blocks with one reviewed shell helper used by the existing manifest jobs.
- Keep each agent's independent job dependency, required-check name, image, artifact name, and amd64/arm64 manifest publication unchanged.
- Check out the exact workflow revision with persisted credentials disabled before each manifest job calls the helper.
- Test the helper for all three agents and both native platform digests, including malformed-digest rejection.
- Map the workflow and helper inputs to their focused contract tests for changed-file and watch-mode selection.

The current base image workflow has three consumers of one identical contract schema. A direct edit would preserve three independent implementations. `test/managed-base-image-contract.test.ts` protects the shared helper contract, and the workflow tests protect each consumer.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This internal image-publication refactor does not change a command, configuration, runtime selection, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed #7744 slice; the exact immutable digest, reference, source revision, run identity, all-agent, and amd64/arm64 checks remain fail closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: blocked
- Evidence: No independent reviewer slot was available before this durability-first draft was opened. The diff changes internal publication implementation and tests only.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 2060e9ccf -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/managed-base-image-contract.test.ts test/managed-image-publication-workflow.test.ts test/dcode-base-image-workflow.test.ts test/vitest-watch-triggers.test.ts` passed 25 tests in 4 files on `2060e9ccf`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; the focused workflow and helper tests cover this refactor.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
