### PR TITLE
test(images): add protected multiarch build contract

### DIFF
--- a/scripts/checks/build-protected-managed-images.sh
+++ b/scripts/checks/build-protected-managed-images.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 --output <json> --revision <sha> --cohort <id> --platform <linux/amd64|linux/arm64> --openclaw-base <exact-ref> --hermes-base <exact-ref> --dcode-base <exact-ref>" >&2
+  exit 2
+}
+
+output=""
+revision=""
+cohort=""
+platform=""
+openclaw_base=""
+hermes_base=""
+dcode_base=""
+while (($# > 0)); do
+  case "$1" in
+    --output)
+      (($# >= 2)) || usage
+      output="$2"
+      shift 2
+      ;;
+    --revision)
+      (($# >= 2)) || usage
+      revision="$2"
+      shift 2
+      ;;
+    --cohort)
+      (($# >= 2)) || usage
+      cohort="$2"
+      shift 2
+      ;;
+    --platform)
+      (($# >= 2)) || usage
+      platform="$2"
+      shift 2
+      ;;
+    --openclaw-base)
+      (($# >= 2)) || usage
+      openclaw_base="$2"
+      shift 2
+      ;;
+    --hermes-base)
+      (($# >= 2)) || usage
+      hermes_base="$2"
+      shift 2
+      ;;
+    --dcode-base)
+      (($# >= 2)) || usage
+      dcode_base="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ "$output" == /* && "$output" != *$'\n'* ]] || usage
+[[ "$revision" =~ ^[a-f0-9]{40}$ ]] || usage
+[[ "$cohort" =~ ^protected-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}$ ]] || usage
+[[ "$platform" == "linux/amd64" || "$platform" == "linux/arm64" ]] || usage
+[[ "$openclaw_base" =~ ^ghcr[.]io/nvidia/nemoclaw/sandbox-base@sha256:[a-f0-9]{64}$ ]] || usage
+[[ "$hermes_base" =~ ^ghcr[.]io/nvidia/nemoclaw/hermes-sandbox-base@sha256:[a-f0-9]{64}$ ]] || usage
+[[ "$dcode_base" =~ ^ghcr[.]io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base@sha256:[a-f0-9]{64}$ ]] || usage
+
+for command in docker jq sha256sum; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "ERROR: protected managed-image build requires $command" >&2
+    exit 1
+  }
+done
+
+work_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/nemoclaw-protected-images.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+contracts="$work_dir/contracts.jsonl"
+: >"$contracts"
+
+build_agent() {
+  local agent="$1"
+  local dockerfile="$2"
+  local base_reference="$3"
+  local image_repository="localhost:5000/nemoclaw-managed-protected/${agent}"
+  local exact_base_raw="$work_dir/${agent}-base-exact.raw"
+  local metadata="$work_dir/${agent}-build-metadata.json"
+  local exact_image_raw="$work_dir/${agent}-image-exact.raw"
+
+  local base_digest="${base_reference##*@}"
+  docker buildx imagetools inspect "$base_reference" --raw >"$exact_base_raw"
+  local actual_base
+  actual_base="sha256:$(sha256sum "$exact_base_raw" | awk '{print $1}')"
+  [[ "$actual_base" == "$base_digest" ]] || {
+    echo "ERROR: ${agent} exact base bytes do not match its descriptor" >&2
+    exit 1
+  }
+
+  scripts/check-production-build-args.sh \
+    -f "$dockerfile" \
+    --build-arg "BASE_IMAGE=${base_reference}" \
+    --build-arg "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1" \
+    --build-arg "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root"
+
+  docker buildx build \
+    --file "$dockerfile" \
+    --platform "$platform" \
+    --push \
+    --provenance=false \
+    --sbom=false \
+    --metadata-file "$metadata" \
+    --tag "${image_repository}:${revision}" \
+    --label "org.opencontainers.image.source=https://github.com/NVIDIA/NemoClaw" \
+    --label "org.opencontainers.image.revision=${revision}" \
+    --label "io.nvidia.nemoclaw.agent=${agent}" \
+    --label "io.nvidia.nemoclaw.managed-image.contract=1" \
+    --label "io.nvidia.nemoclaw.managed-image.platform=${platform}" \
+    --label "io.nvidia.nemoclaw.managed-image.startup-profile=1" \
+    --label "io.nvidia.nemoclaw.managed-image.capabilities=1" \
+    --label "io.nvidia.nemoclaw.managed-image.cohort=${cohort}" \
+    --build-arg "BASE_IMAGE=${base_reference}" \
+    --build-arg "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1" \
+    --build-arg "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root" \
+    .
+
+  local digest
+  digest="$(jq -er '."containerimage.digest"' "$metadata")"
+  [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+    echo "ERROR: ${agent} build did not return an immutable manifest digest" >&2
+    exit 1
+  }
+  local reference="${image_repository}@${digest}"
+  docker buildx imagetools inspect "$reference" --raw >"$exact_image_raw"
+  local actual_image
+  actual_image="sha256:$(sha256sum "$exact_image_raw" | awk '{print $1}')"
+  [[ "$actual_image" == "$digest" ]] || {
+    echo "ERROR: ${agent} isolated-registry bytes do not match the build digest" >&2
+    exit 1
+  }
+  docker pull --platform "$platform" "$reference"
+  local image_json
+  image_json="$(docker image inspect "$reference")"
+  local image_id
+  image_id="$(jq -er 'if length == 1 then .[0].Id else error("not one image") end' <<<"$image_json")"
+  [[ "$image_id" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+    echo "ERROR: ${agent} exact manifest did not resolve to one local content ID" >&2
+    exit 1
+  }
+  jq -e \
+    --arg agent "$agent" \
+    --arg cohort "$cohort" \
+    --arg image_id "$image_id" \
+    --arg platform "$platform" \
+    --arg revision "$revision" '
+      length == 1 and
+      .[0].Id == $image_id and
+      ((.[0].Config.User // "") as $user |
+        $user == "" or $user == "root" or $user == "0") and
+      .[0].Config.Labels["io.nvidia.nemoclaw.agent"] == $agent and
+      .[0].Config.Labels["io.nvidia.nemoclaw.managed-image.contract"] == "1" and
+      .[0].Config.Labels["io.nvidia.nemoclaw.managed-image.platform"] == $platform and
+      .[0].Config.Labels["io.nvidia.nemoclaw.managed-image.startup-profile"] == "1" and
+      .[0].Config.Labels["io.nvidia.nemoclaw.managed-image.capabilities"] == "1" and
+      .[0].Config.Labels["io.nvidia.nemoclaw.managed-image.cohort"] == $cohort and
+      .[0].Config.Labels["org.opencontainers.image.revision"] == $revision
+    ' <<<"$image_json" >/dev/null || {
+    echo "ERROR: ${agent} exact protected image contract is invalid" >&2
+    exit 1
+  }
+
+  jq -nc \
+    --arg agent "$agent" \
+    --arg reference "$reference" \
+    --arg digest "$digest" \
+    --arg localContentId "$image_id" \
+    --arg baseReference "$base_reference" \
+    --arg platform "$platform" \
+    '{
+      agent: $agent,
+      platform: $platform,
+      reference: $reference,
+      digest: $digest,
+      localContentId: $localContentId,
+      baseReference: $baseReference
+    }' >>"$contracts"
+}
+
+build_agent \
+  openclaw \
+  Dockerfile \
+  "$openclaw_base"
+build_agent \
+  hermes \
+  agents/hermes/Dockerfile \
+  "$hermes_base"
+build_agent \
+  langchain-deepagents-code \
+  agents/langchain-deepagents-code/Dockerfile \
+  "$dcode_base"
+
+mkdir -p "$(dirname "$output")"
+jq -se \
+  --arg platform "$platform" '
+  if (
+    length == 3 and
+    ([.[].agent] | sort) == ["hermes", "langchain-deepagents-code", "openclaw"] and
+    ([.[].platform] | unique) == [$platform] and
+    ([.[].reference] | unique | length) == 3
+  )
+  then .
+  else error("protected managed-image set is incomplete")
+  end
+' "$contracts" >"${output}.tmp"
+mv "${output}.tmp" "$output"

--- a/scripts/checks/protected-managed-image-contract.ts
+++ b/scripts/checks/protected-managed-image-contract.ts
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ManagedStartupAgent } from "../../src/lib/onboard/managed-startup/profile.ts";
+
+export const PROTECTED_MANAGED_IMAGE_AGENTS = [
+  "openclaw",
+  "hermes",
+  "langchain-deepagents-code",
+] as const satisfies readonly ManagedStartupAgent[];
+
+export const PROTECTED_MANAGED_IMAGE_PLATFORMS = ["linux/amd64", "linux/arm64"] as const;
+
+export type ProtectedManagedImagePlatform = (typeof PROTECTED_MANAGED_IMAGE_PLATFORMS)[number];
+
+export type ProtectedManagedImageContract = {
+  readonly agent: ManagedStartupAgent;
+  readonly baseReference: string;
+  readonly digest: string;
+  readonly localContentId: string;
+  readonly platform: ProtectedManagedImagePlatform;
+  readonly reference: string;
+};
+
+const DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/u;
+const BASE_REPOSITORIES: Readonly<Record<ManagedStartupAgent, string>> = Object.freeze({
+  openclaw: "ghcr.io/nvidia/nemoclaw/sandbox-base",
+  hermes: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base",
+  "langchain-deepagents-code": "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
+});
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("protected managed-image contract entry must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>): void {
+  const actual = Object.keys(value).sort();
+  const expected = [
+    "agent",
+    "baseReference",
+    "digest",
+    "localContentId",
+    "platform",
+    "reference",
+  ].sort();
+  if (actual.some((key, index) => key !== expected[index]) || actual.length !== expected.length) {
+    throw new Error("protected managed-image contract entry has unexpected fields");
+  }
+}
+
+function parseEntry(
+  value: unknown,
+  expectedPlatform: ProtectedManagedImagePlatform,
+): ProtectedManagedImageContract {
+  const entry = record(value);
+  exactKeys(entry);
+  if (
+    typeof entry.agent !== "string" ||
+    !PROTECTED_MANAGED_IMAGE_AGENTS.includes(entry.agent as ManagedStartupAgent)
+  ) {
+    throw new Error("protected managed-image contract entry has an invalid agent");
+  }
+  if (entry.platform !== expectedPlatform) {
+    throw new Error("protected managed-image contract entry has the wrong platform");
+  }
+  if (
+    typeof entry.digest !== "string" ||
+    !DIGEST_PATTERN.test(entry.digest) ||
+    typeof entry.localContentId !== "string" ||
+    !DIGEST_PATTERN.test(entry.localContentId)
+  ) {
+    throw new Error("protected managed-image contract entry has an invalid content identity");
+  }
+  const expectedRepository = `localhost:5000/nemoclaw-managed-protected/${entry.agent}`;
+  if (entry.reference !== `${expectedRepository}@${entry.digest}`) {
+    throw new Error("protected managed-image contract entry is not the exact agent digest");
+  }
+  const basePrefix = `${BASE_REPOSITORIES[entry.agent as ManagedStartupAgent]}@`;
+  if (
+    typeof entry.baseReference !== "string" ||
+    !entry.baseReference.startsWith(basePrefix) ||
+    !DIGEST_PATTERN.test(entry.baseReference.slice(basePrefix.length))
+  ) {
+    throw new Error("protected managed-image contract entry has an invalid base reference");
+  }
+  return {
+    agent: entry.agent as ManagedStartupAgent,
+    baseReference: entry.baseReference,
+    digest: entry.digest,
+    localContentId: entry.localContentId,
+    platform: expectedPlatform,
+    reference: entry.reference,
+  };
+}
+
+export function parseProtectedManagedImageContracts(
+  value: unknown,
+  expectedPlatform: ProtectedManagedImagePlatform,
+): ProtectedManagedImageContract[] {
+  if (!Array.isArray(value) || value.length !== PROTECTED_MANAGED_IMAGE_AGENTS.length) {
+    throw new Error("protected managed-image contract must contain exactly all shipped agents");
+  }
+  const contracts = value.map((entry) => parseEntry(entry, expectedPlatform));
+  const actualAgents = contracts.map(({ agent }) => agent).sort();
+  const expectedAgents = [...PROTECTED_MANAGED_IMAGE_AGENTS].sort();
+  if (actualAgents.some((agent, index) => agent !== expectedAgents[index])) {
+    throw new Error("protected managed-image contract must contain each shipped agent once");
+  }
+  if (
+    new Set(contracts.map(({ reference }) => reference)).size !== contracts.length ||
+    new Set(contracts.map(({ localContentId }) => localContentId)).size !== contracts.length
+  ) {
+    throw new Error("protected managed-image contract must contain unique immutable images");
+  }
+  return contracts;
+}

--- a/test/protected-managed-image-contract.test.ts
+++ b/test/protected-managed-image-contract.test.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  PROTECTED_MANAGED_IMAGE_AGENTS,
+  PROTECTED_MANAGED_IMAGE_PLATFORMS,
+  type ProtectedManagedImagePlatform,
+  parseProtectedManagedImageContracts,
+} from "../scripts/checks/protected-managed-image-contract.ts";
+
+const BASE_REPOSITORIES = {
+  openclaw: "sandbox-base",
+  hermes: "hermes-sandbox-base",
+  "langchain-deepagents-code": "langchain-deepagents-code-sandbox-base",
+} as const;
+
+function contracts(platform: ProtectedManagedImagePlatform) {
+  return PROTECTED_MANAGED_IMAGE_AGENTS.map((agent, index) => {
+    const digit = String(index + 1);
+    const digest = `sha256:${digit.repeat(64)}`;
+    return {
+      agent,
+      baseReference: `ghcr.io/nvidia/nemoclaw/${BASE_REPOSITORIES[agent]}@sha256:${String(index + 4).repeat(64)}`,
+      digest,
+      localContentId: `sha256:${String(index + 7).repeat(64)}`,
+      platform,
+      reference: `localhost:5000/nemoclaw-managed-protected/${agent}@${digest}`,
+    };
+  });
+}
+
+describe("protected managed-image build contract", () => {
+  it.each(
+    PROTECTED_MANAGED_IMAGE_PLATFORMS,
+  )("accepts one unique immutable image for every shipped agent on %s (#7744)", (platform) => {
+    const value = contracts(platform);
+    expect(parseProtectedManagedImageContracts(value, platform)).toEqual(value);
+  });
+
+  it("rejects an incomplete or duplicated all-agent cohort (#7744)", () => {
+    const value = contracts("linux/amd64");
+    expect(() => parseProtectedManagedImageContracts(value.slice(0, 2), "linux/amd64")).toThrow(
+      "exactly all shipped agents",
+    );
+    expect(() =>
+      parseProtectedManagedImageContracts([value[0], value[0], value[2]], "linux/amd64"),
+    ).toThrow("each shipped agent once");
+  });
+
+  it("rejects cross-platform or mutable image evidence (#7744)", () => {
+    const value = contracts("linux/amd64");
+    expect(() => parseProtectedManagedImageContracts(value, "linux/arm64")).toThrow(
+      "wrong platform",
+    );
+    expect(() =>
+      parseProtectedManagedImageContracts(
+        [{ ...value[0], reference: value[0].reference.split("@")[0] }, value[1], value[2]],
+        "linux/amd64",
+      ),
+    ).toThrow("exact agent digest");
+  });
+
+  it("rejects identity drift and unexpected receipt fields (#7744)", () => {
+    const value = contracts("linux/arm64");
+    expect(() =>
+      parseProtectedManagedImageContracts(
+        [{ ...value[0], digest: `sha256:${"f".repeat(64)}` }, value[1], value[2]],
+        "linux/arm64",
+      ),
+    ).toThrow("exact agent digest");
+    expect(() =>
+      parseProtectedManagedImageContracts(
+        [{ ...value[0], baseReference: value[1].baseReference }, value[1], value[2]],
+        "linux/arm64",
+      ),
+    ).toThrow("invalid base reference");
+    expect(() =>
+      parseProtectedManagedImageContracts(
+        [{ ...value[0], aliases: ["latest"] }, value[1], value[2]],
+        "linux/arm64",
+      ),
+    ).toThrow("unexpected fields");
+  });
+});


### PR DESCRIPTION
## Summary

- add a protected build harness that produces an exact immutable managed image contract for every shipped agent
- require independent amd64 and arm64 qualification inputs with digest-pinned per-agent base images
- validate agent, platform, base-image, output-digest, and local-content identity without publishing mutable aliases

## Stack

PR3.14B1 in #7744. Stacked on #8065. This slice is test and qualification substrate only: it does not activate or advertise buildless support.

## Validation

- focused contract tests: 5/5
- shellcheck and shfmt
- Biome format and lint
- CLI typecheck
- repository architecture checks
- commit and pre-push hooks

Closes no issue; contributes to #7744.

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>