### PR TITLE
fix(images): resolve provenance-wrapped base manifests

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -492,7 +492,7 @@ jobs:
           fi
 
           declare -A seen_arches=()
-          declare -A platform_digests=()
+          declare -A source_digests=()
           sources=()
           for digest_file in "${digest_files[@]}"; do
             digest_artifact="$(basename "$digest_file")"
@@ -516,7 +516,7 @@ jobs:
               exit 1
             fi
             seen_arches["$expected_arch"]=1
-            platform_digests["linux/$expected_arch"]="sha256:$digest"
+            source_digests["linux/$expected_arch"]="sha256:$digest"
             sources+=("$source")
           done
           if [ "${seen_arches[amd64]:-0}" -ne 1 ] || [ "${seen_arches[arm64]:-0}" -ne 1 ]; then
@@ -536,31 +536,40 @@ jobs:
             exit 1
           fi
 
-          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
-          first_tag="${tags[0]}"
+          candidate_tag="$IMAGE:base-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          candidate_metadata="$RUNNER_TEMP/$AGENT-base-candidate-metadata.json"
+          docker buildx imagetools create \
+            --tag "$candidate_tag" \
+            --metadata-file "$candidate_metadata" \
+            "${sources[@]}"
+          digest="$(jq -er '.["containerimage.descriptor"].digest' "$candidate_metadata")"
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "ERROR: expected one staged Hermes base digest." >&2
+            exit 1
+          fi
+          reference="$IMAGE@$digest"
           actual_platforms="$(
-            docker buildx imagetools inspect "$first_tag" --raw \
+            docker buildx imagetools inspect "$reference" --raw \
               | jq -r '.manifests[] | select(.platform.os == "linux") | .platform.architecture' \
               | sort -u \
               | paste -sd, -
           )"
           if [ "$actual_platforms" != "amd64,arm64" ]; then
-            echo "ERROR: published manifest has unexpected platforms: $actual_platforms" >&2
+            echo "ERROR: staged manifest has unexpected platforms: $actual_platforms" >&2
             exit 1
           fi
-          digest="$(
-            docker buildx imagetools inspect "$first_tag" \
-              --format '{{.Manifest.Digest}}'
+          platform_digests_json="$(
+            scripts/checks/validate-managed-base-index.sh \
+              "$reference" \
+              "${source_digests[linux/amd64]}" \
+              "${source_digests[linux/arm64]}"
           )"
-          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "ERROR: expected one published Hermes base digest." >&2
-            exit 1
-          fi
-          reference="$IMAGE@$digest"
-          scripts/checks/validate-managed-base-index.sh \
-            "$reference" \
-            "${platform_digests[linux/amd64]}" \
-            "${platform_digests[linux/arm64]}"
+          declare -A platform_digests=()
+          for platform in linux/amd64 linux/arm64; do
+            platform_digests["$platform"]="$(
+              jq -er --arg platform "$platform" '.[$platform]' <<< "$platform_digests_json"
+            )"
+          done
 
           scripts/export-managed-base-image-contract.sh \
             "$AGENT" \
@@ -572,6 +581,17 @@ jobs:
             "$GITHUB_RUN_ID" \
             "$GITHUB_RUN_ATTEMPT" \
             "$RUNNER_TEMP/managed-base-contract/contract.json"
+
+          publication_metadata="$RUNNER_TEMP/$AGENT-base-publication-metadata.json"
+          docker buildx imagetools create \
+            "${tag_args[@]}" \
+            --metadata-file "$publication_metadata" \
+            "$reference"
+          published_digest="$(jq -er '.["containerimage.descriptor"].digest' "$publication_metadata")"
+          if [ "$published_digest" != "$digest" ]; then
+            echo "ERROR: published Hermes base digest differs from the validated candidate." >&2
+            exit 1
+          fi
           printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
 
       - name: Upload managed base image contract
@@ -639,7 +659,7 @@ jobs:
           fi
 
           declare -A seen_arches=()
-          declare -A platform_digests=()
+          declare -A source_digests=()
           sources=()
           for digest_file in "${digest_files[@]}"; do
             digest_artifact="$(basename "$digest_file")"
@@ -663,7 +683,7 @@ jobs:
               exit 1
             fi
             seen_arches["$expected_arch"]=1
-            platform_digests["linux/$expected_arch"]="sha256:$digest"
+            source_digests["linux/$expected_arch"]="sha256:$digest"
             sources+=("$source")
           done
           if [ "${seen_arches[amd64]:-0}" -ne 1 ] || [ "${seen_arches[arm64]:-0}" -ne 1 ]; then
@@ -683,31 +703,40 @@ jobs:
             exit 1
           fi
 
-          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
-          first_tag="${tags[0]}"
+          candidate_tag="$IMAGE:base-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          candidate_metadata="$RUNNER_TEMP/$AGENT-base-candidate-metadata.json"
+          docker buildx imagetools create \
+            --tag "$candidate_tag" \
+            --metadata-file "$candidate_metadata" \
+            "${sources[@]}"
+          digest="$(jq -er '.["containerimage.descriptor"].digest' "$candidate_metadata")"
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "ERROR: expected one staged Deep Agents Code base digest." >&2
+            exit 1
+          fi
+          reference="$IMAGE@$digest"
           actual_platforms="$(
-            docker buildx imagetools inspect "$first_tag" --raw \
+            docker buildx imagetools inspect "$reference" --raw \
               | jq -r '.manifests[] | select(.platform.os == "linux") | .platform.architecture' \
               | sort -u \
               | paste -sd, -
           )"
           if [ "$actual_platforms" != "amd64,arm64" ]; then
-            echo "ERROR: published manifest has unexpected platforms: $actual_platforms" >&2
+            echo "ERROR: staged manifest has unexpected platforms: $actual_platforms" >&2
             exit 1
           fi
-          digest="$(
-            docker buildx imagetools inspect "$first_tag" \
-              --format '{{.Manifest.Digest}}'
+          platform_digests_json="$(
+            scripts/checks/validate-managed-base-index.sh \
+              "$reference" \
+              "${source_digests[linux/amd64]}" \
+              "${source_digests[linux/arm64]}"
           )"
-          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "ERROR: expected one published Deep Agents Code base digest." >&2
-            exit 1
-          fi
-          reference="$IMAGE@$digest"
-          scripts/checks/validate-managed-base-index.sh \
-            "$reference" \
-            "${platform_digests[linux/amd64]}" \
-            "${platform_digests[linux/arm64]}"
+          declare -A platform_digests=()
+          for platform in linux/amd64 linux/arm64; do
+            platform_digests["$platform"]="$(
+              jq -er --arg platform "$platform" '.[$platform]' <<< "$platform_digests_json"
+            )"
+          done
 
           scripts/export-managed-base-image-contract.sh \
             "$AGENT" \
@@ -719,6 +748,17 @@ jobs:
             "$GITHUB_RUN_ID" \
             "$GITHUB_RUN_ATTEMPT" \
             "$RUNNER_TEMP/managed-base-contract/contract.json"
+
+          publication_metadata="$RUNNER_TEMP/$AGENT-base-publication-metadata.json"
+          docker buildx imagetools create \
+            "${tag_args[@]}" \
+            --metadata-file "$publication_metadata" \
+            "$reference"
+          published_digest="$(jq -er '.["containerimage.descriptor"].digest' "$publication_metadata")"
+          if [ "$published_digest" != "$digest" ]; then
+            echo "ERROR: published Deep Agents Code base digest differs from the validated candidate." >&2
+            exit 1
+          fi
           printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
 
       - name: Upload managed base image contract
@@ -788,7 +828,7 @@ jobs:
           fi
 
           declare -A seen_arches=()
-          declare -A platform_digests=()
+          declare -A source_digests=()
           sources=()
           for digest_file in "${digest_files[@]}"; do
             digest_artifact="$(basename "$digest_file")"
@@ -812,7 +852,7 @@ jobs:
               exit 1
             fi
             seen_arches["$expected_arch"]=1
-            platform_digests["linux/$expected_arch"]="sha256:$digest"
+            source_digests["linux/$expected_arch"]="sha256:$digest"
             sources+=("$source")
           done
           if [ "${seen_arches[amd64]:-0}" -ne 1 ] || [ "${seen_arches[arm64]:-0}" -ne 1 ]; then
@@ -832,31 +872,40 @@ jobs:
             exit 1
           fi
 
-          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
-          first_tag="${tags[0]}"
+          candidate_tag="$IMAGE:base-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          candidate_metadata="$RUNNER_TEMP/$AGENT-base-candidate-metadata.json"
+          docker buildx imagetools create \
+            --tag "$candidate_tag" \
+            --metadata-file "$candidate_metadata" \
+            "${sources[@]}"
+          digest="$(jq -er '.["containerimage.descriptor"].digest' "$candidate_metadata")"
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "ERROR: expected one staged OpenClaw base digest." >&2
+            exit 1
+          fi
+          reference="$IMAGE@$digest"
           actual_platforms="$(
-            docker buildx imagetools inspect "$first_tag" --raw \
+            docker buildx imagetools inspect "$reference" --raw \
               | jq -r '.manifests[] | select(.platform.os == "linux") | .platform.architecture' \
               | sort -u \
               | paste -sd, -
           )"
           if [ "$actual_platforms" != "amd64,arm64" ]; then
-            echo "ERROR: published manifest has unexpected platforms: $actual_platforms" >&2
+            echo "ERROR: staged manifest has unexpected platforms: $actual_platforms" >&2
             exit 1
           fi
-          digest="$(
-            docker buildx imagetools inspect "$first_tag" \
-              --format '{{.Manifest.Digest}}'
+          platform_digests_json="$(
+            scripts/checks/validate-managed-base-index.sh \
+              "$reference" \
+              "${source_digests[linux/amd64]}" \
+              "${source_digests[linux/arm64]}"
           )"
-          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "ERROR: expected one published OpenClaw base digest." >&2
-            exit 1
-          fi
-          reference="$IMAGE@$digest"
-          scripts/checks/validate-managed-base-index.sh \
-            "$reference" \
-            "${platform_digests[linux/amd64]}" \
-            "${platform_digests[linux/arm64]}"
+          declare -A platform_digests=()
+          for platform in linux/amd64 linux/arm64; do
+            platform_digests["$platform"]="$(
+              jq -er --arg platform "$platform" '.[$platform]' <<< "$platform_digests_json"
+            )"
+          done
 
           scripts/export-managed-base-image-contract.sh \
             "$AGENT" \
@@ -868,6 +917,17 @@ jobs:
             "$GITHUB_RUN_ID" \
             "$GITHUB_RUN_ATTEMPT" \
             "$RUNNER_TEMP/managed-base-contract/contract.json"
+
+          publication_metadata="$RUNNER_TEMP/$AGENT-base-publication-metadata.json"
+          docker buildx imagetools create \
+            "${tag_args[@]}" \
+            --metadata-file "$publication_metadata" \
+            "$reference"
+          published_digest="$(jq -er '.["containerimage.descriptor"].digest' "$publication_metadata")"
+          if [ "$published_digest" != "$digest" ]; then
+            echo "ERROR: published OpenClaw base digest differs from the validated candidate." >&2
+            exit 1
+          fi
           printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
 
       - name: Upload managed base image contract

--- a/scripts/checks/validate-managed-base-index.sh
+++ b/scripts/checks/validate-managed-base-index.sh
@@ -5,27 +5,104 @@
 set -euo pipefail
 
 if [ "$#" -ne 3 ]; then
-  echo "usage: $0 <index-reference> <linux-amd64-digest> <linux-arm64-digest>" >&2
+  echo "usage: $0 <index-reference> <linux-amd64-source-digest> <linux-arm64-source-digest>" >&2
   exit 2
 fi
 
 reference="$1"
-expected_amd64="$2"
-expected_arm64="$3"
+source_amd64="$2"
+source_arm64="$3"
 
 if [[ ! "$reference" =~ @sha256:[0-9a-f]{64}$ ]]; then
   echo "ERROR: managed base index reference must be immutable." >&2
   exit 1
 fi
-for expected in "$expected_amd64" "$expected_arm64"; do
-  if [[ ! "$expected" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-    echo "ERROR: managed base platform digest is invalid." >&2
+for source_digest in "$source_amd64" "$source_arm64"; do
+  if [[ ! "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "ERROR: managed base platform source digest is invalid." >&2
     exit 1
   fi
 done
 
+image="${reference%@*}"
+declare -A platform_digests=()
+expected_descriptors='[]'
+for arch in amd64 arm64; do
+  case "$arch" in
+    amd64) source_digest="$source_amd64" ;;
+    arm64) source_digest="$source_arm64" ;;
+  esac
+  source_reference="$image@$source_digest"
+  source_json="$(docker buildx imagetools inspect "$source_reference" --raw)"
+
+  mapfile -t workload_digests < <(
+    jq -r --arg arch "$arch" \
+      '.manifests[]? | select(.platform.os == "linux" and .platform.architecture == $arch) | .digest' \
+      <<<"$source_json"
+  )
+  if [ "${#workload_digests[@]}" -ne 1 ]; then
+    echo "ERROR: managed base source index must contain exactly one linux/$arch descriptor." >&2
+    exit 1
+  fi
+  workload_digest="${workload_digests[0]}"
+  if [[ ! "$workload_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "ERROR: managed base source index linux/$arch descriptor digest is invalid." >&2
+    exit 1
+  fi
+  if ! jq -e \
+    --arg arch "$arch" \
+    --arg workload_digest "$workload_digest" \
+    '
+      .schemaVersion == 2
+      and .mediaType == "application/vnd.oci.image.index.v1+json"
+      and (.manifests | type == "array" and length == 2)
+      and ([
+        .manifests[]
+        | select(
+            .platform.os == "linux"
+            and .mediaType == "application/vnd.oci.image.manifest.v1+json"
+            and (.digest | test("^sha256:[0-9a-f]{64}$"))
+            and (.size | type == "number" and . > 0 and floor == .)
+          )
+      ] | length) == 1
+      and ([
+        .manifests[]
+        | select(
+            .platform.os == "unknown"
+            and .platform.architecture == "unknown"
+            and .mediaType == "application/vnd.oci.image.manifest.v1+json"
+            and (.digest | test("^sha256:[0-9a-f]{64}$"))
+            and (.size | type == "number" and . > 0 and floor == .)
+            and .annotations["vnd.docker.reference.type"] == "attestation-manifest"
+            and .annotations["vnd.docker.reference.digest"] == $workload_digest
+          )
+      ] | length) == 1
+      and ([
+        .manifests[]
+        | select(.platform.os == "linux" and .platform.architecture == $arch)
+      ] | length) == 1
+    ' <<<"$source_json" >/dev/null; then
+    echo "ERROR: managed base source index for linux/$arch is not one workload plus its provenance manifest." >&2
+    exit 1
+  fi
+
+  platform_digests["$arch"]="$workload_digest"
+  source_descriptors="$(jq -c '.manifests' <<<"$source_json")"
+  expected_descriptors="$(
+    jq -cn \
+      --argjson expected "$expected_descriptors" \
+      --argjson source "$source_descriptors" \
+      '$expected + $source'
+  )"
+done
+
 index_json="$(docker buildx imagetools inspect "$reference" --raw)"
-if ! jq -e '.manifests | type == "array"' <<<"$index_json" >/dev/null; then
+if ! jq -e \
+  '
+    .schemaVersion == 2
+    and .mediaType == "application/vnd.oci.image.index.v1+json"
+    and (.manifests | type == "array")
+  ' <<<"$index_json" >/dev/null; then
   echo "ERROR: managed base index does not contain a manifest array." >&2
   exit 1
 fi
@@ -40,12 +117,21 @@ for arch in amd64 arm64; do
     echo "ERROR: managed base index must contain exactly one linux/$arch descriptor." >&2
     exit 1
   fi
-  case "$arch" in
-    amd64) expected_digest="$expected_amd64" ;;
-    arm64) expected_digest="$expected_arm64" ;;
-  esac
+  expected_digest="${platform_digests[$arch]}"
   if [ "${actual_digests[0]}" != "$expected_digest" ]; then
-    echo "ERROR: managed base index linux/$arch descriptor does not match this run's platform digest." >&2
+    echo "ERROR: managed base index linux/$arch descriptor does not match this run's resolved workload descriptor." >&2
     exit 1
   fi
 done
+
+actual_descriptors="$(jq -cS '.manifests | sort_by(.digest)' <<<"$index_json")"
+expected_descriptors="$(jq -cS 'sort_by(.digest)' <<<"$expected_descriptors")"
+if [ "$actual_descriptors" != "$expected_descriptors" ]; then
+  echo "ERROR: managed base index descriptors do not match this run's platform source indexes." >&2
+  exit 1
+fi
+
+jq -cn \
+  --arg amd64 "${platform_digests[amd64]}" \
+  --arg arm64 "${platform_digests[arm64]}" \
+  '{"linux/amd64": $amd64, "linux/arm64": $arm64}'

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -485,6 +485,8 @@ describe("base-image publication behavior", () => {
     expect(openClawValidationIndex).toBeLessThan(openClawPromotionIndex);
     expect(openClawManifestScript.slice(openClawPromotionIndex)).toContain('"${tag_args[@]}"');
     expect(openClawManifestScript.slice(openClawPromotionIndex)).toContain('"$reference"');
+    expect(openClawManifestScript).toContain("published_digest=");
+    expect(openClawManifestScript).toContain('if [ "$published_digest" != "$digest" ]; then');
     for (const step of (manifestJob?.steps ?? []).filter((step) => step.uses)) {
       expect(step.uses, step.name).toMatch(FULL_SHA_ACTION);
     }
@@ -628,6 +630,8 @@ describe("base-image publication behavior", () => {
       expect(validationIndex).toBeLessThan(promotionIndex);
       expect(manifestScript.slice(promotionIndex)).toContain('"${tag_args[@]}"');
       expect(manifestScript.slice(promotionIndex)).toContain('"$reference"');
+      expect(manifestScript).toContain("published_digest=");
+      expect(manifestScript).toContain('if [ "$published_digest" != "$digest" ]; then');
       for (const step of (manifestJob?.steps ?? []).filter((step) => step.uses)) {
         expect(step.uses, step.name).toMatch(FULL_SHA_ACTION);
       }

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -457,14 +457,34 @@ describe("base-image publication behavior", () => {
       'if [ "$source_platform" != "linux/$expected_arch" ]; then',
     );
     expect(openClawManifestScript).toContain("duplicate platform digest");
+    expect(openClawManifestScript).toContain("declare -A source_digests=()");
+    expect(openClawManifestScript).toContain(
+      'source_digests["linux/$expected_arch"]="sha256:$digest"',
+    );
     expect(openClawManifestScript.indexOf("source_platform=")).toBeLessThan(
       openClawManifestScript.indexOf("docker buildx imagetools create"),
     );
-    expect(openClawManifestScript).toContain(
-      'docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"',
-    );
+    expect(openClawManifestScript).toContain('--tag "$candidate_tag"');
+    expect(openClawManifestScript).toContain('--metadata-file "$candidate_metadata"');
+    expect(openClawManifestScript).toContain('"${sources[@]}"');
     expect(openClawManifestScript).toContain('"amd64,arm64"');
+    expect(openClawManifestScript).toContain('"${source_digests[linux/amd64]}"');
+    expect(openClawManifestScript).toContain('"${source_digests[linux/arm64]}"');
+    expect(openClawManifestScript).toContain("platform_digests_json=");
+    expect(openClawManifestScript).toContain("declare -A platform_digests=()");
     expect(openClawManifestScript).toContain("scripts/export-managed-base-image-contract.sh");
+    expect(openClawManifestScript).not.toContain("first_tag=");
+    expect(openClawManifestScript).not.toContain(
+      'imagetools create "${tag_args[@]}" "${sources[@]}"',
+    );
+    const openClawValidationIndex = openClawManifestScript.indexOf(
+      "scripts/checks/validate-managed-base-index.sh",
+    );
+    const openClawPromotionIndex = openClawManifestScript.indexOf("publication_metadata=");
+    expect(openClawManifestScript.indexOf("candidate_tag=")).toBeLessThan(openClawValidationIndex);
+    expect(openClawValidationIndex).toBeLessThan(openClawPromotionIndex);
+    expect(openClawManifestScript.slice(openClawPromotionIndex)).toContain('"${tag_args[@]}"');
+    expect(openClawManifestScript.slice(openClawPromotionIndex)).toContain('"$reference"');
     for (const step of (manifestJob?.steps ?? []).filter((step) => step.uses)) {
       expect(step.uses, step.name).toMatch(FULL_SHA_ACTION);
     }
@@ -583,15 +603,31 @@ describe("base-image publication behavior", () => {
       expect(manifestScript).toContain("--format '{{.Image.OS}}/{{.Image.Architecture}}'");
       expect(manifestScript).toContain('if [ "$source_platform" != "linux/$expected_arch" ]; then');
       expect(manifestScript).toContain("duplicate platform digest");
+      expect(manifestScript).toContain("declare -A source_digests=()");
+      expect(manifestScript).toContain('source_digests["linux/$expected_arch"]="sha256:$digest"');
       expect(manifestScript.indexOf("source_platform=")).toBeLessThan(
         manifestScript.indexOf("docker buildx imagetools create"),
       );
-      expect(manifestScript).toContain(
-        'docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"',
-      );
+      expect(manifestScript).toContain('--tag "$candidate_tag"');
+      expect(manifestScript).toContain('--metadata-file "$candidate_metadata"');
+      expect(manifestScript).toContain('"${sources[@]}"');
       expect(manifestScript).toContain('"amd64,arm64"');
       expect(manifestScript).toContain("scripts/checks/validate-managed-base-index.sh");
+      expect(manifestScript).toContain('"${source_digests[linux/amd64]}"');
+      expect(manifestScript).toContain('"${source_digests[linux/arm64]}"');
+      expect(manifestScript).toContain("platform_digests_json=");
+      expect(manifestScript).toContain("declare -A platform_digests=()");
       expect(manifestScript).toContain("scripts/export-managed-base-image-contract.sh");
+      expect(manifestScript).not.toContain("first_tag=");
+      expect(manifestScript).not.toContain('imagetools create "${tag_args[@]}" "${sources[@]}"');
+      const validationIndex = manifestScript.indexOf(
+        "scripts/checks/validate-managed-base-index.sh",
+      );
+      const promotionIndex = manifestScript.indexOf("publication_metadata=");
+      expect(manifestScript.indexOf("candidate_tag=")).toBeLessThan(validationIndex);
+      expect(validationIndex).toBeLessThan(promotionIndex);
+      expect(manifestScript.slice(promotionIndex)).toContain('"${tag_args[@]}"');
+      expect(manifestScript.slice(promotionIndex)).toContain('"$reference"');
       for (const step of (manifestJob?.steps ?? []).filter((step) => step.uses)) {
         expect(step.uses, step.name).toMatch(FULL_SHA_ACTION);
       }

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -101,6 +101,10 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     ),
   },
   {
+    pattern: /(?:^|\/)scripts\/checks\/validate-managed-base-index\.sh$/,
+    testsToRun: runTests("test/validate-managed-base-index.test.ts"),
+  },
+  {
     pattern: /(?:^|\/)scripts\/e2e\/sanitize-trace-timing\.py$/,
     testsToRun: runTests(
       "test/e2e/support/e2e-scorecard.test.ts",

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -382,6 +382,8 @@ describe("complete managed-image publication workflow", () => {
       const promotionIndex = manifestRun.indexOf("publication_metadata=");
       expect(manifestRun.indexOf("candidate_tag=")).toBeLessThan(validationIndex);
       expect(validationIndex).toBeLessThan(promotionIndex);
+      expect(manifestRun).toContain("published_digest=");
+      expect(manifestRun).toContain('if [ "$published_digest" != "$digest" ]; then');
       expect(manifestRun).not.toContain("first_tag=");
       expect(manifestRun).not.toContain('imagetools create "${tag_args[@]}" "${sources[@]}"');
       expect(step(basePublisher, "Checkout").with?.["persist-credentials"]).toBe(false);

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -363,14 +363,27 @@ describe("complete managed-image publication workflow", () => {
         `base-image workflow is missing ${expectedPublisher.agent} manifest publisher`,
       );
       const manifest = step(basePublisher, "Create and verify multi-platform manifest");
+      const manifestRun = manifest.run ?? "";
       expect(manifest.id).toBe("manifest");
       expect(manifest.env?.AGENT).toBe(expectedPublisher.agent);
       expect(manifest.run).toContain('reference="$IMAGE@$digest"');
-      expect(manifest.run).toContain("--format '{{.Manifest.Digest}}'");
+      expect(manifest.run).toContain('.["containerimage.descriptor"].digest');
+      expect(manifest.run).toContain('--metadata-file "$candidate_metadata"');
       expect(manifest.run).toContain("scripts/checks/validate-managed-base-index.sh");
+      expect(manifest.run).toContain("declare -A source_digests=()");
+      expect(manifest.run).toContain('"${source_digests[linux/amd64]}"');
+      expect(manifest.run).toContain('"${source_digests[linux/arm64]}"');
+      expect(manifest.run).toContain("platform_digests_json=");
+      expect(manifest.run).toContain("declare -A platform_digests=()");
       expect(manifest.run).toContain("scripts/export-managed-base-image-contract.sh");
       expect(manifest.run).toContain('"${platform_digests[linux/amd64]}"');
       expect(manifest.run).toContain('"${platform_digests[linux/arm64]}"');
+      const validationIndex = manifestRun.indexOf("scripts/checks/validate-managed-base-index.sh");
+      const promotionIndex = manifestRun.indexOf("publication_metadata=");
+      expect(manifestRun.indexOf("candidate_tag=")).toBeLessThan(validationIndex);
+      expect(validationIndex).toBeLessThan(promotionIndex);
+      expect(manifestRun).not.toContain("first_tag=");
+      expect(manifestRun).not.toContain('imagetools create "${tag_args[@]}" "${sources[@]}"');
       expect(step(basePublisher, "Checkout").with?.["persist-credentials"]).toBe(false);
       expect(step(basePublisher, "Upload managed base image contract").with?.name).toBe(
         expectedPublisher.artifact,

--- a/test/validate-managed-base-index.test.ts
+++ b/test/validate-managed-base-index.test.ts
@@ -10,63 +10,191 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const validator = path.join(repoRoot, "scripts/checks/validate-managed-base-index.sh");
-const amd64Digest = `sha256:${"a".repeat(64)}`;
-const arm64Digest = `sha256:${"b".repeat(64)}`;
+const image = "ghcr.io/nvidia/nemoclaw/base";
+const amd64SourceDigest = `sha256:${"a".repeat(64)}`;
+const arm64SourceDigest = `sha256:${"b".repeat(64)}`;
 const indexDigest = `sha256:${"c".repeat(64)}`;
+const amd64WorkloadDigest = `sha256:${"d".repeat(64)}`;
+const arm64WorkloadDigest = `sha256:${"e".repeat(64)}`;
+const amd64AttestationDigest = `sha256:${"f".repeat(64)}`;
+const arm64AttestationDigest = `sha256:${"0".repeat(64)}`;
+const foreignDigest = `sha256:${"9".repeat(64)}`;
 
-function index(amd64: string, arm64: string): string {
+type Descriptor = {
+  annotations?: Record<string, string>;
+  digest: string;
+  mediaType: string;
+  platform: { architecture: string; os: string };
+  size: number;
+};
+
+function workloadDescriptor(architecture: string, digest: string): Descriptor {
+  return {
+    mediaType: "application/vnd.oci.image.manifest.v1+json",
+    digest,
+    size: 1234,
+    platform: { architecture, os: "linux" },
+  };
+}
+
+function attestationDescriptor(workloadDigest: string, digest: string): Descriptor {
+  return {
+    mediaType: "application/vnd.oci.image.manifest.v1+json",
+    digest,
+    size: 567,
+    annotations: {
+      "vnd.docker.reference.digest": workloadDigest,
+      "vnd.docker.reference.type": "attestation-manifest",
+    },
+    platform: { architecture: "unknown", os: "unknown" },
+  };
+}
+
+function index(manifests: Descriptor[]): string {
   return JSON.stringify({
     schemaVersion: 2,
-    manifests: [
-      { digest: amd64, platform: { architecture: "amd64", os: "linux" } },
-      { digest: arm64, platform: { architecture: "arm64", os: "linux" } },
-    ],
+    mediaType: "application/vnd.oci.image.index.v1+json",
+    manifests,
   });
 }
 
-describe("managed base index validation", () => {
-  it("rejects a retagged index whose platform descriptors came from another run", () => {
-    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-index-"));
-    const fakeBin = path.join(temporaryRoot, "bin");
-    const rawIndex = path.join(temporaryRoot, "index.json");
-    fs.mkdirSync(fakeBin);
-    fs.writeFileSync(
-      path.join(fakeBin, "docker"),
-      `#!/usr/bin/env bash
+const amd64Workload = workloadDescriptor("amd64", amd64WorkloadDigest);
+const arm64Workload = workloadDescriptor("arm64", arm64WorkloadDigest);
+const amd64Attestation = attestationDescriptor(amd64WorkloadDigest, amd64AttestationDigest);
+const arm64Attestation = attestationDescriptor(arm64WorkloadDigest, arm64AttestationDigest);
+
+type Fixture = {
+  amd64Source?: string;
+  arm64Source?: string;
+  published?: string;
+};
+
+function runValidator(fixture: Fixture = {}) {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-index-"));
+  const fakeBin = path.join(temporaryRoot, "bin");
+  fs.mkdirSync(fakeBin);
+  fs.writeFileSync(
+    path.join(temporaryRoot, "amd64-source.json"),
+    fixture.amd64Source ?? index([amd64Workload, amd64Attestation]),
+  );
+  fs.writeFileSync(
+    path.join(temporaryRoot, "arm64-source.json"),
+    fixture.arm64Source ?? index([arm64Workload, arm64Attestation]),
+  );
+  fs.writeFileSync(
+    path.join(temporaryRoot, "published.json"),
+    fixture.published ?? index([amd64Workload, amd64Attestation, arm64Workload, arm64Attestation]),
+  );
+  fs.writeFileSync(
+    path.join(fakeBin, "docker"),
+    `#!/usr/bin/env bash
 set -euo pipefail
 test "\${1:-} \${2:-} \${3:-} \${5:-}" = "buildx imagetools inspect --raw"
-cat "$RAW_INDEX"
+case "\${4:-}" in
+  "$FINAL_REFERENCE") cat "$FIXTURE_ROOT/published.json" ;;
+  "$AMD64_SOURCE_REFERENCE") cat "$FIXTURE_ROOT/amd64-source.json" ;;
+  "$ARM64_SOURCE_REFERENCE") cat "$FIXTURE_ROOT/arm64-source.json" ;;
+  *) exit 90 ;;
+esac
 `,
-      { mode: 0o755 },
+    { mode: 0o755 },
+  );
+
+  try {
+    return spawnSync(validator, [`${image}@${indexDigest}`, amd64SourceDigest, arm64SourceDigest], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        FIXTURE_ROOT: temporaryRoot,
+        FINAL_REFERENCE: `${image}@${indexDigest}`,
+        AMD64_SOURCE_REFERENCE: `${image}@${amd64SourceDigest}`,
+        ARM64_SOURCE_REFERENCE: `${image}@${arm64SourceDigest}`,
+      },
+    });
+  } finally {
+    fs.rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+}
+
+describe("managed base index validation", () => {
+  it("resolves runnable descriptors from provenance-wrapped platform indexes (#7744)", () => {
+    const accepted = runValidator();
+
+    expect(accepted.status, accepted.stderr).toBe(0);
+    expect(JSON.parse(accepted.stdout)).toEqual({
+      "linux/amd64": amd64WorkloadDigest,
+      "linux/arm64": arm64WorkloadDigest,
+    });
+  });
+
+  it("rejects a retagged index whose workload descriptor is stale (#7744)", () => {
+    const retagged = runValidator({
+      published: index([
+        workloadDescriptor("amd64", foreignDigest),
+        amd64Attestation,
+        arm64Workload,
+        arm64Attestation,
+      ]),
+    });
+
+    expect(retagged.status).not.toBe(0);
+    expect(retagged.stderr).toContain(
+      "linux/amd64 descriptor does not match this run's resolved workload descriptor",
     );
+  });
 
-    const run = () =>
-      spawnSync(
-        validator,
-        [`ghcr.io/nvidia/nemoclaw/base@${indexDigest}`, amd64Digest, arm64Digest],
-        {
-          encoding: "utf8",
-          env: {
-            ...process.env,
-            PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
-            RAW_INDEX: rawIndex,
-          },
-        },
-      );
+  it("rejects a stale source index whose workload differs from publication (#7744)", () => {
+    const staleSource = runValidator({
+      amd64Source: index([
+        workloadDescriptor("amd64", foreignDigest),
+        attestationDescriptor(foreignDigest, amd64AttestationDigest),
+      ]),
+    });
 
-    try {
-      fs.writeFileSync(rawIndex, index(amd64Digest, arm64Digest));
-      const accepted = run();
-      expect(accepted.status, accepted.stderr).toBe(0);
+    expect(staleSource.status).not.toBe(0);
+    expect(staleSource.stderr).toContain(
+      "linux/amd64 descriptor does not match this run's resolved workload descriptor",
+    );
+  });
 
-      fs.writeFileSync(rawIndex, index(`sha256:${"d".repeat(64)}`, arm64Digest));
-      const retagged = run();
-      expect(retagged.status).not.toBe(0);
-      expect(retagged.stderr).toContain(
-        "linux/amd64 descriptor does not match this run's platform digest",
-      );
-    } finally {
-      fs.rmSync(temporaryRoot, { force: true, recursive: true });
-    }
+  it("rejects an ambiguous source index with duplicate workload descriptors (#7744)", () => {
+    const ambiguousSource = runValidator({
+      amd64Source: index([
+        amd64Workload,
+        workloadDescriptor("amd64", foreignDigest),
+        amd64Attestation,
+      ]),
+    });
+
+    expect(ambiguousSource.status).not.toBe(0);
+    expect(ambiguousSource.stderr).toContain(
+      "source index must contain exactly one linux/amd64 descriptor",
+    );
+  });
+
+  it("rejects a final index that drops this run's provenance descriptor (#7744)", () => {
+    const missingProvenance = runValidator({
+      published: index([amd64Workload, arm64Workload, arm64Attestation]),
+    });
+
+    expect(missingProvenance.status).not.toBe(0);
+    expect(missingProvenance.stderr).toContain(
+      "index descriptors do not match this run's platform source indexes",
+    );
+  });
+
+  it("rejects a source index whose provenance is bound to another workload (#7744)", () => {
+    const mismatchedProvenance = runValidator({
+      amd64Source: index([
+        amd64Workload,
+        attestationDescriptor(arm64WorkloadDigest, amd64AttestationDigest),
+      ]),
+    });
+
+    expect(mismatchedProvenance.status).not.toBe(0);
+    expect(mismatchedProvenance.stderr).toContain(
+      "source index for linux/amd64 is not one workload plus its provenance manifest",
+    );
   });
 });

--- a/test/validate-managed-base-index.test.ts
+++ b/test/validate-managed-base-index.test.ts
@@ -65,8 +65,11 @@ const arm64Attestation = attestationDescriptor(arm64WorkloadDigest, arm64Attesta
 
 type Fixture = {
   amd64Source?: string;
+  amd64SourceDigestArgument?: string;
   arm64Source?: string;
+  arm64SourceDigestArgument?: string;
   published?: string;
+  reference?: string;
 };
 
 function runValidator(fixture: Fixture = {}) {
@@ -101,17 +104,25 @@ esac
   );
 
   try {
-    return spawnSync(validator, [`${image}@${indexDigest}`, amd64SourceDigest, arm64SourceDigest], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
-        FIXTURE_ROOT: temporaryRoot,
-        FINAL_REFERENCE: `${image}@${indexDigest}`,
-        AMD64_SOURCE_REFERENCE: `${image}@${amd64SourceDigest}`,
-        ARM64_SOURCE_REFERENCE: `${image}@${arm64SourceDigest}`,
+    return spawnSync(
+      validator,
+      [
+        fixture.reference ?? `${image}@${indexDigest}`,
+        fixture.amd64SourceDigestArgument ?? amd64SourceDigest,
+        fixture.arm64SourceDigestArgument ?? arm64SourceDigest,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          FIXTURE_ROOT: temporaryRoot,
+          FINAL_REFERENCE: `${image}@${indexDigest}`,
+          AMD64_SOURCE_REFERENCE: `${image}@${amd64SourceDigest}`,
+          ARM64_SOURCE_REFERENCE: `${image}@${arm64SourceDigest}`,
+        },
       },
-    });
+    );
   } finally {
     fs.rmSync(temporaryRoot, { force: true, recursive: true });
   }
@@ -126,6 +137,32 @@ describe("managed base index validation", () => {
       "linux/amd64": amd64WorkloadDigest,
       "linux/arm64": arm64WorkloadDigest,
     });
+  });
+
+  it("rejects a mutable managed base reference (#7744)", () => {
+    const mutable = runValidator({ reference: `${image}:latest` });
+
+    expect(mutable.status).not.toBe(0);
+    expect(mutable.stderr).toContain("managed base index reference must be immutable");
+  });
+
+  it("rejects a malformed platform source digest argument (#7744)", () => {
+    const malformed = runValidator({ amd64SourceDigestArgument: "sha256:not-a-digest" });
+
+    expect(malformed.status).not.toBe(0);
+    expect(malformed.stderr).toContain("managed base platform source digest is invalid");
+  });
+
+  it("rejects platform source digest arguments assigned to the wrong architecture (#7744)", () => {
+    const swapped = runValidator({
+      amd64SourceDigestArgument: arm64SourceDigest,
+      arm64SourceDigestArgument: amd64SourceDigest,
+    });
+
+    expect(swapped.status).not.toBe(0);
+    expect(swapped.stderr).toContain(
+      "source index must contain exactly one linux/amd64 descriptor",
+    );
   });
 
   it("rejects a retagged index whose workload descriptor is stale (#7744)", () => {

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -62,6 +62,7 @@ const OPAQUE_INPUTS = [
   "scripts/setup-jetson.sh",
   ".github/workflows/base-image.yaml",
   "scripts/export-managed-base-image-contract.sh",
+  "scripts/checks/validate-managed-base-index.sh",
   "scripts/e2e/sanitize-trace-timing.py",
   "test/e2e/manifests/openclaw-nvidia.yaml",
   "test/e2e/docs/parity-inventory.generated.json",
@@ -134,6 +135,9 @@ describe("Vitest opaque-input watch triggers", () => {
       "test/managed-base-image-contract.test.ts",
       "test/managed-image-publication-workflow.test.ts",
       "test/dcode-base-image-workflow.test.ts",
+    ]);
+    expect(triggeredBy("scripts/checks/validate-managed-base-index.sh")).toEqual([
+      "test/validate-managed-base-index.test.ts",
     ]);
     expect(triggeredBy("scripts/e2e/sanitize-trace-timing.py")).toEqual([
       "test/e2e/support/e2e-scorecard.test.ts",


### PR DESCRIPTION
## Summary

Corrects base-image publication for provenance-bearing single-platform indexes. The workflow now validates runnable descriptors and provenance before it updates consumer tags.

## Changes

- Keep each provenance-bearing source index digest for multi-platform composition.
- Resolve the runnable child manifest for platform validation and managed base-image contract export.
- Compare the complete published descriptor set with both source indexes to reject stale workloads, missing provenance, and misbound attestations.
- Stage the combined index under a run-scoped candidate tag. Publish consumer tags only from the validated immutable reference.
- Add provenance-wrapper regression coverage and focused Vitest watch routing for the validator.

The shared validator is required by the OpenClaw, Hermes, and Deep Agents Code publishers. One implementation prevents the three publication paths from applying different provenance rules.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This corrects an internal CI publication contract. CLI behavior, configuration, image references, and supported user workflows do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the nine-category security review. The review passed after consumer-tag promotion moved behind provenance validation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. Existing managed base-image publication and changelog text remains accurate.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f5e6b97df -->
<!-- docs-review-agents-blob-sha: b1b6664e5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Five focused validator, base-contract, workflow, and watch-routing files passed 34/34 after rebase.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this internal workflow correction. `npm run checks:repository` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Failure evidence: [first affected base-image run](https://github.com/NVIDIA/NemoClaw/actions/runs/30937515942) and [release-blocking base-image run](https://github.com/NVIDIA/NemoClaw/actions/runs/30939277561).

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
