### PR TITLE
test(e2e): align gateway recovery startup path

### DIFF
--- a/test/e2e/live/gateway-guard-recovery.test.ts
+++ b/test/e2e/live/gateway-guard-recovery.test.ts
@@ -302,7 +302,7 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
     originalContainerId,
     "restart-command-before",
   );
-  expect(originalStartupCommand).toMatch(/(?:^| )nemoclaw-start$/);
+  expect(originalStartupCommand).toMatch(/(?:^| )\/usr\/local\/bin\/nemoclaw-start$/);
   await host.cleanupForward(18789, {
     artifactName: "restart-stop-dashboard-forward",
     env: buildAvailabilityProbeEnv(),
@@ -339,7 +339,7 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
     recoveredContainerId,
     "restart-command-after",
   );
-  expect(recoveredStartupCommand).toMatch(/(?:^| )nemoclaw-start$/);
+  expect(recoveredStartupCommand).toMatch(/(?:^| )\/usr\/local\/bin\/nemoclaw-start$/);
   expect(recoveredStartupCommand).not.toContain("CUSTOM_PROVIDER_CREDENTIAL");
   expect(recoveredStartupCommand).not.toContain(credentialCanary);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The `gateway-guard-recovery` E2E rejected the canonical managed startup command introduced by #8047. This change requires `/usr/local/bin/nemoclaw-start` for the modern container before and after Docker restart, while preserving the separate legacy keepalive compatibility contract.

Failed release-gate job: https://github.com/NVIDIA/NemoClaw/actions/runs/30930457908/job/92070742370

## Changes

- Align the fresh-container startup assertion with the managed executable path produced by onboarding.
- Require the restarted modern container to retain that same canonical executable path.
- Leave the legacy short-form recovery assertion and all credential-canary checks unchanged.
- Change no production code or runtime behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Test-only regression assertion; no user-facing behavior or documentation claim changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop security review passed for validated commit `1c1b4531ceea5e25a34a64358d34f583e798dc44`. The modern path check is strengthened, the legacy compatibility and credential-exclusion checks remain intact, and no production security boundary changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The test-only change requires the managed startup executable path already defined by the implementation. It does not change commands, output, configuration, defaults, workflows, or supported behavior. The focused source contract passed 17 tests.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1c1b4531c -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host-preparation code changed.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 33 CLI source-contract tests, 20 recovery integration tests, and 7 E2E-support tests passed. Semantic phase, title, test-size, source-shape, type, formatting, repository, and secret checks passed.
- [ ] Applicable broad gate passed — not applicable to a two-assertion E2E contract repair; the affected live target must pass through the PR E2E gate.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated container startup validation to require the full executable path for both initial and recovered managed containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->