### PR TITLE
feat(onboard): add Windows MXC host qualification

### DIFF
--- a/src/lib/onboard/windows-mxc/host-qualification.test.ts
+++ b/src/lib/onboard/windows-mxc/host-qualification.test.ts
@@ -7,7 +7,6 @@ import {
   assessWindowsMxcProcessContainerCandidate,
   parseWindowsBuild,
   WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
-  WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD,
 } from "./host-qualification";
 
 describe("native Windows/MXC process_container host qualification", () => {
@@ -15,15 +14,15 @@ describe("native Windows/MXC process_container host qualification", () => {
     expect(
       assessWindowsMxcProcessContainerCandidate({
         platform: "win32",
-        architecture: "x64",
-        release: `10.0.${WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD}`,
+        nativeArchitecture: "x64",
+        release: "10.0.26100",
       }),
     ).toEqual({
       candidate: true,
       contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
       platform: "win32",
-      architecture: "x64",
-      windowsBuild: WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD,
+      nativeArchitecture: "x64",
+      windowsBuild: 26100,
     });
   });
 
@@ -31,7 +30,7 @@ describe("native Windows/MXC process_container host qualification", () => {
     expect(
       assessWindowsMxcProcessContainerCandidate({
         platform: "win32",
-        architecture: "x64",
+        nativeArchitecture: "x64",
         release: "10.0.28000.1836",
       }),
     ).toMatchObject({ candidate: true, windowsBuild: 28000 });
@@ -41,17 +40,17 @@ describe("native Windows/MXC process_container host qualification", () => {
     expect(
       assessWindowsMxcProcessContainerCandidate({
         platform: "linux",
-        architecture: "x64",
+        nativeArchitecture: "x64",
         release: "6.6.87.2-microsoft-standard-WSL2",
       }),
     ).toMatchObject({ candidate: false, reason: "non-windows-host" });
   });
 
-  it("fails closed for an architecture outside the initial candidate (#8178)", () => {
+  it("rejects an emulated x64 process on a native ARM64 host (#8178)", () => {
     expect(
       assessWindowsMxcProcessContainerCandidate({
         platform: "win32",
-        architecture: "arm64",
+        nativeArchitecture: "arm64",
         release: "10.0.28000",
       }),
     ).toMatchObject({ candidate: false, reason: "unqualified-architecture" });
@@ -61,8 +60,8 @@ describe("native Windows/MXC process_container host qualification", () => {
     expect(
       assessWindowsMxcProcessContainerCandidate({
         platform: "win32",
-        architecture: "x64",
-        release: `10.0.${WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD - 1}`,
+        nativeArchitecture: "x64",
+        release: "10.0.26099",
       }),
     ).toMatchObject({
       candidate: false,
@@ -80,7 +79,7 @@ describe("native Windows/MXC process_container host qualification", () => {
     expect(
       assessWindowsMxcProcessContainerCandidate({
         platform: "win32",
-        architecture: "x64",
+        nativeArchitecture: "x64",
         release,
       }),
     ).toMatchObject({ candidate: false, reason: "unknown-windows-build" });

--- a/src/lib/onboard/windows-mxc/host-qualification.test.ts
+++ b/src/lib/onboard/windows-mxc/host-qualification.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assessWindowsMxcProcessContainerCandidate,
+  parseWindowsBuild,
+  WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
+  WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD,
+} from "./host-qualification";
+
+describe("native Windows/MXC process_container host qualification", () => {
+  it("returns a candidate at the exact inactive x64 build floor (#8178)", () => {
+    expect(
+      assessWindowsMxcProcessContainerCandidate({
+        platform: "win32",
+        architecture: "x64",
+        release: `10.0.${WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD}`,
+      }),
+    ).toEqual({
+      candidate: true,
+      contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
+      platform: "win32",
+      architecture: "x64",
+      windowsBuild: WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD,
+    });
+  });
+
+  it("accepts a newer Windows revision without treating it as the build (#8178)", () => {
+    expect(
+      assessWindowsMxcProcessContainerCandidate({
+        platform: "win32",
+        architecture: "x64",
+        release: "10.0.28000.1836",
+      }),
+    ).toMatchObject({ candidate: true, windowsBuild: 28000 });
+  });
+
+  it("rejects WSL and every other non-Windows host (#8178)", () => {
+    expect(
+      assessWindowsMxcProcessContainerCandidate({
+        platform: "linux",
+        architecture: "x64",
+        release: "6.6.87.2-microsoft-standard-WSL2",
+      }),
+    ).toMatchObject({ candidate: false, reason: "non-windows-host" });
+  });
+
+  it("fails closed for an architecture outside the initial candidate (#8178)", () => {
+    expect(
+      assessWindowsMxcProcessContainerCandidate({
+        platform: "win32",
+        architecture: "arm64",
+        release: "10.0.28000",
+      }),
+    ).toMatchObject({ candidate: false, reason: "unqualified-architecture" });
+  });
+
+  it("fails closed below the process_container candidate build floor (#8178)", () => {
+    expect(
+      assessWindowsMxcProcessContainerCandidate({
+        platform: "win32",
+        architecture: "x64",
+        release: `10.0.${WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD - 1}`,
+      }),
+    ).toMatchObject({
+      candidate: false,
+      reason: "windows-build-below-candidate-floor",
+    });
+  });
+
+  it.each([
+    "",
+    "10",
+    "10.0",
+    "10.0.build",
+    "6.6.87.2-microsoft-standard-WSL2",
+  ])("fails closed when release %j is not a Windows build form (#8178)", (release) => {
+    expect(
+      assessWindowsMxcProcessContainerCandidate({
+        platform: "win32",
+        architecture: "x64",
+        release,
+      }),
+    ).toMatchObject({ candidate: false, reason: "unknown-windows-build" });
+  });
+});
+
+describe("Windows build parsing", () => {
+  it.each([
+    ["10.0.26100", 26100],
+    ["10.0.26300.8553", 26300],
+    [" 10.0.28000.1836 ", 28000],
+  ])("extracts the build from %s (#8178)", (release, expected) => {
+    expect(parseWindowsBuild(release)).toBe(expected);
+  });
+});

--- a/src/lib/onboard/windows-mxc/host-qualification.ts
+++ b/src/lib/onboard/windows-mxc/host-qualification.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import os from "node:os";
+
+export const WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION = 1 as const;
+export const WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD = 26100 as const;
+
+export interface WindowsMxcHostFacts {
+  readonly platform: NodeJS.Platform;
+  readonly architecture: string;
+  readonly release: string;
+}
+
+export type WindowsMxcProcessContainerCandidateResult =
+  | {
+      readonly candidate: true;
+      readonly contractVersion: typeof WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION;
+      readonly platform: "win32";
+      readonly architecture: "x64";
+      readonly windowsBuild: number;
+    }
+  | {
+      readonly candidate: false;
+      readonly contractVersion: typeof WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION;
+      readonly reason:
+        | "non-windows-host"
+        | "unqualified-architecture"
+        | "unknown-windows-build"
+        | "windows-build-below-candidate-floor";
+      readonly detail: string;
+    };
+
+/**
+ * Extract the Windows build from the Node.js `os.release()` form
+ * `<major>.<minor>.<build>[.<revision>]`.
+ */
+export function parseWindowsBuild(release: string): number | null {
+  const match = /^\d+\.\d+\.(\d+)(?:\.\d+)?$/.exec(release.trim());
+  if (!match) return null;
+
+  const build = Number(match[1]);
+  return Number.isSafeInteger(build) ? build : null;
+}
+
+/**
+ * Evaluate the inactive native Windows/MXC `process_container` candidate.
+ *
+ * This is a host-facts contract only. A positive result does not select a
+ * runtime provider or establish a supported Windows compatibility matrix.
+ */
+export function assessWindowsMxcProcessContainerCandidate(
+  facts: WindowsMxcHostFacts = {
+    platform: process.platform,
+    architecture: process.arch,
+    release: os.release(),
+  },
+): WindowsMxcProcessContainerCandidateResult {
+  if (facts.platform !== "win32") {
+    return {
+      candidate: false,
+      contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
+      reason: "non-windows-host",
+      detail: "Native Windows/MXC requires a Windows host; WSL is not a native Windows host.",
+    };
+  }
+
+  if (facts.architecture !== "x64") {
+    return {
+      candidate: false,
+      contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
+      reason: "unqualified-architecture",
+      detail: "The inactive Windows/MXC process_container candidate currently qualifies x64 only.",
+    };
+  }
+
+  const windowsBuild = parseWindowsBuild(facts.release);
+  if (windowsBuild === null) {
+    return {
+      candidate: false,
+      contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
+      reason: "unknown-windows-build",
+      detail: "The Windows build could not be determined from the host release.",
+    };
+  }
+
+  if (windowsBuild < WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD) {
+    return {
+      candidate: false,
+      contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
+      reason: "windows-build-below-candidate-floor",
+      detail: `The Windows/MXC process_container candidate requires Windows build ${WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD} or newer.`,
+    };
+  }
+
+  return {
+    candidate: true,
+    contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
+    platform: "win32",
+    architecture: "x64",
+    windowsBuild,
+  };
+}

--- a/src/lib/onboard/windows-mxc/host-qualification.ts
+++ b/src/lib/onboard/windows-mxc/host-qualification.ts
@@ -1,14 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import os from "node:os";
-
 export const WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION = 1 as const;
 export const WINDOWS_MXC_PROCESS_CONTAINER_MINIMUM_BUILD = 26100 as const;
 
 export interface WindowsMxcHostFacts {
   readonly platform: NodeJS.Platform;
-  readonly architecture: string;
+  readonly nativeArchitecture: string;
   readonly release: string;
 }
 
@@ -17,7 +15,7 @@ export type WindowsMxcProcessContainerCandidateResult =
       readonly candidate: true;
       readonly contractVersion: typeof WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION;
       readonly platform: "win32";
-      readonly architecture: "x64";
+      readonly nativeArchitecture: "x64";
       readonly windowsBuild: number;
     }
   | {
@@ -50,11 +48,7 @@ export function parseWindowsBuild(release: string): number | null {
  * runtime provider or establish a supported Windows compatibility matrix.
  */
 export function assessWindowsMxcProcessContainerCandidate(
-  facts: WindowsMxcHostFacts = {
-    platform: process.platform,
-    architecture: process.arch,
-    release: os.release(),
-  },
+  facts: WindowsMxcHostFacts,
 ): WindowsMxcProcessContainerCandidateResult {
   if (facts.platform !== "win32") {
     return {
@@ -65,7 +59,9 @@ export function assessWindowsMxcProcessContainerCandidate(
     };
   }
 
-  if (facts.architecture !== "x64") {
+  // `process.arch` identifies the Node.js binary and can report x64 under
+  // Windows ARM64 emulation. The caller must supply the native host value.
+  if (facts.nativeArchitecture !== "x64") {
     return {
       candidate: false,
       contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
@@ -97,7 +93,7 @@ export function assessWindowsMxcProcessContainerCandidate(
     candidate: true,
     contractVersion: WINDOWS_MXC_PROCESS_CONTAINER_HOST_CONTRACT_VERSION,
     platform: "win32",
-    architecture: "x64",
+    nativeArchitecture: "x64",
     windowsBuild,
   };
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds an inactive host-facts assessment for the native Windows/OpenShell MXC `process_container` candidate. The assessment fails closed for non-Windows hosts, unqualified architectures, malformed release data, and Windows builds below the candidate floor.

## Related Issue

Part of #8178

## Changes

- Add a versioned, package-independent host qualification result for the initial Windows x64 `process_container` candidate required by #8178.
- Keep production runtime selection unchanged because #8178 activation gates and the non-OCI workload receipt contract are not complete.
- Add a source test for the exact build floor, newer builds, WSL rejection, architecture rejection, older builds, and malformed release data.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The new module is inactive and changes no CLI, configuration, workflow, output, provider registration, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The host assessment is read-only, executes no command, mutates no state, and fails closed for unknown platform facts. Issue #8178 requires production registration to remain absent.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The inactive host-facts module remains referenced only by its source test and changes no user-visible or supported product surface. The second base update was mechanical; both feature blobs and the effective feature diff are unchanged. Changed comments and test titles pass the writing and terminology review.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 08d8115fa -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/windows-mxc/host-qualification.test.ts` passed 13 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to the isolated two-file source change. `npm run checks:repository` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host qualification for native Windows MXC process containers.
  * Validates Windows platform, x64 architecture, minimum supported build, and recognizable Windows release formats.
  * Provides clear qualification results and rejection reasons for unsupported hosts.

* **Tests**
  * Added coverage for supported builds, newer revisions, older or malformed releases, whitespace-tolerant parsing, unsupported platforms, WSL environments, and architecture mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
