### PR TITLE
ci(e2e): include shared CLI runtime in artifact

### DIFF
--- a/.github/actions/restore-e2e-cli-artifact/action.yaml
+++ b/.github/actions/restore-e2e-cli-artifact/action.yaml
@@ -146,7 +146,7 @@ runs:
           { echo "::error::exact-commit CLI artifact payload digest mismatch"; exit 1; }
         while IFS= read -r member; do
           case "$member" in
-            dist | dist/*) ;;
+            dist | dist/* | nemoclaw/dist/shared | nemoclaw/dist/shared/*) ;;
             *) echo "::error::CLI artifact contains an unsafe member: $member"; exit 1 ;;
           esac
           case "/$member/" in
@@ -158,11 +158,22 @@ runs:
           { echo "::error::CLI artifact contains a link or special file"; exit 1; }
         [[ ! -e "$GITHUB_WORKSPACE/dist" && ! -L "$GITHUB_WORKSPACE/dist" ]] ||
           { echo "::error::consumer unexpectedly built dist before artifact restore"; exit 1; }
+        [[ -d "$GITHUB_WORKSPACE/nemoclaw" && ! -L "$GITHUB_WORKSPACE/nemoclaw" ]] ||
+          { echo "::error::consumer nemoclaw directory is invalid before artifact restore"; exit 1; }
+        [[ ! -e "$GITHUB_WORKSPACE/nemoclaw/dist" && ! -L "$GITHUB_WORKSPACE/nemoclaw/dist" ]] ||
+          { echo "::error::consumer unexpectedly built nemoclaw/dist before artifact restore"; exit 1; }
         restore_dir="$(mktemp -d "${RUNNER_TEMP}/nemoclaw-cli-restore.XXXXXX")"
         trap 'rm -rf -- "$restore_dir"' EXIT
         tar --no-same-owner --no-same-permissions -xf "$payload" -C "$restore_dir"
         test -s "$restore_dir/dist/nemoclaw.js" ||
           { echo "::error::restored CLI artifact is missing dist/nemoclaw.js"; exit 1; }
+        for shared_module in \
+          openshell-policy-boundary.cjs \
+          sandbox-name.cjs \
+          snapshot-sanitizer-boundary.cjs; do
+          test -s "$restore_dir/nemoclaw/dist/shared/${shared_module}" ||
+            { echo "::error::restored CLI artifact is missing the generated shared runtime"; exit 1; }
+        done
         jq -e --arg candidateSha "$CANDIDATE_SHA" '
           type == "object" and
           (keys | sort) == ["nemoclawVersion", "sourceRevision"] and
@@ -170,5 +181,6 @@ runs:
           .sourceRevision == $candidateSha
         ' "$restore_dir/dist/build-identity.json" >/dev/null ||
           { echo "::error::restored CLI build identity does not match the candidate SHA"; exit 1; }
+        mv "$restore_dir/nemoclaw/dist" "$GITHUB_WORKSPACE/nemoclaw/dist"
         mv "$restore_dir/dist" "$GITHUB_WORKSPACE/dist"
         node "$GITHUB_WORKSPACE/bin/nemoclaw.js" --version >/dev/null

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -396,6 +396,13 @@ jobs:
             { echo "::error::candidate CLI build did not produce dist/nemoclaw.js"; exit 1; }
           test -s dist/build-identity.json ||
             { echo "::error::candidate CLI build did not produce dist/build-identity.json"; exit 1; }
+          for shared_module in \
+            openshell-policy-boundary.cjs \
+            sandbox-name.cjs \
+            snapshot-sanitizer-boundary.cjs; do
+            test -s "nemoclaw/dist/shared/${shared_module}" ||
+              { echo "::error::candidate CLI build did not produce nemoclaw/dist/shared/${shared_module}"; exit 1; }
+          done
           jq -e --arg candidateSha "$CANDIDATE_SHA" '
             type == "object" and
             (keys | sort) == ["nemoclawVersion", "sourceRevision"] and
@@ -415,7 +422,8 @@ jobs:
             --group=0 \
             --numeric-owner \
             -cf "$payload" \
-            dist
+            dist \
+            nemoclaw/dist/shared
           payload_sha256="$(sha256sum "$payload" | awk '{print $1}')"
           source_tree="$(git rev-parse 'HEAD^{tree}')"
           lockfile_sha256="$(sha256sum package-lock.json | awk '{print $1}')"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -628,7 +628,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -806,7 +806,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -969,7 +969,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1020,7 +1020,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1294,7 +1294,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1426,7 +1426,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1548,7 +1548,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1660,7 +1660,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1743,7 +1743,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1788,7 +1788,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1867,7 +1867,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -1925,7 +1925,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
       - name: Install OpenShell CLI
@@ -2884,7 +2884,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
       - name: Initialize runner comparison telemetry
@@ -2958,7 +2958,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
       - name: Install OpenShell CLI
@@ -3045,7 +3045,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
       - name: Initialize runner comparison telemetry
@@ -3109,7 +3109,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3216,7 +3216,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3293,7 +3293,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3359,7 +3359,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3408,7 +3408,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3473,7 +3473,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3555,7 +3555,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3700,7 +3700,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3908,7 +3908,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -3998,7 +3998,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4097,7 +4097,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4261,7 +4261,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4320,7 +4320,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4398,7 +4398,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4520,7 +4520,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4636,7 +4636,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4687,7 +4687,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4754,7 +4754,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4839,7 +4839,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4901,7 +4901,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -4964,7 +4964,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5026,7 +5026,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5220,7 +5220,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5318,7 +5318,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5379,7 +5379,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5441,7 +5441,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5501,7 +5501,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5560,7 +5560,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5676,7 +5676,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5734,7 +5734,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5846,7 +5846,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -5949,7 +5949,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6015,7 +6015,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6087,7 +6087,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6162,7 +6162,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6241,7 +6241,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6310,7 +6310,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6406,7 +6406,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6488,7 +6488,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6543,7 +6543,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6606,7 +6606,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6683,7 +6683,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6783,7 +6783,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6876,7 +6876,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -6948,7 +6948,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -7013,7 +7013,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
@@ -7085,7 +7085,7 @@ jobs:
           build-cli: "false"
 
       - name: Restore exact-commit CLI artifact
-        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -26,7 +26,8 @@ before those targets run; local runners must provide it themselves.
 ### Candidate CLI Artifact
 
 The candidate CLI comes from the source commit that an E2E run tests.
-The `generate-matrix` job builds it once and publishes `dist/` as a content-addressed artifact.
+The `generate-matrix` job builds it once and publishes `dist/` and
+`nemoclaw/dist/shared/` as one content-addressed artifact.
 The workflow has 62 artifact-using job definitions.
 Each selected job execution restores the artifact instead of running `npm run build:cli`.
 Each selected job still runs the pinned preparation action to install Node.js and project dependencies.
@@ -58,17 +59,18 @@ Before download, the action rejects extra or missing provenance fields.
 It also compares the candidate checkout, repository, workflow SHA, run ID, and attempt with the provenance object.
 The action downloads the artifact by immutable ID and sets digest mismatch handling to `error`.
 
-Before the action restores `dist/` into the workspace, it verifies these conditions:
+Before the action restores either compiled directory into the workspace, it verifies these conditions:
 
 - The upload digest is present and well formed.
 - The candidate SHA matches the expected commit.
 - The manifest matches the source, workflow run, toolchain contract, and payload.
-- The archive contains no path traversal, links, special files, or files outside `dist/`.
-- The candidate checkout has no preexisting `dist/` path.
+- The archive contains no path traversal, links, special files, or files outside `dist/` and `nemoclaw/dist/shared/`.
+- The candidate checkout has no preexisting `dist/` or `nemoclaw/dist/` path.
 - The staged `dist/build-identity.json` names the candidate commit SHA.
+- The staged shared runtime contains each generated module that the CLI imports.
 
-If a pre-restore check fails, the action stops before it moves `dist/` into the workspace.
-After the checks pass, the action moves `dist/` and runs `bin/nemoclaw.js --version`.
+If a pre-restore check fails, the action stops before it moves either directory into the workspace.
+After the checks pass, the action moves both directories and runs `bin/nemoclaw.js --version`.
 If the version command fails, the action stops before the live test runs.
 This boundary keeps candidate source separate from the trusted workflow implementation.
 

--- a/test/e2e/support/cli-artifact-workflow-boundary.test.ts
+++ b/test/e2e/support/cli-artifact-workflow-boundary.test.ts
@@ -67,11 +67,12 @@ function workflowFixture(): Workflow {
 }
 
 type RestoreFixtureOptions = {
-  archive?: "valid" | "non-dist" | "link" | "traversal";
+  archive?: "valid" | "missing-shared-runtime" | "non-dist" | "link" | "traversal";
   buildIdentitySha?: string;
   expectedPayloadSha256?: string;
   manifestCandidateSha?: string;
   preexistingDist?: "dangling-symlink" | "directory";
+  preexistingSharedRuntime?: "dangling-symlink" | "directory";
 };
 
 type ArchiveFixtureContext = {
@@ -84,13 +85,17 @@ function sha256File(file: string): string {
   return createHash("sha256").update(fs.readFileSync(file)).digest("hex");
 }
 
-function writeDistArchive(
+function writeCliArchive(
   context: ArchiveFixtureContext,
   customizeDist: (dist: string) => void,
+  includeSharedRuntime = true,
 ): void {
   const dist = path.join(context.payloadRoot, "dist");
   fs.mkdirSync(dist);
-  fs.writeFileSync(path.join(dist, "nemoclaw.js"), 'console.log("nemoclaw v0.0.0");\n');
+  fs.writeFileSync(
+    path.join(dist, "nemoclaw.js"),
+    'require("../nemoclaw/dist/shared/sandbox-name.cjs");\nconsole.log("nemoclaw v0.0.0");\n',
+  );
   fs.writeFileSync(
     path.join(dist, "build-identity.json"),
     `${JSON.stringify({
@@ -99,15 +104,32 @@ function writeDistArchive(
     })}\n`,
   );
   customizeDist(dist);
-  execFileSync("tar", ["-cf", context.payload, "-C", context.payloadRoot, "dist"]);
+  const archiveMembers = ["dist"];
+  if (includeSharedRuntime) {
+    const sharedRuntime = path.join(context.payloadRoot, "nemoclaw", "dist", "shared");
+    fs.mkdirSync(sharedRuntime, { recursive: true });
+    for (const moduleName of [
+      "openshell-policy-boundary.cjs",
+      "sandbox-name.cjs",
+      "snapshot-sanitizer-boundary.cjs",
+    ]) {
+      fs.writeFileSync(path.join(sharedRuntime, moduleName), "module.exports = {};\n");
+    }
+    archiveMembers.push("nemoclaw/dist/shared");
+  }
+  execFileSync("tar", ["-cf", context.payload, "-C", context.payloadRoot, ...archiveMembers]);
 }
 
 function writeValidArchive(context: ArchiveFixtureContext): void {
-  writeDistArchive(context, () => undefined);
+  writeCliArchive(context, () => undefined);
+}
+
+function writeArchiveWithoutSharedRuntime(context: ArchiveFixtureContext): void {
+  writeCliArchive(context, () => undefined, false);
 }
 
 function writeLinkArchive(context: ArchiveFixtureContext): void {
-  writeDistArchive(context, (dist) => {
+  writeCliArchive(context, (dist) => {
     fs.symlinkSync("nemoclaw.js", path.join(dist, "linked-cli.js"));
   });
 }
@@ -135,6 +157,7 @@ function writeTraversalArchive(context: ArchiveFixtureContext): void {
 
 const ARCHIVE_FIXTURE_WRITERS = {
   link: writeLinkArchive,
+  "missing-shared-runtime": writeArchiveWithoutSharedRuntime,
   "non-dist": writeNonDistArchive,
   traversal: writeTraversalArchive,
   valid: writeValidArchive,
@@ -154,12 +177,33 @@ function writePreexistingDistDirectory(workspace: string): void {
   fs.writeFileSync(path.join(workspace, "dist", "existing.txt"), "preserve\n");
 }
 
+function writeDanglingSharedRuntimeSymlink(workspace: string): void {
+  const nemoclaw = path.join(workspace, "nemoclaw");
+  fs.mkdirSync(nemoclaw, { recursive: true });
+  fs.symlinkSync("missing-dist", path.join(nemoclaw, "dist"));
+}
+
+function writePreexistingSharedRuntimeDirectory(workspace: string): void {
+  const sharedRuntime = path.join(workspace, "nemoclaw", "dist");
+  fs.mkdirSync(sharedRuntime, { recursive: true });
+  fs.writeFileSync(path.join(sharedRuntime, "existing.txt"), "preserve\n");
+}
+
 const PREEXISTING_DIST_WRITERS = {
   "dangling-symlink": writeDanglingDistSymlink,
   directory: writePreexistingDistDirectory,
   none: () => undefined,
 } satisfies Record<
   NonNullable<RestoreFixtureOptions["preexistingDist"]> | "none",
+  (workspace: string) => void
+>;
+
+const PREEXISTING_SHARED_RUNTIME_WRITERS = {
+  "dangling-symlink": writeDanglingSharedRuntimeSymlink,
+  directory: writePreexistingSharedRuntimeDirectory,
+  none: () => undefined,
+} satisfies Record<
+  NonNullable<RestoreFixtureOptions["preexistingSharedRuntime"]> | "none",
   (workspace: string) => void
 >;
 
@@ -171,6 +215,7 @@ function runRestoreValidation(options: RestoreFixtureOptions = {}) {
   const payloadRoot = path.join(root, "payload-root");
   const toolDirectory = path.join(root, "tools");
   fs.mkdirSync(path.join(workspace, "bin"), { recursive: true });
+  fs.mkdirSync(path.join(workspace, "nemoclaw"), { recursive: true });
   fs.mkdirSync(artifactDirectory, { recursive: true });
   fs.mkdirSync(payloadRoot, { recursive: true });
   fs.mkdirSync(toolDirectory, { recursive: true });
@@ -248,6 +293,7 @@ function runRestoreValidation(options: RestoreFixtureOptions = {}) {
     { mode: 0o755 },
   );
   PREEXISTING_DIST_WRITERS[options.preexistingDist ?? "none"](workspace);
+  PREEXISTING_SHARED_RUNTIME_WRITERS[options.preexistingSharedRuntime ?? "none"](workspace);
 
   const action = readYaml<CompositeAction>(".github/actions/restore-e2e-cli-artifact/action.yaml");
   const result = spawnSync("bash", ["-c", action.runs.steps[2]!.run!], {
@@ -389,6 +435,11 @@ describe("exact-commit CLI artifact workflow boundary", () => {
         ),
       ).toEqual({ nemoclawVersion: "0.0.0", sourceRevision: fixture.candidateSha });
       expect(
+        fs.existsSync(
+          path.join(fixture.workspace, "nemoclaw", "dist", "shared", "sandbox-name.cjs"),
+        ),
+      ).toBe(true);
+      expect(
         fs
           .readdirSync(fixture.runnerTemp)
           .filter((entry) => entry.startsWith("nemoclaw-cli-restore.")),
@@ -416,6 +467,13 @@ describe("exact-commit CLI artifact workflow boundary", () => {
     expectRestoreFailure(
       { archive: "non-dist" },
       "CLI artifact contains an unsafe member: outside.txt",
+    );
+  });
+
+  it("rejects a payload that omits the generated shared CLI runtime", () => {
+    expectRestoreFailure(
+      { archive: "missing-shared-runtime" },
+      "restored CLI artifact is missing the generated shared runtime",
     );
   });
 
@@ -447,6 +505,30 @@ describe("exact-commit CLI artifact workflow boundary", () => {
       expect(fixture.output).toContain("consumer unexpectedly built dist before artifact restore");
       expect(fs.lstatSync(path.join(fixture.workspace, "dist")).isSymbolicLink()).toBe(true);
       expect(fs.readlinkSync(path.join(fixture.workspace, "dist"))).toBe("missing-dist");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each([
+    "directory",
+    "dangling-symlink",
+  ] as const)("does not overwrite a preexisting generated shared runtime %s", (preexistingSharedRuntime) => {
+    const fixture = runRestoreValidation({ preexistingSharedRuntime });
+    try {
+      expect(fixture.result.status, fixture.output).not.toBe(0);
+      expect(fixture.output).toContain(
+        "consumer unexpectedly built nemoclaw/dist before artifact restore",
+      );
+      const sharedRuntime = path.join(fixture.workspace, "nemoclaw", "dist");
+      if (preexistingSharedRuntime === "directory") {
+        expect(fs.readFileSync(path.join(sharedRuntime, "existing.txt"), "utf8")).toBe(
+          "preserve\n",
+        );
+      } else {
+        expect(fs.lstatSync(sharedRuntime).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(sharedRuntime)).toBe("missing-dist");
+      }
     } finally {
       fixture.cleanup();
     }

--- a/tools/e2e/cli-artifact-workflow-boundary.mts
+++ b/tools/e2e/cli-artifact-workflow-boundary.mts
@@ -19,7 +19,7 @@ export const CLI_ARTIFACT_DOWNLOAD_ACTION =
 export const CLI_ARTIFACT_UPLOAD_ACTION =
   "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 export const CLI_ARTIFACT_RESTORE_ACTION =
-  "NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@4b911e40f3f41ce500d69330ca9280b79ceede0f";
+  "NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@ba10383ce965a78b470e15c65948bbf739bfb0ca";
 export const CLI_ARTIFACT_PACKAGE_STEP = "Package exact-commit CLI";
 export const CLI_ARTIFACT_PUBLISH_STEP = "Publish content-addressed CLI artifact";
 export const CLI_ARTIFACT_RESTORE_STEP = "Restore exact-commit CLI artifact";

--- a/tools/e2e/cli-artifact-workflow-boundary.mts
+++ b/tools/e2e/cli-artifact-workflow-boundary.mts
@@ -33,7 +33,7 @@ const DEFAULT_RESTORE_ACTION_PATH = join(
   "action.yaml",
 );
 const RESTORE_ACTION_CONTENT_SHA256 =
-  "bae2b6b99b46f7d007be9b792d7179fbef30c38d31623849e025d7341f179d0d";
+  "25845253d5fdc625cda34c796c54182178476c9f0ff967cdc48ed3d908b6d22b";
 const CLI_ARTIFACT_DOWNLOAD_STEP = "Download exact-commit CLI artifact";
 const CLI_ARTIFACT_VERIFY_STEP = "Verify and restore exact-commit CLI artifact";
 const CLI_ARTIFACT_PROVENANCE_STEP = "Record CLI artifact provenance";
@@ -164,9 +164,13 @@ export function validateCliArtifactRestoreAction(
     '*) echo "::error::CLI artifact contains an unsafe member',
     "CLI artifact contains a link or special file",
     '[[ ! -e "$GITHUB_WORKSPACE/dist" && ! -L "$GITHUB_WORKSPACE/dist" ]]',
+    '[[ -d "$GITHUB_WORKSPACE/nemoclaw" && ! -L "$GITHUB_WORKSPACE/nemoclaw" ]]',
+    '[[ ! -e "$GITHUB_WORKSPACE/nemoclaw/dist" && ! -L "$GITHUB_WORKSPACE/nemoclaw/dist" ]]',
     'restore_dir="$(mktemp -d',
     'tar --no-same-owner --no-same-permissions -xf "$payload" -C "$restore_dir"',
+    'test -s "$restore_dir/nemoclaw/dist/shared/${shared_module}"',
     ".sourceRevision == $candidateSha",
+    'mv "$restore_dir/nemoclaw/dist" "$GITHUB_WORKSPACE/nemoclaw/dist"',
     'mv "$restore_dir/dist" "$GITHUB_WORKSPACE/dist"',
     'node "$GITHUB_WORKSPACE/bin/nemoclaw.js" --version',
   ]);
@@ -224,10 +228,12 @@ function validateProducer(errors: string[], producer: WorkflowRecord): void {
     'git rev-parse --verify HEAD)" == "$CANDIDATE_SHA"',
     "test -s dist/nemoclaw.js",
     "test -s dist/build-identity.json",
+    'test -s "nemoclaw/dist/shared/${shared_module}"',
     ".sourceRevision == $candidateSha",
     "candidate CLI build identity does not match the candidate commit SHA",
     "--sort=name",
     "--mtime=@0",
+    "nemoclaw/dist/shared",
     "source_tree=\"$(git rev-parse 'HEAD^{tree}')\"",
     'lockfile_sha256="$(sha256sum package-lock.json',
     'artifact_name="nemoclaw-cli-${CANDIDATE_SHA}-${payload_sha256}"',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The shared E2E artifact restored `dist/` but omitted the generated modules under `nemoclaw/dist/shared/`, so artifact consumers stopped before tests with `MODULE_NOT_FOUND`. The artifact now packages, validates, and restores both compiled roots before the CLI version check.

## Changes

- Package `dist/` and `nemoclaw/dist/shared/` in the content-addressed candidate CLI artifact.
- Reject an archive that omits required generated modules, adds unexpected paths, or would overwrite either compiled destination.
- Execute the restored shared runtime in the regression fixture instead of using a standalone fake CLI.
- Pin all 62 artifact consumers to action commit `ba10383ce965a78b470e15c65948bbf739bfb0ca`.
- Update `test/e2e/README.md` with the two-root artifact and restore contract.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal CI artifact contract. `test/e2e/README.md` documents that contract; no user-facing command, configuration, or output changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review of the archive extraction and activation boundary is pending.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md` documents the two-root candidate CLI artifact, validation requirements, and restore behavior.
- Agent: Codex CLI
<!-- docs-review-head-sha: e55060afa -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/cli-artifact-workflow-boundary.test.ts test/e2e/support/prepare-e2e-workflow-boundary.test.ts test/e2e/support/runner-comparison-workflow-boundary.test.ts` — 3 files, 69 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end CLI artifact restoration for shared runtime files.
  * Added validation to reject incomplete artifacts and avoid overwriting existing compiled directories.
  * Updated artifact packaging and restoration checks to support the relocated shared runtime.
* **Tests**
  * Expanded end-to-end coverage for successful restoration, missing files, existing directories, and dangling links.
* **Documentation**
  * Updated end-to-end artifact workflow guidance and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->