### PR TITLE
fix(onboard): gate the legacy gateway destroy verb on installed OpenShell support

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -55,7 +55,7 @@
   },
   "allowedCycles": [],
   "maxRootFiles": {
-    "src/lib/onboard": 310,
+    "src/lib/onboard": 311,
     "src/lib/actions": 19,
     "src/lib/actions/sandbox": 183,
     "src/lib/state": 37,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1326,11 +1326,8 @@ function destroyGateway(
 
 const handleFinalGatewayStartFailure = createFinalGatewayStartFailureHandler({
   getGatewayName: () => GATEWAY_NAME,
-  collectDiagnostics: () =>
-    runCaptureOpenshell(["doctor", "logs", "--name", GATEWAY_NAME], {
-      ignoreError: true,
-      timeout: 10_000,
-    }),
+  // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+  collectDiagnostics: () => runCaptureOpenshell(["doctor", "logs", "--name", GATEWAY_NAME], { ignoreError: true, timeout: 10_000 }),
   cleanupGateway: destroyGateway,
   supportsLifecycleCommands: () => gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
 });

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1332,6 +1332,7 @@ const handleFinalGatewayStartFailure = createFinalGatewayStartFailureHandler({
       timeout: 10_000,
     }),
   cleanupGateway: destroyGateway,
+  supportsLifecycleCommands: () => gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
 });
 
 function getGatewayClusterContainerState(): string {

--- a/src/lib/onboard/gateway-gpu-passthrough.test.ts
+++ b/src/lib/onboard/gateway-gpu-passthrough.test.ts
@@ -7,8 +7,13 @@ vi.mock("../adapters/docker", () => ({
   dockerInspect: vi.fn(),
 }));
 
+vi.mock("../state/registry", () => ({
+  listSandboxes: vi.fn(() => ({ sandboxes: [], defaultSandbox: null })),
+}));
+
 import * as docker from "../adapters/docker";
 import type { GatewayReuseState } from "../state/gateway";
+import * as registry from "../state/registry";
 import {
   canRestartCpuOnlyGatewayForGpuIntent,
   decideGatewayGpuReuseForGpuIntent,
@@ -161,5 +166,60 @@ describe("gateway GPU passthrough inspection", () => {
     expect(stopDashboardForwards).not.toHaveBeenCalled();
     expect(retireLegacyGatewayForDockerDriverUpgrade).not.toHaveBeenCalled();
     expect(destroyGatewayRuntimeForGpuReuse).not.toHaveBeenCalled();
+  });
+
+  it("omits the legacy gateway destroy verb from the unreadable-registry hint (#8139)", () => {
+    const runReconcile = (supportsLifecycleCommands: boolean): string[] => {
+      const errors: string[] = [];
+      vi.mocked(docker.dockerInspect).mockReturnValue({
+        pid: 0,
+        output: [null, "[]", ""],
+        stdout: "[]",
+        stderr: "",
+        status: 0,
+        signal: null,
+      });
+      vi.mocked(registry.listSandboxes).mockImplementation(() => {
+        throw new Error("registry unreadable");
+      });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+        errors.push(String(message));
+      });
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+        throw new Error(`exit ${code}`);
+      }) as never);
+
+      try {
+        expect(() =>
+          reconcileGatewayGpuReuseForGpuIntent({
+            gatewayReuseState: healthy,
+            gpuPassthrough: true,
+            gatewayName: "nemoclaw",
+            currentSandboxName: null,
+            recreateSandbox: false,
+            confirmedDockerDriverGateway: false,
+            stopDashboardForwards: vi.fn(),
+            retireLegacyGatewayForDockerDriverUpgrade: vi.fn(),
+            destroyGatewayRuntimeForGpuReuse: vi.fn(),
+            supportsLifecycleCommands,
+          }),
+        ).toThrow(/exit 1/);
+      } finally {
+        errorSpy.mockRestore();
+        exitSpy.mockRestore();
+        // Explicitly restore the shared module mocks for later tests in this file.
+        vi.mocked(registry.listSandboxes).mockReturnValue({ sandboxes: [], defaultSandbox: null });
+        vi.mocked(docker.dockerInspect).mockReset();
+      }
+      return errors;
+    };
+
+    const modern = runReconcile(false).join("\n");
+    expect(modern).toContain("openshell gateway remove nemoclaw");
+    expect(modern).not.toContain("gateway destroy");
+
+    const legacy = runReconcile(true).join("\n");
+    expect(legacy).toContain("openshell gateway remove nemoclaw");
+    expect(legacy).toContain("openshell gateway destroy -g nemoclaw");
   });
 });

--- a/src/lib/onboard/gateway-gpu-passthrough.ts
+++ b/src/lib/onboard/gateway-gpu-passthrough.ts
@@ -221,6 +221,12 @@ export function reconcileGatewayGpuReuseForGpuIntent({
       process.exit(1);
     }
   } else if (gatewayGpuReuseDecision === "abort-with-recovery") {
+    // Defensive uniformity with the sibling call above: this branch is only
+    // reached with a non-empty registeredSandboxNames (abort-with-recovery
+    // implies !cpuOnlyGatewayRestartSafe, which implies names.length > 0), so
+    // gpuPassthroughRecoveryLines always takes its one-sandbox/multi-sandbox
+    // branch here and supportsLifecycleCommands cannot reach the gated
+    // gatewayRemovalHintLines output.
     reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames, {
       supportsLifecycleCommands,
     });

--- a/src/lib/onboard/gateway-gpu-passthrough.ts
+++ b/src/lib/onboard/gateway-gpu-passthrough.ts
@@ -7,6 +7,7 @@ import type { GatewayReuseState } from "../state/gateway";
 import * as registry from "../state/registry";
 import { isLinuxDockerDriverGatewayEnabled } from "./docker-driver-platform";
 import { destroyGatewayForReuse } from "./gateway-cleanup";
+import { gatewayRemovalHintLines } from "./gateway-removal-hint";
 import { reportGpuPassthroughRecovery } from "./gpu-recovery";
 
 export type LegacyGatewayGpuInspection = "gpu-enabled" | "cpu-only" | "not-found" | "unknown";
@@ -30,6 +31,7 @@ export type GatewayGpuReuseReconcileOptions = {
   stopDashboardForwards: () => void;
   retireLegacyGatewayForDockerDriverUpgrade: () => void;
   destroyGatewayRuntimeForGpuReuse: () => boolean;
+  supportsLifecycleCommands?: boolean;
 };
 
 // Docker-driver/package-managed gateways do not expose reusable GPU state
@@ -109,6 +111,7 @@ function reportUnreadableSandboxRegistryForGpuGatewayReuse(
   error: (line: string) => void,
   exit: (code: number) => never,
   gatewayName: string,
+  supportsLifecycleCommands: boolean,
 ): never {
   error("  Existing gateway was started without GPU passthrough.");
   error(
@@ -117,9 +120,9 @@ function reportUnreadableSandboxRegistryForGpuGatewayReuse(
   error(
     "  Fix the registry read error and rerun, or manually verify no sandboxes depend on the gateway before running:",
   );
-  error(`    openshell gateway remove ${gatewayName}`);
-  error("    # For OpenShell releases that still expose lifecycle commands:");
-  error(`    openshell gateway destroy -g ${gatewayName}`);
+  for (const line of gatewayRemovalHintLines(gatewayName, supportsLifecycleCommands)) {
+    error(line);
+  }
   error("    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains");
   error("    nemoclaw onboard --gpu");
   exit(1);
@@ -144,6 +147,7 @@ export function reconcileGatewayGpuReuseForGpuIntent({
   stopDashboardForwards,
   retireLegacyGatewayForDockerDriverUpgrade,
   destroyGatewayRuntimeForGpuReuse,
+  supportsLifecycleCommands = false,
 }: GatewayGpuReuseReconcileOptions): GatewayReuseState {
   if (
     !shouldInspectLegacyGatewayGpuPassthrough(
@@ -174,7 +178,12 @@ export function reconcileGatewayGpuReuseForGpuIntent({
   const registeredSandboxNames =
     legacyGatewayGpuInspection === "cpu-only" ? readRegisteredSandboxNamesForGatewayGpuReuse() : [];
   if (registeredSandboxNames === null) {
-    reportUnreadableSandboxRegistryForGpuGatewayReuse(console.error, process.exit, gatewayName);
+    reportUnreadableSandboxRegistryForGpuGatewayReuse(
+      console.error,
+      process.exit,
+      gatewayName,
+      supportsLifecycleCommands,
+    );
   }
 
   const gatewayGpuReuseDecision = decideGatewayGpuReuseForGpuIntent({
@@ -206,11 +215,15 @@ export function reconcileGatewayGpuReuseForGpuIntent({
       );
     }
     if (gatewayReuseState !== "missing") {
-      reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames);
+      reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames, {
+        supportsLifecycleCommands,
+      });
       process.exit(1);
     }
   } else if (gatewayGpuReuseDecision === "abort-with-recovery") {
-    reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames);
+    reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames, {
+      supportsLifecycleCommands,
+    });
     process.exit(1);
   }
   return gatewayReuseState;

--- a/src/lib/onboard/gateway-removal-hint.test.ts
+++ b/src/lib/onboard/gateway-removal-hint.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { gatewayRemovalHintLines } from "./gateway-removal-hint";
+
+describe("gatewayRemovalHintLines", () => {
+  it("prints only the modern remove verb when the installed OpenShell has no lifecycle commands (#8139)", () => {
+    const lines = gatewayRemovalHintLines("nemoclaw", false);
+
+    expect(lines).toEqual(["    openshell gateway remove nemoclaw"]);
+    expect(lines.join("\n")).not.toContain("gateway destroy");
+  });
+
+  it("omits the legacy destroy verb when support is unknown", () => {
+    expect(gatewayRemovalHintLines("nemoclaw").join("\n")).not.toContain("gateway destroy");
+  });
+
+  it("appends the legacy destroy verb only when the installed OpenShell advertises it", () => {
+    const lines = gatewayRemovalHintLines("nemoclaw", true);
+
+    expect(lines).toEqual([
+      "    openshell gateway remove nemoclaw",
+      "    # For OpenShell releases that still expose lifecycle commands:",
+      "    openshell gateway destroy -g nemoclaw",
+    ]);
+  });
+
+  it("renders the caller's gateway name in every emitted command", () => {
+    const lines = gatewayRemovalHintLines("nemoclaw-8081", true);
+
+    expect(lines).toContain("    openshell gateway remove nemoclaw-8081");
+    expect(lines).toContain("    openshell gateway destroy -g nemoclaw-8081");
+    expect(lines.join("\n")).not.toMatch(/\bnemoclaw\b(?!-8081)/);
+  });
+});

--- a/src/lib/onboard/gateway-removal-hint.test.ts
+++ b/src/lib/onboard/gateway-removal-hint.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 
 import { gatewayRemovalHintLines } from "./gateway-removal-hint";

--- a/src/lib/onboard/gateway-removal-hint.ts
+++ b/src/lib/onboard/gateway-removal-hint.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Renders the manual gateway-removal command block shared by every onboard
  * failure hint.

--- a/src/lib/onboard/gateway-removal-hint.ts
+++ b/src/lib/onboard/gateway-removal-hint.ts
@@ -1,0 +1,28 @@
+/**
+ * Renders the manual gateway-removal command block shared by every onboard
+ * failure hint.
+ *
+ * OpenShell dropped the `gateway destroy` lifecycle verb in 0.0.44; current
+ * builds answer it with `error: unrecognized subcommand 'destroy'` (#8139).
+ * #6570 fixed the destroy-path hint but left the onboard hints printing the
+ * legacy verb behind a prose caveat the reader cannot evaluate, so gate it on
+ * the same capability probe the execution paths already use
+ * (`gatewayCliSupportsLifecycleCommands`).
+ *
+ * `supportsLifecycleCommands` defaults to false so an un-probed caller prints
+ * only the verb that current OpenShell accepts.
+ *
+ * Current consumers: gateway-start-failure.ts, gpu-recovery.ts,
+ * gateway-gpu-passthrough.ts.
+ */
+export function gatewayRemovalHintLines(
+  gatewayName: string,
+  supportsLifecycleCommands = false,
+): string[] {
+  const lines = [`    openshell gateway remove ${gatewayName}`];
+  if (supportsLifecycleCommands) {
+    lines.push("    # For OpenShell releases that still expose lifecycle commands:");
+    lines.push(`    openshell gateway destroy -g ${gatewayName}`);
+  }
+  return lines;
+}

--- a/src/lib/onboard/gateway-start-failure.test.ts
+++ b/src/lib/onboard/gateway-start-failure.test.ts
@@ -125,4 +125,26 @@ describe("createFinalGatewayStartFailureHandler", () => {
     expect(output).not.toContain("fghijklmno");
     expect(output).toMatch(/NVIDIA_API_KEY=ghp_\*+/);
   });
+
+  it("prints the legacy destroy verb from the deps-level supportsLifecycleCommands when no per-call override is given (#8139)", () => {
+    const printed: string[] = [];
+    const handleFailure = createFinalGatewayStartFailureHandler({
+      getGatewayName: () => "nemoclaw-test",
+      collectDiagnostics: () => "",
+      cleanupGateway: vi.fn(),
+      supportsLifecycleCommands: () => true,
+    });
+
+    expect(() =>
+      handleFailure({
+        retries: 0,
+        printError: (message = "") => printed.push(message),
+        exitProcess: (code): never => {
+          throw new Error(`exit ${code}`);
+        },
+      }),
+    ).toThrow("exit 1");
+
+    expect(printed).toContain("    openshell gateway destroy -g nemoclaw-test");
+  });
 });

--- a/src/lib/onboard/gateway-start-failure.ts
+++ b/src/lib/onboard/gateway-start-failure.ts
@@ -4,6 +4,7 @@
 import { compactText } from "../core/url-utils";
 import { redact } from "../security/redact";
 import { classifyGatewayStartFailure } from "../validation";
+import { gatewayRemovalHintLines } from "./gateway-removal-hint";
 
 const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/g;
 
@@ -14,12 +15,14 @@ export type FinalGatewayStartFailureOptions = {
   cleanupGateway?: () => void;
   exitProcess?: (code: number) => never;
   printError?: (message?: string) => void;
+  supportsLifecycleCommands?: () => boolean;
 };
 
 export type FinalGatewayStartFailureDeps = {
   getGatewayName(): string;
   collectDiagnostics(): string | null | undefined;
   cleanupGateway(): void;
+  supportsLifecycleCommands?(): boolean;
 };
 
 export function normalizeGatewayStartError(error: unknown): Error {
@@ -66,6 +69,7 @@ export function createFinalGatewayStartFailureHandler(deps: FinalGatewayStartFai
     cleanupGateway = deps.cleanupGateway,
     exitProcess = (code) => process.exit(code),
     printError = (message = "") => console.error(message),
+    supportsLifecycleCommands = deps.supportsLifecycleCommands ?? (() => false),
   }: FinalGatewayStartFailureOptions): never {
     if (dockerUnreachable) {
       printDockerDaemonRecovery(printError);
@@ -107,9 +111,9 @@ export function createFinalGatewayStartFailureHandler(deps: FinalGatewayStartFai
     printError("    openshell doctor check");
     printError("");
     printError("  If gateway cleanup did not complete, run:");
-    printError(`    openshell gateway remove ${gatewayName}`);
-    printError("    # For OpenShell releases that still expose lifecycle commands:");
-    printError(`    openshell gateway destroy -g ${gatewayName}`);
+    for (const line of gatewayRemovalHintLines(gatewayName, supportsLifecycleCommands())) {
+      printError(line);
+    }
     if (process.platform === "linux") {
       printError(
         "    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains",

--- a/src/lib/onboard/gpu-recovery.test.ts
+++ b/src/lib/onboard/gpu-recovery.test.ts
@@ -27,13 +27,13 @@ describe("gpuPassthroughRecoveryLines", () => {
     expect(joined).toContain("Existing gateway was started without GPU passthrough");
     expect(joined).toContain("attempted safe gateway replacement automatically");
     expect(joined).toContain("openshell gateway remove nemoclaw");
-    expect(joined).toContain("openshell gateway destroy -g nemoclaw");
+    expect(joined).not.toContain("openshell gateway destroy -g nemoclaw");
     expect(joined).toContain("sudo pkill -f openshell-gateway");
     expect(joined).toContain("nemoclaw onboard --gpu");
     expect(joined).not.toContain("nemoclaw uninstall");
     // Must NOT suggest the per-sandbox `nemoclaw <name> destroy` form — there
-    // is nothing to destroy. (`openshell gateway destroy -g` is fine; it's
-    // the legacy gateway-lifecycle verb, not a sandbox destroy.)
+    // is nothing to destroy. The legacy `openshell gateway destroy -g` verb is
+    // also absent: current OpenShell rejects it (#8139).
     expect(joined).not.toMatch(/nemoclaw [a-z-]+ destroy/);
   });
 
@@ -89,6 +89,25 @@ describe("gpuPassthroughRecoveryLines", () => {
     expect(joined).toContain("missing NVIDIA runtime");
     expect(joined).not.toContain("destroy --yes");
     expect(joined).not.toContain("nemoclaw onboard --gpu");
+  });
+
+  it("emits the legacy gateway destroy verb only when the installed OpenShell advertises it (#8139)", () => {
+    const modern = gpuPassthroughRecoveryLines([], { supportsLifecycleCommands: false }).join("\n");
+    expect(modern).toContain("openshell gateway remove nemoclaw");
+    expect(modern).not.toContain("gateway destroy");
+
+    const legacy = gpuPassthroughRecoveryLines([], { supportsLifecycleCommands: true }).join("\n");
+    expect(legacy).toContain("openshell gateway remove nemoclaw");
+    expect(legacy).toContain("openshell gateway destroy -g nemoclaw");
+  });
+
+  it("keeps the legacy verb out of the sandbox-destroy branches regardless of CLI support", () => {
+    for (const names of [["alpha"], ["alpha", "beta"]]) {
+      const joined = gpuPassthroughRecoveryLines(names, {
+        supportsLifecycleCommands: true,
+      }).join("\n");
+      expect(joined).not.toContain("gateway destroy");
+    }
   });
 });
 

--- a/src/lib/onboard/gpu-recovery.ts
+++ b/src/lib/onboard/gpu-recovery.ts
@@ -14,9 +14,11 @@
  */
 
 import * as registry from "../state/registry";
+import { gatewayRemovalHintLines } from "./gateway-removal-hint";
 
 export type GpuPassthroughRecoveryOptions = {
   missingRuntimePlatform?: "jetson" | null;
+  supportsLifecycleCommands?: boolean;
 };
 
 /**
@@ -53,9 +55,7 @@ export function gpuPassthroughRecoveryLines(
       "  Existing gateway was started without GPU passthrough.",
       "  No sandboxes are registered, so onboard attempted safe gateway replacement automatically.",
       "  If the retry still fails, clear the stale gateway state and re-onboard with GPU enabled:",
-      "    openshell gateway remove nemoclaw",
-      "    # For OpenShell releases that still expose lifecycle commands:",
-      "    openshell gateway destroy -g nemoclaw",
+      ...gatewayRemovalHintLines("nemoclaw", options.supportsLifecycleCommands ?? false),
       "    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains",
       "    nemoclaw onboard --gpu",
     ];

--- a/src/lib/onboard/machine/handlers/gateway.test.ts
+++ b/src/lib/onboard/machine/handlers/gateway.test.ts
@@ -530,6 +530,28 @@ describe("handleGatewayState", () => {
     expect(calls.startGateway).toHaveBeenCalledOnce();
     expect(result.gatewayReuseState).toBe("missing");
   });
+
+  it("forwards the CLI lifecycle-support probe result to the GPU reuse reconciler (#8139)", async () => {
+    const { deps: supportedDeps, calls: supportedCalls } = createDeps({
+      gatewayCliSupportsLifecycleCommands: vi.fn(() => true),
+    });
+
+    await handleGatewayState(baseOptions(supportedDeps, "missing"));
+
+    expect(supportedCalls.reconcileGpu).toHaveBeenCalledWith(
+      expect.objectContaining({ supportsLifecycleCommands: true }),
+    );
+
+    const { deps: unsupportedDeps, calls: unsupportedCalls } = createDeps({
+      gatewayCliSupportsLifecycleCommands: vi.fn(() => false),
+    });
+
+    await handleGatewayState(baseOptions(unsupportedDeps, "missing"));
+
+    expect(unsupportedCalls.reconcileGpu).toHaveBeenCalledWith(
+      expect.objectContaining({ supportsLifecycleCommands: false }),
+    );
+  });
 });
 
 describe("externally supervised gateway lifecycle authority", () => {

--- a/src/lib/onboard/machine/handlers/gateway.ts
+++ b/src/lib/onboard/machine/handlers/gateway.ts
@@ -61,6 +61,7 @@ export interface GatewayStateOptions<Gpu> {
       hostGpuPlatform: NvidiaPlatform | null;
       recreateSandbox: boolean;
       confirmedDockerDriverGateway: boolean;
+      supportsLifecycleCommands: boolean;
       stopDashboardForwards: () => void;
       retireLegacyGatewayForDockerDriverUpgrade: () => void;
       destroyGatewayRuntimeForGpuReuse: () => boolean;
@@ -211,6 +212,7 @@ async function handleGatewayStatePhase<Gpu>({
       deps.isLinuxDockerDriverGatewayEnabled() &&
       gatewayReuseState === "healthy" &&
       !supportsLifecycleCommands,
+    supportsLifecycleCommands,
     stopDashboardForwards: deps.stopAllDashboardForwards,
     retireLegacyGatewayForDockerDriverUpgrade: deps.retireLegacyGatewayForDockerDriverUpgrade,
     destroyGatewayRuntimeForGpuReuse: deps.destroyGatewayRuntimeForGpuReuse,

--- a/test/gateway-final-failure-cleanup.test.ts
+++ b/test/gateway-final-failure-cleanup.test.ts
@@ -56,6 +56,7 @@ describe("final gateway startup failure cleanup", () => {
         printError: (message = "") => {
           errors.push(message);
         },
+        supportsLifecycleCommands: () => false,
       }),
     ).toThrow("exit 1");
 

--- a/test/gateway-final-failure-cleanup.test.ts
+++ b/test/gateway-final-failure-cleanup.test.ts
@@ -9,6 +9,7 @@ type FinalGatewayStartFailureOptions = {
   cleanupGateway?: () => void;
   exitProcess?: (code: number) => never;
   printError?: (message?: string) => void;
+  supportsLifecycleCommands?: () => boolean;
 };
 
 type OnboardGatewayFailureInternals = {
@@ -64,7 +65,7 @@ describe("final gateway startup failure cleanup", () => {
     expect(errors).toContain("    gateway log line");
     expect(errors).toContain("  Cleanup attempted.");
     expect(errors).toContain("    openshell gateway remove nemoclaw");
-    expect(errors).toContain("    openshell gateway destroy -g nemoclaw");
+    expect(errors).not.toContain("    openshell gateway destroy -g nemoclaw");
     if (process.platform === "linux") {
       expect(errors).toContain(
         "    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains",
@@ -109,5 +110,34 @@ describe("final gateway startup failure cleanup", () => {
     expect(errors).toContain("  Diagnostic command attempted before cleanup:");
     expect(errors).toContain("    openshell doctor logs --name nemoclaw");
     expect(errors).toContain("  If gateway cleanup did not complete, run:");
+  });
+
+  it("prints the legacy gateway destroy verb only when the installed OpenShell advertises it (#8139)", () => {
+    const collect = (supportsLifecycleCommands: boolean): string[] => {
+      const errors: string[] = [];
+      expect(() =>
+        handleFinalGatewayStartFailure({
+          retries: 0,
+          collectDiagnostics: () => "",
+          cleanupGateway: () => {},
+          exitProcess: (code: number): never => {
+            throw new Error(`exit ${code}`);
+          },
+          printError: (message = "") => {
+            errors.push(message);
+          },
+          supportsLifecycleCommands: () => supportsLifecycleCommands,
+        }),
+      ).toThrow("exit 1");
+      return errors;
+    };
+
+    const modern = collect(false);
+    expect(modern).toContain("    openshell gateway remove nemoclaw");
+    expect(modern.join("\n")).not.toContain("gateway destroy");
+
+    const legacy = collect(true);
+    expect(legacy).toContain("    openshell gateway remove nemoclaw");
+    expect(legacy).toContain("    openshell gateway destroy -g nemoclaw");
   });
 });

--- a/test/gateway-final-failure-cleanup.test.ts
+++ b/test/gateway-final-failure-cleanup.test.ts
@@ -103,6 +103,7 @@ describe("final gateway startup failure cleanup", () => {
         printError: (message = "") => {
           errors.push(message);
         },
+        supportsLifecycleCommands: () => false,
       }),
     ).toThrow("exit 1");
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Three onboard failure hints printed `openshell gateway destroy -g <name>`, a subcommand current OpenShell rejects with `error: unrecognized subcommand 'destroy'`. Each printed it unconditionally behind a prose caveat an operator reading a failure hint has no way to evaluate. All three now render their command block through a shared helper gated on `gatewayCliSupportsLifecycleCommands`, the probe the gateway *execution* paths already consumed, so the printed commands match the installed OpenShell.

## Related Issue

Fixes #8139

## Changes

- Add `src/lib/onboard/gateway-removal-hint.ts` exporting `gatewayRemovalHintLines(gatewayName, supportsLifecycleCommands)`. This is consolidation, not a new layer: it has three named current consumers, listed in its docblock, that previously duplicated the same three-line block. `src/lib/onboard/gateway-removal-hint.test.ts` protects the contract in both directions.
- Gate the legacy verb in `src/lib/onboard/gateway-start-failure.ts` (gateway fails to start after all retries), `src/lib/onboard/gpu-recovery.ts` (GPU passthrough mismatch, no sandboxes registered), and `src/lib/onboard/gateway-gpu-passthrough.ts` (GPU passthrough mismatch, registry unreadable).
- Thread `supportsLifecycleCommands` from the probe. `src/lib/onboard/machine/handlers/gateway.ts` already computed it for its own use and now forwards it to the reconcile call; `src/lib/onboard.ts` wires it into the start-failure handler. No new probe call is introduced.
- The flag defaults to `false` at every layer, so a caller that has not run the probe prints only the verb current OpenShell accepts. The field on `GatewayGpuReuseReconcileOptions` is optional for the same reason: the other four construction sites keep compiling and passing untouched.
- Retarget three pre-existing assertions that asserted the invalid verb *was* printed. Each retarget is paired with new coverage exercising both the gated and ungated directions, so no test is weakened into a bare negation.
- Bump `src/lib/onboard` in `ci/source-architecture-budget.json` from 310 to 311 for the one new production file.

Known remaining, out of scope: `scripts/install.sh:2428` prints `openshell gateway remove X || openshell gateway destroy -g X`. The `||` makes it self-correcting, so it cannot produce the `unrecognized subcommand` failure this PR fixes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: A documentation writer subagent searched `docs/` and found no page quotes these hint strings. This change alters which commands NemoClaw *prints*, never which it *runs*, so the gateway-teardown prose in `docs/deployment/gateway-lifecycle-authority.mdx` and `docs/reference/commands.mdx` remains accurate.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Requesting maintainer review of the onboarding-path change. No waiver is recorded and none is claimed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Searched `docs/` for `gateway destroy`, `gateway remove`, `lifecycle command`, and `unrecognized subcommand`. No page quotes the onboard-hint strings from the changed files. Checked and confirmed still accurate: `docs/reference/troubleshooting.mdx` GPU-passthrough section (refers generically to "the commands printed by onboarding" without naming verbs); `docs/reference/commands.mdx` and `docs/deployment/gateway-lifecycle-authority.mdx:190` (both describe execution behavior on separate, already-gated paths, not hint strings); two unrelated `openshell gateway remove` snippets in `docs/reference/troubleshooting.mdx` TLS/CoreDNS recovery that never carried the legacy verb. Review was rerun at head `f853cb030` after the growth-guardrail commit; that commit only reformats one line in `src/lib/onboard.ts` with no behavior, string, or interface change.
- Agent: Claude Code
<!-- docs-review-head-sha: f853cb030 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/gateway-removal-hint.test.ts src/lib/onboard/gpu-recovery.test.ts src/lib/onboard/gateway-start-failure.test.ts src/lib/onboard/gateway-gpu-passthrough.test.ts src/lib/onboard/machine/handlers/gateway.test.ts` → 63/63 passing. `npx vitest run --project integration test/gateway-final-failure-cleanup.test.ts` → 3/3 passing. Both rerun after rebasing onto current `origin/main`. `npm run source-shape:check` → exit 0, `source_shape_cases=0`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Azeel Sajjad <aasajjad05@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gateway recovery and failure messages to recommend the modern `gateway remove` command.
  * Legacy `gateway destroy` guidance now appears only when supported by the installed CLI.
  * Improved GPU passthrough recovery and cleanup instructions across supported scenarios.

* **Tests**
  * Added regression coverage for modern and legacy gateway command handling, including unreadable registry and startup failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->