### PR TITLE
fix(onboard): persist the bumped dashboard port in the machine handler path (#8214)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4460,6 +4460,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
         }),
         ensureAgentDashboardForward: (name, selectedAgent) =>
           selectedAgent ? ensureAgentDashboardForward(name, selectedAgent) : 0,
+        persistDashboardPort: (name, port) => registry.updateSandbox(name, { dashboardPort: port }),
         recordStepSkipped,
         isOpenclawReady,
         skippedStepMessage,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4434,7 +4434,6 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
     setupInferenceFactory.selectGatewayForFollowupOrExit(GATEWAY_NAME, runOpenshell);
     const finalFlowContext = prepareFinalOnboardFlowContext(coreFlowResult);
     let liveFinalFlowContext: InitialOnboardFlowContext = finalFlowContext;
-
     const finalFlowPhases = createFinalOnboardFlowPhases<
       InitialOnboardFlowContext,
       import("./dashboard/contract").DashboardDeliveryChain,

--- a/src/lib/onboard/machine/final-flow-phases.ts
+++ b/src/lib/onboard/machine/final-flow-phases.ts
@@ -10,6 +10,7 @@ import {
   createPoliciesPhase,
   createPostVerifyPhase,
 } from "./flow-phases/agent-policy-finalization";
+import { UnexpectedOnboardFlowSliceStateError } from "./flow-slice-error";
 import { runFinalOnboardFlowSequence } from "./flow-slices";
 import { type AgentSetupStateOptions, handleAgentSetupState } from "./handlers/agent-setup";
 import {
@@ -18,7 +19,6 @@ import {
   handlePostVerifyState,
 } from "./handlers/finalization";
 import { handlePoliciesState, type PoliciesStateOptions } from "./handlers/policies";
-import { UnexpectedOnboardFlowSliceStateError } from "./flow-slice-error";
 import { createPhaseProgressReporter } from "./phase-progress";
 import type { OnboardStateResult } from "./result";
 import type { OnboardMachineRunnerRuntime, OnboardStateHandlerResult } from "./runner";
@@ -39,11 +39,10 @@ export interface FinalOnboardFlowPhaseOptions<
     migratedLegacyKeys: ReadonlySet<string>;
     webSearchEnabled(webSearchConfig: WebSearchConfig | null): boolean;
   };
-  finalizationDeps: FinalizationStateOptions<
-    Context["agent"],
-    VerifyChain,
-    VerificationResult
-  >["deps"];
+  finalizationDeps: Omit<
+    FinalizationStateOptions<Context["agent"], VerifyChain, VerificationResult>["deps"],
+    "persistDashboardPort"
+  >;
 }
 
 export function createFinalOnboardFlowPhases<
@@ -58,6 +57,10 @@ export function createFinalOnboardFlowPhases<
   OnboardSequencePhase<Context>,
   OnboardSequencePhase<Context>,
 ] {
+  const finalizationDeps = {
+    ...options.finalizationDeps,
+    persistDashboardPort: options.agentSetupDeps.persistDashboardPort,
+  };
   const createBranchPhase =
     options.branchState === "agent_setup" ? createAgentSetupPhase : createOpenclawSetupPhase;
   const branchSetupPhase = createBranchPhase<Context>(async (context) => {
@@ -119,7 +122,7 @@ export function createFinalOnboardFlowPhases<
       stagedLegacyKeys: options.finalization.stagedLegacyKeys,
       migratedLegacyKeys: options.finalization.migratedLegacyKeys,
       webSearchEnabled: options.finalization.webSearchEnabled(context.webSearchConfig),
-      deps: options.finalizationDeps,
+      deps: finalizationDeps,
     });
     return { result: finalizationResult.stateResult };
   });
@@ -137,7 +140,7 @@ export function createFinalOnboardFlowPhases<
       stagedLegacyKeys: options.finalization.stagedLegacyKeys,
       migratedLegacyKeys: options.finalization.migratedLegacyKeys,
       webSearchEnabled: options.finalization.webSearchEnabled(context.webSearchConfig),
-      deps: options.finalizationDeps,
+      deps: finalizationDeps,
     });
     return { result: postVerifyResult.stateResult };
   });

--- a/src/lib/onboard/machine/handlers/agent-setup.test.ts
+++ b/src/lib/onboard/machine/handlers/agent-setup.test.ts
@@ -14,6 +14,7 @@ function createDeps(overrides: Partial<AgentSetupStateOptions<Agent>["deps"]> = 
     handleAgentSetup: vi.fn(async () => undefined),
     context: vi.fn(() => ({ ctx: true })),
     ensureDashboard: vi.fn(() => 18789),
+    persistDashboardPort: vi.fn(),
     skipped: vi.fn(async (stepName: string) => {
       session.steps[stepName].status = "skipped";
       return session;
@@ -36,6 +37,7 @@ function createDeps(overrides: Partial<AgentSetupStateOptions<Agent>["deps"]> = 
       handleAgentSetup: calls.handleAgentSetup,
       agentSetupContext: calls.context,
       ensureAgentDashboardForward: calls.ensureDashboard,
+      persistDashboardPort: calls.persistDashboardPort,
       recordStepSkipped: calls.skipped,
       isOpenclawReady: calls.openclawReady,
       skippedStepMessage: calls.skippedMessage,
@@ -99,6 +101,27 @@ describe("handleAgentSetupState", () => {
       updates: undefined,
       metadata: { state: "agent_setup" },
     });
+  });
+
+  it("persists the bumped dashboard port returned by the forward (#8214)", async () => {
+    const { deps, calls } = createDeps({});
+    calls.ensureDashboard.mockReturnValue(18791);
+    const agent = { name: "hermes", displayName: "Hermes" };
+
+    await handleAgentSetupState({ ...baseOptions(deps, agent), resume: true });
+
+    expect(calls.ensureDashboard).toHaveBeenCalledWith("my-assistant", agent);
+    expect(calls.persistDashboardPort).toHaveBeenCalledWith("my-assistant", 18791);
+  });
+
+  it("does not persist a dashboard port when the agent manages no dashboard (#8214)", async () => {
+    const { deps, calls } = createDeps({});
+    calls.ensureDashboard.mockReturnValue(0);
+    const agent = { name: "hermes", displayName: "Hermes" };
+
+    await handleAgentSetupState({ ...baseOptions(deps, agent), resume: true });
+
+    expect(calls.persistDashboardPort).not.toHaveBeenCalled();
   });
 
   it("skips OpenClaw setup on resume when OpenClaw is ready", async () => {

--- a/src/lib/onboard/machine/handlers/agent-setup.ts
+++ b/src/lib/onboard/machine/handlers/agent-setup.ts
@@ -25,6 +25,7 @@ export interface AgentSetupStateOptions<Agent> {
     ): Promise<void>;
     agentSetupContext(): unknown;
     ensureAgentDashboardForward(sandboxName: string, agent: Agent): number;
+    persistDashboardPort(sandboxName: string, dashboardPort: number): void;
     recordStepSkipped(stepName: string): Promise<Session>;
     isOpenclawReady(sandboxName: string): boolean;
     skippedStepMessage(stepName: string, detail?: string | null): void;
@@ -69,7 +70,15 @@ export async function handleAgentSetupState<Agent>({
       session,
       deps.agentSetupContext(),
     );
-    deps.ensureAgentDashboardForward(sandboxName, agent);
+    // ensureAgentDashboardForward returns the port the dashboard forward was
+    // actually established on, which may be bumped when the default is already
+    // taken by another sandbox. Persist it to the registry so `dashboard-url`
+    // reports the live port instead of the default. Discarding the return here
+    // regressed multi-sandbox onboarding in the machine handler path (#8214).
+    const dashboardPort = deps.ensureAgentDashboardForward(sandboxName, agent);
+    if (dashboardPort > 0) {
+      deps.persistDashboardPort(sandboxName, dashboardPort);
+    }
     session = await deps.recordStepSkipped("openclaw");
     return { session, stateResult: advanceTo("policies", { metadata: { state: "agent_setup" } }) };
   }

--- a/src/lib/onboard/machine/handlers/finalization.test.ts
+++ b/src/lib/onboard/machine/handlers/finalization.test.ts
@@ -30,6 +30,7 @@ function createDeps(
   const calls = {
     setDefaultSandbox: vi.fn(),
     ensureAgentDashboard: vi.fn(() => 18789),
+    persistDashboardPort: vi.fn(),
     removeLegacy: vi.fn(),
     cleanupHost: vi.fn(),
     recoverProcesses: vi.fn(),
@@ -50,6 +51,7 @@ function createDeps(
     calls,
     deps: {
       ensureAgentDashboardForward: calls.ensureAgentDashboard,
+      persistDashboardPort: calls.persistDashboardPort,
       setDefaultSandbox: calls.setDefaultSandbox,
       toSessionUpdates: (updates: Record<string, unknown>) => updates as SessionUpdates,
       removeLegacyCredentialsFile: calls.removeLegacy,
@@ -211,6 +213,36 @@ describe("finalization handlers", () => {
     );
     expect(result.deploymentHealthy).toBe(true);
     expect(result.stateResult.type).toBe("complete");
+  });
+
+  it("persists the dashboard port selected after final recovery (#8214)", async () => {
+    const persistDashboardPort = vi.fn();
+    const { deps } = createDeps({
+      ensureAgentDashboardForward: vi.fn(() => 18792),
+      persistDashboardPort,
+    });
+
+    await handleFinalizationPhase({
+      ...baseOptions(deps),
+      agent: { name: "hermes" },
+    });
+
+    expect(persistDashboardPort).toHaveBeenCalledWith("my-assistant", 18792);
+  });
+
+  it("does not persist a zero dashboard port after final recovery (#8214)", async () => {
+    const persistDashboardPort = vi.fn();
+    const { deps } = createDeps({
+      ensureAgentDashboardForward: vi.fn(() => 0),
+      persistDashboardPort,
+    });
+
+    await handleFinalizationPhase({
+      ...baseOptions(deps),
+      agent: { name: "hermes" },
+    });
+
+    expect(persistDashboardPort).not.toHaveBeenCalled();
   });
 
   it("ensures agent dashboard forwarding before completion for non-OpenClaw agents", async () => {

--- a/src/lib/onboard/machine/handlers/finalization.ts
+++ b/src/lib/onboard/machine/handlers/finalization.ts
@@ -24,6 +24,7 @@ export interface FinalizationStateOptions<Agent, VerifyChain, VerificationResult
   webSearchEnabled: boolean;
   deps: {
     ensureAgentDashboardForward(sandboxName: string, agent: Agent): number;
+    persistDashboardPort(sandboxName: string, dashboardPort: number): void;
     /**
      * Mark this sandbox as the default. Called here (not at sandbox creation) so
      * a cancel at the policy-preset step never leaves an unconfigured sandbox
@@ -185,7 +186,10 @@ export async function handleFinalizationState<Agent, VerifyChain, VerificationRe
     deps.checkAndRecoverSandboxProcesses(sandboxName, { quiet: true });
     // Reconcile after the final recovery because any restart above can
     // invalidate the forward created earlier in onboarding.
-    deps.ensureAgentDashboardForward(sandboxName, agent);
+    const dashboardPort = deps.ensureAgentDashboardForward(sandboxName, agent);
+    if (dashboardPort > 0) {
+      deps.persistDashboardPort(sandboxName, dashboardPort);
+    }
   }
 
   return {

--- a/test/credential-migration-reconciliation.test.ts
+++ b/test/credential-migration-reconciliation.test.ts
@@ -67,6 +67,7 @@ async function finalizeMigration(
     webSearchEnabled: false,
     deps: {
       ensureAgentDashboardForward: () => 0,
+      persistDashboardPort: () => undefined,
       setDefaultSandbox: () => undefined,
       toSessionUpdates: (updates) => updates,
       removeLegacyCredentialsFile,

--- a/test/helpers/onboard-final-flow-phases.ts
+++ b/test/helpers/onboard-final-flow-phases.ts
@@ -192,6 +192,7 @@ export function createPhases(
         order.push("agent-forward");
         return 45123;
       }),
+      persistDashboardPort: vi.fn(),
       recordStepSkipped: recorders.recordStepSkipped ?? vi.fn(async () => createSession()),
       isOpenclawReady: () => false,
       skippedStepMessage: vi.fn(),

--- a/test/onboard-fsm-live-slices.test.ts
+++ b/test/onboard-fsm-live-slices.test.ts
@@ -202,6 +202,9 @@ function runSliceProbe(options: ProbeOptions) {
   const dashboardUrlCommandPath = JSON.stringify(
     path.join(repoRoot, "src", "lib", "dashboard-url-command.ts"),
   );
+  const finalizationDepsPath = JSON.stringify(
+    path.join(repoRoot, "src", "lib", "onboard", "finalization-deps.ts"),
+  );
 
   fs.writeFileSync(
     scriptPath,
@@ -219,11 +222,21 @@ const called = [];
 const sentinel = new Error("slice-called");
 
 if (scenario.mode === "dashboard-port-composition") {
+  const finalizationHandlerDeps = require(${finalizationDepsPath}).finalizationHandlerDeps;
+  finalizationHandlerDeps.checkAndRecoverSandboxProcesses = () => undefined;
+  finalizationHandlerDeps.warmupScopeUpgrade = () => undefined;
+  finalizationHandlerDeps.autoPairScopeApproval = () => undefined;
   const onboardDashboard = require(${onboardDashboardPath});
   const createOnboardDashboardHelpers = onboardDashboard.createOnboardDashboardHelpers;
+  let dashboardForwardCalls = 0;
   onboardDashboard.createOnboardDashboardHelpers = (deps) => ({
     ...createOnboardDashboardHelpers(deps),
-    ensureAgentDashboardForward: () => 18791,
+    ensureAgentDashboardForward: () => {
+      const port = dashboardForwardCalls === 0 ? 18791 : 18792;
+      dashboardForwardCalls += 1;
+      called.push("forward-port:" + String(port));
+      return port;
+    },
   });
   require(${agentOnboardPath}).handleAgentSetup = async () => undefined;
   require(${agentSelectionPath}).createOnboardAgentSelector = () => async () => ({
@@ -382,6 +395,9 @@ flowSlices.runFinalOnboardFlowSequence = async ({ context, phases }) => {
     const agentSetupPhase = phases.find((phase) => phase.state === "agent_setup");
     if (!agentSetupPhase) throw new Error("agent setup phase was not composed");
     await agentSetupPhase.run(context);
+    const finalizationPhase = phases.find((phase) => phase.state === "finalizing");
+    if (!finalizationPhase) throw new Error("finalization phase was not composed");
+    await finalizationPhase.run(context);
 
     const dashboardOutput = [];
     require(${dashboardUrlCommandPath}).runDashboardUrlCommand(
@@ -528,12 +544,14 @@ describe("live onboard FSM slice boundaries", () => {
     assert.deepEqual(runSliceProbe({ slice: "final" }), ["initial:init", "core", "final"]);
   });
 
-  it("returns the collision-selected dashboard port after agent onboarding (#8214)", () => {
+  it("returns the post-recovery dashboard port after agent onboarding (#8214)", () => {
     assert.deepEqual(runSliceProbe({ slice: "final", mode: "dashboard-port-composition" }), [
       "initial:init",
       "core",
-      "registry-port:18791",
-      "dashboard-url:http://127.0.0.1:18791/",
+      "forward-port:18791",
+      "forward-port:18792",
+      "registry-port:18792",
+      "dashboard-url:http://127.0.0.1:18792/",
     ]);
   }, 60_000);
 

--- a/test/onboard-fsm-live-slices.test.ts
+++ b/test/onboard-fsm-live-slices.test.ts
@@ -21,6 +21,7 @@ type ProbeMode =
   | "resume-core-gateway-provenance-resolver"
   | "authoritative-core-gateway"
   | "authoritative-core-gateway-policy-tier"
+  | "dashboard-port-composition"
   | "ordinary-policy-tier"
   | "ahead-core";
 
@@ -191,6 +192,16 @@ function runSliceProbe(options: ProbeOptions) {
     path.join(repoRoot, "src", "lib", "onboard", "machine", "core-flow-phases.ts"),
   );
   const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
+  const onboardDashboardPath = JSON.stringify(
+    path.join(repoRoot, "src", "lib", "onboard", "dashboard.ts"),
+  );
+  const agentOnboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "agent", "onboard.ts"));
+  const agentSelectionPath = JSON.stringify(
+    path.join(repoRoot, "src", "lib", "onboard", "agent-selection.ts"),
+  );
+  const dashboardUrlCommandPath = JSON.stringify(
+    path.join(repoRoot, "src", "lib", "dashboard-url-command.ts"),
+  );
 
   fs.writeFileSync(
     scriptPath,
@@ -206,6 +217,20 @@ const coreFlowPhases = require(${coreFlowPhasesPath});
 const registry = require(${registryPath});
 const called = [];
 const sentinel = new Error("slice-called");
+
+if (scenario.mode === "dashboard-port-composition") {
+  const onboardDashboard = require(${onboardDashboardPath});
+  const createOnboardDashboardHelpers = onboardDashboard.createOnboardDashboardHelpers;
+  onboardDashboard.createOnboardDashboardHelpers = (deps) => ({
+    ...createOnboardDashboardHelpers(deps),
+    ensureAgentDashboardForward: () => 18791,
+  });
+  require(${agentOnboardPath}).handleAgentSetup = async () => undefined;
+  require(${agentSelectionPath}).createOnboardAgentSelector = () => async () => ({
+    name: "hermes",
+    displayName: "Hermes Agent",
+  });
+}
 
 if (scenario.mode.endsWith("policy-tier") || scenario.mode.endsWith("provenance-resolver")) {
   const readsProvenance = scenario.mode.endsWith("provenance-resolver");
@@ -335,12 +360,44 @@ flowSlices.runCoreOnboardFlowSequence = async ({ context, runtime }) => {
   if (scenario.slice === "core") throw sentinel;
   await runtime.applyResult(advanceTo("inference", { metadata: { state: "provider_selection" } }));
   await runtime.applyResult(advanceTo("sandbox", { metadata: { state: "inference" } }));
-  await runtime.applyResult(branchTo("openclaw", { metadata: { state: "sandbox" } }));
+  await runtime.applyResult(
+    branchTo(scenario.mode === "dashboard-port-composition" ? "agent_setup" : "openclaw", {
+      metadata: { state: "sandbox" },
+    }),
+  );
   const session = await runtime.session();
   return { context: baseContext(context, { session }), session };
 };
 
-flowSlices.runFinalOnboardFlowSequence = async ({ context }) => {
+flowSlices.runFinalOnboardFlowSequence = async ({ context, phases }) => {
+  if (scenario.mode === "dashboard-port-composition") {
+    registry.registerSandbox({
+      name: "fsm-sandbox",
+      agent: "hermes",
+      provider: "openai-api",
+      model: "gpt-test",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+    });
+    const agentSetupPhase = phases.find((phase) => phase.state === "agent_setup");
+    if (!agentSetupPhase) throw new Error("agent setup phase was not composed");
+    await agentSetupPhase.run(context);
+
+    const dashboardOutput = [];
+    require(${dashboardUrlCommandPath}).runDashboardUrlCommand(
+      "fsm-sandbox",
+      { quiet: true },
+      {
+        fetchToken: () => null,
+        getSandbox: (name) => registry.getSandbox(name),
+        getAgentDashboardAuth: () => "session",
+        log: (message) => dashboardOutput.push(String(message)),
+      },
+    );
+    called.push("registry-port:" + String(registry.getSandbox("fsm-sandbox")?.dashboardPort));
+    called.push("dashboard-url:" + String(dashboardOutput.at(-1)));
+    throw sentinel;
+  }
   called.push("final");
   if (scenario.slice === "final") throw sentinel;
   throw new Error("unexpected final slice fallthrough");
@@ -397,7 +454,12 @@ const { onboard } = require(${onboardPath});
       (scenario.mode === "endpoint-override" &&
         error?.name === "OpenShellGatewayEndpointOverrideError")
     ) {
-      console.log(JSON.stringify({ called }));
+      const payload = JSON.stringify({ called });
+      if (scenario.mode === "dashboard-port-composition") {
+        process.stdout.write(payload + "\\n", () => process.exit(0));
+        return;
+      }
+      console.log(payload);
       return;
     }
     console.error(error);
@@ -420,7 +482,7 @@ const { onboard } = require(${onboardPath});
           : {}),
         ...(options.policyTier ? { NEMOCLAW_POLICY_TIER: options.policyTier } : {}),
       },
-      timeout: probeTimeoutMs,
+      timeout: scenario.mode === "dashboard-port-composition" ? 60_000 : probeTimeoutMs,
     },
   );
   try {
@@ -465,6 +527,15 @@ describe("live onboard FSM slice boundaries", () => {
   it("enters the final slice after the core slice reaches the branch state", () => {
     assert.deepEqual(runSliceProbe({ slice: "final" }), ["initial:init", "core", "final"]);
   });
+
+  it("returns the collision-selected dashboard port after agent onboarding (#8214)", () => {
+    assert.deepEqual(runSliceProbe({ slice: "final", mode: "dashboard-port-composition" }), [
+      "initial:init",
+      "core",
+      "registry-port:18791",
+      "dashboard-url:http://127.0.0.1:18791/",
+    ]);
+  }, 60_000);
 
   it("enters the strict initial runner at preflight on an exact-state resume", () => {
     assert.deepEqual(runSliceProbe({ slice: "initial", mode: "resume-initial" }), [


### PR DESCRIPTION
## Summary

When port 18789 is already taken by another sandbox, the onboard machine handler allocates a bumped dashboard port (for example, 18791) and the dashboard starts there—but `nemoclaw <sandbox> dashboard-url --quiet` returned `http://127.0.0.1:18789` (the default), so dashboard HTTP probes failed with `ECONNREFUSED`.

**Root cause:** In the machine handler path, `src/lib/onboard/machine/handlers/agent-setup.ts` called `ensureAgentDashboardForward(sandboxName, agent)` and discarded its return value—the actual, possibly bumped port—so the sandbox registry `dashboardPort` field kept the default. The old `onboard.ts` path persisted the returned port (`dashboardPort: actualDashboardPort`); the machine handler path regressed it.

Fixes #8214.

## Changes

- `src/lib/onboard/machine/handlers/agent-setup.ts`: capture `ensureAgentDashboardForward`'s returned port and, when the agent manages a dashboard (`port > 0`), persist it through a new `persistDashboardPort` dependency.
- `src/lib/onboard.ts`: wire `persistDashboardPort` to `registry.updateSandbox(name, { dashboardPort: port })`.
- `src/lib/onboard/machine/handlers/agent-setup.test.ts`: add tests that a bumped port is persisted and a no-dashboard agent (port 0) persists nothing.
- `src/lib/onboard/machine/handlers/finalization.ts`: persist a positive port selected when final recovery reconciles the dashboard forward, using the same registry callback as agent setup.
- `test/helpers/onboard-final-flow-phases.ts`: provide the new dependency in the shared agent-setup dependency fixture.
- `test/onboard-fsm-live-slices.test.ts`: cover the production-composed path from collision-selected port allocation through post-recovery reallocation, registry persistence, and `dashboard-url` output.

## Verification

Run on the Ubuntu host (`npm ci` + plugin build, Node 22), against a clean clone of this branch:

- **`npm run typecheck:cli`** → exit 0.
- **Affected suites with the fix**: `agent-setup.test.ts`, `finalization.test.ts`, `final-flow-phases.runtime.test.ts` → **42 passed**; `test/credential-migration-reconciliation.test.ts` → **2 passed**.
- **Reverting only the handler source, keeping the tests**: the `persists the bumped dashboard port (#8214)` test **fails** (`persistDashboardPort` not called)—the discarded-return regression, reproduced by driving the real `handleAgentSetupState` handler.
- **Advisor regression coverage**: the first composed regression and related suites passed **22 tests**. The post-recovery follow-up passed **48 targeted tests**, including a composed forward change from 18791 to 18792 with the registry and `dashboard-url` reporting 18792.
- Biome, test-title validation, and `git diff --check` passed.
- Normal pre-commit and pre-push hooks passed, including repository checks and CLI type-checking.

The revert run confirms the test exercises the real handler path rather than hand-built state; the passing runs confirm the live port is persisted and returned.

## Documentation

No user-visible surface change. This restores correct `dashboard-url` output on multi-sandbox onboarding, matching documented behavior. No documentation update is required.

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation change is needed. Commit `36be2b2f2` restores the documented dashboard-port contract by recording the positive port selected after final onboarding recovery. Existing documentation already explains next-free dashboard-port selection and recorded dashboard URLs for OpenClaw and Hermes. Agent-variant and route checks passed, and 48 focused tests passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 36be2b2f2 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

Signed-off-by: Jason Ma <jama@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent dashboard connection details are now retained during setup and finalization when a valid dashboard port is available.
  * Dashboard port information is skipped when no valid port is returned.
  * Dashboard URLs now reflect the retained connection details after onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
