### PR TITLE
fix(ci): preserve history for documentation-only checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Setup Node.js for docs-only checks
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -75,11 +76,10 @@ jobs:
           [ "$HADOLINT_SHA256" = "$ACTUAL" ] || { echo "::error::hadolint checksum mismatch"; exit 1; }
           chmod +x /usr/local/bin/hadolint
 
-      - name: Fetch checked-out merge base for docs-only checks
+      - name: Select checked-out merge base for docs-only checks
         shell: bash
         run: |
           DOCS_ONLY_FROM_REF="${{ github.event.pull_request.base.sha }}"
-          git fetch --no-tags --depth=1 origin "$DOCS_ONLY_FROM_REF"
           echo "DOCS_ONLY_FROM_REF=$DOCS_ONLY_FROM_REF" >> "$GITHUB_ENV"
 
       - name: Run docs-only hook checks

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -76,7 +76,7 @@ jobs:
           [ "$HADOLINT_SHA256" = "$ACTUAL" ] || { echo "::error::hadolint checksum mismatch"; exit 1; }
           chmod +x /usr/local/bin/hadolint
 
-      - name: Select checked-out merge base for docs-only checks
+      - name: Record pull request base SHA for docs-only checks
         shell: bash
         run: |
           DOCS_ONLY_FROM_REF="${{ github.event.pull_request.base.sha }}"

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -813,9 +813,12 @@ describe("pull request and main workflow contracts", () => {
         "${{ github.workflow }}-${{ github.ref }}-${{ github.event.action != 'edited' || github.event.changes.base != null }}",
       "cancel-in-progress": true,
     });
-    expect(
-      requiredWorkflowStep(prWorkflow.jobs["static-checks"], "Checkout").with?.["fetch-depth"],
-    ).toBe(0);
+    for (const jobName of ["static-checks", "docs-only-checks"]) {
+      expect(requiredWorkflowStep(prWorkflow.jobs[jobName], "Checkout").with?.["fetch-depth"]).toBe(
+        0,
+      );
+    }
+    expect(stepRuns(prWorkflow.jobs["docs-only-checks"]).join("\n")).not.toContain("git fetch");
     for (const [jobName, stepName, trustedActionPath, mainActionPath] of [
       [
         "static-checks",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Documentation-only pull requests can fail repository validation because their CI checkout lacks the history needed to compare with the pull request base. This change gives that job complete history, removes the shallow refetch, and extends the existing workflow contract to preserve both conditions.

## Changes

- Fetch complete Git history in the documentation-only check job.
- Record the pull request base SHA without a second shallow fetch.
- Extend the existing pull request workflow contract to require complete history and reject a later fetch.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes repository pull request CI only and does not change a user-facing NemoClaw surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent review of commit `bd270422a661ee3f25b39b88234d99aea4a0cc49` passed all nine security categories with no warnings or blocking findings. The workflow remains read-only and checkout credentials remain disabled.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This change updates pull request CI history handling for documentation-only checks. It does not change a user-facing NemoClaw surface. The changed workflow text and contract-test additions were reviewed against the repository writing and documentation rules.
- Agent: Codex Desktop
<!-- docs-review-head-sha: bd270422a661ee3f25b39b88234d99aea4a0cc49 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70934b540c404d3939e3321f5c7558 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Pending GitHub CI. No standalone local test was run because GitHub CI is authoritative for this repository workflow change.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run separately; GitHub CI will run the repository gates.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation workflow history handling for more reliable checks.
  * Simplified pull request base revision detection without an additional repository fetch.

* **Tests**
  * Updated workflow validation to confirm full-history checkouts and prevent unnecessary fetch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->