### PR TITLE
docs: correct snapshot restore selector guidance

### DIFF
--- a/docs/manage-sandboxes/backup-restore.mdx
+++ b/docs/manage-sandboxes/backup-restore.mdx
@@ -115,7 +115,7 @@ $$nemoclaw my-assistant snapshot restore
 ```
 
 Pass an exact version, name, or timestamp to select a specific snapshot.
-Use the complete timestamp from `snapshot list`; a timestamp prefix does not select a snapshot.
+Use the exact timestamp from `snapshot list`; a timestamp prefix does not select a snapshot.
 
 ```bash
 $$nemoclaw my-assistant snapshot restore v3

--- a/docs/manage-sandboxes/backup-restore.mdx
+++ b/docs/manage-sandboxes/backup-restore.mdx
@@ -114,12 +114,13 @@ Restore the latest snapshot:
 $$nemoclaw my-assistant snapshot restore
 ```
 
-Pass a version, name, or timestamp prefix to select a specific snapshot:
+Pass an exact version, name, or timestamp to select a specific snapshot.
+Use the complete timestamp from `snapshot list`; a timestamp prefix does not select a snapshot.
 
 ```bash
 $$nemoclaw my-assistant snapshot restore v3
 $$nemoclaw my-assistant snapshot restore before-upgrade
-$$nemoclaw my-assistant snapshot restore 2026-04-14T
+$$nemoclaw my-assistant snapshot restore 2026-04-14T09-40-09-760Z
 ```
 
 <AgentOnly variant="hermes">


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The snapshot restore guide previously described timestamp prefixes, but selector resolution accepts only exact timestamps.
This change tells readers to copy the exact timestamp from `snapshot list` and provides an exact-timestamp example.

## Related Issue
Fixes #8217

## Changes
- Correct the snapshot selector description to require an exact version, name, or timestamp.
- Replace the timestamp-prefix command with an exact timestamp from `snapshot list`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This documentation-only change aligns the guide with existing exact-selector behavior and tests.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible and hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/manage-sandboxes/backup-restore.mdx`. Reviewed this documentation-only change at exact head `0bb2734b010f91ac7f0ef1ec0a57fca2f9351071` against base `5fe23192a6fe378537fc2730c081730bc3ff72b9` under the repository writing and documentation contracts. The exact-only timestamp claim matches `src/lib/state/sandbox.ts` and `test/snapshot.test.ts`; all three generated guide variants contain the corrected instruction and variant-specific CLI command. The external merge changed no effective documentation content; stable patch ID `1ec62081ec1d90f51545f4cdc7976ebfb9a0125d` is unchanged. At this exact head, `npm run docs` passed with 0 errors and 2 known warnings, `npm run validate:pr` passed, and `git diff --check` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 0bb2734b0 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Tests are not applicable to this documentation-only correction.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — 0 errors and 2 baseline warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated snapshot restore guidance to require an exact snapshot version, name, or timestamp.
  * Clarified that partial timestamp prefixes are no longer accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

