### PR TITLE
fix(cli): report oclif parse errors without a raw stack trace

### DIFF
--- a/src/lib/cli/oclif-runner.test.ts
+++ b/src/lib/cli/oclif-runner.test.ts
@@ -246,6 +246,97 @@ describe("runOclifCommandById", () => {
     expect(exit).toHaveBeenCalledWith(2);
   });
 
+  it("formats an invalid enum flag value instead of rethrowing it (#8123)", async () => {
+    class FlagInvalidOptionError extends Error {
+      oclif = { exit: 2 };
+      parse = {};
+      showHelp = false;
+    }
+    runCommandMock.mockRejectedValue(
+      new FlagInvalidOptionError(
+        "Expected --reasoning-effort=ultra to be one of: low, medium, high, default\nSee more help with --help",
+      ),
+    );
+    const errorLine = vi.fn();
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit:${code}`);
+    });
+
+    await expect(
+      runOclifCommandById("inference:set", ["--reasoning-effort", "ultra"], {
+        rootDir: "/repo",
+        error: errorLine,
+        exit,
+      }),
+    ).rejects.toThrow("exit:2");
+
+    expect(errorLine).toHaveBeenCalledWith(
+      "  Expected --reasoning-effort=ultra to be one of: low, medium, high, default\nSee more help with --help",
+    );
+    expect(exit).toHaveBeenCalledWith(2);
+  });
+
+  it("formats an invalid enum argument value instead of rethrowing it (#8123)", async () => {
+    class ArgInvalidOptionError extends Error {
+      oclif = { exit: 2 };
+      parse = {};
+      showHelp = false;
+    }
+    runCommandMock.mockRejectedValue(
+      new ArgInvalidOptionError("Expected powershell to be one of: bash, zsh, fish"),
+    );
+    const errorLine = vi.fn();
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit:${code}`);
+    });
+
+    await expect(
+      runOclifCommandById("completion", ["powershell"], {
+        rootDir: "/repo",
+        error: errorLine,
+        exit,
+      }),
+    ).rejects.toThrow("exit:2");
+
+    expect(errorLine).toHaveBeenCalledWith("  Expected powershell to be one of: bash, zsh, fish");
+    expect(exit).toHaveBeenCalledWith(2);
+  });
+
+  it("recognizes a parse error by shape when its class name is unknown (#8123)", async () => {
+    class SomeLaterParserError extends Error {
+      oclif = { exit: 2 };
+      parse = {};
+      showHelp = true;
+    }
+    runCommandMock.mockRejectedValue(new SomeLaterParserError("A parser rule rejected the input"));
+    const errorLine = vi.fn();
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit:${code}`);
+    });
+
+    await expect(
+      runOclifCommandById("list", ["--json"], { rootDir: "/repo", error: errorLine, exit }),
+    ).rejects.toThrow("exit:2");
+
+    expect(errorLine).toHaveBeenCalledWith("  A parser rule rejected the input");
+    expect(exit).toHaveBeenCalledWith(2);
+  });
+
+  it("keeps rethrowing a command failure that carries an unrelated parse property (#8123)", async () => {
+    class CommandFailure extends Error {
+      oclif = { exit: 2 };
+      parse = { source: "sandboxes.json" };
+    }
+    const error = new CommandFailure("Could not read the sandbox registry");
+    runCommandMock.mockRejectedValue(error);
+    const errorLine = vi.fn();
+
+    await expect(
+      runOclifCommandById("list", [], { rootDir: "/repo", error: errorLine }),
+    ).rejects.toBe(error);
+    expect(errorLine).not.toHaveBeenCalled();
+  });
+
   it("treats oclif graceful ExitError(0) as silent success", async () => {
     // Mirrors what `Command.exit(0)` and `--help` actually throw in oclif: an
     // ExitError instance whose synthetic `EEXIT: 0` message must NOT leak to

--- a/src/lib/cli/oclif-runner.ts
+++ b/src/lib/cli/oclif-runner.ts
@@ -25,6 +25,14 @@ function getOclifExitCode(error: unknown): number | null {
   return typeof oclif?.exit === "number" ? oclif.exit : null;
 }
 
+function hasOclifParseErrorShape(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if (typeof getOclifExitCode(error) !== "number") return false;
+  return (
+    Object.hasOwn(error, "parse") && typeof (error as { showHelp?: unknown }).showHelp === "boolean"
+  );
+}
+
 function isOclifParseError(error: unknown): boolean {
   const name =
     error && typeof error === "object"
@@ -32,6 +40,7 @@ function isOclifParseError(error: unknown): boolean {
       : "";
   const message = error instanceof Error ? error.message : "";
   return (
+    hasOclifParseErrorShape(error) ||
     name === "NonExistentFlagsError" ||
     name === "RequiredArgsError" ||
     name === "UnexpectedArgsError" ||

--- a/test/cli/oclif-parse-errors.test.ts
+++ b/test/cli/oclif-parse-errors.test.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { PARSER_EXIT_CODE, run } from "./helpers";
+
+function expectCleanParseFailure(out: string): void {
+  expect(out).not.toMatch(/^\s+at /m);
+  expect(out).not.toContain("Node.js v");
+  expect(out).not.toContain("@oclif/core/lib/parser");
+  expect(out).not.toContain("InvalidOptionError");
+  expect(out).not.toContain("showHelp:");
+}
+
+describe("oclif parse errors", () => {
+  it("reports an invalid enum flag value without a stack trace (#8123)", () => {
+    const r = run(
+      "inference set --provider compatible-endpoint --model gpt-4o-mini --reasoning-effort ultra --no-verify",
+    );
+
+    expect(r.code).toBe(PARSER_EXIT_CODE);
+    expect(r.out).toContain(
+      "Expected --reasoning-effort=ultra to be one of: low, medium, high, default",
+    );
+    expectCleanParseFailure(r.out);
+  });
+
+  it("reports an invalid enum argument value without a stack trace (#8123)", () => {
+    const r = run("completion powershell");
+
+    expect(r.code).toBe(PARSER_EXIT_CODE);
+    expect(r.out).toContain("Expected powershell to be one of: bash, zsh, fish");
+    expectCleanParseFailure(r.out);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Passing a value outside a flag's or argument's declared enum crashed the CLI instead of reporting the mistake. oclif's parse error escaped as an unhandled rejection, so the user got a Node stack trace, an error-property dump, and the Node version banner, and the process exited 1 instead of the declared parser code 2. The actionable line was present but buried mid-trace. Those commands now print that line on its own and exit 2.

## Related Issue

Fixes #8123

## Changes

- `src/lib/cli/oclif-runner.ts`: `runOclifCommandById` maps oclif errors to exit codes by hand rather than delegating to oclif's `handle()`, and it recognized parse errors from a list of class names. That list covered four of oclif's seven `CLIParseError` subclasses, so `FlagInvalidOptionError` and `ArgInvalidOptionError` fell through to the final rethrow and out of `dispatchCli()`, which has no rejection handler. Added `hasOclifParseErrorShape`, which matches on the three markers the `CLIParseError` base class gives every subclass: a numeric `oclif.exit`, an own `parse` property, and a boolean `showHelp`. Matching the shape rather than the name covers the subclasses added since the list was written and any added later.
- `src/lib/cli/oclif-runner.ts`: the existing name list stays as written and is OR'd with the new check, so no error that already reached the parse branch changes route. Recognized errors keep using the existing `exit(exitCode ?? 1)` line, which yields 2 for a parse error with no further change.
- Only the direct command-id route was affected. The native `internal` and `sandbox` namespaces go through `runOclifArgv`, which does call oclif's `handle()` and already printed these cleanly, which is why `nemoclaw <sandbox-name> inference set` behaved while the global `nemoclaw inference set` crashed.
- Tests: `src/lib/cli/oclif-runner.test.ts` covers an invalid enum flag value, an invalid enum argument value, a parse error whose class name is unknown but whose shape matches, and a command failure carrying an unrelated `parse` property that must still rethrow. `test/cli/oclif-parse-errors.test.ts` runs the real CLI for both user-visible commands and asserts the exit code, the actionable line, and the absence of stack frames, `@oclif/core` paths, and the Node version banner.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no documented behavior changes. `docs/inference/configure-model-capabilities.mdx` documents which `--reasoning-effort` values are accepted, and `docs/reference/commands.mdx` lists the commands and flags. No page documents the previous exit code, the stack trace, or the error text for a rejected value.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [ ] Documentation writer subagent reviewed the completed changes
- Result: `blocked`
- Evidence: no documentation paths changed. The subagent review did not run because the authoring session is configured not to spawn subagents without an explicit request. The documentation assessment recorded under Quality Gates was made directly against the two pages that mention the affected commands and flag values.
- Agent: Claude Code
<!-- docs-review-head-sha: de827bf32 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/cli/ --project integration test/cli/dispatch-basics.test.ts test/cli/onboard-compatibility.test.ts test/cli/oclif-parse-errors.test.ts` — 13 files, 136 tests passed. With `src/lib/cli/oclif-runner.ts` reverted and `dist` rebuilt, the 5 new assertions fail and the other 15 in those two files still pass, which pins both the recognition change and the exit code. Before the fix, `nemoclaw inference set --reasoning-effort ultra` and `nemoclaw completion powershell` reproduced the reported trace and exit 1; after it, both print one line plus the help hint and exit 2, while `nemoclaw onboard --non-interactiv` is unchanged. `npm run typecheck:cli` clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid command-line flag and argument values.
  * Parse errors now consistently display clear validation messages and exit with code 2.
  * Prevented stack traces and internal parser details from appearing in user-facing error output.
  * Unrelated command failures continue to propagate normally without being incorrectly formatted as parse errors.

* **Tests**
  * Added coverage for invalid enum values and structurally recognized parser errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->