### PR TITLE
fix(maintainer): verify final E2E coordinator evidence

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
+++ b/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
@@ -10,6 +10,7 @@
  * Usage: node --experimental-strip-types --no-warnings .agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts <pr-number> [--repo OWNER/REPO]
  */
 
+import { isDeepStrictEqual } from "node:util";
 import {
   ghJson,
   isRiskyFile,
@@ -317,6 +318,55 @@ interface E2eCoordinationEvidence {
   startedAt?: number;
   completedAt?: number;
   trustedCustomCheckId?: number;
+  checkSnapshot?: E2eCoordinationCheckSnapshot;
+  coordinatorSnapshot?: E2eCoordinatorInventorySnapshot;
+  selectedCheckId?: number;
+}
+
+interface E2eCoordinationCheckSnapshot {
+  checkRuns: Array<Record<string, unknown>>;
+}
+
+interface E2eCoordinatorRunMetadata {
+  id: number;
+  attempt: number;
+  createdAt: number;
+  updatedAt: number;
+  event: E2eCoordinatorEvent;
+  displayTitle: string;
+  headSha: string;
+  status: string;
+  conclusion: string | null;
+}
+
+type E2eCoordinatorEvent = "workflow_run" | "workflow_dispatch";
+
+interface E2eCoordinatorRunPartition {
+  startedAt: number;
+  completedAt: number;
+}
+
+interface E2eCoordinatorInventoryRecord {
+  value: Record<string, unknown>;
+  createdAt: number;
+  event: E2eCoordinatorEvent;
+  partitionIndex: number;
+}
+
+interface E2eCoordinatorCandidateSnapshot {
+  listedRun: Record<string, unknown>;
+  firstRun: Record<string, unknown>;
+  jobPages: unknown[];
+  refreshedRun: Record<string, unknown>;
+}
+
+interface E2eCoordinatorInventorySnapshot {
+  candidates: E2eCoordinatorCandidateSnapshot[];
+}
+
+interface E2eCoordinatorEvaluation {
+  valid: boolean | null;
+  snapshot?: E2eCoordinatorInventorySnapshot;
 }
 
 const E2E_RETRYABLE_FAILURE_MARKER_PREFIX = "<!-- nemoclaw-pr-e2e-retry:v1:";
@@ -346,6 +396,504 @@ function parseGitHubTimestamp(value: string | undefined): number {
     parsed.getUTCSeconds() === second
     ? Date.parse(match[0])
     : Number.NaN;
+}
+
+const E2E_COORDINATOR_WORKFLOW_PATH = ".github/workflows/pr-e2e-gate.yaml";
+const E2E_COORDINATOR_PARTITION_MS = 12 * 60 * 60 * 1000;
+const E2E_COORDINATOR_INVENTORY_MAX_MS = 14 * 24 * 60 * 60 * 1000;
+const E2E_COORDINATOR_MAX_PARTITIONS = Math.ceil(
+  E2E_COORDINATOR_INVENTORY_MAX_MS / E2E_COORDINATOR_PARTITION_MS,
+);
+const GITHUB_WORKFLOW_RUN_RESULT_CAP = 1000;
+
+function formatGitHubTimestamp(value: number): string {
+  return new Date(value).toISOString().replace(".000Z", "Z");
+}
+
+function e2eCoordinatorRunPartitions(
+  historyStartedAt: number,
+  observationAt: number,
+): E2eCoordinatorRunPartition[] | null {
+  if (!Number.isFinite(historyStartedAt) || !Number.isFinite(observationAt)) return null;
+  const checkStart = new Date(historyStartedAt);
+  const inventoryStartedAt = Date.UTC(
+    checkStart.getUTCFullYear(),
+    checkStart.getUTCMonth(),
+    checkStart.getUTCDate() - 1,
+  );
+  const inventoryCompletedAt = Math.ceil(observationAt / 1000) * 1000;
+  const inventorySpan = inventoryCompletedAt - inventoryStartedAt;
+  const partitionCount = Math.ceil(inventorySpan / E2E_COORDINATOR_PARTITION_MS);
+  if (
+    inventorySpan <= 0 ||
+    inventorySpan > E2E_COORDINATOR_INVENTORY_MAX_MS ||
+    !Number.isSafeInteger(partitionCount) ||
+    partitionCount < 1 ||
+    partitionCount > E2E_COORDINATOR_MAX_PARTITIONS
+  ) {
+    return null;
+  }
+  return Array.from({ length: partitionCount }, (_value, index) => {
+    const startedAt = inventoryStartedAt + index * E2E_COORDINATOR_PARTITION_MS;
+    return {
+      startedAt,
+      completedAt: Math.min(startedAt + E2E_COORDINATOR_PARTITION_MS, inventoryCompletedAt),
+    };
+  });
+}
+
+function automaticE2eCoordinatorRunTitle(exactDiff: ExactDiffIdentity): string {
+  return (
+    "E2E Gate coordinate from CI PR #" +
+    exactDiff.number +
+    " head " +
+    exactDiff.headSha +
+    " base " +
+    exactDiff.baseSha +
+    " gate true"
+  );
+}
+
+function manualE2eCoordinatorRunTitle(exactDiff: ExactDiffIdentity): string {
+  return (
+    "E2E Gate approve PR #" +
+    exactDiff.number +
+    " head " +
+    exactDiff.headSha +
+    " base " +
+    exactDiff.baseSha
+  );
+}
+
+function hasRepositoryName(value: unknown, repo: string): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (value as Record<string, unknown>).full_name === repo
+  );
+}
+
+function parseE2eCoordinatorRun(
+  value: unknown,
+  repo: string,
+  exactDiff: ExactDiffIdentity,
+): E2eCoordinatorRunMetadata | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const createdAt =
+    typeof record.created_at === "string" ? parseGitHubTimestamp(record.created_at) : Number.NaN;
+  const updatedAt =
+    typeof record.updated_at === "string" ? parseGitHubTimestamp(record.updated_at) : Number.NaN;
+  const status = typeof record.status === "string" ? record.status.toUpperCase() : null;
+  const conclusion =
+    typeof record.conclusion === "string" ? record.conclusion.toUpperCase() : record.conclusion;
+  const event =
+    record.event === "workflow_run" || record.event === "workflow_dispatch" ? record.event : null;
+  const expectedTitle =
+    event === "workflow_run"
+      ? automaticE2eCoordinatorRunTitle(exactDiff)
+      : event === "workflow_dispatch"
+        ? manualE2eCoordinatorRunTitle(exactDiff)
+        : null;
+  const headSha = typeof record.head_sha === "string" ? record.head_sha : "";
+  if (
+    !Number.isSafeInteger(record.id) ||
+    (record.id as number) < 1 ||
+    record.run_attempt !== 1 ||
+    !event ||
+    !expectedTitle ||
+    record.display_title !== expectedTitle ||
+    record.path !== E2E_COORDINATOR_WORKFLOW_PATH ||
+    record.head_branch !== "main" ||
+    !/^[0-9a-f]{40}$/u.test(headSha) ||
+    (event === "workflow_run" && headSha !== exactDiff.baseSha) ||
+    !status ||
+    !ACTION_STATUSES.has(status) ||
+    (conclusion !== null &&
+      (typeof conclusion !== "string" || !ACTION_CONCLUSIONS.has(conclusion))) ||
+    (status === "COMPLETED" ? conclusion === null : conclusion !== null) ||
+    !hasRepositoryName(record.repository, repo) ||
+    !hasRepositoryName(record.head_repository, repo) ||
+    !Number.isFinite(createdAt) ||
+    !Number.isFinite(updatedAt) ||
+    createdAt > updatedAt
+  ) {
+    return null;
+  }
+  return {
+    id: record.id as number,
+    attempt: 1,
+    createdAt,
+    updatedAt,
+    event,
+    displayTitle: expectedTitle,
+    headSha,
+    status,
+    conclusion,
+  };
+}
+
+function sameE2eCoordinatorRun(
+  left: E2eCoordinatorRunMetadata,
+  right: E2eCoordinatorRunMetadata,
+): boolean {
+  return (
+    left.id === right.id &&
+    left.attempt === right.attempt &&
+    left.createdAt === right.createdAt &&
+    left.updatedAt === right.updatedAt &&
+    left.event === right.event &&
+    left.displayTitle === right.displayTitle &&
+    left.headSha === right.headSha &&
+    left.status === right.status &&
+    left.conclusion === right.conclusion
+  );
+}
+
+type E2eCoordinatorCandidateResult =
+  | "authorization-predecessor"
+  | "enclosing"
+  | "history"
+  | false
+  | null;
+
+interface E2eCoordinatorCandidateEvaluation {
+  result: E2eCoordinatorCandidateResult;
+  snapshot?: E2eCoordinatorCandidateSnapshot;
+  event?: E2eCoordinatorEvent;
+  runCreatedAt?: number;
+  runUpdatedAt?: number;
+  coordinateStartedAt?: number;
+  coordinateCompletedAt?: number;
+}
+
+function evaluateE2eCoordinatorCandidate(
+  listedValue: unknown,
+  repo: string,
+  exactDiff: ExactDiffIdentity,
+  coordinationStartedAt: number,
+  coordinationCompletedAt: number,
+): E2eCoordinatorCandidateEvaluation {
+  const listedRun = parseE2eCoordinatorRun(listedValue, repo, exactDiff);
+  if (!listedRun) return { result: false };
+  const firstRunResponse = ghJson(["api", "repos/" + repo + "/actions/runs/" + listedRun.id]);
+  if (firstRunResponse === null) return { result: null };
+  const firstRun = parseE2eCoordinatorRun(firstRunResponse, repo, exactDiff);
+  if (!firstRun || !sameE2eCoordinatorRun(listedRun, firstRun)) return { result: false };
+
+  const jobPages = ghJson([
+    "api",
+    "--paginate",
+    "--slurp",
+    "repos/" +
+      repo +
+      "/actions/runs/" +
+      firstRun.id +
+      "/attempts/" +
+      firstRun.attempt +
+      "/jobs?per_page=100",
+  ]);
+  if (!Array.isArray(jobPages) || jobPages.length === 0) return { result: null };
+
+  let expectedJobs: number | null = null;
+  let observedJobs = 0;
+  const jobIds = new Set<number>();
+  const coordinateJobs: Array<Record<string, unknown>> = [];
+  for (const page of jobPages) {
+    if (typeof page !== "object" || page === null || Array.isArray(page)) {
+      return { result: null };
+    }
+    const { total_count: totalCount, jobs } = page as Record<string, unknown>;
+    if (
+      !Number.isSafeInteger(totalCount) ||
+      (totalCount as number) < 0 ||
+      (expectedJobs !== null && totalCount !== expectedJobs) ||
+      !Array.isArray(jobs)
+    ) {
+      return { result: null };
+    }
+    expectedJobs = totalCount as number;
+    observedJobs += jobs.length;
+    for (const value of jobs) {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return { result: null };
+      }
+      const record = value as Record<string, unknown>;
+      if (
+        !Number.isSafeInteger(record.id) ||
+        (record.id as number) < 1 ||
+        jobIds.has(record.id as number) ||
+        typeof record.name !== "string" ||
+        !record.name
+      ) {
+        return { result: false };
+      }
+      jobIds.add(record.id as number);
+      if (record.name === "coordinate") coordinateJobs.push(record);
+    }
+  }
+
+  const refreshedRunResponse = ghJson(["api", "repos/" + repo + "/actions/runs/" + firstRun.id]);
+  if (refreshedRunResponse === null) return { result: null };
+  const refreshedRun = parseE2eCoordinatorRun(refreshedRunResponse, repo, exactDiff);
+  if (!refreshedRun || !sameE2eCoordinatorRun(firstRun, refreshedRun)) {
+    return { result: false };
+  }
+
+  const snapshot: E2eCoordinatorCandidateSnapshot = {
+    listedRun: listedValue as Record<string, unknown>,
+    firstRun: firstRunResponse as Record<string, unknown>,
+    jobPages,
+    refreshedRun: refreshedRunResponse as Record<string, unknown>,
+  };
+  if (
+    expectedJobs === null ||
+    observedJobs !== expectedJobs ||
+    jobIds.size !== expectedJobs ||
+    coordinateJobs.length !== 1
+  ) {
+    return { result: false, snapshot };
+  }
+
+  const coordinate = coordinateJobs[0];
+  const coordinateStatus =
+    typeof coordinate.status === "string" ? coordinate.status.toUpperCase() : null;
+  const coordinateConclusion =
+    typeof coordinate.conclusion === "string"
+      ? coordinate.conclusion.toUpperCase()
+      : coordinate.conclusion;
+  const coordinateStartedAt =
+    typeof coordinate.started_at === "string"
+      ? parseGitHubTimestamp(coordinate.started_at)
+      : Number.NaN;
+  const coordinateCompletedAt =
+    typeof coordinate.completed_at === "string"
+      ? parseGitHubTimestamp(coordinate.completed_at)
+      : Number.NaN;
+  if (
+    !coordinateStatus ||
+    !ACTION_STATUSES.has(coordinateStatus) ||
+    (coordinateConclusion !== null &&
+      (typeof coordinateConclusion !== "string" ||
+        !ACTION_CONCLUSIONS.has(coordinateConclusion))) ||
+    (coordinateStatus === "COMPLETED"
+      ? coordinateConclusion === null
+      : coordinateConclusion !== null) ||
+    !Number.isFinite(coordinateStartedAt) ||
+    !Number.isFinite(coordinateCompletedAt) ||
+    coordinateStartedAt > coordinateCompletedAt
+  ) {
+    return { result: false, snapshot };
+  }
+
+  const completedSuccessfully =
+    firstRun.status === "COMPLETED" &&
+    firstRun.conclusion === "SUCCESS" &&
+    coordinateStatus === "COMPLETED" &&
+    coordinateConclusion === "SUCCESS";
+  const coordinateWithinRun =
+    firstRun.createdAt <= coordinateStartedAt &&
+    coordinateStartedAt <= coordinateCompletedAt &&
+    coordinateCompletedAt <= firstRun.updatedAt;
+  const candidateEvidence = {
+    snapshot,
+    event: firstRun.event,
+    runCreatedAt: firstRun.createdAt,
+    runUpdatedAt: firstRun.updatedAt,
+    coordinateStartedAt,
+    coordinateCompletedAt,
+  };
+  if (
+    completedSuccessfully &&
+    coordinateWithinRun &&
+    coordinateStartedAt <= coordinationCompletedAt &&
+    coordinationCompletedAt <= coordinateCompletedAt
+  ) {
+    return { result: "enclosing", ...candidateEvidence };
+  }
+
+  const completedHistory =
+    completedSuccessfully && coordinateWithinRun && firstRun.updatedAt <= coordinationStartedAt;
+  if (completedHistory) return { result: "history", ...candidateEvidence };
+
+  const authorizationPredecessor =
+    completedSuccessfully &&
+    coordinateWithinRun &&
+    firstRun.event === "workflow_run" &&
+    coordinationStartedAt <= coordinateStartedAt &&
+    coordinateCompletedAt < coordinationCompletedAt;
+  return {
+    result: authorizationPredecessor ? "authorization-predecessor" : false,
+    ...candidateEvidence,
+  };
+}
+
+function fetchE2eCoordinatorEvidence(
+  repo: string,
+  exactDiff: ExactDiffIdentity,
+  historyStartedAt: number,
+  coordinationStartedAt: number,
+  coordinationCompletedAt: number,
+  observationAt: number,
+): E2eCoordinatorEvaluation {
+  const inventoryById = new Map<number, E2eCoordinatorInventoryRecord>();
+  const partitions = e2eCoordinatorRunPartitions(historyStartedAt, observationAt);
+  if (!partitions) return { valid: null };
+  const events: E2eCoordinatorEvent[] = ["workflow_run", "workflow_dispatch"];
+  for (const event of events) {
+    for (const [partitionIndex, partition] of partitions.entries()) {
+      const createdRange = encodeURIComponent(
+        formatGitHubTimestamp(partition.startedAt) +
+          ".." +
+          formatGitHubTimestamp(partition.completedAt),
+      );
+      const pages = ghJson([
+        "api",
+        "--paginate",
+        "--slurp",
+        "repos/" +
+          repo +
+          "/actions/workflows/pr-e2e-gate.yaml/runs?event=" +
+          event +
+          "&created=" +
+          createdRange +
+          "&per_page=100",
+      ]);
+      if (!Array.isArray(pages) || pages.length === 0) return { valid: null };
+
+      let expectedTotal: number | null = null;
+      let observedTotal = 0;
+      const partitionIds = new Set<number>();
+      const partitionRecords: Array<{ value: Record<string, unknown>; createdAt: number }> = [];
+      for (const page of pages) {
+        if (typeof page !== "object" || page === null || Array.isArray(page)) {
+          return { valid: null };
+        }
+        const { total_count: totalCount, workflow_runs: workflowRuns } = page as Record<
+          string,
+          unknown
+        >;
+        if (
+          !Number.isSafeInteger(totalCount) ||
+          (totalCount as number) < 0 ||
+          (totalCount as number) >= GITHUB_WORKFLOW_RUN_RESULT_CAP ||
+          (expectedTotal !== null && totalCount !== expectedTotal) ||
+          !Array.isArray(workflowRuns)
+        ) {
+          return { valid: null };
+        }
+        expectedTotal = totalCount as number;
+        observedTotal += workflowRuns.length;
+        for (const value of workflowRuns) {
+          if (typeof value !== "object" || value === null || Array.isArray(value)) {
+            return { valid: null };
+          }
+          const record = value as Record<string, unknown>;
+          const createdAt =
+            typeof record.created_at === "string"
+              ? parseGitHubTimestamp(record.created_at)
+              : Number.NaN;
+          if (
+            !Number.isSafeInteger(record.id) ||
+            (record.id as number) < 1 ||
+            partitionIds.has(record.id as number) ||
+            record.event !== event ||
+            !Number.isFinite(createdAt) ||
+            createdAt < partition.startedAt ||
+            createdAt > partition.completedAt
+          ) {
+            return { valid: null };
+          }
+          partitionIds.add(record.id as number);
+          partitionRecords.push({ value: record, createdAt });
+        }
+      }
+      if (
+        expectedTotal === null ||
+        observedTotal !== expectedTotal ||
+        partitionIds.size !== expectedTotal
+      ) {
+        return { valid: null };
+      }
+
+      for (const record of partitionRecords) {
+        const id = record.value.id as number;
+        const existing = inventoryById.get(id);
+        if (!existing) {
+          inventoryById.set(id, {
+            value: record.value,
+            createdAt: record.createdAt,
+            event,
+            partitionIndex,
+          });
+          continue;
+        }
+        const exactBoundaryDuplicate =
+          existing.event === event &&
+          existing.partitionIndex === partitionIndex - 1 &&
+          existing.createdAt === partition.startedAt &&
+          record.createdAt === partition.startedAt &&
+          isDeepStrictEqual(existing.value, record.value);
+        if (!exactBoundaryDuplicate) return { valid: null };
+      }
+    }
+  }
+
+  const expectedTitles = new Set([
+    automaticE2eCoordinatorRunTitle(exactDiff),
+    manualE2eCoordinatorRunTitle(exactDiff),
+  ]);
+  const candidates = [...inventoryById.values()]
+    .map((record) => record.value)
+    .filter((record) => expectedTitles.has(String(record.display_title)));
+  if (candidates.length === 0) return { valid: false };
+
+  const enclosingCandidates: E2eCoordinatorCandidateEvaluation[] = [];
+  const authorizationPredecessors: E2eCoordinatorCandidateEvaluation[] = [];
+  const candidateSnapshots: E2eCoordinatorCandidateSnapshot[] = [];
+  for (const candidate of candidates) {
+    const evaluation = evaluateE2eCoordinatorCandidate(
+      candidate,
+      repo,
+      exactDiff,
+      coordinationStartedAt,
+      coordinationCompletedAt,
+    );
+    if (evaluation.result === null) return { valid: null };
+    if (evaluation.result === false || !evaluation.snapshot) return { valid: false };
+    candidateSnapshots.push(evaluation.snapshot);
+    if (evaluation.result === "enclosing") enclosingCandidates.push(evaluation);
+    if (evaluation.result === "authorization-predecessor") {
+      authorizationPredecessors.push(evaluation);
+    }
+  }
+  if (enclosingCandidates.length !== 1) return { valid: false };
+  if (authorizationPredecessors.length > 0) {
+    const predecessor = authorizationPredecessors[0];
+    const encloser = enclosingCandidates[0];
+    if (
+      exactDiff.headRepository === repo ||
+      authorizationPredecessors.length !== 1 ||
+      predecessor.event !== "workflow_run" ||
+      encloser.event !== "workflow_dispatch" ||
+      predecessor.runUpdatedAt === undefined ||
+      encloser.runCreatedAt === undefined ||
+      predecessor.coordinateCompletedAt === undefined ||
+      encloser.coordinateStartedAt === undefined ||
+      predecessor.runUpdatedAt > encloser.runCreatedAt ||
+      predecessor.coordinateCompletedAt > encloser.coordinateStartedAt
+    ) {
+      return { valid: false };
+    }
+  }
+  candidateSnapshots.sort(
+    (left, right) => (left.listedRun.id as number) - (right.listedRun.id as number),
+  );
+  return {
+    valid: true,
+    snapshot: { candidates: candidateSnapshots },
+  };
 }
 
 function hasRetryableE2eFailureMarker(check: Record<string, unknown>): boolean {
@@ -390,10 +938,11 @@ function currentE2eCoordinationCheck(
   if (active[0] && active[0].id !== current.id) return undefined;
   return current;
 }
-function fetchE2eCoordinationEvidence(
+
+function fetchE2eCoordinationCheckSnapshot(
   repo: string,
   exactDiff: ExactDiffIdentity,
-): E2eCoordinationEvidence {
+): E2eCoordinationCheckSnapshot | null {
   const checkNames = ["E2E / PR Gate", "E2E / PR Gate Coordination"];
   const checkRuns: Array<Record<string, unknown>> = [];
   const ids = new Set<number>();
@@ -404,14 +953,12 @@ function fetchE2eCoordinationEvidence(
       "--slurp",
       `repos/${repo}/commits/${exactDiff.headSha}/check-runs?check_name=${encodeURIComponent(checkName)}&filter=all&per_page=100`,
     ]);
-    if (!Array.isArray(pages) || pages.length === 0) return { valid: null };
+    if (!Array.isArray(pages) || pages.length === 0) return null;
 
     let expectedTotal: number | null = null;
     let observedTotal = 0;
     for (const page of pages) {
-      if (typeof page !== "object" || page === null || Array.isArray(page)) {
-        return { valid: null };
-      }
+      if (typeof page !== "object" || page === null || Array.isArray(page)) return null;
       const { total_count: totalCount, check_runs: pageRuns } = page as Record<string, unknown>;
       if (
         !Number.isSafeInteger(totalCount) ||
@@ -419,14 +966,12 @@ function fetchE2eCoordinationEvidence(
         (expectedTotal !== null && totalCount !== expectedTotal) ||
         !Array.isArray(pageRuns)
       ) {
-        return { valid: null };
+        return null;
       }
       expectedTotal = totalCount as number;
       observedTotal += pageRuns.length;
       for (const value of pageRuns) {
-        if (typeof value !== "object" || value === null || Array.isArray(value)) {
-          return { valid: null };
-        }
+        if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
         const record = value as Record<string, unknown>;
         if (
           !Number.isSafeInteger(record.id) ||
@@ -434,19 +979,32 @@ function fetchE2eCoordinationEvidence(
           ids.has(record.id as number) ||
           (typeof record.external_id !== "string" && record.external_id !== null)
         ) {
-          return { valid: null };
+          return null;
         }
         ids.add(record.id as number);
         checkRuns.push(record);
       }
     }
-    if (expectedTotal === null || observedTotal !== expectedTotal) {
-      return { valid: null };
+    if (
+      expectedTotal === null ||
+      observedTotal !== expectedTotal ||
+      ids.size !== checkRuns.length
+    ) {
+      return null;
     }
   }
 
+  checkRuns.sort((left, right) => (left.id as number) - (right.id as number));
+  return { checkRuns };
+}
+
+function selectE2eCoordinationCheck(
+  snapshot: E2eCoordinationCheckSnapshot,
+  exactDiff: ExactDiffIdentity,
+): Record<string, unknown> | undefined {
+  const checkNames = ["E2E / PR Gate", "E2E / PR Gate Coordination"];
   const externalId = `nemoclaw-pr-e2e:v2:${exactDiff.number}:${exactDiff.headSha}:${exactDiff.baseSha}`;
-  const claimedChecks = checkRuns.filter((check) => check.external_id === externalId);
+  const claimedChecks = snapshot.checkRuns.filter((check) => check.external_id === externalId);
   if (
     claimedChecks.some(
       (check) =>
@@ -459,20 +1017,58 @@ function fetchE2eCoordinationEvidence(
         (check.app as Record<string, unknown>).id !== 15368,
     )
   ) {
-    return { valid: false };
+    return undefined;
   }
   const currentNameChecks = claimedChecks.filter((check) => check.name === "E2E / PR Gate");
   const exactChecks =
     currentNameChecks.length > 0
       ? currentNameChecks
       : claimedChecks.filter((check) => check.name === "E2E / PR Gate Coordination");
-  const exact = currentE2eCoordinationCheck(exactChecks);
+  return currentE2eCoordinationCheck(exactChecks);
+}
+
+function e2eCoordinationHistoryStartedAt(
+  snapshot: E2eCoordinationCheckSnapshot,
+  exactDiff: ExactDiffIdentity,
+): number {
+  const externalId = `nemoclaw-pr-e2e:v2:${exactDiff.number}:${exactDiff.headSha}:${exactDiff.baseSha}`;
+  const claimedChecks = snapshot.checkRuns.filter((check) => check.external_id === externalId);
+  if (claimedChecks.length === 0) return Number.NaN;
+
+  let earliest = Number.POSITIVE_INFINITY;
+  for (const check of claimedChecks) {
+    const startedAt =
+      typeof check.started_at === "string" ? parseGitHubTimestamp(check.started_at) : Number.NaN;
+    const completedAt =
+      typeof check.completed_at === "string"
+        ? parseGitHubTimestamp(check.completed_at)
+        : Number.NaN;
+    if (
+      !Number.isFinite(startedAt) ||
+      (check.status === "completed" && (!Number.isFinite(completedAt) || startedAt > completedAt))
+    ) {
+      return Number.NaN;
+    }
+    earliest = Math.min(earliest, startedAt);
+  }
+  return earliest;
+}
+
+function fetchE2eCoordinationEvidence(
+  repo: string,
+  exactDiff: ExactDiffIdentity,
+): E2eCoordinationEvidence {
+  const checkSnapshot = fetchE2eCoordinationCheckSnapshot(repo, exactDiff);
+  if (!checkSnapshot) return { valid: null };
+  const exact = selectE2eCoordinationCheck(checkSnapshot, exactDiff);
   if (!exact) return { valid: false };
+  const checkNames = ["E2E / PR Gate", "E2E / PR Gate Coordination"];
   const app = exact.app;
   const startedAt =
     typeof exact.started_at === "string" ? parseGitHubTimestamp(exact.started_at) : Number.NaN;
   const completedAt =
     typeof exact.completed_at === "string" ? parseGitHubTimestamp(exact.completed_at) : Number.NaN;
+  const historyStartedAt = e2eCoordinationHistoryStartedAt(checkSnapshot, exactDiff);
   const valid =
     typeof exact.name === "string" &&
     checkNames.includes(exact.name) &&
@@ -485,11 +1081,30 @@ function fetchE2eCoordinationEvidence(
     exact.conclusion === "success" &&
     Number.isFinite(startedAt) &&
     Number.isFinite(completedAt) &&
+    Number.isFinite(historyStartedAt) &&
     startedAt <= completedAt;
+  const coordinator = valid
+    ? fetchE2eCoordinatorEvidence(
+        repo,
+        exactDiff,
+        historyStartedAt,
+        startedAt,
+        completedAt,
+        Date.now(),
+      )
+    : { valid: false };
+  const completeEvidence = valid && coordinator.valid === true && Boolean(coordinator.snapshot);
   return {
-    valid,
-    ...(valid ? { startedAt, completedAt } : {}),
-    ...(valid && exact.name === "E2E / PR Gate"
+    valid: coordinator.valid === null ? null : completeEvidence,
+    ...(completeEvidence ? { startedAt, completedAt } : {}),
+    ...(completeEvidence
+      ? {
+          checkSnapshot,
+          coordinatorSnapshot: coordinator.snapshot,
+          selectedCheckId: exact.id as number,
+        }
+      : {}),
+    ...(completeEvidence && exact.name === "E2E / PR Gate"
       ? { trustedCustomCheckId: exact.id as number }
       : {}),
   };
@@ -571,6 +1186,18 @@ interface ActionJobMetadata {
   conclusion: string | null;
 }
 
+interface CiActionEvidenceCache {
+  actionRunMetadataById: Map<string, ActionRunMetadata | null>;
+  latestAttemptJobsByRun: Map<string, Map<string, ActionJobMetadata> | null>;
+}
+
+function createCiActionEvidenceCache(): CiActionEvidenceCache {
+  return {
+    actionRunMetadataById: new Map(),
+    latestAttemptJobsByRun: new Map(),
+  };
+}
+
 interface CurrentCheckRollup {
   checks: StatusCheck[];
   incompleteAttemptEvidence: string[];
@@ -581,12 +1208,14 @@ function currentCheckRollup(
   repo: string,
   exactDiff: ExactDiffIdentity,
   e2eCoordinationEvidence: E2eCoordinationEvidence,
+  actionEvidence = createCiActionEvidenceCache(),
+  allowActionEvidenceReads = true,
 ): CurrentCheckRollup {
-  const actionRunMetadataById = new Map<string, ActionRunMetadata | null>();
-  const latestAttemptJobsByRun = new Map<string, Map<string, ActionJobMetadata> | null>();
+  const { actionRunMetadataById, latestAttemptJobsByRun } = actionEvidence;
   const incompleteAttemptEvidence = new Set<string>();
 
   const fetchActionRunMetadata = (runId: string): ActionRunMetadata | null => {
+    if (!allowActionEvidenceReads) return null;
     const runData = ghJson(["api", `repos/${repo}/actions/runs/${runId}`]);
     if (typeof runData !== "object" || runData === null || Array.isArray(runData)) {
       return null;
@@ -734,6 +1363,7 @@ function currentCheckRollup(
 
   const actionRunMetadata = (runId: string): ActionRunMetadata | null => {
     if (actionRunMetadataById.has(runId)) return actionRunMetadataById.get(runId) ?? null;
+    if (!allowActionEvidenceReads) return null;
     const metadata = fetchActionRunMetadata(runId);
     actionRunMetadataById.set(runId, metadata);
     return metadata;
@@ -741,6 +1371,7 @@ function currentCheckRollup(
 
   const latestAttemptJobs = (runId: string): Map<string, ActionJobMetadata> | null => {
     if (latestAttemptJobsByRun.has(runId)) return latestAttemptJobsByRun.get(runId) ?? null;
+    if (!allowActionEvidenceReads) return null;
 
     const metadata = actionRunMetadata(runId);
     if (!metadata) {
@@ -899,13 +1530,8 @@ function currentCheckRollup(
       : "unknown";
   };
 
-  const e2eCoordinationIsEnclosed = (run: ActionRunMetadata): boolean =>
-    e2eControllerHeadBinding(run) === "current" &&
-    run.e2eGateRun === true &&
-    e2eCoordinationEvidence.startedAt !== undefined &&
-    e2eCoordinationEvidence.completedAt !== undefined &&
-    run.createdAt <= e2eCoordinationEvidence.startedAt &&
-    e2eCoordinationEvidence.completedAt <= run.updatedAt;
+  const isCurrentE2eSeedRun = (run: ActionRunMetadata): boolean =>
+    e2eControllerHeadBinding(run) === "current" && run.e2eGateRun === true;
 
   const isNonAttemptRun = (runId: string): boolean => {
     const run = actionRunMetadata(runId);
@@ -1083,7 +1709,7 @@ function currentCheckRollup(
     const e2eHeadBinding = e2eControllerHeadBinding(metadata);
     if (e2eHeadBinding === "other") return "other";
     if (e2eHeadBinding === "current") {
-      return e2eCoordinationIsEnclosed(metadata) ? "current" : "unknown";
+      return isCurrentE2eSeedRun(metadata) ? "current" : "unknown";
     }
     if (
       exactDiff.headRepository !== repo &&
@@ -1300,22 +1926,74 @@ function currentCheckRollup(
   return { checks: current, incompleteAttemptEvidence: [...incompleteAttemptEvidence].sort() };
 }
 
-function checkCi(
-  statusCheckRollup: StatusCheck[] | null,
-  repo: string,
-  exactDiff: ExactDiffIdentity,
-): GateResult & {
+interface CiGateResult extends GateResult {
   failingChecks?: string[];
   pendingChecks?: string[];
   missingChecks?: string[];
   trustedCustomCheckId?: number;
-} {
+}
+
+interface RequiredCheckSnapshotRecord {
+  type: string | null;
+  name: string | null;
+  context: string | null;
+  workflowName: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  detailsUrl: string | null;
+  status: string | null;
+  conclusion: string | null;
+  state: string | null;
+}
+
+interface CiEvaluation {
+  gate: CiGateResult;
+  e2eCoordinationEvidence: E2eCoordinationEvidence;
+  requiredCheckSnapshot: RequiredCheckSnapshotRecord[] | null;
+}
+
+function captureRequiredCheckSnapshot(
+  statusCheckRollup: StatusCheck[] | null,
+): RequiredCheckSnapshotRecord[] | null {
+  if (!statusCheckRollup) return null;
+  const snapshot = statusCheckRollup
+    .filter((check) => REQUIRED_CHECK_NAMES.includes(check.name ?? check.context ?? ""))
+    .map((check) => ({
+      type: check.__typename ?? null,
+      name: check.name ?? null,
+      context: check.context ?? null,
+      workflowName: check.workflowName ?? null,
+      startedAt: check.startedAt ?? null,
+      completedAt: check.completedAt ?? null,
+      detailsUrl: check.detailsUrl ?? null,
+      status: check.status ?? null,
+      conclusion: check.conclusion ?? null,
+      state: check.state ?? null,
+    }));
+  snapshot.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  return snapshot;
+}
+
+function evaluateCiRollup(
+  statusCheckRollup: StatusCheck[] | null,
+  repo: string,
+  exactDiff: ExactDiffIdentity,
+  e2eCoordinationEvidence: E2eCoordinationEvidence,
+  actionEvidence = createCiActionEvidenceCache(),
+  allowActionEvidenceReads = true,
+): CiGateResult {
   if (!statusCheckRollup || statusCheckRollup.length === 0) {
     return { pass: false, details: "No status checks found" };
   }
 
-  const e2eCoordinationEvidence = fetchE2eCoordinationEvidence(repo, exactDiff);
-  const rollup = currentCheckRollup(statusCheckRollup, repo, exactDiff, e2eCoordinationEvidence);
+  const rollup = currentCheckRollup(
+    statusCheckRollup,
+    repo,
+    exactDiff,
+    e2eCoordinationEvidence,
+    actionEvidence,
+    allowActionEvidenceReads,
+  );
   const currentChecks = rollup.checks;
   const incompleteAttemptEvidence = new Set(rollup.incompleteAttemptEvidence);
   if (e2eCoordinationEvidence.valid !== true) {
@@ -1391,6 +2069,122 @@ function checkCi(
       ? { trustedCustomCheckId: e2eCoordinationEvidence.trustedCustomCheckId }
       : {}),
   };
+}
+
+function checkCi(
+  statusCheckRollup: StatusCheck[] | null,
+  repo: string,
+  exactDiff: ExactDiffIdentity,
+): CiEvaluation {
+  const e2eCoordinationEvidence =
+    statusCheckRollup && statusCheckRollup.length > 0
+      ? fetchE2eCoordinationEvidence(repo, exactDiff)
+      : { valid: false };
+  return {
+    gate: evaluateCiRollup(statusCheckRollup, repo, exactDiff, e2eCoordinationEvidence),
+    e2eCoordinationEvidence,
+    requiredCheckSnapshot: captureRequiredCheckSnapshot(statusCheckRollup),
+  };
+}
+
+function checkFinalCi(
+  initial: CiEvaluation,
+  finalStatusCheckRollup: StatusCheck[] | null,
+  repo: string,
+  exactDiff: ExactDiffIdentity,
+  actionEvidence: CiActionEvidenceCache,
+): CiGateResult {
+  if (!initial.gate.pass) return initial.gate;
+  const finalGate = evaluateCiRollup(
+    finalStatusCheckRollup,
+    repo,
+    exactDiff,
+    initial.e2eCoordinationEvidence,
+    actionEvidence,
+  );
+  if (!finalGate.pass) return finalGate;
+  const finalRequiredCheckSnapshot = captureRequiredCheckSnapshot(finalStatusCheckRollup);
+  if (
+    !initial.requiredCheckSnapshot ||
+    !finalRequiredCheckSnapshot ||
+    !isDeepStrictEqual(finalRequiredCheckSnapshot, initial.requiredCheckSnapshot)
+  ) {
+    return {
+      pass: false,
+      details: "Required check rollup changed during gate evaluation",
+      failingChecks: ["Required check rollup changed during gate evaluation"],
+    };
+  }
+  return finalGate;
+}
+
+function checkFinalE2eEvidence(
+  ci: CiGateResult,
+  initial: CiEvaluation,
+  finalE2eEvidence: E2eCoordinationEvidence,
+  exactDiff: ExactDiffIdentity,
+): CiGateResult {
+  if (!ci.pass) return ci;
+  const initialE2eCheckSnapshot = initial.e2eCoordinationEvidence.checkSnapshot;
+  const initialCoordinatorSnapshot = initial.e2eCoordinationEvidence.coordinatorSnapshot;
+  const initialSelectedCheckId = initial.e2eCoordinationEvidence.selectedCheckId;
+  const finalE2eCheckSnapshot = finalE2eEvidence.checkSnapshot;
+  const finalSelectedCheck = finalE2eCheckSnapshot
+    ? selectE2eCoordinationCheck(finalE2eCheckSnapshot, exactDiff)
+    : undefined;
+  if (
+    !initialE2eCheckSnapshot ||
+    !initialCoordinatorSnapshot ||
+    initialSelectedCheckId === undefined ||
+    finalE2eEvidence.valid !== true ||
+    !finalE2eCheckSnapshot ||
+    !finalE2eEvidence.coordinatorSnapshot ||
+    !finalSelectedCheck ||
+    finalSelectedCheck.id !== initialSelectedCheckId ||
+    !isDeepStrictEqual(finalE2eCheckSnapshot, initialE2eCheckSnapshot) ||
+    !isDeepStrictEqual(finalE2eEvidence.coordinatorSnapshot, initialCoordinatorSnapshot)
+  ) {
+    return {
+      pass: false,
+      details: "E2E custom-check history changed during gate evaluation",
+      failingChecks: ["E2E / PR Gate: final evidence changed"],
+    };
+  }
+  return ci;
+}
+
+function checkLastCi(
+  ci: CiGateResult,
+  initial: CiEvaluation,
+  lastStatusCheckRollup: StatusCheck[] | null,
+  repo: string,
+  exactDiff: ExactDiffIdentity,
+  finalE2eEvidence: E2eCoordinationEvidence,
+  actionEvidence: CiActionEvidenceCache,
+): CiGateResult {
+  if (!ci.pass) return ci;
+  const lastGate = evaluateCiRollup(
+    lastStatusCheckRollup,
+    repo,
+    exactDiff,
+    finalE2eEvidence,
+    actionEvidence,
+    false,
+  );
+  if (!lastGate.pass) return lastGate;
+  const lastRequiredCheckSnapshot = captureRequiredCheckSnapshot(lastStatusCheckRollup);
+  if (
+    !initial.requiredCheckSnapshot ||
+    !lastRequiredCheckSnapshot ||
+    !isDeepStrictEqual(lastRequiredCheckSnapshot, initial.requiredCheckSnapshot)
+  ) {
+    return {
+      pass: false,
+      details: "Required check rollup changed during final gate evaluation",
+      failingChecks: ["Required check rollup changed during final gate evaluation"],
+    };
+  }
+  return lastGate;
 }
 
 // ---------------------------------------------------------------------------
@@ -1766,6 +2560,7 @@ interface PrRevisionSnapshot {
   headRefName: string;
   baseRefName: string;
   headRepository: string;
+  statusCheckRollup: StatusCheck[];
 }
 
 function parseHeadRepository(headRepository: unknown, headRepositoryOwner: unknown): string | null {
@@ -1807,7 +2602,7 @@ function fetchPrRevisionSnapshot(repo: string, number: number): PrRevisionSnapsh
     "--repo",
     repo,
     "--json",
-    "title,body,state,isDraft,mergeable,mergeStateStatus,headRefOid,baseRefOid,headRefName,baseRefName,headRepository,headRepositoryOwner",
+    "title,body,state,isDraft,mergeable,mergeStateStatus,headRefOid,baseRefOid,headRefName,baseRefName,headRepository,headRepositoryOwner,statusCheckRollup",
   ]);
   if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
@@ -1823,6 +2618,10 @@ function fetchPrRevisionSnapshot(repo: string, number: number): PrRevisionSnapsh
     typeof record.baseRefOid !== "string" ||
     typeof record.headRefName !== "string" ||
     typeof record.baseRefName !== "string" ||
+    !Array.isArray(record.statusCheckRollup) ||
+    record.statusCheckRollup.some(
+      (check) => typeof check !== "object" || check === null || Array.isArray(check),
+    ) ||
     !headRepository
   ) {
     return null;
@@ -1839,6 +2638,7 @@ function fetchPrRevisionSnapshot(repo: string, number: number): PrRevisionSnapsh
     headRefName: record.headRefName,
     baseRefName: record.baseRefName,
     headRepository,
+    statusCheckRollup: record.statusCheckRollup as StatusCheck[],
   };
 }
 
@@ -1946,13 +2746,14 @@ function main(): void {
     process.exit(1);
   }
 
-  const ci = checkCi(prData.statusCheckRollup, repo, {
+  const exactDiff = {
     number: prNumber,
     headSha: prData.headRefOid,
     baseSha: prData.baseRefOid,
     headRefName: prData.headRefName,
     headRepository,
-  });
+  };
+  const initialCi = checkCi(prData.statusCheckRollup, repo, exactDiff);
   const coderabbit = checkCodeRabbit(repo, prNumber);
   const riskyCodeTested = checkRiskyCodeTested(prData.files ?? []);
   const contributorCompliance = checkContributorCompliance(
@@ -1966,25 +2767,57 @@ function main(): void {
     prData,
     contributorApprovalHistory,
   );
+  const capturedRevision: PrRevisionSnapshot = {
+    title: prData.title,
+    body: prData.body,
+    state: prData.state,
+    isDraft: prData.isDraft,
+    mergeable: prData.mergeable,
+    mergeStateStatus: prData.mergeStateStatus,
+    headRefOid: prData.headRefOid,
+    baseRefOid: prData.baseRefOid,
+    headRefName: prData.headRefName,
+    baseRefName: prData.baseRefName,
+    headRepository,
+    statusCheckRollup: prData.statusCheckRollup,
+  };
   const currentBaseSha = fetchCurrentBaseSha(repo, prNumber);
+  const revisionBeforeFinalCi = fetchPrRevisionSnapshot(repo, prNumber);
+  const finalCiActionEvidence = createCiActionEvidenceCache();
+  const evaluatedRollupCi = checkFinalCi(
+    initialCi,
+    revisionBeforeFinalCi?.statusCheckRollup ?? null,
+    repo,
+    exactDiff,
+    finalCiActionEvidence,
+  );
+  const finalE2eEvidence = evaluatedRollupCi.pass
+    ? fetchE2eCoordinationEvidence(repo, exactDiff)
+    : { valid: false };
+  const evaluatedCi = checkFinalE2eEvidence(
+    evaluatedRollupCi,
+    initialCi,
+    finalE2eEvidence,
+    exactDiff,
+  );
   const currentRevision = fetchPrRevisionSnapshot(repo, prNumber);
-  const conflicts = checkFinalRevision(
-    {
-      title: prData.title,
-      body: prData.body,
-      state: prData.state,
-      isDraft: prData.isDraft,
-      mergeable: prData.mergeable,
-      mergeStateStatus: prData.mergeStateStatus,
-      headRefOid: prData.headRefOid,
-      baseRefOid: prData.baseRefOid,
-      headRefName: prData.headRefName,
-      baseRefName: prData.baseRefName,
-      headRepository,
-    },
-    currentRevision,
+  const ci = checkLastCi(
+    evaluatedCi,
+    initialCi,
+    currentRevision?.statusCheckRollup ?? null,
+    repo,
+    exactDiff,
+    finalE2eEvidence,
+    finalCiActionEvidence,
+  );
+  const revisionBeforeFinalCiGate = checkFinalRevision(
+    capturedRevision,
+    revisionBeforeFinalCi,
     currentBaseSha,
   );
+  const conflicts = revisionBeforeFinalCiGate.pass
+    ? checkFinalRevision(revisionBeforeFinalCi!, currentRevision, currentBaseSha)
+    : revisionBeforeFinalCiGate;
 
   const output: GateOutput = {
     pr: prNumber,

--- a/test/skills/check-gates-coordinator-evidence.test.ts
+++ b/test/skills/check-gates-coordinator-evidence.test.ts
@@ -1,0 +1,1191 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type {
+  ActionJobFixture,
+  ActionRunFixture,
+  ComplianceFixture,
+  CoordinatorRunPartitionFixture,
+} from "./check-gates-test-fixtures.ts";
+import {
+  BASE_SHA,
+  coordinationCheck,
+  e2eCoordinatorRun,
+  e2eManualCoordinatorRun,
+  exactDiffGateRun,
+  HEAD_SHA,
+  prWorkflowRun,
+  runGate,
+  successfulRequiredChecks,
+} from "./check-gates-test-fixtures.ts";
+
+function seedJobs(): ActionJobFixture[] {
+  return [
+    { id: 471, name: "cancel-superseded" },
+    { id: 472, name: "initialize" },
+    { id: 473, name: "coordinate", conclusion: "skipped" },
+  ];
+}
+
+function coordinatorJobs(overrides: Partial<ActionJobFixture> = {}): ActionJobFixture[] {
+  return (e2eCoordinatorRun().jobs ?? []).map((job) =>
+    job.name === "coordinate" ? { ...job, ...overrides } : job,
+  );
+}
+
+function historicalCoordinatorRun(): ActionRunFixture {
+  return {
+    ...e2eCoordinatorRun(
+      "success",
+      coordinatorJobs({
+        conclusion: "success",
+        startedAt: "2026-01-01T00:00:20Z",
+        completedAt: "2026-01-01T00:00:59Z",
+      }),
+    ),
+    createdAt: "2026-01-01T00:00:10Z",
+    updatedAt: "2026-01-01T00:01:00Z",
+  };
+}
+
+function retryableFailure(id: number, startedAt: string, completedAt: string) {
+  return coordinationCheck({
+    id,
+    conclusion: "failure",
+    started_at: startedAt,
+    completed_at: completedAt,
+    output: {
+      title: "Retryable E2E failure",
+      summary: "Retryable failure.\n\n<!-- nemoclaw-pr-e2e-retry:v1:prerequisite-ci -->",
+    },
+  });
+}
+
+const DEFAULT_COORDINATOR_RANGES = [
+  "2025-12-31T00:00:00Z..2025-12-31T12:00:00Z",
+  "2025-12-31T12:00:00Z..2026-01-01T00:00:00Z",
+  "2026-01-01T00:00:00Z..2026-01-01T00:03:00Z",
+] as const;
+
+function paginatedRunIds(ids: number[]): number[][] {
+  return Array.from({ length: Math.ceil(ids.length / 100) }, (_value, index) =>
+    ids.slice(index * 100, (index + 1) * 100),
+  );
+}
+
+interface CoordinatorFixture {
+  coordinator?: Partial<ActionRunFixture>;
+  coordinatorList?: Partial<ActionRunFixture>;
+  coordinatorJobs?: ActionJobFixture[];
+  coordinatorRunPages?: number[][];
+  coordinatorRunPartitions?: CoordinatorRunPartitionFixture[];
+  coordinationCheckPages?: unknown[];
+  customCheck?: Record<string, unknown>;
+  extraRuns?: Record<string, ActionRunFixture>;
+  finalCheckOverrides?: Record<
+    string,
+    Partial<NonNullable<ComplianceFixture["statusChecks"]>[number]>
+  >;
+  finalCoordinationCheckPages?: unknown[];
+  finalFormerCoordinationCheckPages?: unknown[];
+  finalPrAfterCiEvidence?: Record<string, unknown>;
+  additionalChecksAfterE2eEvidence?: NonNullable<ComplianceFixture["statusChecks"]>;
+  headRepository?: string;
+  observationTime?: string;
+  seedRun?: Partial<ActionRunFixture>;
+}
+
+const LIVE_FORK_COORDINATOR_RANGES = [
+  "2026-08-03T00:00:00Z..2026-08-03T12:00:00Z",
+  "2026-08-03T12:00:00Z..2026-08-04T00:00:00Z",
+  "2026-08-04T00:00:00Z..2026-08-04T12:00:00Z",
+  "2026-08-04T12:00:00Z..2026-08-04T14:58:00Z",
+] as const;
+
+function authorizedForkLifecycleFixture(
+  additionalAutomaticRuns: Record<string, ActionRunFixture> = {},
+): CoordinatorFixture {
+  const automaticCoordinator = {
+    ...e2eCoordinatorRun(),
+    createdAt: "2026-08-04T14:36:34Z",
+    updatedAt: "2026-08-04T14:37:04Z",
+    jobs: coordinatorJobs({
+      startedAt: "2026-08-04T14:36:35Z",
+      completedAt: "2026-08-04T14:37:03Z",
+    }),
+  };
+  const manualCoordinator = {
+    ...e2eManualCoordinatorRun(),
+    createdAt: "2026-08-04T14:38:13Z",
+    updatedAt: "2026-08-04T14:57:43Z",
+    headSha: "d".repeat(40),
+    jobs: coordinatorJobs({
+      startedAt: "2026-08-04T14:38:14Z",
+      completedAt: "2026-08-04T14:57:42Z",
+    }),
+  };
+  const automaticRunIds = [9501, ...Object.keys(additionalAutomaticRuns).map(Number)];
+  return {
+    headRepository: "example/fork",
+    observationTime: "2026-08-04T14:58:00Z",
+    customCheck: {
+      started_at: "2026-08-04T14:23:40Z",
+      completed_at: "2026-08-04T14:57:39Z",
+    },
+    coordinator: manualCoordinator,
+    seedRun: { headRepository: "example/fork" },
+    coordinatorRunPartitions: [
+      ...LIVE_FORK_COORDINATOR_RANGES.map((createdRange, index) => ({
+        createdRange,
+        runPages: [index === LIVE_FORK_COORDINATOR_RANGES.length - 1 ? automaticRunIds : []],
+      })),
+      {
+        createdRange: LIVE_FORK_COORDINATOR_RANGES.at(-1)!,
+        event: "workflow_dispatch",
+        runPages: [[9500]],
+      },
+    ],
+    extraRuns: {
+      "90": {
+        ...prWorkflowRun(
+          "success",
+          [
+            { id: 1, name: "checks" },
+            { id: 2, name: "changes" },
+          ],
+          true,
+        ),
+        headRepository: "example/fork",
+        pullRequests: [],
+      },
+      "9501": automaticCoordinator,
+      ...additionalAutomaticRuns,
+    },
+  };
+}
+
+function runGateWithCoordinator({
+  coordinator = {},
+  coordinatorList,
+  coordinatorJobs: configuredJobs,
+  coordinatorRunPages = [[9500]],
+  coordinatorRunPartitions,
+  coordinationCheckPages,
+  customCheck = {},
+  extraRuns = {},
+  finalCheckOverrides = {},
+  finalCoordinationCheckPages,
+  finalFormerCoordinationCheckPages,
+  finalPrAfterCiEvidence,
+  additionalChecksAfterE2eEvidence,
+  headRepository,
+  observationTime,
+  seedRun = {},
+}: CoordinatorFixture = {}) {
+  const defaultCoordinator = e2eCoordinatorRun();
+  const jobs = seedRun.jobs ?? seedJobs();
+  const statusChecks = [
+    ...successfulRequiredChecks(),
+    ...jobs.map((job) => ({
+      __typename: "CheckRun",
+      name: job.name,
+      workflowName: "E2E / PR Gate Controller",
+      detailsUrl: "https://github.com/NVIDIA/NemoClaw/actions/runs/407/job/" + String(job.id),
+      startedAt: job.startedAt ?? seedRun.createdAt ?? "2026-01-01T00:01:00Z",
+      status: "COMPLETED",
+      conclusion: (job.conclusion ?? "success").toUpperCase(),
+    })),
+  ];
+  const finalStatusChecks =
+    Object.keys(finalCheckOverrides).length > 0
+      ? statusChecks.map((check) => ({
+          ...check,
+          ...finalCheckOverrides[check.name],
+        }))
+      : undefined;
+  const coordinatorJobs = configuredJobs ?? coordinator.jobs ?? defaultCoordinator.jobs;
+  return runGate({
+    body: "Signed-off-by: Example User <user@example.com>",
+    verified: true,
+    headRepository,
+    observationTime,
+    statusChecks,
+    coordinatorRunPages,
+    coordinatorRunPartitions,
+    coordinatorListAttempts: coordinatorList
+      ? {
+          "9500": {
+            ...defaultCoordinator,
+            ...coordinator,
+            ...coordinatorList,
+            jobs: coordinatorJobs,
+          },
+        }
+      : undefined,
+    coordinationCheckPages: coordinationCheckPages ?? [
+      {
+        total_count: 1,
+        check_runs: [coordinationCheck(customCheck)],
+      },
+    ],
+    finalCoordinationCheckPages,
+    finalFormerCoordinationCheckPages,
+    finalPr: finalStatusChecks ? { statusCheckRollup: finalStatusChecks } : undefined,
+    finalPrAfterCiEvidence: additionalChecksAfterE2eEvidence
+      ? {
+          ...finalPrAfterCiEvidence,
+          statusCheckRollup: [
+            ...(finalStatusChecks ?? statusChecks),
+            ...additionalChecksAfterE2eEvidence,
+          ],
+        }
+      : finalPrAfterCiEvidence,
+    actionRunAttempts: {
+      "9500": {
+        ...defaultCoordinator,
+        ...coordinator,
+        jobs: coordinatorJobs,
+      },
+      "407": {
+        ...exactDiffGateRun("success", jobs),
+        createdAt: "2026-01-01T00:01:00Z",
+        updatedAt: "2026-01-01T00:01:31Z",
+        pullRequests: [],
+        ...seedRun,
+        jobs,
+      },
+      ...extraRuns,
+    },
+  });
+}
+
+describe("maintainer merge-gate E2E coordinator evidence", () => {
+  it("accepts a custom check completed after its seed run when the repository coordinator encloses completion", () => {
+    const result = runGateWithCoordinator();
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("accepts a repository-owned manual coordinator for an authorized fork revision", () => {
+    const manualCoordinator = {
+      ...e2eManualCoordinatorRun(),
+      headSha: "d".repeat(40),
+    };
+    const result = runGateWithCoordinator({
+      headRepository: "example/fork",
+      coordinator: manualCoordinator,
+      seedRun: { headRepository: "example/fork" },
+      coordinatorRunPartitions: [
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[0],
+          event: "workflow_dispatch",
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[1],
+          event: "workflow_dispatch",
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          event: "workflow_dispatch",
+          runPages: [[9500]],
+        },
+      ],
+      extraRuns: {
+        "90": {
+          ...prWorkflowRun(
+            "success",
+            [
+              { id: 1, name: "checks" },
+              { id: 2, name: "changes" },
+            ],
+            true,
+          ),
+          headRepository: "example/fork",
+          pullRequests: [],
+        },
+      },
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("accepts a fork check completed by manual authorization after automatic coordination", () => {
+    const result = runGateWithCoordinator(authorizedForkLifecycleFixture());
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("rejects two automatic authorization predecessors for one manual coordinator", () => {
+    const result = runGateWithCoordinator(
+      authorizedForkLifecycleFixture({
+        "9502": {
+          ...e2eCoordinatorRun(),
+          createdAt: "2026-08-04T14:37:05Z",
+          updatedAt: "2026-08-04T14:37:34Z",
+          jobs: coordinatorJobs({
+            startedAt: "2026-08-04T14:37:06Z",
+            completedAt: "2026-08-04T14:37:33Z",
+          }),
+        },
+      }),
+    );
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain(
+      "E2E / PR Gate: latest attempt evidence incomplete",
+    );
+  });
+
+  it("accepts the exact coordinator from a later complete workflow-runs page", () => {
+    const unrelatedRun = {
+      ...e2eCoordinatorRun(),
+      displayTitle: "E2E Gate coordinate from unrelated CI",
+    };
+    const result = runGateWithCoordinator({
+      coordinatorRunPages: [[9501], [9500]],
+      extraRuns: { "9501": unrelatedRun },
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("accepts one enclosing coordinator with older same-revision coordinator history", () => {
+    const result = runGateWithCoordinator({
+      coordinatorRunPages: [[9501, 9500]],
+      extraRuns: { "9501": historicalCoordinatorRun() },
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("accepts a retry coordinator created before the current custom check", () => {
+    const result = runGateWithCoordinator({
+      coordinator: { createdAt: "2026-01-01T00:01:20Z" },
+      coordinatorJobs: coordinatorJobs({
+        startedAt: "2026-01-01T00:01:25Z",
+      }),
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("accepts a retry check that starts after its authenticated seed run finishes", () => {
+    const result = runGateWithCoordinator({
+      seedRun: {
+        createdAt: "2026-08-04T14:07:32Z",
+        updatedAt: "2026-08-04T14:08:01Z",
+        jobs: seedJobs().map((job) => ({
+          ...job,
+          startedAt: "2026-08-04T14:07:40Z",
+          completedAt: "2026-08-04T14:08:00Z",
+        })),
+      },
+      customCheck: {
+        started_at: "2026-08-04T14:28:06Z",
+        completed_at: "2026-08-04T14:38:01Z",
+      },
+      coordinator: {
+        createdAt: "2026-08-04T14:27:44Z",
+        updatedAt: "2026-08-04T14:38:06Z",
+      },
+      coordinatorJobs: coordinatorJobs({
+        startedAt: "2026-08-04T14:27:47Z",
+        completedAt: "2026-08-04T14:38:05Z",
+      }),
+      coordinatorRunPartitions: [
+        {
+          createdRange: "2026-08-03T00:00:00Z..2026-08-03T12:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2026-08-03T12:00:00Z..2026-08-04T00:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2026-08-04T00:00:00Z..2026-08-04T12:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2026-08-04T12:00:00Z..2026-08-04T14:38:01Z",
+          runPages: [[9500]],
+        },
+      ],
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("finds a coordinator created before midnight for a check completed after midnight", () => {
+    const result = runGateWithCoordinator({
+      customCheck: {
+        started_at: "2026-01-02T00:00:10Z",
+        completed_at: "2026-01-02T00:00:40Z",
+      },
+      coordinator: {
+        createdAt: "2026-01-01T23:59:50Z",
+        updatedAt: "2026-01-02T00:00:45Z",
+      },
+      coordinatorJobs: coordinatorJobs({
+        startedAt: "2026-01-01T23:59:55Z",
+        completedAt: "2026-01-02T00:00:44Z",
+      }),
+      coordinatorRunPartitions: [
+        {
+          createdRange: "2026-01-01T00:00:00Z..2026-01-01T12:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2026-01-01T12:00:00Z..2026-01-02T00:00:00Z",
+          runPages: [[9500]],
+        },
+        {
+          createdRange: "2026-01-02T00:00:00Z..2026-01-02T00:00:40Z",
+          runPages: [[]],
+        },
+      ],
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("accepts more than 1,000 workflow runs across complete partitions", () => {
+    const firstPartitionIds = Array.from({ length: 600 }, (_value, index) => 10_000 + index);
+    const secondPartitionIds = Array.from({ length: 600 }, (_value, index) => 20_000 + index);
+    const result = runGateWithCoordinator({
+      coordinatorRunPartitions: [
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[0],
+          runPages: paginatedRunIds(firstPartitionIds),
+          fallbackCreatedAt: "2025-12-31T06:00:00Z",
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[1],
+          runPages: paginatedRunIds(secondPartitionIds),
+          fallbackCreatedAt: "2025-12-31T18:00:00Z",
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          runPages: [[9500]],
+        },
+      ],
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("deduplicates an identical coordinator returned at an inclusive partition boundary", () => {
+    const result = runGateWithCoordinator({
+      coordinator: { createdAt: "2026-01-01T00:00:00Z" },
+      coordinatorRunPartitions: [
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[0],
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[1],
+          runPages: [[9500]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          runPages: [[9500]],
+        },
+      ],
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("rejects a newer custom-check retry that appears during final observation", () => {
+    const result = runGateWithCoordinator({
+      finalCoordinationCheckPages: [
+        {
+          total_count: 2,
+          check_runs: [
+            coordinationCheck(),
+            coordinationCheck({
+              id: 8001,
+              status: "in_progress",
+              conclusion: null,
+              started_at: "2026-01-01T00:02:31Z",
+              completed_at: null,
+            }),
+          ],
+        },
+      ],
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain("E2E / PR Gate: final evidence changed");
+  });
+
+  it("rejects a newer queued coordinator before it creates a custom check", () => {
+    const result = runGateWithCoordinator({
+      coordinatorRunPartitions: [
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[0],
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[1],
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          runPages: [[9500]],
+          finalRunPages: [[9500, 9501]],
+        },
+      ],
+      extraRuns: {
+        "9501": {
+          ...e2eCoordinatorRun(),
+          createdAt: "2026-01-01T00:02:40Z",
+          updatedAt: "2026-01-01T00:02:40Z",
+          status: "queued",
+          conclusion: null,
+          jobs: [],
+        },
+      },
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain("E2E / PR Gate: final evidence changed");
+  });
+
+  it("rejects a PR revision that changes while final CI evidence is read", () => {
+    const result = runGateWithCoordinator({
+      finalPrAfterCiEvidence: {
+        body: "Signed-off-by: Example User <user@example.com>\n\nChanged during final CI.",
+      },
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: {
+        conflicts: {
+          pass: false,
+          details:
+            "PR revision or merge state changed during gate evaluation; rerun the gate checker",
+        },
+      },
+    });
+  });
+
+  it("rejects failed coordinator history from an earlier day for the same revision", () => {
+    const result = runGateWithCoordinator({
+      coordinationCheckPages: [
+        {
+          total_count: 2,
+          check_runs: [
+            retryableFailure(7999, "2025-12-29T00:01:00Z", "2025-12-29T00:03:00Z"),
+            coordinationCheck(),
+          ],
+        },
+      ],
+      coordinatorRunPartitions: [
+        {
+          createdRange: "2025-12-28T00:00:00Z..2025-12-28T12:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2025-12-28T12:00:00Z..2025-12-29T00:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2025-12-29T00:00:00Z..2025-12-29T12:00:00Z",
+          runPages: [[9501]],
+        },
+        {
+          createdRange: "2025-12-29T12:00:00Z..2025-12-30T00:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2025-12-30T00:00:00Z..2025-12-30T12:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2025-12-30T12:00:00Z..2025-12-31T00:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2025-12-31T00:00:00Z..2025-12-31T12:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: "2025-12-31T12:00:00Z..2026-01-01T00:00:00Z",
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          runPages: [[9500]],
+        },
+      ],
+      extraRuns: {
+        "9501": {
+          ...e2eCoordinatorRun("failure"),
+          createdAt: "2025-12-29T00:02:00Z",
+          updatedAt: "2025-12-29T00:03:01Z",
+          jobs: coordinatorJobs({
+            startedAt: "2025-12-29T00:02:01Z",
+            completedAt: "2025-12-29T00:03:00Z",
+          }),
+        },
+      },
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain(
+      "E2E / PR Gate: latest attempt evidence incomplete",
+    );
+  });
+
+  it("rejects an extreme custom-check timestamp span before inventory traversal", () => {
+    const result = runGateWithCoordinator({
+      customCheck: {
+        started_at: "2000-01-01T00:00:00Z",
+        completed_at: "2026-01-01T00:02:30Z",
+      },
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain(
+      "E2E / PR Gate: latest attempt evidence incomplete",
+    );
+  });
+
+  it.each([
+    {
+      field: "status",
+      overrides: { status: "in_progress", conclusion: null, completed_at: null },
+    },
+    { field: "conclusion", overrides: { conclusion: "neutral" } },
+    { field: "start time", overrides: { started_at: "2026-01-01T00:01:31Z" } },
+    { field: "completion time", overrides: { completed_at: "2026-01-01T00:02:31Z" } },
+    {
+      field: "details URL",
+      overrides: { details_url: "https://github.com/NVIDIA/NemoClaw/runs/8001" },
+    },
+  ])("rejects a changed selected custom-check $field during final observation", ({ overrides }) => {
+    const result = runGateWithCoordinator({
+      finalCoordinationCheckPages: [
+        {
+          total_count: 1,
+          check_runs: [coordinationCheck(overrides)],
+        },
+      ],
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain("E2E / PR Gate: final evidence changed");
+  });
+
+  it("rejects changed former custom-check history during final observation", () => {
+    const result = runGateWithCoordinator({
+      finalFormerCoordinationCheckPages: [
+        {
+          total_count: 1,
+          check_runs: [
+            coordinationCheck({
+              id: 7999,
+              name: "E2E / PR Gate Coordination",
+            }),
+          ],
+        },
+      ],
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain("E2E / PR Gate: final evidence changed");
+  });
+
+  it.each([
+    {
+      condition: "fails",
+      status: "COMPLETED",
+      conclusion: "FAILURE",
+      resultField: "failingChecks",
+      expected: "Repository policy: FAILURE",
+    },
+    {
+      condition: "remains pending",
+      status: "IN_PROGRESS",
+      conclusion: undefined,
+      resultField: "pendingChecks",
+      expected: "Repository policy",
+    },
+  ])("rejects a non-required repository check that $condition after final E2E evidence", ({
+    status,
+    conclusion,
+    resultField,
+    expected,
+  }) => {
+    const result = runGateWithCoordinator({
+      additionalChecksAfterE2eEvidence: [
+        {
+          __typename: "CheckRun",
+          name: "Repository policy",
+          detailsUrl: "https://github.com/NVIDIA/NemoClaw/runs/99001",
+          startedAt: "2026-01-01T00:02:40Z",
+          completedAt: status === "COMPLETED" ? "2026-01-01T00:02:50Z" : undefined,
+          status,
+          conclusion,
+        },
+      ],
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci[resultField]).toContain(expected);
+  });
+
+  it("rejects a changed passing required-check record during final observation", () => {
+    const result = runGateWithCoordinator({
+      finalCheckOverrides: {
+        checks: { startedAt: "2026-01-01T00:00:01Z" },
+      },
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain(
+      "Required check rollup changed during gate evaluation",
+    );
+  });
+
+  it("rejects a required check that fails during final observation", () => {
+    const result = runGateWithCoordinator({
+      finalCheckOverrides: {
+        checks: { conclusion: "FAILURE" },
+      },
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain("checks: FAILURE");
+  });
+
+  it("rejects a required check that becomes pending during final observation", () => {
+    const result = runGateWithCoordinator({
+      finalCheckOverrides: {
+        checks: { conclusion: undefined, status: "IN_PROGRESS" },
+      },
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.pendingChecks).toContain("checks");
+  });
+
+  it("rejects a partition capped before its complete workflow-run inventory", () => {
+    const cappedIds = Array.from({ length: 1_000 }, (_value, index) => 30_000 + index);
+    const result = runGateWithCoordinator({
+      coordinatorRunPartitions: [
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[0],
+          runPages: paginatedRunIds(cappedIds),
+          totalCount: 1_001,
+          fallbackCreatedAt: "2025-12-31T06:00:00Z",
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[1],
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          runPages: [[9500]],
+        },
+      ],
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain(
+      "E2E / PR Gate: latest attempt evidence incomplete",
+    );
+  });
+
+  const rejectedCoordinatorEvidence: Array<
+    CoordinatorFixture & {
+      condition: string;
+    }
+  > = [
+    {
+      condition: "an inclusive boundary repeats changed metadata for the same run",
+      coordinator: { createdAt: "2026-01-01T00:00:00Z" },
+      coordinatorRunPartitions: [
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[0],
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[1],
+          runPages: [[9500]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          runPages: [[9500]],
+          runOverrides: {
+            "9500": { updatedAt: "2026-01-01T00:02:33Z" },
+          },
+        },
+      ],
+    },
+    {
+      condition: "the same run appears outside adjacent partition boundaries",
+      coordinatorRunPartitions: [
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[0],
+          runPages: [[10000]],
+          fallbackCreatedAt: "2025-12-31T06:00:00Z",
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[1],
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          runPages: [[10000, 9500]],
+          fallbackCreatedAt: "2026-01-01T00:01:00Z",
+        },
+      ],
+    },
+    {
+      condition: "coordinator metadata changes between inventory and detail reads",
+      coordinatorList: { updatedAt: "2026-01-01T00:02:33Z" },
+    },
+    {
+      condition: "a partition reports inconsistent totals across pages",
+      coordinatorRunPartitions: [
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[0],
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[1],
+          runPages: [[]],
+        },
+        {
+          createdRange: DEFAULT_COORDINATOR_RANGES[2],
+          runPages: [[9500], []],
+          pageTotalCounts: [1, 2],
+        },
+      ],
+    },
+    {
+      condition: "the custom check has no coordinator",
+      coordinatorRunPages: [[]],
+    },
+    {
+      condition: "two coordinator runs enclose the current custom check",
+      coordinatorRunPages: [[9500, 9501]],
+      extraRuns: { "9501": e2eCoordinatorRun() },
+    },
+    {
+      condition: "older same-revision coordinator metadata is malformed",
+      coordinatorRunPages: [[9501, 9500]],
+      extraRuns: {
+        "9501": {
+          ...historicalCoordinatorRun(),
+          repository: "example/NemoClaw",
+        },
+      },
+    },
+    {
+      condition: "an older same-revision coordinator run failed",
+      coordinatorRunPages: [[9501, 9500]],
+      extraRuns: {
+        "9501": {
+          ...historicalCoordinatorRun(),
+          conclusion: "failure",
+        },
+      },
+    },
+    {
+      condition: "an older same-revision coordinate job failed",
+      coordinatorRunPages: [[9501, 9500]],
+      extraRuns: {
+        "9501": {
+          ...historicalCoordinatorRun(),
+          jobs: coordinatorJobs({
+            conclusion: "failure",
+            startedAt: "2026-01-01T00:00:20Z",
+            completedAt: "2026-01-01T00:00:59Z",
+          }),
+        },
+      },
+    },
+    {
+      condition: "an older same-revision coordinate job completes after its run",
+      coordinatorRunPages: [[9501, 9500]],
+      extraRuns: {
+        "9501": {
+          ...historicalCoordinatorRun(),
+          jobs: coordinatorJobs({
+            startedAt: "2026-01-01T00:00:20Z",
+            completedAt: "2026-01-01T00:01:01Z",
+          }),
+        },
+      },
+    },
+    {
+      condition: "a failed same-revision coordinator overlaps the current custom check",
+      coordinatorRunPages: [[9501, 9500]],
+      extraRuns: {
+        "9501": e2eCoordinatorRun("failure", coordinatorJobs({ conclusion: "failure" })),
+      },
+    },
+    {
+      condition: "the coordinator title does not match",
+      coordinator: { displayTitle: "E2E Gate coordinate from another workflow" },
+    },
+    {
+      condition: "the coordinator title names another PR head",
+      coordinator: {
+        displayTitle:
+          "E2E Gate coordinate from CI PR #42 head " +
+          "c".repeat(40) +
+          " base " +
+          BASE_SHA +
+          " gate true",
+      },
+    },
+    {
+      condition: "the coordinator title names another PR base",
+      coordinator: {
+        displayTitle:
+          "E2E Gate coordinate from CI PR #42 head " +
+          HEAD_SHA +
+          " base " +
+          "c".repeat(40) +
+          " gate true",
+      },
+    },
+    {
+      condition: "the coordinator title sets gate false",
+      coordinator: {
+        displayTitle:
+          "E2E Gate coordinate from CI PR #42 head " +
+          HEAD_SHA +
+          " base " +
+          BASE_SHA +
+          " gate false",
+      },
+    },
+    {
+      condition: "the coordinator uses another event",
+      coordinator: { event: "pull_request_target" },
+    },
+    {
+      condition: "the coordinator uses another workflow path",
+      coordinator: { path: ".github/workflows/pr.yaml" },
+    },
+    {
+      condition: "the coordinator belongs to another repository",
+      coordinator: { repository: "example/NemoClaw" },
+    },
+    {
+      condition: "the coordinator head belongs to another repository",
+      coordinator: { headRepository: "example/NemoClaw" },
+    },
+    {
+      condition: "the coordinator uses another attempt",
+      coordinator: { attempt: 2 },
+    },
+    {
+      condition: "the coordinator run is not completed",
+      coordinator: { status: "in_progress", conclusion: null },
+    },
+    {
+      condition: "the coordinator run has a non-success conclusion",
+      coordinator: { conclusion: "neutral" },
+    },
+    {
+      condition: "the coordinator run failed",
+      coordinator: { conclusion: "failure" },
+    },
+    {
+      condition: "the coordinator has no coordinate job",
+      coordinatorJobs: coordinatorJobs().filter((job) => job.name !== "coordinate"),
+    },
+    {
+      condition: "the coordinator has duplicate coordinate jobs",
+      coordinatorJobs: [
+        ...coordinatorJobs(),
+        {
+          ...coordinatorJobs().find((job) => job.name === "coordinate")!,
+          id: 954,
+        },
+      ],
+    },
+    {
+      condition: "the coordinator job has another name",
+      coordinatorJobs: coordinatorJobs({ name: "finish" }),
+    },
+    {
+      condition: "the coordinate job is not completed",
+      coordinatorJobs: coordinatorJobs({ status: "in_progress", conclusion: null }),
+    },
+    {
+      condition: "the coordinate job failed",
+      coordinatorJobs: coordinatorJobs({ conclusion: "failure" }),
+    },
+    {
+      condition: "the coordinate job has no started_at timestamp",
+      coordinatorJobs: coordinatorJobs({ omitStartedAt: true }),
+    },
+    {
+      condition: "the coordinate job has no completed_at timestamp",
+      coordinatorJobs: coordinatorJobs({ omitCompletedAt: true }),
+    },
+    {
+      condition: "the coordinate job started_at timestamp is null",
+      coordinatorJobs: coordinatorJobs({ startedAt: null }),
+    },
+    {
+      condition: "the coordinate job completed_at timestamp is null",
+      coordinatorJobs: coordinatorJobs({ completedAt: null }),
+    },
+    {
+      condition: "the coordinate job started_at timestamp is malformed",
+      coordinatorJobs: coordinatorJobs({ startedAt: "not-a-time" }),
+    },
+    {
+      condition: "the coordinate job completed_at timestamp is malformed",
+      coordinatorJobs: coordinatorJobs({ completedAt: "not-a-time" }),
+    },
+    {
+      condition: "the coordinate job starts after it completes",
+      coordinatorJobs: coordinatorJobs({
+        startedAt: "2026-01-01T00:02:32Z",
+        completedAt: "2026-01-01T00:02:31Z",
+      }),
+    },
+    {
+      condition: "the coordinate job completes before custom check completion",
+      coordinatorJobs: coordinatorJobs({
+        completedAt: "2026-01-01T00:02:29Z",
+      }),
+    },
+    {
+      condition: "the coordinate job starts after custom check completion",
+      coordinatorJobs: coordinatorJobs({
+        startedAt: "2026-01-01T00:02:31Z",
+      }),
+    },
+    {
+      condition: "the coordinator run has no created_at timestamp",
+      coordinator: { omitCreatedAt: true },
+    },
+    {
+      condition: "the coordinator run has no updated_at timestamp",
+      coordinator: { omitUpdatedAt: true },
+    },
+    {
+      condition: "the coordinator run created_at timestamp is malformed",
+      coordinator: { createdAt: "not-a-time" },
+    },
+    {
+      condition: "the coordinator run updated_at timestamp is malformed",
+      coordinator: { updatedAt: "not-a-time" },
+    },
+    {
+      condition: "the coordinator run is updated before it is created",
+      coordinator: {
+        createdAt: "2026-01-01T00:02:33Z",
+        updatedAt: "2026-01-01T00:02:32Z",
+      },
+    },
+  ];
+
+  it.each(rejectedCoordinatorEvidence)("rejects terminal custom check evidence when $condition", ({
+    condition: _condition,
+    ...fixture
+  }) => {
+    const result = runGateWithCoordinator(fixture);
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
+    });
+    expect(output.gates.ci.failingChecks).toContain(
+      "E2E / PR Gate: latest attempt evidence incomplete",
+    );
+  });
+});

--- a/test/skills/check-gates-test-fixtures.ts
+++ b/test/skills/check-gates-test-fixtures.ts
@@ -50,6 +50,10 @@ interface ActionJobFixture {
   name: string;
   status?: string;
   conclusion?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  omitStartedAt?: boolean;
+  omitCompletedAt?: boolean;
 }
 
 interface ActionRunFixture {
@@ -62,11 +66,14 @@ interface ActionRunFixture {
   nextConclusion?: string | null;
   jobs?: ActionJobFixture[];
   jobPages?: ActionJobFixture[][];
-  createdAt?: string;
-  updatedAt?: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  omitCreatedAt?: boolean;
+  omitUpdatedAt?: boolean;
   headSha?: string;
   headBranch?: string;
   headRepository?: string;
+  repository?: string;
   pullRequestHeadSha?: string;
   pullRequests?: unknown[];
   baseSha?: string;
@@ -75,6 +82,20 @@ interface ActionRunFixture {
   path?: string;
   status?: string;
   conclusion?: string | null;
+}
+
+interface CoordinatorRunPartitionFixture {
+  createdRange: string;
+  runPages: number[][];
+  event?: "workflow_run" | "workflow_dispatch";
+  totalCount?: number;
+  pageTotalCounts?: number[];
+  fallbackCreatedAt?: string;
+  runOverrides?: Record<string, Partial<ActionRunFixture>>;
+  finalRunPages?: number[][];
+  finalTotalCount?: number;
+  finalPageTotalCounts?: number[];
+  finalRunOverrides?: Record<string, Partial<ActionRunFixture>>;
 }
 
 interface ComplianceFixture {
@@ -123,11 +144,18 @@ interface ComplianceFixture {
   verified: boolean;
   reason?: string;
   actionRunAttempts?: Record<string, ActionRunFixture>;
+  coordinatorListAttempts?: Record<string, ActionRunFixture>;
+  coordinatorRunPages?: number[][];
+  coordinatorRunPartitions?: CoordinatorRunPartitionFixture[];
   issueEventPages?: unknown[];
   coordinationCheckPages?: unknown[];
   formerCoordinationCheckPages?: unknown[];
+  finalCoordinationCheckPages?: unknown[];
+  finalFormerCoordinationCheckPages?: unknown[];
+  observationTime?: string;
   finalPr?: Record<string, unknown>;
   finalPrAfterCurrentBase?: Record<string, unknown>;
+  finalPrAfterCiEvidence?: Record<string, unknown>;
 }
 
 interface ComparatorFixture extends ComplianceFixture {
@@ -201,6 +229,60 @@ function exactDiffGateRun(result: string, jobs: ActionJobFixture[], attempt = 1)
   };
 }
 
+function e2eCoordinatorRun(
+  result = "success",
+  jobs: ActionJobFixture[] = [
+    {
+      id: 951,
+      name: "coordinate",
+      startedAt: "2026-01-01T00:02:00Z",
+      completedAt: "2026-01-01T00:02:31Z",
+    },
+    {
+      id: 952,
+      name: "initialize",
+      conclusion: "skipped",
+      startedAt: "2026-01-01T00:02:00Z",
+      completedAt: "2026-01-01T00:02:00Z",
+    },
+    {
+      id: 953,
+      name: "cancel-superseded",
+      conclusion: "skipped",
+      startedAt: "2026-01-01T00:02:00Z",
+      completedAt: "2026-01-01T00:02:00Z",
+    },
+  ],
+): ActionRunFixture {
+  return {
+    attempt: 1,
+    createdAt: "2026-01-01T00:02:00Z",
+    updatedAt: "2026-01-01T00:02:32Z",
+    headSha: BASE_SHA,
+    headBranch: "main",
+    headRepository: "NVIDIA/NemoClaw",
+    repository: "NVIDIA/NemoClaw",
+    pullRequests: [],
+    displayTitle: `E2E Gate coordinate from CI PR #42 head ${HEAD_SHA} base ${BASE_SHA} gate true`,
+    event: "workflow_run",
+    path: ".github/workflows/pr-e2e-gate.yaml",
+    status: "completed",
+    conclusion: result,
+    jobs,
+  };
+}
+
+function e2eManualCoordinatorRun(
+  result = "success",
+  jobs: ActionJobFixture[] = e2eCoordinatorRun().jobs ?? [],
+): ActionRunFixture {
+  return {
+    ...e2eCoordinatorRun(result, jobs),
+    displayTitle: `E2E Gate approve PR #42 head ${HEAD_SHA} base ${BASE_SHA}`,
+    event: "workflow_dispatch",
+  };
+}
+
 function installerHashRun(
   result: string,
   jobs: ActionJobFixture[],
@@ -267,6 +349,12 @@ function runGate(fixture: ComplianceFixture) {
   const bin = path.join(tmp, "bin");
   fs.mkdirSync(bin);
   const ghPath = path.join(bin, "gh");
+  const clockPath = path.join(tmp, "clock.mjs");
+  const observationTime =
+    fixture.observationTime ??
+    fixture.coordinatorRunPartitions?.at(-1)?.createdRange.split("..")[1] ??
+    "2026-01-01T00:03:00Z";
+  fs.writeFileSync(clockPath, `Date.now = () => ${Date.parse(observationTime)};\n`);
 
   const headRepository = fixture.headRepository ?? "NVIDIA/NemoClaw";
   const [headRepositoryOwner, headRepositoryName] = headRepository.split("/");
@@ -300,6 +388,10 @@ function runGate(fixture: ComplianceFixture) {
   };
   const finalPr = { ...pr, ...fixture.finalPr };
   const finalPrAfterCurrentBase = { ...finalPr, ...fixture.finalPrAfterCurrentBase };
+  const finalPrAfterCiEvidence = {
+    ...finalPrAfterCurrentBase,
+    ...fixture.finalPrAfterCiEvidence,
+  };
   const contributorCommitPages = (
     fixture.contributorCommitPages ?? [
       [
@@ -369,7 +461,10 @@ function runGate(fixture: ComplianceFixture) {
   const formerCoordinationCheckPages = fixture.formerCoordinationCheckPages ?? [
     { total_count: 0, check_runs: [] },
   ];
-  const actionRunCases = Object.entries({
+  const finalCoordinationCheckPages = fixture.finalCoordinationCheckPages ?? coordinationCheckPages;
+  const finalFormerCoordinationCheckPages =
+    fixture.finalFormerCoordinationCheckPages ?? formerCoordinationCheckPages;
+  const actionRunFixtures: Record<string, ActionRunFixture> = {
     "90": prWorkflowRun(
       "success",
       [
@@ -392,50 +487,71 @@ function runGate(fixture: ComplianceFixture) {
       path: ".github/workflows/dco-check.yaml",
     },
     "94": exactDiffGateRun("success", [{ id: 1, name: "E2E / PR Gate" }]),
+    "9500": e2eCoordinatorRun(),
     ...fixture.actionRunAttempts,
-  })
+  };
+  const actionRunData = (runId: string, value: ActionRunFixture): Record<string, unknown> => ({
+    id: Number(runId),
+    run_attempt: value.attempt,
+    ...(value.omitCreatedAt
+      ? {}
+      : {
+          created_at: value.createdAt === undefined ? "2026-01-01T00:01:00Z" : value.createdAt,
+        }),
+    ...(value.omitUpdatedAt
+      ? {}
+      : {
+          updated_at: value.updatedAt === undefined ? "2026-01-01T00:03:00Z" : value.updatedAt,
+        }),
+    event: value.event,
+    path: value.path,
+    status: value.status,
+    conclusion: value.conclusion,
+    display_title: value.displayTitle,
+    repository: { full_name: value.repository ?? "NVIDIA/NemoClaw" },
+    ...(value.headSha ? { head_sha: value.headSha } : {}),
+    ...(value.headBranch ? { head_branch: value.headBranch } : {}),
+    ...(value.headRepository ? { head_repository: { full_name: value.headRepository } } : {}),
+    ...(value.pullRequests !== undefined
+      ? { pull_requests: value.pullRequests }
+      : value.headSha
+        ? {
+            pull_requests: value.baseSha
+              ? [
+                  {
+                    number: 42,
+                    head: { sha: value.pullRequestHeadSha ?? value.headSha },
+                    base: { sha: value.baseSha },
+                  },
+                ]
+              : [],
+          }
+        : {}),
+  });
+  const actionRunCases = Object.entries(actionRunFixtures)
     .flatMap(([runId, value]) => {
       const jobPages = (value.jobPages ?? [value.jobs ?? []]).map((page) =>
-        page.map((job) => ({
+        page.map(({ startedAt, completedAt, omitStartedAt, omitCompletedAt, ...job }) => ({
           ...job,
           status: job.status ?? "completed",
           conclusion: job.conclusion === undefined ? "success" : job.conclusion,
+          ...(omitStartedAt
+            ? {}
+            : { started_at: startedAt === undefined ? "2026-01-01T00:01:00Z" : startedAt }),
+          ...(omitCompletedAt
+            ? {}
+            : {
+                completed_at: completedAt === undefined ? "2026-01-01T00:03:00Z" : completedAt,
+              }),
         })),
       );
       const jobs = jobPages.flat();
-      const runData = {
-        run_attempt: value.attempt,
-        created_at: value.createdAt ?? "2026-01-01T00:01:00Z",
-        updated_at: value.updatedAt ?? "2026-01-01T00:03:00Z",
-        event: value.event,
-        path: value.path,
-        status: value.status,
-        conclusion: value.conclusion,
-        display_title: value.displayTitle,
-        ...(value.headSha ? { head_sha: value.headSha } : {}),
-        ...(value.headBranch ? { head_branch: value.headBranch } : {}),
-        ...(value.headRepository ? { head_repository: { full_name: value.headRepository } } : {}),
-        ...(value.pullRequests !== undefined
-          ? { pull_requests: value.pullRequests }
-          : value.headSha
-            ? {
-                pull_requests: value.baseSha
-                  ? [
-                      {
-                        number: 42,
-                        head: { sha: value.pullRequestHeadSha ?? value.headSha },
-                        base: { sha: value.baseSha },
-                      },
-                    ]
-                  : [],
-              }
-            : {}),
-      };
+      const runData = actionRunData(runId, value);
       const refreshedRunData = {
         ...runData,
         run_attempt: value.nextAttempt ?? value.attempt,
-        created_at: value.nextCreatedAt ?? runData.created_at,
-        updated_at: value.nextUpdatedAt ?? runData.updated_at,
+        ...(value.nextCreatedAt === undefined ? {} : { created_at: value.nextCreatedAt }),
+        ...(value.nextUpdatedAt === undefined ? {} : { updated_at: value.nextUpdatedAt }),
         display_title: value.nextDisplayTitle ?? runData.display_title,
         status: value.nextStatus ?? runData.status,
         conclusion: value.nextConclusion === undefined ? runData.conclusion : value.nextConclusion,
@@ -454,13 +570,106 @@ function runGate(fixture: ComplianceFixture) {
       ];
     })
     .join("\n");
+  const coordinatorRunPages = fixture.coordinatorRunPages ?? [[9500]];
+  const configuredCoordinatorRunPartitions = fixture.coordinatorRunPartitions ?? [
+    {
+      createdRange: "2025-12-31T00:00:00Z..2025-12-31T12:00:00Z",
+      runPages: [[]],
+    },
+    {
+      createdRange: "2025-12-31T12:00:00Z..2026-01-01T00:00:00Z",
+      runPages: [[]],
+    },
+    {
+      createdRange: "2026-01-01T00:00:00Z..2026-01-01T00:03:00Z",
+      runPages: coordinatorRunPages,
+    },
+  ];
+  const coordinatorRunPartitions = [...configuredCoordinatorRunPartitions];
+  const coordinatorCreatedRanges = [
+    ...new Set(configuredCoordinatorRunPartitions.map((partition) => partition.createdRange)),
+  ];
+  for (const event of ["workflow_run", "workflow_dispatch"] as const) {
+    for (const createdRange of coordinatorCreatedRanges) {
+      if (
+        !coordinatorRunPartitions.some(
+          (partition) =>
+            (partition.event ?? "workflow_run") === event &&
+            partition.createdRange === createdRange,
+        )
+      ) {
+        coordinatorRunPartitions.push({ createdRange, event, runPages: [[]] });
+      }
+    }
+  }
+  const coordinatorWorkflowRunCases = coordinatorRunPartitions
+    .map((partition, partitionIndex) => {
+      const fallbackCreatedAt =
+        partition.fallbackCreatedAt ?? partition.createdRange.split("..")[0];
+      const event = partition.event ?? "workflow_run";
+      const responsePages = (
+        runPages: number[][],
+        totalCount: number | undefined,
+        pageTotalCounts: number[] | undefined,
+        runOverrides: Record<string, Partial<ActionRunFixture>> | undefined,
+      ) => {
+        const partitionTotal = totalCount ?? runPages.flat().length;
+        return runPages.map((page, pageIndex) => ({
+          total_count: pageTotalCounts?.[pageIndex] ?? partitionTotal,
+          workflow_runs: page.map((runId) => {
+            const listedValue =
+              fixture.coordinatorListAttempts?.[String(runId)] ?? actionRunFixtures[String(runId)];
+            const value =
+              listedValue && runOverrides?.[String(runId)]
+                ? { ...listedValue, ...runOverrides[String(runId)] }
+                : listedValue;
+            return value
+              ? actionRunData(String(runId), value)
+              : {
+                  id: runId,
+                  created_at: fallbackCreatedAt,
+                  display_title: `unrelated workflow run ${runId}`,
+                  event,
+                };
+          }),
+        }));
+      };
+      const pages = responsePages(
+        partition.runPages,
+        partition.totalCount,
+        partition.pageTotalCounts,
+        partition.runOverrides,
+      );
+      const finalPages = responsePages(
+        partition.finalRunPages ?? partition.runPages,
+        partition.finalTotalCount ?? partition.totalCount,
+        partition.finalPageTotalCounts ?? partition.pageTotalCounts,
+        partition.finalRunOverrides ?? partition.runOverrides,
+      );
+      const query =
+        "api --paginate --slurp repos/NVIDIA/NemoClaw/actions/workflows/pr-e2e-gate.yaml/runs?event=" +
+        event +
+        "&created=" +
+        encodeURIComponent(partition.createdRange) +
+        "&per_page=100";
+      const marker = path.join(tmp, `coordinator-partition-${partitionIndex}-seen`);
+      return `  ${shellSingleQuote(query)}) if mkdir ${shellSingleQuote(marker)} 2>/dev/null; then printf '%s' ${shellSingleQuote(JSON.stringify(pages))}; else printf '%s' ${shellSingleQuote(JSON.stringify(finalPages))}; fi ;;`;
+    })
+    .join("\n");
+  const coordinationCheckMarker = path.join(tmp, "coordination-checks-seen");
+  const formerCoordinationCheckMarker = path.join(tmp, "former-coordination-checks-seen");
+  const finalPrReadMarker = path.join(tmp, "final-pr-read");
 
   fs.writeFileSync(
     ghPath,
     `#!/usr/bin/env bash
 set -euo pipefail
+if [ -d ${shellSingleQuote(finalPrReadMarker)} ]; then
+  echo "unexpected gh args after final PR read: $*" >&2
+  exit 9
+fi
 case "$*" in
-  "pr view"*) if mkdir ${shellSingleQuote(path.join(tmp, "pr-view-seen"))} 2>/dev/null; then printf '%s' ${shellSingleQuote(JSON.stringify(pr))}; elif [ -d ${shellSingleQuote(path.join(tmp, "current-base-seen"))} ]; then printf '%s' ${shellSingleQuote(JSON.stringify(finalPrAfterCurrentBase))}; else printf '%s' ${shellSingleQuote(JSON.stringify(finalPr))}; fi ;;
+  "pr view"*) if mkdir ${shellSingleQuote(path.join(tmp, "pr-view-seen"))} 2>/dev/null; then printf '%s' ${shellSingleQuote(JSON.stringify(pr))}; elif mkdir ${shellSingleQuote(path.join(tmp, "pr-before-final-ci-seen"))} 2>/dev/null; then printf '%s' ${shellSingleQuote(JSON.stringify(finalPrAfterCurrentBase))}; else mkdir -p ${shellSingleQuote(finalPrReadMarker)}; printf '%s' ${shellSingleQuote(JSON.stringify(finalPrAfterCiEvidence))}; fi ;;
   *"ContributorCommits"*) printf '%s' ${shellSingleQuote(contributorCommitOutput)} ;;
   *"ContributorReviews"*) printf '%s' ${shellSingleQuote(contributorReviewOutput)} ;;
   *"CurrentBaseRef"*) mkdir -p ${shellSingleQuote(path.join(tmp, "current-base-seen"))}; printf '%s' ${shellSingleQuote(currentBaseOutput)} ;;
@@ -468,8 +677,9 @@ case "$*" in
   "api repos/NVIDIA/NemoClaw/issues/42/comments"*) printf '%s' '{"id":1,"body":"ordinary comment","user":{"login":"reviewer"},"updated_at":"2026-01-01T00:00:00Z"}' ;;
   "api repos/NVIDIA/NemoClaw/pulls/42/commits"*) printf '%s' ${shellSingleQuote(commitOutput)} ;;
   "api --paginate --slurp repos/NVIDIA/NemoClaw/issues/42/events?per_page=100") printf '%s' ${shellSingleQuote(JSON.stringify(issueEventPages))} ;;
-  "api --paginate --slurp repos/NVIDIA/NemoClaw/commits/${HEAD_SHA}/check-runs?check_name=E2E%20%2F%20PR%20Gate&filter=all&per_page=100") printf '%s' ${shellSingleQuote(JSON.stringify(coordinationCheckPages))} ;;
-  "api --paginate --slurp repos/NVIDIA/NemoClaw/commits/${HEAD_SHA}/check-runs?check_name=E2E%20%2F%20PR%20Gate%20Coordination&filter=all&per_page=100") printf '%s' ${shellSingleQuote(JSON.stringify(formerCoordinationCheckPages))} ;;
+  "api --paginate --slurp repos/NVIDIA/NemoClaw/commits/${HEAD_SHA}/check-runs?check_name=E2E%20%2F%20PR%20Gate&filter=all&per_page=100") if mkdir ${shellSingleQuote(coordinationCheckMarker)} 2>/dev/null; then printf '%s' ${shellSingleQuote(JSON.stringify(coordinationCheckPages))}; else printf '%s' ${shellSingleQuote(JSON.stringify(finalCoordinationCheckPages))}; fi ;;
+  "api --paginate --slurp repos/NVIDIA/NemoClaw/commits/${HEAD_SHA}/check-runs?check_name=E2E%20%2F%20PR%20Gate%20Coordination&filter=all&per_page=100") if mkdir ${shellSingleQuote(formerCoordinationCheckMarker)} 2>/dev/null; then printf '%s' ${shellSingleQuote(JSON.stringify(formerCoordinationCheckPages))}; else printf '%s' ${shellSingleQuote(JSON.stringify(finalFormerCoordinationCheckPages))}; fi ;;
+${coordinatorWorkflowRunCases}
 ${actionRunCases}
   *) echo "unexpected gh args: $*" >&2; exit 9 ;;
 esac
@@ -481,6 +691,8 @@ esac
     return spawnSync(
       process.execPath,
       [
+        "--import",
+        clockPath,
         "--experimental-strip-types",
         "--no-warnings",
         ".agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts",
@@ -563,6 +775,7 @@ export type {
   ActionRunFixture,
   ComparatorFixture,
   ComplianceFixture,
+  CoordinatorRunPartitionFixture,
   E2eCheckFixture,
 };
 export {
@@ -572,6 +785,8 @@ export {
   E2E_COORDINATION_EXTERNAL_ID,
   E2E_COORDINATION_NAME,
   e2eChecks,
+  e2eCoordinatorRun,
+  e2eManualCoordinatorRun,
   e2eGateCheck,
   e2eJobs,
   e2eRunFixture,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make the maintainer merge check verify the complete E2E coordinator history and the final pull request state. This prevents a passing result when coordinator evidence is ambiguous or another repository check changes before the merge decision.

## Changes

- Accept a fork approval only when one automatic coordinator is followed by the sole enclosing manual approval coordinator.
- Reject missing, duplicate, malformed, queued, or ambiguous coordinator evidence across the bounded paginated history.
- Re-evaluate the complete check rollup from the final pull request snapshot and require the required checks to remain unchanged.
- Add regression fixtures for fork approval timing, duplicate predecessors, pagination limits, queued runs, and late pending or failing checks.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal maintainer merge check and does not change a supported user surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop security review passed all nine categories for `f3b9686b3`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The changed maintainer script and test fixtures do not alter user-facing behavior or documentation.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f3b9686b3dac3061c8c9d1e57bd4face0aec9e70 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70934b540c404d3939e3321f5c7558 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: GitHub CI pending.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: GitHub CI pending.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI gate validation to detect stale, incomplete, duplicated, or conflicting workflow evidence.
  * Added stronger validation for required checks, E2E results, pull request revisions, and final CI status.
  * Improved handling of paginated workflow results and repeated observations for more reliable merge decisions.

* **Tests**
  * Expanded automated coverage for valid and invalid CI evidence, timestamp edge cases, retries, pagination, and changing check results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->