### PR TITLE
test(e2e): cover Hermes managed policy changes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5024,7 +5024,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        agent: [openclaw]
+        agent: [openclaw, hermes]
     env:
       E2E_JOB: "1"
       E2E_TARGET_ID: "bedrock-runtime-compatible-anthropic"
@@ -5039,6 +5039,26 @@ jobs:
       NEMOCLAW_SANDBOX_NAME: e2e-bedrock-${{ matrix.agent }}
       OPENSHELL_GATEWAY: "nemoclaw"
     steps:
+      - id: trusted_hermes_swap
+        name: Provision trusted Hermes E2E swap
+        if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && matrix.agent == 'hermes' }}
+        shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+        env:
+          BASH_ENV: /dev/null
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+          DISPATCH_SHA: ${{ github.sha }}
+          ENV: /dev/null
+          EVENT_NAME: ${{ github.event_name }}
+          EXPECTED_WORKFLOW_SHA: ${{ inputs.workflow_sha }}
+          LC_ALL: C
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          RUNNER_ARCH_KIND: ${{ runner.arch }}
+          RUNNER_ENVIRONMENT_KIND: ${{ runner.environment }}
+          RUNNER_OS_KIND: ${{ runner.os }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: *trusted-hermes-e2e-swap
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.checkout_repository || github.repository }}
@@ -5052,7 +5072,7 @@ jobs:
 
       - name: Run Bedrock Runtime compatible Anthropic live test
         # Preserves the fake Bedrock Runtime endpoint, /etc/hosts mapping,
-        # source CLI onboard, OpenShell adapter route, OpenClaw runtime probe,
+        # source CLI onboard, OpenShell adapter route, agent runtime probes,
         # and leak-scan contract.
         run: |
           set -euo pipefail

--- a/test/e2e/support/e2e-cross-runtime-compatibility.test.ts
+++ b/test/e2e/support/e2e-cross-runtime-compatibility.test.ts
@@ -45,7 +45,7 @@ describe("cross-runtime foundation compatibility", () => {
     ];
 
     expect(digestOutput(cases.map(buildRiskPlan))).toBe(
-      "39949b976e4ad2315c6d0696419c178367be425699ff657f45a41df0ec9241bd",
+      "80ba8dfc73d0c7568d77338f0061a205a4414858749b33a7a7af6b4b670be8d7",
     );
   });
 });

--- a/test/e2e/support/trusted-hermes-swap-workflow-boundary.test.ts
+++ b/test/e2e/support/trusted-hermes-swap-workflow-boundary.test.ts
@@ -33,6 +33,7 @@ type SwapWorkflow = {
 
 const PROTECTED_JOBS = [
   "agent-turn-latency",
+  "bedrock-runtime-compatible-anthropic",
   "channels-stop-start",
   "common-egress-agent",
   "hermes-discord",

--- a/test/pr-e2e-gate-shards.test.ts
+++ b/test/pr-e2e-gate-shards.test.ts
@@ -27,7 +27,7 @@ function temporaryE2eWorkflow(source: string): string {
 describe("PR E2E shard policy", () => {
   it("derives Bedrock signal shards from the agent matrix (#6938)", () => {
     expect(expectedSignalShards(["bedrock-runtime-compatible-anthropic"])).toEqual({
-      "bedrock-runtime-compatible-anthropic": ["openclaw"],
+      "bedrock-runtime-compatible-anthropic": ["openclaw", "hermes"],
     });
   });
 

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -16,6 +16,25 @@ import {
 import { classifyTestDepth } from "../tools/pr-review-advisor/analyze.mts";
 
 const HEAD_SHA = "a".repeat(40);
+const HERMES_MANAGED_POLICY_JOBS = [
+  "bedrock-runtime-compatible-anthropic",
+  "channels-stop-start",
+  "dashboard-remote-bind",
+  "hermes-e2e",
+  "hermes-inference-switch",
+  "hermes-shields-config",
+  "security-posture",
+];
+const HERMES_MANAGED_POLICY_FILES = [
+  "agents/hermes/config/managed-policy.ts",
+  "agents/hermes/hermes-wrapper.py",
+  "agents/hermes/image-build-probes.py",
+  "agents/hermes/managed_policy.py",
+  "agents/hermes/patch-profile-policy-defaults.py",
+  "agents/hermes/seed-dashboard-config.py",
+  "agents/hermes/start.sh",
+  "src/lib/hermes-managed-route.ts",
+];
 
 function plan(...changedFiles: string[]) {
   return buildRiskPlan({ headSha: HEAD_SHA, changedFiles });
@@ -117,41 +136,28 @@ describe("deterministic PR risk plan", () => {
     ]);
   });
 
-  it("selects every Hermes managed-policy live E2E job (#8008)", () => {
-    const changedFiles = [
-      "agents/hermes/config/managed-policy.ts",
-      "agents/hermes/managed_policy.py",
-      "agents/hermes/seed-dashboard-config.py",
-      "src/lib/hermes-managed-route.ts",
-    ];
-    const result = plan(...changedFiles);
+  it.each(
+    HERMES_MANAGED_POLICY_FILES,
+  )("selects every Hermes managed-policy live E2E job for %s (#8008)", (changedFile) => {
+    const result = plan(changedFile);
 
     expect(result.families).toContainEqual(
       expect.objectContaining({
         id: "focused-e2e",
-        matchedFiles: changedFiles,
-        requiredJobs: [
-          "bedrock-runtime-compatible-anthropic",
-          "channels-stop-start",
-          "dashboard-remote-bind",
-          "hermes-e2e",
-          "hermes-inference-switch",
-          "hermes-shields-config",
-          "security-posture",
-        ],
+        matchedFiles: [changedFile],
+        requiredJobs: HERMES_MANAGED_POLICY_JOBS,
       }),
     );
     expect(riskPlanRequiredJobIds(result)).toEqual(
-      expect.arrayContaining([
-        "bedrock-runtime-compatible-anthropic",
-        "channels-stop-start",
-        "dashboard-remote-bind",
-        "hermes-e2e",
-        "hermes-inference-switch",
-        "hermes-shields-config",
-        "security-posture",
-      ]),
+      expect.arrayContaining(HERMES_MANAGED_POLICY_JOBS),
     );
+  });
+
+  it("does not select managed-policy E2E for an unrelated Hermes runtime file (#8008)", () => {
+    const result = plan("agents/hermes/runtime-version.py");
+
+    expect(result.families).not.toContainEqual(expect.objectContaining({ id: "focused-e2e" }));
+    expect(riskPlanRequiredJobIds(result)).toEqual(["full-e2e", "hermes-e2e", "security-posture"]);
   });
 
   it("leaves E2E support-only changes in the fast e2e-support project (#7921)", () => {

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -27,7 +27,7 @@ describe("deterministic PR risk plan", () => {
     const second = plan("src/lib/onboard.ts", "src/lib/state/registry.ts");
 
     expect(first).toEqual(second);
-    expect(first.version).toBe(10);
+    expect(first.version).toBe(11);
     expect(first.headSha).toBe(HEAD_SHA);
     expect(first.planHash).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.changedFiles).toEqual(["src/lib/onboard.ts", "src/lib/state/registry.ts"]);
@@ -115,6 +115,43 @@ describe("deterministic PR risk plan", () => {
       "onboard-repair",
       "onboard-resume",
     ]);
+  });
+
+  it("selects every Hermes managed-policy live E2E job (#8008)", () => {
+    const changedFiles = [
+      "agents/hermes/config/managed-policy.ts",
+      "agents/hermes/managed_policy.py",
+      "agents/hermes/seed-dashboard-config.py",
+      "src/lib/hermes-managed-route.ts",
+    ];
+    const result = plan(...changedFiles);
+
+    expect(result.families).toContainEqual(
+      expect.objectContaining({
+        id: "focused-e2e",
+        matchedFiles: changedFiles,
+        requiredJobs: [
+          "bedrock-runtime-compatible-anthropic",
+          "channels-stop-start",
+          "dashboard-remote-bind",
+          "hermes-e2e",
+          "hermes-inference-switch",
+          "hermes-shields-config",
+          "security-posture",
+        ],
+      }),
+    );
+    expect(riskPlanRequiredJobIds(result)).toEqual(
+      expect.arrayContaining([
+        "bedrock-runtime-compatible-anthropic",
+        "channels-stop-start",
+        "dashboard-remote-bind",
+        "hermes-e2e",
+        "hermes-inference-switch",
+        "hermes-shields-config",
+        "security-posture",
+      ]),
+    );
   });
 
   it("leaves E2E support-only changes in the fast e2e-support project (#7921)", () => {

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -3,7 +3,7 @@
 
 import { createHash } from "node:crypto";
 
-export const RISK_PLAN_VERSION = 10 as const;
+export const RISK_PLAN_VERSION = 11 as const;
 
 export const PR_E2E_TYPED_TARGET_IDS = [
   "ubuntu-repo-cloud-langchain-deepagents-code",
@@ -25,6 +25,24 @@ const MANAGED_STARTUP_E2E_JOB_IDS = [
   "issue-4462-scope-upgrade-approval",
   "openclaw-inference-switch",
 ] as const;
+const HERMES_MANAGED_POLICY_E2E_JOB_IDS = [
+  "bedrock-runtime-compatible-anthropic",
+  "channels-stop-start",
+  "dashboard-remote-bind",
+  "hermes-e2e",
+  "hermes-inference-switch",
+  "hermes-shields-config",
+  "security-posture",
+] as const;
+const HERMES_MANAGED_POLICY_FILES = new Set([
+  "agents/hermes/hermes-wrapper.py",
+  "agents/hermes/image-build-probes.py",
+  "agents/hermes/managed_policy.py",
+  "agents/hermes/patch-profile-policy-defaults.py",
+  "agents/hermes/seed-dashboard-config.py",
+  "agents/hermes/start.sh",
+  "src/lib/hermes-managed-route.ts",
+]);
 
 export type RiskTier = 0 | 1 | 2 | 3;
 export type RiskFamilyId =
@@ -165,7 +183,7 @@ export function focusedPrE2eTargetsForChangedFiles(
 export function focusedPrE2eJobsForChangedFiles(
   changedFiles: readonly string[],
 ): TrustedFocusedE2eJob[] {
-  const matchedFiles = stableUnique(
+  const managedStartupFiles = stableUnique(
     changedFiles.filter(
       (file) =>
         (file.startsWith("src/lib/onboard/managed-startup/") ||
@@ -174,8 +192,20 @@ export function focusedPrE2eJobsForChangedFiles(
         isRuntimeRelevant(file),
     ),
   );
-  if (matchedFiles.length === 0) return [];
-  return MANAGED_STARTUP_E2E_JOB_IDS.map((id) => ({ id, matchedFiles }));
+  const hermesManagedPolicyFiles = stableUnique(
+    changedFiles.filter(
+      (file) =>
+        (file.startsWith("agents/hermes/config/") || HERMES_MANAGED_POLICY_FILES.has(file)) &&
+        isRuntimeRelevant(file),
+    ),
+  );
+  return [
+    ...MANAGED_STARTUP_E2E_JOB_IDS.map((id) => ({ id, matchedFiles: managedStartupFiles })),
+    ...HERMES_MANAGED_POLICY_E2E_JOB_IDS.map((id) => ({
+      id,
+      matchedFiles: hermesManagedPolicyFiles,
+    })),
+  ].filter((selection) => selection.matchedFiles.length > 0);
 }
 
 export const RISK_RULES: readonly RiskRule[] = [

--- a/tools/e2e/trusted-hermes-swap-workflow-boundary.mts
+++ b/tools/e2e/trusted-hermes-swap-workflow-boundary.mts
@@ -219,6 +219,7 @@ export const TRUSTED_HERMES_SWAP_SCRIPT = [
 
 const JOB_CONDITIONS = {
   "agent-turn-latency": `\${{ ${TRUSTED_HERMES_SWAP_IF} }}`,
+  "bedrock-runtime-compatible-anthropic": `\${{ ${TRUSTED_HERMES_SWAP_IF} && matrix.agent == 'hermes' }}`,
   "channels-stop-start": `\${{ ${TRUSTED_HERMES_SWAP_IF} && matrix.agent == 'hermes' }}`,
   "common-egress-agent": `\${{ ${TRUSTED_HERMES_SWAP_IF} && matrix.scenario == 'hermes-open-reference' }}`,
   "hermes-discord": `\${{ ${TRUSTED_HERMES_SWAP_IF} }}`,

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -44,10 +44,7 @@ import { validateRunnerComparisonWorkflowBoundary } from "./runner-comparison-wo
 import { validateRunnerPressureWorkflow } from "./runner-pressure-workflow-boundary.mts";
 import { validateSandboxOperationsWorkflow } from "./sandbox-operations-workflow-boundary.mts";
 import { validateSecurityPostureWorkflow } from "./security-posture-workflow-boundary.mts";
-import {
-  normalizeE2eSelectorIds,
-  selectorsForCanonicalE2eId,
-} from "./selector-aliases.mts";
+import { normalizeE2eSelectorIds, selectorsForCanonicalE2eId } from "./selector-aliases.mts";
 import {
   validateTrustedHermesSwapHelperSource,
   validateTrustedHermesSwapWorkflow,
@@ -3735,8 +3732,8 @@ function validateBedrockRuntimeCompatibleAnthropicJob(
     errors.push("bedrock-runtime-compatible-anthropic strategy.fail-fast must be false");
   }
   const matrix = asRecord(strategy.matrix);
-  if (!Array.isArray(matrix.agent) || matrix.agent.join(",") !== "openclaw") {
-    errors.push("bedrock-runtime-compatible-anthropic matrix.agent must be openclaw");
+  if (!Array.isArray(matrix.agent) || matrix.agent.join(",") !== "openclaw,hermes") {
+    errors.push("bedrock-runtime-compatible-anthropic matrix.agent must be openclaw,hermes");
   }
 
   const jobEnv = asRecord(job.env);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes managed-policy changes currently receive only the generic sandbox E2E floor, and the Bedrock Runtime compatible Anthropic job runs only its OpenClaw shard. This change selects every live E2E job required by #8008 and enables the existing Hermes-aware Bedrock test through the trusted Hermes runner setup.

## Changes

- Select the seven Hermes managed-policy live E2E jobs when the policy generator, schema, consumers, or validation probes change.
- Run the Bedrock Runtime compatible Anthropic job for OpenClaw and Hermes.
- Provision the existing trusted Hermes swap before checkout for the Hermes Bedrock shard.
- Pin the expanded job set, shard set, workflow matrix, and trusted-runner condition in boundary tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes maintainer-owned PR risk planning and trusted live E2E execution only. It does not change a supported user-facing API, CLI, configuration, workflow, default, or error.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the completed diff through commit `e2a01b309` against the nine-category security checklist. No findings were identified; trusted dispatch conditions remain exact, fork-controlled code does not run before the trusted swap step, no new secrets are exposed, and gitleaks passed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change only updates maintainer-owned PR risk planning, workflow boundaries, trusted live E2E selection, and their regression coverage. It does not change a supported user-facing API, CLI, configuration, workflow, default, or error.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e2a01b309 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 83 focused risk-plan and compatibility tests passed; the affected `e2e-support` lane passed. The earlier complete PR E2E controller and risk-plan suite passed 302 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bedrock Runtime-compatible Anthropic end-to-end testing now supports both OpenClaw and Hermes agents.
  * Hermes test runs include trusted environment validation before execution.

* **Bug Fixes**
  * Improved change detection so relevant Hermes policy updates select all required end-to-end jobs.
  * Updated risk and workflow checks to cover the expanded agent test matrix.
  * Refined runtime compatibility validation for the expanded testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->