### PR TITLE
fix(ci): refresh successful PR E2E gate

### DIFF
--- a/test/pr-e2e-gate-retry-history.test.ts
+++ b/test/pr-e2e-gate-retry-history.test.ts
@@ -155,6 +155,74 @@ describe("PR E2E controller retry history", () => {
     });
   });
 
+  it("preserves a successful gate and skips E2E dispatch when prerequisite CI reruns (#8293)", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-control-"));
+    const outputPath = path.join(workDir, "github-output");
+    fs.writeFileSync(outputPath, "", { mode: 0o600 });
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_REPOSITORY", "NVIDIA/NemoClaw");
+    vi.stubEnv("GITHUB_OUTPUT", outputPath);
+    const requests: RecordedGitHubRequest[] = [];
+    let completedCheck = exactPrGateCheck({
+      status: "completed",
+      conclusion: "success",
+      details_url: "https://github.com/NVIDIA/NemoClaw/runs/17",
+      output: {
+        title: "No E2E checks selected",
+        summary: "No changed files matched an E2E risk rule.",
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      createGitHubFetchRouter(
+        [
+          githubFetchRoute(
+            ({ url, method }) =>
+              url.includes(`/commits/${HEAD_SHA}/check-runs?`) && method === "GET",
+            () => githubResponse({ total_count: 1, check_runs: [completedCheck] }),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/pulls/42") && method === "GET",
+            () => githubResponse(pullRequest()),
+          ),
+          githubFetchRoute(
+            ({ url, method }) => url.endsWith("/check-runs/17") && method === "PATCH",
+            (request) => {
+              completedCheck = {
+                ...completedCheck,
+                ...(request.body as Record<string, unknown> | undefined),
+              };
+              return githubResponse(completedCheck);
+            },
+          ),
+        ],
+        requests,
+      ),
+    );
+
+    try {
+      await expect(startPrGate(startCommand(workDir))).resolves.toBeUndefined();
+      const updates = requests.filter(
+        (request) => request.url.endsWith("/check-runs/17") && request.method === "PATCH",
+      );
+      expect(updates).toHaveLength(1);
+      expect(updates[0]?.body).toMatchObject({
+        status: "completed",
+        conclusion: "success",
+        details_url: "https://github.com/NVIDIA/NemoClaw/runs/17",
+        output: {
+          title: "No E2E checks selected",
+          summary: "No changed files matched an E2E risk rule.",
+        },
+      });
+      expect(requests.some((request) => request.method === "POST")).toBe(false);
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("check_id=17");
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("dispatched=false");
+      expect(fs.readFileSync(outputPath, "utf8")).toContain("finalized=true");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("creates a fresh check and dispatches internal E2E after a marker-backed infrastructure failure (#7052)", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pr-e2e-gate-control-"));
     const outputPath = path.join(workDir, "github-output");

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -3052,6 +3052,32 @@ export async function startPrGate(
   ) {
     throw new Error("PR repository or branch does not match the triggering CI run");
   }
+  const existingCheck = existingChecks[0];
+  if (
+    command.ciConclusion === "success" &&
+    existingCheck?.status === "completed" &&
+    existingCheck.conclusion === "success"
+  ) {
+    const title = existingCheck.output?.title;
+    const summary = existingCheck.output?.summary;
+    if (!title || !summary) {
+      throw new Error("Successful PR gate check is missing its title or summary");
+    }
+    appendOutput("check_id", String(existingCheck.id));
+    await completeCheck(
+      { repository, checkRunId: existingCheck.id },
+      token,
+      { conclusion: "success", title, summary },
+      existingCheck.details_url ?? undefined,
+    );
+    appendOutput("dispatched", "false");
+    appendOutput("finalized", "true");
+    console.log(
+      `Updated successful PR gate after CI rerun: pr=${ciIdentity.prNumber} head=${ciIdentity.headSha} base=${ciIdentity.baseSha} attempt=${command.ciRunAttempt}`,
+    );
+    return;
+  }
+
   assertCheckCanStart(existingChecks[0], command.ciConclusion);
   if (retryableFailureReason(existingChecks[0] ?? {}) === "dispatch-not-observed") {
     const summary = existingChecks[0]?.output?.summary;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

A successful `E2E / PR Gate` caused the controller to fail when prerequisite CI reran for the same PR head and base. The controller now updates the existing successful check without creating another check or dispatching E2E again.

## Changes

- Update the existing successful gate after trusted prerequisite CI reruns for the same PR head and base.
- Preserve the check title, summary, and details URL while emitting the finalized controller outputs.
- Add a regression test for the successful-gate rerun sequence observed on PR #8293.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal GitHub Actions control-plane behavior without changing a public API, CLI, configuration, user procedure, agent variant, or supported product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review of exact commit `e5465def0c610603588d488e9ab95308bb882b97` confirmed that exact PR head, base, and GitHub Actions App validation remain unchanged. The update preserves an existing successful result and does not create a check, dispatch E2E, grant permissions, expose credentials, or accept weaker evidence.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independent exact-head review confirmed that `tools/e2e/pr-e2e-gate.mts` and `test/pr-e2e-gate-retry-history.test.ts` change internal GitHub Actions control-plane behavior only. No public API, CLI, configuration, user procedure, support claim, or agent variant changes. The focused regression file passed 3/3 after review changes.
- Agent: Pi CLI
<!-- docs-review-head-sha: e5465def0 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `test/pr-e2e-gate-retry-history.test.ts` passed 3/3; the complete PR E2E controller suite passed 243/243 across 16 files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of successful CI reruns when a pull request gate has already completed successfully.
  - Existing successful gate results are preserved and finalized without creating or starting a duplicate workflow.
- **Tests**
  - Added end-to-end coverage verifying retry history, finalized check status, and the absence of unnecessary workflow dispatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->