### PR TITLE
test(inference): allow YAML-only Spark activation

### DIFF
--- a/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
+++ b/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
@@ -33,7 +33,7 @@ function namedStep(value: WorkflowRecord, jobId: string, name: string): Record<s
 }
 
 describe("llama.cpp DGX Spark qualification workflow boundary (#8260)", () => {
-  it("accepts the exact dormant trusted qualification lane", () => {
+  it("accepts the exact trusted qualification lane", () => {
     expect(validateLlamaCppDgxSparkQualificationWorkflow(workflow())).toEqual([]);
   });
 

--- a/test/llama-cpp-dgx-spark-qualification-plan.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-plan.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
+import YAML from "yaml";
 
 import { exportLlamaCppDgxSparkQualificationPlan } from "../scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts";
 import {
@@ -28,15 +29,26 @@ function candidateRoot(options: { activation?: string; enabled?: boolean } = {})
     path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml"),
     "utf8",
   );
-  const enabledImage = sourceImage
-    .replace("      execution: disabled", "      execution: enabled")
-    .replace("      runner: null", "      runner: linux-arm64-gpu-dgx-spark-gb10-protected-1")
-    .replace("      environment: null", "      environment: approve-dgx-spark-image-qualification")
-    .replace(
-      "        hostPath: null",
-      "        hostPath: /var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
-    );
-  const image = options.enabled ? enabledImage : sourceImage;
+  const imageDocument = YAML.parse(sourceImage) as {
+    spec: {
+      publication: {
+        qualification: {
+          environment: string | null;
+          execution: "disabled" | "enabled";
+          model: { hostPath: string | null };
+          runner: string | null;
+        };
+      };
+    };
+  };
+  const qualification = imageDocument.spec.publication.qualification;
+  qualification.execution = options.enabled ? "enabled" : "disabled";
+  qualification.runner = options.enabled ? "linux-arm64-gpu-dgx-spark-gb10-protected-1" : null;
+  qualification.environment = options.enabled ? "approve-dgx-spark-image-qualification" : null;
+  qualification.model.hostPath = options.enabled
+    ? "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf"
+    : null;
+  const image = YAML.stringify(imageDocument);
   fs.writeFileSync(path.join(imageDirectory, "image.yaml"), image);
   fs.copyFileSync(
     path.join(

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -112,16 +112,33 @@ function parseOutput(value: string): Record<string, string> {
   );
 }
 
+function configureQualification(
+  source: string,
+  options: { execution: "disabled" | "enabled"; publicationEnabled: boolean },
+): string {
+  const candidate = YAML.parse(source) as ImageManifest;
+  const publication = candidate.spec?.publication;
+  const qualification = publication?.qualification;
+  const model = qualification?.model;
+  if (!publication || !qualification || !model) {
+    throw new Error("llama.cpp qualification fixture is incomplete");
+  }
+
+  publication.enabled = options.publicationEnabled;
+  qualification.execution = options.execution;
+  qualification.runner =
+    options.execution === "enabled" ? "linux-arm64-gpu-dgx-spark-gb10-protected-1" : null;
+  qualification.environment =
+    options.execution === "enabled" ? "approve-dgx-spark-image-qualification" : null;
+  model.hostPath =
+    options.execution === "enabled"
+      ? "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf"
+      : null;
+  return YAML.stringify(candidate);
+}
+
 function enablePublication(source: string): string {
-  return source
-    .replace("    enabled: false", "    enabled: true")
-    .replace("      execution: disabled", "      execution: enabled")
-    .replace("      runner: null", "      runner: linux-arm64-gpu-dgx-spark-gb10-protected-1")
-    .replace("      environment: null", "      environment: approve-dgx-spark-image-qualification")
-    .replace(
-      "        hostPath: null",
-      "        hostPath: /var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
-    );
+  return configureQualification(source, { execution: "enabled", publicationEnabled: true });
 }
 
 describe("declarative llama.cpp server image", () => {
@@ -178,25 +195,39 @@ describe("declarative llama.cpp server image", () => {
     ]);
   });
 
-  it("keeps publication manual and disabled while protected DGX Spark inputs are unset (#8250)", () => {
+  it("compiles the repository-declared publication and qualification state (#8260)", () => {
     const output = loadLlamaCppImageConfig(manifestSource);
+    const qualification = JSON.parse(output.publication_qualification) as NonNullable<
+      NonNullable<ImageManifest["spec"]>["publication"]
+    >["qualification"];
 
     expect(output).toMatchObject({
       publication_allowed_ref: "refs/heads/main",
       publication_candidate_tag_template: "llama-cpp-candidate-{runId}-{runAttempt}",
-      publication_enabled: "false",
+      publication_enabled: String(manifest.spec?.publication?.enabled),
       publication_platforms: '["linux/amd64","linux/arm64"]',
       publication_repository: "ghcr.io/nvidia/nemoclaw/llama-cpp-server",
       publication_trigger: "workflow_dispatch",
     });
-    expect(JSON.parse(output.publication_qualification)).toMatchObject({
-      environment: null,
-      execution: "disabled",
-      model: { hostPath: null },
+    expect(qualification).toEqual(manifest.spec?.publication?.qualification);
+    expect(qualification).toMatchObject({
       recipeRef: "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
       required: true,
-      runner: null,
     });
+    if (qualification?.execution === "disabled") {
+      expect(qualification).toMatchObject({
+        environment: null,
+        model: { hostPath: null },
+        runner: null,
+      });
+    } else {
+      expect(qualification).toMatchObject({
+        environment: expect.stringMatching(/^approve-dgx-spark-/u),
+        execution: "enabled",
+        model: { hostPath: expect.stringMatching(/^\/.+\.gguf$/u) },
+        runner: expect.stringMatching(/^linux-arm64-gpu-dgx-spark-gb10-/u),
+      });
+    }
     expect(JSON.parse(output.publication_qualification_plan)).toMatchObject({
       contractVersion: 1,
       imageBuild: {
@@ -213,7 +244,7 @@ describe("declarative llama.cpp server image", () => {
       },
     });
     expect(output.publication_qualification_plan_sha256).toMatch(/^sha256:[0-9a-f]{64}$/u);
-    expect(output.qualification_execution).toBe("disabled");
+    expect(output.qualification_execution).toBe(qualification?.execution);
   });
 
   it("compiles the fail-closed workflow inputs from YAML (#8231)", () => {
@@ -340,7 +371,10 @@ describe("declarative llama.cpp server image", () => {
   });
 
   it("keeps publication disabled when complete DGX Spark infrastructure is configured (#8250)", () => {
-    const candidate = enablePublication(manifestSource).replace("enabled: true", "enabled: false");
+    const candidate = configureQualification(manifestSource, {
+      execution: "enabled",
+      publicationEnabled: false,
+    });
 
     expect(loadLlamaCppImageConfig(candidate).publication_enabled).toBe("false");
   });
@@ -475,11 +509,17 @@ describe("declarative llama.cpp server image", () => {
     ],
     [
       "unknown DGX Spark qualification execution",
-      manifestSource.replace("execution: disabled", "execution: automatic"),
+      configureQualification(manifestSource, {
+        execution: "disabled",
+        publicationEnabled: false,
+      }).replace("execution: disabled", "execution: automatic"),
     ],
     [
       "duplicate DGX Spark qualification keys",
-      manifestSource.replace(
+      configureQualification(manifestSource, {
+        execution: "disabled",
+        publicationEnabled: false,
+      }).replace(
         "      execution: disabled",
         "      execution: disabled\n      execution: disabled",
       ),
@@ -495,11 +535,17 @@ describe("declarative llama.cpp server image", () => {
     ["partial GPU offload", manifestSource.replace("fullOffload: true", "fullOffload: false")],
     [
       "partial disabled infrastructure",
-      manifestSource.replace("runner: null", "runner: linux-arm64-gpu-dgx-spark-gb10-protected-1"),
+      configureQualification(manifestSource, {
+        execution: "disabled",
+        publicationEnabled: false,
+      }).replace("runner: null", "runner: linux-arm64-gpu-dgx-spark-gb10-protected-1"),
     ],
     [
       "enablement without infrastructure",
-      manifestSource.replace("enabled: false", "enabled: true"),
+      configureQualification(manifestSource, {
+        execution: "disabled",
+        publicationEnabled: true,
+      }),
     ],
     [
       "enablement on a generic runner",

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -117,12 +117,9 @@ function configureQualification(
   options: { execution: "disabled" | "enabled"; publicationEnabled: boolean },
 ): string {
   const candidate = YAML.parse(source) as ImageManifest;
-  const publication = candidate.spec?.publication;
-  const qualification = publication?.qualification;
-  const model = qualification?.model;
-  if (!publication || !qualification || !model) {
-    throw new Error("llama.cpp qualification fixture is incomplete");
-  }
+  const publication = candidate.spec!.publication!;
+  const qualification = publication.qualification!;
+  const model = qualification.model!;
 
   publication.enabled = options.publicationEnabled;
   qualification.execution = options.execution;
@@ -214,20 +211,6 @@ describe("declarative llama.cpp server image", () => {
       recipeRef: "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
       required: true,
     });
-    if (qualification?.execution === "disabled") {
-      expect(qualification).toMatchObject({
-        environment: null,
-        model: { hostPath: null },
-        runner: null,
-      });
-    } else {
-      expect(qualification).toMatchObject({
-        environment: expect.stringMatching(/^approve-dgx-spark-/u),
-        execution: "enabled",
-        model: { hostPath: expect.stringMatching(/^\/.+\.gguf$/u) },
-        runner: expect.stringMatching(/^linux-arm64-gpu-dgx-spark-gb10-/u),
-      });
-    }
     expect(JSON.parse(output.publication_qualification_plan)).toMatchObject({
       contractVersion: 1,
       imageBuild: {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Prepare the protected llama.cpp DGX Spark qualification tests for a later YAML-only activation. The tests now derive dormant and enabled fixtures from parsed YAML instead of assuming that the repository manifest remains dormant.

## Related Issue

Part of #8260

## Changes

- Construct dormant and enabled qualification fixtures by changing parsed YAML fields. The protected qualification exporter consumes these fixtures, and its existing tests cover both states.
- Validate the publication and qualification state declared by the repository manifest without adding a TypeScript default.
- Remove the dormant-state wording from the workflow-boundary test title because the trusted workflow supports both declared states.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This PR changes deterministic test fixtures only. It does not change production source, repository YAML, workflows, commands, defaults, errors, or supported product behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed the full three-file test diff at `e0e0eaa5b`. The tests remove dormant-state assumptions and construct qualification fixtures through YAML without changing production source, repository-owned YAML, CLI behavior, workflow behavior, defaults, errors, or supported product behavior. No documentation changes are required. Focused tests passed (59/59); Biome and the test-conditionals scan passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e0e0eaa5b -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/llama-cpp-image.test.ts test/llama-cpp-dgx-spark-qualification-plan.test.ts test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts --project integration --project e2e-support` passed 59 tests.
- [ ] Applicable broad gate passed — Not applicable; this PR changes deterministic fixtures in three existing tests and does not change the test harness.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved qualification test coverage by configuring YAML fixtures through structured data.
  * Updated publication checks to validate enabled and disabled qualification states from the manifest.
  * Preserved validation coverage for invalid qualification configurations.
  * Clarified trusted qualification workflow test naming without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->