### PR TITLE
fix(ci): provision pinned Pi search tools

### DIFF
--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -57,6 +57,45 @@ runs:
         node-version: "22"
         cache: npm
 
+    - name: Install pinned Pi search tools
+      shell: bash
+      env:
+        FD_FIND_VERSION: "9.0.0-1"
+        RIPGREP_VERSION: "14.1.0-1"
+      run: |
+        set -euo pipefail
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends \
+          "fd-find=${FD_FIND_VERSION}" \
+          "ripgrep=${RIPGREP_VERSION}"
+
+        INSTALLED_FD_FIND_VERSION="$(dpkg-query -W -f='${Version}' fd-find)"
+        INSTALLED_RIPGREP_VERSION="$(dpkg-query -W -f='${Version}' ripgrep)"
+        if [ "$INSTALLED_FD_FIND_VERSION" != "$FD_FIND_VERSION" ]; then
+          echo "::error::fd-find package version $INSTALLED_FD_FIND_VERSION does not match $FD_FIND_VERSION"
+          exit 1
+        fi
+        if [ "$INSTALLED_RIPGREP_VERSION" != "$RIPGREP_VERSION" ]; then
+          echo "::error::ripgrep package version $INSTALLED_RIPGREP_VERSION does not match $RIPGREP_VERSION"
+          exit 1
+        fi
+
+        command -v fdfind >/dev/null
+        command -v rg >/dev/null
+        EXPECTED_FD_BINARY_VERSION="${FD_FIND_VERSION%%-*}"
+        EXPECTED_RG_BINARY_VERSION="${RIPGREP_VERSION%%-*}"
+        FD_BINARY_VERSION="$(fdfind --version)"
+        RG_BINARY_VERSION="$(rg --version)"
+        RG_BINARY_VERSION="${RG_BINARY_VERSION%%$'\n'*}"
+        if [ "$FD_BINARY_VERSION" != "fdfind $EXPECTED_FD_BINARY_VERSION" ]; then
+          echo "::error::fdfind binary version $FD_BINARY_VERSION does not match fdfind $EXPECTED_FD_BINARY_VERSION"
+          exit 1
+        fi
+        if [ "$RG_BINARY_VERSION" != "ripgrep $EXPECTED_RG_BINARY_VERSION" ]; then
+          echo "::error::rg binary version $RG_BINARY_VERSION does not match ripgrep $EXPECTED_RG_BINARY_VERSION"
+          exit 1
+        fi
+
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -136,7 +136,7 @@ jobs:
         run: npx vitest run --project integration test/openclaw-security-audit-suppressions-real.test.ts --silent=false --reporter=default
 
   cli-test-shards:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -374,7 +374,7 @@ jobs:
   cli-test-shards:
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -411,6 +411,54 @@ jobs:
             echo "e2e-support=true" >> "$GITHUB_OUTPUT"
           else
             echo "e2e-support=false" >> "$GITHUB_OUTPUT"
+          fi
+          if grep -Fq -- 'name: Install pinned Pi search tools' \
+            .trusted-ci-actions/.github/actions/ci-cli-coverage-shard/action.yaml; then
+            echo "pi-search-tools=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pi-search-tools=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The PR action comes from the base commit. Provision Pi's search tools here until
+      # the trusted action contains the same pinned, version-verified contract.
+      - name: Install pinned Pi search tools (bootstrap)
+        if: ${{ steps.trusted-shard-capabilities.outputs.pi-search-tools != 'true' }}
+        shell: bash
+        env:
+          FD_FIND_VERSION: "9.0.0-1"
+          RIPGREP_VERSION: "14.1.0-1"
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            "fd-find=${FD_FIND_VERSION}" \
+            "ripgrep=${RIPGREP_VERSION}"
+
+          INSTALLED_FD_FIND_VERSION="$(dpkg-query -W -f='${Version}' fd-find)"
+          INSTALLED_RIPGREP_VERSION="$(dpkg-query -W -f='${Version}' ripgrep)"
+          if [ "$INSTALLED_FD_FIND_VERSION" != "$FD_FIND_VERSION" ]; then
+            echo "::error::fd-find package version $INSTALLED_FD_FIND_VERSION does not match $FD_FIND_VERSION"
+            exit 1
+          fi
+          if [ "$INSTALLED_RIPGREP_VERSION" != "$RIPGREP_VERSION" ]; then
+            echo "::error::ripgrep package version $INSTALLED_RIPGREP_VERSION does not match $RIPGREP_VERSION"
+            exit 1
+          fi
+
+          command -v fdfind >/dev/null
+          command -v rg >/dev/null
+          EXPECTED_FD_BINARY_VERSION="${FD_FIND_VERSION%%-*}"
+          EXPECTED_RG_BINARY_VERSION="${RIPGREP_VERSION%%-*}"
+          FD_BINARY_VERSION="$(fdfind --version)"
+          RG_BINARY_VERSION="$(rg --version)"
+          RG_BINARY_VERSION="${RG_BINARY_VERSION%%$'\n'*}"
+          if [ "$FD_BINARY_VERSION" != "fdfind $EXPECTED_FD_BINARY_VERSION" ]; then
+            echo "::error::fdfind binary version $FD_BINARY_VERSION does not match fdfind $EXPECTED_FD_BINARY_VERSION"
+            exit 1
+          fi
+          if [ "$RG_BINARY_VERSION" != "ripgrep $EXPECTED_RG_BINARY_VERSION" ]; then
+            echo "::error::rg binary version $RG_BINARY_VERSION does not match ripgrep $EXPECTED_RG_BINARY_VERSION"
+            exit 1
           fi
 
       - name: Run CLI coverage shard

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -42,6 +42,11 @@
       "category": "security"
     },
     {
+      "file": "test/ci-cli-coverage-pi-tools-workflow.test.ts",
+      "test": "installs pinned fd and ripgrep before CLI coverage can invoke Pi",
+      "category": "security"
+    },
+    {
       "file": "test/cloudflared-update-check-workflow.test.ts",
       "test": "keeps automatic and on-demand update checks reachable and credential-free",
       "category": "security"

--- a/test/ci-cli-coverage-pi-tools-workflow.test.ts
+++ b/test/ci-cli-coverage-pi-tools-workflow.test.ts
@@ -22,8 +22,8 @@ const mainWorkflow = readYaml<PullRequestWorkflow>(".github/workflows/main.yaml"
 
 function requiredStep(steps: WorkflowStep[], name: string): WorkflowStep {
   const step = steps.find((candidate) => candidate.name === name);
-  if (!step) throw new Error(`Missing workflow step: ${name}`);
-  return step;
+  expect(step, `Missing workflow step: ${name}`).toBeDefined();
+  return step as WorkflowStep;
 }
 
 function fakeCommand(directory: string, name: string, source: string): void {

--- a/test/ci-cli-coverage-pi-tools-workflow.test.ts
+++ b/test/ci-cli-coverage-pi-tools-workflow.test.ts
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  type CompositeAction,
+  readYaml,
+  type WorkflowJob,
+  type WorkflowStep,
+} from "./helpers/e2e-workflow-contract";
+
+type PullRequestWorkflow = { jobs: Record<string, WorkflowJob> };
+
+const action = readYaml<CompositeAction>(".github/actions/ci-cli-coverage-shard/action.yaml");
+const pullRequestWorkflow = readYaml<PullRequestWorkflow>(".github/workflows/pr.yaml");
+const mainWorkflow = readYaml<PullRequestWorkflow>(".github/workflows/main.yaml");
+
+function requiredStep(steps: WorkflowStep[], name: string): WorkflowStep {
+  const step = steps.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+function fakeCommand(directory: string, name: string, source: string): void {
+  writeFileSync(join(directory, name), source, { mode: 0o755 });
+}
+
+describe("CLI coverage Pi search-tool provisioning", () => {
+  // source-shape-contract: security -- Base-trusted and bootstrap paths must share one pinned, verified tool contract before untrusted tests invoke Pi
+  it("installs pinned fd and ripgrep before CLI coverage can invoke Pi", () => {
+    const actionSteps = action.runs.steps;
+    const pullRequestJob = pullRequestWorkflow.jobs["cli-test-shards"];
+    const mainJob = mainWorkflow.jobs["cli-test-shards"];
+    const jobSteps = pullRequestJob.steps ?? [];
+    const install = requiredStep(actionSteps, "Install pinned Pi search tools");
+    const detect = requiredStep(jobSteps, "Detect trusted E2E support sharding");
+    const bootstrap = requiredStep(jobSteps, "Install pinned Pi search tools (bootstrap)");
+
+    expect(install.env).toEqual({
+      FD_FIND_VERSION: "9.0.0-1",
+      RIPGREP_VERSION: "14.1.0-1",
+    });
+    expect(pullRequestJob["runs-on"]).toBe("ubuntu-24.04");
+    expect(mainJob["runs-on"]).toBe("ubuntu-24.04");
+    expect(actionSteps.indexOf(install)).toBeLessThan(
+      actionSteps.indexOf(requiredStep(actionSteps, "Install dependencies")),
+    );
+    expect(actionSteps.indexOf(install)).toBeLessThan(
+      actionSteps.indexOf(requiredStep(actionSteps, "Run CLI coverage and E2E support shard")),
+    );
+    expect(detect.run).toContain("name: Install pinned Pi search tools");
+    expect(detect.run).toContain('echo "pi-search-tools=true" >> "$GITHUB_OUTPUT"');
+    expect(detect.run).toContain('echo "pi-search-tools=false" >> "$GITHUB_OUTPUT"');
+    expect(bootstrap.if).toBe(
+      "${{ steps.trusted-shard-capabilities.outputs.pi-search-tools != 'true' }}",
+    );
+    expect(bootstrap.env).toEqual(install.env);
+    expect(bootstrap.run).toBe(install.run);
+    expect(jobSteps.indexOf(bootstrap)).toBeLessThan(
+      jobSteps.indexOf(requiredStep(jobSteps, "Run CLI coverage shard")),
+    );
+
+    const temp = mkdtempSync(join(tmpdir(), "nemoclaw-cli-pi-tools-install-"));
+    const fakeBin = join(temp, "bin");
+    const callLog = join(temp, "calls.log");
+    mkdirSync(fakeBin);
+    fakeCommand(fakeBin, "sudo", '#!/bin/bash\nprintf \'sudo %s\\n\' "$*" >> "$CALL_LOG"\n');
+    fakeCommand(
+      fakeBin,
+      "dpkg-query",
+      `#!/bin/bash
+printf 'dpkg-query %s\\n' "$*" >> "$CALL_LOG"
+case "$*" in
+  *fd-find) printf '%s' "$FD_FIND_VERSION" ;;
+  *ripgrep) printf '%s' "$RIPGREP_VERSION" ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+    fakeCommand(
+      fakeBin,
+      "fdfind",
+      "#!/bin/bash\nprintf 'fdfind %s\\n' \"$*\" >> \"$CALL_LOG\"\nprintf 'fdfind 9.0.0\\n'\n",
+    );
+    fakeCommand(
+      fakeBin,
+      "rg",
+      "#!/bin/bash\nprintf 'rg %s\\n' \"$*\" >> \"$CALL_LOG\"\nprintf 'ripgrep 14.1.0\\n-SIMD -AVX\\n'\n",
+    );
+
+    try {
+      const result = spawnSync("bash", ["-c", install.run ?? ""], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...install.env,
+          CALL_LOG: callLog,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+        timeout: 5_000,
+      });
+      expect(result.status, String(result.stderr)).toBe(0);
+      const calls = readFileSync(callLog, "utf8");
+      expect(calls).toContain("sudo apt-get update -qq");
+      expect(calls).toContain(
+        "sudo apt-get install -y --no-install-recommends fd-find=9.0.0-1 ripgrep=14.1.0-1",
+      );
+      expect(calls).toContain("dpkg-query -W -f=${Version} fd-find");
+      expect(calls).toContain("dpkg-query -W -f=${Version} ripgrep");
+      expect(calls).toContain("fdfind --version");
+      expect(calls).toContain("rg --version");
+    } finally {
+      rmSync(temp, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Makes the CLI coverage shards provision Pi's required filesystem search tools before any untrusted test code runs. This removes the intermittent shard failure where Pi could neither find nor acquire `fd` or `rg` on a GitHub-hosted runner.

The change is limited to CI execution and does not alter NemoClaw runtime behavior or support claims.

## Related Issue

Relates #7744

## Changes

- Pin the affected PR and main CLI shard jobs to Ubuntu 24.04 so the package contract is stable.
- Install exact Noble packages `fd-find=9.0.0-1` and `ripgrep=14.1.0-1` before Pi runs.
- Verify both installed package versions and executable-reported versions, failing closed on drift.
- Add a capability-detected PR bootstrap because pull-request jobs execute the composite action from the base-trusted checkout.
- Suppress the bootstrap once the trusted composite action owns the same exact contract.
- Add an executable workflow contract covering runner selection, ordering, version pins, and bootstrap/action parity.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal CI provisioning only and does not change user-facing NemoClaw behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head review covers the base-trusted action boundary, pre-untrusted-code ordering, immutable runner selection, exact package pins, and fail-closed version verification through an executable contract test.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact-head review found only internal CI provisioning and regression-test changes; no user-facing documentation surface changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9752e3a76 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/ci-cli-coverage-pi-tools-workflow.test.ts test/pr-workflow-contract.test.ts` passed 22/22 on the exact head.
- [x] Applicable broad gate passed — `npm run check:diff`, repository/config validation, source-shape, test-size, project-membership, and test-title checks passed on the exact head.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Risk Plan

- Primary risk: package or runner-image drift could break a CI shard before tests execute.
- Containment: the job is pinned to Ubuntu 24.04 and verifies both exact package and binary versions before invoking Pi.
- Trust boundary: the PR bootstrap runs before the base-trusted composite action only when that action lacks the reviewed capability marker; both paths share byte-identical installation logic.
- Rollback: this five-file CI-only patch is independently revertible.

## Stack

- Base: current `main` at `b76a70d420fc1b316a2313fca0f7d71b5a00f5c8`.
- Exact head: `9752e3a76b698b65f21efe06bb9f03278738bb37`.
- Original reviewed head `e3a2e8685296d82abcea51632cb7f2b4d2aaa724` is retained as append-only ancestry; the first-parent PR patch remains five files, `+215/-2`, with stable patch ID `0e8d44a205201d5e45e2644ebc9b7c50c6454764`.
- This CI reliability fix is independent of runtime activation and does not enable buildless or Podman support.

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * CLI coverage workflows now run on a consistent Ubuntu 24.04 environment.
  * Required search tools are installed at verified, pinned versions when unavailable in the CI environment, improving consistency and reducing unexpected test failures.

* **Testing**
  * Added automated validation for tool availability, version checks, workflow configuration, installation behavior, and execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->