### PR TITLE
feat(inference): add declarative GGUF cache contract

### DIFF
--- a/managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml
+++ b/managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml
@@ -29,6 +29,22 @@ spec:
         format: gguf
         quantization: UD-Q4_K_XL
         license: NVIDIA-Open-Model-License
+    acquisition:
+      ref: hugging-face-exact-file/v1
+      authentication:
+        mode: optional
+        environment: HF_TOKEN
+    cache:
+      ref: llama-cpp.gguf-content-addressed/v1
+      receiptRef: llama-cpp.gguf-cache-entry.receipt/v1
+      root: user-cache
+      quotaBytes: 34359738368
+      stagingHeadroomBytes: 5368709120
+      staging: same-filesystem
+      publication: atomic-no-clobber
+      reuse: verified-only-offline
+      sharing: owner-only
+      cleanup: receipt-owner-only
 
   runtime:
     image: ghcr.io/ggml-org/llama.cpp@sha256:866ad568474de9e835e487ae841ad6ace1a494b5eab4f292cbd45adb6180f711

--- a/managed-inference/schemas/catalog.schema.json
+++ b/managed-inference/schemas/catalog.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "schemaVersion": { "const": "1.0.0" },
-    "compilerVersion": { "const": "1.1.0" },
+    "compilerVersion": { "const": "1.2.0" },
     "sourceRevision": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
     "readinessSchemaRef": {
       "const": "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json"

--- a/managed-inference/schemas/recipe.schema.json
+++ b/managed-inference/schemas/recipe.schema.json
@@ -109,6 +109,12 @@
                 },
                 "additionalProperties": false
               }
+            },
+            "acquisition": {
+              "$ref": "#/$defs/llamaCppModelAcquisition"
+            },
+            "cache": {
+              "$ref": "#/$defs/llamaCppModelCache"
             }
           },
           "additionalProperties": false
@@ -957,6 +963,83 @@
         }
       ]
     },
+    "llamaCppModelAcquisition": {
+      "type": "object",
+      "required": [
+        "ref",
+        "authentication"
+      ],
+      "properties": {
+        "ref": {
+          "const": "hugging-face-exact-file/v1"
+        },
+        "authentication": {
+          "type": "object",
+          "required": [
+            "mode",
+            "environment"
+          ],
+          "properties": {
+            "mode": {
+              "const": "optional"
+            },
+            "environment": {
+              "const": "HF_TOKEN"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "llamaCppModelCache": {
+      "type": "object",
+      "required": [
+        "ref",
+        "receiptRef",
+        "root",
+        "quotaBytes",
+        "stagingHeadroomBytes",
+        "staging",
+        "publication",
+        "reuse",
+        "sharing",
+        "cleanup"
+      ],
+      "properties": {
+        "ref": {
+          "const": "llama-cpp.gguf-content-addressed/v1"
+        },
+        "receiptRef": {
+          "const": "llama-cpp.gguf-cache-entry.receipt/v1"
+        },
+        "root": {
+          "const": "user-cache"
+        },
+        "quotaBytes": {
+          "$ref": "#/$defs/positiveSafeInteger"
+        },
+        "stagingHeadroomBytes": {
+          "$ref": "#/$defs/positiveSafeInteger"
+        },
+        "staging": {
+          "const": "same-filesystem"
+        },
+        "publication": {
+          "const": "atomic-no-clobber"
+        },
+        "reuse": {
+          "const": "verified-only-offline"
+        },
+        "sharing": {
+          "const": "owner-only"
+        },
+        "cleanup": {
+          "const": "receipt-owner-only"
+        }
+      },
+      "additionalProperties": false
+    },
     "llamaCppRecipeSpec": {
       "if": {
         "type": "object",
@@ -1039,7 +1122,9 @@
               "id",
               "revision",
               "servedName",
-              "files"
+              "files",
+              "acquisition",
+              "cache"
             ],
             "properties": {
               "id": {
@@ -1078,6 +1163,12 @@
                     "license": {}
                   }
                 }
+              },
+              "acquisition": {
+                "$ref": "#/$defs/llamaCppModelAcquisition"
+              },
+              "cache": {
+                "$ref": "#/$defs/llamaCppModelCache"
               }
             },
             "propertyNames": {
@@ -1277,6 +1368,35 @@
               },
               "required": [
                 "capabilities"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "model": {
+                  "type": "object",
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "acquisition": {}
+                      },
+                      "required": [
+                        "acquisition"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "cache": {}
+                      },
+                      "required": [
+                        "cache"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "model"
               ]
             }
           ]

--- a/src/lib/inference/llama-cpp/gguf-cache-plan.test.ts
+++ b/src/lib/inference/llama-cpp/gguf-cache-plan.test.ts
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import type { LlamaCppServingRecipe } from "../serving/types";
+import { compileLlamaCppGgufCachePlan } from "./gguf-cache-plan";
+
+interface RecipeOverrides {
+  readonly repository?: string;
+  readonly revision?: string;
+  readonly path?: string;
+  readonly digest?: string;
+  readonly sizeBytes?: number;
+  readonly quotaBytes?: number;
+  readonly stagingHeadroomBytes?: number;
+}
+
+function recipe(overrides: RecipeOverrides = {}): LlamaCppServingRecipe {
+  return {
+    apiVersion: "nemoclaw.nvidia.com/managed-inference/v1",
+    kind: "ServingRecipe",
+    metadata: { id: "test.llama.recipe" },
+    spec: {
+      backend: "install-llama-cpp",
+      providerId: "llama-cpp-local",
+      model: {
+        id: overrides.repository ?? "test/model",
+        revision: overrides.revision ?? "a".repeat(40),
+        files: [
+          {
+            path: overrides.path ?? "model.Q4_K_M.gguf",
+            digest: overrides.digest ?? `sha256:${"b".repeat(64)}`,
+            sizeBytes: overrides.sizeBytes ?? 1024,
+            format: "gguf",
+          },
+        ],
+        acquisition: {
+          ref: "hugging-face-exact-file/v1",
+          authentication: { mode: "optional", environment: "HF_TOKEN" },
+        },
+        cache: {
+          ref: "llama-cpp.gguf-content-addressed/v1",
+          receiptRef: "llama-cpp.gguf-cache-entry.receipt/v1",
+          root: "user-cache",
+          quotaBytes: overrides.quotaBytes ?? 2048,
+          stagingHeadroomBytes: overrides.stagingHeadroomBytes ?? 512,
+          staging: "same-filesystem",
+          publication: "atomic-no-clobber",
+          reuse: "verified-only-offline",
+          sharing: "owner-only",
+          cleanup: "receipt-owner-only",
+        },
+      },
+      policy: {
+        egress: "disabled",
+        modelSource: "verified-local",
+        modelDownloads: "disabled",
+      },
+    },
+  } as unknown as LlamaCppServingRecipe;
+}
+
+describe("compileLlamaCppGgufCachePlan", () => {
+  it("derives one deterministic Hugging Face cache plan from the recipe (#8279)", () => {
+    const first = compileLlamaCppGgufCachePlan(recipe());
+    const second = compileLlamaCppGgufCachePlan(recipe());
+
+    expect(second).toEqual(first);
+    expect(first).toMatchObject({
+      schemaVersion: 1,
+      recipeId: "test.llama.recipe",
+      acquisition: {
+        ref: "hugging-face-exact-file/v1",
+        url: `https://huggingface.co/test/model/resolve/${"a".repeat(40)}/model.Q4_K_M.gguf`,
+        authentication: { mode: "optional", environment: "HF_TOKEN" },
+        source: {
+          repository: "test/model",
+          revision: "a".repeat(40),
+          file: {
+            path: "model.Q4_K_M.gguf",
+            digest: `sha256:${"b".repeat(64)}`,
+            sizeBytes: 1024,
+          },
+        },
+      },
+      cache: {
+        ref: "llama-cpp.gguf-content-addressed/v1",
+        receiptRef: "llama-cpp.gguf-cache-entry.receipt/v1",
+        root: "user-cache",
+        quotaBytes: 2048,
+        stagingHeadroomBytes: 512,
+        staging: "same-filesystem",
+        publication: "atomic-no-clobber",
+        reuse: "verified-only-offline",
+        sharing: "owner-only",
+        cleanup: "receipt-owner-only",
+      },
+    });
+    expect(first.cache.key).toBe(
+      "sha256-711b4f2b33679e7ea8c3c0066929f9fb91bf6d8cf23535b46a450388ca8c4e3b",
+    );
+    expect(first.planDigest).toBe(
+      "sha256:3d1c36437dd13ea12ea4aaaff21e3972ad8db97069822a9d787581a02dd03122",
+    );
+  });
+
+  it.each([
+    ["repository", { repository: "other/model" }],
+    ["revision", { revision: "c".repeat(40) }],
+    ["file name", { path: "other.Q4_K_M.gguf" }],
+    ["file digest", { digest: `sha256:${"d".repeat(64)}` }],
+    ["file size", { sizeBytes: 1025 }],
+  ] satisfies readonly [
+    string,
+    RecipeOverrides,
+  ][])("changes the cache key when the immutable %s changes (#8279)", (_field, overrides) => {
+    const baseline = compileLlamaCppGgufCachePlan(recipe());
+    const changed = compileLlamaCppGgufCachePlan(recipe(overrides));
+
+    expect(changed.cache.key).not.toBe(baseline.cache.key);
+    expect(changed.planDigest).not.toBe(baseline.planDigest);
+  });
+
+  it("changes only the plan digest when the cache quota changes (#8279)", () => {
+    const baseline = compileLlamaCppGgufCachePlan(recipe());
+    const changed = compileLlamaCppGgufCachePlan(recipe({ quotaBytes: 4096 }));
+
+    expect(changed.cache.key).toBe(baseline.cache.key);
+    expect(changed.planDigest).not.toBe(baseline.planDigest);
+  });
+
+  it("accepts a quota equal to the file size plus staging headroom (#8279)", () => {
+    expect(() =>
+      compileLlamaCppGgufCachePlan(
+        recipe({ sizeBytes: 1024, stagingHeadroomBytes: 512, quotaBytes: 1536 }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects a quota below the file size plus staging headroom (#8279)", () => {
+    expect(() =>
+      compileLlamaCppGgufCachePlan(
+        recipe({ sizeBytes: 1024, stagingHeadroomBytes: 512, quotaBytes: 1535 }),
+      ),
+    ).toThrow("cache quota must be at least 1536 bytes");
+  });
+});

--- a/src/lib/inference/llama-cpp/gguf-cache-plan.ts
+++ b/src/lib/inference/llama-cpp/gguf-cache-plan.ts
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import type { LlamaCppServingRecipe } from "../serving/types";
+
+export const LLAMA_CPP_GGUF_CACHE_PLAN_SCHEMA_VERSION = 1 as const;
+
+export interface LlamaCppGgufCachePlan {
+  readonly schemaVersion: typeof LLAMA_CPP_GGUF_CACHE_PLAN_SCHEMA_VERSION;
+  readonly recipeId: string;
+  readonly acquisition: {
+    readonly ref: "hugging-face-exact-file/v1";
+    readonly url: string;
+    readonly authentication: {
+      readonly mode: "optional";
+      readonly environment: "HF_TOKEN";
+    };
+    readonly source: {
+      readonly repository: string;
+      readonly revision: string;
+      readonly file: {
+        readonly path: string;
+        readonly digest: string;
+        readonly sizeBytes: number;
+      };
+    };
+  };
+  readonly cache: {
+    readonly ref: "llama-cpp.gguf-content-addressed/v1";
+    readonly receiptRef: "llama-cpp.gguf-cache-entry.receipt/v1";
+    readonly root: "user-cache";
+    readonly key: string;
+    readonly quotaBytes: number;
+    readonly stagingHeadroomBytes: number;
+    readonly staging: "same-filesystem";
+    readonly publication: "atomic-no-clobber";
+    readonly reuse: "verified-only-offline";
+    readonly sharing: "owner-only";
+    readonly cleanup: "receipt-owner-only";
+  };
+  readonly planDigest: string;
+}
+
+export class LlamaCppGgufCachePlanError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LlamaCppGgufCachePlanError";
+  }
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function normalizeForCanonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeForCanonicalJson);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => compareText(left, right))
+        .map(([key, nested]) => [key, normalizeForCanonicalJson(nested)]),
+    );
+  }
+  return value;
+}
+
+function digest(value: unknown): string {
+  const canonicalJson = JSON.stringify(normalizeForCanonicalJson(value));
+  return `sha256:${createHash("sha256").update(canonicalJson).digest("hex")}`;
+}
+
+function assertDeclarativeContract(recipe: LlamaCppServingRecipe): void {
+  const { acquisition, cache, files } = recipe.spec.model;
+  if (recipe.spec.backend !== "install-llama-cpp" || recipe.spec.providerId !== "llama-cpp-local") {
+    throw new LlamaCppGgufCachePlanError("The recipe is not a typed llama.cpp recipe.");
+  }
+  if (
+    acquisition.ref !== "hugging-face-exact-file/v1" ||
+    acquisition.authentication.mode !== "optional" ||
+    acquisition.authentication.environment !== "HF_TOKEN"
+  ) {
+    throw new LlamaCppGgufCachePlanError("The recipe has an unsupported acquisition contract.");
+  }
+  if (
+    cache.ref !== "llama-cpp.gguf-content-addressed/v1" ||
+    cache.receiptRef !== "llama-cpp.gguf-cache-entry.receipt/v1" ||
+    cache.root !== "user-cache" ||
+    cache.staging !== "same-filesystem" ||
+    cache.publication !== "atomic-no-clobber" ||
+    cache.reuse !== "verified-only-offline" ||
+    cache.sharing !== "owner-only" ||
+    cache.cleanup !== "receipt-owner-only"
+  ) {
+    throw new LlamaCppGgufCachePlanError("The recipe has an unsupported cache contract.");
+  }
+  if (
+    recipe.spec.policy.egress !== "disabled" ||
+    recipe.spec.policy.modelSource !== "verified-local" ||
+    recipe.spec.policy.modelDownloads !== "disabled"
+  ) {
+    throw new LlamaCppGgufCachePlanError("The recipe permits runtime model acquisition.");
+  }
+  if (files.length !== 1) {
+    throw new LlamaCppGgufCachePlanError("The recipe must identify one GGUF file.");
+  }
+}
+
+function requiredStorageBytes(modelSizeBytes: number, stagingHeadroomBytes: number): number {
+  if (
+    !Number.isSafeInteger(modelSizeBytes) ||
+    modelSizeBytes < 1 ||
+    !Number.isSafeInteger(stagingHeadroomBytes) ||
+    stagingHeadroomBytes < 1 ||
+    modelSizeBytes > Number.MAX_SAFE_INTEGER - stagingHeadroomBytes
+  ) {
+    throw new LlamaCppGgufCachePlanError("The GGUF storage requirement is not a safe integer.");
+  }
+  return modelSizeBytes + stagingHeadroomBytes;
+}
+
+function huggingFaceExactFileUrl(repository: string, revision: string, path: string): string {
+  const [namespace, name] = repository.split("/");
+  if (!namespace || !name || repository.split("/").length !== 2) {
+    throw new LlamaCppGgufCachePlanError("The model repository identity is invalid.");
+  }
+  return `https://huggingface.co/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/resolve/${encodeURIComponent(revision)}/${encodeURIComponent(path)}`;
+}
+
+export function compileLlamaCppGgufCachePlan(recipe: LlamaCppServingRecipe): LlamaCppGgufCachePlan {
+  assertDeclarativeContract(recipe);
+  const file = recipe.spec.model.files[0]!;
+  const { acquisition, cache } = recipe.spec.model;
+  const requiredBytes = requiredStorageBytes(file.sizeBytes, cache.stagingHeadroomBytes);
+  if (!Number.isSafeInteger(cache.quotaBytes) || cache.quotaBytes < requiredBytes) {
+    throw new LlamaCppGgufCachePlanError(
+      `The cache quota must be at least ${String(requiredBytes)} bytes for the GGUF file and staging headroom.`,
+    );
+  }
+
+  const source = {
+    repository: recipe.spec.model.id,
+    revision: recipe.spec.model.revision,
+    file: {
+      path: file.path,
+      digest: file.digest,
+      sizeBytes: file.sizeBytes,
+    },
+  } as const;
+  const cacheKey = digest(source).replace("sha256:", "sha256-");
+  const payload = {
+    schemaVersion: LLAMA_CPP_GGUF_CACHE_PLAN_SCHEMA_VERSION,
+    recipeId: recipe.metadata.id,
+    acquisition: {
+      ref: acquisition.ref,
+      url: huggingFaceExactFileUrl(source.repository, source.revision, source.file.path),
+      authentication: acquisition.authentication,
+      source,
+    },
+    cache: {
+      ref: cache.ref,
+      receiptRef: cache.receiptRef,
+      root: cache.root,
+      key: cacheKey,
+      quotaBytes: cache.quotaBytes,
+      stagingHeadroomBytes: cache.stagingHeadroomBytes,
+      staging: cache.staging,
+      publication: cache.publication,
+      reuse: cache.reuse,
+      sharing: cache.sharing,
+      cleanup: cache.cleanup,
+    },
+  } as const;
+
+  return { ...payload, planDigest: digest(payload) };
+}

--- a/src/lib/inference/llama-cpp/gguf-cache-receipt.test.ts
+++ b/src/lib/inference/llama-cpp/gguf-cache-receipt.test.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import type { LlamaCppGgufCachePlan } from "./gguf-cache-plan";
+import {
+  createLlamaCppGgufCacheEntryReceipt,
+  parseLlamaCppGgufCacheEntryReceipt,
+  verifyLlamaCppGgufCacheEntryReceipt,
+} from "./gguf-cache-receipt";
+
+const PLAN: LlamaCppGgufCachePlan = {
+  schemaVersion: 1,
+  recipeId: "test.llama.recipe",
+  acquisition: {
+    ref: "hugging-face-exact-file/v1",
+    url: `https://huggingface.co/test/model/resolve/${"a".repeat(40)}/model.gguf`,
+    authentication: { mode: "optional", environment: "HF_TOKEN" },
+    source: {
+      repository: "test/model",
+      revision: "a".repeat(40),
+      file: { path: "model.gguf", digest: `sha256:${"b".repeat(64)}`, sizeBytes: 1024 },
+    },
+  },
+  cache: {
+    ref: "llama-cpp.gguf-content-addressed/v1",
+    receiptRef: "llama-cpp.gguf-cache-entry.receipt/v1",
+    root: "user-cache",
+    key: `sha256-${"c".repeat(64)}`,
+    quotaBytes: 2048,
+    stagingHeadroomBytes: 512,
+    staging: "same-filesystem",
+    publication: "atomic-no-clobber",
+    reuse: "verified-only-offline",
+    sharing: "owner-only",
+    cleanup: "receipt-owner-only",
+  },
+  planDigest: `sha256:${"d".repeat(64)}`,
+};
+const OWNER = { id: "gateway.primary", generation: "e".repeat(32) } as const;
+
+describe("GGUF cache entry receipt", () => {
+  it("round-trips the exact plan and owner identity without host paths or credentials (#8279)", () => {
+    const receipt = createLlamaCppGgufCacheEntryReceipt(PLAN, OWNER);
+    const serialized = JSON.stringify(receipt);
+
+    expect(parseLlamaCppGgufCacheEntryReceipt(serialized, PLAN, OWNER)).toEqual(receipt);
+    expect(serialized).not.toContain(PLAN.acquisition.url);
+    expect(serialized).not.toContain("HF_TOKEN");
+    expect(serialized).not.toMatch(/\/(?:Users|home|var)\//u);
+  });
+
+  it.each([
+    ["an extra field", (receipt: Record<string, unknown>) => ({ ...receipt, path: "/tmp/model" })],
+    [
+      "a substituted plan digest",
+      (receipt: Record<string, unknown>) => ({
+        ...receipt,
+        planDigest: `sha256:${"0".repeat(64)}`,
+      }),
+    ],
+    [
+      "a substituted cache key",
+      (receipt: Record<string, unknown>) => ({
+        ...receipt,
+        cache: { ...(receipt.cache as object), key: `sha256-${"0".repeat(64)}` },
+      }),
+    ],
+    [
+      "a substituted model file",
+      (receipt: Record<string, unknown>) => ({
+        ...receipt,
+        model: {
+          ...(receipt.model as object),
+          file: { ...(receipt.model as { file: object }).file, path: "other.gguf" },
+        },
+      }),
+    ],
+    [
+      "a foreign owner",
+      (receipt: Record<string, unknown>) => ({
+        ...receipt,
+        owner: { id: "gateway.foreign", generation: OWNER.generation },
+      }),
+    ],
+  ])("rejects %s (#8279)", (_case, mutate) => {
+    const receipt = createLlamaCppGgufCacheEntryReceipt(PLAN, OWNER);
+    expect(() =>
+      verifyLlamaCppGgufCacheEntryReceipt(
+        mutate(receipt as unknown as Record<string, unknown>),
+        PLAN,
+        OWNER,
+      ),
+    ).toThrow();
+  });
+
+  it("rejects malformed receipt JSON (#8279)", () => {
+    expect(() => parseLlamaCppGgufCacheEntryReceipt("not-json", PLAN, OWNER)).toThrow(
+      "not valid JSON",
+    );
+  });
+
+  it("rejects an owner ID that contains a path separator (#8279)", () => {
+    expect(() =>
+      createLlamaCppGgufCacheEntryReceipt(PLAN, {
+        id: "../foreign",
+        generation: OWNER.generation,
+      }),
+    ).toThrow("owner does not match");
+  });
+});

--- a/src/lib/inference/llama-cpp/gguf-cache-receipt.ts
+++ b/src/lib/inference/llama-cpp/gguf-cache-receipt.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { LlamaCppGgufCachePlan } from "./gguf-cache-plan";
+
+export const LLAMA_CPP_GGUF_CACHE_RECEIPT_SCHEMA_VERSION = 1 as const;
+
+export interface LlamaCppGgufCacheOwner {
+  readonly id: string;
+  readonly generation: string;
+}
+
+export interface LlamaCppGgufCacheEntryReceipt {
+  readonly schemaVersion: typeof LLAMA_CPP_GGUF_CACHE_RECEIPT_SCHEMA_VERSION;
+  readonly receiptRef: "llama-cpp.gguf-cache-entry.receipt/v1";
+  readonly planDigest: string;
+  readonly recipeId: string;
+  readonly cache: {
+    readonly ref: "llama-cpp.gguf-content-addressed/v1";
+    readonly key: string;
+  };
+  readonly model: {
+    readonly repository: string;
+    readonly revision: string;
+    readonly file: {
+      readonly path: string;
+      readonly digest: string;
+      readonly sizeBytes: number;
+    };
+  };
+  readonly owner: LlamaCppGgufCacheOwner;
+}
+
+export class LlamaCppGgufCacheReceiptError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LlamaCppGgufCacheReceiptError";
+  }
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new LlamaCppGgufCacheReceiptError(`${label} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const required = [...expected].sort();
+  if (actual.length !== required.length || actual.some((key, index) => key !== required[index])) {
+    throw new LlamaCppGgufCacheReceiptError(`${label} has invalid fields.`);
+  }
+}
+
+function validateOwner(value: unknown, expected: LlamaCppGgufCacheOwner): LlamaCppGgufCacheOwner {
+  const owner = record(value, "GGUF cache receipt owner");
+  requireExactKeys(owner, ["generation", "id"], "GGUF cache receipt owner");
+  if (
+    typeof owner.id !== "string" ||
+    !/^[a-z0-9][a-z0-9._-]{0,127}$/u.test(owner.id) ||
+    typeof owner.generation !== "string" ||
+    !/^[0-9a-f]{32}$/u.test(owner.generation) ||
+    owner.id !== expected.id ||
+    owner.generation !== expected.generation
+  ) {
+    throw new LlamaCppGgufCacheReceiptError("GGUF cache receipt owner does not match.");
+  }
+  return { id: owner.id, generation: owner.generation };
+}
+
+export function createLlamaCppGgufCacheEntryReceipt(
+  plan: LlamaCppGgufCachePlan,
+  owner: LlamaCppGgufCacheOwner,
+): LlamaCppGgufCacheEntryReceipt {
+  validateOwner(owner, owner);
+  return {
+    schemaVersion: LLAMA_CPP_GGUF_CACHE_RECEIPT_SCHEMA_VERSION,
+    receiptRef: plan.cache.receiptRef,
+    planDigest: plan.planDigest,
+    recipeId: plan.recipeId,
+    cache: { ref: plan.cache.ref, key: plan.cache.key },
+    model: plan.acquisition.source,
+    owner,
+  };
+}
+
+export function verifyLlamaCppGgufCacheEntryReceipt(
+  value: unknown,
+  plan: LlamaCppGgufCachePlan,
+  expectedOwner: LlamaCppGgufCacheOwner,
+): LlamaCppGgufCacheEntryReceipt {
+  const receipt = record(value, "GGUF cache receipt");
+  requireExactKeys(
+    receipt,
+    ["cache", "model", "owner", "planDigest", "receiptRef", "recipeId", "schemaVersion"],
+    "GGUF cache receipt",
+  );
+  const cache = record(receipt.cache, "GGUF cache receipt cache identity");
+  requireExactKeys(cache, ["key", "ref"], "GGUF cache receipt cache identity");
+  const model = record(receipt.model, "GGUF cache receipt model identity");
+  requireExactKeys(model, ["file", "repository", "revision"], "GGUF cache receipt model identity");
+  const file = record(model.file, "GGUF cache receipt model file");
+  requireExactKeys(file, ["digest", "path", "sizeBytes"], "GGUF cache receipt model file");
+
+  const expected = createLlamaCppGgufCacheEntryReceipt(plan, expectedOwner);
+  if (
+    receipt.schemaVersion !== expected.schemaVersion ||
+    receipt.receiptRef !== expected.receiptRef ||
+    receipt.planDigest !== expected.planDigest ||
+    receipt.recipeId !== expected.recipeId ||
+    cache.ref !== expected.cache.ref ||
+    cache.key !== expected.cache.key ||
+    model.repository !== expected.model.repository ||
+    model.revision !== expected.model.revision ||
+    file.path !== expected.model.file.path ||
+    file.digest !== expected.model.file.digest ||
+    file.sizeBytes !== expected.model.file.sizeBytes
+  ) {
+    throw new LlamaCppGgufCacheReceiptError("GGUF cache receipt identity does not match the plan.");
+  }
+
+  return { ...expected, owner: validateOwner(receipt.owner, expectedOwner) };
+}
+
+export function parseLlamaCppGgufCacheEntryReceipt(
+  source: string,
+  plan: LlamaCppGgufCachePlan,
+  expectedOwner: LlamaCppGgufCacheOwner,
+): LlamaCppGgufCacheEntryReceipt {
+  let value: unknown;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    throw new LlamaCppGgufCacheReceiptError("GGUF cache receipt is not valid JSON.");
+  }
+  return verifyLlamaCppGgufCacheEntryReceipt(value, plan, expectedOwner);
+}

--- a/src/lib/inference/llama-cpp/index.ts
+++ b/src/lib/inference/llama-cpp/index.ts
@@ -14,6 +14,8 @@ import {
 } from "./contract";
 
 export * from "./contract";
+export * from "./gguf-cache-plan";
+export * from "./gguf-cache-receipt";
 
 type LlamaCppModelEntry = {
   id?: unknown;

--- a/src/lib/inference/serving/catalog-loader.test.ts
+++ b/src/lib/inference/serving/catalog-loader.test.ts
@@ -17,7 +17,7 @@ import type { CompiledServingCatalog, ServingPreset, ServingRecipe } from "./typ
 
 const EMPTY_CATALOG: CompiledServingCatalog = {
   schemaVersion: "1.0.0",
-  compilerVersion: "1.1.0",
+  compilerVersion: "1.2.0",
   sourceRevision: "a".repeat(40),
   readinessSchemaRef: "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json",
   recipes: [],

--- a/src/lib/inference/serving/catalog.test.ts
+++ b/src/lib/inference/serving/catalog.test.ts
@@ -141,6 +141,22 @@ spec:
         format: gguf
         quantization: Q4_K_M
         license: Apache-2.0
+    acquisition:
+      ref: hugging-face-exact-file/v1
+      authentication:
+        mode: optional
+        environment: HF_TOKEN
+    cache:
+      ref: llama-cpp.gguf-content-addressed/v1
+      receiptRef: llama-cpp.gguf-cache-entry.receipt/v1
+      root: user-cache
+      quotaBytes: 6442450944
+      stagingHeadroomBytes: 1073741824
+      staging: same-filesystem
+      publication: atomic-no-clobber
+      reuse: verified-only-offline
+      sharing: owner-only
+      cleanup: receipt-owner-only
   runtime:
     image: registry.example/test/llama-server@sha256:${"2".repeat(64)}
     imageDownloadSizeBytes: 1073741824
@@ -315,7 +331,7 @@ describe("managed inference serving catalog compiler", () => {
     expect(first.readinessSchemaRef).toBe(
       "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json",
     );
-    expect(first.compilerVersion).toBe("1.1.0");
+    expect(first.compilerVersion).toBe("1.2.0");
     expect(first.recipes.map((definition) => definition.metadata.id)).toEqual(["test.recipe.v1"]);
     expect(first.presets.map((definition) => definition.metadata.id)).toEqual(["test.preset.auto"]);
     expect(first.sources.map((source) => source.path)).toEqual([
@@ -367,7 +383,37 @@ describe("managed inference serving catalog compiler", () => {
       "      revision: main",
     ],
     ["a mutable model revision", `    revision: ${"f".repeat(40)}`, "    revision: latest"],
+    ["a missing GGUF digest", `        digest: sha256:${"1".repeat(64)}\n`, ""],
     ["a missing GGUF byte size", "        sizeBytes: 4294967296\n", ""],
+    ["a non-GGUF file", "      - path: test-model.Q4_K_M.gguf", "      - path: model.bin"],
+    [
+      "an unsupported acquisition transport",
+      "      ref: hugging-face-exact-file/v1",
+      "      ref: arbitrary-url/v1",
+    ],
+    ["a required acquisition credential", "        mode: optional", "        mode: required"],
+    [
+      "an arbitrary acquisition endpoint",
+      "      ref: hugging-face-exact-file/v1",
+      "      ref: hugging-face-exact-file/v1\n      endpoint: https://example.test/model.gguf",
+    ],
+    [
+      "an embedded acquisition credential",
+      "        environment: HF_TOKEN",
+      "        environment: HF_TOKEN\n        token: test-secret",
+    ],
+    ["a shared cache owner", "      sharing: owner-only", "      sharing: host-user"],
+    [
+      "cross-filesystem staging",
+      "      staging: same-filesystem",
+      "      staging: system-temporary",
+    ],
+    [
+      "clobbering cache publication",
+      "      publication: atomic-no-clobber",
+      "      publication: replace-existing",
+    ],
+    ["unverified cache reuse", "      reuse: verified-only-offline", "      reuse: trust-existing"],
     [
       "a mutable server image",
       `    image: registry.example/test/llama-server@sha256:${"2".repeat(64)}`,
@@ -463,6 +509,39 @@ describe("managed inference serving catalog compiler", () => {
     expect(() => compile([recipe])).toThrow("does not satisfy the ServingRecipe schema");
   });
 
+  it.each([
+    [
+      "acquisition",
+      `    revision: ${MODEL_REVISION}`,
+      `    revision: ${MODEL_REVISION}
+    acquisition:
+      ref: hugging-face-exact-file/v1
+      authentication:
+        mode: optional
+        environment: HF_TOKEN`,
+    ],
+    [
+      "cache",
+      `    revision: ${MODEL_REVISION}`,
+      `    revision: ${MODEL_REVISION}
+    cache:
+      ref: llama-cpp.gguf-content-addressed/v1
+      receiptRef: llama-cpp.gguf-cache-entry.receipt/v1
+      root: user-cache
+      quotaBytes: 2048
+      stagingHeadroomBytes: 1024
+      staging: same-filesystem
+      publication: atomic-no-clobber
+      reuse: verified-only-offline
+      sharing: owner-only
+      cleanup: receipt-owner-only`,
+    ],
+  ])("rejects llama.cpp model %s on a generic recipe (#8279)", (_field, expected, replacement) => {
+    const recipe = replaceSource(recipeSource(), expected, replacement);
+
+    expect(() => compile([recipe])).toThrow("does not satisfy the ServingRecipe schema");
+  });
+
   it("rejects a llama.cpp readiness model that differs from the served name (#8181)", () => {
     const wrongExpectedModel = replaceSource(
       llamaCppRecipeSource(),
@@ -496,6 +575,18 @@ describe("managed inference serving catalog compiler", () => {
 
     expect(() => compile([invalidBatching])).toThrow(
       "serve.microBatchSize cannot exceed serve.batchSize",
+    );
+  });
+
+  it("rejects a llama.cpp cache quota below the file size and staging headroom (#8279)", () => {
+    const insufficientQuota = replaceSource(
+      llamaCppRecipeSource(),
+      "      quotaBytes: 6442450944",
+      "      quotaBytes: 5368709119",
+    );
+
+    expect(() => compile([insufficientQuota])).toThrow(
+      "cache quota must be at least 5368709120 bytes",
     );
   });
 

--- a/src/lib/inference/serving/catalog.ts
+++ b/src/lib/inference/serving/catalog.ts
@@ -7,6 +7,7 @@ import { posix } from "node:path";
 import Ajv2020, { type AnySchema, type ValidateFunction } from "ajv/dist/2020.js";
 import { parseDocument } from "yaml";
 
+import { compileLlamaCppGgufCachePlan } from "../llama-cpp/gguf-cache-plan";
 import type {
   CompiledServingCatalog,
   CompiledServingCatalogPayload,
@@ -20,14 +21,14 @@ import type {
   ServingReadinessComparison,
   ServingReadinessObservationRole,
   ServingReadinessRegistryEntry,
-  ServingReadinessRequirement,
   ServingReadinessRegistryValue,
+  ServingReadinessRequirement,
   ServingRecipe,
 } from "./types";
 
 const API_VERSION = "nemoclaw.nvidia.com/managed-inference/v1" as const;
 const CATALOG_SCHEMA_VERSION = "1.0.0" as const;
-const COMPILER_VERSION = "1.1.0" as const;
+const COMPILER_VERSION = "1.2.0" as const;
 const READINESS_SCHEMA_REF =
   "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json" as const;
 const RECIPE_SCHEMA_ID =
@@ -235,6 +236,13 @@ function validateRecipeSemantics(
   }
 
   if (isLlamaCppServingRecipe(recipe)) {
+    try {
+      compileLlamaCppGgufCachePlan(recipe);
+    } catch (error) {
+      throw new ServingCatalogValidationError(
+        `Recipe ${recipe.metadata.id}: ${error instanceof Error ? error.message : "GGUF cache plan compilation failed."}`,
+      );
+    }
     const servedName = recipe.spec.model.servedName;
     if (recipe.spec.readiness.expectedModel !== servedName) {
       throw new ServingCatalogValidationError(

--- a/src/lib/inference/serving/types.ts
+++ b/src/lib/inference/serving/types.ts
@@ -185,6 +185,25 @@ export interface LlamaCppServingRecipe extends ServingRecipeEnvelope {
         readonly quantization: string;
         readonly license: string;
       }[];
+      readonly acquisition: {
+        readonly ref: "hugging-face-exact-file/v1";
+        readonly authentication: {
+          readonly mode: "optional";
+          readonly environment: "HF_TOKEN";
+        };
+      };
+      readonly cache: {
+        readonly ref: "llama-cpp.gguf-content-addressed/v1";
+        readonly receiptRef: "llama-cpp.gguf-cache-entry.receipt/v1";
+        readonly root: "user-cache";
+        readonly quotaBytes: number;
+        readonly stagingHeadroomBytes: number;
+        readonly staging: "same-filesystem";
+        readonly publication: "atomic-no-clobber";
+        readonly reuse: "verified-only-offline";
+        readonly sharing: "owner-only";
+        readonly cleanup: "receipt-owner-only";
+      };
     };
     readonly runtime: {
       readonly image: string;
@@ -380,7 +399,7 @@ export interface ServingCatalogSourceProvenance {
 
 export interface CompiledServingCatalogPayload {
   readonly schemaVersion: "1.0.0";
-  readonly compilerVersion: "1.1.0";
+  readonly compilerVersion: "1.2.0";
   readonly sourceRevision: string;
   readonly readinessSchemaRef: "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json";
   readonly recipes: readonly ServingRecipe[];

--- a/test/managed-inference-catalog-compiler.test.ts
+++ b/test/managed-inference-catalog-compiler.test.ts
@@ -111,6 +111,22 @@ describe("managed inference YAML profile contract", () => {
       model: {
         servedName: "nvidia-nemotron-3-nano-30b-a3b",
         files: [{ digest: LLAMA_CPP_MODEL_DIGEST, sizeBytes: 22833947424 }],
+        acquisition: {
+          ref: "hugging-face-exact-file/v1",
+          authentication: { mode: "optional", environment: "HF_TOKEN" },
+        },
+        cache: {
+          ref: "llama-cpp.gguf-content-addressed/v1",
+          receiptRef: "llama-cpp.gguf-cache-entry.receipt/v1",
+          root: "user-cache",
+          quotaBytes: 34359738368,
+          stagingHeadroomBytes: 5368709120,
+          staging: "same-filesystem",
+          publication: "atomic-no-clobber",
+          reuse: "verified-only-offline",
+          sharing: "owner-only",
+          cleanup: "receipt-owner-only",
+        },
       },
       runtime: {
         image: LLAMA_CPP_IMAGE,


### PR DESCRIPTION
## Summary

Adds the declarative GGUF acquisition and verified cache contract for the llama.cpp DGX Spark recipe. The repository-owned YAML is now the source of truth for the exact model artifact, authentication mode, quota, staging, publication, reuse, ownership, and cleanup policy; this slice does not yet download a model or activate a runtime.

## Related Issue

Part of #8279
Part of #8144

## Changes

- Extends the serving recipe schema and types with a llama.cpp-only acquisition/cache contract and declares it in the Nemotron DGX Spark recipe.
- Compiles a deterministic cache plan from that YAML, including the fixed Hugging Face exact-file URL, content-addressed key, quota/headroom checks, and golden plan digest.
- Adds a strict, versioned cache-entry receipt parser/verifier bound to the plan, recipe, artifact, and owner generation without persisting host paths, URLs, or credentials.
- Bumps the managed-inference catalog compiler contract to `1.2.0` and adds positive, drift, substitution, ownership, malformed-input, and cross-backend rejection coverage.
- Current consumer: catalog semantic validation compiles the plan, and the llama.cpp module exports the receipt contract. A direct downloader/lifecycle change is intentionally deferred because those consumers first need this stable, versioned declarative artifact and ownership boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This adds an experimental repository-owned contract with no CLI, onboarding, acquisition, lifecycle, default, output, or supported runtime consumer.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop performed a skeptical exact-head review of schema/type parity, trust boundaries, receipt substitution resistance, ownership, and regression coverage; no blockers remained.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Adds an experimental, repository-owned GGUF acquisition, cache-plan, and receipt-validation contract. No CLI, onboarding, acquisition, lifecycle, default, output, or supported runtime path consumes the contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f0cd8dcbb -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Targeted Vitest coverage passed: 105 CLI tests and 6 integration tests, including cache-plan, receipt, catalog, catalog-loader, and catalog-compiler suites.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run validate:pr` passed on `f0cd8dcbb` after `npm run build:cli`; this change is contract/compiler scoped rather than a broad runtime or harness change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure acquisition and content-addressed caching for llama.cpp GGUF models.
  - Added Hugging Face authentication support and verified offline cache reuse.
  - Added cache ownership, quota, staging, atomic publication, and cleanup policies.
  - Added tamper-resistant cache receipts and validation.

- **Updates**
  - Updated the catalog compiler version to 1.2.0.
  - Added validation requiring cache configuration for llama.cpp models and rejecting it for other model types.

- **Tests**
  - Expanded coverage for cache planning, receipts, validation, ownership, quotas, and configuration policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->