### PR TITLE
docs(policy): add N1X platform taxonomy

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-policies/references/examples.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/examples.md
@@ -200,6 +200,41 @@ Dry run:
 }
 ```
 
+### N1X Linux Install Failure
+
+Evidence:
+
+- The title identifies an N1x Linux Laptop and an OpenShell install failure.
+- Ubuntu and ARM64 appear only in the environment and are not independently routing-relevant.
+- The report contrasts the N1X failure with successful driver detection on DGX Spark.
+
+Dry run:
+
+```json
+{
+  "item_number": 8095,
+  "item_kind": "issue",
+  "issue_type_to_set": "Bug",
+  "labels_to_add": ["area: install", "platform: n1x"],
+  "labels_to_remove": [],
+  "labels_to_create": [],
+  "labels_to_delete": [],
+  "issue_fields_to_set": {},
+  "project_fields_to_set": {
+    "Status": "Backlog"
+  },
+  "recommended_action": "triage",
+  "confidence": "high",
+  "rationale": {
+    "issue_type_to_set": "The report describes broken install behavior.",
+    "area: install": "The failure occurs during OpenShell installation.",
+    "platform: n1x": "The report identifies N1X as the affected platform and contrasts its behavior with DGX Spark."
+  },
+  "questions_for_author": [],
+  "human_review_required": false
+}
+```
+
 ### Feature Request Needing Design
 
 Evidence:

--- a/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json
@@ -384,6 +384,7 @@
         "platform: k8s",
         "platform: linux",
         "platform: macos",
+        "platform: n1x",
         "platform: ubuntu",
         "platform: windows",
         "platform: wsl"
@@ -454,6 +455,12 @@
           "description": "macOS, Darwin, Homebrew, or Apple Silicon behavior.",
           "positive_signals": ["macOS-specific error", "Darwin", "Homebrew", "Apple Silicon path", "macOS permission behavior"],
           "negative_signals": ["macOS only listed as tested environment", "Docker only listed in environment", "same issue reproduced on Linux or Windows"]
+        },
+        {
+          "name": "platform: n1x",
+          "description": "Affects N1X hardware or workflows.",
+          "positive_signals": ["N1X hardware named as affected platform", "N1x Linux Laptop", "NVIDIA RTX Spark N1X", "N1X-specific install or runtime behavior"],
+          "negative_signals": ["ARM64 issue without N1X evidence", "NVIDIA hardware mentioned without N1X relevance", "N1X appears only in an unrelated environment inventory"]
         },
         {
           "name": "platform: ubuntu",

--- a/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md
@@ -124,6 +124,7 @@ Do not add a platform label only because the environment template names Docker, 
 Use a platform label when the platform appears in the error, title, or affected install path.
 `Windows ARM`, `Windows ARM64`, and `aarch64` support `platform: arm64`.
 `WSL`, `WSL2`, and `Windows Subsystem for Linux` support `platform: wsl`.
+`N1X`, `N1x Linux Laptop`, and `NVIDIA RTX Spark N1X` support `platform: n1x` when N1X is the affected platform.
 
 | Label | Description |
 |---|---|
@@ -138,6 +139,7 @@ Use a platform label when the platform appears in the error, title, or affected 
 | `platform: k8s` | Kubernetes-specific behavior. |
 | `platform: linux` | Linux behavior without Ubuntu specificity. |
 | `platform: macos` | macOS, Darwin, Homebrew, or Apple Silicon behavior. |
+| `platform: n1x` | Affects N1X hardware or workflows. |
 | `platform: ubuntu` | Ubuntu-specific behavior. |
 | `platform: windows` | Native Windows or PowerShell behavior. |
 | `platform: wsl` | Windows Subsystem for Linux behavior. |

--- a/.agents/skills/nemoclaw-maintainer-policies/references/triage-instructions.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/triage-instructions.md
@@ -25,6 +25,7 @@ They apply to Issue Type, labels, Project fields, comments, and questions.
 1. Classify the issue using native GitHub Issue Type: `Bug`, `Enhancement`, `Task`, `Documentation`, `Epic`, or `Initiative`.
 2. Add area labels only when the affected surface is clear.
 3. Require evidence for platform, provider, and integration labels.
+   Map N1X, N1x Linux Laptop, and NVIDIA RTX Spark N1X evidence to `platform: n1x` when N1X is the affected platform.
    If a listed integration is the affected subject, add its `integration:*` label.
    Do not use only `area: integrations`.
    Map LangChain Deep Code, Deep Code, `langchain-deepagents-code`, and `dcode` to `integration: dcode`.

--- a/.agents/skills/nemoclaw-maintainer-verify-stale/reference/candidate-selection.md
+++ b/.agents/skills/nemoclaw-maintainer-verify-stale/reference/candidate-selection.md
@@ -113,7 +113,7 @@ Apply these rules in order. Drop any issue that fails a rule.
 
 **Security skip:** drop items carrying the canonical `security` label. Potential vulnerability reports require the dedicated security workflow and neutral handling, not public stale-verification commentary.
 
-**Platform skip (Brev-reproducible only in v1):** drop `platform: windows`, `platform: wsl`, `platform: macos`, and `platform: jetson`. Brev has no equivalent hardware for those targets, so verification would produce a misleading cross-platform verdict. Keep `platform: ubuntu`, `platform: dgx-spark`, `platform: gb10`, or no platform label. DGX Spark and GB10 remain in scope only with the Step 10 hardware-substitution caveat.
+**Platform skip (Brev-reproducible only in v1):** drop `platform: windows`, `platform: wsl`, `platform: macos`, `platform: jetson`, and `platform: n1x`. Brev has no equivalent hardware for those targets, so verification would produce a misleading cross-platform verdict. Keep `platform: ubuntu`, `platform: dgx-spark`, `platform: gb10`, or no platform label. DGX Spark and GB10 remain in scope only with the Step 10 hardware-substitution caveat.
 
 **TUI / interactive-UI skip:** drop if the issue title contains `TUI`, `dashboard UI`, `chat UI`, `keystroke`, or `key press`, OR if the body describes interactive UI behavior (key sequences, mouse interactions, browser-side UI state) without a non-interactive reproducer (no `NEMOCLAW_NON_INTERACTIVE=1` or equivalent env var pattern). `brev exec` does not allocate a real TTY by default, so TUI reproducers hang or silently fail at the first prompt; v1 documents this as out-of-scope rather than emitting a wrong verdict. v1.1 may add a `script(1)` / `expect` / `tmux send-keys` harness to lift this skip.
 

--- a/test/maintainer-skills-policy.test.ts
+++ b/test/maintainer-skills-policy.test.ts
@@ -43,6 +43,63 @@ describe("maintainer skills follow canonical workflow policy", () => {
     ).toBe(false);
   });
 
+  it("keeps N1X routing canonical across maintainer policy sources (#8095)", () => {
+    const taxonomy = JSON.parse(
+      read(".agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json"),
+    ) as {
+      label_families: {
+        platform: {
+          entries: Array<{
+            description: string;
+            name: string;
+            negative_signals: string[];
+            positive_signals: string[];
+          }>;
+          values: string[];
+        };
+      };
+    };
+    const markdown = read(
+      ".agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md",
+    );
+    const instructions = read(
+      ".agents/skills/nemoclaw-maintainer-policies/references/triage-instructions.md",
+    );
+    const examples = read(".agents/skills/nemoclaw-maintainer-policies/references/examples.md");
+    const staleCandidateSelection = read(
+      ".agents/skills/nemoclaw-maintainer-verify-stale/reference/candidate-selection.md",
+    );
+    const n1xExample = examples.match(
+      /### N1X Linux Install Failure[\s\S]*?(?=\n### |\n## |$)/,
+    )?.[0];
+    const n1x = taxonomy.label_families.platform.entries.find(
+      (entry) => entry.name === "platform: n1x",
+    );
+
+    expect(taxonomy.label_families.platform.values).toContain("platform: n1x");
+    expect(n1x).toEqual(
+      expect.objectContaining({
+        name: "platform: n1x",
+        description: "Affects N1X hardware or workflows.",
+        positive_signals: expect.arrayContaining(["N1x Linux Laptop", "NVIDIA RTX Spark N1X"]),
+        negative_signals: expect.arrayContaining([
+          "ARM64 issue without N1X evidence",
+          "NVIDIA hardware mentioned without N1X relevance",
+        ]),
+      }),
+    );
+    expect(markdown).toContain("| `platform: n1x` | Affects N1X hardware or workflows. |");
+    expect(instructions).toContain(
+      "Map N1X, N1x Linux Laptop, and NVIDIA RTX Spark N1X evidence to `platform: n1x`",
+    );
+    expect(n1xExample).toContain('"labels_to_add": ["area: install", "platform: n1x"]');
+    expect(n1xExample).not.toContain('"platform: ubuntu"');
+    expect(n1xExample).not.toContain('"platform: arm64"');
+    expect(staleCandidateSelection).toContain(
+      "`platform: jetson`, and `platform: n1x`. Brev has no equivalent hardware",
+    );
+  });
+
   it("reads priority from Project 199 instead of a priority label", () => {
     const finder = read(".agents/skills/nemoclaw-maintainer-find-review-pr/SKILL.md");
     const triage = read(".agents/skills/nemoclaw-maintainer-day/scripts/triage.ts");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add `platform: n1x` to the canonical maintainer taxonomy so issues that identify N1X as the affected platform route consistently. Use issue #8095 as the reference case and keep generic Ubuntu or ARM64 environment metadata from producing broader platform labels.

## Related Issue

Reference: #8095. This taxonomy change uses the issue as an example but does not resolve its reported install failure.

## Changes

- Add `platform: n1x` with the description `Affects N1X hardware or workflows.` to the machine-readable and human-readable taxonomy.
- Add N1X evidence rules and a dry-run example based on #8095.
- Exclude N1X-only reports from generic Brev stale verification.
- Add a contract test for the canonical label, description, routing signals, example label set, and Brev exclusion.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes maintainer label policy, not user-facing product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop review of commit `b1fa424bcd2fae8dc2bfeb1b27dd3abf974de757` confirmed label-policy consistency, attribution preservation, and no runtime or security policy changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed the five changed maintainer-policy sources and `test/maintainer-skills-policy.test.ts` at commit `b1fa424bcd2fae8dc2bfeb1b27dd3abf974de757`. N1X terminology, taxonomy ordering, triage guidance, stale-verification exclusion, JSON examples, and regression coverage remain consistent after the conflict-free current-main merge. Normal hooks passed; GitHub CI is the current validation authority.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b1fa424bc -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: GitHub CI is running for commit `b1fa424bcd2fae8dc2bfeb1b27dd3abf974de757`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: GitHub CI is running for commit `b1fa424bcd2fae8dc2bfeb1b27dd3abf974de757`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — GitHub CI is running for commit `b1fa424bcd2fae8dc2bfeb1b27dd3abf974de757`.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Will Curran <wcurran@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for identifying and labeling N1X platform-related issues.
  * Added an issue triage example demonstrating recommended routing for N1X installation failures.
  * Updated stale-candidate verification guidance to account for N1X platforms.

* **Tests**
  * Added coverage to ensure N1X labeling and routing guidance remains consistent across policy documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->