### PR TITLE
test(cli): isolate Shields and tunnel tests under coverage

### DIFF
--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -592,42 +592,23 @@ describe("shields — unit logic", () => {
       expect(appliedPolicy).not.toContain("mcp_bridge_alpha");
     });
 
-    it("auto-restore applies a snapshot with no managed MCP entries when policy staging is unavailable (#7952)", async () => {
-      const sandboxName = "openclaw";
-      const processToken = "d".repeat(32);
-      const snapshotPath = path.join(stateDir(), "policy-snapshot-no-managed-mcp.yaml");
-      fs.mkdirSync(stateDir(), { recursive: true });
-      fs.writeFileSync(snapshotPath, "version: 1\nnetwork_policies:\n  restrictive_baseline: {}\n");
-      writeState(sandboxName, {
-        shieldsDown: true,
-        shieldsPolicySnapshotPath: snapshotPath,
-        shieldsManagedMcpPolicyKeys: [],
+    it("reuses the snapshot without staging when the managed MCP policy set is unchanged (#7952)", async () => {
+      const snapshotPath = "/state/policy-snapshot-no-managed-mcp.yaml";
+      const snapshotYaml = "version: 1\nnetwork_policies:\n  restrictive_baseline: {}\n";
+      const writeTempPolicy = vi.fn(() => {
+        throw new Error("policy staging is unavailable");
       });
-      writeMarker(sandboxName, {
-        pid: 2_147_483_647,
-        sandboxName,
-        snapshotPath,
-        restoreAt: new Date(Date.now() - 1_000).toISOString(),
-        processToken,
-      });
-      vi.spyOn(process, "kill").mockImplementation(routeProcessKill);
-      const { applyShieldsPolicySnapshot } = await loadShieldsModule();
-      const { buildPolicySetCommand } = await import("../policy");
-      const createTempDirectory = vi.spyOn(fs, "mkdtempSync").mockImplementation(() => {
-        throw Object.assign(new Error("ENOSPC: simulated temporary storage full"), {
-          code: "ENOSPC",
-        });
+      const { buildDeadlineRuntimeManagedMcpPolicy } = await import("./permissive-runtime");
+
+      const result = buildDeadlineRuntimeManagedMcpPolicy(snapshotPath, {
+        managedMcpPolicies: [],
+        snapshotManagedPolicyKeys: [],
+        readBasePolicy: () => snapshotYaml,
+        writeTempPolicy,
       });
 
-      const result = applyShieldsPolicySnapshot(sandboxName, snapshotPath, {
-        transitionProcessToken: processToken,
-        deadlineAuthoritative: true,
-        expiredTimerRecovery: true,
-      });
-
-      expect(result.status).toBe(0);
-      expect(createTempDirectory).not.toHaveBeenCalled();
-      expect(buildPolicySetCommand).toHaveBeenCalledWith(snapshotPath, sandboxName);
+      expect(result).toEqual({ path: snapshotPath, omissions: [] });
+      expect(writeTempPolicy).not.toHaveBeenCalled();
     });
 
     it("shieldsStatus warns and stays DOWN when inline recovery fails", async () => {

--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -592,7 +592,7 @@ describe("shields — unit logic", () => {
       expect(appliedPolicy).not.toContain("mcp_bridge_alpha");
     });
 
-    it("reuses the snapshot without staging when the managed MCP policy set is unchanged (#7952)", async () => {
+    it("reuses the snapshot without staging when the snapshot and current policy have no managed MCP entries (#7952)", async () => {
       const snapshotPath = "/state/policy-snapshot-no-managed-mcp.yaml";
       const snapshotYaml = "version: 1\nnetwork_policies:\n  restrictive_baseline: {}\n";
       const writeTempPolicy = vi.fn(() => {

--- a/src/lib/tunnel/services.test.ts
+++ b/src/lib/tunnel/services.test.ts
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Import source directly so tests cannot pass against a stale build.
 import { registerTunnelOrigin } from "./allowed-origins";
@@ -445,9 +445,7 @@ describe("stopAll", () => {
   let spawnSyncCalls: Array<{ command: string; args: readonly string[] }>;
   let originalSpawnSync: typeof childProcess.spawnSync;
 
-  beforeEach(() => {
-    pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-svc-test-"));
-    spawnSyncCalls = [];
+  beforeAll(() => {
     originalSpawnSync = childProcess.spawnSync;
     // @ts-expect-error — partial mock signature is intentional.
     childProcess.spawnSync = (command: string, args: readonly string[]) => {
@@ -468,16 +466,24 @@ describe("stopAll", () => {
       return reply;
     };
     // The Ollama proxy source module destructures `spawnSync` at
-    // require time, so to make `stopAll` pick up the patched function we
-    // bust its cache. `services.ts` requires the proxy lazily, so the
-    // next call sees the freshly-loaded module.
+    // require time. Load it once with the stable suite-level mock instead of
+    // re-evaluating the large module under coverage for every stopAll test.
     delete require.cache[require.resolve(ollamaProxySourcePath)];
+    require(ollamaProxySourcePath);
+  });
+
+  beforeEach(() => {
+    pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-svc-test-"));
+    spawnSyncCalls = [];
   });
 
   afterEach(() => {
+    rmSync(pidDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
     childProcess.spawnSync = originalSpawnSync;
     delete require.cache[require.resolve(ollamaProxySourcePath)];
-    rmSync(pidDir, { recursive: true, force: true });
   });
 
   // A scripted ProcessControl models PID identity/liveness/signalling without


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make two CLI source tests deterministic under coverage. The Shields test directly verifies empty managed MCP snapshot reuse. The tunnel `stopAll` suite loads the Ollama proxy once with a suite-level `spawnSync` mock. Production behavior is unchanged.

## Changes

- Replace the external-process Shields restoration test with a direct helper test for snapshot reuse when saved and current managed MCP entries are empty.
- Load the Ollama proxy once for the tunnel `stopAll` suite. Reset captured calls and temporary directories before each test.
- Restore the original `spawnSync` function and clear the Ollama proxy module cache after the tunnel suite.
- Preserve the exact Shields commits from #8278 and add the tunnel test isolation fix.
- Preserve Carlos as the Git author of the Shields commits. The co-author trailer preserves attribution if this PR supplies the squash commit.
- Add a signed, tree-identical commit to refresh the pull request gate identity after a completed gate could not be reused for the rerun.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: These changes affect source-test isolation only. Production behavior, commands, configuration, output, and supported behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: PASS for commit `bdf9d111f`. Its tree matches reviewed commit `274fb7750`. The combined diff changes two test files only. It does not change production credential, authorization, network, filesystem-policy, privilege, persistence, dependency, or secret behavior. The direct Shields helper test uses a throwing temporary writer. The tunnel suite restores the global function and module cache.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `bdf9d111f` adds no file changes to the reviewed tree. `src/lib/shields/index.test.ts` directly tests empty managed MCP snapshot reuse. `src/lib/tunnel/services.test.ts` changes suite setup and teardown only. Neither file changes production behavior or a user-visible surface. The changed test title, comment, and PR wording meet the NemoClaw writing rules and controlled word list.
- Agent: Codex Desktop
<!-- docs-review-head-sha: bdf9d111f -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — The focused Shields snapshot-reuse test passed (1 of 1), and all 7 tunnel `stopAll` tests passed under coverage in 118 ms. Biome, CLI type-check, and repository checks passed on `274fb7750`. Commit `bdf9d111f` has the same tree, and its normal pre-push checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to these two focused source-test isolation changes. Fresh GitHub CI is authoritative for commit `bdf9d111f`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
Co-authored-by: Carlos Villela <cvillela@nvidia.com>
