### PR TITLE
fix(agent): replace openclaw embedded-fallback raw output with clean recovery message (#8100)

### DIFF
--- a/src/lib/actions/sandbox/agent/passthrough-json.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-json.ts
@@ -29,7 +29,7 @@ function text(value: string | Buffer | null | undefined): string {
   return typeof value === "string" ? value : "";
 }
 
-function defaultGetOpenshellBinary(): string {
+export function defaultGetOpenshellBinary(): string {
   // Lazy require keeps this module unit-testable under Vitest's TS loader; the
   // OpenShell runtime imports runner/platform modules that only exist in built
   // CLI layouts.

--- a/src/lib/actions/sandbox/agent/passthrough-ollama-recovery.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-ollama-recovery.test.ts
@@ -122,9 +122,10 @@ function makePassthroughDeps(
     ensureLive: (async () => ({ state: "present", output: "Phase: Ready" })) as NonNullable<
       AgentPassthroughDeps["ensureLive"]
     >,
-    exec: (async () => {
+    execNonJson: ((): never => {
       events.push("dispatch");
-    }) as NonNullable<AgentPassthroughDeps["exec"]>,
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>,
     getRecentShieldsAutoRestore: () => ({ kind: "none" }),
     process: {
       exit: ((code: number) => {
@@ -177,11 +178,13 @@ describe("agent passthrough Ollama recovery ordering", () => {
       events.push("recovery");
     });
 
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--agent", "main", "-m", "ping"] },
-      { ...deps, runOllamaRestartRecovery: runRecovery },
-    );
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--agent", "main", "-m", "ping"] },
+        { ...deps, runOllamaRestartRecovery: runRecovery },
+      ),
+    ).rejects.toThrow("__exit:0");
 
     expect(runRecovery).toHaveBeenCalledWith(expect.objectContaining(route), deps.process);
     expect(events).toEqual(["recovery", "dispatch"]);
@@ -199,11 +202,13 @@ describe("agent passthrough Ollama recovery ordering", () => {
     );
     const runRecovery = vi.fn();
 
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--agent", "main", "-m", "ping"] },
-      { ...deps, runOllamaRestartRecovery: runRecovery },
-    );
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--agent", "main", "-m", "ping"] },
+        { ...deps, runOllamaRestartRecovery: runRecovery },
+      ),
+    ).rejects.toThrow("__exit:0");
 
     expect(runRecovery).not.toHaveBeenCalled();
     expect(events).toEqual(["dispatch"]);

--- a/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
@@ -27,7 +27,15 @@ const isTerminalAgentMock = vi.hoisted(() =>
   vi.fn((agent: { runtime?: { kind?: string } }) => agent.runtime?.kind === "terminal"),
 );
 
-vi.mock("../exec", () => ({ execSandbox: execMock }));
+vi.mock("../exec", () => ({
+  execSandbox: execMock,
+  buildOpenshellExecArgs: vi.fn((_sb: string, cmd: readonly string[]) => cmd),
+  wrapExecCommandWithRuntimeEnv: vi.fn((cmd: readonly string[]) => cmd),
+  computeExitCode: vi.fn((result: { status: number | null }) => ({
+    code: result.status ?? 1,
+    errorMessage: null,
+  })),
+}));
 vi.mock("../gateway-state", () => ({ ensureLiveSandboxOrExit: ensureLiveMock }));
 vi.mock("../../../state/registry", () => ({ getSandbox: getSandboxMock }));
 vi.mock("../../../agent/defs", () => ({
@@ -63,13 +71,22 @@ describe("runAgentPassthrough shields-relock warning", () => {
     result: ShieldsAutoRestoreReadResult,
     sandboxName = "alpha",
   ): Promise<string> {
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
     const { writes, proc } = makeProcMock();
-    await runAgentPassthrough(
-      sandboxName,
-      { extraArgs: ["--agent", "main", "-m", "hi"] },
-      { process: proc, getRecentShieldsAutoRestore: () => result },
-    );
+    await expect(
+      runAgentPassthrough(
+        sandboxName,
+        { extraArgs: ["--agent", "main", "-m", "hi"] },
+        {
+          process: proc,
+          execNonJson,
+          getRecentShieldsAutoRestore: () => result,
+        },
+      ),
+    ).rejects.toThrow("__exit:0");
     return writes.join("");
   }
 
@@ -78,7 +95,6 @@ describe("runAgentPassthrough shields-relock warning", () => {
       kind: "event",
       event: { timestamp: new Date().toISOString(), timeoutSeconds: 20 },
     });
-    expect(execMock).toHaveBeenCalled();
     expect(output).toMatch(/[Ss]hields auto-relocked after 20s/);
     expect(output).toMatch(/shields down --timeout 20s/);
   });
@@ -88,7 +104,6 @@ describe("runAgentPassthrough shields-relock warning", () => {
       kind: "event",
       event: { timestamp: new Date().toISOString(), timeoutSeconds: null },
     });
-    expect(execMock).toHaveBeenCalled();
     expect(output).toMatch(/[Ss]hields auto-relocked/);
     expect(output).toMatch(/shields down --timeout 60s/);
   });
@@ -183,13 +198,11 @@ describe("runAgentPassthrough shields-relock warning", () => {
 
   it("emits no relock warning when the audit has no recent event (#5922)", async () => {
     const output = await runWarning({ kind: "none" });
-    expect(execMock).toHaveBeenCalled();
     expect(output).not.toMatch(/[Ss]hields auto-relocked/);
   });
 
   it("reports unreadable audit history without blocking agent dispatch (#5922)", async () => {
     const output = await runWarning({ kind: "unreadable" });
-    expect(execMock).toHaveBeenCalled();
     expect(output).toMatch(/Could not read shields audit history/);
     expect(output).toMatch(/shields status/);
   });

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -34,7 +34,15 @@ const isTerminalAgentMock = vi.hoisted(() =>
   vi.fn((agent: { runtime?: { kind?: string } }) => agent.runtime?.kind === "terminal"),
 );
 
-vi.mock("../exec", () => ({ execSandbox: execMock }));
+vi.mock("../exec", () => ({
+  execSandbox: execMock,
+  buildOpenshellExecArgs: vi.fn((_sb: string, cmd: readonly string[]) => cmd),
+  wrapExecCommandWithRuntimeEnv: vi.fn((cmd: readonly string[]) => cmd),
+  computeExitCode: vi.fn((result: { status: number | null }) => ({
+    code: result.status ?? 1,
+    errorMessage: null,
+  })),
+}));
 vi.mock("../gateway-state", () => ({ ensureLiveSandboxOrExit: ensureLiveMock }));
 vi.mock("../../../state/registry", () => ({ getSandbox: getSandboxMock }));
 vi.mock("../../../agent/defs", () => ({
@@ -54,7 +62,12 @@ vi.mock("../../../../../nemoclaw/src/onboard/config.js", () => ({
 }));
 
 import registerPlugin, { type OpenClawPluginApi } from "../../../../../nemoclaw/src/index";
-import { type AgentPassthroughDeps, runAgentPassthrough } from "./passthrough";
+import {
+  type AgentNonJsonPassthroughDeps,
+  type AgentPassthroughDeps,
+  runAgentNonJsonPassthrough,
+  runAgentPassthrough,
+} from "./passthrough";
 
 function createPluginApi(): OpenClawPluginApi {
   return {
@@ -111,49 +124,74 @@ describe("runAgentPassthrough", () => {
   });
 
   it("forwards extraArgs verbatim to `openclaw agent` for OpenClaw sandboxes with --no-tty enforced", async () => {
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
-    await runAgentPassthrough("alpha", {
-      extraArgs: ["--agent", "work", "--session-id", "s-1", "-m", "ping"],
-    });
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--agent", "work", "--session-id", "s-1", "-m", "ping"] },
+        { execNonJson },
+      ),
+    ).rejects.toThrow("__exit:0");
     expect(ensureLiveMock).toHaveBeenCalledWith("alpha", { allowNonReadyPhase: true });
-    expect(execMock).toHaveBeenCalledWith(
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execNonJson).toHaveBeenCalledWith(
       "alpha",
       ["openclaw", "agent", "--agent", "work", "--session-id", "s-1", "-m", "ping"],
-      { tty: false },
+      expect.anything(),
     );
   });
 
   it("keeps a non-JSON agent reply isolated from the plugin banner (#5654)", async () => {
-    const stdout: string[] = [];
-    const stderr: string[] = [];
-    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(((chunk) => {
-      stdout.push(String(chunk));
-      return true;
-    }) as typeof process.stdout.write);
-    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(((chunk) => {
-      stderr.push(String(chunk));
-      return true;
-    }) as typeof process.stderr.write);
-    const exec = vi.fn(async () => {
-      registerPlugin(createPluginApi());
-      process.stdout.write("ack\n");
+    const stdoutWrites: string[] = [];
+    const stderrWrites: string[] = [];
+    const exit = vi.fn((code: number) => {
+      throw new Error(`__exit:${code}`);
     });
+    const proc = {
+      exit: exit as unknown as (code: number) => never,
+      stdout: {
+        write: (s: string) => {
+          stdoutWrites.push(s);
+          return true;
+        },
+      },
+      stderr: {
+        write: (s: string) => {
+          stderrWrites.push(s);
+          return true;
+        },
+      },
+    };
+    const execNonJson = vi.fn(
+      (
+        _sb: string,
+        _cmd: readonly string[],
+        procArg: NonNullable<AgentPassthroughDeps["process"]>,
+      ): never => {
+        // Simulate NemoClaw replaying captured OpenClaw output: banner goes to proc.stderr,
+        // agent reply goes to proc.stdout. This is what the captured transport path does
+        // (#5654: banner must not pollute stdout).
+        procArg.stdout!.write("ack\n");
+        procArg.stderr.write("[gateway]   NemoClaw registered\n");
+        throw new Error("__exit:0");
+      },
+    ) as NonNullable<AgentPassthroughDeps["execNonJson"]>;
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
 
-    try {
-      await runAgentPassthrough(
+    await expect(
+      runAgentPassthrough(
         "alpha",
         { extraArgs: ["--agent", "main", "-m", "ping"] },
-        { exec, getRecentShieldsAutoRestore: () => ({ kind: "none" }) },
-      );
-    } finally {
-      stdoutWrite.mockRestore();
-      stderrWrite.mockRestore();
-    }
+        { execNonJson, process: proc, getRecentShieldsAutoRestore: () => ({ kind: "none" }) },
+      ),
+    ).rejects.toThrow("__exit:0");
 
-    expect(stdout.join("")).toBe("ack\n");
-    expect(stdout.join("")).not.toContain("NemoClaw registered");
-    expect(stderr.join("")).toContain("NemoClaw registered");
+    expect(stdoutWrites.join("")).toBe("ack\n");
+    expect(stdoutWrites.join("")).not.toContain("NemoClaw registered");
+    expect(stderrWrites.join("")).toContain("NemoClaw registered");
   });
 
   it("uses the captured JSON path for `openclaw agent --json` so provenance can be emitted on stderr", async () => {
@@ -186,19 +224,25 @@ describe("runAgentPassthrough", () => {
     const execJson = vi.fn(((): never => {
       throw new Error("__unexpected-json");
     }) as NonNullable<AgentPassthroughDeps["execJson"]>);
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
 
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--agent", "work", "-m", "--json"] },
-      { execJson },
-    );
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--agent", "work", "-m", "--json"] },
+        { execJson, execNonJson },
+      ),
+    ).rejects.toThrow("__exit:0");
 
     expect(execJson).not.toHaveBeenCalled();
-    expect(execMock).toHaveBeenCalledWith(
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execNonJson).toHaveBeenCalledWith(
       "alpha",
       ["openclaw", "agent", "--agent", "work", "-m", "--json"],
-      { tty: false },
+      expect.anything(),
     );
   });
 
@@ -206,19 +250,25 @@ describe("runAgentPassthrough", () => {
     const execJson = vi.fn(((): never => {
       throw new Error("__unexpected-json");
     }) as NonNullable<AgentPassthroughDeps["execJson"]>);
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
 
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--agent", "work", "--", "--json"] },
-      { execJson },
-    );
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--agent", "work", "--", "--json"] },
+        { execJson, execNonJson },
+      ),
+    ).rejects.toThrow("__exit:0");
 
     expect(execJson).not.toHaveBeenCalled();
-    expect(execMock).toHaveBeenCalledWith(
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execNonJson).toHaveBeenCalledWith(
       "alpha",
       ["openclaw", "agent", "--agent", "work", "--", "--json"],
-      { tty: false },
+      expect.anything(),
     );
   });
 
@@ -226,20 +276,26 @@ describe("runAgentPassthrough", () => {
     const execJson = vi.fn(((): never => {
       throw new Error("__unexpected-json");
     }) as NonNullable<AgentPassthroughDeps["execJson"]>);
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
 
     // The first unknown flag selects conservative passthrough before the later --json token.
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--agent", "work", "--json-something", "--json"] },
-      { execJson },
-    );
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--agent", "work", "--json-something", "--json"] },
+        { execJson, execNonJson },
+      ),
+    ).rejects.toThrow("__exit:0");
 
     expect(execJson).not.toHaveBeenCalled();
-    expect(execMock).toHaveBeenCalledWith(
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execNonJson).toHaveBeenCalledWith(
       "alpha",
       ["openclaw", "agent", "--agent", "work", "--json-something", "--json"],
-      { tty: false },
+      expect.anything(),
     );
   });
 
@@ -306,19 +362,25 @@ describe("runAgentPassthrough", () => {
     const execJson = vi.fn(((): never => {
       throw new Error("__unexpected-json");
     }) as NonNullable<AgentPassthroughDeps["execJson"]>);
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
 
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--session-id", "s-1", flag, value] },
-      { execJson },
-    );
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--session-id", "s-1", flag, value] },
+        { execJson, execNonJson },
+      ),
+    ).rejects.toThrow("__exit:0");
 
     expect(execJson).not.toHaveBeenCalled();
-    expect(execMock).toHaveBeenCalledWith(
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execNonJson).toHaveBeenCalledWith(
       "alpha",
       ["openclaw", "agent", "--session-id", "s-1", flag, value],
-      { tty: false },
+      expect.anything(),
     );
   });
 
@@ -358,12 +420,18 @@ describe("runAgentPassthrough", () => {
   });
 
   it("treats a clean registry miss as OpenClaw (preserves bootstrap and recovery paths)", async () => {
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
     getSandboxMock.mockReturnValueOnce(null);
-    await runAgentPassthrough("ghost", { extraArgs: ["--agent", "main", "-m", "hi"] });
-    expect(execMock).toHaveBeenCalledWith(
+    await expect(
+      runAgentPassthrough("ghost", { extraArgs: ["--agent", "main", "-m", "hi"] }, { execNonJson }),
+    ).rejects.toThrow("__exit:0");
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execNonJson).toHaveBeenCalledWith(
       "ghost",
       ["openclaw", "agent", "--agent", "main", "-m", "hi"],
-      { tty: false },
+      expect.anything(),
     );
   });
 
@@ -512,14 +580,22 @@ describe("runAgentPassthrough", () => {
   });
 
   it("accepts selector in --flag=value form and forwards verbatim", async () => {
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
-    await runAgentPassthrough("alpha", {
-      extraArgs: ["--session-key=abc-123", "-m", "ping"],
-    });
-    expect(execMock).toHaveBeenCalledWith(
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--session-key=abc-123", "-m", "ping"] },
+        { execNonJson },
+      ),
+    ).rejects.toThrow("__exit:0");
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execNonJson).toHaveBeenCalledWith(
       "alpha",
       ["openclaw", "agent", "--session-key=abc-123", "-m", "ping"],
-      { tty: false },
+      expect.anything(),
     );
   });
 
@@ -561,5 +637,140 @@ describe("runAgentPassthrough", () => {
     const all = writes.join("");
     expect(all).toMatch(/Could not parse a 'Phase:' line/);
     expect(all).toMatch(/Refusing to dispatch/);
+  });
+
+  it("routes non-JSON OpenClaw commands through execNonJson for embedded-fallback interception", async () => {
+    const execNonJson = vi.fn(((): never => {
+      throw new Error("__exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execNonJson"]>);
+    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
+    await expect(
+      runAgentPassthrough(
+        "alpha",
+        { extraArgs: ["--agent", "main", "-m", "ping"] },
+        { execNonJson },
+      ),
+    ).rejects.toThrow("__exit:0");
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execNonJson).toHaveBeenCalledWith(
+      "alpha",
+      ["openclaw", "agent", "--agent", "main", "-m", "ping"],
+      expect.anything(),
+    );
+  });
+});
+
+describe("runAgentNonJsonPassthrough", () => {
+  function makeNonJsonProcMock() {
+    const stdoutWrites: string[] = [];
+    const stderrWrites: string[] = [];
+    const exit = vi.fn((code: number) => {
+      throw new Error(`__exit:${code}`);
+    });
+    return {
+      stdoutWrites,
+      stderrWrites,
+      exit,
+      proc: {
+        exit: exit as unknown as (code: number) => never,
+        stdout: {
+          write: (s: string) => {
+            stdoutWrites.push(s);
+            return true;
+          },
+        },
+        stderr: {
+          write: (s: string) => {
+            stderrWrites.push(s);
+            return true;
+          },
+        },
+      } as NonNullable<AgentPassthroughDeps["process"]>,
+    };
+  }
+
+  function makeSpawnMock(
+    stdout: string,
+    stderr: string,
+    status: number | null = 0,
+  ): NonNullable<AgentNonJsonPassthroughDeps["spawnSync"]> {
+    return vi.fn(() => ({
+      stdout,
+      stderr,
+      status,
+      pid: 1,
+      signal: null,
+      output: [],
+      error: undefined,
+    }));
+  }
+
+  const stubBinary = () => "/usr/local/bin/openshell";
+
+  it("emits a clean embedded-fallback error and exits 1 when EMBEDDED FALLBACK appears in stdout", () => {
+    const { stderrWrites, stdoutWrites, exit, proc } = makeNonJsonProcMock();
+    const spawnSyncMock = makeSpawnMock("EMBEDDED FALLBACK: using local model\nPONG\n", "", 0);
+    expect(() =>
+      runAgentNonJsonPassthrough("my-sb", ["openclaw", "agent", "--agent", "main"], proc, {
+        getOpenshellBinary: stubBinary,
+        spawnSync: spawnSyncMock,
+      }),
+    ).toThrow("__exit:1");
+    expect(exit).toHaveBeenCalledWith(1);
+    const errText = stderrWrites.join("");
+    expect(errText).toMatch(/embedded-fallback mode in sandbox 'my-sb'/);
+    expect(errText).toMatch(/my-sb recover/);
+    expect(errText).toMatch(/my-sb rebuild --yes/);
+    expect(errText).toMatch(/onboard --resume/);
+    expect(stdoutWrites.join("")).toBe("");
+  });
+
+  it("emits a clean embedded-fallback error and exits 1 when [agent/embedded] appears in stderr", () => {
+    const { stderrWrites, exit, proc } = makeNonJsonProcMock();
+    const spawnSyncMock = makeSpawnMock(
+      "",
+      "[agent/embedded] transport active\nsome response\n",
+      0,
+    );
+    expect(() =>
+      runAgentNonJsonPassthrough("my-sb", ["openclaw", "agent", "--agent", "main"], proc, {
+        getOpenshellBinary: stubBinary,
+        spawnSync: spawnSyncMock,
+      }),
+    ).toThrow("__exit:1");
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(stderrWrites.join("")).toMatch(/embedded-fallback mode/);
+  });
+
+  it("passes through clean stdout and exits with the real exit code when no embedded-fallback pattern is found", () => {
+    const { stdoutWrites, stderrWrites, exit, proc } = makeNonJsonProcMock();
+    const spawnSyncMock = makeSpawnMock("PONG\n", "", 0);
+    expect(() =>
+      runAgentNonJsonPassthrough(
+        "my-sb",
+        ["openclaw", "agent", "--agent", "main", "-m", "ping"],
+        proc,
+        {
+          getOpenshellBinary: stubBinary,
+          spawnSync: spawnSyncMock,
+        },
+      ),
+    ).toThrow("__exit:0");
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(stdoutWrites.join("")).toBe("PONG\n");
+    expect(stderrWrites.join("")).toBe("");
+  });
+
+  it("passes through non-zero exit code on clean failure without embedded-fallback", () => {
+    const { stderrWrites, exit, proc } = makeNonJsonProcMock();
+    const spawnSyncMock = makeSpawnMock("", "Error: agent session not found\n", 1);
+    expect(() =>
+      runAgentNonJsonPassthrough("my-sb", ["openclaw", "agent", "--agent", "main"], proc, {
+        getOpenshellBinary: stubBinary,
+        spawnSync: spawnSyncMock,
+      }),
+    ).toThrow("__exit:1");
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(stderrWrites.join("")).toContain("Error: agent session not found");
   });
 });

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type SpawnSyncOptions, type SpawnSyncReturns, spawnSync } from "node:child_process";
+
 // Source-of-truth boundary for the `nemoclaw <name> agent` passthrough.
 //
 // The wrapper enforces three host-side mirrors of upstream contracts, one
@@ -106,10 +108,19 @@ import { CLI_NAME } from "../../../cli/branding";
 import type { ShieldsAutoRestoreReadResult } from "../../../shields/audit";
 import { parseSandboxPhase } from "../../../state/gateway";
 import * as registry from "../../../state/registry";
-import { execSandbox } from "../exec";
+import {
+  buildOpenshellExecArgs,
+  computeExitCode,
+  execSandbox,
+  wrapExecCommandWithRuntimeEnv,
+} from "../exec";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
 import { hasAgentPassthroughHelpToken, printAgentPassthroughHelp } from "./passthrough-help";
-import { type AgentJsonPassthroughProcess, runAgentJsonPassthrough } from "./passthrough-json";
+import {
+  defaultGetOpenshellBinary,
+  type AgentJsonPassthroughProcess,
+  runAgentJsonPassthrough,
+} from "./passthrough-json";
 import { OLLAMA_LOCAL_PROVIDER, runOllamaRestartRecovery } from "./passthrough-ollama-recovery";
 import { maybeEmitShieldsRelockWarning } from "./passthrough-shields-warning";
 
@@ -135,6 +146,78 @@ const OPENCLAW_AGENT_VALUE_FLAGS = new Set([
 
 const OPENCLAW_AGENT_BOOLEAN_FLAGS = new Set(["--deliver"]);
 
+// OpenClaw can exit zero after running in embedded-fallback mode and does not
+// expose a stable machine-readable transport discriminator. These patterns mirror
+// the gateway-auth live tests in restore-gateway-pairing.ts and extend them with
+// the reporter-observed `[agent/embedded]` line prefix (#8100). Removal condition:
+// OpenClaw provides a supported machine-readable gateway-only result or removes
+// embedded-fallback mode.
+const OPENCLAW_EMBEDDED_FALLBACK_PATTERN =
+  /EMBEDDED FALLBACK|\[agent\/embedded\]|fallbackFrom[": ]+gateway|transport[": ]+embedded/i;
+
+const AGENT_NON_JSON_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
+function nonJsonAsText(value: string | Buffer | null | undefined): string {
+  if (Buffer.isBuffer(value)) return value.toString("utf-8");
+  return typeof value === "string" ? value : "";
+}
+
+export type AgentNonJsonPassthroughDeps = {
+  getOpenshellBinary?: () => string;
+  spawnSync?: (
+    command: string,
+    args: readonly string[],
+    options: SpawnSyncOptions,
+  ) => SpawnSyncReturns<string | Buffer>;
+};
+
+export function runAgentNonJsonPassthrough(
+  sandboxName: string,
+  command: readonly string[],
+  proc: NonNullable<AgentPassthroughDeps["process"]>,
+  deps: AgentNonJsonPassthroughDeps = {},
+): never {
+  const binary = (deps.getOpenshellBinary ?? defaultGetOpenshellBinary)();
+  const spawnSyncImpl = deps.spawnSync ?? spawnSync;
+  const result = spawnSyncImpl(
+    binary,
+    buildOpenshellExecArgs(sandboxName, wrapExecCommandWithRuntimeEnv(command), { tty: false }),
+    {
+      encoding: "utf-8",
+      maxBuffer: AGENT_NON_JSON_MAX_BUFFER_BYTES,
+      stdio: ["inherit", "pipe", "pipe"],
+    },
+  );
+  const stdout = nonJsonAsText(result.stdout);
+  const stderr = nonJsonAsText(result.stderr);
+
+  if (OPENCLAW_EMBEDDED_FALLBACK_PATTERN.test(`${stdout}\n${stderr}`)) {
+    proc.stderr.write(
+      `  OpenClaw is running in embedded-fallback mode in sandbox '${sandboxName}': gateway pairing is broken or missing.\n`,
+    );
+    proc.stderr.write("  Documented recovery paths:\n");
+    proc.stderr.write(
+      `    ${CLI_NAME} ${sandboxName} recover         — re-pair the gateway without recreating the sandbox\n`,
+    );
+    proc.stderr.write(
+      `    ${CLI_NAME} ${sandboxName} rebuild --yes   — recreate container, workspace preserved\n`,
+    );
+    proc.stderr.write(
+      `    ${CLI_NAME} onboard --resume               — restore sandbox registration\n`,
+    );
+    return proc.exit(1);
+  }
+
+  if (stdout) (proc.stdout ?? process.stdout).write(stdout);
+  if (stderr) proc.stderr.write(stderr);
+  const { code, errorMessage } = computeExitCode(result);
+  if (errorMessage) {
+    proc.stderr.write(`  Failed to invoke openshell: ${errorMessage}\n`);
+    proc.stderr.write("  Ensure 'openshell' is installed and on PATH.\n");
+  }
+  return proc.exit(code);
+}
+
 export interface AgentPassthroughOptions {
   extraArgs?: readonly string[];
 }
@@ -144,6 +227,7 @@ export interface AgentPassthroughDeps {
   ensureLive?: typeof ensureLiveSandboxOrExit;
   exec?: typeof execSandbox;
   execJson?: typeof runAgentJsonPassthrough;
+  execNonJson?: typeof runAgentNonJsonPassthrough;
   runOllamaRestartRecovery?: typeof runOllamaRestartRecovery;
   getRecentShieldsAutoRestore?: (sandboxName: string) => ShieldsAutoRestoreReadResult;
   process?: {
@@ -461,6 +545,11 @@ export async function runAgentPassthrough(
       stdout: proc.stdout ?? process.stdout,
       stderr: proc.stderr,
     } satisfies AgentJsonPassthroughProcess);
+    return;
+  }
+  if (isOpenClawPassthroughCommand(command)) {
+    const execNonJson = deps.execNonJson ?? runAgentNonJsonPassthrough;
+    execNonJson(sandboxName, command, proc);
     return;
   }
   const exec = deps.exec ?? execSandbox;


### PR DESCRIPTION
## Summary

When `recover` fails after a Docker restart, OpenClaw loses its `operator.write` scope and falls back to embedded mode. The non-JSON passthrough path previously used `["ignore", "inherit", "inherit"]` stdio — raw OpenClaw transport internals (e.g. `[agent/embedded]` prefixed lines) leaked directly to the user's terminal with no actionable guidance.

## Root cause

`runAgentPassthrough` dispatched non-JSON OpenClaw commands through `execSandbox` with `["ignore", "inherit", "inherit"]` stdio. NemoClaw could not intercept the output, so transport-layer noise passed straight through.

## Fix

- Add `runAgentNonJsonPassthrough` in `passthrough.ts` that uses `spawnSync` with `["inherit", "pipe", "pipe"]` to capture stdout/stderr.
- After the process exits, scan combined output for the embedded-fallback pattern (`EMBEDDED FALLBACK`, `[agent/embedded]`, `fallbackFrom: gateway`, `transport: embedded`).
- On a match: suppress raw output, print three documented recovery paths (`recover`, `rebuild --yes`, `onboard --resume`), exit 1.
- On clean output: replay stdout/stderr verbatim and propagate the real exit code.
- Export `defaultGetOpenshellBinary` from `passthrough-json.ts` so `passthrough.ts` can reuse it without adding a new fan-in edge to `adapters/openshell/runtime.ts` (budget: 52 → stays 52).
- Add `execNonJson?: typeof runAgentNonJsonPassthrough` to `AgentPassthroughDeps` for unit-test injection.

## Changed files

- `src/lib/actions/sandbox/agent/passthrough.ts` — core fix
- `src/lib/actions/sandbox/agent/passthrough-json.ts` — export `defaultGetOpenshellBinary`
- `src/lib/actions/sandbox/agent/passthrough.test.ts` — updated 8 tests + 5 new tests for `runAgentNonJsonPassthrough`
- `src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts` — updated mock + `runWarning` helper
- `src/lib/actions/sandbox/agent/passthrough-ollama-recovery.test.ts` — updated `makePassthroughDeps` + 2 tests

## Test plan

- [ ] `npx vitest run src/lib/actions/sandbox/agent/` — all 93 tests pass
- [ ] `npm run build:cli` — clean build
- [ ] Architecture budget check passes (fan-in for `runtime.ts` stays at 52)
- [ ] Manual repro: restart Docker while a sandbox is running, run `nemoclaw <sandbox> agent …` — confirm clean error message with recovery steps instead of raw `[agent/embedded]` output
- [ ] `nemoclaw <sandbox> recover` succeeds after the above — confirm normal passthrough resumes

Fixes #8100

Signed-off-by: yanyunl1991 <mzhong@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)