### PR TITLE
feat(onboard): add inactive OpenShell MXC provider

### DIFF
--- a/src/lib/onboard/runtime-provider/contract.ts
+++ b/src/lib/onboard/runtime-provider/contract.ts
@@ -73,8 +73,17 @@ export type RuntimeProviderManagedImageSupport = {
   readonly capabilityContractVersions: readonly number[];
 };
 
+export type RuntimeProviderNativeArtifactSupport = {
+  readonly exactDigestReferences: boolean;
+  readonly platforms: readonly "windows/x64"[];
+  readonly agents: readonly "openclaw"[];
+  readonly contractVersions: readonly number[];
+  readonly startupProfileContractVersions: readonly number[];
+};
+
 export interface RuntimeProviderWorkloadProfile {
   readonly support: RuntimeProviderManagedImageSupport | null;
+  readonly nativeArtifactSupport?: RuntimeProviderNativeArtifactSupport | null;
   readonly hostArchitectures: readonly string[];
   readonly managedImageSelectionPolicy: ManagedImageSelectionPolicy;
   readonly legacyDockerfileBuilds: boolean;

--- a/src/lib/onboard/runtime-provider/docker.ts
+++ b/src/lib/onboard/runtime-provider/docker.ts
@@ -284,6 +284,7 @@ function acceptsReceipt(
 ): boolean {
   if (!receipt) return true;
   if (receipt.kind === "legacy-dockerfile") return profile.legacyDockerfileBuilds;
+  if (receipt.kind === "native-artifact") return false;
   if (receipt.platform === undefined) return false;
   return (
     profile.support !== null &&

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import type { SandboxWorkloadReceipt } from "../../state/registry/types";
+import { cloneSandboxWorkloadReceipt } from "../../state/registry/workload";
+import { encodeManagedStartupProfile } from "../managed-startup/profile";
+import type { NativeArtifactWorkloadReceiptV1 } from "../workload/native-artifact";
+import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "./current";
+import { createDockerRuntimeProviderBundle } from "./docker";
+import { createMxcRuntimeProviderBundle } from "./mxc";
+import {
+  createRuntimeProviderBundleRegistry,
+  RuntimeProviderRegistrationError,
+  requireRuntimeProviderMutationAuthority,
+} from "./registry";
+
+const ENCODED_PROFILE = encodeManagedStartupProfile(managedStartupE2eProfile("openclaw"));
+const PROFILE_SHA256 = createHash("sha256").update(ENCODED_PROFILE, "utf8").digest("hex");
+const NATIVE_RECEIPT = {
+  schemaVersion: 1,
+  kind: "native-artifact",
+  contractVersion: 1,
+  agent: "openclaw",
+  platform: "windows/x64",
+  artifact: {
+    digest: `sha256:${"a".repeat(64)}`,
+    version: "2026.7.1",
+    source: {
+      repository: "NVIDIA/NemoClaw",
+      revision: "b".repeat(40),
+    },
+  },
+  launch: {
+    executable: {
+      relativePath: "node/node.exe",
+      digest: `sha256:${"c".repeat(64)}`,
+    },
+    arguments: ["openclaw.mjs", "gateway"],
+    workingDirectory: ".",
+    environmentNames: ["PATH"],
+  },
+  startupProfileContractVersion: 1,
+  encodedProfile: ENCODED_PROFILE,
+  startupProfileSha256: PROFILE_SHA256,
+  credentialProxyReplayRequired: true,
+  shared: true,
+} as const satisfies NativeArtifactWorkloadReceiptV1;
+
+function candidateBundle() {
+  return createMxcRuntimeProviderBundle({
+    hostFacts: {
+      platform: "win32",
+      nativeArchitecture: "x64",
+      release: "10.0.28000.1836",
+    },
+  });
+}
+
+describe("inactive OpenShell MXC runtime provider", () => {
+  it("registers one identity-consistent candidate without entering production selection (#8178)", () => {
+    const providers = createRuntimeProviderBundleRegistry([["mxc", candidateBundle()]]);
+    const provider = providers.mxc!;
+
+    expect(Object.hasOwn(CURRENT_RUNTIME_PROVIDER_BUNDLES, "mxc")).toBe(false);
+    expect(provider.identity).toMatchObject({ id: "mxc", displayName: "OpenShell MXC" });
+    for (const surface of [
+      "plan",
+      "capabilities",
+      "preflightDoctor",
+      "gateway",
+      "workload",
+      "lifecycle",
+      "mutationAuthority",
+      "bootstrap",
+      "snapshot",
+      "recovery",
+      "cleanup",
+      "containerEngine",
+    ] as const) {
+      expect(provider[surface].providerId, surface).toBe("mxc");
+    }
+  });
+
+  it("accepts only a validated OpenClaw Windows native-artifact receipt (#8178)", () => {
+    const provider = candidateBundle();
+    const cloned = cloneSandboxWorkloadReceipt(NATIVE_RECEIPT);
+    const malformed = {
+      ...NATIVE_RECEIPT,
+      artifact: { ...NATIVE_RECEIPT.artifact, digest: `sha256:${"A".repeat(64)}` },
+    } as unknown as SandboxWorkloadReceipt;
+    const legacy = {
+      schemaVersion: 1,
+      kind: "legacy-dockerfile",
+      reference: null,
+      shared: false,
+    } as const satisfies SandboxWorkloadReceipt;
+
+    expect(cloned).toEqual(NATIVE_RECEIPT);
+    expect(cloned).not.toBe(NATIVE_RECEIPT);
+    expect(provider.workload.acceptsReceipt(cloned)).toBe(true);
+    expect(provider.workload.acceptsReceipt(undefined)).toBe(false);
+    expect(provider.workload.acceptsReceipt(legacy)).toBe(false);
+    expect(provider.workload.acceptsReceipt(malformed)).toBe(false);
+    expect(createDockerRuntimeProviderBundle().workload.acceptsReceipt(cloned)).toBe(false);
+  });
+
+  it("reports candidate host facts without claiming runtime readiness (#8178)", () => {
+    expect(candidateBundle().preflightDoctor.inspectHost()).toEqual({
+      group: "Host",
+      label: "OpenShell MXC process_container candidate",
+      status: "info",
+      detail: "Windows x64 build 28000 meets the inactive host floor.",
+      hint: "MXC remains unavailable until the OpenShell package and live E2E gates pass.",
+    });
+
+    const rejected = createMxcRuntimeProviderBundle({
+      hostFacts: {
+        platform: "linux",
+        nativeArchitecture: "x64",
+        release: "6.6.87.2-microsoft-standard-WSL2",
+      },
+    });
+    expect(rejected.preflightDoctor.inspectHost()).toMatchObject({
+      status: "fail",
+      detail: expect.stringMatching(/WSL is not a native Windows host/u),
+    });
+  });
+
+  it("fails closed for every unqualified mutation and lifecycle surface (#8178)", () => {
+    const provider = candidateBundle();
+
+    expect(provider.capabilities).toMatchObject({
+      hostLocalInference: false,
+      directLifecycle: false,
+      workloadImageCleanup: false,
+    });
+    for (const surface of [
+      provider.lifecycle,
+      provider.mutationAuthority,
+      provider.bootstrap,
+      provider.snapshot,
+      provider.recovery,
+      provider.cleanup,
+      provider.containerEngine,
+    ]) {
+      expect(surface).toMatchObject({ providerId: "mxc", supported: false });
+      expect("reason" in surface ? surface.reason : "").not.toBe("");
+    }
+    expect(provider.preflightDoctor.preflightLifecycle("start", {} as never)).toMatchObject({
+      exitCode: 1,
+      message: expect.stringMatching(/has not passed live E2E/u),
+    });
+    expect(() => requireRuntimeProviderMutationAuthority(provider, "registration")).toThrow(
+      /does not authorize 'registration'/u,
+    );
+  });
+
+  it("rejects a native-artifact profile with an unaccepted agent (#8178)", () => {
+    const provider = candidateBundle();
+    const invalid = {
+      ...provider,
+      workload: {
+        ...provider.workload,
+        profile: {
+          ...provider.workload.profile,
+          nativeArtifactSupport: {
+            ...provider.workload.profile.nativeArtifactSupport!,
+            agents: ["hermes"],
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      createRuntimeProviderBundleRegistry([["mxc", invalid as typeof provider]]),
+    ).toThrow(RuntimeProviderRegistrationError);
+  });
+});

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -1,15 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createHash } from "node:crypto";
-
 import { describe, expect, it } from "vitest";
 
 import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import type { SandboxWorkloadReceipt } from "../../state/registry/types";
 import { cloneSandboxWorkloadReceipt } from "../../state/registry/workload";
 import { encodeManagedStartupProfile } from "../managed-startup/profile";
-import type { NativeArtifactWorkloadReceiptV1 } from "../workload/native-artifact";
+import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "./current";
 import { createDockerRuntimeProviderBundle } from "./docker";
 import { createMxcRuntimeProviderBundle } from "./mxc";
@@ -19,37 +17,9 @@ import {
   requireRuntimeProviderMutationAuthority,
 } from "./registry";
 
-const ENCODED_PROFILE = encodeManagedStartupProfile(managedStartupE2eProfile("openclaw"));
-const PROFILE_SHA256 = createHash("sha256").update(ENCODED_PROFILE, "utf8").digest("hex");
-const NATIVE_RECEIPT = {
-  schemaVersion: 1,
-  kind: "native-artifact",
-  contractVersion: 1,
-  agent: "openclaw",
-  platform: "windows/x64",
-  artifact: {
-    digest: `sha256:${"a".repeat(64)}`,
-    version: "2026.7.1",
-    source: {
-      repository: "NVIDIA/NemoClaw",
-      revision: "b".repeat(40),
-    },
-  },
-  launch: {
-    executable: {
-      relativePath: "node/node.exe",
-      digest: `sha256:${"c".repeat(64)}`,
-    },
-    arguments: ["openclaw.mjs", "gateway"],
-    workingDirectory: ".",
-    environmentNames: ["PATH"],
-  },
-  startupProfileContractVersion: 1,
-  encodedProfile: ENCODED_PROFILE,
-  startupProfileSha256: PROFILE_SHA256,
-  credentialProxyReplayRequired: true,
-  shared: true,
-} as const satisfies NativeArtifactWorkloadReceiptV1;
+const NATIVE_RECEIPT = nativeArtifactWorkloadReceiptFixture(
+  encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
+);
 
 function candidateBundle() {
   return createMxcRuntimeProviderBundle({

--- a/src/lib/onboard/runtime-provider/mxc.ts
+++ b/src/lib/onboard/runtime-provider/mxc.ts
@@ -7,6 +7,7 @@ import {
   type WindowsMxcHostFacts,
 } from "../windows-mxc/host-qualification";
 import {
+  MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
   NATIVE_ARTIFACT_WORKLOAD_AGENT,
   NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
   NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
@@ -24,7 +25,6 @@ export interface MxcRuntimeProviderOptions {
 }
 
 const MXC_PROVIDER_ID = "mxc";
-const STARTUP_PROFILE_CONTRACT_VERSION = 1;
 
 const MXC_NATIVE_ARTIFACT_PROFILE = {
   support: null,
@@ -33,7 +33,7 @@ const MXC_NATIVE_ARTIFACT_PROFILE = {
     platforms: [NATIVE_ARTIFACT_WORKLOAD_PLATFORM],
     agents: [NATIVE_ARTIFACT_WORKLOAD_AGENT],
     contractVersions: [NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION],
-    startupProfileContractVersions: [STARTUP_PROFILE_CONTRACT_VERSION],
+    startupProfileContractVersions: [MANAGED_STARTUP_PROFILE_SCHEMA_VERSION],
   },
   hostArchitectures: ["x64"],
   managedImageSelectionPolicy: "require-managed",

--- a/src/lib/onboard/runtime-provider/mxc.ts
+++ b/src/lib/onboard/runtime-provider/mxc.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SandboxWorkloadReceipt } from "../../state/registry/types";
+import {
+  assessWindowsMxcProcessContainerCandidate,
+  type WindowsMxcHostFacts,
+} from "../windows-mxc/host-qualification";
+import {
+  NATIVE_ARTIFACT_WORKLOAD_AGENT,
+  NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
+  NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
+  parseNativeArtifactWorkloadReceiptV1,
+} from "../workload/native-artifact";
+import {
+  RUNTIME_PROVIDER_BUNDLE_CONTRACT_VERSION,
+  type RuntimeProviderBundle,
+  type RuntimeProviderDoctorCheck,
+  type RuntimeProviderWorkloadProfile,
+} from "./contract";
+
+export interface MxcRuntimeProviderOptions {
+  readonly hostFacts: WindowsMxcHostFacts;
+}
+
+const MXC_PROVIDER_ID = "mxc";
+const STARTUP_PROFILE_CONTRACT_VERSION = 1;
+
+const MXC_NATIVE_ARTIFACT_PROFILE = {
+  support: null,
+  nativeArtifactSupport: {
+    exactDigestReferences: true,
+    platforms: [NATIVE_ARTIFACT_WORKLOAD_PLATFORM],
+    agents: [NATIVE_ARTIFACT_WORKLOAD_AGENT],
+    contractVersions: [NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION],
+    startupProfileContractVersions: [STARTUP_PROFILE_CONTRACT_VERSION],
+  },
+  hostArchitectures: ["x64"],
+  managedImageSelectionPolicy: "require-managed",
+  legacyDockerfileBuilds: false,
+} as const satisfies RuntimeProviderWorkloadProfile;
+
+function unsupported(reason: string) {
+  return { providerId: MXC_PROVIDER_ID, supported: false as const, reason };
+}
+
+function inspectMxcHost(hostFacts: WindowsMxcHostFacts): RuntimeProviderDoctorCheck {
+  const assessment = assessWindowsMxcProcessContainerCandidate(hostFacts);
+  if (assessment.candidate) {
+    return {
+      group: "Host",
+      label: "OpenShell MXC process_container candidate",
+      status: "info",
+      detail: `Windows x64 build ${assessment.windowsBuild} meets the inactive host floor.`,
+      hint: "MXC remains unavailable until the OpenShell package and live E2E gates pass.",
+    };
+  }
+  return {
+    group: "Host",
+    label: "OpenShell MXC process_container candidate",
+    status: "fail",
+    detail: assessment.detail,
+  };
+}
+
+function acceptsNativeArtifactReceipt(receipt: SandboxWorkloadReceipt | undefined): boolean {
+  if (receipt?.kind !== "native-artifact") return false;
+  try {
+    parseNativeArtifactWorkloadReceiptV1(receipt);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Construct the inactive OpenShell MXC provider candidate.
+ *
+ * The bundle is intentionally absent from the production registry. Unsupported
+ * surfaces record the current OpenShell and live-validation dependencies.
+ */
+export function createMxcRuntimeProviderBundle({
+  hostFacts,
+}: MxcRuntimeProviderOptions): RuntimeProviderBundle {
+  const lifecycleReason =
+    "OpenShell MXC process_container lifecycle termination has not passed live E2E.";
+  const cleanupReason =
+    "OpenShell MXC exact workload termination and orphan cleanup are not qualified.";
+  return {
+    identity: {
+      contractVersion: RUNTIME_PROVIDER_BUNDLE_CONTRACT_VERSION,
+      id: MXC_PROVIDER_ID,
+      displayName: "OpenShell MXC",
+    },
+    plan: {
+      providerId: MXC_PROVIDER_ID,
+      supported: true,
+      gatewayLauncher: "openshell",
+    },
+    capabilities: {
+      providerId: MXC_PROVIDER_ID,
+      supported: true,
+      hostLocalInference: false,
+      directLifecycle: false,
+      legacyGatewayContainerInspection: false,
+      workloadImageCleanup: false,
+    },
+    preflightDoctor: {
+      providerId: MXC_PROVIDER_ID,
+      supported: true,
+      inspectHost: () => inspectMxcHost(hostFacts),
+      preflightLifecycle: () => ({ exitCode: 1, message: lifecycleReason }),
+    },
+    gateway: {
+      providerId: MXC_PROVIDER_ID,
+      supported: true,
+      launcher: "openshell",
+      inspectLegacyContainer: false,
+    },
+    workload: {
+      providerId: MXC_PROVIDER_ID,
+      supported: true,
+      profile: MXC_NATIVE_ARTIFACT_PROFILE,
+      acceptsReceipt: acceptsNativeArtifactReceipt,
+    },
+    lifecycle: unsupported(lifecycleReason),
+    mutationAuthority: unsupported(
+      "MXC mutations remain disabled until lifecycle and cleanup pass live E2E.",
+    ),
+    bootstrap: unsupported(
+      "The OpenShell MXC driver does not expose a per-sandbox native artifact launch contract.",
+    ),
+    snapshot: unsupported("OpenShell MXC snapshot and restore are unavailable."),
+    recovery: unsupported(
+      "OpenShell MXC gateway-restart reconciliation and orphan recovery are unavailable.",
+    ),
+    cleanup: unsupported(cleanupReason),
+    containerEngine: unsupported(
+      "MXC has no container-engine operations; OpenShell owns the MXC control plane.",
+    ),
+  };
+}

--- a/src/lib/onboard/runtime-provider/registry.ts
+++ b/src/lib/onboard/runtime-provider/registry.ts
@@ -53,6 +53,8 @@ const CHANNEL_STOP_TRANSPORTS: ReadonlySet<unknown> = new Set<RuntimeProviderCha
 ]);
 const MANAGED_IMAGE_SELECTION_POLICIES = new Set(["prefer-managed", "require-managed"]);
 const MANAGED_IMAGE_PLATFORMS = new Set(["linux/amd64", "linux/arm64"]);
+const NATIVE_ARTIFACT_PLATFORMS = new Set(["windows/x64"]);
+const NATIVE_ARTIFACT_AGENTS = new Set(["openclaw"]);
 const MUTATION_OPERATIONS = new Set<RuntimeProviderMutationOperation>([
   "registration",
   "start",
@@ -224,6 +226,44 @@ function validateWorkloadProfile(providerId: string, surface: Record<string, unk
     throw new RuntimeProviderRegistrationError(
       `workload profile for '${providerId}' has invalid host architectures`,
     );
+  }
+  if (profile.nativeArtifactSupport !== undefined && profile.nativeArtifactSupport !== null) {
+    if (!isPlainRecord(profile.nativeArtifactSupport)) {
+      throw new RuntimeProviderRegistrationError(
+        `workload profile for '${providerId}' has invalid native-artifact support`,
+      );
+    }
+    const nativeSupport = profile.nativeArtifactSupport;
+    if (
+      typeof nativeSupport.exactDigestReferences !== "boolean" ||
+      !Array.isArray(nativeSupport.platforms) ||
+      nativeSupport.platforms.length === 0 ||
+      nativeSupport.platforms.some(
+        (platform) => !NATIVE_ARTIFACT_PLATFORMS.has(String(platform)),
+      ) ||
+      new Set(nativeSupport.platforms).size !== nativeSupport.platforms.length ||
+      !Array.isArray(nativeSupport.agents) ||
+      nativeSupport.agents.length === 0 ||
+      nativeSupport.agents.some((agent) => !NATIVE_ARTIFACT_AGENTS.has(String(agent))) ||
+      new Set(nativeSupport.agents).size !== nativeSupport.agents.length
+    ) {
+      throw new RuntimeProviderRegistrationError(
+        `workload profile for '${providerId}' has invalid native-artifact identity`,
+      );
+    }
+    for (const field of ["contractVersions", "startupProfileContractVersions"] as const) {
+      const versions = nativeSupport[field];
+      if (
+        !Array.isArray(versions) ||
+        versions.length === 0 ||
+        versions.some((version) => !Number.isSafeInteger(version) || Number(version) <= 0) ||
+        new Set(versions).size !== versions.length
+      ) {
+        throw new RuntimeProviderRegistrationError(
+          `workload profile for '${providerId}' has invalid native-artifact ${field}`,
+        );
+      }
+    }
   }
   if (profile.support === null) return;
   if (!isPlainRecord(profile.support)) {

--- a/src/lib/onboard/sandbox-recreate-transaction.test.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import { decisionSelected } from "../state/onboard-checkpoint-decision";
 import { deriveCheckpointFromSession } from "../state/onboard-checkpoint-migrate";
 import type {
@@ -14,6 +15,7 @@ import type {
 } from "../state/onboard-checkpoint-types";
 import { createSession } from "../state/onboard-session";
 import type { SandboxEntry } from "../state/registry";
+import { encodeManagedStartupProfile } from "./managed-startup/profile";
 import { createDockerRuntimeProviderBundle } from "./runtime-provider/docker";
 import { createRuntimeProviderBundleRegistry } from "./runtime-provider/registry";
 import {
@@ -31,6 +33,7 @@ import {
   sandboxRecreateSourceWorkloadEntry,
   selectedGatewayForSandboxRecreate,
 } from "./sandbox-recreate-transaction";
+import { nativeArtifactWorkloadReceiptFixture } from "./workload/native-artifact-test-fixture";
 
 const ISO = "2026-07-27T20:00:00.000Z";
 const TX_ID = "11111111-1111-4111-8111-111111111111";
@@ -181,7 +184,9 @@ describe("sandbox recreate journal", () => {
     ]);
     const replacement: SandboxEntry = {
       ...SOURCE_ENTRY,
-      workload: { kind: "native-artifact", shared: true } as SandboxEntry["workload"],
+      workload: nativeArtifactWorkloadReceiptFixture(
+        encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
+      ),
       lifecycleGeneration: TARGET_GENERATION,
       lifecycleLiveIdentityFingerprint: TARGET_ID,
     };

--- a/src/lib/onboard/sandbox-recreate-transaction.test.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.test.ts
@@ -174,6 +174,38 @@ describe("sandbox recreate journal", () => {
     expect(removeImage).not.toHaveBeenCalled();
   });
 
+  it("removes the owned source image when a native-artifact replacement retains a stale imageTag (#8178)", () => {
+    const removeImage = vi.fn(() => ({ status: 0 }));
+    const runtimeProviders = createRuntimeProviderBundleRegistry([
+      ["docker", createDockerRuntimeProviderBundle({ removeImage })],
+    ]);
+    const replacement: SandboxEntry = {
+      ...SOURCE_ENTRY,
+      workload: { kind: "native-artifact", shared: true } as SandboxEntry["workload"],
+      lifecycleGeneration: TARGET_GENERATION,
+      lifecycleLiveIdentityFingerprint: TARGET_ID,
+    };
+
+    expect(
+      retireReplacedSandboxWorkload(
+        "alpha",
+        TARGET_GENERATION,
+        TARGET_ID,
+        SOURCE_ENTRY,
+        replacement,
+        { runtimeProviders },
+      ),
+    ).toEqual({
+      status: "removed",
+      engineDisplayName: "Docker",
+      reference: SOURCE_ENTRY.imageTag,
+    });
+    expect(removeImage).toHaveBeenCalledExactlyOnceWith(SOURCE_ENTRY.imageTag, {
+      ignoreError: true,
+      timeout: 30_000,
+    });
+  });
+
   it("starts at deleted when the source is already absent", () => {
     const session = createSession({ sandboxName: "alpha" });
 

--- a/src/lib/onboard/sandbox-recreate-transaction.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.ts
@@ -37,7 +37,7 @@ export type ReplacedSandboxWorkloadCleanupResult =
 
 export type ReplacedSandboxSourceEntry = Omit<SandboxEntry, "workload"> & {
   readonly workload?:
-    | Extract<NonNullable<SandboxEntry["workload"]>, { readonly kind: "managed-image" }>
+    | Exclude<NonNullable<SandboxEntry["workload"]>, { readonly kind: "legacy-dockerfile" }>
     | {
         readonly schemaVersion: 1;
         readonly kind: "legacy-dockerfile";
@@ -53,8 +53,12 @@ interface ReplacedSandboxWorkloadCleanupDeps {
 function providerCleanupSource(source: ReplacedSandboxSourceEntry): SandboxEntry {
   const { workload, ...entry } = source;
   if (!workload) return entry;
-  if (workload.kind === "managed-image") return { ...entry, workload };
+  if (workload.kind !== "legacy-dockerfile") return { ...entry, workload };
   return { ...entry, workload: { ...workload, shared: false } };
+}
+
+function workloadReference(workload: SandboxEntry["workload"]): string | null {
+  return !workload || workload.kind === "native-artifact" ? null : workload.reference;
 }
 
 /** Remove an owned source image only after the journaled replacement is registered. */
@@ -104,7 +108,7 @@ export function retireReplacedSandboxWorkload(
   }
   if (
     replacement.imageTag === plan.reference ||
-    replacement.workload?.reference === plan.reference
+    workloadReference(replacement.workload) === plan.reference
   ) {
     return { status: "skipped", reason: "image-reused" };
   }

--- a/src/lib/onboard/sandbox-recreate-transaction.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.ts
@@ -107,7 +107,7 @@ export function retireReplacedSandboxWorkload(
     return { status: "skipped", reason: "authority-unproven" };
   }
   if (
-    replacement.imageTag === plan.reference ||
+    (replacement.workload?.kind !== "native-artifact" && replacement.imageTag === plan.reference) ||
     workloadReference(replacement.workload) === plan.reference
   ) {
     return { status: "skipped", reason: "image-reused" };

--- a/src/lib/onboard/sandbox-workload-authority.test.ts
+++ b/src/lib/onboard/sandbox-workload-authority.test.ts
@@ -19,12 +19,13 @@ import { ManagedWorkloadAuthorityError, readManagedWorkloadAuthority } from "./w
 
 const AGENTS = ["openclaw", "hermes", "langchain-deepagents-code"] as const;
 const PLATFORMS = ["linux/amd64", "linux/arm64"] as const;
+type ManagedWorkloadReceipt = Extract<SandboxWorkloadReceipt, { readonly kind: "managed-image" }>;
 
 function managedReceipt(
   agent: ShippedManagedImageAgent,
   platform: ManagedImagePlatform,
   profileAgent: ShippedManagedImageAgent = agent,
-): Extract<SandboxWorkloadReceipt, { kind: "managed-image" }> {
+): ManagedWorkloadReceipt {
   const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile(profileAgent));
   const digest = agent === "openclaw" ? "a" : agent === "hermes" ? "b" : "c";
   return {
@@ -47,7 +48,7 @@ function managedReceipt(
 function managedEntry(
   agent: ShippedManagedImageAgent,
   platform: ManagedImagePlatform = "linux/amd64",
-  receipt: SandboxWorkloadReceipt = managedReceipt(agent, platform),
+  receipt: ManagedWorkloadReceipt = managedReceipt(agent, platform),
 ): SandboxEntry {
   return {
     name: `authority-${agent}`,
@@ -107,7 +108,7 @@ describe("managed workload authority", () => {
     const { platform: _platform, ...withoutPlatform } = managedReceipt("openclaw", "linux/amd64");
     expect(() =>
       readManagedWorkloadAuthority(
-        managedEntry("openclaw", "linux/amd64", withoutPlatform as SandboxWorkloadReceipt),
+        managedEntry("openclaw", "linux/amd64", withoutPlatform as ManagedWorkloadReceipt),
       ),
     ).toThrow(/does not record an explicit OCI platform/u);
   });
@@ -134,7 +135,7 @@ describe("managed workload authority", () => {
         managedEntry("openclaw", "linux/amd64", {
           ...managedReceipt("openclaw", "linux/amd64"),
           platform: "linux/s390x",
-        } as unknown as SandboxWorkloadReceipt),
+        } as unknown as ManagedWorkloadReceipt),
       ),
     ).toThrow(ManagedWorkloadAuthorityError);
   });

--- a/src/lib/onboard/workload/native-artifact-test-fixture.ts
+++ b/src/lib/onboard/workload/native-artifact-test-fixture.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import {
+  MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
+  NATIVE_ARTIFACT_SOURCE_REPOSITORY,
+  NATIVE_ARTIFACT_WORKLOAD_AGENT,
+  NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
+  NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
+  NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION,
+  type NativeArtifactWorkloadReceiptV1,
+} from "./native-artifact";
+
+export function nativeArtifactWorkloadReceiptFixture(
+  encodedProfile: string,
+): NativeArtifactWorkloadReceiptV1 {
+  return {
+    schemaVersion: NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION,
+    kind: "native-artifact",
+    contractVersion: NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION,
+    agent: NATIVE_ARTIFACT_WORKLOAD_AGENT,
+    platform: NATIVE_ARTIFACT_WORKLOAD_PLATFORM,
+    artifact: {
+      digest: `sha256:${"a".repeat(64)}`,
+      version: "2026.7.1",
+      source: {
+        repository: NATIVE_ARTIFACT_SOURCE_REPOSITORY,
+        revision: "b".repeat(40),
+      },
+    },
+    launch: {
+      executable: {
+        relativePath: "node/node.exe",
+        digest: `sha256:${"c".repeat(64)}`,
+      },
+      arguments: ["openclaw.mjs", "gateway"],
+      workingDirectory: ".",
+      environmentNames: ["PATH"],
+    },
+    startupProfileContractVersion: MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
+    encodedProfile,
+    startupProfileSha256: createHash("sha256").update(encodedProfile, "utf8").digest("hex"),
+    credentialProxyReplayRequired: true,
+    shared: true,
+  };
+}

--- a/src/lib/onboard/workload/native-artifact.ts
+++ b/src/lib/onboard/workload/native-artifact.ts
@@ -9,6 +9,8 @@ import {
   MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
 } from "../managed-startup/profile";
 
+export { MANAGED_STARTUP_PROFILE_SCHEMA_VERSION };
+
 export const NATIVE_ARTIFACT_WORKLOAD_CONTRACT_VERSION = 1 as const;
 export const NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION = 1 as const;
 export const NATIVE_ARTIFACT_WORKLOAD_PLATFORM = "windows/x64" as const;

--- a/src/lib/state/registry/types.ts
+++ b/src/lib/state/registry/types.ts
@@ -4,6 +4,7 @@
 import type { InferenceSelection } from "../../inference/selection";
 import type { WebSearchProvider } from "../../inference/web-search";
 import type { DcodeAutoApprovalMode } from "../../onboard/dcode-auto-approval";
+import type { NativeArtifactWorkloadReceiptV1 } from "../../onboard/workload/native-artifact";
 import type { ToolDisclosure } from "../../tool-disclosure";
 import type { OpenClawImagePluginInstall } from "../openclaw-plugin-restore";
 import type { SandboxMcpState } from "../registry-mcp";
@@ -181,7 +182,8 @@ export type SandboxWorkloadReceipt =
       readonly kind: "legacy-dockerfile";
       readonly reference: string | null;
       readonly shared: false;
-    };
+    }
+  | NativeArtifactWorkloadReceiptV1;
 
 export interface SandboxRegistry {
   sandboxes: Record<string, SandboxEntry>;

--- a/src/lib/state/registry/workload.ts
+++ b/src/lib/state/registry/workload.ts
@@ -10,6 +10,7 @@ import {
   MANAGED_STARTUP_PROFILE_MAX_BYTES,
   MANAGED_STARTUP_PROFILE_MAX_ENCODED_BYTES,
 } from "../../onboard/managed-startup/profile";
+import { parseNativeArtifactWorkloadReceiptV1 } from "../../onboard/workload/native-artifact";
 import type { SandboxWorkloadReceipt } from "./types";
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
@@ -72,6 +73,13 @@ export function cloneSandboxWorkloadReceipt(
   value: SandboxWorkloadReceipt | undefined,
 ): SandboxWorkloadReceipt | undefined {
   if (!value || value.schemaVersion !== 1) return undefined;
+  if (value.kind === "native-artifact") {
+    try {
+      return parseNativeArtifactWorkloadReceiptV1(value);
+    } catch {
+      return undefined;
+    }
+  }
   if (value.kind === "legacy-dockerfile") {
     if (value.shared !== false || (value.reference !== null && !nonEmptyString(value.reference))) {
       return undefined;

--- a/test/helpers/runtime-provider-bundle.ts
+++ b/test/helpers/runtime-provider-bundle.ts
@@ -112,8 +112,18 @@ export function createInMemoryRuntimeProviderBundle({
           ? true
           : receipt.kind === "legacy-dockerfile"
             ? workloadProfile.legacyDockerfileBuilds
-            : receipt.platform !== undefined &&
-              workloadProfile.support?.platforms.includes(receipt.platform) === true;
+            : receipt.kind === "native-artifact"
+              ? workloadProfile.nativeArtifactSupport?.platforms.includes(receipt.platform) ===
+                  true &&
+                workloadProfile.nativeArtifactSupport.agents.includes(receipt.agent) &&
+                workloadProfile.nativeArtifactSupport.contractVersions.includes(
+                  receipt.contractVersion,
+                ) &&
+                workloadProfile.nativeArtifactSupport.startupProfileContractVersions.includes(
+                  receipt.startupProfileContractVersion,
+                )
+              : receipt.platform !== undefined &&
+                workloadProfile.support?.platforms.includes(receipt.platform) === true;
       },
     },
     lifecycle: {

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -154,6 +154,7 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/runtime-provider/contract.ts",
       "src/lib/onboard/runtime-provider/current.ts",
       "src/lib/onboard/runtime-provider/docker.ts",
+      "src/lib/onboard/runtime-provider/mxc.ts",
       "src/lib/onboard/runtime-provider/registry.ts",
       "src/lib/onboard/runtime-provider/snapshot.ts",
     ]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds an inactive OpenShell MXC runtime-provider candidate for native Windows/OpenClaw work. The candidate consumes the merged host-qualification and native-artifact contracts, but remains absent from production selection and fails closed for every unqualified lifecycle or mutation surface.

## Related Issue

Related to #8178.

## Changes

- Extend the provider workload profile and persisted workload receipt to recognize the strict Windows/OpenClaw native-artifact contract from #8243 while making Docker reject that receipt.
- Add one identity-consistent `mxc` provider bundle that reports candidate host facts through #8236 and accepts only validated native-artifact receipts.
- Keep lifecycle, mutation authority, bootstrap, snapshot, recovery, cleanup, and container-engine operations typed as unsupported until the corresponding OpenShell contracts and protected live E2E pass.
- Preserve native-artifact receipts through replacement bookkeeping and add registry, source-boundary, and fail-closed tests. This uses #7744's provider bundle rather than adding MXC branches to central orchestration.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: MXC remains absent from `CURRENT_RUNTIME_PROVIDER_BUNDLES`, has no production import or selection path, and exposes no CLI, configuration, workflow, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head nine-category security review PASS at `8e8a32b73bbc9938018a0980d2a99f0f74720f4e` against base `962f1c3bf3a1354a8cfdc2056e04a27828be0dc0`. The effective binary diff SHA-256 remains `157885993ef0731db6b77653e778b296d1f15b786431b64832e9da4e3aff42ca`, identical to the previously reviewed patch. MXC remains unregistered and unselectable; the strict native-receipt parser and Docker rejection are unchanged; lifecycle and mutation operations fail closed. The merge adds only current-main history outside the effective diff. No secrets, dependencies, network calls, privilege paths, credential handling, authentication, or cryptography changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed exact base `0385c0423125abbb29aa6028877c3e5c34ef8b46` through head `8239b1ad312d3e8278f4945537b6264dba405dc2`. The immutable compare contains 14 source and test files with 469 insertions and 11 deletions; it contains no documentation or Fern files. `CURRENT_RUNTIME_PROVIDER_BUNDLES` still registers only Docker and Kubernetes, so MXC remains unregistered and unselectable. Issue #8178 explicitly sequences #8271 as an inactive provider slice and keeps activation and support documentation gated on later package contracts and protected Windows/MXC/OpenClaw live E2E. Changed comments, diagnostics, and behavior-oriented test titles have no writing findings. No user-facing command, configuration, workflow, default, error, or supported behavior changed. A docs build is not applicable.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8239b1ad312d3e8278f4945537b6264dba405dc2 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70934b540c404d3939e3321f5c7558 -->
## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every published commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact head `8e8a32b73`: 4 focused files and 64 tests passed. `npm run build:cli`, `npm run typecheck:cli`, `npm run validate:pr`, and `git diff --check` passed. The effective patch is byte-identical to the previously reviewed head.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable because the provider is inactive and unregistered; protected CI is authoritative for the complete repository matrix.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
