### PR TITLE
fix(onboard): claim bootstrap terminal outcomes

### DIFF
--- a/src/lib/onboard/docker-gpu-local-inference.test.ts
+++ b/src/lib/onboard/docker-gpu-local-inference.test.ts
@@ -425,6 +425,27 @@ describe("verifyGpuSandboxLocalInferenceAndCommitAfterReady", () => {
     expect(runtimePatch.rollbackManagedStartupAfterCreateFailure).toHaveBeenCalledOnce();
     expect(runtimePatch.commitAfterReady).not.toHaveBeenCalled();
   });
+
+  it("treats a failed commit as terminal without attempting rollback", async () => {
+    const runtimePatch = {
+      commitAfterReady: vi.fn(async () => {
+        throw new Error("durable commit acknowledgement failed");
+      }),
+      rollbackManagedStartupAfterCreateFailure: vi.fn(),
+    };
+    await expect(
+      verifyGpuSandboxLocalInferenceAndCommitAfterReady(
+        GPU_CONFIG,
+        "ollama-local",
+        {
+          ...options(),
+          deps: { execInSandbox: execEmitting("HTTP_200"), sleep: vi.fn() },
+        },
+        runtimePatch,
+      ),
+    ).rejects.toThrow("durable commit acknowledgement failed");
+    expect(runtimePatch.rollbackManagedStartupAfterCreateFailure).not.toHaveBeenCalled();
+  });
 });
 
 describe("printDockerGpuSandboxInferenceVerificationFailure", () => {

--- a/src/lib/onboard/docker-gpu-local-inference.ts
+++ b/src/lib/onboard/docker-gpu-local-inference.ts
@@ -511,7 +511,6 @@ export async function verifyGpuSandboxLocalInferenceAndCommitAfterReady(
 ): Promise<void> {
   try {
     verifyGpuSandboxLocalInferenceAfterReady(config, provider, options);
-    await runtimePatch.commitAfterReady();
   } catch (error) {
     const failure = error instanceof Error ? error : new Error(String(error));
     try {
@@ -523,4 +522,5 @@ export async function verifyGpuSandboxLocalInferenceAndCommitAfterReady(
     }
     throw failure;
   }
+  await runtimePatch.commitAfterReady();
 }

--- a/src/lib/onboard/docker-gpu-sandbox-create-lifecycle.test.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create-lifecycle.test.ts
@@ -118,7 +118,7 @@ describe("createDockerGpuSandboxCreatePatch composed flow", () => {
     patch.waitForSupervisorReconnectIfNeeded();
     expect(onPatchFailureExit).not.toHaveBeenCalled();
 
-    await patch.commitAfterReady();
+    await expect(patch.commitAfterReady()).rejects.toThrow("rollback backup");
 
     expect(onPatchFailureExit).toHaveBeenCalledOnce();
     expect(onPatchFailureExit.mock.calls[0]?.[1]).toEqual(
@@ -134,6 +134,33 @@ describe("createDockerGpuSandboxCreatePatch composed flow", () => {
         }),
       }),
     );
+  });
+
+  it("rejects an early commit after rolling back before supervisor reconnect", async () => {
+    const deps = makeDeps();
+    const result = deferredCreateResult();
+    const finalizeBackup = vi.fn(() => ({ backupRemoved: false, rolledBack: true }));
+    const onPatchFailureExit = vi.fn();
+    const patch = createDockerGpuSandboxCreatePatch({
+      route: "compatibility",
+      sandboxName: "alpha",
+      timeoutSecs: 60,
+      deps,
+      overrides: {
+        findContainerIds: vi.fn(() => ["existing-container"]),
+        recreatePatch: vi.fn(() => result),
+        finalizeBackup,
+        onPatchFailureExit,
+      },
+    });
+
+    patch.maybeApplyDuringCreate();
+
+    await expect(patch.commitAfterReady()).rejects.toThrow(
+      "cannot commit before the recreated OpenShell supervisor reconnects",
+    );
+    expect(finalizeBackup).toHaveBeenCalledWith({ result, supervisorReady: false }, deps);
+    expect(onPatchFailureExit).toHaveBeenCalledOnce();
   });
 
   it("rolls back to the backup container and surfaces rolledBack=true diagnostics when supervisorReady=false", () => {

--- a/src/lib/onboard/docker-gpu-sandbox-create.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create.ts
@@ -368,18 +368,15 @@ export function createDockerGpuSandboxCreatePatch(
           "Managed startup cannot commit before the recreated OpenShell supervisor reconnects.",
         );
         const rollbackError = await rollbackAfterFailure();
-        onPatchFailureExit(
-          options.sandboxName,
-          rollbackError
-            ? new Error(`${error.message} Rollback failed: ${rollbackError.message}`)
-            : error,
-          {
-            runCaptureOpenshell: options.deps.runCaptureOpenshell,
-            dockerCapture: options.deps.dockerCapture,
-            additionalSummaryLines: routeAdapter.additionalSummaryLines,
-          },
-        );
-        return;
+        const failure = rollbackError
+          ? new Error(`${error.message} Rollback failed: ${rollbackError.message}`)
+          : error;
+        onPatchFailureExit(options.sandboxName, failure, {
+          runCaptureOpenshell: options.deps.runCaptureOpenshell,
+          dockerCapture: options.deps.dockerCapture,
+          additionalSummaryLines: routeAdapter.additionalSummaryLines,
+        });
+        throw failure;
       }
       if (cutoverFinalization) {
         if (cutoverFinalizationOutcome !== "commit") {
@@ -417,7 +414,7 @@ export function createDockerGpuSandboxCreatePatch(
                 rolledBack: rollbackError === null,
               },
             });
-            return;
+            throw failure;
           }
         }
         const finalizeOutcome = result
@@ -425,16 +422,16 @@ export function createDockerGpuSandboxCreatePatch(
           : null;
         cutoverFinalized = true;
         if (!finalizeOutcome || finalizeOutcome.backupRemoved) return;
-        onPatchFailureExit(
-          options.sandboxName,
-          new Error("Managed startup passed Ready, but its rollback backup could not be removed."),
-          {
-            runCaptureOpenshell: options.deps.runCaptureOpenshell,
-            dockerCapture: options.deps.dockerCapture,
-            additionalSummaryLines: routeAdapter.additionalSummaryLines,
-            context: failureContext(),
-          },
+        const failure = new Error(
+          "Managed startup passed Ready, but its rollback backup could not be removed.",
         );
+        onPatchFailureExit(options.sandboxName, failure, {
+          runCaptureOpenshell: options.deps.runCaptureOpenshell,
+          dockerCapture: options.deps.dockerCapture,
+          additionalSummaryLines: routeAdapter.additionalSummaryLines,
+          context: failureContext(),
+        });
+        throw failure;
       })();
       cutoverFinalization = finalization;
       cutoverFinalizationOutcome = "commit";

--- a/src/lib/onboard/docker-startup-command-sandbox-create.test.ts
+++ b/src/lib/onboard/docker-startup-command-sandbox-create.test.ts
@@ -233,7 +233,7 @@ describe("Docker startup-command sandbox creation", () => {
       rollback,
     });
 
-    await patch.commitAfterReady();
+    await expect(patch.commitAfterReady()).rejects.toThrow("receipt validation failed");
 
     expect(events).toEqual(["commit", "rollback", "exit"]);
     expect(onPatchFailureExit).toHaveBeenCalledWith(

--- a/src/lib/onboard/managed-bootstrap/README.md
+++ b/src/lib/onboard/managed-bootstrap/README.md
@@ -83,6 +83,7 @@ ordinary startup handoff. OpenClaw, Hermes, and DCode images now package the
 root-owned hold, trampoline, runtime bundle, and complete inert capability
 union. Pull-request and publication workflows build the exact images and run
 the direct root-stdin and hold contract without advertising buildless support.
-No production provider invokes the trampoline yet. Until the later provider
-activation and protected E2E slices pass, every production runtime provider
-keeps bootstrap unsupported.
+No production provider invokes the trampoline yet. Until the provider
+activation and protected all-agent E2E exit criteria tracked by
+[epic #7744](https://github.com/NVIDIA/NemoClaw/issues/7744) pass, every
+production runtime provider keeps bootstrap unsupported.

--- a/src/lib/onboard/managed-bootstrap/README.md
+++ b/src/lib/onboard/managed-bootstrap/README.md
@@ -44,7 +44,11 @@ all three names, both launch-spec hashes, image identity, profile fingerprint,
 and sandbox ID and then enter the destructive cutover. Rollback publishes
 `rollback-authorized` before exact replacement deletion; commit publishes
 `shared-state-committed` before exact backup deletion. Cleanup is bound to full
-runtime IDs. Its private state root now retains enumerable, versioned unfinished
+runtime IDs. Commit or rollback is claimed synchronously before asynchronous
+finalization begins. Repeated calls for the claimed outcome share its one pending
+result, while the opposite outcome remains invalid even if acknowledgement of the
+first finalization is lost. Its private state root now retains enumerable,
+versioned unfinished
 records containing the provider and sandbox identities, plan and profile
 fingerprints, exact original and replacement IDs, rollback target, and phase.
 Exact commit and cleanup receipts are durable terminal records, so adapter

--- a/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const adapterMocks = vi.hoisted(() => ({
+  activate: vi.fn<typeof import("./adapter").activateManagedBootstrapSequence>(),
+  finalize: vi.fn<typeof import("./adapter").finalizeManagedBootstrapSequence>(),
+  prepare: vi.fn<typeof import("./adapter").prepareManagedBootstrapSequence>(),
+}));
+
+vi.mock("./adapter", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./adapter")>()),
+  activateManagedBootstrapSequence: adapterMocks.activate,
+  finalizeManagedBootstrapSequence: adapterMocks.finalize,
+  prepareManagedBootstrapSequence: adapterMocks.prepare,
+}));
+
+import type {
+  ManagedBootstrapActivatedTransaction,
+  ManagedBootstrapAdapter,
+  ManagedBootstrapPreparedTransaction,
+} from "./adapter";
+import { createDockerManagedBootstrapSurface } from "./docker-runtime";
+import { authority, IDENTITY, NEW_ID, OLD_ID } from "./docker-test-fixture";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Docker managed-bootstrap lifecycle composition", () => {
+  it("does not finalize rollback after a claimed commit loses acknowledgement", async () => {
+    const seed = authority("openclaw");
+    const prepared = Object.freeze({}) as ManagedBootstrapPreparedTransaction;
+    const activated = Object.freeze({
+      snapshot: { runtimeId: OLD_ID },
+      replacement: { replacementRuntimeId: NEW_ID },
+    }) as ManagedBootstrapActivatedTransaction;
+    adapterMocks.prepare.mockImplementation(async (_adapter, input) => {
+      await input.create.launch({
+        heldWorkloadArgv: seed.handle.heldWorkloadArgv,
+        bootstrapIdentity: IDENTITY,
+      });
+      return prepared;
+    });
+    adapterMocks.activate.mockResolvedValue(activated);
+    adapterMocks.finalize.mockRejectedValue(new Error("commit acknowledgement lost"));
+    const onPatchFailure = vi.fn((error: unknown): never => {
+      throw error;
+    });
+    const lifecycle = createDockerManagedBootstrapSurface().createLifecycle({
+      providerId: "docker",
+      bootstrapIdentity: IDENTITY,
+      request: seed.request,
+      image: seed.plan.image,
+      agentIdentity: seed.plan.agentIdentity,
+      intendedWorkloadArgv: seed.plan.intendedWorkloadArgv,
+      expectedSupervisorArgv: seed.plan.expectedSupervisorArgv,
+      launchArgv: ["openshell", "sandbox", "create", "--name", "alpha"],
+      heldWorkloadArgv: seed.handle.heldWorkloadArgv,
+      authorityStore: {
+        recordPreparedAuthority: vi.fn(),
+      },
+      adapterOverride: {} as ManagedBootstrapAdapter,
+      route: "none",
+      persistStartupCommand: false,
+      sandboxName: "alpha",
+      sandboxGpuConfig: {
+        mode: "0",
+        hostGpuDetected: false,
+        hostGpuPlatform: null,
+        sandboxGpuEnabled: false,
+        sandboxGpuDevice: null,
+        errors: [],
+      },
+      requiredLimits: [],
+      timeoutSecs: 30,
+      onPatchFailure,
+      network: {
+        inferenceProvider: "openai",
+        dockerDriverGateway: false,
+        gatewayPort: 0,
+      },
+      dependencies: {},
+    });
+
+    await expect(
+      lifecycle.runCreate(async () => ({ value: "launched", receipt: seed.handle.createReceipt })),
+    ).resolves.toBe("launched");
+    const failure = (await Promise.resolve(lifecycle.patch.commitAfterReady()).catch(
+      (error: unknown) => error,
+    )) as Error & { managedBootstrapRollbackError?: Error };
+
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure.message).toBe("commit acknowledgement lost");
+    expect(failure.managedBootstrapRollbackError?.message).toBe(
+      "Managed bootstrap rollback is no longer legal after commit finalization began.",
+    );
+    expect(adapterMocks.finalize).toHaveBeenCalledOnce();
+    expect(adapterMocks.finalize).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ outcome: "commit", transaction: activated }),
+    );
+    expect(onPatchFailure).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/docker-runtime.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.ts
@@ -31,6 +31,7 @@ import type {
   ManagedBootstrapRuntimeCreateLifecycleInput,
   ManagedBootstrapRuntimeOnboardRoutingInput,
 } from "./runtime-create";
+import { createManagedBootstrapTerminalFinalizer } from "./runtime-create";
 
 type SupportedBootstrapSurface = Extract<
   RuntimeProviderBootstrapSurface,
@@ -191,7 +192,12 @@ function createDockerLifecycle(
         });
         throw new Error("Managed bootstrap did not return its OpenShell create receipt.");
       }
-      let finalized = false;
+      const finalizer = createManagedBootstrapTerminalFinalizer((outcome) =>
+        finalizeManagedBootstrapSequence(adapter, {
+          outcome,
+          transaction: activated,
+        }).then(() => undefined),
+      );
       patch.attachManagedBootstrapCutover({
         selectedMode: mode,
         failureContext: {
@@ -201,22 +207,8 @@ function createDockerLifecycle(
           backupContainerName: null,
           selectedMode: mode,
         },
-        async rollback() {
-          if (finalized) return;
-          await finalizeManagedBootstrapSequence(adapter, {
-            outcome: "rollback",
-            transaction: activated,
-          });
-          finalized = true;
-        },
-        async commit() {
-          if (finalized) return;
-          await finalizeManagedBootstrapSequence(adapter, {
-            outcome: "commit",
-            transaction: activated,
-          });
-          finalized = true;
-        },
+        rollback: finalizer.rollback,
+        commit: finalizer.commit,
       });
       return launched.value;
     },

--- a/src/lib/onboard/managed-bootstrap/runtime-create.test.ts
+++ b/src/lib/onboard/managed-bootstrap/runtime-create.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createManagedBootstrapTerminalFinalizer } from "./runtime-create";
+
+describe("managed bootstrap terminal finalizer", () => {
+  it("shares one in-flight outcome and rejects an opposite concurrent outcome", async () => {
+    let release = (): void => {};
+    const finalize = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const finalizer = createManagedBootstrapTerminalFinalizer(finalize);
+
+    const firstCommit = finalizer.commit();
+    const duplicateCommit = finalizer.commit();
+
+    expect(duplicateCommit).toBe(firstCommit);
+    await expect(finalizer.rollback()).rejects.toThrow(
+      "rollback is no longer legal after commit finalization began",
+    );
+    release();
+    await expect(Promise.all([firstCommit, duplicateCommit])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(finalize).toHaveBeenCalledExactlyOnceWith("commit");
+  });
+
+  it("retains the claimed outcome after a lost finalization acknowledgement", async () => {
+    const finalize = vi.fn(async () => {
+      throw new Error("commit acknowledgement lost");
+    });
+    const finalizer = createManagedBootstrapTerminalFinalizer(finalize);
+
+    await expect(finalizer.commit()).rejects.toThrow("commit acknowledgement lost");
+    await expect(finalizer.rollback()).rejects.toThrow(
+      "rollback is no longer legal after commit finalization began",
+    );
+    expect(finalize).toHaveBeenCalledExactlyOnceWith("commit");
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/runtime-create.ts
+++ b/src/lib/onboard/managed-bootstrap/runtime-create.ts
@@ -91,6 +91,42 @@ export interface ManagedBootstrapRuntimeCreateLaunchResult<T> {
   readonly receipt: ManagedBootstrapCreateReceipt;
 }
 
+export type ManagedBootstrapTerminalOutcome = "commit" | "rollback";
+
+export interface ManagedBootstrapTerminalFinalizer {
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
+}
+
+/**
+ * Claim one terminal outcome before driver finalization starts. Duplicate calls
+ * for that outcome share the in-flight promise; the opposite outcome fails
+ * closed even when finalization loses acknowledgement.
+ */
+export function createManagedBootstrapTerminalFinalizer(
+  finalize: (outcome: ManagedBootstrapTerminalOutcome) => Promise<void>,
+): ManagedBootstrapTerminalFinalizer {
+  let claimedOutcome: ManagedBootstrapTerminalOutcome | null = null;
+  let pending: Promise<void> | null = null;
+  const run = (outcome: ManagedBootstrapTerminalOutcome): Promise<void> => {
+    if (claimedOutcome === outcome && pending !== null) return pending;
+    if (claimedOutcome !== null) {
+      return Promise.reject(
+        new Error(
+          `Managed bootstrap ${outcome} is no longer legal after ${claimedOutcome} finalization began.`,
+        ),
+      );
+    }
+    claimedOutcome = outcome;
+    pending = Promise.resolve().then(() => finalize(outcome));
+    return pending;
+  };
+  return Object.freeze({
+    commit: () => run("commit"),
+    rollback: () => run("rollback"),
+  });
+}
+
 export interface ManagedBootstrapRuntimeCreateLifecycle {
   readonly launchArgv: readonly string[];
   readonly patch: ManagedBootstrapRuntimePatch;

--- a/src/lib/onboard/sandbox-create-launch.ts
+++ b/src/lib/onboard/sandbox-create-launch.ts
@@ -62,7 +62,11 @@ export interface SandboxCreateLaunchInput {
   openshellShellCommand: OpenshellShellCommand;
   openshellArgv?: OpenshellArgv;
   buildEnv?(): Record<string, string>;
-  /** Dormant until a complete runtime bundle and durable authority store are selected. */
+  /**
+   * Intentional partial migration: dormant until epic #7744 supplies a complete
+   * runtime bundle, durable authority store, and protected all-agent E2E proof.
+   * https://github.com/NVIDIA/NemoClaw/issues/7744
+   */
   managedStartupRootApplyRequest?: ManagedStartupRootApplyRequest | null;
 }
 

--- a/src/lib/onboard/sandbox-create-launch.ts
+++ b/src/lib/onboard/sandbox-create-launch.ts
@@ -63,8 +63,10 @@ export interface SandboxCreateLaunchInput {
   openshellArgv?: OpenshellArgv;
   buildEnv?(): Record<string, string>;
   /**
-   * Intentional partial migration: dormant until epic #7744 supplies a complete
-   * runtime bundle, durable authority store, and protected all-agent E2E proof.
+   * Intentional partial migration: remains unset until production selects a
+   * complete runtime bundle with supported bootstrap after epic #7744's durable
+   * lifecycle, recovery, and rollback gates plus exact-head/base protected
+   * all-agent amd64/arm64, GPU/local-inference, and regression matrix pass.
    * https://github.com/NVIDIA/NemoClaw/issues/7744
    */
   managedStartupRootApplyRequest?: ManagedStartupRootApplyRequest | null;

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -169,8 +169,21 @@ describe("runtime provider central source boundary", () => {
       /(?:driverId|providerId)\s*(?:===|!==)\s*["'](?:docker|podman)["']/iu,
     );
     expect(bootstrapProtocol.join("\n")).not.toMatch(/\b(?:docker|podman|openshell|mxc)\b/iu);
-    expect(activationSources.join("\n")).not.toMatch(
-      /(?:from\s+["'][^"']*managed-bootstrap\/(?:docker|docker-journal|docker-runtime)|require\([^)]*managed-bootstrap)/u,
+    const activationWithoutAllowedProtocolImports = activationSources
+      .map((source) =>
+        source
+          .replace(
+            /import\s+(?:type\s+)?\{[^}]*\}\s+from\s+["'][^"']*managed-bootstrap\/(?:adapter|envelope)["'];?/gu,
+            "",
+          )
+          .replace(
+            /import\s+type\s+\{[^}]*\}\s+from\s+["'][^"']*managed-bootstrap\/runtime-create["'];?/gu,
+            "",
+          ),
+      )
+      .join("\n");
+    expect(activationWithoutAllowedProtocolImports).not.toMatch(
+      /(?:from\s+["'][^"']*managed-bootstrap|require\([^)]*managed-bootstrap|import\([^)]*managed-bootstrap)/u,
     );
     expect(dockerProvider).not.toMatch(
       /(?:from\s+["'][^"']*managed-bootstrap|require\([^)]*managed-bootstrap)/u,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make managed bootstrap completion a single claimed terminal outcome so commit and rollback cannot race, and ensure post-ready commit failures remain fatal instead of allowing onboarding to report failure and continue. The finalizer is provider-neutral so later Podman and MXC-style runtimes can reuse it without central driver switches.

## Related Issue

Part of #7744.

## Stack Position

- Base: #8047 at `862492d14be86897c23daf1f8106d8126579dbc1`
- This exact head: `83e7fe53a05619bfc5c1401701ec844bbde818d9`
- Current parent-relative patch ID: `c54d875bb1bc397ddd7c257e9ca4622ddacd0e97`; the non-document slice remains byte-identical at `6b09c9e459ecea4c29549cae05e92d6d7121bee1`, while #8047 absorbed the epic-link portion of the earlier documentation patch.
- Next slice: shared-state legacy compatibility and durable commit authority

## Changes

- Add a provider-neutral terminal finalizer that synchronously claims commit or rollback, shares duplicate same-outcome calls, and rejects the opposite outcome even when the first caller loses its acknowledgement.
- Route Docker managed-bootstrap finalization through that contract without adding provider-specific orchestration state.
- Make early commit, managed commit, and backup-removal failures terminate sandbox creation after reporting the failure.
- Keep local-inference verification rollback-safe while treating a failed post-verification commit as terminal.
- Expand the source-shape guard so future managed-bootstrap modules cannot leak into central runtime-provider orchestration, while retaining the explicit driver-neutral protocol imports.
- Link the dormant launch field and managed-bootstrap documentation to the all-agent protected-E2E activation criteria in #7744.
- Cover transaction races, lost acknowledgements, lifecycle failures, and local-inference commit behavior with focused tests.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Prior exact-head advisor, CodeRabbit, and protected E2E review passed; the ancestry-only sanitizer append was independently security-reviewed with no findings. Fresh exact-head qualification remains required before merge.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `src/lib/onboard/managed-bootstrap/README.md` now records synchronous terminal-outcome claiming, same-outcome promise sharing, and opposite-outcome rejection after acknowledgement loss. `src/lib/onboard/sandbox-create-launch.ts` now names the complete durable lifecycle, recovery, rollback, all-agent amd64/arm64, GPU/local-inference, regression, and exact-head/base activation gates tracked by #7744. The independent review passed on correction commit `c2c3b400a2bdd12b248f96fa39398dfc90a4c62d`; the signed append-only stack now reaches exact #8047 head `862492d14be86897c23daf1f8106d8126579dbc1` at this PR head `83e7fe53a05619bfc5c1401701ec844bbde818d9`. Advisor-requested Docker lifecycle composition coverage proves that a failed claimed commit cannot finalize rollback. #8047 now supplies the epic link directly; the provider-neutral terminal-outcome documentation remains unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 83e7fe53a05619bfc5c1401701ec844bbde818d9 -->
<!-- docs-review-agents-blob-sha: 7c02f2314c52746ba89cf6a501de29156d94cece -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- Append-only ancestry refresh: exact head `83e7fe53a05619bfc5c1401701ec844bbde818d9` is signed-DCO and GitHub Verified on exact #8047 base `862492d14be86897c23daf1f8106d8126579dbc1`. The current patch is `c54d875bb1bc397ddd7c257e9ca4622ddacd0e97`; all non-document changes remain byte-identical, and the documentation delta only shrank because #8047 already carries the epic link. Fresh exact-head CI, advisors, CodeRabbit, managed-image builds, and protected E2E are running.
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — the implementation suite passed 5 files / 41 tests; the advisor composition increment passed 3 focused files / 11 tests with the real cutover patch, and `npm run build:cli`, CLI typecheck, Biome, the test-conditional scan, and `git diff --check` passed. The refreshed exact head additionally passes 5 focused files / 40 tests, the source-shape inventory 2/2, `npm run build:cli`, CLI typecheck, targeted Biome, and `git diff --check`.
- [ ] Applicable broad gate passed — exact-head CI and protected E2E are starting.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding reliability by correctly surfacing commit failures as terminal errors.
  * Prevented incomplete reconnections, failed bootstrap commits, and backup cleanup failures from appearing successful.
  * Ensured commit and rollback actions cannot conflict once finalization begins.
  * Improved local GPU inference verification and rollback behavior.
  * Preserved original errors when finalization fails after acknowledgement is lost.

* **Documentation**
  * Clarified onboarding lifecycle, recovery, rollback, platform, GPU, and local-inference requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
