### PR TITLE
fix(ci): validate installed managed plugins

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -592,13 +592,25 @@ jobs:
             .map((entry) => path.join(projectsRoot, entry.name));
           for (const [id, [name, version]] of Object.entries(packages)) {
             const matches = projectRoots.flatMap((projectRoot) => {
-              const packageRoot = path.join(projectRoot, "node_modules", ...name.split("/"));
+              const nodeModulesRoot = path.join(projectRoot, "node_modules");
+              const packageRoot = path.join(nodeModulesRoot, ...name.split("/"));
               const manifestPath = path.join(packageRoot, "package.json");
               if (
+                !fs.existsSync(nodeModulesRoot) ||
                 !fs.existsSync(packageRoot) ||
                 !fs.lstatSync(packageRoot).isDirectory() ||
                 !fs.existsSync(manifestPath) ||
                 !fs.lstatSync(manifestPath).isFile()
+              ) return [];
+              const packageRelative = path.relative(
+                fs.realpathSync(nodeModulesRoot),
+                fs.realpathSync(packageRoot),
+              );
+              if (
+                packageRelative === "" ||
+                packageRelative === ".." ||
+                packageRelative.startsWith(`..${path.sep}`) ||
+                path.isAbsolute(packageRelative)
               ) return [];
               const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
               return manifest.name === name && manifest.version === version ? [manifestPath] : [];

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -586,19 +586,23 @@ jobs:
             googlechat: ["@openclaw/googlechat", "2026.7.1"],
           };
           const projectsRoot = "/sandbox/.openclaw/npm/projects";
-          const installedPackages = fs
+          const projectRoots = fs
             .readdirSync(projectsRoot, { withFileTypes: true })
             .filter((entry) => entry.isDirectory())
-            .flatMap((entry) => {
-              const manifestPath = path.join(projectsRoot, entry.name, "package.json");
-              if (!fs.existsSync(manifestPath) || !fs.lstatSync(manifestPath).isFile()) return [];
-              const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-              return [{ name: manifest.name, version: manifest.version }];
-            });
+            .map((entry) => path.join(projectsRoot, entry.name));
           for (const [id, [name, version]] of Object.entries(packages)) {
-            const matches = installedPackages.filter(
-              (installed) => installed.name === name && installed.version === version,
-            );
+            const matches = projectRoots.flatMap((projectRoot) => {
+              const packageRoot = path.join(projectRoot, "node_modules", ...name.split("/"));
+              const manifestPath = path.join(packageRoot, "package.json");
+              if (
+                !fs.existsSync(packageRoot) ||
+                !fs.lstatSync(packageRoot).isDirectory() ||
+                !fs.existsSync(manifestPath) ||
+                !fs.lstatSync(manifestPath).isFile()
+              ) return [];
+              const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+              return manifest.name === name && manifest.version === version ? [manifestPath] : [];
+            });
             if (matches.length !== 1 || config.plugins?.entries?.[id]?.enabled !== false) {
               throw new Error(`managed OpenClaw plugin ${id} is missing, duplicated, or active`);
             }

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -122,6 +122,16 @@ function step(job: Job, name: string): Step {
   );
 }
 
+function isStrictChildPath(root: string, candidate: string): boolean {
+  const relative = path.relative(fs.realpathSync(root), fs.realpathSync(candidate));
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
 function managedPublisher(workflow: Workflow): Job {
   return required(
     workflow.jobs?.["build-and-validate"],
@@ -183,9 +193,14 @@ function publicationBoundaryErrors(baseWorkflow: Workflow, managedWorkflow: Work
     "@openclaw/msteams",
     "@openclaw/googlechat",
     "/sandbox/.openclaw/npm/projects",
-    '"node_modules", ...name.split("/")',
+    'const nodeModulesRoot = path.join(projectRoot, "node_modules")',
+    'path.join(nodeModulesRoot, ...name.split("/"))',
     "lstatSync(packageRoot).isDirectory()",
     "lstatSync(manifestPath).isFile()",
+    "realpathSync(nodeModulesRoot)",
+    "realpathSync(packageRoot)",
+    "packageRelative.startsWith(`..${path.sep}`)",
+    "path.isAbsolute(packageRelative)",
     "matches.length !== 1",
     "microsoft-teams-apps",
     "config.plugins?.entries?.[id]?.enabled !== false",
@@ -248,6 +263,24 @@ function publicationBoundaryErrors(baseWorkflow: Workflow, managedWorkflow: Work
 }
 
 describe("complete managed-image publication workflow", () => {
+  it("rejects managed package paths redirected outside node_modules", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-plugin-"));
+    try {
+      const nodeModulesRoot = path.join(fixtureRoot, "project", "node_modules");
+      const outsideScope = path.join(fixtureRoot, "outside-scope");
+      const installedPackageRoot = path.join(nodeModulesRoot, "direct-package");
+      const escapedPackageRoot = path.join(nodeModulesRoot, "@scope", "plugin");
+      fs.mkdirSync(installedPackageRoot, { recursive: true });
+      fs.mkdirSync(path.join(outsideScope, "plugin"), { recursive: true });
+      fs.symlinkSync(outsideScope, path.join(nodeModulesRoot, "@scope"));
+
+      expect(isStrictChildPath(nodeModulesRoot, installedPackageRoot)).toBe(true);
+      expect(isStrictChildPath(nodeModulesRoot, escapedPackageRoot)).toBe(false);
+    } finally {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("starts after exact base contracts with complete main triggers and does not cancel release-tag runs (#7744)", () => {
     const baseWorkflow = readWorkflow("base-image.yaml");
     const managedWorkflow = readWorkflow("managed-images.yaml");
@@ -284,11 +317,11 @@ describe("complete managed-image publication workflow", () => {
       "Validate exact managed image before promotion",
     );
     projectRootWeakenedValidation.run = projectRootWeakenedValidation.run?.replace(
-      ', "node_modules", ...name.split("/")',
+      'path.join(nodeModulesRoot, ...name.split("/"))',
       "",
     );
     expect(publicationBoundaryErrors(baseWorkflow, projectRootWeakenedWorkflow)).toContain(
-      'exact managed image validation is missing "node_modules", ...name.split("/")',
+      'exact managed image validation is missing path.join(nodeModulesRoot, ...name.split("/"))',
     );
     expect(publisher).toMatchObject({
       needs: ["build-and-push-hermes", "build-and-push-dcode", "build-and-push-openclaw"],

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -183,6 +183,8 @@ function publicationBoundaryErrors(baseWorkflow: Workflow, managedWorkflow: Work
     "@openclaw/msteams",
     "@openclaw/googlechat",
     "/sandbox/.openclaw/npm/projects",
+    '"node_modules", ...name.split("/")',
+    "lstatSync(packageRoot).isDirectory()",
     "lstatSync(manifestPath).isFile()",
     "matches.length !== 1",
     "microsoft-teams-apps",
@@ -259,6 +261,7 @@ describe("complete managed-image publication workflow", () => {
     const validationRun =
       step(managedPublisher(managedWorkflow), "Validate exact managed image before promotion")
         .run ?? "";
+    expect(validationRun).not.toContain('path.join(projectsRoot, entry.name, "package.json")');
     const channelGuardEnd = validationRun.indexOf("managed OpenClaw channel");
     const channelGuardStart = validationRun.lastIndexOf("for (const id of [", channelGuardEnd);
     expect(channelGuardStart).toBeGreaterThan(-1);
@@ -269,11 +272,23 @@ describe("complete managed-image publication workflow", () => {
       "Validate exact managed image before promotion",
     );
     weakenedValidation.run = weakenedValidation.run?.replace(
-      " || !fs.lstatSync(manifestPath).isFile()",
-      "",
+      "!fs.lstatSync(manifestPath).isFile()",
+      "false",
     );
     expect(publicationBoundaryErrors(baseWorkflow, weakenedWorkflow)).toContain(
       "exact managed image validation is missing lstatSync(manifestPath).isFile()",
+    );
+    const projectRootWeakenedWorkflow = structuredClone(managedWorkflow);
+    const projectRootWeakenedValidation = step(
+      managedPublisher(projectRootWeakenedWorkflow),
+      "Validate exact managed image before promotion",
+    );
+    projectRootWeakenedValidation.run = projectRootWeakenedValidation.run?.replace(
+      ', "node_modules", ...name.split("/")',
+      "",
+    );
+    expect(publicationBoundaryErrors(baseWorkflow, projectRootWeakenedWorkflow)).toContain(
+      'exact managed image validation is missing "node_modules", ...name.split("/")',
     );
     expect(publisher).toMatchObject({
       needs: ["build-and-push-hermes", "build-and-push-dcode", "build-and-push-openclaw"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed-image publication now validates OpenClaw plugin manifests at their installed package paths. The previous guard read each wrapper project's manifest and rejected a valid image after the build completed.

## Changes

- Resolve each expected plugin under its managed npm project's `node_modules` directory.
- Preserve exact package name, version, directory, regular-file, duplicate, and disabled-state validation.
- Extend the workflow contract test to reject the wrapper-project manifest path that caused Base Images run 30916380356 to fail.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change corrects an internal image-publication validation guard. It does not change a user-facing command, configuration, or supported workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Security code review passed all nine categories. The guard validates fixed package identities inside an immutable pulled image, fails closed, and rejects canonical package paths outside the managed `node_modules` root.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The review found no user-facing documentation impact or changed-text findings. The change affects only an internal image-publication guard and its regression test.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7c5d20287 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx --no-install vitest run test/managed-image-publication-workflow.test.ts` passed 16 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new doc pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of managed plugins by checking package manifests throughout project dependency directories.
  * Ensured plugin names and versions are validated consistently across project-specific dependencies.
  * Preserved safeguards requiring each managed plugin to match exactly once and remain disabled.
  * Added checks to prevent validation workflows from omitting required package directory or manifest verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
