### PR TITLE
fix(e2e): make managed-image GPU builds network-independent

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1982,7 +1982,7 @@ jobs:
       NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha }}
       NEMOCLAW_E2E_SHARD: ${{ matrix.shard }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: ${{ inputs.base_sha }}
-      NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE: ${{ runner.temp }}/nemoclaw-protected-managed-image-build-cache/${{ matrix.shard }}
+      NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE: ${{ github.workspace }}/.protected-managed-image-build-cache/${{ matrix.shard }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT: protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT: protected-${{ github.run_id }}-${{ github.run_attempt }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT: ${{ github.workspace }}/e2e-artifacts/live/managed-image-multiarch-startup/${{ matrix.shard }}/contracts.json
@@ -2589,7 +2589,7 @@ jobs:
       NEMOCLAW_E2E_SHARD: linux-amd64-gpu
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: ${{ inputs.base_sha }}
-      NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE: ${{ runner.temp }}/nemoclaw-protected-managed-image-build-cache/linux-amd64
+      NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE: ${{ github.workspace }}/.protected-managed-image-build-cache/linux-amd64
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT: protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT: protected-${{ github.run_id }}-${{ github.run_attempt }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT: ${{ github.workspace }}/e2e-artifacts/live/managed-image-protected-runtime/contracts.json

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2583,7 +2583,9 @@ jobs:
   # regressionTest: The build-script behavior test proves complete-cache-only,
   # symlink-free offline imports and exact --cache-from/--network none Docker
   # arguments; workflow boundary tests pin the producer/consumer handoff.
-  # lifecycleDecision: PR #8366 records the observable removal condition.
+  # lifecycleDecision: PR #8366 owns removal after three consecutive protected
+  # GPU cold builds of all three images reach GPU, Ollama, NIM, and vLLM
+  # assertions without the hosted cache.
   managed-image-protected-runtime:
     name: Protected managed-image GPU and local inference
     needs: [generate-matrix, managed-image-multiarch-startup]

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1958,7 +1958,7 @@ jobs:
   managed-image-multiarch-startup:
     name: Protected managed-image startup (${{ matrix.platform }})
     needs: generate-matrix
-    if: ${{ contains(format(',{0},', inputs.jobs), ',managed-image-multiarch-startup,') || contains(format(',{0},', inputs.targets), ',managed-image-multiarch-startup,') }}
+    if: ${{ contains(format(',{0},', inputs.jobs), ',managed-image-multiarch-startup,') || contains(format(',{0},', inputs.targets), ',managed-image-multiarch-startup,') || contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,') }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 210
     permissions:
@@ -1982,6 +1982,8 @@ jobs:
       NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha }}
       NEMOCLAW_E2E_SHARD: ${{ matrix.shard }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: ${{ inputs.base_sha }}
+      NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE: ${{ runner.temp }}/nemoclaw-protected-managed-image-build-cache/${{ matrix.shard }}
+      NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT: protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT: protected-${{ github.run_id }}-${{ github.run_attempt }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT: ${{ github.workspace }}/e2e-artifacts/live/managed-image-multiarch-startup/${{ matrix.shard }}/contracts.json
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_EVIDENCE: ${{ github.workspace }}/e2e-artifacts/live/managed-image-multiarch-startup/${{ matrix.shard }}/evidence.json
@@ -2169,6 +2171,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          cache_args=()
+          if [[ "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_PLATFORM" == "linux/amd64" ]]; then
+            cache_args=(--cache-to "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE")
+          fi
           scripts/checks/build-protected-managed-images.sh \
             --output "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT" \
             --revision "$CHECKOUT_SHA" \
@@ -2176,7 +2182,8 @@ jobs:
             --platform "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_PLATFORM" \
             --openclaw-base "$BASE_OPENCLAW" \
             --hermes-base "$BASE_HERMES" \
-            --dcode-base "$BASE_DCODE"
+            --dcode-base "$BASE_DCODE" \
+            "${cache_args[@]}"
 
       - name: Run every exact managed-image contract directly
         env:
@@ -2269,6 +2276,17 @@ jobs:
         run: >-
           npx tsx tools/e2e/live-vitest-invocation.mts run
           --test-path test/e2e/live/managed-image-multiarch-startup.test.ts
+
+      - name: Publish exact amd64 protected runtime build cache
+        if: ${{ matrix.platform == 'linux/amd64' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT }}
+          path: ${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE }}/
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
 
       - name: Upload protected managed-image evidence
         if: always()
@@ -2549,14 +2567,17 @@ jobs:
   # This explicit-only lane runs only when the exact candidate includes
   # ci/protected-managed-image-runtime-activation-v1.json. The trusted
   # controller can then qualify that candidate's exact head without executing
-  # PR-controlled workflow code.
+  # PR-controlled workflow code. Its hosted amd64 prerequisite exports the
+  # exact candidate build cache; this GPU lane imports it and rebuilds with
+  # BuildKit networking disabled so a cache miss fails closed.
   managed-image-protected-runtime:
     name: Protected managed-image GPU and local inference
-    needs: generate-matrix
-    if: ${{ contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,') }}
+    needs: [generate-matrix, managed-image-multiarch-startup]
+    if: ${{ always() && needs.generate-matrix.result == 'success' && needs.managed-image-multiarch-startup.result == 'success' && (contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,')) }}
     runs-on: linux-amd64-gpu-rtxpro6000-latest-1
     timeout-minutes: 300
     permissions:
+      actions: read
       contents: read
     env:
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/live/managed-image-protected-runtime
@@ -2568,6 +2589,8 @@ jobs:
       NEMOCLAW_E2E_SHARD: linux-amd64-gpu
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: ${{ inputs.base_sha }}
+      NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE: ${{ runner.temp }}/nemoclaw-protected-managed-image-build-cache/linux-amd64
+      NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT: protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT: protected-${{ github.run_id }}-${{ github.run_attempt }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT: ${{ github.workspace }}/e2e-artifacts/live/managed-image-protected-runtime/contracts.json
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_PLATFORM: linux/amd64
@@ -2627,6 +2650,12 @@ jobs:
           path: .candidate-runtime
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Download exact protected runtime build cache
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT }}
+          path: ${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE }}
 
       - *dockerhub-auth
 
@@ -2764,6 +2793,7 @@ jobs:
             --cohort "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT" \
             --platform linux/amd64 \
             --source-root "$GITHUB_WORKSPACE/.candidate-runtime" \
+            --offline-cache "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE" \
             --openclaw-base "$BASE_OPENCLAW" \
             --hermes-base "$BASE_HERMES" \
             --dcode-base "$BASE_DCODE"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2576,8 +2576,10 @@ jobs:
   # sourceBoundary: The hosted amd64 lane builds the same exact candidate and
   # exports only BuildKit cache records; the GPU lane verifies that complete
   # all-agent cache and rebuilds with network access disabled.
-  # whyNotSourceFix: The failure is in the protected runner's external npm
-  # network path, outside candidate source and runner configuration owned here.
+  # whyNotSourceFix: The root cause is unverified. Protected run 31012875592
+  # failed twice during npm install before qualification while hosted builds of
+  # the same candidate passed; the protected runner infrastructure is not owned
+  # by this change. Evidence: https://github.com/NVIDIA/NemoClaw/actions/runs/31012875592
   # regressionTest: The build-script behavior test proves complete-cache-only,
   # symlink-free offline imports and exact --cache-from/--network none Docker
   # arguments; workflow boundary tests pin the producer/consumer handoff.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2570,6 +2570,20 @@ jobs:
   # PR-controlled workflow code. Its hosted amd64 prerequisite exports the
   # exact candidate build cache; this GPU lane imports it and rebuilds with
   # BuildKit networking disabled so a cache miss fails closed.
+  # invalidState: Cold managed-image builds on the protected GPU runner can
+  # stall in npm and terminate with "Exit handler never called!" before any
+  # GPU, Ollama, NIM, or vLLM assertion executes.
+  # sourceBoundary: The hosted amd64 lane builds the same exact candidate and
+  # exports only BuildKit cache records; the GPU lane verifies that complete
+  # all-agent cache and rebuilds with network access disabled.
+  # whyNotSourceFix: The failure is in the protected runner's external npm
+  # network path, outside candidate source and runner configuration owned here.
+  # regressionTest: The build-script behavior test proves complete-cache-only,
+  # symlink-free offline imports and exact --cache-from/--network none Docker
+  # arguments; workflow boundary tests pin the producer/consumer handoff.
+  # removalCondition: Remove the handoff after protected GPU cold builds of all
+  # three managed images complete reliably and the direct local-inference lane
+  # reaches its assertions without the hosted cache.
   managed-image-protected-runtime:
     name: Protected managed-image GPU and local inference
     needs: [generate-matrix, managed-image-multiarch-startup]

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2583,6 +2583,7 @@ jobs:
   # regressionTest: The build-script behavior test proves complete-cache-only,
   # symlink-free offline imports and exact --cache-from/--network none Docker
   # arguments; workflow boundary tests pin the producer/consumer handoff.
+  # lifecycleDecision: PR #8366 records the observable removal condition.
   managed-image-protected-runtime:
     name: Protected managed-image GPU and local inference
     needs: [generate-matrix, managed-image-multiarch-startup]

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2581,9 +2581,6 @@ jobs:
   # regressionTest: The build-script behavior test proves complete-cache-only,
   # symlink-free offline imports and exact --cache-from/--network none Docker
   # arguments; workflow boundary tests pin the producer/consumer handoff.
-  # removalCondition: Remove the handoff after protected GPU cold builds of all
-  # three managed images complete reliably and the direct local-inference lane
-  # reaches its assertions without the hosted cache.
   managed-image-protected-runtime:
     name: Protected managed-image GPU and local inference
     needs: [generate-matrix, managed-image-multiarch-startup]

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2573,7 +2573,7 @@ jobs:
   managed-image-protected-runtime:
     name: Protected managed-image GPU and local inference
     needs: [generate-matrix, managed-image-multiarch-startup]
-    if: ${{ always() && needs.generate-matrix.result == 'success' && needs.managed-image-multiarch-startup.result == 'success' && (contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,')) }}
+    if: ${{ always() && needs['generate-matrix'].result == 'success' && needs['managed-image-multiarch-startup'].result == 'success' && (contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,')) }}
     runs-on: linux-amd64-gpu-rtxpro6000-latest-1
     timeout-minutes: 300
     permissions:

--- a/scripts/checks/build-protected-managed-images.sh
+++ b/scripts/checks/build-protected-managed-images.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: $0 --output <json> --revision <sha> --cohort <id> --platform <linux/amd64|linux/arm64> --openclaw-base <exact-ref> --hermes-base <exact-ref> --dcode-base <exact-ref> [--source-root <absolute-dir>]" >&2
+  echo "usage: $0 --output <json> --revision <sha> --cohort <id> --platform <linux/amd64|linux/arm64> --openclaw-base <exact-ref> --hermes-base <exact-ref> --dcode-base <exact-ref> [--source-root <absolute-dir>] [--cache-to <absolute-dir>] [--offline-cache <absolute-dir>]" >&2
   exit 2
 }
 
@@ -17,8 +17,15 @@ openclaw_base=""
 hermes_base=""
 dcode_base=""
 source_root="$PWD"
+cache_to=""
+offline_cache=""
 while (($# > 0)); do
   case "$1" in
+    --cache-to)
+      (($# >= 2)) || usage
+      cache_to="$2"
+      shift 2
+      ;;
     --output)
       (($# >= 2)) || usage
       output="$2"
@@ -42,6 +49,11 @@ while (($# > 0)); do
     --openclaw-base)
       (($# >= 2)) || usage
       openclaw_base="$2"
+      shift 2
+      ;;
+    --offline-cache)
+      (($# >= 2)) || usage
+      offline_cache="$2"
       shift 2
       ;;
     --hermes-base)
@@ -74,6 +86,31 @@ done
 [[ "$dcode_base" =~ ^ghcr[.]io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base@sha256:[a-f0-9]{64}$ ]] || usage
 [[ "$source_root" == /* && "$source_root" != *$'\n'* && -d "$source_root" && ! -L "$source_root" ]] || usage
 source_root="$(cd -- "$source_root" && pwd -P)"
+if [[ -n "$cache_to" ]]; then
+  [[ "$cache_to" == /* && "$cache_to" != *$'\n'* && ! -L "$cache_to" ]] || usage
+  mkdir -p -- "$cache_to"
+  [[ -d "$cache_to" && ! -L "$cache_to" ]] || usage
+  cache_to="$(cd -- "$cache_to" && pwd -P)"
+  [[ -z "$(find "$cache_to" -mindepth 1 -print -quit)" ]] || {
+    echo "ERROR: protected managed-image cache destination must be empty" >&2
+    exit 1
+  }
+fi
+if [[ -n "$offline_cache" ]]; then
+  [[ "$offline_cache" == /* && "$offline_cache" != *$'\n'* && -d "$offline_cache" && ! -L "$offline_cache" ]] || usage
+  offline_cache="$(cd -- "$offline_cache" && pwd -P)"
+  [[ -z "$(find "$offline_cache" -type l -print -quit)" ]] || {
+    echo "ERROR: protected managed-image offline cache contains a symlink" >&2
+    exit 1
+  }
+  for agent in openclaw hermes langchain-deepagents-code; do
+    cache_source="$offline_cache/$agent"
+    [[ -d "$cache_source/blobs/sha256" && -f "$cache_source/index.json" ]] || {
+      echo "ERROR: protected managed-image offline cache is incomplete for ${agent}" >&2
+      exit 1
+    }
+  done
+fi
 
 for command in docker jq sha256sum; do
   command -v "$command" >/dev/null 2>&1 || {
@@ -96,6 +133,16 @@ build_agent() {
   local exact_base_raw="$work_dir/${agent}-base-exact.raw"
   local metadata="$work_dir/${agent}-build-metadata.json"
   local exact_image_raw="$work_dir/${agent}-image-exact.raw"
+  local -a cache_args=()
+
+  if [[ -n "$cache_to" ]]; then
+    local cache_destination="$cache_to/$agent"
+    cache_args+=(--cache-to "type=local,dest=${cache_destination},mode=max")
+  fi
+  if [[ -n "$offline_cache" ]]; then
+    local cache_source="$offline_cache/$agent"
+    cache_args+=(--cache-from "type=local,src=${cache_source}" --network none)
+  fi
 
   local base_digest="${base_reference##*@}"
   docker buildx imagetools inspect "$base_reference" --raw >"$exact_base_raw"
@@ -119,6 +166,7 @@ build_agent() {
     --provenance=false \
     --sbom=false \
     --metadata-file "$metadata" \
+    "${cache_args[@]}" \
     --tag "${image_repository}:${revision}" \
     --label "org.opencontainers.image.source=https://github.com/NVIDIA/NemoClaw" \
     --label "org.opencontainers.image.revision=${revision}" \

--- a/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
+++ b/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
 
+import { validateManagedImageMultiarchWorkflow } from "../../../tools/e2e/managed-image-multiarch-workflow-boundary.mts";
 import { validateManagedImageProtectedRuntimeWorkflow } from "../../../tools/e2e/managed-image-protected-runtime-workflow-boundary.mts";
 
 type WorkflowRecord = Record<string, unknown>;
@@ -24,6 +25,10 @@ function runtimeJob(value: WorkflowRecord): Record<string, unknown> {
   return (value.jobs as Record<string, Record<string, unknown>>)["managed-image-protected-runtime"];
 }
 
+function multiarchJob(value: WorkflowRecord): Record<string, unknown> {
+  return (value.jobs as Record<string, Record<string, unknown>>)["managed-image-multiarch-startup"];
+}
+
 function namedStep(value: WorkflowRecord, name: string): Record<string, unknown> {
   const step = (runtimeJob(value).steps as Array<Record<string, unknown>>).find(
     (step) => step.name === name,
@@ -35,6 +40,13 @@ function namedStep(value: WorkflowRecord, name: string): Record<string, unknown>
 describe("protected managed-image runtime workflow boundary", () => {
   it("accepts the exact activated trusted runtime lane", () => {
     expect(validateManagedImageProtectedRuntimeWorkflow(workflow())).toEqual([]);
+  });
+
+  it("accepts the exact hosted-build to protected-runtime cache handoff", () => {
+    const value = workflow();
+
+    expect(validateManagedImageMultiarchWorkflow(value)).toEqual([]);
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toEqual([]);
   });
 
   it("ships the exact activation contract consumed by the trusted lane (#7744)", () => {
@@ -128,6 +140,62 @@ describe("protected managed-image runtime workflow boundary", () => {
 
     expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
       "managed-image-protected-runtime protected qualification and cleanup steps drifted",
+    );
+  });
+
+  it("rejects protected runtime execution without the hosted cache producer", () => {
+    const value = workflow();
+    runtimeJob(value).needs = ["generate-matrix"];
+
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
+      "managed-image-protected-runtime must depend on generate-matrix and managed-image-multiarch-startup",
+    );
+  });
+
+  it("rejects removing the exact protected runtime cache download", () => {
+    const value = workflow();
+    const job = runtimeJob(value);
+    job.steps = (job.steps as Array<Record<string, unknown>>).filter(
+      (step) => step.name !== "Download exact protected runtime build cache",
+    );
+
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
+      "managed-image-protected-runtime must define exactly one 'Download exact protected runtime build cache' step",
+    );
+  });
+
+  it("rejects a GPU rebuild that can reach the network on a cache miss", () => {
+    const value = workflow();
+    const build = namedStep(value, "Build exact all-agent protected runtime images");
+    build.run = String(build.run).replace(
+      '--offline-cache "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE"',
+      "",
+    );
+
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
+      "managed-image-protected-runtime step 'Build exact all-agent protected runtime images' must include --offline-cache \"$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE\"",
+    );
+  });
+
+  it("rejects a hosted producer that is not selected with protected runtime", () => {
+    const value = workflow();
+    multiarchJob(value).if =
+      "${{ contains(format(',{0},', inputs.jobs), ',managed-image-multiarch-startup,') || contains(format(',{0},', inputs.targets), ',managed-image-multiarch-startup,') }}";
+
+    expect(validateManagedImageMultiarchWorkflow(value)).toContain(
+      "managed-image-multiarch-startup must remain explicit-only and selector-bound",
+    );
+  });
+
+  it("rejects removing the exact amd64 build cache publication", () => {
+    const value = workflow();
+    const job = multiarchJob(value);
+    job.steps = (job.steps as Array<Record<string, unknown>>).filter(
+      (step) => step.name !== "Publish exact amd64 protected runtime build cache",
+    );
+
+    expect(validateManagedImageMultiarchWorkflow(value)).toContain(
+      "managed-image-multiarch-startup must define exactly one 'Publish exact amd64 protected runtime build cache' step",
     );
   });
 });

--- a/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
+++ b/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
@@ -9,6 +9,7 @@ import YAML from "yaml";
 
 import { validateManagedImageMultiarchWorkflow } from "../../../tools/e2e/managed-image-multiarch-workflow-boundary.mts";
 import { validateManagedImageProtectedRuntimeWorkflow } from "../../../tools/e2e/managed-image-protected-runtime-workflow-boundary.mts";
+import { validateE2eWorkflow } from "../../../tools/e2e/workflow-boundary.mts";
 
 type WorkflowRecord = Record<string, unknown>;
 
@@ -161,6 +162,22 @@ describe("protected managed-image runtime workflow boundary", () => {
 
     expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
       "managed-image-protected-runtime must define exactly one 'Download exact protected runtime build cache' step",
+    );
+  });
+
+  it("rejects Docker authentication before the protected cache download", () => {
+    const value = workflow();
+    const job = runtimeJob(value);
+    const workflowSteps = job.steps as Array<Record<string, unknown>>;
+    const auth = namedStep(value, "Authenticate to Docker Hub");
+    job.steps = [
+      ...workflowSteps.slice(0, 3),
+      auth,
+      ...workflowSteps.slice(3).filter((step) => step !== auth),
+    ];
+
+    expect(validateE2eWorkflow(value)).toContain(
+      "managed-image-protected-runtime Docker Hub auth must run immediately after the protected cache download",
     );
   });
 

--- a/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
+++ b/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
@@ -121,6 +121,20 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
+  it("rejects reusing the protected build-cache upload exception for another step", () => {
+    const workflow = mutableWorkflow();
+    const job = workflow.jobs["managed-image-multiarch-startup"];
+    const cacheUpload = job.steps?.find(
+      (step) => step.name === "Publish exact amd64 protected runtime build cache",
+    );
+    expect(cacheUpload).toBeDefined();
+    cacheUpload!.name = "Publish another direct artifact";
+
+    expect(validateUploadE2eArtifactsInvocations(workflow)).toContain(
+      "managed-image-multiarch-startup must not invoke actions/upload-artifact directly",
+    );
+  });
+
   it("rejects missing and duplicate shared upload invocations", () => {
     const workflow = mutableWorkflow();
     const missingJob = workflow.jobs["shared-e2e"];

--- a/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
+++ b/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
@@ -135,6 +135,40 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
+  it.each([
+    ["name", "another-cache-artifact"],
+    ["path", "another-cache-path/"],
+  ])("rejects protected build-cache upload %s drift", (input, value) => {
+    const workflow = mutableWorkflow();
+    const job = workflow.jobs["managed-image-multiarch-startup"];
+    const cacheUpload = job.steps?.find(
+      (step) => step.name === "Publish exact amd64 protected runtime build cache",
+    );
+    expect(cacheUpload).toBeDefined();
+    cacheUpload!.with![input] = value;
+
+    expect(validateUploadE2eArtifactsInvocations(workflow)).toEqual(
+      expect.arrayContaining([
+        "managed-image-multiarch-startup must define exactly one exact protected build-cache direct upload",
+        "managed-image-multiarch-startup must not invoke actions/upload-artifact directly",
+      ]),
+    );
+  });
+
+  it("rejects duplicate exact protected build-cache upload steps", () => {
+    const workflow = mutableWorkflow();
+    const job = workflow.jobs["managed-image-multiarch-startup"];
+    const cacheUpload = job.steps?.find(
+      (step) => step.name === "Publish exact amd64 protected runtime build cache",
+    );
+    expect(cacheUpload).toBeDefined();
+    job.steps!.push({ ...cacheUpload!, with: { ...cacheUpload!.with } });
+
+    expect(validateUploadE2eArtifactsInvocations(workflow)).toContain(
+      "managed-image-multiarch-startup must define exactly one exact protected build-cache direct upload",
+    );
+  });
+
   it("rejects missing and duplicate shared upload invocations", () => {
     const workflow = mutableWorkflow();
     const missingJob = workflow.jobs["shared-e2e"];

--- a/test/protected-managed-image-build-script.test.ts
+++ b/test/protected-managed-image-build-script.test.ts
@@ -191,6 +191,18 @@ describe("protected managed-image build-cache boundary", () => {
     expect(existsSync(dockerLog)).toBe(false);
   });
 
+  it("rejects a populated cache export root before invoking Docker", () => {
+    const cacheRoot = path.join(testRoot, "export-cache");
+    mkdirSync(cacheRoot);
+    writeFileSync(path.join(cacheRoot, "foreign-record"), "untrusted\n", "utf8");
+
+    const result = runBuild(REPO_ROOT, ["--cache-to", cacheRoot]);
+
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("protected managed-image cache destination must be empty");
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
   it("rejects an incomplete offline cache before invoking Docker", () => {
     const cacheRoot = path.join(testRoot, "offline-cache");
     mkdirSync(cacheRoot);

--- a/test/protected-managed-image-build-script.test.ts
+++ b/test/protected-managed-image-build-script.test.ts
@@ -37,9 +37,35 @@ function writeExecutable(name: string, source: string): void {
 function stubBuildInvocation(): void {
   writeExecutable(
     "docker",
-    '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$NEMOCLAW_TEST_DOCKER_LOG"\ncase "$*" in\n  "buildx imagetools inspect "*) printf "{}\\n"; exit 0 ;;\n  "buildx build "*) exit 88 ;;\nesac\nexit 91\n',
+    '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$NEMOCLAW_TEST_DOCKER_LOG"\ncase "$*" in\n  "buildx imagetools inspect "*) printf "{}\\n" ;;\n  "buildx build "*) ;;\n  "pull "*) ;;\n  "image inspect "*) printf "[]\\n" ;;\n  *) exit 91 ;;\nesac\n',
+  );
+  writeExecutable(
+    "jq",
+    `#!/usr/bin/env bash
+case "$*" in
+  *containerimage.digest*) printf 'sha256:${DIGEST}\\n' ;;
+  *"if length == 1 then .[0].Id"*) printf 'sha256:${DIGEST}\\n' ;;
+  *"--arg agent "*) printf '{}\\n' ;;
+  *"-se "*) printf '[]\\n' ;;
+  *) ;;
+esac
+`,
   );
   writeExecutable("sha256sum", `#!/usr/bin/env bash\nprintf '%s  %s\\n' '${DIGEST}' "$1"\n`);
+}
+
+function recordedBuildInvocations(): string[] {
+  return readFileSync(dockerLog, "utf8")
+    .split("\n")
+    .filter((line) => line.startsWith("buildx build "));
+}
+
+function recordedBuildInvocation(agent: string): string {
+  const invocation = recordedBuildInvocations().find((line) =>
+    line.includes(`io.nvidia.nemoclaw.agent=${agent}`),
+  );
+  expect(invocation, `missing ${agent} build invocation`).toBeDefined();
+  return invocation!;
 }
 
 function runBuild(sourceRoot: string, extraArgs: readonly string[] = []) {
@@ -130,17 +156,20 @@ describe("protected managed-image source-root boundary", () => {
 });
 
 describe("protected managed-image build-cache boundary", () => {
-  it("accepts one empty absolute cache export root before invoking Docker", () => {
+  it("passes each agent one empty absolute cache export root", () => {
     const cacheRoot = path.join(testRoot, "export-cache");
     stubBuildInvocation();
 
     const result = runBuild(REPO_ROOT, ["--cache-to", cacheRoot]);
 
-    expect(result.status, result.stderr).toBe(88);
+    expect(result.status, result.stderr).toBe(0);
     expect(existsSync(cacheRoot)).toBe(true);
-    expect(readFileSync(dockerLog, "utf8")).toContain(
-      `--cache-to type=local,dest=${realpathSync(cacheRoot)}/openclaw,mode=max`,
-    );
+    expect(recordedBuildInvocations()).toHaveLength(3);
+    for (const agent of ["openclaw", "hermes", "langchain-deepagents-code"]) {
+      expect(recordedBuildInvocation(agent)).toContain(
+        `--cache-to type=local,dest=${realpathSync(cacheRoot)}/${agent},mode=max`,
+      );
+    }
   });
 
   it.each([
@@ -173,7 +202,7 @@ describe("protected managed-image build-cache boundary", () => {
     expect(existsSync(dockerLog)).toBe(false);
   });
 
-  it("accepts complete all-agent offline cache metadata before invoking Docker", () => {
+  it("passes each agent complete offline cache metadata with network disabled", () => {
     const cacheRoot = path.join(testRoot, "offline-cache");
     for (const agent of ["openclaw", "hermes", "langchain-deepagents-code"]) {
       mkdirSync(path.join(cacheRoot, agent, "blobs", "sha256"), {
@@ -185,10 +214,13 @@ describe("protected managed-image build-cache boundary", () => {
 
     const result = runBuild(REPO_ROOT, ["--offline-cache", cacheRoot]);
 
-    expect(result.status, result.stderr).toBe(88);
-    expect(readFileSync(dockerLog, "utf8")).toContain(
-      `--cache-from type=local,src=${realpathSync(cacheRoot)}/openclaw --network none`,
-    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(recordedBuildInvocations()).toHaveLength(3);
+    for (const agent of ["openclaw", "hermes", "langchain-deepagents-code"]) {
+      expect(recordedBuildInvocation(agent)).toContain(
+        `--cache-from type=local,src=${realpathSync(cacheRoot)}/${agent} --network none`,
+      );
+    }
   });
 
   it("rejects a nested symlink in a complete offline cache before invoking Docker", () => {

--- a/test/protected-managed-image-build-script.test.ts
+++ b/test/protected-managed-image-build-script.test.ts
@@ -8,6 +8,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -33,7 +34,15 @@ function writeExecutable(name: string, source: string): void {
   chmodSync(target, 0o755);
 }
 
-function runBuild(sourceRoot: string) {
+function stubBuildInvocation(): void {
+  writeExecutable(
+    "docker",
+    '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$NEMOCLAW_TEST_DOCKER_LOG"\ncase "$*" in\n  "buildx imagetools inspect "*) printf "{}\\n"; exit 0 ;;\n  "buildx build "*) exit 88 ;;\nesac\nexit 91\n',
+  );
+  writeExecutable("sha256sum", `#!/usr/bin/env bash\nprintf '%s  %s\\n' '${DIGEST}' "$1"\n`);
+}
+
+function runBuild(sourceRoot: string, extraArgs: readonly string[] = []) {
   const output = path.join(testRoot, "contracts.json");
   return spawnSync(
     "bash",
@@ -55,6 +64,7 @@ function runBuild(sourceRoot: string) {
       `ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base@sha256:${DIGEST}`,
       "--source-root",
       sourceRoot,
+      ...extraArgs,
     ],
     {
       cwd: REPO_ROOT,
@@ -116,5 +126,68 @@ describe("protected managed-image source-root boundary", () => {
 
     expect(result.status, result.stderr).toBe(2);
     expect(existsSync(dockerLog)).toBe(false);
+  });
+});
+
+describe("protected managed-image build-cache boundary", () => {
+  it("accepts one empty absolute cache export root before invoking Docker", () => {
+    const cacheRoot = path.join(testRoot, "export-cache");
+    stubBuildInvocation();
+
+    const result = runBuild(REPO_ROOT, ["--cache-to", cacheRoot]);
+
+    expect(result.status, result.stderr).toBe(88);
+    expect(existsSync(cacheRoot)).toBe(true);
+    expect(readFileSync(dockerLog, "utf8")).toContain(
+      `--cache-to type=local,dest=${realpathSync(cacheRoot)}/openclaw,mode=max`,
+    );
+  });
+
+  it.each([
+    ["relative", () => "export-cache"],
+    [
+      "symlink",
+      () => {
+        const target = path.join(testRoot, "cache-target");
+        const link = path.join(testRoot, "cache-link");
+        mkdirSync(target);
+        symlinkSync(target, link, "dir");
+        return link;
+      },
+    ],
+  ])("rejects a %s cache export root before invoking Docker", (_case, cacheRoot) => {
+    const result = runBuild(REPO_ROOT, ["--cache-to", cacheRoot()]);
+
+    expect(result.status, result.stderr).toBe(2);
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  it("rejects an incomplete offline cache before invoking Docker", () => {
+    const cacheRoot = path.join(testRoot, "offline-cache");
+    mkdirSync(cacheRoot);
+
+    const result = runBuild(REPO_ROOT, ["--offline-cache", cacheRoot]);
+
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("offline cache is incomplete for openclaw");
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  it("accepts complete all-agent offline cache metadata before invoking Docker", () => {
+    const cacheRoot = path.join(testRoot, "offline-cache");
+    for (const agent of ["openclaw", "hermes", "langchain-deepagents-code"]) {
+      mkdirSync(path.join(cacheRoot, agent, "blobs", "sha256"), {
+        recursive: true,
+      });
+      writeFileSync(path.join(cacheRoot, agent, "index.json"), "{}\n", "utf8");
+    }
+    stubBuildInvocation();
+
+    const result = runBuild(REPO_ROOT, ["--offline-cache", cacheRoot]);
+
+    expect(result.status, result.stderr).toBe(88);
+    expect(readFileSync(dockerLog, "utf8")).toContain(
+      `--cache-from type=local,src=${realpathSync(cacheRoot)}/openclaw --network none`,
+    );
   });
 });

--- a/test/protected-managed-image-build-script.test.ts
+++ b/test/protected-managed-image-build-script.test.ts
@@ -190,4 +190,24 @@ describe("protected managed-image build-cache boundary", () => {
       `--cache-from type=local,src=${realpathSync(cacheRoot)}/openclaw --network none`,
     );
   });
+
+  it("rejects a nested symlink in a complete offline cache before invoking Docker", () => {
+    const cacheRoot = path.join(testRoot, "offline-cache");
+    for (const agent of ["openclaw", "hermes", "langchain-deepagents-code"]) {
+      mkdirSync(path.join(cacheRoot, agent, "blobs", "sha256"), {
+        recursive: true,
+      });
+      writeFileSync(path.join(cacheRoot, agent, "index.json"), "{}\n", "utf8");
+    }
+    symlinkSync(
+      path.join(cacheRoot, "hermes", "index.json"),
+      path.join(cacheRoot, "openclaw", "blobs", "sha256", "nested-link"),
+    );
+
+    const result = runBuild(REPO_ROOT, ["--offline-cache", cacheRoot]);
+
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("offline cache contains a symlink");
+    expect(existsSync(dockerLog)).toBe(false);
+  });
 });

--- a/tools/e2e/managed-image-multiarch-workflow-boundary.mts
+++ b/tools/e2e/managed-image-multiarch-workflow-boundary.mts
@@ -28,7 +28,8 @@ type WorkflowStep = WorkflowRecord & {
 };
 
 const JOB_ID = PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID;
-const SELECTOR = `\${{ contains(format(',{0},', inputs.jobs), ',${JOB_ID},') || contains(format(',{0},', inputs.targets), ',${JOB_ID},') }}`;
+const PROTECTED_RUNTIME_JOB_ID = "managed-image-protected-runtime";
+const SELECTOR = `\${{ contains(format(',{0},', inputs.jobs), ',${JOB_ID},') || contains(format(',{0},', inputs.targets), ',${JOB_ID},') || contains(format(',{0},', inputs.jobs), ',${PROTECTED_RUNTIME_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${PROTECTED_RUNTIME_JOB_ID},') }}`;
 const ACTIVATION_PATH = PROTECTED_MANAGED_IMAGE_ACTIVATION_PATH;
 const DIRECT_TEST_PATH = "test/e2e/live/managed-image-multiarch-startup.test.ts";
 const REGISTRY_IMAGE =
@@ -123,8 +124,16 @@ export function validateManagedImageMultiarchWorkflow(workflow: WorkflowRecord):
     "fail-fast": false,
     matrix: {
       include: [
-        { platform: "linux/amd64", runner: "ubuntu-24.04", shard: "linux-amd64" },
-        { platform: "linux/arm64", runner: "ubuntu-24.04-arm", shard: "linux-arm64" },
+        {
+          platform: "linux/amd64",
+          runner: "ubuntu-24.04",
+          shard: "linux-amd64",
+        },
+        {
+          platform: "linux/arm64",
+          runner: "ubuntu-24.04-arm",
+          shard: "linux-arm64",
+        },
       ],
     },
   };
@@ -141,6 +150,10 @@ export function validateManagedImageMultiarchWorkflow(workflow: WorkflowRecord):
     NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha }}",
     NEMOCLAW_E2E_SHARD: "${{ matrix.shard }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: "${{ inputs.base_sha }}",
+    NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE:
+      "${{ runner.temp }}/nemoclaw-protected-managed-image-build-cache/${{ matrix.shard }}",
+    NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT:
+      "protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT:
       "protected-${{ github.run_id }}-${{ github.run_attempt }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT:
@@ -233,6 +246,8 @@ export function validateManagedImageMultiarchWorkflow(workflow: WorkflowRecord):
     '--revision "$CHECKOUT_SHA"',
     '--cohort "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT"',
     '--platform "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_PLATFORM"',
+    'cache_args=(--cache-to "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE")',
+    '"${cache_args[@]}"',
     '--openclaw-base "$BASE_OPENCLAW"',
     '--hermes-base "$BASE_HERMES"',
     '--dcode-base "$BASE_DCODE"',
@@ -271,6 +286,25 @@ export function validateManagedImageMultiarchWorkflow(workflow: WorkflowRecord):
     "tools/e2e/live-vitest-invocation.mts run",
     `--test-path ${DIRECT_TEST_PATH}`,
   ]);
+  const cacheUpload = requireStep(
+    errors,
+    steps,
+    "Publish exact amd64 protected runtime build cache",
+  );
+  if (cacheUpload?.if !== "${{ matrix.platform == 'linux/amd64' }}") {
+    errors.push(`${JOB_ID} build cache publication must remain amd64-only`);
+  }
+  if (cacheUpload?.uses !== "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a") {
+    errors.push(`${JOB_ID} must pin the reviewed build cache upload action`);
+  }
+  requireValues(errors, `${JOB_ID} build cache upload`, record(cacheUpload?.with), {
+    name: "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT }}",
+    path: "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE }}/",
+    "if-no-files-found": "error",
+    "retention-days": 1,
+    "compression-level": 0,
+    overwrite: true,
+  });
   requireStep(errors, steps, "Upload protected managed-image evidence");
   requireStep(errors, steps, "Clean up Docker auth");
   requireOrderedSteps(errors, steps, [
@@ -282,6 +316,7 @@ export function validateManagedImageMultiarchWorkflow(workflow: WorkflowRecord):
     "Run every exact managed-image contract directly",
     "Remove isolated protected managed-image registry",
     "Validate protected managed-image evidence",
+    "Publish exact amd64 protected runtime build cache",
     "Upload protected managed-image evidence",
     "Clean up Docker auth",
   ]);

--- a/tools/e2e/managed-image-multiarch-workflow-boundary.mts
+++ b/tools/e2e/managed-image-multiarch-workflow-boundary.mts
@@ -151,7 +151,7 @@ export function validateManagedImageMultiarchWorkflow(workflow: WorkflowRecord):
     NEMOCLAW_E2E_SHARD: "${{ matrix.shard }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: "${{ inputs.base_sha }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE:
-      "${{ runner.temp }}/nemoclaw-protected-managed-image-build-cache/${{ matrix.shard }}",
+      "${{ github.workspace }}/.protected-managed-image-build-cache/${{ matrix.shard }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT:
       "protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT:

--- a/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
+++ b/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
@@ -14,7 +14,7 @@ type WorkflowStep = WorkflowRecord & {
 
 const JOB_ID = "managed-image-protected-runtime";
 const SELECTOR =
-  "${{ always() && needs.generate-matrix.result == 'success' && needs.managed-image-multiarch-startup.result == 'success' && (contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,')) }}";
+  "${{ always() && needs['generate-matrix'].result == 'success' && needs['managed-image-multiarch-startup'].result == 'success' && (contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,')) }}";
 const ACTIVATION_PATH = "ci/protected-managed-image-runtime-activation-v1.json";
 const LIVE_TEST_PATH = "test/e2e/live/managed-image-protected-runtime.test.ts";
 const REGISTRY_IMAGE =

--- a/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
+++ b/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
@@ -120,7 +120,7 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: "${{ inputs.base_sha }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE:
-      "${{ runner.temp }}/nemoclaw-protected-managed-image-build-cache/linux-amd64",
+      "${{ github.workspace }}/.protected-managed-image-build-cache/linux-amd64",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT:
       "protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT:

--- a/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
+++ b/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isDeepStrictEqual } from "node:util";
+
 type WorkflowRecord = Record<string, unknown>;
 type WorkflowStep = WorkflowRecord & {
   env?: WorkflowRecord;
@@ -12,7 +14,7 @@ type WorkflowStep = WorkflowRecord & {
 
 const JOB_ID = "managed-image-protected-runtime";
 const SELECTOR =
-  "${{ contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,') }}";
+  "${{ always() && needs.generate-matrix.result == 'success' && needs.managed-image-multiarch-startup.result == 'success' && (contains(format(',{0},', inputs.jobs), ',managed-image-protected-runtime,') || contains(format(',{0},', inputs.targets), ',managed-image-protected-runtime,')) }}";
 const ACTIVATION_PATH = "ci/protected-managed-image-runtime-activation-v1.json";
 const LIVE_TEST_PATH = "test/e2e/live/managed-image-protected-runtime.test.ts";
 const REGISTRY_IMAGE =
@@ -89,7 +91,9 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
   const job = record(record(workflow.jobs)[JOB_ID]);
   if (Object.keys(job).length === 0) return [`workflow missing ${JOB_ID} job`];
 
-  if (job.needs !== "generate-matrix") errors.push(`${JOB_ID} must depend on generate-matrix`);
+  if (!isDeepStrictEqual(job.needs, ["generate-matrix", "managed-image-multiarch-startup"])) {
+    errors.push(`${JOB_ID} must depend on generate-matrix and managed-image-multiarch-startup`);
+  }
   if (job.if !== SELECTOR) errors.push(`${JOB_ID} must remain explicit-only and selector-bound`);
   if (job["runs-on"] !== "linux-amd64-gpu-rtxpro6000-latest-1") {
     errors.push(`${JOB_ID} must run on the protected amd64 GPU runner`);
@@ -97,6 +101,9 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
   if (job["timeout-minutes"] !== 300) errors.push(`${JOB_ID} must keep the 300 minute timeout`);
   if (record(job.permissions).contents !== "read") {
     errors.push(`${JOB_ID} permissions must be contents: read`);
+  }
+  if (record(job.permissions).actions !== "read") {
+    errors.push(`${JOB_ID} permissions must be actions: read`);
   }
   if (job["continue-on-error"] !== undefined) {
     errors.push(`${JOB_ID} must not weaken failures with continue-on-error`);
@@ -112,6 +119,10 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     NEMOCLAW_E2E_SHARD: "linux-amd64-gpu",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: "${{ inputs.base_sha }}",
+    NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE:
+      "${{ runner.temp }}/nemoclaw-protected-managed-image-build-cache/linux-amd64",
+    NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT:
+      "protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT:
       "protected-${{ github.run_id }}-${{ github.run_attempt }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT:
@@ -185,6 +196,21 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     "persist-credentials": false,
   });
 
+  const cacheDownload = requireStep(
+    errors,
+    workflowSteps,
+    "Download exact protected runtime build cache",
+  );
+  if (
+    cacheDownload?.uses !== "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+  ) {
+    errors.push(`${JOB_ID} must pin the reviewed build cache download action`);
+  }
+  requireValues(errors, `${JOB_ID} build cache download`, record(cacheDownload?.with), {
+    name: "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT }}",
+    path: "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE }}",
+  });
+
   const buildx = requireStep(errors, workflowSteps, "Set up protected runtime Buildx");
   if (buildx?.uses !== "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c") {
     errors.push(`${JOB_ID} must pin the reviewed Buildx setup action`);
@@ -252,6 +278,7 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     '--cohort "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT"',
     "--platform linux/amd64",
     '--source-root "$GITHUB_WORKSPACE/.candidate-runtime"',
+    '--offline-cache "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE"',
     '--openclaw-base "$BASE_OPENCLAW"',
     '--hermes-base "$BASE_HERMES"',
     '--dcode-base "$BASE_DCODE"',
@@ -313,6 +340,7 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     "Validate protected runtime exact-head dispatch",
     "Checkout trusted protected runtime qualification",
     "Checkout exact protected runtime candidate source",
+    "Download exact protected runtime build cache",
     "Prepare E2E workspace",
     "Validate protected runtime activation contract",
     "Resolve exact amd64 runtime base images",

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -34,6 +34,7 @@ const CHECKOUT_LOCAL_UPLOAD_E2E_ARTIFACTS_ACTION = "./.github/actions/upload-e2e
 const UPLOAD_E2E_ARTIFACTS_ACTION_PREFIX = "NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@";
 const UPLOAD_ARTIFACT_ACTION = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 const UPLOAD_ARTIFACT_ACTION_PREFIX = "actions/upload-artifact@";
+const MANAGED_IMAGE_BUILD_CACHE_PUBLISH_STEP = "Publish exact amd64 protected runtime build cache";
 const INNER_ALWAYS = "${{ always() }}";
 const CALLER_ALWAYS = "always()";
 const RETIRED_SELECTOR_COMPATIBILITY_JOB = "retired-selector-compatibility";
@@ -447,7 +448,15 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
         jobName === "generate-matrix" &&
         step.name === CLI_ARTIFACT_PUBLISH_STEP &&
         uses === CLI_ARTIFACT_UPLOAD_ACTION;
-      if (uses.startsWith(UPLOAD_ARTIFACT_ACTION_PREFIX) && !isExactCommitCliArtifactUpload) {
+      const isExactManagedImageBuildCacheUpload =
+        jobName === "managed-image-multiarch-startup" &&
+        step.name === MANAGED_IMAGE_BUILD_CACHE_PUBLISH_STEP &&
+        uses === UPLOAD_ARTIFACT_ACTION;
+      if (
+        uses.startsWith(UPLOAD_ARTIFACT_ACTION_PREFIX) &&
+        !isExactCommitCliArtifactUpload &&
+        !isExactManagedImageBuildCacheUpload
+      ) {
         errors.push(`${jobName} must not invoke actions/upload-artifact directly`);
       }
       if (

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -35,6 +35,10 @@ const UPLOAD_E2E_ARTIFACTS_ACTION_PREFIX = "NVIDIA/NemoClaw/.github/actions/uplo
 const UPLOAD_ARTIFACT_ACTION = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 const UPLOAD_ARTIFACT_ACTION_PREFIX = "actions/upload-artifact@";
 const MANAGED_IMAGE_BUILD_CACHE_PUBLISH_STEP = "Publish exact amd64 protected runtime build cache";
+const MANAGED_IMAGE_BUILD_CACHE_ARTIFACT_NAME =
+  "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT }}";
+const MANAGED_IMAGE_BUILD_CACHE_ARTIFACT_PATH =
+  "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE }}/";
 const INNER_ALWAYS = "${{ always() }}";
 const CALLER_ALWAYS = "always()";
 const RETIRED_SELECTOR_COMPATIBILITY_JOB = "retired-selector-compatibility";
@@ -72,6 +76,17 @@ type ExplicitUploadContract = {
   name: string;
   path?: string;
 };
+
+function isExactManagedImageBuildCacheUpload(jobName: string, step: WorkflowStep): boolean {
+  const inputs = record(step.with);
+  return (
+    jobName === "managed-image-multiarch-startup" &&
+    step.name === MANAGED_IMAGE_BUILD_CACHE_PUBLISH_STEP &&
+    step.uses === UPLOAD_ARTIFACT_ACTION &&
+    inputs.name === MANAGED_IMAGE_BUILD_CACHE_ARTIFACT_NAME &&
+    inputs.path === MANAGED_IMAGE_BUILD_CACHE_ARTIFACT_PATH
+  );
+}
 
 const EXPLICIT_UPLOAD_CONTRACTS = new Map<string, ExplicitUploadContract>([
   [
@@ -438,6 +453,17 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
     const job = record(value);
     const jobSteps = steps(job.steps);
     const expected = expectedJobs.has(jobName);
+    const exactManagedImageBuildCacheUploads = jobSteps.filter((step) =>
+      isExactManagedImageBuildCacheUpload(jobName, step),
+    );
+    if (
+      jobName === "managed-image-multiarch-startup" &&
+      exactManagedImageBuildCacheUploads.length !== 1
+    ) {
+      errors.push(
+        "managed-image-multiarch-startup must define exactly one exact protected build-cache direct upload",
+      );
+    }
 
     for (const step of jobSteps) {
       const uses = typeof step.uses === "string" ? step.uses : "";
@@ -448,14 +474,10 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
         jobName === "generate-matrix" &&
         step.name === CLI_ARTIFACT_PUBLISH_STEP &&
         uses === CLI_ARTIFACT_UPLOAD_ACTION;
-      const isExactManagedImageBuildCacheUpload =
-        jobName === "managed-image-multiarch-startup" &&
-        step.name === MANAGED_IMAGE_BUILD_CACHE_PUBLISH_STEP &&
-        uses === UPLOAD_ARTIFACT_ACTION;
       if (
         uses.startsWith(UPLOAD_ARTIFACT_ACTION_PREFIX) &&
         !isExactCommitCliArtifactUpload &&
-        !isExactManagedImageBuildCacheUpload
+        !isExactManagedImageBuildCacheUpload(jobName, step)
       ) {
         errors.push(`${jobName} must not invoke actions/upload-artifact directly`);
       }

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -162,6 +162,8 @@ const FREE_STANDING_SELECTOR_SPECIAL_CASES = new Set([
   "hermes-e2e",
   "hermes-gpu-startup",
   "llama-cpp-dgx-spark-qualification",
+  "managed-image-multiarch-startup",
+  "managed-image-protected-runtime",
   "openshell-credential-generation-window",
   "staging-brev-launchable",
 ]);
@@ -2519,12 +2521,16 @@ function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): 
         ? checkoutIndex + 2
         : jobName === "hermes-gpu-startup"
           ? checkoutIndex + 3
-          : checkoutIndex + 1;
+          : jobName === "managed-image-protected-runtime"
+            ? checkoutIndex + 2
+            : checkoutIndex + 1;
     if (checkoutIndex < 0 || authIndex !== expectedAuthIndex) {
       errors.push(
         jobName === "jetson-nvmap-gpu"
           ? `${jobName} Docker Hub auth must run immediately after the Jetson dispatch guard`
-          : `${jobName} Docker Hub auth must run immediately after checkout`,
+          : jobName === "managed-image-protected-runtime"
+            ? `${jobName} Docker Hub auth must run immediately after the protected cache download`
+            : `${jobName} Docker Hub auth must run immediately after checkout`,
       );
     }
     if (authIndex < 0 || cleanupIndex <= authIndex) {

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -2514,6 +2514,10 @@ function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): 
       }
       return stringValue(step.uses).startsWith("actions/checkout@");
     });
+    const protectedCacheDownloadIndex =
+      jobName === "managed-image-protected-runtime"
+        ? steps.findIndex((step) => step.name === "Download exact protected runtime build cache")
+        : -1;
     const authIndex = steps.indexOf(auth);
     const cleanupIndex = steps.indexOf(cleanup);
     const expectedAuthIndex =
@@ -2522,9 +2526,13 @@ function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): 
         : jobName === "hermes-gpu-startup"
           ? checkoutIndex + 3
           : jobName === "managed-image-protected-runtime"
-            ? checkoutIndex + 2
+            ? protectedCacheDownloadIndex + 1
             : checkoutIndex + 1;
-    if (checkoutIndex < 0 || authIndex !== expectedAuthIndex) {
+    if (
+      checkoutIndex < 0 ||
+      (jobName === "managed-image-protected-runtime" && protectedCacheDownloadIndex < 0) ||
+      authIndex !== expectedAuthIndex
+    ) {
       errors.push(
         jobName === "jetson-nvmap-gpu"
           ? `${jobName} Docker Hub auth must run immediately after the Jetson dispatch guard`


### PR DESCRIPTION
## Summary

- export the exact all-agent linux/amd64 BuildKit cache from the hosted protected startup lane only after direct startup and evidence validation pass
- make the protected GPU/local-inference lane depend on that producer, download the exact run/head artifact, and rebuild the candidate with BuildKit networking disabled
- fail closed before GPU qualification when any OpenClaw, Hermes, or DCode cache is missing, incomplete, symlinked, or misses a build layer
- enforce the producer/consumer/security relationship with executable workflow-boundary and shell behavior tests

## Why

This is a trusted-workflow prerequisite for #8261 and the #7744 Podman epic. Protected run 31012875592 passed the all-agent amd64/arm64 startup lanes, but its GPU/local-inference job failed twice at the same 368.8-second npm install point while building exact candidate images on the GPU runner. Neither attempt reached the GPU, Ollama, NIM, or vLLM assertions.

The hosted amd64 lane already builds and directly starts the exact candidate images without credentials. Reusing its BuildKit cache removes the GPU runners broken npm-network path while preserving an exact candidate rebuild on the GPU host. The rebuild runs with network none, so any cache miss fails instead of silently reaching the network.

This PR does not activate buildless or Podman support and does not change product runtime behavior. It must land before #8261 can be rerun against the corrected trusted workflow.

## Temporary handoff removal

Remove the hosted-cache handoff after three consecutive protected GPU cold builds of all three managed images reach the GPU, Ollama, NIM, and vLLM assertions without the hosted cache.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Internal protected E2E cache handoff and its regression tests do not change a public CLI, configuration, default, or supported operator workflow. The new test title names the rejected state and Docker boundary.
- Agent: Codex Desktop
<!-- docs-review-head-sha: af77aa746e0e127fc76b28489bc21a8bdacd6868 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70934b540c404d3939e3321f5c7558 -->

## Validation

- all pre-commit and pre-push hooks
- protected build script behavior: 12/12
- protected runtime workflow boundary: 15/15
- E2E semantic phase coverage
- CLI build and typecheck
- repository checks, shellcheck, source-shape, test-size, and test-conditional guardrails

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protected managed-image runtime builds now reuse the exact startup build cache.
  * Multi-architecture startup builds publish a temporary amd64 cache for offline GPU image builds.
  * Protected runtime workflows support the `managed-image-protected-runtime` selection.

* **Bug Fixes**
  * Improved validation rejects incomplete, invalid, or incorrectly connected build-cache workflows.
  * Offline builds now verify cache completeness, reject unsafe cache contents, and prevent unintended network access.

* **Tests**
  * Added coverage for cache creation, transfer, offline builds, workflow dependencies, artifact handling, and required build settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


