### PR TITLE
test(e2e): require Hermes adapter lifecycle lanes

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -616,13 +616,17 @@ controller completes it as cancelled with `Superseded by PR update` or
 `PR closed — gate no longer applies` and identifies the obsolete head and base.
 The closed-PR outcome also applies when a fork repository was deleted and
 GitHub consequently returns no head-repository object.
-Shared sandbox-boundary changes have a floor of `full-e2e`, `hermes-e2e`, and
-`security-posture`. E2E control-plane changes select `cloud-onboard`,
-`cloud-inference`, and `security-posture`. The `e2e-control-plane`
+Shared sandbox-boundary changes have a floor of `full-e2e`, `hermes-e2e`,
+`hermes-inference-switch`, and `security-posture`. E2E control-plane changes
+select `cloud-onboard`, `cloud-inference`, and `security-posture`. The `e2e-control-plane`
 family remains the conservative boundary for shared E2E tools, workflow and
 security files, unknown live test paths, risk policy, dependency and test
 configuration, and preparation and upload actions. These cross-cutting changes
 keep the broad three-job floor.
+Changes to the Hermes CLI wrapper, adapter manifest, or adapter validator also
+select `channels-stop-start` and `mcp-bridge`. Both jobs include the Hermes
+shard. The shards exercise the adapter during messaging-channel disable/re-enable
+and managed MCP add/restart/remove operations.
 Repository-root `Dockerfile` changes additionally select `full-e2e` alongside
 the platform-install `cloud-onboard` floor so OpenClaw final-image changes run
 through cold onboarding and a real first turn.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -625,8 +625,8 @@ configuration, and preparation and upload actions. These cross-cutting changes
 keep the broad three-job floor.
 Changes to the Hermes CLI wrapper, adapter manifest, or adapter validator also
 select `channels-stop-start` and `mcp-bridge`. Both jobs include the Hermes
-shard. The shards exercise the adapter during messaging-channel disable/re-enable
-and managed MCP add/restart/remove operations.
+shard. The Hermes shards exercise the wrapper during `channels stop` and
+`channels start`, and the adapter during `mcp add`, `mcp restart`, and `mcp remove`.
 Repository-root `Dockerfile` changes additionally select `full-e2e` alongside
 the platform-install `cloud-onboard` floor so OpenClaw final-image changes run
 through cold onboarding and a real first turn.

--- a/test/e2e/support/e2e-cross-runtime-compatibility.test.ts
+++ b/test/e2e/support/e2e-cross-runtime-compatibility.test.ts
@@ -45,7 +45,7 @@ describe("cross-runtime foundation compatibility", () => {
     ];
 
     expect(digestOutput(cases.map(buildRiskPlan))).toBe(
-      "80ba8dfc73d0c7568d77338f0061a205a4414858749b33a7a7af6b4b670be8d7",
+      "b9f2f00f87b7a18caac504048c72eea224c10621690d2cf66549733487d3d342",
     );
   });
 });

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -16,6 +16,13 @@ import {
 import { classifyTestDepth } from "../tools/pr-review-advisor/analyze.mts";
 
 const HEAD_SHA = "a".repeat(40);
+const HERMES_SANDBOX_BOUNDARY_JOBS = [
+  "full-e2e",
+  "hermes-e2e",
+  "hermes-inference-switch",
+  "security-posture",
+];
+const HERMES_CLI_ADAPTER_JOBS = ["channels-stop-start", "mcp-bridge"];
 const HERMES_MANAGED_POLICY_JOBS = [
   "bedrock-runtime-compatible-anthropic",
   "channels-stop-start",
@@ -25,6 +32,28 @@ const HERMES_MANAGED_POLICY_JOBS = [
   "hermes-shields-config",
   "security-posture",
 ];
+const HERMES_CLI_ADAPTER_REQUIRED_JOBS = [
+  ...HERMES_SANDBOX_BOUNDARY_JOBS,
+  ...HERMES_CLI_ADAPTER_JOBS,
+];
+const HERMES_MANAGED_POLICY_REQUIRED_JOBS = [
+  ...HERMES_SANDBOX_BOUNDARY_JOBS,
+  "bedrock-runtime-compatible-anthropic",
+  "channels-stop-start",
+  "dashboard-remote-bind",
+  "hermes-shields-config",
+];
+const HERMES_WRAPPER_FOCUSED_JOBS = [
+  "bedrock-runtime-compatible-anthropic",
+  "channels-stop-start",
+  "dashboard-remote-bind",
+  "hermes-e2e",
+  "hermes-inference-switch",
+  "hermes-shields-config",
+  "mcp-bridge",
+  "security-posture",
+];
+const HERMES_WRAPPER_REQUIRED_JOBS = [...HERMES_MANAGED_POLICY_REQUIRED_JOBS, "mcp-bridge"];
 const HERMES_MANAGED_POLICY_FILES = [
   "agents/hermes/config/managed-policy.ts",
   "agents/hermes/hermes-wrapper.py",
@@ -46,7 +75,7 @@ describe("deterministic PR risk plan", () => {
     const second = plan("src/lib/onboard.ts", "src/lib/state/registry.ts");
 
     expect(first).toEqual(second);
-    expect(first.version).toBe(11);
+    expect(first.version).toBe(12);
     expect(first.headSha).toBe(HEAD_SHA);
     expect(first.planHash).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.changedFiles).toEqual(["src/lib/onboard.ts", "src/lib/state/registry.ts"]);
@@ -136,30 +165,76 @@ describe("deterministic PR risk plan", () => {
     ]);
   });
 
+  it.each([
+    "agents/hermes/hermes-cli-adapter-v1.json",
+    "agents/hermes/hermes-wrapper.py",
+    "agents/hermes/validate-cli-adapter.py",
+  ])("selects Hermes MCP and channel lifecycle E2E for %s (#8011)", (changedFile) => {
+    const result = plan(changedFile);
+    const isWrapper = changedFile === "agents/hermes/hermes-wrapper.py";
+    const expectedFocusedJobs = isWrapper ? HERMES_WRAPPER_FOCUSED_JOBS : HERMES_CLI_ADAPTER_JOBS;
+    const expectedRequiredJobs = isWrapper
+      ? HERMES_WRAPPER_REQUIRED_JOBS
+      : HERMES_CLI_ADAPTER_REQUIRED_JOBS;
+
+    const focusedFamily = result.families.find((family) => family.id === "focused-e2e");
+    expect(focusedFamily).toEqual(
+      expect.objectContaining({
+        matchedFiles: [changedFile],
+        requiredJobs: expectedFocusedJobs,
+      }),
+    );
+    expect(riskPlanRequiredJobIds(result)).toEqual(expectedRequiredJobs);
+  });
+
   it.each(
     HERMES_MANAGED_POLICY_FILES,
   )("selects every Hermes managed-policy live E2E job for %s (#8008)", (changedFile) => {
     const result = plan(changedFile);
+    const isWrapper = changedFile === "agents/hermes/hermes-wrapper.py";
+    const expectedFocusedJobs = isWrapper
+      ? HERMES_WRAPPER_FOCUSED_JOBS
+      : HERMES_MANAGED_POLICY_JOBS;
+    const expectedRequiredJobs = isWrapper
+      ? HERMES_WRAPPER_REQUIRED_JOBS
+      : changedFile === "src/lib/hermes-managed-route.ts"
+        ? HERMES_MANAGED_POLICY_JOBS
+        : HERMES_MANAGED_POLICY_REQUIRED_JOBS;
 
-    expect(result.families).toContainEqual(
+    const focusedFamily = result.families.find((family) => family.id === "focused-e2e");
+    expect(focusedFamily).toEqual(
       expect.objectContaining({
-        id: "focused-e2e",
         matchedFiles: [changedFile],
-        requiredJobs: HERMES_MANAGED_POLICY_JOBS,
+        requiredJobs: expectedFocusedJobs,
       }),
     );
-    expect(riskPlanRequiredJobIds(result)).toEqual(
-      expect.arrayContaining(HERMES_MANAGED_POLICY_JOBS),
-    );
+    expect(riskPlanRequiredJobIds(result)).toEqual(expectedRequiredJobs);
   });
 
   it("does not select managed-policy E2E for an unrelated Hermes runtime file (#8008)", () => {
     const result = plan("agents/hermes/runtime-version.py");
 
     expect(result.families).not.toContainEqual(expect.objectContaining({ id: "focused-e2e" }));
-    expect(riskPlanRequiredJobIds(result)).toEqual(["full-e2e", "hermes-e2e", "security-posture"]);
+    expect(riskPlanRequiredJobIds(result)).toEqual([
+      "full-e2e",
+      "hermes-e2e",
+      "hermes-inference-switch",
+      "security-posture",
+    ]);
   });
 
+  it("combines CLI adapter and managed-policy E2E for the Hermes wrapper (#8011)", () => {
+    const result = plan("agents/hermes/hermes-wrapper.py");
+
+    expect(result.families).toContainEqual(
+      expect.objectContaining({
+        id: "focused-e2e",
+        matchedFiles: ["agents/hermes/hermes-wrapper.py"],
+        requiredJobs: HERMES_WRAPPER_FOCUSED_JOBS,
+      }),
+    );
+    expect(riskPlanRequiredJobIds(result)).toEqual(HERMES_WRAPPER_REQUIRED_JOBS);
+  });
   it("leaves E2E support-only changes in the fast e2e-support project (#7921)", () => {
     const changedFiles = ["test/e2e/support/workflow-plan.test.ts"];
     const focusedE2eJobs = focusedE2eJobsForChangedFiles(changedFiles);
@@ -543,7 +618,12 @@ describe("deterministic PR risk plan", () => {
 
     expect(result.families.map((family) => family.id)).toContain("sandbox-boundary");
     expect(riskPlanRequiredJobIds(result)).toEqual(
-      expect.arrayContaining(["full-e2e", "hermes-e2e", "security-posture"]),
+      expect.arrayContaining([
+        "full-e2e",
+        "hermes-e2e",
+        "hermes-inference-switch",
+        "security-posture",
+      ]),
     );
   });
 

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -3,7 +3,7 @@
 
 import { createHash } from "node:crypto";
 
-export const RISK_PLAN_VERSION = 11 as const;
+export const RISK_PLAN_VERSION = 12 as const;
 
 export const PR_E2E_TYPED_TARGET_IDS = [
   "ubuntu-repo-cloud-langchain-deepagents-code",
@@ -25,6 +25,12 @@ const MANAGED_STARTUP_E2E_JOB_IDS = [
   "issue-4462-scope-upgrade-approval",
   "openclaw-inference-switch",
 ] as const;
+const HERMES_CLI_ADAPTER_E2E_JOB_IDS = ["channels-stop-start", "mcp-bridge"] as const;
+const HERMES_CLI_ADAPTER_RUNTIME_FILES = new Set([
+  "agents/hermes/hermes-cli-adapter-v1.json",
+  "agents/hermes/hermes-wrapper.py",
+  "agents/hermes/validate-cli-adapter.py",
+]);
 const HERMES_MANAGED_POLICY_E2E_JOB_IDS = [
   "bedrock-runtime-compatible-anthropic",
   "channels-stop-start",
@@ -192,6 +198,11 @@ export function focusedPrE2eJobsForChangedFiles(
         isRuntimeRelevant(file),
     ),
   );
+  const hermesCliAdapterFiles = stableUnique(
+    changedFiles.filter(
+      (file) => HERMES_CLI_ADAPTER_RUNTIME_FILES.has(file) && isRuntimeRelevant(file),
+    ),
+  );
   const hermesManagedPolicyFiles = stableUnique(
     changedFiles.filter(
       (file) =>
@@ -201,6 +212,10 @@ export function focusedPrE2eJobsForChangedFiles(
   );
   return [
     ...MANAGED_STARTUP_E2E_JOB_IDS.map((id) => ({ id, matchedFiles: managedStartupFiles })),
+    ...HERMES_CLI_ADAPTER_E2E_JOB_IDS.map((id) => ({
+      id,
+      matchedFiles: hermesCliAdapterFiles,
+    })),
     ...HERMES_MANAGED_POLICY_E2E_JOB_IDS.map((id) => ({
       id,
       matchedFiles: hermesManagedPolicyFiles,
@@ -372,9 +387,10 @@ export const RISK_RULES: readonly RiskRule[] = [
     summary:
       "Sandbox blueprint and agent-runtime changes must preserve equivalent isolation and readiness across supported agents.",
     tier: 3,
-    requiredJobs: ["full-e2e", "hermes-e2e", "security-posture"],
+    requiredJobs: ["full-e2e", "hermes-e2e", "hermes-inference-switch", "security-posture"],
     invariants: [
       "OpenClaw and Hermes both reach readiness through the changed sandbox boundary",
+      "the Hermes runtime preserves provider and model selection across managed inference route changes",
       "the sandbox retains its required security posture and isolation controls",
       "blueprint state agrees with the runtime observed by both supported agents",
     ],

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -390,7 +390,7 @@ export const RISK_RULES: readonly RiskRule[] = [
     requiredJobs: ["full-e2e", "hermes-e2e", "hermes-inference-switch", "security-posture"],
     invariants: [
       "OpenClaw and Hermes both reach readiness through the changed sandbox boundary",
-      "the Hermes runtime preserves provider and model selection across managed inference route changes",
+      "the Hermes runtime and managed inference route agree on the selected provider and model after each route change",
       "the sandbox retains its required security posture and isolation controls",
       "blueprint state agrees with the runtime observed by both supported agents",
     ],

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -112,7 +112,7 @@ Authors and coding agents should follow the shared [PR CI and Review Follow-Up](
   job that the model omits or downgrades. The PR E2E controller separately dispatches every listed
   job without consuming the advisor's normalized result.
 
-Risk plan version 10 maps runtime changes from these paths to the `focused-e2e` family:
+Risk plan version 12 maps runtime changes from these paths to the `focused-e2e` family:
 
 - `src/lib/onboard/managed-startup/**`.
 - `src/lib/onboard/sandbox-create-launch.ts`.
@@ -123,6 +123,17 @@ Each match selects these focused E2E jobs:
 - `device-auth-health`.
 - `issue-4462-scope-upgrade-approval`.
 - `openclaw-inference-switch`.
+
+The same risk plan maps these Hermes CLI adapter paths to `focused-e2e`:
+
+- `agents/hermes/hermes-cli-adapter-v1.json`.
+- `agents/hermes/hermes-wrapper.py`.
+- `agents/hermes/validate-cli-adapter.py`.
+
+Each Hermes CLI adapter match selects these focused E2E jobs:
+
+- `channels-stop-start`.
+- `mcp-bridge`.
 
 ## Required secret
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The risk plan on `main` does not select `mcp-bridge` for Hermes CLI adapter changes. PR #8025 therefore cannot run the live E2E coverage required by issue #8011 before this selector lands. This change adds the required jobs and increments the risk-plan version to 12.

Julie Yaunches authored the first commit and the risk-plan wording clarification. Carlos Villela applied the review fixes and authored the compatibility-digest update. GitHub reports all three commits as Verified.

## Related Issue

Related to #8011. Unblocks #8025.

## Changes

- Select `channels-stop-start` and `mcp-bridge` when the Hermes wrapper, adapter manifest, or adapter validator changes.
- Keep all managed-policy and sandbox-boundary jobs selected when the Hermes wrapper changes.
- Add `hermes-inference-switch` to the Hermes sandbox-boundary jobs.
- Increment the deterministic risk-plan version to 12.
- Assert the complete job list for each adapter and managed-policy path.
- Document the selector and the messaging-channel and managed MCP lifecycle coverage.
- Update the compatibility digest for the version 12 risk-plan output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This PR changes trusted E2E selection, not a user-visible command or supported behavior. Internal E2E and advisor documentation was updated.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed commit `34af730876508d272c1dbd15a3755a35a0815cab` against base SHA `4cd4d64fe67143b57707f874afa0b9d269dfeff2`, including the functional changes and compatibility-digest correction. All nine categories received PASS, with no findings. Commit `cc3f505dc941b3dc3c26578724b413491e014bb9` changes only independently reviewed explanatory wording. [Security review](https://github.com/NVIDIA/NemoClaw/pull/8107#issuecomment-5164527010).
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md` and `tools/pr-review-advisor/README.md` document risk-plan version 12 and the Hermes adapter lifecycle mapping. The documentation writer review at head SHA `cc3f505dc` covered terminology, structure, voice, test titles, and code-sample presentation. The focused Vitest command passed 87 tests in 2 files, and the repository hooks passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: cc3f505dc -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: This PR does not change `scripts/prepare-dgx-station-host.sh`.
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run test/pr-risk-plan.test.ts test/e2e/support/e2e-cross-runtime-compatibility.test.ts --reporter=dot` passed 87 tests in 2 files at commit `cc3f505dc`.
- [x] Applicable broad gate passed — `E2E / PR Gate` passed for commit `cc3f505dc` in [run 30824493943](https://github.com/NVIDIA/NemoClaw/actions/runs/30824493943).
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated validation for Hermes CLI adapters, managed policies, sandbox boundaries, and wrapper workflows.
  * Added checks to preserve provider and model settings during managed inference route changes.
  * Updated compatibility checks and targeted test-selection expectations.

* **Chores**
  * Updated risk-plan metadata and documentation to reflect the expanded validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
