### PR TITLE
feat(inference): add protected llama.cpp Spark qualification

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2148,7 +2148,7 @@ jobs:
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_BASE_SHA: ${{ inputs.base_sha }}
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_CANDIDATE_ROOT: ${{ github.workspace }}/.candidate-llama-cpp
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_EVIDENCE: ${{ github.workspace }}/e2e-artifacts/live/llama-cpp-dgx-spark-qualification/evidence.json
-      NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN: ${{ runner.temp }}/llama-cpp-dgx-spark-plan.json
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN: ${{ github.workspace }}/.llama-cpp-qualification/plan.json
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN_SHA256: ${{ needs.llama-cpp-dgx-spark-plan.outputs.plan_sha256 }}
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_REGISTRY: nemoclaw-llama-cpp-${{ github.run_id }}-${{ github.run_attempt }}
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_WORKFLOW_SHA: ${{ inputs.workflow_sha }}
@@ -2212,10 +2212,7 @@ jobs:
       - name: Set up protected llama.cpp Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
-          driver-opts: network=host
-          buildkitd-config-inline: |
-            [registry."localhost:5000"]
-              http = true
+          driver: docker
 
       - name: Prepare E2E workspace
         uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@f6304bc25fc35bfaa441c8c2fbfee38f72805a75
@@ -2236,6 +2233,7 @@ jobs:
             exit 1
           }
           install -d -m 0700 "$E2E_ARTIFACT_DIR"
+          install -d -m 0700 "$(dirname "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN")"
           umask 077
           printf '%s' "$PLAN" > "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN"
           [[ "sha256:$(sha256sum "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN" | awk '{print $1}')" == "$PLAN_SHA256" ]] || {

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2033,6 +2033,272 @@ jobs:
         shell: bash
         run: bash .github/scripts/docker-auth-cleanup.sh
 
+  # The trusted plan compiler runs on a standard runner before the protected
+  # job can be assigned. Candidate workflow code is never evaluated; trusted
+  # main compiles the exact candidate's declarative YAML into bounded outputs.
+  llama-cpp-dgx-spark-plan:
+    name: Compile protected llama.cpp DGX Spark plan
+    needs: generate-matrix
+    if: ${{ contains(format(',{0},', inputs.jobs), ',llama-cpp-dgx-spark-qualification,') || contains(format(',{0},', inputs.targets), ',llama-cpp-dgx-spark-qualification,') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      environment: ${{ steps.plan.outputs.environment }}
+      execution: ${{ steps.plan.outputs.execution }}
+      model_host_path: ${{ steps.plan.outputs.model_host_path }}
+      plan: ${{ steps.plan.outputs.plan }}
+      plan_sha256: ${{ steps.plan.outputs.plan_sha256 }}
+      qualification: ${{ steps.plan.outputs.qualification }}
+      runner: ${{ steps.plan.outputs.runner }}
+    steps:
+      - name: Validate trusted llama.cpp plan dispatch
+        env:
+          ACTOR: ${{ github.actor }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          EXPECTED_WORKFLOW_SHA: ${{ inputs.workflow_sha }}
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$REPOSITORY" == "NVIDIA/NemoClaw" && "$REF" == "refs/heads/main" && "$EVENT_NAME" == "workflow_dispatch" ]] || {
+            echo "::error::Protected llama.cpp planning must run from trusted NVIDIA/NemoClaw main" >&2
+            exit 1
+          }
+          [[ "$ACTOR" == "github-actions[bot]" ]] || {
+            echo "::error::Protected llama.cpp planning requires the trusted controller actor" >&2
+            exit 1
+          }
+          [[ "$CHECKOUT_SHA" =~ ^[a-f0-9]{40}$ && "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]] || {
+            echo "::error::Protected llama.cpp planning requires exact PR and base SHAs" >&2
+            exit 1
+          }
+          [[ "$EXPECTED_WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ && "$WORKFLOW_SHA" == "$EXPECTED_WORKFLOW_SHA" ]] || {
+            echo "::error::Protected llama.cpp planning requires the exact trusted workflow SHA" >&2
+            exit 1
+          }
+
+      - name: Checkout trusted llama.cpp plan compiler
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ inputs.workflow_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact llama.cpp candidate configuration
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_sha || github.sha }}
+          path: .candidate-llama-cpp
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node for trusted llama.cpp plan compilation
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install trusted llama.cpp plan dependencies
+        run: npm ci --ignore-scripts
+
+      - id: plan
+        name: Compile exact candidate llama.cpp qualification plan
+        env:
+          CANDIDATE_ROOT: ${{ github.workspace }}/.candidate-llama-cpp
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git -C "$CANDIDATE_ROOT" rev-parse --verify HEAD)" == "$CHECKOUT_SHA" ]] || {
+            echo "::error::Protected llama.cpp candidate checkout does not match the exact PR SHA" >&2
+            exit 1
+          }
+          node --experimental-strip-types --no-warnings \
+            scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts \
+            --source-root "$CANDIDATE_ROOT"
+
+  # This explicit-only lane is dormant until a follow-on candidate adds the
+  # YAML activation contract and enables complete protected infrastructure in
+  # the image manifest. Trusted main then proves that exact candidate head.
+  llama-cpp-dgx-spark-qualification:
+    name: Protected llama.cpp on NVIDIA DGX Spark
+    needs: [generate-matrix, llama-cpp-dgx-spark-plan]
+    if: ${{ (contains(format(',{0},', inputs.jobs), ',llama-cpp-dgx-spark-qualification,') || contains(format(',{0},', inputs.targets), ',llama-cpp-dgx-spark-qualification,')) && needs.llama-cpp-dgx-spark-plan.outputs.execution == 'enabled' }}
+    runs-on: ${{ needs.llama-cpp-dgx-spark-plan.outputs.runner }}
+    environment:
+      name: ${{ needs.llama-cpp-dgx-spark-plan.outputs.environment }}
+    timeout-minutes: 300
+    permissions:
+      contents: read
+    env:
+      E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/live/llama-cpp-dgx-spark-qualification
+      E2E_DEFAULT_ENABLED: "0"
+      E2E_JOB: "1"
+      E2E_TARGET_ID: "llama-cpp-dgx-spark-qualification"
+      NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha }}
+      NEMOCLAW_E2E_SHARD: linux-arm64-gpu-dgx-spark-gb10
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_BASE_SHA: ${{ inputs.base_sha }}
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_CANDIDATE_ROOT: ${{ github.workspace }}/.candidate-llama-cpp
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_EVIDENCE: ${{ github.workspace }}/e2e-artifacts/live/llama-cpp-dgx-spark-qualification/evidence.json
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN: ${{ runner.temp }}/llama-cpp-dgx-spark-plan.json
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN_SHA256: ${{ needs.llama-cpp-dgx-spark-plan.outputs.plan_sha256 }}
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_REGISTRY: nemoclaw-llama-cpp-${{ github.run_id }}-${{ github.run_attempt }}
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_WORKFLOW_SHA: ${{ inputs.workflow_sha }}
+      NEMOCLAW_RUN_LIVE_E2E: "1"
+      RELEASE_E2E_ACTIVATION_PATH: ci/llama-cpp-dgx-spark-qualification-v1.yaml
+    steps:
+      - name: Validate protected llama.cpp exact-head dispatch
+        env:
+          ACTOR: ${{ github.actor }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          EXPECTED_WORKFLOW_SHA: ${{ inputs.workflow_sha }}
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          RUNNER_ARCH_KIND: ${{ runner.arch }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$REPOSITORY" == "NVIDIA/NemoClaw" && "$REF" == "refs/heads/main" && "$EVENT_NAME" == "workflow_dispatch" ]] || {
+            echo "::error::Protected llama.cpp qualification must run from trusted NVIDIA/NemoClaw main" >&2
+            exit 1
+          }
+          [[ "$ACTOR" == "github-actions[bot]" ]] || {
+            echo "::error::Protected llama.cpp qualification requires the trusted controller actor" >&2
+            exit 1
+          }
+          [[ "$CHECKOUT_SHA" =~ ^[a-f0-9]{40}$ && "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]] || {
+            echo "::error::Protected llama.cpp qualification requires exact PR and base SHAs" >&2
+            exit 1
+          }
+          [[ "$EXPECTED_WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ && "$WORKFLOW_SHA" == "$EXPECTED_WORKFLOW_SHA" ]] || {
+            echo "::error::Protected llama.cpp qualification requires the exact trusted workflow SHA" >&2
+            exit 1
+          }
+          [[ "$RUNNER_ARCH_KIND" == "ARM64" ]] || {
+            echo "::error::Protected llama.cpp qualification requires native Linux ARM64" >&2
+            exit 1
+          }
+
+      - name: Checkout trusted llama.cpp qualification
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ inputs.workflow_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact llama.cpp qualification candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_sha || github.sha }}
+          path: .candidate-llama-cpp
+          fetch-depth: 0
+          persist-credentials: false
+
+      - *dockerhub-auth
+
+      - name: Set up protected llama.cpp Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."localhost:5000"]
+              http = true
+
+      - name: Prepare E2E workspace
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@f6304bc25fc35bfaa441c8c2fbfee38f72805a75
+        with:
+          build-cli: "false"
+
+      - name: Materialize trusted llama.cpp qualification plan
+        env:
+          CANDIDATE_ROOT: ${{ github.workspace }}/.candidate-llama-cpp
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+          PLAN: ${{ needs.llama-cpp-dgx-spark-plan.outputs.plan }}
+          PLAN_SHA256: ${{ needs.llama-cpp-dgx-spark-plan.outputs.plan_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git -C "$CANDIDATE_ROOT" rev-parse --verify HEAD)" == "$CHECKOUT_SHA" ]] || {
+            echo "::error::Protected llama.cpp candidate checkout does not match the exact PR SHA" >&2
+            exit 1
+          }
+          install -d -m 0700 "$E2E_ARTIFACT_DIR"
+          umask 077
+          printf '%s' "$PLAN" > "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN"
+          [[ "sha256:$(sha256sum "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN" | awk '{print $1}')" == "$PLAN_SHA256" ]] || {
+            echo "::error::Protected llama.cpp qualification plan digest changed" >&2
+            exit 1
+          }
+
+      - id: qualify
+        name: Build and qualify exact llama.cpp candidate
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+          CANDIDATE_ROOT: ${{ github.workspace }}/.candidate-llama-cpp
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+          MODEL_HOST_PATH: ${{ needs.llama-cpp-dgx-spark-plan.outputs.model_host_path }}
+          WORKFLOW_SHA: ${{ inputs.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse --verify HEAD)" == "$WORKFLOW_SHA" ]] || {
+            echo "::error::Protected llama.cpp qualification must execute trusted workflow code" >&2
+            exit 1
+          }
+          npx --no-install tsx scripts/checks/run-llama-cpp-dgx-spark-qualification.mts \
+            --base-sha "$BASE_SHA" \
+            --candidate-root "$CANDIDATE_ROOT" \
+            --head-sha "$CHECKOUT_SHA" \
+            --model-host-path "$MODEL_HOST_PATH" \
+            --output "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_EVIDENCE" \
+            --plan "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN" \
+            --plan-sha256 "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN_SHA256" \
+            --registry-name "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_REGISTRY" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --run-id "$GITHUB_RUN_ID" \
+            --workflow-sha "$WORKFLOW_SHA"
+
+      - name: Remove protected llama.cpp qualification resources
+        if: always()
+        shell: bash
+        run: >-
+          npx --no-install tsx scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+          --cleanup-only
+          --registry-name "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_REGISTRY"
+          --run-attempt "$GITHUB_RUN_ATTEMPT"
+          --run-id "$GITHUB_RUN_ID"
+
+      - name: Validate protected llama.cpp evidence
+        shell: bash
+        run: >-
+          npx --no-install tsx tools/e2e/live-vitest-invocation.mts run
+          --test-path test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts
+
+      - name: Upload protected llama.cpp evidence
+        if: always()
+        uses: NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@7768e15eb90d3ee2d33432f481dfe8747e4f6d57
+        with:
+          name: e2e-llama-cpp-dgx-spark-qualification
+          path: e2e-artifacts/live/llama-cpp-dgx-spark-qualification/
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   # This explicit-only lane runs only when the exact candidate includes
   # ci/protected-managed-image-runtime-activation-v1.json. The trusted
   # controller can then qualify that candidate's exact head without executing
@@ -6350,6 +6616,8 @@ jobs:
         cloud-inference,
         gpu-e2e,
         managed-image-multiarch-startup,
+        llama-cpp-dgx-spark-plan,
+        llama-cpp-dgx-spark-qualification,
         managed-image-protected-runtime,
         agent-turn-latency,
         kimi-inference-compat,

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -288,9 +288,11 @@ jobs:
             exit 1
           fi
           if ! jq -e '
-            (keys | sort) == ["environment", "gpu", "model", "platform", "probes", "profile", "required", "runner"]
+            (keys | sort) == ["environment", "execution", "gpu", "model", "platform", "probes", "profile", "recipeRef", "required", "runner"]
             and .required == true
+            and .execution == "enabled"
             and .profile == "dgx-spark-gb10-single"
+            and .recipeRef == "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1"
             and .platform == "linux/arm64"
             and (.runner | type) == "string" and (.runner | length) > 0
             and (.environment | type) == "string" and (.environment | length) > 0

--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -40,7 +40,9 @@ spec:
         retentionDays: 90
     qualification:
       required: true
+      execution: disabled
       profile: dgx-spark-gb10-single
+      recipeRef: llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1
       platform: linux/arm64
       runner: null
       environment: null

--- a/scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts
+++ b/scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { githubOutput, loadLlamaCppImageConfigFromRoot } from "./export-llama-cpp-image-config.mts";
+import {
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
+  parseLlamaCppDgxSparkExecutionPlan,
+  parseLlamaCppDgxSparkQualificationActivation,
+  parseLlamaCppDgxSparkQualificationPlan,
+} from "./llama-cpp-dgx-spark-qualification-contract.mts";
+
+function readBoundedRegularFile(root: string, relativePath: string): string {
+  const file = path.resolve(root, relativePath);
+  const relative = path.relative(root, file);
+  if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`invalid protected qualification path: ${relativePath}`);
+  }
+  const descriptor = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const status = fs.fstatSync(descriptor);
+    if (!status.isFile() || status.size < 1 || status.size > 4096) {
+      throw new Error(`protected qualification activation must be a bounded regular file`);
+    }
+    return fs.readFileSync(descriptor, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+export function exportLlamaCppDgxSparkQualificationPlan(sourceRoot: string) {
+  const root = fs.realpathSync(sourceRoot);
+  parseLlamaCppDgxSparkQualificationActivation(
+    readBoundedRegularFile(root, LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH),
+  );
+
+  const config = loadLlamaCppImageConfigFromRoot(root);
+  const qualification = parseLlamaCppDgxSparkQualificationPlan(
+    JSON.parse(config.publication_qualification) as unknown,
+  );
+  if (
+    qualification.execution !== "enabled" ||
+    qualification.runner === null ||
+    qualification.environment === null ||
+    qualification.model.hostPath === null
+  ) {
+    throw new Error("protected llama.cpp DGX Spark qualification is not enabled");
+  }
+  parseLlamaCppDgxSparkExecutionPlan(
+    JSON.parse(config.publication_qualification_plan) as unknown,
+    config.publication_qualification_plan_sha256,
+  );
+
+  return {
+    environment: qualification.environment,
+    execution: qualification.execution,
+    model_host_path: qualification.model.hostPath,
+    plan: config.publication_qualification_plan,
+    plan_sha256: config.publication_qualification_plan_sha256,
+    qualification: config.publication_qualification,
+    runner: qualification.runner,
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  if (args.length !== 2 || args[0] !== "--source-root" || !args[1]) {
+    throw new Error("usage: export-llama-cpp-dgx-spark-qualification-plan.mts --source-root PATH");
+  }
+  const output = githubOutput(exportLlamaCppDgxSparkQualificationPlan(args[1]));
+  const githubOutputPath = process.env.GITHUB_OUTPUT;
+  if (githubOutputPath)
+    fs.appendFileSync(githubOutputPath, output, { encoding: "utf8", mode: 0o600 });
+  else process.stdout.write(output);
+}

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import Ajv2020 from "ajv/dist/2020.js";
 import YAML from "yaml";
 
 type ServerImageManifest = {
@@ -40,11 +42,13 @@ type ServerImageManifest = {
       platforms?: unknown;
       qualification?: {
         environment?: unknown;
+        execution?: unknown;
         gpu?: unknown;
         model?: unknown;
         platform?: unknown;
         probes?: unknown;
         profile?: unknown;
+        recipeRef?: unknown;
         required?: unknown;
         runner?: unknown;
       };
@@ -70,9 +74,84 @@ type ServerImageManifest = {
   };
 };
 
+type LlamaCppQualificationRecipe = {
+  apiVersion: string;
+  kind: string;
+  metadata: { id: string };
+  spec: {
+    backend: string;
+    providerId: string;
+    server: {
+      technology: string;
+      source: { repository: string; revision: string };
+    };
+    model: {
+      id: string;
+      revision: string;
+      servedName: string;
+      files: Array<{
+        path: string;
+        digest: string;
+        sizeBytes: number;
+        format: string;
+        quantization: string;
+        license: string;
+      }>;
+    };
+    runtime: {
+      image: string;
+      imageDownloadSizeBytes: number;
+      platforms: string[];
+      containerRuntime: string;
+      networkExposure: string;
+      hosts: number;
+      cuda: { baseImage: string; minimumDriverVersion: string };
+      gpu: { vendor: string; count: number; offload: string; cpuFallback: string };
+      resources: { memoryBytes: number; writableStorageBytes: number; pidsLimit: number };
+    };
+    execution: { receiptRef: string; materializerRef: string; lifecycleRef: string };
+    serve: {
+      protocol: string;
+      authentication: string;
+      port: number;
+      chatTemplate: string;
+      contextSize: number;
+      slots: number;
+      idleSleepSeconds: number;
+      batchSize: number;
+      microBatchSize: number;
+      flashAttention: string;
+      kvCache: { key: string; value: string };
+      speculativeDecoding: string;
+      limits: {
+        maxRequestBodyBytes: number;
+        maxPromptTokens: number;
+        maxCompletionTokens: number;
+        requestTimeoutSeconds: number;
+      };
+    };
+    readiness: {
+      contractRef: string;
+      timeoutSeconds: number;
+      expectedModel: string;
+      probes: { models: boolean; health: boolean; properties: boolean; metrics: boolean };
+    };
+    policy: { egress: string; modelSource: string; modelDownloads: string };
+    surfaces: Record<string, string>;
+    capabilities: Record<string, unknown>;
+  };
+};
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 const manifestPath = path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml");
+const recipePath = path.join(
+  repoRoot,
+  "managed-inference",
+  "recipes",
+  "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
+);
+const recipeSchemaPath = path.join(repoRoot, "managed-inference", "schemas", "recipe.schema.json");
 
 const nvidiaCudaDigestReference = /^docker\.io\/nvidia\/cuda@sha256:[0-9a-f]{64}$/u;
 const fullRevision = /^[0-9a-f]{40}$/u;
@@ -136,8 +215,41 @@ function assertExactKeys(value: unknown, name: string, expected: string[]): void
   }
 }
 
-export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "utf8")) {
-  const manifest = YAML.parse(source) as ServerImageManifest;
+function parseQualificationRecipe(
+  source: string,
+  schemaSource: string,
+): LlamaCppQualificationRecipe {
+  const document = YAML.parseDocument(source, { strict: true, uniqueKeys: true });
+  if (document.errors.length > 0) {
+    throw new Error(`invalid llama.cpp qualification recipe YAML: ${document.errors.join("; ")}`);
+  }
+  const value = document.toJS({ maxAliasCount: 0 }) as unknown;
+  const schema = JSON.parse(schemaSource) as object;
+  const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+  if (!validate(value)) {
+    const details = (validate.errors ?? [])
+      .map((error) => `${error.instancePath || "/"} ${error.message ?? "is invalid"}`)
+      .join("; ");
+    throw new Error(`invalid llama.cpp qualification recipe: ${details}`);
+  }
+  return value as LlamaCppQualificationRecipe;
+}
+
+function parseImageManifest(source: string): ServerImageManifest {
+  const document = YAML.parseDocument(source, { strict: true, uniqueKeys: true });
+  if (document.errors.length > 0) {
+    throw new Error(`invalid llama.cpp image manifest YAML: ${document.errors.join("; ")}`);
+  }
+  return document.toJS({ maxAliasCount: 0 }) as ServerImageManifest;
+}
+
+export function loadLlamaCppImageConfig(
+  source = fs.readFileSync(manifestPath, "utf8"),
+  recipeSource = fs.readFileSync(recipePath, "utf8"),
+  recipeSchemaSource = fs.readFileSync(recipeSchemaPath, "utf8"),
+) {
+  const manifest = parseImageManifest(source);
+  const recipe = parseQualificationRecipe(recipeSource, recipeSchemaSource);
   assertExactKeys(manifest, "manifest", ["apiVersion", "kind", "metadata", "spec"]);
   assertExactKeys(manifest.metadata, "metadata", ["id"]);
   assertExactKeys(manifest.spec, "spec", [
@@ -210,11 +322,13 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   ]);
   assertExactKeys(manifest.spec?.publication?.qualification, "publication qualification", [
     "environment",
+    "execution",
     "gpu",
     "model",
     "platform",
     "probes",
     "profile",
+    "recipeRef",
     "required",
     "runner",
   ]);
@@ -249,6 +363,16 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   const publicationPlatforms = publication?.platforms;
   const qualificationRunner = qualification?.runner;
   const qualificationEnvironment = qualification?.environment;
+  const qualificationExecution = requiredString(
+    qualification?.execution,
+    "qualification execution",
+    /^(?:disabled|enabled)$/u,
+  );
+  const qualificationRecipeRef = requiredString(
+    qualification?.recipeRef,
+    "qualification recipe reference",
+    /^llama-cpp\.nemotron-3-nano-30b-a3b\.spark-single\.v1$/u,
+  );
   const qualificationModel = qualification?.model as
     | { digest?: unknown; hostPath?: unknown; id?: unknown }
     | undefined;
@@ -256,6 +380,16 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     | { cpuFallback?: unknown; fullOffload?: unknown; vendor?: unknown }
     | undefined;
   const qualificationHostPath = qualificationModel?.hostPath;
+  const recipeModelFile = recipe.spec.model.files[0];
+  const expectedSurfaces = {
+    agentMode: "disabled",
+    mcpProxy: "disabled",
+    multimodalProjection: "disabled",
+    router: "disabled",
+    serverTools: "disabled",
+    slotInspection: "disabled",
+    ui: "disabled",
+  };
   if (
     publication?.trigger !== "workflow_dispatch" ||
     publication?.allowedRef !== "refs/heads/main" ||
@@ -290,10 +424,10 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     }) ||
     qualification?.required !== true ||
     qualification?.profile !== "dgx-spark-gb10-single" ||
+    qualificationRecipeRef !== recipe.metadata.id ||
     qualification?.platform !== "linux/arm64" ||
-    qualificationModel?.id !== "unsloth/Nemotron-3-Nano-30B-A3B-GGUF" ||
-    qualificationModel?.digest !==
-      "sha256:627f5b04aedc97f967332f331bd75b7a4ed2f33ca83e6ee74b44235cc1887890" ||
+    qualificationModel?.id !== recipe.spec.model.id ||
+    qualificationModel?.digest !== recipeModelFile?.digest ||
     !matchesExactRecord(qualification?.gpu, {
       cpuFallback: "reject",
       fullOffload: true,
@@ -305,6 +439,59 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   }
   if (publicationRepository !== spec?.repository) {
     throw new Error("publication repository must match the image repository");
+  }
+  if (
+    recipe.apiVersion !== "nemoclaw.nvidia.com/managed-inference/v1" ||
+    recipe.kind !== "ServingRecipe" ||
+    recipe.spec.backend !== "install-llama-cpp" ||
+    recipe.spec.providerId !== "llama-cpp-local" ||
+    recipe.spec.server.technology !== "llama.cpp" ||
+    recipe.spec.server.source.repository !== "ggml-org/llama.cpp" ||
+    recipe.spec.server.source.revision !== spec?.source?.revision ||
+    recipe.spec.model.files.length !== 1 ||
+    recipeModelFile?.format !== "gguf" ||
+    recipe.spec.runtime.containerRuntime !== "docker" ||
+    recipe.spec.runtime.networkExposure !== "loopback" ||
+    recipe.spec.runtime.hosts !== 1 ||
+    !recipe.spec.runtime.platforms.includes("linux/arm64") ||
+    recipe.spec.runtime.cuda.baseImage !== spec?.cuda?.runtimeBase ||
+    !matchesExactRecord(recipe.spec.runtime.gpu, {
+      count: 1,
+      cpuFallback: "reject",
+      offload: "full",
+      vendor: "nvidia",
+    }) ||
+    !matchesExactRecord(recipe.spec.execution, {
+      lifecycleRef: "llama-cpp.host-local.lifecycle/v1",
+      materializerRef: "llama-cpp.host-local/v1",
+      receiptRef: "llama-cpp.host-local.receipt/v1",
+    }) ||
+    recipe.spec.serve.protocol !== "openai-completions" ||
+    recipe.spec.serve.authentication !== "bearer" ||
+    recipe.spec.serve.port !== spec?.runtime?.port ||
+    recipe.spec.serve.slots !== 1 ||
+    recipe.spec.serve.idleSleepSeconds !== -1 ||
+    recipe.spec.serve.flashAttention !== "enabled" ||
+    recipe.spec.serve.speculativeDecoding !== "disabled" ||
+    recipe.spec.serve.microBatchSize > recipe.spec.serve.batchSize ||
+    recipe.spec.serve.limits.maxPromptTokens + recipe.spec.serve.limits.maxCompletionTokens >
+      recipe.spec.serve.contextSize ||
+    recipe.spec.readiness.contractRef !== "llama-cpp.server-readiness/v1" ||
+    recipe.spec.readiness.expectedModel !== recipe.spec.model.servedName ||
+    !matchesExactRecord(recipe.spec.readiness.probes, {
+      health: true,
+      metrics: true,
+      models: true,
+      properties: true,
+    }) ||
+    !matchesExactRecord(recipe.spec.policy, {
+      egress: "disabled",
+      modelDownloads: "disabled",
+      modelSource: "verified-local",
+    }) ||
+    !matchesExactRecord(recipe.spec.surfaces, expectedSurfaces)
+  ) {
+    throw new Error("invalid llama.cpp DGX Spark qualification recipe contract");
   }
   const infrastructureComplete =
     typeof qualificationRunner === "string" &&
@@ -322,11 +509,18 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   if (publicationEnabled && !infrastructureComplete) {
     throw new Error("publication qualification infrastructure is incomplete");
   }
+  if (publicationEnabled && qualificationExecution !== "enabled") {
+    throw new Error("publication requires enabled DGX Spark qualification execution");
+  }
+  if (qualificationExecution === "enabled" && !infrastructureComplete) {
+    throw new Error("enabled DGX Spark qualification infrastructure is incomplete");
+  }
   if (!publicationEnabled && !infrastructureUnset && !infrastructureComplete) {
     throw new Error("disabled publication must not bind partial infrastructure");
   }
   const normalizedQualification = {
     environment: qualificationEnvironment,
+    execution: qualificationExecution,
     gpu: {
       cpuFallback: qualificationGpu?.cpuFallback,
       fullOffload: qualificationGpu?.fullOffload,
@@ -340,6 +534,7 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
     platform: qualification?.platform,
     probes: qualification?.probes,
     profile: qualification?.profile,
+    recipeRef: qualificationRecipeRef,
     required: qualification?.required,
     runner: qualificationRunner,
   };
@@ -441,6 +636,59 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
   if (new Set(include.map(({ platform }) => platform)).size !== 2) {
     throw new Error("llama.cpp server image platforms must be unique");
   }
+  const arm64 = include.find(({ platform }) => platform === "linux/arm64");
+  if (!arm64) {
+    throw new Error("llama.cpp qualification requires one native linux/arm64 build");
+  }
+  const qualificationPlan = {
+    contractVersion: 1,
+    imageBuild: {
+      backendDirectory: "/opt/llama.cpp/lib",
+      compiler: expectedCompiler,
+      cuda: {
+        developmentBase: spec?.cuda?.developmentBase,
+        runtimeBase: spec?.cuda?.runtimeBase,
+      },
+      platform: {
+        cudaArchitectures: arm64.cuda_architectures,
+        platform: arm64.platform,
+      },
+      repository: publicationRepository,
+      runtime: {
+        gid: spec?.runtime?.gid,
+        port: spec?.runtime?.port,
+        uid: spec?.runtime?.uid,
+      },
+      source: {
+        archiveSha256: spec?.source?.archiveSha256,
+        repository: spec?.source?.repository,
+        revision: spec?.source?.revision,
+      },
+    },
+    recipe: {
+      id: recipe.metadata.id,
+      model: {
+        file: recipeModelFile,
+        id: recipe.spec.model.id,
+        revision: recipe.spec.model.revision,
+        servedName: recipe.spec.model.servedName,
+      },
+      policy: recipe.spec.policy,
+      readiness: recipe.spec.readiness,
+      runtime: {
+        cuda: recipe.spec.runtime.cuda,
+        gpu: recipe.spec.runtime.gpu,
+        resources: recipe.spec.runtime.resources,
+      },
+      serve: recipe.spec.serve,
+      server: recipe.spec.server,
+      surfaces: recipe.spec.surfaces,
+    },
+  };
+  const qualificationPlanJson = JSON.stringify(qualificationPlan);
+  const qualificationPlanSha256 = `sha256:${createHash("sha256")
+    .update(qualificationPlanJson)
+    .digest("hex")}`;
 
   return {
     backend_directory: "/opt/llama.cpp/lib",
@@ -550,6 +798,14 @@ export function loadLlamaCppImageConfig(source = fs.readFileSync(manifestPath, "
       ),
     ),
     publication_qualification: JSON.stringify(normalizedQualification),
+    publication_qualification_plan: qualificationPlanJson,
+    publication_qualification_plan_sha256: qualificationPlanSha256,
+    qualification_environment:
+      typeof qualificationEnvironment === "string" ? qualificationEnvironment : "",
+    qualification_execution: qualificationExecution,
+    qualification_model_host_path:
+      typeof qualificationHostPath === "string" ? qualificationHostPath : "",
+    qualification_runner: typeof qualificationRunner === "string" ? qualificationRunner : "",
     runtime_gid: requiredRuntimeId(spec?.runtime?.gid, "runtime gid"),
     runtime_forbidden_paths: JSON.stringify(expectedForbiddenPaths),
     runtime_required_paths: JSON.stringify(expectedRequiredPaths),
@@ -569,8 +825,46 @@ export function githubOutput(config: Record<string, string>): string {
     .join("\n")}\n`;
 }
 
+function readBoundedRegularFile(root: string, relativePath: string): string {
+  const file = path.resolve(root, relativePath);
+  const relative = path.relative(root, file);
+  if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`invalid qualification source path: ${relativePath}`);
+  }
+  const descriptor = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const status = fs.fstatSync(descriptor);
+    if (!status.isFile() || status.size < 1 || status.size > 1024 * 1024) {
+      throw new Error(`qualification source must be a bounded regular file: ${relativePath}`);
+    }
+    return fs.readFileSync(descriptor, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+export function loadLlamaCppImageConfigFromRoot(sourceRoot: string) {
+  const root = fs.realpathSync(sourceRoot);
+  return loadLlamaCppImageConfig(
+    readBoundedRegularFile(root, "managed-inference/images/llama-cpp/image.yaml"),
+    readBoundedRegularFile(
+      root,
+      "managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
+    ),
+    fs.readFileSync(recipeSchemaPath, "utf8"),
+  );
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const output = githubOutput(loadLlamaCppImageConfig());
+  const args = process.argv.slice(2);
+  let sourceRoot = repoRoot;
+  if (args.length > 0) {
+    if (args.length !== 2 || args[0] !== "--source-root" || !args[1]) {
+      throw new Error("usage: export-llama-cpp-image-config.mts [--source-root PATH]");
+    }
+    sourceRoot = args[1];
+  }
+  const output = githubOutput(loadLlamaCppImageConfigFromRoot(sourceRoot));
   const githubOutputPath = process.env.GITHUB_OUTPUT;
   if (githubOutputPath) {
     fs.appendFileSync(githubOutputPath, output, {

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -1,13 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import Ajv2020 from "ajv/dist/2020.js";
 import YAML from "yaml";
+
+import {
+  llamaCppDgxSparkExecutionPlanSha256,
+  parseLlamaCppDgxSparkExecutionPlan,
+} from "./llama-cpp-dgx-spark-qualification-contract.mts";
 
 type ServerImageManifest = {
   apiVersion?: unknown;
@@ -220,8 +224,9 @@ function parseQualificationRecipe(
   schemaSource: string,
 ): LlamaCppQualificationRecipe {
   const document = YAML.parseDocument(source, { strict: true, uniqueKeys: true });
-  if (document.errors.length > 0) {
-    throw new Error(`invalid llama.cpp qualification recipe YAML: ${document.errors.join("; ")}`);
+  const issues = [...document.errors, ...document.warnings];
+  if (issues.length > 0) {
+    throw new Error(`invalid llama.cpp qualification recipe YAML: ${issues.join("; ")}`);
   }
   const value = document.toJS({ maxAliasCount: 0 }) as unknown;
   const schema = JSON.parse(schemaSource) as object;
@@ -237,8 +242,9 @@ function parseQualificationRecipe(
 
 function parseImageManifest(source: string): ServerImageManifest {
   const document = YAML.parseDocument(source, { strict: true, uniqueKeys: true });
-  if (document.errors.length > 0) {
-    throw new Error(`invalid llama.cpp image manifest YAML: ${document.errors.join("; ")}`);
+  const issues = [...document.errors, ...document.warnings];
+  if (issues.length > 0) {
+    throw new Error(`invalid llama.cpp image manifest YAML: ${issues.join("; ")}`);
   }
   return document.toJS({ maxAliasCount: 0 }) as ServerImageManifest;
 }
@@ -685,10 +691,9 @@ export function loadLlamaCppImageConfig(
       surfaces: recipe.spec.surfaces,
     },
   };
-  const qualificationPlanJson = JSON.stringify(qualificationPlan);
-  const qualificationPlanSha256 = `sha256:${createHash("sha256")
-    .update(qualificationPlanJson)
-    .digest("hex")}`;
+  const canonicalQualificationPlan = parseLlamaCppDgxSparkExecutionPlan(qualificationPlan);
+  const qualificationPlanJson = JSON.stringify(canonicalQualificationPlan);
+  const qualificationPlanSha256 = llamaCppDgxSparkExecutionPlanSha256(canonicalQualificationPlan);
 
   return {
     backend_directory: "/opt/llama.cpp/lib",

--- a/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
+++ b/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
@@ -285,7 +285,9 @@ function parseActivationYaml(source: string): unknown {
     source.length > 4096 ||
     /[\0-\x08\x0b\x0c\x0e-\x1f\x7f]/u.test(source)
   ) {
-    throw new Error("llama.cpp DGX Spark activation YAML is unsafe");
+    throw new Error(
+      "llama.cpp DGX Spark activation YAML is empty, exceeds 4096 bytes, or contains control characters",
+    );
   }
   const document = YAML.parseDocument(source, { strict: true, uniqueKeys: true });
   if (document.errors.length > 0 || document.warnings.length > 0) {

--- a/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
+++ b/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
@@ -1,0 +1,1086 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import YAML from "yaml";
+
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID =
+  "llama-cpp-dgx-spark-qualification" as const;
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH =
+  "ci/llama-cpp-dgx-spark-qualification-v1.yaml" as const;
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND =
+  "nemoclaw-llama-cpp-dgx-spark-qualification-v1" as const;
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE = "dgx-spark-gb10-single" as const;
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM = "linux/arm64" as const;
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE =
+  "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1" as const;
+export const LLAMA_CPP_DGX_SPARK_MODEL_ID = "unsloth/Nemotron-3-Nano-30B-A3B-GGUF" as const;
+export const LLAMA_CPP_DGX_SPARK_MODEL_DIGEST =
+  "sha256:627f5b04aedc97f967332f331bd75b7a4ed2f33ca83e6ee74b44235cc1887890" as const;
+export const LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID = "nvidia-nemotron-3-nano-30b-a3b" as const;
+export const LLAMA_CPP_DGX_SPARK_SOURCE_REVISION =
+  "22dc605c4ead20e36f447cc67b55ef87e523bd55" as const;
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY =
+  "localhost:5000/nemoclaw-llama-cpp-dgx-spark/llama-cpp-server" as const;
+export const LLAMA_CPP_DGX_SPARK_OWNED_IMAGE_REPOSITORY =
+  "ghcr.io/nvidia/nemoclaw/llama-cpp-server" as const;
+export const LLAMA_CPP_DGX_SPARK_SOURCE_REPOSITORY =
+  "https://github.com/ggml-org/llama.cpp" as const;
+export const LLAMA_CPP_DGX_SPARK_SOURCE_ARCHIVE_SHA256 =
+  "sha256:975f70723e053785e894f4e1d9cf770f2f1a7bc762fd3af174ff5635014108b6" as const;
+export const LLAMA_CPP_DGX_SPARK_CUDA_DEVELOPMENT_BASE =
+  "docker.io/nvidia/cuda@sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52" as const;
+export const LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE =
+  "docker.io/nvidia/cuda@sha256:789e629e49401647e22b7054ae9c6c4f6427dba68010ba428deb4cc6b063676e" as const;
+export const LLAMA_CPP_DGX_SPARK_MINIMUM_DRIVER_VERSION = "580.65.06" as const;
+
+export const LLAMA_CPP_DGX_SPARK_SHA_PATTERN = /^[a-f0-9]{40}$/u;
+export const LLAMA_CPP_DGX_SPARK_DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/u;
+export const LLAMA_CPP_DGX_SPARK_RUNNER_PATTERN =
+  /^linux-arm64-gpu-dgx-spark-gb10-[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u;
+export const LLAMA_CPP_DGX_SPARK_ENVIRONMENT_PATTERN =
+  /^approve-dgx-spark-[a-z0-9](?:[a-z0-9-]{0,109}[a-z0-9])?$/u;
+export const LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN =
+  /^\/(?:[A-Za-z0-9._-]+\/)*Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL\.gguf$/u;
+export const LLAMA_CPP_DGX_SPARK_GPU_PATTERN = /^NVIDIA GB10$/u;
+export const LLAMA_CPP_DGX_SPARK_DRIVER_PATTERN = /^[0-9]{3,4}\.[0-9]{1,3}\.[0-9]{1,3}$/u;
+
+export type LlamaCppDgxSparkQualificationActivation = {
+  readonly contractVersion: 1;
+  readonly jobId: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID;
+  readonly platform: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM;
+  readonly profile: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE;
+};
+
+export type LlamaCppDgxSparkQualificationPlan = {
+  readonly environment: string | null;
+  readonly execution: "disabled" | "enabled";
+  readonly gpu: {
+    readonly cpuFallback: "reject";
+    readonly fullOffload: true;
+    readonly vendor: "nvidia";
+  };
+  readonly model: {
+    readonly digest: typeof LLAMA_CPP_DGX_SPARK_MODEL_DIGEST;
+    readonly hostPath: string | null;
+    readonly id: typeof LLAMA_CPP_DGX_SPARK_MODEL_ID;
+  };
+  readonly platform: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM;
+  readonly probes: readonly ["health", "completion"];
+  readonly profile: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE;
+  readonly recipeRef: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE;
+  readonly required: true;
+  readonly runner: string | null;
+};
+
+export type LlamaCppDgxSparkQualificationEvidenceIdentity = {
+  readonly baseSha: string;
+  readonly headSha: string;
+  readonly runAttempt: number;
+  readonly runId: number;
+  readonly workflowSha: string;
+};
+
+export type LlamaCppDgxSparkExecutionPlan = {
+  readonly contractVersion: 1;
+  readonly imageBuild: {
+    readonly backendDirectory: "/opt/llama.cpp/lib";
+    readonly compiler: {
+      readonly c: "gcc-14";
+      readonly cudaHostCxx: "g++-14";
+      readonly cxx: "g++-14";
+    };
+    readonly cuda: {
+      readonly developmentBase: typeof LLAMA_CPP_DGX_SPARK_CUDA_DEVELOPMENT_BASE;
+      readonly runtimeBase: typeof LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE;
+    };
+    readonly platform: {
+      readonly cudaArchitectures: "121a-real";
+      readonly platform: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM;
+    };
+    readonly repository: typeof LLAMA_CPP_DGX_SPARK_OWNED_IMAGE_REPOSITORY;
+    readonly runtime: {
+      readonly gid: number;
+      readonly port: 8081;
+      readonly uid: number;
+    };
+    readonly source: {
+      readonly archiveSha256: typeof LLAMA_CPP_DGX_SPARK_SOURCE_ARCHIVE_SHA256;
+      readonly repository: typeof LLAMA_CPP_DGX_SPARK_SOURCE_REPOSITORY;
+      readonly revision: typeof LLAMA_CPP_DGX_SPARK_SOURCE_REVISION;
+    };
+  };
+  readonly recipe: {
+    readonly id: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE;
+    readonly model: {
+      readonly file: {
+        readonly digest: typeof LLAMA_CPP_DGX_SPARK_MODEL_DIGEST;
+        readonly format: "gguf";
+        readonly license: "NVIDIA-Open-Model-License";
+        readonly path: "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
+        readonly quantization: "UD-Q4_K_XL";
+        readonly sizeBytes: number;
+      };
+      readonly id: typeof LLAMA_CPP_DGX_SPARK_MODEL_ID;
+      readonly revision: "9ad8b366c308f931b2a96b9306f0b41aef9cd405";
+      readonly servedName: typeof LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID;
+    };
+    readonly policy: {
+      readonly egress: "disabled";
+      readonly modelDownloads: "disabled";
+      readonly modelSource: "verified-local";
+    };
+    readonly readiness: {
+      readonly contractRef: "llama-cpp.server-readiness/v1";
+      readonly expectedModel: typeof LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID;
+      readonly probes: {
+        readonly health: true;
+        readonly metrics: true;
+        readonly models: true;
+        readonly properties: true;
+      };
+      readonly timeoutSeconds: number;
+    };
+    readonly runtime: {
+      readonly cuda: {
+        readonly baseImage: typeof LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE;
+        readonly minimumDriverVersion: string;
+      };
+      readonly gpu: {
+        readonly count: 1;
+        readonly cpuFallback: "reject";
+        readonly offload: "full";
+        readonly vendor: "nvidia";
+      };
+      readonly resources: {
+        readonly memoryBytes: number;
+        readonly pidsLimit: number;
+        readonly writableStorageBytes: number;
+      };
+    };
+    readonly serve: {
+      readonly authentication: "bearer";
+      readonly batchSize: number;
+      readonly chatTemplate: "nemotron-v3-embedded";
+      readonly contextSize: number;
+      readonly flashAttention: "enabled";
+      readonly idleSleepSeconds: -1;
+      readonly kvCache: {
+        readonly key: "f16" | "q8_0" | "q4_0";
+        readonly value: "f16" | "q8_0" | "q4_0";
+      };
+      readonly limits: {
+        readonly maxCompletionTokens: number;
+        readonly maxPromptTokens: number;
+        readonly maxRequestBodyBytes: number;
+        readonly requestTimeoutSeconds: number;
+      };
+      readonly microBatchSize: number;
+      readonly port: 8081;
+      readonly protocol: "openai-completions";
+      readonly slots: 1;
+      readonly speculativeDecoding: "disabled";
+    };
+    readonly server: {
+      readonly source: {
+        readonly repository: "ggml-org/llama.cpp";
+        readonly revision: typeof LLAMA_CPP_DGX_SPARK_SOURCE_REVISION;
+      };
+      readonly technology: "llama.cpp";
+    };
+    readonly surfaces: {
+      readonly agentMode: "disabled";
+      readonly mcpProxy: "disabled";
+      readonly multimodalProjection: "disabled";
+      readonly router: "disabled";
+      readonly serverTools: "disabled";
+      readonly slotInspection: "disabled";
+      readonly ui: "disabled";
+    };
+  };
+};
+
+export type LlamaCppDgxSparkQualificationReceipt = {
+  readonly baseSha: string;
+  readonly cleanup: {
+    readonly containerRemoved: true;
+    readonly credentialsRemoved: true;
+    readonly listenerClosed: true;
+    readonly registryRemoved: true;
+  };
+  readonly execution: {
+    readonly cpuFallback: false;
+    readonly cpuWarning: false;
+    readonly fullOffload: true;
+    readonly offloadedLayers: number;
+    readonly totalLayers: number;
+  };
+  readonly headSha: string;
+  readonly host: {
+    readonly architecture: "arm64";
+    readonly driverVersion: string;
+    readonly gpuName: "NVIDIA GB10";
+    readonly profile: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE;
+  };
+  readonly image: {
+    readonly digest: string;
+    readonly platform: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM;
+    readonly reference: string;
+    readonly sourceRevision: typeof LLAMA_CPP_DGX_SPARK_SOURCE_REVISION;
+  };
+  readonly kind: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND;
+  readonly model: {
+    readonly digest: typeof LLAMA_CPP_DGX_SPARK_MODEL_DIGEST;
+    readonly id: typeof LLAMA_CPP_DGX_SPARK_MODEL_ID;
+  };
+  readonly probes: {
+    readonly completion: {
+      readonly httpStatus: 200;
+      readonly model: typeof LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID;
+      readonly ok: true;
+    };
+    readonly health: {
+      readonly httpStatus: 200;
+      readonly ok: true;
+    };
+  };
+  readonly repository: "NVIDIA/NemoClaw";
+  readonly run: {
+    readonly attempt: number;
+    readonly id: number;
+  };
+  readonly workflowSha: string;
+};
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  if (
+    actual.length !== sortedExpected.length ||
+    actual.some((key, index) => key !== sortedExpected[index])
+  ) {
+    throw new Error(`${label} has unexpected fields`);
+  }
+}
+
+function parseActivationYaml(source: string): unknown {
+  if (
+    source.length === 0 ||
+    source.length > 4096 ||
+    /[\0-\x08\x0b\x0c\x0e-\x1f\x7f]/u.test(source)
+  ) {
+    throw new Error("llama.cpp DGX Spark activation YAML is unsafe");
+  }
+  const document = YAML.parseDocument(source, { strict: true, uniqueKeys: true });
+  if (document.errors.length > 0 || document.warnings.length > 0) {
+    throw new Error("llama.cpp DGX Spark activation YAML is invalid");
+  }
+  try {
+    return document.toJS({ maxAliasCount: 0 });
+  } catch {
+    throw new Error("llama.cpp DGX Spark activation YAML is invalid");
+  }
+}
+
+function safeInteger(value: unknown, label: string, maximum: number): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 1 || Number(value) > maximum) {
+    throw new Error(`${label} is invalid`);
+  }
+  return Number(value);
+}
+
+function boundedInteger(value: unknown, label: string, minimum: number, maximum: number): number {
+  if (!Number.isSafeInteger(value) || Number(value) < minimum || Number(value) > maximum) {
+    throw new Error(`${label} is invalid`);
+  }
+  return Number(value);
+}
+
+function requiredSha(value: unknown, label: string): string {
+  if (typeof value !== "string" || !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requiredDigest(value: unknown, label: string): string {
+  if (typeof value !== "string" || !LLAMA_CPP_DGX_SPARK_DIGEST_PATTERN.test(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function driverVersionAtLeast(actual: string, minimum: string): boolean {
+  const actualParts = actual.split(".").map(Number);
+  const minimumParts = minimum.split(".").map(Number);
+  for (let index = 0; index < minimumParts.length; index += 1) {
+    const difference = (actualParts[index] ?? 0) - (minimumParts[index] ?? 0);
+    if (difference !== 0) return difference > 0;
+  }
+  return true;
+}
+
+function parseInfrastructure(
+  value: Record<string, unknown>,
+  execution: "disabled" | "enabled",
+): { environment: string | null; hostPath: string | null; runner: string | null } {
+  const environment = value.environment;
+  const runner = value.runner;
+  const model = record(value.model, "llama.cpp DGX Spark qualification model");
+  const hostPath = model.hostPath;
+  const unset = environment === null && runner === null && hostPath === null;
+  const complete =
+    typeof environment === "string" &&
+    LLAMA_CPP_DGX_SPARK_ENVIRONMENT_PATTERN.test(environment) &&
+    typeof runner === "string" &&
+    LLAMA_CPP_DGX_SPARK_RUNNER_PATTERN.test(runner) &&
+    typeof hostPath === "string" &&
+    LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN.test(hostPath) &&
+    !hostPath.split("/").some((segment) => segment === "." || segment === "..");
+  if ((!unset && !complete) || (execution === "enabled" && !complete)) {
+    throw new Error("llama.cpp DGX Spark qualification infrastructure is incomplete");
+  }
+  return {
+    environment: environment as string | null,
+    hostPath: hostPath as string | null,
+    runner: runner as string | null,
+  };
+}
+
+export function parseLlamaCppDgxSparkQualificationActivation(
+  value: unknown,
+): LlamaCppDgxSparkQualificationActivation {
+  const activation = record(
+    typeof value === "string" ? parseActivationYaml(value) : value,
+    "llama.cpp DGX Spark activation",
+  );
+  requireExactKeys(
+    activation,
+    ["contractVersion", "jobId", "platform", "profile"],
+    "llama.cpp DGX Spark activation",
+  );
+  if (
+    activation.contractVersion !== 1 ||
+    activation.jobId !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID ||
+    activation.platform !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM ||
+    activation.profile !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE
+  ) {
+    throw new Error("llama.cpp DGX Spark activation contract is invalid");
+  }
+  return {
+    contractVersion: 1,
+    jobId: LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+    profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+  };
+}
+
+export function parseLlamaCppDgxSparkQualificationPlan(
+  value: unknown,
+): LlamaCppDgxSparkQualificationPlan {
+  const plan = record(value, "llama.cpp DGX Spark qualification plan");
+  requireExactKeys(
+    plan,
+    [
+      "environment",
+      "execution",
+      "gpu",
+      "model",
+      "platform",
+      "probes",
+      "profile",
+      "recipeRef",
+      "required",
+      "runner",
+    ],
+    "llama.cpp DGX Spark qualification plan",
+  );
+  if (plan.execution !== "disabled" && plan.execution !== "enabled") {
+    throw new Error("llama.cpp DGX Spark qualification execution is invalid");
+  }
+  const infrastructure = parseInfrastructure(plan, plan.execution);
+  const gpu = record(plan.gpu, "llama.cpp DGX Spark qualification GPU");
+  requireExactKeys(gpu, ["cpuFallback", "fullOffload", "vendor"], "qualification GPU");
+  const model = record(plan.model, "llama.cpp DGX Spark qualification model");
+  requireExactKeys(model, ["digest", "hostPath", "id"], "qualification model");
+  if (
+    plan.required !== true ||
+    plan.profile !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE ||
+    plan.recipeRef !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE ||
+    plan.platform !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM ||
+    gpu.vendor !== "nvidia" ||
+    gpu.fullOffload !== true ||
+    gpu.cpuFallback !== "reject" ||
+    model.id !== LLAMA_CPP_DGX_SPARK_MODEL_ID ||
+    model.digest !== LLAMA_CPP_DGX_SPARK_MODEL_DIGEST ||
+    JSON.stringify(plan.probes) !== JSON.stringify(["health", "completion"])
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification plan is invalid");
+  }
+  return {
+    environment: infrastructure.environment,
+    execution: plan.execution,
+    gpu: { cpuFallback: "reject", fullOffload: true, vendor: "nvidia" },
+    model: {
+      digest: LLAMA_CPP_DGX_SPARK_MODEL_DIGEST,
+      hostPath: infrastructure.hostPath,
+      id: LLAMA_CPP_DGX_SPARK_MODEL_ID,
+    },
+    platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+    probes: ["health", "completion"],
+    profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+    recipeRef: LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE,
+    required: true,
+    runner: infrastructure.runner,
+  };
+}
+
+export function parseLlamaCppDgxSparkExecutionPlan(
+  value: unknown,
+  expectedSha256?: unknown,
+): LlamaCppDgxSparkExecutionPlan {
+  const plan = record(value, "compiled llama.cpp DGX Spark qualification plan");
+  requireExactKeys(
+    plan,
+    ["contractVersion", "imageBuild", "recipe"],
+    "compiled llama.cpp DGX Spark qualification plan",
+  );
+  if (plan.contractVersion !== 1) {
+    throw new Error("compiled llama.cpp DGX Spark qualification plan version is invalid");
+  }
+
+  const imageBuild = record(plan.imageBuild, "compiled qualification image build");
+  requireExactKeys(
+    imageBuild,
+    ["backendDirectory", "compiler", "cuda", "platform", "repository", "runtime", "source"],
+    "compiled qualification image build",
+  );
+  const compiler = record(imageBuild.compiler, "compiled qualification compiler");
+  requireExactKeys(compiler, ["c", "cudaHostCxx", "cxx"], "compiled qualification compiler");
+  const imageCuda = record(imageBuild.cuda, "compiled qualification image CUDA");
+  requireExactKeys(
+    imageCuda,
+    ["developmentBase", "runtimeBase"],
+    "compiled qualification image CUDA",
+  );
+  const platform = record(imageBuild.platform, "compiled qualification image platform");
+  requireExactKeys(
+    platform,
+    ["cudaArchitectures", "platform"],
+    "compiled qualification image platform",
+  );
+  const imageRuntime = record(imageBuild.runtime, "compiled qualification image runtime");
+  requireExactKeys(imageRuntime, ["gid", "port", "uid"], "compiled qualification image runtime");
+  const imageSource = record(imageBuild.source, "compiled qualification image source");
+  requireExactKeys(
+    imageSource,
+    ["archiveSha256", "repository", "revision"],
+    "compiled qualification image source",
+  );
+  const uid = boundedInteger(imageRuntime.uid, "compiled qualification runtime UID", 1, 65_535);
+  const gid = boundedInteger(imageRuntime.gid, "compiled qualification runtime GID", 1, 65_535);
+  if (
+    imageBuild.backendDirectory !== "/opt/llama.cpp/lib" ||
+    imageBuild.repository !== LLAMA_CPP_DGX_SPARK_OWNED_IMAGE_REPOSITORY ||
+    compiler.c !== "gcc-14" ||
+    compiler.cudaHostCxx !== "g++-14" ||
+    compiler.cxx !== "g++-14" ||
+    imageCuda.developmentBase !== LLAMA_CPP_DGX_SPARK_CUDA_DEVELOPMENT_BASE ||
+    imageCuda.runtimeBase !== LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE ||
+    platform.platform !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM ||
+    platform.cudaArchitectures !== "121a-real" ||
+    imageRuntime.port !== 8081 ||
+    imageSource.repository !== LLAMA_CPP_DGX_SPARK_SOURCE_REPOSITORY ||
+    imageSource.revision !== LLAMA_CPP_DGX_SPARK_SOURCE_REVISION ||
+    imageSource.archiveSha256 !== LLAMA_CPP_DGX_SPARK_SOURCE_ARCHIVE_SHA256
+  ) {
+    throw new Error("compiled llama.cpp DGX Spark image build identity is invalid");
+  }
+
+  const recipe = record(plan.recipe, "compiled llama.cpp DGX Spark qualification recipe");
+  requireExactKeys(
+    recipe,
+    ["id", "model", "policy", "readiness", "runtime", "serve", "server", "surfaces"],
+    "compiled llama.cpp DGX Spark qualification recipe",
+  );
+  const model = record(recipe.model, "compiled qualification recipe model");
+  requireExactKeys(
+    model,
+    ["file", "id", "revision", "servedName"],
+    "compiled qualification recipe model",
+  );
+  const modelFile = record(model.file, "compiled qualification recipe model file");
+  requireExactKeys(
+    modelFile,
+    ["digest", "format", "license", "path", "quantization", "sizeBytes"],
+    "compiled qualification recipe model file",
+  );
+  const modelSizeBytes = safeInteger(
+    modelFile.sizeBytes,
+    "compiled qualification model size",
+    128 * 1024 ** 3,
+  );
+  if (
+    recipe.id !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE ||
+    model.id !== LLAMA_CPP_DGX_SPARK_MODEL_ID ||
+    model.revision !== "9ad8b366c308f931b2a96b9306f0b41aef9cd405" ||
+    model.servedName !== LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID ||
+    modelFile.path !== "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf" ||
+    modelFile.digest !== LLAMA_CPP_DGX_SPARK_MODEL_DIGEST ||
+    modelFile.format !== "gguf" ||
+    modelFile.quantization !== "UD-Q4_K_XL" ||
+    modelFile.license !== "NVIDIA-Open-Model-License"
+  ) {
+    throw new Error("compiled llama.cpp DGX Spark model identity is invalid");
+  }
+
+  const policy = record(recipe.policy, "compiled qualification recipe policy");
+  requireExactKeys(
+    policy,
+    ["egress", "modelDownloads", "modelSource"],
+    "compiled qualification recipe policy",
+  );
+  if (
+    policy.egress !== "disabled" ||
+    policy.modelDownloads !== "disabled" ||
+    policy.modelSource !== "verified-local"
+  ) {
+    throw new Error("compiled llama.cpp DGX Spark policy is invalid");
+  }
+
+  const readiness = record(recipe.readiness, "compiled qualification recipe readiness");
+  requireExactKeys(
+    readiness,
+    ["contractRef", "expectedModel", "probes", "timeoutSeconds"],
+    "compiled qualification recipe readiness",
+  );
+  const readinessProbes = record(readiness.probes, "compiled qualification readiness probes");
+  requireExactKeys(
+    readinessProbes,
+    ["health", "metrics", "models", "properties"],
+    "compiled qualification readiness probes",
+  );
+  const readinessTimeout = boundedInteger(
+    readiness.timeoutSeconds,
+    "compiled qualification readiness timeout",
+    1,
+    3600,
+  );
+  if (
+    readiness.contractRef !== "llama-cpp.server-readiness/v1" ||
+    readiness.expectedModel !== LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID ||
+    readinessProbes.health !== true ||
+    readinessProbes.metrics !== true ||
+    readinessProbes.models !== true ||
+    readinessProbes.properties !== true
+  ) {
+    throw new Error("compiled llama.cpp DGX Spark readiness contract is invalid");
+  }
+
+  const recipeRuntime = record(recipe.runtime, "compiled qualification recipe runtime");
+  requireExactKeys(
+    recipeRuntime,
+    ["cuda", "gpu", "resources"],
+    "compiled qualification recipe runtime",
+  );
+  const recipeCuda = record(recipeRuntime.cuda, "compiled qualification recipe CUDA");
+  requireExactKeys(
+    recipeCuda,
+    ["baseImage", "minimumDriverVersion"],
+    "compiled qualification recipe CUDA",
+  );
+  const gpu = record(recipeRuntime.gpu, "compiled qualification recipe GPU");
+  requireExactKeys(
+    gpu,
+    ["count", "cpuFallback", "offload", "vendor"],
+    "compiled qualification recipe GPU",
+  );
+  const resources = record(recipeRuntime.resources, "compiled qualification recipe resources");
+  requireExactKeys(
+    resources,
+    ["memoryBytes", "pidsLimit", "writableStorageBytes"],
+    "compiled qualification recipe resources",
+  );
+  const memoryBytes = boundedInteger(
+    resources.memoryBytes,
+    "compiled qualification memory limit",
+    modelSizeBytes,
+    128 * 1024 ** 3,
+  );
+  const writableStorageBytes = boundedInteger(
+    resources.writableStorageBytes,
+    "compiled qualification writable storage limit",
+    64 * 1024 ** 2,
+    128 * 1024 ** 3,
+  );
+  const pidsLimit = boundedInteger(
+    resources.pidsLimit,
+    "compiled qualification PID limit",
+    16,
+    4096,
+  );
+  if (
+    recipeCuda.baseImage !== LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE ||
+    typeof recipeCuda.minimumDriverVersion !== "string" ||
+    !LLAMA_CPP_DGX_SPARK_DRIVER_PATTERN.test(recipeCuda.minimumDriverVersion) ||
+    !driverVersionAtLeast(
+      recipeCuda.minimumDriverVersion,
+      LLAMA_CPP_DGX_SPARK_MINIMUM_DRIVER_VERSION,
+    ) ||
+    gpu.vendor !== "nvidia" ||
+    gpu.count !== 1 ||
+    gpu.offload !== "full" ||
+    gpu.cpuFallback !== "reject"
+  ) {
+    throw new Error("compiled llama.cpp DGX Spark runtime contract is invalid");
+  }
+
+  const serve = record(recipe.serve, "compiled qualification recipe serve contract");
+  requireExactKeys(
+    serve,
+    [
+      "authentication",
+      "batchSize",
+      "chatTemplate",
+      "contextSize",
+      "flashAttention",
+      "idleSleepSeconds",
+      "kvCache",
+      "limits",
+      "microBatchSize",
+      "port",
+      "protocol",
+      "slots",
+      "speculativeDecoding",
+    ],
+    "compiled qualification recipe serve contract",
+  );
+  const contextSize = boundedInteger(
+    serve.contextSize,
+    "compiled qualification context size",
+    1024,
+    1024 * 1024,
+  );
+  const batchSize = boundedInteger(serve.batchSize, "compiled qualification batch size", 1, 8192);
+  const microBatchSize = boundedInteger(
+    serve.microBatchSize,
+    "compiled qualification micro-batch size",
+    1,
+    batchSize,
+  );
+  const kvCache = record(serve.kvCache, "compiled qualification KV cache");
+  requireExactKeys(kvCache, ["key", "value"], "compiled qualification KV cache");
+  const allowedKvTypes = new Set(["f16", "q8_0", "q4_0"]);
+  const limits = record(serve.limits, "compiled qualification request limits");
+  requireExactKeys(
+    limits,
+    ["maxCompletionTokens", "maxPromptTokens", "maxRequestBodyBytes", "requestTimeoutSeconds"],
+    "compiled qualification request limits",
+  );
+  const maxPromptTokens = boundedInteger(
+    limits.maxPromptTokens,
+    "compiled qualification prompt token limit",
+    1,
+    contextSize,
+  );
+  const maxCompletionTokens = boundedInteger(
+    limits.maxCompletionTokens,
+    "compiled qualification completion token limit",
+    1,
+    contextSize,
+  );
+  const maxRequestBodyBytes = boundedInteger(
+    limits.maxRequestBodyBytes,
+    "compiled qualification request body limit",
+    1024,
+    64 * 1024 ** 2,
+  );
+  const requestTimeoutSeconds = boundedInteger(
+    limits.requestTimeoutSeconds,
+    "compiled qualification request timeout",
+    1,
+    3600,
+  );
+  if (
+    serve.protocol !== "openai-completions" ||
+    serve.authentication !== "bearer" ||
+    serve.port !== 8081 ||
+    serve.chatTemplate !== "nemotron-v3-embedded" ||
+    serve.slots !== 1 ||
+    serve.idleSleepSeconds !== -1 ||
+    serve.flashAttention !== "enabled" ||
+    serve.speculativeDecoding !== "disabled" ||
+    typeof kvCache.key !== "string" ||
+    !allowedKvTypes.has(kvCache.key) ||
+    typeof kvCache.value !== "string" ||
+    !allowedKvTypes.has(kvCache.value) ||
+    maxPromptTokens + maxCompletionTokens > contextSize
+  ) {
+    throw new Error("compiled llama.cpp DGX Spark serve contract is invalid");
+  }
+
+  const server = record(recipe.server, "compiled qualification recipe server");
+  requireExactKeys(server, ["source", "technology"], "compiled qualification recipe server");
+  const serverSource = record(server.source, "compiled qualification recipe server source");
+  requireExactKeys(
+    serverSource,
+    ["repository", "revision"],
+    "compiled qualification recipe server source",
+  );
+  if (
+    server.technology !== "llama.cpp" ||
+    serverSource.repository !== "ggml-org/llama.cpp" ||
+    serverSource.revision !== LLAMA_CPP_DGX_SPARK_SOURCE_REVISION
+  ) {
+    throw new Error("compiled llama.cpp DGX Spark server identity is invalid");
+  }
+
+  const surfaces = record(recipe.surfaces, "compiled qualification recipe surfaces");
+  const surfaceNames = [
+    "agentMode",
+    "mcpProxy",
+    "multimodalProjection",
+    "router",
+    "serverTools",
+    "slotInspection",
+    "ui",
+  ] as const;
+  requireExactKeys(surfaces, surfaceNames, "compiled qualification recipe surfaces");
+  if (surfaceNames.some((name) => surfaces[name] !== "disabled")) {
+    throw new Error("compiled llama.cpp DGX Spark server surfaces are not disabled");
+  }
+
+  const parsed: LlamaCppDgxSparkExecutionPlan = {
+    contractVersion: 1,
+    imageBuild: {
+      backendDirectory: "/opt/llama.cpp/lib",
+      compiler: { c: "gcc-14", cudaHostCxx: "g++-14", cxx: "g++-14" },
+      cuda: {
+        developmentBase: LLAMA_CPP_DGX_SPARK_CUDA_DEVELOPMENT_BASE,
+        runtimeBase: LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE,
+      },
+      platform: {
+        cudaArchitectures: "121a-real",
+        platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+      },
+      repository: LLAMA_CPP_DGX_SPARK_OWNED_IMAGE_REPOSITORY,
+      runtime: { gid, port: 8081, uid },
+      source: {
+        archiveSha256: LLAMA_CPP_DGX_SPARK_SOURCE_ARCHIVE_SHA256,
+        repository: LLAMA_CPP_DGX_SPARK_SOURCE_REPOSITORY,
+        revision: LLAMA_CPP_DGX_SPARK_SOURCE_REVISION,
+      },
+    },
+    recipe: {
+      id: LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE,
+      model: {
+        file: {
+          path: "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
+          digest: LLAMA_CPP_DGX_SPARK_MODEL_DIGEST,
+          sizeBytes: modelSizeBytes,
+          format: "gguf",
+          quantization: "UD-Q4_K_XL",
+          license: "NVIDIA-Open-Model-License",
+        },
+        id: LLAMA_CPP_DGX_SPARK_MODEL_ID,
+        revision: "9ad8b366c308f931b2a96b9306f0b41aef9cd405",
+        servedName: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+      },
+      policy: {
+        egress: "disabled",
+        modelSource: "verified-local",
+        modelDownloads: "disabled",
+      },
+      readiness: {
+        contractRef: "llama-cpp.server-readiness/v1",
+        timeoutSeconds: readinessTimeout,
+        expectedModel: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+        probes: { models: true, health: true, properties: true, metrics: true },
+      },
+      runtime: {
+        cuda: {
+          baseImage: LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE,
+          minimumDriverVersion: recipeCuda.minimumDriverVersion,
+        },
+        gpu: { vendor: "nvidia", count: 1, offload: "full", cpuFallback: "reject" },
+        resources: { memoryBytes, writableStorageBytes, pidsLimit },
+      },
+      serve: {
+        protocol: "openai-completions",
+        authentication: "bearer",
+        port: 8081,
+        chatTemplate: "nemotron-v3-embedded",
+        contextSize,
+        slots: 1,
+        idleSleepSeconds: -1,
+        batchSize,
+        microBatchSize,
+        flashAttention: "enabled",
+        kvCache: {
+          key: kvCache.key as "f16" | "q8_0" | "q4_0",
+          value: kvCache.value as "f16" | "q8_0" | "q4_0",
+        },
+        speculativeDecoding: "disabled",
+        limits: {
+          maxRequestBodyBytes,
+          maxPromptTokens,
+          maxCompletionTokens,
+          requestTimeoutSeconds,
+        },
+      },
+      server: {
+        technology: "llama.cpp",
+        source: {
+          repository: "ggml-org/llama.cpp",
+          revision: LLAMA_CPP_DGX_SPARK_SOURCE_REVISION,
+        },
+      },
+      surfaces: {
+        ui: "disabled",
+        slotInspection: "disabled",
+        router: "disabled",
+        mcpProxy: "disabled",
+        serverTools: "disabled",
+        agentMode: "disabled",
+        multimodalProjection: "disabled",
+      },
+    },
+  };
+  if (expectedSha256 !== undefined) {
+    const expected = requiredDigest(
+      expectedSha256,
+      "compiled llama.cpp DGX Spark qualification plan digest",
+    );
+    const actual = `sha256:${createHash("sha256").update(JSON.stringify(parsed)).digest("hex")}`;
+    if (actual !== expected) {
+      throw new Error("compiled llama.cpp DGX Spark qualification plan digest does not match");
+    }
+  }
+  return parsed;
+}
+
+export function llamaCppDgxSparkExecutionPlanSha256(value: unknown): string {
+  const plan = parseLlamaCppDgxSparkExecutionPlan(value);
+  return `sha256:${createHash("sha256").update(JSON.stringify(plan)).digest("hex")}`;
+}
+
+export function verifyLlamaCppDgxSparkExecutionPlanSha256(
+  value: unknown,
+  expectedDigest: unknown,
+): LlamaCppDgxSparkExecutionPlan {
+  return parseLlamaCppDgxSparkExecutionPlan(value, expectedDigest);
+}
+
+export function parseLlamaCppDgxSparkQualificationEvidenceIdentity(
+  value: unknown,
+): LlamaCppDgxSparkQualificationEvidenceIdentity {
+  const identity = record(value, "llama.cpp DGX Spark evidence identity");
+  requireExactKeys(
+    identity,
+    ["baseSha", "headSha", "runAttempt", "runId", "workflowSha"],
+    "llama.cpp DGX Spark evidence identity",
+  );
+  return {
+    baseSha: requiredSha(identity.baseSha, "llama.cpp DGX Spark base SHA"),
+    headSha: requiredSha(identity.headSha, "llama.cpp DGX Spark head SHA"),
+    runAttempt: safeInteger(identity.runAttempt, "llama.cpp DGX Spark run attempt", 1_000_000),
+    runId: safeInteger(identity.runId, "llama.cpp DGX Spark run id", Number.MAX_SAFE_INTEGER),
+    workflowSha: requiredSha(identity.workflowSha, "llama.cpp DGX Spark workflow SHA"),
+  };
+}
+
+export function parseLlamaCppDgxSparkQualificationReceipt(
+  value: unknown,
+  expectedValue: unknown,
+): LlamaCppDgxSparkQualificationReceipt {
+  const expected = parseLlamaCppDgxSparkQualificationEvidenceIdentity(expectedValue);
+  const receipt = record(value, "llama.cpp DGX Spark qualification receipt");
+  requireExactKeys(
+    receipt,
+    [
+      "baseSha",
+      "cleanup",
+      "execution",
+      "headSha",
+      "host",
+      "image",
+      "kind",
+      "model",
+      "probes",
+      "repository",
+      "run",
+      "workflowSha",
+    ],
+    "llama.cpp DGX Spark qualification receipt",
+  );
+  if (
+    receipt.kind !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND ||
+    receipt.repository !== "NVIDIA/NemoClaw" ||
+    receipt.baseSha !== expected.baseSha ||
+    receipt.headSha !== expected.headSha ||
+    receipt.workflowSha !== expected.workflowSha ||
+    !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(String(receipt.baseSha)) ||
+    !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(String(receipt.headSha)) ||
+    !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(String(receipt.workflowSha))
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification receipt identity is invalid");
+  }
+
+  const run = record(receipt.run, "llama.cpp DGX Spark qualification receipt run");
+  requireExactKeys(run, ["attempt", "id"], "qualification receipt run");
+  if (
+    run.id !== expected.runId ||
+    run.attempt !== expected.runAttempt ||
+    !Number.isSafeInteger(run.id) ||
+    !Number.isSafeInteger(run.attempt)
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification receipt run is invalid");
+  }
+
+  const image = record(receipt.image, "llama.cpp DGX Spark qualification receipt image");
+  requireExactKeys(image, ["digest", "platform", "reference", "sourceRevision"], "receipt image");
+  const imageDigest = requiredDigest(image.digest, "llama.cpp DGX Spark image digest");
+  if (
+    image.platform !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM ||
+    image.sourceRevision !== LLAMA_CPP_DGX_SPARK_SOURCE_REVISION ||
+    image.reference !== `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY}@${imageDigest}`
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification image identity is invalid");
+  }
+
+  const model = record(receipt.model, "llama.cpp DGX Spark qualification receipt model");
+  requireExactKeys(model, ["digest", "id"], "receipt model");
+  if (
+    model.id !== LLAMA_CPP_DGX_SPARK_MODEL_ID ||
+    model.digest !== LLAMA_CPP_DGX_SPARK_MODEL_DIGEST
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification model identity is invalid");
+  }
+
+  const host = record(receipt.host, "llama.cpp DGX Spark qualification receipt host");
+  requireExactKeys(host, ["architecture", "driverVersion", "gpuName", "profile"], "receipt host");
+  if (
+    host.architecture !== "arm64" ||
+    host.profile !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE ||
+    typeof host.gpuName !== "string" ||
+    !LLAMA_CPP_DGX_SPARK_GPU_PATTERN.test(host.gpuName) ||
+    typeof host.driverVersion !== "string" ||
+    !LLAMA_CPP_DGX_SPARK_DRIVER_PATTERN.test(host.driverVersion) ||
+    !driverVersionAtLeast(host.driverVersion, LLAMA_CPP_DGX_SPARK_MINIMUM_DRIVER_VERSION)
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification host identity is invalid");
+  }
+
+  const execution = record(
+    receipt.execution,
+    "llama.cpp DGX Spark qualification receipt execution",
+  );
+  requireExactKeys(
+    execution,
+    ["cpuFallback", "cpuWarning", "fullOffload", "offloadedLayers", "totalLayers"],
+    "receipt execution",
+  );
+  const offloadedLayers = safeInteger(execution.offloadedLayers, "offloaded layer count", 100_000);
+  const totalLayers = safeInteger(execution.totalLayers, "total layer count", 100_000);
+  if (
+    execution.cpuFallback !== false ||
+    execution.cpuWarning !== false ||
+    execution.fullOffload !== true ||
+    offloadedLayers !== totalLayers
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification did not prove full GPU offload");
+  }
+
+  const probes = record(receipt.probes, "llama.cpp DGX Spark qualification receipt probes");
+  requireExactKeys(probes, ["completion", "health"], "receipt probes");
+  const health = record(probes.health, "llama.cpp DGX Spark health probe");
+  requireExactKeys(health, ["httpStatus", "ok"], "health probe");
+  const completion = record(probes.completion, "llama.cpp DGX Spark completion probe");
+  requireExactKeys(completion, ["httpStatus", "model", "ok"], "completion probe");
+  if (
+    health.ok !== true ||
+    health.httpStatus !== 200 ||
+    completion.ok !== true ||
+    completion.httpStatus !== 200 ||
+    completion.model !== LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification probes did not pass");
+  }
+
+  const cleanup = record(receipt.cleanup, "llama.cpp DGX Spark qualification receipt cleanup");
+  requireExactKeys(
+    cleanup,
+    ["containerRemoved", "credentialsRemoved", "listenerClosed", "registryRemoved"],
+    "receipt cleanup",
+  );
+  if (
+    cleanup.containerRemoved !== true ||
+    cleanup.credentialsRemoved !== true ||
+    cleanup.listenerClosed !== true ||
+    cleanup.registryRemoved !== true
+  ) {
+    throw new Error("llama.cpp DGX Spark qualification cleanup is incomplete");
+  }
+
+  return {
+    baseSha: expected.baseSha,
+    cleanup: {
+      containerRemoved: true,
+      credentialsRemoved: true,
+      listenerClosed: true,
+      registryRemoved: true,
+    },
+    execution: {
+      cpuFallback: false,
+      cpuWarning: false,
+      fullOffload: true,
+      offloadedLayers,
+      totalLayers,
+    },
+    headSha: expected.headSha,
+    host: {
+      architecture: "arm64",
+      driverVersion: host.driverVersion,
+      gpuName: "NVIDIA GB10",
+      profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+    },
+    image: {
+      digest: imageDigest,
+      platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+      reference: image.reference as string,
+      sourceRevision: LLAMA_CPP_DGX_SPARK_SOURCE_REVISION,
+    },
+    kind: LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND,
+    model: {
+      digest: LLAMA_CPP_DGX_SPARK_MODEL_DIGEST,
+      id: LLAMA_CPP_DGX_SPARK_MODEL_ID,
+    },
+    probes: {
+      completion: {
+        httpStatus: 200,
+        model: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+        ok: true,
+      },
+      health: { httpStatus: 200, ok: true },
+    },
+    repository: "NVIDIA/NemoClaw",
+    run: { attempt: expected.runAttempt, id: expected.runId },
+    workflowSha: expected.workflowSha,
+  };
+}

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -30,7 +30,11 @@ const expectedWorkflowRef = "NVIDIA/NemoClaw/.github/workflows/e2e.yaml@refs/hea
 const containerModelPath = "/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
 const containerApiKeyPath = "/run/secrets/llama-cpp-api-key";
 const maximumPlanBytes = 1024 * 1024;
+const maximumDockerfileBytes = 1024 * 1024;
 const maximumModelBytes = 128 * 1024 * 1024 * 1024;
+const relativeImageRoot = "managed-inference/images/llama-cpp";
+const trustedRepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const trustedImageRoot = path.join(trustedRepoRoot, relativeImageRoot);
 
 type JsonRecord = Record<string, unknown>;
 
@@ -208,10 +212,7 @@ export function parseQualificationInvocation(
     "registry name",
     /^nemoclaw-llama-cpp-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}$/u,
   );
-  if (
-    registryOwner !== expectedRegistryOwner(runId, runAttempt) ||
-    registryName !== expectedRegistryName(runId, runAttempt)
-  ) {
+  if (registryName !== expectedRegistryName(runId, runAttempt)) {
     throw new Error("registry ownership does not match this workflow run");
   }
   requireTrustedEnvironment(environment, runId, runAttempt);
@@ -261,11 +262,7 @@ export function buildCandidateImageArgv(
   invocation: QualificationInvocation,
   metadataFile: string,
 ): string[] {
-  const dockerfile = path.join(
-    invocation.candidateRoot,
-    "managed-inference/images/llama-cpp/Dockerfile",
-  );
-  const context = path.dirname(dockerfile);
+  const dockerfile = path.join(trustedImageRoot, "Dockerfile");
   const buildArguments = [
     `C_COMPILER=${plan.imageBuild.compiler.c}`,
     `CUDA_HOST_CXX_COMPILER=${plan.imageBuild.compiler.cudaHostCxx}`,
@@ -296,7 +293,7 @@ export function buildCandidateImageArgv(
     "--tag",
     `${localImageRepository}:${invocation.candidateHead}`,
     ...buildArguments.flatMap((argument) => ["--build-arg", argument]),
-    context,
+    trustedImageRoot,
   ];
 }
 
@@ -498,7 +495,7 @@ function commandSucceeds(command: string, args: string[]): boolean {
   return spawnSync(command, args, { stdio: "ignore" }).status === 0;
 }
 
-function readBoundedRegularFile(file: string, maximumBytes: number): string {
+function readBoundedRegularFileBytes(file: string, maximumBytes: number): Buffer {
   if (fs.realpathSync(file) !== file) {
     throw new Error("trusted input path must not use symlinks");
   }
@@ -508,9 +505,23 @@ function readBoundedRegularFile(file: string, maximumBytes: number): string {
     if (!status.isFile() || status.size < 1 || status.size > maximumBytes) {
       throw new Error("trusted input must be a bounded regular file");
     }
-    return fs.readFileSync(descriptor, "utf8");
+    return fs.readFileSync(descriptor);
   } finally {
     fs.closeSync(descriptor);
+  }
+}
+
+function readBoundedRegularFile(file: string, maximumBytes: number): string {
+  return readBoundedRegularFileBytes(file, maximumBytes).toString("utf8");
+}
+
+export function validateCandidateDockerfile(candidateRoot: string): void {
+  const candidateDockerfile = path.join(candidateRoot, relativeImageRoot, "Dockerfile");
+  const trustedDockerfile = path.join(trustedImageRoot, "Dockerfile");
+  const candidateSource = readBoundedRegularFileBytes(candidateDockerfile, maximumDockerfileBytes);
+  const trustedSource = readBoundedRegularFileBytes(trustedDockerfile, maximumDockerfileBytes);
+  if (!candidateSource.equals(trustedSource)) {
+    throw new Error("candidate Dockerfile must byte-match the trusted main Dockerfile");
   }
 }
 
@@ -533,7 +544,6 @@ function validateCandidateCheckout(invocation: QualificationInvocation): string 
     invocation.candidateBase,
     invocation.candidateHead,
   ]);
-  const relativeImageRoot = "managed-inference/images/llama-cpp";
   const status = runCommand("git", [
     "-C",
     root,
@@ -546,15 +556,7 @@ function validateCandidateCheckout(invocation: QualificationInvocation): string 
     .toString("utf8")
     .trim();
   if (status) throw new Error("candidate image source must match the exact committed head");
-  const dockerfile = path.join(root, relativeImageRoot, "Dockerfile");
-  const dockerfileStatus = fs.lstatSync(dockerfile);
-  if (
-    !dockerfileStatus.isFile() ||
-    dockerfileStatus.isSymbolicLink() ||
-    dockerfileStatus.size < 1
-  ) {
-    throw new Error("candidate Dockerfile must be a non-empty regular file");
-  }
+  validateCandidateDockerfile(root);
   return root;
 }
 
@@ -685,6 +687,7 @@ async function cleanupOwnedRuntime(
   names: RuntimeNames,
   loopbackPort?: number,
 ): Promise<CleanupEvidence> {
+  const registryWasOwned = dockerContainerOwner(names.registryName) === names.registryOwner;
   for (const name of [names.containerName, names.registryName]) {
     const owner = dockerContainerOwner(name);
     if (owner !== null && owner !== names.registryOwner) {
@@ -705,7 +708,7 @@ async function cleanupOwnedRuntime(
     keyFileRemoved: !fs.existsSync(keyFile),
     loopbackListenerClosed: loopbackPort === undefined || !(await tcpOpen(loopbackPort)),
     networkRemoved: dockerNetworkOwner(names.networkName) === null,
-    registryListenerClosed: !(await tcpOpen(5000)),
+    registryListenerClosed: !registryWasOwned || !(await tcpOpen(5000)),
     registryRemoved: dockerContainerOwner(names.registryName) === null,
     tempFilesRemoved: !fs.existsSync(names.tempRoot),
   };

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -1,0 +1,1072 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+  type LlamaCppDgxSparkExecutionPlan,
+  parseLlamaCppDgxSparkExecutionPlan,
+} from "./llama-cpp-dgx-spark-qualification-contract.mts";
+
+const sha256Pattern = /^sha256:[0-9a-f]{64}$/u;
+const gitShaPattern = /^[0-9a-f]{40}$/u;
+const runIdPattern = /^[1-9][0-9]{0,19}$/u;
+const runAttemptPattern = /^[1-9][0-9]{0,9}$/u;
+const safePathPattern = /^\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+$/u;
+const registryImage =
+  "docker.io/library/registry@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373";
+const registryOwnerLabel = "io.nvidia.nemoclaw.llama-cpp-qualification-owner";
+const localImageRepository = LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY;
+const expectedWorkflowRef = "NVIDIA/NemoClaw/.github/workflows/e2e.yaml@refs/heads/main";
+const containerModelPath = "/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
+const containerApiKeyPath = "/run/secrets/llama-cpp-api-key";
+const maximumPlanBytes = 1024 * 1024;
+const maximumModelBytes = 128 * 1024 * 1024 * 1024;
+
+type JsonRecord = Record<string, unknown>;
+
+export type QualificationPlan = LlamaCppDgxSparkExecutionPlan;
+
+export type QualificationInvocation = {
+  candidateBase: string;
+  candidateHead: string;
+  candidateRoot: string;
+  cleanupOnly: false;
+  modelHostPath: string;
+  output: string;
+  planFile: string;
+  planSha256: string;
+  registryName: string;
+  registryOwner: string;
+  runAttempt: string;
+  runId: string;
+  workflowSha: string;
+};
+
+export type CleanupInvocation = {
+  cleanupOnly: true;
+  registryName: string;
+  registryOwner: string;
+  runAttempt: string;
+  runId: string;
+};
+
+type TrustedEnvironment = Record<string, string | undefined>;
+
+type RuntimeNames = {
+  containerName: string;
+  networkName: string;
+  registryName: string;
+  registryOwner: string;
+  tempRoot: string;
+};
+
+type CleanupEvidence = {
+  containerRemoved: boolean;
+  keyFileRemoved: boolean;
+  loopbackListenerClosed: boolean;
+  networkRemoved: boolean;
+  registryListenerClosed: boolean;
+  registryRemoved: boolean;
+  tempFilesRemoved: boolean;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown, name: string, pattern: RegExp): string {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new Error(`invalid ${name}`);
+  }
+  return value;
+}
+
+function requiredInteger(value: unknown, name: string, minimum: number, maximum: number): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < minimum ||
+    value > maximum
+  ) {
+    throw new Error(`invalid ${name}`);
+  }
+  return value;
+}
+
+export function sha256Text(value: string | Buffer): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export function validateQualificationPlan(source: string, expectedHash: string): QualificationPlan {
+  requiredString(expectedHash, "qualification plan digest", sha256Pattern);
+  if (Buffer.byteLength(source) < 1 || Buffer.byteLength(source) > maximumPlanBytes) {
+    throw new Error("qualification plan must be a bounded non-empty document");
+  }
+  if (sha256Text(source) !== expectedHash) {
+    throw new Error("qualification plan digest mismatch");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(source) as unknown;
+  } catch {
+    throw new Error("qualification plan is not valid JSON");
+  }
+  if (JSON.stringify(value) !== source) {
+    throw new Error("qualification plan must be canonical compact JSON");
+  }
+  return parseLlamaCppDgxSparkExecutionPlan(value, expectedHash);
+}
+function requiredAbsolutePath(value: unknown, name: string, pattern: RegExp): string {
+  const validated = requiredString(value, name, pattern);
+  if (validated.split(path.sep).some((segment) => segment === "." || segment === "..")) {
+    throw new Error(`invalid ${name}`);
+  }
+  return validated;
+}
+
+function parseOptions(argv: string[]): Map<string, string> {
+  const options = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || !value || value.startsWith("--") || options.has(name)) {
+      throw new Error("invalid qualification command arguments");
+    }
+    options.set(name, value);
+  }
+  return options;
+}
+
+function requireTrustedEnvironment(
+  environment: TrustedEnvironment,
+  runId: string,
+  runAttempt: string,
+  workflowSha?: string,
+): void {
+  if (
+    environment.GITHUB_REPOSITORY !== "NVIDIA/NemoClaw" ||
+    environment.GITHUB_REF !== "refs/heads/main" ||
+    environment.GITHUB_EVENT_NAME !== "workflow_dispatch" ||
+    environment.GITHUB_ACTOR !== "github-actions[bot]" ||
+    environment.GITHUB_RUN_ID !== runId ||
+    environment.GITHUB_RUN_ATTEMPT !== runAttempt ||
+    !/^[1-9][0-9]*$/u.test(environment.GITHUB_ACTOR_ID ?? "") ||
+    (workflowSha !== undefined && environment.GITHUB_SHA !== workflowSha) ||
+    environment.GITHUB_WORKFLOW_REF !== expectedWorkflowRef
+  ) {
+    throw new Error("qualification invocation does not match the trusted workflow identity");
+  }
+}
+
+export function expectedRegistryOwner(runId: string, runAttempt: string): string {
+  return `llama-cpp-dgx-spark-${runId}-${runAttempt}`;
+}
+
+export function expectedRegistryName(runId: string, runAttempt: string): string {
+  return `nemoclaw-llama-cpp-${runId}-${runAttempt}`;
+}
+
+export function parseQualificationInvocation(
+  argv: string[],
+  environment: TrustedEnvironment = process.env,
+): QualificationInvocation | CleanupInvocation {
+  const cleanupOnly = argv[0] === "--cleanup-only";
+  const options = parseOptions(cleanupOnly ? argv.slice(1) : argv);
+  const required = cleanupOnly
+    ? ["--registry-name", "--run-attempt", "--run-id"]
+    : [
+        "--base-sha",
+        "--candidate-root",
+        "--head-sha",
+        "--model-host-path",
+        "--output",
+        "--plan",
+        "--plan-sha256",
+        "--registry-name",
+        "--run-attempt",
+        "--run-id",
+        "--workflow-sha",
+      ];
+  if (JSON.stringify([...options.keys()].sort()) !== JSON.stringify([...required].sort())) {
+    throw new Error("qualification command fields do not match the trusted contract");
+  }
+  const runId = requiredString(options.get("--run-id"), "run id", runIdPattern);
+  const runAttempt = requiredString(options.get("--run-attempt"), "run attempt", runAttemptPattern);
+  const registryOwner = expectedRegistryOwner(runId, runAttempt);
+  const registryName = requiredString(
+    options.get("--registry-name"),
+    "registry name",
+    /^nemoclaw-llama-cpp-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}$/u,
+  );
+  if (
+    registryOwner !== expectedRegistryOwner(runId, runAttempt) ||
+    registryName !== expectedRegistryName(runId, runAttempt)
+  ) {
+    throw new Error("registry ownership does not match this workflow run");
+  }
+  requireTrustedEnvironment(environment, runId, runAttempt);
+  if (cleanupOnly) return { cleanupOnly: true, registryName, registryOwner, runAttempt, runId };
+
+  const workflowSha = requiredString(options.get("--workflow-sha"), "workflow SHA", gitShaPattern);
+  requireTrustedEnvironment(environment, runId, runAttempt, workflowSha);
+  const candidateHead = requiredString(options.get("--head-sha"), "candidate head", gitShaPattern);
+  const candidateBase = requiredString(options.get("--base-sha"), "candidate base", gitShaPattern);
+  if (candidateBase === candidateHead) throw new Error("candidate head must differ from its base");
+  const candidateRoot = requiredAbsolutePath(
+    options.get("--candidate-root"),
+    "candidate root",
+    safePathPattern,
+  );
+  const modelHostPath = requiredAbsolutePath(
+    options.get("--model-host-path"),
+    "model host path",
+    LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN,
+  );
+  const planFile = requiredAbsolutePath(options.get("--plan"), "plan file", safePathPattern);
+  const output = requiredAbsolutePath(options.get("--output"), "output path", safePathPattern);
+  const planSha256 = requiredString(
+    options.get("--plan-sha256"),
+    "qualification plan digest",
+    sha256Pattern,
+  );
+  return {
+    candidateBase,
+    candidateHead,
+    candidateRoot,
+    cleanupOnly: false,
+    modelHostPath,
+    output,
+    planFile,
+    planSha256,
+    registryName,
+    registryOwner,
+    runAttempt,
+    runId,
+    workflowSha,
+  };
+}
+
+export function buildCandidateImageArgv(
+  plan: QualificationPlan,
+  invocation: QualificationInvocation,
+  metadataFile: string,
+): string[] {
+  const dockerfile = path.join(
+    invocation.candidateRoot,
+    "managed-inference/images/llama-cpp/Dockerfile",
+  );
+  const context = path.dirname(dockerfile);
+  const buildArguments = [
+    `C_COMPILER=${plan.imageBuild.compiler.c}`,
+    `CUDA_HOST_CXX_COMPILER=${plan.imageBuild.compiler.cudaHostCxx}`,
+    `CXX_COMPILER=${plan.imageBuild.compiler.cxx}`,
+    `CUDA_ARCHITECTURES=${plan.imageBuild.platform.cudaArchitectures}`,
+    `CUDA_DEV_IMAGE=${plan.imageBuild.cuda.developmentBase}`,
+    `CUDA_RUNTIME_IMAGE=${plan.imageBuild.cuda.runtimeBase}`,
+    `GGML_BACKEND_DIR=${plan.imageBuild.backendDirectory}`,
+    `LLAMA_CPP_ARCHIVE_SHA256=${plan.imageBuild.source.archiveSha256}`,
+    `LLAMA_CPP_REVISION=${plan.imageBuild.source.revision}`,
+    `NEMOCLAW_REVISION=${invocation.candidateHead}`,
+    `RUNTIME_GID=${plan.imageBuild.runtime.gid}`,
+    `RUNTIME_UID=${plan.imageBuild.runtime.uid}`,
+    `TARGETPLATFORM=${plan.imageBuild.platform.platform}`,
+  ];
+  return [
+    "buildx",
+    "build",
+    "--file",
+    dockerfile,
+    "--platform",
+    "linux/arm64",
+    "--push",
+    "--provenance=false",
+    "--sbom=false",
+    "--metadata-file",
+    metadataFile,
+    "--tag",
+    `${localImageRepository}:${invocation.candidateHead}`,
+    ...buildArguments.flatMap((argument) => ["--build-arg", argument]),
+    context,
+  ];
+}
+
+export function buildServerContainerArgv(
+  plan: QualificationPlan,
+  options: {
+    apiKeyHostPath: string;
+    containerName: string;
+    imageReference: string;
+    modelHostPath: string;
+    networkName: string;
+    registryOwner: string;
+    runtimeGid: number;
+    runtimeUid: number;
+  },
+): string[] {
+  const { resources } = plan.recipe.runtime;
+  const { serve } = plan.recipe;
+  const runtimeUid = requiredInteger(options.runtimeUid, "runtime uid", 1, 2_147_483_647);
+  const runtimeGid = requiredInteger(options.runtimeGid, "runtime gid", 1, 2_147_483_647);
+  return [
+    "run",
+    "--detach",
+    "--name",
+    options.containerName,
+    "--label",
+    `${registryOwnerLabel}=${options.registryOwner}`,
+    "--network",
+    options.networkName,
+    "--user",
+    `${runtimeUid}:${runtimeGid}`,
+    "--publish",
+    `127.0.0.1::${serve.port}`,
+    "--read-only",
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges=true",
+    "--memory",
+    `${resources.memoryBytes}b`,
+    "--memory-swap",
+    `${resources.memoryBytes}b`,
+    "--pids-limit",
+    String(resources.pidsLimit),
+    "--gpus",
+    "1",
+    "--tmpfs",
+    `/tmp:rw,noexec,nosuid,nodev,size=${resources.writableStorageBytes},uid=${runtimeUid},gid=${runtimeGid},mode=1777`,
+    "--mount",
+    `type=bind,source=${options.modelHostPath},target=${containerModelPath},readonly`,
+    "--mount",
+    `type=bind,source=${options.apiKeyHostPath},target=${containerApiKeyPath},readonly`,
+    options.imageReference,
+    "--model",
+    containerModelPath,
+    "--alias",
+    plan.recipe.model.servedName,
+    "--host",
+    "0.0.0.0",
+    "--port",
+    String(serve.port),
+    "--gpu-layers",
+    "all",
+    "--ctx-size",
+    String(serve.contextSize),
+    "--parallel",
+    String(serve.slots),
+    "--sleep-idle-seconds",
+    String(serve.idleSleepSeconds),
+    "--batch-size",
+    String(serve.batchSize),
+    "--ubatch-size",
+    String(serve.microBatchSize),
+    "--cache-type-k",
+    serve.kvCache.key,
+    "--cache-type-v",
+    serve.kvCache.value,
+    "--flash-attn",
+    "on",
+    "--timeout",
+    String(serve.limits.requestTimeoutSeconds),
+    "--api-key-file",
+    containerApiKeyPath,
+    "--metrics",
+    "--no-ui",
+    "--no-slots",
+    "--no-mmproj",
+    "--no-agent",
+  ];
+}
+
+export function validateStartupLog(log: string): { offloadedLayers: number; totalLayers: number } {
+  if (Buffer.byteLength(log) < 1 || Buffer.byteLength(log) > 16 * 1024 * 1024) {
+    throw new Error("startup evidence is missing or exceeds the bounded log size");
+  }
+  if (
+    /no usable GPU|gpu-layers[^\n]*ignored|compiled without[^\n]*GPU|CPU fallback|fallback to CPU|falling back to CPU/iu.test(
+      log,
+    )
+  ) {
+    throw new Error("startup evidence reports a rejected GPU or CPU fallback warning");
+  }
+  const matches = [
+    ...log.matchAll(/offloaded\s+([1-9][0-9]*)\/([1-9][0-9]*)\s+layers?\s+to\s+GPU/giu),
+  ];
+  if (matches.length < 1)
+    throw new Error("startup evidence is missing the pinned GPU offload line");
+  const counts = matches.map((match) => ({
+    offloadedLayers: Number.parseInt(match[1] ?? "0", 10),
+    totalLayers: Number.parseInt(match[2] ?? "0", 10),
+  }));
+  if (counts.some(({ offloadedLayers, totalLayers }) => offloadedLayers !== totalLayers)) {
+    throw new Error("startup evidence reports partial GPU offload");
+  }
+  const uniqueCounts = new Set(counts.map(({ offloadedLayers }) => offloadedLayers));
+  if (uniqueCounts.size !== 1)
+    throw new Error("startup evidence has inconsistent GPU offload counts");
+  return counts[0] as { offloadedLayers: number; totalLayers: number };
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+export function parseNvidiaSmi(
+  output: string,
+  minimumDriverVersion: string,
+): { count: 1; driverVersion: string; name: "NVIDIA GB10" } {
+  const lines = output
+    .trim()
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length !== 1) throw new Error("qualification requires exactly one visible NVIDIA GPU");
+  const match = /^(NVIDIA GB10)\s*,\s*([0-9]{3}\.[0-9]{2}\.[0-9]{2})$/u.exec(lines[0] ?? "");
+  if (!match) throw new Error("qualification host is not the expected NVIDIA GB10 profile");
+  const driverVersion = match[2] as string;
+  if (compareVersions(driverVersion, minimumDriverVersion) < 0) {
+    throw new Error("NVIDIA driver is below the qualification minimum");
+  }
+  return { count: 1, driverVersion, name: "NVIDIA GB10" };
+}
+
+export function validateModelsResponse(value: unknown, expectedModel: string): void {
+  if (
+    !isRecord(value) ||
+    value.object !== "list" ||
+    !Array.isArray(value.data) ||
+    value.data.length !== 1 ||
+    !isRecord(value.data[0]) ||
+    value.data[0].id !== expectedModel
+  ) {
+    throw new Error("models probe did not return the exact served model identity");
+  }
+}
+
+export function validateChatCompletionResponse(value: unknown, expectedModel: string): void {
+  if (
+    !isRecord(value) ||
+    value.object !== "chat.completion" ||
+    value.model !== expectedModel ||
+    !Array.isArray(value.choices) ||
+    value.choices.length < 1 ||
+    !isRecord(value.choices[0]) ||
+    !isRecord(value.choices[0].message) ||
+    typeof value.choices[0].message.content !== "string" ||
+    value.choices[0].message.content.length < 1 ||
+    value.choices[0].message.content.length > 4096
+  ) {
+    throw new Error("authenticated chat completion probe failed its response contract");
+  }
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+  options: { capture?: boolean; maximumBytes?: number } = {},
+): Buffer {
+  const capture = options.capture ?? true;
+  const result = spawnSync(command, args, {
+    encoding: null,
+    maxBuffer: options.maximumBytes ?? 16 * 1024 * 1024,
+    stdio: capture ? ["ignore", "pipe", "pipe"] : ["ignore", "ignore", "ignore"],
+  });
+  if (result.error || result.status !== 0) {
+    const operation = args.slice(0, 2).join(" ");
+    throw new Error(`${command} ${operation} failed`);
+  }
+  return Buffer.isBuffer(result.stdout) ? result.stdout : Buffer.alloc(0);
+}
+
+function commandSucceeds(command: string, args: string[]): boolean {
+  return spawnSync(command, args, { stdio: "ignore" }).status === 0;
+}
+
+function readBoundedRegularFile(file: string, maximumBytes: number): string {
+  if (fs.realpathSync(file) !== file) {
+    throw new Error("trusted input path must not use symlinks");
+  }
+  const descriptor = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const status = fs.fstatSync(descriptor);
+    if (!status.isFile() || status.size < 1 || status.size > maximumBytes) {
+      throw new Error("trusted input must be a bounded regular file");
+    }
+    return fs.readFileSync(descriptor, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function validateCandidateCheckout(invocation: QualificationInvocation): string {
+  const candidateRootStatus = fs.lstatSync(invocation.candidateRoot);
+  if (!candidateRootStatus.isDirectory() || candidateRootStatus.isSymbolicLink()) {
+    throw new Error("candidate root must be a real directory");
+  }
+  const root = fs.realpathSync(invocation.candidateRoot);
+  if (root !== invocation.candidateRoot) throw new Error("candidate root must not use symlinks");
+  const head = runCommand("git", ["-C", root, "rev-parse", "HEAD"]).toString("utf8").trim();
+  if (head !== invocation.candidateHead)
+    throw new Error("candidate checkout does not match its head");
+  runCommand("git", ["-C", root, "cat-file", "-e", `${invocation.candidateBase}^{commit}`]);
+  runCommand("git", [
+    "-C",
+    root,
+    "merge-base",
+    "--is-ancestor",
+    invocation.candidateBase,
+    invocation.candidateHead,
+  ]);
+  const relativeImageRoot = "managed-inference/images/llama-cpp";
+  const status = runCommand("git", [
+    "-C",
+    root,
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+    "--",
+    relativeImageRoot,
+  ])
+    .toString("utf8")
+    .trim();
+  if (status) throw new Error("candidate image source must match the exact committed head");
+  const dockerfile = path.join(root, relativeImageRoot, "Dockerfile");
+  const dockerfileStatus = fs.lstatSync(dockerfile);
+  if (
+    !dockerfileStatus.isFile() ||
+    dockerfileStatus.isSymbolicLink() ||
+    dockerfileStatus.size < 1
+  ) {
+    throw new Error("candidate Dockerfile must be a non-empty regular file");
+  }
+  return root;
+}
+
+function hashModelFile(
+  modelHostPath: string,
+  plan: QualificationPlan,
+): { digest: string; sizeBytes: number } {
+  if (path.basename(modelHostPath) !== plan.recipe.model.file.path) {
+    throw new Error("model file name does not match the qualification plan");
+  }
+  const realPath = fs.realpathSync(modelHostPath);
+  if (realPath !== modelHostPath) throw new Error("model file path must not use symlinks");
+  const descriptor = fs.openSync(modelHostPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (
+      !before.isFile() ||
+      before.size !== plan.recipe.model.file.sizeBytes ||
+      before.size < 1 ||
+      before.size > maximumModelBytes
+    ) {
+      throw new Error("model file size does not match the bounded qualification plan");
+    }
+    const hash = createHash("sha256");
+    const buffer = Buffer.allocUnsafe(8 * 1024 * 1024);
+    let position = 0;
+    while (position < before.size) {
+      const read = fs.readSync(
+        descriptor,
+        buffer,
+        0,
+        Math.min(buffer.length, before.size - position),
+        position,
+      );
+      if (read < 1) throw new Error("model file changed during verification");
+      hash.update(buffer.subarray(0, read));
+      position += read;
+    }
+    const after = fs.fstatSync(descriptor);
+    if (
+      before.size !== after.size ||
+      before.mtimeMs !== after.mtimeMs ||
+      before.ctimeMs !== after.ctimeMs
+    ) {
+      throw new Error("model file changed during verification");
+    }
+    const digest = `sha256:${hash.digest("hex")}`;
+    if (digest !== plan.recipe.model.file.digest) {
+      throw new Error("model file digest does not match the qualification plan");
+    }
+    return { digest, sizeBytes: after.size };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+async function tcpOpen(port: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const done = (value: boolean) => {
+      socket.destroy();
+      resolve(value);
+    };
+    socket.setTimeout(500, () => done(false));
+    socket.once("connect", () => done(true));
+    socket.once("error", () => done(false));
+  });
+}
+
+async function waitForRegistry(): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      const response = await fetch("http://127.0.0.1:5000/v2/", {
+        signal: AbortSignal.timeout(1000),
+      });
+      if (response.ok) return;
+    } catch {
+      // The bounded retry loop owns transient startup failures.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error("isolated registry did not become ready");
+}
+
+function dockerContainerOwner(name: string): string | null {
+  const result = spawnSync(
+    "docker",
+    ["container", "inspect", "--format", `{{index .Config.Labels "${registryOwnerLabel}"}}`, name],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  );
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function dockerNetworkOwner(name: string): string | null {
+  const result = spawnSync(
+    "docker",
+    ["network", "inspect", "--format", `{{index .Labels "${registryOwnerLabel}"}}`, name],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  );
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function runtimeNames(
+  invocation: Pick<CleanupInvocation, "registryName" | "registryOwner" | "runAttempt" | "runId">,
+  environment: TrustedEnvironment,
+): RuntimeNames {
+  const runnerTemp = environment.RUNNER_TEMP;
+  if (!runnerTemp || !path.isAbsolute(runnerTemp)) {
+    throw new Error("RUNNER_TEMP must be an absolute trusted runner directory");
+  }
+  const tempStatus = fs.lstatSync(runnerTemp);
+  if (!tempStatus.isDirectory() || tempStatus.isSymbolicLink()) {
+    throw new Error("RUNNER_TEMP must be a real directory");
+  }
+  const realRunnerTemp = fs.realpathSync(runnerTemp);
+  return {
+    containerName: `nemoclaw-llama-cpp-server-${invocation.runId}-${invocation.runAttempt}`,
+    networkName: `nemoclaw-llama-cpp-network-${invocation.runId}-${invocation.runAttempt}`,
+    registryName: invocation.registryName,
+    registryOwner: invocation.registryOwner,
+    tempRoot: path.join(realRunnerTemp, invocation.registryOwner),
+  };
+}
+
+async function cleanupOwnedRuntime(
+  names: RuntimeNames,
+  loopbackPort?: number,
+): Promise<CleanupEvidence> {
+  for (const name of [names.containerName, names.registryName]) {
+    const owner = dockerContainerOwner(name);
+    if (owner !== null && owner !== names.registryOwner) {
+      throw new Error("refusing to remove a Docker container not owned by this qualification run");
+    }
+    if (owner === names.registryOwner) runCommand("docker", ["rm", "--force", name]);
+  }
+  const networkOwner = dockerNetworkOwner(names.networkName);
+  if (networkOwner !== null && networkOwner !== names.registryOwner) {
+    throw new Error("refusing to remove a Docker network not owned by this qualification run");
+  }
+  if (networkOwner === names.registryOwner)
+    runCommand("docker", ["network", "rm", names.networkName]);
+  const keyFile = path.join(names.tempRoot, "api-key");
+  fs.rmSync(names.tempRoot, { force: true, recursive: true });
+  const evidence = {
+    containerRemoved: dockerContainerOwner(names.containerName) === null,
+    keyFileRemoved: !fs.existsSync(keyFile),
+    loopbackListenerClosed: loopbackPort === undefined || !(await tcpOpen(loopbackPort)),
+    networkRemoved: dockerNetworkOwner(names.networkName) === null,
+    registryListenerClosed: !(await tcpOpen(5000)),
+    registryRemoved: dockerContainerOwner(names.registryName) === null,
+    tempFilesRemoved: !fs.existsSync(names.tempRoot),
+  };
+  if (Object.values(evidence).includes(false))
+    throw new Error("qualification cleanup is incomplete");
+  return evidence;
+}
+
+async function removeOwnedRegistry(names: RuntimeNames): Promise<void> {
+  const owner = dockerContainerOwner(names.registryName);
+  if (owner !== names.registryOwner) {
+    throw new Error("refusing to remove a registry not owned by this qualification run");
+  }
+  runCommand("docker", ["rm", "--force", names.registryName]);
+  if (dockerContainerOwner(names.registryName) !== null || (await tcpOpen(5000))) {
+    throw new Error("isolated registry was not removed before model launch");
+  }
+}
+
+function startRegistry(names: RuntimeNames): void {
+  if (dockerContainerOwner(names.registryName) !== null) {
+    throw new Error("isolated registry name is already in use");
+  }
+  runCommand(
+    "docker",
+    [
+      "run",
+      "--detach",
+      "--name",
+      names.registryName,
+      "--label",
+      `${registryOwnerLabel}=${names.registryOwner}`,
+      "--publish",
+      "127.0.0.1:5000:5000",
+      registryImage,
+    ],
+    { capture: false },
+  );
+}
+
+function inspectBuiltImage(
+  plan: QualificationPlan,
+  invocation: QualificationInvocation,
+  metadataFile: string,
+): { digest: string; imageId: string; reference: string } {
+  const metadata = JSON.parse(readBoundedRegularFile(metadataFile, maximumPlanBytes)) as unknown;
+  if (!isRecord(metadata)) throw new Error("build metadata is malformed");
+  const digest = requiredString(
+    metadata["containerimage.digest"],
+    "candidate digest",
+    sha256Pattern,
+  );
+  const reference = `${localImageRepository}@${digest}`;
+  const raw = runCommand("docker", ["buildx", "imagetools", "inspect", reference, "--raw"], {
+    maximumBytes: 4 * 1024 * 1024,
+  });
+  if (sha256Text(raw) !== digest)
+    throw new Error("candidate manifest bytes do not match its digest");
+  runCommand("docker", ["pull", "--platform", "linux/arm64", reference], { capture: false });
+  const inspected = JSON.parse(
+    runCommand("docker", ["image", "inspect", reference]).toString("utf8"),
+  ) as unknown;
+  if (!Array.isArray(inspected) || inspected.length !== 1 || !isRecord(inspected[0])) {
+    throw new Error("candidate image inspect did not return one image");
+  }
+  const image = inspected[0];
+  const imageId = requiredString(image.Id, "candidate image id", sha256Pattern);
+  if (!isRecord(image.Config) || !isRecord(image.Config.Labels)) {
+    throw new Error("candidate image configuration is malformed");
+  }
+  const labels = image.Config.Labels;
+  if (
+    image.Os !== "linux" ||
+    image.Architecture !== "arm64" ||
+    image.Config.User !== `${plan.imageBuild.runtime.uid}:${plan.imageBuild.runtime.gid}` ||
+    JSON.stringify(image.Config.Entrypoint) !== JSON.stringify(["/usr/local/bin/llama-server"]) ||
+    labels["org.opencontainers.image.revision"] !== invocation.candidateHead ||
+    labels["io.nvidia.nemoclaw.inference-server.contract"] !== "1" ||
+    labels["io.nvidia.nemoclaw.inference-server.component"] !== "llama.cpp" ||
+    labels["io.nvidia.nemoclaw.inference-server.platform"] !== "linux/arm64" ||
+    labels["io.nvidia.nemoclaw.inference-server.upstream.repository"] !==
+      "https://github.com/ggml-org/llama.cpp" ||
+    labels["io.nvidia.nemoclaw.inference-server.upstream.revision"] !==
+      plan.imageBuild.source.revision ||
+    labels["io.nvidia.nemoclaw.inference-server.upstream.archive-sha256"] !==
+      plan.imageBuild.source.archiveSha256 ||
+    labels["io.nvidia.nemoclaw.inference-server.cuda.development-base"] !==
+      plan.imageBuild.cuda.developmentBase ||
+    labels["io.nvidia.nemoclaw.inference-server.cuda.runtime-base"] !==
+      plan.imageBuild.cuda.runtimeBase ||
+    labels["io.nvidia.nemoclaw.inference-server.cuda.architectures"] !== "121a-real"
+  ) {
+    throw new Error("candidate image identity does not match the qualification plan");
+  }
+  return { digest, imageId, reference };
+}
+
+function resolveLoopbackPort(containerName: string, containerPort: number): number {
+  const value = runCommand("docker", ["port", containerName, `${containerPort}/tcp`])
+    .toString("utf8")
+    .trim();
+  const match = /^127\.0\.0\.1:([1-9][0-9]{3,4})$/u.exec(value);
+  if (!match) throw new Error("model server did not receive one loopback-only ephemeral port");
+  return requiredInteger(Number.parseInt(match[1] ?? "0", 10), "loopback port", 1024, 65_535);
+}
+
+async function requestJson(
+  url: string,
+  init: RequestInit,
+  timeoutMilliseconds: number,
+  maximumBytes: number,
+): Promise<unknown> {
+  const response = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMilliseconds) });
+  if (!response.ok) throw new Error("qualification HTTP probe returned a non-success status");
+  const body = await response.text();
+  if (Buffer.byteLength(body) < 1 || Buffer.byteLength(body) > maximumBytes) {
+    throw new Error("qualification HTTP probe response exceeded its bound");
+  }
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new Error("qualification HTTP probe did not return JSON");
+  }
+}
+
+async function waitForHealth(port: number, timeoutSeconds: number): Promise<void> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (response.ok) return;
+    } catch {
+      // The bounded readiness window owns transient model-load failures.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error("model server did not become healthy within the qualification timeout");
+}
+
+function writeReceipt(output: string, receipt: unknown, tempRoot: string): void {
+  if (output === tempRoot || output.startsWith(`${tempRoot}${path.sep}`)) {
+    throw new Error("qualification receipt must not be written inside transient state");
+  }
+  const parent = path.dirname(output);
+  fs.mkdirSync(parent, { mode: 0o700, recursive: true });
+  const parentStatus = fs.lstatSync(parent);
+  if (
+    !parentStatus.isDirectory() ||
+    parentStatus.isSymbolicLink() ||
+    fs.realpathSync(parent) !== parent
+  ) {
+    throw new Error("qualification receipt parent must be a real directory");
+  }
+  if (fs.existsSync(output) && fs.lstatSync(output).isSymbolicLink()) {
+    throw new Error("qualification receipt path must not be a symlink");
+  }
+  const temporary = `${output}.tmp-${process.pid}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(receipt)}\n`, { encoding: "utf8", mode: 0o600 });
+  fs.renameSync(temporary, output);
+}
+
+async function runQualification(
+  invocation: QualificationInvocation,
+  environment: TrustedEnvironment,
+): Promise<void> {
+  if (process.platform !== "linux" || process.arch !== "arm64") {
+    throw new Error("DGX Spark qualification requires a Linux ARM64 host");
+  }
+  for (const command of ["docker", "git"]) {
+    if (!commandSucceeds(command, ["--version"]))
+      throw new Error(`qualification requires ${command}`);
+  }
+  validateCandidateCheckout(invocation);
+  const planSource = readBoundedRegularFile(invocation.planFile, maximumPlanBytes);
+  const plan = validateQualificationPlan(planSource, invocation.planSha256);
+  const names = runtimeNames(invocation, environment);
+  if (fs.existsSync(names.tempRoot)) fs.rmSync(names.tempRoot, { force: true, recursive: true });
+  fs.mkdirSync(names.tempRoot, { mode: 0o700 });
+  const metadataFile = path.join(names.tempRoot, "build-metadata.json");
+  const apiKeyHostPath = path.join(names.tempRoot, "api-key");
+  let loopbackPort: number | undefined;
+  let successReceipt: JsonRecord | undefined;
+  let failure: unknown;
+  let cleanupEvidence: CleanupEvidence | undefined;
+  try {
+    if (await tcpOpen(5000)) throw new Error("refusing to reuse an existing localhost registry");
+    startRegistry(names);
+    await waitForRegistry();
+    runCommand("docker", buildCandidateImageArgv(plan, invocation, metadataFile), {
+      capture: false,
+    });
+    const image = inspectBuiltImage(plan, invocation, metadataFile);
+    await removeOwnedRegistry(names);
+    fs.rmSync(names.tempRoot, { force: true, recursive: true });
+    fs.mkdirSync(names.tempRoot, { mode: 0o700 });
+    const model = hashModelFile(invocation.modelHostPath, plan);
+    const apiKey = randomBytes(32).toString("hex");
+    fs.writeFileSync(apiKeyHostPath, apiKey, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    const hostUid = process.getuid?.();
+    const hostGid = process.getgid?.();
+    if (hostUid === undefined || hostGid === undefined) {
+      throw new Error("qualification requires a POSIX runtime identity");
+    }
+    if (hostUid !== 0 && hostGid === 0) {
+      throw new Error("qualification requires a non-root POSIX group identity");
+    }
+    const runtimeUid = hostUid === 0 ? plan.imageBuild.runtime.uid : hostUid;
+    const runtimeGid = hostUid === 0 ? plan.imageBuild.runtime.gid : hostGid;
+    if (hostUid === 0) fs.chownSync(apiKeyHostPath, runtimeUid, runtimeGid);
+    const apiKeyStatus = fs.statSync(apiKeyHostPath);
+    if (
+      (apiKeyStatus.mode & 0o777) !== 0o600 ||
+      apiKeyStatus.uid !== runtimeUid ||
+      apiKeyStatus.gid !== runtimeGid ||
+      runtimeUid < 1
+    ) {
+      throw new Error("API key file permissions are not mode 0600");
+    }
+    runCommand("docker", [
+      "network",
+      "create",
+      "--internal",
+      "--label",
+      `${registryOwnerLabel}=${names.registryOwner}`,
+      names.networkName,
+    ]);
+    runCommand(
+      "docker",
+      buildServerContainerArgv(plan, {
+        apiKeyHostPath,
+        containerName: names.containerName,
+        imageReference: image.reference,
+        modelHostPath: invocation.modelHostPath,
+        networkName: names.networkName,
+        registryOwner: names.registryOwner,
+        runtimeGid,
+        runtimeUid,
+      }),
+      { capture: false },
+    );
+    loopbackPort = resolveLoopbackPort(names.containerName, plan.recipe.serve.port);
+    const smi = parseNvidiaSmi(
+      runCommand("docker", [
+        "exec",
+        names.containerName,
+        "nvidia-smi",
+        "--query-gpu=name,driver_version",
+        "--format=csv,noheader,nounits",
+      ]).toString("utf8"),
+      plan.recipe.runtime.cuda.minimumDriverVersion,
+    );
+    await waitForHealth(loopbackPort, plan.recipe.readiness.timeoutSeconds);
+    const authorization = `Bearer ${apiKey}`;
+    const models = await requestJson(
+      `http://127.0.0.1:${loopbackPort}/v1/models`,
+      { headers: { Authorization: authorization } },
+      10_000,
+      1024 * 1024,
+    );
+    validateModelsResponse(models, plan.recipe.readiness.expectedModel);
+    const completion = await requestJson(
+      `http://127.0.0.1:${loopbackPort}/v1/chat/completions`,
+      {
+        body: JSON.stringify({
+          max_tokens: 16,
+          messages: [{ content: "Return one short readiness token.", role: "user" }],
+          model: plan.recipe.model.servedName,
+          temperature: 0,
+        }),
+        headers: { Authorization: authorization, "Content-Type": "application/json" },
+        method: "POST",
+      },
+      plan.recipe.serve.limits.requestTimeoutSeconds * 1000,
+      plan.recipe.serve.limits.maxRequestBodyBytes,
+    );
+    validateChatCompletionResponse(completion, plan.recipe.model.servedName);
+    const offload = validateStartupLog(
+      runCommand("docker", ["logs", "--tail", "20000", names.containerName], {
+        maximumBytes: 16 * 1024 * 1024,
+      }).toString("utf8"),
+    );
+    successReceipt = {
+      baseSha: invocation.candidateBase,
+      headSha: invocation.candidateHead,
+      kind: LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND,
+      repository: "NVIDIA/NemoClaw",
+      run: {
+        attempt: Number.parseInt(invocation.runAttempt, 10),
+        id: Number.parseInt(invocation.runId, 10),
+      },
+      workflowSha: invocation.workflowSha,
+      image: {
+        digest: image.digest,
+        platform: "linux/arm64",
+        reference: image.reference,
+        sourceRevision: plan.imageBuild.source.revision,
+      },
+      model: {
+        digest: model.digest,
+        id: plan.recipe.model.id,
+      },
+      host: {
+        architecture: "arm64",
+        driverVersion: smi.driverVersion,
+        gpuName: smi.name,
+        profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+      },
+      execution: {
+        cpuFallback: false,
+        cpuWarning: false,
+        fullOffload: true,
+        ...offload,
+      },
+      probes: {
+        completion: {
+          httpStatus: 200,
+          model: plan.recipe.model.servedName,
+          ok: true,
+        },
+        health: { httpStatus: 200, ok: true },
+      },
+    };
+  } catch (error) {
+    failure = error;
+  } finally {
+    try {
+      cleanupEvidence = await cleanupOwnedRuntime(names, loopbackPort);
+    } catch (cleanupError) {
+      failure ??= cleanupError;
+    }
+  }
+  if (failure) throw failure;
+  if (!successReceipt || !cleanupEvidence)
+    throw new Error("qualification did not produce evidence");
+  successReceipt.cleanup = {
+    containerRemoved: cleanupEvidence.containerRemoved && cleanupEvidence.networkRemoved,
+    credentialsRemoved: cleanupEvidence.keyFileRemoved && cleanupEvidence.tempFilesRemoved,
+    listenerClosed:
+      cleanupEvidence.loopbackListenerClosed && cleanupEvidence.registryListenerClosed,
+    registryRemoved: cleanupEvidence.registryRemoved,
+  };
+  writeReceipt(invocation.output, successReceipt, names.tempRoot);
+}
+
+async function main(): Promise<void> {
+  const invocation = parseQualificationInvocation(process.argv.slice(2));
+  if (invocation.cleanupOnly) {
+    const names = runtimeNames(invocation, process.env);
+    await cleanupOwnedRuntime(names);
+    process.stdout.write("DGX Spark qualification cleanup complete.\n");
+    return;
+  }
+  await runQualification(invocation, process.env);
+  process.stdout.write("DGX Spark qualification receipt created.\n");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch {
+    process.stderr.write("ERROR: DGX Spark qualification failed.\n");
+    process.exitCode = 1;
+  }
+}

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -636,7 +636,9 @@ async function waitForRegistry(): Promise<void> {
     }
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
-  throw new Error("isolated registry did not become ready");
+  throw new Error(
+    "isolated registry did not return a successful /v2/ response before the retry limit",
+  );
 }
 
 function dockerContainerOwner(name: string): string | null {

--- a/test/e2e/live/llama-cpp-dgx-spark-qualification-helpers.ts
+++ b/test/e2e/live/llama-cpp-dgx-spark-qualification-helpers.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  LLAMA_CPP_DGX_SPARK_SHA_PATTERN,
+  type LlamaCppDgxSparkQualificationEvidenceIdentity,
+} from "../../../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
+
+export interface LlamaCppDgxSparkQualificationEnvironment {
+  activationRoot: string;
+  artifactDirectory: string;
+  evidenceFile: string;
+  identity: LlamaCppDgxSparkQualificationEvidenceIdentity;
+  planFile: string;
+  planSha256: string;
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function positiveIntegerEnvironment(name: string): number {
+  const value = requiredEnvironment(name);
+  if (!/^[1-9][0-9]*$/u.test(value)) throw new Error(`${name} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${name} must be a safe integer`);
+  return parsed;
+}
+
+export function llamaCppDgxSparkQualificationEnvironment(): LlamaCppDgxSparkQualificationEnvironment {
+  const identity = {
+    baseSha: requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_BASE_SHA"),
+    headSha: requiredEnvironment("NEMOCLAW_E2E_EXPECTED_SHA"),
+    runAttempt: positiveIntegerEnvironment("GITHUB_RUN_ATTEMPT"),
+    runId: positiveIntegerEnvironment("GITHUB_RUN_ID"),
+    workflowSha: requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_WORKFLOW_SHA"),
+  };
+  if (
+    !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(identity.baseSha) ||
+    !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(identity.headSha) ||
+    !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(identity.workflowSha)
+  ) {
+    throw new Error("llama.cpp DGX Spark dispatch identity is invalid");
+  }
+  return {
+    activationRoot: fs.realpathSync(
+      requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_CANDIDATE_ROOT"),
+    ),
+    artifactDirectory: fs.realpathSync(requiredEnvironment("E2E_ARTIFACT_DIR")),
+    evidenceFile: requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_EVIDENCE"),
+    identity,
+    planFile: requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN"),
+    planSha256: requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN_SHA256"),
+  };
+}
+
+export function readLlamaCppQualificationArtifact(file: string, root: string): Buffer {
+  const realRoot = fs.realpathSync(root);
+  const parent = fs.realpathSync(path.dirname(file));
+  const candidate = path.join(parent, path.basename(file));
+  const relative = path.relative(realRoot, candidate);
+  if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${file} must be a child of the protected qualification root`);
+  }
+  const descriptor = fs.openSync(candidate, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const status = fs.fstatSync(descriptor);
+    if (!status.isFile() || status.size < 1 || status.size > 1024 * 1024) {
+      throw new Error(`${file} must be a bounded regular file`);
+    }
+    return fs.readFileSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}

--- a/test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts
+++ b/test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+import {
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
+  parseLlamaCppDgxSparkExecutionPlan,
+  parseLlamaCppDgxSparkQualificationActivation,
+  parseLlamaCppDgxSparkQualificationReceipt,
+} from "../../../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
+import { expect, test } from "../fixtures/e2e-test.ts";
+import {
+  llamaCppDgxSparkQualificationEnvironment,
+  readLlamaCppQualificationArtifact,
+} from "./llama-cpp-dgx-spark-qualification-helpers.ts";
+
+test("binds the exact owned llama.cpp candidate to protected NVIDIA DGX Spark evidence (#8260)", {
+  meta: {
+    e2ePhases: [
+      "validate trusted activation and dispatch identity",
+      "validate declarative image and serving plan",
+      "validate exact DGX Spark execution and cleanup evidence",
+    ],
+  },
+}, ({ progress }) => {
+  const environment = llamaCppDgxSparkQualificationEnvironment();
+
+  progress.phase("validate trusted activation and dispatch identity");
+  const activation = readLlamaCppQualificationArtifact(
+    path.join(environment.activationRoot, LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH),
+    environment.activationRoot,
+  );
+  parseLlamaCppDgxSparkQualificationActivation(activation.toString("utf8"));
+
+  progress.phase("validate declarative image and serving plan");
+  const plan = readLlamaCppQualificationArtifact(
+    environment.planFile,
+    path.dirname(environment.planFile),
+  );
+  expect(() =>
+    parseLlamaCppDgxSparkExecutionPlan(
+      JSON.parse(plan.toString("utf8")) as unknown,
+      environment.planSha256,
+    ),
+  ).not.toThrow();
+
+  progress.phase("validate exact DGX Spark execution and cleanup evidence");
+  const evidence = readLlamaCppQualificationArtifact(
+    environment.evidenceFile,
+    environment.artifactDirectory,
+  );
+  expect(() =>
+    parseLlamaCppDgxSparkQualificationReceipt(
+      JSON.parse(evidence.toString("utf8")) as unknown,
+      environment.identity,
+    ),
+  ).not.toThrow();
+});

--- a/test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts
+++ b/test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts
@@ -15,7 +15,7 @@ import {
   readLlamaCppQualificationArtifact,
 } from "./llama-cpp-dgx-spark-qualification-helpers.ts";
 
-test("binds the exact owned llama.cpp candidate to protected NVIDIA DGX Spark evidence (#8260)", {
+test("binds the exact NemoClaw-built llama.cpp image candidate to protected NVIDIA DGX Spark evidence (#8260)", {
   meta: {
     e2ePhases: [
       "validate trusted activation and dispatch identity",

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -3,6 +3,17 @@
   "version": 1,
   "entries": [
     {
+      "live": "test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts",
+      "fast": [
+        "test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts",
+        "test/llama-cpp-dgx-spark-qualification-contract.test.ts",
+        "test/llama-cpp-dgx-spark-qualification-plan.test.ts",
+        "test/llama-cpp-dgx-spark-qualification-runner.test.ts",
+        "test/llama-cpp-image.test.ts",
+        "test/pr-risk-plan.test.ts"
+      ]
+    },
+    {
       "live": "test/e2e/live/managed-image-multiarch-startup.test.ts",
       "fast": [
         "test/e2e/support/base-image-publication.test.ts",

--- a/test/e2e/support/e2e-cross-runtime-compatibility.test.ts
+++ b/test/e2e/support/e2e-cross-runtime-compatibility.test.ts
@@ -29,7 +29,7 @@ describe("cross-runtime foundation compatibility", () => {
       ),
     ).toBe("6272aab16cf4b9555bdc4b3f4c0cdd24b5faa55118cbd61cbb4b30a3d418a63a");
     expect(digestOutput(buildE2eWorkflowPlan())).toBe(
-      "00dddd726f979dfddceef7b61b7e4937d48394af3e7224b22bb4014d5b362106",
+      "ac63268158d590d7dfefa814f948e72c663878c5f82e53298185ae51a8fd2911",
     );
   });
 
@@ -45,7 +45,7 @@ describe("cross-runtime foundation compatibility", () => {
     ];
 
     expect(digestOutput(cases.map(buildRiskPlan))).toBe(
-      "7f55218cbfc184b0c2478ae435075c0fc2b9b053b01dda3fdb15c4697bf427e0",
+      "b566803732025bff773b4d9b063d961a429d5f8b8af65d9e9d51e1f6f8deeeb1",
     );
   });
 });

--- a/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
+++ b/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import { validateLlamaCppDgxSparkQualificationWorkflow } from "../../../tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts";
+
+type WorkflowRecord = Record<string, unknown>;
+
+function workflow(): WorkflowRecord {
+  return YAML.parse(
+    fs.readFileSync(
+      path.resolve(import.meta.dirname, "../../../.github/workflows/e2e.yaml"),
+      "utf8",
+    ),
+  ) as WorkflowRecord;
+}
+
+function job(value: WorkflowRecord, id: string): Record<string, unknown> {
+  return (value.jobs as Record<string, Record<string, unknown>>)[id];
+}
+
+function namedStep(value: WorkflowRecord, jobId: string, name: string): Record<string, unknown> {
+  const step = (job(value, jobId).steps as Array<Record<string, unknown>>).find(
+    (candidate) => candidate.name === name,
+  );
+  expect(step, `workflow step '${name}' is missing`).toBeDefined();
+  return step as Record<string, unknown>;
+}
+
+describe("llama.cpp DGX Spark qualification workflow boundary", () => {
+  it("accepts the exact dormant trusted qualification lane", () => {
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(workflow())).toEqual([]);
+  });
+
+  it("rejects bypassing the declarative protected-runner plan", () => {
+    const value = workflow();
+    job(value, "llama-cpp-dgx-spark-qualification")["runs-on"] = "self-hosted";
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification runner must come from validated YAML",
+    );
+  });
+
+  it("rejects checking candidate source out over trusted qualification code", () => {
+    const value = workflow();
+    const checkout = namedStep(
+      value,
+      "llama-cpp-dgx-spark-qualification",
+      "Checkout exact llama.cpp qualification candidate",
+    );
+    (checkout.with as Record<string, unknown>).path = ".";
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama.cpp qualification candidate checkout must bind path to .candidate-llama-cpp",
+    );
+  });
+
+  it("rejects exposing the protected model path at job scope", () => {
+    const value = workflow();
+    const protectedJob = job(value, "llama-cpp-dgx-spark-qualification");
+    protectedJob.env = {
+      ...(protectedJob.env as Record<string, unknown>),
+      MODEL_HOST_PATH: "/models/model.gguf",
+    };
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification must not expose MODEL_HOST_PATH at job scope",
+    );
+  });
+
+  it("rejects executing candidate-controlled plan compiler code", () => {
+    const value = workflow();
+    const compile = namedStep(
+      value,
+      "llama-cpp-dgx-spark-plan",
+      "Compile exact candidate llama.cpp qualification plan",
+    );
+    compile.run = `${String(compile.run)}\nnpx tsx .candidate-llama-cpp/scripts/leak.ts`;
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-plan must not execute candidate-controlled scripts",
+    );
+  });
+
+  it("rejects cleanup that can be skipped after qualification failure", () => {
+    const value = workflow();
+    namedStep(
+      value,
+      "llama-cpp-dgx-spark-qualification",
+      "Remove protected llama.cpp qualification resources",
+    ).if = "success()";
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification cleanup must always run",
+    );
+  });
+
+  it("rejects qualification before the trusted plan is materialized", () => {
+    const value = workflow();
+    const protectedJob = job(value, "llama-cpp-dgx-spark-qualification");
+    const workflowSteps = protectedJob.steps as Array<Record<string, unknown>>;
+    const qualify = namedStep(
+      value,
+      "llama-cpp-dgx-spark-qualification",
+      "Build and qualify exact llama.cpp candidate",
+    );
+    protectedJob.steps = [qualify, ...workflowSteps.filter((step) => step !== qualify)];
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification trusted planning, execution, cleanup, and evidence steps drifted",
+    );
+  });
+});

--- a/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
+++ b/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
@@ -32,7 +32,7 @@ function namedStep(value: WorkflowRecord, jobId: string, name: string): Record<s
   return step as Record<string, unknown>;
 }
 
-describe("llama.cpp DGX Spark qualification workflow boundary", () => {
+describe("llama.cpp DGX Spark qualification workflow boundary (#8260)", () => {
   it("accepts the exact dormant trusted qualification lane", () => {
     expect(validateLlamaCppDgxSparkQualificationWorkflow(workflow())).toEqual([]);
   });
@@ -57,6 +57,56 @@ describe("llama.cpp DGX Spark qualification workflow boundary", () => {
 
     expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
       "llama.cpp qualification candidate checkout must bind path to .candidate-llama-cpp",
+    );
+  });
+
+  it.each([
+    [
+      "llama-cpp-dgx-spark-plan",
+      "Checkout exact llama.cpp candidate configuration",
+      "llama-cpp-dgx-spark-plan must pin checkout",
+    ],
+    [
+      "llama-cpp-dgx-spark-qualification",
+      "Checkout trusted llama.cpp qualification",
+      "llama-cpp-dgx-spark-qualification must pin trusted checkout",
+    ],
+    [
+      "llama-cpp-dgx-spark-qualification",
+      "Checkout exact llama.cpp qualification candidate",
+      "llama-cpp-dgx-spark-qualification must pin candidate checkout",
+    ],
+  ])("rejects an unpinned %s checkout", (jobId, name, error) => {
+    const value = workflow();
+    namedStep(value, jobId, name).uses = "actions/checkout@main";
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(error);
+  });
+
+  it("rejects host networking or extra Buildx configuration", () => {
+    const value = workflow();
+    const buildx = namedStep(
+      value,
+      "llama-cpp-dgx-spark-qualification",
+      "Set up protected llama.cpp Buildx",
+    );
+    buildx.with = { driver: "docker-container", "driver-opts": "network=host" };
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification must use the host-network-free Docker driver",
+    );
+  });
+
+  it("rejects a plan path that depends on unavailable job-level runner context", () => {
+    const value = workflow();
+    const protectedJob = job(value, "llama-cpp-dgx-spark-qualification");
+    protectedJob.env = {
+      ...(protectedJob.env as Record<string, unknown>),
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN: "${{ runner.temp }}/llama-cpp-dgx-spark-plan.json",
+    };
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification env must bind NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN to ${{ github.workspace }}/.llama-cpp-qualification/plan.json",
     );
   });
 

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -20,6 +20,7 @@ const E2E_WORKFLOW_CONTRACTS = [
   "test/e2e/support/hermes-workflow-boundary.test.ts",
   "test/hosted-runner-recovery-workflow.test.ts",
   "test/e2e/support/inference-switch-workflow-boundary.test.ts",
+  "test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts",
   "test/e2e/support/jetson-workflow-boundary.test.ts",
   "test/e2e/support/mcp-workflow-boundary.test.ts",
   "test/e2e/support/mcp-workflow-compatibility.test.ts",

--- a/test/llama-cpp-dgx-spark-qualification-contract.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-contract.test.ts
@@ -278,7 +278,7 @@ describe("llama.cpp DGX Spark qualification contract", () => {
       parseLlamaCppDgxSparkQualificationActivation(
         `contractVersion: 1\njobId: ${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID}\u0000\nplatform: linux/arm64\nprofile: dgx-spark-gb10-single\n`,
       ),
-    ).toThrow("activation YAML is unsafe");
+    ).toThrow("activation YAML is empty, exceeds 4096 bytes, or contains control characters");
   });
 
   it("accepts dormant and completely bound enabled plans compiled from YAML (#8260)", () => {
@@ -473,7 +473,7 @@ describe("llama.cpp DGX Spark qualification contract", () => {
     ).toThrow("surfaces are not disabled");
   });
 
-  it("accepts one sanitized receipt bound to exact workflow, image, model, and Spark evidence (#8260)", () => {
+  it("accepts one bounded receipt with only allowlisted workflow, image, model, and Spark evidence (#8260)", () => {
     expect(parseLlamaCppDgxSparkQualificationReceipt(receipt(), evidenceIdentity())).toEqual(
       receipt(),
     );

--- a/test/llama-cpp-dgx-spark-qualification-contract.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-contract.test.ts
@@ -1,0 +1,610 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  LLAMA_CPP_DGX_SPARK_CUDA_DEVELOPMENT_BASE,
+  LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE,
+  LLAMA_CPP_DGX_SPARK_DIGEST_PATTERN,
+  LLAMA_CPP_DGX_SPARK_ENVIRONMENT_PATTERN,
+  LLAMA_CPP_DGX_SPARK_GPU_PATTERN,
+  LLAMA_CPP_DGX_SPARK_MODEL_DIGEST,
+  LLAMA_CPP_DGX_SPARK_MODEL_ID,
+  LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN,
+  LLAMA_CPP_DGX_SPARK_OWNED_IMAGE_REPOSITORY,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE,
+  LLAMA_CPP_DGX_SPARK_RUNNER_PATTERN,
+  LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+  LLAMA_CPP_DGX_SPARK_SOURCE_ARCHIVE_SHA256,
+  LLAMA_CPP_DGX_SPARK_SOURCE_REPOSITORY,
+  LLAMA_CPP_DGX_SPARK_SOURCE_REVISION,
+  llamaCppDgxSparkExecutionPlanSha256,
+  parseLlamaCppDgxSparkExecutionPlan,
+  parseLlamaCppDgxSparkQualificationActivation,
+  parseLlamaCppDgxSparkQualificationEvidenceIdentity,
+  parseLlamaCppDgxSparkQualificationPlan,
+  parseLlamaCppDgxSparkQualificationReceipt,
+  verifyLlamaCppDgxSparkExecutionPlanSha256,
+} from "../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
+
+const HEAD_SHA = "a".repeat(40);
+const BASE_SHA = "b".repeat(40);
+const WORKFLOW_SHA = "c".repeat(40);
+const IMAGE_DIGEST = `sha256:${"d".repeat(64)}`;
+const MODEL_HOST_PATH = "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
+
+function activation() {
+  return {
+    contractVersion: 1,
+    jobId: LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+    profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+  };
+}
+
+function disabledPlan() {
+  return {
+    environment: null,
+    execution: "disabled",
+    gpu: { cpuFallback: "reject", fullOffload: true, vendor: "nvidia" },
+    model: {
+      digest: LLAMA_CPP_DGX_SPARK_MODEL_DIGEST,
+      hostPath: null,
+      id: LLAMA_CPP_DGX_SPARK_MODEL_ID,
+    },
+    platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+    probes: ["health", "completion"],
+    profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+    recipeRef: LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE,
+    required: true,
+    runner: null,
+  };
+}
+
+function enabledPlan() {
+  return {
+    ...disabledPlan(),
+    environment: "approve-dgx-spark-image-qualification",
+    execution: "enabled",
+    model: { ...disabledPlan().model, hostPath: MODEL_HOST_PATH },
+    runner: "linux-arm64-gpu-dgx-spark-gb10-protected-1",
+  };
+}
+
+function evidenceIdentity() {
+  return {
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    runAttempt: 2,
+    runId: 42,
+    workflowSha: WORKFLOW_SHA,
+  };
+}
+
+function receipt() {
+  return {
+    baseSha: BASE_SHA,
+    cleanup: {
+      containerRemoved: true,
+      credentialsRemoved: true,
+      listenerClosed: true,
+      registryRemoved: true,
+    },
+    execution: {
+      cpuFallback: false,
+      cpuWarning: false,
+      fullOffload: true,
+      offloadedLayers: 57,
+      totalLayers: 57,
+    },
+    headSha: HEAD_SHA,
+    host: {
+      architecture: "arm64",
+      driverVersion: "580.65.06",
+      gpuName: "NVIDIA GB10",
+      profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+    },
+    image: {
+      digest: IMAGE_DIGEST,
+      platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+      reference: `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY}@${IMAGE_DIGEST}`,
+      sourceRevision: LLAMA_CPP_DGX_SPARK_SOURCE_REVISION,
+    },
+    kind: LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND,
+    model: {
+      digest: LLAMA_CPP_DGX_SPARK_MODEL_DIGEST,
+      id: LLAMA_CPP_DGX_SPARK_MODEL_ID,
+    },
+    probes: {
+      completion: { httpStatus: 200, model: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID, ok: true },
+      health: { httpStatus: 200, ok: true },
+    },
+    repository: "NVIDIA/NemoClaw",
+    run: { attempt: 2, id: 42 },
+    workflowSha: WORKFLOW_SHA,
+  };
+}
+
+function executionPlan() {
+  return {
+    contractVersion: 1,
+    imageBuild: {
+      backendDirectory: "/opt/llama.cpp/lib",
+      compiler: { c: "gcc-14", cudaHostCxx: "g++-14", cxx: "g++-14" },
+      cuda: {
+        developmentBase: LLAMA_CPP_DGX_SPARK_CUDA_DEVELOPMENT_BASE,
+        runtimeBase: LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE,
+      },
+      platform: { cudaArchitectures: "121a-real", platform: "linux/arm64" },
+      repository: LLAMA_CPP_DGX_SPARK_OWNED_IMAGE_REPOSITORY,
+      runtime: { gid: 10001, port: 8081, uid: 10001 },
+      source: {
+        archiveSha256: LLAMA_CPP_DGX_SPARK_SOURCE_ARCHIVE_SHA256,
+        repository: LLAMA_CPP_DGX_SPARK_SOURCE_REPOSITORY,
+        revision: LLAMA_CPP_DGX_SPARK_SOURCE_REVISION,
+      },
+    },
+    recipe: {
+      id: LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE,
+      model: {
+        file: {
+          path: "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
+          digest: LLAMA_CPP_DGX_SPARK_MODEL_DIGEST,
+          sizeBytes: 22833947424,
+          format: "gguf",
+          quantization: "UD-Q4_K_XL",
+          license: "NVIDIA-Open-Model-License",
+        },
+        id: LLAMA_CPP_DGX_SPARK_MODEL_ID,
+        revision: "9ad8b366c308f931b2a96b9306f0b41aef9cd405",
+        servedName: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+      },
+      policy: {
+        egress: "disabled",
+        modelSource: "verified-local",
+        modelDownloads: "disabled",
+      },
+      readiness: {
+        contractRef: "llama-cpp.server-readiness/v1",
+        timeoutSeconds: 1800,
+        expectedModel: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+        probes: { models: true, health: true, properties: true, metrics: true },
+      },
+      runtime: {
+        cuda: {
+          baseImage: LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE,
+          minimumDriverVersion: "580.65.06",
+        },
+        gpu: { vendor: "nvidia", count: 1, offload: "full", cpuFallback: "reject" },
+        resources: {
+          memoryBytes: 51539607552,
+          writableStorageBytes: 42949672960,
+          pidsLimit: 256,
+        },
+      },
+      serve: {
+        protocol: "openai-completions",
+        authentication: "bearer",
+        port: 8081,
+        chatTemplate: "nemotron-v3-embedded",
+        contextSize: 262144,
+        slots: 1,
+        idleSleepSeconds: -1,
+        batchSize: 2048,
+        microBatchSize: 512,
+        flashAttention: "enabled",
+        kvCache: { key: "f16", value: "f16" },
+        speculativeDecoding: "disabled",
+        limits: {
+          maxRequestBodyBytes: 16777216,
+          maxPromptTokens: 253952,
+          maxCompletionTokens: 8192,
+          requestTimeoutSeconds: 900,
+        },
+      },
+      server: {
+        technology: "llama.cpp",
+        source: {
+          repository: "ggml-org/llama.cpp",
+          revision: LLAMA_CPP_DGX_SPARK_SOURCE_REVISION,
+        },
+      },
+      surfaces: {
+        ui: "disabled",
+        slotInspection: "disabled",
+        router: "disabled",
+        mcpProxy: "disabled",
+        serverTools: "disabled",
+        agentMode: "disabled",
+        multimodalProjection: "disabled",
+      },
+    },
+  };
+}
+
+describe("llama.cpp DGX Spark qualification contract", () => {
+  it("pins the exact protected ARM64 activation identity and patterns (#8260)", () => {
+    expect(LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH).toBe(
+      "ci/llama-cpp-dgx-spark-qualification-v1.yaml",
+    );
+    expect(LLAMA_CPP_DGX_SPARK_RUNNER_PATTERN.test("ubuntu-latest")).toBe(false);
+    expect(
+      LLAMA_CPP_DGX_SPARK_RUNNER_PATTERN.test("linux-arm64-gpu-dgx-spark-gb10-protected-1"),
+    ).toBe(true);
+    expect(LLAMA_CPP_DGX_SPARK_ENVIRONMENT_PATTERN.test("production")).toBe(false);
+    expect(
+      LLAMA_CPP_DGX_SPARK_ENVIRONMENT_PATTERN.test("approve-dgx-spark-image-qualification"),
+    ).toBe(true);
+    expect(LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN.test(MODEL_HOST_PATH)).toBe(true);
+    expect(LLAMA_CPP_DGX_SPARK_GPU_PATTERN.test("NVIDIA GB10")).toBe(true);
+    expect(LLAMA_CPP_DGX_SPARK_DIGEST_PATTERN.test(IMAGE_DIGEST)).toBe(true);
+  });
+
+  it("accepts only the exact activation mapping as YAML or an object (#8260)", () => {
+    const expected = activation();
+    const yaml = `contractVersion: 1\njobId: ${expected.jobId}\nplatform: ${expected.platform}\nprofile: ${expected.profile}\n`;
+
+    expect(parseLlamaCppDgxSparkQualificationActivation(expected)).toEqual(expected);
+    expect(parseLlamaCppDgxSparkQualificationActivation(yaml)).toEqual(expected);
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationActivation({ ...expected, jobId: "gpu-e2e" }),
+    ).toThrow("activation contract is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationActivation({ ...expected, token: "secret" }),
+    ).toThrow("unexpected fields");
+  });
+
+  it("rejects ambiguous or unsafe activation YAML before selecting protected work (#8260)", () => {
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationActivation(
+        `contractVersion: 1\ncontractVersion: 1\njobId: ${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID}\nplatform: linux/arm64\nprofile: dgx-spark-gb10-single\n`,
+      ),
+    ).toThrow("activation YAML is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationActivation(
+        `contractVersion: &version 1\njobId: ${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID}\nplatform: linux/arm64\nprofile: *version\n`,
+      ),
+    ).toThrow();
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationActivation(
+        `contractVersion: 1\njobId: ${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID}\u0000\nplatform: linux/arm64\nprofile: dgx-spark-gb10-single\n`,
+      ),
+    ).toThrow("activation YAML is unsafe");
+  });
+
+  it("accepts dormant and completely bound enabled plans compiled from YAML (#8260)", () => {
+    expect(parseLlamaCppDgxSparkQualificationPlan(disabledPlan())).toEqual(disabledPlan());
+    expect(parseLlamaCppDgxSparkQualificationPlan(enabledPlan())).toEqual(enabledPlan());
+  });
+
+  it("rejects enabled or partially bound plans without the exact protected infrastructure (#8260)", () => {
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationPlan({ ...disabledPlan(), execution: "enabled" }),
+    ).toThrow("infrastructure is incomplete");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationPlan({
+        ...disabledPlan(),
+        runner: "linux-arm64-gpu-dgx-spark-gb10-protected-1",
+      }),
+    ).toThrow("infrastructure is incomplete");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationPlan({ ...enabledPlan(), runner: "ubuntu-latest" }),
+    ).toThrow("infrastructure is incomplete");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationPlan({
+        ...enabledPlan(),
+        environment: "approve-dgx-spark-image-qualification\nTOKEN=secret",
+      }),
+    ).toThrow("infrastructure is incomplete");
+  });
+
+  it("rejects plan drift, unsafe model paths, and unexpected fields (#8260)", () => {
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationPlan({
+        ...enabledPlan(),
+        recipeRef: "llama-cpp.unreviewed.v1",
+      }),
+    ).toThrow("qualification plan is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationPlan({
+        ...enabledPlan(),
+        gpu: { ...enabledPlan().gpu, fullOffload: false },
+      }),
+    ).toThrow("qualification plan is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationPlan({
+        ...enabledPlan(),
+        model: { ...enabledPlan().model, hostPath: "/models/../model.gguf" },
+      }),
+    ).toThrow("infrastructure is incomplete");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationPlan({ ...enabledPlan(), arguments: ["--shell"] }),
+    ).toThrow("unexpected fields");
+  });
+
+  it("validates the exact workflow evidence identity before receipt parsing (#8260)", () => {
+    expect(parseLlamaCppDgxSparkQualificationEvidenceIdentity(evidenceIdentity())).toEqual(
+      evidenceIdentity(),
+    );
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationEvidenceIdentity({
+        ...evidenceIdentity(),
+        headSha: "A".repeat(40),
+      }),
+    ).toThrow("head SHA is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationEvidenceIdentity({
+        ...evidenceIdentity(),
+        runAttempt: 0,
+      }),
+    ).toThrow("run attempt is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationEvidenceIdentity({
+        ...evidenceIdentity(),
+        actor: "untrusted",
+      }),
+    ).toThrow("unexpected fields");
+  });
+
+  it("parses and verifies the exact immutable execution plan emitted from YAML (#8260)", () => {
+    const value = executionPlan();
+    const expectedDigest = `sha256:${createHash("sha256")
+      .update(JSON.stringify(value))
+      .digest("hex")}`;
+
+    expect(parseLlamaCppDgxSparkExecutionPlan(value)).toEqual(value);
+    expect(llamaCppDgxSparkExecutionPlanSha256(value)).toBe(expectedDigest);
+    expect(parseLlamaCppDgxSparkExecutionPlan(value, expectedDigest)).toEqual(value);
+    expect(verifyLlamaCppDgxSparkExecutionPlanSha256(value, expectedDigest)).toEqual(value);
+    expect(() => parseLlamaCppDgxSparkExecutionPlan(value, `sha256:${"e".repeat(64)}`)).toThrow(
+      "plan digest does not match",
+    );
+  });
+
+  it("canonicalizes execution plan field order before digest verification (#8260)", () => {
+    const value = executionPlan();
+    const reordered = {
+      recipe: value.recipe,
+      imageBuild: value.imageBuild,
+      contractVersion: value.contractVersion,
+    };
+
+    expect(llamaCppDgxSparkExecutionPlanSha256(reordered)).toBe(
+      llamaCppDgxSparkExecutionPlanSha256(value),
+    );
+  });
+
+  it("allows bounded YAML tuning while preserving the Spark execution invariants (#8260)", () => {
+    const value = executionPlan();
+    const tuned = {
+      ...value,
+      recipe: {
+        ...value.recipe,
+        readiness: { ...value.recipe.readiness, timeoutSeconds: 1200 },
+        runtime: {
+          ...value.recipe.runtime,
+          resources: {
+            memoryBytes: 68719476736,
+            writableStorageBytes: 34359738368,
+            pidsLimit: 512,
+          },
+        },
+        serve: {
+          ...value.recipe.serve,
+          contextSize: 131072,
+          batchSize: 1024,
+          microBatchSize: 256,
+          kvCache: { key: "q8_0", value: "q8_0" },
+          limits: {
+            maxRequestBodyBytes: 8388608,
+            maxPromptTokens: 120000,
+            maxCompletionTokens: 4096,
+            requestTimeoutSeconds: 600,
+          },
+        },
+      },
+    };
+
+    expect(parseLlamaCppDgxSparkExecutionPlan(tuned)).toEqual(tuned);
+  });
+
+  it("rejects mutable build inputs and unsafe execution plan extensions (#8260)", () => {
+    const value = executionPlan();
+    expect(() =>
+      parseLlamaCppDgxSparkExecutionPlan({
+        ...value,
+        imageBuild: { ...value.imageBuild, repository: "ghcr.io/nvidia/nemoclaw:latest" },
+      }),
+    ).toThrow("image build identity is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkExecutionPlan({
+        ...value,
+        imageBuild: {
+          ...value.imageBuild,
+          platform: { ...value.imageBuild.platform, cudaArchitectures: "native" },
+        },
+      }),
+    ).toThrow("image build identity is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkExecutionPlan({
+        ...value,
+        recipe: { ...value.recipe, arguments: ["--server-tools", "all"] },
+      }),
+    ).toThrow("unexpected fields");
+  });
+
+  it("rejects unbounded serving values and weakened recipe behavior (#8260)", () => {
+    const value = executionPlan();
+    expect(() =>
+      parseLlamaCppDgxSparkExecutionPlan({
+        ...value,
+        recipe: {
+          ...value.recipe,
+          serve: { ...value.recipe.serve, microBatchSize: 4096 },
+        },
+      }),
+    ).toThrow("micro-batch size is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkExecutionPlan({
+        ...value,
+        recipe: {
+          ...value.recipe,
+          policy: { ...value.recipe.policy, egress: "enabled" },
+        },
+      }),
+    ).toThrow("policy is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkExecutionPlan({
+        ...value,
+        recipe: {
+          ...value.recipe,
+          surfaces: { ...value.recipe.surfaces, serverTools: "enabled" },
+        },
+      }),
+    ).toThrow("surfaces are not disabled");
+  });
+
+  it("accepts one sanitized receipt bound to exact workflow, image, model, and Spark evidence (#8260)", () => {
+    expect(parseLlamaCppDgxSparkQualificationReceipt(receipt(), evidenceIdentity())).toEqual(
+      receipt(),
+    );
+  });
+
+  it("rejects stale workflow identity and extra sensitive receipt fields (#8260)", () => {
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), headSha: "e".repeat(40) },
+        evidenceIdentity(),
+      ),
+    ).toThrow("receipt identity is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), run: { attempt: 3, id: 42 } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("receipt run is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), bearerToken: "secret", prompt: "sensitive" },
+        evidenceIdentity(),
+      ),
+    ).toThrow("unexpected fields");
+  });
+
+  it("rejects mutable, mismatched, or wrong-platform image identity (#8260)", () => {
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        {
+          ...receipt(),
+          image: {
+            ...receipt().image,
+            reference: `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY}:latest`,
+          },
+        },
+        evidenceIdentity(),
+      ),
+    ).toThrow("image identity is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        {
+          ...receipt(),
+          image: { ...receipt().image, digest: `sha256:${"e".repeat(64)}` },
+        },
+        evidenceIdentity(),
+      ),
+    ).toThrow("image identity is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), image: { ...receipt().image, platform: "linux/amd64" } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("image identity is invalid");
+  });
+
+  it("rejects model, GB10, and minimum driver identity drift (#8260)", () => {
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), model: { ...receipt().model, id: "unreviewed/model" } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("model identity is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), host: { ...receipt().host, gpuName: "NVIDIA H100" } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("host identity is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), host: { ...receipt().host, driverVersion: "579.99.99" } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("host identity is invalid");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), host: { ...receipt().host, gpuName: "NVIDIA GB10\nTOKEN=secret" } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("host identity is invalid");
+  });
+
+  it("rejects partial offload, CPU fallback, and CPU warnings (#8260)", () => {
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), execution: { ...receipt().execution, offloadedLayers: 56 } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("did not prove full GPU offload");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), execution: { ...receipt().execution, cpuFallback: true } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("did not prove full GPU offload");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), execution: { ...receipt().execution, cpuWarning: true } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("did not prove full GPU offload");
+  });
+
+  it("rejects failed probes and incomplete cleanup evidence (#8260)", () => {
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        {
+          ...receipt(),
+          probes: { ...receipt().probes, health: { httpStatus: 503, ok: false } },
+        },
+        evidenceIdentity(),
+      ),
+    ).toThrow("probes did not pass");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        {
+          ...receipt(),
+          probes: {
+            ...receipt().probes,
+            completion: { ...receipt().probes.completion, model: "/models/private.gguf" },
+          },
+        },
+        evidenceIdentity(),
+      ),
+    ).toThrow("probes did not pass");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        { ...receipt(), cleanup: { ...receipt().cleanup, credentialsRemoved: false } },
+        evidenceIdentity(),
+      ),
+    ).toThrow("cleanup is incomplete");
+  });
+});

--- a/test/llama-cpp-dgx-spark-qualification-plan.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-plan.test.ts
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { exportLlamaCppDgxSparkQualificationPlan } from "../scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts";
+import {
+  parseLlamaCppDgxSparkExecutionPlan,
+  parseLlamaCppDgxSparkQualificationPlan,
+} from "../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const temporaryRoots: string[] = [];
+
+function candidateRoot(options: { activation?: string; enabled?: boolean } = {}): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-llama-cpp-plan-"));
+  temporaryRoots.push(root);
+  const imageDirectory = path.join(root, "managed-inference", "images", "llama-cpp");
+  const recipeDirectory = path.join(root, "managed-inference", "recipes");
+  fs.mkdirSync(imageDirectory, { recursive: true });
+  fs.mkdirSync(recipeDirectory, { recursive: true });
+
+  let image = fs.readFileSync(
+    path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml"),
+    "utf8",
+  );
+  if (options.enabled) {
+    image = image
+      .replace("      execution: disabled", "      execution: enabled")
+      .replace("      runner: null", "      runner: linux-arm64-gpu-dgx-spark-gb10-protected-1")
+      .replace(
+        "      environment: null",
+        "      environment: approve-dgx-spark-image-qualification",
+      )
+      .replace(
+        "        hostPath: null",
+        "        hostPath: /var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
+      );
+  }
+  fs.writeFileSync(path.join(imageDirectory, "image.yaml"), image);
+  fs.copyFileSync(
+    path.join(
+      repoRoot,
+      "managed-inference",
+      "recipes",
+      "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
+    ),
+    path.join(recipeDirectory, "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml"),
+  );
+  if (options.activation !== undefined) {
+    const activationPath = path.join(root, "ci", "llama-cpp-dgx-spark-qualification-v1.yaml");
+    fs.mkdirSync(path.dirname(activationPath), { recursive: true });
+    fs.writeFileSync(activationPath, options.activation);
+  }
+  return root;
+}
+
+const activation = `contractVersion: 1
+jobId: llama-cpp-dgx-spark-qualification
+platform: linux/arm64
+profile: dgx-spark-gb10-single
+`;
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("llama.cpp DGX Spark qualification plan export", () => {
+  it("exports only an activated, enabled declarative qualification", () => {
+    const output = exportLlamaCppDgxSparkQualificationPlan(
+      candidateRoot({ activation, enabled: true }),
+    );
+
+    expect(output.execution).toBe("enabled");
+    expect(output.runner).toBe("linux-arm64-gpu-dgx-spark-gb10-protected-1");
+    expect(parseLlamaCppDgxSparkQualificationPlan(JSON.parse(output.qualification))).toMatchObject({
+      execution: "enabled",
+      platform: "linux/arm64",
+      profile: "dgx-spark-gb10-single",
+    });
+    expect(
+      parseLlamaCppDgxSparkExecutionPlan(JSON.parse(output.plan), output.plan_sha256),
+    ).toMatchObject({ contractVersion: 1 });
+  });
+
+  it("rejects a dormant image even when an activation file exists", () => {
+    expect(() => exportLlamaCppDgxSparkQualificationPlan(candidateRoot({ activation }))).toThrow(
+      "protected llama.cpp DGX Spark qualification is not enabled",
+    );
+  });
+
+  it("rejects enabled infrastructure without the explicit activation file", () => {
+    expect(() =>
+      exportLlamaCppDgxSparkQualificationPlan(candidateRoot({ enabled: true })),
+    ).toThrow();
+  });
+
+  it("rejects duplicate activation keys", () => {
+    expect(() =>
+      exportLlamaCppDgxSparkQualificationPlan(
+        candidateRoot({
+          activation: `${activation}profile: dgx-spark-gb10-single\n`,
+          enabled: true,
+        }),
+      ),
+    ).toThrow();
+  });
+});

--- a/test/llama-cpp-dgx-spark-qualification-plan.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-plan.test.ts
@@ -24,23 +24,19 @@ function candidateRoot(options: { activation?: string; enabled?: boolean } = {})
   fs.mkdirSync(imageDirectory, { recursive: true });
   fs.mkdirSync(recipeDirectory, { recursive: true });
 
-  let image = fs.readFileSync(
+  const sourceImage = fs.readFileSync(
     path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml"),
     "utf8",
   );
-  if (options.enabled) {
-    image = image
-      .replace("      execution: disabled", "      execution: enabled")
-      .replace("      runner: null", "      runner: linux-arm64-gpu-dgx-spark-gb10-protected-1")
-      .replace(
-        "      environment: null",
-        "      environment: approve-dgx-spark-image-qualification",
-      )
-      .replace(
-        "        hostPath: null",
-        "        hostPath: /var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
-      );
-  }
+  const enabledImage = sourceImage
+    .replace("      execution: disabled", "      execution: enabled")
+    .replace("      runner: null", "      runner: linux-arm64-gpu-dgx-spark-gb10-protected-1")
+    .replace("      environment: null", "      environment: approve-dgx-spark-image-qualification")
+    .replace(
+      "        hostPath: null",
+      "        hostPath: /var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
+    );
+  const image = options.enabled ? enabledImage : sourceImage;
   fs.writeFileSync(path.join(imageDirectory, "image.yaml"), image);
   fs.copyFileSync(
     path.join(
@@ -51,10 +47,10 @@ function candidateRoot(options: { activation?: string; enabled?: boolean } = {})
     ),
     path.join(recipeDirectory, "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml"),
   );
-  if (options.activation !== undefined) {
+  for (const activation of options.activation === undefined ? [] : [options.activation]) {
     const activationPath = path.join(root, "ci", "llama-cpp-dgx-spark-qualification-v1.yaml");
     fs.mkdirSync(path.dirname(activationPath), { recursive: true });
-    fs.writeFileSync(activationPath, options.activation);
+    fs.writeFileSync(activationPath, activation);
   }
   return root;
 }

--- a/test/llama-cpp-dgx-spark-qualification-plan.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-plan.test.ts
@@ -67,7 +67,7 @@ afterEach(() => {
   }
 });
 
-describe("llama.cpp DGX Spark qualification plan export", () => {
+describe("llama.cpp DGX Spark qualification plan export (#8260)", () => {
   it("exports only an activated, enabled declarative qualification", () => {
     const output = exportLlamaCppDgxSparkQualificationPlan(
       candidateRoot({ activation, enabled: true }),

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { loadLlamaCppImageConfig } from "../scripts/checks/export-llama-cpp-image-config.mts";
@@ -14,6 +18,7 @@ import {
   type QualificationInvocation,
   type QualificationPlan,
   sha256Text,
+  validateCandidateDockerfile,
   validateChatCompletionResponse,
   validateModelsResponse,
   validateQualificationPlan,
@@ -27,6 +32,8 @@ const RUN_ID = "42";
 const RUN_ATTEMPT = "2";
 const MODEL_PATH = "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
 const EXPECTED_MODEL = "nvidia-nemotron-3-nano-30b-a3b";
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const trustedImageRoot = path.join(repoRoot, "managed-inference", "images", "llama-cpp");
 
 const config = loadLlamaCppImageConfig();
 const planSource = config.publication_qualification_plan;
@@ -194,7 +201,7 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     }
   });
 
-  it("builds the exact ARM64 candidate into the isolated local registry (#8260)", () => {
+  it("builds the exact ARM64 candidate plan from the trusted image context (#8260)", () => {
     const argv = buildCandidateImageArgv(plan, parsedInvocation(), "/work/tmp/metadata.json");
     expect(valuesAfter(argv, "--platform")).toEqual(["linux/arm64"]);
     expect(valuesAfter(argv, "--tag")).toEqual([
@@ -202,7 +209,9 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     ]);
     expect(argv).toContain("--push");
     expect(argv).not.toContain("--load");
-    expect(argv.at(-1)).toBe("/work/candidate/managed-inference/images/llama-cpp");
+    expect(valuesAfter(argv, "--file")).toEqual([path.join(trustedImageRoot, "Dockerfile")]);
+    expect(argv.at(-1)).toBe(trustedImageRoot);
+    expect(argv).not.toContain("/work/candidate");
     expect(valuesAfter(argv, "--build-arg")).toEqual(
       expect.arrayContaining([
         "CUDA_ARCHITECTURES=121a-real",
@@ -214,6 +223,28 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         "TARGETPLATFORM=linux/arm64",
       ]),
     );
+  });
+
+  it("requires the candidate Dockerfile to byte-match trusted main (#8260)", () => {
+    const candidateRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-llama-cpp-candidate-")),
+    );
+    const candidateImageRoot = path.join(candidateRoot, "managed-inference", "images", "llama-cpp");
+    fs.mkdirSync(candidateImageRoot, { recursive: true });
+    fs.copyFileSync(
+      path.join(trustedImageRoot, "Dockerfile"),
+      path.join(candidateImageRoot, "Dockerfile"),
+    );
+    try {
+      expect(() => validateCandidateDockerfile(candidateRoot)).not.toThrow();
+      fs.appendFileSync(
+        path.join(candidateImageRoot, "Dockerfile"),
+        "\nRUN curl attacker.invalid\n",
+      );
+      expect(() => validateCandidateDockerfile(candidateRoot)).toThrow(/byte-match/u);
+    } finally {
+      fs.rmSync(candidateRoot, { force: true, recursive: true });
+    }
   });
 
   it("constructs a read-only bounded one-GPU server without putting the key on argv (#8260)", () => {
@@ -261,7 +292,6 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     expect(valuesAfter(argv, "--user")).toEqual(["1001:1001"]);
     expect(valuesAfter(argv, "--api-key-file")).toEqual(["/run/secrets/llama-cpp-api-key"]);
     expect(argv).not.toContain("--api-key");
-    expect(argv.join(" ")).not.toContain("raw-secret-value");
     expect(valuesAfter(argv, "--mount")).toEqual([
       `type=bind,source=${MODEL_PATH},target=/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf,readonly`,
       "type=bind,source=/work/tmp/api-key,target=/run/secrets/llama-cpp-api-key,readonly",

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -77,8 +77,8 @@ function invocationArguments() {
 
 function parsedInvocation(): QualificationInvocation {
   const invocation = parseQualificationInvocation(invocationArguments(), trustedEnvironment());
-  if (invocation.cleanupOnly) throw new Error("expected a qualification invocation");
-  return invocation;
+  expect(invocation).toMatchObject({ cleanupOnly: false });
+  return invocation as QualificationInvocation;
 }
 
 function mutatedPlan(mutate: (value: Record<string, any>) => void): [string, string] {

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -1,0 +1,358 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { loadLlamaCppImageConfig } from "../scripts/checks/export-llama-cpp-image-config.mts";
+import {
+  buildCandidateImageArgv,
+  buildServerContainerArgv,
+  expectedRegistryName,
+  expectedRegistryOwner,
+  parseNvidiaSmi,
+  parseQualificationInvocation,
+  type QualificationInvocation,
+  type QualificationPlan,
+  sha256Text,
+  validateChatCompletionResponse,
+  validateModelsResponse,
+  validateQualificationPlan,
+  validateStartupLog,
+} from "../scripts/checks/run-llama-cpp-dgx-spark-qualification.mts";
+
+const BASE_SHA = "b".repeat(40);
+const HEAD_SHA = "a".repeat(40);
+const WORKFLOW_SHA = "c".repeat(40);
+const RUN_ID = "42";
+const RUN_ATTEMPT = "2";
+const MODEL_PATH = "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
+const EXPECTED_MODEL = "nvidia-nemotron-3-nano-30b-a3b";
+
+const config = loadLlamaCppImageConfig();
+const planSource = config.publication_qualification_plan;
+const planDigest = config.publication_qualification_plan_sha256;
+const plan = validateQualificationPlan(planSource, planDigest);
+
+function trustedEnvironment(overrides: Record<string, string | undefined> = {}) {
+  return {
+    GITHUB_ACTOR: "github-actions[bot]",
+    GITHUB_ACTOR_ID: "41898282",
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+    GITHUB_RUN_ATTEMPT: RUN_ATTEMPT,
+    GITHUB_RUN_ID: RUN_ID,
+    GITHUB_SHA: WORKFLOW_SHA,
+    GITHUB_WORKFLOW_REF: "NVIDIA/NemoClaw/.github/workflows/e2e.yaml@refs/heads/main",
+    ...overrides,
+  };
+}
+
+function invocationArguments() {
+  return [
+    "--base-sha",
+    BASE_SHA,
+    "--candidate-root",
+    "/work/candidate",
+    "--head-sha",
+    HEAD_SHA,
+    "--model-host-path",
+    MODEL_PATH,
+    "--output",
+    "/work/artifacts/evidence.json",
+    "--plan",
+    "/work/tmp/plan.json",
+    "--plan-sha256",
+    planDigest,
+    "--registry-name",
+    expectedRegistryName(RUN_ID, RUN_ATTEMPT),
+    "--run-attempt",
+    RUN_ATTEMPT,
+    "--run-id",
+    RUN_ID,
+    "--workflow-sha",
+    WORKFLOW_SHA,
+  ];
+}
+
+function parsedInvocation(): QualificationInvocation {
+  const invocation = parseQualificationInvocation(invocationArguments(), trustedEnvironment());
+  if (invocation.cleanupOnly) throw new Error("expected a qualification invocation");
+  return invocation;
+}
+
+function mutatedPlan(mutate: (value: Record<string, any>) => void): [string, string] {
+  const value = JSON.parse(planSource) as Record<string, any>;
+  mutate(value);
+  const source = JSON.stringify(value);
+  return [source, sha256Text(source)];
+}
+
+function valuesAfter(argv: string[], option: string): string[] {
+  return argv.flatMap((value, index) => (argv[index - 1] === option ? [value] : []));
+}
+
+describe("trusted llama.cpp DGX Spark qualification runner", () => {
+  it("accepts only the canonical digest-bound declarative execution plan (#8260)", () => {
+    expect(plan.contractVersion).toBe(1);
+    expect(plan.recipe.id).toBe("llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1");
+    expect(() => validateQualificationPlan(planSource, `sha256:${"0".repeat(64)}`)).toThrow(
+      /digest mismatch/u,
+    );
+
+    const spaced = `${planSource}\n`;
+    expect(() => validateQualificationPlan(spaced, sha256Text(spaced))).toThrow(/canonical/u);
+
+    for (const mutate of [
+      (value: Record<string, any>) => {
+        value.untrusted = true;
+      },
+      (value: Record<string, any>) => {
+        value.imageBuild.platform.platform = "linux/amd64";
+      },
+      (value: Record<string, any>) => {
+        value.imageBuild.cuda.runtimeBase = "docker.io/nvidia/cuda:latest";
+      },
+      (value: Record<string, any>) => {
+        value.recipe.runtime.gpu.cpuFallback = "allow";
+      },
+      (value: Record<string, any>) => {
+        value.recipe.surfaces.ui = "enabled";
+      },
+    ]) {
+      const [source, digest] = mutatedPlan(mutate);
+      expect(() => validateQualificationPlan(source, digest)).toThrow();
+    }
+  });
+
+  it("binds normal and cleanup invocations to the trusted workflow run (#8260)", () => {
+    expect(parsedInvocation()).toEqual({
+      candidateBase: BASE_SHA,
+      candidateHead: HEAD_SHA,
+      candidateRoot: "/work/candidate",
+      cleanupOnly: false,
+      modelHostPath: MODEL_PATH,
+      output: "/work/artifacts/evidence.json",
+      planFile: "/work/tmp/plan.json",
+      planSha256: planDigest,
+      registryName: expectedRegistryName(RUN_ID, RUN_ATTEMPT),
+      registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
+      runAttempt: RUN_ATTEMPT,
+      runId: RUN_ID,
+      workflowSha: WORKFLOW_SHA,
+    });
+
+    expect(
+      parseQualificationInvocation(
+        [
+          "--cleanup-only",
+          "--registry-name",
+          expectedRegistryName(RUN_ID, RUN_ATTEMPT),
+          "--run-attempt",
+          RUN_ATTEMPT,
+          "--run-id",
+          RUN_ID,
+        ],
+        trustedEnvironment(),
+      ),
+    ).toEqual({
+      cleanupOnly: true,
+      registryName: expectedRegistryName(RUN_ID, RUN_ATTEMPT),
+      registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
+      runAttempt: RUN_ATTEMPT,
+      runId: RUN_ID,
+    });
+  });
+
+  it("rejects hostile CLI fields, paths, ownership, and workflow identity (#8260)", () => {
+    const unknown = [...invocationArguments(), "--extra", "value"];
+    expect(() => parseQualificationInvocation(unknown, trustedEnvironment())).toThrow();
+
+    const duplicate = [...invocationArguments(), "--run-id", RUN_ID];
+    expect(() => parseQualificationInvocation(duplicate, trustedEnvironment())).toThrow();
+
+    const traversal = invocationArguments();
+    traversal[traversal.indexOf("--candidate-root") + 1] = "/work/../candidate";
+    expect(() => parseQualificationInvocation(traversal, trustedEnvironment())).toThrow();
+
+    const wrongRegistry = invocationArguments();
+    wrongRegistry[wrongRegistry.indexOf("--registry-name") + 1] = "nemoclaw-llama-cpp-999-1";
+    expect(() => parseQualificationInvocation(wrongRegistry, trustedEnvironment())).toThrow();
+
+    for (const environment of [
+      trustedEnvironment({ GITHUB_REPOSITORY: "attacker/fork" }),
+      trustedEnvironment({ GITHUB_REF: "refs/pull/1/merge" }),
+      trustedEnvironment({ GITHUB_EVENT_NAME: "pull_request_target" }),
+      trustedEnvironment({ GITHUB_ACTOR: "untrusted-user" }),
+      trustedEnvironment({ GITHUB_RUN_ID: "43" }),
+      trustedEnvironment({ GITHUB_SHA: HEAD_SHA }),
+      trustedEnvironment({
+        GITHUB_WORKFLOW_REF: "NVIDIA/NemoClaw/.github/workflows/e2e.yaml@refs/heads/feature",
+      }),
+    ]) {
+      expect(() => parseQualificationInvocation(invocationArguments(), environment)).toThrow();
+    }
+  });
+
+  it("builds the exact ARM64 candidate into the isolated local registry (#8260)", () => {
+    const argv = buildCandidateImageArgv(plan, parsedInvocation(), "/work/tmp/metadata.json");
+    expect(valuesAfter(argv, "--platform")).toEqual(["linux/arm64"]);
+    expect(valuesAfter(argv, "--tag")).toEqual([
+      `localhost:5000/nemoclaw-llama-cpp-dgx-spark/llama-cpp-server:${HEAD_SHA}`,
+    ]);
+    expect(argv).toContain("--push");
+    expect(argv).not.toContain("--load");
+    expect(argv.at(-1)).toBe("/work/candidate/managed-inference/images/llama-cpp");
+    expect(valuesAfter(argv, "--build-arg")).toEqual(
+      expect.arrayContaining([
+        "CUDA_ARCHITECTURES=121a-real",
+        `CUDA_DEV_IMAGE=${plan.imageBuild.cuda.developmentBase}`,
+        `CUDA_RUNTIME_IMAGE=${plan.imageBuild.cuda.runtimeBase}`,
+        `LLAMA_CPP_ARCHIVE_SHA256=${plan.imageBuild.source.archiveSha256}`,
+        `LLAMA_CPP_REVISION=${plan.imageBuild.source.revision}`,
+        `NEMOCLAW_REVISION=${HEAD_SHA}`,
+        "TARGETPLATFORM=linux/arm64",
+      ]),
+    );
+  });
+
+  it("constructs a read-only bounded one-GPU server without putting the key on argv (#8260)", () => {
+    const argv = buildServerContainerArgv(plan, {
+      apiKeyHostPath: "/work/tmp/api-key",
+      containerName: "qualified-server",
+      imageReference: `localhost:5000/repo@sha256:${"d".repeat(64)}`,
+      modelHostPath: MODEL_PATH,
+      networkName: "qualified-internal",
+      registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
+      runtimeGid: 1001,
+      runtimeUid: 1001,
+    });
+    expect(argv).toEqual(
+      expect.arrayContaining([
+        "--read-only",
+        "--cap-drop",
+        "ALL",
+        "no-new-privileges=true",
+        "--gpus",
+        "1",
+        "--gpu-layers",
+        "all",
+        "--ctx-size",
+        String(plan.recipe.serve.contextSize),
+        "--batch-size",
+        String(plan.recipe.serve.batchSize),
+        "--ubatch-size",
+        String(plan.recipe.serve.microBatchSize),
+        "--cache-type-k",
+        plan.recipe.serve.kvCache.key,
+        "--cache-type-v",
+        plan.recipe.serve.kvCache.value,
+        "--flash-attn",
+        "on",
+        "--metrics",
+        "--no-ui",
+        "--no-slots",
+        "--no-mmproj",
+        "--no-agent",
+      ]),
+    );
+    expect(valuesAfter(argv, "--publish")).toEqual(["127.0.0.1::8081"]);
+    expect(valuesAfter(argv, "--network")).toEqual(["qualified-internal"]);
+    expect(valuesAfter(argv, "--user")).toEqual(["1001:1001"]);
+    expect(valuesAfter(argv, "--api-key-file")).toEqual(["/run/secrets/llama-cpp-api-key"]);
+    expect(argv).not.toContain("--api-key");
+    expect(argv.join(" ")).not.toContain("raw-secret-value");
+    expect(valuesAfter(argv, "--mount")).toEqual([
+      `type=bind,source=${MODEL_PATH},target=/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf,readonly`,
+      "type=bind,source=/work/tmp/api-key,target=/run/secrets/llama-cpp-api-key,readonly",
+    ]);
+    expect(valuesAfter(argv, "--memory")).toEqual([
+      `${plan.recipe.runtime.resources.memoryBytes}b`,
+    ]);
+    expect(valuesAfter(argv, "--memory-swap")).toEqual([
+      `${plan.recipe.runtime.resources.memoryBytes}b`,
+    ]);
+    expect(valuesAfter(argv, "--pids-limit")).toEqual([
+      String(plan.recipe.runtime.resources.pidsLimit),
+    ]);
+    expect(valuesAfter(argv, "--tmpfs")).toEqual([
+      `/tmp:rw,noexec,nosuid,nodev,size=${plan.recipe.runtime.resources.writableStorageBytes},uid=1001,gid=1001,mode=1777`,
+    ]);
+    expect(() =>
+      buildServerContainerArgv(plan, {
+        apiKeyHostPath: "/work/tmp/api-key",
+        containerName: "qualified-server",
+        imageReference: `localhost:5000/repo@sha256:${"d".repeat(64)}`,
+        modelHostPath: MODEL_PATH,
+        networkName: "qualified-internal",
+        registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
+        runtimeGid: 1001,
+        runtimeUid: 0,
+      }),
+    ).toThrow(/runtime uid/u);
+  });
+
+  it("requires unambiguous full GPU offload and rejects CPU fallback warnings (#8260)", () => {
+    expect(validateStartupLog("llama_model_loader: offloaded 57/57 layers to GPU\n")).toEqual({
+      offloadedLayers: 57,
+      totalLayers: 57,
+    });
+    for (const log of [
+      "llama_model_loader: offloaded 56/57 layers to GPU",
+      "warning: no usable GPU found, --gpu-layers option will be ignored",
+      "CPU fallback enabled\noffloaded 57/57 layers to GPU",
+      "server is listening",
+      "offloaded 57/57 layers to GPU\noffloaded 58/58 layers to GPU",
+    ]) {
+      expect(() => validateStartupLog(log)).toThrow();
+    }
+  });
+
+  it("accepts only one NVIDIA GB10 at or above the declarative driver floor (#8260)", () => {
+    expect(parseNvidiaSmi("NVIDIA GB10, 580.65.06\n", "580.65.06")).toEqual({
+      count: 1,
+      driverVersion: "580.65.06",
+      name: "NVIDIA GB10",
+    });
+    for (const output of [
+      "NVIDIA GB10, 580.65.05",
+      "NVIDIA H100 80GB HBM3, 580.65.06",
+      "NVIDIA GB10, 580.65.06\nNVIDIA GB10, 580.65.06",
+    ]) {
+      expect(() => parseNvidiaSmi(output, "580.65.06")).toThrow();
+    }
+  });
+
+  it("validates exact served-model and authenticated completion response shapes (#8260)", () => {
+    expect(() =>
+      validateModelsResponse({ data: [{ id: EXPECTED_MODEL }], object: "list" }, EXPECTED_MODEL),
+    ).not.toThrow();
+    expect(() =>
+      validateModelsResponse(
+        { data: [{ id: EXPECTED_MODEL }, { id: "unexpected" }], object: "list" },
+        EXPECTED_MODEL,
+      ),
+    ).toThrow();
+
+    expect(() =>
+      validateChatCompletionResponse(
+        {
+          choices: [{ message: { content: "ready", role: "assistant" } }],
+          model: EXPECTED_MODEL,
+          object: "chat.completion",
+        },
+        EXPECTED_MODEL,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateChatCompletionResponse(
+        {
+          choices: [{ message: { content: "ready", role: "assistant" } }],
+          model: "unexpected",
+          object: "chat.completion",
+        },
+        EXPECTED_MODEL,
+      ),
+    ).toThrow();
+  });
+});

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -370,6 +370,40 @@ describe("declarative llama.cpp server image", () => {
     ).toBe(1024);
   });
 
+  it("canonicalizes the protected plan independently of YAML key order (#8260)", () => {
+    const recipeSource = fs.readFileSync(recipePath, "utf8");
+    const reorderedRecipe = YAML.parse(recipeSource) as {
+      spec: { serve: Record<string, unknown> };
+    };
+    reorderedRecipe.spec.serve = Object.fromEntries(
+      Object.entries(reorderedRecipe.spec.serve).reverse(),
+    );
+    const baseline = loadLlamaCppImageConfig(manifestSource, recipeSource);
+    const reordered = loadLlamaCppImageConfig(manifestSource, YAML.stringify(reorderedRecipe));
+
+    expect(reordered.publication_qualification_plan).toBe(baseline.publication_qualification_plan);
+    expect(reordered.publication_qualification_plan_sha256).toBe(
+      baseline.publication_qualification_plan_sha256,
+    );
+  });
+
+  it("rejects YAML parser warnings in image and recipe inputs (#8260)", () => {
+    const recipeSource = fs.readFileSync(recipePath, "utf8");
+
+    expect(() =>
+      loadLlamaCppImageConfig(
+        manifestSource.replace("kind: ServerImageBuild", "kind: !unknown ServerImageBuild"),
+        recipeSource,
+      ),
+    ).toThrow(/Unresolved tag/u);
+    expect(() =>
+      loadLlamaCppImageConfig(
+        manifestSource,
+        recipeSource.replace("kind: ServingRecipe", "kind: !unknown ServingRecipe"),
+      ),
+    ).toThrow(/Unresolved tag/u);
+  });
+
   it.each([
     [
       "an unexpected publication field",

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -64,11 +64,13 @@ type ImageManifest = {
       platforms?: string[];
       qualification?: {
         environment?: string | null;
+        execution?: string;
         gpu?: { cpuFallback?: string; fullOffload?: boolean; vendor?: string };
         model?: { digest?: string; hostPath?: string | null; id?: string };
         platform?: string;
         probes?: string[];
         profile?: string;
+        recipeRef?: string;
         required?: boolean;
         runner?: string | null;
       };
@@ -113,6 +115,7 @@ function parseOutput(value: string): Record<string, string> {
 function enablePublication(source: string): string {
   return source
     .replace("    enabled: false", "    enabled: true")
+    .replace("      execution: disabled", "      execution: enabled")
     .replace("      runner: null", "      runner: linux-arm64-gpu-dgx-spark-gb10-protected-1")
     .replace("      environment: null", "      environment: approve-dgx-spark-image-qualification")
     .replace(
@@ -188,10 +191,29 @@ describe("declarative llama.cpp server image", () => {
     });
     expect(JSON.parse(output.publication_qualification)).toMatchObject({
       environment: null,
+      execution: "disabled",
       model: { hostPath: null },
+      recipeRef: "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
       required: true,
       runner: null,
     });
+    expect(JSON.parse(output.publication_qualification_plan)).toMatchObject({
+      contractVersion: 1,
+      imageBuild: {
+        platform: { cudaArchitectures: "121a-real", platform: "linux/arm64" },
+        source: { revision: manifest.spec?.source?.revision },
+      },
+      recipe: {
+        id: "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
+        model: {
+          id: "unsloth/Nemotron-3-Nano-30B-A3B-GGUF",
+          servedName: "nvidia-nemotron-3-nano-30b-a3b",
+        },
+        runtime: { gpu: { count: 1, cpuFallback: "reject", offload: "full" } },
+      },
+    });
+    expect(output.publication_qualification_plan_sha256).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    expect(output.qualification_execution).toBe("disabled");
   });
 
   it("compiles the fail-closed workflow inputs from YAML (#8231)", () => {
@@ -309,6 +331,7 @@ describe("declarative llama.cpp server image", () => {
     expect(output.publication_enabled).toBe("true");
     expect(JSON.parse(output.publication_qualification)).toMatchObject({
       environment: "approve-dgx-spark-image-qualification",
+      execution: "enabled",
       model: {
         hostPath: "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
       },
@@ -320,6 +343,31 @@ describe("declarative llama.cpp server image", () => {
     const candidate = enablePublication(manifestSource).replace("enabled: true", "enabled: false");
 
     expect(loadLlamaCppImageConfig(candidate).publication_enabled).toBe("false");
+  });
+
+  it("rejects serving-recipe drift before compiling the protected DGX Spark plan (#8260)", () => {
+    const recipeSource = fs.readFileSync(recipePath, "utf8");
+
+    expect(() =>
+      loadLlamaCppImageConfig(
+        manifestSource,
+        recipeSource.replace("offload: full", "offload: partial"),
+      ),
+    ).toThrow();
+    expect(() =>
+      loadLlamaCppImageConfig(
+        manifestSource,
+        recipeSource.replace("batchSize: 2048", "batchSize: 1024"),
+      ),
+    ).not.toThrow();
+    expect(
+      JSON.parse(
+        loadLlamaCppImageConfig(
+          manifestSource,
+          recipeSource.replace("batchSize: 2048", "batchSize: 1024"),
+        ).publication_qualification_plan,
+      ).recipe.serve.batchSize,
+    ).toBe(1024);
   });
 
   it.each([
@@ -390,6 +438,24 @@ describe("declarative llama.cpp server image", () => {
     [
       "optional DGX Spark qualification",
       manifestSource.replace("required: true", "required: false"),
+    ],
+    [
+      "unknown DGX Spark qualification execution",
+      manifestSource.replace("execution: disabled", "execution: automatic"),
+    ],
+    [
+      "duplicate DGX Spark qualification keys",
+      manifestSource.replace(
+        "      execution: disabled",
+        "      execution: disabled\n      execution: disabled",
+      ),
+    ],
+    [
+      "an unbound qualification recipe",
+      manifestSource.replace(
+        "recipeRef: llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
+        "recipeRef: llama-cpp.untrusted.v1",
+      ),
     ],
     ["CPU fallback", manifestSource.replace("cpuFallback: reject", "cpuFallback: allow")],
     ["partial GPU offload", manifestSource.replace("fullOffload: true", "fullOffload: false")],

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -80,7 +80,7 @@ describe("deterministic PR risk plan", () => {
     const second = plan("src/lib/onboard.ts", "src/lib/state/registry.ts");
 
     expect(first).toEqual(second);
-    expect(first.version).toBe(14);
+    expect(first.version).toBe(15);
     expect(first.headSha).toBe(HEAD_SHA);
     expect(first.planHash).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.changedFiles).toEqual(["src/lib/onboard.ts", "src/lib/state/registry.ts"]);
@@ -402,6 +402,29 @@ describe("deterministic PR risk plan", () => {
     expect(
       dormantImplementation.families.some(
         (family) => family.id === "managed-image-protected-runtime",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps protected llama.cpp DGX Spark qualification activation-only until trusted (#8260)", () => {
+    const activation = "ci/llama-cpp-dgx-spark-qualification-v1.yaml";
+    const result = plan(activation);
+    const dormantImplementation = plan(
+      "scripts/checks/run-llama-cpp-dgx-spark-qualification.mts",
+      "test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts",
+    );
+
+    expect(result.families).toContainEqual(
+      expect.objectContaining({
+        id: "llama-cpp-dgx-spark-qualification",
+        matchedFiles: [activation],
+        requiredJobs: ["llama-cpp-dgx-spark-qualification"],
+      }),
+    );
+    expect(riskPlanRequiredJobIds(result)).toEqual(["llama-cpp-dgx-spark-qualification"]);
+    expect(
+      dormantImplementation.families.some(
+        (family) => family.id === "llama-cpp-dgx-spark-qualification",
       ),
     ).toBe(false);
   });

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -26,6 +26,7 @@ const E2E_WORKFLOW_CONTRACTS = [
   "test/e2e/support/hermes-workflow-boundary.test.ts",
   "test/hosted-runner-recovery-workflow.test.ts",
   "test/e2e/support/inference-switch-workflow-boundary.test.ts",
+  "test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts",
   "test/e2e/support/jetson-workflow-boundary.test.ts",
   "test/e2e/support/mcp-workflow-boundary.test.ts",
   "test/e2e/support/mcp-workflow-compatibility.test.ts",

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -483,7 +483,7 @@ export const RISK_RULES: readonly RiskRule[] = [
   {
     id: LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
     summary:
-      "Protected DGX Spark qualification must build and prove the exact owned llama.cpp ARM64 candidate from declarative serving YAML.",
+      "Protected DGX Spark qualification must build and prove the exact NemoClaw-built llama.cpp ARM64 image candidate from declarative serving YAML.",
     tier: 3,
     requiredJobs: [LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID],
     invariants: [

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -18,7 +18,7 @@ const protectedManagedImageContract = (
 const { PROTECTED_MANAGED_IMAGE_ACTIVATION_PATH, PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID } =
   protectedManagedImageContract;
 
-export const RISK_PLAN_VERSION = 14 as const;
+export const RISK_PLAN_VERSION = 15 as const;
 
 export const PR_E2E_TYPED_TARGET_IDS = [
   "ubuntu-repo-cloud-langchain-deepagents-code",
@@ -68,6 +68,8 @@ const HERMES_MANAGED_POLICY_FILES = new Set([
 const MANAGED_IMAGE_PROTECTED_RUNTIME_ACTIVATION =
   "ci/protected-managed-image-runtime-activation-v1.json";
 const MANAGED_IMAGE_PROTECTED_RUNTIME_JOB_ID = "managed-image-protected-runtime" as const;
+const LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION = "ci/llama-cpp-dgx-spark-qualification-v1.yaml";
+const LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID = "llama-cpp-dgx-spark-qualification" as const;
 // The activation-only phase is complete. Any input that can change bytes or
 // startup policy in a shipped managed image must requalify the exact all-agent
 // amd64/arm64 cohort; the positive and adjacent-path cases in
@@ -112,6 +114,7 @@ export type RiskFamilyId =
   | "e2e-control-plane"
   | "managed-image-multiarch"
   | typeof MANAGED_IMAGE_PROTECTED_RUNTIME_JOB_ID
+  | typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID
   | "sandbox-boundary"
   | "focused-e2e";
 
@@ -476,6 +479,22 @@ export const RISK_RULES: readonly RiskRule[] = [
     // activation slice broadens this boundary to runtime inputs after the
     // protected job exists on main and can safely qualify candidate code.
     matches: (file) => file === MANAGED_IMAGE_PROTECTED_RUNTIME_ACTIVATION,
+  },
+  {
+    id: LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    summary:
+      "Protected DGX Spark qualification must build and prove the exact owned llama.cpp ARM64 candidate from declarative serving YAML.",
+    tier: 3,
+    requiredJobs: [LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID],
+    invariants: [
+      "trusted main workflow code compiles candidate YAML and builds the exact PR head without executing candidate workflow code",
+      "one physical NVIDIA DGX Spark proves the exact model digest, image digest, server health, authenticated completion, and full GPU offload",
+      "the isolated registry, server container, network, credential file, and listener are removed before passing evidence is uploaded",
+    ],
+    // The trusted workflow and validators land while dormant. A later YAML-only
+    // activation candidate selects this protected lane after the Spark runner,
+    // approval environment, and verified local model path are provisioned.
+    matches: (file) => file === LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION,
   },
   {
     id: "sandbox-boundary",

--- a/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
+++ b/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
@@ -21,6 +21,7 @@ const PLAN_JOB_ID = "llama-cpp-dgx-spark-plan";
 const SELECTOR = `\${{ contains(format(',{0},', inputs.jobs), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') }}`;
 const QUALIFICATION_SELECTOR = `\${{ (contains(format(',{0},', inputs.jobs), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},')) && needs.${PLAN_JOB_ID}.outputs.execution == 'enabled' }}`;
 const CHECKOUT = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
+const BUILDX = "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c";
 const PREPARE =
   "NVIDIA/NemoClaw/.github/actions/prepare-e2e@f6304bc25fc35bfaa441c8c2fbfee38f72805a75";
 
@@ -158,6 +159,7 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
     planSteps,
     "Checkout exact llama.cpp candidate configuration",
   );
+  if (candidatePlanCheckout?.uses !== CHECKOUT) errors.push(`${PLAN_JOB_ID} must pin checkout`);
   requireValues(errors, `${PLAN_JOB_ID} candidate checkout`, record(candidatePlanCheckout?.with), {
     repository: "${{ inputs.checkout_repository || github.repository }}",
     ref: "${{ inputs.checkout_sha || github.sha }}",
@@ -218,6 +220,8 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
     RELEASE_E2E_ACTIVATION_PATH: LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
     NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha }}",
     NEMOCLAW_LLAMA_CPP_QUALIFICATION_BASE_SHA: "${{ inputs.base_sha }}",
+    NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN:
+      "${{ github.workspace }}/.llama-cpp-qualification/plan.json",
     NEMOCLAW_LLAMA_CPP_QUALIFICATION_WORKFLOW_SHA: "${{ inputs.workflow_sha }}",
     NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN_SHA256: `\${{ needs.${PLAN_JOB_ID}.outputs.plan_sha256 }}`,
   });
@@ -255,6 +259,9 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
     qualificationSteps,
     "Checkout trusted llama.cpp qualification",
   );
+  if (trustedCheckout?.uses !== CHECKOUT) {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must pin trusted checkout`);
+  }
   requireValues(errors, "trusted llama.cpp qualification checkout", record(trustedCheckout?.with), {
     repository: "${{ github.repository }}",
     ref: "${{ inputs.workflow_sha }}",
@@ -267,6 +274,9 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
     qualificationSteps,
     "Checkout exact llama.cpp qualification candidate",
   );
+  if (candidateCheckout?.uses !== CHECKOUT) {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must pin candidate checkout`);
+  }
   requireValues(
     errors,
     "llama.cpp qualification candidate checkout",
@@ -279,6 +289,20 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
       "persist-credentials": false,
     },
   );
+  const buildx = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Set up protected llama.cpp Buildx",
+  );
+  if (buildx?.uses !== BUILDX) {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must pin Buildx setup`);
+  }
+  if (!isDeepStrictEqual(buildx?.with, { driver: "docker" })) {
+    errors.push(
+      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must use the host-network-free Docker driver`,
+    );
+  }
   const prepare = requireStep(
     errors,
     LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
@@ -298,6 +322,7 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
   );
   requireFragments(errors, LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID, materialize, [
     'git -C "$CANDIDATE_ROOT" rev-parse --verify HEAD',
+    'install -d -m 0700 "$(dirname "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN")"',
     "printf '%s' \"$PLAN\"",
     'sha256sum "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN"',
     '"$PLAN_SHA256"',

--- a/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
+++ b/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
@@ -1,0 +1,381 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+} from "../../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
+
+type RecordValue = Record<string, unknown>;
+type WorkflowStep = RecordValue & {
+  env?: RecordValue;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: RecordValue;
+};
+
+const PLAN_JOB_ID = "llama-cpp-dgx-spark-plan";
+const SELECTOR = `\${{ contains(format(',{0},', inputs.jobs), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') }}`;
+const QUALIFICATION_SELECTOR = `\${{ (contains(format(',{0},', inputs.jobs), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},')) && needs.${PLAN_JOB_ID}.outputs.execution == 'enabled' }}`;
+const CHECKOUT = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
+const PREPARE =
+  "NVIDIA/NemoClaw/.github/actions/prepare-e2e@f6304bc25fc35bfaa441c8c2fbfee38f72805a75";
+
+function record(value: unknown): RecordValue {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as RecordValue) : {};
+}
+
+function steps(value: unknown): WorkflowStep[] {
+  return Array.isArray(value) ? (value as WorkflowStep[]) : [];
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function requireStep(
+  errors: string[],
+  jobId: string,
+  workflowSteps: readonly WorkflowStep[],
+  name: string,
+): WorkflowStep | undefined {
+  const matches = workflowSteps.filter((step) => step.name === name);
+  if (matches.length !== 1) errors.push(`${jobId} must define exactly one '${name}' step`);
+  return matches[0];
+}
+
+function requireValues(
+  errors: string[],
+  subject: string,
+  actual: RecordValue,
+  expected: Readonly<Record<string, unknown>>,
+): void {
+  for (const [name, value] of Object.entries(expected)) {
+    if (actual[name] !== value) errors.push(`${subject} must bind ${name} to ${String(value)}`);
+  }
+}
+
+function requireFragments(
+  errors: string[],
+  jobId: string,
+  step: WorkflowStep | undefined,
+  fragments: readonly string[],
+): void {
+  const run = text(step?.run);
+  for (const fragment of fragments) {
+    if (!run.includes(fragment)) {
+      errors.push(`${jobId} step '${step?.name ?? "missing"}' must include ${fragment}`);
+    }
+  }
+}
+
+function requireOrderedSteps(
+  errors: string[],
+  jobId: string,
+  workflowSteps: readonly WorkflowStep[],
+  names: readonly string[],
+): void {
+  const indexes = names.map((name) => workflowSteps.findIndex((step) => step.name === name));
+  if (indexes.some((index) => index < 0)) return;
+  if (indexes.some((index, offset) => offset > 0 && index <= indexes[offset - 1])) {
+    errors.push(`${jobId} trusted planning, execution, cleanup, and evidence steps drifted`);
+  }
+}
+
+export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordValue): string[] {
+  const errors: string[] = [];
+  const jobs = record(workflow.jobs);
+  const planJob = record(jobs[PLAN_JOB_ID]);
+  const qualificationJob = record(jobs[LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID]);
+  if (Object.keys(planJob).length === 0) errors.push(`workflow missing ${PLAN_JOB_ID} job`);
+  if (Object.keys(qualificationJob).length === 0) {
+    errors.push(`workflow missing ${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} job`);
+    return errors;
+  }
+
+  if (planJob.needs !== "generate-matrix") {
+    errors.push(`${PLAN_JOB_ID} must depend on generate-matrix`);
+  }
+  if (planJob.if !== SELECTOR) errors.push(`${PLAN_JOB_ID} must remain explicit-only`);
+  if (planJob["runs-on"] !== "ubuntu-24.04") {
+    errors.push(`${PLAN_JOB_ID} must run on a standard trusted planner`);
+  }
+  if (planJob["timeout-minutes"] !== 15) {
+    errors.push(`${PLAN_JOB_ID} must keep the 15 minute timeout`);
+  }
+  if (!isDeepStrictEqual(planJob.permissions, { contents: "read" })) {
+    errors.push(`${PLAN_JOB_ID} permissions must be contents: read`);
+  }
+  const expectedOutputs = Object.fromEntries(
+    [
+      "environment",
+      "execution",
+      "model_host_path",
+      "plan",
+      "plan_sha256",
+      "qualification",
+      "runner",
+    ].map((name) => [name, `\${{ steps.plan.outputs.${name} }}`]),
+  );
+  if (!isDeepStrictEqual(planJob.outputs, expectedOutputs)) {
+    errors.push(`${PLAN_JOB_ID} must expose only validated declarative plan outputs`);
+  }
+
+  const planSteps = steps(planJob.steps);
+  const planGuard = requireStep(
+    errors,
+    PLAN_JOB_ID,
+    planSteps,
+    "Validate trusted llama.cpp plan dispatch",
+  );
+  requireFragments(errors, PLAN_JOB_ID, planGuard, [
+    '"NVIDIA/NemoClaw"',
+    '"refs/heads/main"',
+    '"workflow_dispatch"',
+    '"github-actions[bot]"',
+    '[[ "$CHECKOUT_SHA" =~ ^[a-f0-9]{40}$ && "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]',
+    '"$WORKFLOW_SHA" == "$EXPECTED_WORKFLOW_SHA"',
+  ]);
+  const trustedPlanCheckout = requireStep(
+    errors,
+    PLAN_JOB_ID,
+    planSteps,
+    "Checkout trusted llama.cpp plan compiler",
+  );
+  if (trustedPlanCheckout?.uses !== CHECKOUT) errors.push(`${PLAN_JOB_ID} must pin checkout`);
+  requireValues(errors, `${PLAN_JOB_ID} trusted checkout`, record(trustedPlanCheckout?.with), {
+    repository: "${{ github.repository }}",
+    ref: "${{ inputs.workflow_sha }}",
+    "fetch-depth": 0,
+    "persist-credentials": false,
+  });
+  const candidatePlanCheckout = requireStep(
+    errors,
+    PLAN_JOB_ID,
+    planSteps,
+    "Checkout exact llama.cpp candidate configuration",
+  );
+  requireValues(errors, `${PLAN_JOB_ID} candidate checkout`, record(candidatePlanCheckout?.with), {
+    repository: "${{ inputs.checkout_repository || github.repository }}",
+    ref: "${{ inputs.checkout_sha || github.sha }}",
+    path: ".candidate-llama-cpp",
+    "fetch-depth": 0,
+    "persist-credentials": false,
+  });
+  const compile = requireStep(
+    errors,
+    PLAN_JOB_ID,
+    planSteps,
+    "Compile exact candidate llama.cpp qualification plan",
+  );
+  requireFragments(errors, PLAN_JOB_ID, compile, [
+    'git -C "$CANDIDATE_ROOT" rev-parse --verify HEAD',
+    '"$CHECKOUT_SHA"',
+    "scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts",
+    '--source-root "$CANDIDATE_ROOT"',
+  ]);
+  if (text(compile?.run).includes(".candidate-llama-cpp/scripts")) {
+    errors.push(`${PLAN_JOB_ID} must not execute candidate-controlled scripts`);
+  }
+
+  if (!isDeepStrictEqual(qualificationJob.needs, ["generate-matrix", PLAN_JOB_ID])) {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must depend on the trusted plan`);
+  }
+  if (qualificationJob.if !== QUALIFICATION_SELECTOR) {
+    errors.push(
+      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must require explicit enabled selection`,
+    );
+  }
+  if (qualificationJob["runs-on"] !== `\${{ needs.${PLAN_JOB_ID}.outputs.runner }}`) {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} runner must come from validated YAML`);
+  }
+  if (
+    !isDeepStrictEqual(qualificationJob.environment, {
+      name: `\${{ needs.${PLAN_JOB_ID}.outputs.environment }}`,
+    })
+  ) {
+    errors.push(
+      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} approval environment must come from validated YAML`,
+    );
+  }
+  if (qualificationJob["timeout-minutes"] !== 300) {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must keep the 300 minute timeout`);
+  }
+  if (!isDeepStrictEqual(qualificationJob.permissions, { contents: "read" })) {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} permissions must be contents: read`);
+  }
+  if (qualificationJob["continue-on-error"] !== undefined) {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must not weaken failures`);
+  }
+  const jobEnv = record(qualificationJob.env);
+  requireValues(errors, `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} env`, jobEnv, {
+    E2E_DEFAULT_ENABLED: "0",
+    E2E_JOB: "1",
+    E2E_TARGET_ID: LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    RELEASE_E2E_ACTIVATION_PATH: LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
+    NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha }}",
+    NEMOCLAW_LLAMA_CPP_QUALIFICATION_BASE_SHA: "${{ inputs.base_sha }}",
+    NEMOCLAW_LLAMA_CPP_QUALIFICATION_WORKFLOW_SHA: "${{ inputs.workflow_sha }}",
+    NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN_SHA256: `\${{ needs.${PLAN_JOB_ID}.outputs.plan_sha256 }}`,
+  });
+  for (const secret of [
+    "DOCKERHUB_TOKEN",
+    "DOCKERHUB_USERNAME",
+    "GITHUB_TOKEN",
+    "MODEL_HOST_PATH",
+    "NVIDIA_API_KEY",
+  ]) {
+    if (jobEnv[secret] !== undefined) {
+      errors.push(
+        `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must not expose ${secret} at job scope`,
+      );
+    }
+  }
+
+  const qualificationSteps = steps(qualificationJob.steps);
+  const guard = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Validate protected llama.cpp exact-head dispatch",
+  );
+  requireFragments(errors, LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID, guard, [
+    '"NVIDIA/NemoClaw"',
+    '"refs/heads/main"',
+    '"github-actions[bot]"',
+    '"$WORKFLOW_SHA" == "$EXPECTED_WORKFLOW_SHA"',
+    '"$RUNNER_ARCH_KIND" == "ARM64"',
+  ]);
+  const trustedCheckout = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Checkout trusted llama.cpp qualification",
+  );
+  requireValues(errors, "trusted llama.cpp qualification checkout", record(trustedCheckout?.with), {
+    repository: "${{ github.repository }}",
+    ref: "${{ inputs.workflow_sha }}",
+    "fetch-depth": 0,
+    "persist-credentials": false,
+  });
+  const candidateCheckout = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Checkout exact llama.cpp qualification candidate",
+  );
+  requireValues(
+    errors,
+    "llama.cpp qualification candidate checkout",
+    record(candidateCheckout?.with),
+    {
+      repository: "${{ inputs.checkout_repository || github.repository }}",
+      ref: "${{ inputs.checkout_sha || github.sha }}",
+      path: ".candidate-llama-cpp",
+      "fetch-depth": 0,
+      "persist-credentials": false,
+    },
+  );
+  const prepare = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Prepare E2E workspace",
+  );
+  if (prepare?.uses !== PREPARE || !isDeepStrictEqual(prepare.with, { "build-cli": "false" })) {
+    errors.push(
+      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must use trusted no-build preparation`,
+    );
+  }
+  const materialize = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Materialize trusted llama.cpp qualification plan",
+  );
+  requireFragments(errors, LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID, materialize, [
+    'git -C "$CANDIDATE_ROOT" rev-parse --verify HEAD',
+    "printf '%s' \"$PLAN\"",
+    'sha256sum "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN"',
+    '"$PLAN_SHA256"',
+  ]);
+  const qualify = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Build and qualify exact llama.cpp candidate",
+  );
+  requireValues(errors, "llama.cpp qualification step env", record(qualify?.env), {
+    BASE_SHA: "${{ inputs.base_sha }}",
+    CANDIDATE_ROOT: "${{ github.workspace }}/.candidate-llama-cpp",
+    CHECKOUT_SHA: "${{ inputs.checkout_sha }}",
+    MODEL_HOST_PATH: `\${{ needs.${PLAN_JOB_ID}.outputs.model_host_path }}`,
+    WORKFLOW_SHA: "${{ inputs.workflow_sha }}",
+  });
+  requireFragments(errors, LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID, qualify, [
+    'git rev-parse --verify HEAD)" == "$WORKFLOW_SHA"',
+    "scripts/checks/run-llama-cpp-dgx-spark-qualification.mts",
+    '--candidate-root "$CANDIDATE_ROOT"',
+    '--model-host-path "$MODEL_HOST_PATH"',
+    '--plan-sha256 "$NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN_SHA256"',
+    '--workflow-sha "$WORKFLOW_SHA"',
+  ]);
+  if (text(qualify?.run).includes(".candidate-llama-cpp/scripts")) {
+    errors.push(
+      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must execute only trusted helper code`,
+    );
+  }
+  const cleanup = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Remove protected llama.cpp qualification resources",
+  );
+  if (cleanup?.if !== "always()") {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} cleanup must always run`);
+  }
+  requireFragments(errors, LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID, cleanup, [
+    "run-llama-cpp-dgx-spark-qualification.mts",
+    "--cleanup-only",
+    '"$NEMOCLAW_LLAMA_CPP_QUALIFICATION_REGISTRY"',
+  ]);
+  const evidence = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Validate protected llama.cpp evidence",
+  );
+  requireFragments(errors, LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID, evidence, [
+    "tools/e2e/live-vitest-invocation.mts run",
+    "--test-path test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts",
+  ]);
+  const upload = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Upload protected llama.cpp evidence",
+  );
+  if (upload?.if !== "always()") {
+    errors.push(`${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} evidence upload must always run`);
+  }
+  requireValues(errors, "llama.cpp qualification evidence upload", record(upload?.with), {
+    name: "e2e-llama-cpp-dgx-spark-qualification",
+    path: "e2e-artifacts/live/llama-cpp-dgx-spark-qualification/",
+  });
+  requireOrderedSteps(errors, LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID, qualificationSteps, [
+    "Validate protected llama.cpp exact-head dispatch",
+    "Checkout trusted llama.cpp qualification",
+    "Checkout exact llama.cpp qualification candidate",
+    "Prepare E2E workspace",
+    "Materialize trusted llama.cpp qualification plan",
+    "Build and qualify exact llama.cpp candidate",
+    "Remove protected llama.cpp qualification resources",
+    "Validate protected llama.cpp evidence",
+    "Upload protected llama.cpp evidence",
+    "Clean up Docker auth",
+  ]);
+  return errors;
+}

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -424,12 +424,24 @@ function validatePrGateDispatch(errors: string[], workflow: OperationsWorkflow):
         step.name === "Checkout trusted protected runtime qualification" &&
         step.with?.repository === "${{ github.repository }}" &&
         step.with?.ref === "${{ inputs.workflow_sha }}";
+      const trustedLlamaCppPlanCheckout =
+        jobName === "llama-cpp-dgx-spark-plan" &&
+        step.name === "Checkout trusted llama.cpp plan compiler" &&
+        step.with?.repository === "${{ github.repository }}" &&
+        step.with?.ref === "${{ inputs.workflow_sha }}";
+      const trustedLlamaCppQualificationCheckout =
+        jobName === "llama-cpp-dgx-spark-qualification" &&
+        step.name === "Checkout trusted llama.cpp qualification" &&
+        step.with?.repository === "${{ github.repository }}" &&
+        step.with?.ref === "${{ inputs.workflow_sha }}";
       const trustedCheckout =
         trustedHermesFixtureCheckout ||
         trustedReportHelperCheckout ||
         trustedLaunchableLaneCheckout ||
         trustedPublicationCheckout ||
-        trustedManagedImageRuntimeCheckout;
+        trustedManagedImageRuntimeCheckout ||
+        trustedLlamaCppPlanCheckout ||
+        trustedLlamaCppQualificationCheckout;
       if (
         step.uses?.startsWith("actions/checkout@") &&
         step.with?.ref !== "${{ inputs.checkout_sha || github.sha }}" &&

--- a/tools/e2e/prepare-e2e-workflow-boundary.mts
+++ b/tools/e2e/prepare-e2e-workflow-boundary.mts
@@ -27,6 +27,7 @@ const RETIRED_SELECTOR_COMPATIBILITY_JOB = "retired-selector-compatibility";
 const NO_BUILD_JOBS = new Set([
   "generate-matrix",
   "bootstrap-install-smoke",
+  "llama-cpp-dgx-spark-qualification",
   "managed-image-multiarch-startup",
   "ollama-auth-proxy",
   "security-posture",

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -158,6 +158,13 @@ const EXPLICIT_UPLOAD_CONTRACTS = new Map<string, ExplicitUploadContract>([
     },
   ],
   [
+    "llama-cpp-dgx-spark-qualification",
+    {
+      name: "e2e-llama-cpp-dgx-spark-qualification",
+      path: "e2e-artifacts/live/llama-cpp-dgx-spark-qualification/",
+    },
+  ],
+  [
     "network-policy",
     {
       name: "e2e-network-policy-${{ matrix.scenario }}",

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -26,6 +26,7 @@ import {
   type InferenceSwitchWorkflow,
   validateInferenceSwitchWorkflow,
 } from "./inference-switch-workflow-boundary.mts";
+import { validateLlamaCppDgxSparkQualificationWorkflow } from "./llama-cpp-dgx-spark-qualification-workflow-boundary.mts";
 import { validateManagedImageMultiarchWorkflow } from "./managed-image-multiarch-workflow-boundary.mts";
 import { validateManagedImageProtectedRuntimeWorkflow } from "./managed-image-protected-runtime-workflow-boundary.mts";
 import {
@@ -157,6 +158,7 @@ const COMMON_SECRET_ENV_NAMES = [
 const FREE_STANDING_SELECTOR_SPECIAL_CASES = new Set([
   "hermes-e2e",
   "hermes-gpu-startup",
+  "llama-cpp-dgx-spark-qualification",
   "openshell-credential-generation-window",
   "staging-brev-launchable",
 ]);
@@ -2493,11 +2495,15 @@ function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): 
     }
     requireCanonicalDockerHubCleanupRun(errors, jobName, cleanup);
 
-    const checkoutIndex = steps.findIndex((step) =>
-      jobName === "managed-image-protected-runtime"
-        ? step.name === "Checkout exact protected runtime candidate source"
-        : stringValue(step.uses).startsWith("actions/checkout@"),
-    );
+    const checkoutIndex = steps.findIndex((step) => {
+      if (jobName === "managed-image-protected-runtime") {
+        return step.name === "Checkout exact protected runtime candidate source";
+      }
+      if (jobName === "llama-cpp-dgx-spark-qualification") {
+        return step.name === "Checkout exact llama.cpp qualification candidate";
+      }
+      return stringValue(step.uses).startsWith("actions/checkout@");
+    });
     const authIndex = steps.indexOf(auth);
     const cleanupIndex = steps.indexOf(cleanup);
     const expectedAuthIndex =
@@ -4241,6 +4247,7 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
   errors.push(...validateHermesDashboardWorkflow(workflow as unknown as HermesDashboardWorkflow));
   errors.push(...validateHermesGpuStartupWorkflow(workflow));
   errors.push(...validateInferenceSwitchWorkflow(workflow as unknown as InferenceSwitchWorkflow));
+  errors.push(...validateLlamaCppDgxSparkQualificationWorkflow(workflow));
   errors.push(...validateManagedImageMultiarchWorkflow(workflow));
   errors.push(...validateManagedImageProtectedRuntimeWorkflow(workflow));
   errors.push(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds a dormant, protected qualification lane that can prove an exact NemoClaw-built llama.cpp ARM64 image candidate on one NVIDIA DGX Spark. The lane remains disabled until a follow-up YAML-only activation supplies the protected runner, approval environment, and verified local model path.

## Related Issue

Part of #8260

## Changes

- Compile the candidate image manifest and Spark serving recipe into a strict, hashed execution plan using trusted `main` code. A direct dynamic workflow binding is insufficient because candidate-controlled runner, environment, model-path, and command data must be rejected before protected work is scheduled; contract and plan-export tests cover the boundary.
- Add a trusted qualification runner that builds the exact candidate plan from the trusted `main` Dockerfile and context in an isolated localhost registry. The candidate Dockerfile must byte-match trusted `main`, Buildx cannot use host networking, and the runner verifies the pinned Nemotron GGUF, non-root one-GPU execution without egress, authenticated Chat Completions, full GPU-layer offload on NVIDIA GB10, and sanitized cleanup evidence.
- Add an explicit-only trusted plan job and protected DGX Spark job to E2E, with activation-only risk selection and workflow-boundary tests. The current manifest keeps execution disabled and publication false, so this PR does not schedule the protected job or change a supported serving default.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The protected lane is dormant; publication remains false, execution remains disabled, protected infrastructure remains unset, and supported onboarding, serving defaults, aliases, and operator procedures do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-approved scope is recorded in #8260. The lane is fail-closed and protected by strict plan, runner, workflow, and hostile-input contract tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Adds a dormant internal CI qualification lane. Execution and publication remain disabled, protected infrastructure inputs remain unset, and no supported recipe, default, CLI, configuration, or onboarding behavior changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b470a752e -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: The 15-file focused Vitest run passed 352 tests. The final hardening suite passed 88/88, including the exact previously failing shard-5 compatibility test. Build, strict typecheck, `npm run validate:pr`, semantic E2E phases, test-title style, and test-size checks pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional, protected llama.cpp qualification workflow for NVIDIA DGX Spark.
  * Validates ARM64 execution, GPU offload, model serving, health checks, authenticated completions, and cleanup.
  * Publishes qualification plans, integrity checks, execution evidence, and downloadable artifacts.
  * Added llama.cpp recipe and qualification settings for DGX Spark.

* **Bug Fixes**
  * Improved validation of qualification configuration, recipe references, serving policies, and publication readiness.

* **Tests**
  * Added comprehensive workflow, configuration, execution, evidence, and failure-path coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->