### PR TITLE
feat(inference): add owned llama.cpp image build

### DIFF
--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -28,7 +28,9 @@ jobs:
       cuda_runtime_image: ${{ steps.manifest.outputs.cuda_runtime_image }}
       image: ${{ steps.manifest.outputs.image }}
       matrix: ${{ steps.manifest.outputs.matrix }}
+      runtime_forbidden_paths: ${{ steps.manifest.outputs.runtime_forbidden_paths }}
       runtime_gid: ${{ steps.manifest.outputs.runtime_gid }}
+      runtime_required_paths: ${{ steps.manifest.outputs.runtime_required_paths }}
       runtime_uid: ${{ steps.manifest.outputs.runtime_uid }}
       source_archive_sha256: ${{ steps.manifest.outputs.source_archive_sha256 }}
       source_revision: ${{ steps.manifest.outputs.source_revision }}
@@ -100,7 +102,9 @@ jobs:
           CUDA_RUNTIME_IMAGE: ${{ needs.config.outputs.cuda_runtime_image }}
           IMAGE: nemoclaw-llama-cpp-pr:${{ matrix.arch }}-${{ github.sha }}
           PLATFORM: ${{ matrix.platform }}
+          RUNTIME_FORBIDDEN_PATHS: ${{ needs.config.outputs.runtime_forbidden_paths }}
           RUNTIME_GID: ${{ needs.config.outputs.runtime_gid }}
+          RUNTIME_REQUIRED_PATHS: ${{ needs.config.outputs.runtime_required_paths }}
           RUNTIME_UID: ${{ needs.config.outputs.runtime_uid }}
           SOURCE_ARCHIVE_SHA256: ${{ needs.config.outputs.source_archive_sha256 }}
           SOURCE_REVISION: ${{ needs.config.outputs.source_revision }}
@@ -141,16 +145,22 @@ jobs:
             "$IMAGE" --version 2>&1 | tee "$RUNNER_TEMP/llama-server-version.txt"
           grep -F "$SOURCE_REVISION" "$RUNNER_TEMP/llama-server-version.txt"
 
-          docker run --rm \
-            --network none \
-            --read-only \
-            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777 \
-            --entrypoint /bin/sh \
-            "$IMAGE" -eu -c '
-              test -x /usr/local/bin/llama-server
-              test -r /usr/local/share/licenses/llama.cpp/LICENSE
-              test -r /usr/local/share/licenses/llama.cpp/AUTHORS
-              test ! -e /opt/llama.cpp/ui
-              test "$(id -u)" = "$1"
-              test "$(id -g)" = "$2"
-            ' -- "$RUNTIME_UID" "$RUNTIME_GID"
+          container_id="$(docker create "$IMAGE" --version)"
+          trap 'docker rm --force "$container_id" >/dev/null 2>&1 || true' EXIT
+          filesystem_paths="$(docker export "$container_id" | tar --list --file - | sed 's#^\./##')"
+          while IFS= read -r required_path; do
+            if ! grep --fixed-strings --line-regexp "${required_path#/}" <<< "$filesystem_paths" >/dev/null; then
+              echo "ERROR: required image path is missing: $required_path" >&2
+              exit 1
+            fi
+          done < <(jq --raw-output '.[]' <<< "$RUNTIME_REQUIRED_PATHS")
+          while IFS= read -r forbidden_path; do
+            if awk -v path="${forbidden_path#/}" \
+              '$0 == path || index($0, path "/") == 1 { found = 1 } END { exit !found }' \
+              <<< "$filesystem_paths"; then
+              echo "ERROR: forbidden image path is present: $forbidden_path" >&2
+              exit 1
+            fi
+          done < <(jq --raw-output '.[]' <<< "$RUNTIME_FORBIDDEN_PATHS")
+          docker rm "$container_id" >/dev/null
+          trap - EXIT

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/llama-cpp-image.yaml"
       - "managed-inference/images/llama-cpp/**"
+      - "managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml"
       - "scripts/checks/export-llama-cpp-image-config.mts"
       - "test/llama-cpp-image.test.ts"
       - "test/llama-cpp-image-workflow.test.ts"
@@ -15,12 +16,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   config:
     name: Compile declarative image configuration
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
+      backend_directory: ${{ steps.manifest.outputs.backend_directory }}
       compiler_c: ${{ steps.manifest.outputs.compiler_c }}
       compiler_cuda_host_cxx: ${{ steps.manifest.outputs.compiler_cuda_host_cxx }}
       compiler_cxx: ${{ steps.manifest.outputs.compiler_cxx }}
@@ -85,6 +91,7 @@ jobs:
             CUDA_ARCHITECTURES=${{ matrix.cuda_architectures }}
             CUDA_DEV_IMAGE=${{ needs.config.outputs.cuda_dev_image }}
             CUDA_RUNTIME_IMAGE=${{ needs.config.outputs.cuda_runtime_image }}
+            GGML_BACKEND_DIR=${{ needs.config.outputs.backend_directory }}
             LLAMA_CPP_ARCHIVE_SHA256=${{ needs.config.outputs.source_archive_sha256 }}
             LLAMA_CPP_REVISION=${{ needs.config.outputs.source_revision }}
             NEMOCLAW_REVISION=${{ github.sha }}
@@ -93,6 +100,8 @@ jobs:
             TARGETPLATFORM=${{ matrix.platform }}
           provenance: false
           sbom: false
+          cache-from: type=gha,scope=llama-cpp-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=llama-cpp-${{ matrix.arch }}
 
       - name: Validate native PR image contract
         shell: bash

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -8,7 +8,7 @@ on:
     paths:
       - ".github/workflows/llama-cpp-image.yaml"
       - "managed-inference/images/llama-cpp/**"
-      - "scripts/checks/export-llama-cpp-image-config.mjs"
+      - "scripts/checks/export-llama-cpp-image-config.mts"
       - "test/llama-cpp-image.test.ts"
       - "test/llama-cpp-image-workflow.test.ts"
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Compile image manifest
         id: manifest
-        run: node scripts/checks/export-llama-cpp-image-config.mjs
+        run: node --experimental-strip-types --no-warnings scripts/checks/export-llama-cpp-image-config.mts
 
   pr-build:
     name: Build native llama.cpp server (${{ matrix.arch }})

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
+      compiler_c: ${{ steps.manifest.outputs.compiler_c }}
+      compiler_cuda_host_cxx: ${{ steps.manifest.outputs.compiler_cuda_host_cxx }}
+      compiler_cxx: ${{ steps.manifest.outputs.compiler_cxx }}
       cuda_dev_image: ${{ steps.manifest.outputs.cuda_dev_image }}
       cuda_runtime_image: ${{ steps.manifest.outputs.cuda_runtime_image }}
       image: ${{ steps.manifest.outputs.image }}
@@ -74,6 +77,9 @@ jobs:
           push: false
           tags: nemoclaw-llama-cpp-pr:${{ matrix.arch }}-${{ github.sha }}
           build-args: |
+            C_COMPILER=${{ needs.config.outputs.compiler_c }}
+            CUDA_HOST_CXX_COMPILER=${{ needs.config.outputs.compiler_cuda_host_cxx }}
+            CXX_COMPILER=${{ needs.config.outputs.compiler_cxx }}
             CUDA_ARCHITECTURES=${{ matrix.cuda_architectures }}
             CUDA_DEV_IMAGE=${{ needs.config.outputs.cuda_dev_image }}
             CUDA_RUNTIME_IMAGE=${{ needs.config.outputs.cuda_runtime_image }}

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Images / llama.cpp Server
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/llama-cpp-image.yaml"
+      - "managed-inference/images/llama-cpp/**"
+      - "scripts/checks/export-llama-cpp-image-config.mjs"
+      - "test/llama-cpp-image.test.ts"
+      - "test/llama-cpp-image-workflow.test.ts"
+
+permissions:
+  contents: read
+
+jobs:
+  config:
+    name: Compile declarative image configuration
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      cuda_dev_image: ${{ steps.manifest.outputs.cuda_dev_image }}
+      cuda_runtime_image: ${{ steps.manifest.outputs.cuda_runtime_image }}
+      image: ${{ steps.manifest.outputs.image }}
+      matrix: ${{ steps.manifest.outputs.matrix }}
+      runtime_gid: ${{ steps.manifest.outputs.runtime_gid }}
+      runtime_uid: ${{ steps.manifest.outputs.runtime_uid }}
+      source_archive_sha256: ${{ steps.manifest.outputs.source_archive_sha256 }}
+      source_revision: ${{ steps.manifest.outputs.source_revision }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.19.0
+
+      - name: Install manifest compiler dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Compile image manifest
+        id: manifest
+        run: node scripts/checks/export-llama-cpp-image-config.mjs
+
+  pr-build:
+    name: Build native llama.cpp server (${{ matrix.arch }})
+    needs: config
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build native PR image without publishing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: managed-inference/images/llama-cpp
+          file: managed-inference/images/llama-cpp/Dockerfile
+          platforms: ${{ matrix.platform }}
+          load: true
+          push: false
+          tags: nemoclaw-llama-cpp-pr:${{ matrix.arch }}-${{ github.sha }}
+          build-args: |
+            CUDA_ARCHITECTURES=${{ matrix.cuda_architectures }}
+            CUDA_DEV_IMAGE=${{ needs.config.outputs.cuda_dev_image }}
+            CUDA_RUNTIME_IMAGE=${{ needs.config.outputs.cuda_runtime_image }}
+            LLAMA_CPP_ARCHIVE_SHA256=${{ needs.config.outputs.source_archive_sha256 }}
+            LLAMA_CPP_REVISION=${{ needs.config.outputs.source_revision }}
+            NEMOCLAW_REVISION=${{ github.sha }}
+            RUNTIME_GID=${{ needs.config.outputs.runtime_gid }}
+            RUNTIME_UID=${{ needs.config.outputs.runtime_uid }}
+            TARGETPLATFORM=${{ matrix.platform }}
+          provenance: false
+          sbom: false
+
+      - name: Validate native PR image contract
+        shell: bash
+        env:
+          CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
+          CUDA_DEV_IMAGE: ${{ needs.config.outputs.cuda_dev_image }}
+          CUDA_RUNTIME_IMAGE: ${{ needs.config.outputs.cuda_runtime_image }}
+          IMAGE: nemoclaw-llama-cpp-pr:${{ matrix.arch }}-${{ github.sha }}
+          PLATFORM: ${{ matrix.platform }}
+          RUNTIME_GID: ${{ needs.config.outputs.runtime_gid }}
+          RUNTIME_UID: ${{ needs.config.outputs.runtime_uid }}
+          SOURCE_ARCHIVE_SHA256: ${{ needs.config.outputs.source_archive_sha256 }}
+          SOURCE_REVISION: ${{ needs.config.outputs.source_revision }}
+        run: |
+          set -euo pipefail
+          image_json="$(docker image inspect "$IMAGE")"
+          if ! jq -e \
+            --arg archive "$SOURCE_ARCHIVE_SHA256" \
+            --arg architectures "$CUDA_ARCHITECTURES" \
+            --arg dev "$CUDA_DEV_IMAGE" \
+            --arg gid "$RUNTIME_GID" \
+            --arg platform "$PLATFORM" \
+            --arg revision "$GITHUB_SHA" \
+            --arg runtime "$CUDA_RUNTIME_IMAGE" \
+            --arg uid "$RUNTIME_UID" \
+            --arg upstream "$SOURCE_REVISION" '
+              length == 1
+              and .[0].Config.User == ($uid + ":" + $gid)
+              and .[0].Config.Entrypoint == ["/usr/local/bin/llama-server"]
+              and .[0].Config.Labels["org.opencontainers.image.revision"] == $revision
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.contract"] == "1"
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.component"] == "llama.cpp"
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.platform"] == $platform
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.upstream.revision"] == $upstream
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.upstream.archive-sha256"] == $archive
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.cuda.development-base"] == $dev
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.cuda.runtime-base"] == $runtime
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.cuda.architectures"] == $architectures
+            ' <<< "$image_json" >/dev/null; then
+            echo "ERROR: llama.cpp PR image identity does not match the declarative manifest." >&2
+            exit 1
+          fi
+
+          docker run --rm \
+            --network none \
+            --read-only \
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777 \
+            "$IMAGE" --version 2>&1 | tee "$RUNNER_TEMP/llama-server-version.txt"
+          grep -F "$SOURCE_REVISION" "$RUNNER_TEMP/llama-server-version.txt"
+
+          docker run --rm \
+            --network none \
+            --read-only \
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777 \
+            --entrypoint /bin/sh \
+            "$IMAGE" -eu -c '
+              test -x /usr/local/bin/llama-server
+              test -r /usr/local/share/licenses/llama.cpp/LICENSE
+              test -r /usr/local/share/licenses/llama.cpp/AUTHORS
+              test ! -e /opt/llama.cpp/ui
+              test "$(id -u)" = "$1"
+              test "$(id -g)" = "$2"
+            ' -- "$RUNTIME_UID" "$RUNTIME_GID"

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -75,6 +75,38 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      - name: Validate native PR image build args
+        env:
+          C_COMPILER: ${{ needs.config.outputs.compiler_c }}
+          CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
+          CUDA_DEV_IMAGE: ${{ needs.config.outputs.cuda_dev_image }}
+          CUDA_HOST_CXX_COMPILER: ${{ needs.config.outputs.compiler_cuda_host_cxx }}
+          CUDA_RUNTIME_IMAGE: ${{ needs.config.outputs.cuda_runtime_image }}
+          CXX_COMPILER: ${{ needs.config.outputs.compiler_cxx }}
+          GGML_BACKEND_DIR: ${{ needs.config.outputs.backend_directory }}
+          LLAMA_CPP_ARCHIVE_SHA256: ${{ needs.config.outputs.source_archive_sha256 }}
+          LLAMA_CPP_REVISION: ${{ needs.config.outputs.source_revision }}
+          NEMOCLAW_REVISION: ${{ github.sha }}
+          RUNTIME_GID: ${{ needs.config.outputs.runtime_gid }}
+          RUNTIME_UID: ${{ needs.config.outputs.runtime_uid }}
+          TARGETPLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          scripts/check-production-build-args.sh \
+            --build-arg "C_COMPILER=${C_COMPILER}" \
+            --build-arg "CUDA_HOST_CXX_COMPILER=${CUDA_HOST_CXX_COMPILER}" \
+            --build-arg "CXX_COMPILER=${CXX_COMPILER}" \
+            --build-arg "CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}" \
+            --build-arg "CUDA_DEV_IMAGE=${CUDA_DEV_IMAGE}" \
+            --build-arg "CUDA_RUNTIME_IMAGE=${CUDA_RUNTIME_IMAGE}" \
+            --build-arg "GGML_BACKEND_DIR=${GGML_BACKEND_DIR}" \
+            --build-arg "LLAMA_CPP_ARCHIVE_SHA256=${LLAMA_CPP_ARCHIVE_SHA256}" \
+            --build-arg "LLAMA_CPP_REVISION=${LLAMA_CPP_REVISION}" \
+            --build-arg "NEMOCLAW_REVISION=${NEMOCLAW_REVISION}" \
+            --build-arg "RUNTIME_GID=${RUNTIME_GID}" \
+            --build-arg "RUNTIME_UID=${RUNTIME_UID}" \
+            --build-arg "TARGETPLATFORM=${TARGETPLATFORM}"
+
       - name: Build native PR image without publishing
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/managed-inference/images/llama-cpp/Dockerfile
+++ b/managed-inference/images/llama-cpp/Dockerfile
@@ -9,6 +9,7 @@ FROM ${CUDA_DEV_IMAGE} AS build
 ARG LLAMA_CPP_REVISION
 ARG LLAMA_CPP_ARCHIVE_SHA256
 ARG CUDA_ARCHITECTURES
+ARG GGML_BACKEND_DIR
 ARG C_COMPILER
 ARG CXX_COMPILER
 ARG CUDA_HOST_CXX_COMPILER
@@ -18,6 +19,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN test -n "${LLAMA_CPP_REVISION}" \
     && test -n "${LLAMA_CPP_ARCHIVE_SHA256}" \
     && test -n "${CUDA_ARCHITECTURES}" \
+    && test -n "${GGML_BACKEND_DIR}" \
     && test -n "${C_COMPILER}" \
     && test -n "${CXX_COMPILER}" \
     && test -n "${CUDA_HOST_CXX_COMPILER}"
@@ -51,6 +53,7 @@ RUN curl --fail --location --proto '=https' --tlsv1.2 --retry 5 \
 RUN cmake -S . -B build \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" \
+      -DGGML_BACKEND_DIR="${GGML_BACKEND_DIR}" \
       -DGGML_BACKEND_DL=ON \
       -DGGML_CPU_ALL_VARIANTS=ON \
       -DGGML_CUDA=ON \
@@ -72,7 +75,10 @@ RUN cmake -S . -B build \
     && cp build/bin/llama-server /opt/llama.cpp/bin/llama-server \
     && find build -type f -name '*.so*' -exec cp -P '{}' /opt/llama.cpp/lib/ \; \
     && find build -type l -name '*.so*' -exec cp -P '{}' /opt/llama.cpp/lib/ \; \
-    && cp LICENSE AUTHORS /opt/llama.cpp/licenses/llama.cpp/
+    && cp LICENSE AUTHORS /opt/llama.cpp/licenses/llama.cpp/ \
+    && test -f "${GGML_BACKEND_DIR}/libggml-cuda.so" \
+    && find /opt/llama.cpp/licenses -type d -exec chmod 0555 '{}' + \
+    && find /opt/llama.cpp/licenses -type f -exec chmod 0444 '{}' +
 
 FROM ${CUDA_RUNTIME_IMAGE} AS runtime
 
@@ -117,7 +123,7 @@ RUN apt-get update \
 
 COPY --from=build --chmod=0555 /opt/llama.cpp/bin/llama-server /usr/local/bin/llama-server
 COPY --from=build --chmod=0555 /opt/llama.cpp/lib/ /opt/llama.cpp/lib/
-COPY --from=build --chmod=0444 /opt/llama.cpp/licenses/ /usr/local/share/licenses/
+COPY --from=build /opt/llama.cpp/licenses/ /usr/local/share/licenses/
 
 ENV CUDA_CACHE_PATH=/tmp/nemoclaw-cuda-cache \
     HOME=/tmp/nemoclaw-home \

--- a/managed-inference/images/llama-cpp/Dockerfile
+++ b/managed-inference/images/llama-cpp/Dockerfile
@@ -9,12 +9,18 @@ FROM ${CUDA_DEV_IMAGE} AS build
 ARG LLAMA_CPP_REVISION
 ARG LLAMA_CPP_ARCHIVE_SHA256
 ARG CUDA_ARCHITECTURES
+ARG C_COMPILER
+ARG CXX_COMPILER
+ARG CUDA_HOST_CXX_COMPILER
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN test -n "${LLAMA_CPP_REVISION}" \
     && test -n "${LLAMA_CPP_ARCHIVE_SHA256}" \
-    && test -n "${CUDA_ARCHITECTURES}"
+    && test -n "${CUDA_ARCHITECTURES}" \
+    && test -n "${C_COMPILER}" \
+    && test -n "${CXX_COMPILER}" \
+    && test -n "${CUDA_HOST_CXX_COMPILER}"
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -22,9 +28,15 @@ RUN apt-get update \
       ca-certificates=20260601~24.04.1 \
       cmake=3.28.3-1build7 \
       curl=8.5.0-2ubuntu10.11 \
+      g++-14=14.2.0-4ubuntu2~24.04.1 \
+      gcc-14=14.2.0-4ubuntu2~24.04.1 \
       libcurl4-openssl-dev=8.5.0-2ubuntu10.11 \
       libssl-dev=3.0.13-0ubuntu3.12 \
     && rm -rf /var/lib/apt/lists/*
+
+ENV CC=${C_COMPILER} \
+    CXX=${CXX_COMPILER} \
+    CUDAHOSTCXX=${CUDA_HOST_CXX_COMPILER}
 
 WORKDIR /src/llama.cpp
 

--- a/managed-inference/images/llama-cpp/Dockerfile
+++ b/managed-inference/images/llama-cpp/Dockerfile
@@ -104,7 +104,16 @@ RUN apt-get update \
     && groupadd --gid "${RUNTIME_GID}" nemoclaw-llama \
     && useradd --uid "${RUNTIME_UID}" --gid "${RUNTIME_GID}" \
       --home-dir /nonexistent --no-create-home --shell /usr/sbin/nologin nemoclaw-llama \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f \
+      /bin/bash \
+      /bin/dash \
+      /bin/rbash \
+      /bin/sh \
+      /usr/bin/bash \
+      /usr/bin/dash \
+      /usr/bin/rbash \
+      /usr/bin/sh
 
 COPY --from=build --chmod=0555 /opt/llama.cpp/bin/llama-server /usr/local/bin/llama-server
 COPY --from=build --chmod=0555 /opt/llama.cpp/lib/ /opt/llama.cpp/lib/

--- a/managed-inference/images/llama-cpp/Dockerfile
+++ b/managed-inference/images/llama-cpp/Dockerfile
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG CUDA_DEV_IMAGE
+ARG CUDA_RUNTIME_IMAGE
+
+FROM ${CUDA_DEV_IMAGE} AS build
+
+ARG LLAMA_CPP_REVISION
+ARG LLAMA_CPP_ARCHIVE_SHA256
+ARG CUDA_ARCHITECTURES
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN test -n "${LLAMA_CPP_REVISION}" \
+    && test -n "${LLAMA_CPP_ARCHIVE_SHA256}" \
+    && test -n "${CUDA_ARCHITECTURES}"
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential=12.10ubuntu1 \
+      ca-certificates=20260601~24.04.1 \
+      cmake=3.28.3-1build7 \
+      curl=8.5.0-2ubuntu10.11 \
+      libcurl4-openssl-dev=8.5.0-2ubuntu10.11 \
+      libssl-dev=3.0.13-0ubuntu3.12 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src/llama.cpp
+
+RUN curl --fail --location --proto '=https' --tlsv1.2 --retry 5 \
+      --output /tmp/llama.cpp.tar.gz \
+      "https://github.com/ggml-org/llama.cpp/archive/${LLAMA_CPP_REVISION}.tar.gz" \
+    && printf '%s  %s\n' "${LLAMA_CPP_ARCHIVE_SHA256#sha256:}" /tmp/llama.cpp.tar.gz \
+      | sha256sum --check --strict \
+    && tar --extract --gzip --file /tmp/llama.cpp.tar.gz --strip-components=1 \
+    && rm /tmp/llama.cpp.tar.gz
+
+RUN cmake -S . -B build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" \
+      -DGGML_BACKEND_DL=ON \
+      -DGGML_CPU_ALL_VARIANTS=ON \
+      -DGGML_CUDA=ON \
+      -DGGML_CURL=ON \
+      -DGGML_NATIVE=OFF \
+      -DGGML_RPC=OFF \
+      -DLLAMA_BUILD_APP=OFF \
+      -DLLAMA_BUILD_EXAMPLES=OFF \
+      -DLLAMA_BUILD_SERVER=ON \
+      -DLLAMA_BUILD_TESTS=OFF \
+      -DLLAMA_BUILD_TOOLS=ON \
+      -DLLAMA_BUILD_UI=OFF \
+      -DLLAMA_OPENSSL=ON \
+      -DLLAMA_SUBPROCESS=OFF \
+      -DLLAMA_USE_PREBUILT_UI=OFF \
+      -DLLAMA_BUILD_COMMIT="${LLAMA_CPP_REVISION}" \
+    && cmake --build build --config Release --target llama-server --parallel "$(nproc)" \
+    && mkdir -p /opt/llama.cpp/bin /opt/llama.cpp/lib /opt/llama.cpp/licenses/llama.cpp \
+    && cp build/bin/llama-server /opt/llama.cpp/bin/llama-server \
+    && find build -type f -name '*.so*' -exec cp -P '{}' /opt/llama.cpp/lib/ \; \
+    && find build -type l -name '*.so*' -exec cp -P '{}' /opt/llama.cpp/lib/ \; \
+    && cp LICENSE AUTHORS /opt/llama.cpp/licenses/llama.cpp/
+
+FROM ${CUDA_RUNTIME_IMAGE} AS runtime
+
+ARG CUDA_DEV_IMAGE
+ARG CUDA_RUNTIME_IMAGE
+ARG CUDA_ARCHITECTURES
+ARG LLAMA_CPP_REVISION
+ARG LLAMA_CPP_ARCHIVE_SHA256
+ARG NEMOCLAW_REVISION
+ARG TARGETPLATFORM
+ARG RUNTIME_UID
+ARG RUNTIME_GID
+
+RUN test -n "${CUDA_DEV_IMAGE}" \
+    && test -n "${CUDA_RUNTIME_IMAGE}" \
+    && test -n "${CUDA_ARCHITECTURES}" \
+    && test -n "${LLAMA_CPP_REVISION}" \
+    && test -n "${LLAMA_CPP_ARCHIVE_SHA256}" \
+    && test -n "${NEMOCLAW_REVISION}" \
+    && test -n "${TARGETPLATFORM}" \
+    && test -n "${RUNTIME_UID}" \
+    && test -n "${RUNTIME_GID}"
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      ca-certificates=20260601~24.04.1 \
+      libcurl4t64=8.5.0-2ubuntu10.11 \
+      libgomp1=14.2.0-4ubuntu2~24.04.1 \
+    && groupadd --gid "${RUNTIME_GID}" nemoclaw-llama \
+    && useradd --uid "${RUNTIME_UID}" --gid "${RUNTIME_GID}" \
+      --home-dir /nonexistent --no-create-home --shell /usr/sbin/nologin nemoclaw-llama \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build --chmod=0555 /opt/llama.cpp/bin/llama-server /usr/local/bin/llama-server
+COPY --from=build --chmod=0555 /opt/llama.cpp/lib/ /opt/llama.cpp/lib/
+COPY --from=build --chmod=0444 /opt/llama.cpp/licenses/ /usr/local/share/licenses/
+
+ENV CUDA_CACHE_PATH=/tmp/nemoclaw-cuda-cache \
+    HOME=/tmp/nemoclaw-home \
+    LD_LIBRARY_PATH=/opt/llama.cpp/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64 \
+    XDG_CACHE_HOME=/tmp/nemoclaw-cache
+
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/NemoClaw" \
+      org.opencontainers.image.revision="${NEMOCLAW_REVISION}" \
+      org.opencontainers.image.title="NemoClaw llama.cpp server" \
+      org.opencontainers.image.description="NemoClaw-owned CUDA llama-server runtime" \
+      io.nvidia.nemoclaw.inference-server.contract="1" \
+      io.nvidia.nemoclaw.inference-server.component="llama.cpp" \
+      io.nvidia.nemoclaw.inference-server.platform="${TARGETPLATFORM}" \
+      io.nvidia.nemoclaw.inference-server.upstream.repository="https://github.com/ggml-org/llama.cpp" \
+      io.nvidia.nemoclaw.inference-server.upstream.revision="${LLAMA_CPP_REVISION}" \
+      io.nvidia.nemoclaw.inference-server.upstream.archive-sha256="${LLAMA_CPP_ARCHIVE_SHA256}" \
+      io.nvidia.nemoclaw.inference-server.cuda.development-base="${CUDA_DEV_IMAGE}" \
+      io.nvidia.nemoclaw.inference-server.cuda.runtime-base="${CUDA_RUNTIME_IMAGE}" \
+      io.nvidia.nemoclaw.inference-server.cuda.architectures="${CUDA_ARCHITECTURES}"
+
+WORKDIR /opt/llama.cpp
+
+EXPOSE 8081
+
+USER ${RUNTIME_UID}:${RUNTIME_GID}
+
+ENTRYPOINT ["/usr/local/bin/llama-server"]

--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -29,11 +29,17 @@ spec:
 
   build:
     target: llama-server
+    compiler:
+      c: gcc-14
+      cxx: g++-14
+      cudaHostCxx: g++-14
     packages:
       build-essential: 12.10ubuntu1
       ca-certificates: 20260601~24.04.1
       cmake: 3.28.3-1build7
       curl: 8.5.0-2ubuntu10.11
+      g++-14: 14.2.0-4ubuntu2~24.04.1
+      gcc-14: 14.2.0-4ubuntu2~24.04.1
       libcurl4-openssl-dev: 8.5.0-2ubuntu10.11
       libssl-dev: 3.0.13-0ubuntu3.12
     cmake:

--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -29,6 +29,7 @@ spec:
 
   build:
     target: llama-server
+    backendDirectory: /opt/llama.cpp/lib
     compiler:
       c: gcc-14
       cxx: g++-14
@@ -65,6 +66,7 @@ spec:
     port: 8081
     entrypoint: /usr/local/bin/llama-server
     requiredPaths:
+      - /opt/llama.cpp/lib/libggml-cuda.so
       - /usr/local/bin/llama-server
       - /usr/local/share/licenses/llama.cpp/AUTHORS
       - /usr/local/share/licenses/llama.cpp/LICENSE

--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServerImageBuild
+
+metadata:
+  id: llama-cpp-server.v1
+
+spec:
+  repository: ghcr.io/nvidia/nemoclaw/llama-cpp-server
+
+  source:
+    repository: https://github.com/ggml-org/llama.cpp
+    revision: 22dc605c4ead20e36f447cc67b55ef87e523bd55
+    archiveSha256: sha256:975f70723e053785e894f4e1d9cf770f2f1a7bc762fd3af174ff5635014108b6
+
+  cuda:
+    developmentBase: docker.io/nvidia/cuda@sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52
+    runtimeBase: docker.io/nvidia/cuda@sha256:789e629e49401647e22b7054ae9c6c4f6427dba68010ba428deb4cc6b063676e
+
+  platforms:
+    - platform: linux/amd64
+      runner: ubuntu-24.04
+      cudaArchitectures: 89-real;100-real;120-real
+    - platform: linux/arm64
+      runner: ubuntu-24.04-arm
+      cudaArchitectures: 121a-real
+
+  build:
+    target: llama-server
+    packages:
+      build-essential: 12.10ubuntu1
+      ca-certificates: 20260601~24.04.1
+      cmake: 3.28.3-1build7
+      curl: 8.5.0-2ubuntu10.11
+      libcurl4-openssl-dev: 8.5.0-2ubuntu10.11
+      libssl-dev: 3.0.13-0ubuntu3.12
+    cmake:
+      ggmlBackendDl: true
+      ggmlCpuAllVariants: true
+      ggmlCuda: true
+      ggmlCurl: true
+      ggmlNative: false
+      ggmlRpc: false
+      llamaBuildApp: false
+      llamaBuildExamples: false
+      llamaBuildServer: true
+      llamaBuildTests: false
+      llamaBuildTools: true
+      llamaBuildUi: false
+      llamaOpenSsl: true
+      llamaSubprocess: false
+      llamaUsePrebuiltUi: false
+
+  runtime:
+    uid: 10001
+    gid: 10001
+    port: 8081
+    entrypoint: /usr/local/bin/llama-server
+    packages:
+      ca-certificates: 20260601~24.04.1
+      libcurl4t64: 8.5.0-2ubuntu10.11
+      libgomp1: 14.2.0-4ubuntu2~24.04.1
+    writablePaths:
+      - /tmp

--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -64,6 +64,20 @@ spec:
     gid: 10001
     port: 8081
     entrypoint: /usr/local/bin/llama-server
+    requiredPaths:
+      - /usr/local/bin/llama-server
+      - /usr/local/share/licenses/llama.cpp/AUTHORS
+      - /usr/local/share/licenses/llama.cpp/LICENSE
+    forbiddenPaths:
+      - /bin/bash
+      - /bin/dash
+      - /bin/rbash
+      - /bin/sh
+      - /opt/llama.cpp/ui
+      - /usr/bin/bash
+      - /usr/bin/dash
+      - /usr/bin/rbash
+      - /usr/bin/sh
     packages:
       ca-certificates: 20260601~24.04.1
       libcurl4t64: 8.5.0-2ubuntu10.11

--- a/scripts/checks/export-llama-cpp-image-config.mjs
+++ b/scripts/checks/export-llama-cpp-image-config.mjs
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import YAML from "yaml";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const manifestPath = path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml");
+
+const digestReference = /^(?:docker\.io|ghcr\.io)\/[a-z0-9._/-]+@sha256:[0-9a-f]{64}$/u;
+const fullRevision = /^[0-9a-f]{40}$/u;
+const sha256 = /^sha256:[0-9a-f]{64}$/u;
+
+function requiredString(value, name, pattern) {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new Error(`invalid ${name}`);
+  }
+  return value;
+}
+
+function requiredRuntimeId(value, name) {
+  if (!Number.isSafeInteger(value) || value < 1 || value > 65535) {
+    throw new Error(`invalid ${name}`);
+  }
+  return String(value);
+}
+
+function matchesExactRecord(value, expected) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Object.keys(value).length === Object.keys(expected).length &&
+    Object.entries(expected).every(([key, expectedValue]) => value[key] === expectedValue)
+  );
+}
+
+export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "utf8")) {
+  const manifest = YAML.parse(source);
+  if (
+    manifest?.apiVersion !== "nemoclaw.nvidia.com/managed-inference/v1" ||
+    manifest?.kind !== "ServerImageBuild" ||
+    manifest?.metadata?.id !== "llama-cpp-server.v1"
+  ) {
+    throw new Error("invalid llama.cpp server image manifest identity");
+  }
+
+  const spec = manifest.spec;
+  const expectedCmake = {
+    ggmlBackendDl: true,
+    ggmlCpuAllVariants: true,
+    ggmlCuda: true,
+    ggmlCurl: true,
+    ggmlNative: false,
+    ggmlRpc: false,
+    llamaBuildApp: false,
+    llamaBuildExamples: false,
+    llamaBuildServer: true,
+    llamaBuildTests: false,
+    llamaBuildTools: true,
+    llamaBuildUi: false,
+    llamaOpenSsl: true,
+    llamaSubprocess: false,
+    llamaUsePrebuiltUi: false,
+  };
+  const expectedBuildPackages = {
+    "build-essential": "12.10ubuntu1",
+    "ca-certificates": "20260601~24.04.1",
+    cmake: "3.28.3-1build7",
+    curl: "8.5.0-2ubuntu10.11",
+    "libcurl4-openssl-dev": "8.5.0-2ubuntu10.11",
+    "libssl-dev": "3.0.13-0ubuntu3.12",
+  };
+  const expectedRuntimePackages = {
+    "ca-certificates": "20260601~24.04.1",
+    libcurl4t64: "8.5.0-2ubuntu10.11",
+    libgomp1: "14.2.0-4ubuntu2~24.04.1",
+  };
+  const cmake = spec?.build?.cmake;
+  if (
+    spec?.source?.repository !== "https://github.com/ggml-org/llama.cpp" ||
+    spec?.build?.target !== "llama-server" ||
+    !matchesExactRecord(cmake, expectedCmake) ||
+    !matchesExactRecord(spec?.build?.packages, expectedBuildPackages) ||
+    !matchesExactRecord(spec?.runtime?.packages, expectedRuntimePackages) ||
+    spec?.runtime?.entrypoint !== "/usr/local/bin/llama-server" ||
+    spec?.runtime?.port !== 8081 ||
+    JSON.stringify(spec?.runtime?.writablePaths) !== JSON.stringify(["/tmp"])
+  ) {
+    throw new Error("invalid llama.cpp server image build or runtime contract");
+  }
+  const platforms = Array.isArray(spec?.platforms) ? spec.platforms : [];
+  if (platforms.length !== 2) {
+    throw new Error("llama.cpp server image manifest must declare exactly two platforms");
+  }
+
+  const include = platforms.map((entry) => {
+    const platform = requiredString(entry?.platform, "platform", /^linux\/(?:amd64|arm64)$/u);
+    const expectedRunner = platform === "linux/amd64" ? "ubuntu-24.04" : "ubuntu-24.04-arm";
+    if (entry?.runner !== expectedRunner) {
+      throw new Error(`invalid native runner for ${platform}`);
+    }
+    const cudaArchitectures = requiredString(
+      entry?.cudaArchitectures,
+      `CUDA architectures for ${platform}`,
+      /^[0-9]+[a-z]?(?:-real)?(?:;[0-9]+[a-z]?(?:-real)?)*$/u,
+    );
+    return {
+      arch: platform.slice("linux/".length),
+      cuda_architectures: cudaArchitectures,
+      platform,
+      runner: expectedRunner,
+    };
+  });
+  if (new Set(include.map(({ platform }) => platform)).size !== 2) {
+    throw new Error("llama.cpp server image platforms must be unique");
+  }
+
+  return {
+    cuda_dev_image: requiredString(
+      spec?.cuda?.developmentBase,
+      "CUDA development base",
+      digestReference,
+    ),
+    cuda_runtime_image: requiredString(
+      spec?.cuda?.runtimeBase,
+      "CUDA runtime base",
+      digestReference,
+    ),
+    image: requiredString(
+      spec?.repository,
+      "image repository",
+      /^ghcr\.io\/nvidia\/nemoclaw\/llama-cpp-server$/u,
+    ),
+    matrix: JSON.stringify({ include }),
+    runtime_gid: requiredRuntimeId(spec?.runtime?.gid, "runtime gid"),
+    runtime_uid: requiredRuntimeId(spec?.runtime?.uid, "runtime uid"),
+    source_archive_sha256: requiredString(
+      spec?.source?.archiveSha256,
+      "source archive SHA-256",
+      sha256,
+    ),
+    source_revision: requiredString(spec?.source?.revision, "source revision", fullRevision),
+  };
+}
+
+export function githubOutput(config) {
+  return `${Object.entries(config)
+    .map(([name, value]) => `${name}=${value}`)
+    .join("\n")}\n`;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const output = githubOutput(loadLlamaCppImageConfig());
+  const githubOutputPath = process.env.GITHUB_OUTPUT;
+  if (githubOutputPath) {
+    fs.appendFileSync(githubOutputPath, output, { encoding: "utf8", mode: 0o600 });
+  } else {
+    process.stdout.write(output);
+  }
+}

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -12,7 +12,13 @@ type ServerImageManifest = {
   kind?: unknown;
   metadata?: { id?: unknown };
   spec?: {
-    build?: { cmake?: unknown; compiler?: unknown; packages?: unknown; target?: unknown };
+    build?: {
+      backendDirectory?: unknown;
+      cmake?: unknown;
+      compiler?: unknown;
+      packages?: unknown;
+      target?: unknown;
+    };
     cuda?: { developmentBase?: unknown; runtimeBase?: unknown };
     platforms?: Array<{
       cudaArchitectures?: unknown;
@@ -89,7 +95,13 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     "runtime",
     "source",
   ]);
-  assertExactKeys(manifest.spec?.build, "build", ["cmake", "compiler", "packages", "target"]);
+  assertExactKeys(manifest.spec?.build, "build", [
+    "backendDirectory",
+    "cmake",
+    "compiler",
+    "packages",
+    "target",
+  ]);
   assertExactKeys(manifest.spec?.cuda, "cuda", ["developmentBase", "runtimeBase"]);
   assertExactKeys(manifest.spec?.runtime, "runtime", [
     "entrypoint",
@@ -149,6 +161,7 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     libgomp1: "14.2.0-4ubuntu2~24.04.1",
   };
   const expectedRequiredPaths = [
+    "/opt/llama.cpp/lib/libggml-cuda.so",
     "/usr/local/bin/llama-server",
     "/usr/local/share/licenses/llama.cpp/AUTHORS",
     "/usr/local/share/licenses/llama.cpp/LICENSE",
@@ -168,6 +181,7 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   if (
     spec?.source?.repository !== "https://github.com/ggml-org/llama.cpp" ||
     spec?.build?.target !== "llama-server" ||
+    spec?.build?.backendDirectory !== "/opt/llama.cpp/lib" ||
     !matchesExactRecord(cmake, expectedCmake) ||
     !matchesExactRecord(spec?.build?.compiler, expectedCompiler) ||
     !matchesExactRecord(spec?.build?.packages, expectedBuildPackages) ||
@@ -209,6 +223,7 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   }
 
   return {
+    backend_directory: "/opt/llama.cpp/lib",
     compiler_c: expectedCompiler.c,
     compiler_cuda_host_cxx: expectedCompiler.cudaHostCxx,
     compiler_cxx: expectedCompiler.cxx,

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -22,9 +22,11 @@ type ServerImageManifest = {
     repository?: unknown;
     runtime?: {
       entrypoint?: unknown;
+      forbiddenPaths?: unknown;
       gid?: unknown;
       packages?: unknown;
       port?: unknown;
+      requiredPaths?: unknown;
       uid?: unknown;
       writablePaths?: unknown;
     };
@@ -36,7 +38,7 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 const manifestPath = path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml");
 
-const digestReference = /^(?:docker\.io|ghcr\.io)\/[a-z0-9._/-]+@sha256:[0-9a-f]{64}$/u;
+const nvidiaCudaDigestReference = /^docker\.io\/nvidia\/cuda@sha256:[0-9a-f]{64}$/u;
 const fullRevision = /^[0-9a-f]{40}$/u;
 const sha256 = /^sha256:[0-9a-f]{64}$/u;
 
@@ -65,8 +67,41 @@ function matchesExactRecord(value: unknown, expected: Record<string, unknown>): 
   );
 }
 
+function assertExactKeys(value: unknown, name: string, expected: string[]): void {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    JSON.stringify(Object.keys(value).sort()) !== JSON.stringify([...expected].sort())
+  ) {
+    throw new Error(`invalid ${name} fields`);
+  }
+}
+
 export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "utf8")) {
   const manifest = YAML.parse(source) as ServerImageManifest;
+  assertExactKeys(manifest, "manifest", ["apiVersion", "kind", "metadata", "spec"]);
+  assertExactKeys(manifest.metadata, "metadata", ["id"]);
+  assertExactKeys(manifest.spec, "spec", [
+    "build",
+    "cuda",
+    "platforms",
+    "repository",
+    "runtime",
+    "source",
+  ]);
+  assertExactKeys(manifest.spec?.build, "build", ["cmake", "compiler", "packages", "target"]);
+  assertExactKeys(manifest.spec?.cuda, "cuda", ["developmentBase", "runtimeBase"]);
+  assertExactKeys(manifest.spec?.runtime, "runtime", [
+    "entrypoint",
+    "forbiddenPaths",
+    "gid",
+    "packages",
+    "port",
+    "requiredPaths",
+    "uid",
+    "writablePaths",
+  ]);
+  assertExactKeys(manifest.spec?.source, "source", ["archiveSha256", "repository", "revision"]);
   if (
     manifest?.apiVersion !== "nemoclaw.nvidia.com/managed-inference/v1" ||
     manifest?.kind !== "ServerImageBuild" ||
@@ -113,6 +148,22 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     libcurl4t64: "8.5.0-2ubuntu10.11",
     libgomp1: "14.2.0-4ubuntu2~24.04.1",
   };
+  const expectedRequiredPaths = [
+    "/usr/local/bin/llama-server",
+    "/usr/local/share/licenses/llama.cpp/AUTHORS",
+    "/usr/local/share/licenses/llama.cpp/LICENSE",
+  ];
+  const expectedForbiddenPaths = [
+    "/bin/bash",
+    "/bin/dash",
+    "/bin/rbash",
+    "/bin/sh",
+    "/opt/llama.cpp/ui",
+    "/usr/bin/bash",
+    "/usr/bin/dash",
+    "/usr/bin/rbash",
+    "/usr/bin/sh",
+  ];
   const cmake = spec?.build?.cmake;
   if (
     spec?.source?.repository !== "https://github.com/ggml-org/llama.cpp" ||
@@ -123,6 +174,8 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     !matchesExactRecord(spec?.runtime?.packages, expectedRuntimePackages) ||
     spec?.runtime?.entrypoint !== "/usr/local/bin/llama-server" ||
     spec?.runtime?.port !== 8081 ||
+    JSON.stringify(spec?.runtime?.requiredPaths) !== JSON.stringify(expectedRequiredPaths) ||
+    JSON.stringify(spec?.runtime?.forbiddenPaths) !== JSON.stringify(expectedForbiddenPaths) ||
     JSON.stringify(spec?.runtime?.writablePaths) !== JSON.stringify(["/tmp"])
   ) {
     throw new Error("invalid llama.cpp server image build or runtime contract");
@@ -133,6 +186,7 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   }
 
   const include = platforms.map((entry) => {
+    assertExactKeys(entry, "platform", ["cudaArchitectures", "platform", "runner"]);
     const platform = requiredString(entry?.platform, "platform", /^linux\/(?:amd64|arm64)$/u);
     const expectedRunner = platform === "linux/amd64" ? "ubuntu-24.04" : "ubuntu-24.04-arm";
     if (entry?.runner !== expectedRunner) {
@@ -161,12 +215,12 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     cuda_dev_image: requiredString(
       spec?.cuda?.developmentBase,
       "CUDA development base",
-      digestReference,
+      nvidiaCudaDigestReference,
     ),
     cuda_runtime_image: requiredString(
       spec?.cuda?.runtimeBase,
       "CUDA runtime base",
-      digestReference,
+      nvidiaCudaDigestReference,
     ),
     image: requiredString(
       spec?.repository,
@@ -175,6 +229,8 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     ),
     matrix: JSON.stringify({ include }),
     runtime_gid: requiredRuntimeId(spec?.runtime?.gid, "runtime gid"),
+    runtime_forbidden_paths: JSON.stringify(expectedForbiddenPaths),
+    runtime_required_paths: JSON.stringify(expectedRequiredPaths),
     runtime_uid: requiredRuntimeId(spec?.runtime?.uid, "runtime uid"),
     source_archive_sha256: requiredString(
       spec?.source?.archiveSha256,

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -7,6 +7,31 @@ import { fileURLToPath } from "node:url";
 
 import YAML from "yaml";
 
+type ServerImageManifest = {
+  apiVersion?: unknown;
+  kind?: unknown;
+  metadata?: { id?: unknown };
+  spec?: {
+    build?: { cmake?: unknown; packages?: unknown; target?: unknown };
+    cuda?: { developmentBase?: unknown; runtimeBase?: unknown };
+    platforms?: Array<{
+      cudaArchitectures?: unknown;
+      platform?: unknown;
+      runner?: unknown;
+    }>;
+    repository?: unknown;
+    runtime?: {
+      entrypoint?: unknown;
+      gid?: unknown;
+      packages?: unknown;
+      port?: unknown;
+      uid?: unknown;
+      writablePaths?: unknown;
+    };
+    source?: { archiveSha256?: unknown; repository?: unknown; revision?: unknown };
+  };
+};
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 const manifestPath = path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml");
@@ -15,31 +40,33 @@ const digestReference = /^(?:docker\.io|ghcr\.io)\/[a-z0-9._/-]+@sha256:[0-9a-f]
 const fullRevision = /^[0-9a-f]{40}$/u;
 const sha256 = /^sha256:[0-9a-f]{64}$/u;
 
-function requiredString(value, name, pattern) {
+function requiredString(value: unknown, name: string, pattern: RegExp): string {
   if (typeof value !== "string" || !pattern.test(value)) {
     throw new Error(`invalid ${name}`);
   }
   return value;
 }
 
-function requiredRuntimeId(value, name) {
-  if (!Number.isSafeInteger(value) || value < 1 || value > 65535) {
+function requiredRuntimeId(value: unknown, name: string): string {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1 || value > 65535) {
     throw new Error(`invalid ${name}`);
   }
   return String(value);
 }
 
-function matchesExactRecord(value, expected) {
+function matchesExactRecord(value: unknown, expected: Record<string, unknown>): boolean {
   return (
     typeof value === "object" &&
     value !== null &&
     Object.keys(value).length === Object.keys(expected).length &&
-    Object.entries(expected).every(([key, expectedValue]) => value[key] === expectedValue)
+    Object.entries(expected).every(
+      ([key, expectedValue]) => (value as Record<string, unknown>)[key] === expectedValue,
+    )
   );
 }
 
 export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "utf8")) {
-  const manifest = YAML.parse(source);
+  const manifest = YAML.parse(source) as ServerImageManifest;
   if (
     manifest?.apiVersion !== "nemoclaw.nvidia.com/managed-inference/v1" ||
     manifest?.kind !== "ServerImageBuild" ||
@@ -147,7 +174,7 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   };
 }
 
-export function githubOutput(config) {
+export function githubOutput(config: Record<string, string>): string {
   return `${Object.entries(config)
     .map(([name, value]) => `${name}=${value}`)
     .join("\n")}\n`;

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -12,7 +12,7 @@ type ServerImageManifest = {
   kind?: unknown;
   metadata?: { id?: unknown };
   spec?: {
-    build?: { cmake?: unknown; packages?: unknown; target?: unknown };
+    build?: { cmake?: unknown; compiler?: unknown; packages?: unknown; target?: unknown };
     cuda?: { developmentBase?: unknown; runtimeBase?: unknown };
     platforms?: Array<{
       cudaArchitectures?: unknown;
@@ -98,8 +98,15 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     "ca-certificates": "20260601~24.04.1",
     cmake: "3.28.3-1build7",
     curl: "8.5.0-2ubuntu10.11",
+    "g++-14": "14.2.0-4ubuntu2~24.04.1",
+    "gcc-14": "14.2.0-4ubuntu2~24.04.1",
     "libcurl4-openssl-dev": "8.5.0-2ubuntu10.11",
     "libssl-dev": "3.0.13-0ubuntu3.12",
+  };
+  const expectedCompiler = {
+    c: "gcc-14",
+    cudaHostCxx: "g++-14",
+    cxx: "g++-14",
   };
   const expectedRuntimePackages = {
     "ca-certificates": "20260601~24.04.1",
@@ -111,6 +118,7 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     spec?.source?.repository !== "https://github.com/ggml-org/llama.cpp" ||
     spec?.build?.target !== "llama-server" ||
     !matchesExactRecord(cmake, expectedCmake) ||
+    !matchesExactRecord(spec?.build?.compiler, expectedCompiler) ||
     !matchesExactRecord(spec?.build?.packages, expectedBuildPackages) ||
     !matchesExactRecord(spec?.runtime?.packages, expectedRuntimePackages) ||
     spec?.runtime?.entrypoint !== "/usr/local/bin/llama-server" ||
@@ -147,6 +155,9 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   }
 
   return {
+    compiler_c: expectedCompiler.c,
+    compiler_cuda_host_cxx: expectedCompiler.cudaHostCxx,
+    compiler_cxx: expectedCompiler.cxx,
     cuda_dev_image: requiredString(
       spec?.cuda?.developmentBase,
       "CUDA development base",

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -26,6 +26,7 @@ type Job = {
 };
 
 type Workflow = {
+  concurrency?: { "cancel-in-progress"?: boolean; group?: string };
   jobs?: Record<string, Job>;
   on?: Record<string, { paths?: string[] }>;
   permissions?: Record<string, string>;
@@ -64,19 +65,29 @@ describe("llama.cpp image PR workflow", () => {
       expect.arrayContaining([
         ".github/workflows/llama-cpp-image.yaml",
         "managed-inference/images/llama-cpp/**",
+        "managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
         "scripts/checks/export-llama-cpp-image-config.mts",
       ]),
     );
     expect(Object.keys(workflow.on ?? {})).toEqual(["pull_request"]);
     expect(workflow.permissions).toEqual({ contents: "read" });
-    expect(JSON.stringify(workflow)).not.toContain("packages:write");
+    const permissionValues = [
+      ...Object.values(workflow.permissions ?? {}),
+      ...Object.values(workflow.jobs ?? {}).flatMap((job) => Object.values(job.permissions ?? {})),
+    ];
+    expect(permissionValues).not.toContain("write");
     expect(JSON.stringify(workflow)).not.toContain("docker/login-action");
     expect(buildStep.with?.push).toBe(false);
     expect(buildStep.with?.load).toBe(true);
+    expect(workflow.concurrency).toEqual({
+      "cancel-in-progress": true,
+      group: "${{ github.workflow }}-${{ github.event.pull_request.number }}",
+    });
   });
 
   it("passes declarative source, base image, runtime ID, and platform values to each image build (#8231)", () => {
     expect(config.outputs).toEqual({
+      backend_directory: "${{ steps.manifest.outputs.backend_directory }}",
       compiler_c: "${{ steps.manifest.outputs.compiler_c }}",
       compiler_cuda_host_cxx: "${{ steps.manifest.outputs.compiler_cuda_host_cxx }}",
       compiler_cxx: "${{ steps.manifest.outputs.compiler_cxx }}",
@@ -100,6 +111,7 @@ describe("llama.cpp image PR workflow", () => {
 
     const args = String(buildStep.with?.["build-args"] ?? "");
     for (const output of [
+      "backend_directory",
       "compiler_c",
       "compiler_cuda_host_cxx",
       "compiler_cxx",
@@ -130,6 +142,10 @@ describe("llama.cpp image PR workflow", () => {
     expect(buildStep.with?.platforms).toBe("${{ matrix.platform }}");
     expect(buildStep.with?.provenance).toBe(false);
     expect(buildStep.with?.sbom).toBe(false);
+    expect(buildStep.with?.["cache-from"]).toBe("type=gha,scope=llama-cpp-${{ matrix.arch }}");
+    expect(buildStep.with?.["cache-to"]).toBe(
+      "type=gha,mode=max,scope=llama-cpp-${{ matrix.arch }}",
+    );
     expect(validate.run).toContain('.Config.User == ($uid + ":" + $gid)');
     expect(validate.run).toContain("io.nvidia.nemoclaw.inference-server.upstream.revision");
     expect(validate.run).toContain("--network none");

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -77,6 +77,9 @@ describe("llama.cpp image PR workflow", () => {
 
   it("passes declarative source, base image, runtime ID, and platform values to each image build (#8231)", () => {
     expect(config.outputs).toEqual({
+      compiler_c: "${{ steps.manifest.outputs.compiler_c }}",
+      compiler_cuda_host_cxx: "${{ steps.manifest.outputs.compiler_cuda_host_cxx }}",
+      compiler_cxx: "${{ steps.manifest.outputs.compiler_cxx }}",
       cuda_dev_image: "${{ steps.manifest.outputs.cuda_dev_image }}",
       cuda_runtime_image: "${{ steps.manifest.outputs.cuda_runtime_image }}",
       image: "${{ steps.manifest.outputs.image }}",
@@ -95,6 +98,9 @@ describe("llama.cpp image PR workflow", () => {
 
     const args = String(buildStep.with?.["build-args"] ?? "");
     for (const output of [
+      "compiler_c",
+      "compiler_cuda_host_cxx",
+      "compiler_cxx",
       "cuda_dev_image",
       "cuda_runtime_image",
       "runtime_gid",

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -38,8 +38,12 @@ const workflow = YAML.parse(
 const fullShaAction = /^[^@]+@[0-9a-f]{40}$/u;
 
 function required<T>(value: T | undefined, message: string): T {
-  if (value === undefined) throw new Error(message);
-  return value;
+  return (
+    value ??
+    (() => {
+      throw new Error(message);
+    })()
+  );
 }
 
 function namedStep(job: Job, name: string): Step {
@@ -107,10 +111,12 @@ describe("llama.cpp image PR workflow", () => {
   });
 
   it("pins actions and validates the native non-root read-only image (#8231)", () => {
-    for (const job of Object.values(workflow.jobs ?? {})) {
-      for (const step of job.steps ?? []) {
-        if (step.uses) expect(step.uses).toMatch(fullShaAction);
-      }
+    const actions = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .map((step) => step.uses)
+      .filter((uses): uses is string => uses !== undefined);
+    for (const action of actions) {
+      expect(action).toMatch(fullShaAction);
     }
 
     expect(buildStep.with?.platforms).toBe("${{ matrix.platform }}");

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -84,7 +84,9 @@ describe("llama.cpp image PR workflow", () => {
       cuda_runtime_image: "${{ steps.manifest.outputs.cuda_runtime_image }}",
       image: "${{ steps.manifest.outputs.image }}",
       matrix: "${{ steps.manifest.outputs.matrix }}",
+      runtime_forbidden_paths: "${{ steps.manifest.outputs.runtime_forbidden_paths }}",
       runtime_gid: "${{ steps.manifest.outputs.runtime_gid }}",
+      runtime_required_paths: "${{ steps.manifest.outputs.runtime_required_paths }}",
       runtime_uid: "${{ steps.manifest.outputs.runtime_uid }}",
       source_archive_sha256: "${{ steps.manifest.outputs.source_archive_sha256 }}",
       source_revision: "${{ steps.manifest.outputs.source_revision }}",
@@ -134,6 +136,9 @@ describe("llama.cpp image PR workflow", () => {
     expect(validate.run).toContain("--read-only");
     expect(validate.run).toContain("--tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777");
     expect(validate.run).toContain('grep -F "$SOURCE_REVISION"');
-    expect(validate.run).toContain("test ! -e /opt/llama.cpp/ui");
+    expect(validate.run).toContain('docker export "$container_id"');
+    expect(validate.run).toContain("RUNTIME_REQUIRED_PATHS");
+    expect(validate.run).toContain("RUNTIME_FORBIDDEN_PATHS");
+    expect(validate.run).not.toContain("--entrypoint /bin/sh");
   });
 });

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -19,7 +19,7 @@ type Step = {
 type Job = {
   needs?: string;
   outputs?: Record<string, string>;
-  permissions?: Record<string, string>;
+  permissions?: string | Record<string, string>;
   "runs-on"?: string;
   steps?: Step[];
   strategy?: { matrix?: unknown };
@@ -29,7 +29,7 @@ type Workflow = {
   concurrency?: { "cancel-in-progress"?: boolean; group?: string };
   jobs?: Record<string, Job>;
   on?: Record<string, { paths?: string[] }>;
-  permissions?: Record<string, string>;
+  permissions?: string | Record<string, string>;
 };
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -54,9 +54,20 @@ function namedStep(job: Job, name: string): Step {
   );
 }
 
+function permissionValues(value: string | Record<string, string> | undefined): string[] {
+  return typeof value === "string" ? [value] : Object.values(value ?? {});
+}
+
+function jobPermissionValues(workflowValue: Workflow): string[] {
+  return Object.values(workflowValue.jobs ?? {}).flatMap((job) =>
+    permissionValues(job.permissions),
+  );
+}
+
 describe("llama.cpp image PR workflow", () => {
   const config = required(workflow.jobs?.config, "config job is missing");
   const build = required(workflow.jobs?.["pr-build"], "native PR build job is missing");
+  const buildArgGuard = namedStep(build, "Validate native PR image build args");
   const buildStep = namedStep(build, "Build native PR image without publishing");
   const validate = namedStep(build, "Validate native PR image contract");
 
@@ -71,11 +82,14 @@ describe("llama.cpp image PR workflow", () => {
     );
     expect(Object.keys(workflow.on ?? {})).toEqual(["pull_request"]);
     expect(workflow.permissions).toEqual({ contents: "read" });
-    const permissionValues = [
-      ...Object.values(workflow.permissions ?? {}),
-      ...Object.values(workflow.jobs ?? {}).flatMap((job) => Object.values(job.permissions ?? {})),
+    const declaredPermissions = [
+      ...permissionValues(workflow.permissions),
+      ...jobPermissionValues(workflow),
     ];
-    expect(permissionValues).not.toContain("write");
+    expect(declaredPermissions).not.toContain("write");
+    expect(declaredPermissions).not.toContain("write-all");
+    const unsafeFixture = YAML.parse("jobs:\n  unsafe:\n    permissions: write-all\n") as Workflow;
+    expect(jobPermissionValues(unsafeFixture)).toContain("write-all");
     expect(JSON.stringify(workflow)).not.toContain("docker/login-action");
     expect(buildStep.with?.push).toBe(false);
     expect(buildStep.with?.load).toBe(true);
@@ -128,6 +142,16 @@ describe("llama.cpp image PR workflow", () => {
     expect(args).toContain("TARGETPLATFORM=${{ matrix.platform }}");
     expect(args).not.toMatch(/sha256:[0-9a-f]{64}/u);
     expect(args).not.toMatch(/[0-9a-f]{40}/u);
+
+    const buildArgNames = [...args.matchAll(/^([A-Z0-9_]+)=/gmu)].map((match) => match[1]);
+    const guardedArgNames = [
+      ...(buildArgGuard.run ?? "").matchAll(/--build-arg "([A-Z0-9_]+)=/gu),
+    ].map((match) => match[1]);
+    expect(guardedArgNames).toEqual(buildArgNames);
+    expect(buildArgGuard.run).toContain("scripts/check-production-build-args.sh");
+    expect(build.steps?.indexOf(buildArgGuard)).toBeLessThan(
+      build.steps?.indexOf(buildStep) ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it("pins actions and validates the native non-root read-only image (#8231)", () => {

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+type Step = {
+  env?: Record<string, unknown>;
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type Job = {
+  needs?: string;
+  outputs?: Record<string, string>;
+  permissions?: Record<string, string>;
+  "runs-on"?: string;
+  steps?: Step[];
+  strategy?: { matrix?: unknown };
+};
+
+type Workflow = {
+  jobs?: Record<string, Job>;
+  on?: Record<string, { paths?: string[] }>;
+  permissions?: Record<string, string>;
+};
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = YAML.parse(
+  fs.readFileSync(path.join(repoRoot, ".github", "workflows", "llama-cpp-image.yaml"), "utf8"),
+) as Workflow;
+const fullShaAction = /^[^@]+@[0-9a-f]{40}$/u;
+
+function required<T>(value: T | undefined, message: string): T {
+  if (value === undefined) throw new Error(message);
+  return value;
+}
+
+function namedStep(job: Job, name: string): Step {
+  return required(
+    job.steps?.find((candidate) => candidate.name === name),
+    `llama.cpp image workflow is missing '${name}'`,
+  );
+}
+
+describe("llama.cpp image PR workflow", () => {
+  const config = required(workflow.jobs?.config, "config job is missing");
+  const build = required(workflow.jobs?.["pr-build"], "native PR build job is missing");
+  const buildStep = namedStep(build, "Build native PR image without publishing");
+  const validate = namedStep(build, "Validate native PR image contract");
+
+  it("is a read-only pull-request gate with no publication path (#8231)", () => {
+    expect(workflow.on?.pull_request?.paths).toEqual(
+      expect.arrayContaining([
+        ".github/workflows/llama-cpp-image.yaml",
+        "managed-inference/images/llama-cpp/**",
+        "scripts/checks/export-llama-cpp-image-config.mjs",
+      ]),
+    );
+    expect(Object.keys(workflow.on ?? {})).toEqual(["pull_request"]);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(JSON.stringify(workflow)).not.toContain("packages:write");
+    expect(JSON.stringify(workflow)).not.toContain("docker/login-action");
+    expect(buildStep.with?.push).toBe(false);
+    expect(buildStep.with?.load).toBe(true);
+  });
+
+  it("passes declarative source, base image, runtime ID, and platform values to each image build (#8231)", () => {
+    expect(config.outputs).toEqual({
+      cuda_dev_image: "${{ steps.manifest.outputs.cuda_dev_image }}",
+      cuda_runtime_image: "${{ steps.manifest.outputs.cuda_runtime_image }}",
+      image: "${{ steps.manifest.outputs.image }}",
+      matrix: "${{ steps.manifest.outputs.matrix }}",
+      runtime_gid: "${{ steps.manifest.outputs.runtime_gid }}",
+      runtime_uid: "${{ steps.manifest.outputs.runtime_uid }}",
+      source_archive_sha256: "${{ steps.manifest.outputs.source_archive_sha256 }}",
+      source_revision: "${{ steps.manifest.outputs.source_revision }}",
+    });
+    expect(namedStep(config, "Compile image manifest").run).toBe(
+      "node scripts/checks/export-llama-cpp-image-config.mjs",
+    );
+    expect(build.needs).toBe("config");
+    expect(build["runs-on"]).toBe("${{ matrix.runner }}");
+    expect(build.strategy?.matrix).toBe("${{ fromJSON(needs.config.outputs.matrix) }}");
+
+    const args = String(buildStep.with?.["build-args"] ?? "");
+    for (const output of [
+      "cuda_dev_image",
+      "cuda_runtime_image",
+      "runtime_gid",
+      "runtime_uid",
+      "source_archive_sha256",
+      "source_revision",
+    ]) {
+      expect(args).toContain(`needs.config.outputs.${output}`);
+    }
+    expect(args).toContain("CUDA_ARCHITECTURES=${{ matrix.cuda_architectures }}");
+    expect(args).toContain("TARGETPLATFORM=${{ matrix.platform }}");
+    expect(args).not.toMatch(/sha256:[0-9a-f]{64}/u);
+    expect(args).not.toMatch(/[0-9a-f]{40}/u);
+  });
+
+  it("pins actions and validates the native non-root read-only image (#8231)", () => {
+    for (const job of Object.values(workflow.jobs ?? {})) {
+      for (const step of job.steps ?? []) {
+        if (step.uses) expect(step.uses).toMatch(fullShaAction);
+      }
+    }
+
+    expect(buildStep.with?.platforms).toBe("${{ matrix.platform }}");
+    expect(buildStep.with?.provenance).toBe(false);
+    expect(buildStep.with?.sbom).toBe(false);
+    expect(validate.run).toContain('.Config.User == ($uid + ":" + $gid)');
+    expect(validate.run).toContain("io.nvidia.nemoclaw.inference-server.upstream.revision");
+    expect(validate.run).toContain("--network none");
+    expect(validate.run).toContain("--read-only");
+    expect(validate.run).toContain("--tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777");
+    expect(validate.run).toContain('grep -F "$SOURCE_REVISION"');
+    expect(validate.run).toContain("test ! -e /opt/llama.cpp/ui");
+  });
+});

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -60,7 +60,7 @@ describe("llama.cpp image PR workflow", () => {
       expect.arrayContaining([
         ".github/workflows/llama-cpp-image.yaml",
         "managed-inference/images/llama-cpp/**",
-        "scripts/checks/export-llama-cpp-image-config.mjs",
+        "scripts/checks/export-llama-cpp-image-config.mts",
       ]),
     );
     expect(Object.keys(workflow.on ?? {})).toEqual(["pull_request"]);
@@ -83,7 +83,7 @@ describe("llama.cpp image PR workflow", () => {
       source_revision: "${{ steps.manifest.outputs.source_revision }}",
     });
     expect(namedStep(config, "Compile image manifest").run).toBe(
-      "node scripts/checks/export-llama-cpp-image-config.mjs",
+      "node --experimental-strip-types --no-warnings scripts/checks/export-llama-cpp-image-config.mts",
     );
     expect(build.needs).toBe("config");
     expect(build["runs-on"]).toBe("${{ matrix.runner }}");

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -8,6 +8,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
 
+import { loadLlamaCppImageConfig } from "../scripts/checks/export-llama-cpp-image-config.mts";
+
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const imageRoot = path.join(repoRoot, "managed-inference", "images", "llama-cpp");
 const manifestPath = path.join(imageRoot, "image.yaml");
@@ -67,7 +69,8 @@ function parseOutput(value: string): Record<string, string> {
 }
 
 describe("declarative llama.cpp server image", () => {
-  const manifest = YAML.parse(fs.readFileSync(manifestPath, "utf8")) as ImageManifest;
+  const manifestSource = fs.readFileSync(manifestPath, "utf8");
+  const manifest = YAML.parse(manifestSource) as ImageManifest;
   const recipe = YAML.parse(fs.readFileSync(recipePath, "utf8")) as ServingRecipe;
   const dockerfile = fs.readFileSync(dockerfilePath, "utf8");
 
@@ -141,6 +144,37 @@ describe("declarative llama.cpp server image", () => {
         runner,
       })),
     });
+  });
+
+  it.each([
+    [
+      "a base image outside the allowed registries",
+      manifestSource.replace("docker.io/nvidia/cuda@", "registry.example.invalid/cuda@"),
+    ],
+    [
+      "a runner that does not match the platform",
+      manifestSource.replace("runner: ubuntu-24.04", "runner: ubuntu-latest"),
+    ],
+    [
+      "a malformed base image digest",
+      manifestSource.replace(
+        "sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52",
+        "sha256:invalid",
+      ),
+    ],
+    [
+      "a duplicate platform",
+      manifestSource.replace("platform: linux/arm64", "platform: linux/amd64"),
+    ],
+    [
+      "an unexpected fixed CMake field",
+      manifestSource.replace(
+        "      ggmlBackendDl: true",
+        "      ggmlBackendDl: true\n      ggmlWidgets: true",
+      ),
+    ],
+  ])("rejects %s before exporting image build inputs (#8231)", (_case, candidate) => {
+    expect(() => loadLlamaCppImageConfig(candidate)).toThrow();
   });
 
   it("builds only the pinned non-root llama-server runtime surfaces (#8231)", () => {

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const imageRoot = path.join(repoRoot, "managed-inference", "images", "llama-cpp");
+const manifestPath = path.join(imageRoot, "image.yaml");
+const dockerfilePath = path.join(imageRoot, "Dockerfile");
+const recipePath = path.join(
+  repoRoot,
+  "managed-inference",
+  "recipes",
+  "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
+);
+const exporterPath = path.join(repoRoot, "scripts", "checks", "export-llama-cpp-image-config.mjs");
+
+type ImageManifest = {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: { id?: string };
+  spec?: {
+    build?: {
+      cmake?: Record<string, boolean>;
+      packages?: Record<string, string>;
+      target?: string;
+    };
+    cuda?: { developmentBase?: string; runtimeBase?: string };
+    platforms?: Array<{
+      cudaArchitectures?: string;
+      platform?: string;
+      runner?: string;
+    }>;
+    repository?: string;
+    runtime?: {
+      entrypoint?: string;
+      gid?: number;
+      packages?: Record<string, string>;
+      port?: number;
+      uid?: number;
+      writablePaths?: string[];
+    };
+    source?: { archiveSha256?: string; repository?: string; revision?: string };
+  };
+};
+
+type ServingRecipe = {
+  spec?: {
+    runtime?: { cuda?: { baseImage?: string } };
+    server?: { source?: { repository?: string; revision?: string } };
+    serve?: { port?: number };
+  };
+};
+
+function parseOutput(value: string): Record<string, string> {
+  return Object.fromEntries(
+    value
+      .trim()
+      .split("\n")
+      .map((line) => line.split("=", 2) as [string, string]),
+  );
+}
+
+describe("declarative llama.cpp server image", () => {
+  const manifest = YAML.parse(fs.readFileSync(manifestPath, "utf8")) as ImageManifest;
+  const recipe = YAML.parse(fs.readFileSync(recipePath, "utf8")) as ServingRecipe;
+  const dockerfile = fs.readFileSync(dockerfilePath, "utf8");
+
+  it("binds the llama.cpp image build to the DGX Spark serving recipe (#8231)", () => {
+    expect(manifest).toMatchObject({
+      apiVersion: "nemoclaw.nvidia.com/managed-inference/v1",
+      kind: "ServerImageBuild",
+      metadata: { id: "llama-cpp-server.v1" },
+      spec: {
+        repository: "ghcr.io/nvidia/nemoclaw/llama-cpp-server",
+        runtime: {
+          entrypoint: "/usr/local/bin/llama-server",
+          port: 8081,
+          writablePaths: ["/tmp"],
+        },
+        source: { repository: "https://github.com/ggml-org/llama.cpp" },
+      },
+    });
+    expect(manifest.spec?.source?.revision).toBe(recipe.spec?.server?.source?.revision);
+    expect(manifest.spec?.cuda?.runtimeBase).toBe(recipe.spec?.runtime?.cuda?.baseImage);
+    expect(manifest.spec?.runtime?.port).toBe(recipe.spec?.serve?.port);
+    expect(manifest.spec?.source?.archiveSha256).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    expect(manifest.spec?.cuda?.developmentBase).toMatch(
+      /^docker\.io\/nvidia\/cuda@sha256:[0-9a-f]{64}$/u,
+    );
+    expect(manifest.spec?.runtime?.uid).toBeGreaterThan(0);
+    expect(manifest.spec?.runtime?.gid).toBeGreaterThan(0);
+  });
+
+  it("declares native amd64 and DGX Spark arm64 compilation explicitly (#8231)", () => {
+    expect(manifest.spec?.platforms).toEqual([
+      {
+        cudaArchitectures: "89-real;100-real;120-real",
+        platform: "linux/amd64",
+        runner: "ubuntu-24.04",
+      },
+      {
+        cudaArchitectures: "121a-real",
+        platform: "linux/arm64",
+        runner: "ubuntu-24.04-arm",
+      },
+    ]);
+  });
+
+  it("compiles the fail-closed workflow inputs from YAML (#8231)", () => {
+    const result = spawnSync(process.execPath, [exporterPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_OUTPUT: "" },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const output = parseOutput(result.stdout);
+    expect(output).toMatchObject({
+      cuda_dev_image: manifest.spec?.cuda?.developmentBase,
+      cuda_runtime_image: manifest.spec?.cuda?.runtimeBase,
+      image: manifest.spec?.repository,
+      runtime_gid: String(manifest.spec?.runtime?.gid),
+      runtime_uid: String(manifest.spec?.runtime?.uid),
+      source_archive_sha256: manifest.spec?.source?.archiveSha256,
+      source_revision: manifest.spec?.source?.revision,
+    });
+    expect(JSON.parse(output.matrix ?? "null")).toEqual({
+      include: manifest.spec?.platforms?.map(({ cudaArchitectures, platform, runner }) => ({
+        arch: platform?.slice("linux/".length),
+        cuda_architectures: cudaArchitectures,
+        platform,
+        runner,
+      })),
+    });
+  });
+
+  it("builds only the pinned non-root llama-server runtime surfaces (#8231)", () => {
+    const cmakeMarkers: Record<string, string> = {
+      ggmlBackendDl: "-DGGML_BACKEND_DL=ON",
+      ggmlCpuAllVariants: "-DGGML_CPU_ALL_VARIANTS=ON",
+      ggmlCuda: "-DGGML_CUDA=ON",
+      ggmlCurl: "-DGGML_CURL=ON",
+      ggmlNative: "-DGGML_NATIVE=OFF",
+      ggmlRpc: "-DGGML_RPC=OFF",
+      llamaBuildApp: "-DLLAMA_BUILD_APP=OFF",
+      llamaBuildExamples: "-DLLAMA_BUILD_EXAMPLES=OFF",
+      llamaBuildServer: "-DLLAMA_BUILD_SERVER=ON",
+      llamaBuildTests: "-DLLAMA_BUILD_TESTS=OFF",
+      llamaBuildTools: "-DLLAMA_BUILD_TOOLS=ON",
+      llamaBuildUi: "-DLLAMA_BUILD_UI=OFF",
+      llamaOpenSsl: "-DLLAMA_OPENSSL=ON",
+      llamaSubprocess: "-DLLAMA_SUBPROCESS=OFF",
+      llamaUsePrebuiltUi: "-DLLAMA_USE_PREBUILT_UI=OFF",
+    };
+    for (const [field, marker] of Object.entries(cmakeMarkers)) {
+      expect(manifest.spec?.build?.cmake?.[field]).toBe(marker.endsWith("=ON"));
+      expect(dockerfile).toContain(marker);
+    }
+
+    expect(manifest.spec?.build?.target).toBe("llama-server");
+    expect(dockerfile).toContain("--target llama-server");
+    for (const [packageName, version] of Object.entries({
+      ...manifest.spec?.build?.packages,
+      ...manifest.spec?.runtime?.packages,
+    })) {
+      expect(dockerfile).toContain(`${packageName}=${version}`);
+    }
+    expect(dockerfile).toContain("USER ${RUNTIME_UID}:${RUNTIME_GID}");
+    expect(dockerfile).toContain('SHELL ["/bin/bash", "-o", "pipefail", "-c"]');
+    expect(dockerfile).toContain('ENTRYPOINT ["/usr/local/bin/llama-server"]');
+    expect(dockerfile).toContain("sha256sum --check --strict");
+    expect(dockerfile).toContain("cp LICENSE AUTHORS");
+    expect(dockerfile).not.toContain("# syntax=");
+    expect(dockerfile).not.toContain("git clone");
+    expect(dockerfile).not.toContain(" huggingface");
+    expect(dockerfile).not.toMatch(/[0-9a-f]{40}/u);
+    expect(dockerfile).not.toMatch(/sha256:[0-9a-f]{64}/u);
+  });
+});

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -29,6 +29,7 @@ type ImageManifest = {
   spec?: {
     build?: {
       cmake?: Record<string, boolean>;
+      compiler?: { c?: string; cudaHostCxx?: string; cxx?: string };
       packages?: Record<string, string>;
       target?: string;
     };
@@ -128,6 +129,9 @@ describe("declarative llama.cpp server image", () => {
     expect(result.status, result.stderr).toBe(0);
     const output = parseOutput(result.stdout);
     expect(output).toMatchObject({
+      compiler_c: manifest.spec?.build?.compiler?.c,
+      compiler_cuda_host_cxx: manifest.spec?.build?.compiler?.cudaHostCxx,
+      compiler_cxx: manifest.spec?.build?.compiler?.cxx,
       cuda_dev_image: manifest.spec?.cuda?.developmentBase,
       cuda_runtime_image: manifest.spec?.cuda?.runtimeBase,
       image: manifest.spec?.repository,
@@ -211,6 +215,9 @@ describe("declarative llama.cpp server image", () => {
     expect(dockerfile).toContain("USER ${RUNTIME_UID}:${RUNTIME_GID}");
     expect(dockerfile).toContain('SHELL ["/bin/bash", "-o", "pipefail", "-c"]');
     expect(dockerfile).toContain('ENTRYPOINT ["/usr/local/bin/llama-server"]');
+    expect(dockerfile).toContain("ENV CC=${C_COMPILER}");
+    expect(dockerfile).toContain("CXX=${CXX_COMPILER}");
+    expect(dockerfile).toContain("CUDAHOSTCXX=${CUDA_HOST_CXX_COMPILER}");
     expect(dockerfile).toContain("sha256sum --check --strict");
     expect(dockerfile).toContain("cp LICENSE AUTHORS");
     expect(dockerfile).not.toContain("# syntax=");

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -18,7 +18,7 @@ const recipePath = path.join(
   "recipes",
   "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
 );
-const exporterPath = path.join(repoRoot, "scripts", "checks", "export-llama-cpp-image-config.mjs");
+const exporterPath = path.join(repoRoot, "scripts", "checks", "export-llama-cpp-image-config.mts");
 
 type ImageManifest = {
   apiVersion?: string;
@@ -113,11 +113,15 @@ describe("declarative llama.cpp server image", () => {
   });
 
   it("compiles the fail-closed workflow inputs from YAML (#8231)", () => {
-    const result = spawnSync(process.execPath, [exporterPath], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: { ...process.env, GITHUB_OUTPUT: "" },
-    });
+    const result = spawnSync(
+      process.execPath,
+      ["--experimental-strip-types", "--no-warnings", exporterPath],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_OUTPUT: "" },
+      },
+    );
     expect(result.status, result.stderr).toBe(0);
     const output = parseOutput(result.stdout);
     expect(output).toMatchObject({

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -28,6 +28,7 @@ type ImageManifest = {
   metadata?: { id?: string };
   spec?: {
     build?: {
+      backendDirectory?: string;
       cmake?: Record<string, boolean>;
       compiler?: { c?: string; cudaHostCxx?: string; cxx?: string };
       packages?: Record<string, string>;
@@ -67,7 +68,10 @@ function parseOutput(value: string): Record<string, string> {
     value
       .trim()
       .split("\n")
-      .map((line) => line.split("=", 2) as [string, string]),
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [line.slice(0, separator), line.slice(separator + 1)] as [string, string];
+      }),
   );
 }
 
@@ -84,11 +88,13 @@ describe("declarative llama.cpp server image", () => {
       metadata: { id: "llama-cpp-server.v1" },
       spec: {
         repository: "ghcr.io/nvidia/nemoclaw/llama-cpp-server",
+        build: { backendDirectory: "/opt/llama.cpp/lib" },
         runtime: {
           entrypoint: "/usr/local/bin/llama-server",
           forbiddenPaths: expect.arrayContaining(["/bin/sh", "/usr/bin/sh"]),
           port: 8081,
           requiredPaths: expect.arrayContaining([
+            "/opt/llama.cpp/lib/libggml-cuda.so",
             "/usr/local/bin/llama-server",
             "/usr/local/share/licenses/llama.cpp/LICENSE",
           ]),
@@ -136,6 +142,7 @@ describe("declarative llama.cpp server image", () => {
     expect(result.status, result.stderr).toBe(0);
     const output = parseOutput(result.stdout);
     expect(output).toMatchObject({
+      backend_directory: manifest.spec?.build?.backendDirectory,
       compiler_c: manifest.spec?.build?.compiler?.c,
       compiler_cuda_host_cxx: manifest.spec?.build?.compiler?.cudaHostCxx,
       compiler_cxx: manifest.spec?.build?.compiler?.cxx,
@@ -219,6 +226,8 @@ describe("declarative llama.cpp server image", () => {
 
     expect(manifest.spec?.build?.target).toBe("llama-server");
     expect(dockerfile).toContain("--target llama-server");
+    expect(dockerfile).toContain('-DGGML_BACKEND_DIR="${GGML_BACKEND_DIR}"');
+    expect(dockerfile).toContain('test -f "${GGML_BACKEND_DIR}/libggml-cuda.so"');
     for (const [packageName, version] of Object.entries({
       ...manifest.spec?.build?.packages,
       ...manifest.spec?.runtime?.packages,
@@ -238,6 +247,9 @@ describe("declarative llama.cpp server image", () => {
     }
     expect(dockerfile).toContain("sha256sum --check --strict");
     expect(dockerfile).toContain("cp LICENSE AUTHORS");
+    expect(dockerfile).toContain("find /opt/llama.cpp/licenses -type d -exec chmod 0555");
+    expect(dockerfile).toContain("find /opt/llama.cpp/licenses -type f -exec chmod 0444");
+    expect(dockerfile).not.toContain("COPY --from=build --chmod=0444");
     expect(dockerfile).not.toContain("# syntax=");
     expect(dockerfile).not.toContain("git clone");
     expect(dockerfile).not.toContain(" huggingface");

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -42,9 +42,11 @@ type ImageManifest = {
     repository?: string;
     runtime?: {
       entrypoint?: string;
+      forbiddenPaths?: string[];
       gid?: number;
       packages?: Record<string, string>;
       port?: number;
+      requiredPaths?: string[];
       uid?: number;
       writablePaths?: string[];
     };
@@ -84,7 +86,12 @@ describe("declarative llama.cpp server image", () => {
         repository: "ghcr.io/nvidia/nemoclaw/llama-cpp-server",
         runtime: {
           entrypoint: "/usr/local/bin/llama-server",
+          forbiddenPaths: expect.arrayContaining(["/bin/sh", "/usr/bin/sh"]),
           port: 8081,
+          requiredPaths: expect.arrayContaining([
+            "/usr/local/bin/llama-server",
+            "/usr/local/share/licenses/llama.cpp/LICENSE",
+          ]),
           writablePaths: ["/tmp"],
         },
         source: { repository: "https://github.com/ggml-org/llama.cpp" },
@@ -135,7 +142,9 @@ describe("declarative llama.cpp server image", () => {
       cuda_dev_image: manifest.spec?.cuda?.developmentBase,
       cuda_runtime_image: manifest.spec?.cuda?.runtimeBase,
       image: manifest.spec?.repository,
+      runtime_forbidden_paths: JSON.stringify(manifest.spec?.runtime?.forbiddenPaths),
       runtime_gid: String(manifest.spec?.runtime?.gid),
+      runtime_required_paths: JSON.stringify(manifest.spec?.runtime?.requiredPaths),
       runtime_uid: String(manifest.spec?.runtime?.uid),
       source_archive_sha256: manifest.spec?.source?.archiveSha256,
       source_revision: manifest.spec?.source?.revision,
@@ -152,8 +161,8 @@ describe("declarative llama.cpp server image", () => {
 
   it.each([
     [
-      "a base image outside the allowed registries",
-      manifestSource.replace("docker.io/nvidia/cuda@", "registry.example.invalid/cuda@"),
+      "a non-NVIDIA base image",
+      manifestSource.replace("docker.io/nvidia/cuda@", "docker.io/example/cuda@"),
     ],
     [
       "a runner that does not match the platform",
@@ -176,6 +185,10 @@ describe("declarative llama.cpp server image", () => {
         "      ggmlBackendDl: true",
         "      ggmlBackendDl: true\n      ggmlWidgets: true",
       ),
+    ],
+    [
+      "an unexpected top-level field",
+      manifestSource.replace("kind: ServerImageBuild", "kind: ServerImageBuild\nunexpected: true"),
     ],
   ])("rejects %s before exporting image build inputs (#8231)", (_case, candidate) => {
     expect(() => loadLlamaCppImageConfig(candidate)).toThrow();
@@ -218,6 +231,11 @@ describe("declarative llama.cpp server image", () => {
     expect(dockerfile).toContain("ENV CC=${C_COMPILER}");
     expect(dockerfile).toContain("CXX=${CXX_COMPILER}");
     expect(dockerfile).toContain("CUDAHOSTCXX=${CUDA_HOST_CXX_COMPILER}");
+    for (const shellPath of manifest.spec?.runtime?.forbiddenPaths?.filter(
+      (forbiddenPath) => forbiddenPath !== "/opt/llama.cpp/ui",
+    ) ?? []) {
+      expect(dockerfile).toContain(shellPath);
+    }
     expect(dockerfile).toContain("sha256sum --check --strict");
     expect(dockerfile).toContain("cp LICENSE AUTHORS");
     expect(dockerfile).not.toContain("# syntax=");

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -184,7 +184,9 @@ describe("declarative llama.cpp server image", () => {
     ],
     [
       "a duplicate platform",
-      manifestSource.replace("platform: linux/arm64", "platform: linux/amd64"),
+      manifestSource
+        .replace("platform: linux/arm64", "platform: linux/amd64")
+        .replace("runner: ubuntu-24.04-arm", "runner: ubuntu-24.04"),
     ],
     [
       "an unexpected fixed CMake field",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

NemoClaw has no repository-owned llama.cpp image build. This PR adds a declarative build manifest and pull-request checks for native amd64 and DGX Spark arm64 images. The checks do not publish an image or change the managed inference support state.

## Related Issue

Part of #8231.

## Changes

- Add a `ServerImageBuild` YAML manifest for the image registry, pinned llama.cpp source archive, NVIDIA CUDA bases, package versions, native platform matrix, CMake settings, and runtime identity. The PR workflow consumes this manifest because the accepted managed inference design requires declarative configuration; focused contract tests reject drift between the manifest, serving recipe, Dockerfile, and workflow.
- Add a multi-stage `llama-server` Dockerfile. It verifies the pinned source archive, builds the CUDA server without UI, RPC, or subprocess surfaces, preserves upstream license files, and creates a non-root runtime image. The runtime removes command shells, and PR validation inspects its exported filesystem without executing a shell.
- Add a read-only GitHub Actions pull-request workflow for native `linux/amd64` and `linux/arm64` builds. It has no package-write permission or registry login. Each lane checks the exact source and base labels, server revision, runtime user, license files, disabled UI assets, and read-only root filesystem behavior.
- Add behavior tests for the declarative manifest compiler, Dockerfile contract, native matrix, action pins, and no-publication boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This PR adds a pull-request-only image build check. It publishes no artifact and changes no user-facing API, CLI, supported configuration, default, or support state.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Accepted epic #8144 and issue #8231 define this image boundary. This PR performs no registry write, credential operation, serving selection, default change, or support activation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The image build is limited to pull-request validation. It publishes nothing and does not change a user-facing or supported surface. The review covered all changed comments, test titles, workflow text, and security claims; no findings remain.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8ca6b8cf0 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx --no-install vitest run test/llama-cpp-image.test.ts test/llama-cpp-image-workflow.test.ts` — 2 files and 13 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CUDA-enabled llama.cpp server image for managed inference.
  - Supports AMD64 and ARM64 platforms with pinned, reproducible source and runtime components.
  - Runs securely as a non-root user, serves requests on port 8081, and includes required runtime libraries and writable temporary storage.

- **Tests**
  - Added pull-request validation covering image configuration, supported platforms, security settings, runtime behavior, metadata, and build reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->