### PR TITLE
fix(onboard): validate Windows Ollama from Docker

### DIFF
--- a/src/lib/adapters/http/container-curl-probe.test.ts
+++ b/src/lib/adapters/http/container-curl-probe.test.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CONTAINER_REACHABILITY_IMAGE,
+  createContainerCurlProbeSpawn,
+} from "./container-curl-probe";
+
+function successfulSpawn(): SpawnSyncReturns<string> {
+  return {
+    pid: 123,
+    output: ["200", ""],
+    stdout: "200",
+    stderr: "",
+    status: 0,
+    signal: null,
+  };
+}
+
+describe("container curl probe", () => {
+  it("mounts only the temporary output directory and preserves curl arguments", () => {
+    const spawn = vi.fn(
+      (_command: string, _args: readonly string[], _options: SpawnSyncOptionsWithStringEncoding) =>
+        successfulSpawn(),
+    );
+    const outputPath = path.join(os.tmpdir(), "nemoclaw-curl-probe-test", "response.json");
+    const args = ["-sS", "-o", outputPath, "-w", "%{http_code}", "http://example.test/v1"];
+
+    createContainerCurlProbeSpawn(spawn)("curl", args, { encoding: "utf8" });
+
+    expect(spawn).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining([
+        "run",
+        "--rm",
+        "--volume",
+        `${path.dirname(outputPath)}:${path.dirname(outputPath)}`,
+        CONTAINER_REACHABILITY_IMAGE,
+        ...args,
+      ]),
+      { encoding: "utf8" },
+    );
+  });
+
+  it("rejects credential configs and output paths outside the temporary directory", () => {
+    const spawn = vi.fn(() => successfulSpawn());
+    const run = createContainerCurlProbeSpawn(spawn);
+    const outputPath = path.join(os.tmpdir(), "nemoclaw-curl-probe-test", "response.json");
+
+    expect(() =>
+      run("curl", ["--config", path.join(os.tmpdir(), "auth.conf"), "-o", outputPath], {
+        encoding: "utf8",
+      }),
+    ).toThrow(/does not accept credential config files/);
+    expect(() =>
+      run("curl", ["-o", path.join(process.cwd(), "response.json")], { encoding: "utf8" }),
+    ).toThrow(/must stay inside the temporary directory/);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/adapters/http/container-curl-probe.ts
+++ b/src/lib/adapters/http/container-curl-probe.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+  spawnSync,
+} from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+export const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
+
+type CurlProbeSpawn = (
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptionsWithStringEncoding,
+) => SpawnSyncReturns<string>;
+
+function curlOutputPath(args: readonly string[]): string {
+  const outputIndex = args.indexOf("-o");
+  const outputPath = outputIndex >= 0 ? args[outputIndex + 1] : undefined;
+  if (!outputPath || !path.isAbsolute(outputPath)) {
+    throw new Error("container curl probe requires an absolute output path");
+  }
+  const relative = path.relative(path.resolve(os.tmpdir()), path.resolve(outputPath));
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("container curl probe output must stay inside the temporary directory");
+  }
+  return outputPath;
+}
+
+/** Run a credential-free curl probe from Docker Desktop's network context. */
+export function createContainerCurlProbeSpawn(
+  spawnSyncImpl: CurlProbeSpawn = spawnSync,
+): CurlProbeSpawn {
+  return (command, args, options) => {
+    if (command !== "curl") {
+      throw new Error(`container curl probe expected curl, received ${command}`);
+    }
+    if (
+      args.some(
+        (arg) =>
+          arg === "--config" || arg === "-K" || arg.startsWith("--config=") || arg.startsWith("-K"),
+      )
+    ) {
+      throw new Error("container curl probe does not accept credential config files");
+    }
+    const outputPath = curlOutputPath(args);
+    const outputDir = path.dirname(outputPath);
+    const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+    const gid = typeof process.getgid === "function" ? process.getgid() : 0;
+    return spawnSyncImpl(
+      "docker",
+      [
+        "run",
+        "--rm",
+        "--user",
+        `${uid}:${gid}`,
+        "--volume",
+        `${outputDir}:${outputDir}`,
+        CONTAINER_REACHABILITY_IMAGE,
+        ...args,
+      ],
+      options,
+    );
+  };
+}

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -17,6 +17,7 @@ const LARGE_OLLAMA_FIT_MEMORY_MB = Math.max(
 );
 
 import {
+  buildOllamaProbeOptions,
   CONTAINER_REACHABILITY_IMAGE,
   DEFAULT_OLLAMA_MODEL,
   getBootstrapOllamaModelOptions,
@@ -40,6 +41,8 @@ import {
   probeOllamaAuthProxyHealth,
   QWEN3_6_OLLAMA_MODEL,
   resetOllamaContainerPortCache,
+  resetOllamaHostCache,
+  setResolvedOllamaHost,
   validateLocalProvider,
   validateOllamaModel,
 } from "./local";
@@ -82,11 +85,26 @@ describe("local inference helpers", () => {
   });
 
   afterEach(() => {
+    resetOllamaHostCache();
     if (originalSandboxHostUrl === undefined) {
       delete process.env[LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV];
     } else {
       process.env[LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV] = originalSandboxHostUrl;
     }
+  });
+
+  it("uses Docker-context validation only for Windows-host Ollama (#8127)", () => {
+    expect(buildOllamaProbeOptions(false)).toMatchObject({
+      allowHostDockerInternal: false,
+      probeFromDocker: null,
+    });
+
+    setResolvedOllamaHost("host.docker.internal");
+
+    expect(buildOllamaProbeOptions(false)).toMatchObject({
+      allowHostDockerInternal: true,
+      probeFromDocker: { expectedPort: 11434 },
+    });
   });
 
   it("returns the expected base URL for vllm-local", () => {

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -11,6 +11,7 @@ import os from "node:os";
 import nodePath from "node:path";
 import { detectContainerRuntimeFromDockerInfo } from "../adapters/docker/runtime";
 import { createBearerAuthConfig } from "../adapters/http/auth-config";
+import { CONTAINER_REACHABILITY_IMAGE } from "../adapters/http/container-curl-probe";
 import { buildValidatedCurlCommandArgs } from "../adapters/http/curl-args";
 import type { CurlProbeOptions, CurlProbeResult } from "../adapters/http/probe";
 import { runCurlProbe } from "../adapters/http/probe";
@@ -70,7 +71,8 @@ export function resetOllamaContainerPortCache(): void {
 
 export const HOST_GATEWAY_URL = "http://host.openshell.internal";
 export const LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV = "NEMOCLAW_LOCAL_INFERENCE_SANDBOX_HOST_URL";
-export const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
+export { CONTAINER_REACHABILITY_IMAGE } from "../adapters/http/container-curl-probe";
+
 // These tags are convenience aliases for callers that want to refer to a
 // specific bootstrap model by role rather than by string. The canonical
 // metadata (memory requirements, download sizes) lives in
@@ -1456,11 +1458,14 @@ export function buildOllamaProbeOptions(allowToolsIncompatible: boolean): {
   skipResponsesProbe: true;
   requireChatCompletionsToolCalling: boolean;
   allowHostDockerInternal: boolean;
+  probeFromDocker: { expectedPort: number } | null;
 } {
+  const windowsHostOllama = getResolvedOllamaHost() === OLLAMA_HOST_DOCKER_INTERNAL;
   return {
     skipResponsesProbe: true,
     requireChatCompletionsToolCalling: !allowToolsIncompatible,
-    allowHostDockerInternal: getResolvedOllamaHost() === OLLAMA_HOST_DOCKER_INTERNAL,
+    allowHostDockerInternal: windowsHostOllama,
+    probeFromDocker: windowsHostOllama ? { expectedPort: OLLAMA_PORT } : null,
   };
 }
 

--- a/src/lib/inference/onboard-host-docker-internal.test.ts
+++ b/src/lib/inference/onboard-host-docker-internal.test.ts
@@ -1,13 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const { isHijackedDockerInternalUrl } = require("./onboard-host-docker-internal");
-const { isSandboxInternalUrl, probeOpenAiLikeEndpoint } = require("./onboard-probes");
+const {
+  isSandboxInternalUrl,
+  probeOpenAiLikeEndpoint,
+  probeOpenAiLikeEndpointOptimized,
+} = require("./onboard-probes");
 
 describe("host.docker.internal onboarding inference policy", () => {
   it("does not treat host.docker.internal as a usable sandbox URL", () => {
@@ -44,46 +47,53 @@ describe("host.docker.internal onboarding inference policy", () => {
     expect(result.message).toMatch(/host\.openshell\.internal:11435/);
   });
 
-  it("allows explicit Windows-host Ollama validation to probe host.docker.internal", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-docker-probe-"));
-    const fakeBin = path.join(tmpDir, "bin");
-    const seenUrl = path.join(tmpDir, "url");
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(
-      path.join(fakeBin, "curl"),
-      `#!/usr/bin/env bash
-outfile=""
-url=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -o) outfile="$2"; shift 2 ;;
-    -w) shift 2 ;;
-    *) url="$1"; shift ;;
-  esac
-done
-printf '%s' "$url" > "${seenUrl}"
-if [ -n "$outfile" ]; then
-  cat <<'JSON' > "$outfile"
-{"choices":[{"message":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"sessions_send","arguments":"{\\"message\\":\\"hello\\"}"}}]}}]}
-JSON
-fi
-printf '200'
-exit 0
-`,
-      { mode: 0o755 },
-    );
+  it("validates Windows-host Ollama from Docker for strict and compatibility paths (#8127)", async () => {
+    const seenCommands: Array<{ command: string; args: readonly string[] }> = [];
+    const containerProbeSpawnSyncImpl = (
+      command: string,
+      args: readonly string[],
+    ): SpawnSyncReturns<string> => {
+      seenCommands.push({ command, args });
+      const outputIndex = args.indexOf("-o");
+      const outputPath = args[outputIndex + 1];
+      fs.writeFileSync(
+        outputPath,
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                tool_calls: [
+                  {
+                    id: "call_1",
+                    type: "function",
+                    function: { name: "sessions_send", arguments: '{"message":"hello"}' },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      );
+      return {
+        pid: 123,
+        output: ["200", ""],
+        stdout: "200",
+        stderr: "",
+        status: 0,
+        signal: null,
+      };
+    };
 
-    const originalPath = process.env.PATH;
-    process.env.PATH = `${fakeBin}:${originalPath || ""}`;
-    try {
-      const result = probeOpenAiLikeEndpoint(
+    for (const requireChatCompletionsToolCalling of [true, false]) {
+      const result = await probeOpenAiLikeEndpointOptimized(
         "http://host.docker.internal:11434/v1",
         "openai/nemotron-mini",
         "",
         {
           skipResponsesProbe: true,
-          requireChatCompletionsToolCalling: true,
+          requireChatCompletionsToolCalling,
           allowHostDockerInternal: true,
+          probeFromDocker: { expectedPort: 11434, spawnSyncImpl: containerProbeSpawnSyncImpl },
         },
       );
 
@@ -92,12 +102,47 @@ exit 0
         api: "openai-completions",
         label: "Chat Completions API",
       });
-      expect(fs.readFileSync(seenUrl, "utf8")).toBe(
-        "http://host.docker.internal:11434/v1/chat/completions",
-      );
-    } finally {
-      process.env.PATH = originalPath;
-      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+    expect(seenCommands).toHaveLength(2);
+    for (const { command, args } of seenCommands) {
+      expect(command).toBe("docker");
+      expect(args).toContain("curlimages/curl:8.10.1");
+      expect(args).toContain("http://host.docker.internal:11434/v1/chat/completions");
+    }
+  });
+
+  it.each([
+    {
+      endpointUrl: "http://host.docker.internal:11434/v1",
+      apiKey: "not-a-real-secret",
+      extraHeaders: undefined,
+    },
+    {
+      endpointUrl: "http://host.docker.internal:11434/v1?debug=1",
+      apiKey: "",
+      extraHeaders: undefined,
+    },
+    {
+      endpointUrl: "http://host.docker.internal:11434/v1",
+      apiKey: "",
+      extraHeaders: ["Authorization: Bearer not-a-real-secret"],
+    },
+  ])("refuses credentials and non-canonical Windows-host Ollama routes in Docker-context validation (#8127)", ({
+    endpointUrl,
+    apiKey,
+    extraHeaders,
+  }) => {
+    const result = probeOpenAiLikeEndpoint(endpointUrl, "openai/nemotron-mini", apiKey, {
+      skipResponsesProbe: true,
+      requireChatCompletionsToolCalling: true,
+      allowHostDockerInternal: true,
+      probeFromDocker: { expectedPort: 11434 },
+      extraHeaders,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      failures: [expect.objectContaining({ name: "Docker-context validation boundary" })],
+    });
   });
 });

--- a/src/lib/inference/onboard-host-docker-internal.ts
+++ b/src/lib/inference/onboard-host-docker-internal.ts
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+const { createContainerCurlProbeSpawn } = require("../adapters/http/container-curl-probe");
+
 const HOST_DOCKER_INTERNAL = "host.docker.internal";
 const OLLAMA_PROXY_URL = "http://host.openshell.internal:11435/v1";
 
@@ -40,6 +42,7 @@ function getHostDockerInternalProbeFailure() {
 module.exports = {
   HOST_DOCKER_INTERNAL,
   OLLAMA_PROXY_URL,
+  createContainerCurlProbeSpawn,
   isHijackedDockerInternalUrl,
   getHostDockerInternalProbeFailure,
 };

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -31,6 +31,7 @@ const authConfigModule = require("../adapters/http/auth-config");
 const openrouter = require("./openrouter");
 const trace = require("../trace");
 const {
+  createContainerCurlProbeSpawn,
   getHostDockerInternalProbeFailure,
   isHijackedDockerInternalUrl,
 } = require("./onboard-host-docker-internal");
@@ -278,6 +279,7 @@ function calibrateOpenAiLikeValidationTiming(baseUrl, options = {}) {
       timeoutMs: getProbeProcessTimeoutMs(args),
       pinnedAddresses: options.pinnedAddresses,
       trustedPrivateCapability: options.trustedPrivateCapability,
+      spawnSyncImpl: options.spawnSyncImpl,
     });
     const durationMs = Date.now() - startedAtMs;
     const calibration =
@@ -468,6 +470,7 @@ function probeChatCompletionsToolCalling(endpointUrl, model, apiKey, options = {
       trustedConfigFiles: authConfig.trustedConfigFiles,
       pinnedAddresses: options.pinnedAddresses,
       trustedPrivateCapability: options.trustedPrivateCapability,
+      spawnSyncImpl: options.spawnSyncImpl,
     });
 
     if (!result.ok) {
@@ -571,6 +574,7 @@ function runChatCompletionsProbe({
   pinnedAddresses,
   trustedPrivateCapability,
   validationTiming,
+  spawnSyncImpl,
 }) {
   const args = getChatCompletionsProbeCurlArgs({
     credentialArgs,
@@ -584,6 +588,7 @@ function runChatCompletionsProbe({
     timeoutMs: getProbeProcessTimeoutMs(args),
     pinnedAddresses,
     trustedPrivateCapability,
+    spawnSyncImpl,
   };
   if (trustedConfigFiles && trustedConfigFiles.length > 0) {
     probeOpts.trustedConfigFiles = trustedConfigFiles;
@@ -628,6 +633,7 @@ function runDoubledTimeoutChatCompletionsRetry({
           timingArgs: doubledArgs,
           pinnedAddresses: options.pinnedAddresses,
           trustedPrivateCapability: options.trustedPrivateCapability,
+          spawnSyncImpl: options.spawnSyncImpl,
         })
       : (() => {
           const retryArgs = buildRetryArgs();
@@ -636,6 +642,7 @@ function runDoubledTimeoutChatCompletionsRetry({
             trustedConfigFiles: authConfig.trustedConfigFiles,
             pinnedAddresses: options.pinnedAddresses,
             trustedPrivateCapability: options.trustedPrivateCapability,
+            spawnSyncImpl: options.spawnSyncImpl,
           });
         })();
   return runChatCompletionsRetryLoop(runRetryProbe);
@@ -668,6 +675,52 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
           body: "",
         },
       ],
+    };
+  }
+
+  if (options.probeFromDocker) {
+    let isWindowsHostOllama = false;
+    try {
+      const parsed = new URL(String(endpointUrl));
+      const expectedPort = Number(options.probeFromDocker.expectedPort);
+      isWindowsHostOllama =
+        parsed.protocol === "http:" &&
+        parsed.hostname === "host.docker.internal" &&
+        Number.isInteger(expectedPort) &&
+        expectedPort > 0 &&
+        parsed.port === String(expectedPort) &&
+        parsed.pathname.replace(/\/+$/, "") === "/v1" &&
+        parsed.username === "" &&
+        parsed.password === "" &&
+        parsed.search === "" &&
+        parsed.hash === "";
+    } catch {
+      /* Invalid URLs fail the restricted Docker-context boundary below. */
+    }
+    if (
+      options.allowHostDockerInternal !== true ||
+      options.skipResponsesProbe !== true ||
+      !isWindowsHostOllama ||
+      String(apiKey || "") !== "" ||
+      (Array.isArray(options.extraHeaders) && options.extraHeaders.length > 0)
+    ) {
+      return {
+        ok: false,
+        message: "Docker-context validation is restricted to credential-free Windows-host Ollama.",
+        failures: [
+          {
+            name: "Docker-context validation boundary",
+            httpStatus: 0,
+            curlStatus: 0,
+            message: "probe request is outside the approved Windows-host Ollama route",
+            body: "",
+          },
+        ],
+      };
+    }
+    options = {
+      ...options,
+      spawnSyncImpl: createContainerCurlProbeSpawn(options.probeFromDocker.spawnSyncImpl),
     };
   }
 
@@ -807,6 +860,7 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
               pinnedAddresses,
               trustedPrivateCapability: options.trustedPrivateCapability,
               validationTiming,
+              spawnSyncImpl: options.spawnSyncImpl,
             })
           : runChatCompletionsProbe({
               credentialArgs: authConfig.args,
@@ -817,6 +871,7 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
               pinnedAddresses,
               trustedPrivateCapability: options.trustedPrivateCapability,
               validationTiming,
+              spawnSyncImpl: options.spawnSyncImpl,
             }),
     };
 
@@ -1001,6 +1056,9 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
 }
 
 async function probeOpenAiLikeEndpointOptimized(endpointUrl, model, apiKey, options = {}) {
+  if (options.probeFromDocker) {
+    return probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options);
+  }
   const normalizedKey = apiKey ? normalizeCredentialValue(apiKey) : "";
   const baseUrl = String(endpointUrl).replace(/\/+$/, "");
   const validationTiming = resolveOpenAiLikeValidationTiming(baseUrl, options);

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -94,6 +94,7 @@ export interface InferenceSelectionValidationHelpers {
       skipResponsesProbe?: boolean;
       probeStreaming?: boolean;
       allowHostDockerInternal?: boolean;
+      probeFromDocker?: { expectedPort: number } | null;
       capabilityCache?: OnboardInferenceCapabilityCache;
     },
   ): Promise<EndpointValidationResult>;
@@ -261,6 +262,7 @@ export function createInferenceSelectionValidationHelpers(
       skipResponsesProbe?: boolean;
       probeStreaming?: boolean;
       allowHostDockerInternal?: boolean;
+      probeFromDocker?: { expectedPort: number } | null;
       capabilityCache?: OnboardInferenceCapabilityCache;
     } = {},
   ): Promise<EndpointValidationResult> {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Windows-host Ollama validation on WSL ran from the WSL host, where Docker Desktop does not define `host.docker.internal`. This change runs the credential-free validation request from Docker Desktop's network context and restricts that path to the configured Windows-host Ollama endpoint.

## Related Issue

Fixes #8127

## Changes

- Add a Docker-context curl adapter that preserves validated curl arguments, rejects credential config files, and binds only the probe response directory under the operating-system temporary directory.
- Use the adapter only for the configured `http://host.docker.internal:<ollama-port>/v1` route with no API key, extra headers, query, fragment, or embedded URL credentials.
- Keep the direct host probe for every other inference endpoint.
- Add source tests for strict and compatibility validation paths, credential and route rejection, temp-directory mount boundaries, and Windows-host Ollama option selection.

The adapter is required because Docker Desktop defines `host.docker.internal` in the container network context, not in the WSL host resolver. `src/lib/inference/onboard-host-docker-internal.test.ts` protects the current Windows-host Ollama consumer and verifies that both validation modes execute through Docker.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `docs/inference/set-up-ollama.mdx` already documents Windows-host Ollama from WSL, Docker Desktop integration, `host.docker.internal:11434`, validation, and the unauthenticated-port warning. This change restores that documented path.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed command injection, authentication, credential handling, cryptography, network exposure, input parsing, dependencies, filesystem access, and logic. The path uses argv-based process execution, accepts only the configured credential-free Windows-host Ollama route, rejects curl credential configs, and limits the bind mount to the probe response directory under the operating-system temporary directory.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing `docs/inference/set-up-ollama.mdx` and `docs/reference/troubleshooting.mdx` already cover the restored Windows-host Ollama behavior, validation, security warning, detection, and restart remediation. No documentation paths changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: add8bf074 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec vitest run -- --project cli src/lib/adapters/http/container-curl-probe.test.ts src/lib/inference/onboard-host-docker-internal.test.ts src/lib/inference/local.test.ts src/lib/onboard/inference-selection-validation.test.ts` passed 112 tests in 4 files. `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this change is limited to the Windows-host Ollama validation path and has focused source-test coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container-based connectivity checks for supported local AI endpoints.
  * Added validation for Docker-hosted Ollama endpoints, including port, route, credential, and output-path checks.
  * Added support for injecting and reusing custom probe processes during endpoint validation.

* **Bug Fixes**
  * Improved Docker-context detection and fallback behavior when container probing is unavailable.
  * Prevented invalid or unsafe curl requests from being executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->