### PR TITLE
fix(ci): restore main image and platform gates

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -615,6 +615,7 @@ jobs:
             "slack",
             "whatsapp",
             "msteams",
+            "googlechat",
           ]) {
             if (config.channels?.[id]?.enabled !== false) {
               throw new Error(`managed OpenClaw channel ${id} is not explicitly disabled`);

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -591,7 +591,7 @@ jobs:
             .filter((entry) => entry.isDirectory())
             .flatMap((entry) => {
               const manifestPath = path.join(projectsRoot, entry.name, "package.json");
-              if (!fs.existsSync(manifestPath)) return [];
+              if (!fs.existsSync(manifestPath) || !fs.lstatSync(manifestPath).isFile()) return [];
               const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
               return [{ name: manifest.name, version: manifest.version }];
             });

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -583,21 +583,24 @@ jobs:
             slack: ["@openclaw/slack", "2026.7.1"],
             whatsapp: ["@openclaw/whatsapp", "2026.7.1"],
             msteams: ["@openclaw/msteams", "2026.7.1"],
+            googlechat: ["@openclaw/googlechat", "2026.7.1"],
           };
+          const projectsRoot = "/sandbox/.openclaw/npm/projects";
+          const installedPackages = fs
+            .readdirSync(projectsRoot, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .flatMap((entry) => {
+              const manifestPath = path.join(projectsRoot, entry.name, "package.json");
+              if (!fs.existsSync(manifestPath)) return [];
+              const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+              return [{ name: manifest.name, version: manifest.version }];
+            });
           for (const [id, [name, version]] of Object.entries(packages)) {
-            const install = config.plugins?.installs?.[id];
-            if (
-              !install ||
-              typeof install.installPath !== "string" ||
-              config.plugins?.entries?.[id]?.enabled !== false
-            ) {
-              throw new Error(`managed OpenClaw plugin ${id} is missing or active`);
-            }
-            const manifest = JSON.parse(
-              fs.readFileSync(path.join(install.installPath, "package.json"), "utf8"),
+            const matches = installedPackages.filter(
+              (installed) => installed.name === name && installed.version === version,
             );
-            if (manifest.name !== name || manifest.version !== version) {
-              throw new Error(`managed OpenClaw plugin ${id} has an unexpected package identity`);
+            if (matches.length !== 1 || config.plugins?.entries?.[id]?.enabled !== false) {
+              throw new Error(`managed OpenClaw plugin ${id} is missing, duplicated, or active`);
             }
           }
           for (const id of ["telegram", "tavily"]) {
@@ -634,7 +637,7 @@ jobs:
               raise SystemExit("managed Hermes optional platform is not explicitly disabled")
           if metadata.version("microsoft-teams-apps") != "2.0.13.4":
               raise SystemExit("managed Hermes microsoft-teams-apps version is wrong")
-          if metadata.version("aiohttp") != "3.14.1":
+          if metadata.version("aiohttp") != "3.14.3":
               raise SystemExit("managed Hermes aiohttp version is wrong")
           VALIDATE_HERMES_UNION
               ;;

--- a/.github/workflows/platform-vitest-main.yaml
+++ b/.github/workflows/platform-vitest-main.yaml
@@ -65,7 +65,10 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Build CLI
-        run: npm run build:cli
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          test "$(git rev-parse --verify HEAD)" = "$GITHUB_SHA"
+          npm run build:cli
 
       - name: Run Ubuntu 26.04 compatibility contracts
         run: |

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -699,7 +699,7 @@ RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \
 RUN HERMES_HOME=/sandbox/.hermes /usr/local/bin/hermes doctor --fix \
     && node --experimental-strip-types /opt/nemoclaw-hermes-config/generate-config.ts \
     && if [ "$NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION" = "1" ]; then \
-        /opt/hermes/.venv/bin/python -I -c 'import importlib.metadata as m, pathlib, yaml; config=yaml.safe_load(pathlib.Path("/sandbox/.hermes/config.yaml").read_text()); neutral={name: value for name, value in config["platforms"].items() if name != "api_server"}; assert len(neutral) == 30; assert all(value == {"enabled": False} for value in neutral.values()); assert m.version("microsoft-teams-apps") == "2.0.13.4"; assert m.version("aiohttp") == "3.14.1"'; \
+        /opt/hermes/.venv/bin/python -I -c 'import importlib.metadata as m, pathlib, yaml; config=yaml.safe_load(pathlib.Path("/sandbox/.hermes/config.yaml").read_text()); neutral={name: value for name, value in config["platforms"].items() if name != "api_server"}; assert len(neutral) == 30; assert all(value == {"enabled": False} for value in neutral.values()); assert m.version("microsoft-teams-apps") == "2.0.13.4"; assert m.version("aiohttp") == "3.14.3"'; \
         GOOGLE_CHAT_PROJECT_ID=nemoclaw-hostile \
         GOOGLE_CHAT_SUBSCRIPTION_NAME=projects/nemoclaw-hostile/subscriptions/nemoclaw-hostile \
         GOOGLE_CHAT_SERVICE_ACCOUNT_JSON='{"type":"service_account","project_id":"nemoclaw-hostile"}' \

--- a/scripts/checks/verify-managed-image-publication-evidence.sh
+++ b/scripts/checks/verify-managed-image-publication-evidence.sh
@@ -312,7 +312,8 @@ fi
 
 workload_sha256="${workload_digest#sha256:}"
 base_sha256="${base_reference##*@sha256:}"
-base_dependency_uri="pkg:docker/${base_reference}?platform=${platform//\//%2F}"
+base_repository="${base_reference%@sha256:*}"
+base_dependency_uri="pkg:docker/${base_repository}?digest=sha256:${base_sha256}&platform=${platform//\//%2F}"
 source_url="https://github.com/${repository}"
 builder_id="${source_url}/actions/runs/${run_id}/attempts/${run_attempt}"
 if ! jq -e \

--- a/test/hermes-final-image-layout.test.ts
+++ b/test/hermes-final-image-layout.test.ts
@@ -414,7 +414,7 @@ describe("Hermes final image layout", () => {
     );
     expect(doctorLayer).toContain('if [ "$NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION" = "1" ]; then');
     expect(doctorLayer).toContain('assert m.version("microsoft-teams-apps") == "2.0.13.4"');
-    expect(doctorLayer).toContain('assert m.version("aiohttp") == "3.14.1"');
+    expect(doctorLayer).toContain('assert m.version("aiohttp") == "3.14.3"');
     expect(doctorLayer).toContain("assert len(neutral) == 30");
     expect(doctorLayer).toContain("neutral-platform-inertness");
     expect(doctorLayer).toContain("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON");

--- a/test/managed-image-capability-union.test.ts
+++ b/test/managed-image-capability-union.test.ts
@@ -49,7 +49,7 @@ describe("managed-image capability union", () => {
     );
     expect(collectManagedImageHermesUvPackages()).toEqual([
       "microsoft-teams-apps==2.0.13.4",
-      "aiohttp==3.14.1",
+      "aiohttp==3.14.3",
     ]);
   });
 
@@ -149,7 +149,7 @@ describe("managed-image capability union", () => {
         NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION: "1",
       });
       expect(fs.readFileSync(trace, "utf8").trim()).toBe(
-        "pip install --python /opt/hermes/.venv/bin/python --no-cache -- microsoft-teams-apps==2.0.13.4 aiohttp==3.14.1",
+        "pip install --python /opt/hermes/.venv/bin/python --no-cache -- microsoft-teams-apps==2.0.13.4 aiohttp==3.14.3",
       );
     } finally {
       fs.rmSync(temporaryRoot, { force: true, recursive: true });

--- a/test/managed-image-publication-evidence.test.ts
+++ b/test/managed-image-publication-evidence.test.ts
@@ -27,6 +27,10 @@ const runAttempt = "1";
 const cohort = `ghrun-${runId}-${runAttempt}`;
 const baseReference = `ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:${"5".repeat(64)}`;
 const image = "ghcr.io/nvidia/nemoclaw/openclaw-sandbox";
+const buildkitBaseDependencyUri = (targetPlatform: string) => {
+  const [repositoryName, digest] = baseReference.split("@sha256:");
+  return `pkg:docker/${repositoryName}?digest=sha256:${digest}&platform=${targetPlatform.replace("/", "%2F")}`;
+};
 
 type FixtureOptions = {
   attestationWorkloadDigest?: string;
@@ -117,7 +121,7 @@ function runEvidence(options: FixtureOptions = {}, digestOverride?: string) {
         internalParameters: { buildConfig: {} },
         resolvedDependencies: [
           {
-            uri: options.slsaDependencyUri ?? `pkg:docker/${baseReference}?platform=linux%2Famd64`,
+            uri: options.slsaDependencyUri ?? buildkitBaseDependencyUri(platform),
             digest: { sha256: baseReference.split("@sha256:")[1] },
           },
         ],
@@ -488,7 +492,7 @@ describe("managed image publication evidence verifier", () => {
     [
       "base dependency platform",
       {
-        slsaDependencyUri: `pkg:docker/${baseReference}?platform=linux%2Farm64`,
+        slsaDependencyUri: buildkitBaseDependencyUri("linux/arm64"),
       },
     ],
     [

--- a/test/managed-image-publication-evidence.test.ts
+++ b/test/managed-image-publication-evidence.test.ts
@@ -29,7 +29,7 @@ const baseReference = `ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:${"5".repeat(
 const image = "ghcr.io/nvidia/nemoclaw/openclaw-sandbox";
 const buildkitBaseDependencyUri = (targetPlatform: string) => {
   const [repositoryName, digest] = baseReference.split("@sha256:");
-  return `pkg:docker/${repositoryName}?digest=sha256:${digest}&platform=${targetPlatform.replace("/", "%2F")}`;
+  return `pkg:docker/${repositoryName}?digest=sha256:${digest}&platform=${targetPlatform.replaceAll("/", "%2F")}`;
 };
 
 type FixtureOptions = {

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -181,6 +181,9 @@ function publicationBoundaryErrors(baseWorkflow: Workflow, managedWorkflow: Work
     "@openclaw/slack",
     "@openclaw/whatsapp",
     "@openclaw/msteams",
+    "@openclaw/googlechat",
+    "/sandbox/.openclaw/npm/projects",
+    "matches.length !== 1",
     "microsoft-teams-apps",
     "config.plugins?.entries?.[id]?.enabled !== false",
     'config["platforms"].get(name) != {"enabled": False}',
@@ -251,6 +254,7 @@ describe("complete managed-image publication workflow", () => {
     );
 
     expect(publicationBoundaryErrors(baseWorkflow, managedWorkflow)).toEqual([]);
+    expect(JSON.stringify(managedWorkflow)).not.toContain("config.plugins?.installs?.[id]");
     expect(publisher).toMatchObject({
       needs: ["build-and-push-hermes", "build-and-push-dcode", "build-and-push-openclaw"],
       permissions: {

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -255,6 +255,13 @@ describe("complete managed-image publication workflow", () => {
 
     expect(publicationBoundaryErrors(baseWorkflow, managedWorkflow)).toEqual([]);
     expect(JSON.stringify(managedWorkflow)).not.toContain("config.plugins?.installs?.[id]");
+    const validationRun =
+      step(managedPublisher(managedWorkflow), "Validate exact managed image before promotion")
+        .run ?? "";
+    const channelGuardEnd = validationRun.indexOf("managed OpenClaw channel");
+    const channelGuardStart = validationRun.lastIndexOf("for (const id of [", channelGuardEnd);
+    expect(channelGuardStart).toBeGreaterThan(-1);
+    expect(validationRun.slice(channelGuardStart, channelGuardEnd)).toContain('"googlechat",');
     expect(publisher).toMatchObject({
       needs: ["build-and-push-hermes", "build-and-push-dcode", "build-and-push-openclaw"],
       permissions: {

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -183,6 +183,7 @@ function publicationBoundaryErrors(baseWorkflow: Workflow, managedWorkflow: Work
     "@openclaw/msteams",
     "@openclaw/googlechat",
     "/sandbox/.openclaw/npm/projects",
+    "lstatSync(manifestPath).isFile()",
     "matches.length !== 1",
     "microsoft-teams-apps",
     "config.plugins?.entries?.[id]?.enabled !== false",
@@ -262,6 +263,18 @@ describe("complete managed-image publication workflow", () => {
     const channelGuardStart = validationRun.lastIndexOf("for (const id of [", channelGuardEnd);
     expect(channelGuardStart).toBeGreaterThan(-1);
     expect(validationRun.slice(channelGuardStart, channelGuardEnd)).toContain('"googlechat",');
+    const weakenedWorkflow = structuredClone(managedWorkflow);
+    const weakenedValidation = step(
+      managedPublisher(weakenedWorkflow),
+      "Validate exact managed image before promotion",
+    );
+    weakenedValidation.run = weakenedValidation.run?.replace(
+      " || !fs.lstatSync(manifestPath).isFile()",
+      "",
+    );
+    expect(publicationBoundaryErrors(baseWorkflow, weakenedWorkflow)).toContain(
+      "exact managed image validation is missing lstatSync(manifestPath).isFile()",
+    );
     expect(publisher).toMatchObject({
       needs: ["build-and-push-hermes", "build-and-push-dcode", "build-and-push-openclaw"],
       permissions: {

--- a/test/platform-vitest-main-workflow.test.ts
+++ b/test/platform-vitest-main-workflow.test.ts
@@ -32,6 +32,12 @@ function step(jobName: string, name: string): WorkflowStep {
 }
 
 describe("platform Vitest main workflow", () => {
+  it("marks the container checkout safe before generating build identity", () => {
+    const run = step("ubuntu-2604-contract", "Build CLI").run ?? "";
+    expect(run).toContain('git config --global --add safe.directory "$GITHUB_WORKSPACE"');
+    expect(run).toContain('test "$(git rev-parse --verify HEAD)" = "$GITHUB_SHA"');
+    expect(run.indexOf("safe.directory")).toBeLessThan(run.indexOf("npm run build:cli"));
+  });
   // source-shape-contract: security -- The trusted helper installs only checksum-verified official Node.js archives
   it("pins and verifies the Node.js archive in the trusted WSL helper", () => {
     const installSteps = [{ run: wslHelperSource }];

--- a/test/snapshot-gateway-guard.test.ts
+++ b/test/snapshot-gateway-guard.test.ts
@@ -196,6 +196,7 @@ function makeVmRestoreToEnv(
   const cloneReadyMarker = path.join(home, "clone-1-ready");
   const cloneRunningMarker = path.join(home, "clone-1-running");
   const gatewayLifecycleLog = path.join(home, "gateway-lifecycle.log");
+  const dashboardBind = process.env.WSL_DISTRO_NAME ? "0.0.0.0" : "127.0.0.1";
   writeExecutable(path.join(localBin, "openshell"), [
     'case "$1 $2" in',
     '  "gateway info") printf "Gateway Info\\n\\nGateway: nemoclaw\\nGateway endpoint: https://127.0.0.1:8080/\\n"; exit 0 ;;',
@@ -208,7 +209,7 @@ function makeVmRestoreToEnv(
     '    printf "NEMOCLAW_DCODE_PROBE=no-runtime\\n"; exit 0 ;;',
     '  "sandbox ssh-config") printf "Host openshell-alpha\\n  HostName 127.0.0.1\\n  User sandbox\\n"; exit 0 ;;',
     `  "sandbox create") touch ${JSON.stringify(cloneReadyMarker)} ${JSON.stringify(cloneRunningMarker)}; printf "created clone-1\\n"; exit 0 ;;`,
-    `  "forward list") printf "SANDBOX BIND PORT PID STATUS\\nclone-1 127.0.0.1 ${String(dashboardPort)} 4242 running\\n"; exit 0 ;;`,
+    `  "forward list") printf "SANDBOX BIND PORT PID STATUS\\nclone-1 ${dashboardBind} ${String(dashboardPort)} 4242 running\\n"; exit 0 ;;`,
     '  "forward stop") exit 1 ;;',
     "esac",
     'if [ "$1" = "status" ]; then exit 0; fi',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Recent main changes left managed-image validation and platform-watch fixtures out of sync with their production contracts. This change restores those gates without weakening package identity, provenance, or forward ownership checks.

## Changes

- Align the Hermes managed-image capability checks with the reviewed `aiohttp==3.14.3` update from #8203.
- Validate neutral OpenClaw plugin packages from the installed project directories because OpenClaw 2026.7.1 does not persist `plugins.installs` metadata.
- Validate Google Chat with the rest of the installed OpenClaw capability union.
- Match the BuildKit SLSA base-dependency URI emitted for digest-pinned images while retaining the separate digest check.
- Mark the Ubuntu container checkout as a Git safe directory and verify `HEAD` before generating build identity.
- Make the VM-driver snapshot fixture report the all-interface forward binding required on WSL.
- Leave the macOS Homebrew failure to existing PR #7739, which has the focused product fix.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This repair changes CI validation and platform test fixtures. It does not change a supported user command, configuration, workflow, or default.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending review of managed-image provenance and package-identity validation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `blocked`
- Evidence: No documentation paths changed. This host has no independent documentation-writer subagent, so the required final review is pending.
- Agent: Pi coding agent
<!-- docs-review-head-sha: 6cd1da386c811720e4318c1b9317b49cf575fc64 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70934b540c404d3939e3321f5c7558 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 6 integration files / 60 tests passed; WSL-bound snapshot fixture passed 5/5; review follow-ups passed 33 and 15 focused tests; repository checks, ShellCheck, and normal hooks passed; the repaired verifier accepted the failed main Deep Agents attestation.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: GitHub CI will run the broad gate; the redundant local broad run was stopped after focused validation passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed image validation for Google Chat and plugin installation consistency.
  - Updated Hermes image checks to use the latest approved `aiohttp` version.
  - Improved dashboard traffic forwarding behavior in WSL environments.
  - Corrected Docker dependency evidence generation for platform-specific image references.

- **Reliability**
  - Added safeguards to ensure builds use the intended source revision.
  - Expanded automated checks for image publication, plugin configuration, and workflow integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->