### PR TITLE
test(cli): isolate Shields and tunnel tests under coverage

### DIFF
--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -592,42 +592,23 @@ describe("shields — unit logic", () => {
       expect(appliedPolicy).not.toContain("mcp_bridge_alpha");
     });
 
-    it("auto-restore applies a snapshot with no managed MCP entries when policy staging is unavailable (#7952)", async () => {
-      const sandboxName = "openclaw";
-      const processToken = "d".repeat(32);
-      const snapshotPath = path.join(stateDir(), "policy-snapshot-no-managed-mcp.yaml");
-      fs.mkdirSync(stateDir(), { recursive: true });
-      fs.writeFileSync(snapshotPath, "version: 1\nnetwork_policies:\n  restrictive_baseline: {}\n");
-      writeState(sandboxName, {
-        shieldsDown: true,
-        shieldsPolicySnapshotPath: snapshotPath,
-        shieldsManagedMcpPolicyKeys: [],
+    it("reuses the snapshot without staging when the managed MCP policy set is unchanged (#7952)", async () => {
+      const snapshotPath = "/state/policy-snapshot-no-managed-mcp.yaml";
+      const snapshotYaml = "version: 1\nnetwork_policies:\n  restrictive_baseline: {}\n";
+      const writeTempPolicy = vi.fn(() => {
+        throw new Error("policy staging is unavailable");
       });
-      writeMarker(sandboxName, {
-        pid: 2_147_483_647,
-        sandboxName,
-        snapshotPath,
-        restoreAt: new Date(Date.now() - 1_000).toISOString(),
-        processToken,
-      });
-      vi.spyOn(process, "kill").mockImplementation(routeProcessKill);
-      const { applyShieldsPolicySnapshot } = await loadShieldsModule();
-      const { buildPolicySetCommand } = await import("../policy");
-      const createTempDirectory = vi.spyOn(fs, "mkdtempSync").mockImplementation(() => {
-        throw Object.assign(new Error("ENOSPC: simulated temporary storage full"), {
-          code: "ENOSPC",
-        });
+      const { buildDeadlineRuntimeManagedMcpPolicy } = await import("./permissive-runtime");
+
+      const result = buildDeadlineRuntimeManagedMcpPolicy(snapshotPath, {
+        managedMcpPolicies: [],
+        snapshotManagedPolicyKeys: [],
+        readBasePolicy: () => snapshotYaml,
+        writeTempPolicy,
       });
 
-      const result = applyShieldsPolicySnapshot(sandboxName, snapshotPath, {
-        transitionProcessToken: processToken,
-        deadlineAuthoritative: true,
-        expiredTimerRecovery: true,
-      });
-
-      expect(result.status).toBe(0);
-      expect(createTempDirectory).not.toHaveBeenCalled();
-      expect(buildPolicySetCommand).toHaveBeenCalledWith(snapshotPath, sandboxName);
+      expect(result).toEqual({ path: snapshotPath, omissions: [] });
+      expect(writeTempPolicy).not.toHaveBeenCalled();
     });
 
     it("shieldsStatus warns and stays DOWN when inline recovery fails", async () => {

--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -592,7 +592,7 @@ describe("shields — unit logic", () => {
       expect(appliedPolicy).not.toContain("mcp_bridge_alpha");
     });
 
-    it("reuses the snapshot without staging when the managed MCP policy set is unchanged (#7952)", async () => {
+    it("reuses the snapshot without staging when the snapshot and current policy have no managed MCP entries (#7952)", async () => {
       const snapshotPath = "/state/policy-snapshot-no-managed-mcp.yaml";
       const snapshotYaml = "version: 1\nnetwork_policies:\n  restrictive_baseline: {}\n";
       const writeTempPolicy = vi.fn(() => {

--- a/src/lib/tunnel/services.test.ts
+++ b/src/lib/tunnel/services.test.ts
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Import source directly so tests cannot pass against a stale build.
 import { registerTunnelOrigin } from "./allowed-origins";
@@ -445,9 +445,7 @@ describe("stopAll", () => {
   let spawnSyncCalls: Array<{ command: string; args: readonly string[] }>;
   let originalSpawnSync: typeof childProcess.spawnSync;
 
-  beforeEach(() => {
-    pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-svc-test-"));
-    spawnSyncCalls = [];
+  beforeAll(() => {
     originalSpawnSync = childProcess.spawnSync;
     // @ts-expect-error — partial mock signature is intentional.
     childProcess.spawnSync = (command: string, args: readonly string[]) => {
@@ -468,16 +466,24 @@ describe("stopAll", () => {
       return reply;
     };
     // The Ollama proxy source module destructures `spawnSync` at
-    // require time, so to make `stopAll` pick up the patched function we
-    // bust its cache. `services.ts` requires the proxy lazily, so the
-    // next call sees the freshly-loaded module.
+    // require time. Load it once with the stable suite-level mock instead of
+    // re-evaluating the large module under coverage for every stopAll test.
     delete require.cache[require.resolve(ollamaProxySourcePath)];
+    require(ollamaProxySourcePath);
+  });
+
+  beforeEach(() => {
+    pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-svc-test-"));
+    spawnSyncCalls = [];
   });
 
   afterEach(() => {
+    rmSync(pidDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
     childProcess.spawnSync = originalSpawnSync;
     delete require.cache[require.resolve(ollamaProxySourcePath)];
-    rmSync(pidDir, { recursive: true, force: true });
   });
 
   // A scripted ProcessControl models PID identity/liveness/signalling without


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restore deterministic CLI coverage in the Shields and tunnel service test suites. The Shields regression exercises empty managed MCP snapshot reuse at the helper that owns that decision. The tunnel suite loads its require-time Ollama proxy mock once, outside each test timeout. Production code is unchanged.

## Changes

- Replace the stateful auto-restore harness case with a direct test of `buildDeadlineRuntimeManagedMcpPolicy`.
- Verify that empty current and saved managed MCP policy sets reuse the original snapshot without staging a temporary policy.
- Load the Ollama proxy module once with the suite-level `spawnSync` mock. Reset per-test state, then restore process and module-cache state after the suite.
- Supersedes #8293 and transfers Senthil Ravichandran’s tunnel test isolation.
- The source commit preserves Senthil as Git author. The co-author trailer preserves attribution in the squash commit.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Both changes affect internal test isolation and setup only. Supported product behavior is unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed a nine-category security review for commit `b0c65225ec9cd39df84ad4fddc6e82e7633e3e44` against base `15b0c553d7cd56f5dd20298a4e9d1daa2a80efc1`. All categories PASS with no findings. The diff changes two test files and no production source, dependency, credential, network, policy, sandbox, or authorization behavior. The Shields test targets the owning helper. The tunnel suite resets per-test state and restores `spawnSync` plus the module cache after the suite.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independent review of commit `b0c65225ec9cd39df84ad4fddc6e82e7633e3e44` against base `15b0c553d7cd56f5dd20298a4e9d1daa2a80efc1` found changes only in `src/lib/shields/index.test.ts` and `src/lib/tunnel/services.test.ts`. The diff changes test scope, isolation, and setup performance. It changes no public API, CLI, configuration, output, workflow, default, error, supported behavior, or documentation surface. The changed test title describes snapshot reuse. The tunnel comment explains suite-level module loading.
- Agent: Codex Desktop documentation writer subagent
<!-- docs-review-head-sha: b0c65225ec -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every published commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set — 72 focused Shields and tunnel tests passed without coverage. The same 72 tests passed with coverage enabled. The focused coverage command then reported the expected repository-wide per-file floors for unselected suites.
- [ ] Applicable broad gate passed — GitHub CI and E2E are authoritative for commit `b0c65225ec` and remain required before merge.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
Co-authored-by: Senthil Ravichandran <senthilr@nvidia.com>
