### PR TITLE
ci(e2e): omit Jetson from automatic PR plans

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -638,10 +638,18 @@ Changes to `src/lib/actions/sandbox/status-snapshot.ts` select the exact
 delivery-recovery changes bound to the reboot simulation that independently
 probes the restored gateway and host forwarding.
 Every internal revision with selected jobs or targets automatically dispatches
-its deterministic plan after eligible PR CI passes. This behavior includes all
-internal E2E control-plane changes. Internal dispatch does not use
-`approve-e2e` or a maintainer role check. If no job or target is selected, the
-required check passes without an E2E run.
+its deterministic plan after eligible PR CI passes, except that automatic PR
+E2E planning temporarily omits only `jetson-nvmap-gpu`. This behavior includes
+all internal E2E control-plane changes. Internal dispatch does not use
+`approve-e2e` or a maintainer role check. If no job or target remains after the
+Jetson omission, the required check passes without an E2E run.
+
+The `jetson-nvmap-gpu` job remains available through an explicit manual `E2E
+main` dispatch with `jobs=jetson-nvmap-gpu`. Before setting
+`allow_jetson_runner_queue=true`, a repository administrator must confirm that
+the Jetson runner is online in the authoritative repository runner inventory.
+Restore automatic selection only after the Colossus-backed Jetson runner path
+is available and its online state can be confirmed before queueing.
 When selected E2E fails, a later internal PR commit starts a new dispatch after
 eligible PR CI passes for that commit. The dispatch runs the complete
 deterministic plan for the later commit, not only the selection that failed.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -638,9 +638,10 @@ Changes to `src/lib/actions/sandbox/status-snapshot.ts` select the exact
 delivery-recovery changes bound to the reboot simulation that independently
 probes the restored gateway and host forwarding.
 Every internal revision with selected jobs or targets automatically dispatches
-its deterministic plan after eligible PR CI passes, except that automatic PR
-E2E planning temporarily omits only `jetson-nvmap-gpu`. This behavior includes
-all internal E2E control-plane changes. Internal dispatch does not use
+its deterministic plan after eligible PR CI passes. Automatic PR E2E planning
+and PR Review Advisor E2E recommendations temporarily omit only
+`jetson-nvmap-gpu`. This behavior includes all internal E2E control-plane
+changes. Internal dispatch does not use
 `approve-e2e` or a maintainer role check. If no job or target remains after the
 Jetson omission, the required check passes without an E2E run.
 
@@ -648,8 +649,9 @@ The `jetson-nvmap-gpu` job remains available through an explicit manual `E2E
 main` dispatch with `jobs=jetson-nvmap-gpu`. Before setting
 `allow_jetson_runner_queue=true`, a repository administrator must confirm that
 the Jetson runner is online in the authoritative repository runner inventory.
-Restore automatic selection only after the Colossus-backed Jetson runner path
-is available and its online state can be confirmed before queueing.
+Restore Jetson automatic planning and PR Review Advisor recommendations only
+after the Colossus-backed Jetson runner path is available and its online state
+can be confirmed before queueing.
 When selected E2E fails, a later internal PR commit starts a new dispatch after
 eligible PR CI passes for that commit. The dispatch runs the complete
 deterministic plan for the later commit, not only the selection that failed.

--- a/test/pr-e2e-gate-jetson-exclusion.test.ts
+++ b/test/pr-e2e-gate-jetson-exclusion.test.ts
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, it } from "vitest";
+import {
+  normalizeE2eCoverageResult,
+  normalizeE2eTargetAdvisorResult,
+  trustedE2eRecommendationInventory,
+} from "../tools/advisors/e2e-recommendations.mts";
 import { buildRiskPlan, riskPlanRequiredJobIds } from "../tools/advisors/risk-plan.mts";
 import {
   focusedPrGateE2eJobsForChangedFiles,
@@ -21,9 +26,51 @@ it("omits the guarded Jetson job from automatic PR E2E plans (#7610)", () => {
     focusedE2eJobs: focusedPrGateE2eJobsForChangedFiles(changedFiles),
   });
 
+  expect(focusedPrGateE2eJobsForChangedFiles(changedFiles)).toEqual([]);
   expect(validateRiskPlan(plan, new Set(riskPlanRequiredJobIds(plan)))).toEqual(plan);
   expect(riskPlanRequiredJobIds(plan)).not.toContain("jetson-nvmap-gpu");
   expect(riskPlanRequiredJobIds(plan)).toEqual(
     expect.arrayContaining(["cloud-inference", "cloud-onboard", "security-posture"]),
   );
+});
+
+it("omits the guarded Jetson job from advisor E2E recommendations (#7610)", () => {
+  const changedFiles = ["test/e2e/live/jetson-nvmap-gpu.test.ts"];
+  const metadata = { baseRef: "origin/main", headRef: "HEAD", changedFiles };
+  const riskPlan = buildRiskPlan({
+    headSha: "a".repeat(40),
+    changedFiles,
+    focusedE2eJobs: focusedPrGateE2eJobsForChangedFiles(changedFiles),
+  });
+  const modelGuidance = {
+    requiredTests: [{ id: "jetson-nvmap-gpu", reason: "Model-selected coverage." }],
+    optionalTests: [{ id: "jetson-nvmap-gpu", reason: "Model-selected coverage." }],
+    required: [
+      {
+        id: "jetson-nvmap-gpu",
+        workflow: "e2e.yaml",
+        selectorType: "job",
+        reason: "Model-selected job.",
+      },
+    ],
+    optional: [],
+    confidence: "high",
+  };
+
+  const coverage = normalizeE2eCoverageResult(modelGuidance, metadata, riskPlan);
+  const targets = normalizeE2eTargetAdvisorResult(modelGuidance, metadata, { riskPlan });
+  const dynamicallyDiscovered = normalizeE2eTargetAdvisorResult(modelGuidance, metadata, {
+    riskPlan,
+    changedFileSources: {
+      [changedFiles[0]]: "// @module-tag e2e/credential-free\n",
+    },
+  });
+
+  expect(trustedE2eRecommendationInventory().allowedJobIds).not.toContain("jetson-nvmap-gpu");
+  expect(coverage.requiredTests.map((item) => item.id)).not.toContain("jetson-nvmap-gpu");
+  expect(coverage.optionalTests.map((item) => item.id)).not.toContain("jetson-nvmap-gpu");
+  expect(targets.required.map((item) => item.id)).not.toContain("jetson-nvmap-gpu");
+  expect(targets.optional.map((item) => item.id)).not.toContain("jetson-nvmap-gpu");
+  expect(dynamicallyDiscovered.changedCredentialFreeTests).toEqual([]);
+  expect(dynamicallyDiscovered.required.map((item) => item.id)).not.toContain("jetson-nvmap-gpu");
 });

--- a/test/pr-e2e-gate-jetson-exclusion.test.ts
+++ b/test/pr-e2e-gate-jetson-exclusion.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, it } from "vitest";
+import { buildRiskPlan, riskPlanRequiredJobIds } from "../tools/advisors/risk-plan.mts";
+import {
+  focusedPrGateE2eJobsForChangedFiles,
+  validateRiskPlan,
+} from "../tools/e2e/pr-e2e-gate.mts";
+import { focusedE2eJobsForChangedFiles } from "../tools/e2e/workflow-boundary.mts";
+
+it("omits the guarded Jetson job from automatic PR E2E plans (#7610)", () => {
+  const changedFiles = ["test/e2e/live/jetson-nvmap-gpu.test.ts"];
+
+  expect(focusedE2eJobsForChangedFiles(changedFiles)).toEqual([
+    { id: "jetson-nvmap-gpu", matchedFiles: changedFiles },
+  ]);
+  const plan = buildRiskPlan({
+    headSha: "a".repeat(40),
+    changedFiles,
+    focusedE2eJobs: focusedPrGateE2eJobsForChangedFiles(changedFiles),
+  });
+
+  expect(validateRiskPlan(plan, new Set(riskPlanRequiredJobIds(plan)))).toEqual(plan);
+  expect(riskPlanRequiredJobIds(plan)).not.toContain("jetson-nvmap-gpu");
+  expect(riskPlanRequiredJobIds(plan)).toEqual(
+    expect.arrayContaining(["cloud-inference", "cloud-onboard", "security-posture"]),
+  );
+});

--- a/tools/advisors/e2e-recommendations.mts
+++ b/tools/advisors/e2e-recommendations.mts
@@ -11,7 +11,7 @@ import { liveTargetSupport } from "../../test/e2e/registry/runtime-support.ts";
 import { moduleTagDeclarations } from "../e2e/module-tags.mts";
 import { containsCommandShapedE2eText } from "./e2e-text.mts";
 import { enumValue, recordItems, stringOrUndefined } from "./json.mts";
-import { buildRiskPlan, type RiskPlan } from "./risk-plan.mts";
+import { buildRiskPlan, isPrE2ePlanningJob, type RiskPlan } from "./risk-plan.mts";
 
 const E2E_WORKFLOW = "e2e.yaml";
 const E2E_WORKFLOW_PATH = `.github/workflows/${E2E_WORKFLOW}`;
@@ -191,12 +191,13 @@ export function normalizeE2eCoverageResult(
 }
 
 function deterministicCoverageTests(changedFiles: string[], riskPlan: RiskPlan): E2eCoverageTest[] {
-  const tests: E2eCoverageTest[] = [...riskPlan.requiredJobs, ...riskPlan.requiredTargets].map(
-    (selection) => ({
-      id: selection.id,
-      reason: selection.reasons.join(" "),
-    }),
-  );
+  const tests: E2eCoverageTest[] = [
+    ...riskPlan.requiredJobs.filter((job) => isPrE2ePlanningJob(job.id)),
+    ...riskPlan.requiredTargets,
+  ].map((selection) => ({
+    id: selection.id,
+    reason: selection.reasons.join(" "),
+  }));
   if (requiresCloudOnboardE2e(changedFiles) && !tests.some((test) => test.id === "cloud-onboard")) {
     tests.push({
       id: "cloud-onboard",
@@ -352,7 +353,9 @@ function buildE2eTargetNormalizationContext(
   const trustedWorkflowText = readTrustedE2eWorkflowText();
   const trustedCredentialFreeTests = discoverTrustedCredentialFreeTests();
   const allowedJobIds = new Set(
-    extractAllowedE2eJobIds(trustedWorkflowText, trustedCredentialFreeTests),
+    extractAllowedE2eJobIds(trustedWorkflowText, trustedCredentialFreeTests).filter(
+      isPrE2ePlanningJob,
+    ),
   );
   // The analyzed workflow is untrusted input. It may explain why a changed test is
   // unwired, but it must never introduce a selector that CI could later dispatch.
@@ -380,7 +383,7 @@ function buildE2eTargetNormalizationContext(
   for (const [file, project] of changedCredentialFreeProjects) {
     const source = changedSource(file, changedFileSources);
     const row = source ? credentialFreeTestRow(file, source) : undefined;
-    if (!row || !project) continue;
+    if (!row || !project || !isPrE2ePlanningJob(row.id)) continue;
     addMapValue(liveTestToJobs, row.file, row.id);
     allowedJobIds.add(row.id);
     changedCredentialFreeTests.push(row);
@@ -454,7 +457,7 @@ function trustedAllowedJobIds(): string[] {
   return extractAllowedE2eJobIds(
     readTrustedE2eWorkflowText(),
     discoverTrustedCredentialFreeTests(),
-  );
+  ).filter(isPrE2ePlanningJob);
 }
 
 function extractAllowedE2eJobIds(

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -11,6 +11,7 @@ export const PR_E2E_TYPED_TARGET_IDS = [
 ] as const;
 
 const PR_E2E_TYPED_TARGET_ID_SET = new Set<string>(PR_E2E_TYPED_TARGET_IDS);
+const PR_E2E_PLANNING_OMITTED_JOB_IDS = new Set(["jetson-nvmap-gpu"]);
 const DEEPAGENTS_HEADLESS_INFERENCE_CHECK =
   "test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh";
 const DEEPAGENTS_CODE_RUNTIME_ROOT = "agents/langchain-deepagents-code/";
@@ -151,6 +152,12 @@ const FOCUSED_E2E_INVARIANTS = [
 
 export function isPrE2eTypedTargetId(value: string): boolean {
   return PR_E2E_TYPED_TARGET_ID_SET.has(value);
+}
+
+export function isPrE2ePlanningJob(value: string): boolean {
+  // Automatic PR planning cannot confirm an online self-hosted Jetson runner.
+  // Remove this exclusion after the Colossus-backed runner path can make that confirmation.
+  return !PR_E2E_PLANNING_OMITTED_JOB_IDS.has(value);
 }
 
 export function focusedPrE2eTargetsForChangedFiles(

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -63,6 +63,7 @@ export { validateWorkflowDispatchDetails } from "./pr-e2e-dispatch-reconciliatio
 
 const E2E_WORKFLOW = "e2e.yaml";
 const E2E_WORKFLOW_PATH = `.github/workflows/${E2E_WORKFLOW}`;
+const JETSON_E2E_JOB = "jetson-nvmap-gpu";
 const PR_GATE_WORKFLOW = "pr-e2e-gate.yaml";
 const CHECK_NAME = "E2E / PR Gate";
 const WORKFLOW_NAME = "E2E / PR Gate Controller";
@@ -690,7 +691,7 @@ export function validateRiskPlan(value: unknown, allowedJobs: ReadonlySet<string
   const rebuilt = buildRiskPlan({
     headSha: value.headSha,
     changedFiles: value.changedFiles as string[],
-    focusedE2eJobs: focusedE2eJobsForChangedFiles(value.changedFiles as string[]),
+    focusedE2eJobs: focusedPrGateE2eJobsForChangedFiles(value.changedFiles as string[]),
   });
   if (JSON.stringify(value) !== JSON.stringify(rebuilt)) {
     throw new Error("risk plan does not match its hash and inputs");
@@ -715,6 +716,17 @@ export function validateRiskPlan(value: unknown, allowedJobs: ReadonlySet<string
     }
   }
   return rebuilt;
+}
+
+export function focusedPrGateE2eJobsForChangedFiles(
+  changedFiles: readonly string[],
+  inventory = readFreeStandingJobsInventory(),
+): ReturnType<typeof focusedE2eJobsForChangedFiles> {
+  // The automatic PR gate cannot confirm an online self-hosted Jetson runner.
+  // Remove this exclusion after the Colossus-backed runner path can make that confirmation.
+  return focusedE2eJobsForChangedFiles(changedFiles, inventory).filter(
+    (selection) => selection.id !== JETSON_E2E_JOB,
+  );
 }
 
 function riskPlanSelectionIds(plan: RiskPlan): string[] {
@@ -3135,7 +3147,7 @@ export async function startPrGate(
       buildRiskPlan({
         headSha: command.headSha,
         changedFiles,
-        focusedE2eJobs: focusedE2eJobsForChangedFiles(changedFiles, inventory),
+        focusedE2eJobs: focusedPrGateE2eJobsForChangedFiles(changedFiles, inventory),
       }),
       allowedJobs,
     );
@@ -3257,7 +3269,7 @@ async function startAuthorizedPrGate(command: AuthorizedE2ECommand): Promise<voi
       buildRiskPlan({
         headSha: command.headSha,
         changedFiles,
-        focusedE2eJobs: focusedE2eJobsForChangedFiles(changedFiles, inventory),
+        focusedE2eJobs: focusedPrGateE2eJobsForChangedFiles(changedFiles, inventory),
       }),
       new Set(inventory.allowedJobs),
     );

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -15,6 +15,7 @@ import { githubApi, githubApiWithResponse, githubRestPaginated } from "../adviso
 import { parseArgs } from "../advisors/io.mts";
 import {
   buildRiskPlan,
+  isPrE2ePlanningJob,
   isPrE2eTypedTargetId,
   RISK_PLAN_VERSION,
   type RiskPlan,
@@ -63,7 +64,6 @@ export { validateWorkflowDispatchDetails } from "./pr-e2e-dispatch-reconciliatio
 
 const E2E_WORKFLOW = "e2e.yaml";
 const E2E_WORKFLOW_PATH = `.github/workflows/${E2E_WORKFLOW}`;
-const JETSON_E2E_JOB = "jetson-nvmap-gpu";
 const PR_GATE_WORKFLOW = "pr-e2e-gate.yaml";
 const CHECK_NAME = "E2E / PR Gate";
 const WORKFLOW_NAME = "E2E / PR Gate Controller";
@@ -722,10 +722,8 @@ export function focusedPrGateE2eJobsForChangedFiles(
   changedFiles: readonly string[],
   inventory = readFreeStandingJobsInventory(),
 ): ReturnType<typeof focusedE2eJobsForChangedFiles> {
-  // The automatic PR gate cannot confirm an online self-hosted Jetson runner.
-  // Remove this exclusion after the Colossus-backed runner path can make that confirmation.
-  return focusedE2eJobsForChangedFiles(changedFiles, inventory).filter(
-    (selection) => selection.id !== JETSON_E2E_JOB,
+  return focusedE2eJobsForChangedFiles(changedFiles, inventory).filter((selection) =>
+    isPrE2ePlanningJob(selection.id),
   );
 }
 

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -34,7 +34,7 @@ import {
   stringOrDefault,
   stringOrUndefined,
 } from "../advisors/json.mts";
-import { buildRiskPlan, type RiskPlan } from "../advisors/risk-plan.mts";
+import { buildRiskPlan, isPrE2ePlanningJob, type RiskPlan } from "../advisors/risk-plan.mts";
 import {
   type AdvisorCompletedTurn,
   type AdvisorContextToolResult,
@@ -1043,7 +1043,9 @@ async function collectDeterministicContext(options: {
   const riskPlan = buildRiskPlan({
     headSha: options.headSha,
     changedFiles: options.changedFiles,
-    focusedE2eJobs: focusedE2eJobsForChangedFiles(options.changedFiles),
+    focusedE2eJobs: focusedE2eJobsForChangedFiles(options.changedFiles).filter((selection) =>
+      isPrE2ePlanningJob(selection.id),
+    ),
   });
   const riskyAreas = [
     ...detectRiskyAreas(options.changedFiles),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Automatic PR E2E planning and PR Review Advisor recommendations selected `jetson-nvmap-gpu`, but the E2E workflow rejects that job unless an administrator confirms an online Jetson runner. This change omits only that job from both automatic surfaces until the Colossus-backed runner path can confirm runner availability; explicit manual dispatch remains available.

## Related Issue

Relates to #7610.

## Changes

- Apply one trusted PR-planning rule to omit `jetson-nvmap-gpu` from automatic gate selections, advisor deterministic context, and advisor recommendation allowlists while leaving the generic focused-job selector and explicit manual workflow dispatch unchanged.
- Add regression coverage for automatic omission, generic selector retention, preservation of other risk-selected jobs, required and optional model guidance, and dynamic credential-free selector discovery.
- Document the temporary exception, guarded manual dispatch, and Colossus-backed removal condition in `test/e2e/README.md`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The nine-category focused review found no issues. Trusted normalization rejects Jetson from deterministic, model-selected, and dynamically discovered advisor guidance; explicit administrator-guarded dispatch and every other risk-selected job remain unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: The reviewer covered all six changed files at `b404713c5`, reported no findings, and confirmed that automatic gate planning, advisor guidance, generic selector discovery, guarded manual dispatch, and the Colossus-backed restoration condition are consistent. The focused suite passed 107 tests; CLI type-checking, Biome, test-size, Markdown lint, and diff checks passed.
- Agent: Codex CLI
<!-- docs-review-head-sha: b404713c5 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/pr-e2e-gate.test.ts test/pr-e2e-gate-jetson-exclusion.test.ts test/e2e-recommendations.test.ts test/pr-review-advisor.test.ts` passed 107 tests; `npm run typecheck:cli` and `npm run test-size:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic PR E2E planning and review recommendations now exclude the Jetson GPU job.
  * Required checks pass without running E2E when no eligible jobs or targets remain.
  * Other applicable cloud E2E jobs continue to run as required.

* **Documentation**
  * Clarified that Jetson E2E runs remain available through manual dispatch with administrator confirmation that the runner is online.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->