### PR TITLE
feat(inference): add trusted llama.cpp publication evidence

### DIFF
--- a/.github/workflows/llama-cpp-image-attest.yaml
+++ b/.github/workflows/llama-cpp-image-attest.yaml
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Attest llama.cpp server image
+
+on:
+  workflow_call:
+    inputs:
+      candidate_tag:
+        description: Run-unique candidate tag
+        required: true
+        type: string
+      digest:
+        description: Exact candidate index digest
+        required: true
+        type: string
+      image:
+        description: Owned llama.cpp server image repository
+        required: true
+        type: string
+      retention_days:
+        description: Evidence artifact retention in days
+        required: true
+        type: number
+      sbom_format:
+        description: SBOM document format
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  validate-inputs:
+    name: Validate attestation inputs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      candidate_tag: ${{ steps.validate.outputs.candidate_tag }}
+      digest: ${{ steps.validate.outputs.digest }}
+      image: ${{ steps.validate.outputs.image }}
+      retention_days: ${{ steps.validate.outputs.retention_days }}
+      sbom_format: ${{ steps.validate.outputs.sbom_format }}
+    steps:
+      - name: Validate exact inputs
+        id: validate
+        shell: bash
+        env:
+          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
+          INPUT_CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          INPUT_DIGEST: ${{ inputs.digest }}
+          INPUT_IMAGE: ${{ inputs.image }}
+          INPUT_RETENTION_DAYS: ${{ inputs.retention_days }}
+          INPUT_SBOM_FORMAT: ${{ inputs.sbom_format }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REPOSITORY" != "NVIDIA/NemoClaw" ] \
+            || [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] \
+            || [ "$GITHUB_REF" != "refs/heads/main" ] \
+            || [ "$CALLER_WORKFLOW_REF" != "NVIDIA/NemoClaw/.github/workflows/llama-cpp-image.yaml@refs/heads/main" ]; then
+            echo "ERROR: attestation caller does not match the trusted main workflow." >&2
+            exit 1
+          fi
+          expected_candidate_tag="llama-cpp-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          if [ "$INPUT_CANDIDATE_TAG" != "$expected_candidate_tag" ]; then
+            echo "ERROR: candidate tag does not match llama-cpp-candidate-RUN_ID-RUN_ATTEMPT." >&2
+            exit 1
+          fi
+          if [[ ! "$INPUT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "ERROR: candidate digest is invalid." >&2
+            exit 1
+          fi
+          if [ "$INPUT_IMAGE" != "ghcr.io/nvidia/nemoclaw/llama-cpp-server" ]; then
+            echo "ERROR: image repository is not the owned llama.cpp server repository." >&2
+            exit 1
+          fi
+          if [ "$INPUT_SBOM_FORMAT" != "spdx-json" ]; then
+            echo "ERROR: SBOM format must be spdx-json." >&2
+            exit 1
+          fi
+          if [[ ! "$INPUT_RETENTION_DAYS" =~ ^[1-9][0-9]*$ ]] \
+            || [ "$INPUT_RETENTION_DAYS" -gt 90 ]; then
+            echo "ERROR: evidence retention must be between 1 and 90 days." >&2
+            exit 1
+          fi
+          {
+            printf 'candidate_tag=%s\n' "$INPUT_CANDIDATE_TAG"
+            printf 'digest=%s\n' "$INPUT_DIGEST"
+            printf 'image=%s\n' "$INPUT_IMAGE"
+            printf 'retention_days=%s\n' "$INPUT_RETENTION_DAYS"
+            printf 'sbom_format=%s\n' "$INPUT_SBOM_FORMAT"
+          } >> "$GITHUB_OUTPUT"
+
+  attest:
+    name: Generate and publish image evidence
+    needs: validate-inputs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Generate amd64 SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        env:
+          SYFT_PLATFORM: linux/amd64
+        with:
+          image: ${{ needs.validate-inputs.outputs.image }}@${{ needs.validate-inputs.outputs.digest }}
+          format: ${{ needs.validate-inputs.outputs.sbom_format }}
+          artifact-name: llama-cpp-sbom-amd64-${{ needs.validate-inputs.outputs.candidate_tag }}
+          output-file: llama-cpp-sbom-amd64.spdx.json
+          upload-artifact: true
+          upload-artifact-retention: ${{ needs.validate-inputs.outputs.retention_days }}
+          upload-release-assets: false
+
+      - name: Generate arm64 SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        env:
+          SYFT_PLATFORM: linux/arm64
+        with:
+          image: ${{ needs.validate-inputs.outputs.image }}@${{ needs.validate-inputs.outputs.digest }}
+          format: ${{ needs.validate-inputs.outputs.sbom_format }}
+          artifact-name: llama-cpp-sbom-arm64-${{ needs.validate-inputs.outputs.candidate_tag }}
+          output-file: llama-cpp-sbom-arm64.spdx.json
+          upload-artifact: true
+          upload-artifact-retention: ${{ needs.validate-inputs.outputs.retention_days }}
+          upload-release-assets: false
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
+
+      - name: Attest amd64 SPDX SBOM
+        shell: bash
+        env:
+          DIGEST: ${{ needs.validate-inputs.outputs.digest }}
+          IMAGE: ${{ needs.validate-inputs.outputs.image }}
+        run: |
+          set -euo pipefail
+          timeout --foreground 120s cosign attest \
+            --yes \
+            --predicate llama-cpp-sbom-amd64.spdx.json \
+            --type spdxjson \
+            "$IMAGE@$DIGEST"
+
+      - name: Attest arm64 SPDX SBOM
+        shell: bash
+        env:
+          DIGEST: ${{ needs.validate-inputs.outputs.digest }}
+          IMAGE: ${{ needs.validate-inputs.outputs.image }}
+        run: |
+          set -euo pipefail
+          timeout --foreground 120s cosign attest \
+            --yes \
+            --predicate llama-cpp-sbom-arm64.spdx.json \
+            --type spdxjson \
+            "$IMAGE@$DIGEST"
+
+      - name: Attest SLSA build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-name: ${{ needs.validate-inputs.outputs.image }}
+          subject-digest: ${{ needs.validate-inputs.outputs.digest }}
+          push-to-registry: true
+
+      - name: Sign exact candidate index
+        shell: bash
+        env:
+          DIGEST: ${{ needs.validate-inputs.outputs.digest }}
+          IMAGE: ${{ needs.validate-inputs.outputs.image }}
+        run: |
+          set -euo pipefail
+          timeout --foreground 120s cosign sign --yes "$IMAGE@$DIGEST"

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -7,18 +7,28 @@ on:
   pull_request:
     paths:
       - ".github/workflows/llama-cpp-image.yaml"
+      - ".github/workflows/llama-cpp-image-attest.yaml"
       - "managed-inference/images/llama-cpp/**"
       - "managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml"
       - "scripts/checks/export-llama-cpp-image-config.mts"
+      - "scripts/checks/verify-llama-cpp-image-publication-evidence.sh"
       - "test/llama-cpp-image.test.ts"
+      - "test/llama-cpp-image-publication-evidence.test.ts"
       - "test/llama-cpp-image-workflow.test.ts"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the declaratively enabled run-unique candidate from main
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   config:
@@ -34,6 +44,25 @@ jobs:
       cuda_runtime_image: ${{ steps.manifest.outputs.cuda_runtime_image }}
       image: ${{ steps.manifest.outputs.image }}
       matrix: ${{ steps.manifest.outputs.matrix }}
+      publication_allowed_ref: ${{ steps.manifest.outputs.publication_allowed_ref }}
+      publication_anonymous_exact_digest_pull: ${{ steps.manifest.outputs.publication_anonymous_exact_digest_pull }}
+      publication_candidate_tag_template: ${{ steps.manifest.outputs.publication_candidate_tag_template }}
+      publication_enabled: ${{ steps.manifest.outputs.publication_enabled }}
+      publication_platforms: ${{ steps.manifest.outputs.publication_platforms }}
+      publication_provenance_predicate_type: ${{ steps.manifest.outputs.publication_provenance_predicate_type }}
+      publication_qualification: ${{ steps.manifest.outputs.publication_qualification }}
+      publication_receipt_retention_days: ${{ steps.manifest.outputs.publication_receipt_retention_days }}
+      publication_receipt_schema_version: ${{ steps.manifest.outputs.publication_receipt_schema_version }}
+      publication_repository: ${{ steps.manifest.outputs.publication_repository }}
+      publication_sbom_format: ${{ steps.manifest.outputs.publication_sbom_format }}
+      publication_signature_identity: ${{ steps.manifest.outputs.publication_signature_identity }}
+      publication_signature_issuer: ${{ steps.manifest.outputs.publication_signature_issuer }}
+      publication_signature_mode: ${{ steps.manifest.outputs.publication_signature_mode }}
+      publication_signature_transparency_log: ${{ steps.manifest.outputs.publication_signature_transparency_log }}
+      publication_trigger: ${{ steps.manifest.outputs.publication_trigger }}
+      publication_vulnerability_only_fixed: ${{ steps.manifest.outputs.publication_vulnerability_only_fixed }}
+      publication_vulnerability_scanner: ${{ steps.manifest.outputs.publication_vulnerability_scanner }}
+      publication_vulnerability_severity_cutoff: ${{ steps.manifest.outputs.publication_vulnerability_severity_cutoff }}
       runtime_forbidden_paths: ${{ steps.manifest.outputs.runtime_forbidden_paths }}
       runtime_gid: ${{ steps.manifest.outputs.runtime_gid }}
       runtime_required_paths: ${{ steps.manifest.outputs.runtime_required_paths }}
@@ -61,6 +90,7 @@ jobs:
   pr-build:
     name: Build native llama.cpp server (${{ matrix.arch }})
     needs: config
+    if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     strategy:
@@ -205,3 +235,560 @@ jobs:
           done < <(jq --raw-output '.[]' <<< "$RUNTIME_FORBIDDEN_PATHS")
           docker rm "$container_id" >/dev/null
           trap - EXIT
+
+  publication-gate:
+    name: Validate trusted publication request
+    needs: config
+    if: github.event_name == 'workflow_dispatch' && inputs.publish == true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      candidate_tag: ${{ steps.gate.outputs.candidate_tag }}
+    steps:
+      - name: Enforce declarative publication boundary
+        id: gate
+        shell: bash
+        env:
+          ALLOWED_REF: ${{ needs.config.outputs.publication_allowed_ref }}
+          ANONYMOUS_EXACT_DIGEST_PULL: ${{ needs.config.outputs.publication_anonymous_exact_digest_pull }}
+          CANDIDATE_TAG_TEMPLATE: ${{ needs.config.outputs.publication_candidate_tag_template }}
+          IMAGE: ${{ needs.config.outputs.image }}
+          PLATFORMS: ${{ needs.config.outputs.publication_platforms }}
+          PUBLICATION_ENABLED: ${{ needs.config.outputs.publication_enabled }}
+          PUBLICATION_REPOSITORY: ${{ needs.config.outputs.publication_repository }}
+          PUBLICATION_TRIGGER: ${{ needs.config.outputs.publication_trigger }}
+          QUALIFICATION: ${{ needs.config.outputs.publication_qualification }}
+          RECEIPT_SCHEMA_VERSION: ${{ needs.config.outputs.publication_receipt_schema_version }}
+          SBOM_FORMAT: ${{ needs.config.outputs.publication_sbom_format }}
+          SIGNATURE_MODE: ${{ needs.config.outputs.publication_signature_mode }}
+          SIGNATURE_TRANSPARENCY_LOG: ${{ needs.config.outputs.publication_signature_transparency_log }}
+          SLSA_PREDICATE_TYPE: ${{ needs.config.outputs.publication_provenance_predicate_type }}
+          VULNERABILITY_ONLY_FIXED: ${{ needs.config.outputs.publication_vulnerability_only_fixed }}
+          VULNERABILITY_SCANNER: ${{ needs.config.outputs.publication_vulnerability_scanner }}
+          VULNERABILITY_SEVERITY_CUTOFF: ${{ needs.config.outputs.publication_vulnerability_severity_cutoff }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REPOSITORY" != "NVIDIA/NemoClaw" ] \
+            || [ "$GITHUB_REF" != "$ALLOWED_REF" ] \
+            || [ "$PUBLICATION_TRIGGER" != "workflow_dispatch" ] \
+            || [ "$PUBLICATION_ENABLED" != "true" ] \
+            || [ "$PUBLICATION_REPOSITORY" != "$IMAGE" ] \
+            || [ "$PLATFORMS" != '["linux/amd64","linux/arm64"]' ] \
+            || [ "$SBOM_FORMAT" != "spdx-json" ] \
+            || [ "$SLSA_PREDICATE_TYPE" != "https://slsa.dev/provenance/v1" ] \
+            || [ "$SIGNATURE_MODE" != "sigstore-keyless" ] \
+            || [ "$SIGNATURE_TRANSPARENCY_LOG" != "required" ] \
+            || [ "$VULNERABILITY_SCANNER" != "grype" ] \
+            || [ "$VULNERABILITY_SEVERITY_CUTOFF" != "high" ] \
+            || [ "$VULNERABILITY_ONLY_FIXED" != "true" ] \
+            || [ "$ANONYMOUS_EXACT_DIGEST_PULL" != "true" ] \
+            || [ "$RECEIPT_SCHEMA_VERSION" != "1" ]; then
+            echo "ERROR: repository, ref, trigger, enablement, image, or publication policy does not match the trusted contract." >&2
+            exit 1
+          fi
+          if ! jq -e '
+            (keys | sort) == ["environment", "gpu", "model", "platform", "probes", "profile", "required", "runner"]
+            and .required == true
+            and .profile == "dgx-spark-gb10-single"
+            and .platform == "linux/arm64"
+            and (.runner | type) == "string" and (.runner | length) > 0
+            and (.environment | type) == "string" and (.environment | length) > 0
+            and (.model.hostPath | type) == "string" and (.model.hostPath | startswith("/"))
+            and .gpu == {vendor:"nvidia", fullOffload:true, cpuFallback:"reject"}
+            and .probes == ["health", "completion"]
+          ' <<< "$QUALIFICATION" >/dev/null; then
+            echo "ERROR: protected DGX Spark qualification infrastructure is incomplete." >&2
+            exit 1
+          fi
+          candidate_tag="${CANDIDATE_TAG_TEMPLATE/\{runId\}/$GITHUB_RUN_ID}"
+          candidate_tag="${candidate_tag/\{runAttempt\}/$GITHUB_RUN_ATTEMPT}"
+          if [[ ! "$candidate_tag" =~ ^llama-cpp-candidate-[1-9][0-9]*-[1-9][0-9]*$ ]]; then
+            echo "ERROR: generated candidate tag is invalid." >&2
+            exit 1
+          fi
+          printf 'candidate_tag=%s\n' "$candidate_tag" >> "$GITHUB_OUTPUT"
+
+  publication-preflight:
+    name: Require public GHCR package
+    needs: [config, publication-gate]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      packages: read
+    steps:
+      - name: Verify public package visibility before registry writes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ${{ needs.config.outputs.publication_repository }}
+        run: |
+          set -euo pipefail
+          package_name="${IMAGE#ghcr.io/nvidia/}"
+          encoded_package_name="${package_name//\//%2F}"
+          package_api="/orgs/NVIDIA/packages/container/${encoded_package_name}"
+          if ! visibility="$(gh api "$package_api" --jq .visibility)"; then
+            echo "::error::GHCR package ${IMAGE} must exist with public visibility before publication. Bootstrap the package, set public visibility, then rerun this workflow."
+            exit 1
+          fi
+          if [ "$visibility" != "public" ]; then
+            echo "::error::GHCR package ${IMAGE} has ${visibility} visibility. Set public visibility, then rerun this workflow."
+            exit 1
+          fi
+
+  publish-platform:
+    name: Publish native llama.cpp digest (${{ matrix.arch }})
+    needs: [config, publication-gate, publication-preflight]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Authenticate to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Validate trusted image build args
+        env:
+          C_COMPILER: ${{ needs.config.outputs.compiler_c }}
+          CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
+          CUDA_DEV_IMAGE: ${{ needs.config.outputs.cuda_dev_image }}
+          CUDA_HOST_CXX_COMPILER: ${{ needs.config.outputs.compiler_cuda_host_cxx }}
+          CUDA_RUNTIME_IMAGE: ${{ needs.config.outputs.cuda_runtime_image }}
+          CXX_COMPILER: ${{ needs.config.outputs.compiler_cxx }}
+          GGML_BACKEND_DIR: ${{ needs.config.outputs.backend_directory }}
+          LLAMA_CPP_ARCHIVE_SHA256: ${{ needs.config.outputs.source_archive_sha256 }}
+          LLAMA_CPP_REVISION: ${{ needs.config.outputs.source_revision }}
+          NEMOCLAW_REVISION: ${{ github.sha }}
+          RUNTIME_GID: ${{ needs.config.outputs.runtime_gid }}
+          RUNTIME_UID: ${{ needs.config.outputs.runtime_uid }}
+          TARGETPLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          scripts/check-production-build-args.sh \
+            --build-arg "C_COMPILER=${C_COMPILER}" \
+            --build-arg "CUDA_HOST_CXX_COMPILER=${CUDA_HOST_CXX_COMPILER}" \
+            --build-arg "CXX_COMPILER=${CXX_COMPILER}" \
+            --build-arg "CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}" \
+            --build-arg "CUDA_DEV_IMAGE=${CUDA_DEV_IMAGE}" \
+            --build-arg "CUDA_RUNTIME_IMAGE=${CUDA_RUNTIME_IMAGE}" \
+            --build-arg "GGML_BACKEND_DIR=${GGML_BACKEND_DIR}" \
+            --build-arg "LLAMA_CPP_ARCHIVE_SHA256=${LLAMA_CPP_ARCHIVE_SHA256}" \
+            --build-arg "LLAMA_CPP_REVISION=${LLAMA_CPP_REVISION}" \
+            --build-arg "NEMOCLAW_REVISION=${NEMOCLAW_REVISION}" \
+            --build-arg "RUNTIME_GID=${RUNTIME_GID}" \
+            --build-arg "RUNTIME_UID=${RUNTIME_UID}" \
+            --build-arg "TARGETPLATFORM=${TARGETPLATFORM}"
+
+      - name: Publish exact platform digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: managed-inference/images/llama-cpp
+          file: managed-inference/images/llama-cpp/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ needs.config.outputs.publication_repository }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            C_COMPILER=${{ needs.config.outputs.compiler_c }}
+            CUDA_HOST_CXX_COMPILER=${{ needs.config.outputs.compiler_cuda_host_cxx }}
+            CXX_COMPILER=${{ needs.config.outputs.compiler_cxx }}
+            CUDA_ARCHITECTURES=${{ matrix.cuda_architectures }}
+            CUDA_DEV_IMAGE=${{ needs.config.outputs.cuda_dev_image }}
+            CUDA_RUNTIME_IMAGE=${{ needs.config.outputs.cuda_runtime_image }}
+            GGML_BACKEND_DIR=${{ needs.config.outputs.backend_directory }}
+            LLAMA_CPP_ARCHIVE_SHA256=${{ needs.config.outputs.source_archive_sha256 }}
+            LLAMA_CPP_REVISION=${{ needs.config.outputs.source_revision }}
+            NEMOCLAW_REVISION=${{ github.sha }}
+            RUNTIME_GID=${{ needs.config.outputs.runtime_gid }}
+            RUNTIME_UID=${{ needs.config.outputs.runtime_uid }}
+            TARGETPLATFORM=${{ matrix.platform }}
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=llama-cpp-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=llama-cpp-${{ matrix.arch }}
+
+      - name: Export validated platform digest
+        env:
+          ARCH: ${{ matrix.arch }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ needs.config.outputs.publication_repository }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$ARCH" =~ ^(amd64|arm64)$ ]] \
+            || [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "ERROR: native build did not return an exact platform digest." >&2
+            exit 1
+          fi
+          actual_platform="$(
+            docker buildx imagetools inspect "$IMAGE@$DIGEST" \
+              --format '{{.Image.OS}}/{{.Image.Architecture}}'
+          )"
+          if [ "$actual_platform" != "$PLATFORM" ]; then
+            echo "ERROR: published digest resolves to $actual_platform instead of $PLATFORM." >&2
+            exit 1
+          fi
+          install -d -m 0700 "$RUNNER_TEMP/llama-cpp-digests"
+          touch "$RUNNER_TEMP/llama-cpp-digests/${ARCH}-${DIGEST#sha256:}"
+
+      - name: Upload platform digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llama-cpp-platform-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/llama-cpp-digests/*
+          if-no-files-found: error
+          retention-days: ${{ fromJSON(needs.config.outputs.publication_receipt_retention_days) }}
+
+  assemble-candidate:
+    name: Assemble exact llama.cpp candidate index
+    needs: [config, publication-gate, publish-platform]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      candidate_tag: ${{ steps.assemble.outputs.candidate_tag }}
+      digest: ${{ steps.assemble.outputs.digest }}
+      platform_digests: ${{ steps.assemble.outputs.platform_digests }}
+      reference: ${{ steps.assemble.outputs.reference }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Authenticate to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Download platform digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: llama-cpp-platform-${{ github.run_id }}-${{ github.run_attempt }}-*
+          path: ${{ runner.temp }}/llama-cpp-digests
+          merge-multiple: true
+
+      - name: Assemble candidate index and capture exact digest
+        id: assemble
+        shell: bash
+        env:
+          CANDIDATE_TAG: ${{ needs.publication-gate.outputs.candidate_tag }}
+          IMAGE: ${{ needs.config.outputs.publication_repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          digest_files=("$RUNNER_TEMP"/llama-cpp-digests/*)
+          if [ "${#digest_files[@]}" -ne 2 ]; then
+            echo "ERROR: expected exactly two native digest artifacts." >&2
+            exit 1
+          fi
+          declare -A platform_digests=()
+          sources=()
+          for digest_file in "${digest_files[@]}"; do
+            digest_artifact="$(basename "$digest_file")"
+            if [[ ! "$digest_artifact" =~ ^(amd64|arm64)-([0-9a-f]{64})$ ]]; then
+              echo "ERROR: malformed platform digest artifact: $digest_artifact" >&2
+              exit 1
+            fi
+            arch="${BASH_REMATCH[1]}"
+            digest="sha256:${BASH_REMATCH[2]}"
+            platform="linux/$arch"
+            if [ -n "${platform_digests[$platform]:-}" ]; then
+              echo "ERROR: duplicate platform digest for $platform." >&2
+              exit 1
+            fi
+            source="$IMAGE@$digest"
+            actual_platform="$(
+              docker buildx imagetools inspect "$source" \
+                --format '{{.Image.OS}}/{{.Image.Architecture}}'
+            )"
+            if [ "$actual_platform" != "$platform" ]; then
+              echo "ERROR: $source resolves to $actual_platform instead of $platform." >&2
+              exit 1
+            fi
+            platform_digests["$platform"]="$digest"
+            sources+=("$source")
+          done
+          if [ -z "${platform_digests[linux/amd64]:-}" ] \
+            || [ -z "${platform_digests[linux/arm64]:-}" ]; then
+            echo "ERROR: candidate requires one amd64 and one arm64 digest." >&2
+            exit 1
+          fi
+          docker buildx imagetools create --tag "$IMAGE:$CANDIDATE_TAG" "${sources[@]}"
+          digest="$(
+            docker buildx imagetools inspect "$IMAGE:$CANDIDATE_TAG" \
+              --format '{{.Manifest.Digest}}'
+          )"
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "ERROR: candidate index digest is invalid." >&2
+            exit 1
+          fi
+          reference="$IMAGE@$digest"
+          scripts/checks/validate-managed-base-index.sh \
+            "$reference" \
+            "${platform_digests[linux/amd64]}" \
+            "${platform_digests[linux/arm64]}"
+          install -d -m 0700 "$RUNNER_TEMP/llama-cpp-candidate"
+          docker buildx imagetools inspect "$reference" --raw \
+            > "$RUNNER_TEMP/llama-cpp-candidate/candidate-index.json"
+          actual_digest="sha256:$(sha256sum "$RUNNER_TEMP/llama-cpp-candidate/candidate-index.json" | awk '{print $1}')"
+          if [ "$actual_digest" != "$digest" ]; then
+            echo "ERROR: candidate index bytes do not match its registry digest." >&2
+            exit 1
+          fi
+          platform_json="$(
+            jq -cnS \
+              --arg amd64 "${platform_digests[linux/amd64]}" \
+              --arg arm64 "${platform_digests[linux/arm64]}" \
+              '{"linux/amd64":$amd64,"linux/arm64":$arm64}'
+          )"
+          printf '%s\n' "$platform_json" \
+            > "$RUNNER_TEMP/llama-cpp-candidate/platform-digests.json"
+          {
+            printf 'candidate_tag=%s\n' "$CANDIDATE_TAG"
+            printf 'digest=%s\n' "$digest"
+            printf 'platform_digests=%s\n' "$platform_json"
+            printf 'reference=%s\n' "$reference"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload candidate descriptors
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llama-cpp-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/llama-cpp-candidate
+          if-no-files-found: error
+          retention-days: ${{ fromJSON(needs.config.outputs.publication_receipt_retention_days) }}
+
+  scan-candidate:
+    name: Scan llama.cpp digest (${{ matrix.arch }})
+    needs: [config, publication-gate, assemble-candidate]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+          - arch: arm64
+            platform: linux/arm64
+    steps:
+      - name: Authenticate to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Scan exact platform digest
+        id: scan
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        env:
+          GRYPE_PLATFORM: ${{ matrix.platform }}
+        with:
+          image: ${{ needs.config.outputs.publication_repository }}@${{ fromJSON(needs.assemble-candidate.outputs.platform_digests)[matrix.platform] }}
+          severity-cutoff: ${{ needs.config.outputs.publication_vulnerability_severity_cutoff }}
+          only-fixed: ${{ needs.config.outputs.publication_vulnerability_only_fixed }}
+          fail-build: true
+          output-format: json
+          output-file: scan-${{ matrix.arch }}.json
+        continue-on-error: true
+
+      - name: Upload vulnerability report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llama-cpp-scan-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
+          path: scan-${{ matrix.arch }}.json
+          if-no-files-found: error
+          retention-days: ${{ fromJSON(needs.config.outputs.publication_receipt_retention_days) }}
+
+      - name: Enforce vulnerability policy
+        if: steps.scan.outcome != 'success'
+        env:
+          IMAGE: ${{ needs.config.outputs.publication_repository }}@${{ fromJSON(needs.assemble-candidate.outputs.platform_digests)[matrix.platform] }}
+        run: |
+          echo "ERROR: exact llama.cpp platform digest failed the declarative vulnerability policy: $IMAGE" >&2
+          exit 1
+
+  attest-candidate:
+    name: Attest and sign exact llama.cpp candidate
+    needs: [config, publication-gate, assemble-candidate, scan-candidate]
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    uses: ./.github/workflows/llama-cpp-image-attest.yaml
+    with:
+      candidate_tag: ${{ needs.assemble-candidate.outputs.candidate_tag }}
+      digest: ${{ needs.assemble-candidate.outputs.digest }}
+      image: ${{ needs.config.outputs.publication_repository }}
+      retention_days: ${{ fromJSON(needs.config.outputs.publication_receipt_retention_days) }}
+      sbom_format: ${{ needs.config.outputs.publication_sbom_format }}
+
+  verify-candidate:
+    name: Verify evidence and emit publication receipt
+    needs:
+      [
+        config,
+        publication-gate,
+        assemble-candidate,
+        scan-candidate,
+        attest-candidate,
+      ]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      attestations: read
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Authenticate to GHCR for cryptographic verification
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
+
+      - name: Download candidate descriptors
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llama-cpp-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/llama-cpp-evidence
+
+      - name: Download vulnerability reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: llama-cpp-scan-${{ github.run_id }}-${{ github.run_attempt }}-*
+          path: ${{ runner.temp }}/llama-cpp-evidence
+          merge-multiple: true
+
+      - name: Download SPDX SBOMs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: llama-cpp-sbom-*-${{ needs.assemble-candidate.outputs.candidate_tag }}
+          path: ${{ runner.temp }}/llama-cpp-evidence
+          merge-multiple: true
+
+      - name: Verify cryptographic evidence
+        shell: bash
+        env:
+          CERTIFICATE_IDENTITY: ${{ needs.config.outputs.publication_signature_identity }}
+          CERTIFICATE_OIDC_ISSUER: ${{ needs.config.outputs.publication_signature_issuer }}
+          EXPECTED_REF: ${{ needs.config.outputs.publication_allowed_ref }}
+          EXPECTED_REVISION: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PROVENANCE_PREDICATE_TYPE: ${{ needs.config.outputs.publication_provenance_predicate_type }}
+          REFERENCE: ${{ needs.assemble-candidate.outputs.reference }}
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/llama-cpp-evidence"
+          cosign verify \
+            --certificate-identity "$CERTIFICATE_IDENTITY" \
+            --certificate-oidc-issuer "$CERTIFICATE_OIDC_ISSUER" \
+            --output json \
+            "$REFERENCE" > "$evidence/signature-verification.raw.json"
+          jq -s '
+            if length == 1 and (.[0] | type) == "array" then .[0] else . end
+          ' "$evidence/signature-verification.raw.json" \
+            > "$evidence/signature-verification.json"
+          cosign verify-attestation \
+            --certificate-identity "$CERTIFICATE_IDENTITY" \
+            --certificate-oidc-issuer "$CERTIFICATE_OIDC_ISSUER" \
+            --type spdxjson \
+            --output json \
+            "$REFERENCE" > "$evidence/sbom-verification.raw.json"
+          jq -s '
+            if length == 1 and (.[0] | type) == "array" then .[0] else . end
+          ' "$evidence/sbom-verification.raw.json" \
+            > "$evidence/sbom-verification.json"
+          gh attestation verify "oci://$REFERENCE" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/llama-cpp-image-attest.yaml" \
+            --source-ref "$EXPECTED_REF" \
+            --source-digest "$EXPECTED_REVISION" \
+            --predicate-type "$PROVENANCE_PREDICATE_TYPE" \
+            --format json > "$evidence/provenance-verification.json"
+
+      - name: Verify publication evidence and create receipt
+        shell: bash
+        env:
+          CERTIFICATE_IDENTITY: ${{ needs.config.outputs.publication_signature_identity }}
+          CERTIFICATE_OIDC_ISSUER: ${{ needs.config.outputs.publication_signature_issuer }}
+          CUDA_DEVELOPMENT_BASE: ${{ needs.config.outputs.cuda_dev_image }}
+          CUDA_RUNTIME_BASE: ${{ needs.config.outputs.cuda_runtime_image }}
+          REFERENCE: ${{ needs.assemble-candidate.outputs.reference }}
+          SOURCE_ARCHIVE_SHA256: ${{ needs.config.outputs.source_archive_sha256 }}
+          SOURCE_REVISION: ${{ needs.config.outputs.source_revision }}
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/llama-cpp-evidence"
+          scripts/checks/verify-llama-cpp-image-publication-evidence.sh \
+            --reference "$REFERENCE" \
+            --candidate-index "$evidence/candidate-index.json" \
+            --platform-digests "$evidence/platform-digests.json" \
+            --sbom-amd64 "$evidence/llama-cpp-sbom-amd64.spdx.json" \
+            --sbom-arm64 "$evidence/llama-cpp-sbom-arm64.spdx.json" \
+            --sbom-verification "$evidence/sbom-verification.json" \
+            --provenance-verification "$evidence/provenance-verification.json" \
+            --signature-verification "$evidence/signature-verification.json" \
+            --scan-amd64 "$evidence/scan-amd64.json" \
+            --scan-arm64 "$evidence/scan-arm64.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --revision "$GITHUB_SHA" \
+            --source-revision "$SOURCE_REVISION" \
+            --source-archive-sha256 "$SOURCE_ARCHIVE_SHA256" \
+            --cuda-development-base "$CUDA_DEVELOPMENT_BASE" \
+            --cuda-runtime-base "$CUDA_RUNTIME_BASE" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --certificate-identity "$CERTIFICATE_IDENTITY" \
+            --certificate-oidc-issuer "$CERTIFICATE_OIDC_ISSUER" \
+            --output "$evidence/publication-receipt.json"
+
+      - name: Upload canonical publication receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llama-cpp-publication-receipt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/llama-cpp-evidence/publication-receipt.json
+          if-no-files-found: error
+          retention-days: ${{ fromJSON(needs.config.outputs.publication_receipt_retention_days) }}

--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -10,6 +10,52 @@ metadata:
 spec:
   repository: ghcr.io/nvidia/nemoclaw/llama-cpp-server
 
+  publication:
+    enabled: false
+    trigger: workflow_dispatch
+    allowedRef: refs/heads/main
+    repository: ghcr.io/nvidia/nemoclaw/llama-cpp-server
+    candidateTagTemplate: llama-cpp-candidate-{runId}-{runAttempt}
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    evidence:
+      sbom:
+        format: spdx-json
+      provenance:
+        predicateType: https://slsa.dev/provenance/v1
+      signature:
+        mode: sigstore-keyless
+        certificateIdentity: https://github.com/NVIDIA/NemoClaw/.github/workflows/llama-cpp-image-attest.yaml@refs/heads/main
+        certificateOidcIssuer: https://token.actions.githubusercontent.com
+        transparencyLog: required
+      vulnerability:
+        scanner: grype
+        severityCutoff: high
+        onlyFixed: true
+      anonymousPull:
+        exactDigest: true
+      receipt:
+        schemaVersion: 1
+        retentionDays: 90
+    qualification:
+      required: true
+      profile: dgx-spark-gb10-single
+      platform: linux/arm64
+      runner: null
+      environment: null
+      model:
+        id: unsloth/Nemotron-3-Nano-30B-A3B-GGUF
+        digest: sha256:627f5b04aedc97f967332f331bd75b7a4ed2f33ca83e6ee74b44235cc1887890
+        hostPath: null
+      gpu:
+        vendor: nvidia
+        fullOffload: true
+        cpuFallback: reject
+      probes:
+        - health
+        - completion
+
   source:
     repository: https://github.com/ggml-org/llama.cpp
     revision: 22dc605c4ead20e36f447cc67b55ef87e523bd55

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -25,6 +25,32 @@ type ServerImageManifest = {
       platform?: unknown;
       runner?: unknown;
     }>;
+    publication?: {
+      allowedRef?: unknown;
+      candidateTagTemplate?: unknown;
+      enabled?: unknown;
+      evidence?: {
+        anonymousPull?: unknown;
+        provenance?: unknown;
+        receipt?: unknown;
+        sbom?: unknown;
+        signature?: unknown;
+        vulnerability?: unknown;
+      };
+      platforms?: unknown;
+      qualification?: {
+        environment?: unknown;
+        gpu?: unknown;
+        model?: unknown;
+        platform?: unknown;
+        probes?: unknown;
+        profile?: unknown;
+        required?: unknown;
+        runner?: unknown;
+      };
+      repository?: unknown;
+      trigger?: unknown;
+    };
     repository?: unknown;
     runtime?: {
       entrypoint?: unknown;
@@ -36,7 +62,11 @@ type ServerImageManifest = {
       uid?: unknown;
       writablePaths?: unknown;
     };
-    source?: { archiveSha256?: unknown; repository?: unknown; revision?: unknown };
+    source?: {
+      archiveSha256?: unknown;
+      repository?: unknown;
+      revision?: unknown;
+    };
   };
 };
 
@@ -47,6 +77,10 @@ const manifestPath = path.join(repoRoot, "managed-inference", "images", "llama-c
 const nvidiaCudaDigestReference = /^docker\.io\/nvidia\/cuda@sha256:[0-9a-f]{64}$/u;
 const fullRevision = /^[0-9a-f]{40}$/u;
 const sha256 = /^sha256:[0-9a-f]{64}$/u;
+const protectedDgxSparkRunner =
+  /^linux-arm64-gpu-dgx-spark-gb10-[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u;
+const protectedDgxSparkEnvironment = /^approve-dgx-spark-[a-z0-9](?:[a-z0-9-]{0,109}[a-z0-9])?$/u;
+const absoluteModelPath = /^\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.gguf$/u;
 
 function requiredString(value: unknown, name: string, pattern: RegExp): string {
   if (typeof value !== "string" || !pattern.test(value)) {
@@ -60,6 +94,25 @@ function requiredRuntimeId(value: unknown, name: string): string {
     throw new Error(`invalid ${name}`);
   }
   return String(value);
+}
+
+function requiredBoolean(value: unknown, name: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`invalid ${name}`);
+  }
+  return value;
+}
+
+function requiredInteger(value: unknown, name: string, minimum: number, maximum: number): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < minimum ||
+    value > maximum
+  ) {
+    throw new Error(`invalid ${name}`);
+  }
+  return value;
 }
 
 function matchesExactRecord(value: unknown, expected: Record<string, unknown>): boolean {
@@ -91,6 +144,7 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     "build",
     "cuda",
     "platforms",
+    "publication",
     "repository",
     "runtime",
     "source",
@@ -114,6 +168,66 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     "writablePaths",
   ]);
   assertExactKeys(manifest.spec?.source, "source", ["archiveSha256", "repository", "revision"]);
+  assertExactKeys(manifest.spec?.publication, "publication", [
+    "allowedRef",
+    "candidateTagTemplate",
+    "enabled",
+    "evidence",
+    "platforms",
+    "qualification",
+    "repository",
+    "trigger",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.evidence, "publication evidence", [
+    "anonymousPull",
+    "provenance",
+    "receipt",
+    "sbom",
+    "signature",
+    "vulnerability",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.evidence?.anonymousPull, "anonymous pull", [
+    "exactDigest",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.evidence?.provenance, "provenance", [
+    "predicateType",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.evidence?.receipt, "publication receipt", [
+    "retentionDays",
+    "schemaVersion",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.evidence?.sbom, "SBOM", ["format"]);
+  assertExactKeys(manifest.spec?.publication?.evidence?.signature, "signature", [
+    "certificateIdentity",
+    "certificateOidcIssuer",
+    "mode",
+    "transparencyLog",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.evidence?.vulnerability, "vulnerability", [
+    "onlyFixed",
+    "scanner",
+    "severityCutoff",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.qualification, "publication qualification", [
+    "environment",
+    "gpu",
+    "model",
+    "platform",
+    "probes",
+    "profile",
+    "required",
+    "runner",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.qualification?.gpu, "qualification GPU", [
+    "cpuFallback",
+    "fullOffload",
+    "vendor",
+  ]);
+  assertExactKeys(manifest.spec?.publication?.qualification?.model, "qualification model", [
+    "digest",
+    "hostPath",
+    "id",
+  ]);
   if (
     manifest?.apiVersion !== "nemoclaw.nvidia.com/managed-inference/v1" ||
     manifest?.kind !== "ServerImageBuild" ||
@@ -123,6 +237,112 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   }
 
   const spec = manifest.spec;
+  const publication = spec?.publication;
+  const evidence = publication?.evidence;
+  const qualification = publication?.qualification;
+  const publicationEnabled = requiredBoolean(publication?.enabled, "publication enablement");
+  const publicationRepository = requiredString(
+    publication?.repository,
+    "publication repository",
+    /^ghcr\.io\/nvidia\/nemoclaw\/llama-cpp-server$/u,
+  );
+  const publicationPlatforms = publication?.platforms;
+  const qualificationRunner = qualification?.runner;
+  const qualificationEnvironment = qualification?.environment;
+  const qualificationModel = qualification?.model as
+    | { digest?: unknown; hostPath?: unknown; id?: unknown }
+    | undefined;
+  const qualificationGpu = qualification?.gpu as
+    | { cpuFallback?: unknown; fullOffload?: unknown; vendor?: unknown }
+    | undefined;
+  const qualificationHostPath = qualificationModel?.hostPath;
+  if (
+    publication?.trigger !== "workflow_dispatch" ||
+    publication?.allowedRef !== "refs/heads/main" ||
+    publication?.candidateTagTemplate !== "llama-cpp-candidate-{runId}-{runAttempt}" ||
+    JSON.stringify(publicationPlatforms) !== JSON.stringify(["linux/amd64", "linux/arm64"]) ||
+    evidence?.sbom === undefined ||
+    !matchesExactRecord(evidence.sbom, { format: "spdx-json" }) ||
+    evidence?.provenance === undefined ||
+    !matchesExactRecord(evidence.provenance, {
+      predicateType: "https://slsa.dev/provenance/v1",
+    }) ||
+    evidence?.signature === undefined ||
+    !matchesExactRecord(evidence.signature, {
+      certificateIdentity:
+        "https://github.com/NVIDIA/NemoClaw/.github/workflows/llama-cpp-image-attest.yaml@refs/heads/main",
+      certificateOidcIssuer: "https://token.actions.githubusercontent.com",
+      mode: "sigstore-keyless",
+      transparencyLog: "required",
+    }) ||
+    evidence?.vulnerability === undefined ||
+    !matchesExactRecord(evidence.vulnerability, {
+      onlyFixed: true,
+      scanner: "grype",
+      severityCutoff: "high",
+    }) ||
+    evidence?.anonymousPull === undefined ||
+    !matchesExactRecord(evidence.anonymousPull, { exactDigest: true }) ||
+    evidence?.receipt === undefined ||
+    !matchesExactRecord(evidence.receipt, {
+      retentionDays: 90,
+      schemaVersion: 1,
+    }) ||
+    qualification?.required !== true ||
+    qualification?.profile !== "dgx-spark-gb10-single" ||
+    qualification?.platform !== "linux/arm64" ||
+    qualificationModel?.id !== "unsloth/Nemotron-3-Nano-30B-A3B-GGUF" ||
+    qualificationModel?.digest !==
+      "sha256:627f5b04aedc97f967332f331bd75b7a4ed2f33ca83e6ee74b44235cc1887890" ||
+    !matchesExactRecord(qualification?.gpu, {
+      cpuFallback: "reject",
+      fullOffload: true,
+      vendor: "nvidia",
+    }) ||
+    JSON.stringify(qualification?.probes) !== JSON.stringify(["health", "completion"])
+  ) {
+    throw new Error("invalid llama.cpp image publication contract");
+  }
+  if (publicationRepository !== spec?.repository) {
+    throw new Error("publication repository must match the image repository");
+  }
+  const infrastructureComplete =
+    typeof qualificationRunner === "string" &&
+    protectedDgxSparkRunner.test(qualificationRunner) &&
+    typeof qualificationEnvironment === "string" &&
+    protectedDgxSparkEnvironment.test(qualificationEnvironment) &&
+    typeof qualificationHostPath === "string" &&
+    absoluteModelPath.test(qualificationHostPath) &&
+    !qualificationHostPath.split("/").includes("..") &&
+    !qualificationHostPath.split("/").includes(".");
+  const infrastructureUnset =
+    qualificationRunner === null &&
+    qualificationEnvironment === null &&
+    qualificationHostPath === null;
+  if (publicationEnabled && !infrastructureComplete) {
+    throw new Error("publication qualification infrastructure is incomplete");
+  }
+  if (!publicationEnabled && !infrastructureUnset && !infrastructureComplete) {
+    throw new Error("disabled publication must not bind partial infrastructure");
+  }
+  const normalizedQualification = {
+    environment: qualificationEnvironment,
+    gpu: {
+      cpuFallback: qualificationGpu?.cpuFallback,
+      fullOffload: qualificationGpu?.fullOffload,
+      vendor: qualificationGpu?.vendor,
+    },
+    model: {
+      digest: qualificationModel?.digest,
+      hostPath: qualificationHostPath,
+      id: qualificationModel?.id,
+    },
+    platform: qualification?.platform,
+    probes: qualification?.probes,
+    profile: qualification?.profile,
+    required: qualification?.required,
+    runner: qualificationRunner,
+  };
   const expectedCmake = {
     ggmlBackendDl: true,
     ggmlCpuAllVariants: true,
@@ -243,6 +463,93 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
       /^ghcr\.io\/nvidia\/nemoclaw\/llama-cpp-server$/u,
     ),
     matrix: JSON.stringify({ include }),
+    publication_allowed_ref: requiredString(
+      publication.allowedRef,
+      "publication allowed ref",
+      /^refs\/heads\/main$/u,
+    ),
+    publication_candidate_tag_template: requiredString(
+      publication.candidateTagTemplate,
+      "publication candidate tag template",
+      /^llama-cpp-candidate-\{runId\}-\{runAttempt\}$/u,
+    ),
+    publication_enabled: String(publicationEnabled),
+    publication_platforms: JSON.stringify(publicationPlatforms),
+    publication_repository: publicationRepository,
+    publication_trigger: requiredString(
+      publication.trigger,
+      "publication trigger",
+      /^workflow_dispatch$/u,
+    ),
+    publication_sbom_format: requiredString(
+      (evidence?.sbom as { format?: unknown }).format,
+      "publication SBOM format",
+      /^spdx-json$/u,
+    ),
+    publication_provenance_predicate_type: requiredString(
+      (evidence?.provenance as { predicateType?: unknown }).predicateType,
+      "publication provenance predicate type",
+      /^https:\/\/slsa\.dev\/provenance\/v1$/u,
+    ),
+    publication_signature_mode: requiredString(
+      (evidence?.signature as { mode?: unknown }).mode,
+      "publication signature mode",
+      /^sigstore-keyless$/u,
+    ),
+    publication_signature_identity: requiredString(
+      (evidence?.signature as { certificateIdentity?: unknown }).certificateIdentity,
+      "publication signature identity",
+      /^https:\/\/github\.com\/NVIDIA\/NemoClaw\/\.github\/workflows\/llama-cpp-image-attest\.yaml@refs\/heads\/main$/u,
+    ),
+    publication_signature_issuer: requiredString(
+      (evidence?.signature as { certificateOidcIssuer?: unknown }).certificateOidcIssuer,
+      "publication signature issuer",
+      /^https:\/\/token\.actions\.githubusercontent\.com$/u,
+    ),
+    publication_signature_transparency_log: requiredString(
+      (evidence?.signature as { transparencyLog?: unknown }).transparencyLog,
+      "publication signature transparency log",
+      /^required$/u,
+    ),
+    publication_vulnerability_scanner: requiredString(
+      (evidence?.vulnerability as { scanner?: unknown }).scanner,
+      "publication vulnerability scanner",
+      /^grype$/u,
+    ),
+    publication_vulnerability_severity_cutoff: requiredString(
+      (evidence?.vulnerability as { severityCutoff?: unknown }).severityCutoff,
+      "publication vulnerability severity cutoff",
+      /^high$/u,
+    ),
+    publication_vulnerability_only_fixed: String(
+      requiredBoolean(
+        (evidence?.vulnerability as { onlyFixed?: unknown }).onlyFixed,
+        "publication vulnerability only-fixed policy",
+      ),
+    ),
+    publication_anonymous_exact_digest_pull: String(
+      requiredBoolean(
+        (evidence?.anonymousPull as { exactDigest?: unknown }).exactDigest,
+        "publication anonymous exact-digest pull",
+      ),
+    ),
+    publication_receipt_schema_version: String(
+      requiredInteger(
+        (evidence?.receipt as { schemaVersion?: unknown }).schemaVersion,
+        "publication receipt schema version",
+        1,
+        1,
+      ),
+    ),
+    publication_receipt_retention_days: String(
+      requiredInteger(
+        (evidence?.receipt as { retentionDays?: unknown }).retentionDays,
+        "publication receipt retention days",
+        90,
+        90,
+      ),
+    ),
+    publication_qualification: JSON.stringify(normalizedQualification),
     runtime_gid: requiredRuntimeId(spec?.runtime?.gid, "runtime gid"),
     runtime_forbidden_paths: JSON.stringify(expectedForbiddenPaths),
     runtime_required_paths: JSON.stringify(expectedRequiredPaths),
@@ -266,7 +573,10 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const output = githubOutput(loadLlamaCppImageConfig());
   const githubOutputPath = process.env.GITHUB_OUTPUT;
   if (githubOutputPath) {
-    fs.appendFileSync(githubOutputPath, output, { encoding: "utf8", mode: 0o600 });
+    fs.appendFileSync(githubOutputPath, output, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
   } else {
     process.stdout.write(output);
   }

--- a/scripts/checks/verify-llama-cpp-image-publication-evidence.sh
+++ b/scripts/checks/verify-llama-cpp-image-publication-evidence.sh
@@ -280,7 +280,11 @@ sbom_expected="$temporary_root/sbom-expected.txt"
   printf '\n'
   jq -cS . "$sbom_arm64" | sha256_file /dev/stdin
   printf '\n'
-} | sort >"$sbom_expected"
+} | sort -u >"$sbom_expected"
+if [ "$(wc -l <"$sbom_expected" | tr -d '[:space:]')" -ne 2 ]; then
+  echo "ERROR: amd64 and arm64 SPDX documents must be distinct." >&2
+  exit 1
+fi
 sbom_actual="$temporary_root/sbom-actual.txt"
 sbom_attestation_count="$(jq -er 'length' "$sbom_verification")"
 for ((index = 0; index < sbom_attestation_count; index += 1)); do
@@ -300,9 +304,8 @@ for ((index = 0; index < sbom_attestation_count; index += 1)); do
   jq -cS .predicate "$statement" | sha256_file /dev/stdin
   printf '\n'
 done | sort -u >"$sbom_actual"
-if ! while IFS= read -r expected_hash; do
-  grep --fixed-strings --line-regexp "$expected_hash" "$sbom_actual" >/dev/null
-done <"$sbom_expected"; then
+missing_sbom_hashes="$(comm -23 "$sbom_expected" "$sbom_actual")"
+if [ -n "$missing_sbom_hashes" ]; then
   echo "ERROR: verified SBOM attestations do not match both platform documents." >&2
   exit 1
 fi

--- a/scripts/checks/verify-llama-cpp-image-publication-evidence.sh
+++ b/scripts/checks/verify-llama-cpp-image-publication-evidence.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+  printf '%s\n' "Usage: $0 --reference IMAGE@DIGEST --candidate-index PATH --platform-digests PATH --sbom-amd64 PATH --sbom-arm64 PATH --sbom-verification PATH --provenance-verification PATH --signature-verification PATH --scan-amd64 PATH --scan-arm64 PATH --repository OWNER/REPOSITORY --revision GIT_SHA --source-revision GIT_SHA --source-archive-sha256 DIGEST --cuda-development-base IMAGE@DIGEST --cuda-runtime-base IMAGE@DIGEST --run-id ID --run-attempt ATTEMPT --certificate-identity IDENTITY --certificate-oidc-issuer ISSUER --output PATH" >&2
+  exit 64
+}
+
+reference=""
+candidate_index=""
+platform_digests=""
+sbom_amd64=""
+sbom_arm64=""
+sbom_verification=""
+provenance_verification=""
+signature_verification=""
+scan_amd64=""
+scan_arm64=""
+repository=""
+revision=""
+source_revision=""
+source_archive_sha256=""
+cuda_development_base=""
+cuda_runtime_base=""
+run_id=""
+run_attempt=""
+certificate_identity=""
+certificate_oidc_issuer=""
+output=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --reference)
+      reference="${2:-}"
+      shift 2
+      ;;
+    --candidate-index)
+      candidate_index="${2:-}"
+      shift 2
+      ;;
+    --platform-digests)
+      platform_digests="${2:-}"
+      shift 2
+      ;;
+    --sbom-amd64)
+      sbom_amd64="${2:-}"
+      shift 2
+      ;;
+    --sbom-arm64)
+      sbom_arm64="${2:-}"
+      shift 2
+      ;;
+    --sbom-verification)
+      sbom_verification="${2:-}"
+      shift 2
+      ;;
+    --provenance-verification)
+      provenance_verification="${2:-}"
+      shift 2
+      ;;
+    --signature-verification)
+      signature_verification="${2:-}"
+      shift 2
+      ;;
+    --scan-amd64)
+      scan_amd64="${2:-}"
+      shift 2
+      ;;
+    --scan-arm64)
+      scan_arm64="${2:-}"
+      shift 2
+      ;;
+    --repository)
+      repository="${2:-}"
+      shift 2
+      ;;
+    --revision)
+      revision="${2:-}"
+      shift 2
+      ;;
+    --source-revision)
+      source_revision="${2:-}"
+      shift 2
+      ;;
+    --source-archive-sha256)
+      source_archive_sha256="${2:-}"
+      shift 2
+      ;;
+    --cuda-development-base)
+      cuda_development_base="${2:-}"
+      shift 2
+      ;;
+    --cuda-runtime-base)
+      cuda_runtime_base="${2:-}"
+      shift 2
+      ;;
+    --run-id)
+      run_id="${2:-}"
+      shift 2
+      ;;
+    --run-attempt)
+      run_attempt="${2:-}"
+      shift 2
+      ;;
+    --certificate-identity)
+      certificate_identity="${2:-}"
+      shift 2
+      ;;
+    --certificate-oidc-issuer)
+      certificate_oidc_issuer="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+
+digest_pattern='sha256:[0-9a-f]{64}'
+owned_image='ghcr.io/nvidia/nemoclaw/llama-cpp-server'
+image="${reference%@*}"
+reference_digest="${reference##*@}"
+if [[ ! "$reference" =~ ^ghcr\.io/nvidia/nemoclaw/llama-cpp-server@${digest_pattern}$ ]] \
+  || [ "$image" != "$owned_image" ] \
+  || [ "$repository" != "NVIDIA/NemoClaw" ] \
+  || [[ ! "$revision" =~ ^[0-9a-f]{40}$ ]] \
+  || [[ ! "$source_revision" =~ ^[0-9a-f]{40}$ ]] \
+  || [[ ! "$source_archive_sha256" =~ ^${digest_pattern}$ ]] \
+  || [[ ! "$cuda_development_base" =~ ^docker\.io/nvidia/cuda@${digest_pattern}$ ]] \
+  || [[ ! "$cuda_runtime_base" =~ ^docker\.io/nvidia/cuda@${digest_pattern}$ ]] \
+  || [[ ! "$run_id" =~ ^[1-9][0-9]{0,19}$ ]] \
+  || [[ ! "$run_attempt" =~ ^[1-9][0-9]{0,9}$ ]] \
+  || [ "$certificate_identity" != "https://github.com/NVIDIA/NemoClaw/.github/workflows/llama-cpp-image-attest.yaml@refs/heads/main" ] \
+  || [ "$certificate_oidc_issuer" != "https://token.actions.githubusercontent.com" ] \
+  || [ -z "$output" ]; then
+  echo "ERROR: llama.cpp publication identity is invalid." >&2
+  exit 1
+fi
+
+for evidence_file in \
+  "$candidate_index" \
+  "$platform_digests" \
+  "$sbom_amd64" \
+  "$sbom_arm64" \
+  "$sbom_verification" \
+  "$provenance_verification" \
+  "$signature_verification" \
+  "$scan_amd64" \
+  "$scan_arm64"; do
+  if [ ! -f "$evidence_file" ] || [ -L "$evidence_file" ] || [ ! -s "$evidence_file" ]; then
+    echo "ERROR: publication evidence must be a non-empty regular file and not a symlink: $evidence_file" >&2
+    exit 1
+  fi
+done
+
+output_parent="$(dirname "$output")"
+if [ -L "$output_parent" ] || { [ -e "$output_parent" ] && [ ! -d "$output_parent" ]; }; then
+  echo "ERROR: publication receipt output parent must be absent or a directory and not a symlink." >&2
+  exit 1
+fi
+install -d -m 0700 "$output_parent"
+if [ -L "$output" ] || { [ -e "$output" ] && [ ! -f "$output" ]; }; then
+  echo "ERROR: publication receipt output must be absent or a regular file and not a symlink." >&2
+  exit 1
+fi
+
+temporary_root="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/llama-cpp-publication-evidence-XXXXXX")"
+cleanup() {
+  rm -rf "$temporary_root"
+}
+trap cleanup EXIT
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf 'sha256:%s' "$(sha256sum "$1" | awk '{print $1}')"
+  else
+    printf 'sha256:%s' "$(shasum -a 256 "$1" | awk '{print $1}')"
+  fi
+}
+
+candidate_digest="$(sha256_file "$candidate_index")"
+if [ "$candidate_digest" != "$reference_digest" ]; then
+  echo "ERROR: candidate index bytes do not match the exact reference." >&2
+  exit 1
+fi
+
+if ! jq -e '
+  (keys | sort) == ["manifests", "mediaType", "schemaVersion"]
+  and .schemaVersion == 2
+  and .mediaType == "application/vnd.oci.image.index.v1+json"
+  and (.manifests | length) == 2
+  and all(.manifests[];
+    (keys | sort) == ["digest", "mediaType", "platform", "size"]
+    and .mediaType == "application/vnd.oci.image.manifest.v1+json"
+    and (.digest | test("^sha256:[0-9a-f]{64}$"))
+    and (.size | type) == "number" and .size > 0 and (.size | floor) == .size
+    and (.platform | keys | sort) == ["architecture", "os"]
+    and .platform.os == "linux"
+    and (.platform.architecture == "amd64" or .platform.architecture == "arm64")
+  )
+  and ([.manifests[].platform.architecture] | sort) == ["amd64", "arm64"]
+' "$candidate_index" >/dev/null; then
+  echo "ERROR: candidate index is not the exact two-platform contract." >&2
+  exit 1
+fi
+
+if ! jq -e '
+  (keys | sort) == ["linux/amd64", "linux/arm64"]
+  and all(.[]; type == "string" and test("^sha256:[0-9a-f]{64}$"))
+' "$platform_digests" >/dev/null; then
+  echo "ERROR: platform digest map does not match the exact two-platform contract." >&2
+  exit 1
+fi
+for arch in amd64 arm64; do
+  expected="$(jq -er --arg platform "linux/$arch" '.[$platform]' "$platform_digests")"
+  actual="$(jq -er --arg arch "$arch" '.manifests[] | select(.platform == {os:"linux", architecture:$arch}) | .digest' "$candidate_index")"
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: candidate linux/$arch descriptor is not bound to this run." >&2
+    exit 1
+  fi
+done
+
+mkdir -m 0700 "$temporary_root/docker-config"
+anonymous_index="$temporary_root/anonymous-index.json"
+DOCKER_CONFIG="$temporary_root/docker-config" \
+  docker buildx imagetools inspect "$reference" --raw >"$anonymous_index"
+if ! cmp -s "$candidate_index" "$anonymous_index"; then
+  echo "ERROR: anonymous exact-digest pull does not match the candidate bytes." >&2
+  exit 1
+fi
+
+anonymous_pull_summary="$temporary_root/anonymous-pull-summary.jsonl"
+: >"$anonymous_pull_summary"
+for arch in amd64 arm64; do
+  platform="linux/$arch"
+  if ! DOCKER_CONFIG="$temporary_root/docker-config" \
+    docker pull --platform "$platform" "$reference"; then
+    echo "ERROR: anonymous exact-digest pull failed for $platform." >&2
+    exit 1
+  fi
+  image_id="$(docker image inspect --format '{{.Id}}' "$reference")"
+  if [[ ! "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || [ "$(docker image inspect --format '{{.Id}}' "$image_id")" != "$image_id" ]; then
+    echo "ERROR: anonymous $platform pull did not resolve to one immutable local image ID." >&2
+    exit 1
+  fi
+  jq -cn \
+    --arg imageId "$image_id" \
+    --arg platform "$platform" \
+    '{platform:$platform,imageId:$imageId}' >>"$anonymous_pull_summary"
+done
+
+for sbom in "$sbom_amd64" "$sbom_arm64"; do
+  if ! jq -e '
+    (type == "object")
+    and .SPDXID == "SPDXRef-DOCUMENT"
+    and (.spdxVersion == "SPDX-2.2" or .spdxVersion == "SPDX-2.3")
+    and .dataLicense == "CC0-1.0"
+    and (.documentNamespace | type) == "string" and (.documentNamespace | length) > 0
+    and (.creationInfo.creators | type) == "array" and (.creationInfo.creators | length) > 0
+    and (.packages | type) == "array"
+  ' "$sbom" >/dev/null; then
+    echo "ERROR: SPDX SBOM document is malformed." >&2
+    exit 1
+  fi
+done
+
+if ! jq -e 'type == "array" and length >= 2 and all(.[]; (.payload | type) == "string" and (.payload | length) > 0)' "$sbom_verification" >/dev/null; then
+  echo "ERROR: expected verified SBOM attestations." >&2
+  exit 1
+fi
+sbom_expected="$temporary_root/sbom-expected.txt"
+{
+  jq -cS . "$sbom_amd64" | sha256_file /dev/stdin
+  printf '\n'
+  jq -cS . "$sbom_arm64" | sha256_file /dev/stdin
+  printf '\n'
+} | sort >"$sbom_expected"
+sbom_actual="$temporary_root/sbom-actual.txt"
+sbom_attestation_count="$(jq -er 'length' "$sbom_verification")"
+for ((index = 0; index < sbom_attestation_count; index += 1)); do
+  payload="$(jq -er --argjson index "$index" '.[$index].payload' "$sbom_verification")"
+  statement="$temporary_root/sbom-statement-$index.json"
+  printf '%s' "$payload" | openssl base64 -d -A >"$statement"
+  if ! jq -e --arg digest "${reference_digest#sha256:}" '
+    ._type == "https://in-toto.io/Statement/v1"
+    and .predicateType == "https://spdx.dev/Document"
+    and (.subject | length) == 1
+    and .subject[0].digest == {sha256:$digest}
+    and (.predicate | type) == "object"
+  ' "$statement" >/dev/null; then
+    echo "ERROR: SBOM attestation does not bind the candidate index." >&2
+    exit 1
+  fi
+  jq -cS .predicate "$statement" | sha256_file /dev/stdin
+  printf '\n'
+done | sort -u >"$sbom_actual"
+if ! while IFS= read -r expected_hash; do
+  grep --fixed-strings --line-regexp "$expected_hash" "$sbom_actual" >/dev/null
+done <"$sbom_expected"; then
+  echo "ERROR: verified SBOM attestations do not match both platform documents." >&2
+  exit 1
+fi
+
+if ! jq -e --arg digest "${reference_digest#sha256:}" '
+  type == "array" and length >= 1
+  and any(.[].verificationResult;
+    .statement._type == "https://in-toto.io/Statement/v1"
+    and .statement.predicateType == "https://slsa.dev/provenance/v1"
+    and (.statement.subject | length) == 1
+    and .statement.subject[0].digest == {sha256:$digest}
+    and (.verifiedTimestamps | type) == "array"
+    and (.verifiedTimestamps | length) > 0
+  )
+' "$provenance_verification" >/dev/null; then
+  echo "ERROR: SLSA provenance verification does not bind the candidate index." >&2
+  exit 1
+fi
+
+if ! jq -e --arg digest "$reference_digest" --arg image "$image" '
+  type == "array" and length >= 1
+  and all(.[].critical;
+    .type == "cosign container image signature"
+    and .identity["docker-reference"] == $image
+    and .image["docker-manifest-digest"] == $digest
+  )
+' "$signature_verification" >/dev/null; then
+  echo "ERROR: keyless signature verification does not bind the candidate index." >&2
+  exit 1
+fi
+
+scan_summary="$temporary_root/scan-summary.jsonl"
+: >"$scan_summary"
+for arch in amd64 arm64; do
+  scan_variable="scan_$arch"
+  scan_file="${!scan_variable}"
+  platform="linux/$arch"
+  platform_digest="$(jq -er --arg platform "$platform" '.[$platform]' "$platform_digests")"
+  platform_reference="$image@$platform_digest"
+  if ! jq -e --arg reference "$platform_reference" '
+    (.descriptor.name | ascii_downcase) == "grype"
+    and (.descriptor.version | type) == "string" and (.descriptor.version | length) > 0
+    and (.matches | type) == "array"
+    and .source.type == "image"
+    and .source.target.userInput == $reference
+    and ([.matches[].vulnerability.severity | ascii_downcase | select(. == "high" or . == "critical")] | length) == 0
+  ' "$scan_file" >/dev/null; then
+    echo "ERROR: linux/$arch vulnerability evidence violates the high/only-fixed policy." >&2
+    exit 1
+  fi
+  jq -cn \
+    --arg platform "$platform" \
+    --arg reference "$platform_reference" \
+    --arg reportSha256 "$(sha256_file "$scan_file")" \
+    --arg scannerVersion "$(jq -er '.descriptor.version' "$scan_file")" \
+    --argjson matchCount "$(jq -er '.matches | length' "$scan_file")" \
+    '{platform:$platform,reference:$reference,reportSha256:$reportSha256,scannerVersion:$scannerVersion,matchCount:$matchCount}' \
+    >>"$scan_summary"
+done
+
+candidate_size="$(wc -c <"$candidate_index" | tr -d '[:space:]')"
+candidate_tag="llama-cpp-candidate-${run_id}-${run_attempt}"
+temporary_output="$temporary_root/receipt.json"
+jq -nS \
+  --arg certificateIdentity "$certificate_identity" \
+  --arg certificateOidcIssuer "$certificate_oidc_issuer" \
+  --arg cudaDevelopmentBase "$cuda_development_base" \
+  --arg cudaRuntimeBase "$cuda_runtime_base" \
+  --arg candidateTag "$candidate_tag" \
+  --arg digest "$reference_digest" \
+  --arg image "$image" \
+  --arg provenanceSha256 "$(sha256_file "$provenance_verification")" \
+  --arg reference "$reference" \
+  --arg repository "$repository" \
+  --arg revision "$revision" \
+  --arg runAttempt "$run_attempt" \
+  --arg runId "$run_id" \
+  --arg sbomAmd64Sha256 "$(sha256_file "$sbom_amd64")" \
+  --arg sbomArm64Sha256 "$(sha256_file "$sbom_arm64")" \
+  --arg sbomVerificationSha256 "$(sha256_file "$sbom_verification")" \
+  --arg signatureVerificationSha256 "$(sha256_file "$signature_verification")" \
+  --arg sourceArchiveSha256 "$source_archive_sha256" \
+  --arg sourceRevision "$source_revision" \
+  --argjson candidateSize "$candidate_size" \
+  --slurpfile platformDigests "$platform_digests" \
+  --slurpfile anonymousPlatforms "$anonymous_pull_summary" \
+  --slurpfile scans "$scan_summary" \
+  '{
+    schemaVersion: 1,
+    image: {
+      repository: $image,
+      candidateTag: $candidateTag,
+      index: {reference:$reference,digest:$digest,size:$candidateSize},
+      platforms: $platformDigests[0]
+    },
+    build: {
+      repository: $repository,
+      revision: $revision,
+      run: {id:$runId,attempt:$runAttempt},
+      source: {revision:$sourceRevision,archiveSha256:$sourceArchiveSha256},
+      cuda: {developmentBase:$cudaDevelopmentBase,runtimeBase:$cudaRuntimeBase}
+    },
+    evidence: {
+      sbom: {
+        format:"spdx-json",
+        amd64Sha256:$sbomAmd64Sha256,
+        arm64Sha256:$sbomArm64Sha256,
+        verificationSha256:$sbomVerificationSha256
+      },
+      provenance: {predicateType:"https://slsa.dev/provenance/v1",verificationSha256:$provenanceSha256},
+      signature: {
+        mode:"sigstore-keyless",
+        certificateIdentity:$certificateIdentity,
+        certificateOidcIssuer:$certificateOidcIssuer,
+        transparencyLog:"verified",
+        verificationSha256:$signatureVerificationSha256
+      },
+      vulnerability: {scanner:"grype",severityCutoff:"high",onlyFixed:true,platforms:$scans},
+      anonymousPull: {
+        exactDigest:true,
+        reference:$reference,
+        indexSha256:$digest,
+        platforms:$anonymousPlatforms
+      }
+    }
+  }' >"$temporary_output"
+
+chmod 0600 "$temporary_output"
+mv -f "$temporary_output" "$output"

--- a/test/llama-cpp-image-publication-evidence.test.ts
+++ b/test/llama-cpp-image-publication-evidence.test.ts
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const verifier = path.join(
+  repoRoot,
+  "scripts",
+  "checks",
+  "verify-llama-cpp-image-publication-evidence.sh",
+);
+const image = "ghcr.io/nvidia/nemoclaw/llama-cpp-server";
+const amd64Digest = `sha256:${"a".repeat(64)}`;
+const arm64Digest = `sha256:${"b".repeat(64)}`;
+const revision = "c".repeat(40);
+const sourceRevision = "d".repeat(40);
+const sourceArchiveSha256 = `sha256:${"e".repeat(64)}`;
+const cudaDevelopmentBase = `docker.io/nvidia/cuda@sha256:${"1".repeat(64)}`;
+const cudaRuntimeBase = `docker.io/nvidia/cuda@sha256:${"2".repeat(64)}`;
+const runId = "30935138368";
+const runAttempt = "1";
+const certificateIdentity =
+  "https://github.com/NVIDIA/NemoClaw/.github/workflows/llama-cpp-image-attest.yaml@refs/heads/main";
+const certificateOidcIssuer = "https://token.actions.githubusercontent.com";
+const sha256 = (value: string) => `sha256:${createHash("sha256").update(value).digest("hex")}`;
+
+type FixtureOptions = {
+  anonymousMismatch?: boolean;
+  anonymousPullFailure?: "amd64" | "arm64";
+  duplicateSbom?: boolean;
+  indexArm64Digest?: string;
+  provenanceDigest?: string;
+  provenanceTimestamps?: unknown[];
+  repository?: string;
+  sbomDigest?: string;
+  scanHigh?: "amd64" | "arm64";
+  signatureDigest?: string;
+};
+
+function spdx(namespace: string) {
+  return {
+    SPDXID: "SPDXRef-DOCUMENT",
+    spdxVersion: "SPDX-2.3",
+    dataLicense: "CC0-1.0",
+    documentNamespace: `https://example.test/spdx/${namespace}`,
+    creationInfo: { creators: ["Tool: fixture"] },
+    packages: [],
+  };
+}
+
+function runEvidence(options: FixtureOptions = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-llama-publication-"));
+  const bin = path.join(root, "bin");
+  const evidence = path.join(root, "evidence");
+  const receiptPath = path.join(evidence, "receipt.json");
+  fs.mkdirSync(bin);
+  fs.mkdirSync(evidence);
+
+  const candidate = JSON.stringify({
+    schemaVersion: 2,
+    mediaType: "application/vnd.oci.image.index.v1+json",
+    manifests: [
+      {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: amd64Digest,
+        size: 101,
+        platform: { os: "linux", architecture: "amd64" },
+      },
+      {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: options.indexArm64Digest ?? arm64Digest,
+        size: 102,
+        platform: { os: "linux", architecture: "arm64" },
+      },
+    ],
+  });
+  const candidateDigest = sha256(candidate);
+  const reference = `${image}@${candidateDigest}`;
+  const amd64Sbom = spdx("amd64");
+  const arm64Sbom = spdx("arm64");
+  const sbomStatement = (predicate: ReturnType<typeof spdx>) => ({
+    _type: "https://in-toto.io/Statement/v1",
+    predicateType: "https://spdx.dev/Document",
+    subject: [
+      {
+        name: image,
+        digest: {
+          sha256: options.sbomDigest ?? candidateDigest.slice("sha256:".length),
+        },
+      },
+    ],
+    predicate,
+  });
+  const sbomVerification = [
+    {
+      payload: Buffer.from(JSON.stringify(sbomStatement(amd64Sbom))).toString("base64"),
+    },
+    {
+      payload: Buffer.from(
+        JSON.stringify(sbomStatement(options.duplicateSbom ? amd64Sbom : arm64Sbom)),
+      ).toString("base64"),
+    },
+  ];
+  const provenanceVerification = [
+    {
+      attestation: { bundle: "fixture" },
+      verificationResult: {
+        statement: {
+          _type: "https://in-toto.io/Statement/v1",
+          predicateType: "https://slsa.dev/provenance/v1",
+          subject: [
+            {
+              name: image,
+              digest: {
+                sha256: options.provenanceDigest ?? candidateDigest.slice("sha256:".length),
+              },
+            },
+          ],
+          predicate: {},
+        },
+        signature: {
+          certificate: { subjectAlternativeName: certificateIdentity },
+        },
+        verifiedTimestamps: options.provenanceTimestamps ?? [{ type: "transparency-log" }],
+      },
+    },
+  ];
+  const signatureVerification = [
+    {
+      critical: {
+        identity: { "docker-reference": image },
+        image: {
+          "docker-manifest-digest": options.signatureDigest ?? candidateDigest,
+        },
+        type: "cosign container image signature",
+      },
+      optional: null,
+    },
+  ];
+  const scan = (arch: "amd64" | "arm64", digest: string) => ({
+    matches:
+      options.scanHigh === arch
+        ? [
+            {
+              vulnerability: {
+                id: "CVE-2099-0001",
+                severity: "High",
+                fix: { versions: ["2.0.0"] },
+              },
+            },
+          ]
+        : [],
+    source: { type: "image", target: { userInput: `${image}@${digest}` } },
+    descriptor: { name: "grype", version: "0.99.0" },
+  });
+
+  const files = {
+    "candidate-index.json": candidate,
+    "anonymous-index.json": options.anonymousMismatch ? `${candidate}\n` : candidate,
+    "platform-digests.json": JSON.stringify({
+      "linux/amd64": amd64Digest,
+      "linux/arm64": arm64Digest,
+    }),
+    "sbom-amd64.json": JSON.stringify(amd64Sbom),
+    "sbom-arm64.json": JSON.stringify(arm64Sbom),
+    "sbom-verification.json": JSON.stringify(sbomVerification),
+    "provenance-verification.json": JSON.stringify(provenanceVerification),
+    "signature-verification.json": JSON.stringify(signatureVerification),
+    "scan-amd64.json": JSON.stringify(scan("amd64", amd64Digest)),
+    "scan-arm64.json": JSON.stringify(scan("arm64", arm64Digest)),
+  };
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(evidence, name), contents);
+  }
+  fs.writeFileSync(
+    path.join(bin, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$*" = "buildx imagetools inspect ${reference} --raw" ]; then
+  cp "$FIXTURE_ROOT/evidence/anonymous-index.json" /dev/stdout
+elif [ "$1" = "pull" ] && [ "$2" = "--platform" ]; then
+  platform="$3"
+  if [ "$platform" = "linux/${options.anonymousPullFailure ?? "none"}" ]; then
+    exit 91
+  fi
+  printf '%s\n' "$platform" > "$FIXTURE_ROOT/last-pulled-platform"
+elif [ "$*" = "image inspect --format {{.Id}} ${reference}" ]; then
+  case "$(cat "$FIXTURE_ROOT/last-pulled-platform")" in
+    linux/amd64) printf 'sha256:%s\n' '${"3".repeat(64)}' ;;
+    linux/arm64) printf 'sha256:%s\n' '${"4".repeat(64)}' ;;
+    *) exit 92 ;;
+  esac
+elif [ "$1" = "image" ] && [ "$2" = "inspect" ] \
+  && [ "$3" = "--format" ] && [[ "$5" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  printf '%s\n' "$5"
+else
+  printf 'unexpected docker invocation: %s\n' "$*" >&2
+  exit 90
+fi
+`,
+    { mode: 0o755 },
+  );
+
+  const result = spawnSync(
+    "bash",
+    [
+      verifier,
+      "--reference",
+      reference,
+      "--candidate-index",
+      path.join(evidence, "candidate-index.json"),
+      "--platform-digests",
+      path.join(evidence, "platform-digests.json"),
+      "--sbom-amd64",
+      path.join(evidence, "sbom-amd64.json"),
+      "--sbom-arm64",
+      path.join(evidence, "sbom-arm64.json"),
+      "--sbom-verification",
+      path.join(evidence, "sbom-verification.json"),
+      "--provenance-verification",
+      path.join(evidence, "provenance-verification.json"),
+      "--signature-verification",
+      path.join(evidence, "signature-verification.json"),
+      "--scan-amd64",
+      path.join(evidence, "scan-amd64.json"),
+      "--scan-arm64",
+      path.join(evidence, "scan-arm64.json"),
+      "--repository",
+      options.repository ?? "NVIDIA/NemoClaw",
+      "--revision",
+      revision,
+      "--source-revision",
+      sourceRevision,
+      "--source-archive-sha256",
+      sourceArchiveSha256,
+      "--cuda-development-base",
+      cudaDevelopmentBase,
+      "--cuda-runtime-base",
+      cudaRuntimeBase,
+      "--run-id",
+      runId,
+      "--run-attempt",
+      runAttempt,
+      "--certificate-identity",
+      certificateIdentity,
+      "--certificate-oidc-issuer",
+      certificateOidcIssuer,
+      "--output",
+      receiptPath,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FIXTURE_ROOT: root,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        RUNNER_TEMP: root,
+      },
+    },
+  );
+  const receipt = fs.existsSync(receiptPath)
+    ? (JSON.parse(fs.readFileSync(receiptPath, "utf8")) as Record<string, unknown>)
+    : null;
+  fs.rmSync(root, { recursive: true, force: true });
+  return { candidateDigest, receipt, result };
+}
+
+describe("llama.cpp image publication evidence verifier", () => {
+  it("binds the exact index, platforms, supply-chain evidence, scans, and anonymous pull (#8250)", () => {
+    const fixture = runEvidence();
+
+    expect(fixture.result.status, fixture.result.stderr).toBe(0);
+    expect(fixture.receipt).toMatchObject({
+      schemaVersion: 1,
+      image: {
+        repository: image,
+        candidateTag: `llama-cpp-candidate-${runId}-${runAttempt}`,
+        index: { digest: fixture.candidateDigest },
+        platforms: { "linux/amd64": amd64Digest, "linux/arm64": arm64Digest },
+      },
+      build: {
+        repository: "NVIDIA/NemoClaw",
+        revision,
+        source: {
+          revision: sourceRevision,
+          archiveSha256: sourceArchiveSha256,
+        },
+        cuda: {
+          developmentBase: cudaDevelopmentBase,
+          runtimeBase: cudaRuntimeBase,
+        },
+      },
+      evidence: {
+        sbom: { format: "spdx-json" },
+        provenance: { predicateType: "https://slsa.dev/provenance/v1" },
+        signature: {
+          mode: "sigstore-keyless",
+          certificateIdentity,
+          certificateOidcIssuer,
+          transparencyLog: "verified",
+        },
+        vulnerability: {
+          scanner: "grype",
+          severityCutoff: "high",
+          onlyFixed: true,
+        },
+        anonymousPull: {
+          exactDigest: true,
+          platforms: [
+            { platform: "linux/amd64", imageId: `sha256:${"3".repeat(64)}` },
+            { platform: "linux/arm64", imageId: `sha256:${"4".repeat(64)}` },
+          ],
+        },
+      },
+    });
+  });
+
+  it.each([
+    ["substituted platform descriptor", { indexArm64Digest: `sha256:${"f".repeat(64)}` }],
+    ["anonymous bytes mismatch", { anonymousMismatch: true }],
+    ["anonymous arm64 pull failure", { anonymousPullFailure: "arm64" as const }],
+    ["duplicate SBOM predicate", { duplicateSbom: true }],
+    ["SBOM subject mismatch", { sbomDigest: "0".repeat(64) }],
+    ["provenance subject mismatch", { provenanceDigest: "0".repeat(64) }],
+    ["missing provenance transparency evidence", { provenanceTimestamps: [] }],
+    ["signature subject mismatch", { signatureDigest: `sha256:${"0".repeat(64)}` }],
+    ["source repository mismatch", { repository: "attacker/repository" }],
+    ["high-severity vulnerability with an available fix", { scanHigh: "arm64" as const }],
+  ])("rejects %s", (_name, options) => {
+    const fixture = runEvidence(options);
+    expect(fixture.result.status).not.toBe(0);
+    expect(fixture.receipt).toBeNull();
+  });
+});

--- a/test/llama-cpp-image-publication-evidence.test.ts
+++ b/test/llama-cpp-image-publication-evidence.test.ts
@@ -35,6 +35,7 @@ type FixtureOptions = {
   anonymousMismatch?: boolean;
   anonymousPullFailure?: "amd64" | "arm64";
   duplicateSbom?: boolean;
+  identicalSbomDocuments?: boolean;
   indexArm64Digest?: string;
   provenanceDigest?: string;
   provenanceTimestamps?: unknown[];
@@ -84,7 +85,7 @@ function runEvidence(options: FixtureOptions = {}) {
   const candidateDigest = sha256(candidate);
   const reference = `${image}@${candidateDigest}`;
   const amd64Sbom = spdx("amd64");
-  const arm64Sbom = spdx("arm64");
+  const arm64Sbom = options.identicalSbomDocuments ? amd64Sbom : spdx("arm64");
   const sbomStatement = (predicate: ReturnType<typeof spdx>) => ({
     _type: "https://in-toto.io/Statement/v1",
     predicateType: "https://spdx.dev/Document",
@@ -327,6 +328,7 @@ describe("llama.cpp image publication evidence verifier", () => {
     ["anonymous bytes mismatch", { anonymousMismatch: true }],
     ["anonymous arm64 pull failure", { anonymousPullFailure: "arm64" as const }],
     ["duplicate SBOM predicate", { duplicateSbom: true }],
+    ["identical platform SBOM documents", { identicalSbomDocuments: true }],
     ["SBOM subject mismatch", { sbomDigest: "0".repeat(64) }],
     ["provenance subject mismatch", { provenanceDigest: "0".repeat(64) }],
     ["missing provenance transparency evidence", { provenanceTimestamps: [] }],

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -306,7 +306,24 @@ describe("llama.cpp image PR workflow", () => {
     expect(crypto.run).toContain('--source-ref "$EXPECTED_REF"');
     expect(crypto.run).toContain('--source-digest "$EXPECTED_REVISION"');
     expect(receipt.run).toContain("scripts/checks/verify-llama-cpp-image-publication-evidence.sh");
-    expect(JSON.stringify(workflow)).not.toMatch(/(?:latest|stable|release)-?alias/iu);
+    const publicationJobs = [
+      "publish-platform",
+      "assemble-candidate",
+      "scan-candidate",
+      "attest-candidate",
+      "verify-candidate",
+    ].map((name) => required(workflow.jobs?.[name], `${name} job is missing`));
+    const shellTags = publicationJobs.flatMap((job) =>
+      (job.steps ?? []).flatMap((step) =>
+        [...(step.run ?? "").matchAll(/--tag\s+("[^"]+"|'[^']+'|\S+)/gu)].map((match) => match[1]),
+      ),
+    );
+    const actionTags = publicationJobs.flatMap((job) =>
+      (job.steps ?? []).flatMap((step) =>
+        step.with?.tags === undefined ? [] : [String(step.with.tags)],
+      ),
+    );
+    expect([...shellTags, ...actionTags]).toEqual(['"$IMAGE:$CANDIDATE_TAG"']);
   });
 
   it("uses an isolated reusable workflow for SPDX, SLSA, and keyless index signing (#8250)", () => {

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -17,24 +17,39 @@ type Step = {
 };
 
 type Job = {
-  needs?: string;
+  if?: string;
+  needs?: string | string[];
   outputs?: Record<string, string>;
   permissions?: string | Record<string, string>;
   "runs-on"?: string;
   steps?: Step[];
   strategy?: { matrix?: unknown };
+  uses?: string;
+  with?: Record<string, unknown>;
 };
 
 type Workflow = {
-  concurrency?: { "cancel-in-progress"?: boolean; group?: string };
+  concurrency?: { "cancel-in-progress"?: boolean | string; group?: string };
   jobs?: Record<string, Job>;
-  on?: Record<string, { paths?: string[] }>;
+  on?: Record<
+    string,
+    {
+      inputs?: Record<string, { default?: unknown; required?: boolean; type?: string }>;
+      paths?: string[];
+    }
+  >;
   permissions?: string | Record<string, string>;
 };
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const workflow = YAML.parse(
   fs.readFileSync(path.join(repoRoot, ".github", "workflows", "llama-cpp-image.yaml"), "utf8"),
+) as Workflow;
+const attestationWorkflow = YAML.parse(
+  fs.readFileSync(
+    path.join(repoRoot, ".github", "workflows", "llama-cpp-image-attest.yaml"),
+    "utf8",
+  ),
 ) as Workflow;
 const fullShaAction = /^[^@]+@[0-9a-f]{40}$/u;
 
@@ -71,36 +86,42 @@ describe("llama.cpp image PR workflow", () => {
   const buildStep = namedStep(build, "Build native PR image without publishing");
   const validate = namedStep(build, "Validate native PR image contract");
 
-  it("is a read-only pull-request gate with no publication path (#8231)", () => {
+  it("keeps pull requests read-only while exposing only an explicit manual publication trigger (#8250)", () => {
     expect(workflow.on?.pull_request?.paths).toEqual(
       expect.arrayContaining([
         ".github/workflows/llama-cpp-image.yaml",
+        ".github/workflows/llama-cpp-image-attest.yaml",
         "managed-inference/images/llama-cpp/**",
         "managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
         "scripts/checks/export-llama-cpp-image-config.mts",
+        "scripts/checks/verify-llama-cpp-image-publication-evidence.sh",
+        "test/llama-cpp-image-publication-evidence.test.ts",
       ]),
     );
-    expect(Object.keys(workflow.on ?? {})).toEqual(["pull_request"]);
+    expect(Object.keys(workflow.on ?? {})).toEqual(["pull_request", "workflow_dispatch"]);
+    expect(workflow.on?.workflow_dispatch?.inputs?.publish).toEqual({
+      description: "Publish the declaratively enabled run-unique candidate from main",
+      required: true,
+      default: false,
+      type: "boolean",
+    });
     expect(workflow.permissions).toEqual({ contents: "read" });
-    const declaredPermissions = [
-      ...permissionValues(workflow.permissions),
-      ...jobPermissionValues(workflow),
-    ];
-    expect(declaredPermissions).not.toContain("write");
-    expect(declaredPermissions).not.toContain("write-all");
+    expect(permissionValues(build.permissions)).not.toContain("write");
+    expect(permissionValues(build.permissions)).not.toContain("write-all");
     const unsafeFixture = YAML.parse("jobs:\n  unsafe:\n    permissions: write-all\n") as Workflow;
     expect(jobPermissionValues(unsafeFixture)).toContain("write-all");
-    expect(JSON.stringify(workflow)).not.toContain("docker/login-action");
+    expect(JSON.stringify(build)).not.toContain("docker/login-action");
     expect(buildStep.with?.push).toBe(false);
     expect(buildStep.with?.load).toBe(true);
     expect(workflow.concurrency).toEqual({
-      "cancel-in-progress": true,
-      group: "${{ github.workflow }}-${{ github.event.pull_request.number }}",
+      "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
+      group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
     });
+    expect(build.if).toBe("github.event_name == 'pull_request'");
   });
 
   it("passes declarative source, base image, runtime ID, and platform values to each image build (#8231)", () => {
-    expect(config.outputs).toEqual({
+    expect(config.outputs).toMatchObject({
       backend_directory: "${{ steps.manifest.outputs.backend_directory }}",
       compiler_c: "${{ steps.manifest.outputs.compiler_c }}",
       compiler_cuda_host_cxx: "${{ steps.manifest.outputs.compiler_cuda_host_cxx }}",
@@ -116,6 +137,29 @@ describe("llama.cpp image PR workflow", () => {
       source_archive_sha256: "${{ steps.manifest.outputs.source_archive_sha256 }}",
       source_revision: "${{ steps.manifest.outputs.source_revision }}",
     });
+    for (const output of [
+      "publication_allowed_ref",
+      "publication_anonymous_exact_digest_pull",
+      "publication_candidate_tag_template",
+      "publication_enabled",
+      "publication_platforms",
+      "publication_provenance_predicate_type",
+      "publication_qualification",
+      "publication_receipt_retention_days",
+      "publication_receipt_schema_version",
+      "publication_repository",
+      "publication_sbom_format",
+      "publication_signature_identity",
+      "publication_signature_issuer",
+      "publication_signature_mode",
+      "publication_signature_transparency_log",
+      "publication_trigger",
+      "publication_vulnerability_only_fixed",
+      "publication_vulnerability_scanner",
+      "publication_vulnerability_severity_cutoff",
+    ]) {
+      expect(config.outputs?.[output]).toBe(`\${{ steps.manifest.outputs.${output} }}`);
+    }
     expect(namedStep(config, "Compile image manifest").run).toBe(
       "node --experimental-strip-types --no-warnings scripts/checks/export-llama-cpp-image-config.mts",
     );
@@ -152,6 +196,182 @@ describe("llama.cpp image PR workflow", () => {
     expect(build.steps?.indexOf(buildArgGuard)).toBeLessThan(
       build.steps?.indexOf(buildStep) ?? Number.POSITIVE_INFINITY,
     );
+  });
+
+  it("gates digest-first native publication on an enabled main-only declarative contract (#8250)", () => {
+    const gate = required(workflow.jobs?.["publication-gate"], "publication gate is missing");
+    const preflight = required(
+      workflow.jobs?.["publication-preflight"],
+      "publication preflight is missing",
+    );
+    const publish = required(workflow.jobs?.["publish-platform"], "platform publisher is missing");
+    const publishGuard = namedStep(publish, "Validate trusted image build args");
+    const publishBuild = namedStep(publish, "Publish exact platform digest");
+    const assemble = required(
+      workflow.jobs?.["assemble-candidate"],
+      "candidate assembly job is missing",
+    );
+    const assembleStep = namedStep(assemble, "Assemble candidate index and capture exact digest");
+
+    expect(gate.if).toContain("github.event_name == 'workflow_dispatch'");
+    expect(gate.if).toContain("inputs.publish == true");
+    expect(gate.permissions).toEqual({});
+    expect(namedStep(gate, "Enforce declarative publication boundary").run).toContain(
+      'PUBLICATION_ENABLED" != "true"',
+    );
+    expect(namedStep(gate, "Enforce declarative publication boundary").run).toContain(
+      'GITHUB_REPOSITORY" != "NVIDIA/NemoClaw"',
+    );
+    expect(namedStep(gate, "Enforce declarative publication boundary").run).toContain(
+      'GITHUB_REF" != "$ALLOWED_REF"',
+    );
+    expect(preflight.needs).toEqual(["config", "publication-gate"]);
+    expect(preflight.permissions).toEqual({ packages: "read" });
+    expect(
+      namedStep(preflight, "Verify public package visibility before registry writes").run,
+    ).toContain("must exist with public visibility before publication");
+    expect(publish.needs).toEqual(["config", "publication-gate", "publication-preflight"]);
+    expect(publish.permissions).toEqual({
+      contents: "read",
+      packages: "write",
+    });
+    expect(publish.strategy?.matrix).toBe("${{ fromJSON(needs.config.outputs.matrix) }}");
+    expect(publishBuild.with?.outputs).toBe(
+      "type=image,name=${{ needs.config.outputs.publication_repository }},push-by-digest=true,name-canonical=true,push=true",
+    );
+    expect(publishBuild.with?.tags).toBeUndefined();
+    expect(publishBuild.with?.provenance).toBe(false);
+    expect(publishBuild.with?.sbom).toBe(false);
+    const publishArgs = String(publishBuild.with?.["build-args"] ?? "");
+    const publishArgNames = [...publishArgs.matchAll(/^([A-Z0-9_]+)=/gmu)].map((match) => match[1]);
+    const guardedArgNames = [
+      ...(publishGuard.run ?? "").matchAll(/--build-arg "([A-Z0-9_]+)=/gu),
+    ].map((match) => match[1]);
+    expect(guardedArgNames).toEqual(publishArgNames);
+    expect(publish.steps?.indexOf(publishGuard)).toBeLessThan(
+      publish.steps?.indexOf(publishBuild) ?? Number.POSITIVE_INFINITY,
+    );
+    expect(assemble.needs).toEqual(["config", "publication-gate", "publish-platform"]);
+    expect(assembleStep.run).toContain(
+      'docker buildx imagetools create --tag "$IMAGE:$CANDIDATE_TAG" "${sources[@]}"',
+    );
+    expect(assembleStep.run).toContain("scripts/checks/validate-managed-base-index.sh");
+    expect(assembleStep.run).toContain("candidate-index.json");
+    expect(assembleStep.run).toContain("platform-digests.json");
+    expect(assembleStep.run).not.toMatch(/latest|stable|release/iu);
+  });
+
+  it("scans, attests, verifies, and creates a receipt for the exact candidate without a consumer alias (#8250)", () => {
+    const scan = required(workflow.jobs?.["scan-candidate"], "scan job is missing");
+    const attest = required(workflow.jobs?.["attest-candidate"], "attestation job is missing");
+    const verify = required(workflow.jobs?.["verify-candidate"], "verification job is missing");
+    const scanStep = namedStep(scan, "Scan exact platform digest");
+    const crypto = namedStep(verify, "Verify cryptographic evidence");
+    const receipt = namedStep(verify, "Verify publication evidence and create receipt");
+
+    expect(scan.needs).toEqual(["config", "publication-gate", "assemble-candidate"]);
+    expect(scanStep.uses).toBe("anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2");
+    expect(scanStep.with).toMatchObject({
+      "severity-cutoff": "${{ needs.config.outputs.publication_vulnerability_severity_cutoff }}",
+      "only-fixed": "${{ needs.config.outputs.publication_vulnerability_only_fixed }}",
+      "fail-build": true,
+      "output-format": "json",
+    });
+    expect(attest.needs).toEqual([
+      "config",
+      "publication-gate",
+      "assemble-candidate",
+      "scan-candidate",
+    ]);
+    expect(attest.uses).toBe("./.github/workflows/llama-cpp-image-attest.yaml");
+    expect(attest.permissions).toEqual({
+      attestations: "write",
+      contents: "read",
+      "id-token": "write",
+      packages: "write",
+    });
+    expect(verify.needs).toEqual([
+      "config",
+      "publication-gate",
+      "assemble-candidate",
+      "scan-candidate",
+      "attest-candidate",
+    ]);
+    expect(crypto.run).toContain("cosign verify \\");
+    expect(crypto.run).toContain("cosign verify-attestation \\");
+    expect(crypto.run).toContain('--certificate-identity "$CERTIFICATE_IDENTITY"');
+    expect(crypto.run).toContain('--certificate-oidc-issuer "$CERTIFICATE_OIDC_ISSUER"');
+    expect(crypto.run).toContain("gh attestation verify");
+    expect(crypto.run).toContain("--signer-workflow");
+    expect(crypto.run).toContain('--source-ref "$EXPECTED_REF"');
+    expect(crypto.run).toContain('--source-digest "$EXPECTED_REVISION"');
+    expect(receipt.run).toContain("scripts/checks/verify-llama-cpp-image-publication-evidence.sh");
+    expect(JSON.stringify(workflow)).not.toMatch(/(?:latest|stable|release)-?alias/iu);
+  });
+
+  it("uses an isolated reusable workflow for SPDX, SLSA, and keyless index signing (#8250)", () => {
+    expect(attestationWorkflow.permissions).toEqual({});
+    expect(attestationWorkflow.on?.workflow_call?.inputs).toEqual(
+      expect.objectContaining({
+        candidate_tag: expect.objectContaining({
+          required: true,
+          type: "string",
+        }),
+        digest: expect.objectContaining({ required: true, type: "string" }),
+        image: expect.objectContaining({ required: true, type: "string" }),
+        retention_days: expect.objectContaining({
+          required: true,
+          type: "number",
+        }),
+        sbom_format: expect.objectContaining({
+          required: true,
+          type: "string",
+        }),
+      }),
+    );
+    const validateInputs = required(
+      attestationWorkflow.jobs?.["validate-inputs"],
+      "reusable input validation is missing",
+    );
+    const attest = required(
+      attestationWorkflow.jobs?.attest,
+      "reusable attestation job is missing",
+    );
+    expect(validateInputs.permissions).toEqual({});
+    const reusableGate = namedStep(validateInputs, "Validate exact inputs");
+    expect(reusableGate.env?.CALLER_WORKFLOW_REF).toBe("${{ github.workflow_ref }}");
+    expect(reusableGate.run).toContain('GITHUB_REPOSITORY" != "NVIDIA/NemoClaw"');
+    expect(reusableGate.run).toContain('GITHUB_EVENT_NAME" != "workflow_dispatch"');
+    expect(reusableGate.run).toContain('GITHUB_REF" != "refs/heads/main"');
+    expect(reusableGate.run).toContain(
+      'CALLER_WORKFLOW_REF" != "NVIDIA/NemoClaw/.github/workflows/llama-cpp-image.yaml@refs/heads/main"',
+    );
+    expect(attest.permissions).toEqual({
+      attestations: "write",
+      contents: "read",
+      "id-token": "write",
+      packages: "write",
+    });
+    const sbomSteps = (attest.steps ?? []).filter((step) =>
+      step.uses?.startsWith("anchore/sbom-action@"),
+    );
+    expect(sbomSteps).toHaveLength(2);
+    expect(sbomSteps.map((step) => step.uses)).toEqual([
+      "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610",
+      "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610",
+    ]);
+    expect(namedStep(attest, "Attest SLSA build provenance").uses).toBe(
+      "actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f",
+    );
+    expect(namedStep(attest, "Sign exact candidate index").run).toContain(
+      'cosign sign --yes "$IMAGE@$DIGEST"',
+    );
+    expect(JSON.stringify(attestationWorkflow)).not.toContain("secrets.");
+    for (const action of (attest.steps ?? [])
+      .map((step) => step.uses)
+      .filter((uses): uses is string => uses !== undefined)) {
+      expect(action).toMatch(fullShaAction);
+    }
   });
 
   it("pins actions and validates the native non-root read-only image (#8231)", () => {

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -40,6 +40,41 @@ type ImageManifest = {
       platform?: string;
       runner?: string;
     }>;
+    publication?: {
+      allowedRef?: string;
+      candidateTagTemplate?: string;
+      enabled?: boolean;
+      evidence?: {
+        anonymousPull?: { exactDigest?: boolean };
+        provenance?: { predicateType?: string };
+        receipt?: { retentionDays?: number; schemaVersion?: number };
+        sbom?: { format?: string };
+        signature?: {
+          certificateIdentity?: string;
+          certificateOidcIssuer?: string;
+          mode?: string;
+          transparencyLog?: string;
+        };
+        vulnerability?: {
+          onlyFixed?: boolean;
+          scanner?: string;
+          severityCutoff?: string;
+        };
+      };
+      platforms?: string[];
+      qualification?: {
+        environment?: string | null;
+        gpu?: { cpuFallback?: string; fullOffload?: boolean; vendor?: string };
+        model?: { digest?: string; hostPath?: string | null; id?: string };
+        platform?: string;
+        probes?: string[];
+        profile?: string;
+        required?: boolean;
+        runner?: string | null;
+      };
+      repository?: string;
+      trigger?: string;
+    };
     repository?: string;
     runtime?: {
       entrypoint?: string;
@@ -73,6 +108,17 @@ function parseOutput(value: string): Record<string, string> {
         return [line.slice(0, separator), line.slice(separator + 1)] as [string, string];
       }),
   );
+}
+
+function enablePublication(source: string): string {
+  return source
+    .replace("    enabled: false", "    enabled: true")
+    .replace("      runner: null", "      runner: linux-arm64-gpu-dgx-spark-gb10-protected-1")
+    .replace("      environment: null", "      environment: approve-dgx-spark-image-qualification")
+    .replace(
+      "        hostPath: null",
+      "        hostPath: /var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
+    );
 }
 
 describe("declarative llama.cpp server image", () => {
@@ -129,6 +175,25 @@ describe("declarative llama.cpp server image", () => {
     ]);
   });
 
+  it("keeps publication manual and disabled while protected DGX Spark inputs are unset (#8250)", () => {
+    const output = loadLlamaCppImageConfig(manifestSource);
+
+    expect(output).toMatchObject({
+      publication_allowed_ref: "refs/heads/main",
+      publication_candidate_tag_template: "llama-cpp-candidate-{runId}-{runAttempt}",
+      publication_enabled: "false",
+      publication_platforms: '["linux/amd64","linux/arm64"]',
+      publication_repository: "ghcr.io/nvidia/nemoclaw/llama-cpp-server",
+      publication_trigger: "workflow_dispatch",
+    });
+    expect(JSON.parse(output.publication_qualification)).toMatchObject({
+      environment: null,
+      model: { hostPath: null },
+      required: true,
+      runner: null,
+    });
+  });
+
   it("compiles the fail-closed workflow inputs from YAML (#8231)", () => {
     const result = spawnSync(
       process.execPath,
@@ -149,6 +214,38 @@ describe("declarative llama.cpp server image", () => {
       cuda_dev_image: manifest.spec?.cuda?.developmentBase,
       cuda_runtime_image: manifest.spec?.cuda?.runtimeBase,
       image: manifest.spec?.repository,
+      publication_allowed_ref: manifest.spec?.publication?.allowedRef,
+      publication_anonymous_exact_digest_pull: String(
+        manifest.spec?.publication?.evidence?.anonymousPull?.exactDigest,
+      ),
+      publication_candidate_tag_template: manifest.spec?.publication?.candidateTagTemplate,
+      publication_enabled: String(manifest.spec?.publication?.enabled),
+      publication_platforms: JSON.stringify(manifest.spec?.publication?.platforms),
+      publication_provenance_predicate_type:
+        manifest.spec?.publication?.evidence?.provenance?.predicateType,
+      publication_receipt_retention_days: String(
+        manifest.spec?.publication?.evidence?.receipt?.retentionDays,
+      ),
+      publication_receipt_schema_version: String(
+        manifest.spec?.publication?.evidence?.receipt?.schemaVersion,
+      ),
+      publication_repository: manifest.spec?.publication?.repository,
+      publication_sbom_format: manifest.spec?.publication?.evidence?.sbom?.format,
+      publication_signature_identity:
+        manifest.spec?.publication?.evidence?.signature?.certificateIdentity,
+      publication_signature_issuer:
+        manifest.spec?.publication?.evidence?.signature?.certificateOidcIssuer,
+      publication_signature_mode: manifest.spec?.publication?.evidence?.signature?.mode,
+      publication_signature_transparency_log:
+        manifest.spec?.publication?.evidence?.signature?.transparencyLog,
+      publication_trigger: manifest.spec?.publication?.trigger,
+      publication_vulnerability_only_fixed: String(
+        manifest.spec?.publication?.evidence?.vulnerability?.onlyFixed,
+      ),
+      publication_vulnerability_scanner:
+        manifest.spec?.publication?.evidence?.vulnerability?.scanner,
+      publication_vulnerability_severity_cutoff:
+        manifest.spec?.publication?.evidence?.vulnerability?.severityCutoff,
       runtime_forbidden_paths: JSON.stringify(manifest.spec?.runtime?.forbiddenPaths),
       runtime_gid: String(manifest.spec?.runtime?.gid),
       runtime_required_paths: JSON.stringify(manifest.spec?.runtime?.requiredPaths),
@@ -164,6 +261,9 @@ describe("declarative llama.cpp server image", () => {
         runner,
       })),
     });
+    expect(JSON.parse(output.publication_qualification ?? "null")).toEqual(
+      manifest.spec?.publication?.qualification,
+    );
   });
 
   it.each([
@@ -200,6 +300,129 @@ describe("declarative llama.cpp server image", () => {
       manifestSource.replace("kind: ServerImageBuild", "kind: ServerImageBuild\nunexpected: true"),
     ],
   ])("rejects %s before exporting image build inputs (#8231)", (_case, candidate) => {
+    expect(() => loadLlamaCppImageConfig(candidate)).toThrow();
+  });
+
+  it("accepts publication enablement only when all protected DGX Spark inputs are bound (#8250)", () => {
+    const output = loadLlamaCppImageConfig(enablePublication(manifestSource));
+
+    expect(output.publication_enabled).toBe("true");
+    expect(JSON.parse(output.publication_qualification)).toMatchObject({
+      environment: "approve-dgx-spark-image-qualification",
+      model: {
+        hostPath: "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
+      },
+      runner: "linux-arm64-gpu-dgx-spark-gb10-protected-1",
+    });
+  });
+
+  it("keeps publication disabled when complete DGX Spark infrastructure is configured (#8250)", () => {
+    const candidate = enablePublication(manifestSource).replace("enabled: true", "enabled: false");
+
+    expect(loadLlamaCppImageConfig(candidate).publication_enabled).toBe("false");
+  });
+
+  it.each([
+    [
+      "an unexpected publication field",
+      manifestSource.replace("    enabled: false", "    enabled: false\n    consumerAlias: latest"),
+    ],
+    ["automatic publication", manifestSource.replace("workflow_dispatch", "push")],
+    ["an untrusted ref", manifestSource.replace("refs/heads/main", "refs/heads/release")],
+    [
+      "a mutable repository reference",
+      manifestSource.replace(
+        "repository: ghcr.io/nvidia/nemoclaw/llama-cpp-server\n    candidateTagTemplate",
+        "repository: ghcr.io/nvidia/nemoclaw/llama-cpp-server:latest\n    candidateTagTemplate",
+      ),
+    ],
+    [
+      "a non-unique candidate tag",
+      manifestSource.replace(
+        "llama-cpp-candidate-{runId}-{runAttempt}",
+        "llama-cpp-candidate-{runId}",
+      ),
+    ],
+    [
+      "a duplicate publication platform",
+      manifestSource.replace(
+        "    platforms:\n      - linux/amd64\n      - linux/arm64\n    evidence:",
+        "    platforms:\n      - linux/amd64\n      - linux/amd64\n    evidence:",
+      ),
+    ],
+    ["a non-SPDX SBOM", manifestSource.replace("format: spdx-json", "format: cyclonedx-json")],
+    [
+      "legacy provenance",
+      manifestSource.replace("https://slsa.dev/provenance/v1", "https://slsa.dev/provenance/v0.2"),
+    ],
+    [
+      "a signing identity outside main",
+      manifestSource.replace(
+        "llama-cpp-image-attest.yaml@refs/heads/main",
+        "llama-cpp-image-attest.yaml@refs/heads/feature",
+      ),
+    ],
+    [
+      "a non-GitHub OIDC issuer",
+      manifestSource.replace(
+        "https://token.actions.githubusercontent.com",
+        "https://issuer.example.test",
+      ),
+    ],
+    [
+      "an optional transparency log",
+      manifestSource.replace("transparencyLog: required", "transparencyLog: optional"),
+    ],
+    [
+      "a different scan cutoff",
+      manifestSource.replace("severityCutoff: high", "severityCutoff: critical"),
+    ],
+    [
+      "scanning outside the fixed-finding policy",
+      manifestSource.replace("onlyFixed: true", "onlyFixed: false"),
+    ],
+    ["an authenticated pull", manifestSource.replace("exactDigest: true", "exactDigest: false")],
+    ["an unversioned receipt", manifestSource.replace("schemaVersion: 1", "schemaVersion: 0")],
+    [
+      "a shortened receipt lifetime",
+      manifestSource.replace("retentionDays: 90", "retentionDays: 1"),
+    ],
+    [
+      "optional DGX Spark qualification",
+      manifestSource.replace("required: true", "required: false"),
+    ],
+    ["CPU fallback", manifestSource.replace("cpuFallback: reject", "cpuFallback: allow")],
+    ["partial GPU offload", manifestSource.replace("fullOffload: true", "fullOffload: false")],
+    [
+      "partial disabled infrastructure",
+      manifestSource.replace("runner: null", "runner: linux-arm64-gpu-dgx-spark-gb10-protected-1"),
+    ],
+    [
+      "enablement without infrastructure",
+      manifestSource.replace("enabled: false", "enabled: true"),
+    ],
+    [
+      "enablement on a generic runner",
+      enablePublication(manifestSource).replace(
+        "linux-arm64-gpu-dgx-spark-gb10-protected-1",
+        "ubuntu-latest",
+      ),
+    ],
+    [
+      "enablement without an approval environment",
+      enablePublication(manifestSource).replace(
+        "approve-dgx-spark-image-qualification",
+        "production",
+      ),
+    ],
+    [
+      "enablement with a relative model path",
+      enablePublication(manifestSource).replace(
+        "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
+        "models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
+      ),
+    ],
+  ])("rejects %s in the publication contract (#8250)", (_case, candidate) => {
     expect(() => loadLlamaCppImageConfig(candidate)).toThrow();
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This change adds a digest-first, manually gated publication path for the NemoClaw-owned llama.cpp server image. Publication remains disabled in declarative YAML until the public GHCR package and protected DGX Spark qualification infrastructure exist, and this slice does not move a consumer alias.

## Related Issue

Fixes #8250

## Changes

- Declare the publication repository, platforms, evidence policy, signing identity, vulnerability threshold, receipt schema, and enablement boundary in `managed-inference/images/llama-cpp/image.yaml`.
- Validate and export the exact publication contract from the existing manifest compiler. The dedicated llama.cpp publisher consumes this configuration; workflow-local defaults would violate the accepted declarative serving-configuration decision.
- Add a main-only manual publisher that builds native digests, requires a public GHCR package before registry writes, assembles an exact two-platform index, scans both platform digests, and creates no consumer alias.
- Add an independently gated reusable workflow for SPDX SBOM attestations, SLSA provenance, and Sigstore keyless index signing.
- Add a fail-closed receipt verifier that binds source, CUDA bases, descriptors, attestations, scans, anonymous per-platform pulls, and immutable local image IDs.
- Add workflow-contract and hostile-mutation tests for the compiler, trust boundary, digest handoff, and evidence verifier.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Publication remains disabled; no recipe digest, consumer alias, onboarding default, operator procedure, or supported surface changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent supply-chain review of the complete change through `c3fc700f6` found no remaining trust-boundary, evidence-integrity, or workflow-permission blocker.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Publication is declaratively disabled, protected DGX Spark inputs are unset, and this change adds no consumer alias, recipe digest, onboarding default, operator procedure, or supported surface.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5677dc9b3 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 66 tests passed across the four focused integration files, including the dependency-review guard.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
