### PR TITLE
fix(onboard): allow packaged service teardown fallback

### DIFF
--- a/docs/deployment/gateway-lifecycle-authority.mdx
+++ b/docs/deployment/gateway-lifecycle-authority.mdx
@@ -151,11 +151,12 @@ Resume resolves the current authority again and compares the complete record wit
 If any value changes, including the per-port gateway binding, resume fails before gateway effects and directs you to start a fresh onboarding run.
 A completed gateway step does not bypass listener, supervisor, identity, health, registration, or checkpoint validation.
 
-### Migrate Managed Authority During Rebuild
+### Migrate Managed Authority During Rebuild and Full Uninstall
 
 A transactional sandbox rebuild can adopt one managed lifecycle change when the recorded package-managed service is no longer selected and NemoClaw selects its standalone gateway.
 NemoClaw records the standalone authority in the replacement journal before it changes managed MCP state, providers, or deletes the sandbox.
-This exception does not apply to credential mutation, ordinary gateway teardown, an authority declaration change, the reverse transition to a package-managed service, or other authority drift.
+Full uninstall can also complete gateway teardown when an earlier uninstall step already removed the package-managed service and the same NemoClaw-managed gateway resolves as standalone.
+These exceptions do not apply to credential mutation, ordinary gateway teardown outside full uninstall, an authority declaration change, the reverse transition to a package-managed service, or other authority drift.
 Those operations continue to fail closed before gateway effects.
 
 ## Inspect the selected authority
@@ -184,6 +185,8 @@ Stop, final-sandbox cleanup, and uninstall reload the declaration before gateway
 When a valid checkpoint exists, they compare the current authority with that checkpoint.
 The comparison uses the exact gateway name and port.
 If the authority changed, teardown stops before it scans listeners or changes gateway runtime resources.
+During full uninstall, a recorded package-managed default gateway can resolve as standalone after the service has already been removed.
+That narrow transition is allowed so uninstall can finish removing the remaining selected gateway registration and runtime resources.
 
 `$$nemoclaw stop` does not scan or signal the externally supervised gateway.
 Final-sandbox cleanup can stop local dashboard forwards and remove the modern local gateway registration.

--- a/src/lib/actions/uninstall/run-plan-gateway-service.test.ts
+++ b/src/lib/actions/uninstall/run-plan-gateway-service.test.ts
@@ -213,6 +213,31 @@ describe("uninstall OpenShell gateway user service", () => {
     expect(calls).toContainEqual(["systemctl", "--user", "daemon-reload"]);
   });
 
+  it("opts full uninstall gateway teardown into missing packaged-service recovery (#8215)", () => {
+    const test = fixture(true);
+    const resolveGatewayTeardownAuthority = vi.fn(({ gatewayName, gatewayPort }) => ({
+      gatewayName,
+      gatewayPort,
+      mode: "nemoclaw-managed" as const,
+      source: "standalone" as const,
+      endpoint: null,
+      stateDir: null,
+      supervisor: null,
+      requiredCapabilities: [],
+    }));
+
+    const result = uninstall(test, false, {
+      commandExists: () => true,
+      resolveGatewayTeardownAuthority,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(resolveGatewayTeardownAuthority).toHaveBeenCalledWith(
+      { gatewayName: "nemoclaw", gatewayPort: 8080 },
+      expect.objectContaining({ allowMissingPackagedServiceTeardown: true }),
+    );
+  });
+
   it("reports an incomplete uninstall when the marked service cannot be disabled (#6903)", () => {
     const test = fixture();
     const servicePath = writeManagedService(test);

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -2076,7 +2076,7 @@ export function runUninstallPlan(
     externallySupervised = isExternallySupervised(
       runtime.resolveGatewayTeardownAuthority(
         { gatewayName: expectedGatewayName, gatewayPort: GATEWAY_PORT },
-        { env: runtime.env },
+        { allowMissingPackagedServiceTeardown: true, env: runtime.env },
       ),
     );
   } catch (error) {

--- a/src/lib/onboard/gateway-teardown-authority.test.ts
+++ b/src/lib/onboard/gateway-teardown-authority.test.ts
@@ -40,6 +40,14 @@ function owner(currentDeclaration: GatewayManagementDeclaration | null): Gateway
   });
 }
 
+function managedOwner(hasPackagedService: boolean): GatewayOwner {
+  return resolveGatewayOwner({
+    ...target,
+    declaration: null,
+    hasPackagedService,
+  });
+}
+
 function checkpointSession(recordedOwner: GatewayOwner) {
   const session = createSession();
   bindGatewayAuthorityToCheckpoint(session, recordedOwner);
@@ -114,6 +122,38 @@ describe("resolveGatewayTeardownAuthority", () => {
         loadSession: () => checkpointSession(recordedOwner),
       }),
     ).toThrow(/authority changed since onboarding.*teardown will not perform gateway effects/);
+  });
+
+  it("allows opted-in uninstall teardown after the packaged service was already removed (#8215)", () => {
+    const recordedOwner = managedOwner(true);
+
+    expect(
+      resolveGatewayTeardownAuthority(target, {
+        allowMissingPackagedServiceTeardown: true,
+        hasPackagedService: () => false,
+        loadDeclaration: () => ({ ok: true, declaration: null, source: null }),
+        loadSession: () => checkpointSession(recordedOwner),
+      }),
+    ).toMatchObject({
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      mode: "nemoclaw-managed",
+      source: "standalone",
+    });
+  });
+
+  it("still rejects credential mutation after the recorded packaged service is removed (#8215)", () => {
+    const recordedOwner = managedOwner(true);
+
+    expect(() =>
+      resolveGatewayCredentialMutationAuthority(target, {
+        hasPackagedService: () => false,
+        loadDeclaration: () => ({ ok: true, declaration: null, source: null }),
+        loadSession: () => checkpointSession(recordedOwner),
+      }),
+    ).toThrow(
+      /packaged-service -> nemoclaw@8080:nemoclaw-managed:standalone.*provider credential mutation will not perform gateway effects/,
+    );
   });
 
   it("fails closed before credential mutation when authority changed since onboarding (#6576)", () => {

--- a/src/lib/onboard/gateway-teardown-authority.ts
+++ b/src/lib/onboard/gateway-teardown-authority.ts
@@ -37,6 +37,7 @@ export interface GatewayTeardownTarget {
 }
 
 export interface GatewayTeardownAuthorityDeps {
+  allowMissingPackagedServiceTeardown?: boolean;
   env?: NodeJS.ProcessEnv;
   hasPackagedService?: () => boolean;
   loadDeclaration?: (env: NodeJS.ProcessEnv) => GatewayManagementLoadResult;
@@ -171,6 +172,13 @@ function resolveGatewayEffectAuthority(
   }
   if (sameGatewayOwner(recorded, resolved)) return recorded;
   if (effect === "rebuild" && isManagedPackagedServiceMigration(recorded, resolved)) {
+    return resolved;
+  }
+  if (
+    effect === "teardown" &&
+    deps.allowMissingPackagedServiceTeardown === true &&
+    isManagedPackagedServiceMigration(recorded, resolved)
+  ) {
     return resolved;
   }
   throw new GatewayAuthorityError(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`nemohermes uninstall --yes` no longer fails when teardown revalidates a default NemoClaw-managed gateway after the packaged gateway service has already been removed. Uninstall opts into that expected `packaged-service` to `standalone` resolution, while other teardown callers and credential mutation still use the default fail-closed authority check.

## Related Issue
Fixes #8215

## Changes
- Add an explicit uninstall opt-in that allows gateway teardown to proceed when the recorded default NemoClaw-managed authority was `packaged-service` and the current default resolution is `standalone` because the packaged service has already been removed.
- Keep the default teardown and provider credential mutation paths strict for the same transition so non-uninstall gateway effects still require a fresh onboarding run.
- Add regression coverage for the uninstall teardown path and the credential-mutation fail-closed boundary.
- Update the gateway lifecycle authority docs to describe the narrow full-uninstall exception.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Local security-sensitive review kept the exception opt-in for uninstall teardown of the same default NemoClaw-managed gateway; default teardown and credential mutation remain fail-closed and are covered by regression tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/deployment/gateway-lifecycle-authority.mdx`; writing rules and documentation style reviewed.
- Agent: Codex Desktop documentation writer reviewer
<!-- docs-review-head-sha: aaf212f5e -->
<!-- docs-review-agents-blob-sha: 3dd7c242 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/gateway-teardown-authority.test.ts src/lib/onboard/gateway-authority-migration.test.ts src/lib/actions/uninstall/run-plan-gateway-service.test.ts src/lib/actions/uninstall/run-plan.test.ts` passed.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run check:diff` passed; `npm run docs` passed with Fern reporting 0 errors and 2 unrelated warnings. `fern check --warnings` reported an unauthenticated redirects check and a global light-mode accent color contrast warning.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Vinay Bhagavath <bhagavathvinay@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Full uninstall now completes when a packaged gateway service has already been removed.
  - Remaining gateway registration and runtime resources are cleaned up correctly during this scenario.
  - Credential changes remain protected when teardown authority cannot be verified.

- **Documentation**
  - Clarified gateway authority migration rules and the limited exception available during full uninstall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->