### PR TITLE
fix(ci): approve trusted maintainer PR workflow runs

### DIFF
--- a/.github/workflows/approve-maintainer-pr-workflow-runs.yaml
+++ b/.github/workflows/approve-maintainer-pr-workflow-runs.yaml
@@ -7,8 +7,9 @@ name: Automation / Approve Maintainer PR Workflow Runs
 # pinned action reads repository metadata and approves exact workflow-run IDs.
 # Do not add a checkout or execute pull-request code in this workflow.
 on:
+  # Keep every target branch eligible so maintainer-owned stacked PRs receive
+  # the same exact-head approval policy as PRs that target main.
   pull_request_target:
-    branches: [main]
     types: [opened, synchronize, reopened, edited, ready_for_review]
 
 permissions:

--- a/.github/workflows/approve-maintainer-pr-workflow-runs.yaml
+++ b/.github/workflows/approve-maintainer-pr-workflow-runs.yaml
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Automation / Approve Maintainer PR Workflow Runs
+
+# pull_request_target loads this workflow from the trusted base branch. The
+# pinned action reads repository metadata and approves exact workflow-run IDs.
+# Do not add a checkout or execute pull-request code in this workflow.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: approve-maintainer-pr-workflow-runs-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Approve exact-head maintainer workflow runs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            // Keeping this policy inline prevents a write-capable
+            // pull_request_target job from checking out repository files.
+            const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+            const TRUSTED_BASE_PERMISSIONS = new Set(['write', 'admin']);
+            const POLL_ATTEMPTS = 12;
+            const POLL_INTERVAL_MS = 5000;
+            const { owner, repo } = context.repo;
+
+            function validateEventPullRequest(value) {
+              if (!value || typeof value !== 'object') {
+                throw new Error('Invalid pull_request_target payload: pull_request is missing');
+              }
+              if (!Number.isInteger(value.number) || value.number <= 0) {
+                throw new Error(`Invalid pull request number: ${value.number}`);
+              }
+              if (typeof value.head?.sha !== 'string' || !SHA_PATTERN.test(value.head.sha)) {
+                throw new Error(`Invalid event head SHA for PR #${value.number}`);
+              }
+              return { number: value.number, headSha: value.head.sha.toLowerCase() };
+            }
+
+            function liveHeadSha(pullRequest, prNumber) {
+              const headSha = pullRequest?.head?.sha;
+              if (typeof headSha !== 'string' || !SHA_PATTERN.test(headSha)) {
+                throw new Error(`Invalid live head SHA for PR #${prNumber}`);
+              }
+              return headSha.toLowerCase();
+            }
+
+            function repositoryName(value) {
+              return typeof value === 'string' ? value.toLowerCase() : '';
+            }
+
+            function isSameRepositoryHead(pullRequest) {
+              return (
+                repositoryName(pullRequest?.head?.repo?.full_name) ===
+                repositoryName(`${owner}/${repo}`)
+              );
+            }
+
+            async function loadLivePullRequest(prNumber) {
+              const response = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              const pullRequest = response.data;
+              if (pullRequest?.number !== prNumber || pullRequest?.state !== 'open') {
+                throw new Error(`PR #${prNumber} is not an open pull request`);
+              }
+              const baseRepository = pullRequest.base?.repo?.full_name;
+              if (
+                typeof baseRepository !== 'string' ||
+                baseRepository.toLowerCase() !== `${owner}/${repo}`.toLowerCase()
+              ) {
+                throw new Error(`PR #${prNumber} does not target ${owner}/${repo}`);
+              }
+              return pullRequest;
+            }
+
+            async function loadAuthorPermission(author) {
+              try {
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username: author,
+                });
+                const responseLogin = response.data.user?.login;
+                if (
+                  typeof responseLogin !== 'string' ||
+                  responseLogin.toLowerCase() !== author.toLowerCase()
+                ) {
+                  throw new Error(`Permission response did not match PR author ${author}`);
+                }
+                return response.data;
+              } catch (error) {
+                if (error?.status === 404) return null;
+                throw error;
+              }
+            }
+
+            function hasWritePermission(permission) {
+              const basePermission = String(permission?.permission ?? '').toLowerCase();
+              // GitHub maps maintain to the write base permission. role_name can
+              // contain an arbitrary custom-role label, so it is not authority.
+              return TRUSTED_BASE_PERMISSIONS.has(basePermission);
+            }
+
+            function belongsToExactPullRequest(run, prNumber, headSha) {
+              if (
+                !Number.isInteger(run?.id) ||
+                run.id <= 0 ||
+                run.event !== 'pull_request' ||
+                run.status !== 'completed' ||
+                run.conclusion !== 'action_required' ||
+                String(run.head_sha ?? '').toLowerCase() !== headSha ||
+                repositoryName(run.head_repository?.full_name) !==
+                  repositoryName(`${owner}/${repo}`)
+              ) {
+                return false;
+              }
+              return (
+                Array.isArray(run.pull_requests) &&
+                run.pull_requests.some(
+                  (pullRequest) =>
+                    pullRequest?.number === prNumber &&
+                    String(pullRequest.head?.sha ?? '').toLowerCase() === headSha,
+                )
+              );
+            }
+
+            const eventPullRequest = validateEventPullRequest(context.payload.pull_request);
+            const initialPullRequest = await loadLivePullRequest(eventPullRequest.number);
+            const expectedHeadSha = liveHeadSha(initialPullRequest, eventPullRequest.number);
+            if (expectedHeadSha !== eventPullRequest.headSha) {
+              core.info(
+                `PR #${eventPullRequest.number} moved from event head ${eventPullRequest.headSha} to ${expectedHeadSha}; no workflow runs approved`,
+              );
+              return;
+            }
+            if (!isSameRepositoryHead(initialPullRequest)) {
+              core.info(
+                `PR #${eventPullRequest.number} head repository is not ${owner}/${repo}; workflow runs remain gated`,
+              );
+              return;
+            }
+
+            const author = initialPullRequest.user?.login;
+            if (typeof author !== 'string' || author.length === 0) {
+              throw new Error(`PR #${eventPullRequest.number} has no live author`);
+            }
+            const permission = await loadAuthorPermission(author);
+            if (!permission || !hasWritePermission(permission)) {
+              core.info(
+                `PR #${eventPullRequest.number} author ${author} does not have write, maintain, or admin permission; workflow runs remain gated`,
+              );
+              return;
+            }
+
+            const approvedRunIds = new Set();
+            for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt += 1) {
+              const currentPullRequest = await loadLivePullRequest(eventPullRequest.number);
+              if (liveHeadSha(currentPullRequest, eventPullRequest.number) !== expectedHeadSha) {
+                core.warning(
+                  `PR #${eventPullRequest.number} head changed during workflow-run discovery; no further runs approved`,
+                );
+                return;
+              }
+
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRunsForRepo,
+                {
+                  owner,
+                  repo,
+                  event: 'pull_request',
+                  head_sha: expectedHeadSha,
+                  status: 'action_required',
+                  per_page: 100,
+                },
+              );
+
+              for (const run of runs) {
+                if (
+                  approvedRunIds.has(run?.id) ||
+                  !belongsToExactPullRequest(
+                    run,
+                    eventPullRequest.number,
+                    expectedHeadSha,
+                  )
+                ) {
+                  continue;
+                }
+
+                const liveBeforeApproval = await loadLivePullRequest(eventPullRequest.number);
+                if (
+                  liveHeadSha(liveBeforeApproval, eventPullRequest.number) !==
+                  expectedHeadSha
+                ) {
+                  core.warning(
+                    `PR #${eventPullRequest.number} head changed before workflow-run approval; no further runs approved`,
+                  );
+                  return;
+                }
+                if (!isSameRepositoryHead(liveBeforeApproval)) {
+                  core.warning(
+                    `PR #${eventPullRequest.number} head repository changed; no further runs approved`,
+                  );
+                  return;
+                }
+                if (
+                  String(liveBeforeApproval.user?.login ?? '').toLowerCase() !==
+                  author.toLowerCase()
+                ) {
+                  throw new Error(
+                    `PR #${eventPullRequest.number} author changed during workflow-run discovery`,
+                  );
+                }
+                const livePermission = await loadAuthorPermission(author);
+                if (!livePermission || !hasWritePermission(livePermission)) {
+                  core.warning(
+                    `PR #${eventPullRequest.number} author ${author} no longer has write, maintain, or admin permission; no further runs approved`,
+                  );
+                  return;
+                }
+
+                await github.rest.actions.approveWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                });
+                approvedRunIds.add(run.id);
+                core.info(
+                  `Approved pull_request workflow run ${run.id} for PR #${eventPullRequest.number} at ${expectedHeadSha}`,
+                );
+              }
+
+              if (attempt + 1 < POLL_ATTEMPTS) {
+                await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+              }
+            }
+
+            core.info(
+              `Approved ${approvedRunIds.size} exact-head workflow run(s) for PR #${eventPullRequest.number}`,
+            );

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -297,6 +297,11 @@
       "category": "security"
     },
     {
+      "file": "test/maintainer-pr-workflow-approval.test.ts",
+      "test": "keeps workflow approval inside the trusted metadata boundary",
+      "category": "security"
+    },
+    {
       "file": "test/macos-e2e-workflow-boundary.test.ts",
       "test": "keeps secret-bearing live E2E on trusted main-branch code",
       "category": "security"

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -107,6 +107,10 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     testsToRun: runTests("test/code-scanning-workflow.test.ts"),
   },
   {
+    pattern: /(?:^|\/)\.github\/workflows\/approve-maintainer-pr-workflow-runs\.yaml$/,
+    testsToRun: runTests("test/maintainer-pr-workflow-approval.test.ts"),
+  },
+  {
     pattern: /(?:^|\/)\.github\/workflows\/pr-e2e-gate\.yaml$/,
     testsToRun: runTests("test/pr-e2e-gate-workflow.test.ts", "test/pr-e2e-required.test.ts"),
   },

--- a/test/maintainer-pr-workflow-approval.test.ts
+++ b/test/maintainer-pr-workflow-approval.test.ts
@@ -81,20 +81,20 @@ function createHarness(options: HarnessOptions = {}) {
       },
     };
   });
-  const getCollaboratorPermissionLevel = vi.fn(async () => {
-    if (options.permissionError) throw options.permissionError;
-    return {
-      data:
-        (options.permission
-          ? { ...options.permission, user: options.permission.user ?? { login: author } }
-          : undefined) ??
-        ({
-          permission: "write",
-          role_name: "write",
-          user: { login: author },
-        } as const),
-    };
-  });
+  const permissionResponse =
+    (options.permission
+      ? { ...options.permission, user: options.permission.user ?? { login: author } }
+      : undefined) ??
+    ({
+      permission: "write",
+      role_name: "write",
+      user: { login: author },
+    } as const);
+  const getCollaboratorPermissionLevel = vi.fn(
+    options.permissionError
+      ? async () => Promise.reject(options.permissionError)
+      : async () => ({ data: permissionResponse }),
+  );
   const listWorkflowRunsForRepo = vi.fn(async () => {
     const runs = options.runsByPoll?.[workflowRunPoll] ?? [];
     workflowRunPoll += 1;

--- a/test/maintainer-pr-workflow-approval.test.ts
+++ b/test/maintainer-pr-workflow-approval.test.ts
@@ -13,7 +13,6 @@ type ApprovalWorkflow = {
   concurrency?: { group?: string; "cancel-in-progress"?: boolean };
   on?: {
     pull_request_target?: {
-      branches?: string[];
       types?: string[];
     };
   };
@@ -159,7 +158,6 @@ describe("maintainer PR workflow-run approval", () => {
   // source-shape-contract: security -- The write-capable pull_request_target workflow must keep its exact trigger, permission, action, and no-checkout execution boundary
   it("keeps workflow approval inside the trusted metadata boundary", () => {
     expect(workflow.on?.pull_request_target).toEqual({
-      branches: ["main"],
       types: ["opened", "synchronize", "reopened", "edited", "ready_for_review"],
     });
     expect(workflow.permissions).toEqual({

--- a/test/maintainer-pr-workflow-approval.test.ts
+++ b/test/maintainer-pr-workflow-approval.test.ts
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { readYaml, type WorkflowJob } from "./helpers/e2e-workflow-contract";
+
+const AsyncFunction = Object.getPrototypeOf(async () => undefined).constructor as new (
+  ...parameters: string[]
+) => (...args: unknown[]) => Promise<unknown>;
+
+type ApprovalWorkflow = {
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  on?: {
+    pull_request_target?: {
+      branches?: string[];
+      types?: string[];
+    };
+  };
+  permissions?: Record<string, string>;
+  jobs: Record<string, WorkflowJob>;
+};
+
+type HarnessOptions = {
+  author?: string;
+  eventHead?: string;
+  headRepository?: string;
+  liveHeads?: string[];
+  permission?: {
+    permission?: string;
+    role_name?: string;
+    user?: { login?: string };
+  };
+  permissionError?: { status: number };
+  runsByPoll?: unknown[][];
+};
+
+const WORKFLOW_PATH = ".github/workflows/approve-maintainer-pr-workflow-runs.yaml";
+const HEAD_SHA = "a".repeat(40);
+const MOVED_HEAD_SHA = "b".repeat(40);
+const PR_NUMBER = 42;
+const workflow = readYaml<ApprovalWorkflow>(WORKFLOW_PATH);
+const job = workflow.jobs.approve;
+const actionStep = job.steps?.find(
+  (step) => step.name === "Approve exact-head maintainer workflow runs",
+);
+const script = actionStep?.with?.script;
+
+function actionRequiredRun(id: number, overrides: Record<string, unknown> = {}) {
+  return {
+    actor: { login: "github-actions[bot]" },
+    conclusion: "action_required",
+    event: "pull_request",
+    head_repository: { full_name: "NVIDIA/NemoClaw" },
+    head_sha: HEAD_SHA,
+    id,
+    pull_requests: [{ head: { sha: HEAD_SHA }, number: PR_NUMBER }],
+    status: "completed",
+    ...overrides,
+  };
+}
+
+function createHarness(options: HarnessOptions = {}) {
+  const author = options.author ?? "maintainer";
+  const liveHeads = options.liveHeads ?? [HEAD_SHA];
+  let pullRequestRead = 0;
+  let workflowRunPoll = 0;
+
+  const getPullRequest = vi.fn(async () => {
+    const headSha = liveHeads[Math.min(pullRequestRead, liveHeads.length - 1)];
+    pullRequestRead += 1;
+    return {
+      data: {
+        base: { repo: { full_name: "NVIDIA/NemoClaw" } },
+        head: {
+          repo: { full_name: options.headRepository ?? "NVIDIA/NemoClaw" },
+          sha: headSha,
+        },
+        number: PR_NUMBER,
+        state: "open",
+        user: { login: author },
+      },
+    };
+  });
+  const getCollaboratorPermissionLevel = vi.fn(async () => {
+    if (options.permissionError) throw options.permissionError;
+    return {
+      data:
+        (options.permission
+          ? { ...options.permission, user: options.permission.user ?? { login: author } }
+          : undefined) ??
+        ({
+          permission: "write",
+          role_name: "write",
+          user: { login: author },
+        } as const),
+    };
+  });
+  const listWorkflowRunsForRepo = vi.fn(async () => {
+    const runs = options.runsByPoll?.[workflowRunPoll] ?? [];
+    workflowRunPoll += 1;
+    return { data: { total_count: runs.length, workflow_runs: runs } };
+  });
+  const approveWorkflowRun = vi.fn().mockResolvedValue({ status: 201 });
+  const paginate = vi.fn(
+    async (
+      endpoint: () => Promise<{ data: { workflow_runs: unknown[] } }>,
+      _parameters: Record<string, unknown>,
+    ) => (await endpoint()).data.workflow_runs,
+  );
+  const info = vi.fn();
+  const warning = vi.fn();
+  const setTimeout = vi.fn((resolve: () => void, _delay: number) => {
+    resolve();
+    return 0;
+  });
+
+  return {
+    approveWorkflowRun,
+    context: {
+      payload: {
+        pull_request: {
+          head: { sha: options.eventHead ?? HEAD_SHA },
+          number: PR_NUMBER,
+        },
+      },
+      repo: { owner: "NVIDIA", repo: "NemoClaw" },
+    },
+    core: { info, warning },
+    getCollaboratorPermissionLevel,
+    getPullRequest,
+    github: {
+      paginate,
+      rest: {
+        actions: { approveWorkflowRun, listWorkflowRunsForRepo },
+        pulls: { get: getPullRequest },
+        repos: { getCollaboratorPermissionLevel },
+      },
+    },
+    info,
+    listWorkflowRunsForRepo,
+    paginate,
+    setTimeout,
+    warning,
+  };
+}
+
+async function runScript(harness: ReturnType<typeof createHarness>): Promise<void> {
+  expect(script).toEqual(expect.any(String));
+  await new AsyncFunction("github", "context", "core", "setTimeout", script as string)(
+    harness.github,
+    harness.context,
+    harness.core,
+    harness.setTimeout,
+  );
+}
+
+describe("maintainer PR workflow-run approval", () => {
+  // source-shape-contract: security -- The write-capable pull_request_target workflow must keep its exact trigger, permission, action, and no-checkout execution boundary
+  it("keeps workflow approval inside the trusted metadata boundary", () => {
+    expect(workflow.on?.pull_request_target).toEqual({
+      branches: ["main"],
+      types: ["opened", "synchronize", "reopened", "edited", "ready_for_review"],
+    });
+    expect(workflow.permissions).toEqual({
+      actions: "write",
+      contents: "read",
+      "pull-requests": "read",
+    });
+    expect(workflow.concurrency).toEqual({
+      group:
+        "approve-maintainer-pr-workflow-runs-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}",
+      "cancel-in-progress": false,
+    });
+    expect(job.if).toBe("${{ github.repository == 'NVIDIA/NemoClaw' }}");
+    expect(job["timeout-minutes"]).toBe(2);
+    expect(job.steps).toHaveLength(1);
+    expect(actionStep?.uses).toMatch(/^actions\/github-script@[0-9a-f]{40}$/u);
+    expect(job.steps?.some((step) => step.uses?.startsWith("actions/checkout@"))).toBe(false);
+    expect(job.steps?.some((step) => typeof step.run === "string")).toBe(false);
+    expect(script).not.toContain("github.rest.repos.getContent");
+    expect(script).not.toContain("github.rest.git");
+    expect(script).not.toContain("require(");
+  });
+
+  it.each([
+    ["write", { permission: "write", role_name: "custom-write" }],
+    ["maintain", { permission: "write", role_name: "maintain" }],
+    ["admin", { permission: "admin", role_name: "admin" }],
+  ])("approves an exact same-repository bot-restack run for a PR author with %s permission", async (_name, role) => {
+    const harness = createHarness({
+      permission: { ...role, user: { login: "MAINTAINER" } },
+      runsByPoll: [[actionRequiredRun(101)]],
+    });
+
+    await runScript(harness);
+
+    expect(harness.getCollaboratorPermissionLevel).toHaveBeenCalledWith({
+      owner: "NVIDIA",
+      repo: "NemoClaw",
+      username: "maintainer",
+    });
+    expect(harness.approveWorkflowRun).toHaveBeenCalledOnce();
+    expect(harness.approveWorkflowRun).toHaveBeenCalledWith({
+      owner: "NVIDIA",
+      repo: "NemoClaw",
+      run_id: 101,
+    });
+  });
+
+  it("polls boundedly and approves exact-head runs that appear asynchronously", async () => {
+    const firstRun = actionRequiredRun(101);
+    const secondRun = actionRequiredRun(102);
+    const harness = createHarness({
+      runsByPoll: [[], [firstRun], [firstRun], [firstRun, secondRun]],
+    });
+
+    await runScript(harness);
+
+    expect(harness.listWorkflowRunsForRepo).toHaveBeenCalledTimes(12);
+    expect(harness.paginate).toHaveBeenCalledWith(harness.listWorkflowRunsForRepo, {
+      event: "pull_request",
+      head_sha: HEAD_SHA,
+      owner: "NVIDIA",
+      per_page: 100,
+      repo: "NemoClaw",
+      status: "action_required",
+    });
+    expect(harness.setTimeout).toHaveBeenCalledTimes(11);
+    expect(harness.setTimeout).toHaveBeenCalledWith(expect.any(Function), 5000);
+    expect(harness.approveWorkflowRun.mock.calls.map(([input]) => input.run_id)).toEqual([
+      101, 102,
+    ]);
+  });
+
+  it.each([
+    ["read permission", { permission: { permission: "read", role_name: "maintain" } }],
+    ["no collaborator record", { permissionError: { status: 404 } }],
+  ])("leaves an external author's runs gated for %s", async (_name, options) => {
+    const harness = createHarness({
+      author: "external-contributor",
+      ...options,
+      runsByPoll: [[actionRequiredRun(101)]],
+    });
+
+    await runScript(harness);
+
+    expect(harness.listWorkflowRunsForRepo).not.toHaveBeenCalled();
+    expect(harness.approveWorkflowRun).not.toHaveBeenCalled();
+    expect(harness.info).toHaveBeenCalledWith(
+      expect.stringContaining("workflow runs remain gated"),
+    );
+  });
+
+  it("does not approve from a stale pull_request_target event", async () => {
+    const harness = createHarness({ liveHeads: [MOVED_HEAD_SHA] });
+
+    await runScript(harness);
+
+    expect(harness.getCollaboratorPermissionLevel).not.toHaveBeenCalled();
+    expect(harness.listWorkflowRunsForRepo).not.toHaveBeenCalled();
+    expect(harness.approveWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it("leaves a write-author PR gated when an external repository controls its head", async () => {
+    const harness = createHarness({
+      headRepository: "external-contributor/NemoClaw",
+      runsByPoll: [[actionRequiredRun(101)]],
+    });
+
+    await runScript(harness);
+
+    expect(harness.getCollaboratorPermissionLevel).not.toHaveBeenCalled();
+    expect(harness.listWorkflowRunsForRepo).not.toHaveBeenCalled();
+    expect(harness.approveWorkflowRun).not.toHaveBeenCalled();
+    expect(harness.info).toHaveBeenCalledWith(
+      expect.stringContaining("head repository is not NVIDIA/NemoClaw"),
+    );
+  });
+
+  it("stops when the live PR head changes before approval", async () => {
+    const harness = createHarness({
+      liveHeads: [HEAD_SHA, HEAD_SHA, MOVED_HEAD_SHA],
+      runsByPoll: [[actionRequiredRun(101)]],
+    });
+
+    await runScript(harness);
+
+    expect(harness.approveWorkflowRun).not.toHaveBeenCalled();
+    expect(harness.warning).toHaveBeenCalledWith(
+      expect.stringContaining("head changed before workflow-run approval"),
+    );
+  });
+
+  it("stops when the PR author loses write permission before approval", async () => {
+    const harness = createHarness({ runsByPoll: [[actionRequiredRun(101)]] });
+    harness.getCollaboratorPermissionLevel
+      .mockResolvedValueOnce({
+        data: { permission: "write", role_name: "write", user: { login: "maintainer" } },
+      })
+      .mockResolvedValueOnce({
+        data: { permission: "read", role_name: "triage", user: { login: "maintainer" } },
+      });
+
+    await runScript(harness);
+
+    expect(harness.approveWorkflowRun).not.toHaveBeenCalled();
+    expect(harness.warning).toHaveBeenCalledWith(
+      expect.stringContaining("no longer has write, maintain, or admin permission"),
+    );
+  });
+
+  it("ignores runs that do not bind the exact PR number and head SHA", async () => {
+    const harness = createHarness({
+      runsByPoll: [
+        [
+          actionRequiredRun(101, {
+            pull_requests: [{ head: { sha: HEAD_SHA }, number: PR_NUMBER + 1 }],
+          }),
+          actionRequiredRun(102, {
+            pull_requests: [{ head: { sha: MOVED_HEAD_SHA }, number: PR_NUMBER }],
+          }),
+          actionRequiredRun(103, { head_sha: MOVED_HEAD_SHA }),
+          actionRequiredRun(104, { conclusion: "success" }),
+          actionRequiredRun(105, { event: "workflow_dispatch" }),
+          actionRequiredRun(106, {
+            head_repository: { full_name: "external-contributor/NemoClaw" },
+          }),
+        ],
+      ],
+    });
+
+    await runScript(harness);
+
+    expect(harness.approveWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it("rejects a permission response for a different user", async () => {
+    const harness = createHarness({
+      permission: {
+        permission: "admin",
+        role_name: "admin",
+        user: { login: "different-user" },
+      },
+    });
+
+    await expect(runScript(harness)).rejects.toThrow(
+      "Permission response did not match PR author maintainer",
+    );
+    expect(harness.listWorkflowRunsForRepo).not.toHaveBeenCalled();
+    expect(harness.approveWorkflowRun).not.toHaveBeenCalled();
+  });
+});

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -64,6 +64,7 @@ const OPAQUE_INPUTS = [
   "test/e2e/docs/parity-inventory.generated.json",
   ".github/workflows/e2e.yaml",
   ".github/workflows/code-scanning.yaml",
+  ".github/workflows/approve-maintainer-pr-workflow-runs.yaml",
   ".github/workflows/pr-e2e-gate.yaml",
   ".github/workflows/pr-review-advisor.yaml",
   "tools/pr-review-advisor/openshell-policy.yaml",
@@ -130,6 +131,9 @@ describe("Vitest opaque-input watch triggers", () => {
     expect(triggeredBy(".github/workflows/e2e.yaml")).toEqual(E2E_WORKFLOW_CONTRACTS);
     expect(triggeredBy(".github/workflows/code-scanning.yaml")).toEqual([
       "test/code-scanning-workflow.test.ts",
+    ]);
+    expect(triggeredBy(".github/workflows/approve-maintainer-pr-workflow-runs.yaml")).toEqual([
+      "test/maintainer-pr-workflow-approval.test.ts",
     ]);
     expect(triggeredBy(".github/workflows/pr-e2e-gate.yaml")).toEqual([
       "test/pr-e2e-gate-workflow.test.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->
Maintainer-authored, same-repository pull requests can currently strand their `pull_request` workflow runs in `ACTION_REQUIRED` after an automated restack. This change adds a trusted metadata-only controller that approves only exact-head runs for live write, maintain, or admin authors while leaving external authors and external-head repositories gated.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->
- Add a pinned `pull_request_target` controller with only `actions: write`, `contents: read`, and `pull-requests: read` permissions.
- Bind approval to the live PR number, current head SHA, same-repository head provenance, current author permission, and matching workflow-run metadata.
- Poll for asynchronously created `ACTION_REQUIRED` runs for a bounded 55-second window without checking out or executing pull-request code.
- Cover maintainer roles, stacked PR bases, bot restacks, external authors and heads, stale heads, permission revocation, and mismatched workflow-run associations.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal GitHub approval automation and its executable contract tests; it does not change NemoClaw CLI, configuration, runtime behavior, or user-facing documentation.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop review of exact head `f876009` confirmed the same-repository provenance, coarse permission, exact-head, pinned-action, and no-checkout boundaries after the stacked-branch trigger fix; no security findings remain.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change is limited to internal GitHub approval automation, inline policy comments, and contract tests; no CLI or user-facing behavior changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f876009 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/maintainer-pr-workflow-approval.test.ts test/vitest-watch-triggers.test.ts` passed 2 files and 18 tests at `f876009`; YAML, Biome, test-conditionals, source-shape, test-size, and test-title checks also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated approval handling for eligible maintainer pull request workflow runs.
  * Approvals are restricted to verified, current pull request commits and stop when repository, author, or permission details change.
  * Added safeguards to prevent duplicate approvals and limit approval attempts.

* **Tests**
  * Added comprehensive coverage for security checks, polling behavior, stale events, external branches, filtering, and permission changes.
  * Added monitoring to ensure the workflow remains covered by automated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->