### PR TITLE
docs(messaging): clarify Slack conflict scope

### DIFF
--- a/docs/manage-sandboxes/manage-messaging-channels.mdx
+++ b/docs/manage-sandboxes/manage-messaging-channels.mdx
@@ -97,15 +97,20 @@ If policy restoration fails, the command keeps the channel disabled and exits wi
 
 ## Avoid Cross-Sandbox Conflicts
 
+<Warning title="Conflict Detection Scope">
+NemoClaw checks only the sandboxes recorded in the selected OpenShell gateway's sandbox registry.
+It cannot detect or prevent Slack credential reuse across independent OpenShell gateways.
+</Warning>
+
 Use distinct credentials and resources for each active messaging sandbox.
 Follow these channel-specific rules:
 
 - Use a distinct iLink `accountId` for each WeChat sandbox.
-- Use distinct bot and Socket Mode app tokens for each Slack sandbox.
-- Use a different gateway for each Slack sandbox.
+- Run only one active Slack sandbox on each OpenShell gateway.
+- Use distinct bot and Socket Mode app tokens across OpenShell gateways.
 - Use a different local webhook port for each Microsoft Teams sandbox.
 
-When you onboard, rebuild, or add a channel, the command aborts on a conflict or an incomplete required check.
+When you onboard, rebuild, or add a channel, the command aborts on a conflict or an incomplete required check within the selected OpenShell gateway's sandbox registry.
 Legacy entries without credential hashes count as incomplete.
 An unreadable messaging registry also causes onboarding and rebuild to abort.
 Onboarding and rebuild have no conflict override.
@@ -117,7 +122,7 @@ Rerun `channels add <channel>` with the intended token to refresh stored non-sec
 Before a rebuild, NemoClaw checks the messaging plan before backup or deletion.
 A conflict leaves the original sandbox intact.
 Resolve any conflict, then rerun the operation.
-`$$nemoclaw status` reports cross-sandbox overlaps.
+`$$nemoclaw status` reports cross-sandbox overlaps within the selected OpenShell gateway's sandbox registry.
 
 ## Stop All Delivery
 

--- a/docs/manage-sandboxes/set-up-slack.mdx
+++ b/docs/manage-sandboxes/set-up-slack.mdx
@@ -48,8 +48,8 @@ This uses the existing Slack credentials and does not require additional scopes 
 ## Avoid Duplicate Socket Mode Sessions
 
 <Warning title="Conflict Detection Scope">
-NemoClaw checks for duplicate Slack credentials only among sandboxes in the selected OpenShell gateway's sandbox registry.
-It cannot detect or prevent reuse across independent OpenShell gateways.
+NemoClaw checks for another active Slack sandbox only in the selected OpenShell gateway's sandbox registry.
+It cannot detect or prevent Slack credential reuse across independent OpenShell gateways.
 </Warning>
 
 Run only one active Slack sandbox on each OpenShell gateway.

--- a/docs/manage-sandboxes/set-up-slack.mdx
+++ b/docs/manage-sandboxes/set-up-slack.mdx
@@ -4,7 +4,7 @@
 title: "Set Up Slack"
 sidebar-title: "Set Up Slack"
 description: "Prepare Slack Socket Mode credentials and user or channel allowlists for NemoClaw."
-description-agent: "Explains Slack bot and app token validation, allowlists, mention behavior, rich Hermes rendering, and duplicate Socket Mode detection. Use before enabling Slack."
+description-agent: "Explains Slack bot and app token validation, allowlists, mention behavior, rich Hermes rendering, and selected-gateway Socket Mode conflict checks. Use before enabling Slack."
 keywords: ["nemoclaw slack", "slack socket mode", "slack app token", "slack allowlist"]
 content:
   type: "how_to"
@@ -19,6 +19,7 @@ Use `SLACK_APP_TOKEN` for the app-level Socket Mode token that begins with `xapp
 
 NemoClaw validates both tokens before it saves Slack credentials or enables the channel.
 This validation calls the live Slack APIs `auth.test` and `apps.connections.open`, so the tokens must belong to a real Slack app.
+These probes confirm token validity but do not report whether another Socket Mode connection uses the Slack app.
 
 If Slack rejects the tokens, NemoClaw skips the Slack channel and does not apply the `slack` network policy preset.
 When Slack is skipped, the preset does not appear as applied in `$$nemoclaw <name> policy list`.
@@ -46,9 +47,14 @@ This uses the existing Slack credentials and does not require additional scopes 
 
 ## Avoid Duplicate Socket Mode Sessions
 
-The [cross-sandbox conflict policy](manage-messaging-channels) applies to Slack.
-Use different bot tokens, app tokens, and gateways for each active Slack sandbox.
-Onboarding, rebuild, and `channels add slack` abort on a conflict.
+<Warning title="Conflict Detection Scope">
+NemoClaw checks for duplicate Slack credentials only among sandboxes in the selected OpenShell gateway's sandbox registry.
+It cannot detect or prevent reuse across independent OpenShell gateways.
+</Warning>
+
+Run only one active Slack sandbox on each OpenShell gateway.
+Use distinct bot and app tokens for Slack sandboxes on different OpenShell gateways.
+Onboarding, rebuild, and `channels add slack` abort when they detect a conflict in the selected OpenShell gateway's sandbox registry.
 Onboarding and rebuild have no override.
 For `channels add slack` only, pass `--force` to accept the conflict risk.
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1421,7 +1421,8 @@ When OpenShell reports an active policy version, the displayed YAML `version` li
 If the sandbox is running an outdated agent version, the output includes an `Update` line with the available version and a `$$nemoclaw <name> rebuild` hint.
 
 <AgentOnly variant="openclaw,hermes">
-When other sandboxes have the same messaging channel enabled (Telegram, Discord, or Slack) with the same bot token, the output includes a cross-sandbox overlap warning so you can resolve the conflict before messages start dropping.
+When NemoClaw detects a messaging overlap between sandboxes in the selected OpenShell gateway's sandbox registry, the output includes a cross-sandbox overlap warning.
+The command cannot report overlaps in an independent OpenShell gateway's registry.
 The command also tails `/tmp/gateway.log` inside the default sandbox and flags Telegram `409 Conflict` errors that indicate a duplicate consumer for the bot token.
 </AgentOnly>
 
@@ -1507,7 +1508,7 @@ The rebuild reuses the existing sandbox name and preserved manifest-defined stat
 Run a focused health check for one sandbox and the host services it depends on.
 The command checks the local CLI build, Docker daemon, OpenShell CLI, NemoClaw gateway container, gateway port mapping, live sandbox state, inference route, configured-provider model invocation, Ollama reachability, and the cloudflared tunnel state.
 <AgentOnly variant="openclaw,hermes">
-For gateway-based agents, it also reports messaging channel conflicts.
+For gateway-based agents, it also reports messaging channel conflicts within the selected OpenShell gateway's sandbox registry.
 </AgentOnly>
 
 `doctor` also checks whether the sandbox registry contains the metadata required for snapshot, rebuild, upgrade, recovery, and reboot.
@@ -2099,6 +2100,9 @@ $$nemoclaw my-assistant channels add telegram
 | `--force` | Add the channel despite a credential conflict, shared-resource conflict, or incomplete required check. This flag is the only conflict override. |
 
 Slack requires both `SLACK_BOT_TOKEN` (bot user OAuth) and `SLACK_APP_TOKEN` (app-level Socket Mode token); the command prompts for each in turn.
+The conflict check compares only sandboxes in the selected OpenShell gateway's sandbox registry.
+It cannot detect Slack token reuse across independent OpenShell gateways.
+Run only one active Slack sandbox on each OpenShell gateway, and use distinct Slack bot and app tokens across gateways.
 Optional Slack allowlists come from `SLACK_ALLOWED_USERS` and `SLACK_ALLOWED_CHANNELS` at rebuild time.
 Telegram and Discord mention mode default to `1` when no environment, session, or saved state value exists for that setting.
 Discord applies that default only when a server ID is configured.
@@ -2805,7 +2809,8 @@ Before backup or deletion, `rebuild` also refuses an incomplete MCP destroy tran
 It also refuses a pending baseline exclusion transaction before opening a shields-down window, starting backup, or deleting the sandbox, and prints the exact `policy exclude` or `policy restore` command to rerun.
 For a prepared-only transaction, the redacted diagnostic points to `$$nemoclaw <name> mcp remove <server> --force` when the sandbox is still live.
 For a pending or both-marker transaction, it points to `$$nemoclaw <name> destroy` because the registry records that OpenShell deletion was already confirmed.
-Before backup or deletion, rebuild checks the staged messaging configuration for credentials or channel resources already used by another registered sandbox.
+Before backup or deletion, rebuild checks the staged messaging configuration against other sandboxes in the selected OpenShell gateway's sandbox registry.
+A rebuild cannot detect messaging conflicts in an independent OpenShell gateway's registry.
 A conflict aborts with the original sandbox registered and intact so you can resolve the conflict before retrying.
 After OpenShell accepts the sandbox deletion, `rebuild` waits until OpenShell explicitly reports that the old sandbox is absent.
 Only then can NemoClaw perform any required local registry removal and begin creating the replacement.
@@ -3163,7 +3168,7 @@ Supervisor-owned agent runtime processes remain managed inside their sandbox.
 Show the global sandbox list and the status of host auxiliary services (for example cloudflared).
 This command is host-wide. It summarizes registered sandboxes, the default sandbox's live inference route, gateway health, and host services.
 <AgentOnly variant="openclaw,hermes">
-For gateway-based messaging agents, it also reports messaging overlap warnings.
+For gateway-based messaging agents, it also reports messaging overlap warnings within the selected OpenShell gateway's sandbox registry.
 </AgentOnly>
 Use `$$nemoclaw <name> status` when you need one sandbox's live health and recovery guidance.
 Pass `--json` for machine-readable output with registered sandboxes, service state, inference routes, and health details.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2024,7 +2024,9 @@ Check the gateway logs and blocked-request output with `openshell term`, and loo
 
 ### Messaging bridge appears running but no messages arrive
 
-Bot tokens for Telegram (`getUpdates`), Discord (gateway), and Slack (Socket Mode) only allow one active consumer per token. If two NemoClaw sandboxes are configured with the same bot token, each one kicks the other off its polling connection and neither delivers messages. `$$nemoclaw status` still reports the bridge as running because the gateway process itself is alive.
+Telegram `getUpdates` allows only one active poller per bot token.
+Reusing Discord or Slack credentials can create competing gateway or Socket Mode sessions and unreliable message delivery.
+`$$nemoclaw status` can still report a bridge as running because the gateway process itself is alive.
 
 For Telegram group chats, first check BotFather privacy mode.
 New Telegram bots default to privacy mode enabled, which prevents group messages from reaching `getUpdates` even when the user mentions the bot.
@@ -2054,10 +2056,13 @@ A repeating line like the following confirms the conflict:
 ```
 
 To fix, run `$$nemoclaw <other-sandbox> destroy` on whichever sandbox should stop polling, or rerun onboarding on it with the channel disabled.
-The same fail-closed policy applies to every supported messaging channel.
-Onboarding, rebuild, and `channels add` abort on a conflict or an incomplete required check, including unavailable credential hashes.
+NemoClaw checks only the sandboxes in the selected OpenShell gateway's sandbox registry.
+It cannot detect or prevent Slack credential reuse across independent OpenShell gateways.
+Run only one active Slack sandbox on each OpenShell gateway.
+Use distinct Slack bot and app tokens for Slack sandboxes on different OpenShell gateways.
+Within the selected registry, onboarding, rebuild, and `channels add` abort on a conflict or an incomplete required check, including unavailable credential hashes.
 Only `channels add <channel> --force` can accept the duplicate-consumer or shared-resource risk.
-Sandboxes created before these checks were added may still be in a conflict loop.
+Sandboxes created before these checks were added, or managed by independent gateways, may still have a conflict without a NemoClaw warning.
 
 </AgentOnly>
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Clarifies that NemoClaw detects messaging conflicts only within the selected OpenShell gateway's sandbox registry.
Documents the operating constraints for Slack across independent gateways and distinguishes credential validation from active Socket Mode connection detection.

## Related Issue

Refs #7808

## Changes

- Document the selected-gateway registry boundary for onboarding, rebuild, channel-add, status, and doctor checks.
- State that each OpenShell gateway should have one active Slack sandbox and that independent gateways should use distinct Slack bot and app tokens.
- Explain that Slack credential validation does not identify another active Socket Mode connection.
- Remove the inaccurate claim that Slack permits only one active consumer per token.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Documentation-only clarification; no executable behavior or code sample changed.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence:
  - Reviewed `docs/manage-sandboxes/manage-messaging-channels.mdx`.
  - Reviewed `docs/manage-sandboxes/set-up-slack.mdx`.
  - Reviewed `docs/reference/commands.mdx`.
  - Reviewed `docs/reference/troubleshooting.mdx`.
  - Exact-head review passed for terminology, structure, voice, code samples, product scope, implementation accuracy, and OpenClaw and Hermes guide variants.
  - `npm run docs:sync-agent-variants` passed.
  - `npm run docs` passed with 0 errors and 2 existing Fern warnings.
- Agent: Codex CLI
<!-- docs-review-head-sha: caf48a176 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host script changed.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Tests are not applicable to documentation-only prose changes.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to documentation-only prose changes.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — validation passed with 0 errors; Fern reported 2 existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no pages were added.

`npm run docs` passed with 0 errors. Fern reported 2 existing warnings.

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that messaging conflict detection only covers sandboxes registered with the selected gateway.
  * Added Slack guidance to use one active sandbox per gateway and distinct bot or Socket Mode credentials across gateways.
  * Documented conflict behavior for onboarding, rebuilds, channel additions, status, and troubleshooting.
  * Clarified that credential probes may not detect active Socket Mode connections and that incomplete checks fail closed unless overridden with `--force`.
  * Added guidance for cases where delivery fails despite a “running” status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->