### PR TITLE
test(dcode): cover secret rejection exit code

### DIFF
--- a/test/dcode-wrapper-identity.test.ts
+++ b/test/dcode-wrapper-identity.test.ts
@@ -184,6 +184,21 @@ describe.skipIf(!canRun)(
       });
     });
 
+    it("returns exit code 2 when .env contains a raw OpenAI API key (#8137)", () => {
+      withTempDir((dir) => {
+        const fixture = buildFixture(dir, SAMPLE_CONFIG);
+        fs.writeFileSync(fixture.envFile, "OPENAI_API_KEY=sk-live-XXXXXXXXXXXXX\n", "utf8");
+
+        const run = runBashWrapper(fixture, ["-n", "Reply with PING."], {});
+
+        expect(run.status).toBe(2);
+        expect(run.launched).toBe(false);
+        expect(run.stderr).toContain("refusing to start");
+        expect(run.stderr).toContain("OPENAI_API_KEY");
+        expect(run.stderr).not.toContain("sk-live-XXXXXXXXXXXXX");
+      });
+    });
+
     it("ignores traversal-shaped agent preferences", () => {
       withTempDir((dir) => {
         const config = SAMPLE_CONFIG.replace('default = "backend-dev"', 'default = ".."');

--- a/test/dcode-wrapper-identity.test.ts
+++ b/test/dcode-wrapper-identity.test.ts
@@ -195,7 +195,7 @@ describe.skipIf(!canRun)(
         expect(run.launched).toBe(false);
         expect(run.stderr).toContain("refusing to start");
         expect(run.stderr).toContain("OPENAI_API_KEY");
-        expect(run.stderr).not.toContain("sk-live-XXXXXXXXXXXXX");
+        expect(`${run.stdout}\n${run.stderr}`).not.toContain("sk-live-XXXXXXXXXXXXX");
       });
     });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Add a Linux regression test for dcode secret rejection. The test covers a raw `OPENAI_API_KEY` in the managed `.env` file and verifies exit code `2`, no launch, and no secret leakage. The current wrapper already implements this behavior; the test protects the contract reported by #8137.

## Related Issue
Fixes #8137

## Changes
- Add the exact `OPENAI_API_KEY=sk-live-...` `.env` case to the dcode wrapper security-boundary test.
- Assert exit code `2`, no dcode launch, the variable name in the refusal, and absence of the raw value.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Test-only regression coverage; no user-facing documentation changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending maintainer review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed; the review covered the test title and PR wording.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6f64df81 -->
<!-- docs-review-agents-blob-sha: 0082a58b -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — `npm run check:diff` reached the repository checks; all applicable file checks and the secret scan passed, but the existing source-architecture budget failed because `src/lib/core/shell-quote.ts` fan-in is 26 against a 27 limit.
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/dcode-wrapper-identity.test.ts` collected 26 Linux-only tests and skipped them on macOS. The related supervisor and empty-prompt tests passed 2 tests, with 18 Linux-only tests skipped.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Vinay Bhagavath <bhagavathvinay@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added coverage ensuring startup is blocked when a raw API key is present in the environment file.
  * Confirmed the application reports the affected variable, safely redacts the secret, and prevents launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->