### PR TITLE
docs: complete v0.0.100 post-tag audit follow-ups

### DIFF
--- a/docs/changelog/2026-07-31.mdx
+++ b/docs/changelog/2026-07-31.mdx
@@ -20,11 +20,13 @@ It also improves onboarding recovery, lifecycle cleanup, Hermes image builds, ru
   For more information, refer to [Quickstart with Deep Agents](/user-guide/deepagents/get-started/quickstart) and [Configure Model Capabilities](/user-guide/openclaw/inference/manage-inference/configure-model-capabilities).
 - `rebuild` and same-name onboarding replacement now record a transaction before the first destructive mutation.
   Recovery binds the source, replacement, registry generation, and OpenShell gateway, then continues the recorded operation or fails closed when those identities drift.
+  After the registry proves the replacement identity and generation, NemoClaw removes an obsolete owned source image unless the source is shared or the replacement reuses it.
   For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
 - Compatible-endpoint onboarding now limits the Responses API streaming-event probe to 5 seconds while preserving the Chat Completions API fallback.
   Onboarding reuses a successful Chat Completions validation result instead of sending the immediate host-side validation request when the public endpoint, model, authentication mode, and request requirements match.
   The validated IP address set must also match, so onboarding sends another validation request after the DNS pin changes.
   NemoClaw still sends a separate validation request for an operator-trusted private endpoint.
+  Final in-sandbox route verification for OpenClaw and Hermes now requires `inference.local` to return an HTTP response within 2 seconds per attempt, which leaves client overhead before OpenClaw's 2.5-second provider preflight limit.
   Host interruptions during an active onboarding step produce the existing resumable recovery path instead of an invalid state transition.
   DGX Station Express also preserves its owner-only resume receipt when automatic dual-Station discovery selects the single-Station fallback.
   For more information, refer to [Choose a Compatible Inference API](/user-guide/openclaw/inference/custom-endpoints/choose-compatible-inference-api), [Quickstart](/user-guide/openclaw/get-started/quickstart), and [Prepare DGX Station to Install NemoClaw](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).

--- a/docs/inference/understand-provider-validation.mdx
+++ b/docs/inference/understand-provider-validation.mdx
@@ -71,6 +71,23 @@ Compatible endpoint validation sends a real inference request because many proxi
 For an OpenAI-compatible endpoint, a reasoning model that returns only reasoning content can receive a retry with a larger response budget before NemoClaw reports failure.
 Route, configuration, and authentication failures still fail immediately.
 
+During one onboarding invocation, NemoClaw can reuse one successful Chat Completions validation instead of sending the same immediate host-side request.
+Reuse requires all these inputs to match:
+
+- The public endpoint URL.
+- The model ID.
+- The authentication mode.
+- Whether tool calling is required.
+- The validated DNS IP address set.
+
+Trailing endpoint slashes, duplicate IP addresses, and IP address order do not prevent reuse.
+NemoClaw sends another validation request in any of these cases:
+
+- Any of these inputs changes, including the DNS IP address set.
+- The endpoint URL contains embedded credentials, a query string, or a fragment.
+- Validation uses custom headers.
+- The endpoint is an operator-trusted private endpoint.
+
 An endpoint that is reachable only through `http://host.openshell.internal:<port>` cannot receive the host-side API probe.
 Verify that route from inside the sandbox after onboarding.
 

--- a/docs/inference/understand-provider-validation.mdx
+++ b/docs/inference/understand-provider-validation.mdx
@@ -83,7 +83,7 @@ Reuse requires all these inputs to match:
 Trailing endpoint slashes, duplicate IP addresses, and IP address order do not prevent reuse.
 NemoClaw sends another validation request in any of these cases:
 
-- Any of these inputs changes, including the DNS IP address set.
+- Any listed input differs after NemoClaw normalizes the endpoint URL and IP address set, including when the DNS IP address set changes.
 - The endpoint URL contains embedded credentials, a query string, or a fragment.
 - Validation uses custom headers.
 - The endpoint is an operator-trusted private endpoint.

--- a/docs/inference/verify-inference-route.mdx
+++ b/docs/inference/verify-inference-route.mdx
@@ -51,6 +51,12 @@ For those routes, continue to the final route check, then use the status command
 ## Understand Final Route Checks
 
 When onboarding prints a dashboard summary, it first requests `https://inference.local/v1/models` from inside the sandbox after policy and process recovery.
+<AgentOnly variant="openclaw,hermes">
+Each attempt allows 2 seconds for the route to return an HTTP response.
+</AgentOnly>
+<AgentOnly variant="openclaw">
+For OpenClaw, this leaves time for client overhead before its 2.5-second provider preflight stops.
+</AgentOnly>
 A transport failure or HTTP 5xx response leaves the onboarding session retryable at final verification instead of completing it.
 After restoring the route, resume onboarding to run the check again without rebuilding a healthy sandbox.
 

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -184,6 +184,10 @@ An accepted replacement is not deleted again.
 The command reports `Sandbox '<name>' already holds the replacement from the interrupted rebuild.` and preserves the state backup path when one exists.
 Pass `--verbose` to include the replacement identifier, OpenShell gateway, and journal phase in rebuild diagnostics.
 
+After the sandbox registry proves the journaled replacement identity and generation, NemoClaw removes an obsolete source image that it owns.
+It retains the image when the source is shared or the registered replacement reuses it.
+If image removal fails, NemoClaw keeps the accepted replacement and tells you to run `$$nemoclaw gc` for cleanup.
+
 NemoClaw fails closed when the selected gateway, replacement settings, durable source registry fields, or live source or target identity no longer matches the journal.
 The error names the sandbox and the mismatch that stopped recovery.
 Do not delete a same-name sandbox to bypass this check.

--- a/docs/reference/system-readiness.mdx
+++ b/docs/reference/system-readiness.mdx
@@ -52,7 +52,7 @@ Consumers can ignore fields that they do not recognize within major version 1.
 Use stable capability and finding IDs instead of parsing human summaries.
 Treat bounded evidence as diagnostic context unless an observation, capability, or finding references that evidence ID.
 
-## Verify the report producer
+## Verify the Report Producer
 
 Schema version `1.1.0` adds a required immutable identity for the CLI build that produced the report.
 The identity is present for `supported`, `incompatible`, and `inconclusive` reports.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -134,7 +134,7 @@ docker info
 The managed default gateway service accepts `DOCKER_HOST` only as an absolute local `unix://` socket path.
 It rejects remote endpoints and relative socket paths before service startup.
 
-### Onboarding reports `invalid_docker_host`
+### Onboarding Reports an Invalid Docker Host
 
 The `invalid_docker_host` advisory means that `DOCKER_HOST` is not an absolute local `unix://` socket path that NemoClaw can write to the managed OpenShell gateway service environment.
 NemoClaw does not use the standalone gateway fallback when this validation fails.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Completes the documentation follow-ups identified after the v0.0.100 tag.
The durable guides and `docs/changelog/2026-07-31.mdx` now cover final inference-route timing, validation reuse boundaries, and replacement-image cleanup.

## Changes

- [#8046](https://github.com/NVIDIA/NemoClaw/pull/8046) -> `docs/inference/verify-inference-route.mdx` and `docs/changelog/2026-07-31.mdx`: Documents the 2-second final `inference.local` response budget for OpenClaw and Hermes, including the OpenClaw client-overhead rationale.
- [#8044](https://github.com/NVIDIA/NemoClaw/pull/8044) -> `docs/inference/understand-provider-validation.mdx`: Documents the exact one-shot Chat Completions validation reuse and forced-revalidation conditions.
- [#8039](https://github.com/NVIDIA/NemoClaw/pull/8039) and [#8042](https://github.com/NVIDIA/NemoClaw/pull/8042) -> `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx` and `docs/changelog/2026-07-31.mdx`: Documents obsolete owned source-image cleanup after durable replacement proof and the `gc` recovery action.
- `docs/reference/system-readiness.mdx` and `docs/reference/troubleshooting.mdx`: Applies title case and removes code styling from headings while preserving literal identifiers in prose.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This documentation-only change does not modify executable behavior.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-07-31.mdx`, `docs/inference/understand-provider-validation.mdx`, `docs/inference/verify-inference-route.mdx`, `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx`, `docs/reference/system-readiness.mdx`, and `docs/reference/troubleshooting.mdx`. The documentation-only diff was reviewed against the writing rules and documentation style.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6d2cd17bd -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Documentation-only; `npx vitest run test/changelog-docs.test.ts test/agent-variant-docs.test.ts` passed 23 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npm run docs` completed with 0 errors and the existing Fern warning.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>
