### PR TITLE
fix(security): remove gosu from managed images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Layers PR-specific code (plugin, blueprint, config, startup script) on top
 # of the pre-built base image from GHCR. The base image contains all the
-# expensive, rarely-changing layers (apt, gosu, users, openclaw CLI).
+# expensive, rarely-changing layers (apt, setpriv, users, openclaw CLI).
 #
 # For local builds without GHCR access, build the base first:
 #   docker build -f Dockerfile.base -t ghcr.io/nvidia/nemoclaw/sandbox-base:latest .

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -3,7 +3,7 @@
 #
 # NemoClaw sandbox base image — expensive, rarely-changing layers.
 #
-# Contains: node:22-trixie-slim, apt packages, gosu, user/group setup,
+# Contains: node:22-trixie-slim, apt packages, setpriv, user/group setup,
 # .openclaw directory structure, OpenClaw CLI, and PyYAML.
 #
 # Built on main merges and pushed to GHCR. The production Dockerfile
@@ -18,7 +18,7 @@
 #   node:22-trixie-slim — pinned by sha256 digest, checked weekly by
 #                          docker-pin-check.yaml
 #   apt packages        — pinned to exact Debian trixie versions
-#   gosu 1.19           — pinned release + per-arch sha256 checksum
+#   util-linux          — pinned Debian package providing setpriv
 #   npm 11.18.0         — reviewed archive + sha512 integrity
 #   gateway/sandbox     — OS users and groups; names and UIDs are a
 #     users               stable contract with OpenShell
@@ -39,7 +39,7 @@
 #
 #   1. OpenClaw CLI version bump    — update OPENCLAW_VERSION default below, or override via --build-arg / workflow_dispatch
 #   2. New apt package needed       — add it to the apt-get install list
-#   3. gosu upgrade                 — update URL, checksum, and version
+#   3. util-linux upgrade           — update the pinned apt package version
 #   4. node:22-trixie-slim digest rotated — update-docker-pin.sh updates all
 #                                      Dockerfile and Dockerfile.base
 #   5. npm upgrade                  — update upgrade-bundled-npm.mts
@@ -124,6 +124,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         iptables=1.8.11-2 \
         nftables=1.1.3-1 \
         libcap2-bin=1:2.75-10+deb13u1+b1 \
+        util-linux=2.41-5 \
         procps=2:4.0.4-9 \
         e2fsprogs=1.47.2-3+b11 \
         "dos2unix=7.5.2-1*" \
@@ -259,24 +260,9 @@ RUN apt-get update \
     && git --version \
     && test -z "$(dpkg --audit)"
 
-# gosu for privilege separation (gateway vs sandbox user).
-# Install from GitHub release with checksum verification instead of
-# Debian's packaged gosu can lag upstream. Pinned to 1.19 (2025-09).
-# Binary release asset downloads can be slower than hash fetches; keep
-# longer bounded transfer timeouts while preserving checksum verification.
-# hadolint ignore=DL4006
-RUN arch="$(dpkg --print-architecture)" \
-    && case "$arch" in \
-        amd64) gosu_asset="gosu-amd64"; gosu_sha256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0" ;; \
-        arm64) gosu_asset="gosu-arm64"; gosu_sha256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
-        *) echo "Unsupported architecture for gosu: $arch" >&2; exit 1 ;; \
-    esac \
-    && curl --proto '=https' --tlsv1.2 -fsSL \
-        --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
-        -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
-    && echo "${gosu_sha256}  /usr/local/bin/gosu" | sha256sum -c - \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu --version
+# setpriv runtime contract for gateway and sandbox privilege separation.
+RUN test -x /usr/bin/setpriv \
+    && /usr/bin/setpriv --version
 
 # Create sandbox user (matches OpenShell convention) and gateway user.
 # The gateway runs as 'gateway' so the 'sandbox' user (agent) cannot
@@ -641,7 +627,8 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
 ARG HOMEBREW_VERSION=5.1.12
 RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
     && chown -R sandbox:sandbox /home/linuxbrew \
-    && gosu sandbox git clone --depth=1 --branch="${HOMEBREW_VERSION}" \
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- \
+        env HOME=/sandbox git clone --depth=1 --branch="${HOMEBREW_VERSION}" \
         https://github.com/Homebrew/brew.git \
         /home/linuxbrew/.linuxbrew/Homebrew \
     && ln -s /home/linuxbrew/.linuxbrew/Homebrew/bin/brew \
@@ -655,10 +642,13 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
     && chmod 755 /usr/local/bin/brew \
     && grep -qx 'export HOMEBREW_TEMP=/tmp' /usr/local/bin/brew \
     && grep -qx 'export TMPDIR=/tmp' /usr/local/bin/brew \
-    && gosu sandbox env HOMEBREW_TEMP=/var/tmp TMPDIR=/var/tmp /usr/local/bin/brew --prefix \
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- \
+        env HOME=/sandbox HOMEBREW_TEMP=/var/tmp TMPDIR=/var/tmp /usr/local/bin/brew --prefix \
         | grep -qx /home/linuxbrew/.linuxbrew \
-    && gosu sandbox /usr/local/bin/brew --prefix | grep -qx /home/linuxbrew/.linuxbrew \
-    && gosu sandbox /usr/local/bin/brew --version
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- \
+        env HOME=/sandbox /usr/local/bin/brew --prefix | grep -qx /home/linuxbrew/.linuxbrew \
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- \
+        env HOME=/sandbox /usr/local/bin/brew --version
 RUN { \
         printf '%s\n' "if [ \"\$(/usr/bin/id -un 2>/dev/null || true)\" = sandbox ]; then"; \
         printf '%s\n' "  export PATH=\"\${PATH}:/home/linuxbrew/.linuxbrew/bin\""; \
@@ -671,10 +661,10 @@ RUN { \
     && chmod 755 /tmp/nemoclaw-hostile-bin/id \
     && PATH="/tmp/nemoclaw-hostile-bin:${PATH}" bash -lc "case \":\${PATH}:\" in *:/home/linuxbrew/.linuxbrew/bin:*) exit 1 ;; *) exit 0 ;; esac" \
     && rm -rf /tmp/nemoclaw-hostile-bin \
-    && gosu sandbox bash -lc 'command -v brew >/dev/null' \
-    && gosu sandbox bash -lc 'command -v brew' | grep -qx /usr/local/bin/brew \
-    && gosu sandbox bash -lc 'brew --prefix' | grep -qx /home/linuxbrew/.linuxbrew \
-    && gosu sandbox bash -lc "case \":\${PATH}:\" in *:/home/linuxbrew/.linuxbrew/bin:*) exit 0 ;; *) exit 1 ;; esac"
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- env HOME=/sandbox bash -lc 'command -v brew >/dev/null' \
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- env HOME=/sandbox bash -lc 'command -v brew' | grep -qx /usr/local/bin/brew \
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- env HOME=/sandbox bash -lc 'brew --prefix' | grep -qx /home/linuxbrew/.linuxbrew \
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- env HOME=/sandbox bash -lc "case \":\${PATH}:\" in *:/home/linuxbrew/.linuxbrew/bin:*) exit 0 ;; *) exit 1 ;; esac"
 
 # Gate the exact completed base filesystem before it can be published.
 COPY scripts/checks/node-tar-image-scan.mts /scripts/checks/node-tar-image-scan.mts

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -948,17 +948,17 @@ RUN set -eu; \
 RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/runtime)" = "gateway:sandbox 2770" \
     && test ! -e /sandbox/.hermes/cron/executions.db \
     && umask 0007 \
-    && HERMES_HOME=/sandbox/.hermes gosu gateway /opt/hermes/.venv/bin/python -I \
+    && HERMES_HOME=/sandbox/.hermes /usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py cron-create
 
 RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/runtime/cron-executions.db)" = "gateway:sandbox 640" \
     && umask 0007 \
-    && HERMES_HOME=/sandbox/.hermes gosu sandbox /opt/hermes/.venv/bin/python -I \
+    && HERMES_HOME=/sandbox/.hermes /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py cron-backup
 
 RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/runtime/cron-executions.db)" = "sandbox:sandbox 660" \
     && umask 0007 \
-    && HERMES_HOME=/sandbox/.hermes gosu gateway /opt/hermes/.venv/bin/python -I \
+    && HERMES_HOME=/sandbox/.hermes /usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py cron-reopen
 
 RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/runtime/cron-executions.db)" = "sandbox:sandbox 660" \
@@ -972,17 +972,17 @@ RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/runtime/cron-executions.db)" = "
 # reopens that replacement for a write.
 RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/gateway)" = "gateway:sandbox 2770" \
     && umask 0007 \
-    && HERMES_HOME=/sandbox/.hermes gosu gateway /opt/hermes/.venv/bin/python -I \
+    && HERMES_HOME=/sandbox/.hermes /usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py discord-create
 
 RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/gateway/discord_message_recovery.db)" = "gateway:sandbox 660" \
     && umask 0007 \
-    && HERMES_HOME=/sandbox/.hermes gosu sandbox /opt/hermes/.venv/bin/python -I \
+    && HERMES_HOME=/sandbox/.hermes /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py discord-backup
 
 RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/gateway/discord_message_recovery.db)" = "sandbox:sandbox 660" \
     && umask 0007 \
-    && HERMES_HOME=/sandbox/.hermes gosu gateway /opt/hermes/.venv/bin/python -I \
+    && HERMES_HOME=/sandbox/.hermes /usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py discord-reopen
 
 RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/gateway/discord_message_recovery.db)" = "sandbox:sandbox 660" \
@@ -1139,6 +1139,6 @@ RUN set -eu; \
 # End completed-image security package verification.
 
 # start.sh handles privilege separation: runs as root initially, then drops
-# to 'gateway' user via gosu for the agent process. See start.sh.
+# to the 'gateway' user via setpriv for the agent process. See start.sh.
 ENTRYPOINT ["/usr/local/bin/nemoclaw-start"]
 CMD ["/bin/bash"]

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -3,7 +3,7 @@
 #
 # Hermes sandbox base image — expensive, rarely-changing layers.
 #
-# Contains: node:24-trixie-slim (OpenShell needs Node), apt packages, gosu,
+# Contains: node:24-trixie-slim (OpenShell needs Node), apt packages, setpriv,
 # user/group setup, .hermes directory structure, Hermes CLI, and the
 # dependencies for NemoClaw-supported Hermes integrations.
 #
@@ -13,7 +13,7 @@
 # ── When to rebuild ─────────────────────────────────────────────
 #   1. Hermes version bump      — run scripts/update-hermes-agent.sh
 #   2. New apt package needed   — add it to the apt-get install list
-#   3. gosu upgrade             — update URL, checksum, and version
+#   3. util-linux upgrade       — update the pinned apt package version
 #   4. node:24-trixie-slim digest rot — update-docker-pin.sh updates all
 #   5. npm upgrade              — update upgrade-bundled-npm.mts
 #   6. New .hermes subdirectory — add mkdir/chmod below
@@ -97,6 +97,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         iptables=1.8.11-2 \
         nftables=1.1.3-1 \
         libcap2-bin=1:2.75-10+deb13u1+b1 \
+        util-linux=2.41-5 \
         procps=2:4.0.4-9 \
         e2fsprogs=1.47.2-3+b11 \
         openssh-sftp-server=1:10.0p1-7+deb13u4 \
@@ -280,19 +281,9 @@ RUN node --experimental-strip-types /scripts/patch-bundled-npm-brace-expansion.m
 RUN node --experimental-strip-types /scripts/lib/patch-bundled-npm-ip-address.mts \
     --npm-root /usr/local/lib/node_modules/npm
 
-# gosu for privilege separation (gateway vs sandbox user).
-# Identical to OpenClaw base — pinned to 1.19 with checksum.
-# hadolint ignore=DL4006
-RUN arch="$(dpkg --print-architecture)" \
-    && case "$arch" in \
-        amd64) gosu_asset="gosu-amd64"; gosu_sha256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0" ;; \
-        arm64) gosu_asset="gosu-arm64"; gosu_sha256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
-        *) echo "Unsupported architecture for gosu: $arch" >&2; exit 1 ;; \
-    esac \
-    && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
-    && echo "${gosu_sha256}  /usr/local/bin/gosu" | sha256sum -c - \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu --version
+# setpriv runtime contract for gateway and sandbox privilege separation.
+RUN test -x /usr/bin/setpriv \
+    && /usr/bin/setpriv --version
 
 # Create sandbox user (matches OpenShell convention) and gateway user.
 # gateway is a member of the sandbox group so it can read Hermes config files

--- a/agents/langchain-deepagents-code/Dockerfile.base
+++ b/agents/langchain-deepagents-code/Dockerfile.base
@@ -91,6 +91,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         iptables=1.8.11-2 \
         nftables=1.1.3-1 \
         libcap2-bin=1:2.75-10+deb13u1+b1 \
+        util-linux=2.41-5 \
         procps=2:4.0.4-9 \
         e2fsprogs=1.47.2-3+b11 \
         openssh-sftp-server=1:10.0p1-7+deb13u4 \

--- a/docs/deployment/sandbox-hardening.mdx
+++ b/docs/deployment/sandbox-hardening.mdx
@@ -48,10 +48,11 @@ Enforce both limits at the container runtime when that residual risk matters to 
 
 The NemoClaw entrypoint drops dangerous capabilities from the process bounding set before it starts agent services.
 It removes `CAP_SYS_ADMIN`, `CAP_SYS_PTRACE`, `CAP_NET_RAW`, `CAP_DAC_OVERRIDE`, `CAP_SYS_CHROOT`, `CAP_FSETID`, `CAP_SETFCAP`, `CAP_MKNOD`, `CAP_AUDIT_WRITE`, and `CAP_NET_BIND_SERVICE`.
-When `setpriv` is available, the entrypoint also removes the remaining privilege-separation capabilities during the switch from root to the `sandbox` and `gateway` users.
+The managed images install `setpriv` from `util-linux` and require it for the switch from root to the `sandbox` and `gateway` users.
+When `CAP_SETPCAP` is available, the same `setpriv` operation also removes the remaining privilege-separation capabilities from the child process bounding set.
 
-The bounding-set drop is best effort: if `capsh` or `CAP_SETPCAP` is unavailable the entrypoint logs a warning and continues with the runtime-provided capability set.
-If `setpriv` is unavailable, the entrypoint falls back to `gosu`.
+The bounding-set drop is best effort: if `capsh` or `CAP_SETPCAP` is unavailable, the entrypoint logs a warning and still uses `setpriv` to change the user, group, and supplementary groups.
+When a root entrypoint must change identity, it fails closed if `setpriv` is missing instead of starting an agent service as root.
 
 To make the drop fail-closed instead, set `NEMOCLAW_REQUIRE_CAP_DROP=1` in the entrypoint environment: the agent then refuses to start unless the agent process tree's bounding set is verified free of the dangerous capabilities.
 This is opt-in because many hosts cannot drop capabilities, including cloud VMs, Docker Desktop, and WSL environments without `CAP_SETPCAP`.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2099,9 +2099,10 @@ When verifying gateway write access by hand, step down to the gateway UID with t
 
 ```bash
 setpriv --reuid=gateway --regid=gateway --init-groups -- sh -c 'echo ok >> /sandbox/.openclaw/openclaw.json'
-# or, where setpriv is unavailable:
-gosu gateway sh -c 'echo ok >> /sandbox/.openclaw/openclaw.json'
 ```
+
+If `setpriv` is unavailable, rebuild the sandbox from a NemoClaw-managed image that includes `util-linux`.
+When a root entrypoint must change identity, it fails closed if this required privilege-separation command is missing.
 
 Do not probe with `su -s /bin/sh gateway ...`: `su` does not initialize the gateway's supplementary groups the same way, so a group-write probe can spuriously report `EACCES` even when the mutable contract is intact.
 

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -431,14 +431,16 @@ Refer to the [Process Controls](https://docs.nvidia.com/openshell/latest/securit
 
 The entrypoint drops dangerous Linux capabilities from the bounding set at startup using `capsh`.
 This limits what capabilities any child process (gateway, sandbox, agent) can ever acquire.
-When the entrypoint switches from root to the `sandbox` and `gateway` users, it uses `setpriv` when available to remove the remaining privilege-separation capabilities from the child process at the same time as the user change.
+The managed images install `setpriv` from `util-linux` and require it when the entrypoint switches from root to the `sandbox` and `gateway` users.
+When `CAP_SETPCAP` is available, the same `setpriv` operation removes the remaining privilege-separation capabilities from the child process at the same time as the user change.
 
 The initial entrypoint drop removes `cap_sys_admin`, `cap_sys_ptrace`, `cap_net_raw`, `cap_dac_override`, `cap_sys_chroot`, `cap_fsetid`, `cap_setfcap`, `cap_mknod`, `cap_audit_write`, and `cap_net_bind_service`.
-During `setpriv` step-down, the child process also loses `cap_setuid`, `cap_setgid`, `cap_fowner`, `cap_chown`, and `cap_kill`.
+When the additional `setpriv` bounding-set drop runs, the child process also loses `cap_setuid`, `cap_setgid`, `cap_fowner`, `cap_chown`, and `cap_kill`.
 
-This behavior is best effort.
-If `capsh` is not available or `CAP_SETPCAP` is not in the bounding set, the entrypoint logs a warning and continues with the default capability set.
-If `setpriv` is unavailable, the entrypoint falls back to `gosu` and logs a warning that the remaining bounding-set capabilities were retained for the child process.
+The extra bounding-set capability drop is best effort.
+If `capsh` is not available or `CAP_SETPCAP` is not in the bounding set, the entrypoint logs a warning and retains the runtime-provided bounding set.
+The entrypoint still uses `setpriv` to change the user, group, and supplementary groups without the extra bounding-set drop.
+When a root entrypoint must change identity, it fails closed if `setpriv` is unavailable instead of starting an agent service as root.
 
 To make the drop fail-closed instead of best-effort, set `NEMOCLAW_REQUIRE_CAP_DROP=1` in the entrypoint environment.
 The agent then refuses to start unless it verifies that the agent process tree's bounding set is free of dangerous capabilities.
@@ -455,10 +457,10 @@ Refer to [Review Sandbox Hardening](../manage-sandboxes/configure-sandboxes/revi
 
 | Aspect | Detail |
 |---|---|
-| Default | The entrypoint drops dangerous capabilities at startup using `capsh`, then uses `setpriv` during user step-down when possible. Best-effort. |
+| Default | The entrypoint drops dangerous capabilities at startup using `capsh`, then requires `setpriv` for user step-down. When `CAP_SETPCAP` is unavailable, the user step-down continues without the extra privilege-separation bounding-set drop and logs a warning. |
 | What you can change | When launching with `docker run` directly, pass `--cap-drop=ALL --cap-add=NET_BIND_SERVICE` for stricter enforcement. In the standard NemoClaw onboarding flow, the entrypoint handles capability dropping automatically. |
-| Risk if relaxed | `CAP_SYS_ADMIN` and `CAP_SYS_PTRACE` expand kernel and process attack surface. `CAP_NET_RAW` allows raw socket access for network sniffing. `CAP_DAC_OVERRIDE` bypasses filesystem permission checks. If `capsh` or `setpriv` cannot run, the container retains more of the runtime-provided capability set. |
-| Recommendation | Run on an image that includes `capsh` and `setpriv` (the NemoClaw image includes them). For defense-in-depth, also pass `--cap-drop=ALL` at the container runtime level. |
+| Risk if relaxed | `CAP_SYS_ADMIN` and `CAP_SYS_PTRACE` expand kernel and process attack surface. `CAP_NET_RAW` allows raw socket access for network sniffing. `CAP_DAC_OVERRIDE` bypasses filesystem permission checks. If `capsh` cannot run or `CAP_SETPCAP` is unavailable, the container retains more of the runtime-provided capability set. |
+| Recommendation | Run on an image that includes `capsh` and `setpriv` (NemoClaw-managed images include them). For defense-in-depth, also pass `--cap-drop=ALL` at the container runtime level. |
 
 ### Gateway Process Isolation
 
@@ -468,7 +470,7 @@ An OpenShell-managed container has OpenShell as PID 1 and launches nonroot `nemo
 
 | Aspect | Detail |
 |---|---|
-| Default | Direct root entrypoints use `gosu gateway` for UID isolation. The OpenShell-managed topology runs the gateway and agent under the same sandbox UID because `no-new-privileges` prevents the nonroot entrypoint from changing users. |
+| Default | Direct root entrypoints use `setpriv` for gateway UID isolation. The OpenShell-managed topology runs the gateway and agent under the same sandbox UID because `no-new-privileges` prevents the nonroot entrypoint from changing users. |
 | What you can change | This is not a user-facing knob. The selected container topology determines whether the entrypoint can step down from root to the gateway UID. |
 | Risk if relaxed | A same-UID agent can signal peer processes and can attempt to imitate the expected gateway process shape. The root managed controller prevents PID-reuse mistakes, but it cannot prove provenance against a malicious same-UID process or provide the direct root-entrypoint restart seal for mutable config. |
 | Recommendation | Use a direct root-entrypoint deployment when separate gateway and agent UIDs are required. Treat the managed controller as authenticated lifecycle and exact-target safety, not as a same-UID provenance boundary. |

--- a/scripts/lib/sandbox-init.sh
+++ b/scripts/lib/sandbox-init.sh
@@ -247,7 +247,7 @@ lock_config_after_write() {
 # Kept (each load-bearing — do not drop without an entrypoint refactor):
 #   cap_chown, cap_fowner — needed to chown/chmod files we did not create
 #     after dropping cap_dac_override (see #2659).
-#   cap_setuid, cap_setgid — required by gosu to step down from root into
+#   cap_setuid, cap_setgid — required by setpriv to step down from root into
 #     the sandbox/gateway UIDs during entrypoint privilege separation.
 #   cap_kill — sandbox user signals gateway-user processes via the UID
 #     separation enforced by the entrypoint (see test 13 in
@@ -424,81 +424,85 @@ report_residual_capabilities() {
 }
 
 # ── Privilege step-down (issue #3280 follow-up) ──────────────────
-# Replaces direct `gosu <user>` invocations with `setpriv` so the load-
-# bearing caps (cap_setuid, cap_setgid, cap_fowner, cap_chown, cap_kill)
-# are stripped from the bounding set *atomically with* the setuid
-# transition. gosu cannot do this: dropping those caps before gosu
-# breaks its setuid() syscall, and after gosu we are non-root and have
-# already lost CAP_SETPCAP. setpriv performs reuid + bounding-set drop
-# in a single process, in the correct order, before exec.
+# Uses `setpriv` for every root-to-user transition. When CAP_SETPCAP is
+# available, setpriv also strips the load-bearing caps (cap_setuid,
+# cap_setgid, cap_fowner, cap_chown, cap_kill) from the bounding set atomically
+# with the setuid transition. setpriv performs both operations in the correct
+# order before exec.
 #
 # Two prefix arrays are populated at source time:
 #   STEP_DOWN_PREFIX_SANDBOX  — step down to the 'sandbox' user
 #   STEP_DOWN_PREFIX_GATEWAY  — step down to the 'gateway' user
 #
-# Callers use them like the old `gosu <user>` prefix:
+# Callers use them as a command prefix:
 #   exec "${STEP_DOWN_PREFIX_SANDBOX[@]}" "${NEMOCLAW_CMD[@]}"
 #   "${STEP_DOWN_PREFIX_SANDBOX[@]}" bash -c "..."
 #   nohup "${STEP_DOWN_PREFIX_GATEWAY[@]}" gateway run --port "$port" &
 #
-# Fallback: if setpriv is missing or CAP_SETPCAP isn't available, the
-# arrays fall back to plain `gosu <user>` and a warning is logged so the
-# residual bounding-set caps surface in the entrypoint log (matches the
-# residual-surface design of report_residual_capabilities).
+# If CAP_SETPCAP is unavailable, setpriv still changes identity and initializes
+# supplementary groups, but cannot remove the remaining load-bearing caps from
+# the bounding set. That case is logged consistently with
+# report_residual_capabilities. If setpriv itself is unavailable, the prefix
+# invokes a fail-closed helper instead of risking execution as root.
 # File-scope array declarations: bash 3.2 (macOS) does not accept `declare -g`,
 # but plain assignment at file scope is global by default. Inside
 # init_step_down_prefixes() we re-assign these without `local`, which targets
 # the globals in both bash 3.2 and 4+.
 #
-# Initialize to the gosu fallback (NOT empty) so callers cannot accidentally
+# Initialize to the fail-closed helper (NOT empty) so callers cannot accidentally
 # `exec "${STEP_DOWN_PREFIX_SANDBOX[@]}" "${NEMOCLAW_CMD[@]}"` with an unset
 # array — which would expand to nothing and run NEMOCLAW_CMD as root (privesc
-# regression). init_step_down_prefixes() below upgrades to setpriv when
-# CAP_SETPCAP is available; otherwise these stay at the gosu defaults.
+# regression).
 # shellcheck disable=SC2034  # consumed by scripts/nemoclaw-start.sh and agents/hermes/start.sh
-STEP_DOWN_PREFIX_SANDBOX=(gosu sandbox)
+STEP_DOWN_PREFIX_SANDBOX=(
+  /bin/sh -c 'echo "[SECURITY] setpriv unavailable: refusing to execute a root privilege transition" >&2; exit 1' --
+)
 # shellcheck disable=SC2034  # consumed by scripts/nemoclaw-start.sh and agents/hermes/start.sh
-STEP_DOWN_PREFIX_GATEWAY=(gosu gateway)
+STEP_DOWN_PREFIX_GATEWAY=(
+  /bin/sh -c 'echo "[SECURITY] setpriv unavailable: refusing to execute a root privilege transition" >&2; exit 1' --
+)
 
 init_step_down_prefixes() {
-  if command -v setpriv >/dev/null 2>&1 \
-    && command -v capsh >/dev/null 2>&1 \
-    && capsh --has-p=cap_setpcap 2>/dev/null; then
-    # setpriv cap names are unprefixed (per `setpriv --list`); capsh uses
-    # cap_* names. Keep them in sync but format-distinct.
-    #
-    # --init-groups (NOT --clear-groups): gateway is a member of the sandbox
-    # group via `usermod -aG sandbox gateway` in Dockerfile.base so it can
-    # write the chmod 660 /sandbox/.openclaw/openclaw.json (setgid'd
-    # config dir, see #2681). --clear-groups would strip that membership
-    # and break mutateConfigFile / control-UI config edits with EACCES.
-    # --init-groups matches gosu's setgroups+initgroups behavior and
-    # restores exactly the groups defined in /etc/group for the target user.
-    #
-    # NOTE (#4538): to verify the group-write contract as the gateway UID, use
-    # the image's installed step-down mechanism — `setpriv --reuid=gateway
-    # --regid=gateway --init-groups` (or `gosu gateway`). Do NOT probe with
-    # `su -s /bin/sh gateway ...`: su does not run init_groups the same way and
-    # will not reflect the gateway's sandbox-group membership, so a group-write
-    # probe can spuriously EACCES even though the mutable contract is intact.
-    local drop="-setuid,-setgid,-fowner,-chown,-kill"
+  local setpriv_path
+  if ! setpriv_path="$(command -v setpriv 2>/dev/null)" || [ -z "$setpriv_path" ]; then
+    echo "[SECURITY WARNING] setpriv unavailable: root privilege transitions will fail closed" >&2
     # shellcheck disable=SC2034  # consumed by entrypoint scripts (cross-file)
     STEP_DOWN_PREFIX_SANDBOX=(
-      setpriv "--reuid=sandbox" "--regid=sandbox" --init-groups
-      "--bounding-set=$drop" --
+      /bin/sh -c 'echo "[SECURITY] setpriv unavailable: refusing to execute a root privilege transition" >&2; exit 1' --
     )
     # shellcheck disable=SC2034  # consumed by entrypoint scripts (cross-file)
     STEP_DOWN_PREFIX_GATEWAY=(
-      setpriv "--reuid=gateway" "--regid=gateway" --init-groups
-      "--bounding-set=$drop" --
+      /bin/sh -c 'echo "[SECURITY] setpriv unavailable: refusing to execute a root privilege transition" >&2; exit 1' --
     )
-  else
-    echo "[SECURITY WARNING] setpriv or CAP_SETPCAP unavailable — falling back to gosu (bounding set will retain cap_setuid/setgid/fowner/chown/kill — issue #3280)" >&2
-    # shellcheck disable=SC2034  # consumed by entrypoint scripts (cross-file)
-    STEP_DOWN_PREFIX_SANDBOX=(gosu sandbox)
-    # shellcheck disable=SC2034  # consumed by entrypoint scripts (cross-file)
-    STEP_DOWN_PREFIX_GATEWAY=(gosu gateway)
+    return 0
   fi
+
+  # --init-groups (NOT --clear-groups): gateway is a member of the sandbox
+  # group via `usermod -aG sandbox gateway` in Dockerfile.base so it can write
+  # the chmod 660 /sandbox/.openclaw/openclaw.json. --clear-groups would strip
+  # that membership and break config edits with EACCES.
+  local -a sandbox_prefix=(
+    "$setpriv_path" "--reuid=sandbox" "--regid=sandbox" --init-groups
+  )
+  local -a gateway_prefix=(
+    "$setpriv_path" "--reuid=gateway" "--regid=gateway" --init-groups
+  )
+
+  if command -v capsh >/dev/null 2>&1 && capsh --has-p=cap_setpcap 2>/dev/null; then
+    # setpriv cap names are unprefixed (per `setpriv --list`); capsh uses cap_*.
+    local drop="-setuid,-setgid,-fowner,-chown,-kill"
+    sandbox_prefix+=("--bounding-set=$drop")
+    gateway_prefix+=("--bounding-set=$drop")
+  else
+    echo "[SECURITY WARNING] CAP_SETPCAP unavailable: setpriv will change identity without dropping the remaining privilege-separation capabilities from the bounding set" >&2
+  fi
+
+  sandbox_prefix+=(--)
+  gateway_prefix+=(--)
+  # shellcheck disable=SC2034  # consumed by entrypoint scripts (cross-file)
+  STEP_DOWN_PREFIX_SANDBOX=("${sandbox_prefix[@]}")
+  # shellcheck disable=SC2034  # consumed by entrypoint scripts (cross-file)
+  STEP_DOWN_PREFIX_GATEWAY=("${gateway_prefix[@]}")
 }
 init_step_down_prefixes
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -5577,7 +5577,7 @@ fi
 
 # ── Non-root fallback ──────────────────────────────────────────
 # OpenShell runs containers with --security-opt=no-new-privileges, which
-# blocks gosu's setuid syscall. When we're not root, skip privilege
+# blocks setpriv's setuid syscall. When we're not root, skip privilege
 # separation and run everything as the current user (sandbox).
 # Gateway process isolation is not available in this mode.
 if [ "$(id -u)" -ne 0 ]; then
@@ -5766,7 +5766,7 @@ ensure_runtime_shell_env_shim
 lock_rc_files "$_SANDBOX_HOME"
 # Apply manifest-declared runtime env aliases before any child (the one-shot
 # "${NEMOCLAW_CMD[@]}" exec or the stepped-down gateway) inherits the env.
-# gosu/setpriv preserve the environment, so the export reaches the gateway user.
+# setpriv preserves the environment, so the export reaches the gateway user.
 apply_messaging_runtime_env_aliases
 
 # Messaging channel config was announced before placeholder refresh so the

--- a/src/lib/agent/gateway-script-shared.test.ts
+++ b/src/lib/agent/gateway-script-shared.test.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { gatewayLaunchCommand } from "./gateway-script-shared";
+
+describe("gatewayLaunchCommand", () => {
+  it("uses setpriv for a requested root-to-user transition", () => {
+    const command = gatewayLaunchCommand("agent gateway run --port 19000", "gateway");
+
+    expect(command).toContain(
+      "/usr/bin/setpriv --reuid='gateway' --regid='gateway' --init-groups -- agent gateway run --port 19000",
+    );
+    expect(command).not.toContain("gosu");
+  });
+
+  it("fails closed instead of launching as root when setpriv or the target user is unavailable", () => {
+    const command = gatewayLaunchCommand("agent gateway run", "gateway");
+
+    expect(command).toContain("setpriv or target user unavailable; refusing root gateway launch");
+    expect(command).toContain("exit 1");
+  });
+
+  it("does not add an identity transition when no user is requested", () => {
+    const command = gatewayLaunchCommand("agent gateway run");
+
+    expect(command).not.toContain("setpriv");
+    expect(command).toContain('nohup agent gateway run >> "$_GATEWAY_LOG" 2>&1 &');
+  });
+});

--- a/src/lib/agent/gateway-script-shared.ts
+++ b/src/lib/agent/gateway-script-shared.ts
@@ -81,7 +81,8 @@ export function gatewayLaunchCommand(command: string, runAsUser?: string): strin
   if (!runAsUser) {
     return `${logSelection} ${userLaunch}`;
   }
-  return `${logSelection} if [ "$(id -u)" = "0" ] && command -v gosu >/dev/null 2>&1 && id ${shellQuote(runAsUser)} >/dev/null 2>&1; then nohup gosu ${shellQuote(runAsUser)} ${command} >> "$_GATEWAY_LOG" 2>&1 & else ${userLaunch} fi;`;
+  const user = shellQuote(runAsUser);
+  return `${logSelection} if [ "$(id -u)" = "0" ]; then if [ -x /usr/bin/setpriv ] && id ${user} >/dev/null 2>&1; then nohup /usr/bin/setpriv --reuid=${user} --regid=${user} --init-groups -- ${command} >> "$_GATEWAY_LOG" 2>&1 & else echo "[gateway-recovery] ERROR: setpriv or target user unavailable; refusing root gateway launch" >&2; exit 1; fi; else ${userLaunch} fi;`;
 }
 
 export { buildGatewayGuardRecoveryLines };

--- a/src/lib/agent/runtime.test.ts
+++ b/src/lib/agent/runtime.test.ts
@@ -233,8 +233,7 @@ describe("buildRecoveryScript", () => {
       const script = buildRecoveryScript(minimalAgent, 19000);
       expect(script).not.toContain("chown gateway:gateway /tmp/gateway.log");
       expect(script).not.toContain("chown 'gateway:gateway' /tmp/gateway.log");
-      expect(script).not.toContain("gosu gateway");
-      expect(script).not.toContain("gosu 'gateway'");
+      expect(script).not.toContain("--reuid=gateway");
     });
   });
 });

--- a/src/lib/onboard/managed-startup-sandbox-prefix.test.ts
+++ b/src/lib/onboard/managed-startup-sandbox-prefix.test.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const childProcessMock = vi.hoisted(() => ({ spawnSync: vi.fn() }));
+vi.mock("node:child_process", () => childProcessMock);
+
+import { managedStartupSandboxPrefix } from "./managed-startup/image-runtime";
+
+function setprivStat(
+  overrides: Partial<Pick<fs.Stats, "gid" | "mode" | "uid">> & {
+    file?: boolean;
+    symbolicLink?: boolean;
+  } = {},
+): fs.Stats {
+  return {
+    gid: overrides.gid ?? 0,
+    isFile: () => overrides.file ?? true,
+    isSymbolicLink: () => overrides.symbolicLink ?? false,
+    mode: overrides.mode ?? 0o755,
+    uid: overrides.uid ?? 0,
+  } as fs.Stats;
+}
+
+describe("managed startup sandbox identity prefix", () => {
+  beforeEach(() => {
+    childProcessMock.spawnSync.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the trusted setpriv path with numeric sandbox identity arguments", () => {
+    vi.spyOn(fs, "lstatSync").mockReturnValue(setprivStat());
+    childProcessMock.spawnSync.mockImplementation((_command, args) => ({
+      status: 0,
+      stdout: args[0] === "-u" ? "1000\n" : "1001\n",
+    }));
+
+    expect(managedStartupSandboxPrefix()).toEqual([
+      "/usr/bin/setpriv",
+      "--reuid=1000",
+      "--regid=1001",
+      "--init-groups",
+      "--",
+    ]);
+    expect(childProcessMock.spawnSync.mock.calls).toEqual([
+      ["/usr/bin/id", ["-u", "sandbox"], { encoding: "utf8", env: { PATH: expect.any(String) } }],
+      ["/usr/bin/id", ["-g", "sandbox"], { encoding: "utf8", env: { PATH: expect.any(String) } }],
+    ]);
+  });
+
+  it.each([
+    ["is missing", null],
+    ["is a symbolic link", setprivStat({ symbolicLink: true })],
+    ["is not a regular file", setprivStat({ file: false })],
+    ["is writable by its group", setprivStat({ mode: 0o775 })],
+    ["is writable by other users", setprivStat({ mode: 0o757 })],
+    ["is not executable", setprivStat({ mode: 0o644 })],
+    ["is not owned by root", setprivStat({ uid: 1000 })],
+    ["is not in the root group", setprivStat({ gid: 1000 })],
+  ] as const)("fails before identity lookup when setpriv %s", (_label, stat) => {
+    vi.spyOn(fs, "lstatSync").mockImplementation(() => {
+      if (stat) return stat;
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+
+    expect(() => managedStartupSandboxPrefix()).toThrow("a trusted setpriv executable is required");
+    expect(childProcessMock.spawnSync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["zero", "0\n", 0],
+    ["non-numeric", "sandbox\n", 0],
+    ["lookup failure", "", 1],
+  ] as const)("rejects a %s sandbox identity", (_label, stdout, status) => {
+    vi.spyOn(fs, "lstatSync").mockReturnValue(setprivStat());
+    childProcessMock.spawnSync.mockReturnValue({ status, stdout });
+
+    expect(() => managedStartupSandboxPrefix()).toThrow("could not resolve the sandbox account");
+  });
+});

--- a/src/lib/onboard/managed-startup-sandbox-prefix.test.ts
+++ b/src/lib/onboard/managed-startup-sandbox-prefix.test.ts
@@ -54,7 +54,6 @@ describe("managed startup sandbox identity prefix", () => {
   });
 
   it.each([
-    ["is missing", null],
     ["is a symbolic link", setprivStat({ symbolicLink: true })],
     ["is not a regular file", setprivStat({ file: false })],
     ["is writable by its group", setprivStat({ mode: 0o775 })],
@@ -63,8 +62,14 @@ describe("managed startup sandbox identity prefix", () => {
     ["is not owned by root", setprivStat({ uid: 1000 })],
     ["is not in the root group", setprivStat({ gid: 1000 })],
   ] as const)("fails before identity lookup when setpriv %s", (_label, stat) => {
+    vi.spyOn(fs, "lstatSync").mockReturnValue(stat);
+
+    expect(() => managedStartupSandboxPrefix()).toThrow("a trusted setpriv executable is required");
+    expect(childProcessMock.spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("fails before identity lookup when setpriv is missing", () => {
     vi.spyOn(fs, "lstatSync").mockImplementation(() => {
-      if (stat) return stat;
       throw Object.assign(new Error("missing"), { code: "ENOENT" });
     });
 

--- a/src/lib/onboard/managed-startup/image-runtime.ts
+++ b/src/lib/onboard/managed-startup/image-runtime.ts
@@ -438,9 +438,6 @@ function readSandboxIdentity(): { readonly uid: string; readonly gid: string } {
 }
 
 function sandboxPrefix(): readonly string[] {
-  if (trustedExecutable("/usr/local/bin/gosu")) {
-    return ["/usr/local/bin/gosu", "sandbox"];
-  }
   if (trustedExecutable("/usr/bin/setpriv")) {
     const identity = readSandboxIdentity();
     return [
@@ -451,7 +448,7 @@ function sandboxPrefix(): readonly string[] {
       "--",
     ];
   }
-  return fail("a trusted gosu or setpriv executable is required");
+  return fail("a trusted setpriv executable is required");
 }
 
 function commandEnvironment(

--- a/src/lib/onboard/managed-startup/image-runtime.ts
+++ b/src/lib/onboard/managed-startup/image-runtime.ts
@@ -437,7 +437,7 @@ function readSandboxIdentity(): { readonly uid: string; readonly gid: string } {
   return { uid: readId("-u"), gid: readId("-g") };
 }
 
-function sandboxPrefix(): readonly string[] {
+export function managedStartupSandboxPrefix(): readonly string[] {
   if (trustedExecutable("/usr/bin/setpriv")) {
     const identity = readSandboxIdentity();
     return [
@@ -482,7 +482,7 @@ function execute(
   capture = false,
 ): CommandResult {
   if (argv.length === 0) fail("refusing an empty managed startup command");
-  const command = runAs === "sandbox" ? [...sandboxPrefix(), ...argv] : [...argv];
+  const command = runAs === "sandbox" ? [...managedStartupSandboxPrefix(), ...argv] : [...argv];
   const result = spawnSync(command[0] as string, command.slice(1), {
     encoding: "utf8",
     env: commandEnvironment(configurationEnvironment, applicationRuntime),

--- a/src/lib/shields/openclaw-config-lock.test.ts
+++ b/src/lib/shields/openclaw-config-lock.test.ts
@@ -56,7 +56,7 @@ function createExec(
           case "test":
             return { status: installed ? 0 : 1, signal: null, stdout: "", stderr: "" };
         }
-        return cmd.includes("gosu") ? validationResult : guardResult(cmd);
+        return cmd.includes("/usr/bin/setpriv") ? validationResult : guardResult(cmd);
       },
     },
   };
@@ -120,8 +120,11 @@ describe("OpenClaw top-config guard host wiring", () => {
       "--signal=TERM",
       "--kill-after=5s",
       "30s",
-      "gosu",
-      "gateway",
+      "/usr/bin/setpriv",
+      "--reuid=gateway",
+      "--regid=gateway",
+      "--init-groups",
+      "--",
       "sh",
       "-c",
       expect.stringContaining("openclaw config validate --json"),

--- a/src/lib/shields/openclaw-config-lock.ts
+++ b/src/lib/shields/openclaw-config-lock.ts
@@ -146,7 +146,17 @@ export function validateOpenClawConfigCandidate(
     ];
   }
   const result = privileged.run(
-    [...SCHEMA_VALIDATION_TIMEOUT, "gosu", "gateway", "sh", "-c", SCHEMA_VALIDATION_SCRIPT],
+    [
+      ...SCHEMA_VALIDATION_TIMEOUT,
+      "/usr/bin/setpriv",
+      "--reuid=gateway",
+      "--regid=gateway",
+      "--init-groups",
+      "--",
+      "sh",
+      "-c",
+      SCHEMA_VALIDATION_SCRIPT,
+    ],
     input,
   );
   let payload: unknown;

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -49,7 +49,8 @@ fi
 
 # Helper: run a command inside the container as the sandbox user
 run_as_sandbox() {
-  docker run --rm --entrypoint "" "$IMAGE" gosu sandbox bash -c "$1" 2>&1
+  docker run --rm --entrypoint "" "$IMAGE" /usr/bin/setpriv \
+    --reuid=sandbox --regid=sandbox --init-groups -- bash -c "$1" 2>&1
 }
 
 # Helper: run a command inside the container as root
@@ -120,14 +121,14 @@ else
   fail "sandbox cannot write to config hash — should be writable: $OUT"
 fi
 
-# ── Test 7: gosu is installed ────────────────────────────────────
+# ── Test 7: setpriv is installed and gosu is absent ──────────────
 
-info "7. gosu binary is available"
-OUT=$(run_as_root "command -v gosu && gosu --version")
-if echo "$OUT" | grep -q "gosu"; then
-  pass "gosu installed"
+info "7. setpriv is available and gosu is absent"
+OUT=$(run_as_root "test -x /usr/bin/setpriv && /usr/bin/setpriv --version && ! command -v gosu")
+if echo "$OUT" | grep -q "setpriv"; then
+  pass "setpriv installed; gosu absent"
 else
-  fail "gosu not found: $OUT"
+  fail "setpriv/gosu runtime contract failed: $OUT"
 fi
 
 # ── Test 8: Entrypoint PATH is locked to system dirs ─────────────
@@ -144,7 +145,7 @@ fi
 # ── Test 9: openclaw resolves to expected absolute path ──────────
 
 info "9. Gateway runs the expected openclaw binary"
-OUT=$(run_as_root "gosu gateway which openclaw")
+OUT=$(run_as_root "/usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- which openclaw")
 if [ "$OUT" = "/usr/local/bin/openclaw" ]; then
   pass "openclaw resolves to /usr/local/bin/openclaw"
 else
@@ -192,10 +193,10 @@ fi
 info "13. Sandbox user cannot kill gateway-user processes"
 # Start a dummy process as gateway, try to kill it as sandbox
 OUT=$(docker run --rm --entrypoint "" "$IMAGE" bash -c '
-  gosu gateway sleep 60 &
+  /usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- sleep 60 &
   GW_PID=$!
   sleep 0.5
-  RESULT=$(gosu sandbox kill $GW_PID 2>&1 || echo "EPERM")
+  RESULT=$(/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- kill $GW_PID 2>&1 || echo "EPERM")
   echo "$RESULT"
   kill $GW_PID 2>/dev/null || true
 ')
@@ -252,8 +253,8 @@ info "14. Entrypoint drops the full issue #3280 dangerous-cap inventory from san
 # step-down: (1) the entrypoint-wide capsh drop in drop_capabilities()
 # and (2) the per-user setpriv drop in STEP_DOWN_PREFIX_SANDBOX. The
 # previous test (#3328) only exercised stage 1 and classified
-# CAP_FOWNER/SETUID/SETGID as load-bearing because gosu needed them;
-# the follow-up replaces gosu with setpriv so those three drop
+# CAP_FOWNER/SETUID/SETGID as load-bearing for the user transition;
+# setpriv removes those capabilities atomically during the transition
 # atomically with reuid, and ALL eight issue-named caps must be absent.
 #
 # IMPORTANT: docker's default bounding set already excludes CAP_SYS_ADMIN
@@ -452,7 +453,7 @@ OUT=$(docker run --rm --entrypoint "" "$IMAGE" bash -c '
   echo "# proxy config placeholder" > /tmp/nemoclaw-proxy-env.sh
   chown root:root /tmp/nemoclaw-proxy-env.sh
   chmod 444 /tmp/nemoclaw-proxy-env.sh
-  gosu sandbox bash -c "echo test >> /tmp/nemoclaw-proxy-env.sh 2>&1; echo EXIT=\$?"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- bash -c "echo test >> /tmp/nemoclaw-proxy-env.sh 2>&1; echo EXIT=\$?"
 ' 2>&1)
 if echo "$OUT" | grep -q "EXIT=1\|Permission denied"; then
   pass "sandbox user cannot write to /tmp/nemoclaw-proxy-env.sh"
@@ -517,8 +518,8 @@ OUT=$(docker run --rm --entrypoint "" "$IMAGE" bash -c '
   chmod 444 /tmp/nemoclaw-proxy-env.sh
   echo "ROOT_BASH_IC=$(bash -ic "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
   echo "ROOT_BASH_LC=$(bash -lc "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
-  echo "SANDBOX_BASH_IC=$(gosu sandbox bash -ic "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
-  echo "SANDBOX_BASH_LC=$(gosu sandbox bash -lc "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
+  echo "SANDBOX_BASH_IC=$(/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- bash -ic "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
+  echo "SANDBOX_BASH_LC=$(/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- bash -lc "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
 ' 2>&1)
 EXPECTED="https://probe.invalid:9999"
 if echo "$OUT" | grep -qE "ROOT_BASH_IC=$EXPECTED" \
@@ -530,16 +531,16 @@ else
   fail "proxy env not set in all bash modes (#2704): $OUT"
 fi
 
-# ── Test 27: Non-root mode executes without gosu ──────────────────
-# The entrypoint detects uid != 0, skips gosu, and execs the command directly.
+# ── Test 27: Non-root mode executes without privilege step-down ───
+# The entrypoint detects uid != 0, skips setpriv, and executes directly.
 # Use the image's actual sandbox uid/gid here: the system-assigned sandbox uid
 # is not guaranteed to be 1000 on every runner, and the non-root fallback is
 # designed to run as that sandbox user.
 
-info "27. Non-root mode executes command without gosu"
+info "27. Non-root mode executes command without setpriv"
 OUT=$(docker run --rm --user "${SB_UID}:${SB_GID}" "$IMAGE" bash -c 'printf "%s\n" "NON_ROOT_EXEC_OK"; sleep 0.2' 2>&1 || true)
 if echo "$OUT" | grep -q "NON_ROOT_EXEC_OK"; then
-  pass "non-root mode executed command directly (no gosu)"
+  pass "non-root mode executed command directly (no setpriv)"
 else
   fail "non-root command execution failed: $OUT"
 fi
@@ -624,15 +625,15 @@ OUT=$(docker run --rm --cap-drop DAC_OVERRIDE --entrypoint bash "$IMAGE" -lc '
   source /tmp/normalize.sh
   capsh --has-p=cap_setgid
   capsh --has-p=cap_setuid
-  gosu sandbox sh -c "printf baseline > /sandbox/.openclaw/openclaw.json.nemoclaw-baseline; chmod 600 /sandbox/.openclaw/openclaw.json.nemoclaw-baseline"
-  gosu sandbox chmod 600 /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash
-  gosu sandbox chmod 700 /sandbox/.openclaw
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "printf baseline > /sandbox/.openclaw/openclaw.json.nemoclaw-baseline; chmod 600 /sandbox/.openclaw/openclaw.json.nemoclaw-baseline"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- chmod 600 /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- chmod 700 /sandbox/.openclaw
   normalize_mutable_config_perms
-  gosu sandbox sh -c "test \"\$(stat -c %a /sandbox/.openclaw)\" = 2770"
-  gosu sandbox sh -c "test \"\$(stat -c %a /sandbox/.openclaw/openclaw.json)\" = 660"
-  gosu sandbox sh -c "test \"\$(stat -c %a /sandbox/.openclaw/.config-hash)\" = 660"
-  gosu sandbox sh -c "test \"\$(stat -c \"%a %U:%G\" /sandbox/.openclaw/openclaw.json.nemoclaw-baseline)\" = \"440 root:sandbox\""
-  gosu gateway sh -c "printf \" \" >>/sandbox/.openclaw/openclaw.json"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "test \"\$(stat -c %a /sandbox/.openclaw)\" = 2770"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "test \"\$(stat -c %a /sandbox/.openclaw/openclaw.json)\" = 660"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "test \"\$(stat -c %a /sandbox/.openclaw/.config-hash)\" = 660"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "test \"\$(stat -c \"%a %U:%G\" /sandbox/.openclaw/openclaw.json.nemoclaw-baseline)\" = \"440 root:sandbox\""
+  /usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- sh -c "printf \" \" >>/sandbox/.openclaw/openclaw.json"
   printf "ONESHOT_DAC_REPAIR_OK\n"
 ' 2>&1 || true)
 if echo "$OUT" | grep -q "ONESHOT_DAC_REPAIR_OK"; then
@@ -718,7 +719,7 @@ OUT=$(docker run --rm --entrypoint bash "$IMAGE" -lc '
   source /tmp/normalize.sh
   rm -f /sandbox/.openclaw/openclaw.json.nemoclaw-baseline
   normalize_mutable_config_perms
-  gosu sandbox sh -c "rm -f /sandbox/.openclaw/openclaw.json.nemoclaw-baseline; printf \"{\\\"safe\\\":true}\\n\" > /sandbox/baseline-hardlink-target; chmod 640 /sandbox/baseline-hardlink-target; ln /sandbox/baseline-hardlink-target /sandbox/.openclaw/openclaw.json.nemoclaw-baseline"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "rm -f /sandbox/.openclaw/openclaw.json.nemoclaw-baseline; printf \"{\\\"safe\\\":true}\\n\" > /sandbox/baseline-hardlink-target; chmod 640 /sandbox/baseline-hardlink-target; ln /sandbox/baseline-hardlink-target /sandbox/.openclaw/openclaw.json.nemoclaw-baseline"
   before=$(stat -c "%u %g %a" /sandbox/baseline-hardlink-target)
   [ "$(stat -c "%h" /sandbox/baseline-hardlink-target)" -eq 2 ]
   write_openclaw_config_baseline
@@ -768,9 +769,9 @@ PY_INJECT_HANDOFF_RACE
   } >/tmp/normalize.sh
   source /tmp/normalize.sh
   find /sandbox/.openclaw -mindepth 1 -delete
-  gosu sandbox sh -c "printf \"{}\\n\" > /sandbox/.openclaw/openclaw.json; printf \"hash\\n\" > /sandbox/.openclaw/.config-hash"
-  gosu sandbox chmod 600 /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash
-  gosu sandbox chmod 700 /sandbox/.openclaw
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "printf \"{}\\n\" > /sandbox/.openclaw/openclaw.json; printf \"hash\\n\" > /sandbox/.openclaw/.config-hash"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- chmod 600 /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- chmod 700 /sandbox/.openclaw
   rc=0
   normalize_mutable_config_perms || rc=$?
   [ "$rc" -eq 1 ]
@@ -799,8 +800,8 @@ OUT=$(docker run --rm --entrypoint bash "$IMAGE" -lc '
   printf "protected\n" >/sandbox/recovery-protected
   chmod 600 /sandbox/recovery-protected
   chown root:root /sandbox/recovery-protected
-  gosu sandbox rm -f /sandbox/.openclaw/openclaw.json
-  gosu sandbox ln -s /sandbox/recovery-protected /sandbox/.openclaw/openclaw.json
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- rm -f /sandbox/.openclaw/openclaw.json
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- ln -s /sandbox/recovery-protected /sandbox/.openclaw/openclaw.json
   before=$(stat -c "%U:%G:%a" /sandbox/recovery-protected):$(cat /sandbox/recovery-protected)
   rc=0
   recover_openclaw_config_if_empty || rc=$?
@@ -884,7 +885,7 @@ OUT=$(docker run --rm --entrypoint bash "$IMAGE" -lc '
   [ "$(stat -c "%a %U:%G" /sandbox/.openclaw)" = "2770 sandbox:sandbox" ]
   [ "$(stat -c "%a %U:%G" /sandbox/.openclaw/openclaw.json)" = "660 sandbox:sandbox" ]
   [ "$(stat -c "%a %U:%G" /sandbox/.openclaw/.config-hash)" = "660 sandbox:sandbox" ]
-  gosu sandbox sh -c "printf \" \" >>/sandbox/.openclaw/openclaw.json; touch /sandbox/.openclaw/reclaim-write-check"
+  /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "printf \" \" >>/sandbox/.openclaw/openclaw.json; touch /sandbox/.openclaw/reclaim-write-check"
 
   chown root:root /sandbox/.openclaw /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash
   chmod 755 /sandbox/.openclaw
@@ -893,7 +894,7 @@ OUT=$(docker run --rm --entrypoint bash "$IMAGE" -lc '
   sealed_before=$(stat -c "%u %g %a" /sandbox/.openclaw /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash)
   normalize_mutable_config_perms
   [ "$sealed_before" = "$(stat -c "%u %g %a" /sandbox/.openclaw /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash)" ]
-  ! gosu sandbox sh -c "printf x >>/sandbox/.openclaw/openclaw.json"
+  ! /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c "printf x >>/sandbox/.openclaw/openclaw.json"
 
   chmod 644 /sandbox/.openclaw/openclaw.json
   ambiguous_before=$(stat -c "%u %g %a" /sandbox/.openclaw /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash)

--- a/test/e2e/live/hermes-e2e.test.ts
+++ b/test/e2e/live/hermes-e2e.test.ts
@@ -599,9 +599,9 @@ test("hermes-e2e: install.sh onboards Hermes and proves health plus live inferen
           "set -eu",
           `marker=${shellQuote(envMarker)}`,
           `backup=${shellQuote(envBackup)}`,
-          "command -v gosu >/dev/null 2>&1",
-          'gosu sandbox cp /sandbox/.hermes/.env "$backup"',
-          'gosu sandbox sh -lc \'printf "\\nNEMOCLAW_E2E_RESTART_MARKER=%s\\n" "$1" >> /sandbox/.hermes/.env\' sh "$marker"',
+          "test -x /usr/bin/setpriv",
+          '/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- cp /sandbox/.hermes/.env "$backup"',
+          '/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -lc \'printf "\\nNEMOCLAW_E2E_RESTART_MARKER=%s\\n" "$1" >> /sandbox/.hermes/.env\' sh "$marker"',
         ].join("; "),
       ),
       {
@@ -640,7 +640,7 @@ test("hermes-e2e: install.sh onboards Hermes and proves health plus live inferen
         [
           "set -eu",
           `backup=${shellQuote(envBackup)}`,
-          'gosu sandbox sh -c \'cat "$1" > /sandbox/.hermes/.env && rm -f "$1"\' sh "$backup"',
+          '/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -c \'cat "$1" > /sandbox/.hermes/.env && rm -f "$1"\' sh "$backup"',
           "sha256sum -c /etc/nemoclaw/hermes.config-hash --status",
           "echo ENV_RESTORED",
         ].join("; "),

--- a/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
+++ b/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
@@ -216,7 +216,7 @@ async function assertRuntimeLayout(probe: DockerProbe, container: string): Promi
     probe,
     container,
     "gateway user cannot write required Hermes v0.14 directories",
-    'gosu gateway sh -lc \'for dir in hooks image_cache audio_cache logs/curator; do p="/sandbox/.hermes/$dir/.nemoclaw-write-test"; : >"$p" && rm -f "$p"; done\'',
+    '/usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- sh -lc \'for dir in hooks image_cache audio_cache logs/curator; do p="/sandbox/.hermes/$dir/.nemoclaw-write-test"; : >"$p" && rm -f "$p"; done\'',
   );
   await expectContainerSh(
     probe,
@@ -228,7 +228,7 @@ async function assertRuntimeLayout(probe: DockerProbe, container: string): Promi
     probe,
     container,
     "gateway user was able to remove config.yaml",
-    "gosu gateway rm /sandbox/.hermes/config.yaml",
+    "/usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- rm /sandbox/.hermes/config.yaml",
   );
   await expectContainerSh(
     probe,

--- a/test/hermes-discord-recovery-permissions.test.ts
+++ b/test/hermes-discord-recovery-permissions.test.ts
@@ -181,11 +181,11 @@ describe("Hermes cross-UID ledger permissions", () => {
       `stat -c '%U:%G %a' /sandbox/.hermes/gateway)" = "gateway:sandbox 2770"`,
     );
     expect(dockerfile).toContain(
-      "gosu gateway /opt/hermes/.venv/bin/python -I \\\n" +
+      "/usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- /opt/hermes/.venv/bin/python -I \\\n" +
         "        /opt/nemoclaw-hermes-config/image-build-probes.py discord-create",
     );
     expect(dockerfile).toContain(
-      "gosu sandbox /opt/hermes/.venv/bin/python -I \\\n" +
+      "/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- /opt/hermes/.venv/bin/python -I \\\n" +
         "        /opt/nemoclaw-hermes-config/image-build-probes.py discord-backup",
     );
     const discordBackup = imageBuildProbes.slice(

--- a/test/nemoclaw-start-gateway-health.test.ts
+++ b/test/nemoclaw-start-gateway-health.test.ts
@@ -611,9 +611,13 @@ describe("gateway launch wiring (#4710)", () => {
       `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(openclawLog)}\nexec sleep 30\n`,
       { mode: 0o755 },
     );
-    fs.writeFileSync(path.join(fakeBin, "gosu"), `#!/usr/bin/env bash\nshift\nexec "$@"\n`, {
-      mode: 0o755,
-    });
+    fs.writeFileSync(
+      path.join(fakeBin, "setpriv"),
+      `#!/usr/bin/env bash\nwhile [ "$1" != "--" ]; do shift; done\nshift\nexec "$@"\n`,
+      {
+        mode: 0o755,
+      },
+    );
     fs.writeFileSync(gatewayLog, "gateway booting\n");
 
     const realFunctions = [
@@ -625,6 +629,7 @@ describe("gateway launch wiring (#4710)", () => {
         gatewayLog,
       ),
       extractShellFunction(src, "record_gateway_pid"),
+      extractShellFunction(src, "clear_gateway_pid_record"),
       extractShellFunction(src, "gateway_pid_is_openclaw_gateway"),
       extractShellFunction(src, "gateway_watchdog_positive_int_ok"),
       extractShellFunction(src, "start_gateway_serving_watchdog"),
@@ -649,8 +654,8 @@ describe("gateway launch wiring (#4710)", () => {
         'start_auto_pair() { command sleep 30 & AUTO_PAIR_PID=$!; capture_openclaw_pid_start_identity "$AUTO_PAIR_PID" AUTO_PAIR_PID_START_IDENTITY; }',
         "start_plugin_registry_refresh() { :; }",
         "cleanup_on_signal() { :; }",
-        "STEP_DOWN_PREFIX_SANDBOX=(gosu sandbox)",
-        "STEP_DOWN_PREFIX_GATEWAY=(gosu gateway)",
+        "STEP_DOWN_PREFIX_SANDBOX=(setpriv --reuid=sandbox --regid=sandbox --init-groups --)",
+        "STEP_DOWN_PREFIX_GATEWAY=(setpriv --reuid=gateway --regid=gateway --init-groups --)",
         realFunctions,
         gatewayLaunchBlock(src, kind, gatewayLog),
         `if [ -f ${JSON.stringify(markerPath)} ]; then printf "MARKER_PRESENT=1\\n"; fi`,
@@ -742,9 +747,13 @@ describe("respawn loop pidfile refresh (#4710)", () => {
       `#!/usr/bin/env bash\n[ -f ${JSON.stringify(restoreSentinel)} ] || exit 97\nprintf '%s\\n' "$*" >> ${JSON.stringify(openclawLog)}\nexec sleep 30\n`,
       { mode: 0o755 },
     );
-    fs.writeFileSync(path.join(fakeBin, "gosu"), `#!/usr/bin/env bash\nshift\nexec "$@"\n`, {
-      mode: 0o755,
-    });
+    fs.writeFileSync(
+      path.join(fakeBin, "setpriv"),
+      `#!/usr/bin/env bash\nwhile [ "$1" != "--" ]; do shift; done\nshift\nexec "$@"\n`,
+      {
+        mode: 0o755,
+      },
+    );
 
     fs.writeFileSync(
       scriptPath,
@@ -755,7 +764,7 @@ describe("respawn loop pidfile refresh (#4710)", () => {
         `OPENCLAW=${JSON.stringify(path.join(fakeBin, "openclaw"))}`,
         '_DASHBOARD_PORT="19000"',
         `GATEWAY_PID_FILE=${JSON.stringify(pidFile)}`,
-        "STEP_DOWN_PREFIX_GATEWAY=(gosu gateway)",
+        "STEP_DOWN_PREFIX_GATEWAY=(setpriv --reuid=gateway --regid=gateway --init-groups --)",
         `prepare_openclaw_automatic_respawn() { printf restored >${JSON.stringify(restoreSentinel)}; }`,
         // The loop sleeps 2s between respawns; keep the test fast.
         "sleep() { command sleep 0.05; }",
@@ -923,7 +932,7 @@ describe("nemoclaw-start gateway launch signal handling", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `nemoclaw-launch-${kind}-`));
     const fakeBin = path.join(tmpDir, "bin");
     const openclawLog = path.join(tmpDir, "openclaw.log");
-    const gosuLog = path.join(tmpDir, "gosu.log");
+    const setprivLog = path.join(tmpDir, "setpriv.log");
     const gatewayLog = path.join(tmpDir, "gateway.log");
     const markerPath = path.join(tmpDir, "nemoclaw-gateway-local");
     const scriptPath = path.join(tmpDir, "run.sh");
@@ -937,8 +946,8 @@ describe("nemoclaw-start gateway launch signal handling", () => {
       { mode: 0o755 },
     );
     fs.writeFileSync(
-      path.join(fakeBin, "gosu"),
-      `#!/usr/bin/env bash\nprintf 'user=%s args=%s\\n' "$1" "${"$*"}" >> ${JSON.stringify(gosuLog)}\nshift\nexec "$@"\n`,
+      path.join(fakeBin, "setpriv"),
+      `#!/usr/bin/env bash\nprintf 'args=%s\\n' "${"$*"}" >> ${JSON.stringify(setprivLog)}\nwhile [ "$1" != "--" ]; do shift; done\nshift\nexec "$@"\n`,
       { mode: 0o755 },
     );
     fs.writeFileSync(gatewayLog, "gateway booting\n");
@@ -964,17 +973,18 @@ describe("nemoclaw-start gateway launch signal handling", () => {
         // Stub PID recording and the serving watchdog; each has focused tests
         // elsewhere in this suite (#4710).
         "record_gateway_pid() { :; }",
+        "clear_gateway_pid_record() { :; }",
         'start_gateway_serving_watchdog() { sleep 30 & GATEWAY_WATCHDOG_PID=$!; capture_openclaw_pid_start_identity "$GATEWAY_WATCHDOG_PID" GATEWAY_WATCHDOG_PID_START_IDENTITY; }',
         extractShellFunction(src, "launch_openclaw_gateway_non_root").replaceAll(
           "/tmp/gateway.log",
           gatewayLog,
         ),
         rootGatewayLifecycleFunctions(src, gatewayLog),
-        "STEP_DOWN_PREFIX_SANDBOX=(gosu sandbox)",
-        "STEP_DOWN_PREFIX_GATEWAY=(gosu gateway)",
+        "STEP_DOWN_PREFIX_SANDBOX=(setpriv --reuid=sandbox --regid=sandbox --init-groups --)",
+        "STEP_DOWN_PREFIX_GATEWAY=(setpriv --reuid=gateway --regid=gateway --init-groups --)",
         gatewayLaunchBlock(src, kind, gatewayLog),
         kind === "root"
-          ? `for _ in ${waitForLaunchLogIterations}; do [ -s ${JSON.stringify(gosuLog)} ] && [ -s ${JSON.stringify(openclawLog)} ] && break; sleep 0.1; done`
+          ? `for _ in ${waitForLaunchLogIterations}; do [ -s ${JSON.stringify(setprivLog)} ] && [ -s ${JSON.stringify(openclawLog)} ] && break; sleep 0.1; done`
           : `for _ in ${waitForLaunchLogIterations}; do [ -s ${JSON.stringify(openclawLog)} ] && break; sleep 0.1; done`,
         'printf "GATEWAY_PID=%s\\n" "$GATEWAY_PID"',
         'printf "AUTO_PAIR_PID=%s\\n" "${AUTO_PAIR_PID:-}"',
@@ -991,10 +1001,10 @@ describe("nemoclaw-start gateway launch signal handling", () => {
 
     const result = spawnSync("bash", [scriptPath], { encoding: "utf-8", timeout: 15_000 });
     const openclaw = readFileIfPresent(openclawLog) ?? "";
-    const gosu = readFileIfPresent(gosuLog) ?? "";
+    const setpriv = readFileIfPresent(setprivLog) ?? "";
     const gateway = readFileIfPresent(gatewayLog) ?? "";
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    return { result, openclaw, gosu, gateway };
+    return { result, openclaw, setpriv, gateway };
   }
 
   it("registers child PIDs, redirects gateway output, and traps signals in non-root mode", () => {
@@ -1020,11 +1030,11 @@ describe("nemoclaw-start gateway launch signal handling", () => {
     expect(stdout).toContain("cleanup_openclaw_on_signal");
   });
 
-  it("launches the root gateway through gosu with the configured port and tracks child PIDs", () => {
-    const { result, openclaw, gosu } = runLaunchBlock("root");
-    expect(result.status).toBe(0);
-    expect(gosu).toContain("user=gateway");
-    expect(gosu).toContain("gateway run --port 19000");
+  it("launches the root gateway through setpriv with the configured port and tracks child PIDs", () => {
+    const { result, openclaw, setpriv } = runLaunchBlock("root");
+    expect(result.status, result.stderr).toBe(0);
+    expect(setpriv).toContain("--reuid=gateway --regid=gateway --init-groups --");
+    expect(setpriv).toContain("gateway run --port 19000");
     expect(openclaw).toContain("marker=present");
     expect(openclaw).not.toContain("marker=absent");
     expect(openclaw).toContain(

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -3536,13 +3536,13 @@ describe("Telegram diagnostics (#2766)", () => {
         "chown() { :; }",
         "chown_tree_no_symlink_follow() { :; }",
         "start_persistent_gateway_log_mirror() { :; }",
-        'gosu() { shift; "$@"; }',
+        'setpriv() { while [ "$1" != "--" ]; do shift; done; shift; "$@"; }',
         // STEP_DOWN_PREFIX_* are normally populated by init_step_down_prefixes
         // in sandbox-init.sh; the test scaffolding doesn't source that, so
-        // initialize them here in their fallback form so the gosu() stub still
-        // gets invoked (issue #3280 follow-up).
-        "STEP_DOWN_PREFIX_SANDBOX=(gosu sandbox)",
-        "STEP_DOWN_PREFIX_GATEWAY=(gosu gateway)",
+        // initialize them here because this scaffolding does not source the
+        // shared privilege-transition helper.
+        "STEP_DOWN_PREFIX_SANDBOX=(setpriv --reuid=sandbox --regid=sandbox --init-groups --)",
+        "STEP_DOWN_PREFIX_GATEWAY=(setpriv --reuid=gateway --regid=gateway --init-groups --)",
         'validate_tmp_permissions() { printf "VALIDATE:%s\\n" "$*"; }',
         "_SANDBOX_HOME=/sandbox",
         `_SANDBOX_SAFETY_NET=${JSON.stringify(path.join(tmpDir, "safety.js"))}`,

--- a/test/sandbox-base-runtime-tools.test.ts
+++ b/test/sandbox-base-runtime-tools.test.ts
@@ -14,6 +14,11 @@ import { stageFixedParser, useRealPatchedParser } from "./helpers/python-parser-
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const DOCKERFILE_BASE = path.join(ROOT, "Dockerfile.base");
+const MANAGED_BASE_DOCKERFILES = [
+  DOCKERFILE_BASE,
+  path.join(ROOT, "agents", "hermes", "Dockerfile.base"),
+  path.join(ROOT, "agents", "langchain-deepagents-code", "Dockerfile.base"),
+] as const;
 const fixtures: string[] = [];
 
 function runBaseAptLayer(prefix: string) {
@@ -39,7 +44,7 @@ function runBaseAptLayer(prefix: string) {
   const command = dockerRunCommandBetween(
     dockerfile,
     "RUN apt-get update",
-    "# gosu for privilege separation",
+    "# setpriv runtime contract",
   )
     .replaceAll("/var/lib/apt/lists", lists)
     .replaceAll("/tmp/nemoclaw-debian-security", debianSecurityDebs)
@@ -65,11 +70,21 @@ afterEach(() => {
 });
 
 describe("sandbox base runtime tools", () => {
+  it.each(
+    MANAGED_BASE_DOCKERFILES,
+  )("%s explicitly installs setpriv through pinned util-linux without gosu", (dockerfile) => {
+    const source = fs.readFileSync(dockerfile, "utf-8");
+
+    expect(source).toContain("util-linux=2.41-5");
+    expect(source).not.toMatch(/\bgosu\b/u);
+  });
+
   it("installs the required process, filesystem, and SFTP tools", () => {
     const { calls, result } = runBaseAptLayer("nemoclaw-base-apt-");
 
     expect({ status: result.status, stderr: result.stderr }).toEqual({ status: 0, stderr: "" });
     expect(calls).toContain("procps=2:4.0.4-9");
+    expect(calls).toContain("util-linux=2.41-5");
     expect(calls).toContain("e2fsprogs=1.47.2-3+b11");
     expect(calls).toContain("openssh-sftp-server=1:10.0p1-7+deb13u4");
   });

--- a/test/sandbox-base-security-packages.test.ts
+++ b/test/sandbox-base-security-packages.test.ts
@@ -23,7 +23,7 @@ const SECURITY_IMAGES = [
     startMarker: "# Trixie has not published fixes",
     additionalStartMarker:
       "RUN apt-get update \\\n    && apt-get install -y --no-install-recommends \\\n        /tmp/nemoclaw-native-security/perl-base.deb",
-    endMarker: "# gosu for privilege separation",
+    endMarker: "# setpriv runtime contract",
   },
   {
     name: "Hermes",

--- a/test/sandbox-init.test.ts
+++ b/test/sandbox-init.test.ts
@@ -416,7 +416,7 @@ EOF
     it("function is defined and callable", () => {
       // We can't test actual capsh on macOS, but verify the function exists
       // and handles the no-capsh case gracefully. Capture stderr via redirect.
-      const { stdout, stderr } = runWithLib(
+      const { stdout } = runWithLib(
         `
         # Hide capsh from PATH so the function falls through
         drop_capabilities /usr/local/bin/fake-entrypoint 2>&1

--- a/test/sandbox-init.test.ts
+++ b/test/sandbox-init.test.ts
@@ -416,7 +416,7 @@ EOF
     it("function is defined and callable", () => {
       // We can't test actual capsh on macOS, but verify the function exists
       // and handles the no-capsh case gracefully. Capture stderr via redirect.
-      const { stdout } = runWithLib(
+      const { stdout, stderr } = runWithLib(
         `
         # Hide capsh from PATH so the function falls through
         drop_capabilities /usr/local/bin/fake-entrypoint 2>&1
@@ -773,7 +773,7 @@ EOF
 
     // SECURITY (#4527): the RLIMIT caps are only unraisable if they are set
     // while still root PID 1, BEFORE drop_capabilities (capsh) and the
-    // setpriv/gosu step-down. A refactor that moved the harden call after the
+    // setpriv step-down. A refactor that moved the harden call after the
     // privilege drop would turn it into dead code (cap set as the unprivileged
     // agent, hard limit no longer lowered) while every other test stayed green.
     // Pin the ordering so that regression is caught.
@@ -792,7 +792,7 @@ EOF
   });
 
   describe("init_step_down_prefixes", () => {
-    it("falls back to gosu when setpriv is unavailable", () => {
+    it("fails closed when setpriv is unavailable", () => {
       // Source-time init runs before our test body, so re-run it with a
       // PATH that hides setpriv and capsh to exercise the fallback.
       const { stdout, stderr } = runWithLib(
@@ -805,9 +805,19 @@ EOF
         ].join("\n"),
       );
       const combined = `${stdout}\n${stderr}`;
-      expect(combined).toContain("falling back to gosu");
-      expect(stdout).toContain("gosu\nsandbox");
-      expect(stdout).toContain("gosu\ngateway");
+      expect(combined).toContain("setpriv unavailable");
+      expect(stdout.match(/setpriv unavailable/g)?.length).toBeGreaterThanOrEqual(2);
+      expect(stdout).not.toContain("gosu");
+
+      const refusal = runWithLib(
+        [
+          "export PATH=/nonexistent",
+          "init_step_down_prefixes >/dev/null 2>&1",
+          '"${STEP_DOWN_PREFIX_SANDBOX[@]}" id',
+        ].join("\n"),
+        { expectFail: true },
+      );
+      expect(refusal.stderr).toContain("refusing to execute a root privilege transition");
     });
 
     it("uses setpriv with the issue-3280 bounding-set drop when available", () => {
@@ -825,7 +835,7 @@ EOF
           "STUB",
           'chmod +x "$TMP/setpriv" "$TMP/capsh"',
           'export PATH="$TMP:$PATH"',
-          "init_step_down_prefixes",
+          "init_step_down_prefixes 2>&1",
           "printf '%s\\n' \"${STEP_DOWN_PREFIX_SANDBOX[@]}\"",
           'echo "--"',
           "printf '%s\\n' \"${STEP_DOWN_PREFIX_GATEWAY[@]}\"",
@@ -848,6 +858,33 @@ EOF
       // array elements onto separate lines, so each prefix's last element
       // is a line containing just '--'.
       expect(stdout.match(/^--$/gm)?.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("uses setpriv without the bounding-set drop when CAP_SETPCAP is unavailable", () => {
+      const { stdout } = runWithLib(
+        [
+          "TMP=$(mktemp -d)",
+          "cat >\"$TMP/setpriv\" <<'STUB'",
+          "#!/bin/sh",
+          "exit 0",
+          "STUB",
+          "cat >\"$TMP/capsh\" <<'STUB'",
+          "#!/bin/sh",
+          "exit 1",
+          "STUB",
+          'chmod +x "$TMP/setpriv" "$TMP/capsh"',
+          'export PATH="$TMP:$PATH"',
+          "init_step_down_prefixes 2>&1",
+          "printf '%s\\n' \"${STEP_DOWN_PREFIX_SANDBOX[@]}\"",
+          'echo "--"',
+          "printf '%s\\n' \"${STEP_DOWN_PREFIX_GATEWAY[@]}\"",
+          'rm -rf "$TMP"',
+        ].join("\n"),
+      );
+      expect(stdout).toContain("CAP_SETPCAP unavailable");
+      expect(stdout).toContain("--reuid=sandbox");
+      expect(stdout).toContain("--reuid=gateway");
+      expect(stdout).not.toContain("--bounding-set=");
     });
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Replace the standalone gosu binary in all NemoClaw managed base images with the Debian-pinned `setpriv` implementation from `util-linux`. Root entrypoints now use one reviewed privilege-transition mechanism and fail closed rather than starting an agent service as root when it is unavailable.

## Changes

- Remove the downloaded gosu binary from the OpenClaw and Hermes base images and explicitly pin `util-linux=2.41-5` across all three managed bases.
- Use `setpriv` for build-time and runtime transitions to the `sandbox` and `gateway` users while preserving supplementary groups.
- Drop the remaining privilege-separation capabilities during the transition when `CAP_SETPCAP` is available; otherwise retain the runtime-provided bounding set and still change identity.
- Fail closed when a root entrypoint requires an identity transition but `setpriv` or the target user is unavailable.
- Add regression coverage for the setpriv-only contract and update the sandbox security documentation.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head security review at `fe77d7434` passed all nine categories with no findings. The change adds no secrets or untrusted parsing, pins `util-linux`, uses the managed `/usr/bin/setpriv` boundary, preserves supplementary groups, and fails closed for required root identity transitions.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/deployment/sandbox-hardening.mdx`, `docs/reference/troubleshooting.mdx`, and `docs/security/best-practices.mdx` accurately document the managed-image `setpriv` requirement, supplementary-group initialization, and fail-closed root identity transitions. The merge refresh preserves the previously reviewed PR patch; prior focused test and documentation validation evidence remains applicable. Fresh CI is running.
- Agent: Codex Desktop
<!-- docs-review-head-sha: fe77d7434 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused setpriv and sandbox-init suites passed 60 tests with 1 skipped at `faa243566`; CLI build, CLI typecheck, repository checks, documentation build, and normal hooks passed across the reviewed change set.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not selected. An additional macOS integration batch passed 194 tests and hit 29 existing platform-harness failures in two files (`stat -c`, GNU `timeout`, and `mktemp` suffix behavior). Linux CI and multi-architecture image builds remain the merge gates.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Replaced legacy privilege-transition handling with `setpriv` for safer root-to-user switching.
  * Privilege transitions now fail closed when required tooling or target identities are unavailable.
  * Added best-effort capability removal with clear warnings when full hardening is unavailable.

* **Documentation**
  * Updated deployment, troubleshooting, and security guidance to describe the new privilege-separation requirements.

* **Tests**
  * Expanded coverage for identity transitions, capability handling, container isolation, and runtime tool requirements.
  * Added validation that managed images include the required `setpriv` runtime support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->