### PR TITLE
ci(security): allow reviewed lock transitions

### DIFF
--- a/ci/reviewed-npm-audit.json
+++ b/ci/reviewed-npm-audit.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "nodeVersion": "22.23.1",
   "registryOrigin": "https://registry.npmjs.org/",
   "severityThreshold": "high",
@@ -70,7 +70,10 @@
       "integrity": "sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==",
       "tarballUrl": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.1.tgz",
       "directory": "agents/openclaw/openclaw-runtime",
-      "lockSha256": "82489f62febb12da52833c0b1f7f6969f7e21a098c565ef1f91342b1e5e32d88"
+      "reviewedLockSha256": [
+        "82489f62febb12da52833c0b1f7f6969f7e21a098c565ef1f91342b1e5e32d88",
+        "fdbee91a3f3a0222ec2e8e34864d09dfcff4711e86ac6bfa4d475af0593acd51"
+      ]
     },
     {
       "id": "mcporter-runtime",
@@ -79,7 +82,9 @@
       "integrity": "sha512-egoPVYqTnWb3NjRIxo+xc8OrAI0dlPrJm9pAiZx0pImuNIV5rKhGtTnIfH/Y1ldGPVu74ibj3KR5c9U/QSdQFA==",
       "tarballUrl": "https://registry.npmjs.org/mcporter/-/mcporter-0.7.3.tgz",
       "directory": "agents/openclaw/mcporter-runtime",
-      "lockSha256": "c31959d7950903f7477ca2e143b3f1f4adfd10f1961fe97db40cd72f62b84830"
+      "reviewedLockSha256": [
+        "c31959d7950903f7477ca2e143b3f1f4adfd10f1961fe97db40cd72f62b84830"
+      ]
     }
   ]
 }

--- a/scripts/audit-reviewed-npm-graph.mts
+++ b/scripts/audit-reviewed-npm-graph.mts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -27,7 +28,7 @@ type ReviewedPackage = Readonly<{
   tarballUrl: string;
 }>;
 type LockedGraph = ReviewedPackage &
-  Readonly<{ directory: string; id: string; lockSha256: string }>;
+  Readonly<{ directory: string; id: string; reviewedLockSha256: readonly string[] }>;
 type AuditConfig = Readonly<{
   archivePackages: readonly ReviewedPackage[];
   archiveGraphId: string;
@@ -36,7 +37,7 @@ type AuditConfig = Readonly<{
   lockedGraphs: readonly LockedGraph[];
   nodeVersion: string;
   registryOrigin: string;
-  schemaVersion: 2;
+  schemaVersion: 3;
   severityThreshold: Severity;
 }>;
 
@@ -118,7 +119,7 @@ function run(command: string, args: readonly string[], cwd: string) {
 function readConfig(): AuditConfig {
   const parsed = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")) as AuditConfig;
   if (
-    parsed.schemaVersion !== 2 ||
+    parsed.schemaVersion !== 3 ||
     !SEVERITIES.includes(parsed.severityThreshold) ||
     typeof parsed.archiveGraphId !== "string" ||
     !parsed.archiveGraphId ||
@@ -134,8 +135,12 @@ function readConfig(): AuditConfig {
         !graph.id ||
         typeof graph.directory !== "string" ||
         !graph.directory ||
-        typeof graph.lockSha256 !== "string" ||
-        !/^[0-9a-f]{64}$/.test(graph.lockSha256),
+        !Array.isArray(graph.reviewedLockSha256) ||
+        graph.reviewedLockSha256.length === 0 ||
+        graph.reviewedLockSha256.some(
+          (digest: unknown) => typeof digest !== "string" || !/^[0-9a-f]{64}$/.test(digest),
+        ) ||
+        new Set(graph.reviewedLockSha256).size !== graph.reviewedLockSha256.length,
     )
   ) {
     throw new Error("ci/reviewed-npm-audit.json is invalid");
@@ -192,9 +197,14 @@ function materializeLockedGraph(
     path.join(graph.directory, "package-lock.json"),
     `${graph.label} lockfile`,
   );
+  const expectedLockSha256 = selectReviewedLockSha256(
+    sourceLock,
+    graph.reviewedLockSha256,
+    graph.label,
+  );
   verifyReviewedNpmLock({
     expectedIntegrity: graph.integrity,
-    expectedLockSha256: graph.lockSha256,
+    expectedLockSha256,
     label: graph.label,
     lockfilePath: sourceLock,
     packageSpec: graph.packageSpec,
@@ -207,12 +217,26 @@ function materializeLockedGraph(
   fs.copyFileSync(sourceLock, path.join(destination, "package-lock.json"));
   run("npm", ["ci", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund"], destination);
   verifyInstalledNpmLock({
-    expectedLockSha256: graph.lockSha256,
+    expectedLockSha256,
     installRoot: destination,
     label: graph.label,
     lockfilePath: path.join(destination, "package-lock.json"),
   });
   return destination;
+}
+
+export function selectReviewedLockSha256(
+  lockfilePath: string,
+  reviewedDigests: readonly string[],
+  label: string,
+): string {
+  const actual = createHash("sha256").update(fs.readFileSync(lockfilePath)).digest("hex");
+  if (!reviewedDigests.includes(actual)) {
+    throw new Error(
+      `${label} lock SHA-256 mismatch\nExpected one of: ${reviewedDigests.join(", ")}\nActual:          ${actual}`,
+    );
+  }
+  return actual;
 }
 
 function readJsonObject(file: string, label: string): Record<string, any> {

--- a/test/openclaw-locked-install.test.ts
+++ b/test/openclaw-locked-install.test.ts
@@ -369,8 +369,8 @@ describe("locked OpenClaw production installation (#5896)", () => {
       expect.arrayContaining([
         expect.objectContaining({
           directory: "agents/openclaw/openclaw-runtime",
-          lockSha256: LOCK_SHA256,
           packageSpec: PACKAGE_SPEC,
+          reviewedLockSha256: expect.arrayContaining([LOCK_SHA256]),
         }),
       ]),
     );

--- a/test/reviewed-npm-audit-workflow.test.ts
+++ b/test/reviewed-npm-audit-workflow.test.ts
@@ -6,7 +6,10 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { normalizeOpenClawSignatureAlias } from "../scripts/audit-reviewed-npm-graph.mts";
+import {
+  normalizeOpenClawSignatureAlias,
+  selectReviewedLockSha256,
+} from "../scripts/audit-reviewed-npm-graph.mts";
 import { readYaml } from "./helpers/e2e-workflow-contract";
 
 type WorkflowStep = {
@@ -46,6 +49,22 @@ function requiredStep(job: WorkflowJob, name: string): WorkflowStep {
 }
 
 describe("trusted reviewed npm audit workflow (#5896)", () => {
+  it("accepts only an explicitly reviewed lock during a dependency transition", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-reviewed-lock-transition-"));
+    const lockfile = path.join(root, "package-lock.json");
+    fs.writeFileSync(lockfile, "reviewed lock\n");
+    const reviewed = "534ade489fdb2d8ff619a8b110c28fedbd2066e16ebf434738f64a5a44ec9860";
+    const previous = "a".repeat(64);
+    try {
+      expect(selectReviewedLockSha256(lockfile, [previous, reviewed], "test graph")).toBe(reviewed);
+      expect(() => selectReviewedLockSha256(lockfile, [previous], "test graph")).toThrow(
+        "lock SHA-256 mismatch",
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   // source-shape-contract: security -- PR dependency audit code must come from the base SHA or the one-time signed bootstrap
   it("runs PR audits from trusted code and keeps the main audit on the checked-in action", () => {
     const pr = readYaml<Workflow>(".github/workflows/pr.yaml");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Allow the trusted reviewed npm audit to recognize an explicitly reviewed lock transition.
This lets the current OpenClaw runtime lock and the pending `brace-expansion@5.0.9` lock pass the same base-trusted policy without accepting any unreviewed lock bytes.

## Related Issue

Prerequisite for #8156.

## Changes

- Advance the reviewed npm audit configuration to schema 3 and replace each single lock digest with a nonempty, unique list of reviewed digests.
- Select the exact target lock digest only when it appears in that trusted list, then pass the selected digest through the existing strict source-lock and installed-package verification.
- Temporarily list both the current and pending OpenClaw runtime lock digests; keep the mcporter graph restricted to its current digest.
- Update focused contracts to cover accepted and rejected transition locks and the shared OpenClaw audit authority.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal base-trusted CI audit policy and no supported user-facing behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The exact-head review confirmed the trusted-base boundary remains intact, unlisted lock bytes fail closed, and both existing strict lock verifiers receive one exact selected digest.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The schema transition is internal CI policy and does not change a supported API, CLI, user configuration, workflow, default, or user-facing error.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e7d2be90d -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `vitest` focused integration tests passed, 22/22.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this narrow audit-control change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation:

- `npm run source-shape:check` passed.
- `npm run build:cli` and `npm run typecheck` passed.
- Biome, test title, and Vitest project membership checks passed.
- Normal pre-commit and commit-message hooks passed.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved dependency audit verification to support multiple approved lockfile revisions.
  * Added stricter validation to detect unapproved or mismatched dependency lockfiles before and after installation.
  * Enhanced error reporting to clearly identify expected and actual lockfile checksums.

* **Tests**
  * Expanded coverage for approved lockfile selection and checksum mismatch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->