### PR TITLE
feat(onboard): define native artifact workload contract

### DIFF
--- a/src/lib/onboard/workload/native-artifact.test.ts
+++ b/src/lib/onboard/workload/native-artifact.test.ts
@@ -61,7 +61,7 @@ function executable(value: Record<string, unknown>): Record<string, unknown> {
 }
 
 describe("native OpenClaw artifact workload contract", () => {
-  it("accepts a Windows artifact receipt with fixed digests and credential-free launch data (#8178)", () => {
+  it("accepts exact artifact identity and validated launch intent (#8178)", () => {
     const expected = receipt();
     expect(parseNativeArtifactWorkloadReceiptV1(expected)).toEqual(expected);
   });

--- a/src/lib/onboard/workload/native-artifact.test.ts
+++ b/src/lib/onboard/workload/native-artifact.test.ts
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import { encodeManagedStartupProfile } from "../managed-startup/profile";
+import {
+  NATIVE_ARTIFACT_SOURCE_REPOSITORY,
+  NATIVE_ARTIFACT_WORKLOAD_AGENT,
+  NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
+  NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
+  NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION,
+  NativeArtifactWorkloadContractError,
+  parseNativeArtifactWorkloadReceiptV1,
+} from "./native-artifact";
+
+function receipt(): Record<string, unknown> {
+  const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile("openclaw"));
+  return {
+    schemaVersion: 1,
+    kind: "native-artifact",
+    contractVersion: 1,
+    agent: "openclaw",
+    platform: "windows/x64",
+    artifact: {
+      digest: `sha256:${"a".repeat(64)}`,
+      version: "2026.7.1",
+      source: {
+        repository: "NVIDIA/NemoClaw",
+        revision: "b".repeat(40),
+      },
+    },
+    launch: {
+      executable: {
+        relativePath: "runtime/node.exe",
+        digest: `sha256:${"c".repeat(64)}`,
+      },
+      arguments: ["agent/openclaw.mjs", "gateway", "run"],
+      workingDirectory: ".",
+      environmentNames: ["NEMOCLAW_MANAGED_STARTUP_PROFILE"],
+    },
+    startupProfileContractVersion: 1,
+    encodedProfile,
+    startupProfileSha256: createHash("sha256").update(encodedProfile, "utf8").digest("hex"),
+    credentialProxyReplayRequired: true,
+    shared: true,
+  };
+}
+
+function artifact(value: Record<string, unknown>): Record<string, unknown> {
+  return value.artifact as Record<string, unknown>;
+}
+
+function source(value: Record<string, unknown>): Record<string, unknown> {
+  return artifact(value).source as Record<string, unknown>;
+}
+
+function launch(value: Record<string, unknown>): Record<string, unknown> {
+  return value.launch as Record<string, unknown>;
+}
+
+function executable(value: Record<string, unknown>): Record<string, unknown> {
+  return launch(value).executable as Record<string, unknown>;
+}
+
+describe("native OpenClaw artifact workload contract", () => {
+  it("accepts an immutable Windows artifact and credential-free launch receipt (#8178)", () => {
+    const parsed = parseNativeArtifactWorkloadReceiptV1(receipt());
+    expect(parsed).toMatchObject({
+      schemaVersion: NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION,
+      contractVersion: NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
+      agent: NATIVE_ARTIFACT_WORKLOAD_AGENT,
+      platform: NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
+      artifact: { source: { repository: NATIVE_ARTIFACT_SOURCE_REPOSITORY } },
+    });
+    expect(parsed.launch).toEqual({
+      executable: {
+        relativePath: "runtime/node.exe",
+        digest: `sha256:${"c".repeat(64)}`,
+      },
+      arguments: ["agent/openclaw.mjs", "gateway", "run"],
+      workingDirectory: ".",
+      environmentNames: ["NEMOCLAW_MANAGED_STARTUP_PROFILE"],
+    });
+  });
+
+  it.each([
+    [
+      "artifact digest",
+      (value: Record<string, unknown>) => (artifact(value).digest = "sha256:abc"),
+    ],
+    [
+      "executable digest",
+      (value: Record<string, unknown>) => (executable(value).digest = "c".repeat(64)),
+    ],
+    ["source revision", (value: Record<string, unknown>) => (source(value).revision = "main")],
+    ["agent version", (value: Record<string, unknown>) => (artifact(value).version = "latest")],
+  ])("rejects an inexact %s (#8178)", (_label, mutate) => {
+    const value = receipt();
+    mutate(value);
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+      NativeArtifactWorkloadContractError,
+    );
+  });
+
+  it.each([
+    "C:\\agent\\node.exe",
+    "/agent/node.exe",
+    "../agent/node.exe",
+    "agent/../node.exe",
+    "agent//node.exe",
+  ])("rejects non-canonical executable path %j (#8178)", (relativePath) => {
+    const value = receipt();
+    executable(value).relativePath = relativePath;
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
+  });
+
+  it("records environment-variable names without accepting literal assignments (#8178)", () => {
+    const value = receipt();
+    launch(value).environmentNames = ["NVIDIA_API_KEY=credential"];
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+      /environmentNames\[0\] has an unsupported format/u,
+    );
+  });
+
+  it("rejects duplicate environment-variable names (#8178)", () => {
+    const value = receipt();
+    launch(value).environmentNames = ["PATH", "PATH"];
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+      /must not contain duplicates/u,
+    );
+  });
+
+  it("requires canonical uppercase environment-variable names (#8178)", () => {
+    const value = receipt();
+    launch(value).environmentNames = ["Path"];
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+      /environmentNames\[0\] has an unsupported format/u,
+    );
+  });
+
+  it("rejects a startup profile for another agent (#8178)", () => {
+    const value = receipt();
+    const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile("hermes"));
+    value.encodedProfile = encodedProfile;
+    value.startupProfileSha256 = createHash("sha256").update(encodedProfile, "utf8").digest("hex");
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+      /belongs to 'hermes', not 'openclaw'/u,
+    );
+  });
+
+  it("rejects a startup profile whose digest does not match (#8178)", () => {
+    const value = receipt();
+    value.startupProfileSha256 = "d".repeat(64);
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+      /does not match contract.encodedProfile/u,
+    );
+  });
+
+  it("rejects OCI image and mutable download fields (#8178)", () => {
+    for (const extra of ["image", "imageDigest", "downloadUrl"]) {
+      const value = receipt();
+      value[extra] = "unexpected";
+      expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+        /contract must contain exactly/u,
+      );
+    }
+  });
+
+  it("requires credential proxy replay and shared immutable ownership (#8178)", () => {
+    for (const field of ["credentialProxyReplayRequired", "shared"] as const) {
+      const value = receipt();
+      value[field] = false;
+      expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+        new RegExp(`contract\\.${field} must be true`, "u"),
+      );
+    }
+  });
+});

--- a/src/lib/onboard/workload/native-artifact.test.ts
+++ b/src/lib/onboard/workload/native-artifact.test.ts
@@ -7,11 +7,6 @@ import { describe, expect, it } from "vitest";
 import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import { encodeManagedStartupProfile } from "../managed-startup/profile";
 import {
-  NATIVE_ARTIFACT_SOURCE_REPOSITORY,
-  NATIVE_ARTIFACT_WORKLOAD_AGENT,
-  NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
-  NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
-  NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION,
   NativeArtifactWorkloadContractError,
   parseNativeArtifactWorkloadReceiptV1,
 } from "./native-artifact";
@@ -67,23 +62,8 @@ function executable(value: Record<string, unknown>): Record<string, unknown> {
 
 describe("native OpenClaw artifact workload contract", () => {
   it("accepts an immutable Windows artifact and credential-free launch receipt (#8178)", () => {
-    const parsed = parseNativeArtifactWorkloadReceiptV1(receipt());
-    expect(parsed).toMatchObject({
-      schemaVersion: NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION,
-      contractVersion: NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
-      agent: NATIVE_ARTIFACT_WORKLOAD_AGENT,
-      platform: NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
-      artifact: { source: { repository: NATIVE_ARTIFACT_SOURCE_REPOSITORY } },
-    });
-    expect(parsed.launch).toEqual({
-      executable: {
-        relativePath: "runtime/node.exe",
-        digest: `sha256:${"c".repeat(64)}`,
-      },
-      arguments: ["agent/openclaw.mjs", "gateway", "run"],
-      workingDirectory: ".",
-      environmentNames: ["NEMOCLAW_MANAGED_STARTUP_PROFILE"],
-    });
+    const expected = receipt();
+    expect(parseNativeArtifactWorkloadReceiptV1(expected)).toEqual(expected);
   });
 
   it.each([
@@ -97,6 +77,10 @@ describe("native OpenClaw artifact workload contract", () => {
     ],
     ["source revision", (value: Record<string, unknown>) => (source(value).revision = "main")],
     ["agent version", (value: Record<string, unknown>) => (artifact(value).version = "latest")],
+    [
+      "oversized agent version",
+      (value: Record<string, unknown>) => (artifact(value).version = `1.2.3-${"a".repeat(257)}`),
+    ],
   ])("rejects an inexact %s (#8178)", (_label, mutate) => {
     const value = receipt();
     mutate(value);
@@ -112,6 +96,30 @@ describe("native OpenClaw artifact workload contract", () => {
     "agent/../node.exe",
     "agent//node.exe",
   ])("rejects non-canonical executable path %j (#8178)", (relativePath) => {
+    const value = receipt();
+    executable(value).relativePath = relativePath;
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
+  });
+
+  it.each([
+    "../agent",
+    "agent/../work",
+    "agent//work",
+    "agent/work.",
+    "agent/work ",
+  ])("rejects non-canonical working directory %j (#8178)", (workingDirectory) => {
+    const value = receipt();
+    launch(value).workingDirectory = workingDirectory;
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
+  });
+
+  it.each([
+    "bin/claw.exe.",
+    "bin/claw.exe ",
+    "bin/CON",
+    "bin/nul.txt",
+    "COM1/runtime",
+  ])("rejects Windows-normalizing executable path %j (#8178)", (relativePath) => {
     const value = receipt();
     executable(value).relativePath = relativePath;
     expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
@@ -136,6 +144,14 @@ describe("native OpenClaw artifact workload contract", () => {
   it("requires canonical uppercase environment-variable names (#8178)", () => {
     const value = receipt();
     launch(value).environmentNames = ["Path"];
+    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
+      /environmentNames\[0\] has an unsupported format/u,
+    );
+  });
+
+  it("rejects an oversized environment-variable name (#8178)", () => {
+    const value = receipt();
+    launch(value).environmentNames = ["A".repeat(257)];
     expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
       /environmentNames\[0\] has an unsupported format/u,
     );

--- a/src/lib/onboard/workload/native-artifact.test.ts
+++ b/src/lib/onboard/workload/native-artifact.test.ts
@@ -61,7 +61,7 @@ function executable(value: Record<string, unknown>): Record<string, unknown> {
 }
 
 describe("native OpenClaw artifact workload contract", () => {
-  it("accepts an immutable Windows artifact and credential-free launch receipt (#8178)", () => {
+  it("accepts a Windows artifact receipt with fixed digests and credential-free launch data (#8178)", () => {
     const expected = receipt();
     expect(parseNativeArtifactWorkloadReceiptV1(expected)).toEqual(expected);
   });
@@ -76,9 +76,9 @@ describe("native OpenClaw artifact workload contract", () => {
       (value: Record<string, unknown>) => (executable(value).digest = "c".repeat(64)),
     ],
     ["source revision", (value: Record<string, unknown>) => (source(value).revision = "main")],
-    ["agent version", (value: Record<string, unknown>) => (artifact(value).version = "latest")],
+    ["artifact version", (value: Record<string, unknown>) => (artifact(value).version = "latest")],
     [
-      "oversized agent version",
+      "oversized artifact version",
       (value: Record<string, unknown>) => (artifact(value).version = `1.2.3-${"a".repeat(257)}`),
     ],
   ])("rejects an inexact %s (#8178)", (_label, mutate) => {
@@ -185,7 +185,7 @@ describe("native OpenClaw artifact workload contract", () => {
     }
   });
 
-  it("requires credential proxy replay and shared immutable ownership (#8178)", () => {
+  it("requires credential proxy replay and the shared artifact flag (#8178)", () => {
     for (const field of ["credentialProxyReplayRequired", "shared"] as const) {
       const value = receipt();
       value[field] = false;

--- a/src/lib/onboard/workload/native-artifact.ts
+++ b/src/lib/onboard/workload/native-artifact.ts
@@ -296,10 +296,9 @@ export function parseNativeArtifactWorkloadReceiptV1(
   try {
     profile = decodeManagedStartupProfile(contract.encodedProfile);
   } catch (error) {
-    throw new NativeArtifactWorkloadContractError(
-      "contract.encodedProfile failed closed validation",
-      { cause: error },
-    );
+    throw new NativeArtifactWorkloadContractError("contract.encodedProfile failed validation", {
+      cause: error,
+    });
   }
   if (
     createHash("sha256").update(contract.encodedProfile, "utf8").digest("hex") !==

--- a/src/lib/onboard/workload/native-artifact.ts
+++ b/src/lib/onboard/workload/native-artifact.ts
@@ -45,7 +45,7 @@ export interface NativeArtifactWorkloadReceiptV1 {
     };
     readonly arguments: readonly string[];
     readonly workingDirectory: string;
-    /** Names only. Credential values and literal environment assignments are not receipt data. */
+    /** Environment-variable names only; literal assignments are not accepted. */
     readonly environmentNames: readonly string[];
   };
   readonly startupProfileContractVersion: typeof MANAGED_STARTUP_PROFILE_SCHEMA_VERSION;

--- a/src/lib/onboard/workload/native-artifact.ts
+++ b/src/lib/onboard/workload/native-artifact.ts
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+
+import {
+  decodeManagedStartupProfile,
+  MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
+} from "../managed-startup/profile";
+
+export const NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION = 1 as const;
+export const NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION = 1 as const;
+export const NATIVE_ARTIFACT_WORKLOAD_PLATFORM = "windows/x64" as const;
+export const NATIVE_ARTIFACT_WORKLOAD_AGENT = "openclaw" as const;
+export const NATIVE_ARTIFACT_SOURCE_REPOSITORY = "NVIDIA/NemoClaw" as const;
+
+export type NativeArtifactDigest = `sha256:${string}`;
+
+/**
+ * Inactive OpenClaw-on-Windows workload receipt.
+ *
+ * This schema records immutable identity and launch intent. The future staging
+ * authority must verify each digest before a runtime provider consumes it.
+ */
+export interface NativeArtifactWorkloadReceiptV1 {
+  readonly schemaVersion: typeof NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION;
+  readonly kind: "native-artifact";
+  readonly contractVersion: typeof NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION;
+  readonly agent: typeof NATIVE_ARTIFACT_WORKLOAD_AGENT;
+  readonly platform: typeof NATIVE_ARTIFACT_WORKLOAD_PLATFORM;
+  readonly artifact: {
+    readonly digest: NativeArtifactDigest;
+    readonly version: string;
+    readonly source: {
+      readonly repository: typeof NATIVE_ARTIFACT_SOURCE_REPOSITORY;
+      readonly revision: string;
+    };
+  };
+  readonly launch: {
+    readonly executable: {
+      /** Canonical path beneath the verified artifact root. */
+      readonly relativePath: string;
+      readonly digest: NativeArtifactDigest;
+    };
+    readonly arguments: readonly string[];
+    readonly workingDirectory: string;
+    /** Names only. Credential values and literal environment assignments are not receipt data. */
+    readonly environmentNames: readonly string[];
+  };
+  readonly startupProfileContractVersion: typeof MANAGED_STARTUP_PROFILE_SCHEMA_VERSION;
+  readonly encodedProfile: string;
+  readonly startupProfileSha256: string;
+  readonly credentialProxyReplayRequired: true;
+  readonly shared: true;
+}
+
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const REVISION_PATTERN = /^[0-9a-f]{40}$/u;
+const VERSION_PATTERN = /^[0-9]+(?:\.[0-9]+){2,3}(?:[-.][0-9A-Za-z][0-9A-Za-z.-]*)?$/u;
+const ENVIRONMENT_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/u;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
+const MAX_PATH_BYTES = 4096;
+const MAX_ARGUMENT_BYTES = 4096;
+const MAX_ARGUMENTS = 128;
+const MAX_ENVIRONMENT_NAMES = 128;
+
+export class NativeArtifactWorkloadContractError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(`Invalid native artifact workload contract: ${message}`, options);
+    this.name = "NativeArtifactWorkloadContractError";
+  }
+}
+
+function requireRecord(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new NativeArtifactWorkloadContractError(`${field} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new NativeArtifactWorkloadContractError(`${field} must be a plain object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireExactKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[],
+  field: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...expectedKeys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new NativeArtifactWorkloadContractError(
+      `${field} must contain exactly: ${expected.join(", ")}`,
+    );
+  }
+}
+
+function requireLiteral<T extends string | number | boolean>(
+  value: unknown,
+  expected: T,
+  field: string,
+): T {
+  if (value !== expected) {
+    throw new NativeArtifactWorkloadContractError(`${field} must be ${JSON.stringify(expected)}`);
+  }
+  return expected;
+}
+
+function requirePattern(value: unknown, pattern: RegExp, field: string): string {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new NativeArtifactWorkloadContractError(`${field} has an unsupported format`);
+  }
+  return value;
+}
+
+function requireRelativePath(value: unknown, field: string, allowDot = false): string {
+  if (
+    typeof value !== "string" ||
+    Buffer.byteLength(value, "utf8") > MAX_PATH_BYTES ||
+    CONTROL_CHARACTER_PATTERN.test(value) ||
+    value.includes("\\") ||
+    value.includes(":") ||
+    value.startsWith("/")
+  ) {
+    throw new NativeArtifactWorkloadContractError(`${field} must be a canonical relative path`);
+  }
+  if (allowDot && value === ".") return value;
+  const segments = value.split("/");
+  if (
+    segments.length === 0 ||
+    segments.some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    throw new NativeArtifactWorkloadContractError(`${field} must be a canonical relative path`);
+  }
+  return value;
+}
+
+function requireArguments(value: unknown): readonly string[] {
+  if (!Array.isArray(value) || value.length > MAX_ARGUMENTS) {
+    throw new NativeArtifactWorkloadContractError(
+      `contract.launch.arguments must contain at most ${MAX_ARGUMENTS} strings`,
+    );
+  }
+  return value.map((argument, index) => {
+    if (
+      typeof argument !== "string" ||
+      Buffer.byteLength(argument, "utf8") > MAX_ARGUMENT_BYTES ||
+      CONTROL_CHARACTER_PATTERN.test(argument)
+    ) {
+      throw new NativeArtifactWorkloadContractError(
+        `contract.launch.arguments[${index}] has an unsupported format`,
+      );
+    }
+    return argument;
+  });
+}
+
+function requireEnvironmentNames(value: unknown): readonly string[] {
+  if (!Array.isArray(value) || value.length > MAX_ENVIRONMENT_NAMES) {
+    throw new NativeArtifactWorkloadContractError(
+      `contract.launch.environmentNames must contain at most ${MAX_ENVIRONMENT_NAMES} names`,
+    );
+  }
+  const names = value.map((name, index) =>
+    requirePattern(name, ENVIRONMENT_NAME_PATTERN, `contract.launch.environmentNames[${index}]`),
+  );
+  if (new Set(names).size !== names.length) {
+    throw new NativeArtifactWorkloadContractError(
+      "contract.launch.environmentNames must not contain duplicates",
+    );
+  }
+  return names;
+}
+
+export function parseNativeArtifactWorkloadReceiptV1(
+  value: unknown,
+): NativeArtifactWorkloadReceiptV1 {
+  const contract = requireRecord(value, "contract");
+  requireExactKeys(
+    contract,
+    [
+      "agent",
+      "artifact",
+      "contractVersion",
+      "credentialProxyReplayRequired",
+      "encodedProfile",
+      "kind",
+      "launch",
+      "platform",
+      "schemaVersion",
+      "shared",
+      "startupProfileContractVersion",
+      "startupProfileSha256",
+    ],
+    "contract",
+  );
+  requireLiteral(
+    contract.schemaVersion,
+    NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION,
+    "contract.schemaVersion",
+  );
+  requireLiteral(contract.kind, "native-artifact", "contract.kind");
+  requireLiteral(
+    contract.contractVersion,
+    NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
+    "contract.contractVersion",
+  );
+  const agent = requireLiteral(contract.agent, NATIVE_ARTIFACT_WORKLOAD_AGENT, "contract.agent");
+  const platform = requireLiteral(
+    contract.platform,
+    NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
+    "contract.platform",
+  );
+
+  const artifact = requireRecord(contract.artifact, "contract.artifact");
+  requireExactKeys(artifact, ["digest", "source", "version"], "contract.artifact");
+  const artifactDigest = requirePattern(
+    artifact.digest,
+    DIGEST_PATTERN,
+    "contract.artifact.digest",
+  );
+  const artifactVersion = requirePattern(
+    artifact.version,
+    VERSION_PATTERN,
+    "contract.artifact.version",
+  );
+  const source = requireRecord(artifact.source, "contract.artifact.source");
+  requireExactKeys(source, ["repository", "revision"], "contract.artifact.source");
+  const sourceRepository = requireLiteral(
+    source.repository,
+    NATIVE_ARTIFACT_SOURCE_REPOSITORY,
+    "contract.artifact.source.repository",
+  );
+  const sourceRevision = requirePattern(
+    source.revision,
+    REVISION_PATTERN,
+    "contract.artifact.source.revision",
+  );
+
+  const launch = requireRecord(contract.launch, "contract.launch");
+  requireExactKeys(
+    launch,
+    ["arguments", "environmentNames", "executable", "workingDirectory"],
+    "contract.launch",
+  );
+  const executable = requireRecord(launch.executable, "contract.launch.executable");
+  requireExactKeys(executable, ["digest", "relativePath"], "contract.launch.executable");
+  const executablePath = requireRelativePath(
+    executable.relativePath,
+    "contract.launch.executable.relativePath",
+  );
+  const executableDigest = requirePattern(
+    executable.digest,
+    DIGEST_PATTERN,
+    "contract.launch.executable.digest",
+  );
+  const argumentsList = requireArguments(launch.arguments);
+  const workingDirectory = requireRelativePath(
+    launch.workingDirectory,
+    "contract.launch.workingDirectory",
+    true,
+  );
+  const environmentNames = requireEnvironmentNames(launch.environmentNames);
+
+  const startupProfileContractVersion = requireLiteral(
+    contract.startupProfileContractVersion,
+    MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
+    "contract.startupProfileContractVersion",
+  );
+  const startupProfileSha256 = requirePattern(
+    contract.startupProfileSha256,
+    SHA256_PATTERN,
+    "contract.startupProfileSha256",
+  );
+  if (typeof contract.encodedProfile !== "string") {
+    throw new NativeArtifactWorkloadContractError("contract.encodedProfile must be a string");
+  }
+  if (
+    createHash("sha256").update(contract.encodedProfile, "utf8").digest("hex") !==
+    startupProfileSha256
+  ) {
+    throw new NativeArtifactWorkloadContractError(
+      "contract.startupProfileSha256 does not match contract.encodedProfile",
+    );
+  }
+  try {
+    const profile = decodeManagedStartupProfile(contract.encodedProfile);
+    if (profile.agent !== agent) {
+      throw new NativeArtifactWorkloadContractError(
+        `contract.encodedProfile belongs to '${profile.agent}', not '${agent}'`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof NativeArtifactWorkloadContractError) throw error;
+    throw new NativeArtifactWorkloadContractError(
+      "contract.encodedProfile failed closed validation",
+      { cause: error },
+    );
+  }
+
+  const credentialProxyReplayRequired = requireLiteral(
+    contract.credentialProxyReplayRequired,
+    true,
+    "contract.credentialProxyReplayRequired",
+  );
+  const shared = requireLiteral(contract.shared, true, "contract.shared");
+
+  return {
+    schemaVersion: NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION,
+    kind: "native-artifact",
+    contractVersion: NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
+    agent,
+    platform,
+    artifact: {
+      digest: artifactDigest as NativeArtifactDigest,
+      version: artifactVersion,
+      source: { repository: sourceRepository, revision: sourceRevision },
+    },
+    launch: {
+      executable: {
+        relativePath: executablePath,
+        digest: executableDigest as NativeArtifactDigest,
+      },
+      arguments: argumentsList,
+      workingDirectory,
+      environmentNames,
+    },
+    startupProfileContractVersion,
+    encodedProfile: contract.encodedProfile,
+    startupProfileSha256,
+    credentialProxyReplayRequired,
+    shared,
+  };
+}

--- a/src/lib/onboard/workload/native-artifact.ts
+++ b/src/lib/onboard/workload/native-artifact.ts
@@ -60,9 +60,11 @@ const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
 const REVISION_PATTERN = /^[0-9a-f]{40}$/u;
 const VERSION_PATTERN = /^[0-9]+(?:\.[0-9]+){2,3}(?:[-.][0-9A-Za-z][0-9A-Za-z.-]*)?$/u;
 const ENVIRONMENT_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/u;
+const WINDOWS_RESERVED_PATH_SEGMENT_PATTERN = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/iu;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
 const MAX_PATH_BYTES = 4096;
 const MAX_ARGUMENT_BYTES = 4096;
+const MAX_PATTERN_BYTES = 256;
 const MAX_ARGUMENTS = 128;
 const MAX_ENVIRONMENT_NAMES = 128;
 
@@ -110,7 +112,11 @@ function requireLiteral<T extends string | number | boolean>(
 }
 
 function requirePattern(value: unknown, pattern: RegExp, field: string): string {
-  if (typeof value !== "string" || !pattern.test(value)) {
+  if (
+    typeof value !== "string" ||
+    Buffer.byteLength(value, "utf8") > MAX_PATTERN_BYTES ||
+    !pattern.test(value)
+  ) {
     throw new NativeArtifactWorkloadContractError(`${field} has an unsupported format`);
   }
   return value;
@@ -131,7 +137,15 @@ function requireRelativePath(value: unknown, field: string, allowDot = false): s
   const segments = value.split("/");
   if (
     segments.length === 0 ||
-    segments.some((segment) => segment === "" || segment === "." || segment === "..")
+    segments.some(
+      (segment) =>
+        segment === "" ||
+        segment === "." ||
+        segment === ".." ||
+        segment.endsWith(".") ||
+        segment.endsWith(" ") ||
+        WINDOWS_RESERVED_PATH_SEGMENT_PATTERN.test(segment),
+    )
   ) {
     throw new NativeArtifactWorkloadContractError(`${field} must be a canonical relative path`);
   }
@@ -278,6 +292,15 @@ export function parseNativeArtifactWorkloadReceiptV1(
   if (typeof contract.encodedProfile !== "string") {
     throw new NativeArtifactWorkloadContractError("contract.encodedProfile must be a string");
   }
+  let profile: ReturnType<typeof decodeManagedStartupProfile>;
+  try {
+    profile = decodeManagedStartupProfile(contract.encodedProfile);
+  } catch (error) {
+    throw new NativeArtifactWorkloadContractError(
+      "contract.encodedProfile failed closed validation",
+      { cause: error },
+    );
+  }
   if (
     createHash("sha256").update(contract.encodedProfile, "utf8").digest("hex") !==
     startupProfileSha256
@@ -286,18 +309,9 @@ export function parseNativeArtifactWorkloadReceiptV1(
       "contract.startupProfileSha256 does not match contract.encodedProfile",
     );
   }
-  try {
-    const profile = decodeManagedStartupProfile(contract.encodedProfile);
-    if (profile.agent !== agent) {
-      throw new NativeArtifactWorkloadContractError(
-        `contract.encodedProfile belongs to '${profile.agent}', not '${agent}'`,
-      );
-    }
-  } catch (error) {
-    if (error instanceof NativeArtifactWorkloadContractError) throw error;
+  if (profile.agent !== agent) {
     throw new NativeArtifactWorkloadContractError(
-      "contract.encodedProfile failed closed validation",
-      { cause: error },
+      `contract.encodedProfile belongs to '${profile.agent}', not '${agent}'`,
     );
   }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Defines an inactive, versioned receipt for staging the pinned OpenClaw Windows workload without an OCI image. The parser rejects mutable identity, non-canonical paths, literal environment assignments, and mismatched startup intent; it does not register or activate an MXC provider.

## Related Issue

Related to #8178.

## Changes

- Add the native artifact workload receipt required by the future OpenShell+MXC OpenClaw provider. An OCI receipt is not sufficient because this path identifies a staged Windows executable and its launch intent rather than a container image.
- Bind artifact, executable, source revision, and managed startup-profile identity while restricting environment metadata to variable names. The future staging authority remains responsible for verifying the recorded digests before provider use.
- Add focused tests for the valid receipt and fail-closed handling of mutable or malformed identity, path traversal, environment assignments, duplicate names, startup-profile mismatch, OCI fields, and disabled ownership or credential-replay requirements.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the contract is inactive and unregistered, with no change to a CLI, configuration, workflow, default, error output, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: exact-head maintainer review passed all nine security categories. The schema uses exact keys and bounded inputs, rejects traversal and literal credential assignments, verifies startup-profile identity, adds no dependency or execution path, and remains inactive.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact-head review confirmed that the inactive native-artifact receipt parser has no production consumer and adds no provider registration, CLI, configuration, runtime activation, supported workflow, or documentation surface. The final comments and test titles make field-level claims only; the focused source test passed 29 tests.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e7bde8d85 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/workload/native-artifact.test.ts` passed 29/29; `npm run typecheck:cli`, `npm run build:cli`, `npm --prefix nemoclaw run build`, `npm exec -- biome check` for both changed files, and `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable because this isolated parser is not imported by production code or the runtime registry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for validating Windows/x64 native artifact workload receipts.
  * Validates artifact integrity, launch metadata, executable paths, environment variables, startup profiles, and credential-proxy settings.
  * Rejects unsupported OCI images, mutable downloads, malformed data, and invalid ownership details.
  * Returns normalized receipt information with clear validation errors.

* **Tests**
  * Added comprehensive coverage for valid receipts and invalid or unsupported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



