### PR TITLE
fix(onboard): preserve shared-state commit authority

### DIFF
--- a/src/lib/onboard/managed-bootstrap/README.md
+++ b/src/lib/onboard/managed-bootstrap/README.md
@@ -54,6 +54,13 @@ commit atomically moves its pending manifest and backups into a durable receipt
 namespace, compacts that state to an exact commit receipt, and rejects rollback
 after a restart. The provider may retire that receipt only after it proves the
 external rollback backup is gone, leaving the next bootstrap attempt unblocked.
+The parser accepts the exact canonical schema-v1 manifest written before
+`bootstrapIdentity` was added only for the legacy null-identity path. It rejects
+additional fields, missing historical fields, and legacy state presented as
+identity-bound authority. Before rollback, the Docker adapter stops the
+replacement and copies its writable-layer commit receipt to a protected host
+path for verification. The immutable helper cannot obtain that receipt through
+`--volumes-from`, which exposes volumes but not the replacement writable layer.
 At managed create-lifecycle startup, the driver-neutral coordinator asks the
 selected provider to reconcile every unfinished record before a new sandbox
 create begins. The Docker provider then resumes the durable phase monotonically:

--- a/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DockerGpuPatchDeps } from "../docker-gpu-patch-types";
+import {
+  MANAGED_STARTUP_SHARED_COMMIT_RECEIPT_DIRECTORY,
+  MANAGED_STARTUP_SHARED_ROLLBACK_RECEIPT_DIRECTORY,
+  MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY,
+} from "../managed-startup/shared-state-transaction";
+import {
+  type DockerManagedBootstrapSharedStateTransaction,
+  finalizeDockerManagedStartupSharedState,
+} from "./docker-shared-state";
+
+const CONTAINER_ID = "c".repeat(64);
+const TRANSACTION: DockerManagedBootstrapSharedStateTransaction = {
+  agent: "openclaw",
+  bootstrapIdentity: "b".repeat(64),
+  containerId: CONTAINER_ID,
+  image: `sha256:${"a".repeat(64)}`,
+  profileFingerprint: "d".repeat(64),
+};
+
+interface SharedStateFixture {
+  readonly commands: readonly (readonly string[])[];
+  readonly deps: DockerGpuPatchDeps;
+  readonly events: readonly string[];
+  readonly state: () => "committed" | "none" | "pending";
+}
+
+const copiedReceiptPaths: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const receiptPath of copiedReceiptPaths.splice(0)) {
+    fs.rmSync(path.dirname(receiptPath), { force: true, recursive: true });
+  }
+});
+
+function fixture(initialState: "committed" | "none" | "pending"): SharedStateFixture {
+  let state = initialState;
+  const commands: string[][] = [];
+  const events: string[] = [];
+  const dockerRun = vi.fn((args: readonly string[]) => {
+    commands.push([...args]);
+    if (args[0] === "cp") {
+      const source = String(args[2] ?? "");
+      const destination = String(args[3] ?? "");
+      const sourcePath = source.slice(`${CONTAINER_ID}:`.length);
+      const present =
+        (sourcePath === MANAGED_STARTUP_SHARED_COMMIT_RECEIPT_DIRECTORY && state === "committed") ||
+        (sourcePath === MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY && state === "pending");
+      events.push(`copy:${path.basename(sourcePath)}:${present ? "present" : "absent"}`);
+      if (!present) {
+        return {
+          status: 1,
+          stderr: `Error response from daemon: Could not find the file ${sourcePath} in container ${CONTAINER_ID}`,
+        };
+      }
+      fs.mkdirSync(destination, { recursive: true });
+      copiedReceiptPaths.push(destination);
+      return { status: 0 };
+    }
+    if (args[0] === "run" && args.includes("--shared-state-transaction-status")) {
+      events.push(`status:${state}`);
+      return { status: 0, stdout: `${state}\n` };
+    }
+    if (args[0] === "run" && args.includes("--rollback-shared-state-transaction")) {
+      events.push("rollback");
+      state = "none";
+      return { status: 0 };
+    }
+    throw new Error(`Unexpected Docker command: ${args.join(" ")}`);
+  });
+  return {
+    commands,
+    deps: {
+      dockerRm: vi.fn(() => ({ status: 0 })),
+      dockerRun,
+      dockerStop: vi.fn(() => {
+        events.push("stop");
+        return { status: 0 };
+      }),
+    },
+    events,
+    state: () => state,
+  };
+}
+
+describe("Docker managed-bootstrap shared-state rollback authority", () => {
+  it("copies and verifies writable-layer commit authority before rollback", () => {
+    const fake = fixture("committed");
+
+    expect(() =>
+      finalizeDockerManagedStartupSharedState(
+        { transaction: TRANSACTION, supervisorReady: false },
+        fake.deps,
+      ),
+    ).toThrow(/durably committed and cannot be rolled back/u);
+
+    expect(fake.events).toEqual([
+      "stop",
+      `copy:${path.basename(MANAGED_STARTUP_SHARED_COMMIT_RECEIPT_DIRECTORY)}:present`,
+      "status:committed",
+    ]);
+    const statusCommand = fake.commands.find((args) =>
+      args.includes("--shared-state-transaction-status"),
+    );
+    expect(statusCommand).toContainEqual(
+      expect.stringMatching(
+        new RegExp(
+          `^type=bind,src=.+,dst=${MANAGED_STARTUP_SHARED_COMMIT_RECEIPT_DIRECTORY},readonly$`,
+          "u",
+        ),
+      ),
+    );
+    expect(fake.commands.some((args) => args.includes("--rollback-shared-state-transaction"))).toBe(
+      false,
+    );
+  });
+
+  it("proves pending authority after quiescence before starting the rollback helper", () => {
+    const fake = fixture("pending");
+
+    expect(
+      finalizeDockerManagedStartupSharedState(
+        { transaction: TRANSACTION, supervisorReady: false },
+        fake.deps,
+      ),
+    ).toEqual({ supervisorReady: false, failure: null });
+
+    expect(fake.events[0]).toBe("stop");
+    expect(fake.events.indexOf("status:pending")).toBeLessThan(fake.events.indexOf("rollback"));
+    expect(fake.state()).toBe("none");
+    const rollbackCommand = fake.commands.find((args) =>
+      args.includes("--rollback-shared-state-transaction"),
+    );
+    expect(rollbackCommand).toContainEqual(
+      expect.stringMatching(
+        new RegExp(
+          `^type=bind,src=.+,dst=${MANAGED_STARTUP_SHARED_ROLLBACK_RECEIPT_DIRECTORY},readonly$`,
+          "u",
+        ),
+      ),
+    );
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
@@ -96,12 +96,14 @@ function fixture(
         }
       }
       case "exec":
-        if (!args.includes("--commit-shared-state-transaction")) {
-          throw new Error("Unexpected Docker commit command");
+        switch (args.includes("--commit-shared-state-transaction")) {
+          case true:
+            events.push("commit:failed");
+            state = options.stateAfterCommitFailure ?? state;
+            return { status: 1, stderr: "commit helper failed" };
+          default:
+            throw new Error("Unexpected Docker commit command");
         }
-        events.push("commit:failed");
-        state = options.stateAfterCommitFailure ?? state;
-        return { status: 1, stderr: "commit helper failed" };
       default:
         throw new Error(`Unexpected Docker command: ${args.join(" ")}`);
     }

--- a/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
@@ -163,4 +163,27 @@ describe("Docker managed-bootstrap shared-state rollback authority", () => {
       ),
     );
   });
+
+  it("removes the exact failed container without rollback when both receipts are absent", () => {
+    const fake = fixture("none");
+
+    expect(
+      finalizeDockerManagedStartupSharedState(
+        { transaction: TRANSACTION, supervisorReady: false },
+        fake.deps,
+      ),
+    ).toEqual({ supervisorReady: false, failure: null });
+
+    expect(fake.events).toEqual([
+      "stop",
+      `copy:${path.basename(MANAGED_STARTUP_SHARED_COMMIT_RECEIPT_DIRECTORY)}:absent`,
+      `copy:${path.basename(MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY)}:absent`,
+    ]);
+    expect(fake.commands.some((args) => args.includes("--rollback-shared-state-transaction"))).toBe(
+      false,
+    );
+    expect(fake.deps.dockerRm).toHaveBeenCalledTimes(1);
+    expect(fake.deps.dockerRm).toHaveBeenCalledWith(CONTAINER_ID, expect.any(Object));
+    expect(fake.state()).toBe("none");
+  });
 });

--- a/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
@@ -33,6 +33,11 @@ interface SharedStateFixture {
   readonly state: () => "committed" | "none" | "pending";
 }
 
+interface SharedStateFixtureOptions {
+  readonly stateAfterCommitFailure?: "committed" | "none" | "pending";
+  readonly stateAfterStop?: "committed" | "none" | "pending";
+}
+
 const copiedReceiptPaths: string[] = [];
 
 afterEach(() => {
@@ -42,7 +47,10 @@ afterEach(() => {
   }
 });
 
-function fixture(initialState: "committed" | "none" | "pending"): SharedStateFixture {
+function fixture(
+  initialState: "committed" | "none" | "pending",
+  options: SharedStateFixtureOptions = {},
+): SharedStateFixture {
   let state = initialState;
   const commands: string[][] = [];
   const events: string[] = [];
@@ -87,6 +95,13 @@ function fixture(initialState: "committed" | "none" | "pending"): SharedStateFix
             throw new Error(`Unexpected Docker command: ${args.join(" ")}`);
         }
       }
+      case "exec":
+        if (!args.includes("--commit-shared-state-transaction")) {
+          throw new Error("Unexpected Docker commit command");
+        }
+        events.push("commit:failed");
+        state = options.stateAfterCommitFailure ?? state;
+        return { status: 1, stderr: "commit helper failed" };
       default:
         throw new Error(`Unexpected Docker command: ${args.join(" ")}`);
     }
@@ -98,6 +113,7 @@ function fixture(initialState: "committed" | "none" | "pending"): SharedStateFix
       dockerRun,
       dockerStop: vi.fn(() => {
         events.push("stop");
+        state = options.stateAfterStop ?? state;
         return { status: 0 };
       }),
     },
@@ -185,5 +201,77 @@ describe("Docker managed-bootstrap shared-state rollback authority", () => {
     expect(fake.deps.dockerRm).toHaveBeenCalledTimes(1);
     expect(fake.deps.dockerRm).toHaveBeenCalledWith(CONTAINER_ID, expect.any(Object));
     expect(fake.state()).toBe("none");
+  });
+
+  it("reuses one preserved pending receipt when commit validation fails", () => {
+    const fake = fixture("pending", { stateAfterCommitFailure: "none" });
+
+    const outcome = finalizeDockerManagedStartupSharedState(
+      {
+        retainContainerAfterRollback: true,
+        transaction: TRANSACTION,
+        supervisorReady: true,
+      },
+      fake.deps,
+    );
+
+    expect(outcome.supervisorReady).toBe(false);
+    expect(outcome.failure).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining("commit helper failed"),
+      }),
+    );
+    const pendingSource = CONTAINER_ID + ":" + MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY;
+    const pendingCopies = fake.commands.filter(
+      (args) => args[0] === "cp" && args[2] === pendingSource,
+    );
+    expect(
+      fake.events.filter(
+        (event) =>
+          event ===
+          "copy:" + path.basename(MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY) + ":present",
+      ),
+    ).toHaveLength(1);
+    const preservedReceiptPath = String(pendingCopies[0]?.[3] ?? "");
+    const rollbackCommand = fake.commands.find((args) =>
+      args.includes("--rollback-shared-state-transaction"),
+    );
+    expect(rollbackCommand).toContain(
+      "type=bind,src=" +
+        preservedReceiptPath +
+        ",dst=" +
+        MANAGED_STARTUP_SHARED_ROLLBACK_RECEIPT_DIRECTORY +
+        ",readonly",
+    );
+    expect(fake.deps.dockerRm).not.toHaveBeenCalled();
+  });
+
+  it("rejects rollback when a failed commit becomes durable during quiescence", () => {
+    const fake = fixture("pending", {
+      stateAfterCommitFailure: "none",
+      stateAfterStop: "committed",
+    });
+
+    expect(() =>
+      finalizeDockerManagedStartupSharedState(
+        { transaction: TRANSACTION, supervisorReady: true },
+        fake.deps,
+      ),
+    ).toThrow(/durably committed and cannot be rolled back/u);
+
+    expect(
+      fake.events.filter(
+        (event) =>
+          event ===
+          "copy:" + path.basename(MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY) + ":present",
+      ),
+    ).toHaveLength(1);
+    expect(fake.events).toContain("commit:failed");
+    expect(fake.events).toContain("status:committed");
+    expect(fake.events).not.toContain("rollback");
+    expect(fake.commands.some((args) => args.includes("--rollback-shared-state-transaction"))).toBe(
+      false,
+    );
+    expect(fake.deps.dockerRm).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-shared-state.test.ts
@@ -46,36 +46,50 @@ function fixture(initialState: "committed" | "none" | "pending"): SharedStateFix
   let state = initialState;
   const commands: string[][] = [];
   const events: string[] = [];
+  const copyPresentReceipt = (destination: string) => {
+    fs.mkdirSync(destination, { recursive: true });
+    copiedReceiptPaths.push(destination);
+    return { status: 0 };
+  };
+  const copyMissingReceipt = (sourcePath: string) => ({
+    status: 1,
+    stderr: `Error response from daemon: Could not find the file ${sourcePath} in container ${CONTAINER_ID}`,
+  });
   const dockerRun = vi.fn((args: readonly string[]) => {
     commands.push([...args]);
-    if (args[0] === "cp") {
-      const source = String(args[2] ?? "");
-      const destination = String(args[3] ?? "");
-      const sourcePath = source.slice(`${CONTAINER_ID}:`.length);
-      const present =
-        (sourcePath === MANAGED_STARTUP_SHARED_COMMIT_RECEIPT_DIRECTORY && state === "committed") ||
-        (sourcePath === MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY && state === "pending");
-      events.push(`copy:${path.basename(sourcePath)}:${present ? "present" : "absent"}`);
-      if (!present) {
-        return {
-          status: 1,
-          stderr: `Error response from daemon: Could not find the file ${sourcePath} in container ${CONTAINER_ID}`,
-        };
+    switch (args[0]) {
+      case "cp": {
+        const source = String(args[2] ?? "");
+        const destination = String(args[3] ?? "");
+        const sourcePath = source.slice(`${CONTAINER_ID}:`.length);
+        const present =
+          (sourcePath === MANAGED_STARTUP_SHARED_COMMIT_RECEIPT_DIRECTORY &&
+            state === "committed") ||
+          (sourcePath === MANAGED_STARTUP_SHARED_TRANSACTION_DIRECTORY && state === "pending");
+        events.push(`copy:${path.basename(sourcePath)}:${present ? "present" : "absent"}`);
+        return present ? copyPresentReceipt(destination) : copyMissingReceipt(sourcePath);
       }
-      fs.mkdirSync(destination, { recursive: true });
-      copiedReceiptPaths.push(destination);
-      return { status: 0 };
+      case "run": {
+        const action = args.includes("--shared-state-transaction-status")
+          ? "status"
+          : args.includes("--rollback-shared-state-transaction")
+            ? "rollback"
+            : "unexpected";
+        switch (action) {
+          case "status":
+            events.push(`status:${state}`);
+            return { status: 0, stdout: `${state}\n` };
+          case "rollback":
+            events.push("rollback");
+            state = "none";
+            return { status: 0 };
+          default:
+            throw new Error(`Unexpected Docker command: ${args.join(" ")}`);
+        }
+      }
+      default:
+        throw new Error(`Unexpected Docker command: ${args.join(" ")}`);
     }
-    if (args[0] === "run" && args.includes("--shared-state-transaction-status")) {
-      events.push(`status:${state}`);
-      return { status: 0, stdout: `${state}\n` };
-    }
-    if (args[0] === "run" && args.includes("--rollback-shared-state-transaction")) {
-      events.push("rollback");
-      state = "none";
-      return { status: 0 };
-    }
-    throw new Error(`Unexpected Docker command: ${args.join(" ")}`);
   });
   return {
     commands,

--- a/src/lib/onboard/managed-bootstrap/docker-shared-state.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-shared-state.ts
@@ -465,10 +465,21 @@ function copyManagedStartupReceipt(
 
 function rollbackManagedStartupSharedState(
   transaction: DockerManagedBootstrapSharedStateTransaction,
-  receiptPath: string,
   deps: DockerGpuPatchDeps,
-): void {
+  preservedReceiptPath?: string,
+): boolean {
   const dockerRun = deps.dockerRun ?? defaultDockerRun;
+  const status = probeDockerManagedStartupSharedState(
+    { transaction, profileFingerprint: transaction.profileFingerprint },
+    deps,
+  );
+  if (status === "committed") {
+    throw new Error("Managed-startup shared state is durably committed and cannot be rolled back.");
+  }
+  const receiptPath =
+    preservedReceiptPath ??
+    (status === "pending" ? copyManagedStartupReceipt(transaction, deps) : null);
+  if (!receiptPath) return false;
   let restored = false;
   try {
     const helper = dockerRun(
@@ -517,6 +528,7 @@ function rollbackManagedStartupSharedState(
       cleanupReceiptBestEffort(receiptPath);
     }
   }
+  return true;
 }
 
 function removeFailedUnbackedContainer(
@@ -605,7 +617,7 @@ export function finalizeDockerManagedStartupSharedState(
       `OpenShell supervisor reconnected, but managed shared-state logical commit validation failed: ${commitFailure.message}`,
     );
     quiesceManagedStartupContainer(transaction, deps);
-    rollbackManagedStartupSharedState(transaction, receiptPath, deps);
+    rollbackManagedStartupSharedState(transaction, deps, receiptPath);
     if (!input.patchResult && !input.retainContainerAfterRollback) {
       removeFailedUnbackedContainer(transaction, deps);
     }
@@ -613,14 +625,7 @@ export function finalizeDockerManagedStartupSharedState(
   }
 
   quiesceManagedStartupContainer(transaction, deps);
-  const receiptPath = copyManagedStartupReceipt(transaction, deps, true);
-  if (!receiptPath) {
-    if (!input.patchResult && !input.retainContainerAfterRollback) {
-      removeFailedUnbackedContainer(transaction, deps);
-    }
-    return { supervisorReady: false, failure: null };
-  }
-  rollbackManagedStartupSharedState(transaction, receiptPath, deps);
+  rollbackManagedStartupSharedState(transaction, deps);
   if (!input.patchResult && !input.retainContainerAfterRollback) {
     removeFailedUnbackedContainer(transaction, deps);
   }

--- a/src/lib/onboard/managed-startup-shared-state-transaction.test.ts
+++ b/src/lib/onboard/managed-startup-shared-state-transaction.test.ts
@@ -78,6 +78,20 @@ describe("managed startup shared-state transaction", () => {
     );
   }
 
+  function rewriteManifest(
+    rewrite: (manifest: Record<string, unknown>) => Record<string, unknown> = (manifest) =>
+      manifest,
+  ): void {
+    const manifestFile = path.join(transactionDirectory, "manifest.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8")) as Record<string, unknown>;
+    expect(manifest.bootstrapIdentity).toBeNull();
+    delete manifest.bootstrapIdentity;
+    const rewritten = rewrite(manifest);
+    fs.chmodSync(manifestFile, 0o600);
+    fs.writeFileSync(manifestFile, `${JSON.stringify(rewritten, null, 2)}\n`);
+    fs.chmodSync(manifestFile, 0o400);
+  }
+
   it.each([
     "openclaw",
     "hermes",
@@ -257,6 +271,70 @@ describe("managed startup shared-state transaction", () => {
     expect(commitManagedStartupSharedStateTransaction("openclaw", options)).toBe(false);
   });
 
+  it.each([
+    ["commits", "commit"],
+    ["rolls back", "rollback"],
+  ] as const)("%s an exact historical schema-v1 manifest without bootstrap identity", (_description, action) => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root);
+    const config = path.join(root, "openclaw.json");
+    fs.writeFileSync(config, "before\n");
+    beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), options);
+    rewriteManifest();
+    fs.writeFileSync(config, "after\n");
+
+    const result =
+      action === "commit"
+        ? commitManagedStartupSharedStateTransaction("openclaw", options)
+        : rollbackManagedStartupSharedStateTransaction("openclaw", options);
+
+    expect(result).toBe(true);
+    expect(fs.readFileSync(config, "utf8")).toBe(action === "commit" ? "after\n" : "before\n");
+    expect(fs.existsSync(transactionDirectory)).toBe(false);
+    expect(fs.existsSync(commitReceiptDirectory())).toBe(false);
+  });
+
+  it.each([
+    ["an extra field", (manifest: Record<string, unknown>) => ({ ...manifest, extra: true })],
+    [
+      "a missing historical field",
+      (manifest: Record<string, unknown>) => {
+        delete manifest.directories;
+        return manifest;
+      },
+    ],
+  ] as const)("rejects a schema-v1 legacy manifest with %s", (_case, rewrite) => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, "openclaw.json"), "before\n");
+    beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), options);
+    rewriteManifest(rewrite);
+
+    expect(() => commitManagedStartupSharedStateTransaction("openclaw", options)).toThrow(
+      /unexpected fields/u,
+    );
+    expect(fs.existsSync(transactionDirectory)).toBe(true);
+  });
+
+  it("does not treat a legacy manifest as authority for an identity-bound bootstrap", () => {
+    const root = agentRoot("openclaw");
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, "openclaw.json"), "before\n");
+    const boundOptions = { ...options, bootstrapIdentity: "b".repeat(64) };
+    beginManagedStartupSharedStateTransaction(managedStartupE2eProfile("openclaw"), boundOptions);
+    const manifestFile = path.join(transactionDirectory, "manifest.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8")) as Record<string, unknown>;
+    delete manifest.bootstrapIdentity;
+    fs.chmodSync(manifestFile, 0o600);
+    fs.writeFileSync(manifestFile, `${JSON.stringify(manifest, null, 2)}\n`);
+    fs.chmodSync(manifestFile, 0o400);
+
+    expect(() => rollbackManagedStartupSharedStateTransaction("openclaw", boundOptions)).toThrow(
+      /different bootstrap attempt/u,
+    );
+    expect(fs.existsSync(transactionDirectory)).toBe(true);
+  });
+
   it("fsyncs every transaction namespace before exposing a pending receipt", () => {
     const root = agentRoot("openclaw");
     fs.mkdirSync(root);
@@ -393,10 +471,13 @@ describe("managed startup shared-state transaction", () => {
             throw new Error("injected post-rename cleanup interruption");
           })()
         : originalRmSync(target, removeOptions)) as typeof fs.rmSync);
-    expect(() => commitManagedStartupSharedStateTransaction("openclaw", boundOptions)).toThrow(
-      /injected post-rename cleanup interruption/u,
-    );
-    rm.mockRestore();
+    try {
+      expect(() => commitManagedStartupSharedStateTransaction("openclaw", boundOptions)).toThrow(
+        /injected post-rename cleanup interruption/u,
+      );
+    } finally {
+      rm.mockRestore();
+    }
 
     expect(fs.existsSync(transactionDirectory)).toBe(false);
     const committedDirectory = commitReceiptDirectory();

--- a/src/lib/onboard/managed-startup/shared-state-transaction.ts
+++ b/src/lib/onboard/managed-startup/shared-state-transaction.ts
@@ -538,6 +538,20 @@ function canonicalManifest(manifest: TransactionManifest): string {
   return `${JSON.stringify(manifest, null, 2)}\n`;
 }
 
+function canonicalLegacyManifest(manifest: TransactionManifest): string {
+  return `${JSON.stringify(
+    {
+      schemaVersion: manifest.schemaVersion,
+      agent: manifest.agent,
+      profileFingerprint: manifest.profileFingerprint,
+      files: manifest.files,
+      directories: manifest.directories,
+    },
+    null,
+    2,
+  )}\n`;
+}
+
 function canonicalCommitReceipt(receipt: CommitReceipt): string {
   return `${JSON.stringify(receipt, null, 2)}\n`;
 }
@@ -597,23 +611,29 @@ function parseManifest(text: string): TransactionManifest {
     fail("transaction manifest must be an object");
   }
   const record = parsed as Record<string, unknown>;
-  requireExactKeys(record, [
-    "agent",
-    "bootstrapIdentity",
-    "directories",
-    "files",
-    "profileFingerprint",
-    "schemaVersion",
-  ]);
+  const hasBootstrapIdentity = Object.hasOwn(record, "bootstrapIdentity");
+  requireExactKeys(
+    record,
+    hasBootstrapIdentity
+      ? [
+          "agent",
+          "bootstrapIdentity",
+          "directories",
+          "files",
+          "profileFingerprint",
+          "schemaVersion",
+        ]
+      : ["agent", "directories", "files", "profileFingerprint", "schemaVersion"],
+  );
+  const bootstrapIdentity = hasBootstrapIdentity ? record.bootstrapIdentity : null;
   if (
     record.schemaVersion !== TRANSACTION_SCHEMA_VERSION ||
     !["openclaw", "hermes", "langchain-deepagents-code"].includes(String(record.agent)) ||
     typeof record.profileFingerprint !== "string" ||
     !/^[a-f0-9]{64}$/u.test(record.profileFingerprint) ||
     !(
-      record.bootstrapIdentity === null ||
-      (typeof record.bootstrapIdentity === "string" &&
-        /^[a-f0-9]{64}$/u.test(record.bootstrapIdentity))
+      bootstrapIdentity === null ||
+      (typeof bootstrapIdentity === "string" && /^[a-f0-9]{64}$/u.test(bootstrapIdentity))
     ) ||
     !Array.isArray(record.files) ||
     !Array.isArray(record.directories) ||
@@ -709,11 +729,14 @@ function parseManifest(text: string): TransactionManifest {
     schemaVersion: TRANSACTION_SCHEMA_VERSION,
     agent: record.agent as ManagedStartupAgent,
     profileFingerprint: record.profileFingerprint,
-    bootstrapIdentity: record.bootstrapIdentity as string | null,
+    bootstrapIdentity,
     files,
     directories,
   };
-  if (canonicalManifest(manifest) !== text) {
+  const canonical = hasBootstrapIdentity
+    ? canonicalManifest(manifest)
+    : canonicalLegacyManifest(manifest);
+  if (canonical !== text) {
     fail("transaction manifest is not canonical");
   }
   return manifest;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Recover the exact historical shared-state manifest without weakening identity-bound bootstrap, and fence Docker rollback with durable commit authority copied from the owning container. This prevents a restarted or failed managed bootstrap from rolling back state that already committed while preserving the legacy null-identity path.

## Related Issue

Part of #7744.

## Stack Position

- Base: #8077 at `83e7fe53a05619bfc5c1401701ec844bbde818d9`
- This exact head: `9d4dc59c331aca42f4ead7bc8831db61d1deee0e`
- Stable parent-relative patch ID: `cfaa19326c2bec368ac0ecc4870f20164d48c37d`
- Exact patch size: 5 files, 423 insertions, 28 deletions
- Next slice: durable journal-record compatibility and canonical receipt equality

## Changes

- Accept only the exact canonical schema-v1 manifest written before `bootstrapIdentity`, and map it to null identity solely for the legacy unbound path.
- Continue rejecting extra or missing fields, noncanonical state, caller identity mismatch, and attempts to adopt legacy null authority into an identity-bound bootstrap.
- Quiesce the failed replacement, probe its exact durable commit receipt through a protected host copy, and refuse rollback when that receipt proves commit.
- Copy verified pending authority before starting the immutable rollback helper; do not pretend `--volumes-from` exposes the replacement writable-layer `/var/lib` receipt.
- Preserve the existing provider-neutral shared-state contract; Docker owns only the engine-specific receipt extraction and helper invocation.
- Restore filesystem spies on every test exit and cover exact legacy compatibility, malformed near-misses, durable commit fencing, pending rollback, and provider-boundary behavior.
- Cover the `supervisorReady: true` commit-failure path: preserve exactly one available pending receipt, reuse that host copy for rollback, and reject rollback or container removal when the quiesced replacement re-probes as committed.
- Document the compatibility and writable-layer authority boundary next to the durable shared-state contract.

The compatibility path is required because pre-`bootstrapIdentity` schema-v1 manifests can remain on disk during upgrade. A direct current-schema-only parse would strand valid legacy rollback state, while treating every missing identity as current authority would be unsafe. `managed-startup-shared-state-transaction.test.ts` protects the exact historical shape and rejection boundary; `docker-shared-state.test.ts` protects the host-copy commit fence.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent exact-head review found no production correctness or security issue and identified the now-covered commit-failure regression; fresh exact-head CI, advisors, CodeRabbit, CodeQL, and protected E2E remain required before merge.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `src/lib/onboard/managed-bootstrap/README.md` documents exact legacy null-identity schema-v1 acceptance, rejection of extra/missing/identity-bound adoption, and the Docker protected host-copy boundary required because `--volumes-from` cannot expose the replacement writable layer. Independent review found the wording complete and architecturally consistent with the exact implementation diff.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9d4dc59c331aca42f4ead7bc8831db61d1deee0e -->
<!-- docs-review-agents-blob-sha: 40dac4dfa3c01afec9be049c16909606fb2d2a80 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- Append-only ancestry refresh: exact head `9d4dc59c331aca42f4ead7bc8831db61d1deee0e` is signed-DCO and GitHub Verified on exact #8077 base `83e7fe53a05619bfc5c1401701ec844bbde818d9`; the stable parent-relative slice patch remains `cfaa19326c2bec368ac0ecc4870f20164d48c37d` at 5 files, +423/-28. Fresh exact-head CI, advisors, CodeRabbit, managed-image builds, and protected E2E are running.
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 43 focused/regression CLI tests and 2 provider-boundary integration tests passed for the implementation slice; the linear guardrail fixture introduced zero new `if` statements. The earlier advisor remediation adds the missing no-authority cleanup regression. The current implementation adds preserved-receipt reuse and committed-on-reprobe rollback-fence coverage; the focused Docker shared-state suite passes (5/5), together with Biome, CLI type-checking, repository checks, the exact test-conditional scan, commit hooks, and pre-push gates. The refreshed exact head additionally passes both affected suites, 30/30 tests, CLI typecheck, `git diff --check`, and the normal pre-push TypeScript/version gates.
- [ ] Applicable broad gate passed — public exact-head CI and protected E2E are starting.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved managed startup recovery by preventing rollback after a transaction has been durably committed.
  * Added safeguards for interrupted Docker-based updates, including transaction-status verification and preserved recovery information.
* **Compatibility**
  * Added support for legacy schema-v1 manifests without bootstrap identity information.
  * Added validation to reject incomplete, unexpected, or incompatible manifest fields.
* **Documentation**
  * Documented manifest compatibility rules and Docker rollback protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
