### PR TITLE
fix(messaging): gate channel lifecycle by agent

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2212,6 +2212,7 @@ Use `channels stop` instead of `channels remove` when you want to pause a bridge
 ### `$$nemoclaw <name> channels start <channel>`
 
 Re-enable a channel previously paused with `channels stop`. The channel is removed from the disabled list, the sandbox is rebuilt, and the bridge registers with the gateway again using the stored credentials.
+The available channel names match `channels list` for the sandbox's agent runtime.
 Before the rebuild, NemoClaw reapplies the matching built-in network policy preset so the restored bridge has egress to its upstream API.
 Before updating the disabled list or applying the policy, NemoClaw prints the exact effective egress scope when the preset would open or replace access, or reports that no new egress would be opened when the preset is already effective.
 If policy restoration fails, NemoClaw rolls the channel back to disabled and exits without rebuilding into a partially active state.

--- a/src/lib/actions/sandbox/policy-channel-agent-gate.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-agent-gate.test.ts
@@ -14,7 +14,7 @@ import * as defs from "../../agent/defs";
 import * as store from "../../credentials/store";
 import * as policy from "../../policy";
 import * as registry from "../../state/registry";
-import { addSandboxChannel } from "./policy-channel";
+import { addSandboxChannel, startSandboxChannel, stopSandboxChannel } from "./policy-channel";
 import { policyChannelDependencies } from "./policy-channel-dependencies";
 
 function agentFixture(name: string): defs.AgentDefinition {
@@ -148,5 +148,44 @@ describe("addSandboxChannel agent gate", () => {
     void caught;
     void exitMock;
     void logSpy;
+  });
+});
+
+describe("channel lifecycle agent gate", () => {
+  it.each([
+    ["start", ["googlechat"], () => startSandboxChannel("da-test", { channel: "googlechat" })],
+    ["stop", [], () => stopSandboxChannel("da-test", { channel: "googlechat" })],
+  ])("rejects a stale channel during %s before reading channel state or mutating the sandbox", async (_verb, disabledChannels, run) => {
+    getSandboxMock.mockReturnValue({ name: "da-test", agent: "hermes" });
+    vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("hermes"));
+    const configuredChannelsMock = vi
+      .spyOn(registry, "getConfiguredMessagingChannelsFromEntry")
+      .mockReturnValue(["googlechat"]);
+    const disabledChannelsMock = vi
+      .spyOn(registry, "getDisabledChannels")
+      .mockReturnValue(disabledChannels);
+
+    let caught: unknown;
+    try {
+      await run();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(exitCodeFromError(caught)).toBe(1);
+    const errorText = (errSpy.mock.calls as unknown[][])
+      .map((call) => call.map(String).join(" "))
+      .join("\n");
+    expect(errorText).toMatch(/Channel 'googlechat' does not support agent 'hermes'/);
+    expect(errorText).toMatch(/Channel-supported agents: openclaw/);
+    expect(errorText).toMatch(/Channels supported by agent 'hermes':/);
+
+    expect(configuredChannelsMock).not.toHaveBeenCalled();
+    expect(disabledChannelsMock).not.toHaveBeenCalled();
+    expect(loadPresetForSandboxMock).not.toHaveBeenCalled();
+    expect(applyPresetMock).not.toHaveBeenCalled();
+    expect(updateSandboxMock).not.toHaveBeenCalled();
+    expect(rebuildMock).not.toHaveBeenCalled();
+    expect(runOpenshellMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
@@ -42,17 +42,17 @@ describe("policy channel remove/enable flows", () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("supports stop dry runs for configured channels", async () => {
-    vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "alpha" });
-    vi.spyOn(registry, "getConfiguredMessagingChannelsFromEntry").mockReturnValue(["telegram"]);
+  it("supports stop dry runs for configured Hermes channels", async () => {
+    vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "alpha", agent: "hermes" });
+    vi.spyOn(registry, "getConfiguredMessagingChannelsFromEntry").mockReturnValue(["teams"]);
     vi.spyOn(registry, "getDisabledChannels").mockReturnValue([]);
 
     await expect(
-      stopSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
+      stopSandboxChannel("alpha", { channel: "teams", dryRun: true }),
     ).resolves.toBeUndefined();
 
     expect(logSpy.mock.calls.flat().join("\n")).toContain(
-      "--dry-run: would stop channel 'telegram' for 'alpha'.",
+      "--dry-run: would stop channel 'teams' for 'alpha'.",
     );
     expect(exitSpy).not.toHaveBeenCalled();
   });

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -1731,10 +1731,10 @@ async function sandboxChannelsSetEnabled(
     process.exit(1);
   }
 
-  const channel = getChannelDef(channelArg);
-  if (!channel) {
+  const manifest = resolveChannelManifest(channelArg);
+  if (!manifest) {
     console.error(`  Unknown channel '${channelArg}'.`);
-    console.error(`  Valid channels: ${knownChannelNames().join(", ")}`);
+    console.error(`  Valid channels: ${knownManifestChannelNames().join(", ")}`);
     process.exit(1);
   }
 
@@ -1744,30 +1744,45 @@ async function sandboxChannelsSetEnabled(
     process.exit(1);
   }
 
-  const normalized = channelArg.trim().toLowerCase();
-  const configuredChannels = registry.getConfiguredMessagingChannelsFromEntry(registryEntry);
-  if (!configuredChannels.includes(normalized)) {
-    console.error(`  Channel '${normalized}' is not configured for '${sandboxName}'.`);
+  const canonical = manifest.id;
+  const agent = resolveAgentForSandbox(sandboxName);
+  const availableChannels = availableManifestChannelsForAgent(agent);
+  if (!availableChannels.some((candidate) => candidate.id === canonical)) {
+    console.error(
+      `  Channel '${canonical}' does not support agent '${agent.name}' for sandbox '${sandboxName}'.`,
+    );
+    console.error(
+      `  Channel-supported agents: ${formatSupportedMessagingAgentIds(manifest.supportedAgents)}.`,
+    );
+    console.error(
+      `  Channels supported by agent '${agent.name}': ${formatAvailableChannelsForAgent(agent)}.`,
+    );
     process.exit(1);
   }
-  const alreadyDisabled = registry.getDisabledChannels(sandboxName).includes(normalized);
+
+  const configuredChannels = registry.getConfiguredMessagingChannelsFromEntry(registryEntry);
+  if (!configuredChannels.includes(canonical)) {
+    console.error(`  Channel '${canonical}' is not configured for '${sandboxName}'.`);
+    process.exit(1);
+  }
+  const alreadyDisabled = registry.getDisabledChannels(sandboxName).includes(canonical);
   if (alreadyDisabled === disabled) {
     console.log(
-      `  Channel '${normalized}' is already ${disabled ? "disabled" : "enabled"} for '${sandboxName}'. Nothing to do.`,
+      `  Channel '${canonical}' is already ${disabled ? "disabled" : "enabled"} for '${sandboxName}'. Nothing to do.`,
     );
     return;
   }
 
   const disclosedPresetState = disabled
     ? undefined
-    : loadValidateAndDiscloseChannelPreset(sandboxName, normalized, "start");
+    : loadValidateAndDiscloseChannelPreset(sandboxName, canonical, "start");
 
   if (dryRun) {
-    console.log(`  --dry-run: would ${verb} channel '${normalized}' for '${sandboxName}'.`);
+    console.log(`  --dry-run: would ${verb} channel '${canonical}' for '${sandboxName}'.`);
     return;
   }
 
-  const plan = await persistManifestChannelDisabledPlan(sandboxName, normalized, disabled);
+  const plan = await persistManifestChannelDisabledPlan(sandboxName, canonical, disabled);
   if (!plan) {
     console.error(`  Could not persist messaging plan for '${sandboxName}'.`);
     process.exit(1);
@@ -1779,22 +1794,22 @@ async function sandboxChannelsSetEnabled(
   // runtime configuration cannot later be rebuilt without the required egress.
   if (
     !disabled &&
-    !applyChannelPresetIfAvailable(sandboxName, normalized, "start", {
+    !applyChannelPresetIfAvailable(sandboxName, canonical, "start", {
       disclosedPresetState,
     })
   ) {
-    const rolledBack = await persistManifestChannelDisabledPlan(sandboxName, normalized, true);
+    const rolledBack = await persistManifestChannelDisabledPlan(sandboxName, canonical, true);
     if (!rolledBack) {
       console.error(
-        `  ${YW}⚠${R} Could not restore '${normalized}' to disabled state after its policy preset failed to apply.`,
+        `  ${YW}⚠${R} Could not restore '${canonical}' to disabled state after its policy preset failed to apply.`,
       );
-      console.error(`    Re-run: ${CLI_NAME} ${sandboxName} channels stop ${normalized}`);
+      console.error(`    Re-run: ${CLI_NAME} ${sandboxName} channels stop ${canonical}`);
     }
     process.exit(1);
   }
   const state = disabled ? "disabled" : "enabled";
-  console.log(`  ${G}✓${R} Marked ${normalized} ${state} for '${sandboxName}'.`);
-  const rebuilt = await promptAndRebuild(sandboxName, `${verb} '${normalized}'`);
+  console.log(`  ${G}✓${R} Marked ${canonical} ${state} for '${sandboxName}'.`);
+  const rebuilt = await promptAndRebuild(sandboxName, `${verb} '${canonical}'`);
   if (rebuilt && !disabled) {
     ensureMessagingHostForwardAfterRebuild(sandboxName, plan);
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Channel start and stop accepted stale configured channels that the sandbox agent runtime does not support. They now use the same agent-filtered manifest availability as `channels list` before reading channel state or mutating policy, registry, or sandbox state.

## Changes

- Gate channel start and stop by the sandbox agent's manifest-supported channels.
- Cover stale Google Chat configuration on Hermes with fail-closed start and stop tests.
- Preserve the supported Hermes and Microsoft Teams stop flow.
- Document that both start and stop names match `channels list` for the sandbox agent runtime.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head nine-category security review passed; lifecycle commands now fail closed before state reads or mutations when a configured channel is unsupported by the sandbox agent.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/commands.mdx`; independent review covered the complete change, writing rules, documentation style, 34 focused tests, CLI type-checking, Biome, agent-variant sync, and the docs build.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 76d901898 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/actions/sandbox/policy-channel-agent-gate.test.ts src/lib/actions/sandbox/policy-channel-remove-flow.test.ts src/lib/messaging/manifest/registry.test.ts src/lib/messaging/utils.test.ts` (34 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused lifecycle gate; authoritative PR CI will run the repository-selected broad checks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — build passed with 0 errors and 2 existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
