### PR TITLE
feat(runtime): add dormant Podman CPU lifecycle proof

### DIFF
--- a/.github/workflows/podman-cpu-proof.yaml
+++ b/.github/workflows/podman-cpu-proof.yaml
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Runtime / Podman CPU Proof
+
+run-name: "Podman CPU proof PR #${{ github.event.pull_request.number }} head ${{ github.event.pull_request.head.sha }}"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/podman-cpu-proof.yaml"
+      - "src/lib/adapters/container-engine.ts"
+      - "src/lib/adapters/podman/**"
+      - "src/lib/onboard/runtime-provider/podman*.ts"
+      - "test/e2e/live/podman-cpu-lifecycle.test.ts"
+      - "test/e2e/support/podman-cpu-proof-workflow.test.ts"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  podman-cpu-lifecycle:
+    name: Rootless Podman CPU lifecycle with Docker disabled
+    runs-on: ubuntu-26.04
+    timeout-minutes: 30
+    env:
+      E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/podman-cpu-proof
+      E2E_DEFAULT_ENABLED: "0"
+      E2E_JOB: "1"
+      E2E_TARGET_ID: podman-cpu-lifecycle
+      NEMOCLAW_RUN_LIVE_E2E: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.19.0
+          cache: npm
+
+      - name: Install locked test dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Podman 5 runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes podman
+          version="$(podman --version)"
+          major="$(awk '{split($3, parts, "."); print parts[1]}' <<<"$version")"
+          test "$major" -ge 5
+          printf '### Podman runtime\n\n`%s`\n' "$version" >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Install Docker invocation guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          guard_dir="$RUNNER_TEMP/nemoclaw-podman-cpu-guard"
+          guard_log="$guard_dir/docker-invocations.log"
+          install -d -m 0700 "$guard_dir/bin"
+          : >"$guard_log"
+          cat >"$guard_dir/bin/docker" <<'DOCKER_GUARD'
+          #!/usr/bin/env bash
+          printf '%s\n' "$*" >>"${E2E_DOCKER_GUARD_LOG:?}"
+          printf 'Docker CLI use is forbidden in the native Podman CPU proof.\n' >&2
+          exit 97
+          DOCKER_GUARD
+          chmod 0700 "$guard_dir/bin/docker"
+          {
+            printf 'DOCKER_API_VERSION=\n'
+            printf 'DOCKER_CERT_PATH=\n'
+            printf 'DOCKER_CONFIG=\n'
+            printf 'DOCKER_CONTEXT=\n'
+            printf 'DOCKER_HOST=\n'
+            printf 'DOCKER_TLS_VERIFY=\n'
+            printf 'E2E_DOCKER_GUARD_BIN=%s\n' "$guard_dir/bin/docker"
+            printf 'E2E_DOCKER_GUARD_LOG=%s\n' "$guard_log"
+            printf 'PATH=%s:%s\n' "$guard_dir/bin" "$PATH"
+          } >>"$GITHUB_ENV"
+
+      - name: Disable Docker daemon and socket
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo systemctl stop docker.service docker.socket || true
+          sudo systemctl mask --runtime docker.service docker.socket || true
+          ! systemctl is-active --quiet docker.service
+          ! systemctl is-active --quiet docker.socket
+          test ! -S /var/run/docker.sock
+          test "$(command -v docker)" = "$E2E_DOCKER_GUARD_BIN"
+
+      - name: Start exact rootless Podman API socket
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          uid="$(id -u)"
+          runtime_dir="/run/user/$uid"
+          socket_path="$runtime_dir/podman/podman.sock"
+          if [ ! -d "$runtime_dir" ]; then
+            sudo install -d -o "$uid" -g "$(id -g)" -m 0700 "$runtime_dir"
+          fi
+          install -d -m 0700 "$runtime_dir" "$runtime_dir/podman" "$E2E_ARTIFACT_DIR"
+          service_log="$E2E_ARTIFACT_DIR/podman-system-service.log"
+          podman system service --time=0 "unix://$socket_path" >"$service_log" 2>&1 &
+          service_pid="$!"
+          for attempt in $(seq 1 30); do
+            if podman --url "unix://$socket_path" info --format json \
+              >"$E2E_ARTIFACT_DIR/podman-info.json" 2>>"$service_log"; then
+              break
+            fi
+            test "$attempt" -lt 30
+            sleep 1
+          done
+          test -S "$socket_path"
+          jq -e '
+            (.host.security.rootless // .Host.Security.Rootless) == true
+            and ((.host.cgroupVersion // .Host.CgroupVersion) | ascii_downcase) == "v2"
+          ' "$E2E_ARTIFACT_DIR/podman-info.json" >/dev/null
+          {
+            printf 'E2E_PODMAN_SERVICE_PID=%s\n' "$service_pid"
+            printf 'E2E_PODMAN_SOCKET=%s\n' "$socket_path"
+            printf 'XDG_RUNTIME_DIR=%s\n' "$runtime_dir"
+          } >>"$GITHUB_ENV"
+
+      - name: Create exact managed lifecycle fixtures
+        shell: bash
+        run: |
+          set -euo pipefail
+          endpoint="unix://$E2E_PODMAN_SOCKET"
+          image_ref="docker.io/library/alpine:3.21.3"
+          podman --url "$endpoint" pull --quiet "$image_ref"
+          image_id="$(podman --url "$endpoint" image inspect --format '{{.Id}}' "$image_ref")"
+          test -n "$image_id"
+          for agent in openclaw hermes langchain-deepagents-code; do
+            sandbox_name="podman-$agent"
+            podman --url "$endpoint" create \
+              --name "openshell-sandbox-$sandbox_name" \
+              --label "openshell.managed=true" \
+              --label "openshell.sandbox-id=e2e-$agent" \
+              --label "openshell.sandbox-name=$sandbox_name" \
+              --label "openshell.sandbox-namespace=default" \
+              "$image_id" \
+              /bin/sh -c 'trap "exit 0" TERM INT; while :; do sleep 60; done'
+          done
+
+      - name: Prove native Podman preflight and all-agent CPU lifecycle
+        run: npx vitest run --project e2e-live test/e2e/live/podman-cpu-lifecycle.test.ts
+
+      - name: Verify Docker stayed unavailable
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "$E2E_DOCKER_GUARD_LOG"
+          test ! -s "$E2E_DOCKER_GUARD_LOG"
+          test "$(command -v docker)" = "$E2E_DOCKER_GUARD_BIN"
+          ! systemctl is-active --quiet docker.service
+          ! systemctl is-active --quiet docker.socket
+          test ! -S /var/run/docker.sock
+
+      - name: Clean up rootless Podman fixtures
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          endpoint="unix://${E2E_PODMAN_SOCKET:-/run/user/$(id -u)/podman/podman.sock}"
+          for agent in openclaw hermes langchain-deepagents-code; do
+            podman --url "$endpoint" rm --force "openshell-sandbox-podman-$agent" || true
+          done
+          service_pid="${E2E_PODMAN_SERVICE_PID:-}"
+          if [[ "$service_pid" =~ ^[1-9][0-9]*$ ]]; then
+            kill "$service_pid" 2>/dev/null || true
+            wait "$service_pid" 2>/dev/null || true
+          fi
+
+      - name: Upload Podman CPU proof artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: podman-cpu-proof-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: e2e-artifacts/podman-cpu-proof
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/podman-cpu-proof.yaml
+++ b/.github/workflows/podman-cpu-proof.yaml
@@ -34,11 +34,13 @@ jobs:
       E2E_JOB: "1"
       E2E_TARGET_ID: podman-cpu-lifecycle
       NEMOCLAW_RUN_LIVE_E2E: "1"
+      PODMAN_APT_VERSION: "5.7.0+ds2-3build1"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -54,11 +56,12 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes podman
+          sudo apt-get install --yes "podman=$PODMAN_APT_VERSION"
+          package_version="$(dpkg-query --show --showformat='${Version}' podman)"
           version="$(podman --version)"
-          major="$(awk '{split($3, parts, "."); print parts[1]}' <<<"$version")"
-          test "$major" -ge 5
-          printf '### Podman runtime\n\n`%s`\n' "$version" >>"$GITHUB_STEP_SUMMARY"
+          test "$package_version" = "$PODMAN_APT_VERSION"
+          test "$version" = "podman version 5.7.0"
+          printf '### Podman runtime\n\n`%s` (`%s`)\n' "$version" "$package_version" >>"$GITHUB_STEP_SUMMARY"
 
       - name: Install Docker invocation guard
         shell: bash

--- a/.github/workflows/podman-cpu-proof.yaml
+++ b/.github/workflows/podman-cpu-proof.yaml
@@ -91,12 +91,49 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          install -d -m 0700 "$E2E_ARTIFACT_DIR"
           sudo systemctl stop docker.service docker.socket || true
           sudo systemctl mask --runtime docker.service docker.socket || true
-          ! systemctl is-active --quiet docker.service
-          ! systemctl is-active --quiet docker.socket
-          test ! -S /var/run/docker.sock
-          test "$(command -v docker)" = "$E2E_DOCKER_GUARD_BIN"
+          sudo pkill -TERM -x dockerd 2>/dev/null || true
+          for attempt in $(seq 1 20); do
+            if ! pgrep -x dockerd >/dev/null && [ ! -S /var/run/docker.sock ]; then
+              break
+            fi
+            test "$attempt" -lt 20
+            sleep 1
+          done
+          if pgrep -x dockerd >/dev/null; then
+            echo "::error::dockerd remained active after Docker shutdown" >&2
+            exit 1
+          fi
+          sudo rm -f /var/run/docker.sock
+          if systemctl is-active --quiet docker.service; then
+            echo "::error::docker.service remained active after Docker shutdown" >&2
+            exit 1
+          fi
+          if systemctl is-active --quiet docker.socket; then
+            echo "::error::docker.socket remained active after Docker shutdown" >&2
+            exit 1
+          fi
+          if [ -S /var/run/docker.sock ]; then
+            echo "::error::Docker socket remained available after Docker shutdown" >&2
+            exit 1
+          fi
+          docker_candidate="$(command -v docker || true)"
+          if [ "$docker_candidate" != "$E2E_DOCKER_GUARD_BIN" ]; then
+            echo "::error::Docker command resolution escaped the invocation guard" >&2
+            exit 1
+          fi
+          jq -n \
+            --arg dockerCandidate "$docker_candidate" \
+            '{
+              schemaVersion: 1,
+              dockerServiceActive: false,
+              dockerSocketActive: false,
+              dockerDaemonActive: false,
+              dockerSocketPresent: false,
+              dockerCandidate: $dockerCandidate
+            }' >"$E2E_ARTIFACT_DIR/docker-absence-boundary.json"
 
       - name: Start exact rootless Podman API socket
         shell: bash

--- a/.github/workflows/podman-cpu-proof.yaml
+++ b/.github/workflows/podman-cpu-proof.yaml
@@ -96,10 +96,9 @@ jobs:
           sudo systemctl mask --runtime docker.service docker.socket || true
           sudo pkill -TERM -x dockerd 2>/dev/null || true
           for attempt in $(seq 1 20); do
-            if ! pgrep -x dockerd >/dev/null && [ ! -S /var/run/docker.sock ]; then
+            if ! pgrep -x dockerd >/dev/null; then
               break
             fi
-            test "$attempt" -lt 20
             sleep 1
           done
           if pgrep -x dockerd >/dev/null; then

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -267,6 +267,11 @@
       "category": "security"
     },
     {
+      "file": "test/e2e/support/podman-cpu-proof-workflow.test.ts",
+      "test": "runs as a credential-free exact-head PR workflow",
+      "category": "security"
+    },
+    {
       "file": "test/e2e/support/trusted-hermes-swap-workflow-boundary.test.ts",
       "test": "keeps the fixed privileged program before candidate checkout in every protected job (#7145)",
       "category": "security"

--- a/src/lib/adapters/container-engine.test.ts
+++ b/src/lib/adapters/container-engine.test.ts
@@ -12,6 +12,7 @@ describe("operation-scoped container engine command", () => {
       operation: "sandbox-lifecycle",
       engineId: "podman",
       displayName: "Podman",
+      authorityId: "test:podman-socket",
       executable: "podman",
       endpointArgs: ["--url", "unix:///runtime/podman.sock"],
       capture,
@@ -38,6 +39,7 @@ describe("operation-scoped container engine command", () => {
       operation: "host-doctor",
       engineId: "podman",
       displayName: "Podman",
+      authorityId: "test:doctor",
       executable: "podman-doctor",
       capture: doctorCapture,
     });
@@ -45,6 +47,7 @@ describe("operation-scoped container engine command", () => {
       operation: "sandbox-lifecycle",
       engineId: "podman",
       displayName: "Podman",
+      authorityId: "test:lifecycle",
       executable: "podman-lifecycle",
       capture: lifecycleCapture,
     });
@@ -72,6 +75,7 @@ describe("operation-scoped container engine command", () => {
       operation: "sandbox-lifecycle",
       engineId: "podman",
       displayName: "Podman",
+      authorityId: "test:podman-socket",
       executable: "podman",
       capture: () => {
         throw commandFailure;
@@ -90,13 +94,24 @@ describe("operation-scoped container engine command", () => {
         operation: "host-doctor",
         engineId: "Podman",
         displayName: "Podman",
+        authorityId: "test:podman-socket",
         executable: "podman",
       }),
     ).toThrow("identity is invalid");
+    expect(() =>
+      createContainerEngineCommand({
+        operation: "host-doctor",
+        engineId: "podman",
+        displayName: "Podman",
+        authorityId: "unsafe/socket",
+        executable: "podman",
+      }),
+    ).toThrow("authority identity is invalid");
     const engine = createContainerEngineCommand({
       operation: "host-doctor",
       engineId: "podman",
       displayName: "Podman",
+      authorityId: "test:podman-socket",
       executable: "podman",
       capture,
     });

--- a/src/lib/adapters/container-engine.test.ts
+++ b/src/lib/adapters/container-engine.test.ts
@@ -87,6 +87,30 @@ describe("operation-scoped container engine command", () => {
     expect(guard).toHaveBeenCalledTimes(2);
   });
 
+  it("rejects endpoint rotation observed after a successful command", () => {
+    const authorityChanged = new Error("authority changed");
+    const guard = vi
+      .fn()
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw authorityChanged;
+      });
+    const capture = vi.fn(() => ({ status: 0, stdout: "ok", stderr: "" }));
+    const engine = createContainerEngineCommand({
+      operation: "sandbox-lifecycle",
+      engineId: "podman",
+      displayName: "Podman",
+      authorityId: "test:podman-socket",
+      executable: "podman",
+      capture,
+      guard,
+    });
+
+    expect(() => engine.capture(["start", "a".repeat(64)])).toThrow(authorityChanged);
+    expect(capture).toHaveBeenCalledOnce();
+    expect(guard).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects invalid identities, timeouts, and command arguments before capture", () => {
     const capture = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
     expect(() =>

--- a/src/lib/adapters/container-engine.test.ts
+++ b/src/lib/adapters/container-engine.test.ts
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createContainerEngineCommand } from "./container-engine";
+
+describe("operation-scoped container engine command", () => {
+  it("binds endpoint arguments without changing host-only commands", () => {
+    const capture = vi.fn(() => ({ status: 0, stdout: "ok", stderr: "" }));
+    const engine = createContainerEngineCommand({
+      operation: "sandbox-lifecycle",
+      engineId: "podman",
+      displayName: "Podman",
+      executable: "podman",
+      endpointArgs: ["--url", "unix:///runtime/podman.sock"],
+      capture,
+    });
+
+    expect(engine.capture(["container", "inspect", "abc"], 1234)).toEqual({
+      status: 0,
+      stdout: "ok",
+      stderr: "",
+    });
+    engine.captureHost(["unshare", "cat", "/proc/self/uid_map"], 2345);
+
+    expect(capture.mock.calls).toEqual([
+      ["podman", ["--url", "unix:///runtime/podman.sock", "container", "inspect", "abc"], 1234],
+      ["podman", ["unshare", "cat", "/proc/self/uid_map"], 2345],
+    ]);
+    expect(Object.isFrozen(engine)).toBe(true);
+  });
+
+  it("keeps separately scoped engines isolated", () => {
+    const doctorCapture = vi.fn(() => ({ status: 0, stdout: "doctor", stderr: "" }));
+    const lifecycleCapture = vi.fn(() => ({ status: 0, stdout: "lifecycle", stderr: "" }));
+    const doctor = createContainerEngineCommand({
+      operation: "host-doctor",
+      engineId: "podman",
+      displayName: "Podman",
+      executable: "podman-doctor",
+      capture: doctorCapture,
+    });
+    const lifecycle = createContainerEngineCommand({
+      operation: "sandbox-lifecycle",
+      engineId: "podman",
+      displayName: "Podman",
+      executable: "podman-lifecycle",
+      capture: lifecycleCapture,
+    });
+
+    expect(doctor.capture(["info"]).stdout).toBe("doctor");
+    expect(lifecycle.capture(["start", "abc"]).stdout).toBe("lifecycle");
+    expect(doctorCapture).toHaveBeenCalledExactlyOnceWith("podman-doctor", ["info"], 15_000);
+    expect(lifecycleCapture).toHaveBeenCalledExactlyOnceWith(
+      "podman-lifecycle",
+      ["start", "abc"],
+      15_000,
+    );
+  });
+
+  it("guards before and after commands while preserving command failures", () => {
+    const commandFailure = new Error("command failed");
+    const guardFailure = new Error("authority changed");
+    const guard = vi
+      .fn()
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw guardFailure;
+      });
+    const engine = createContainerEngineCommand({
+      operation: "sandbox-lifecycle",
+      engineId: "podman",
+      displayName: "Podman",
+      executable: "podman",
+      capture: () => {
+        throw commandFailure;
+      },
+      guard,
+    });
+
+    expect(() => engine.capture(["stop", "abc"])).toThrow(commandFailure);
+    expect(guard).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects invalid identities, timeouts, and command arguments before capture", () => {
+    const capture = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+    expect(() =>
+      createContainerEngineCommand({
+        operation: "host-doctor",
+        engineId: "Podman",
+        displayName: "Podman",
+        executable: "podman",
+      }),
+    ).toThrow("identity is invalid");
+    const engine = createContainerEngineCommand({
+      operation: "host-doctor",
+      engineId: "podman",
+      displayName: "Podman",
+      executable: "podman",
+      capture,
+    });
+    expect(() => engine.capture(["info"], 0)).toThrow("positive safe integer");
+    expect(() => engine.capture(["bad\0argument"])).toThrow("arguments[0] is invalid");
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/adapters/container-engine.ts
+++ b/src/lib/adapters/container-engine.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 export type ContainerEngineOperationScope =
   | "host-doctor"
   | "gateway-inspection"
+  | "managed-bootstrap"
   | "sandbox-lifecycle"
   | "workload-cleanup";
 

--- a/src/lib/adapters/container-engine.ts
+++ b/src/lib/adapters/container-engine.ts
@@ -34,6 +34,8 @@ export interface ContainerEngine {
   readonly operation: ContainerEngineOperationScope;
   readonly engineId: string;
   readonly displayName: string;
+  /** Opaque identity for the exact endpoint authority bound to this command. */
+  readonly authorityId: string;
   readonly capture: (args: readonly string[], timeoutMs?: number) => ContainerEngineCommandResult;
   readonly captureHost: (
     args: readonly string[],
@@ -45,6 +47,7 @@ export interface ContainerEngineCommandOptions {
   readonly operation: ContainerEngineOperationScope;
   readonly engineId: string;
   readonly displayName: string;
+  readonly authorityId: string;
   readonly executable: string;
   readonly endpointArgs?: readonly string[];
   readonly capture?: ContainerEngineCommandCapture;
@@ -56,6 +59,7 @@ const MAX_ARGUMENTS = 512;
 const MAX_ARGUMENT_BYTES = 16 * 1024;
 const MAX_OUTPUT_BYTES = 1024 * 1024;
 const ENGINE_ID_PATTERN = /^[a-z][a-z0-9-]{0,62}$/u;
+const AUTHORITY_ID_PATTERN = /^[a-z][a-z0-9-]{0,62}:[A-Za-z0-9._:-]{1,255}$/u;
 const EXECUTABLE_NAME_PATTERN = /^[A-Za-z0-9._-]+$/u;
 const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
 
@@ -174,6 +178,9 @@ export function createContainerEngineCommand(
   if (!ENGINE_ID_PATTERN.test(options.engineId)) {
     throw new Error("Container engine identity is invalid.");
   }
+  if (!AUTHORITY_ID_PATTERN.test(options.authorityId)) {
+    throw new Error("Container engine authority identity is invalid.");
+  }
   const executable = normalizedExecutable(options.executable);
   const displayName = boundedText(options.displayName, "Container engine display name");
   const endpointArgs = normalizedArguments(
@@ -193,6 +200,7 @@ export function createContainerEngineCommand(
     operation: options.operation,
     engineId: options.engineId,
     displayName,
+    authorityId: options.authorityId,
     capture: (args: readonly string[], timeoutMs = DEFAULT_TIMEOUT_MS) =>
       run(args, timeoutMs, true),
     captureHost: (args: readonly string[], timeoutMs = DEFAULT_TIMEOUT_MS) =>

--- a/src/lib/adapters/container-engine.ts
+++ b/src/lib/adapters/container-engine.ts
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { ROOT } from "../state/paths";
+import { buildSubprocessEnv } from "../subprocess-env";
+
+export type ContainerEngineOperationScope =
+  | "host-doctor"
+  | "gateway-inspection"
+  | "sandbox-lifecycle"
+  | "workload-cleanup";
+
+export interface ContainerEngineCommandResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly error?: Error;
+}
+
+export type ContainerEngineCommandCapture = (
+  executable: string,
+  args: readonly string[],
+  timeoutMs: number,
+) => ContainerEngineCommandResult;
+
+/**
+ * Immutable command boundary injected into one provider operation. The
+ * executable and endpoint prefix cannot change after construction, and no
+ * process-global engine selection is consulted by a command.
+ */
+export interface ContainerEngine {
+  readonly operation: ContainerEngineOperationScope;
+  readonly engineId: string;
+  readonly displayName: string;
+  readonly capture: (args: readonly string[], timeoutMs?: number) => ContainerEngineCommandResult;
+  readonly captureHost: (
+    args: readonly string[],
+    timeoutMs?: number,
+  ) => ContainerEngineCommandResult;
+}
+
+export interface ContainerEngineCommandOptions {
+  readonly operation: ContainerEngineOperationScope;
+  readonly engineId: string;
+  readonly displayName: string;
+  readonly executable: string;
+  readonly endpointArgs?: readonly string[];
+  readonly capture?: ContainerEngineCommandCapture;
+  readonly guard?: () => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_ARGUMENTS = 512;
+const MAX_ARGUMENT_BYTES = 16 * 1024;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+const ENGINE_ID_PATTERN = /^[a-z][a-z0-9-]{0,62}$/u;
+const EXECUTABLE_NAME_PATTERN = /^[A-Za-z0-9._-]+$/u;
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
+
+function boundedText(value: string, label: string, allowPath = false): string {
+  const normalized = value.trim();
+  if (
+    normalized === "" ||
+    Buffer.byteLength(normalized, "utf8") > MAX_ARGUMENT_BYTES ||
+    CONTROL_CHARACTERS.test(normalized) ||
+    (!allowPath && /[\\/]/u.test(normalized))
+  ) {
+    throw new Error(`${label} is invalid.`);
+  }
+  return normalized;
+}
+
+function normalizedArguments(args: readonly string[], label: string): readonly string[] {
+  if (!Array.isArray(args) || args.length > MAX_ARGUMENTS) {
+    throw new Error(`${label} has too many arguments.`);
+  }
+  return Object.freeze(
+    args.map((value, index) => {
+      if (
+        typeof value !== "string" ||
+        Buffer.byteLength(value, "utf8") > MAX_ARGUMENT_BYTES ||
+        value.includes("\0")
+      ) {
+        throw new Error(`${label}[${String(index)}] is invalid.`);
+      }
+      return value;
+    }),
+  );
+}
+
+function positiveTimeout(value: number): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error("Container engine command timeout must be a positive safe integer.");
+  }
+  return value;
+}
+
+function normalizedExecutable(value: string): string {
+  const executable = boundedText(value, "Container engine executable", true);
+  if (!path.isAbsolute(executable) && !EXECUTABLE_NAME_PATTERN.test(executable)) {
+    throw new Error("Container engine executable is invalid.");
+  }
+  return executable;
+}
+
+function normalizedResult(value: ContainerEngineCommandResult): ContainerEngineCommandResult {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !Number.isSafeInteger(value.status) ||
+    value.status < 0 ||
+    typeof value.stdout !== "string" ||
+    typeof value.stderr !== "string" ||
+    (value.error !== undefined && !(value.error instanceof Error))
+  ) {
+    throw new Error("Container engine command returned an invalid result.");
+  }
+  return Object.freeze({
+    status: value.status,
+    stdout: value.stdout,
+    stderr: value.stderr,
+    ...(value.error ? { error: value.error } : {}),
+  });
+}
+
+function defaultCapture(
+  executable: string,
+  args: readonly string[],
+  timeoutMs: number,
+): ContainerEngineCommandResult {
+  const result = spawnSync(executable, [...args], {
+    cwd: ROOT,
+    env: buildSubprocessEnv(),
+    encoding: "utf8",
+    maxBuffer: MAX_OUTPUT_BYTES,
+    shell: false,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+  });
+  return {
+    status: result.status ?? (result.error || result.signal ? 1 : 0),
+    stdout: String(result.stdout || ""),
+    stderr: String(result.stderr || ""),
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+function invokeGuarded(
+  guard: (() => void) | undefined,
+  capture: () => ContainerEngineCommandResult,
+): ContainerEngineCommandResult {
+  guard?.();
+  let result: ContainerEngineCommandResult | undefined;
+  let failure: unknown;
+  try {
+    result = capture();
+  } catch (error) {
+    failure = error;
+  }
+  try {
+    guard?.();
+  } catch (error) {
+    if (failure === undefined) failure = error;
+  }
+  if (failure !== undefined) throw failure;
+  return normalizedResult(result as ContainerEngineCommandResult);
+}
+
+export function createContainerEngineCommand(
+  options: ContainerEngineCommandOptions,
+): ContainerEngine {
+  if (!ENGINE_ID_PATTERN.test(options.engineId)) {
+    throw new Error("Container engine identity is invalid.");
+  }
+  const executable = normalizedExecutable(options.executable);
+  const displayName = boundedText(options.displayName, "Container engine display name");
+  const endpointArgs = normalizedArguments(
+    options.endpointArgs ?? [],
+    "Container engine endpoint arguments",
+  );
+  const capture = options.capture ?? defaultCapture;
+  const run = (args: readonly string[], timeoutMs: number, endpoint: boolean) => {
+    const normalized = normalizedArguments(args, "Container engine command arguments");
+    const commandArgs = endpoint ? [...endpointArgs, ...normalized] : [...normalized];
+    return invokeGuarded(options.guard, () =>
+      capture(executable, commandArgs, positiveTimeout(timeoutMs)),
+    );
+  };
+
+  return Object.freeze({
+    operation: options.operation,
+    engineId: options.engineId,
+    displayName,
+    capture: (args: readonly string[], timeoutMs = DEFAULT_TIMEOUT_MS) =>
+      run(args, timeoutMs, true),
+    captureHost: (args: readonly string[], timeoutMs = DEFAULT_TIMEOUT_MS) =>
+      run(args, timeoutMs, false),
+  });
+}

--- a/src/lib/adapters/container-engine.ts
+++ b/src/lib/adapters/container-engine.ts
@@ -3,8 +3,6 @@
 
 import { spawnSync } from "node:child_process";
 import path from "node:path";
-import { ROOT } from "../state/paths";
-import { buildSubprocessEnv } from "../subprocess-env";
 
 export type ContainerEngineOperationScope =
   | "host-doctor"
@@ -62,6 +60,42 @@ const ENGINE_ID_PATTERN = /^[a-z][a-z0-9-]{0,62}$/u;
 const AUTHORITY_ID_PATTERN = /^[a-z][a-z0-9-]{0,62}:[A-Za-z0-9._:-]{1,255}$/u;
 const EXECUTABLE_NAME_PATTERN = /^[A-Za-z0-9._-]+$/u;
 const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
+const COMMAND_ENV_NAMES = new Set([
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "PATH",
+  "TERM",
+  "HOSTNAME",
+  "LANG",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "GIT_SSL_CAINFO",
+  "GIT_SSL_CAPATH",
+  "CURL_CA_BUNDLE",
+]);
+const COMMAND_ENV_PREFIXES = ["LC_", "XDG_"] as const;
+
+function containerEngineCommandEnvironment(): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([name, value]) =>
+        value !== undefined &&
+        (COMMAND_ENV_NAMES.has(name) ||
+          COMMAND_ENV_PREFIXES.some((prefix) => name.startsWith(prefix))),
+    ),
+  );
+}
 
 function boundedText(value: string, label: string, allowPath = false): string {
   const normalized = value.trim();
@@ -135,8 +169,8 @@ function defaultCapture(
   timeoutMs: number,
 ): ContainerEngineCommandResult {
   const result = spawnSync(executable, [...args], {
-    cwd: ROOT,
-    env: buildSubprocessEnv(),
+    cwd: process.cwd(),
+    env: containerEngineCommandEnvironment(),
     encoding: "utf8",
     maxBuffer: MAX_OUTPUT_BYTES,
     shell: false,

--- a/src/lib/adapters/podman/index.test.ts
+++ b/src/lib/adapters/podman/index.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createPodmanContainerEngine, type PodmanSocketAuthority } from "./index";
+
+const AUTHORITY = {
+  directoryChain: [],
+  device: "8",
+  inode: "9001",
+  ownerUid: "1000",
+  socketPath: "/run/user/1000/podman/podman.sock",
+} as const satisfies PodmanSocketAuthority;
+
+describe("Podman container engine command adapter", () => {
+  it("pins the exact socket around each operation-scoped command", () => {
+    const assertAuthority = vi.fn();
+    const capture = vi.fn(() => ({ status: 0, stdout: "ok", stderr: "" }));
+    const engine = createPodmanContainerEngine({
+      operation: "sandbox-lifecycle",
+      socketAuthority: AUTHORITY,
+      executable: "/usr/bin/podman",
+      assertAuthority,
+      capture,
+    });
+
+    expect(engine.capture(["start", "a".repeat(64)], 2000)).toMatchObject({
+      status: 0,
+      stdout: "ok",
+    });
+    expect(assertAuthority).toHaveBeenCalledTimes(2);
+    expect(capture).toHaveBeenCalledExactlyOnceWith(
+      "/usr/bin/podman",
+      ["--url", "unix:///run/user/1000/podman/podman.sock", "start", "a".repeat(64)],
+      2000,
+    );
+    expect(engine).toMatchObject({
+      operation: "sandbox-lifecycle",
+      engineId: "podman",
+      displayName: "Podman",
+    });
+  });
+});

--- a/src/lib/adapters/podman/index.test.ts
+++ b/src/lib/adapters/podman/index.test.ts
@@ -9,6 +9,7 @@ const AUTHORITY = {
   directoryChain: [],
   device: "8",
   inode: "9001",
+  mode: "384",
   ownerUid: "1000",
   socketPath: "/run/user/1000/podman/podman.sock",
 } as const satisfies PodmanSocketAuthority;
@@ -39,6 +40,24 @@ describe("Podman container engine command adapter", () => {
       operation: "sandbox-lifecycle",
       engineId: "podman",
       displayName: "Podman",
+      authorityId: expect.stringMatching(/^podman-sha256:[0-9a-f]{64}$/u),
     });
+  });
+
+  it("gives different socket authorities different opaque identities", () => {
+    const first = createPodmanContainerEngine({
+      operation: "host-doctor",
+      socketAuthority: AUTHORITY,
+      assertAuthority: vi.fn(),
+      capture: vi.fn(),
+    });
+    const second = createPodmanContainerEngine({
+      operation: "sandbox-lifecycle",
+      socketAuthority: { ...AUTHORITY, inode: "9002" },
+      assertAuthority: vi.fn(),
+      capture: vi.fn(),
+    });
+
+    expect(first.authorityId).not.toBe(second.authorityId);
   });
 });

--- a/src/lib/adapters/podman/index.ts
+++ b/src/lib/adapters/podman/index.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type ContainerEngine,
+  type ContainerEngineCommandCapture,
+  createContainerEngineCommand,
+} from "../container-engine";
+import {
+  assertPodmanSocketAuthority,
+  type PodmanSocketAuthority,
+  type PodmanSocketAuthorityDeps,
+} from "./socket-authority";
+
+export interface PodmanContainerEngineOptions {
+  readonly operation: "host-doctor" | "sandbox-lifecycle";
+  readonly socketAuthority: PodmanSocketAuthority;
+  readonly executable?: string;
+  readonly capture?: ContainerEngineCommandCapture;
+  readonly authorityDeps?: PodmanSocketAuthorityDeps;
+  readonly assertAuthority?: (
+    expected: PodmanSocketAuthority,
+    deps?: PodmanSocketAuthorityDeps,
+  ) => void;
+}
+
+/**
+ * Bind one Podman API socket to one provider operation. Callers inject the
+ * returned value directly; unlike the retired donor prototype, this never
+ * changes how Docker-named helpers behave in the rest of the process.
+ */
+export function createPodmanContainerEngine(
+  options: PodmanContainerEngineOptions,
+): ContainerEngine {
+  const assertAuthority = options.assertAuthority ?? assertPodmanSocketAuthority;
+  return createContainerEngineCommand({
+    operation: options.operation,
+    engineId: "podman",
+    displayName: "Podman",
+    executable: options.executable ?? "podman",
+    endpointArgs: ["--url", `unix://${options.socketAuthority.socketPath}`],
+    capture: options.capture,
+    guard: () => assertAuthority(options.socketAuthority, options.authorityDeps),
+  });
+}
+
+export type { PodmanSocketAuthority } from "./socket-authority";
+export { assertPodmanSocketAuthority, capturePodmanSocketAuthority } from "./socket-authority";

--- a/src/lib/adapters/podman/index.ts
+++ b/src/lib/adapters/podman/index.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
+
 import {
   type ContainerEngine,
   type ContainerEngineCommandCapture,
@@ -24,10 +26,28 @@ export interface PodmanContainerEngineOptions {
   ) => void;
 }
 
+function podmanAuthorityId(authority: PodmanSocketAuthority): string {
+  const canonical = JSON.stringify({
+    socketPath: authority.socketPath,
+    device: authority.device,
+    inode: authority.inode,
+    mode: authority.mode,
+    ownerUid: authority.ownerUid,
+    directoryChain: authority.directoryChain.map(({ device, inode, mode, ownerUid, path }) => ({
+      device,
+      inode,
+      mode,
+      ownerUid,
+      path,
+    })),
+  });
+  return `podman-sha256:${createHash("sha256").update(canonical, "utf8").digest("hex")}`;
+}
+
 /**
  * Bind one Podman API socket to one provider operation. Callers inject the
- * returned value directly; unlike the retired donor prototype, this never
- * changes how Docker-named helpers behave in the rest of the process.
+ * returned value directly. The adapter never changes process-wide engine
+ * selection or how Docker-named helpers behave elsewhere in the process.
  */
 export function createPodmanContainerEngine(
   options: PodmanContainerEngineOptions,
@@ -37,6 +57,7 @@ export function createPodmanContainerEngine(
     operation: options.operation,
     engineId: "podman",
     displayName: "Podman",
+    authorityId: podmanAuthorityId(options.socketAuthority),
     executable: options.executable ?? "podman",
     endpointArgs: ["--url", `unix://${options.socketAuthority.socketPath}`],
     capture: options.capture,

--- a/src/lib/adapters/podman/socket-authority.test.ts
+++ b/src/lib/adapters/podman/socket-authority.test.ts
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { assertPodmanSocketAuthority, capturePodmanSocketAuthority } from "./socket-authority";
+
+const SOCKET_PATH = "/run/user/1000/podman/podman.sock";
+
+function stat(
+  overrides: Partial<{
+    dev: bigint;
+    directory: boolean;
+    ino: bigint;
+    mode: bigint;
+    socket: boolean;
+    uid: bigint;
+  }> = {},
+) {
+  return {
+    dev: overrides.dev ?? 8n,
+    ino: overrides.ino ?? 9001n,
+    mode: overrides.mode ?? 0o700n,
+    uid: overrides.uid ?? 1000n,
+    isDirectory: () => overrides.directory ?? false,
+    isSocket: () => overrides.socket ?? true,
+  };
+}
+
+function secureLstat(
+  socketOverrides: Parameters<typeof stat>[0] = {},
+  directoryOverrides: Readonly<Record<string, Parameters<typeof stat>[0]>> = {},
+) {
+  const directoryInodes = new Map<string, bigint>();
+  return (filePath: string) => {
+    const directoryInode = directoryInodes.get(filePath) ?? BigInt(7000 + directoryInodes.size);
+    directoryInodes.set(filePath, directoryInode);
+    return filePath === SOCKET_PATH
+      ? stat(socketOverrides)
+      : stat({
+          directory: true,
+          ino: directoryInode,
+          mode: 0o755n,
+          uid: filePath.startsWith("/run/user/1000") ? 1000n : 0n,
+          ...(directoryOverrides[filePath] ?? {}),
+        });
+  };
+}
+
+describe("Podman socket authority", () => {
+  it("captures the exact current-user socket and secure path identity", () => {
+    const authority = capturePodmanSocketAuthority(SOCKET_PATH, {
+      lstat: vi.fn(secureLstat()),
+      uid: 1000,
+    });
+
+    expect(authority).toMatchObject({
+      device: "8",
+      inode: "9001",
+      ownerUid: "1000",
+      socketPath: SOCKET_PATH,
+    });
+    expect(authority.directoryChain.map(({ ownerUid, path }) => ({ ownerUid, path }))).toEqual([
+      { ownerUid: "1000", path: "/run/user/1000/podman" },
+      { ownerUid: "1000", path: "/run/user/1000" },
+      { ownerUid: "0", path: "/run/user" },
+      { ownerUid: "0", path: "/run" },
+      { ownerUid: "0", path: "/" },
+    ]);
+  });
+
+  it("rejects foreign ownership and writable directory components", () => {
+    expect(() =>
+      capturePodmanSocketAuthority(SOCKET_PATH, {
+        lstat: secureLstat({ uid: 2000n }),
+        uid: 1000,
+      }),
+    ).toThrow("owned by uid 2000");
+    expect(() =>
+      capturePodmanSocketAuthority(SOCKET_PATH, {
+        lstat: secureLstat({}, { "/run/user/1000/podman": { mode: 0o770n } }),
+        uid: 1000,
+      }),
+    ).toThrow("writable by another user or group");
+  });
+
+  it("rejects socket and directory replacement after qualification", () => {
+    const expected = capturePodmanSocketAuthority(SOCKET_PATH, {
+      lstat: secureLstat(),
+      uid: 1000,
+    });
+
+    expect(() =>
+      assertPodmanSocketAuthority(expected, {
+        lstat: secureLstat({ ino: 9002n }),
+        uid: 1000,
+      }),
+    ).toThrow("changed after it was qualified");
+    expect(() =>
+      assertPodmanSocketAuthority(expected, {
+        lstat: secureLstat({}, { "/run/user/1000/podman": { ino: 8000n } }),
+        uid: 1000,
+      }),
+    ).toThrow("changed after it was qualified");
+  });
+
+  it("rejects relative, non-socket, and foreign-directory authorities", () => {
+    expect(() => capturePodmanSocketAuthority("relative.sock", { uid: 1000 })).toThrow(
+      "normalized absolute path",
+    );
+    expect(() =>
+      capturePodmanSocketAuthority(SOCKET_PATH, {
+        lstat: secureLstat({ socket: false }),
+        uid: 1000,
+      }),
+    ).toThrow("not a Unix socket");
+    expect(() =>
+      capturePodmanSocketAuthority(SOCKET_PATH, {
+        lstat: secureLstat({}, { "/run/user/1000/podman": { uid: 2000n } }),
+        uid: 1000,
+      }),
+    ).toThrow("directory is owned by uid 2000");
+  });
+});

--- a/src/lib/adapters/podman/socket-authority.test.ts
+++ b/src/lib/adapters/podman/socket-authority.test.ts
@@ -20,7 +20,7 @@ function stat(
   return {
     dev: overrides.dev ?? 8n,
     ino: overrides.ino ?? 9001n,
-    mode: overrides.mode ?? 0o700n,
+    mode: overrides.mode ?? 0o600n,
     uid: overrides.uid ?? 1000n,
     isDirectory: () => overrides.directory ?? false,
     isSocket: () => overrides.socket ?? true,
@@ -57,6 +57,7 @@ describe("Podman socket authority", () => {
     expect(authority).toMatchObject({
       device: "8",
       inode: "9001",
+      mode: "384",
       ownerUid: "1000",
       socketPath: SOCKET_PATH,
     });
@@ -84,6 +85,15 @@ describe("Podman socket authority", () => {
     ).toThrow("writable by another user or group");
   });
 
+  it.each([0o660n, 0o666n])("rejects another-user-writable socket mode %s", (mode) => {
+    expect(() =>
+      capturePodmanSocketAuthority(SOCKET_PATH, {
+        lstat: secureLstat({ mode }),
+        uid: 1000,
+      }),
+    ).toThrow("socket authority is writable by another user or group");
+  });
+
   it("rejects socket and directory replacement after qualification", () => {
     const expected = capturePodmanSocketAuthority(SOCKET_PATH, {
       lstat: secureLstat(),
@@ -93,6 +103,12 @@ describe("Podman socket authority", () => {
     expect(() =>
       assertPodmanSocketAuthority(expected, {
         lstat: secureLstat({ ino: 9002n }),
+        uid: 1000,
+      }),
+    ).toThrow("changed after it was qualified");
+    expect(() =>
+      assertPodmanSocketAuthority(expected, {
+        lstat: secureLstat({ mode: 0o400n }),
         uid: 1000,
       }),
     ).toThrow("changed after it was qualified");

--- a/src/lib/adapters/podman/socket-authority.ts
+++ b/src/lib/adapters/podman/socket-authority.ts
@@ -35,6 +35,11 @@ export interface PodmanSocketAuthorityDeps {
   readonly uid?: number;
 }
 
+// A rootless Podman service and its client intentionally share one Unix UID,
+// which is the trust principal for this boundary. The captured authority
+// excludes path control by other principals and detects endpoint rotation; it
+// does not claim isolation from another process already running as that UID.
+
 function integerIdentity(value: bigint | number, label: string): string {
   if (typeof value === "bigint") {
     if (value >= 0n) return value.toString(10);

--- a/src/lib/adapters/podman/socket-authority.ts
+++ b/src/lib/adapters/podman/socket-authority.ts
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+export interface PodmanSocketStat {
+  readonly dev: bigint | number;
+  readonly ino: bigint | number;
+  readonly mode: bigint | number;
+  readonly uid: bigint | number;
+  isDirectory(): boolean;
+  isSocket(): boolean;
+}
+
+export interface PodmanSocketDirectoryAuthority {
+  readonly device: string;
+  readonly inode: string;
+  readonly mode: string;
+  readonly ownerUid: string;
+  readonly path: string;
+}
+
+export interface PodmanSocketAuthority {
+  readonly directoryChain: readonly PodmanSocketDirectoryAuthority[];
+  readonly device: string;
+  readonly inode: string;
+  readonly ownerUid: string;
+  readonly socketPath: string;
+}
+
+export interface PodmanSocketAuthorityDeps {
+  readonly lstat?: (filePath: string) => PodmanSocketStat;
+  readonly uid?: number;
+}
+
+function integerIdentity(value: bigint | number, label: string): string {
+  if (typeof value === "bigint") {
+    if (value >= 0n) return value.toString(10);
+  } else if (Number.isSafeInteger(value) && value >= 0) {
+    return String(value);
+  }
+  throw new Error(`Podman socket ${label} identity is invalid.`);
+}
+
+function integerValue(value: bigint | number, label: string): bigint {
+  if (typeof value === "bigint") {
+    if (value >= 0n) return value;
+  } else if (Number.isSafeInteger(value) && value >= 0) {
+    return BigInt(value);
+  }
+  throw new Error(`Podman socket ${label} identity is invalid.`);
+}
+
+function currentUid(configured: number | undefined): number {
+  const uid = configured ?? (typeof process.getuid === "function" ? process.getuid() : Number.NaN);
+  if (!Number.isSafeInteger(uid) || uid < 0) {
+    throw new Error("Podman socket authority requires the current Unix user ID.");
+  }
+  return uid;
+}
+
+function normalizedSocketPath(socketPath: string): string {
+  const normalized = socketPath.trim();
+  if (
+    normalized === "" ||
+    !path.isAbsolute(normalized) ||
+    path.normalize(normalized) !== normalized ||
+    /[\0\r\n]/u.test(normalized)
+  ) {
+    throw new Error("Podman socket authority requires a safe normalized absolute path.");
+  }
+  return normalized;
+}
+
+function captureDirectoryChain(
+  socketPath: string,
+  uid: number,
+  lstat: (filePath: string) => PodmanSocketStat,
+): readonly PodmanSocketDirectoryAuthority[] {
+  const directories: string[] = [];
+  for (let directory = path.dirname(socketPath); ; directory = path.dirname(directory)) {
+    directories.push(directory);
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+  }
+
+  return Object.freeze(
+    directories.map((directory, index) => {
+      const stat = lstat(directory);
+      if (!stat.isDirectory()) {
+        throw new Error(`Podman socket path component '${directory}' is not a real directory.`);
+      }
+      const ownerUid = integerIdentity(stat.uid, "directory owner");
+      if (index === 0 && ownerUid !== String(uid)) {
+        throw new Error(
+          `Podman socket directory is owned by uid ${ownerUid}; expected current uid ${String(uid)}.`,
+        );
+      }
+      const mode = integerValue(stat.mode, "directory mode");
+      if ((mode & 0o022n) !== 0n) {
+        throw new Error(
+          `Podman socket path component '${directory}' is writable by another user or group.`,
+        );
+      }
+      return Object.freeze({
+        device: integerIdentity(stat.dev, "directory device"),
+        inode: integerIdentity(stat.ino, "directory inode"),
+        mode: mode.toString(10),
+        ownerUid,
+        path: directory,
+      });
+    }),
+  );
+}
+
+export function capturePodmanSocketAuthority(
+  socketPath: string,
+  deps: PodmanSocketAuthorityDeps = {},
+): PodmanSocketAuthority {
+  const normalized = normalizedSocketPath(socketPath);
+  const lstat =
+    deps.lstat ??
+    ((filePath: string): PodmanSocketStat => fs.lstatSync(filePath, { bigint: true }));
+  const stat = lstat(normalized);
+  if (!stat.isSocket()) {
+    throw new Error("Podman socket authority path is not a Unix socket.");
+  }
+  const uid = currentUid(deps.uid);
+  const ownerUid = integerIdentity(stat.uid, "owner");
+  if (ownerUid !== String(uid)) {
+    throw new Error(
+      `Podman socket authority is owned by uid ${ownerUid}; expected current uid ${String(uid)}.`,
+    );
+  }
+  return Object.freeze({
+    directoryChain: captureDirectoryChain(normalized, uid, lstat),
+    device: integerIdentity(stat.dev, "device"),
+    inode: integerIdentity(stat.ino, "inode"),
+    ownerUid,
+    socketPath: normalized,
+  });
+}
+
+export function assertPodmanSocketAuthority(
+  expected: PodmanSocketAuthority,
+  deps: PodmanSocketAuthorityDeps = {},
+): void {
+  const actual = capturePodmanSocketAuthority(expected.socketPath, deps);
+  if (
+    actual.device !== expected.device ||
+    actual.inode !== expected.inode ||
+    actual.ownerUid !== expected.ownerUid ||
+    actual.directoryChain.length !== expected.directoryChain.length ||
+    actual.directoryChain.some((component, index) => {
+      const pinned = expected.directoryChain[index];
+      return (
+        !pinned ||
+        component.device !== pinned.device ||
+        component.inode !== pinned.inode ||
+        component.mode !== pinned.mode ||
+        component.ownerUid !== pinned.ownerUid ||
+        component.path !== pinned.path
+      );
+    })
+  ) {
+    throw new Error("Podman socket authority changed after it was qualified.");
+  }
+}

--- a/src/lib/adapters/podman/socket-authority.ts
+++ b/src/lib/adapters/podman/socket-authority.ts
@@ -25,6 +25,7 @@ export interface PodmanSocketAuthority {
   readonly directoryChain: readonly PodmanSocketDirectoryAuthority[];
   readonly device: string;
   readonly inode: string;
+  readonly mode: string;
   readonly ownerUid: string;
   readonly socketPath: string;
 }
@@ -133,10 +134,15 @@ export function capturePodmanSocketAuthority(
       `Podman socket authority is owned by uid ${ownerUid}; expected current uid ${String(uid)}.`,
     );
   }
+  const mode = integerValue(stat.mode, "mode");
+  if ((mode & 0o022n) !== 0n) {
+    throw new Error("Podman socket authority is writable by another user or group.");
+  }
   return Object.freeze({
     directoryChain: captureDirectoryChain(normalized, uid, lstat),
     device: integerIdentity(stat.dev, "device"),
     inode: integerIdentity(stat.ino, "inode"),
+    mode: mode.toString(10),
     ownerUid,
     socketPath: normalized,
   });
@@ -150,6 +156,7 @@ export function assertPodmanSocketAuthority(
   if (
     actual.device !== expected.device ||
     actual.inode !== expected.inode ||
+    actual.mode !== expected.mode ||
     actual.ownerUid !== expected.ownerUid ||
     actual.directoryChain.length !== expected.directoryChain.length ||
     actual.directoryChain.some((component, index) => {

--- a/src/lib/onboard/lifecycle-contracts.md
+++ b/src/lib/onboard/lifecycle-contracts.md
@@ -176,6 +176,33 @@ rebind, durable interrupted-restore recovery, ordinary recreate integration, and
 runtime activation are separately reviewable units tracked by that epic.
 If provider proof fails after filesystem restoration, NemoClaw reports that state changed and requires the operator to retry the exact snapshot after the runtime stabilizes.
 
+## Dormant Podman managed bootstrap authority
+
+The Podman candidate owns a separate `managed-bootstrap` command scope bound
+to one exact rootless engine authority. Before a bootstrap mutation, it
+discovers and stably inspects exactly one held OpenShell workload and acquires a
+durable lease over the exact watcher process and lifecycle owner. Ambiguous
+workloads, watcher ownership, PID reuse, endpoint drift, or a competing lease
+fail closed.
+
+Preparation creates a private managed state volume and a stopped,
+final-labelled replacement while retaining the exact original. Its monotonic
+journal records the engine authority, watcher lease, immutable original and
+replacement identities, image and specification fingerprints, state volume,
+and rollback decision before each external effect. Pre-commit rollback removes
+only the proven stopped replacement and owned volume, restores the exact
+original, and leaves the watcher lease with the caller until a healthy exact
+owner is independently requalified.
+
+The image transaction accepts only that prepared authority. It stages one
+protected root-apply request, starts the exact replacement, and authenticates
+the image-owned completion for OpenClaw, Hermes, or LangChain Deep Agents Code.
+The watcher stays stopped and the journal remains authoritative throughout.
+These provider-owned modules remain disconnected from production runtime
+selection; persisted post-commit recovery, GPU and local inference, installer
+qualification, and supported activation remain later gates in
+[`#7744`](https://github.com/NVIDIA/NemoClaw/issues/7744).
+
 ## Agent-specific differences
 
 | Agent | Lifecycle difference |

--- a/src/lib/onboard/managed-bootstrap/README.md
+++ b/src/lib/onboard/managed-bootstrap/README.md
@@ -100,6 +100,25 @@ restored original quiescent and preserves the journal without a terminal
 receipt until the owning sandbox service removes the exact runtime and the
 provider proves its absence. Unknown runtime presence is a retryable durable
 cleanup failure, never evidence of absence.
+
+The dormant Podman candidate keeps the same provider-neutral coordinator
+boundary but owns its engine-specific authority internally. It binds one
+operation-scoped Podman command adapter to the exact rootless endpoint, captures
+one held OpenShell workload twice, and durably leases the watcher owner before
+any cutover. Preparation creates and proves a stopped, final-labelled
+replacement and its private managed state volume while retaining the exact
+original. The journal records every mutation boundary before the next external
+effect and preserves enough immutable identity to roll back without deleting by
+name.
+
+Image bootstrap accepts only that prepared authority. It stages one protected
+root-apply envelope, starts the exact replacement, and authenticates the
+image-owned completion for OpenClaw, Hermes, or LangChain Deep Agents Code.
+The watcher remains stopped and the journal remains authoritative throughout.
+These modules are intentionally absent from the production provider registry;
+the hidden experimental runtime boundary can qualify them before later slices
+add persisted engine recovery, GPU and local inference, installer coverage,
+and supported activation.
 The image-owned shared-state transaction uses the same identity-bound model: a
 commit atomically moves its pending manifest and backups into a durable receipt
 namespace, compacts that state to an exact commit receipt, and rejects rollback

--- a/src/lib/onboard/managed-bootstrap/podman-bootstrap-journal.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-bootstrap-journal.test.ts
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createFilePodmanBootstrapJournalStore,
+  normalizePodmanBootstrapJournal,
+  PODMAN_BOOTSTRAP_JOURNAL_DIRECTORY,
+  PODMAN_BOOTSTRAP_JOURNAL_SCHEMA_VERSION,
+  type PodmanBootstrapJournal,
+  parsePodmanBootstrapJournal,
+  serializePodmanBootstrapJournal,
+} from "./podman-bootstrap-journal";
+
+const BOOTSTRAP_IDENTITY = "1".repeat(64);
+const ORIGINAL_RUNTIME_ID = "2".repeat(64);
+const REPLACEMENT_RUNTIME_ID = "3".repeat(64);
+const STATE_VOLUME_NAME = "openshell-sandbox-alpha-nemoclaw-bootstrap-state-111111111111";
+const STATE_VOLUME_MOUNTPOINT = "/var/lib/containers/storage/volumes/bootstrap-state/_data";
+const journal = Object.freeze({
+  schemaVersion: PODMAN_BOOTSTRAP_JOURNAL_SCHEMA_VERSION,
+  phase: "preparing-replacement",
+  bootstrapIdentity: BOOTSTRAP_IDENTITY,
+  engineAuthorityId: `podman-sha256:${"4".repeat(64)}`,
+  watcherLeaseId: "123e4567-e89b-42d3-a456-426614174000",
+  sandboxName: "alpha",
+  sandboxId: "sandbox-alpha",
+  originalRuntimeId: ORIGINAL_RUNTIME_ID,
+  originalContainerName: "openshell-sandbox-alpha",
+  originalImageContentId: `sha256:${"5".repeat(64)}`,
+  originalSpecFingerprint: "6".repeat(64),
+  replacementStateVolumeName: STATE_VOLUME_NAME,
+  replacementStateVolumeMountpoint: null,
+  replacementRuntimeId: null,
+  replacementStagingName: "openshell-sandbox-alpha-nemoclaw-bootstrap",
+  replacementImageContentId: `sha256:${"7".repeat(64)}`,
+  replacementSpecFingerprint: "8".repeat(64),
+} satisfies PodmanBootstrapJournal);
+
+const roots: string[] = [];
+
+function temporaryRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-podman-bootstrap-journal-"));
+  roots.push(root);
+  return root;
+}
+
+function journalFile(root: string): string {
+  return path.join(root, PODMAN_BOOTSTRAP_JOURNAL_DIRECTORY, `${BOOTSTRAP_IDENTITY}.json`);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
+});
+
+describe("Podman bootstrap phase journal", () => {
+  it("persists private canonical authority before replacement creation", () => {
+    const root = temporaryRoot();
+    const store = createFilePodmanBootstrapJournalStore(root);
+
+    store.create(journal);
+
+    const directory = path.join(root, PODMAN_BOOTSTRAP_JOURNAL_DIRECTORY);
+    expect(fs.statSync(directory).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(journalFile(root)).mode & 0o777).toBe(0o600);
+    expect(fs.readFileSync(journalFile(root), "utf8")).toBe(
+      serializePodmanBootstrapJournal(journal),
+    );
+    expect(store.load(BOOTSTRAP_IDENTITY)).toEqual(journal);
+    expect(store.listUnfinished()).toEqual([journal]);
+    expect(() => store.create(journal)).toThrow("already exists");
+  });
+
+  it("records one exact replacement and original stop in monotonic order", () => {
+    const store = createFilePodmanBootstrapJournalStore(temporaryRoot());
+    store.create(journal);
+
+    const volume = store.recordStateVolume(BOOTSTRAP_IDENTITY, STATE_VOLUME_MOUNTPOINT);
+    expect(volume.phase).toBe("state-volume-created");
+    expect(volume.replacementStateVolumeMountpoint).toBe(STATE_VOLUME_MOUNTPOINT);
+    expect(store.recordStateVolume(BOOTSTRAP_IDENTITY, STATE_VOLUME_MOUNTPOINT)).toEqual(volume);
+    expect(() =>
+      store.recordStateVolume(BOOTSTRAP_IDENTITY, "/var/lib/containers/storage/other"),
+    ).toThrow("changed for this bootstrap identity");
+
+    const created = store.recordReplacement(BOOTSTRAP_IDENTITY, REPLACEMENT_RUNTIME_ID);
+    expect(created.phase).toBe("replacement-created");
+    expect(created.replacementRuntimeId).toBe(REPLACEMENT_RUNTIME_ID);
+    expect(store.recordReplacement(BOOTSTRAP_IDENTITY, REPLACEMENT_RUNTIME_ID)).toEqual(created);
+    expect(() => store.recordReplacement(BOOTSTRAP_IDENTITY, "9".repeat(64))).toThrow(
+      "changed for this bootstrap identity",
+    );
+
+    const stopped = store.recordOriginalStopped(BOOTSTRAP_IDENTITY);
+    expect(stopped.phase).toBe("original-stopped");
+    expect(store.recordOriginalStopped(BOOTSTRAP_IDENTITY)).toEqual(stopped);
+    expect(() => store.recordReplacement(BOOTSTRAP_IDENTITY, REPLACEMENT_RUNTIME_ID)).toThrow(
+      "requires state-volume-created",
+    );
+  });
+
+  it("makes rollback durable before runtime cleanup begins", () => {
+    const root = temporaryRoot();
+    const store = createFilePodmanBootstrapJournalStore(root);
+    store.create(journal);
+    store.recordStateVolume(BOOTSTRAP_IDENTITY, STATE_VOLUME_MOUNTPOINT);
+    store.recordReplacement(BOOTSTRAP_IDENTITY, REPLACEMENT_RUNTIME_ID);
+
+    const rollback = store.authorizeRollback(BOOTSTRAP_IDENTITY, ["replacement-created"]);
+
+    expect(rollback.phase).toBe("rollback-authorized");
+    expect(fs.readFileSync(`${journalFile(root)}.decision`, "utf8")).toBe("rollback-authorized\n");
+    expect(store.authorizeRollback(BOOTSTRAP_IDENTITY, ["replacement-created"])).toEqual(rollback);
+    store.removeAfterRollback(BOOTSTRAP_IDENTITY);
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+  });
+
+  it("recovers a rollback decision that survived its journal acknowledgement", () => {
+    const root = temporaryRoot();
+    const store = createFilePodmanBootstrapJournalStore(root);
+    store.create(journal);
+    store.recordStateVolume(BOOTSTRAP_IDENTITY, STATE_VOLUME_MOUNTPOINT);
+    store.recordReplacement(BOOTSTRAP_IDENTITY, REPLACEMENT_RUNTIME_ID);
+    fs.writeFileSync(`${journalFile(root)}.decision`, "rollback-authorized\n", {
+      flag: "wx",
+      mode: 0o600,
+    });
+
+    expect(store.load(BOOTSTRAP_IDENTITY)?.phase).toBe("rollback-authorized");
+    expect(parsePodmanBootstrapJournal(fs.readFileSync(journalFile(root), "utf8")).phase).toBe(
+      "rollback-authorized",
+    );
+  });
+
+  it("reconciles an exclusive rollback-decision collision", () => {
+    const root = temporaryRoot();
+    const store = createFilePodmanBootstrapJournalStore(root);
+    store.create(journal);
+    const target = `${journalFile(root)}.decision`;
+    const originalLink = fs.linkSync.bind(fs);
+    vi.spyOn(fs, "linkSync").mockImplementationOnce((source, destination) => {
+      fs.writeFileSync(target, "rollback-authorized\n", { flag: "wx", mode: 0o600 });
+      return originalLink(source, destination);
+    });
+
+    expect(store.authorizeRollback(BOOTSTRAP_IDENTITY, ["preparing-replacement"]).phase).toBe(
+      "rollback-authorized",
+    );
+  });
+
+  it("rejects an orphan rollback decision during recovery enumeration", () => {
+    const root = temporaryRoot();
+    const directory = path.join(root, PODMAN_BOOTSTRAP_JOURNAL_DIRECTORY);
+    fs.mkdirSync(directory, { mode: 0o700 });
+    fs.writeFileSync(
+      path.join(directory, `${BOOTSTRAP_IDENTITY}.json.decision`),
+      "rollback-authorized\n",
+      {
+        mode: 0o600,
+      },
+    );
+
+    expect(() => createFilePodmanBootstrapJournalStore(root).listUnfinished()).toThrow(
+      "has no journal",
+    );
+  });
+
+  it("rejects a symlinked journal before reading outside state", () => {
+    const root = temporaryRoot();
+    const directory = path.join(root, PODMAN_BOOTSTRAP_JOURNAL_DIRECTORY);
+    const outside = path.join(root, "outside.json");
+    fs.mkdirSync(directory, { mode: 0o700 });
+    fs.writeFileSync(outside, serializePodmanBootstrapJournal(journal), { mode: 0o600 });
+    fs.symlinkSync(outside, journalFile(root));
+
+    expect(() => createFilePodmanBootstrapJournalStore(root).load(BOOTSTRAP_IDENTITY)).toThrow(
+      "ownership boundary",
+    );
+  });
+
+  it("rejects a future schema or an identity that does not match its phase", () => {
+    expect(() => normalizePodmanBootstrapJournal({ ...journal, schemaVersion: 2 })).toThrow(
+      "schema is invalid",
+    );
+    expect(() =>
+      normalizePodmanBootstrapJournal({
+        ...journal,
+        phase: "replacement-created",
+        replacementRuntimeId: null,
+      }),
+    ).toThrow("phase does not match");
+    expect(() =>
+      normalizePodmanBootstrapJournal({
+        ...journal,
+        engineAuthorityId: `docker-sha256:${"4".repeat(64)}`,
+      }),
+    ).toThrow("exact Podman authority");
+  });
+
+  it("rejects noncanonical or oversized serialized state", () => {
+    expect(() => parsePodmanBootstrapJournal(JSON.stringify(journal))).toThrow("not canonical");
+    expect(() => parsePodmanBootstrapJournal(`{\"value\":\"${"x".repeat(33 * 1024)}\"}\n`)).toThrow(
+      "too large",
+    );
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/podman-bootstrap-journal.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-bootstrap-journal.ts
@@ -1,0 +1,625 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const PODMAN_BOOTSTRAP_JOURNAL_SCHEMA_VERSION = 1 as const;
+export const PODMAN_BOOTSTRAP_JOURNAL_DIRECTORY = "managed-bootstrap-podman";
+
+const DIRECTORY_MODE = 0o700;
+const FILE_MODE = 0o600;
+const MAX_JOURNAL_BYTES = 32 * 1024;
+const SHA256 = /^[a-f0-9]{64}$/u;
+const IMAGE_CONTENT_ID = /^sha256:[a-f0-9]{64}$/u;
+const AUTHORITY_ID = /^podman-sha256:[a-f0-9]{64}$/u;
+const LEASE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,252}$/u;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f-\u009f]/u;
+
+export type PodmanBootstrapJournalPhase =
+  | "preparing-replacement"
+  | "state-volume-created"
+  | "replacement-created"
+  | "original-stopped"
+  | "rollback-authorized";
+
+export interface PodmanBootstrapJournal {
+  readonly schemaVersion: typeof PODMAN_BOOTSTRAP_JOURNAL_SCHEMA_VERSION;
+  readonly phase: PodmanBootstrapJournalPhase;
+  readonly bootstrapIdentity: string;
+  readonly engineAuthorityId: string;
+  readonly watcherLeaseId: string;
+  readonly sandboxName: string;
+  readonly sandboxId: string;
+  readonly originalRuntimeId: string;
+  readonly originalContainerName: string;
+  readonly originalImageContentId: string;
+  readonly originalSpecFingerprint: string;
+  readonly replacementStateVolumeName: string;
+  readonly replacementStateVolumeMountpoint: string | null;
+  readonly replacementRuntimeId: string | null;
+  readonly replacementStagingName: string;
+  readonly replacementImageContentId: string;
+  readonly replacementSpecFingerprint: string;
+}
+
+export interface PodmanBootstrapJournalStore {
+  /** Create durable mutation authority before the first replacement command. */
+  readonly create: (journal: PodmanBootstrapJournal) => void;
+  readonly load: (bootstrapIdentity: string) => PodmanBootstrapJournal | null;
+  readonly listUnfinished: () => readonly PodmanBootstrapJournal[];
+  /** Record the exact Podman-managed state volume before container creation. */
+  readonly recordStateVolume: (
+    bootstrapIdentity: string,
+    replacementStateVolumeMountpoint: string,
+  ) => PodmanBootstrapJournal;
+  /** Record the exact stopped replacement ID after a stable inspect. */
+  readonly recordReplacement: (
+    bootstrapIdentity: string,
+    replacementRuntimeId: string,
+  ) => PodmanBootstrapJournal;
+  /** Record that the exact original container is stopped. */
+  readonly recordOriginalStopped: (bootstrapIdentity: string) => PodmanBootstrapJournal;
+  /** Make rollback the only legal pre-commit outcome. */
+  readonly authorizeRollback: (
+    bootstrapIdentity: string,
+    expected: readonly Exclude<PodmanBootstrapJournalPhase, "rollback-authorized">[],
+  ) => PodmanBootstrapJournal;
+  /** Remove the journal only after exact rollback state is independently proven. */
+  readonly removeAfterRollback: (bootstrapIdentity: string) => void;
+}
+
+class PodmanBootstrapJournalExistsError extends Error {
+  public constructor() {
+    super("Podman bootstrap journal already exists for this bootstrap identity.");
+    this.name = "PodmanBootstrapJournalExistsError";
+  }
+}
+
+function fail(message: string): never {
+  throw new Error(`Podman bootstrap journal is invalid: ${message}`);
+}
+
+function exactString(value: unknown, label: string, maxBytes = 4096): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value !== value.trim() ||
+    value.includes("\0") ||
+    CONTROL_CHARACTER.test(value) ||
+    Buffer.byteLength(value, "utf8") > maxBytes
+  ) {
+    fail(`${label} must be one bounded exact string`);
+  }
+  return value;
+}
+
+function exactSha256(value: unknown, label: string): string {
+  if (typeof value !== "string" || !SHA256.test(value)) {
+    fail(`${label} must be lowercase SHA-256`);
+  }
+  return value;
+}
+
+function exactRuntimeId(value: unknown, label: string): string {
+  return exactSha256(value, label);
+}
+
+function exactImageContentId(value: unknown, label: string): string {
+  if (typeof value !== "string" || !IMAGE_CONTENT_ID.test(value)) {
+    fail(`${label} must be one immutable sha256 image content ID`);
+  }
+  return value;
+}
+
+function exactPhase(value: unknown): PodmanBootstrapJournalPhase {
+  if (
+    ![
+      "preparing-replacement",
+      "state-volume-created",
+      "replacement-created",
+      "original-stopped",
+      "rollback-authorized",
+    ].includes(String(value))
+  ) {
+    fail("phase is unsupported");
+  }
+  return value as PodmanBootstrapJournalPhase;
+}
+
+function exactAbsolutePath(value: unknown, label: string): string {
+  const target = exactString(value, label);
+  if (
+    !path.isAbsolute(target) ||
+    path.normalize(target) !== target ||
+    target === path.parse(target).root
+  ) {
+    fail(`${label} must be one normalized non-root absolute path`);
+  }
+  return target;
+}
+
+function exactContainerName(value: unknown, label: string): string {
+  const name = exactString(value, label, 253);
+  if (!SAFE_NAME.test(name)) fail(`${label} is malformed`);
+  return name;
+}
+
+export function normalizePodmanBootstrapJournal(value: unknown): PodmanBootstrapJournal {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail("journal must be an object");
+  }
+  const journal = value as Record<string, unknown>;
+  const expectedKeys = [
+    "bootstrapIdentity",
+    "engineAuthorityId",
+    "originalContainerName",
+    "originalImageContentId",
+    "originalRuntimeId",
+    "originalSpecFingerprint",
+    "phase",
+    "replacementImageContentId",
+    "replacementRuntimeId",
+    "replacementSpecFingerprint",
+    "replacementStateVolumeMountpoint",
+    "replacementStateVolumeName",
+    "replacementStagingName",
+    "sandboxId",
+    "sandboxName",
+    "schemaVersion",
+    "watcherLeaseId",
+  ];
+  if (
+    Object.keys(journal).sort().join(",") !== expectedKeys.sort().join(",") ||
+    journal.schemaVersion !== PODMAN_BOOTSTRAP_JOURNAL_SCHEMA_VERSION
+  ) {
+    fail("journal schema is invalid");
+  }
+  const replacementRuntimeId =
+    journal.replacementRuntimeId === null
+      ? null
+      : exactRuntimeId(journal.replacementRuntimeId, "replacement runtime ID");
+  const replacementStateVolumeMountpoint =
+    journal.replacementStateVolumeMountpoint === null
+      ? null
+      : exactAbsolutePath(
+          journal.replacementStateVolumeMountpoint,
+          "replacement state volume mountpoint",
+        );
+  const normalized = Object.freeze({
+    schemaVersion: PODMAN_BOOTSTRAP_JOURNAL_SCHEMA_VERSION,
+    phase: exactPhase(journal.phase),
+    bootstrapIdentity: exactSha256(journal.bootstrapIdentity, "bootstrap identity"),
+    engineAuthorityId: exactString(journal.engineAuthorityId, "engine authority ID", 256),
+    watcherLeaseId: exactString(journal.watcherLeaseId, "watcher lease ID", 64),
+    sandboxName: exactString(journal.sandboxName, "sandbox name", 128),
+    sandboxId: exactString(journal.sandboxId, "sandbox ID"),
+    originalRuntimeId: exactRuntimeId(journal.originalRuntimeId, "original runtime ID"),
+    originalContainerName: exactContainerName(
+      journal.originalContainerName,
+      "original container name",
+    ),
+    originalImageContentId: exactImageContentId(
+      journal.originalImageContentId,
+      "original image content ID",
+    ),
+    originalSpecFingerprint: exactSha256(
+      journal.originalSpecFingerprint,
+      "original spec fingerprint",
+    ),
+    replacementStateVolumeName: exactContainerName(
+      journal.replacementStateVolumeName,
+      "replacement state volume name",
+    ),
+    replacementStateVolumeMountpoint,
+    replacementRuntimeId,
+    replacementStagingName: exactContainerName(
+      journal.replacementStagingName,
+      "replacement staging name",
+    ),
+    replacementImageContentId: exactImageContentId(
+      journal.replacementImageContentId,
+      "replacement image content ID",
+    ),
+    replacementSpecFingerprint: exactSha256(
+      journal.replacementSpecFingerprint,
+      "replacement spec fingerprint",
+    ),
+  } satisfies PodmanBootstrapJournal);
+  if (!AUTHORITY_ID.test(normalized.engineAuthorityId)) {
+    fail("engine authority ID is not an exact Podman authority");
+  }
+  if (!LEASE_ID.test(normalized.watcherLeaseId)) {
+    fail("watcher lease ID is malformed");
+  }
+  if (normalized.originalContainerName === normalized.replacementStagingName) {
+    fail("original and replacement names must differ");
+  }
+  if (normalized.originalRuntimeId === normalized.replacementRuntimeId) {
+    fail("original and replacement runtime IDs must differ");
+  }
+  if (
+    (normalized.phase === "preparing-replacement" &&
+      (replacementStateVolumeMountpoint !== null || replacementRuntimeId !== null)) ||
+    (normalized.phase === "state-volume-created" &&
+      (replacementStateVolumeMountpoint === null || replacementRuntimeId !== null)) ||
+    (["replacement-created", "original-stopped"].includes(normalized.phase) &&
+      (replacementStateVolumeMountpoint === null || replacementRuntimeId === null))
+  ) {
+    fail("phase does not match the replacement runtime identity");
+  }
+  return normalized;
+}
+
+export function serializePodmanBootstrapJournal(journal: PodmanBootstrapJournal): string {
+  const serialized = `${JSON.stringify(normalizePodmanBootstrapJournal(journal))}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MAX_JOURNAL_BYTES) {
+    fail("serialized journal exceeds its bounded transport");
+  }
+  return serialized;
+}
+
+export function parsePodmanBootstrapJournal(text: string): PodmanBootstrapJournal {
+  if (
+    text.length === 0 ||
+    text.includes("\0") ||
+    Buffer.byteLength(text, "utf8") > MAX_JOURNAL_BYTES
+  ) {
+    fail("serialized journal is empty or too large");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    fail("serialized journal is not valid JSON");
+  }
+  const journal = normalizePodmanBootstrapJournal(parsed);
+  if (serializePodmanBootstrapJournal(journal) !== text) {
+    fail("serialized journal is not canonical");
+  }
+  return journal;
+}
+
+function assertDirectory(directory: string): void {
+  fs.mkdirSync(directory, { recursive: true, mode: DIRECTORY_MODE });
+  const stat = fs.lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) {
+    fail("journal directory must be a private real directory");
+  }
+}
+
+function journalPath(directory: string, bootstrapIdentity: string): string {
+  exactSha256(bootstrapIdentity, "bootstrap identity");
+  return path.join(directory, `${bootstrapIdentity}.json`);
+}
+
+function decisionPath(target: string): string {
+  return `${target}.decision`;
+}
+
+function sameStableMetadata(left: fs.BigIntStats, right: fs.BigIntStats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.nlink === right.nlink &&
+    left.uid === right.uid &&
+    left.gid === right.gid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function readPrivateFile(target: string, label: string): string | null {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") {
+    fail(`cannot safely open ${label} because O_NOFOLLOW is unavailable`);
+  }
+  const nonblock = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(target, fs.constants.O_RDONLY | noFollow | nonblock);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      fail(`${label} file ownership boundary is invalid`);
+    }
+    throw error;
+  }
+  try {
+    const before = fs.fstatSync(descriptor, { bigint: true });
+    if (
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      (before.mode & 0o077n) !== 0n ||
+      before.size <= 0n ||
+      before.size > BigInt(MAX_JOURNAL_BYTES)
+    ) {
+      fail(`${label} file ownership boundary is invalid`);
+    }
+    const contents = Buffer.alloc(Number(before.size));
+    let offset = 0;
+    while (offset < contents.length) {
+      const count = fs.readSync(descriptor, contents, offset, contents.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const overflow = Buffer.alloc(1);
+    const overflowCount = fs.readSync(descriptor, overflow, 0, 1, offset);
+    const after = fs.fstatSync(descriptor, { bigint: true });
+    if (offset !== contents.length || overflowCount !== 0 || !sameStableMetadata(before, after)) {
+      fail(`${label} file changed during its stable read`);
+    }
+    return contents.toString("utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function fsyncDirectory(directory: string): void {
+  const descriptor = fs.openSync(directory, "r");
+  try {
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function atomicWrite(
+  directory: string,
+  target: string,
+  contents: string,
+  exclusive: boolean,
+): void {
+  const temporary = path.join(directory, `.${path.basename(target)}.${randomUUID()}.tmp`);
+  let descriptor: number | null = null;
+  let primaryFailure: unknown;
+  try {
+    descriptor = fs.openSync(
+      temporary,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
+      FILE_MODE,
+    );
+    fs.writeFileSync(descriptor, contents, "utf8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = null;
+    if (exclusive) {
+      try {
+        fs.linkSync(temporary, target);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          throw new PodmanBootstrapJournalExistsError();
+        }
+        throw error;
+      }
+      fs.unlinkSync(temporary);
+    } else {
+      fs.renameSync(temporary, target);
+    }
+    fs.chmodSync(target, FILE_MODE);
+    fsyncDirectory(directory);
+  } catch (error) {
+    primaryFailure = error;
+  }
+  let cleanupFailure: unknown;
+  if (descriptor !== null) {
+    try {
+      fs.closeSync(descriptor);
+    } catch (error) {
+      cleanupFailure = error;
+    }
+  }
+  try {
+    fs.unlinkSync(temporary);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT" && cleanupFailure === undefined) {
+      cleanupFailure = error;
+    }
+  }
+  if (primaryFailure !== undefined) throw primaryFailure;
+  if (cleanupFailure !== undefined) throw cleanupFailure;
+}
+
+function sameJournal(left: PodmanBootstrapJournal, right: PodmanBootstrapJournal): boolean {
+  return serializePodmanBootstrapJournal(left) === serializePodmanBootstrapJournal(right);
+}
+
+export function createFilePodmanBootstrapJournalStore(
+  stateRoot: string,
+): PodmanBootstrapJournalStore {
+  const directory = path.join(stateRoot, PODMAN_BOOTSTRAP_JOURNAL_DIRECTORY);
+  const load = (bootstrapIdentity: string): PodmanBootstrapJournal | null => {
+    assertDirectory(directory);
+    const target = journalPath(directory, bootstrapIdentity);
+    const contents = readPrivateFile(target, "journal");
+    if (contents === null) return null;
+    const journal = parsePodmanBootstrapJournal(contents);
+    const decision = readPrivateFile(decisionPath(target), "rollback decision");
+    if (decision === null) return journal;
+    if (decision !== "rollback-authorized\n") {
+      fail("rollback decision is invalid");
+    }
+    if (journal.phase === "rollback-authorized") return journal;
+    const decided = normalizePodmanBootstrapJournal({
+      ...journal,
+      phase: "rollback-authorized",
+    });
+    atomicWrite(directory, target, serializePodmanBootstrapJournal(decided), false);
+    return decided;
+  };
+
+  return Object.freeze({
+    create(journal: PodmanBootstrapJournal) {
+      const normalized = normalizePodmanBootstrapJournal(journal);
+      if (normalized.phase !== "preparing-replacement") {
+        fail("a new journal must begin before replacement creation");
+      }
+      assertDirectory(directory);
+      const target = journalPath(directory, normalized.bootstrapIdentity);
+      if (readPrivateFile(decisionPath(target), "rollback decision") !== null) {
+        fail("stale rollback decision exists for this bootstrap identity");
+      }
+      atomicWrite(directory, target, serializePodmanBootstrapJournal(normalized), true);
+    },
+    load,
+    listUnfinished() {
+      assertDirectory(directory);
+      const identities = new Set<string>();
+      const decisions = new Set<string>();
+      for (const name of fs.readdirSync(directory)) {
+        const journalMatch = name.match(/^([a-f0-9]{64})\.json$/u);
+        if (journalMatch?.[1]) {
+          identities.add(journalMatch[1]);
+          continue;
+        }
+        const decisionMatch = name.match(/^([a-f0-9]{64})\.json\.decision$/u);
+        if (decisionMatch?.[1]) {
+          decisions.add(decisionMatch[1]);
+          continue;
+        }
+        if (/^\.[a-f0-9]{64}\.json(?:\.decision)?\.[0-9a-f-]+\.tmp$/u.test(name)) {
+          continue;
+        }
+        fail(`journal directory contains an unsupported entry: ${name}`);
+      }
+      for (const identity of decisions) {
+        if (!identities.has(identity)) fail(`rollback decision ${identity} has no journal`);
+      }
+      return Object.freeze(
+        [...identities].sort().map((identity) => {
+          const journal = load(identity);
+          if (!journal) fail(`enumerated journal ${identity} disappeared`);
+          return journal;
+        }),
+      );
+    },
+    recordStateVolume(bootstrapIdentity: string, replacementStateVolumeMountpoint: string) {
+      const normalizedMountpoint = exactAbsolutePath(
+        replacementStateVolumeMountpoint,
+        "replacement state volume mountpoint",
+      );
+      assertDirectory(directory);
+      const target = journalPath(directory, bootstrapIdentity);
+      const current = load(bootstrapIdentity);
+      if (current?.phase === "state-volume-created") {
+        if (current.replacementStateVolumeMountpoint !== normalizedMountpoint) {
+          fail("replacement state volume mountpoint changed for this bootstrap identity");
+        }
+        return current;
+      }
+      if (!current || current.phase !== "preparing-replacement") {
+        fail(
+          `state volume recording requires preparing-replacement, found ${current?.phase ?? "absent"}`,
+        );
+      }
+      const updated = normalizePodmanBootstrapJournal({
+        ...current,
+        phase: "state-volume-created",
+        replacementStateVolumeMountpoint: normalizedMountpoint,
+      });
+      atomicWrite(directory, target, serializePodmanBootstrapJournal(updated), false);
+      const persisted = load(bootstrapIdentity);
+      if (!persisted || !sameJournal(persisted, updated)) {
+        fail("replacement state volume was not durably re-readable");
+      }
+      return persisted;
+    },
+    recordReplacement(bootstrapIdentity: string, replacementRuntimeId: string) {
+      const normalizedId = exactRuntimeId(replacementRuntimeId, "replacement runtime ID");
+      assertDirectory(directory);
+      const target = journalPath(directory, bootstrapIdentity);
+      const current = load(bootstrapIdentity);
+      if (current?.phase === "replacement-created") {
+        if (current.replacementRuntimeId !== normalizedId) {
+          fail("replacement runtime ID changed for this bootstrap identity");
+        }
+        return current;
+      }
+      if (!current || current.phase !== "state-volume-created") {
+        fail(
+          `replacement recording requires state-volume-created, found ${current?.phase ?? "absent"}`,
+        );
+      }
+      const updated = normalizePodmanBootstrapJournal({
+        ...current,
+        phase: "replacement-created",
+        replacementRuntimeId: normalizedId,
+      });
+      atomicWrite(directory, target, serializePodmanBootstrapJournal(updated), false);
+      const persisted = load(bootstrapIdentity);
+      if (!persisted || !sameJournal(persisted, updated)) {
+        fail("replacement identity was not durably re-readable");
+      }
+      return persisted;
+    },
+    recordOriginalStopped(bootstrapIdentity: string) {
+      assertDirectory(directory);
+      const target = journalPath(directory, bootstrapIdentity);
+      const current = load(bootstrapIdentity);
+      if (current?.phase === "original-stopped") return current;
+      if (!current || current.phase !== "replacement-created") {
+        fail(
+          `original stop recording requires replacement-created, found ${current?.phase ?? "absent"}`,
+        );
+      }
+      const updated = normalizePodmanBootstrapJournal({ ...current, phase: "original-stopped" });
+      atomicWrite(directory, target, serializePodmanBootstrapJournal(updated), false);
+      const persisted = load(bootstrapIdentity);
+      if (!persisted || !sameJournal(persisted, updated)) {
+        fail("original stop was not durably re-readable");
+      }
+      return persisted;
+    },
+    authorizeRollback(
+      bootstrapIdentity: string,
+      expected: readonly Exclude<PodmanBootstrapJournalPhase, "rollback-authorized">[],
+    ) {
+      if (!Array.isArray(expected) || expected.length === 0) {
+        fail("rollback authorization requires at least one expected phase");
+      }
+      assertDirectory(directory);
+      const target = journalPath(directory, bootstrapIdentity);
+      const current = load(bootstrapIdentity);
+      if (current?.phase === "rollback-authorized") return current;
+      if (!current || !expected.includes(current.phase as (typeof expected)[number])) {
+        fail(`rollback authorization is not allowed from ${current?.phase ?? "absent"}`);
+      }
+      const decision = decisionPath(target);
+      try {
+        atomicWrite(directory, decision, "rollback-authorized\n", true);
+      } catch (error) {
+        if (
+          !(error instanceof PodmanBootstrapJournalExistsError) ||
+          readPrivateFile(decision, "rollback decision") !== "rollback-authorized\n"
+        ) {
+          throw error;
+        }
+      }
+      const updated = normalizePodmanBootstrapJournal({
+        ...current,
+        phase: "rollback-authorized",
+      });
+      atomicWrite(directory, target, serializePodmanBootstrapJournal(updated), false);
+      return updated;
+    },
+    removeAfterRollback(bootstrapIdentity: string) {
+      assertDirectory(directory);
+      const target = journalPath(directory, bootstrapIdentity);
+      const current = load(bootstrapIdentity);
+      if (!current || current.phase !== "rollback-authorized") {
+        fail(`rollback removal requires rollback-authorized, found ${current?.phase ?? "absent"}`);
+      }
+      const decision = decisionPath(target);
+      if (readPrivateFile(decision, "rollback decision") !== null) {
+        fs.unlinkSync(decision);
+        fsyncDirectory(directory);
+      }
+      fs.unlinkSync(target);
+      fsyncDirectory(directory);
+    },
+  });
+}

--- a/src/lib/onboard/managed-bootstrap/podman-bootstrap-replacement.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-bootstrap-replacement.test.ts
@@ -1,0 +1,797 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ContainerEngineCommandResult } from "../../adapters/container-engine";
+import {
+  createFilePodmanBootstrapJournalStore,
+  type PodmanBootstrapJournalStore,
+} from "./podman-bootstrap-journal";
+import {
+  type AuthorityBoundPodmanBootstrapEngine,
+  PODMAN_BOOTSTRAP_IDENTITY_LABEL,
+  PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+  PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+  PODMAN_BOOTSTRAP_STATE_VOLUME_LABEL,
+  type PodmanBootstrapPreparedReplacement,
+  type PodmanBootstrapReplacementPlan,
+  prepareStoppedPodmanBootstrapReplacement,
+  rollbackPodmanBootstrapBeforeCommit,
+  stopExactPodmanBootstrapOriginal,
+} from "./podman-bootstrap-replacement";
+import {
+  PODMAN_MANAGED_LABEL,
+  PODMAN_SANDBOX_ID_LABEL,
+  PODMAN_SANDBOX_NAME_LABEL,
+  PODMAN_SANDBOX_NAMESPACE_LABEL,
+  type PodmanHeldWorkloadObservation,
+} from "./podman-held-workload";
+import {
+  PODMAN_WATCHER_LEASE_SCHEMA_VERSION,
+  type PodmanGatewayWatcherLease,
+} from "./podman-watcher-lease";
+
+const BOOTSTRAP_IDENTITY = "1".repeat(64);
+const ORIGINAL_RUNTIME_ID = "2".repeat(64);
+const REPLACEMENT_RUNTIME_ID = "3".repeat(64);
+const EXTRA_RUNTIME_ID = "4".repeat(64);
+const ORIGINAL_IMAGE_ID = `sha256:${"5".repeat(64)}`;
+const REPLACEMENT_IMAGE_ID = `sha256:${"6".repeat(64)}`;
+const ENGINE_AUTHORITY_ID = `podman-sha256:${"7".repeat(64)}`;
+const SANDBOX_NAME = "alpha";
+const SANDBOX_ID = "sandbox-alpha";
+const ORIGINAL_NAME = `openshell-sandbox-${SANDBOX_NAME}`;
+const STAGING_NAME = "openshell-sandbox-alpha-nemoclaw-bootstrap-111111111111";
+const STATE_VOLUME_NAME = "openshell-sandbox-alpha-nemoclaw-state-111111111111";
+const STATE_VOLUME_MOUNTPOINT = `/var/lib/containers/storage/volumes/${STATE_VOLUME_NAME}/_data`;
+const SUPERVISOR_ARGV = ["/opt/openshell/bin/supervisor", "--config", "/etc/openshell.toml"];
+const ENTRYPOINT_ARGV = ["/usr/local/bin/nemoclaw-managed-bootstrap"];
+const COMMAND_ARGV = ["--apply-root", "--agent", "hermes"];
+const ENVIRONMENT = [
+  "OPENSHELL_SANDBOX_COMMAND=/usr/local/bin/nemoclaw-start",
+  "LOW_ENTROPY_PASSWORD=do-not-put-this-in-process-argv",
+];
+const LABELS = Object.freeze({
+  [PODMAN_MANAGED_LABEL]: "true",
+  [PODMAN_SANDBOX_ID_LABEL]: SANDBOX_ID,
+  [PODMAN_SANDBOX_NAME_LABEL]: SANDBOX_NAME,
+  [PODMAN_SANDBOX_NAMESPACE_LABEL]: "",
+});
+const STATE_VOLUME_LABELS = Object.freeze({
+  [PODMAN_BOOTSTRAP_IDENTITY_LABEL]: BOOTSTRAP_IDENTITY,
+  [PODMAN_BOOTSTRAP_STATE_VOLUME_LABEL]: "true",
+  [PODMAN_SANDBOX_ID_LABEL]: SANDBOX_ID,
+  [PODMAN_SANDBOX_NAME_LABEL]: SANDBOX_NAME,
+});
+
+const heldWorkload = Object.freeze({
+  containerName: ORIGINAL_NAME,
+  heldWorkloadArgv: [
+    "/usr/local/bin/nemoclaw-managed-hold",
+    "--bootstrap-identity",
+    BOOTSTRAP_IDENTITY,
+  ],
+  imageContentId: ORIGINAL_IMAGE_ID,
+  labels: LABELS,
+  runtimeId: ORIGINAL_RUNTIME_ID,
+  running: true,
+  sandboxId: SANDBOX_ID,
+  sandboxName: SANDBOX_NAME,
+  supervisorArgv: SUPERVISOR_ARGV,
+} satisfies PodmanHeldWorkloadObservation);
+
+const plan = Object.freeze({
+  schemaVersion: PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+  bootstrapIdentity: BOOTSTRAP_IDENTITY,
+  heldWorkload,
+  runtimeArgs: ["--network", "network-id", "--mount", "type=volume,source=workspace,dst=/sandbox"],
+  environment: ENVIRONMENT,
+  entrypointArgv: ENTRYPOINT_ARGV,
+  commandArgv: COMMAND_ARGV,
+  replacementImageContentId: REPLACEMENT_IMAGE_ID,
+} satisfies PodmanBootstrapReplacementPlan);
+
+interface ContainerState {
+  readonly id: string;
+  readonly name: string;
+  readonly image: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly entrypoint: readonly string[];
+  readonly command: readonly string[];
+  readonly environment: readonly string[];
+  readonly mounts: readonly Record<string, unknown>[];
+  running: boolean;
+}
+
+interface StateVolume {
+  readonly name: string;
+  readonly mountpoint: string;
+  readonly labels: Readonly<Record<string, string>>;
+}
+
+class PodmanHarness {
+  public readonly calls: string[][] = [];
+  public readonly engine: AuthorityBoundPodmanBootstrapEngine;
+  public original: ContainerState = {
+    id: ORIGINAL_RUNTIME_ID,
+    name: ORIGINAL_NAME,
+    image: ORIGINAL_IMAGE_ID,
+    labels: LABELS,
+    entrypoint: [SUPERVISOR_ARGV[0] as string],
+    command: SUPERVISOR_ARGV.slice(1),
+    environment: [],
+    mounts: [],
+    running: true,
+  };
+  public replacement: ContainerState | null = null;
+  public stateVolume: StateVolume | null = null;
+  public extraStagingIds: string[] = [];
+  public createResult: ContainerEngineCommandResult | null = null;
+  public replacementStartsOnCreate = false;
+  public failReplacementInspectOnce = false;
+  public replacementEnvironment: readonly string[] = ENVIRONMENT;
+  public stateVolumeMountMode = "z";
+  public capturedEnvironmentFile: string | null = null;
+  public capturedEnvironmentContents: string | null = null;
+  public capturedEnvironmentMode: number | null = null;
+
+  public constructor(authorityId = ENGINE_AUTHORITY_ID) {
+    this.engine = {
+      operation: "managed-bootstrap",
+      engineId: "podman",
+      displayName: "Podman",
+      authorityId,
+      capture: (args) => this.capture(args),
+      captureHost: vi.fn(),
+    };
+  }
+
+  private result(
+    stdout = "",
+    overrides: Partial<ContainerEngineCommandResult> = {},
+  ): ContainerEngineCommandResult {
+    return { status: 0, stdout, stderr: "", ...overrides };
+  }
+
+  private inspectOutput(container: ContainerState): string {
+    return JSON.stringify([
+      {
+        Id: container.id,
+        Image: container.image,
+        Name: container.name,
+        Config: {
+          Cmd: container.command,
+          Entrypoint: container.entrypoint,
+          Env: container.environment,
+          Labels: container.labels,
+        },
+        State: {
+          Dead: false,
+          Paused: false,
+          Restarting: false,
+          Running: container.running,
+        },
+        Mounts: container.mounts,
+      },
+    ]);
+  }
+
+  private volumeInspectOutput(volume: StateVolume): string {
+    return JSON.stringify([
+      {
+        Anonymous: false,
+        Driver: "local",
+        Labels: volume.labels,
+        Mountpoint: volume.mountpoint,
+        Name: volume.name,
+        Options: {},
+        Scope: "local",
+      },
+    ]);
+  }
+
+  private capture(args: readonly string[]): ContainerEngineCommandResult {
+    this.calls.push([...args]);
+    switch (`${String(args[0])}:${String(args[1])}`) {
+      case "volume:exists":
+        return this.result("", { status: args[2] === this.stateVolume?.name ? 0 : 1 });
+      case "volume:create":
+        return this.createStateVolume();
+      case "volume:inspect":
+        return args[2] === this.stateVolume?.name
+          ? this.result(this.volumeInspectOutput(this.stateVolume))
+          : this.result("", { status: 125 });
+      case "volume:rm":
+        return this.removeStateVolume(args);
+      case "container:create":
+        return this.createContainer(args);
+      case "container:inspect":
+        return this.inspectContainer(args);
+      case "container:stop":
+        expect(args[2]).toBe(this.original.id);
+        this.original.running = false;
+        return this.result(this.original.id);
+      case "container:start":
+        expect(args[2]).toBe(this.original.id);
+        this.original.running = true;
+        return this.result(this.original.id);
+      case "container:rm":
+        expect(args[2]).toBe(this.replacement?.id);
+        this.replacement = null;
+        return this.result();
+      case "container:exists": {
+        const exists = args[2] === this.original.id || args[2] === this.replacement?.id;
+        return this.result("", { status: exists ? 0 : 1 });
+      }
+      case "container:ls": {
+        const ids = [...(this.replacement ? [this.replacement.id] : []), ...this.extraStagingIds];
+        return this.result(JSON.stringify(ids.map((Id) => ({ Id }))));
+      }
+      default:
+        throw new Error(`Unexpected Podman command: ${args.join(" ")}`);
+    }
+  }
+
+  private createStateVolume(): ContainerEngineCommandResult {
+    switch (this.stateVolume) {
+      case null:
+        this.stateVolume = {
+          name: STATE_VOLUME_NAME,
+          mountpoint: STATE_VOLUME_MOUNTPOINT,
+          labels: STATE_VOLUME_LABELS,
+        };
+        return this.result(`${STATE_VOLUME_NAME}\n`);
+      default:
+        return this.result("", { status: 125 });
+    }
+  }
+
+  private removeStateVolume(args: readonly string[]): ContainerEngineCommandResult {
+    const removable = args[2] === this.stateVolume?.name && this.replacement === null;
+    switch (removable) {
+      case true:
+        this.stateVolume = null;
+        return this.result();
+      default:
+        return this.result("", { status: 125 });
+    }
+  }
+
+  private createContainer(args: readonly string[]): ContainerEngineCommandResult {
+    const environmentFileIndex = args.indexOf("--env-file") + 1;
+    const environmentFile = args[environmentFileIndex] as string;
+    this.capturedEnvironmentFile = environmentFile;
+    this.capturedEnvironmentContents = fs.readFileSync(environmentFile, "utf8");
+    this.capturedEnvironmentMode = fs.statSync(environmentFile).mode & 0o777;
+    const configuredResult = this.createResult;
+    switch (configuredResult) {
+      case null:
+        this.replacement = {
+          id: REPLACEMENT_RUNTIME_ID,
+          name: STAGING_NAME,
+          image: REPLACEMENT_IMAGE_ID,
+          labels: LABELS,
+          entrypoint: ENTRYPOINT_ARGV,
+          command: COMMAND_ARGV,
+          environment: this.replacementEnvironment,
+          mounts: [
+            {
+              Destination: PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+              Driver: "local",
+              Mode: this.stateVolumeMountMode,
+              Name: STATE_VOLUME_NAME,
+              Options: ["rw"],
+              Propagation: "",
+              RW: true,
+              Source: STATE_VOLUME_MOUNTPOINT,
+              Type: "volume",
+            },
+          ],
+          running: this.replacementStartsOnCreate,
+        };
+        return this.result(`${REPLACEMENT_RUNTIME_ID}\n`);
+      default:
+        return configuredResult;
+    }
+  }
+
+  private inspectContainer(args: readonly string[]): ContainerEngineCommandResult {
+    const runtimeId = args[2];
+    const failOnce = runtimeId === this.replacement?.id && this.failReplacementInspectOnce;
+    switch (failOnce) {
+      case true:
+        this.failReplacementInspectOnce = false;
+        return this.result("", { status: 125, error: new Error("inspect interrupted") });
+    }
+    const container =
+      runtimeId === this.original.id
+        ? this.original
+        : runtimeId === this.replacement?.id
+          ? this.replacement
+          : null;
+    return container
+      ? this.result(this.inspectOutput(container))
+      : this.result("", { status: 125, error: new Error("container absent") });
+  }
+}
+
+const roots: string[] = [];
+
+function journalStore(): PodmanBootstrapJournalStore {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-podman-replacement-test-"));
+  roots.push(root);
+  return createFilePodmanBootstrapJournalStore(root);
+}
+
+function watcherLease() {
+  const assertStillStopped = vi.fn();
+  const resumeAndProve = vi.fn();
+  const lease: PodmanGatewayWatcherLease = {
+    record: {
+      schemaVersion: PODMAN_WATCHER_LEASE_SCHEMA_VERSION,
+      holder: { pid: 9_100, processStartIdentity: "holder-start-100" },
+      leaseId: "123e4567-e89b-42d3-a456-426614174000",
+      phase: "stopped",
+      gatewayName: "default",
+      gatewayPort: 8080,
+      launchIdentity: "launch-default",
+      ownerIdentity: "owner-default",
+      ownerKind: "managed-service",
+      pid: 1234,
+      processStartIdentity: "pid-start-1234",
+    },
+    assertStillStopped,
+    resumeAndProve,
+  };
+  return { assertStillStopped, lease, resumeAndProve };
+}
+
+function prepare(
+  harness: PodmanHarness,
+  store: PodmanBootstrapJournalStore,
+  lease: PodmanGatewayWatcherLease,
+): PodmanBootstrapPreparedReplacement {
+  return prepareStoppedPodmanBootstrapReplacement({
+    engine: harness.engine,
+    journalStore: store,
+    watcherLease: lease,
+    plan,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
+});
+
+describe("Podman bootstrap stopped replacement", () => {
+  it("journals authority before creating one exact stopped final-labelled replacement", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    const prepared = prepare(harness, store, watcher.lease);
+
+    expect(prepared.replacementRuntimeId).toBe(REPLACEMENT_RUNTIME_ID);
+    expect(prepared.replacementStagingName).toBe(STAGING_NAME);
+    expect(prepared.replacementStateVolumeName).toBe(STATE_VOLUME_NAME);
+    expect(prepared.replacementStateVolumeMountpoint).toBe(STATE_VOLUME_MOUNTPOINT);
+    expect(prepared.journal.phase).toBe("replacement-created");
+    expect(prepared.journal.engineAuthorityId).toBe(ENGINE_AUTHORITY_ID);
+    expect(prepared.journal.watcherLeaseId).toBe(watcher.lease.record.leaseId);
+    expect(harness.replacement).toMatchObject({
+      id: REPLACEMENT_RUNTIME_ID,
+      name: STAGING_NAME,
+      image: REPLACEMENT_IMAGE_ID,
+      labels: LABELS,
+      running: false,
+    });
+    expect(harness.stateVolume).toEqual({
+      name: STATE_VOLUME_NAME,
+      mountpoint: STATE_VOLUME_MOUNTPOINT,
+      labels: STATE_VOLUME_LABELS,
+    });
+    expect(harness.calls).toContainEqual([
+      "volume",
+      "create",
+      "--driver",
+      "local",
+      "--label",
+      `${PODMAN_BOOTSTRAP_IDENTITY_LABEL}=${BOOTSTRAP_IDENTITY}`,
+      "--label",
+      `${PODMAN_BOOTSTRAP_STATE_VOLUME_LABEL}=true`,
+      "--label",
+      `${PODMAN_SANDBOX_ID_LABEL}=${SANDBOX_ID}`,
+      "--label",
+      `${PODMAN_SANDBOX_NAME_LABEL}=${SANDBOX_NAME}`,
+      STATE_VOLUME_NAME,
+    ]);
+    expect(harness.capturedEnvironmentMode).toBe(0o600);
+    expect(harness.capturedEnvironmentContents).toBe(`${ENVIRONMENT.join("\n")}\n`);
+    expect(fs.existsSync(harness.capturedEnvironmentFile as string)).toBe(false);
+    expect(harness.calls.flat().join("\u0000")).not.toContain(ENVIRONMENT[1]);
+    expect(JSON.stringify(prepared.journal)).not.toContain("do-not-put-this-in-process-argv");
+    expect(watcher.assertStillStopped.mock.calls.length).toBeGreaterThanOrEqual(6);
+    expect(watcher.resumeAndProve).not.toHaveBeenCalled();
+  });
+
+  it("accepts a stable Podman inspect with reordered environment entries", () => {
+    const harness = new PodmanHarness();
+    harness.replacementEnvironment = [...ENVIRONMENT].reverse();
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    const prepared = prepare(harness, store, watcher.lease);
+
+    expect(prepared.journal.phase).toBe("replacement-created");
+    expect(harness.replacement?.environment).toEqual([...ENVIRONMENT].reverse());
+  });
+
+  it("accepts an empty non-authoritative Podman volume mount mode", () => {
+    const harness = new PodmanHarness();
+    harness.stateVolumeMountMode = "";
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    const prepared = prepare(harness, store, watcher.lease);
+
+    expect(prepared.journal.phase).toBe("replacement-created");
+    expect(harness.replacement?.mounts[0]?.Mode).toBe("");
+  });
+
+  it("keeps pre-create authority when Podman create fails without exposing command output", () => {
+    const harness = new PodmanHarness();
+    harness.createResult = {
+      status: 125,
+      stdout: "credential-in-stdout",
+      stderr: "credential-in-stderr",
+      error: new Error("socket interrupted"),
+    };
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    expect(() => prepare(harness, store, watcher.lease)).toThrowError(
+      /^(?![\s\S]*(?:credential-in-stdout|credential-in-stderr))[\s\S]*failed with status 125: socket interrupted/u,
+    );
+    expect(store.load(BOOTSTRAP_IDENTITY)?.phase).toBe("state-volume-created");
+  });
+
+  it("rejects identity flags supplied through provider runtime arguments", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    expect(() =>
+      prepareStoppedPodmanBootstrapReplacement({
+        engine: harness.engine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        plan: { ...plan, runtimeArgs: ["--name=attacker-selected"] },
+      }),
+    ).toThrow("cannot set '--name'");
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+    expect(harness.calls).toEqual([]);
+  });
+
+  it.each([
+    "-eSECRET=1",
+    "-lcom.nvidia.nemoclaw.override=true",
+    "-d=true",
+  ])("rejects attached protected shorthand %s before invoking Podman", (argument) => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    expect(() =>
+      prepareStoppedPodmanBootstrapReplacement({
+        engine: harness.engine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        plan: { ...plan, runtimeArgs: [argument] },
+      }),
+    ).toThrow("cannot set");
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+    expect(harness.calls).toEqual([]);
+  });
+
+  it("rejects runtime mounts that could shadow image transaction state", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    expect(() =>
+      prepareStoppedPodmanBootstrapReplacement({
+        engine: harness.engine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        plan: {
+          ...plan,
+          runtimeArgs: [
+            "--mount",
+            "type=volume,source=attacker,destination=/var/lib/nemoclaw/managed-startup",
+          ],
+        },
+      }),
+    ).toThrow("cannot shadow /var/lib/nemoclaw");
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+    expect(harness.calls).toEqual([]);
+  });
+
+  it("recognizes the Podman dest alias without truncating its value", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    const prepared = prepareStoppedPodmanBootstrapReplacement({
+      engine: harness.engine,
+      journalStore: store,
+      watcherLease: watcher.lease,
+      plan: {
+        ...plan,
+        runtimeArgs: [
+          "--mount",
+          `type=volume,source=workspace,dest=${PODMAN_BOOTSTRAP_STATE_DIRECTORY}=cache`,
+        ],
+      },
+    });
+
+    expect(prepared.journal.phase).toBe("replacement-created");
+  });
+
+  it("rejects a Podman mount specification without a destination", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    expect(() =>
+      prepareStoppedPodmanBootstrapReplacement({
+        engine: harness.engine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        plan: { ...plan, runtimeArgs: ["--mount", "type=volume,source=workspace"] },
+      }),
+    ).toThrow("requires one destination");
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+    expect(harness.calls).toEqual([]);
+  });
+
+  it("checks every recognized Podman mount destination before rejecting ambiguity", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    expect(() =>
+      prepareStoppedPodmanBootstrapReplacement({
+        engine: harness.engine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        plan: {
+          ...plan,
+          runtimeArgs: [
+            "--mount",
+            "type=volume,source=workspace,destination=/sandbox,dest=/var/lib/nemoclaw",
+          ],
+        },
+      }),
+    ).toThrow("cannot shadow /var/lib/nemoclaw");
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+    expect(harness.calls).toEqual([]);
+  });
+
+  it("fails before journaling when the deterministic state-volume name is occupied", () => {
+    const harness = new PodmanHarness();
+    harness.stateVolume = {
+      name: STATE_VOLUME_NAME,
+      mountpoint: STATE_VOLUME_MOUNTPOINT,
+      labels: STATE_VOLUME_LABELS,
+    };
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    expect(() => prepare(harness, store, watcher.lease)).toThrow(
+      "state-volume name is already in use",
+    );
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+    expect(harness.replacement).toBeNull();
+  });
+
+  it("rejects a replacement that starts before the image-owned transaction owns it", () => {
+    const harness = new PodmanHarness();
+    harness.replacementStartsOnCreate = true;
+    const store = journalStore();
+    const watcher = watcherLease();
+
+    expect(() => prepare(harness, store, watcher.lease)).toThrow(
+      "identity or state changed after it was pinned",
+    );
+    expect(store.load(BOOTSTRAP_IDENTITY)?.phase).toBe("state-volume-created");
+  });
+
+  it("stops only the exact original after the stopped replacement remains stable", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+    const prepared = prepare(harness, store, watcher.lease);
+
+    const stopped = stopExactPodmanBootstrapOriginal({
+      engine: harness.engine,
+      journalStore: store,
+      watcherLease: watcher.lease,
+      prepared,
+      heldWorkload,
+    });
+
+    expect(stopped.journal.phase).toBe("original-stopped");
+    expect(harness.original.running).toBe(false);
+    expect(harness.replacement?.running).toBe(false);
+    expect(harness.calls).toContainEqual(["container", "stop", ORIGINAL_RUNTIME_ID]);
+    expect(watcher.resumeAndProve).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "state-volume mountpoint",
+      (prepared: PodmanBootstrapPreparedReplacement) => ({
+        ...prepared,
+        replacementStateVolumeMountpoint: "/different/state-volume/mountpoint",
+      }),
+    ],
+    [
+      "replacement fingerprint",
+      (prepared: PodmanBootstrapPreparedReplacement) => ({
+        ...prepared,
+        replacementSpecFingerprint: "f".repeat(64),
+      }),
+    ],
+  ])("rejects a prepared replacement with a changed %s", (_label, mutate) => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+    const prepared = prepare(harness, store, watcher.lease);
+
+    expect(() =>
+      stopExactPodmanBootstrapOriginal({
+        engine: harness.engine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        prepared: mutate(prepared),
+        heldWorkload,
+      }),
+    ).toThrow("does not match the durable journal");
+    expect(harness.original.running).toBe(true);
+    expect(store.load(BOOTSTRAP_IDENTITY)?.phase).toBe("replacement-created");
+  });
+
+  it("rolls back an exact stopped replacement and restarts the exact original", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+    const prepared = prepare(harness, store, watcher.lease);
+    stopExactPodmanBootstrapOriginal({
+      engine: harness.engine,
+      journalStore: store,
+      watcherLease: watcher.lease,
+      prepared,
+      heldWorkload,
+    });
+
+    const receipt = rollbackPodmanBootstrapBeforeCommit({
+      engine: harness.engine,
+      journalStore: store,
+      watcherLease: watcher.lease,
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      heldWorkload,
+    });
+
+    expect(receipt).toEqual({
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      originalRuntimeId: ORIGINAL_RUNTIME_ID,
+      originalStarted: true,
+      replacementRemoved: true,
+      replacementStateVolumeRemoved: true,
+    });
+    expect(harness.original.running).toBe(true);
+    expect(harness.replacement).toBeNull();
+    expect(harness.stateVolume).toBeNull();
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+    expect(harness.calls).toContainEqual(["container", "rm", REPLACEMENT_RUNTIME_ID]);
+    expect(harness.calls).toContainEqual(["volume", "rm", STATE_VOLUME_NAME]);
+    expect(harness.calls).toContainEqual(["container", "start", ORIGINAL_RUNTIME_ID]);
+    expect(watcher.resumeAndProve).not.toHaveBeenCalled();
+  });
+
+  it("reconciles and removes a replacement after its create acknowledgement is lost", () => {
+    const harness = new PodmanHarness();
+    harness.failReplacementInspectOnce = true;
+    const store = journalStore();
+    const watcher = watcherLease();
+    expect(() => prepare(harness, store, watcher.lease)).toThrow("inspect interrupted");
+    expect(store.load(BOOTSTRAP_IDENTITY)).toMatchObject({
+      phase: "state-volume-created",
+      replacementRuntimeId: null,
+    });
+    expect(harness.replacement?.id).toBe(REPLACEMENT_RUNTIME_ID);
+
+    const receipt = rollbackPodmanBootstrapBeforeCommit({
+      engine: harness.engine,
+      journalStore: store,
+      watcherLease: watcher.lease,
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      heldWorkload,
+    });
+
+    expect(receipt.originalStarted).toBe(false);
+    expect(receipt.replacementRemoved).toBe(true);
+    expect(receipt.replacementStateVolumeRemoved).toBe(true);
+    expect(harness.original.running).toBe(true);
+    expect(harness.replacement).toBeNull();
+    expect(harness.stateVolume).toBeNull();
+    expect(store.load(BOOTSTRAP_IDENTITY)).toBeNull();
+  });
+
+  it("fails closed when a recorded state volume disappears before rollback", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+    prepare(harness, store, watcher.lease);
+    harness.stateVolume = null;
+
+    expect(() =>
+      rollbackPodmanBootstrapBeforeCommit({
+        engine: harness.engine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        bootstrapIdentity: BOOTSTRAP_IDENTITY,
+        heldWorkload,
+      }),
+    ).toThrow("recorded state volume disappeared before rollback");
+    expect(store.load(BOOTSTRAP_IDENTITY)?.phase).toBe("rollback-authorized");
+    expect(harness.original.running).toBe(true);
+  });
+
+  it("fails closed when rollback discovery finds two staging identities", () => {
+    const harness = new PodmanHarness();
+    harness.failReplacementInspectOnce = true;
+    const store = journalStore();
+    const watcher = watcherLease();
+    expect(() => prepare(harness, store, watcher.lease)).toThrow("inspect interrupted");
+    harness.extraStagingIds = [EXTRA_RUNTIME_ID];
+
+    expect(() =>
+      rollbackPodmanBootstrapBeforeCommit({
+        engine: harness.engine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        bootstrapIdentity: BOOTSTRAP_IDENTITY,
+        heldWorkload,
+      }),
+    ).toThrow("ambiguous replacement identities");
+    expect(store.load(BOOTSTRAP_IDENTITY)?.phase).toBe("rollback-authorized");
+    expect(harness.replacement?.id).toBe(REPLACEMENT_RUNTIME_ID);
+  });
+
+  it("rejects a different engine authority before a stopped original can be changed", () => {
+    const harness = new PodmanHarness();
+    const store = journalStore();
+    const watcher = watcherLease();
+    const prepared = prepare(harness, store, watcher.lease);
+    const otherEngine = new PodmanHarness(`podman-sha256:${"8".repeat(64)}`).engine;
+
+    expect(() =>
+      stopExactPodmanBootstrapOriginal({
+        engine: otherEngine,
+        journalStore: store,
+        watcherLease: watcher.lease,
+        prepared,
+        heldWorkload,
+      }),
+    ).toThrow("does not match the active engine");
+    expect(harness.original.running).toBe(true);
+    expect(store.load(BOOTSTRAP_IDENTITY)?.phase).toBe("replacement-created");
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/podman-bootstrap-replacement.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-bootstrap-replacement.ts
@@ -1,0 +1,1199 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+  ContainerEngine,
+  ContainerEngineCommandResult,
+} from "../../adapters/container-engine";
+import {
+  PODMAN_BOOTSTRAP_JOURNAL_SCHEMA_VERSION,
+  type PodmanBootstrapJournal,
+  type PodmanBootstrapJournalPhase,
+  type PodmanBootstrapJournalStore,
+} from "./podman-bootstrap-journal";
+import {
+  PODMAN_MANAGED_LABEL,
+  PODMAN_SANDBOX_ID_LABEL,
+  PODMAN_SANDBOX_NAME_LABEL,
+  PODMAN_SANDBOX_NAMESPACE_LABEL,
+  type PodmanHeldWorkloadObservation,
+} from "./podman-held-workload";
+import type { PodmanGatewayWatcherLease } from "./podman-watcher-lease";
+
+export const PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION = 1 as const;
+export const PODMAN_BOOTSTRAP_STATE_DIRECTORY = "/var/lib/nemoclaw" as const;
+export const PODMAN_BOOTSTRAP_STATE_VOLUME_LABEL =
+  "com.nvidia.nemoclaw.managed-bootstrap-state" as const;
+export const PODMAN_BOOTSTRAP_IDENTITY_LABEL = "com.nvidia.nemoclaw.bootstrap-identity" as const;
+
+const FULL_ID = /^(?:sha256:)?([a-f0-9]{64})$/u;
+const BOOTSTRAP_IDENTITY = /^[a-f0-9]{64}$/u;
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,252}$/u;
+const SAFE_ENVIRONMENT_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f-\u009f]/u;
+const MAX_ARGUMENTS = 512;
+const MAX_ARGUMENT_BYTES = 16 * 1024;
+const MAX_ENVIRONMENT_BYTES = 256 * 1024;
+const CREATE_TIMEOUT_MS = 300_000;
+
+const FORBIDDEN_RUNTIME_FLAGS = new Set([
+  "--cidfile",
+  "--detach",
+  "--env",
+  "--env-file",
+  "--entrypoint",
+  "--http-proxy",
+  "--label",
+  "--name",
+  "--privileged",
+  "--pull",
+  "--replace",
+  "--rm",
+  "--unsetenv-all",
+  "-d",
+  "-e",
+  "-l",
+]);
+const FORBIDDEN_ATTACHED_SHORT_FLAGS = ["-d", "-e", "-l"] as const;
+
+type JsonRecord = Record<string, unknown>;
+
+export type AuthorityBoundPodmanBootstrapEngine = ContainerEngine & {
+  readonly authorityId: string;
+};
+
+export interface PodmanBootstrapReplacementPlan {
+  readonly schemaVersion: typeof PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION;
+  readonly bootstrapIdentity: string;
+  readonly heldWorkload: PodmanHeldWorkloadObservation;
+  /** Podman create flags that do not select identity, labels, environment, entrypoint, or image. */
+  readonly runtimeArgs: readonly string[];
+  /** Written only to a private temporary env file and never put in the journal or process argv. */
+  readonly environment: readonly string[];
+  /** Image-owned bootstrap entrypoint. Its first element must be an absolute container path. */
+  readonly entrypointArgv: readonly string[];
+  readonly commandArgv: readonly string[];
+  readonly replacementImageContentId: string;
+}
+
+export interface PodmanBootstrapPreparedReplacement {
+  readonly schemaVersion: typeof PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION;
+  readonly bootstrapIdentity: string;
+  readonly originalRuntimeId: string;
+  readonly replacementRuntimeId: string;
+  readonly replacementStagingName: string;
+  readonly replacementStateVolumeName: string;
+  readonly replacementStateVolumeMountpoint: string;
+  readonly replacementImageContentId: string;
+  readonly replacementSpecFingerprint: string;
+  readonly journal: PodmanBootstrapJournal;
+}
+
+interface PodmanBootstrapReplacementAuthority {
+  readonly engine: AuthorityBoundPodmanBootstrapEngine;
+  readonly journalStore: PodmanBootstrapJournalStore;
+  readonly watcherLease: PodmanGatewayWatcherLease;
+}
+
+export interface PrepareStoppedPodmanBootstrapReplacementInput
+  extends PodmanBootstrapReplacementAuthority {
+  readonly plan: PodmanBootstrapReplacementPlan;
+}
+
+export interface StopExactPodmanBootstrapOriginalInput extends PodmanBootstrapReplacementAuthority {
+  readonly prepared: PodmanBootstrapPreparedReplacement;
+  readonly heldWorkload: PodmanHeldWorkloadObservation;
+}
+
+export interface RollbackPodmanBootstrapBeforeCommitInput
+  extends PodmanBootstrapReplacementAuthority {
+  readonly bootstrapIdentity: string;
+  readonly heldWorkload: PodmanHeldWorkloadObservation;
+}
+
+export interface PodmanBootstrapRollbackReceipt {
+  readonly bootstrapIdentity: string;
+  readonly originalRuntimeId: string;
+  readonly originalStarted: boolean;
+  readonly replacementRemoved: boolean;
+  readonly replacementStateVolumeRemoved: boolean;
+}
+
+export class PodmanBootstrapPreparationError extends Error {
+  public readonly rollbackRequired: boolean;
+
+  public constructor(message: string, rollbackRequired = true) {
+    super(message);
+    this.name = "PodmanBootstrapPreparationError";
+    this.rollbackRequired = rollbackRequired;
+  }
+}
+
+interface NormalizedReplacementPlan extends PodmanBootstrapReplacementPlan {
+  readonly heldWorkload: PodmanHeldWorkloadObservation;
+  readonly runtimeArgs: readonly string[];
+  readonly environment: readonly string[];
+  readonly entrypointArgv: readonly string[];
+  readonly commandArgv: readonly string[];
+  readonly replacementImageContentId: string;
+  readonly replacementStagingName: string;
+  readonly replacementStateVolumeName: string;
+  readonly replacementStateVolumeLabels: Readonly<Record<string, string>>;
+  readonly originalSpecFingerprint: string;
+  readonly replacementSpecFingerprint: string;
+}
+
+interface ExactContainerExpectation {
+  readonly runtimeId: string;
+  readonly name: string;
+  readonly imageContentId: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly running?: boolean;
+  readonly entrypointArgv?: readonly string[];
+  readonly commandArgv?: readonly string[];
+  readonly environment?: readonly string[];
+  readonly supervisorArgv?: readonly string[];
+  readonly stateVolume?: ExactStateVolumeExpectation;
+}
+
+interface ExactStateVolumeExpectation {
+  readonly name: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly mountpoint?: string;
+}
+
+interface ExactStateVolumeObservation {
+  readonly name: string;
+  readonly driver: "local";
+  readonly mountpoint: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly options: Readonly<Record<string, string>>;
+}
+
+interface ExactContainerStateMountObservation {
+  readonly name: string;
+  readonly source: string;
+  readonly destination: typeof PODMAN_BOOTSTRAP_STATE_DIRECTORY;
+  readonly driver: "local";
+  readonly mode: string;
+  readonly options: readonly string[];
+  readonly propagation: "" | "rprivate";
+  readonly readWrite: true;
+}
+
+interface ExactContainerObservation {
+  readonly runtimeId: string;
+  readonly name: string;
+  readonly imageContentId: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly running: boolean;
+  readonly entrypointArgv: readonly string[];
+  readonly commandArgv: readonly string[];
+  readonly environment: readonly string[];
+  readonly stateVolume: ExactContainerStateMountObservation | null;
+}
+
+function failure(message: string, rollbackRequired = true): never {
+  throw new PodmanBootstrapPreparationError(message, rollbackRequired);
+}
+
+function safeString(value: unknown, label: string, allowEmpty = false): string {
+  if (
+    typeof value !== "string" ||
+    (!allowEmpty && value.length === 0) ||
+    value.includes("\0") ||
+    CONTROL_CHARACTER.test(value) ||
+    Buffer.byteLength(value, "utf8") > MAX_ARGUMENT_BYTES
+  ) {
+    return failure(`${label} must be one bounded exact string.`, false);
+  }
+  return value;
+}
+
+function fullRuntimeId(value: unknown, label: string): string {
+  const match = safeString(value, label).match(FULL_ID);
+  if (!match?.[1]) return failure(`${label} must be one full lowercase runtime ID.`, false);
+  return match[1];
+}
+
+function imageContentId(value: unknown, label: string): string {
+  return `sha256:${fullRuntimeId(value, label)}`;
+}
+
+function exactArgv(value: unknown, label: string, allowEmpty = true): readonly string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_ARGUMENTS ||
+    (!allowEmpty && value.length === 0)
+  ) {
+    return failure(`${label} must be a bounded argv array.`, false);
+  }
+  return Object.freeze(
+    value.map((entry, index) => safeString(entry, `${label}[${String(index)}]`, true)),
+  );
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function exactStringMap(value: unknown, label: string): Readonly<Record<string, string>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return failure(`${label} must be an object.`, false);
+  }
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => compareCodeUnits(left, right))
+        .map(([key, entry]) => [
+          safeString(key, `${label} key`),
+          safeString(entry, `${label}.${key}`, true),
+        ]),
+    ),
+  );
+}
+
+function canonicalLabels(
+  heldWorkload: PodmanHeldWorkloadObservation,
+): Readonly<Record<string, string>> {
+  const labels = exactStringMap(heldWorkload.labels, "Podman held-workload labels");
+  if (
+    labels[PODMAN_MANAGED_LABEL] !== "true" ||
+    labels[PODMAN_SANDBOX_ID_LABEL] !== heldWorkload.sandboxId ||
+    labels[PODMAN_SANDBOX_NAME_LABEL] !== heldWorkload.sandboxName ||
+    !Object.hasOwn(labels, PODMAN_SANDBOX_NAMESPACE_LABEL)
+  ) {
+    return failure("Podman replacement labels do not match exact OpenShell ownership.", false);
+  }
+  return labels;
+}
+
+function environmentEntries(
+  value: unknown,
+  label = "Podman replacement environment",
+): readonly string[] {
+  const entries = exactArgv(value, label);
+  const keys = new Set<string>();
+  for (const entry of entries) {
+    const separator = entry.indexOf("=");
+    const key = separator > 0 ? entry.slice(0, separator) : "";
+    if (!SAFE_ENVIRONMENT_KEY.test(key) || keys.has(key)) {
+      return failure(`${label} contains an invalid or duplicate key.`, false);
+    }
+    keys.add(key);
+  }
+  const serialized = `${entries.join("\n")}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MAX_ENVIRONMENT_BYTES) {
+    return failure(`${label} exceeds its private file transport.`, false);
+  }
+  return entries;
+}
+
+function environmentMap(value: unknown, label: string): Readonly<Record<string, string>> {
+  const entries = environmentEntries(value, label);
+  return Object.freeze(
+    Object.fromEntries(
+      entries
+        .map((entry) => {
+          const separator = entry.indexOf("=");
+          return [entry.slice(0, separator), entry.slice(separator + 1)] as const;
+        })
+        .sort(([left], [right]) => compareCodeUnits(left, right)),
+    ),
+  );
+}
+
+function exactAbsolutePath(value: unknown, label: string): string {
+  const target = safeString(value, label);
+  if (!path.posix.isAbsolute(target) || path.posix.normalize(target) !== target) {
+    return failure(`${label} must be one normalized absolute container path.`, false);
+  }
+  return target;
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  return left === right || left.startsWith(`${right}/`) || right.startsWith(`${left}/`);
+}
+
+function assertMountDoesNotShadowState(specification: string): void {
+  const destinations = specification.split(",").flatMap((entry) => {
+    const separator = entry.indexOf("=");
+    if (separator <= 0) return [];
+    const key = entry.slice(0, separator);
+    return ["dest", "destination", "dst", "target"].includes(key)
+      ? [entry.slice(separator + 1)]
+      : [];
+  });
+  if (destinations.length === 0) {
+    return failure("Podman replacement --mount requires one destination.", false);
+  }
+  for (const destination of destinations) {
+    const normalized = exactAbsolutePath(destination, "Podman runtime mount destination");
+    if (pathsOverlap(normalized, PODMAN_BOOTSTRAP_STATE_DIRECTORY)) {
+      failure(
+        `Podman replacement runtime arguments cannot shadow ${PODMAN_BOOTSTRAP_STATE_DIRECTORY}.`,
+        false,
+      );
+    }
+  }
+  if (destinations.length !== 1) {
+    return failure("Podman replacement --mount requires exactly one destination.", false);
+  }
+}
+
+function runtimeArguments(value: unknown): readonly string[] {
+  const args = exactArgv(value, "Podman replacement runtime arguments");
+  for (const [index, argument] of args.entries()) {
+    const flag = argument.includes("=") ? argument.slice(0, argument.indexOf("=")) : argument;
+    const attachedShortFlag = FORBIDDEN_ATTACHED_SHORT_FLAGS.find(
+      (candidate) => argument.length > candidate.length && argument.startsWith(candidate),
+    );
+    if (attachedShortFlag) {
+      return failure(
+        `Podman replacement runtime arguments cannot set '${attachedShortFlag}'.`,
+        false,
+      );
+    }
+    if (FORBIDDEN_RUNTIME_FLAGS.has(flag)) {
+      return failure(`Podman replacement runtime arguments cannot set '${flag}'.`, false);
+    }
+    if (flag === "--volume" || flag === "-v") {
+      return failure(
+        "Podman replacement runtime arguments must use auditable --mount syntax.",
+        false,
+      );
+    }
+    if (flag === "--mount") {
+      const specification = argument.includes("=")
+        ? argument.slice(argument.indexOf("=") + 1)
+        : args[index + 1];
+      if (!specification) {
+        return failure("Podman replacement --mount requires one specification.", false);
+      }
+      assertMountDoesNotShadowState(specification);
+    }
+  }
+  return args;
+}
+
+function stableHash(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex");
+}
+
+function stagingName(originalName: string, bootstrapIdentity: string): string {
+  const suffix = `-nemoclaw-bootstrap-${bootstrapIdentity.slice(0, 12)}`;
+  const prefixLength = 253 - suffix.length;
+  const value = `${originalName.slice(0, prefixLength)}${suffix}`;
+  if (!SAFE_NAME.test(value) || value === originalName) {
+    return failure("Podman bootstrap staging name is invalid.", false);
+  }
+  return value;
+}
+
+function stateVolumeName(originalName: string, bootstrapIdentity: string): string {
+  const suffix = `-nemoclaw-state-${bootstrapIdentity.slice(0, 12)}`;
+  const value = `${originalName.slice(0, 253 - suffix.length)}${suffix}`;
+  if (!SAFE_NAME.test(value) || value === originalName) {
+    return failure("Podman bootstrap state volume name is invalid.", false);
+  }
+  return value;
+}
+
+function stateVolumeLabels(
+  bootstrapIdentity: string,
+  heldWorkload: PodmanHeldWorkloadObservation,
+): Readonly<Record<string, string>> {
+  return Object.freeze({
+    [PODMAN_BOOTSTRAP_IDENTITY_LABEL]: bootstrapIdentity,
+    [PODMAN_BOOTSTRAP_STATE_VOLUME_LABEL]: "true",
+    [PODMAN_SANDBOX_ID_LABEL]: heldWorkload.sandboxId,
+    [PODMAN_SANDBOX_NAME_LABEL]: heldWorkload.sandboxName,
+  });
+}
+
+function normalizePlan(plan: PodmanBootstrapReplacementPlan): NormalizedReplacementPlan {
+  if (
+    !plan ||
+    typeof plan !== "object" ||
+    plan.schemaVersion !== PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION ||
+    !BOOTSTRAP_IDENTITY.test(plan.bootstrapIdentity)
+  ) {
+    return failure("Podman bootstrap replacement plan identity is invalid.", false);
+  }
+  const held = plan.heldWorkload;
+  if (!held || typeof held !== "object" || held.running !== true) {
+    return failure("Podman bootstrap replacement requires one running held workload.", false);
+  }
+  const runtimeId = fullRuntimeId(held.runtimeId, "Podman held-workload runtime ID");
+  const originalImageContentId = imageContentId(
+    held.imageContentId,
+    "Podman held-workload image content ID",
+  );
+  const labels = canonicalLabels(held);
+  const originalContainerName = safeString(
+    held.containerName,
+    "Podman held-workload container name",
+  );
+  if (!SAFE_NAME.test(originalContainerName)) {
+    return failure("Podman held-workload container name is malformed.", false);
+  }
+  const entrypointArgv = exactArgv(plan.entrypointArgv, "Podman replacement entrypoint", false);
+  if (!entrypointArgv[0]?.startsWith("/")) {
+    return failure("Podman replacement entrypoint must begin with an absolute path.", false);
+  }
+  const commandArgv = exactArgv(plan.commandArgv, "Podman replacement command");
+  const runtimeArgs = runtimeArguments(plan.runtimeArgs);
+  const environment = environmentEntries(plan.environment);
+  const replacementImageContentId = imageContentId(
+    plan.replacementImageContentId,
+    "Podman replacement image content ID",
+  );
+  const replacementStagingName = stagingName(originalContainerName, plan.bootstrapIdentity);
+  const replacementStateVolumeName = stateVolumeName(originalContainerName, plan.bootstrapIdentity);
+  const replacementStateVolumeLabels = stateVolumeLabels(plan.bootstrapIdentity, held);
+  const normalizedHeld = Object.freeze({
+    ...held,
+    runtimeId,
+    imageContentId: originalImageContentId,
+    labels,
+  });
+  return Object.freeze({
+    schemaVersion: PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+    bootstrapIdentity: plan.bootstrapIdentity,
+    heldWorkload: normalizedHeld,
+    runtimeArgs,
+    environment,
+    entrypointArgv,
+    commandArgv,
+    replacementImageContentId,
+    replacementStagingName,
+    replacementStateVolumeName,
+    replacementStateVolumeLabels,
+    originalSpecFingerprint: stableHash({
+      runtimeId,
+      originalContainerName,
+      originalImageContentId,
+      labels,
+      supervisorArgv: held.supervisorArgv,
+      heldWorkloadArgv: held.heldWorkloadArgv,
+    }),
+    replacementSpecFingerprint: stableHash({
+      replacementStagingName,
+      replacementImageContentId,
+      labels,
+      runtimeArgs,
+      environment,
+      entrypointArgv,
+      commandArgv,
+      replacementStateVolumeName,
+      replacementStateVolumeLabels,
+    }),
+  });
+}
+
+function assertAuthority(authority: PodmanBootstrapReplacementAuthority): void {
+  if (
+    authority.engine.engineId !== "podman" ||
+    authority.engine.operation !== "managed-bootstrap" ||
+    !/^podman-sha256:[a-f0-9]{64}$/u.test(authority.engine.authorityId)
+  ) {
+    failure("Podman bootstrap requires one authority-bound managed-bootstrap engine.", false);
+  }
+  if (
+    authority.watcherLease.record.phase !== "stopped" ||
+    typeof authority.watcherLease.assertStillStopped !== "function"
+  ) {
+    failure("Podman bootstrap requires one durable stopped-watcher lease.", false);
+  }
+}
+
+function captureWhileWatcherStopped(
+  authority: PodmanBootstrapReplacementAuthority,
+  args: readonly string[],
+  timeoutMs?: number,
+): ContainerEngineCommandResult {
+  authority.watcherLease.assertStillStopped();
+  let result: ContainerEngineCommandResult | undefined;
+  let commandFailure: unknown;
+  try {
+    result = authority.engine.capture(args, timeoutMs);
+  } catch (error) {
+    commandFailure = error;
+  }
+  try {
+    authority.watcherLease.assertStillStopped();
+  } catch (error) {
+    if (commandFailure === undefined) commandFailure = error;
+  }
+  if (commandFailure !== undefined) throw commandFailure;
+  return result as ContainerEngineCommandResult;
+}
+
+function requireZero(result: ContainerEngineCommandResult, action: string): void {
+  if (result.status === 0) return;
+  const processError = result.error?.message.trim().slice(0, 400);
+  failure(
+    `${action} failed with status ${String(result.status)}${processError ? `: ${processError}` : "."}`,
+  );
+}
+
+function parseJson(text: string, label: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return failure(`${label} returned unreadable JSON.`);
+  }
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return failure(`${label} must be an object.`);
+  }
+  return value as JsonRecord;
+}
+
+function parsedStringArray(value: unknown, label: string): readonly string[] {
+  if (value === undefined || value === null) return Object.freeze([]);
+  return exactArgv(typeof value === "string" ? [value] : value, label);
+}
+
+function sameArray(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
+
+function sameMap(
+  left: Readonly<Record<string, string>>,
+  right: Readonly<Record<string, string>>,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function volumeExists(authority: PodmanBootstrapReplacementAuthority, volumeName: string): boolean {
+  const result = captureWhileWatcherStopped(authority, ["volume", "exists", volumeName]);
+  if (result.status === 0) return true;
+  if (result.status === 1) return false;
+  requireZero(result, "Podman bootstrap state-volume existence check");
+  return false;
+}
+
+function inspectExactStateVolume(
+  authority: PodmanBootstrapReplacementAuthority,
+  expected: ExactStateVolumeExpectation,
+): ExactStateVolumeObservation {
+  const result = captureWhileWatcherStopped(authority, ["volume", "inspect", expected.name]);
+  requireZero(result, "Podman bootstrap state-volume inspect");
+  const entries = parseJson(result.stdout, "Podman bootstrap state-volume inspect");
+  if (!Array.isArray(entries) || entries.length !== 1) {
+    return failure("Podman bootstrap state-volume inspect must identify exactly one volume.");
+  }
+  const inspect = record(entries[0], "Podman bootstrap state-volume inspect entry");
+  const name = safeString(inspect.Name, "Podman bootstrap state-volume name");
+  const driver = safeString(inspect.Driver, "Podman bootstrap state-volume driver");
+  const scope = safeString(inspect.Scope, "Podman bootstrap state-volume scope");
+  const mountpoint = exactAbsolutePath(
+    inspect.Mountpoint,
+    "Podman bootstrap state-volume mountpoint",
+  );
+  const labels = exactStringMap(inspect.Labels, "Podman bootstrap state-volume labels");
+  const options = exactStringMap(inspect.Options, "Podman bootstrap state-volume options");
+  if (
+    name !== expected.name ||
+    driver !== "local" ||
+    scope !== "local" ||
+    (inspect.Anonymous !== undefined && inspect.Anonymous !== false) ||
+    !sameMap(labels, expected.labels) ||
+    Object.keys(options).length !== 0 ||
+    (expected.mountpoint !== undefined && mountpoint !== expected.mountpoint)
+  ) {
+    return failure("Podman bootstrap state-volume ownership or storage identity changed.");
+  }
+  return Object.freeze({ name, driver: "local", mountpoint, labels, options });
+}
+
+function inspectStableStateVolume(
+  authority: PodmanBootstrapReplacementAuthority,
+  expected: ExactStateVolumeExpectation,
+): ExactStateVolumeObservation {
+  const first = inspectExactStateVolume(authority, expected);
+  const second = inspectExactStateVolume(authority, expected);
+  if (JSON.stringify(first) !== JSON.stringify(second)) {
+    return failure("Podman bootstrap state volume changed during stable inspection.");
+  }
+  return second;
+}
+
+function exactContainerStateMount(
+  inspect: JsonRecord,
+  expected: ExactStateVolumeExpectation,
+): ExactContainerStateMountObservation {
+  if (!Array.isArray(inspect.Mounts)) {
+    return failure("Podman bootstrap inspect Mounts must be an array.");
+  }
+  const matches = inspect.Mounts.map((entry, index) =>
+    record(entry, `Podman bootstrap inspect mount ${String(index)}`),
+  ).filter((entry) => entry.Destination === PODMAN_BOOTSTRAP_STATE_DIRECTORY);
+  if (matches.length !== 1 || expected.mountpoint === undefined) {
+    return failure("Podman bootstrap replacement requires one exact managed state volume.");
+  }
+  const mount = matches[0] as JsonRecord;
+  const mode = safeString(mount.Mode, "Podman bootstrap state-volume mount mode", true);
+  const options = parsedStringArray(mount.Options, "Podman bootstrap state-volume mount options");
+  const propagation = safeString(
+    mount.Propagation,
+    "Podman bootstrap state-volume propagation",
+    true,
+  );
+  const modeTokens = new Set(mode.split(",").filter(Boolean));
+  if (
+    mount.Type !== "volume" ||
+    mount.Name !== expected.name ||
+    mount.Source !== expected.mountpoint ||
+    mount.Driver !== "local" ||
+    mount.RW !== true ||
+    !["", "rprivate"].includes(propagation) ||
+    modeTokens.has("Z") ||
+    modeTokens.has("ro") ||
+    options.some((option) => option === "ro" || option === "readonly")
+  ) {
+    return failure("Podman bootstrap replacement state-volume mount changed after creation.");
+  }
+  return Object.freeze({
+    name: expected.name,
+    source: expected.mountpoint,
+    destination: PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+    driver: "local",
+    mode,
+    options,
+    propagation: propagation as "" | "rprivate",
+    readWrite: true,
+  });
+}
+
+function inspectExactContainer(
+  authority: PodmanBootstrapReplacementAuthority,
+  expected: ExactContainerExpectation,
+): ExactContainerObservation {
+  const runtimeId = fullRuntimeId(expected.runtimeId, "Expected Podman runtime ID");
+  const result = captureWhileWatcherStopped(authority, ["container", "inspect", runtimeId]);
+  requireZero(result, "Podman bootstrap container inspect");
+  const entries = parseJson(result.stdout, "Podman bootstrap container inspect");
+  if (!Array.isArray(entries) || entries.length !== 1) {
+    return failure("Podman bootstrap inspect must identify exactly one container.");
+  }
+  const inspect = record(entries[0], "Podman bootstrap inspect entry");
+  const actualRuntimeId = fullRuntimeId(inspect.Id, "Podman bootstrap inspect Id");
+  const name = safeString(inspect.Name, "Podman bootstrap inspect Name");
+  const actualImageContentId = imageContentId(
+    inspect.Image,
+    "Podman bootstrap inspect image content ID",
+  );
+  const config = record(inspect.Config, "Podman bootstrap inspect Config");
+  const labels = exactStringMap(config.Labels, "Podman bootstrap inspect labels");
+  const state = record(inspect.State, "Podman bootstrap inspect State");
+  if (
+    typeof state.Running !== "boolean" ||
+    state.Paused === true ||
+    state.Restarting === true ||
+    state.Dead === true
+  ) {
+    return failure("Podman bootstrap container is not in one stable running or stopped state.");
+  }
+  const entrypointArgv = parsedStringArray(
+    config.Entrypoint,
+    "Podman bootstrap inspect entrypoint",
+  );
+  const commandArgv = parsedStringArray(config.Cmd, "Podman bootstrap inspect command");
+  const environment = parsedStringArray(config.Env, "Podman bootstrap inspect environment");
+  const stateVolumeExpectation = expected.stateVolume;
+  const stateVolumeAuthority = stateVolumeExpectation
+    ? inspectExactStateVolume(authority, stateVolumeExpectation)
+    : null;
+  const stateVolume =
+    stateVolumeAuthority && stateVolumeExpectation
+      ? exactContainerStateMount(inspect, {
+          ...stateVolumeExpectation,
+          mountpoint: stateVolumeAuthority.mountpoint,
+        })
+      : null;
+  if (
+    actualRuntimeId !== runtimeId ||
+    name !== expected.name ||
+    actualImageContentId !== expected.imageContentId ||
+    (expected.running !== undefined && state.Running !== expected.running) ||
+    !sameMap(labels, exactStringMap(expected.labels, "Expected Podman labels"))
+  ) {
+    return failure("Podman bootstrap container identity or state changed after it was pinned.");
+  }
+  if (
+    (expected.entrypointArgv && !sameArray(entrypointArgv, expected.entrypointArgv)) ||
+    (expected.commandArgv && !sameArray(commandArgv, expected.commandArgv)) ||
+    (expected.environment &&
+      !sameMap(
+        environmentMap(environment, "Podman inspected environment"),
+        environmentMap(expected.environment, "Expected Podman environment"),
+      )) ||
+    (expected.supervisorArgv &&
+      !sameArray([...entrypointArgv, ...commandArgv], expected.supervisorArgv))
+  ) {
+    return failure("Podman bootstrap container startup specification changed after creation.");
+  }
+  return Object.freeze({
+    runtimeId,
+    name,
+    imageContentId: actualImageContentId,
+    labels,
+    running: state.Running,
+    entrypointArgv,
+    commandArgv,
+    environment,
+    stateVolume,
+  });
+}
+
+function sameObservation(
+  left: ExactContainerObservation,
+  right: ExactContainerObservation,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function inspectStableContainer(
+  authority: PodmanBootstrapReplacementAuthority,
+  expected: ExactContainerExpectation,
+): ExactContainerObservation {
+  const first = inspectExactContainer(authority, expected);
+  const second = inspectExactContainer(authority, expected);
+  if (!sameObservation(first, second)) {
+    return failure("Podman bootstrap container changed during stable inspection.");
+  }
+  return second;
+}
+
+function privateEnvironmentFile<T>(environment: readonly string[], use: (file: string) => T): T {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-podman-bootstrap-"));
+  fs.chmodSync(directory, 0o700);
+  const file = path.join(directory, "environment");
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(
+      file,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    fs.writeFileSync(descriptor, `${environment.join("\n")}\n`, "utf8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = null;
+    return use(file);
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function createArgs(plan: NormalizedReplacementPlan, environmentFile: string): readonly string[] {
+  const args = [
+    "container",
+    "create",
+    "--pull=never",
+    "--http-proxy=false",
+    "--name",
+    plan.replacementStagingName,
+    "--unsetenv-all",
+    "--env-file",
+    environmentFile,
+  ];
+  for (const [key, value] of Object.entries(plan.heldWorkload.labels)) {
+    args.push("--label", `${key}=${value}`);
+  }
+  args.push(
+    ...plan.runtimeArgs,
+    "--mount",
+    `type=volume,source=${plan.replacementStateVolumeName},destination=${PODMAN_BOOTSTRAP_STATE_DIRECTORY},readonly=false,relabel=shared`,
+    "--entrypoint",
+    JSON.stringify(plan.entrypointArgv),
+    plan.replacementImageContentId,
+    ...plan.commandArgv,
+  );
+  return Object.freeze(args);
+}
+
+function createStateVolumeArgs(plan: NormalizedReplacementPlan): readonly string[] {
+  const args = ["volume", "create", "--driver", "local"];
+  for (const [key, value] of Object.entries(plan.replacementStateVolumeLabels)) {
+    args.push("--label", `${key}=${value}`);
+  }
+  args.push(plan.replacementStateVolumeName);
+  return Object.freeze(args);
+}
+
+function parseCreatedStateVolumeName(output: string, expectedName: string): string {
+  const lines = output.trim().split(/\r?\n/u).filter(Boolean);
+  if (lines.length !== 1 || lines[0] !== expectedName) {
+    return failure("Podman volume create did not return the exact managed state-volume name.");
+  }
+  return expectedName;
+}
+
+function parseCreatedRuntimeId(output: string): string {
+  const lines = output.trim().split(/\r?\n/u).filter(Boolean);
+  if (lines.length !== 1) {
+    return failure("Podman create did not return one exact replacement runtime ID.");
+  }
+  return fullRuntimeId(lines[0], "Podman create replacement runtime ID");
+}
+
+function createJournal(
+  authority: PodmanBootstrapReplacementAuthority,
+  plan: NormalizedReplacementPlan,
+): PodmanBootstrapJournal {
+  return Object.freeze({
+    schemaVersion: PODMAN_BOOTSTRAP_JOURNAL_SCHEMA_VERSION,
+    phase: "preparing-replacement",
+    bootstrapIdentity: plan.bootstrapIdentity,
+    engineAuthorityId: authority.engine.authorityId,
+    watcherLeaseId: authority.watcherLease.record.leaseId,
+    sandboxName: plan.heldWorkload.sandboxName,
+    sandboxId: plan.heldWorkload.sandboxId,
+    originalRuntimeId: plan.heldWorkload.runtimeId,
+    originalContainerName: plan.heldWorkload.containerName,
+    originalImageContentId: plan.heldWorkload.imageContentId,
+    originalSpecFingerprint: plan.originalSpecFingerprint,
+    replacementStateVolumeName: plan.replacementStateVolumeName,
+    replacementStateVolumeMountpoint: null,
+    replacementRuntimeId: null,
+    replacementStagingName: plan.replacementStagingName,
+    replacementImageContentId: plan.replacementImageContentId,
+    replacementSpecFingerprint: plan.replacementSpecFingerprint,
+  });
+}
+
+function assertJournalAuthority(
+  authority: PodmanBootstrapReplacementAuthority,
+  journal: PodmanBootstrapJournal,
+): void {
+  if (
+    journal.engineAuthorityId !== authority.engine.authorityId ||
+    journal.watcherLeaseId !== authority.watcherLease.record.leaseId
+  ) {
+    failure(
+      "Podman bootstrap journal authority does not match the active engine and watcher lease.",
+    );
+  }
+}
+
+function expectedOriginal(
+  journal: PodmanBootstrapJournal,
+  held: PodmanHeldWorkloadObservation,
+  running?: boolean,
+): ExactContainerExpectation {
+  if (
+    held.runtimeId !== journal.originalRuntimeId ||
+    held.containerName !== journal.originalContainerName ||
+    held.imageContentId !== journal.originalImageContentId ||
+    held.sandboxId !== journal.sandboxId ||
+    held.sandboxName !== journal.sandboxName
+  ) {
+    failure("Podman bootstrap held-workload evidence does not match the durable journal.");
+  }
+  return {
+    runtimeId: journal.originalRuntimeId,
+    name: journal.originalContainerName,
+    imageContentId: journal.originalImageContentId,
+    labels: held.labels,
+    running,
+    supervisorArgv: held.supervisorArgv,
+  };
+}
+
+function expectedReplacement(
+  plan: NormalizedReplacementPlan,
+  runtimeId: string,
+  stateVolume: ExactStateVolumeObservation,
+): ExactContainerExpectation {
+  return {
+    runtimeId,
+    name: plan.replacementStagingName,
+    imageContentId: plan.replacementImageContentId,
+    labels: plan.heldWorkload.labels,
+    running: false,
+    entrypointArgv: plan.entrypointArgv,
+    commandArgv: plan.commandArgv,
+    environment: plan.environment,
+    stateVolume,
+  };
+}
+
+function replacementExpectationFromJournal(
+  journal: PodmanBootstrapJournal,
+  held: PodmanHeldWorkloadObservation,
+  runtimeId: string,
+  stateVolume: ExactStateVolumeObservation,
+): ExactContainerExpectation {
+  return {
+    runtimeId,
+    name: journal.replacementStagingName,
+    imageContentId: journal.replacementImageContentId,
+    labels: held.labels,
+    running: false,
+    stateVolume,
+  };
+}
+
+function stateVolumeExpectationFromJournal(
+  journal: PodmanBootstrapJournal,
+  held: PodmanHeldWorkloadObservation,
+): ExactStateVolumeExpectation {
+  return {
+    name: journal.replacementStateVolumeName,
+    labels: stateVolumeLabels(journal.bootstrapIdentity, held),
+    ...(journal.replacementStateVolumeMountpoint
+      ? { mountpoint: journal.replacementStateVolumeMountpoint }
+      : {}),
+  };
+}
+
+function listStagingRuntimeIds(
+  authority: PodmanBootstrapReplacementAuthority,
+  stagingContainerName: string,
+): readonly string[] {
+  const result = captureWhileWatcherStopped(authority, [
+    "container",
+    "ls",
+    "--all",
+    "--no-trunc",
+    "--filter",
+    `name=^${stagingContainerName}$`,
+    "--format",
+    "json",
+  ]);
+  requireZero(result, "Podman bootstrap staging discovery");
+  const entries = parseJson(result.stdout, "Podman bootstrap staging discovery");
+  if (!Array.isArray(entries)) failure("Podman bootstrap staging discovery must return an array.");
+  const ids = entries.map((entry, index) => {
+    const candidate = record(entry, `Podman staging discovery entry ${String(index)}`);
+    return fullRuntimeId(candidate.Id, `Podman staging discovery entry ${String(index)} ID`);
+  });
+  if (ids.length > 1) {
+    failure("Podman bootstrap staging discovery returned ambiguous replacement identities.");
+  }
+  return Object.freeze(ids);
+}
+
+function containerExists(
+  authority: PodmanBootstrapReplacementAuthority,
+  runtimeId: string,
+): boolean {
+  const result = captureWhileWatcherStopped(authority, ["container", "exists", runtimeId]);
+  if (result.status === 0) return true;
+  if (result.status === 1) return false;
+  requireZero(result, "Podman bootstrap container existence check");
+  return false;
+}
+
+function requireJournalPhase(
+  journal: PodmanBootstrapJournal | null,
+  phases: readonly PodmanBootstrapJournalPhase[],
+): PodmanBootstrapJournal {
+  if (!journal || !phases.includes(journal.phase)) {
+    failure(
+      `Podman bootstrap journal requires phase ${phases.join(" or ")}; found ${journal?.phase ?? "absent"}.`,
+    );
+  }
+  return journal;
+}
+
+export function prepareStoppedPodmanBootstrapReplacement(
+  input: PrepareStoppedPodmanBootstrapReplacementInput,
+): PodmanBootstrapPreparedReplacement {
+  assertAuthority(input);
+  const plan = normalizePlan(input.plan);
+  input.watcherLease.assertStillStopped();
+  if (volumeExists(input, plan.replacementStateVolumeName)) {
+    failure("Podman bootstrap state-volume name is already in use.", false);
+  }
+  input.journalStore.create(createJournal(input, plan));
+  const volumeCreate = captureWhileWatcherStopped(input, createStateVolumeArgs(plan));
+  requireZero(volumeCreate, "Podman bootstrap state-volume creation");
+  parseCreatedStateVolumeName(volumeCreate.stdout, plan.replacementStateVolumeName);
+  const stateVolume = inspectStableStateVolume(input, {
+    name: plan.replacementStateVolumeName,
+    labels: plan.replacementStateVolumeLabels,
+  });
+  input.journalStore.recordStateVolume(plan.bootstrapIdentity, stateVolume.mountpoint);
+  const result = privateEnvironmentFile(plan.environment, (environmentFile) =>
+    captureWhileWatcherStopped(input, createArgs(plan, environmentFile), CREATE_TIMEOUT_MS),
+  );
+  requireZero(result, "Podman stopped bootstrap replacement creation");
+  const replacementRuntimeId = parseCreatedRuntimeId(result.stdout);
+  inspectStableContainer(input, expectedReplacement(plan, replacementRuntimeId, stateVolume));
+  const journal = input.journalStore.recordReplacement(
+    plan.bootstrapIdentity,
+    replacementRuntimeId,
+  );
+  assertJournalAuthority(input, journal);
+  return Object.freeze({
+    schemaVersion: PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+    bootstrapIdentity: plan.bootstrapIdentity,
+    originalRuntimeId: plan.heldWorkload.runtimeId,
+    replacementRuntimeId,
+    replacementStagingName: plan.replacementStagingName,
+    replacementStateVolumeName: stateVolume.name,
+    replacementStateVolumeMountpoint: stateVolume.mountpoint,
+    replacementImageContentId: plan.replacementImageContentId,
+    replacementSpecFingerprint: plan.replacementSpecFingerprint,
+    journal,
+  });
+}
+
+export function stopExactPodmanBootstrapOriginal(
+  input: StopExactPodmanBootstrapOriginalInput,
+): PodmanBootstrapPreparedReplacement {
+  assertAuthority(input);
+  const journal = requireJournalPhase(input.journalStore.load(input.prepared.bootstrapIdentity), [
+    "replacement-created",
+  ]);
+  assertJournalAuthority(input, journal);
+  if (
+    input.prepared.originalRuntimeId !== journal.originalRuntimeId ||
+    input.prepared.replacementRuntimeId !== journal.replacementRuntimeId ||
+    input.prepared.replacementStateVolumeName !== journal.replacementStateVolumeName ||
+    input.prepared.replacementStateVolumeMountpoint !== journal.replacementStateVolumeMountpoint ||
+    input.prepared.replacementSpecFingerprint !== journal.replacementSpecFingerprint
+  ) {
+    failure("Podman bootstrap prepared replacement does not match the durable journal.");
+  }
+  inspectStableContainer(input, expectedOriginal(journal, input.heldWorkload, true));
+  const stateVolume = inspectStableStateVolume(
+    input,
+    stateVolumeExpectationFromJournal(journal, input.heldWorkload),
+  );
+  inspectStableContainer(
+    input,
+    replacementExpectationFromJournal(
+      journal,
+      input.heldWorkload,
+      input.prepared.replacementRuntimeId,
+      stateVolume,
+    ),
+  );
+  const stop = captureWhileWatcherStopped(input, ["container", "stop", journal.originalRuntimeId]);
+  requireZero(stop, "Podman bootstrap original-container stop");
+  inspectStableContainer(input, expectedOriginal(journal, input.heldWorkload, false));
+  inspectStableContainer(
+    input,
+    replacementExpectationFromJournal(
+      journal,
+      input.heldWorkload,
+      input.prepared.replacementRuntimeId,
+      stateVolume,
+    ),
+  );
+  const stopped = input.journalStore.recordOriginalStopped(journal.bootstrapIdentity);
+  return Object.freeze({ ...input.prepared, journal: stopped });
+}
+
+export function rollbackPodmanBootstrapBeforeCommit(
+  input: RollbackPodmanBootstrapBeforeCommitInput,
+): PodmanBootstrapRollbackReceipt {
+  assertAuthority(input);
+  const current = requireJournalPhase(input.journalStore.load(input.bootstrapIdentity), [
+    "preparing-replacement",
+    "state-volume-created",
+    "replacement-created",
+    "original-stopped",
+    "rollback-authorized",
+  ]);
+  assertJournalAuthority(input, current);
+  expectedOriginal(current, input.heldWorkload);
+  const journal = input.journalStore.authorizeRollback(input.bootstrapIdentity, [
+    "preparing-replacement",
+    "state-volume-created",
+    "replacement-created",
+    "original-stopped",
+  ]);
+  assertJournalAuthority(input, journal);
+
+  const stateVolumePresent = volumeExists(input, journal.replacementStateVolumeName);
+  const stateVolume = stateVolumePresent
+    ? inspectStableStateVolume(
+        input,
+        stateVolumeExpectationFromJournal(journal, input.heldWorkload),
+      )
+    : null;
+  if (journal.replacementStateVolumeMountpoint !== null && !stateVolume) {
+    failure("Podman bootstrap recorded state volume disappeared before rollback.");
+  }
+
+  const discoveredIds = listStagingRuntimeIds(input, journal.replacementStagingName);
+  const runtimeIds = new Set<string>(discoveredIds);
+  if (journal.replacementRuntimeId) runtimeIds.add(journal.replacementRuntimeId);
+  if (runtimeIds.size > 1) {
+    failure("Podman bootstrap rollback found conflicting replacement runtime identities.");
+  }
+  const replacementRuntimeId = [...runtimeIds][0] ?? null;
+  let replacementRemoved = false;
+  if (replacementRuntimeId && containerExists(input, replacementRuntimeId)) {
+    if (!stateVolume) {
+      failure("Podman bootstrap replacement lost its exact managed state volume.");
+    }
+    inspectStableContainer(
+      input,
+      replacementExpectationFromJournal(
+        journal,
+        input.heldWorkload,
+        replacementRuntimeId,
+        stateVolume,
+      ),
+    );
+    const remove = captureWhileWatcherStopped(input, ["container", "rm", replacementRuntimeId]);
+    requireZero(remove, "Podman bootstrap replacement rollback removal");
+    if (containerExists(input, replacementRuntimeId)) {
+      failure("Podman bootstrap replacement remained after exact rollback removal.");
+    }
+    replacementRemoved = true;
+  }
+  if (listStagingRuntimeIds(input, journal.replacementStagingName).length !== 0) {
+    failure("Podman bootstrap replacement staging name remained after rollback.");
+  }
+
+  let replacementStateVolumeRemoved = false;
+  if (stateVolume) {
+    const removeVolume = captureWhileWatcherStopped(input, ["volume", "rm", stateVolume.name]);
+    requireZero(removeVolume, "Podman bootstrap state-volume rollback removal");
+    if (volumeExists(input, stateVolume.name)) {
+      failure("Podman bootstrap state volume remained after exact rollback removal.");
+    }
+    replacementStateVolumeRemoved = true;
+  }
+
+  const originalWasRunning = inspectStableContainer(
+    input,
+    expectedOriginal(journal, input.heldWorkload),
+  ).running;
+  let originalStarted = false;
+  if (!originalWasRunning) {
+    const start = captureWhileWatcherStopped(input, [
+      "container",
+      "start",
+      journal.originalRuntimeId,
+    ]);
+    requireZero(start, "Podman bootstrap original-container rollback start");
+    originalStarted = true;
+  }
+  inspectStableContainer(input, expectedOriginal(journal, input.heldWorkload, true));
+  input.journalStore.removeAfterRollback(input.bootstrapIdentity);
+  input.watcherLease.assertStillStopped();
+  return Object.freeze({
+    bootstrapIdentity: input.bootstrapIdentity,
+    originalRuntimeId: journal.originalRuntimeId,
+    originalStarted,
+    replacementRemoved,
+    replacementStateVolumeRemoved,
+  });
+}

--- a/src/lib/onboard/managed-bootstrap/podman-held-workload.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-held-workload.test.ts
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ContainerEngine,
+  ContainerEngineCommandResult,
+} from "../../adapters/container-engine";
+import { openshellSandboxCommandEnvValue } from "../docker-startup-command-env";
+import {
+  inspectExactPodmanHeldWorkload,
+  PODMAN_MANAGED_LABEL,
+  PODMAN_SANDBOX_ID_LABEL,
+  PODMAN_SANDBOX_NAME_LABEL,
+  PODMAN_SANDBOX_NAMESPACE_LABEL,
+} from "./podman-held-workload";
+
+const RUNTIME_ID = "1".repeat(64);
+const IMAGE_ID = "2".repeat(64);
+const OTHER_IMAGE_ID = "3".repeat(64);
+const BOOTSTRAP_IDENTITY = "4".repeat(64);
+const SANDBOX_ID = "sandbox-uuid-1";
+const SANDBOX_NAME = "demo-box";
+const SANDBOX_NAMESPACE = "default";
+const SUPERVISOR_ARGV = ["/opt/openshell/bin/supervisor", "--config", "/etc/openshell.toml"];
+const HELD_WORKLOAD_ARGV = [
+  "/usr/local/bin/nemoclaw-managed-hold",
+  "--bootstrap-identity",
+  BOOTSTRAP_IDENTITY,
+  "/usr/local/bin/nemoclaw-start",
+];
+
+function result(stdout: string, overrides: Partial<ContainerEngineCommandResult> = {}) {
+  return { status: 0, stdout, stderr: "", ...overrides };
+}
+
+function listOutput(ids: readonly string[] = [RUNTIME_ID]): string {
+  return JSON.stringify(ids.map((Id) => ({ Id })));
+}
+
+function inspectOutput(
+  overrides: {
+    readonly command?: readonly string[];
+    readonly id?: string;
+    readonly image?: string;
+    readonly labels?: Readonly<Record<string, string>>;
+    readonly name?: string;
+    readonly running?: boolean;
+    readonly user?: string;
+  } = {},
+): string {
+  const command = overrides.command ?? HELD_WORKLOAD_ARGV;
+  return JSON.stringify([
+    {
+      Id: overrides.id ?? RUNTIME_ID,
+      Image: overrides.image ?? `sha256:${IMAGE_ID}`,
+      Name: overrides.name ?? `openshell-sandbox-${SANDBOX_NAME}`,
+      Config: {
+        Cmd: SUPERVISOR_ARGV.slice(1),
+        Entrypoint: [SUPERVISOR_ARGV[0]],
+        Env: [
+          `OPENSHELL_SANDBOX_COMMAND=${openshellSandboxCommandEnvValue(command)}`,
+          "OPENSHELL_SANDBOX_TOKEN_FILE=/run/secrets/openshell-token",
+        ],
+        Labels: overrides.labels ?? {
+          [PODMAN_MANAGED_LABEL]: "true",
+          [PODMAN_SANDBOX_ID_LABEL]: SANDBOX_ID,
+          [PODMAN_SANDBOX_NAME_LABEL]: SANDBOX_NAME,
+          [PODMAN_SANDBOX_NAMESPACE_LABEL]: SANDBOX_NAMESPACE,
+        },
+        User: overrides.user ?? "root",
+      },
+      State: { Paused: false, Restarting: false, Running: overrides.running ?? true },
+    },
+  ]);
+}
+
+function engineWith(
+  outputs: readonly ContainerEngineCommandResult[],
+  overrides: Partial<ContainerEngine> = {},
+) {
+  const queue = [...outputs];
+  const capture = vi.fn(() => queue.shift() as ContainerEngineCommandResult);
+  const engine: ContainerEngine = {
+    operation: "managed-bootstrap",
+    authorityId: "test:podman-socket",
+    engineId: "podman",
+    displayName: "Podman",
+    capture,
+    captureHost: vi.fn(),
+    ...overrides,
+  };
+  return { capture, engine };
+}
+
+function inspect(engine: ContainerEngine, sandboxNamespace = SANDBOX_NAMESPACE) {
+  return inspectExactPodmanHeldWorkload({
+    bootstrapIdentity: BOOTSTRAP_IDENTITY,
+    engine,
+    expectedHeldWorkloadArgv: HELD_WORKLOAD_ARGV,
+    expectedImageContentId: `sha256:${IMAGE_ID}`,
+    expectedSupervisorArgv: SUPERVISOR_ARGV,
+    sandboxId: SANDBOX_ID,
+    sandboxName: SANDBOX_NAME,
+    sandboxNamespace,
+  });
+}
+
+describe("Podman managed bootstrap held-workload inspection", () => {
+  it("pins one exact running OpenShell workload across two inspections", () => {
+    const fake = engineWith([
+      result(listOutput()),
+      result(inspectOutput()),
+      result(inspectOutput()),
+    ]);
+
+    expect(inspect(fake.engine)).toEqual({
+      containerName: `openshell-sandbox-${SANDBOX_NAME}`,
+      heldWorkloadArgv: HELD_WORKLOAD_ARGV,
+      imageContentId: `sha256:${IMAGE_ID}`,
+      labels: {
+        [PODMAN_MANAGED_LABEL]: "true",
+        [PODMAN_SANDBOX_ID_LABEL]: SANDBOX_ID,
+        [PODMAN_SANDBOX_NAME_LABEL]: SANDBOX_NAME,
+        [PODMAN_SANDBOX_NAMESPACE_LABEL]: SANDBOX_NAMESPACE,
+      },
+      runtimeId: RUNTIME_ID,
+      running: true,
+      sandboxId: SANDBOX_ID,
+      sandboxName: SANDBOX_NAME,
+      supervisorArgv: SUPERVISOR_ARGV,
+    });
+    expect(fake.capture.mock.calls).toEqual([
+      [
+        [
+          "container",
+          "ls",
+          "--all",
+          "--no-trunc",
+          "--filter",
+          `label=${PODMAN_MANAGED_LABEL}=true`,
+          "--filter",
+          `label=${PODMAN_SANDBOX_NAME_LABEL}=${SANDBOX_NAME}`,
+          "--format",
+          "json",
+        ],
+      ],
+      [["container", "inspect", RUNTIME_ID]],
+      [["container", "inspect", RUNTIME_ID]],
+    ]);
+  });
+
+  it("rejects an engine outside the immutable managed-bootstrap scope", () => {
+    const fake = engineWith([], { operation: "sandbox-lifecycle" });
+
+    expect(() => inspect(fake.engine)).toThrow("Podman 'managed-bootstrap' command adapter");
+    expect(fake.capture).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty expected namespace before discovering a workload", () => {
+    const fake = engineWith([]);
+
+    expect(() => inspect(fake.engine, "")).toThrow("sandbox namespace must be a bounded non-empty");
+    expect(fake.capture).not.toHaveBeenCalled();
+  });
+
+  it("rejects ambiguous managed containers before inspecting either candidate", () => {
+    const fake = engineWith([result(listOutput([RUNTIME_ID, "5".repeat(64)]))]);
+
+    expect(() => inspect(fake.engine)).toThrow("found 2");
+    expect(fake.capture).toHaveBeenCalledOnce();
+  });
+
+  it("rejects ownership labels that do not match the durable sandbox identity", () => {
+    const fake = engineWith([
+      result(listOutput()),
+      result(
+        inspectOutput({
+          labels: {
+            [PODMAN_MANAGED_LABEL]: "true",
+            [PODMAN_SANDBOX_ID_LABEL]: "another-sandbox",
+            [PODMAN_SANDBOX_NAME_LABEL]: SANDBOX_NAME,
+            [PODMAN_SANDBOX_NAMESPACE_LABEL]: SANDBOX_NAMESPACE,
+          },
+        }),
+      ),
+    ]);
+
+    expect(() => inspect(fake.engine)).toThrow("exact OpenShell ownership");
+  });
+
+  it("rejects a namespace label from a different OpenShell ownership scope", () => {
+    const fake = engineWith([
+      result(listOutput()),
+      result(
+        inspectOutput({
+          labels: {
+            [PODMAN_MANAGED_LABEL]: "true",
+            [PODMAN_SANDBOX_ID_LABEL]: SANDBOX_ID,
+            [PODMAN_SANDBOX_NAME_LABEL]: SANDBOX_NAME,
+            [PODMAN_SANDBOX_NAMESPACE_LABEL]: "another-namespace",
+          },
+        }),
+      ),
+    ]);
+
+    expect(() => inspect(fake.engine)).toThrow("exact OpenShell ownership");
+  });
+
+  it("rejects a label value that exceeds the bounded inspect contract", () => {
+    const fake = engineWith([
+      result(listOutput()),
+      result(
+        inspectOutput({
+          labels: {
+            [PODMAN_MANAGED_LABEL]: "true",
+            [PODMAN_SANDBOX_ID_LABEL]: SANDBOX_ID,
+            [PODMAN_SANDBOX_NAME_LABEL]: SANDBOX_NAME,
+            [PODMAN_SANDBOX_NAMESPACE_LABEL]: "x".repeat(64 * 1024 + 1),
+          },
+        }),
+      ),
+    ]);
+
+    expect(() => inspect(fake.engine)).toThrow("must be a bounded string");
+  });
+
+  it("rejects an inspect response whose full runtime identity changed", () => {
+    const fake = engineWith([result(listOutput()), result(inspectOutput({ id: "6".repeat(64) }))]);
+
+    expect(() => inspect(fake.engine)).toThrow("identity changed after discovery");
+  });
+
+  it("rejects a workload that does not use the image-owned root supervisor", () => {
+    const fake = engineWith([result(listOutput()), result(inspectOutput({ user: "sandbox" }))]);
+
+    expect(() => inspect(fake.engine)).toThrow("image-owned root supervisor boundary");
+  });
+
+  it("rejects a stopped held workload before replacement preparation", () => {
+    const fake = engineWith([result(listOutput()), result(inspectOutput({ running: false }))]);
+
+    expect(() => inspect(fake.engine)).toThrow("stably running");
+  });
+
+  it("rejects drift in the bootstrap-bound held command", () => {
+    const fake = engineWith([
+      result(listOutput()),
+      result(
+        inspectOutput({
+          command: ["/usr/local/bin/nemoclaw-managed-hold", "--bootstrap-identity", "7".repeat(64)],
+        }),
+      ),
+    ]);
+
+    expect(() => inspect(fake.engine)).toThrow("command binding changed");
+  });
+
+  it("rejects image-content drift during the stable capture", () => {
+    const fake = engineWith([
+      result(listOutput()),
+      result(inspectOutput()),
+      result(inspectOutput({ image: OTHER_IMAGE_ID })),
+    ]);
+
+    expect(() => inspect(fake.engine)).toThrow("image content changed");
+  });
+
+  it("does not include command output in a Podman failure", () => {
+    const fake = engineWith([
+      result("credential-in-stdout", {
+        status: 125,
+        stderr: "credential-in-stderr",
+        error: new Error("socket unavailable"),
+      }),
+    ]);
+
+    expect(() => inspect(fake.engine)).toThrow(
+      "Managed bootstrap Podman discovery failed with status 125: socket unavailable",
+    );
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/podman-held-workload.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-held-workload.ts
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  ContainerEngine,
+  ContainerEngineCommandResult,
+} from "../../adapters/container-engine";
+import { openshellSandboxCommandEnvValue } from "../docker-startup-command-env";
+
+// OpenShell v0.0.85 Podman ownership contract. A later label schema must use a
+// separate adapter so this mutation boundary never guesses container ownership.
+export const PODMAN_MANAGED_LABEL = "openshell.managed";
+export const PODMAN_SANDBOX_ID_LABEL = "openshell.sandbox-id";
+export const PODMAN_SANDBOX_NAME_LABEL = "openshell.sandbox-name";
+export const PODMAN_SANDBOX_NAMESPACE_LABEL = "openshell.sandbox-namespace";
+export const PODMAN_SANDBOX_CONTAINER_PREFIX = "openshell-sandbox-";
+
+const FULL_ID = /^(?:sha256:)?([0-9a-f]{64})$/iu;
+const BOOTSTRAP_IDENTITY = /^[0-9a-f]{64}$/u;
+const SAFE_SANDBOX_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/u;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f-\u009f]/u;
+const MAX_STRING_BYTES = 64 * 1024;
+const MAX_ARGV_BYTES = 128 * 1024;
+
+type JsonRecord = Record<string, unknown>;
+
+export interface PodmanHeldWorkloadObservation {
+  readonly containerName: string;
+  readonly heldWorkloadArgv: readonly string[];
+  readonly imageContentId: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly runtimeId: string;
+  readonly running: true;
+  readonly sandboxId: string;
+  readonly sandboxName: string;
+  readonly supervisorArgv: readonly string[];
+}
+
+export interface InspectPodmanHeldWorkloadInput {
+  readonly bootstrapIdentity: string;
+  readonly engine: ContainerEngine;
+  readonly expectedHeldWorkloadArgv: readonly string[];
+  readonly expectedImageContentId?: string;
+  readonly expectedSupervisorArgv: readonly string[];
+  readonly sandboxId: string;
+  readonly sandboxName: string;
+  readonly sandboxNamespace: string;
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as JsonRecord;
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array.`);
+  return value;
+}
+
+function safeString(value: unknown, label: string, allowEmpty = false): string {
+  if (
+    typeof value !== "string" ||
+    (!allowEmpty && value.length === 0) ||
+    Buffer.byteLength(value, "utf8") > MAX_STRING_BYTES ||
+    value !== value.trim() ||
+    value.includes("\0") ||
+    CONTROL_CHARACTER.test(value)
+  ) {
+    throw new Error(`${label} must be a bounded${allowEmpty ? "" : " non-empty"} string.`);
+  }
+  return value;
+}
+
+function safeSandboxName(value: string): string {
+  if (!SAFE_SANDBOX_NAME.test(value)) {
+    throw new Error("Managed bootstrap Podman sandbox name is invalid.");
+  }
+  return value;
+}
+
+function fullId(value: unknown, label: string): string {
+  const match = safeString(value, label).match(FULL_ID);
+  if (!match?.[1]) throw new Error(`${label} must be a full immutable SHA-256 identifier.`);
+  return match[1].toLowerCase();
+}
+
+function stringArray(value: unknown, label: string): readonly string[] {
+  if (value === undefined || value === null) return Object.freeze([]);
+  const values = typeof value === "string" ? [value] : array(value, label);
+  const normalized = values.map((entry, index) =>
+    safeString(entry, `${label}[${String(index)}]`, true),
+  );
+  if (Buffer.byteLength(JSON.stringify(normalized), "utf8") > MAX_ARGV_BYTES) {
+    throw new Error(`${label} exceeds the bounded argv transport.`);
+  }
+  return Object.freeze(normalized);
+}
+
+function stringMap(value: unknown, label: string): Readonly<Record<string, string>> {
+  const source = record(value, label);
+  const result: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(source)) {
+    result[safeString(key, `${label} key`)] = safeString(entry, `${label}.${key}`, true);
+  }
+  return Object.freeze(result);
+}
+
+function assertBootstrapEngine(engine: ContainerEngine): void {
+  if (engine.engineId !== "podman" || engine.operation !== "managed-bootstrap") {
+    throw new Error("Managed bootstrap requires a Podman 'managed-bootstrap' command adapter.");
+  }
+}
+
+function commandFailure(result: ContainerEngineCommandResult, action: string): never {
+  const processError = result.error?.message.trim().slice(0, 400);
+  throw new Error(
+    `${action} failed with status ${String(result.status)}${processError ? `: ${processError}` : "."}`,
+  );
+}
+
+function capture(
+  engine: ContainerEngine,
+  args: readonly string[],
+  action: string,
+): ContainerEngineCommandResult {
+  const result = engine.capture(args);
+  if (result.status !== 0) return commandFailure(result, action);
+  return result;
+}
+
+function parseJson(output: string, label: string): unknown {
+  try {
+    return JSON.parse(output);
+  } catch {
+    throw new Error(`${label} returned unreadable JSON.`);
+  }
+}
+
+function listEntryId(value: unknown, index: number): string {
+  const entry = record(value, `Podman managed container list entry ${String(index)}`);
+  const id = entry.Id ?? entry.ID;
+  if (entry.Id !== undefined && entry.ID !== undefined && entry.Id !== entry.ID) {
+    throw new Error("Podman managed container list returned conflicting identifier fields.");
+  }
+  return fullId(id, `Podman managed container list entry ${String(index)} ID`);
+}
+
+function discoverRuntimeId(engine: ContainerEngine, sandboxName: string): string {
+  const output = capture(
+    engine,
+    [
+      "container",
+      "ls",
+      "--all",
+      "--no-trunc",
+      "--filter",
+      `label=${PODMAN_MANAGED_LABEL}=true`,
+      "--filter",
+      `label=${PODMAN_SANDBOX_NAME_LABEL}=${sandboxName}`,
+      "--format",
+      "json",
+    ],
+    "Managed bootstrap Podman discovery",
+  ).stdout;
+  const entries = array(parseJson(output, "Podman managed container discovery"), "Podman list");
+  const ids = entries.map(listEntryId);
+  if (ids.length !== 1 || new Set(ids).size !== 1) {
+    throw new Error(
+      `Managed bootstrap requires exactly one Podman workload for sandbox '${sandboxName}'; found ${String(ids.length)}.`,
+    );
+  }
+  return ids[0] as string;
+}
+
+function exactEnvironmentCommand(environment: readonly string[]): string | null {
+  const prefix = "OPENSHELL_SANDBOX_COMMAND=";
+  const values = environment.filter((entry) => entry.startsWith(prefix));
+  if (values.length !== 1) {
+    throw new Error("Podman held workload must contain one exact OpenShell command binding.");
+  }
+  return (values[0] as string).slice(prefix.length);
+}
+
+function exactArrayEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function parseObservation(
+  output: string,
+  input: Omit<InspectPodmanHeldWorkloadInput, "engine">,
+  runtimeId: string,
+): PodmanHeldWorkloadObservation {
+  const entries = array(parseJson(output, "Podman container inspect"), "Podman inspect response");
+  if (entries.length !== 1) {
+    throw new Error("Podman container inspect must identify exactly one container.");
+  }
+  const inspect = record(entries[0], "Podman inspect entry");
+  if (fullId(inspect.Id, "Podman inspect Id") !== runtimeId) {
+    throw new Error("Podman held workload identity changed after discovery.");
+  }
+  const containerName = safeString(inspect.Name, "Podman inspect Name");
+  const expectedContainerName = `${PODMAN_SANDBOX_CONTAINER_PREFIX}${input.sandboxName}`;
+  if (containerName !== expectedContainerName) {
+    throw new Error("Podman held workload name does not match its OpenShell sandbox identity.");
+  }
+  const config = record(inspect.Config, "Podman inspect Config");
+  const labels = stringMap(config.Labels, "Podman inspect Config.Labels");
+  if (
+    labels[PODMAN_MANAGED_LABEL] !== "true" ||
+    labels[PODMAN_SANDBOX_NAME_LABEL] !== input.sandboxName ||
+    labels[PODMAN_SANDBOX_ID_LABEL] !== input.sandboxId ||
+    labels[PODMAN_SANDBOX_NAMESPACE_LABEL] !== input.sandboxNamespace
+  ) {
+    throw new Error("Podman held workload labels do not match its exact OpenShell ownership.");
+  }
+  const state = record(inspect.State, "Podman inspect State");
+  if (state.Running !== true || state.Paused === true || state.Restarting === true) {
+    throw new Error("Podman held workload must be stably running before bootstrap preparation.");
+  }
+  const configuredUser = String(config.User ?? "");
+  if (configuredUser !== "" && configuredUser !== "0" && configuredUser !== "root") {
+    throw new Error("Podman held workload does not use the image-owned root supervisor boundary.");
+  }
+  const supervisorArgv = Object.freeze([
+    ...stringArray(config.Entrypoint, "Podman inspect Config.Entrypoint"),
+    ...stringArray(config.Cmd, "Podman inspect Config.Cmd"),
+  ]);
+  if (supervisorArgv.length === 0 || !supervisorArgv[0]?.startsWith("/")) {
+    throw new Error("Podman held workload supervisor argv must begin with an absolute path.");
+  }
+  if (!exactArrayEqual(supervisorArgv, input.expectedSupervisorArgv)) {
+    throw new Error("Podman held workload supervisor argv changed before bootstrap preparation.");
+  }
+  const environment = stringArray(config.Env, "Podman inspect Config.Env");
+  const expectedCommand = openshellSandboxCommandEnvValue(input.expectedHeldWorkloadArgv);
+  if (!expectedCommand || exactEnvironmentCommand(environment) !== expectedCommand) {
+    throw new Error("Podman held workload command binding changed before bootstrap preparation.");
+  }
+  if (!expectedCommand.includes(input.bootstrapIdentity)) {
+    throw new Error("Podman held workload command is not bound to the bootstrap identity.");
+  }
+  const imageContentId = `sha256:${fullId(inspect.Image, "Podman inspect Image")}`;
+  if (
+    input.expectedImageContentId &&
+    imageContentId !== `sha256:${fullId(input.expectedImageContentId, "Expected image content ID")}`
+  ) {
+    throw new Error("Podman held workload image content changed before bootstrap preparation.");
+  }
+  return Object.freeze({
+    containerName,
+    heldWorkloadArgv: Object.freeze([...input.expectedHeldWorkloadArgv]),
+    imageContentId,
+    labels,
+    runtimeId,
+    running: true,
+    sandboxId: input.sandboxId,
+    sandboxName: input.sandboxName,
+    supervisorArgv,
+  });
+}
+
+function sameObservation(
+  left: PodmanHeldWorkloadObservation,
+  right: PodmanHeldWorkloadObservation,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/**
+ * Resolve and inspect one OpenShell v0.0.85 Podman workload twice. The caller
+ * receives only immutable ownership and startup evidence; replacement planning
+ * remains in the provider transaction that owns the complete launch spec.
+ */
+export function inspectExactPodmanHeldWorkload(
+  input: InspectPodmanHeldWorkloadInput,
+): PodmanHeldWorkloadObservation {
+  assertBootstrapEngine(input.engine);
+  if (
+    !BOOTSTRAP_IDENTITY.test(input.bootstrapIdentity) ||
+    !input.expectedHeldWorkloadArgv.includes(input.bootstrapIdentity)
+  ) {
+    throw new Error("Managed bootstrap Podman held command has an invalid bootstrap identity.");
+  }
+  const sandboxName = safeSandboxName(input.sandboxName);
+  const sandboxNamespace = safeString(
+    input.sandboxNamespace,
+    "Managed bootstrap Podman sandbox namespace",
+  );
+  const runtimeId = discoverRuntimeId(input.engine, sandboxName);
+  const inspectArgs = ["container", "inspect", runtimeId] as const;
+  const values = { ...input, sandboxName, sandboxNamespace };
+  const first = parseObservation(
+    capture(input.engine, inspectArgs, "Managed bootstrap Podman inspect").stdout,
+    values,
+    runtimeId,
+  );
+  const second = parseObservation(
+    capture(input.engine, inspectArgs, "Managed bootstrap Podman stable re-inspect").stdout,
+    values,
+    runtimeId,
+  );
+  if (!sameObservation(first, second)) {
+    throw new Error("Podman held workload changed during stable identity capture.");
+  }
+  return second;
+}

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
@@ -1,0 +1,539 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import type { ContainerEngineCommandResult } from "../../adapters/container-engine";
+import {
+  encodeManagedStartupProfile,
+  MANAGED_STARTUP_AGENTS,
+  type ManagedStartupAgent,
+} from "../managed-startup/profile";
+import { createManagedStartupRootApplyRequest } from "../managed-startup/root-apply";
+import {
+  parseManagedBootstrapEnvelope,
+  serializeManagedBootstrapImageCompletion,
+} from "./envelope";
+import type { PodmanBootstrapJournal } from "./podman-bootstrap-journal";
+import {
+  PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+  PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+  type PodmanBootstrapPreparedReplacement,
+} from "./podman-bootstrap-replacement";
+import {
+  awaitPodmanBootstrapImageTransaction,
+  startPodmanBootstrapImageTransaction,
+} from "./podman-image-transaction";
+import {
+  PODMAN_WATCHER_LEASE_SCHEMA_VERSION,
+  type PodmanGatewayWatcherLease,
+} from "./podman-watcher-lease";
+
+const RUNTIME_ID = "1".repeat(64);
+const ORIGINAL_RUNTIME_ID = "0".repeat(64);
+const IMAGE_ID = `sha256:${"2".repeat(64)}`;
+const BOOTSTRAP_IDENTITY = "3".repeat(64);
+const AUTHORITY_ID = `podman-sha256:${"4".repeat(64)}`;
+const LEASE_ID = "01234567-89ab-4cde-8fab-0123456789ab";
+const SPEC_FINGERPRINT = "5".repeat(64);
+const STAGING_NAME = "sandbox-nemoclaw-bootstrap-333333333333";
+const STATE_VOLUME_NAME = "sandbox-nemoclaw-state-333333333333";
+const STATE_VOLUME_MOUNTPOINT = "/var/lib/containers/storage/volumes/state/_data";
+
+function requestFor(agent: ManagedStartupAgent) {
+  return createManagedStartupRootApplyRequest({
+    agent,
+    encodedProfile: encodeManagedStartupProfile(managedStartupE2eProfile(agent, false, false)),
+  });
+}
+
+function result(
+  overrides: Partial<ContainerEngineCommandResult> = {},
+): ContainerEngineCommandResult {
+  return { status: 0, stdout: "", stderr: "", ...overrides };
+}
+
+function watcherLease(): PodmanGatewayWatcherLease {
+  return {
+    record: {
+      schemaVersion: PODMAN_WATCHER_LEASE_SCHEMA_VERSION,
+      holder: { pid: 9_100, processStartIdentity: "holder-start-100" },
+      leaseId: LEASE_ID,
+      phase: "stopped",
+      gatewayName: "gateway",
+      gatewayPort: 8080,
+      launchIdentity: "launch-1",
+      ownerIdentity: "owner-1",
+      ownerKind: "managed-service",
+      pid: 42,
+      processStartIdentity: "pid-start-1",
+    },
+    assertStillStopped: vi.fn(),
+    resumeAndProve: vi.fn(),
+  };
+}
+
+function journal(overrides: Partial<PodmanBootstrapJournal> = {}): PodmanBootstrapJournal {
+  return {
+    schemaVersion: 1,
+    phase: "original-stopped",
+    bootstrapIdentity: BOOTSTRAP_IDENTITY,
+    engineAuthorityId: AUTHORITY_ID,
+    watcherLeaseId: LEASE_ID,
+    sandboxName: "sandbox",
+    sandboxId: "sandbox-id",
+    originalRuntimeId: ORIGINAL_RUNTIME_ID,
+    originalContainerName: "sandbox-original",
+    originalImageContentId: `sha256:${"6".repeat(64)}`,
+    originalSpecFingerprint: "7".repeat(64),
+    replacementStateVolumeName: STATE_VOLUME_NAME,
+    replacementStateVolumeMountpoint: STATE_VOLUME_MOUNTPOINT,
+    replacementRuntimeId: RUNTIME_ID,
+    replacementStagingName: STAGING_NAME,
+    replacementImageContentId: IMAGE_ID,
+    replacementSpecFingerprint: SPEC_FINGERPRINT,
+    ...overrides,
+  };
+}
+
+function preparedReplacement(
+  durableJournal: PodmanBootstrapJournal = journal(),
+): PodmanBootstrapPreparedReplacement {
+  return {
+    schemaVersion: PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+    bootstrapIdentity: durableJournal.bootstrapIdentity,
+    originalRuntimeId: durableJournal.originalRuntimeId,
+    replacementRuntimeId: durableJournal.replacementRuntimeId as string,
+    replacementStagingName: durableJournal.replacementStagingName,
+    replacementStateVolumeName: durableJournal.replacementStateVolumeName,
+    replacementStateVolumeMountpoint: durableJournal.replacementStateVolumeMountpoint as string,
+    replacementImageContentId: durableJournal.replacementImageContentId,
+    replacementSpecFingerprint: durableJournal.replacementSpecFingerprint,
+    journal: durableJournal,
+  };
+}
+
+interface HarnessOptions {
+  readonly completionAgent?: ManagedStartupAgent;
+  readonly completionMode?: number;
+  readonly completionUnavailableCount?: number;
+  readonly inspectImage?: string;
+  readonly inspectName?: string;
+  readonly inspectRuntimeId?: string;
+  readonly inspectStateVolumeMountpoint?: string;
+  readonly inspectStateVolumeMode?: string;
+  readonly inspectStateVolumeName?: string;
+  readonly journal?: PodmanBootstrapJournal | null;
+  readonly startsRunning?: boolean;
+}
+
+function harness(agent: ManagedStartupAgent, options: HarnessOptions = {}) {
+  const request = requestFor(agent);
+  const prepared = preparedReplacement();
+  const durableJournal = options.journal === undefined ? prepared.journal : options.journal;
+  const commands: string[][] = [];
+  const timeouts: number[] = [];
+  let running = options.startsRunning ?? false;
+  let completionAttempts = 0;
+  let stagedEnvelope = "";
+  const inspect = (): ContainerEngineCommandResult =>
+    result({
+      stdout: JSON.stringify([
+        {
+          Id: options.inspectRuntimeId ?? RUNTIME_ID,
+          Image: options.inspectImage ?? IMAGE_ID,
+          Name: options.inspectName ?? STAGING_NAME,
+          Mounts: [
+            {
+              Destination: PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+              Driver: "local",
+              Mode: options.inspectStateVolumeMode ?? "z",
+              Name: options.inspectStateVolumeName ?? STATE_VOLUME_NAME,
+              Options: ["rw"],
+              Propagation: "",
+              RW: true,
+              Source: options.inspectStateVolumeMountpoint ?? STATE_VOLUME_MOUNTPOINT,
+              Type: "volume",
+            },
+          ],
+          State: { Dead: false, Paused: false, Restarting: false, Running: running },
+        },
+      ]),
+    });
+  const start = (): ContainerEngineCommandResult => {
+    running = true;
+    return result({ stdout: RUNTIME_ID });
+  };
+  const stageEnvelope = (source: string): ContainerEngineCommandResult => {
+    stagedEnvelope = fs.readFileSync(source, "utf8");
+    return result();
+  };
+  const publishCompletion = (destination: string): ContainerEngineCommandResult => {
+    fs.writeFileSync(
+      destination,
+      serializeManagedBootstrapImageCompletion({
+        agent: options.completionAgent ?? agent,
+        bootstrapIdentity: BOOTSTRAP_IDENTITY,
+        profileFingerprint: request.profileFingerprint,
+        transactionPending: true,
+      }),
+      { flag: "wx", mode: options.completionMode ?? 0o444 },
+    );
+    fs.chmodSync(destination, options.completionMode ?? 0o444);
+    return result();
+  };
+  const copyCompletion = (destination: string): ContainerEngineCommandResult => {
+    completionAttempts += 1;
+    return completionAttempts <= (options.completionUnavailableCount ?? 0)
+      ? result({ status: 1, stderr: "completion not found" })
+      : publishCompletion(destination);
+  };
+  const copy = (args: readonly string[]): ContainerEngineCommandResult => {
+    const source = args[2] as string;
+    const destination = args[3] as string;
+    return source.startsWith(`${RUNTIME_ID}:`)
+      ? copyCompletion(destination)
+      : stageEnvelope(source);
+  };
+  const handlers: Readonly<
+    Record<string, (args: readonly string[]) => ContainerEngineCommandResult>
+  > = {
+    "container cp": copy,
+    "container inspect": inspect,
+    "container start": start,
+  };
+  const capture = vi.fn(
+    (args: readonly string[], timeoutMs = 15_000): ContainerEngineCommandResult => {
+      commands.push([...args]);
+      timeouts.push(timeoutMs);
+      return (
+        handlers[`${args[0] ?? ""} ${args[1] ?? ""}`]?.(args) ??
+        result({ status: 127, stderr: "unexpected command" })
+      );
+    },
+  );
+  const engine = {
+    operation: "managed-bootstrap" as const,
+    engineId: "podman",
+    displayName: "Podman",
+    authorityId: AUTHORITY_ID,
+    capture,
+    captureHost: vi.fn(),
+  };
+  const journalStore = { load: vi.fn(() => durableJournal) };
+  const watcher = watcherLease();
+  return {
+    commands,
+    completionAttempts: () => completionAttempts,
+    engine,
+    journalStore,
+    prepared,
+    request,
+    stagedEnvelope: () => stagedEnvelope,
+    timeouts,
+    watcher,
+  };
+}
+
+function startInput(agent: ManagedStartupAgent, fake: ReturnType<typeof harness>) {
+  return {
+    agent,
+    engine: fake.engine,
+    journalStore: fake.journalStore,
+    prepared: fake.prepared,
+    profileFingerprint: fake.request.profileFingerprint,
+    request: fake.request,
+    watcherLease: fake.watcher,
+  } as const;
+}
+
+describe("Podman image-owned bootstrap transaction", () => {
+  it.each(
+    MANAGED_STARTUP_AGENTS,
+  )("stages, starts, and authenticates one protected %s completion without exec", (agent) => {
+    const fake = harness(agent);
+    const transaction = startPodmanBootstrapImageTransaction(startInput(agent, fake), {
+      now: () => new Date("2026-08-01T12:00:00.000Z"),
+    });
+    const completion = awaitPodmanBootstrapImageTransaction(
+      {
+        engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 30,
+      },
+      { now: () => new Date("2026-08-01T12:00:01.000Z") },
+    );
+
+    expect(parseManagedBootstrapEnvelope(fake.stagedEnvelope())).toEqual({
+      schemaVersion: 1,
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      rootApplyRequest: fake.request,
+    });
+    expect(transaction).toMatchObject({
+      agent,
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      engineAuthorityId: AUTHORITY_ID,
+      originalRuntimeId: ORIGINAL_RUNTIME_ID,
+      replacementRuntimeId: RUNTIME_ID,
+      replacementImageContentId: IMAGE_ID,
+      replacementSpecFingerprint: SPEC_FINGERPRINT,
+      replacementStagingName: STAGING_NAME,
+      replacementStateVolumeMountpoint: STATE_VOLUME_MOUNTPOINT,
+      replacementStateVolumeName: STATE_VOLUME_NAME,
+      watcherLeaseId: LEASE_ID,
+    });
+    expect(completion).toMatchObject({
+      agent,
+      bootstrapIdentity: BOOTSTRAP_IDENTITY,
+      engineAuthorityId: AUTHORITY_ID,
+      originalRuntimeId: ORIGINAL_RUNTIME_ID,
+      profileFingerprint: fake.request.profileFingerprint,
+      replacementRuntimeId: RUNTIME_ID,
+      replacementImageContentId: IMAGE_ID,
+      replacementSpecFingerprint: SPEC_FINGERPRINT,
+      replacementStagingName: STAGING_NAME,
+      replacementStateVolumeMountpoint: STATE_VOLUME_MOUNTPOINT,
+      replacementStateVolumeName: STATE_VOLUME_NAME,
+      transactionPending: true,
+      watcherLeaseId: LEASE_ID,
+    });
+    expect(fake.commands).toContainEqual(["container", "start", RUNTIME_ID]);
+    expect(fake.commands).toContainEqual([
+      "container",
+      "cp",
+      `${RUNTIME_ID}:/run/nemoclaw/managed-bootstrap-completion.json`,
+      expect.any(String),
+    ]);
+    expect(fake.commands.every((command) => !command.includes("exec"))).toBe(true);
+    expect(fake.commands.every((command) => !command.includes("--user"))).toBe(true);
+    expect(fake.watcher.assertStillStopped).toHaveBeenCalled();
+  });
+
+  it("retries an unpublished completion while retaining the stopped watcher lease", () => {
+    const fake = harness("openclaw", { completionUnavailableCount: 1 });
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+    let milliseconds = 0;
+    const completion = awaitPodmanBootstrapImageTransaction(
+      {
+        engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      },
+      {
+        now: () => new Date(milliseconds),
+        pollIntervalMs: 25,
+        sleep: (duration) => {
+          milliseconds += duration;
+        },
+      },
+    );
+
+    expect(completion.agent).toBe("openclaw");
+    expect(fake.completionAttempts()).toBe(2);
+  });
+
+  it("rejects a durable journal lost after replacement startup", () => {
+    const fake = harness("openclaw");
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+    fake.journalStore.load.mockReturnValue(null);
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("durable prepared-replacement journal is unavailable");
+  });
+
+  it("rejects a root request belonging to another agent before any container mutation", () => {
+    const fake = harness("openclaw");
+
+    expect(() =>
+      startPodmanBootstrapImageTransaction({
+        ...startInput("openclaw", fake),
+        request: requestFor("hermes"),
+      }),
+    ).toThrow("root request does not match");
+    expect(fake.commands).toEqual([]);
+  });
+
+  it("rejects a lost durable replacement journal before request staging", () => {
+    const fake = harness("openclaw", { journal: null });
+
+    expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", fake))).toThrow(
+      "durable prepared-replacement journal is unavailable",
+    );
+    expect(fake.commands).toEqual([]);
+  });
+
+  it.each([
+    ["phase", { phase: "replacement-created" as const }],
+    ["engine authority", { engineAuthorityId: `podman-sha256:${"8".repeat(64)}` }],
+    ["watcher lease", { watcherLeaseId: "fedcba98-7654-4abc-9def-fedcba987654" }],
+    ["replacement runtime", { replacementRuntimeId: "9".repeat(64) }],
+    ["replacement image", { replacementImageContentId: `sha256:${"a".repeat(64)}` }],
+    ["replacement name", { replacementStagingName: "different-staging-name" }],
+    ["state volume", { replacementStateVolumeName: "different-state-volume" }],
+  ])("rejects durable %s drift before request staging", (_label, overrides) => {
+    const fake = harness("openclaw", { journal: journal(overrides) });
+
+    expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", fake))).toThrow(
+      "exact original-stopped authority",
+    );
+    expect(fake.commands).toEqual([]);
+  });
+
+  it("rejects a replacement that was already running before request staging", () => {
+    const fake = harness("hermes", { startsRunning: true });
+
+    expect(() => startPodmanBootstrapImageTransaction(startInput("hermes", fake))).toThrow(
+      "not stably stopped",
+    );
+    expect(fake.commands.some((command) => command[1] === "cp")).toBe(false);
+  });
+
+  it("rejects runtime and image drift before request staging", () => {
+    const runtimeDrift = harness("openclaw", { inspectRuntimeId: "5".repeat(64) });
+    const imageDrift = harness("openclaw", { inspectImage: `sha256:${"6".repeat(64)}` });
+
+    expect(() =>
+      startPodmanBootstrapImageTransaction(startInput("openclaw", runtimeDrift)),
+    ).toThrow("runtime, image, or name identity changed");
+    expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", imageDrift))).toThrow(
+      "runtime, image, or name identity changed",
+    );
+  });
+
+  it.each([
+    ["replacement name", { inspectName: "different-staging-name" }],
+    ["state-volume name", { inspectStateVolumeName: "different-state-volume" }],
+    ["state-volume mountpoint", { inspectStateVolumeMountpoint: "/different/mountpoint" }],
+  ])("rejects live %s drift before request staging", (_label, options) => {
+    const fake = harness("openclaw", options);
+
+    expect(() => startPodmanBootstrapImageTransaction(startInput("openclaw", fake))).toThrow(
+      /replacement (runtime, image, or name identity|state-volume authority) changed/u,
+    );
+    expect(fake.commands.every((command) => command[1] !== "cp")).toBe(true);
+  });
+
+  it("accepts an empty non-authoritative Podman state-volume mount mode", () => {
+    const fake = harness("openclaw", { inspectStateVolumeMode: "" });
+
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+
+    expect(transaction.replacementStateVolumeName).toBe(STATE_VOLUME_NAME);
+    expect(fake.commands).toContainEqual(["container", "start", RUNTIME_ID]);
+  });
+
+  it("rejects a copied completion that is not protected mode 0444", () => {
+    const fake = harness("langchain-deepagents-code", { completionMode: 0o600 });
+    const transaction = startPodmanBootstrapImageTransaction(
+      startInput("langchain-deepagents-code", fake),
+    );
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("protected bounded 0444 file");
+  });
+
+  it("rejects completion from another agent", () => {
+    const fake = harness("openclaw", { completionAgent: "hermes" });
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("does not match its exact transaction authority");
+  });
+
+  it("rejects engine-authority or watcher-lease drift before polling", () => {
+    const fake = harness("openclaw");
+    const transaction = startPodmanBootstrapImageTransaction(startInput("openclaw", fake));
+    const commandsBefore = fake.commands.length;
+    const differentEngine = {
+      ...fake.engine,
+      authorityId: `podman-sha256:${"7".repeat(64)}`,
+    };
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: differentEngine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
+        watcherLease: fake.watcher,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("exact Podman managed-bootstrap engine authority");
+    expect(fake.commands).toHaveLength(commandsBefore);
+
+    const differentLease = watcherLease();
+    Object.defineProperty(differentLease.record, "leaseId", {
+      configurable: true,
+      value: "fedcba98-7654-4abc-9def-fedcba987654",
+    });
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction({
+        engine: fake.engine,
+        journalStore: fake.journalStore,
+        prepared: fake.prepared,
+        watcherLease: differentLease,
+        transaction,
+        timeoutSecs: 1,
+      }),
+    ).toThrow("exact stopped OpenShell watcher lease");
+  });
+
+  it("times out deterministically when the protected completion never appears", () => {
+    const fake = harness("hermes", { completionUnavailableCount: 100 });
+    const transaction = startPodmanBootstrapImageTransaction(startInput("hermes", fake));
+    let milliseconds = 0;
+
+    expect(() =>
+      awaitPodmanBootstrapImageTransaction(
+        {
+          engine: fake.engine,
+          journalStore: fake.journalStore,
+          prepared: fake.prepared,
+          watcherLease: fake.watcher,
+          transaction,
+          timeoutSecs: 1,
+        },
+        {
+          now: () => new Date(milliseconds),
+          pollIntervalMs: 500,
+          sleep: (duration) => {
+            milliseconds += duration;
+          },
+        },
+      ),
+    ).toThrow("not published before timeout");
+    expect(fake.completionAttempts()).toBe(3);
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
@@ -1,0 +1,695 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import type {
+  ContainerEngine,
+  ContainerEngineCommandResult,
+} from "../../adapters/container-engine";
+import type { ManagedStartupRootApplyRequest } from "../managed-startup/root-apply";
+import { cleanupTempDir, secureTempFile } from "../temp-files";
+import {
+  MANAGED_BOOTSTRAP_COMPLETION_FILE,
+  MANAGED_BOOTSTRAP_COMPLETION_MAX_BYTES,
+  MANAGED_BOOTSTRAP_REQUEST_FILE,
+  type ManagedBootstrapImageCompletion,
+  parseManagedBootstrapImageCompletion,
+  serializeManagedBootstrapEnvelope,
+} from "./envelope";
+import {
+  normalizePodmanBootstrapJournal,
+  type PodmanBootstrapJournal,
+  type PodmanBootstrapJournalStore,
+} from "./podman-bootstrap-journal";
+import {
+  PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION,
+  PODMAN_BOOTSTRAP_STATE_DIRECTORY,
+  type PodmanBootstrapPreparedReplacement,
+} from "./podman-bootstrap-replacement";
+import type { PodmanGatewayWatcherLease } from "./podman-watcher-lease";
+
+export const PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION = 1 as const;
+
+const REQUEST_TEMP_PREFIX = "nemoclaw-podman-bootstrap-request";
+const COMPLETION_TEMP_PREFIX = "nemoclaw-podman-bootstrap-completion";
+const FULL_RUNTIME_ID = /^[a-f0-9]{64}$/u;
+const IMAGE_CONTENT_ID = /^sha256:[a-f0-9]{64}$/u;
+const SHA256 = /^[a-f0-9]{64}$/u;
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,252}$/u;
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+const DEFAULT_START_TIMEOUT_MS = 90_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+const MAX_TIMEOUT_SECONDS = 3_600;
+
+type BootstrapEngine = ContainerEngine & { readonly authorityId: string };
+type ManagedStartupAgent = ManagedStartupRootApplyRequest["agent"];
+
+const PODMAN_BOOTSTRAP_AGENTS = Object.freeze({
+  openclaw: true,
+  hermes: true,
+  "langchain-deepagents-code": true,
+} satisfies Record<ManagedStartupAgent, true>);
+
+export interface PodmanBootstrapImageTransactionInput {
+  readonly engine: BootstrapEngine;
+  readonly journalStore: Pick<PodmanBootstrapJournalStore, "load">;
+  readonly watcherLease: PodmanGatewayWatcherLease;
+  readonly agent: ManagedStartupAgent;
+  readonly prepared: PodmanBootstrapPreparedReplacement;
+  readonly profileFingerprint: string;
+  readonly request: ManagedStartupRootApplyRequest;
+}
+
+export interface PodmanBootstrapImageTransaction {
+  readonly schemaVersion: typeof PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION;
+  readonly agent: ManagedStartupAgent;
+  readonly bootstrapIdentity: string;
+  readonly engineAuthorityId: string;
+  readonly originalRuntimeId: string;
+  readonly profileFingerprint: string;
+  readonly replacementRuntimeId: string;
+  readonly replacementStagingName: string;
+  readonly replacementStateVolumeName: string;
+  readonly replacementStateVolumeMountpoint: string;
+  readonly replacementImageContentId: string;
+  readonly replacementSpecFingerprint: string;
+  readonly watcherLeaseId: string;
+  readonly startedAt: string;
+}
+
+export interface PodmanBootstrapImageTransactionCompletion extends ManagedBootstrapImageCompletion {
+  readonly engineAuthorityId: string;
+  readonly originalRuntimeId: string;
+  readonly replacementRuntimeId: string;
+  readonly replacementStagingName: string;
+  readonly replacementStateVolumeName: string;
+  readonly replacementStateVolumeMountpoint: string;
+  readonly replacementImageContentId: string;
+  readonly replacementSpecFingerprint: string;
+  readonly watcherLeaseId: string;
+  readonly completedAt: string;
+}
+
+export interface PodmanBootstrapImageTransactionDeps {
+  readonly now?: () => Date;
+  readonly sleep?: (milliseconds: number) => void;
+  readonly pollIntervalMs?: number;
+}
+
+interface ExactPodmanContainerState {
+  readonly imageContentId: string;
+  readonly name: string;
+  readonly runtimeId: string;
+  readonly running: boolean;
+  readonly stateVolumeMountpoint: string;
+  readonly stateVolumeName: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function fail(message: string): never {
+  throw new Error(`Podman managed bootstrap image transaction failed: ${message}`);
+}
+
+function exactEngine(engine: BootstrapEngine, expectedAuthorityId?: string): BootstrapEngine {
+  if (
+    engine.engineId !== "podman" ||
+    engine.operation !== "managed-bootstrap" ||
+    typeof engine.authorityId !== "string" ||
+    !/^podman-sha256:[a-f0-9]{64}$/u.test(engine.authorityId) ||
+    (expectedAuthorityId !== undefined && engine.authorityId !== expectedAuthorityId)
+  ) {
+    fail("the exact Podman managed-bootstrap engine authority is unavailable");
+  }
+  return engine;
+}
+
+function exactAgent(value: string): ManagedStartupAgent {
+  if (Object.prototype.hasOwnProperty.call(PODMAN_BOOTSTRAP_AGENTS, value)) {
+    return value as ManagedStartupAgent;
+  }
+  return fail("the managed agent is unsupported");
+}
+
+function exactSha256(value: string, label: string): string {
+  if (!SHA256.test(value)) fail(`${label} must be lowercase SHA-256`);
+  return value;
+}
+
+function exactRuntimeId(value: string): string {
+  if (!FULL_RUNTIME_ID.test(value)) fail("replacement runtime ID must be a full lowercase ID");
+  return value;
+}
+
+function exactImageContentId(value: string): string {
+  if (!IMAGE_CONTENT_ID.test(value)) {
+    fail("replacement image identity must be one immutable content ID");
+  }
+  return value;
+}
+
+function exactName(value: string, label: string): string {
+  if (!SAFE_NAME.test(value)) fail(`${label} must be one exact Podman name`);
+  return value;
+}
+
+function exactMountpoint(value: string): string {
+  if (
+    !path.isAbsolute(value) ||
+    path.normalize(value) !== value ||
+    value === path.parse(value).root
+  ) {
+    fail("replacement state-volume mountpoint must be one normalized non-root absolute path");
+  }
+  return value;
+}
+
+function sameJournal(left: PodmanBootstrapJournal, right: PodmanBootstrapJournal): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function exactPreparedAuthority(
+  input: Pick<
+    PodmanBootstrapImageTransactionInput,
+    "engine" | "journalStore" | "prepared" | "watcherLease"
+  >,
+): PodmanBootstrapPreparedReplacement {
+  const prepared = input.prepared;
+  if (
+    !prepared ||
+    typeof prepared !== "object" ||
+    prepared.schemaVersion !== PODMAN_BOOTSTRAP_REPLACEMENT_SCHEMA_VERSION
+  ) {
+    return fail("the prepared replacement authority is invalid");
+  }
+  exactSha256(prepared.bootstrapIdentity, "bootstrap identity");
+  exactRuntimeId(prepared.originalRuntimeId);
+  exactRuntimeId(prepared.replacementRuntimeId);
+  exactImageContentId(prepared.replacementImageContentId);
+  exactSha256(prepared.replacementSpecFingerprint, "replacement specification fingerprint");
+  exactName(prepared.replacementStagingName, "replacement staging name");
+  exactName(prepared.replacementStateVolumeName, "replacement state-volume name");
+  exactMountpoint(prepared.replacementStateVolumeMountpoint);
+  const expectedJournal = normalizePodmanBootstrapJournal(prepared.journal);
+  const loaded = input.journalStore.load(prepared.bootstrapIdentity);
+  if (!loaded) return fail("the durable prepared-replacement journal is unavailable");
+  const journal = normalizePodmanBootstrapJournal(loaded);
+  if (
+    journal.phase !== "original-stopped" ||
+    !sameJournal(journal, expectedJournal) ||
+    journal.engineAuthorityId !== input.engine.authorityId ||
+    journal.watcherLeaseId !== input.watcherLease.record.leaseId ||
+    journal.originalRuntimeId !== prepared.originalRuntimeId ||
+    journal.replacementRuntimeId !== prepared.replacementRuntimeId ||
+    journal.replacementStagingName !== prepared.replacementStagingName ||
+    journal.replacementStateVolumeName !== prepared.replacementStateVolumeName ||
+    journal.replacementStateVolumeMountpoint !== prepared.replacementStateVolumeMountpoint ||
+    journal.replacementImageContentId !== prepared.replacementImageContentId ||
+    journal.replacementSpecFingerprint !== prepared.replacementSpecFingerprint
+  ) {
+    return fail("the prepared replacement does not match its exact original-stopped authority");
+  }
+  return prepared;
+}
+
+function exactWatcherLease(lease: PodmanGatewayWatcherLease, expectedLeaseId?: string): void {
+  if (
+    !lease ||
+    typeof lease !== "object" ||
+    lease.record?.phase !== "stopped" ||
+    (expectedLeaseId !== undefined && lease.record.leaseId !== expectedLeaseId)
+  ) {
+    fail("the exact stopped OpenShell watcher lease is unavailable");
+  }
+  lease.assertStillStopped();
+}
+
+function commandFailure(result: ContainerEngineCommandResult, action: string): never {
+  const detail = result.error?.message.trim().slice(0, 400);
+  fail(`${action} returned status ${String(result.status)}${detail ? `: ${detail}` : ""}`);
+}
+
+function capture(
+  engine: BootstrapEngine,
+  args: readonly string[],
+  action: string,
+  timeoutMs = DEFAULT_COMMAND_TIMEOUT_MS,
+): ContainerEngineCommandResult {
+  const result = engine.capture(args, timeoutMs);
+  if (result.status !== 0) commandFailure(result, action);
+  return result;
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value as JsonRecord;
+}
+
+function normalizedRuntimeId(value: unknown, label: string): string {
+  if (typeof value !== "string") fail(`${label} is missing`);
+  const match = /^(?:sha256:)?([a-f0-9]{64})$/u.exec(value);
+  if (!match?.[1]) fail(`${label} must be one full immutable ID`);
+  return match[1];
+}
+
+function exactString(value: unknown, label: string, allowEmpty = false): string {
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+    return fail(`${label} must be one exact string`);
+  }
+  return value;
+}
+
+function exactStringArray(value: unknown, label: string): readonly string[] {
+  if (value === undefined || value === null) return Object.freeze([]);
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    return fail(`${label} must be an array of strings`);
+  }
+  return Object.freeze([...(value as string[])]);
+}
+
+function exactStateVolume(
+  inspect: JsonRecord,
+  prepared: PodmanBootstrapPreparedReplacement,
+): Pick<ExactPodmanContainerState, "stateVolumeMountpoint" | "stateVolumeName"> {
+  if (!Array.isArray(inspect.Mounts)) {
+    return fail("Podman replacement inspect Mounts must be an array");
+  }
+  const mounts = inspect.Mounts.map((entry, index) =>
+    record(entry, `Podman replacement mount ${String(index)}`),
+  ).filter((entry) => entry.Destination === PODMAN_BOOTSTRAP_STATE_DIRECTORY);
+  if (mounts.length !== 1) {
+    return fail("the exact replacement state-volume mount is unavailable");
+  }
+  const mount = mounts[0] as JsonRecord;
+  const mode = exactString(mount.Mode, "Podman replacement state-volume mode", true);
+  const options = exactStringArray(mount.Options, "Podman replacement state-volume options");
+  const propagation = exactString(
+    mount.Propagation,
+    "Podman replacement state-volume propagation",
+    true,
+  );
+  const modeTokens = new Set(mode.split(",").filter(Boolean));
+  if (
+    mount.Type !== "volume" ||
+    mount.Name !== prepared.replacementStateVolumeName ||
+    mount.Source !== prepared.replacementStateVolumeMountpoint ||
+    mount.Driver !== "local" ||
+    mount.RW !== true ||
+    !["", "rprivate"].includes(propagation) ||
+    modeTokens.has("Z") ||
+    modeTokens.has("ro") ||
+    options.some((option) => option === "ro" || option === "readonly")
+  ) {
+    return fail("the exact replacement state-volume authority changed");
+  }
+  return Object.freeze({
+    stateVolumeMountpoint: prepared.replacementStateVolumeMountpoint,
+    stateVolumeName: prepared.replacementStateVolumeName,
+  });
+}
+
+function parseInspect(
+  text: string,
+  prepared: PodmanBootstrapPreparedReplacement,
+): ExactPodmanContainerState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return fail("Podman inspect returned unreadable JSON");
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 1) {
+    return fail("Podman inspect did not return exactly one replacement");
+  }
+  const inspect = record(parsed[0], "Podman replacement inspect");
+  const runtimeId = normalizedRuntimeId(inspect.Id, "Podman replacement runtime ID");
+  const imageContentId = `sha256:${normalizedRuntimeId(
+    inspect.Image,
+    "Podman replacement image content ID",
+  )}`;
+  const name = exactString(inspect.Name, "Podman replacement name");
+  if (
+    runtimeId !== prepared.replacementRuntimeId ||
+    imageContentId !== prepared.replacementImageContentId ||
+    name !== prepared.replacementStagingName
+  ) {
+    return fail("the exact replacement runtime, image, or name identity changed");
+  }
+  const stateVolume = exactStateVolume(inspect, prepared);
+  const state = record(inspect.State, "Podman replacement state");
+  if (
+    typeof state.Running !== "boolean" ||
+    (state.Paused !== undefined && typeof state.Paused !== "boolean") ||
+    (state.Restarting !== undefined && typeof state.Restarting !== "boolean") ||
+    (state.Dead !== undefined && typeof state.Dead !== "boolean") ||
+    state.Paused === true ||
+    state.Restarting === true ||
+    state.Dead === true
+  ) {
+    return fail("the exact replacement is not in a stable running or stopped state");
+  }
+  return Object.freeze({ imageContentId, name, runtimeId, running: state.Running, ...stateVolume });
+}
+
+function inspectExact(
+  engine: BootstrapEngine,
+  prepared: PodmanBootstrapPreparedReplacement,
+): ExactPodmanContainerState {
+  return parseInspect(
+    capture(
+      engine,
+      ["container", "inspect", prepared.replacementRuntimeId],
+      "exact replacement inspection",
+    ).stdout,
+    prepared,
+  );
+}
+
+function sameState(left: ExactPodmanContainerState, right: ExactPodmanContainerState): boolean {
+  return (
+    left.runtimeId === right.runtimeId &&
+    left.imageContentId === right.imageContentId &&
+    left.name === right.name &&
+    left.running === right.running &&
+    left.stateVolumeMountpoint === right.stateVolumeMountpoint &&
+    left.stateVolumeName === right.stateVolumeName
+  );
+}
+
+function inspectStable(
+  engine: BootstrapEngine,
+  prepared: PodmanBootstrapPreparedReplacement,
+  expectedRunning: boolean,
+): ExactPodmanContainerState {
+  const first = inspectExact(engine, prepared);
+  const second = inspectExact(engine, prepared);
+  if (!sameState(first, second) || second.running !== expectedRunning) {
+    fail(`the exact replacement is not stably ${expectedRunning ? "running" : "stopped"}`);
+  }
+  return second;
+}
+
+function writeProtectedEnvelope(
+  input: PodmanBootstrapImageTransactionInput,
+  prepared: PodmanBootstrapPreparedReplacement,
+): string {
+  const file = secureTempFile(REQUEST_TEMP_PREFIX, ".json");
+  try {
+    fs.writeFileSync(
+      file,
+      serializeManagedBootstrapEnvelope({
+        bootstrapIdentity: prepared.bootstrapIdentity,
+        rootApplyRequest: input.request,
+      }),
+      { encoding: "utf8", flag: "wx", mode: 0o400 },
+    );
+    fs.chmodSync(file, 0o400);
+    const stat = fs.lstatSync(file);
+    if (
+      !stat.isFile() ||
+      stat.isSymbolicLink() ||
+      stat.nlink !== 1 ||
+      (stat.mode & 0o777) !== 0o400
+    ) {
+      fail("the root request source is not one protected 0400 file");
+    }
+    return file;
+  } catch (error) {
+    cleanupTempDir(file, REQUEST_TEMP_PREFIX);
+    throw error;
+  }
+}
+
+function stageProtectedEnvelope(
+  input: PodmanBootstrapImageTransactionInput,
+  prepared: PodmanBootstrapPreparedReplacement,
+): void {
+  const file = writeProtectedEnvelope(input, prepared);
+  try {
+    capture(
+      input.engine,
+      [
+        "container",
+        "cp",
+        file,
+        `${prepared.replacementRuntimeId}:${MANAGED_BOOTSTRAP_REQUEST_FILE}`,
+      ],
+      "protected root request staging",
+    );
+  } finally {
+    cleanupTempDir(file, REQUEST_TEMP_PREFIX);
+  }
+}
+
+function sameStableMetadata(left: fs.BigIntStats, right: fs.BigIntStats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.nlink === right.nlink &&
+    left.uid === right.uid &&
+    left.gid === right.gid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function readProtectedCompletion(file: string): ManagedBootstrapImageCompletion {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") fail("O_NOFOLLOW is unavailable for completion reads");
+  const nonblock = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(file, fs.constants.O_RDONLY | noFollow | nonblock);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      return fail("the copied completion ownership boundary is invalid");
+    }
+    throw error;
+  }
+  try {
+    const before = fs.fstatSync(descriptor, { bigint: true });
+    if (
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      Number(before.mode & 0o777n) !== 0o444 ||
+      before.size < 1n ||
+      before.size > BigInt(MANAGED_BOOTSTRAP_COMPLETION_MAX_BYTES)
+    ) {
+      return fail("the image completion is not one protected bounded 0444 file");
+    }
+    const bytes = Buffer.alloc(Number(before.size));
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = fs.readSync(descriptor, bytes, offset, bytes.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const overflow = Buffer.alloc(1);
+    const overflowCount = fs.readSync(descriptor, overflow, 0, 1, offset);
+    const after = fs.fstatSync(descriptor, { bigint: true });
+    if (offset !== bytes.length || overflowCount !== 0 || !sameStableMetadata(before, after)) {
+      return fail("the image completion changed during its stable read");
+    }
+    return parseManagedBootstrapImageCompletion(bytes.toString("utf8"));
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function tryCopyCompletion(
+  engine: BootstrapEngine,
+  runtimeId: string,
+): { readonly completion: ManagedBootstrapImageCompletion | null; readonly status: number } {
+  const file = secureTempFile(COMPLETION_TEMP_PREFIX, ".json");
+  try {
+    const result = engine.capture(
+      ["container", "cp", `${runtimeId}:${MANAGED_BOOTSTRAP_COMPLETION_FILE}`, file],
+      DEFAULT_COMMAND_TIMEOUT_MS,
+    );
+    if (result.status !== 0) return { completion: null, status: result.status };
+    return { completion: readProtectedCompletion(file), status: result.status };
+  } finally {
+    cleanupTempDir(file, COMPLETION_TEMP_PREFIX);
+  }
+}
+
+function defaultSleep(milliseconds: number): void {
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function timeoutMilliseconds(timeoutSecs: number): number {
+  if (!Number.isSafeInteger(timeoutSecs) || timeoutSecs < 1 || timeoutSecs > MAX_TIMEOUT_SECONDS) {
+    fail(`completion timeout must be an integer from 1 to ${String(MAX_TIMEOUT_SECONDS)} seconds`);
+  }
+  return timeoutSecs * 1_000;
+}
+
+function pollInterval(deps: PodmanBootstrapImageTransactionDeps): number {
+  const value = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  if (!Number.isSafeInteger(value) || value < 1 || value > 10_000) {
+    fail("completion polling interval must be an integer from 1 to 10000 milliseconds");
+  }
+  return value;
+}
+
+function assertInput(
+  input: PodmanBootstrapImageTransactionInput,
+): PodmanBootstrapPreparedReplacement {
+  exactEngine(input.engine);
+  exactWatcherLease(input.watcherLease);
+  exactAgent(input.agent);
+  exactSha256(input.profileFingerprint, "profile fingerprint");
+  if (
+    input.request.agent !== input.agent ||
+    input.request.profileFingerprint !== input.profileFingerprint
+  ) {
+    fail("the root request does not match its exact agent and profile authority");
+  }
+  return exactPreparedAuthority(input);
+}
+
+/**
+ * Stage one identity-bound request into the stopped writable layer, then start
+ * that exact replacement. The image-owned trampoline remains the only root
+ * application boundary; this host path never enters a container process.
+ */
+export function startPodmanBootstrapImageTransaction(
+  input: PodmanBootstrapImageTransactionInput,
+  deps: Pick<PodmanBootstrapImageTransactionDeps, "now"> = {},
+): PodmanBootstrapImageTransaction {
+  const prepared = assertInput(input);
+  inspectStable(input.engine, prepared, false);
+  exactWatcherLease(input.watcherLease);
+  exactPreparedAuthority(input);
+  stageProtectedEnvelope(input, prepared);
+  exactWatcherLease(input.watcherLease);
+  exactPreparedAuthority(input);
+  inspectStable(input.engine, prepared, false);
+  capture(
+    input.engine,
+    ["container", "start", prepared.replacementRuntimeId],
+    "exact replacement start",
+    DEFAULT_START_TIMEOUT_MS,
+  );
+  exactWatcherLease(input.watcherLease);
+  exactPreparedAuthority(input);
+  inspectStable(input.engine, prepared, true);
+  exactWatcherLease(input.watcherLease);
+  exactPreparedAuthority(input);
+  return Object.freeze({
+    schemaVersion: PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION,
+    agent: input.agent,
+    bootstrapIdentity: prepared.bootstrapIdentity,
+    engineAuthorityId: input.engine.authorityId,
+    originalRuntimeId: prepared.originalRuntimeId,
+    profileFingerprint: input.profileFingerprint,
+    replacementRuntimeId: prepared.replacementRuntimeId,
+    replacementStagingName: prepared.replacementStagingName,
+    replacementStateVolumeName: prepared.replacementStateVolumeName,
+    replacementStateVolumeMountpoint: prepared.replacementStateVolumeMountpoint,
+    replacementImageContentId: prepared.replacementImageContentId,
+    replacementSpecFingerprint: prepared.replacementSpecFingerprint,
+    watcherLeaseId: input.watcherLease.record.leaseId,
+    startedAt: (deps.now ?? (() => new Date()))().toISOString(),
+  });
+}
+
+/** Poll one protected image-owned completion while the exact watcher stays stopped. */
+export function awaitPodmanBootstrapImageTransaction(
+  input: {
+    readonly engine: BootstrapEngine;
+    readonly journalStore: Pick<PodmanBootstrapJournalStore, "load">;
+    readonly prepared: PodmanBootstrapPreparedReplacement;
+    readonly watcherLease: PodmanGatewayWatcherLease;
+    readonly transaction: PodmanBootstrapImageTransaction;
+    readonly timeoutSecs: number;
+  },
+  deps: PodmanBootstrapImageTransactionDeps = {},
+): PodmanBootstrapImageTransactionCompletion {
+  const transaction = input.transaction;
+  if (
+    transaction.schemaVersion !== PODMAN_BOOTSTRAP_IMAGE_TRANSACTION_SCHEMA_VERSION ||
+    exactAgent(transaction.agent) !== transaction.agent
+  ) {
+    return fail("the started transaction receipt is invalid");
+  }
+  exactEngine(input.engine, transaction.engineAuthorityId);
+  exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
+  exactSha256(transaction.bootstrapIdentity, "bootstrap identity");
+  exactSha256(transaction.profileFingerprint, "profile fingerprint");
+  exactRuntimeId(transaction.originalRuntimeId);
+  exactRuntimeId(transaction.replacementRuntimeId);
+  exactName(transaction.replacementStagingName, "replacement staging name");
+  exactName(transaction.replacementStateVolumeName, "replacement state-volume name");
+  exactMountpoint(transaction.replacementStateVolumeMountpoint);
+  exactImageContentId(transaction.replacementImageContentId);
+  exactSha256(transaction.replacementSpecFingerprint, "replacement specification fingerprint");
+  const prepared = exactPreparedAuthority(input);
+  if (
+    transaction.bootstrapIdentity !== prepared.bootstrapIdentity ||
+    transaction.originalRuntimeId !== prepared.originalRuntimeId ||
+    transaction.replacementRuntimeId !== prepared.replacementRuntimeId ||
+    transaction.replacementStagingName !== prepared.replacementStagingName ||
+    transaction.replacementStateVolumeName !== prepared.replacementStateVolumeName ||
+    transaction.replacementStateVolumeMountpoint !== prepared.replacementStateVolumeMountpoint ||
+    transaction.replacementImageContentId !== prepared.replacementImageContentId ||
+    transaction.replacementSpecFingerprint !== prepared.replacementSpecFingerprint
+  ) {
+    return fail("the started transaction does not match its prepared replacement authority");
+  }
+  const timeoutMs = timeoutMilliseconds(input.timeoutSecs);
+  const intervalMs = pollInterval(deps);
+  const now = deps.now ?? (() => new Date());
+  const sleep = deps.sleep ?? defaultSleep;
+  const deadline = now().getTime() + timeoutMs;
+  let lastCopyStatus: number | null = null;
+
+  while (true) {
+    exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
+    exactPreparedAuthority(input);
+    inspectStable(input.engine, prepared, true);
+    const copied = tryCopyCompletion(input.engine, transaction.replacementRuntimeId);
+    lastCopyStatus = copied.status;
+    if (copied.completion) {
+      const completion = copied.completion;
+      if (
+        completion.agent !== transaction.agent ||
+        completion.bootstrapIdentity !== transaction.bootstrapIdentity ||
+        completion.profileFingerprint !== transaction.profileFingerprint
+      ) {
+        return fail("the image completion does not match its exact transaction authority");
+      }
+      inspectStable(input.engine, prepared, true);
+      exactWatcherLease(input.watcherLease, transaction.watcherLeaseId);
+      exactPreparedAuthority(input);
+      return Object.freeze({
+        ...completion,
+        engineAuthorityId: transaction.engineAuthorityId,
+        originalRuntimeId: transaction.originalRuntimeId,
+        replacementRuntimeId: transaction.replacementRuntimeId,
+        replacementStagingName: transaction.replacementStagingName,
+        replacementStateVolumeName: transaction.replacementStateVolumeName,
+        replacementStateVolumeMountpoint: transaction.replacementStateVolumeMountpoint,
+        replacementImageContentId: transaction.replacementImageContentId,
+        replacementSpecFingerprint: transaction.replacementSpecFingerprint,
+        watcherLeaseId: transaction.watcherLeaseId,
+        completedAt: now().toISOString(),
+      });
+    }
+    if (now().getTime() >= deadline) {
+      return fail(
+        `protected image completion was not published before timeout (last copy status ${String(
+          lastCopyStatus,
+        )})`,
+      );
+    }
+    sleep(intervalMs);
+  }
+}

--- a/src/lib/onboard/managed-bootstrap/podman-watcher-lease.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-watcher-lease.test.ts
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPodmanManagedGatewayWatcherController,
+  PODMAN_WATCHER_LEASE_SCHEMA_VERSION,
+  PodmanGatewayWatcherLeaseError,
+  type PodmanGatewayWatcherLeaseRecord,
+  type PodmanGatewayWatcherSnapshot,
+  type PodmanManagedGatewayWatcherControllerDeps,
+} from "./podman-watcher-lease";
+
+const LEASE_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_LEASE_ID = "22222222-2222-4222-8222-222222222222";
+const ORIGINAL = Object.freeze({
+  gatewayName: "nemoclaw",
+  gatewayPort: 8080,
+  launchIdentity: "launch-sha256",
+  ownerIdentity: "service-unit-sha256",
+  ownerKind: "managed-service",
+  pid: 4_100,
+  processStartIdentity: "proc-start-100",
+} as const satisfies PodmanGatewayWatcherSnapshot);
+const RESUMED = Object.freeze({
+  ...ORIGINAL,
+  pid: 4_200,
+  processStartIdentity: "proc-start-200",
+});
+const HOLDER = Object.freeze({ pid: 9_100, processStartIdentity: "holder-start-100" });
+
+function record(
+  phase: PodmanGatewayWatcherLeaseRecord["phase"] = "acquiring",
+): PodmanGatewayWatcherLeaseRecord {
+  return Object.freeze({
+    ...ORIGINAL,
+    schemaVersion: PODMAN_WATCHER_LEASE_SCHEMA_VERSION,
+    holder: HOLDER,
+    leaseId: LEASE_ID,
+    phase,
+  });
+}
+
+function harness(overrides: Partial<PodmanManagedGatewayWatcherControllerDeps> = {}) {
+  let durable: PodmanGatewayWatcherLeaseRecord | null = null;
+  let holderAlive = true;
+  let ownerStopped = false;
+  let watchers: PodmanGatewayWatcherSnapshot[] = [ORIGINAL];
+  const alive = new Set(["4100:proc-start-100"]);
+  const healthy = new Set(["4100:proc-start-100"]);
+  const key = (entry: PodmanGatewayWatcherSnapshot) =>
+    `${String(entry.pid)}:${entry.processStartIdentity}`;
+  const writes: PodmanGatewayWatcherLeaseRecord[] = [];
+  const store = {
+    read: vi.fn(() => durable),
+    acquire: vi.fn((value: PodmanGatewayWatcherLeaseRecord) => {
+      expect(durable, "lease already exists").toBeNull();
+      durable = value;
+      writes.push(value);
+    }),
+    advance: vi.fn((expectedLeaseId: string, value: PodmanGatewayWatcherLeaseRecord) => {
+      expect(durable?.leaseId, "lease compare-and-swap failed").toBe(expectedLeaseId);
+      durable = value;
+      writes.push(value);
+    }),
+    clear: vi.fn((expectedLeaseId: string) => {
+      expect(durable?.leaseId, "lease compare-and-clear failed").toBe(expectedLeaseId);
+      durable = null;
+    }),
+  };
+  const stopExactOwner = vi.fn(() => {
+    alive.delete(key(ORIGINAL));
+    healthy.delete(key(ORIGINAL));
+    watchers = [];
+    ownerStopped = true;
+  });
+  const resumeSameOwner = vi.fn(() => {
+    ownerStopped = false;
+    watchers = [RESUMED];
+    alive.add(key(RESUMED));
+    healthy.add(key(RESUMED));
+  });
+  const deps: PodmanManagedGatewayWatcherControllerDeps = {
+    store,
+    captureCurrent: () => ORIGINAL,
+    captureLeaseHolder: () => HOLDER,
+    listTargetWatchers: () => watchers,
+    isProcessInstanceAlive: (entry) => alive.has(key(entry)),
+    isLeaseHolderAlive: (holder) =>
+      holderAlive &&
+      holder.pid === HOLDER.pid &&
+      holder.processStartIdentity === HOLDER.processStartIdentity,
+    isOwnerStopped: () => ownerStopped,
+    stopExactOwner,
+    resumeSameOwner,
+    isHealthy: (entry) => healthy.has(key(entry)),
+    createLeaseId: () => LEASE_ID,
+    now: () => 0,
+    resumePollIntervalMs: 0,
+    resumeTimeoutMs: 1_000,
+    sleep: () => {},
+    ...overrides,
+  };
+  return {
+    alive,
+    controller: createPodmanManagedGatewayWatcherController(deps),
+    durable: () => durable,
+    healthy,
+    ownerStopped: () => ownerStopped,
+    resumeSameOwner,
+    setDurable: (value: PodmanGatewayWatcherLeaseRecord | null) => {
+      durable = value;
+    },
+    setHolderAlive: (value: boolean) => {
+      holderAlive = value;
+    },
+    setOwnerStopped: (value: boolean) => {
+      ownerStopped = value;
+    },
+    setWatchers: (value: PodmanGatewayWatcherSnapshot[]) => {
+      watchers = value;
+    },
+    stopExactOwner,
+    store,
+    watchers: () => watchers,
+    writes,
+  };
+}
+
+describe("durable Podman OpenShell watcher lease", () => {
+  it("persists authority before stop and clears it only after exact healthy resume", () => {
+    const fake = harness();
+    const lease = fake.controller.quiesceAndProve();
+
+    expect(fake.stopExactOwner).toHaveBeenCalledOnce();
+    expect(fake.writes.map((entry) => entry.phase)).toEqual(["acquiring", "stopped"]);
+    expect(fake.ownerStopped()).toBe(true);
+    expect(fake.watchers()).toEqual([]);
+    expect(fake.durable()).toEqual(record("stopped"));
+    lease.assertStillStopped();
+
+    lease.resumeAndProve();
+    expect(fake.resumeSameOwner).toHaveBeenCalledOnce();
+    expect(fake.watchers()).toEqual([RESUMED]);
+    expect(fake.durable()).toBeNull();
+    expect(fake.store.clear).toHaveBeenCalledWith(LEASE_ID);
+  });
+
+  it("clears an acquiring record when the crash preceded the stop request", () => {
+    const fake = harness();
+    fake.setDurable(record("acquiring"));
+    fake.setHolderAlive(false);
+
+    fake.controller.recoverUnfinishedLease();
+
+    expect(fake.resumeSameOwner).not.toHaveBeenCalled();
+    expect(fake.stopExactOwner).not.toHaveBeenCalled();
+    expect(fake.durable()).toBeNull();
+  });
+
+  it("resumes the exact owner when a crash followed stop but preceded the phase write", () => {
+    const fake = harness();
+    fake.setDurable(record("acquiring"));
+    fake.setHolderAlive(false);
+    fake.stopExactOwner();
+
+    fake.controller.recoverUnfinishedLease();
+
+    expect(fake.resumeSameOwner).toHaveBeenCalledOnce();
+    expect(fake.watchers()).toEqual([RESUMED]);
+    expect(fake.durable()).toBeNull();
+  });
+
+  it("recognizes an exact healthy post-resume owner without spawning a duplicate", () => {
+    const fake = harness();
+    fake.setDurable(record("stopped"));
+    fake.setHolderAlive(false);
+    fake.stopExactOwner();
+    fake.resumeSameOwner();
+    fake.resumeSameOwner.mockClear();
+
+    fake.controller.recoverUnfinishedLease();
+
+    expect(fake.resumeSameOwner).not.toHaveBeenCalled();
+    expect(fake.durable()).toBeNull();
+  });
+
+  it("leaves a stopped lease untouched while its exact holder is alive", () => {
+    const fake = harness();
+    fake.setDurable(record("stopped"));
+    fake.stopExactOwner();
+
+    expect(() => fake.controller.recoverUnfinishedLease()).toThrow(
+      "still owned by a live transaction process",
+    );
+    expect(fake.resumeSameOwner).not.toHaveBeenCalled();
+    expect(fake.store.clear).not.toHaveBeenCalled();
+    expect(fake.durable()).toEqual(record("stopped"));
+  });
+
+  it("refuses ambiguous watcher ownership before persisting or stopping", () => {
+    const fake = harness({
+      listTargetWatchers: () => [
+        ORIGINAL,
+        { ...ORIGINAL, pid: 4_101, processStartIdentity: "proc-start-101" },
+      ],
+    });
+
+    expect(() => fake.controller.quiesceAndProve()).toThrow("exactly one target-bound");
+    expect(fake.store.acquire).not.toHaveBeenCalled();
+    expect(fake.stopExactOwner).not.toHaveBeenCalled();
+  });
+
+  it("does not stop when atomic acquisition detects a competing lease", () => {
+    const fake = harness();
+    fake.store.acquire.mockImplementation(() => {
+      fake.setDurable({ ...record(), leaseId: OTHER_LEASE_ID });
+      throw new Error("lease already exists");
+    });
+
+    expect(() => fake.controller.quiesceAndProve()).toThrow("lease already exists");
+    expect(fake.stopExactOwner).not.toHaveBeenCalled();
+    expect(fake.durable()?.leaseId).toBe(OTHER_LEASE_ID);
+  });
+
+  it("restores the watcher when the stopped-phase durable write fails", () => {
+    const fake = harness();
+    fake.store.advance.mockImplementation(() => {
+      throw new Error("fsync failed");
+    });
+
+    expect(() => fake.controller.quiesceAndProve()).toThrow(
+      "Persisting the stopped Podman watcher lease failed",
+    );
+    expect(fake.resumeSameOwner).toHaveBeenCalledOnce();
+    expect(fake.watchers()).toEqual([RESUMED]);
+    expect(fake.durable()).toBeNull();
+  });
+
+  it("leaves recovery authority intact when an unexpected watcher blocks resume", () => {
+    const fake = harness();
+    fake.setDurable(record("stopped"));
+    fake.setHolderAlive(false);
+    fake.stopExactOwner();
+    fake.setOwnerStopped(false);
+    fake.setWatchers([
+      {
+        ...RESUMED,
+        launchIdentity: "unknown-launch",
+        ownerIdentity: "unknown-owner",
+      },
+    ]);
+    fake.alive.add("4200:proc-start-200");
+    fake.healthy.add("4200:proc-start-200");
+
+    let failure: unknown;
+    try {
+      fake.controller.recoverUnfinishedLease();
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(PodmanGatewayWatcherLeaseError);
+    expect((failure as PodmanGatewayWatcherLeaseError).recoveryRequired).toBe(true);
+    expect(fake.durable()).toEqual(record("stopped"));
+    expect(fake.resumeSameOwner).not.toHaveBeenCalled();
+  });
+
+  it("detects durable lease replacement while a lease object is live", () => {
+    const fake = harness();
+    const lease = fake.controller.quiesceAndProve();
+    fake.setDurable({ ...record("stopped"), leaseId: OTHER_LEASE_ID });
+
+    expect(() => lease.assertStillStopped()).toThrow("lease changed while it was held");
+    expect(() => lease.resumeAndProve()).toThrow("lease changed before release");
+    expect(fake.resumeSameOwner).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid persisted authority without attempting lifecycle mutation", () => {
+    const fake = harness();
+    fake.setDurable({ ...record(), leaseId: "not-a-lease" });
+
+    expect(() => fake.controller.recoverUnfinishedLease()).toThrow("lease is invalid");
+    expect(fake.stopExactOwner).not.toHaveBeenCalled();
+    expect(fake.resumeSameOwner).not.toHaveBeenCalled();
+    expect(fake.store.clear).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/managed-bootstrap/podman-watcher-lease.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-watcher-lease.ts
@@ -1,0 +1,566 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomUUID } from "node:crypto";
+
+const DEFAULT_RESUME_TIMEOUT_MS = 30_000;
+const DEFAULT_RESUME_POLL_INTERVAL_MS = 250;
+const MAX_OPAQUE_IDENTITY_LENGTH = 4_096;
+const SAFE_GATEWAY_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/u;
+const SAFE_LEASE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f-\u009f]/u;
+
+export const PODMAN_WATCHER_LEASE_SCHEMA_VERSION = 2;
+
+export type PodmanGatewayWatcherOwnerKind = "managed-service" | "standalone";
+export type PodmanGatewayWatcherLeasePhase = "acquiring" | "stopped";
+
+/**
+ * Immutable, non-secret evidence identifying one target-bound host gateway
+ * watcher and the lifecycle owner capable of stopping and resuming it.
+ *
+ * `processStartIdentity` must distinguish PID reuse. `ownerIdentity` and
+ * `launchIdentity` are opaque, stable identities supplied by the gateway
+ * lifecycle owner. They are compared but never interpolated into commands.
+ */
+export interface PodmanGatewayWatcherSnapshot {
+  readonly gatewayName: string;
+  readonly gatewayPort: number;
+  readonly launchIdentity: string;
+  readonly ownerIdentity: string;
+  readonly ownerKind: PodmanGatewayWatcherOwnerKind;
+  readonly pid: number;
+  readonly processStartIdentity: string;
+}
+
+/** Process identity for the NemoClaw transaction that currently owns a lease. */
+export interface PodmanGatewayWatcherLeaseHolder {
+  readonly pid: number;
+  /** Stable process-start identity that prevents PID reuse from proving liveness. */
+  readonly processStartIdentity: string;
+}
+
+/**
+ * Durable authority written before NemoClaw asks a gateway owner to stop.
+ * Recovery treats both phases as unfinished and derives the real state from
+ * independent process, owner, listener, and health probes.
+ */
+export interface PodmanGatewayWatcherLeaseRecord extends PodmanGatewayWatcherSnapshot {
+  readonly schemaVersion: typeof PODMAN_WATCHER_LEASE_SCHEMA_VERSION;
+  readonly holder: PodmanGatewayWatcherLeaseHolder;
+  readonly leaseId: string;
+  readonly phase: PodmanGatewayWatcherLeasePhase;
+}
+
+export interface PodmanGatewayWatcherLeaseStore {
+  /** Read one exact record. Corrupt or ambiguous storage must throw. */
+  readonly read: () => PodmanGatewayWatcherLeaseRecord | null;
+  /** Atomically create the record only when no lease exists, then durably flush it. */
+  readonly acquire: (record: PodmanGatewayWatcherLeaseRecord) => void;
+  /** Atomically replace only the expected record, then durably flush it. */
+  readonly advance: (expectedLeaseId: string, record: PodmanGatewayWatcherLeaseRecord) => void;
+  /** Atomically clear only the expected record and durably flush the removal. */
+  readonly clear: (expectedLeaseId: string) => void;
+}
+
+export interface PodmanManagedGatewayWatcherControllerDeps {
+  readonly store: PodmanGatewayWatcherLeaseStore;
+  readonly captureCurrent: () => PodmanGatewayWatcherSnapshot;
+  readonly listTargetWatchers: (
+    target: Readonly<Pick<PodmanGatewayWatcherSnapshot, "gatewayName" | "gatewayPort">>,
+  ) => readonly PodmanGatewayWatcherSnapshot[];
+  readonly isProcessInstanceAlive: (snapshot: PodmanGatewayWatcherSnapshot) => boolean;
+  readonly captureLeaseHolder: () => PodmanGatewayWatcherLeaseHolder;
+  readonly isLeaseHolderAlive: (holder: PodmanGatewayWatcherLeaseHolder) => boolean;
+  readonly isOwnerStopped: (snapshot: PodmanGatewayWatcherSnapshot) => boolean;
+  readonly stopExactOwner: (snapshot: PodmanGatewayWatcherSnapshot) => void;
+  readonly resumeSameOwner: (snapshot: PodmanGatewayWatcherSnapshot) => void;
+  readonly isHealthy: (snapshot: PodmanGatewayWatcherSnapshot) => boolean;
+  readonly createLeaseId?: () => string;
+  readonly now?: () => number;
+  readonly resumePollIntervalMs?: number;
+  readonly resumeTimeoutMs?: number;
+  readonly sleep?: (milliseconds: number) => void;
+}
+
+export interface PodmanGatewayWatcherLease {
+  readonly record: PodmanGatewayWatcherLeaseRecord;
+  readonly assertStillStopped: () => void;
+  readonly resumeAndProve: () => void;
+}
+
+export interface PodmanManagedGatewayWatcherController {
+  /** Recover a crash-left lease before another Podman transaction may start. */
+  readonly recoverUnfinishedLease: () => void;
+  /** Durably acquire exclusive authority and prove the exact owner is stopped. */
+  readonly quiesceAndProve: () => PodmanGatewayWatcherLease;
+}
+
+export class PodmanGatewayWatcherLeaseError extends Error {
+  public readonly recoveryRequired: boolean;
+
+  public constructor(message: string, recoveryRequired = false) {
+    super(message);
+    this.name = "PodmanGatewayWatcherLeaseError";
+    this.recoveryRequired = recoveryRequired;
+  }
+}
+
+function sleepMs(milliseconds: number): void {
+  if (milliseconds <= 0 || !Number.isFinite(milliseconds)) return;
+  const buffer = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(buffer, 0, 0, milliseconds);
+}
+
+function safeOpaqueIdentity(value: string, field: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_OPAQUE_IDENTITY_LENGTH ||
+    value !== value.trim() ||
+    CONTROL_CHARACTER.test(value)
+  ) {
+    throw new PodmanGatewayWatcherLeaseError(
+      `Podman OpenShell watcher ${field} is missing or unsafe.`,
+    );
+  }
+  return value;
+}
+
+function normalizeSnapshot(
+  value: PodmanGatewayWatcherSnapshot,
+  expectedTarget?: Readonly<Pick<PodmanGatewayWatcherSnapshot, "gatewayName" | "gatewayPort">>,
+): Readonly<PodmanGatewayWatcherSnapshot> {
+  if (!value || typeof value !== "object") {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher identity proof did not return an object.",
+    );
+  }
+  if (!SAFE_GATEWAY_NAME.test(value.gatewayName)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher identity has an invalid gateway name.",
+    );
+  }
+  if (
+    !Number.isSafeInteger(value.gatewayPort) ||
+    value.gatewayPort < 1 ||
+    value.gatewayPort > 65_535
+  ) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher identity has an invalid gateway port.",
+    );
+  }
+  if (!Number.isSafeInteger(value.pid) || value.pid <= 0) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher identity has an invalid process ID.",
+    );
+  }
+  if (value.ownerKind !== "managed-service" && value.ownerKind !== "standalone") {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher identity has an unsupported lifecycle owner.",
+    );
+  }
+  if (
+    expectedTarget &&
+    (value.gatewayName !== expectedTarget.gatewayName ||
+      value.gatewayPort !== expectedTarget.gatewayPort)
+  ) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher enumeration returned a different gateway target.",
+    );
+  }
+  return Object.freeze({
+    gatewayName: value.gatewayName,
+    gatewayPort: value.gatewayPort,
+    launchIdentity: safeOpaqueIdentity(value.launchIdentity, "launch identity"),
+    ownerIdentity: safeOpaqueIdentity(value.ownerIdentity, "owner identity"),
+    ownerKind: value.ownerKind,
+    pid: value.pid,
+    processStartIdentity: safeOpaqueIdentity(value.processStartIdentity, "process-start identity"),
+  });
+}
+
+function normalizeHolder(value: PodmanGatewayWatcherLeaseHolder): PodmanGatewayWatcherLeaseHolder {
+  if (!value || typeof value !== "object" || !Number.isSafeInteger(value.pid) || value.pid <= 0) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Durable Podman watcher lease holder has an invalid process ID.",
+      true,
+    );
+  }
+  return Object.freeze({
+    pid: value.pid,
+    processStartIdentity: safeOpaqueIdentity(
+      value.processStartIdentity,
+      "lease-holder process-start identity",
+    ),
+  });
+}
+
+function normalizeRecord(value: PodmanGatewayWatcherLeaseRecord): PodmanGatewayWatcherLeaseRecord {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    value.schemaVersion !== PODMAN_WATCHER_LEASE_SCHEMA_VERSION ||
+    !SAFE_LEASE_ID.test(value.leaseId) ||
+    (value.phase !== "acquiring" && value.phase !== "stopped")
+  ) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Durable Podman OpenShell watcher lease is invalid.",
+      true,
+    );
+  }
+  return Object.freeze({
+    ...normalizeSnapshot(value),
+    schemaVersion: PODMAN_WATCHER_LEASE_SCHEMA_VERSION,
+    holder: normalizeHolder(value.holder),
+    leaseId: value.leaseId,
+    phase: value.phase,
+  });
+}
+
+function sameLaunchOwner(
+  left: Readonly<PodmanGatewayWatcherSnapshot>,
+  right: Readonly<PodmanGatewayWatcherSnapshot>,
+): boolean {
+  return (
+    left.gatewayName === right.gatewayName &&
+    left.gatewayPort === right.gatewayPort &&
+    left.ownerKind === right.ownerKind &&
+    left.ownerIdentity === right.ownerIdentity &&
+    left.launchIdentity === right.launchIdentity
+  );
+}
+
+function sameProcessInstance(
+  left: Readonly<PodmanGatewayWatcherSnapshot>,
+  right: Readonly<PodmanGatewayWatcherSnapshot>,
+): boolean {
+  return (
+    left.pid === right.pid &&
+    left.processStartIdentity === right.processStartIdentity &&
+    sameLaunchOwner(left, right)
+  );
+}
+
+function readTargetWatchers(
+  receipt: Readonly<PodmanGatewayWatcherSnapshot>,
+  deps: PodmanManagedGatewayWatcherControllerDeps,
+): readonly Readonly<PodmanGatewayWatcherSnapshot>[] {
+  const target = { gatewayName: receipt.gatewayName, gatewayPort: receipt.gatewayPort } as const;
+  const watchers = deps.listTargetWatchers(target);
+  if (!Array.isArray(watchers)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher enumeration did not return an array.",
+    );
+  }
+  return watchers.map((entry) => normalizeSnapshot(entry, target));
+}
+
+function requireExclusiveCurrent(
+  receipt: Readonly<PodmanGatewayWatcherSnapshot>,
+  deps: PodmanManagedGatewayWatcherControllerDeps,
+): void {
+  const watchers = readTargetWatchers(receipt, deps);
+  if (watchers.length !== 1 || !sameProcessInstance(receipt, watchers[0] as typeof receipt)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman bootstrap requires exactly one target-bound OpenShell watcher matching the captured process and lifecycle owner.",
+    );
+  }
+  if (!deps.isProcessInstanceAlive(receipt) || deps.isOwnerStopped(receipt)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "The captured Podman OpenShell watcher or its lifecycle owner changed before cutover.",
+    );
+  }
+  if (!deps.isHealthy(receipt)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "The captured Podman OpenShell watcher is not healthy before cutover.",
+    );
+  }
+}
+
+function assertStopped(
+  receipt: Readonly<PodmanGatewayWatcherSnapshot>,
+  deps: PodmanManagedGatewayWatcherControllerDeps,
+): void {
+  if (deps.isProcessInstanceAlive(receipt)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "The captured OpenShell watcher process instance is still alive.",
+      true,
+    );
+  }
+  if (!deps.isOwnerStopped(receipt)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "The captured OpenShell watcher lifecycle owner is not proven stopped.",
+      true,
+    );
+  }
+  if (readTargetWatchers(receipt, deps).length !== 0) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "A target-bound OpenShell watcher appeared while the durable stop lease was held.",
+      true,
+    );
+  }
+}
+
+function readinessWaitOptions(deps: PodmanManagedGatewayWatcherControllerDeps) {
+  const timeoutMs = deps.resumeTimeoutMs ?? DEFAULT_RESUME_TIMEOUT_MS;
+  const pollIntervalMs = deps.resumePollIntervalMs ?? DEFAULT_RESUME_POLL_INTERVAL_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher resume timeout must be positive.",
+    );
+  }
+  if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 0) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher resume poll interval must be non-negative.",
+    );
+  }
+  const now = deps.now ?? Date.now;
+  const startedAt = now();
+  if (!Number.isFinite(startedAt)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Podman OpenShell watcher resume clock is unavailable.",
+    );
+  }
+  return {
+    deadlineMs: startedAt + timeoutMs,
+    maxAttempts: Math.max(1, Math.ceil(timeoutMs / Math.max(1, pollIntervalMs)) + 1),
+    now,
+    pollIntervalMs,
+    sleep: deps.sleep ?? sleepMs,
+  };
+}
+
+function waitForExactHealthy(
+  condition: () => boolean,
+  options: ReturnType<typeof readinessWaitOptions>,
+): boolean {
+  for (let attempt = 0; attempt < options.maxAttempts; attempt += 1) {
+    const now = options.now();
+    if (!Number.isFinite(now) || now >= options.deadlineMs) return false;
+    if (condition()) return true;
+    if (attempt + 1 >= options.maxAttempts) return false;
+    const remainingMs = options.deadlineMs - options.now();
+    if (!Number.isFinite(remainingMs) || remainingMs <= 0) return false;
+    options.sleep(Math.min(options.pollIntervalMs, remainingMs));
+  }
+  return false;
+}
+
+function exactHealthyReplacement(
+  receipt: Readonly<PodmanGatewayWatcherSnapshot>,
+  deps: PodmanManagedGatewayWatcherControllerDeps,
+): Readonly<PodmanGatewayWatcherSnapshot> | null {
+  if (deps.isProcessInstanceAlive(receipt) || deps.isOwnerStopped(receipt)) return null;
+  const watchers = readTargetWatchers(receipt, deps);
+  if (watchers.length === 0) return null;
+  if (watchers.length !== 1) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Multiple target-bound OpenShell watchers appeared while resuming the captured owner.",
+      true,
+    );
+  }
+  const resumed = watchers[0] as Readonly<PodmanGatewayWatcherSnapshot>;
+  if (!sameLaunchOwner(receipt, resumed)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "The resumed OpenShell watcher does not match the captured lifecycle owner and launch identity.",
+      true,
+    );
+  }
+  if (!deps.isProcessInstanceAlive(resumed) || !deps.isHealthy(resumed)) return null;
+  return resumed;
+}
+
+function resumeAndProve(
+  receipt: Readonly<PodmanGatewayWatcherSnapshot>,
+  deps: PodmanManagedGatewayWatcherControllerDeps,
+): void {
+  const existing = readTargetWatchers(receipt, deps);
+  if (existing.length > 1) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "Multiple target-bound OpenShell watchers exist; refusing to start another.",
+      true,
+    );
+  }
+  if (existing.length === 1) {
+    const current = existing[0] as Readonly<PodmanGatewayWatcherSnapshot>;
+    if (
+      !sameLaunchOwner(receipt, current) ||
+      deps.isOwnerStopped(receipt) ||
+      !deps.isProcessInstanceAlive(current) ||
+      !deps.isHealthy(current)
+    ) {
+      throw new PodmanGatewayWatcherLeaseError(
+        "A target-bound OpenShell watcher exists without exact healthy owner proof.",
+        true,
+      );
+    }
+    return;
+  }
+  if (!deps.isOwnerStopped(receipt)) {
+    throw new PodmanGatewayWatcherLeaseError(
+      "The captured owner is neither stopped nor serving an exact healthy watcher.",
+      true,
+    );
+  }
+
+  let resumeError: unknown = null;
+  try {
+    deps.resumeSameOwner(receipt);
+  } catch (error) {
+    // The service boundary may lose its reply after completing the start. The
+    // independent owner/process/health proof below remains authoritative.
+    resumeError = error;
+  }
+  let resumed: Readonly<PodmanGatewayWatcherSnapshot> | null = null;
+  const healthy = waitForExactHealthy(() => {
+    resumed = exactHealthyReplacement(receipt, deps);
+    return resumed !== null;
+  }, readinessWaitOptions(deps));
+  if (!healthy || resumed === null) {
+    throw new PodmanGatewayWatcherLeaseError(
+      `The same OpenShell watcher lifecycle owner did not resume one exact healthy target-bound watcher within the bounded deadline${
+        resumeError === null ? "." : " after its start operation failed."
+      }`,
+      true,
+    );
+  }
+}
+
+function readLease(deps: PodmanManagedGatewayWatcherControllerDeps) {
+  const value = deps.store.read();
+  return value === null ? null : normalizeRecord(value);
+}
+
+function sameLease(
+  left: PodmanGatewayWatcherLeaseRecord,
+  right: PodmanGatewayWatcherLeaseRecord,
+): boolean {
+  return (
+    left.leaseId === right.leaseId &&
+    left.holder.pid === right.holder.pid &&
+    left.holder.processStartIdentity === right.holder.processStartIdentity &&
+    sameProcessInstance(left, right)
+  );
+}
+
+/**
+ * Build the inert watcher authority needed by native Podman replacement.
+ *
+ * The lease is persisted before the first stop request. Crash recovery never
+ * guesses whether that request completed: it probes the exact captured owner
+ * and either proves it healthy or resumes that same launch identity. The lease
+ * record is cleared only after the independent health proof succeeds.
+ */
+export function createPodmanManagedGatewayWatcherController(
+  deps: PodmanManagedGatewayWatcherControllerDeps,
+): PodmanManagedGatewayWatcherController {
+  const recoverUnfinishedLease = () => {
+    const record = readLease(deps);
+    if (!record) return;
+    if (deps.isLeaseHolderAlive(record.holder)) {
+      throw new PodmanGatewayWatcherLeaseError(
+        "Durable Podman watcher lease is still owned by a live transaction process.",
+        true,
+      );
+    }
+    resumeAndProve(record, deps);
+    deps.store.clear(record.leaseId);
+  };
+
+  return Object.freeze({
+    recoverUnfinishedLease,
+    quiesceAndProve: () => {
+      recoverUnfinishedLease();
+
+      const captured = normalizeSnapshot(deps.captureCurrent());
+      requireExclusiveCurrent(captured, deps);
+      const leaseId = (deps.createLeaseId ?? randomUUID)();
+      if (!SAFE_LEASE_ID.test(leaseId)) {
+        throw new PodmanGatewayWatcherLeaseError("Podman watcher lease identity is invalid.");
+      }
+      const holder = normalizeHolder(deps.captureLeaseHolder());
+      const acquiring = Object.freeze({
+        ...captured,
+        schemaVersion: PODMAN_WATCHER_LEASE_SCHEMA_VERSION,
+        holder,
+        leaseId,
+        phase: "acquiring" as const,
+      });
+      deps.store.acquire(acquiring);
+
+      try {
+        deps.stopExactOwner(captured);
+        assertStopped(captured, deps);
+      } catch (error) {
+        try {
+          resumeAndProve(captured, deps);
+          deps.store.clear(leaseId);
+        } catch {
+          throw new PodmanGatewayWatcherLeaseError(
+            `Stopping the exact Podman OpenShell watcher failed: ${
+              error instanceof Error ? error.message : String(error)
+            }. Durable recovery is required.`,
+            true,
+          );
+        }
+        throw new PodmanGatewayWatcherLeaseError(
+          `Stopping the exact Podman OpenShell watcher failed: ${
+            error instanceof Error ? error.message : String(error)
+          }. The exact captured watcher was restored.`,
+        );
+      }
+
+      const stopped = Object.freeze({ ...acquiring, phase: "stopped" as const });
+      try {
+        deps.store.advance(leaseId, stopped);
+      } catch (error) {
+        try {
+          resumeAndProve(stopped, deps);
+          deps.store.clear(leaseId);
+        } catch {
+          throw new PodmanGatewayWatcherLeaseError(
+            "The watcher stopped, but persisting the stopped lease failed and exact recovery did not complete.",
+            true,
+          );
+        }
+        throw new PodmanGatewayWatcherLeaseError(
+          `Persisting the stopped Podman watcher lease failed: ${
+            error instanceof Error ? error.message : String(error)
+          }. The exact captured watcher was restored.`,
+        );
+      }
+
+      let released = false;
+      return Object.freeze({
+        record: stopped,
+        assertStillStopped: () => {
+          if (released) {
+            throw new PodmanGatewayWatcherLeaseError("Podman watcher lease was already released.");
+          }
+          const durable = readLease(deps);
+          if (!durable || !sameLease(stopped, durable) || durable.phase !== "stopped") {
+            throw new PodmanGatewayWatcherLeaseError(
+              "Durable Podman watcher lease changed while it was held.",
+              true,
+            );
+          }
+          assertStopped(stopped, deps);
+        },
+        resumeAndProve: () => {
+          if (released) return;
+          const durable = readLease(deps);
+          if (!durable || !sameLease(stopped, durable)) {
+            throw new PodmanGatewayWatcherLeaseError(
+              "Durable Podman watcher lease changed before release.",
+              true,
+            );
+          }
+          resumeAndProve(stopped, deps);
+          deps.store.clear(leaseId);
+          released = true;
+        },
+      });
+    },
+  });
+}

--- a/src/lib/onboard/runtime-provider/podman-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-lifecycle.test.ts
@@ -67,6 +67,7 @@ function harness(initial: { running: boolean; status: string; paused?: boolean }
     operation: "sandbox-lifecycle",
     engineId: "podman",
     displayName: "Podman",
+    authorityId: "test:podman-socket",
     capture,
     captureHost: vi.fn(),
   };

--- a/src/lib/onboard/runtime-provider/podman-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-lifecycle.test.ts
@@ -42,32 +42,26 @@ function harness(initial: { running: boolean; status: string; paused?: boolean }
   let paused = initial.paused ?? false;
   let status = initial.status;
   const capture = vi.fn((args: readonly string[]) => {
-    const operation = args[0];
-    if (operation === "ps") {
-      return { status: 0, stdout: `${CONTAINER_ID}\t${CONTAINER_NAME}\n`, stderr: "" };
+    const operation = String(args[0]);
+    switch (operation) {
+      case "ps":
+        return { status: 0, stdout: `${CONTAINER_ID}\t${CONTAINER_NAME}\n`, stderr: "" };
+      case "container":
+        return { status: 0, stdout: inspect(running, status, paused), stderr: "" };
+      case "start":
+      case "unpause":
+        running = true;
+        paused = false;
+        status = "running";
+        return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+      case "stop":
+        running = false;
+        paused = false;
+        status = "exited";
+        return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+      default:
+        return { status: 125, stdout: "", stderr: `unexpected operation ${operation}` };
     }
-    if (operation === "container" && args[1] === "inspect") {
-      return { status: 0, stdout: inspect(running, status, paused), stderr: "" };
-    }
-    if (operation === "start") {
-      running = true;
-      paused = false;
-      status = "running";
-      return { status: 0, stdout: CONTAINER_ID, stderr: "" };
-    }
-    if (operation === "unpause") {
-      running = true;
-      paused = false;
-      status = "running";
-      return { status: 0, stdout: CONTAINER_ID, stderr: "" };
-    }
-    if (operation === "stop") {
-      running = false;
-      paused = false;
-      status = "exited";
-      return { status: 0, stdout: CONTAINER_ID, stderr: "" };
-    }
-    return { status: 125, stdout: "", stderr: `unexpected operation ${String(operation)}` };
   });
   const engine: ContainerEngine = {
     operation: "sandbox-lifecycle",

--- a/src/lib/onboard/runtime-provider/podman-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-lifecycle.test.ts
@@ -19,6 +19,12 @@ const SANDBOX_NAME = "alpha";
 const CONTAINER_ID = "a".repeat(64);
 const CONTAINER_NAME = `${PODMAN_SANDBOX_CONTAINER_PREFIX}${SANDBOX_NAME}`;
 
+interface HarnessState {
+  readonly running: boolean;
+  readonly status: string;
+  readonly paused?: boolean;
+}
+
 function inspect(running: boolean, status: string, paused = false): string {
   return JSON.stringify([
     {
@@ -37,10 +43,15 @@ function inspect(running: boolean, status: string, paused = false): string {
   ]);
 }
 
-function harness(initial: { running: boolean; status: string; paused?: boolean }) {
+function harness(initial: HarnessState) {
   let running = initial.running;
   let paused = initial.paused ?? false;
   let status = initial.status;
+  const setState = (next: HarnessState) => {
+    running = next.running;
+    paused = next.paused ?? false;
+    status = next.status;
+  };
   const capture = vi.fn((args: readonly string[]) => {
     const operation = String(args[0]);
     switch (operation) {
@@ -50,14 +61,10 @@ function harness(initial: { running: boolean; status: string; paused?: boolean }
         return { status: 0, stdout: inspect(running, status, paused), stderr: "" };
       case "start":
       case "unpause":
-        running = true;
-        paused = false;
-        status = "running";
+        setState({ running: true, status: "running" });
         return { status: 0, stdout: CONTAINER_ID, stderr: "" };
       case "stop":
-        running = false;
-        paused = false;
-        status = "exited";
+        setState({ running: false, status: "exited" });
         return { status: 0, stdout: CONTAINER_ID, stderr: "" };
       default:
         return { status: 125, stdout: "", stderr: `unexpected operation ${operation}` };
@@ -78,7 +85,7 @@ function harness(initial: { running: boolean; status: string; paused?: boolean }
     sandbox: { name: SANDBOX_NAME, openshellDriver: "podman" },
     sandboxName: SANDBOX_NAME,
   };
-  return { capture, engine, input, log };
+  return { capture, engine, input, log, setState };
 }
 
 describe("Podman basic CPU lifecycle", () => {
@@ -159,5 +166,71 @@ describe("Podman basic CPU lifecycle", () => {
       message: expect.stringContaining("operation-scoped Podman engine"),
     });
     expect(runtime.capture).not.toHaveBeenCalled();
+  });
+
+  it("converges on retry after start succeeds but final inspection fails", () => {
+    const runtime = harness({ running: false, status: "exited" });
+    runtime.capture
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: `${CONTAINER_ID}\t${CONTAINER_NAME}\n`,
+        stderr: "",
+      }))
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: inspect(false, "exited"),
+        stderr: "",
+      }))
+      .mockImplementationOnce(() => {
+        runtime.setState({ running: true, status: "running" });
+        return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+      })
+      .mockImplementationOnce(() => ({
+        status: 125,
+        stdout: "",
+        stderr: "inspection unavailable",
+      }));
+
+    expect(startPodmanSandbox(runtime.input, runtime.engine)).toMatchObject({
+      exitCode: 1,
+      message: expect.stringContaining("inspection unavailable"),
+    });
+    expect(startPodmanSandbox(runtime.input, runtime.engine)).toEqual({ exitCode: 0 });
+    expect(
+      runtime.capture.mock.calls.map(([args]) => args).filter(([op]) => op === "start"),
+    ).toEqual([["start", CONTAINER_ID]]);
+  });
+
+  it("retries the exact container after a stop mutation fails", () => {
+    const runtime = harness({ running: true, status: "running" });
+    const beforeStop = vi.fn();
+    runtime.capture
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: `${CONTAINER_ID}\t${CONTAINER_NAME}\n`,
+        stderr: "",
+      }))
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: inspect(true, "running"),
+        stderr: "",
+      }))
+      .mockImplementationOnce(() => ({ status: 125, stdout: "", stderr: "stop failed" }));
+
+    expect(stopPodmanSandbox(runtime.input, { beforeStop }, runtime.engine)).toMatchObject({
+      exitCode: 1,
+      message: expect.stringContaining("stop failed"),
+    });
+    expect(stopPodmanSandbox(runtime.input, { beforeStop }, runtime.engine)).toEqual({
+      exitCode: 0,
+      state: "stopped",
+    });
+    expect(beforeStop).toHaveBeenCalledTimes(2);
+    expect(
+      runtime.capture.mock.calls.map(([args]) => args).filter(([op]) => op === "stop"),
+    ).toEqual([
+      ["stop", "--time", "30", CONTAINER_ID],
+      ["stop", "--time", "30", CONTAINER_ID],
+    ]);
   });
 });

--- a/src/lib/onboard/runtime-provider/podman-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-lifecycle.test.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { ContainerEngine } from "../../adapters/container-engine";
+import type { RuntimeProviderLifecycleInput } from "./contract";
+import {
+  PODMAN_MANAGED_LABEL,
+  PODMAN_SANDBOX_CONTAINER_PREFIX,
+  PODMAN_SANDBOX_ID_LABEL,
+  PODMAN_SANDBOX_NAME_LABEL,
+  PODMAN_SANDBOX_NAMESPACE_LABEL,
+  startPodmanSandbox,
+  stopPodmanSandbox,
+} from "./podman-lifecycle";
+
+const SANDBOX_NAME = "alpha";
+const CONTAINER_ID = "a".repeat(64);
+const CONTAINER_NAME = `${PODMAN_SANDBOX_CONTAINER_PREFIX}${SANDBOX_NAME}`;
+
+function inspect(running: boolean, status: string, paused = false): string {
+  return JSON.stringify([
+    {
+      Id: CONTAINER_ID,
+      Name: CONTAINER_NAME,
+      Config: {
+        Labels: {
+          [PODMAN_MANAGED_LABEL]: "true",
+          [PODMAN_SANDBOX_ID_LABEL]: "sandbox-id",
+          [PODMAN_SANDBOX_NAME_LABEL]: SANDBOX_NAME,
+          [PODMAN_SANDBOX_NAMESPACE_LABEL]: "default",
+        },
+      },
+      State: { Running: running, Paused: paused, Status: status },
+    },
+  ]);
+}
+
+function harness(initial: { running: boolean; status: string; paused?: boolean }) {
+  let running = initial.running;
+  let paused = initial.paused ?? false;
+  let status = initial.status;
+  const capture = vi.fn((args: readonly string[]) => {
+    const operation = args[0];
+    if (operation === "ps") {
+      return { status: 0, stdout: `${CONTAINER_ID}\t${CONTAINER_NAME}\n`, stderr: "" };
+    }
+    if (operation === "container" && args[1] === "inspect") {
+      return { status: 0, stdout: inspect(running, status, paused), stderr: "" };
+    }
+    if (operation === "start") {
+      running = true;
+      paused = false;
+      status = "running";
+      return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+    }
+    if (operation === "unpause") {
+      running = true;
+      paused = false;
+      status = "running";
+      return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+    }
+    if (operation === "stop") {
+      running = false;
+      paused = false;
+      status = "exited";
+      return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+    }
+    return { status: 125, stdout: "", stderr: `unexpected operation ${String(operation)}` };
+  });
+  const engine: ContainerEngine = {
+    operation: "sandbox-lifecycle",
+    engineId: "podman",
+    displayName: "Podman",
+    capture,
+    captureHost: vi.fn(),
+  };
+  const log = vi.fn();
+  const input: RuntimeProviderLifecycleInput = {
+    environment: {},
+    log,
+    sandbox: { name: SANDBOX_NAME, openshellDriver: "podman" },
+    sandboxName: SANDBOX_NAME,
+  };
+  return { capture, engine, input, log };
+}
+
+describe("Podman basic CPU lifecycle", () => {
+  it("stops and restarts the exact managed container", () => {
+    const stopped = harness({ running: true, status: "running" });
+    const beforeStop = vi.fn();
+
+    expect(stopPodmanSandbox(stopped.input, { beforeStop }, stopped.engine)).toEqual({
+      exitCode: 0,
+      state: "stopped",
+    });
+    expect(beforeStop).toHaveBeenCalledOnce();
+    expect(stopped.capture.mock.calls.map(([args]) => args)).toContainEqual([
+      "stop",
+      "--time",
+      "30",
+      CONTAINER_ID,
+    ]);
+
+    const started = harness({ running: false, status: "exited" });
+    expect(startPodmanSandbox(started.input, started.engine)).toEqual({ exitCode: 0 });
+    expect(started.capture.mock.calls.map(([args]) => args)).toContainEqual([
+      "start",
+      CONTAINER_ID,
+    ]);
+  });
+
+  it("unpauses a paused container and treats at-rest stop as idempotent", () => {
+    const paused = harness({ running: true, status: "paused", paused: true });
+    expect(startPodmanSandbox(paused.input, paused.engine)).toEqual({ exitCode: 0 });
+    expect(paused.capture.mock.calls.map(([args]) => args)).toContainEqual([
+      "unpause",
+      CONTAINER_ID,
+    ]);
+
+    const atRest = harness({ running: false, status: "exited" });
+    const beforeStop = vi.fn();
+    expect(stopPodmanSandbox(atRest.input, { beforeStop }, atRest.engine)).toEqual({
+      exitCode: 0,
+      state: "already-stopped",
+    });
+    expect(beforeStop).not.toHaveBeenCalled();
+  });
+
+  it("refuses ambiguous identity and unknown state before mutation hooks", () => {
+    const ambiguous = harness({ running: true, status: "running" });
+    ambiguous.capture.mockImplementationOnce(() => ({
+      status: 0,
+      stdout: `${CONTAINER_ID}\t${CONTAINER_NAME}\n` + `${"b".repeat(64)}\t${CONTAINER_NAME}\n`,
+      stderr: "",
+    }));
+    const ambiguousHook = vi.fn();
+    expect(
+      stopPodmanSandbox(ambiguous.input, { beforeStop: ambiguousHook }, ambiguous.engine),
+    ).toMatchObject({
+      exitCode: 1,
+      message: expect.stringContaining("2 managed containers"),
+    });
+    expect(ambiguousHook).not.toHaveBeenCalled();
+
+    const unknown = harness({ running: false, status: "unknown" });
+    const unknownHook = vi.fn();
+    expect(
+      stopPodmanSandbox(unknown.input, { beforeStop: unknownHook }, unknown.engine),
+    ).toMatchObject({
+      exitCode: 1,
+      message: expect.stringContaining("not safely stoppable"),
+    });
+    expect(unknownHook).not.toHaveBeenCalled();
+  });
+
+  it("rejects another operation-scoped engine without running commands", () => {
+    const runtime = harness({ running: true, status: "running" });
+    const wrongEngine = { ...runtime.engine, operation: "host-doctor" as const };
+
+    expect(startPodmanSandbox(runtime.input, wrongEngine)).toMatchObject({
+      exitCode: 1,
+      message: expect.stringContaining("operation-scoped Podman engine"),
+    });
+    expect(runtime.capture).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/runtime-provider/podman-lifecycle.ts
+++ b/src/lib/onboard/runtime-provider/podman-lifecycle.ts
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  ContainerEngine,
+  ContainerEngineCommandResult,
+} from "../../adapters/container-engine";
+import { isValidName } from "../../name-validation";
+import { cliName } from "../branding";
+import type {
+  RuntimeProviderLifecycleInput,
+  RuntimeProviderLifecycleResult,
+  RuntimeProviderLifecycleStopHooks,
+  RuntimeProviderLifecycleStopOutcome,
+} from "./contract";
+
+export const PODMAN_MANAGED_LABEL = "openshell.managed";
+export const PODMAN_SANDBOX_ID_LABEL = "openshell.sandbox-id";
+export const PODMAN_SANDBOX_NAME_LABEL = "openshell.sandbox-name";
+export const PODMAN_SANDBOX_NAMESPACE_LABEL = "openshell.sandbox-namespace";
+export const PODMAN_SANDBOX_CONTAINER_PREFIX = "openshell-sandbox-";
+
+const PROBE_TIMEOUT_MS = 5000;
+const MUTATION_TIMEOUT_MS = 40_000;
+const STOP_GRACE_SECONDS = 30;
+const FULL_CONTAINER_ID_PATTERN = /^[0-9a-f]{64}$/u;
+const AT_REST_STATES = new Set(["configured", "created", "dead", "exited", "stopped"]);
+const STOPPABLE_TRANSITION_STATES = new Set(["restarting", "stopping"]);
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
+
+type JsonRecord = Record<string, unknown>;
+
+interface PodmanManagedContainer {
+  readonly containerId: string;
+  readonly name: string;
+  readonly paused: boolean;
+  readonly running: boolean;
+  readonly status: string;
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as JsonRecord;
+}
+
+function safeText(value: unknown, label: string): string {
+  if (
+    typeof value !== "string" ||
+    value === "" ||
+    value !== value.trim() ||
+    CONTROL_CHARACTERS.test(value)
+  ) {
+    throw new Error(`${label} must be a safe non-empty string.`);
+  }
+  return value;
+}
+
+function safeLabelValue(value: unknown, label: string): string {
+  if (typeof value !== "string" || value !== value.trim() || CONTROL_CHARACTERS.test(value)) {
+    throw new Error(`${label} must be a safe string.`);
+  }
+  return value;
+}
+
+function fullContainerId(value: unknown, label: string): string {
+  const candidate = safeText(value, label).toLowerCase();
+  const normalized = candidate.startsWith("sha256:") ? candidate.slice(7) : candidate;
+  if (!FULL_CONTAINER_ID_PATTERN.test(normalized)) {
+    throw new Error(`${label} must be a full immutable container ID.`);
+  }
+  return normalized;
+}
+
+function labels(value: unknown): Readonly<Record<string, string>> {
+  const source = record(value, "Podman inspect Config.Labels");
+  const result: Record<string, string> = Object.create(null);
+  for (const [key, entry] of Object.entries(source)) {
+    result[safeText(key, "Podman inspect label key")] = safeLabelValue(
+      entry,
+      `Podman inspect label '${key}'`,
+    );
+  }
+  return result;
+}
+
+function parsePodmanManagedContainer(
+  output: string,
+  expected: { readonly sandboxName: string; readonly name: string; readonly containerId: string },
+): PodmanManagedContainer {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    throw new Error("Podman container inspect returned unreadable JSON.");
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 1) {
+    throw new Error("Podman container inspect must identify exactly one container.");
+  }
+  const entry = record(parsed[0], "Podman container inspect entry");
+  const containerId = fullContainerId(entry.Id, "Podman inspect Id");
+  if (containerId !== expected.containerId) {
+    throw new Error("Podman managed sandbox identity changed after it was pinned.");
+  }
+  const name = safeText(entry.Name, "Podman inspect Name");
+  if (name !== expected.name) {
+    throw new Error(`Podman managed sandbox name changed from '${expected.name}' to '${name}'.`);
+  }
+  const config = record(entry.Config, "Podman inspect Config");
+  const containerLabels = labels(config.Labels);
+  if (containerLabels[PODMAN_MANAGED_LABEL] !== "true") {
+    throw new Error(`Podman sandbox is missing exact label ${PODMAN_MANAGED_LABEL}=true.`);
+  }
+  if (containerLabels[PODMAN_SANDBOX_NAME_LABEL] !== expected.sandboxName) {
+    throw new Error(
+      `Podman sandbox is missing exact label ${PODMAN_SANDBOX_NAME_LABEL}=${expected.sandboxName}.`,
+    );
+  }
+  safeText(containerLabels[PODMAN_SANDBOX_ID_LABEL], `Podman label ${PODMAN_SANDBOX_ID_LABEL}`);
+  safeText(
+    containerLabels[PODMAN_SANDBOX_NAMESPACE_LABEL],
+    `Podman label ${PODMAN_SANDBOX_NAMESPACE_LABEL}`,
+  );
+  const state = record(entry.State, "Podman inspect State");
+  if (typeof state.Running !== "boolean") {
+    throw new Error("Podman inspect State.Running must be a boolean.");
+  }
+  if (state.Paused !== undefined && state.Paused !== null && typeof state.Paused !== "boolean") {
+    throw new Error("Podman inspect State.Paused must be a boolean.");
+  }
+  return {
+    containerId,
+    name,
+    running: state.Running,
+    paused: state.Paused === true,
+    status: safeText(state.Status, "Podman inspect State.Status").toLowerCase(),
+  };
+}
+
+function commandDetail(result: ContainerEngineCommandResult): string {
+  return (result.stderr || result.stdout || result.error?.message || "unknown failure")
+    .replace(/\s+/gu, " ")
+    .trim()
+    .slice(-500);
+}
+
+function commandFailure(operation: string, result: ContainerEngineCommandResult): Error {
+  return new Error(
+    `podman ${operation} failed (exit ${String(result.status)}): ${commandDetail(result)}`,
+  );
+}
+
+function requireLifecycleEngine(engine: ContainerEngine): void {
+  if (engine.operation !== "sandbox-lifecycle" || engine.engineId !== "podman") {
+    throw new Error("Podman lifecycle requires an operation-scoped Podman engine.");
+  }
+}
+
+function inspectExactContainer(
+  engine: ContainerEngine,
+  expected: { readonly sandboxName: string; readonly name: string; readonly containerId: string },
+): PodmanManagedContainer {
+  const inspected = engine.capture(
+    ["container", "inspect", expected.containerId],
+    PROBE_TIMEOUT_MS,
+  );
+  if (inspected.status !== 0 || inspected.error) {
+    throw commandFailure("container inspect", inspected);
+  }
+  return parsePodmanManagedContainer(inspected.stdout, expected);
+}
+
+function resolveManagedContainer(
+  engine: ContainerEngine,
+  sandboxName: string,
+): PodmanManagedContainer {
+  requireLifecycleEngine(engine);
+  if (!isValidName(sandboxName)) {
+    throw new Error("Podman lifecycle requires a valid sandbox name.");
+  }
+  const expectedName = `${PODMAN_SANDBOX_CONTAINER_PREFIX}${sandboxName}`;
+  const lookup = engine.capture(
+    [
+      "ps",
+      "--all",
+      "--no-trunc",
+      "--filter",
+      `label=${PODMAN_MANAGED_LABEL}=true`,
+      "--filter",
+      `label=${PODMAN_SANDBOX_NAME_LABEL}=${sandboxName}`,
+      "--format",
+      "{{.ID}}\t{{.Names}}",
+    ],
+    PROBE_TIMEOUT_MS,
+  );
+  if (lookup.status !== 0 || lookup.error) throw commandFailure("container lookup", lookup);
+  const rows = lookup.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (rows.length === 0) {
+    throw new Error(
+      `No Podman container found for sandbox '${sandboxName}'. Run '${cliName()} ${sandboxName} rebuild' if its workload was removed.`,
+    );
+  }
+  if (rows.length !== 1) {
+    throw new Error(
+      `Refusing Podman lifecycle mutation: sandbox '${sandboxName}' has ${String(rows.length)} managed containers.`,
+    );
+  }
+  const columns = rows[0]?.split("\t") ?? [];
+  if (columns.length !== 2 || columns[1] !== expectedName) {
+    throw new Error(
+      `Refusing Podman lifecycle mutation: sandbox '${sandboxName}' has an unexpected container identity.`,
+    );
+  }
+  const containerId = fullContainerId(columns[0], "Podman managed container ID");
+  return inspectExactContainer(engine, { sandboxName, name: expectedName, containerId });
+}
+
+function resultForFailure(error: unknown): RuntimeProviderLifecycleResult {
+  return {
+    exitCode: 1,
+    message: `  ${error instanceof Error ? error.message : String(error)}`,
+  };
+}
+
+function mutateContainer(
+  engine: ContainerEngine,
+  operation: "start" | "stop" | "unpause",
+  container: PodmanManagedContainer,
+): void {
+  const args = [
+    operation,
+    ...(operation === "stop" ? ["--time", String(STOP_GRACE_SECONDS)] : []),
+    container.containerId,
+  ];
+  const result = engine.capture(args, MUTATION_TIMEOUT_MS);
+  if (result.status !== 0 || result.error) throw commandFailure(operation, result);
+}
+
+export function startPodmanSandbox(
+  input: RuntimeProviderLifecycleInput,
+  engine: ContainerEngine,
+): RuntimeProviderLifecycleResult {
+  try {
+    const container = resolveManagedContainer(engine, input.sandboxName);
+    if (container.running && !container.paused) {
+      input.log(`  Sandbox '${input.sandboxName}' is already running.`);
+      return { exitCode: 0 };
+    }
+    if (!container.paused && !AT_REST_STATES.has(container.status)) {
+      throw new Error(
+        `Refusing Podman start for sandbox '${input.sandboxName}': container state '${container.status}' is not safely restartable.`,
+      );
+    }
+    const operation = container.paused ? "unpause" : "start";
+    mutateContainer(engine, operation, container);
+    const verified = inspectExactContainer(engine, {
+      sandboxName: input.sandboxName,
+      name: container.name,
+      containerId: container.containerId,
+    });
+    if (!verified.running || verified.paused) {
+      throw new Error(`Podman ${operation} did not leave the exact managed container running.`);
+    }
+    input.log(
+      `  Container '${container.name}' ${operation === "unpause" ? "unpaused" : "started"}.`,
+    );
+    return { exitCode: 0 };
+  } catch (error) {
+    return resultForFailure(error);
+  }
+}
+
+export function stopPodmanSandbox(
+  input: RuntimeProviderLifecycleInput,
+  hooks: RuntimeProviderLifecycleStopHooks,
+  engine: ContainerEngine,
+): RuntimeProviderLifecycleStopOutcome {
+  try {
+    const container = resolveManagedContainer(engine, input.sandboxName);
+    const stoppable =
+      container.running || container.paused || STOPPABLE_TRANSITION_STATES.has(container.status);
+    if (!stoppable) {
+      if (AT_REST_STATES.has(container.status)) {
+        return { exitCode: 0, state: "already-stopped" };
+      }
+      throw new Error(
+        `Refusing Podman stop for sandbox '${input.sandboxName}': container state '${container.status}' is not safely stoppable.`,
+      );
+    }
+
+    hooks.beforeStop();
+    input.log(`  Stopping container '${container.name}'…`);
+    mutateContainer(engine, "stop", container);
+    const verified = inspectExactContainer(engine, {
+      sandboxName: input.sandboxName,
+      name: container.name,
+      containerId: container.containerId,
+    });
+    if (verified.running || verified.paused || !AT_REST_STATES.has(verified.status)) {
+      throw new Error("Podman stop did not leave the exact managed container at rest.");
+    }
+    return { exitCode: 0, state: "stopped" };
+  } catch (error) {
+    return resultForFailure(error);
+  }
+}

--- a/src/lib/onboard/runtime-provider/podman-preflight.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-preflight.test.ts
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { ContainerEngine } from "../../adapters/container-engine";
+import {
+  inspectPodmanHost,
+  isPodmanVersionSupported,
+  PodmanHostPreflightError,
+  qualifyPodmanHost,
+} from "./podman-preflight";
+
+const INFO = JSON.stringify({
+  host: {
+    arch: "amd64",
+    os: "linux",
+    cgroupVersion: "v2",
+    networkBackend: "netavark",
+    security: { rootless: true },
+  },
+});
+
+function engine(
+  overrides: Partial<ContainerEngine> & {
+    readonly info?: string;
+    readonly version?: string;
+    readonly idMap?: string;
+  } = {},
+): ContainerEngine {
+  const capture = vi.fn((args: readonly string[]) => ({
+    status: 0,
+    stdout: args[0] === "info" ? (overrides.info ?? INFO) : "",
+    stderr: "",
+  }));
+  const captureHost = vi.fn((args: readonly string[]) => ({
+    status: 0,
+    stdout:
+      args[0] === "--version"
+        ? (overrides.version ?? "podman version 5.6.2\n")
+        : (overrides.idMap ?? "0 1000 1\n1 100000 65536\n"),
+    stderr: "",
+  }));
+  return {
+    operation: overrides.operation ?? "host-doctor",
+    engineId: overrides.engineId ?? "podman",
+    displayName: overrides.displayName ?? "Podman",
+    capture: overrides.capture ?? capture,
+    captureHost: overrides.captureHost ?? captureHost,
+  };
+}
+
+describe("Podman host preflight", () => {
+  it.each([
+    ["4.9.9", false],
+    ["5.0.0", true],
+    ["5.6.2", true],
+    ["6.0.0-dev", true],
+    ["unknown", false],
+  ])("classifies Podman version %s", (version, expected) => {
+    expect(isPodmanVersionSupported(version)).toBe(expected);
+  });
+
+  it("qualifies Linux amd64 rootless CPU lifecycle through the injected engine", () => {
+    const runtime = engine();
+
+    expect(qualifyPodmanHost(runtime, { platform: "linux", architecture: "x64" })).toEqual({
+      providerId: "podman",
+      version: "5.6.2",
+      rootless: true,
+      cgroupVersion: "v2",
+      os: "linux",
+      architecture: "amd64",
+      networkBackend: "netavark",
+    });
+    expect(runtime.capture).toHaveBeenCalledWith(["info", "--format", "json"], 15_000);
+    expect(runtime.captureHost).toHaveBeenCalledWith(["--version"], 10_000);
+    expect(runtime.captureHost).toHaveBeenCalledWith(
+      ["unshare", "cat", "/proc/self/uid_map"],
+      10_000,
+    );
+    expect(runtime.captureHost).toHaveBeenCalledWith(
+      ["unshare", "cat", "/proc/self/gid_map"],
+      10_000,
+    );
+  });
+
+  it("accepts arm64 aliases reported by the Podman service", () => {
+    const info = JSON.stringify({
+      ...JSON.parse(INFO),
+      host: { ...JSON.parse(INFO).host, arch: "aarch64" },
+    });
+    expect(
+      qualifyPodmanHost(engine({ info }), { platform: "linux", architecture: "arm64" }),
+    ).toMatchObject({ architecture: "arm64" });
+  });
+
+  it("rejects an API service architecture that differs from the host", () => {
+    expect(() => qualifyPodmanHost(engine(), { platform: "linux", architecture: "arm64" })).toThrow(
+      "does not match host 'arm64'",
+    );
+  });
+
+  it.each([
+    {
+      label: "rootful service",
+      info: {
+        ...JSON.parse(INFO),
+        host: { ...JSON.parse(INFO).host, security: { rootless: false } },
+      },
+      message: "rootless Podman",
+    },
+    {
+      label: "cgroups v1",
+      info: { ...JSON.parse(INFO), host: { ...JSON.parse(INFO).host, cgroupVersion: "v1" } },
+      message: "cgroups v2",
+    },
+    {
+      label: "unsupported architecture",
+      info: { ...JSON.parse(INFO), host: { ...JSON.parse(INFO).host, arch: "ppc64le" } },
+      message: "amd64 or arm64",
+    },
+  ])("rejects $label", ({ info, message }) => {
+    expect(() =>
+      qualifyPodmanHost(engine({ info: JSON.stringify(info) }), {
+        platform: "linux",
+        architecture: "x64",
+      }),
+    ).toThrow(message);
+  });
+
+  it("rejects missing subordinate user mappings", () => {
+    expect(() =>
+      qualifyPodmanHost(engine({ idMap: "0 1000 1\n" }), {
+        platform: "linux",
+        architecture: "x64",
+      }),
+    ).toThrow("subordinate UID range");
+  });
+
+  it("fails before commands for another engine scope or unsupported host platform", () => {
+    const wrongScope = engine({ operation: "sandbox-lifecycle" });
+    expect(() => qualifyPodmanHost(wrongScope, { platform: "linux", architecture: "x64" })).toThrow(
+      PodmanHostPreflightError,
+    );
+    expect(wrongScope.capture).not.toHaveBeenCalled();
+    expect(wrongScope.captureHost).not.toHaveBeenCalled();
+
+    const unsupportedHost = engine();
+    expect(() =>
+      qualifyPodmanHost(unsupportedHost, { platform: "darwin", architecture: "arm64" }),
+    ).toThrow("requires Linux amd64 or arm64");
+    expect(unsupportedHost.capture).not.toHaveBeenCalled();
+  });
+
+  it("reports a bounded doctor failure without throwing", () => {
+    const failed = engine({
+      captureHost: vi.fn(() => ({ status: 1, stdout: "", stderr: "runtime unavailable" })),
+    });
+
+    expect(inspectPodmanHost(failed, { platform: "linux", architecture: "x64" })).toEqual({
+      group: "Host",
+      label: "Podman runtime",
+      status: "fail",
+      detail: "Podman preflight failed: version inspection: runtime unavailable",
+      hint: "start a rootless Podman 5 API service on Linux and retry",
+    });
+  });
+});

--- a/src/lib/onboard/runtime-provider/podman-preflight.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-preflight.test.ts
@@ -24,15 +24,28 @@ const INFO = JSON.stringify({
 function engine(
   overrides: Partial<ContainerEngine> & {
     readonly info?: string;
+    readonly serverVersion?: string;
     readonly version?: string;
     readonly idMap?: string;
   } = {},
 ): ContainerEngine {
-  const capture = vi.fn((args: readonly string[]) => ({
-    status: 0,
-    stdout: args[0] === "info" ? (overrides.info ?? INFO) : "",
-    stderr: "",
-  }));
+  const capture = vi.fn((args: readonly string[]) => {
+    switch (args[0]) {
+      case "info":
+        return { status: 0, stdout: overrides.info ?? INFO, stderr: "" };
+      case "version":
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            Client: { Version: overrides.version ?? "5.6.2" },
+            Server: { Version: overrides.serverVersion ?? "5.6.2" },
+          }),
+          stderr: "",
+        };
+      default:
+        return { status: 125, stdout: "", stderr: "unexpected command" };
+    }
+  });
   const captureHost = vi.fn((args: readonly string[]) => ({
     status: 0,
     stdout:
@@ -45,6 +58,7 @@ function engine(
     operation: overrides.operation ?? "host-doctor",
     engineId: overrides.engineId ?? "podman",
     displayName: overrides.displayName ?? "Podman",
+    authorityId: overrides.authorityId ?? "test:podman-socket",
     capture: overrides.capture ?? capture,
     captureHost: overrides.captureHost ?? captureHost,
   };
@@ -66,7 +80,8 @@ describe("Podman host preflight", () => {
 
     expect(qualifyPodmanHost(runtime, { platform: "linux", architecture: "x64" })).toEqual({
       providerId: "podman",
-      version: "5.6.2",
+      clientVersion: "5.6.2",
+      serverVersion: "5.6.2",
       rootless: true,
       cgroupVersion: "v2",
       os: "linux",
@@ -74,6 +89,7 @@ describe("Podman host preflight", () => {
       networkBackend: "netavark",
     });
     expect(runtime.capture).toHaveBeenCalledWith(["info", "--format", "json"], 15_000);
+    expect(runtime.capture).toHaveBeenCalledWith(["version", "--format", "json"], 10_000);
     expect(runtime.captureHost).toHaveBeenCalledWith(["--version"], 10_000);
     expect(runtime.captureHost).toHaveBeenCalledWith(
       ["unshare", "cat", "/proc/self/uid_map"],
@@ -99,6 +115,15 @@ describe("Podman host preflight", () => {
     expect(() => qualifyPodmanHost(engine(), { platform: "linux", architecture: "arm64" })).toThrow(
       "does not match host 'arm64'",
     );
+  });
+
+  it("rejects an old API service even when the local client is supported", () => {
+    expect(() =>
+      qualifyPodmanHost(engine({ version: "5.6.2", serverVersion: "4.9.9" }), {
+        platform: "linux",
+        architecture: "x64",
+      }),
+    ).toThrow("required on the server");
   });
 
   it.each([
@@ -162,7 +187,7 @@ describe("Podman host preflight", () => {
       group: "Host",
       label: "Podman runtime",
       status: "fail",
-      detail: "Podman preflight failed: version inspection: runtime unavailable",
+      detail: "Podman preflight failed: client version inspection: runtime unavailable",
       hint: "start a rootless Podman 5 API service on Linux and retry",
     });
   });

--- a/src/lib/onboard/runtime-provider/podman-preflight.ts
+++ b/src/lib/onboard/runtime-provider/podman-preflight.ts
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  ContainerEngine,
+  ContainerEngineCommandResult,
+} from "../../adapters/container-engine";
+import type { RuntimeProviderDoctorCheck } from "./contract";
+
+export const MINIMUM_PODMAN_VERSION = "5.0.0";
+
+export interface PodmanHostPreflightReceipt {
+  readonly providerId: "podman";
+  readonly version: string;
+  readonly rootless: true;
+  readonly cgroupVersion: "v2";
+  readonly os: "linux";
+  readonly architecture: "amd64" | "arm64";
+  readonly networkBackend: string;
+}
+
+export interface PodmanHostPreflightOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly architecture?: NodeJS.Architecture;
+}
+
+export class PodmanHostPreflightError extends Error {
+  constructor(message: string) {
+    super(`Podman preflight failed: ${message}`);
+    this.name = "PodmanHostPreflightError";
+  }
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function record(value: unknown): JsonRecord | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function field(value: unknown, ...names: string[]): unknown {
+  const source = record(value);
+  if (!source) return undefined;
+  for (const name of names) {
+    if (Object.hasOwn(source, name)) return source[name];
+  }
+  return undefined;
+}
+
+function textField(value: unknown, ...names: string[]): string {
+  const candidate = field(value, ...names);
+  return typeof candidate === "string" ? candidate.trim() : "";
+}
+
+function booleanField(value: unknown, ...names: string[]): boolean | null {
+  const candidate = field(value, ...names);
+  return typeof candidate === "boolean" ? candidate : null;
+}
+
+function dottedVersion(value: string): readonly number[] | null {
+  const match = value.match(/(?:^|\s)(\d+)\.(\d+)\.(\d+)(?:\D|$)/u);
+  return match ? match.slice(1, 4).map(Number) : null;
+}
+
+export function isPodmanVersionSupported(
+  actual: string,
+  minimum = MINIMUM_PODMAN_VERSION,
+): boolean {
+  const actualParts = dottedVersion(actual);
+  const minimumParts = dottedVersion(minimum);
+  if (!actualParts || !minimumParts) return false;
+  for (let index = 0; index < minimumParts.length; index += 1) {
+    const delta = (actualParts[index] ?? 0) - (minimumParts[index] ?? 0);
+    if (delta !== 0) return delta > 0;
+  }
+  return true;
+}
+
+function commandDetail(result: ContainerEngineCommandResult): string {
+  return (result.stderr || result.stdout || result.error?.message || "unavailable")
+    .replace(/\s+/gu, " ")
+    .trim()
+    .slice(-500);
+}
+
+function requireSuccessful(
+  operation: string,
+  result: ContainerEngineCommandResult,
+): ContainerEngineCommandResult {
+  if (result.status !== 0 || result.error) {
+    throw new PodmanHostPreflightError(`${operation}: ${commandDetail(result)}`);
+  }
+  return result;
+}
+
+function normalizeArchitecture(value: string): "amd64" | "arm64" | null {
+  if (value === "amd64" || value === "x86_64") return "amd64";
+  if (value === "arm64" || value === "aarch64") return "arm64";
+  return null;
+}
+
+function hasSubordinateIdMapping(output: string): boolean {
+  return output
+    .trim()
+    .split(/\r?\n/u)
+    .some((line) => {
+      const values = line.trim().split(/\s+/u).map(Number);
+      return values.length === 3 && values.every(Number.isFinite) && (values[2] ?? 0) > 1;
+    });
+}
+
+function requireSubordinateIdMappings(engine: ContainerEngine): void {
+  for (const mapping of ["uid_map", "gid_map"] as const) {
+    const result = requireSuccessful(
+      `${mapping} inspection`,
+      engine.captureHost(["unshare", "cat", `/proc/self/${mapping}`], 10_000),
+    );
+    if (!hasSubordinateIdMapping(result.stdout)) {
+      throw new PodmanHostPreflightError(
+        `rootless Podman requires a subordinate ${mapping === "uid_map" ? "UID" : "GID"} range for the current user`,
+      );
+    }
+  }
+}
+
+export function qualifyPodmanHost(
+  engine: ContainerEngine,
+  options: PodmanHostPreflightOptions = {},
+): PodmanHostPreflightReceipt {
+  if (engine.operation !== "host-doctor" || engine.engineId !== "podman") {
+    throw new PodmanHostPreflightError("host qualification requires a Podman host-doctor engine");
+  }
+  const platform = options.platform ?? process.platform;
+  const architecture = options.architecture ?? process.arch;
+  if (platform !== "linux" || !["x64", "arm64"].includes(architecture)) {
+    throw new PodmanHostPreflightError(
+      `basic native lifecycle requires Linux amd64 or arm64; detected ${platform} ${architecture}`,
+    );
+  }
+
+  const versionResult = requireSuccessful(
+    "version inspection",
+    engine.captureHost(["--version"], 10_000),
+  );
+  const version = dottedVersion(versionResult.stdout)?.join(".") ?? "";
+  if (!isPodmanVersionSupported(version)) {
+    throw new PodmanHostPreflightError(
+      `Podman ${MINIMUM_PODMAN_VERSION} or newer is required; detected '${version || "unavailable"}'`,
+    );
+  }
+
+  const infoResult = requireSuccessful(
+    "rootless API inspection",
+    engine.capture(["info", "--format", "json"], 15_000),
+  );
+  let info: unknown;
+  try {
+    info = JSON.parse(infoResult.stdout);
+  } catch {
+    throw new PodmanHostPreflightError("the Podman API returned unreadable system information");
+  }
+  const host = field(info, "host", "Host");
+  const security = field(host, "security", "Security");
+  if (booleanField(security, "rootless", "Rootless") !== true) {
+    throw new PodmanHostPreflightError("a rootless Podman API service is required");
+  }
+  const cgroupVersion = textField(
+    host,
+    "cgroupVersion",
+    "cgroupsVersion",
+    "CgroupVersion",
+    "CgroupsVersion",
+  ).toLowerCase();
+  if (cgroupVersion !== "v2") {
+    throw new PodmanHostPreflightError(
+      `cgroups v2 is required; detected '${cgroupVersion || "unknown"}'`,
+    );
+  }
+  const hostOs = textField(host, "os", "OS").toLowerCase();
+  if (hostOs !== "linux") {
+    throw new PodmanHostPreflightError(
+      `the Podman service must run Linux; detected '${hostOs || "unknown"}'`,
+    );
+  }
+  const reportedArchitecture = textField(host, "arch", "Arch").toLowerCase();
+  const normalizedArchitecture = normalizeArchitecture(reportedArchitecture);
+  if (!normalizedArchitecture) {
+    throw new PodmanHostPreflightError(
+      `the Podman service must report amd64 or arm64; detected '${reportedArchitecture || "unknown"}'`,
+    );
+  }
+  const expectedArchitecture = architecture === "x64" ? "amd64" : "arm64";
+  if (normalizedArchitecture !== expectedArchitecture) {
+    throw new PodmanHostPreflightError(
+      `the Podman service architecture '${normalizedArchitecture}' does not match host '${expectedArchitecture}'`,
+    );
+  }
+  requireSubordinateIdMappings(engine);
+
+  return Object.freeze({
+    providerId: "podman",
+    version,
+    rootless: true,
+    cgroupVersion: "v2",
+    os: "linux",
+    architecture: normalizedArchitecture,
+    networkBackend: textField(host, "networkBackend", "NetworkBackend") || "unknown",
+  });
+}
+
+export function inspectPodmanHost(
+  engine: ContainerEngine,
+  options: PodmanHostPreflightOptions = {},
+): RuntimeProviderDoctorCheck {
+  try {
+    const receipt = qualifyPodmanHost(engine, options);
+    return {
+      group: "Host",
+      label: "Podman runtime",
+      status: "ok",
+      detail: `rootless ${receipt.version}, cgroups v2, ${receipt.os}/${receipt.architecture}`,
+    };
+  } catch (error) {
+    const detail = (error instanceof Error ? error.message : String(error))
+      .replace(/\s+/gu, " ")
+      .trim()
+      .slice(-500);
+    return {
+      group: "Host",
+      label: "Podman runtime",
+      status: "fail",
+      detail,
+      hint: "start a rootless Podman 5 API service on Linux and retry",
+    };
+  }
+}

--- a/src/lib/onboard/runtime-provider/podman-preflight.ts
+++ b/src/lib/onboard/runtime-provider/podman-preflight.ts
@@ -11,7 +11,8 @@ export const MINIMUM_PODMAN_VERSION = "5.0.0";
 
 export interface PodmanHostPreflightReceipt {
   readonly providerId: "podman";
-  readonly version: string;
+  readonly clientVersion: string;
+  readonly serverVersion: string;
   readonly rootless: true;
   readonly cgroupVersion: "v2";
   readonly os: "linux";
@@ -77,6 +78,16 @@ export function isPodmanVersionSupported(
   return true;
 }
 
+function requireSupportedVersion(value: string, subject: "client" | "server"): string {
+  const version = dottedVersion(value)?.join(".") ?? "";
+  if (!isPodmanVersionSupported(version)) {
+    throw new PodmanHostPreflightError(
+      `Podman ${MINIMUM_PODMAN_VERSION} or newer is required on the ${subject}; detected '${version || "unavailable"}'`,
+    );
+  }
+  return version;
+}
+
 function commandDetail(result: ContainerEngineCommandResult): string {
   return (result.stderr || result.stdout || result.error?.message || "unavailable")
     .replace(/\s+/gu, " ")
@@ -139,16 +150,26 @@ export function qualifyPodmanHost(
     );
   }
 
-  const versionResult = requireSuccessful(
-    "version inspection",
+  const clientVersionResult = requireSuccessful(
+    "client version inspection",
     engine.captureHost(["--version"], 10_000),
   );
-  const version = dottedVersion(versionResult.stdout)?.join(".") ?? "";
-  if (!isPodmanVersionSupported(version)) {
-    throw new PodmanHostPreflightError(
-      `Podman ${MINIMUM_PODMAN_VERSION} or newer is required; detected '${version || "unavailable"}'`,
-    );
+  const clientVersion = requireSupportedVersion(clientVersionResult.stdout, "client");
+
+  const serverVersionResult = requireSuccessful(
+    "server version inspection",
+    engine.capture(["version", "--format", "json"], 10_000),
+  );
+  let versionInfo: unknown;
+  try {
+    versionInfo = JSON.parse(serverVersionResult.stdout);
+  } catch {
+    throw new PodmanHostPreflightError("the Podman API returned unreadable version information");
   }
+  const serverVersion = requireSupportedVersion(
+    textField(field(versionInfo, "Server", "server"), "Version", "version"),
+    "server",
+  );
 
   const infoResult = requireSuccessful(
     "rootless API inspection",
@@ -200,7 +221,8 @@ export function qualifyPodmanHost(
 
   return Object.freeze({
     providerId: "podman",
-    version,
+    clientVersion,
+    serverVersion,
     rootless: true,
     cgroupVersion: "v2",
     os: "linux",
@@ -219,7 +241,7 @@ export function inspectPodmanHost(
       group: "Host",
       label: "Podman runtime",
       status: "ok",
-      detail: `rootless ${receipt.version}, cgroups v2, ${receipt.os}/${receipt.architecture}`,
+      detail: `rootless server ${receipt.serverVersion} (client ${receipt.clientVersion}), cgroups v2, ${receipt.os}/${receipt.architecture}`,
     };
   } catch (error) {
     const detail = (error instanceof Error ? error.message : String(error))

--- a/src/lib/onboard/runtime-provider/podman.test.ts
+++ b/src/lib/onboard/runtime-provider/podman.test.ts
@@ -137,12 +137,14 @@ describe("dormant Podman runtime provider", () => {
   )("runs basic CPU start and stop for %s through an injected bundle", async (agent) => {
     const runtime = providerHarness(agent);
     const verifyGateway = vi.fn(async () => undefined);
+    const restoreStartupState = vi.fn();
     const stopSandboxChannels = vi.fn();
 
     await expect(
       startSandbox(runtime.sandboxName, {
         getSandbox: () => runtime.entry,
         runtimeProviders: runtime.providers,
+        restoreStartupState,
         verifyGateway,
         log: vi.fn(),
       }),
@@ -157,6 +159,7 @@ describe("dormant Podman runtime provider", () => {
       }),
     ).toEqual({ exitCode: 0 });
 
+    expect(restoreStartupState).toHaveBeenCalledExactlyOnceWith(runtime.sandboxName);
     expect(verifyGateway).toHaveBeenCalledExactlyOnceWith(runtime.sandboxName);
     expect(stopSandboxChannels).toHaveBeenCalledWith(
       runtime.sandboxName,

--- a/src/lib/onboard/runtime-provider/podman.test.ts
+++ b/src/lib/onboard/runtime-provider/podman.test.ts
@@ -53,43 +53,47 @@ function lifecycleEngine(sandboxName: string): ContainerEngine {
     engineId: "podman",
     displayName: "Podman",
     capture: vi.fn((args: readonly string[]) => {
-      if (args[0] === "ps") {
-        return {
-          status: 0,
-          stdout: `${CONTAINER_ID}\t${PODMAN_SANDBOX_CONTAINER_PREFIX}${sandboxName}\n`,
-          stderr: "",
-        };
-      }
-      if (args[0] === "container" && args[1] === "inspect") {
-        return {
-          status: 0,
-          stdout: JSON.stringify([
-            {
-              Id: CONTAINER_ID,
-              Name: `${PODMAN_SANDBOX_CONTAINER_PREFIX}${sandboxName}`,
-              Config: {
-                Labels: {
-                  [PODMAN_MANAGED_LABEL]: "true",
-                  [PODMAN_SANDBOX_ID_LABEL]: `id-${sandboxName}`,
-                  [PODMAN_SANDBOX_NAME_LABEL]: sandboxName,
-                  [PODMAN_SANDBOX_NAMESPACE_LABEL]: "default",
+      const operation = String(args[0]);
+      switch (operation) {
+        case "ps":
+          return {
+            status: 0,
+            stdout: `${CONTAINER_ID}\t${PODMAN_SANDBOX_CONTAINER_PREFIX}${sandboxName}\n`,
+            stderr: "",
+          };
+        case "container":
+          return {
+            status: 0,
+            stdout: JSON.stringify([
+              {
+                Id: CONTAINER_ID,
+                Name: `${PODMAN_SANDBOX_CONTAINER_PREFIX}${sandboxName}`,
+                Config: {
+                  Labels: {
+                    [PODMAN_MANAGED_LABEL]: "true",
+                    [PODMAN_SANDBOX_ID_LABEL]: `id-${sandboxName}`,
+                    [PODMAN_SANDBOX_NAME_LABEL]: sandboxName,
+                    [PODMAN_SANDBOX_NAMESPACE_LABEL]: "default",
+                  },
+                },
+                State: {
+                  Running: running,
+                  Paused: false,
+                  Status: running ? "running" : "exited",
                 },
               },
-              State: {
-                Running: running,
-                Paused: false,
-                Status: running ? "running" : "exited",
-              },
-            },
-          ]),
-          stderr: "",
-        };
+            ]),
+            stderr: "",
+          };
+        case "start":
+          running = true;
+          return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+        case "stop":
+          running = false;
+          return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+        default:
+          return { status: 125, stdout: "", stderr: `unexpected operation ${operation}` };
       }
-      if (args[0] === "start" || args[0] === "stop") {
-        running = args[0] === "start";
-        return { status: 0, stdout: CONTAINER_ID, stderr: "" };
-      }
-      return { status: 125, stdout: "", stderr: `unexpected operation ${String(args[0])}` };
     }),
     captureHost: vi.fn(),
   };

--- a/src/lib/onboard/runtime-provider/podman.test.ts
+++ b/src/lib/onboard/runtime-provider/podman.test.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import { startSandbox } from "../../actions/sandbox/start";
+import { stopSandbox } from "../../actions/sandbox/stop";
+import type { ContainerEngine } from "../../adapters/container-engine";
+import type { SandboxEntry } from "../../state/registry/types";
+import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "./current";
+import { createPodmanRuntimeProviderBundle } from "./podman";
+import {
+  PODMAN_MANAGED_LABEL,
+  PODMAN_SANDBOX_CONTAINER_PREFIX,
+  PODMAN_SANDBOX_ID_LABEL,
+  PODMAN_SANDBOX_NAME_LABEL,
+  PODMAN_SANDBOX_NAMESPACE_LABEL,
+} from "./podman-lifecycle";
+import { createRuntimeProviderBundleRegistry } from "./registry";
+
+const AGENTS = ["openclaw", "hermes", "langchain-deepagents-code"] as const;
+const CONTAINER_ID = "a".repeat(64);
+
+function hostDoctorEngine(): ContainerEngine {
+  return {
+    operation: "host-doctor",
+    engineId: "podman",
+    displayName: "Podman",
+    capture: vi.fn(() => ({
+      status: 0,
+      stdout: JSON.stringify({
+        host: {
+          arch: "amd64",
+          os: "linux",
+          cgroupVersion: "v2",
+          networkBackend: "netavark",
+          security: { rootless: true },
+        },
+      }),
+      stderr: "",
+    })),
+    captureHost: vi.fn((args: readonly string[]) => ({
+      status: 0,
+      stdout: args[0] === "--version" ? "podman version 5.6.2\n" : "0 1000 1\n1 100000 65536\n",
+      stderr: "",
+    })),
+  };
+}
+
+function lifecycleEngine(sandboxName: string): ContainerEngine {
+  let running = false;
+  return {
+    operation: "sandbox-lifecycle",
+    engineId: "podman",
+    displayName: "Podman",
+    capture: vi.fn((args: readonly string[]) => {
+      if (args[0] === "ps") {
+        return {
+          status: 0,
+          stdout: `${CONTAINER_ID}\t${PODMAN_SANDBOX_CONTAINER_PREFIX}${sandboxName}\n`,
+          stderr: "",
+        };
+      }
+      if (args[0] === "container" && args[1] === "inspect") {
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            {
+              Id: CONTAINER_ID,
+              Name: `${PODMAN_SANDBOX_CONTAINER_PREFIX}${sandboxName}`,
+              Config: {
+                Labels: {
+                  [PODMAN_MANAGED_LABEL]: "true",
+                  [PODMAN_SANDBOX_ID_LABEL]: `id-${sandboxName}`,
+                  [PODMAN_SANDBOX_NAME_LABEL]: sandboxName,
+                  [PODMAN_SANDBOX_NAMESPACE_LABEL]: "default",
+                },
+              },
+              State: {
+                Running: running,
+                Paused: false,
+                Status: running ? "running" : "exited",
+              },
+            },
+          ]),
+          stderr: "",
+        };
+      }
+      if (args[0] === "start" || args[0] === "stop") {
+        running = args[0] === "start";
+        return { status: 0, stdout: CONTAINER_ID, stderr: "" };
+      }
+      return { status: 125, stdout: "", stderr: `unexpected operation ${String(args[0])}` };
+    }),
+    captureHost: vi.fn(),
+  };
+}
+
+function providerHarness(agent: (typeof AGENTS)[number]) {
+  const sandboxName = `${agent}-podman`;
+  const lifecycle = lifecycleEngine(sandboxName);
+  const bundle = createPodmanRuntimeProviderBundle({
+    engines: { hostDoctor: hostDoctorEngine(), sandboxLifecycle: lifecycle },
+    preflight: { platform: "linux", architecture: "x64" },
+  });
+  const providers = createRuntimeProviderBundleRegistry([["podman", bundle]]);
+  const entry: SandboxEntry = {
+    agent,
+    name: sandboxName,
+    openshellDriver: "podman",
+  };
+  return { entry, lifecycle, providers, sandboxName };
+}
+
+describe("dormant Podman runtime provider", () => {
+  it.each(
+    AGENTS,
+  )("runs basic CPU start and stop for %s through an injected bundle", async (agent) => {
+    const runtime = providerHarness(agent);
+    const verifyGateway = vi.fn(async () => undefined);
+    const stopSandboxChannels = vi.fn();
+
+    await expect(
+      startSandbox(runtime.sandboxName, {
+        getSandbox: () => runtime.entry,
+        runtimeProviders: runtime.providers,
+        verifyGateway,
+        log: vi.fn(),
+      }),
+    ).resolves.toEqual({ exitCode: 0 });
+    expect(
+      stopSandbox(runtime.sandboxName, {
+        getSandbox: () => runtime.entry,
+        runtimeProviders: runtime.providers,
+        stopSandboxChannels,
+        teardownSandboxDashboardForward: vi.fn(),
+        log: vi.fn(),
+      }),
+    ).toEqual({ exitCode: 0 });
+
+    expect(verifyGateway).toHaveBeenCalledExactlyOnceWith(runtime.sandboxName);
+    expect(stopSandboxChannels).toHaveBeenCalledWith(
+      runtime.sandboxName,
+      expect.objectContaining({ channelStopTransport: "openshell" }),
+    );
+    expect(
+      JSON.stringify((runtime.lifecycle.capture as ReturnType<typeof vi.fn>).mock.calls),
+    ).not.toContain("docker");
+  });
+
+  it("stays outside the production-selectable registry", () => {
+    expect(Object.keys(CURRENT_RUNTIME_PROVIDER_BUNDLES)).toEqual(["docker", "kubernetes"]);
+    expect(CURRENT_RUNTIME_PROVIDER_BUNDLES).not.toHaveProperty("podman");
+  });
+
+  it("rejects a mismatched engine scope before bundle registration", () => {
+    const doctor = hostDoctorEngine();
+    expect(() =>
+      createPodmanRuntimeProviderBundle({
+        engines: { hostDoctor: doctor, sandboxLifecycle: doctor },
+      }),
+    ).toThrow("'sandbox-lifecycle' Podman engine");
+  });
+});

--- a/src/lib/onboard/runtime-provider/podman.test.ts
+++ b/src/lib/onboard/runtime-provider/podman.test.ts
@@ -170,6 +170,28 @@ describe("dormant Podman runtime provider", () => {
     ).not.toContain("docker");
   });
 
+  it("reports a failed gateway probe after the exact Podman container starts", async () => {
+    const runtime = providerHarness("openclaw");
+    const gatewayFailure = new Error("independent gateway probe failed");
+    const verifyGateway = vi.fn(async () => Promise.reject(gatewayFailure));
+
+    await expect(
+      startSandbox(runtime.sandboxName, {
+        getSandbox: () => runtime.entry,
+        runtimeProviders: runtime.providers,
+        restoreStartupState: vi.fn(),
+        verifyGateway,
+        log: vi.fn(),
+      }),
+    ).rejects.toBe(gatewayFailure);
+    expect(verifyGateway).toHaveBeenCalledExactlyOnceWith(runtime.sandboxName);
+    expect(
+      (runtime.lifecycle.capture as ReturnType<typeof vi.fn>).mock.calls.some(
+        ([args]) => (args as readonly string[])[0] === "start",
+      ),
+    ).toBe(true);
+  });
+
   it("stays outside the production-selectable registry", () => {
     expect(Object.keys(CURRENT_RUNTIME_PROVIDER_BUNDLES)).toEqual(["docker", "kubernetes"]);
     expect(CURRENT_RUNTIME_PROVIDER_BUNDLES).not.toHaveProperty("podman");

--- a/src/lib/onboard/runtime-provider/podman.test.ts
+++ b/src/lib/onboard/runtime-provider/podman.test.ts
@@ -19,25 +19,40 @@ import { createRuntimeProviderBundleRegistry } from "./registry";
 
 const AGENTS = ["openclaw", "hermes", "langchain-deepagents-code"] as const;
 const CONTAINER_ID = "a".repeat(64);
+const AUTHORITY_ID = "test:podman-socket";
 
-function hostDoctorEngine(): ContainerEngine {
+function hostDoctorEngine(authorityId = AUTHORITY_ID): ContainerEngine {
   return {
     operation: "host-doctor",
     engineId: "podman",
     displayName: "Podman",
-    capture: vi.fn(() => ({
-      status: 0,
-      stdout: JSON.stringify({
-        host: {
-          arch: "amd64",
-          os: "linux",
-          cgroupVersion: "v2",
-          networkBackend: "netavark",
-          security: { rootless: true },
-        },
-      }),
-      stderr: "",
-    })),
+    authorityId,
+    capture: vi.fn((args: readonly string[]) => {
+      switch (args[0]) {
+        case "version":
+          return {
+            status: 0,
+            stdout: JSON.stringify({ Server: { Version: "5.6.2" } }),
+            stderr: "",
+          };
+        case "info":
+          return {
+            status: 0,
+            stdout: JSON.stringify({
+              host: {
+                arch: "amd64",
+                os: "linux",
+                cgroupVersion: "v2",
+                networkBackend: "netavark",
+                security: { rootless: true },
+              },
+            }),
+            stderr: "",
+          };
+        default:
+          return { status: 125, stdout: "", stderr: "unexpected command" };
+      }
+    }),
     captureHost: vi.fn((args: readonly string[]) => ({
       status: 0,
       stdout: args[0] === "--version" ? "podman version 5.6.2\n" : "0 1000 1\n1 100000 65536\n",
@@ -46,12 +61,13 @@ function hostDoctorEngine(): ContainerEngine {
   };
 }
 
-function lifecycleEngine(sandboxName: string): ContainerEngine {
+function lifecycleEngine(sandboxName: string, authorityId = AUTHORITY_ID): ContainerEngine {
   let running = false;
   return {
     operation: "sandbox-lifecycle",
     engineId: "podman",
     displayName: "Podman",
+    authorityId,
     capture: vi.fn((args: readonly string[]) => {
       const operation = String(args[0]);
       switch (operation) {
@@ -163,5 +179,16 @@ describe("dormant Podman runtime provider", () => {
         engines: { hostDoctor: doctor, sandboxLifecycle: doctor },
       }),
     ).toThrow("'sandbox-lifecycle' Podman engine");
+  });
+
+  it("rejects engines bound to different endpoint authorities", () => {
+    expect(() =>
+      createPodmanRuntimeProviderBundle({
+        engines: {
+          hostDoctor: hostDoctorEngine("test:doctor-socket"),
+          sandboxLifecycle: lifecycleEngine("mismatched", "test:lifecycle-socket"),
+        },
+      }),
+    ).toThrow("same endpoint authority");
   });
 });

--- a/src/lib/onboard/runtime-provider/podman.ts
+++ b/src/lib/onboard/runtime-provider/podman.ts
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ContainerEngine } from "../../adapters/container-engine";
+import {
+  RUNTIME_PROVIDER_BUNDLE_CONTRACT_VERSION,
+  type RuntimeProviderBundle,
+  type RuntimeProviderLifecycleInput,
+  type RuntimeProviderLifecycleResult,
+  type RuntimeProviderWorkloadProfile,
+} from "./contract";
+import { startPodmanSandbox, stopPodmanSandbox } from "./podman-lifecycle";
+import {
+  inspectPodmanHost,
+  type PodmanHostPreflightOptions,
+  qualifyPodmanHost,
+} from "./podman-preflight";
+
+export interface PodmanRuntimeProviderEngines {
+  readonly hostDoctor: ContainerEngine;
+  readonly sandboxLifecycle: ContainerEngine;
+}
+
+export interface PodmanRuntimeProviderOptions {
+  readonly engines: PodmanRuntimeProviderEngines;
+  readonly preflight?: PodmanHostPreflightOptions;
+}
+
+const DORMANT_WORKLOAD_PROFILE = {
+  support: null,
+  hostArchitectures: [],
+  managedImageSelectionPolicy: "require-managed",
+  legacyDockerfileBuilds: false,
+} as const satisfies RuntimeProviderWorkloadProfile;
+
+function unsupported(providerId: string, reason: string) {
+  return { providerId, supported: false as const, reason };
+}
+
+function requireEngine(
+  engine: ContainerEngine,
+  operation: "host-doctor" | "sandbox-lifecycle",
+): void {
+  if (engine.engineId !== "podman" || engine.operation !== operation) {
+    throw new Error(`Podman provider requires a '${operation}' Podman engine.`);
+  }
+}
+
+function preflightLifecycle(
+  input: RuntimeProviderLifecycleInput,
+  engine: ContainerEngine,
+  options: PodmanHostPreflightOptions,
+): RuntimeProviderLifecycleResult | null {
+  try {
+    qualifyPodmanHost(engine, options);
+    return null;
+  } catch (error) {
+    return {
+      exitCode: 1,
+      message: `  ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Construct an inert Podman provider candidate from explicitly scoped engine
+ * dependencies. This factory is intentionally absent from the production
+ * provider registry until managed startup, recovery, GPU, local inference,
+ * installer, and protected E2E qualification land in later slices.
+ */
+export function createPodmanRuntimeProviderBundle(
+  options: PodmanRuntimeProviderOptions,
+): RuntimeProviderBundle {
+  const providerId = "podman";
+  const { hostDoctor, sandboxLifecycle } = options.engines;
+  requireEngine(hostDoctor, "host-doctor");
+  requireEngine(sandboxLifecycle, "sandbox-lifecycle");
+  const preflight = options.preflight ?? {};
+  const deferred = "This operation is intentionally deferred to a later Podman slice.";
+
+  return {
+    identity: {
+      contractVersion: RUNTIME_PROVIDER_BUNDLE_CONTRACT_VERSION,
+      id: providerId,
+      displayName: "Podman",
+    },
+    plan: { providerId, supported: true, gatewayLauncher: "nemoclaw" },
+    capabilities: {
+      providerId,
+      supported: true,
+      hostLocalInference: false,
+      directLifecycle: true,
+      legacyGatewayContainerInspection: false,
+      workloadImageCleanup: false,
+    },
+    preflightDoctor: {
+      providerId,
+      supported: true,
+      inspectHost: () => inspectPodmanHost(hostDoctor, preflight),
+      preflightLifecycle: (_action, input) => preflightLifecycle(input, hostDoctor, preflight),
+    },
+    gateway: {
+      providerId,
+      supported: true,
+      launcher: "nemoclaw",
+      inspectLegacyContainer: false,
+    },
+    workload: {
+      providerId,
+      supported: true,
+      profile: DORMANT_WORKLOAD_PROFILE,
+      acceptsReceipt: () => false,
+    },
+    lifecycle: {
+      providerId,
+      supported: true,
+      channelStopTransport: "openshell",
+      start: (input) => startPodmanSandbox(input, sandboxLifecycle),
+      verifyStarted: (input, verifyGateway) => verifyGateway(input.sandboxName),
+      stop: (input, hooks) => stopPodmanSandbox(input, hooks, sandboxLifecycle),
+    },
+    mutationAuthority: {
+      providerId,
+      supported: true,
+      operations: ["start", "stop"],
+    },
+    bootstrap: unsupported(providerId, deferred),
+    snapshot: unsupported(providerId, deferred),
+    recovery: unsupported(providerId, deferred),
+    cleanup: unsupported(providerId, deferred),
+    containerEngine: {
+      providerId,
+      supported: true,
+      identities: [
+        {
+          operation: "host-doctor",
+          engineId: hostDoctor.engineId,
+          displayName: hostDoctor.displayName,
+        },
+        {
+          operation: "sandbox-lifecycle",
+          engineId: sandboxLifecycle.engineId,
+          displayName: sandboxLifecycle.displayName,
+        },
+      ],
+    },
+  };
+}

--- a/src/lib/onboard/runtime-provider/podman.ts
+++ b/src/lib/onboard/runtime-provider/podman.ts
@@ -75,6 +75,9 @@ export function createPodmanRuntimeProviderBundle(
   const { hostDoctor, sandboxLifecycle } = options.engines;
   requireEngine(hostDoctor, "host-doctor");
   requireEngine(sandboxLifecycle, "sandbox-lifecycle");
+  if (hostDoctor.authorityId !== sandboxLifecycle.authorityId) {
+    throw new Error("Podman provider engines must bind the same endpoint authority.");
+  }
   const preflight = options.preflight ?? {};
   const deferred = "This operation is intentionally deferred to a later Podman slice.";
 

--- a/test/e2e/live/podman-cpu-lifecycle.test.ts
+++ b/test/e2e/live/podman-cpu-lifecycle.test.ts
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { vi } from "vitest";
+import type { ContainerEngine } from "../../../src/lib/adapters/container-engine";
+import {
+  capturePodmanSocketAuthority,
+  createPodmanContainerEngine,
+} from "../../../src/lib/adapters/podman";
+import type {
+  RuntimeProviderBundle,
+  RuntimeProviderLifecycleInput,
+  RuntimeProviderLifecycleSurface,
+} from "../../../src/lib/onboard/runtime-provider/contract";
+import { createPodmanRuntimeProviderBundle } from "../../../src/lib/onboard/runtime-provider/podman";
+import type { SandboxEntry } from "../../../src/lib/state/registry/types";
+import { expect, test } from "../fixtures/e2e-test.ts";
+
+const AGENTS = ["openclaw", "hermes", "langchain-deepagents-code"] as const;
+const SOCKET_PATH = process.env.E2E_PODMAN_SOCKET ?? "";
+const E2E_PHASES = [
+  "pin the exact rootless Podman endpoint",
+  "qualify the Podman 5 host contract",
+  "exercise all-agent exact-container start and stop",
+  "verify all-agent restart identity and final at-rest state",
+] as const;
+
+type SupportedLifecycle = Extract<RuntimeProviderLifecycleSurface, { supported: true }>;
+
+function engines(): { hostDoctor: ContainerEngine; sandboxLifecycle: ContainerEngine } {
+  expect(SOCKET_PATH).toMatch(/^\/run\/user\/[0-9]+\/podman\/podman[.]sock$/u);
+  const socketAuthority = capturePodmanSocketAuthority(SOCKET_PATH);
+  return {
+    hostDoctor: createPodmanContainerEngine({ operation: "host-doctor", socketAuthority }),
+    sandboxLifecycle: createPodmanContainerEngine({
+      operation: "sandbox-lifecycle",
+      socketAuthority,
+    }),
+  };
+}
+
+function supportedLifecycle(bundle: RuntimeProviderBundle): SupportedLifecycle {
+  expect(bundle.lifecycle.supported).toBe(true);
+  return bundle.lifecycle as SupportedLifecycle;
+}
+
+function inspectContainer(engine: ContainerEngine, sandboxName: string) {
+  const result = engine.capture(["container", "inspect", `openshell-sandbox-${sandboxName}`]);
+  expect(result).toMatchObject({ status: 0, stderr: "" });
+  const entries = JSON.parse(result.stdout) as Array<{
+    Id: string;
+    State: { Paused: boolean; Running: boolean; Status: string };
+  }>;
+  expect(entries).toHaveLength(1);
+  expect(entries[0]?.Id).toMatch(/^[0-9a-f]{64}$/u);
+  return entries[0]!;
+}
+
+test("qualifies rootless Podman and preserves all-agent exact CPU lifecycle identity", {
+  meta: { e2ePhases: E2E_PHASES },
+}, async ({ progress }) => {
+  progress.phase("pin the exact rootless Podman endpoint");
+  const runtimeEngines = engines();
+  const bundle = createPodmanRuntimeProviderBundle({ engines: runtimeEngines });
+
+  progress.phase("qualify the Podman 5 host contract");
+  const doctor = bundle.preflightDoctor.inspectHost();
+
+  expect(doctor).toMatchObject({
+    group: "Host",
+    label: "Podman runtime",
+    status: "ok",
+  });
+  expect(doctor.detail).toContain("rootless server 5.");
+  expect(bundle.identity.id).toBe("podman");
+  expect(bundle.workload.profile.support).toBeNull();
+  expect(bundle.capabilities.hostLocalInference).toBe(false);
+
+  progress.phase("exercise all-agent exact-container start and stop");
+  for (const agent of AGENTS) {
+    const sandboxName = `podman-${agent}`;
+    const agentEngines = engines();
+    const agentBundle = createPodmanRuntimeProviderBundle({ engines: agentEngines });
+    const lifecycle = supportedLifecycle(agentBundle);
+    const sandbox: SandboxEntry = { agent, name: sandboxName, openshellDriver: "podman" };
+    const input: RuntimeProviderLifecycleInput = {
+      environment: process.env,
+      log: vi.fn(),
+      sandbox,
+      sandboxName,
+    };
+    const beforeStop = vi.fn();
+    const initial = inspectContainer(agentEngines.sandboxLifecycle, sandboxName);
+
+    expect(initial.State).toMatchObject({ Paused: false, Running: false });
+    expect(["configured", "created"]).toContain(initial.State.Status);
+    expect(agentBundle.preflightDoctor.preflightLifecycle("start", input)).toBeNull();
+    expect(lifecycle.start(input)).toEqual({ exitCode: 0 });
+    await lifecycle.verifyStarted(
+      input,
+      vi.fn(async () => undefined),
+    );
+
+    const running = inspectContainer(agentEngines.sandboxLifecycle, sandboxName);
+    expect(running.Id).toBe(initial.Id);
+    expect(running.State).toMatchObject({ Paused: false, Running: true, Status: "running" });
+
+    expect(lifecycle.stop(input, { beforeStop })).toEqual({ exitCode: 0, state: "stopped" });
+    expect(beforeStop).toHaveBeenCalledExactlyOnceWith();
+    const stopped = inspectContainer(agentEngines.sandboxLifecycle, sandboxName);
+    expect(stopped.Id).toBe(initial.Id);
+    expect(stopped.State).toMatchObject({ Paused: false, Running: false, Status: "exited" });
+
+    expect(lifecycle.start(input)).toEqual({ exitCode: 0 });
+    const restarted = inspectContainer(agentEngines.sandboxLifecycle, sandboxName);
+    expect(restarted.Id).toBe(initial.Id);
+    expect(restarted.State).toMatchObject({ Paused: false, Running: true, Status: "running" });
+    expect(lifecycle.stop(input, { beforeStop: vi.fn() })).toEqual({
+      exitCode: 0,
+      state: "stopped",
+    });
+  }
+  progress.phase("verify all-agent restart identity and final at-rest state");
+});

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -35,6 +35,19 @@
       ]
     },
     {
+      "live": "test/e2e/live/podman-cpu-lifecycle.test.ts",
+      "fast": [
+        "src/lib/adapters/container-engine.test.ts",
+        "src/lib/adapters/podman/index.test.ts",
+        "src/lib/adapters/podman/socket-authority.test.ts",
+        "src/lib/onboard/runtime-provider/podman-lifecycle.test.ts",
+        "src/lib/onboard/runtime-provider/podman-preflight.test.ts",
+        "src/lib/onboard/runtime-provider/podman.test.ts",
+        "test/e2e/support/podman-cpu-proof-workflow.test.ts",
+        "test/runtime-provider-source-shape.test.ts"
+      ]
+    },
+    {
       "live": "test/e2e/live/hermes-gpu-startup.test.ts",
       "fast": [
         "test/e2e/support/hermes-gpu-startup-fallback.test.ts",

--- a/test/e2e/support/podman-cpu-proof-workflow.test.ts
+++ b/test/e2e/support/podman-cpu-proof-workflow.test.ts
@@ -58,7 +58,9 @@ describe("native Podman CPU proof workflow", () => {
     expect(installGuard).toContain("exit 97");
     expect(installGuard).toContain("DOCKER_HOST=");
     expect(disableDocker).toContain("systemctl stop docker.service docker.socket");
-    expect(disableDocker).toContain("test ! -S /var/run/docker.sock");
+    expect(disableDocker).toContain("pkill -TERM -x dockerd");
+    expect(disableDocker).toContain("docker-absence-boundary.json");
+    expect(disableDocker).toContain("Docker socket remained available after Docker shutdown");
     expect(startPodman).toContain("umask 077");
     expect(startPodman).toContain('socket_path="$runtime_dir/podman/podman.sock"');
     expect(startPodman).toContain('podman system service --time=0 "unix://$socket_path"');

--- a/test/e2e/support/podman-cpu-proof-workflow.test.ts
+++ b/test/e2e/support/podman-cpu-proof-workflow.test.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  readRepoText,
+  readYaml,
+  type Workflow,
+  type WorkflowJob,
+  type WorkflowStep,
+} from "../../helpers/e2e-workflow-contract";
+
+type PodmanProofWorkflow = Workflow & {
+  on: { pull_request: { paths: string[]; types: string[] } };
+  permissions: Record<string, string>;
+};
+
+function workflow(): PodmanProofWorkflow {
+  return readYaml(".github/workflows/podman-cpu-proof.yaml") as PodmanProofWorkflow;
+}
+
+function proofJob(): WorkflowJob {
+  const job = workflow().jobs["podman-cpu-lifecycle"];
+  expect(job).toBeDefined();
+  return job!;
+}
+
+function namedStep(name: string): WorkflowStep {
+  const step = proofJob().steps?.find((candidate) => candidate.name === name);
+  expect(step, `missing Podman CPU proof step '${name}'`).toBeDefined();
+  return step!;
+}
+
+describe("native Podman CPU proof workflow", () => {
+  it("runs as a credential-free exact-head PR workflow", () => {
+    const parsed = workflow();
+    const job = proofJob();
+
+    expect(parsed.permissions).toEqual({ contents: "read" });
+    expect(parsed.on.pull_request.types).toEqual(["opened", "synchronize", "reopened"]);
+    expect(parsed.on.pull_request.paths).toContain("src/lib/adapters/podman/**");
+    expect(job.name).toBe("Rootless Podman CPU lifecycle with Docker disabled");
+    expect(job["runs-on"]).toBe("ubuntu-26.04");
+    expect(job["timeout-minutes"]).toBe(30);
+    expect(job.env?.NEMOCLAW_RUN_LIVE_E2E).toBe("1");
+    expect(readRepoText(".github/workflows/podman-cpu-proof.yaml")).not.toContain("secrets.");
+  });
+
+  it("pins one rootless socket and fails closed on Docker use", () => {
+    const installGuard = namedStep("Install Docker invocation guard").run ?? "";
+    const disableDocker = namedStep("Disable Docker daemon and socket").run ?? "";
+    const startPodman = namedStep("Start exact rootless Podman API socket").run ?? "";
+    const scripts = proofJob()
+      .steps?.map((step) => step.run ?? "")
+      .join("\n");
+
+    expect(installGuard).toContain("exit 97");
+    expect(installGuard).toContain("DOCKER_HOST=");
+    expect(disableDocker).toContain("systemctl stop docker.service docker.socket");
+    expect(disableDocker).toContain("test ! -S /var/run/docker.sock");
+    expect(startPodman).toContain("umask 077");
+    expect(startPodman).toContain('socket_path="$runtime_dir/podman/podman.sock"');
+    expect(startPodman).toContain('podman system service --time=0 "unix://$socket_path"');
+    expect(startPodman).toContain("E2E_PODMAN_SOCKET");
+    expect(scripts).not.toMatch(/\bdocker\s+(?:build|info|login|pull|run)\b/u);
+    expect(scripts).not.toContain("podman-docker");
+  });
+
+  it("creates all-agent fixtures and invokes only the native lifecycle proof", () => {
+    const fixtures = namedStep("Create exact managed lifecycle fixtures").run ?? "";
+    const proof = namedStep("Prove native Podman preflight and all-agent CPU lifecycle");
+    const cleanup = namedStep("Clean up rootless Podman fixtures");
+
+    expect(fixtures).toContain("for agent in openclaw hermes langchain-deepagents-code");
+    expect(fixtures).toContain("openshell.managed=true");
+    expect(fixtures).toContain("openshell.sandbox-name=$sandbox_name");
+    expect(fixtures).toContain("openshell.sandbox-namespace=default");
+    expect(proof.run).toBe(
+      "npx vitest run --project e2e-live test/e2e/live/podman-cpu-lifecycle.test.ts",
+    );
+    expect(cleanup.if).toBe("always()");
+    expect(cleanup.run).toContain('podman --url "$endpoint" rm --force');
+  });
+});

--- a/test/e2e/support/podman-cpu-proof-workflow.test.ts
+++ b/test/e2e/support/podman-cpu-proof-workflow.test.ts
@@ -33,6 +33,7 @@ function namedStep(name: string): WorkflowStep {
 }
 
 describe("native Podman CPU proof workflow", () => {
+  // source-shape-contract: security -- Exact checkout and package pins bind the credential-free Podman proof to the reported PR head and reviewed runtime bytes
   it("runs as a credential-free exact-head PR workflow", () => {
     const parsed = workflow();
     const job = proofJob();
@@ -44,6 +45,14 @@ describe("native Podman CPU proof workflow", () => {
     expect(job["runs-on"]).toBe("ubuntu-26.04");
     expect(job["timeout-minutes"]).toBe(30);
     expect(job.env?.NEMOCLAW_RUN_LIVE_E2E).toBe("1");
+    expect(job.env?.PODMAN_APT_VERSION).toBe("5.7.0+ds2-3build1");
+    expect(namedStep("Checkout").with).toMatchObject({
+      ref: "${{ github.event.pull_request.head.sha }}",
+    });
+    const installPodman = namedStep("Install Podman 5 runtime").run ?? "";
+    expect(installPodman).toContain('apt-get install --yes "podman=$PODMAN_APT_VERSION"');
+    expect(installPodman).toContain('test "$package_version" = "$PODMAN_APT_VERSION"');
+    expect(installPodman).toContain('test "$version" = "podman version 5.7.0"');
     expect(readRepoText(".github/workflows/podman-cpu-proof.yaml")).not.toContain("secrets.");
   });
 

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -148,6 +148,11 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/managed-bootstrap/image-runtime.ts",
       "src/lib/onboard/managed-bootstrap/index.ts",
       "src/lib/onboard/managed-bootstrap/managed-bootstrap-test-fixture.ts",
+      "src/lib/onboard/managed-bootstrap/podman-bootstrap-journal.ts",
+      "src/lib/onboard/managed-bootstrap/podman-bootstrap-replacement.ts",
+      "src/lib/onboard/managed-bootstrap/podman-held-workload.ts",
+      "src/lib/onboard/managed-bootstrap/podman-image-transaction.ts",
+      "src/lib/onboard/managed-bootstrap/podman-watcher-lease.ts",
       "src/lib/onboard/managed-bootstrap/runtime-create.ts",
     ]);
   });

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -158,6 +158,9 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/runtime-provider/contract.ts",
       "src/lib/onboard/runtime-provider/current.ts",
       "src/lib/onboard/runtime-provider/docker.ts",
+      "src/lib/onboard/runtime-provider/podman-lifecycle.ts",
+      "src/lib/onboard/runtime-provider/podman-preflight.ts",
+      "src/lib/onboard/runtime-provider/podman.ts",
       "src/lib/onboard/runtime-provider/registry.ts",
       "src/lib/onboard/runtime-provider/snapshot.ts",
     ]);


### PR DESCRIPTION
## Summary

Adds the dormant, provider-scoped Podman command/preflight/start-stop boundary and proves it against a real rootless Podman 5 service with Docker disabled. The provider remains absent from the production registry: this PR does not activate or advertise Podman support.

Stacked on #8261. Part of #7744.

## Related Issue

Part of #7744.

## Changes

- Adds an immutable operation-scoped container-engine command contract and a Podman adapter pinned to one qualified Unix-socket authority.
- Adds Linux amd64/arm64 rootless Podman 5 preflight, subordinate UID/GID and cgroups v2 validation, and exact labeled-container start/stop semantics.
- Adds an inert Podman runtime bundle with only host doctor and direct CPU lifecycle capabilities; managed bootstrap, snapshots, recovery, cleanup, GPU, local inference, and production selection remain explicitly unsupported for later slices.
- Adds unit coverage across OpenClaw, Hermes, and Deep Agents Code while keeping the production registry limited to qualified providers.
- Adds a credential-free Ubuntu 26.04 PR proof that disables and masks Docker, guards every Docker CLI resolution, starts one exact rootless Podman API socket, and proves all three agents preserve immutable container identity across stop/start/restart.
- The abstraction is required so Podman and future MXC-style providers can inject engine-specific operations without central Podman switches. Directly changing existing Docker helpers would violate the runtime-provider capability boundary; the registry/source-shape and rootless workflow tests protect that seam.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the Podman bundle is deliberately absent from production selection and this PR exposes no user-facing runtime option.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: endpoint authority is pinned before and after every command; Docker is disabled and guarded in the live proof; the provider remains dormant pending later qualification slices.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `.github/workflows/podman-cpu-proof.yaml`; `src/lib/onboard/runtime-provider/podman.ts`; the bundle remains non-selectable and no user-visible behavior is documented in this slice.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a254cf1cc306 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `60/60` focused Podman adapter/provider/workflow/parity tests passed on the restacked head; the advisor follow-up adds `10/10` focused tests and passes source-shape, repository, and CLI pre-push gates on exact head `a254cf1cc306`.
- [x] Applicable broad gate passed — `prek run --files <complete slice>` passed repository checks, semantic E2E phases, source-shape, test-size, formatting, YAML, secret scan, and all other applicable hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
