### PR TITLE
test(onboard): exercise registry HTTPS proxy tunnel

### DIFF
--- a/src/lib/onboard/managed-image-registry-fetch.test.ts
+++ b/src/lib/onboard/managed-image-registry-fetch.test.ts
@@ -39,12 +39,13 @@ describe("managed image registry transport", () => {
   it("routes the default registry fetch through the bounded host proxy", async () => {
     const tunnels: string[] = [];
     const abortController = new AbortController();
+    let destroyTunnel: (() => void) | undefined;
 
     const proxy = createServer();
     proxy.on("connect", (request, socket) => {
       tunnels.push(request.url ?? "");
       abortController.abort();
-      socket.destroy();
+      destroyTunnel = () => socket.destroy();
     });
     const proxyPort = await listen(proxy);
     const session = createManagedImageRegistryFetchSession({
@@ -57,9 +58,11 @@ describe("managed image registry transport", () => {
     try {
       await expect(
         session.fetchImpl("https://registry.invalid/v2/", { signal: abortController.signal }),
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({ name: "AbortError" });
       expect(tunnels).toEqual(["registry.invalid:443"]);
     } finally {
+      destroyTunnel?.();
+
       await session.close();
     }
   });

--- a/src/lib/onboard/managed-image-registry-fetch.test.ts
+++ b/src/lib/onboard/managed-image-registry-fetch.test.ts
@@ -56,9 +56,9 @@ describe("managed image registry transport", () => {
 
     try {
       await expect(
-        session.fetchImpl("http://registry.invalid/v2/", { signal: abortController.signal }),
+        session.fetchImpl("https://registry.invalid/v2/", { signal: abortController.signal }),
       ).rejects.toThrow();
-      expect(tunnels).toEqual(["registry.invalid:80"]);
+      expect(tunnels).toEqual(["registry.invalid:443"]);
     } finally {
       await session.close();
     }

--- a/src/lib/onboard/managed-image-registry-fetch.test.ts
+++ b/src/lib/onboard/managed-image-registry-fetch.test.ts
@@ -38,10 +38,13 @@ afterEach(async () => {
 describe("managed image registry transport", () => {
   it("routes the default registry fetch through the bounded host proxy", async () => {
     const tunnels: string[] = [];
+    const abortController = new AbortController();
+
     const proxy = createServer();
     proxy.on("connect", (request, socket) => {
       tunnels.push(request.url ?? "");
-      socket.end("HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n");
+      abortController.abort();
+      socket.destroy();
     });
     const proxyPort = await listen(proxy);
     const session = createManagedImageRegistryFetchSession({
@@ -52,7 +55,9 @@ describe("managed image registry transport", () => {
     });
 
     try {
-      await expect(session.fetchImpl("http://registry.invalid/v2/")).rejects.toThrow();
+      await expect(
+        session.fetchImpl("http://registry.invalid/v2/", { signal: abortController.signal }),
+      ).rejects.toThrow();
       expect(tunnels).toEqual(["registry.invalid:80"]);
     } finally {
       await session.close();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The managed registry proxy test now exercises the production-like HTTPS proxy route used by the registry client. Undici 8.10.0 sends an HTTP target as a plain proxy request, so the previous synthetic HTTP target could never reach the test's CONNECT handler and timed out in coverage shard 8.

## Changes

- Use an HTTPS registry target so the loopback proxy observes a CONNECT tunnel.
- Abort the test request once that stable behavior boundary is observed.
- Assert both the `AbortError` rejection and `registry.invalid:443` authority.
- Destroy the accepted test socket during deterministic `finally` cleanup.
- Leave production registry-fetch behavior unchanged.

## Stacked landing

This test-only PR is temporarily based on #8175 so CI evaluates the MCP audit fix and this Undici test correction together without creating a circular red dependency. Its public diff remains one test file. Once this PR is approved and green, it should merge into #8175; #8175 can then be revalidated and merged to `main` when its refreshed exact head is approved and green.

Auto-merge is intentionally disabled.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes one deterministic test route and does not change a public API, CLI, configuration, default, error, or supported product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The nine-category exact-head review passed at `405bdd6c09e60205003cb032b5a1f7f088c9799d`; the signed synchronization commit is empty and preserves reviewed tree `c3ad47e26a5387ce62fe95116730cc2777456719`. This is a loopback-only test change with no production, dependency, credential, or external-network behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: At exact head `405bdd6c09e60205003cb032b5a1f7f088c9799d`, the PR still changes only the loopback HTTPS CONNECT fixture. The signed synchronization commit is empty and has the same tree as reviewed parent `21ed6d13a`. No production or user-visible behavior changed; no explanatory comments or test titles changed; the writing review found no findings. `git diff --check` passed and the focused Vitest file passed 5/5. A docs build is not applicable.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 405bdd6c09e60205003cb032b5a1f7f088c9799d -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70934b540c404d3939e3321f5c7558 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact-head focused Vitest passed 5/5; the prior exact behavior correction passed coverage shard 8 in 8m47s.
- [x] Exact-head CLI TypeScript check and `git diff --check` passed.
- [ ] Applicable broad gate passed — exact-head stacked CI is authoritative and pending.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
Signed-off-by: Julie Yaunches <jmyaunch@gmail.com>
