### PR TITLE
test(package): copy published plugin artifacts into fixture

### DIFF
--- a/test/package-contract/helpers/package-fixture.ts
+++ b/test/package-contract/helpers/package-fixture.ts
@@ -18,7 +18,7 @@ export function createPackageFixture(options: {
 
   // npm runs `prepare` when it packs a local directory, even with
   // `--ignore-scripts`. Remove package scripts so parallel package-contract
-  // workers only read `dist`.
+  // workers only read the copied package inputs.
   packageJson.scripts = {};
   writeFileSync(
     path.join(fixtureRoot, "package.json"),

--- a/test/package-contract/openshell-policy-boundary.test.ts
+++ b/test/package-contract/openshell-policy-boundary.test.ts
@@ -230,7 +230,7 @@ describe("OpenShell policy boundary package contract", () => {
 
     const fixtureRoot = createPackageFixture({
       prefix: "nemoclaw-policy-pack-",
-      entries: ["dist", "schemas"],
+      entries: ["dist", "nemoclaw/dist", "schemas"],
     });
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-policy-package-"));
     try {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The isolated package-contract fixture now includes the `nemoclaw/dist` artifacts that the compiled CLI imports. This restores the packaged policy validator check on current main without changing production packaging or runtime behavior.

## Related Issue

Follow-up to #8310.

## Changes

- Copy the published `nemoclaw/dist` artifacts into the isolated npm pack fixture.
- State that parallel package-contract workers read only the copied package inputs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change affects only package-contract fixture inputs and one code comment. It does not change user-visible behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed commit `cc27d79ef`; security review result: PASS for all nine categories.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Package-contract fixture inputs and one code comment changed. No user-visible API, CLI, configuration, workflow, default, or error changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: cc27d79ef -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: GitHub Actions CI / Pull Request run `30994889620` passed, including package contracts, for commit `cc27d79ef`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
