### PR TITLE
docs: prepare v0.0.102 release notes

### DIFF
--- a/docs/changelog/2026-08-04.mdx
+++ b/docs/changelog/2026-08-04.mdx
@@ -1,0 +1,50 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.102
+
+NemoClaw v0.0.102 adds authenticated attachment of operator-managed llama.cpp servers and an Experimental managed vLLM profile for two DGX Spark systems.
+It also improves DGX Station and Windows installation, gateway and sandbox recovery, Shields transactions, inference reliability, multi-port uninstall, and Hermes and LangChain Deep Agents Code workflows.
+
+- Onboarding can now attach an authenticated, operator-managed llama.cpp server on loopback port `8081` as the `llama-cpp-local` provider.
+  NemoClaw requires consistent native fingerprint evidence, bounds probe responses, and retains the generic compatible-endpoint path when the server cannot be identified as llama.cpp.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Experimental Express installation can now discover two qualified DGX Spark systems and select their managed vLLM profile from the declarative serving catalog.
+  DGX Station paths also qualify the May 2026 GB300WS factory image, retain the qualified driver transaction, accept mode-bound Express resume state, and recover host-global dual-Station runtime ownership during later onboarding.
+  For more information, refer to [Set Up vLLM on Two DGX Sparks](/user-guide/openclaw/inference/local-inference/set-up-vllm-on-two-dgx-sparks), [Set Up vLLM on Two DGX Stations](/user-guide/openclaw/inference/local-inference/set-up-vllm-on-two-dgx-stations), and [Additional Setup for DGX Station](/user-guide/openclaw/get-started/additional-setup/dgx-station-preparation).
+- Windows Subsystem for Linux (WSL) onboarding now validates Windows-host Ollama from Docker Desktop's network context and reuses a running daemon on mirrored networking.
+  When WSL has no local `ollama` executable, model pulls use the daemon's HTTP API instead.
+  For more information, refer to [Additional Setup for Windows Machines](/user-guide/openclaw/get-started/additional-setup/windows-preparation) and [Use Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama).
+- Reinstallation now reuses a healthy installer-managed CLI when its selected source and build identity still match.
+  Linux installation rejects incompatible OpenShell gateway versions before onboarding, adopts only a compatible package-managed gateway, and permits the bounded package-service-to-standalone recovery transition.
+  Multi-sandbox onboarding also records the dashboard port selected after a collision or final recovery.
+  For more information, refer to [Gateway Lifecycle Authority](/user-guide/openclaw/deployment/gateway-lifecycle-authority) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Starting a stopped sandbox now restores managed startup state before final gateway and host-forward readiness checks.
+  The gateway watchdog recovers every classified not-serving state after the gateway has served, and managed recovery applies `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` consistently.
+  Docker sandbox creation also retains rollback authority through late readiness, GPU, and local-inference checks.
+  For more information, refer to [Run Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/run-sandboxes) and [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes).
+- Shields deadline recovery now blocks new mutations, waits for the verified owner to release its lock, and enters durable containment when bounded recovery cannot establish authority.
+  Relock can repair a narrowly validated permission-only configuration-hash drift, while corrupt transition locks fail promptly with recovery guidance.
+  For more information, refer to [Understand Runtime Changes](/user-guide/openclaw/manage-sandboxes/configure-sandboxes/understand-runtime-changes) and [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots).
+- `policy restore` now accepts `--yes`, `-y`, and `--force`, previews restored egress or stale-record cleanup, and revalidates the target before mutation.
+  Explicit sandbox destruction can continue after pre-delete Shields hardening fails while preserving the auto-restore authority if deletion is not confirmed.
+  The new `nemoclaw uninstall --all-gateway-ports` mode processes every discovered gateway-port environment independently and preserves shared resources when cleanup remains incomplete.
+  For more information, refer to [Network Policies](/user-guide/openclaw/reference/network-policies), [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- OpenClaw now retries one classified transient remote Model Context Protocol (MCP) startup with a fresh transport and does not retain a degraded tool catalog as the stable session catalog.
+  Hosted inference probes use a bounded reply budget accepted by endpoints with a higher minimum, and onboarding preserves the validated reasoning-capability value through resume and sandbox creation.
+  For more information, refer to [Troubleshoot MCP Servers](/user-guide/openclaw/reference/troubleshoot-mcp-servers) and [Configure Model Capabilities](/user-guide/openclaw/inference/manage-inference/configure-model-capabilities).
+- Hermes WhatsApp pairing and media traffic now use the injected OpenShell proxy.
+  Hermes `sessions delete` invokes the native Hermes command with native identifier validation.
+  Deep Agents Code applies configured corporate certificate authority (CA) trust during local base-image dependency fetches and in the final sandbox image.
+  For more information, refer to [Set Up WhatsApp](/user-guide/hermes/manage-sandboxes/messaging-channels/set-up-whatsapp), the Hermes [NemoClaw CLI Commands Reference](/user-guide/hermes/reference/commands), and [Configure Corporate CA Trust](/user-guide/deepagents/security/configure-corporate-ca-trust).
+- Managed OpenClaw, Hermes, Deep Agents Code, and MCP discovery images now carry reviewed dependency updates for the release advisory set.
+  The changes update locked runtime graphs, remediate private npm dependencies during image assembly, and preserve fail-closed identity and integrity checks.
+  For more information, refer to the [OpenClaw 2026.7.1 Dependency Review](https://github.com/NVIDIA/NemoClaw/blob/main/docs/security/openclaw-2026.7.1-dependency-review.md) and [Hermes 0.19.0 Dependency Review](https://github.com/NVIDIA/NemoClaw/blob/main/docs/security/hermes-0.19.0-dependency-review.md).
+- Affected CLI paths now report invalid enumerated values, unresolved sandbox base images, and changed gateway authority without raw Node.js stack traces.
+  Captured output from non-JSON OpenClaw agent commands is inspected for recognized embedded-fallback markers.
+  When a marker is present, NemoClaw suppresses the captured transport output, exits with status `1`, and prints the documented recovery commands.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- Documentation now gives OpenClaw, Hermes, and Deep Agents Code the same one-command interactive installation start and describes the current product capabilities and boundaries.
+  For more information, refer to the OpenClaw [Quickstart](/user-guide/openclaw/get-started/quickstart), Hermes [Quickstart](/user-guide/hermes/get-started/quickstart), [Quickstart with LangChain Deep Agents Code](/user-guide/deepagents/get-started/quickstart), and [Platform Support](/user-guide/openclaw/reference/platform-support).

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1028,9 +1028,10 @@ $$nemoclaw dcode-sandbox agent -n "Summarize this repository"
 $$nemoclaw dcode-sandbox agent -n "Summarize this repository" --json
 ```
 
-When post-command permission cleanup succeeds, the wrapper inherits the remote command's exit code so host-side pipelines can branch on it.
-If cleanup fails closed, the wrapper prints the command and cleanup statuses to `stderr` and returns the cleanup failure.
-For normal turns, streaming forwards whatever the in-sandbox agent command emits on `stdout`; the wrapper adds no buffering.
+For non-JSON OpenClaw turns, the wrapper captures `stdout` and `stderr` and replays them only after the in-sandbox command exits.
+The combined capture limit is `64 MiB`; exceeding it reports an OpenShell invocation error and exits with status `1`.
+If the captured output contains an embedded-fallback marker, the wrapper suppresses both streams, prints `recover`, `rebuild --yes`, and `onboard --resume` guidance to `stderr`, and exits with status `1`.
+Otherwise, it writes the captured output to the corresponding host streams and returns the OpenShell command's exit status.
 The in-sandbox NemoClaw plugin writes its registration banner to `stderr`, so the banner does not prefix the agent reply on `stdout` in non-JSON mode.
 When the top-level OpenClaw `--json` output flag is present, the wrapper uses a captured no-TTY path with a `64 MiB` buffer so `stdout` stays parseable JSON.
 Raw `stderr` is forwarded, and failed-tool or untrusted-child provenance found in the stdout JSON is appended to `stderr`.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Prepares the canonical v0.0.102 release documentation from the current release-labeled scope.
The change adds a dated changelog for all 38 user-facing shipping PRs and corrects the OpenClaw agent command reference for the behavior delivered by #8191.

## Changes

- Add `docs/changelog/2026-08-04.mdx` with the v0.0.102 release summary, detailed behavior changes, support boundaries, security evidence links, and links to durable documentation.
- Update `docs/reference/commands.mdx` to describe non-JSON OpenClaw output capture, its combined limit, marker handling, stream suppression, recovery guidance, and exit behavior.
- [#8167](https://github.com/NVIDIA/NemoClaw/pull/8167) -> `docs/changelog/2026-08-04.mdx`: Records authenticated attachment of operator-managed llama.cpp servers.
- [#8129](https://github.com/NVIDIA/NemoClaw/pull/8129) -> `docs/changelog/2026-08-04.mdx`: Records the Experimental managed vLLM profile for two DGX Spark systems.
- [#7983](https://github.com/NVIDIA/NemoClaw/pull/7983) -> `docs/changelog/2026-08-04.mdx`: Records qualification of the May 2026 GB300WS factory image.
- [#8207](https://github.com/NVIDIA/NemoClaw/pull/8207) -> `docs/changelog/2026-08-04.mdx`: Records the qualified DGX Station driver transaction.
- [#8208](https://github.com/NVIDIA/NemoClaw/pull/8208) -> `docs/changelog/2026-08-04.mdx`: Records mode-bound Express resume state.
- [#8158](https://github.com/NVIDIA/NemoClaw/pull/8158) -> `docs/changelog/2026-08-04.mdx`: Records recovery of host-global dual-Station runtime ownership.
- [#8145](https://github.com/NVIDIA/NemoClaw/pull/8145) -> `docs/changelog/2026-08-04.mdx`: Records Windows-host Ollama validation from Docker Desktop's network context.
- [#8190](https://github.com/NVIDIA/NemoClaw/pull/8190) -> `docs/changelog/2026-08-04.mdx`: Records HTTP model pulls when WSL has no local Ollama executable.
- [#8195](https://github.com/NVIDIA/NemoClaw/pull/8195) -> `docs/changelog/2026-08-04.mdx`: Records reuse of a healthy installer-managed CLI.
- [#8053](https://github.com/NVIDIA/NemoClaw/pull/8053) -> `docs/changelog/2026-08-04.mdx`: Records early rejection of incompatible OpenShell gateway versions.
- [#8098](https://github.com/NVIDIA/NemoClaw/pull/8098) -> `docs/changelog/2026-08-04.mdx`: Records the bounded package-service-to-standalone gateway recovery transition.
- [#8216](https://github.com/NVIDIA/NemoClaw/pull/8216) -> `docs/changelog/2026-08-04.mdx`: Records the final dashboard port selected during multi-sandbox onboarding.
- [#8146](https://github.com/NVIDIA/NemoClaw/pull/8146) -> `docs/changelog/2026-08-04.mdx`: Records managed startup-state restoration for stopped sandboxes.
- [#8092](https://github.com/NVIDIA/NemoClaw/pull/8092) -> `docs/changelog/2026-08-04.mdx`: Records gateway watchdog recovery for classified not-serving states.
- [#8182](https://github.com/NVIDIA/NemoClaw/pull/8182) -> `docs/changelog/2026-08-04.mdx`: Records consistent managed-recovery wait configuration.
- [#8040](https://github.com/NVIDIA/NemoClaw/pull/8040) -> `docs/changelog/2026-08-04.mdx`: Records Docker sandbox rollback authority through late validation.
- [#8130](https://github.com/NVIDIA/NemoClaw/pull/8130) -> `docs/changelog/2026-08-04.mdx`: Records bounded Shields deadline recovery and durable containment.
- [#8086](https://github.com/NVIDIA/NemoClaw/pull/8086) -> `docs/changelog/2026-08-04.mdx`: Records repair of narrowly validated permission-only configuration drift.
- [#8122](https://github.com/NVIDIA/NemoClaw/pull/8122) -> `docs/changelog/2026-08-04.mdx`: Records prompt failure and guidance for corrupt transition locks.
- [#8124](https://github.com/NVIDIA/NemoClaw/pull/8124) -> `docs/changelog/2026-08-04.mdx`: Records policy restoration flags, previews, and target revalidation.
- [#7886](https://github.com/NVIDIA/NemoClaw/pull/7886) -> `docs/changelog/2026-08-04.mdx`: Records explicit destruction after pre-delete Shields hardening failures while preserving recovery authority.
- [#7901](https://github.com/NVIDIA/NemoClaw/pull/7901) -> `docs/changelog/2026-08-04.mdx`: Records multi-port uninstall behavior and shared-resource preservation.
- [#7984](https://github.com/NVIDIA/NemoClaw/pull/7984) -> `docs/changelog/2026-08-04.mdx`: Records one classified transient remote MCP startup retry.
- [#7954](https://github.com/NVIDIA/NemoClaw/pull/7954) -> `docs/changelog/2026-08-04.mdx`: Records bounded hosted-inference probe replies.
- [#7574](https://github.com/NVIDIA/NemoClaw/pull/7574) -> `docs/changelog/2026-08-04.mdx`: Records preservation of validated reasoning capabilities through onboarding.
- [#8089](https://github.com/NVIDIA/NemoClaw/pull/8089) -> `docs/changelog/2026-08-04.mdx`: Records proxy routing for Hermes WhatsApp pairing and media traffic.
- [#7682](https://github.com/NVIDIA/NemoClaw/pull/7682) -> `docs/changelog/2026-08-04.mdx`: Records native Hermes session deletion and identifier validation.
- [#8150](https://github.com/NVIDIA/NemoClaw/pull/8150) -> `docs/changelog/2026-08-04.mdx`: Records corporate CA trust for LangChain Deep Agents Code image builds.
- [#8156](https://github.com/NVIDIA/NemoClaw/pull/8156) -> `docs/changelog/2026-08-04.mdx`: Records reviewed managed runtime dependency remediation.
- [#8180](https://github.com/NVIDIA/NemoClaw/pull/8180) -> `docs/changelog/2026-08-04.mdx`: Records reviewed MCP discovery runtime dependency updates.
- [#8196](https://github.com/NVIDIA/NemoClaw/pull/8196) -> `docs/changelog/2026-08-04.mdx`: Records private npm dependency remediation across managed images.
- [#8203](https://github.com/NVIDIA/NemoClaw/pull/8203) -> `docs/changelog/2026-08-04.mdx`: Records reviewed Hermes and LangChain Deep Agents Code Python dependency updates.
- [#8125](https://github.com/NVIDIA/NemoClaw/pull/8125) -> `docs/changelog/2026-08-04.mdx`: Records bounded diagnostics for invalid enumerated CLI values.
- [#8193](https://github.com/NVIDIA/NemoClaw/pull/8193) -> `docs/changelog/2026-08-04.mdx`: Records bounded diagnostics for unresolved sandbox base images.
- [#8118](https://github.com/NVIDIA/NemoClaw/pull/8118) -> `docs/changelog/2026-08-04.mdx`: Records bounded diagnostics for changed gateway authority.
- [#8191](https://github.com/NVIDIA/NemoClaw/pull/8191) -> `docs/changelog/2026-08-04.mdx`, `docs/reference/commands.mdx`: Records output capture, marker handling, recovery guidance, and exit behavior for non-JSON OpenClaw agent commands.
- [#8187](https://github.com/NVIDIA/NemoClaw/pull/8187) -> `docs/changelog/2026-08-04.mdx`: Records the aligned interactive-installation start across supported agents.
- [#8153](https://github.com/NVIDIA/NemoClaw/pull/8153) -> `docs/changelog/2026-08-04.mdx`: Records current product capabilities and support boundaries.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This documentation-only release preparation does not change executable behavior. Existing changelog and published-route tests pass.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Independently reviewed `docs/changelog/2026-08-04.mdx` and `docs/reference/commands.mdx` at commit `b89913780`. All 38 user-facing v0.0.102 PRs are represented, #8191 behavior matches the implementation, and the writing rules, documentation style, controlled terminology, route structure, and skip policy pass review. Targeted tests pass 36/36 and the documentation build completes with 0 errors.
- Agent: Codex Desktop independent documentation writer
<!-- docs-review-head-sha: b89913780 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/changelog-docs.test.ts test/check-docs-published-routes.test.ts` passed 36/36.
- [x] Applicable broad gate passed — not applicable to documentation-only changes; `npm run docs` completed successfully with 0 errors.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [x] New doc pages include SPDX header and frontmatter (new pages only) — the native dated changelog uses the required parser-safe MDX SPDX comment and intentionally has no frontmatter.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for v0.0.102, covering authentication, hardware setup, WSL, installer recovery, sandbox resilience, policy management, inference reliability, CLI improvements, and unified quickstarts.
  - Updated command documentation to explain how non-JSON agent output is collected, replayed, and reported.

- **Bug Fixes**
  - Improved command-output recovery guidance when output exceeds limits or contains unsupported fallback markers.
  - Preserved accurate command exit-status reporting after output processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->