### PR TITLE
feat(onboard): add portable experimental profile

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -68,8 +68,6 @@ jobs:
           if ! grep -q "^${USER}:" /etc/subgid; then
             sudo usermod --add-subgids 100000-165535 "$USER"
           fi
-          # Model the fixed host endpoint exposed by the constrained runtime.
-          sudo ip address add 169.254.1.2/32 dev lo
           podman --version
           pasta --version
           docker --version

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -68,6 +68,8 @@ jobs:
           if ! grep -q "^${USER}:" /etc/subgid; then
             sudo usermod --add-subgids 100000-165535 "$USER"
           fi
+          # Model the fixed host endpoint exposed by the constrained runtime.
+          sudo ip address add 169.254.1.2/32 dev lo
           podman --version
           pasta --version
           docker --version

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -51,6 +51,9 @@ jobs:
       - name: Install root dependencies
         run: npm ci --ignore-scripts
 
+      - name: Build shared policy boundary
+        run: npm run build:policy-boundary
+
       - name: Provision restricted rootless Linux runtime
         shell: bash
         run: |

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -14,7 +14,7 @@ on:
       - "src/lib/onboard/**"
       - "src/lib/domain/sandbox/image-tag.ts"
       - "src/lib/sandbox/build-context.ts"
-      - "test/e2e/portable-profile-rootless-linux.mts"
+      - "test/e2e/live/portable-profile-rootless-linux.test.ts"
   push:
     branches:
       - main
@@ -23,7 +23,7 @@ on:
       - "src/lib/onboard/**"
       - "src/lib/domain/sandbox/image-tag.ts"
       - "src/lib/sandbox/build-context.ts"
-      - "test/e2e/portable-profile-rootless-linux.mts"
+      - "test/e2e/live/portable-profile-rootless-linux.test.ts"
 
 permissions:
   contents: read
@@ -73,4 +73,21 @@ jobs:
           docker --version
 
       - name: Exercise portable profile in the rootless environment
-        run: npx tsx test/e2e/portable-profile-rootless-linux.mts
+        env:
+          E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/portable-profile
+          E2E_TARGET_ID: portable-profile
+          NEMOCLAW_RUN_LIVE_E2E: "1"
+        run: >-
+          npx vitest run --project e2e-live
+          test/e2e/live/portable-profile-rootless-linux.test.ts
+          --silent=false --reporter=default
+
+      - name: Upload portable profile E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: portable-profile-e2e-artifacts
+          path: e2e-artifacts/portable-profile/
+          include-hidden-files: false
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: E2E / Portable Profile
+
+run-name: "Portable profile rootless E2E for ${{ github.sha }}"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/portable-profile-e2e.yaml"
+      - "src/lib/onboard/**"
+      - "src/lib/domain/sandbox/image-tag.ts"
+      - "src/lib/sandbox/build-context.ts"
+      - "test/e2e/portable-profile-rootless-linux.mts"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/portable-profile-e2e.yaml"
+      - "src/lib/onboard/**"
+      - "src/lib/domain/sandbox/image-tag.ts"
+      - "src/lib/sandbox/build-context.ts"
+      - "test/e2e/portable-profile-rootless-linux.mts"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: portable-profile-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rootless-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Provision restricted rootless Linux runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes fuse-overlayfs passt podman slirp4netns uidmap
+          runtime_dir="/run/user/$(id -u)"
+          sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$runtime_dir"
+          if ! grep -q "^${USER}:" /etc/subuid; then
+            sudo usermod --add-subuids 100000-165535 "$USER"
+          fi
+          if ! grep -q "^${USER}:" /etc/subgid; then
+            sudo usermod --add-subgids 100000-165535 "$USER"
+          fi
+          podman --version
+          pasta --version
+          docker --version
+
+      - name: Exercise portable profile in the rootless environment
+        run: npx tsx test/e2e/portable-profile-rootless-linux.mts

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -85,6 +85,15 @@ describe("onboard oclif command", () => {
     );
   });
 
+  it("accepts the hidden portable experimental profile", async () => {
+    await OnboardCliCommand.run(["--experimental-profile", "portable"], rootDir);
+
+    expect(runOnboardAction).toHaveBeenCalledWith(
+      expect.objectContaining({ "experimental-profile": "portable" }),
+      mocks.onboardRuntimeDeps,
+    );
+  });
+
   it.each([
     ["--gpu", "--no-gpu"],
     ["--sandbox-gpu", "--no-sandbox-gpu"],

--- a/src/lib/domain/sandbox/image-tag.ts
+++ b/src/lib/domain/sandbox/image-tag.ts
@@ -8,6 +8,7 @@ export const SANDBOX_FROM_IMAGE_REPO = "openshell/sandbox-from";
  * (Linux, or macOS on Apple Silicon — see isLinuxDockerDriverGatewayEnabled).
  */
 export const LOCAL_SANDBOX_IMAGE_REPO = "nemoclaw-sandbox-local";
+export const PORTABLE_LOCAL_SANDBOX_IMAGE_REPO = "localhost:5000/nemoclaw-sandbox-local";
 
 /**
  * Every Docker repository that can hold a sandbox image. Any orphan sweep
@@ -16,7 +17,11 @@ export const LOCAL_SANDBOX_IMAGE_REPO = "nemoclaw-sandbox-local";
  * SANDBOX_FROM_IMAGE_REPO, so scanning only the latter left local orphans
  * invisible to gc (#6301).
  */
-export const SANDBOX_IMAGE_REPOS = [SANDBOX_FROM_IMAGE_REPO, LOCAL_SANDBOX_IMAGE_REPO] as const;
+export const SANDBOX_IMAGE_REPOS = [
+  SANDBOX_FROM_IMAGE_REPO,
+  LOCAL_SANDBOX_IMAGE_REPO,
+  PORTABLE_LOCAL_SANDBOX_IMAGE_REPO,
+] as const;
 
 const BUILT_SANDBOX_IMAGE_RE = /Built image (openshell\/sandbox-from:\d+)/;
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1461,7 +1461,6 @@ async function preflight(
   preflightOpts: PreflightOptions = {},
 ): Promise<ReturnType<typeof nim.detectGpu>> {
   step(1, 8, "Preflight checks");
-
   fatalRuntimePreflight.preparePortableExperimentalHost(process.env);
   const { gpu, host, sandboxGpuConfig } = fatalRuntimePreflight.runFatalOnboardRuntimePreflight(
     preflightOpts,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1461,7 +1461,6 @@ async function preflight(
   preflightOpts: PreflightOptions = {},
 ): Promise<ReturnType<typeof nim.detectGpu>> {
   step(1, 8, "Preflight checks");
-  fatalRuntimePreflight.preparePortableExperimentalHost(process.env);
   const { gpu, host, sandboxGpuConfig } = fatalRuntimePreflight.runFatalOnboardRuntimePreflight(
     preflightOpts,
     {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1462,6 +1462,7 @@ async function preflight(
 ): Promise<ReturnType<typeof nim.detectGpu>> {
   step(1, 8, "Preflight checks");
 
+  fatalRuntimePreflight.preparePortableExperimentalHost(process.env);
   const { gpu, host, sandboxGpuConfig } = fatalRuntimePreflight.runFatalOnboardRuntimePreflight(
     preflightOpts,
     {

--- a/src/lib/onboard/command-support.test.ts
+++ b/src/lib/onboard/command-support.test.ts
@@ -3,7 +3,7 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { buildOnboardFlags, setAgentRegistryReaderForTest } from "./command-support";
+import { buildOnboardFlags, onboardUsage, setAgentRegistryReaderForTest } from "./command-support";
 
 afterEach(() => {
   setAgentRegistryReaderForTest(null);
@@ -52,5 +52,15 @@ describe("buildOnboardFlags --events help", () => {
     );
     expect(onboardFlags.events.options).toEqual(["jsonl"]);
     expect(aliasFlags.events).toBeUndefined();
+  });
+});
+
+describe("buildOnboardFlags experimental profile", () => {
+  it("keeps the portable profile hidden and value constrained", () => {
+    const flags = buildOnboardFlags();
+
+    expect(flags["experimental-profile"].hidden).toBe(true);
+    expect(flags["experimental-profile"].options).toEqual(["portable"]);
+    expect(onboardUsage.join(" ")).not.toContain("experimental-profile");
   });
 });

--- a/src/lib/onboard/command-support.ts
+++ b/src/lib/onboard/command-support.ts
@@ -4,6 +4,7 @@
 import { Flags } from "@oclif/core";
 import { TOOL_DISCLOSURE_VALUES, type ToolDisclosure } from "../tool-disclosure";
 import { describeAgentFlag } from "./agent-flag-help";
+import { PORTABLE_EXPERIMENTAL_PROFILE } from "./docker-driver-platform";
 import { NOTICE_ACCEPT_FLAG, NOTICE_ACCEPT_FLAG_NAME } from "./usage-notice";
 
 type AgentRegistryReader = () => readonly string[];
@@ -80,6 +81,7 @@ export type OnboardFlags = {
   events?: "jsonl";
   yes?: boolean;
   "no-ollama-autostart"?: boolean;
+  "experimental-profile"?: string;
   [NOTICE_ACCEPT_FLAG_NAME]?: boolean;
 };
 
@@ -146,6 +148,10 @@ export function buildOnboardFlags(options: { includeEvents?: boolean } = {}): Re
     "no-ollama-autostart": Flags.boolean({
       description:
         "Skip the wizard's eager Ollama auto-start during inference-provider selection so onboard surfaces the unreachable-Ollama warning and the default fallback model; later setup steps still expect a reachable Ollama, and on Linux/systemd hosts the loopback-override path may still restart the daemon",
+    }),
+    "experimental-profile": Flags.string({
+      hidden: true,
+      options: [PORTABLE_EXPERIMENTAL_PROFILE],
     }),
     [NOTICE_ACCEPT_FLAG_NAME]: Flags.boolean({
       description: "Accept the third-party software notice",

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -126,6 +126,17 @@ describe("onboard command options", () => {
     });
   });
 
+  it("rejects resume when the portable profile requires a deterministic fresh install", () => {
+    const errors: string[] = [];
+    expect(() =>
+      resolve(
+        { "experimental-profile": "portable", resume: true },
+        { error: (message = "") => errors.push(message) },
+      ),
+    ).toThrow("exit:1");
+    expect(errors).toContain("  --resume cannot be combined with --experimental-profile portable.");
+  });
+
   it("maps --no-observability to an explicit disabled request", () => {
     expect(
       resolve(

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -5,12 +5,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resolveOnboardOptions, runOnboardCommand } from "./command";
 import type { OnboardFlags } from "./command-support";
 import { invalidGatewayManagementDeclarationError } from "./gateway-management";
 import { GatewayAuthorityError } from "./gateway-teardown-authority";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 function exitWithCode(code: number): never {
   throw new Error(`exit:${code}`);
@@ -84,6 +88,7 @@ describe("onboard command options", () => {
       noGpu: false,
       autoYes: true,
       noOllamaAutostart: true,
+      experimentalProfile: null,
     });
   });
 
@@ -107,6 +112,17 @@ describe("onboard command options", () => {
       noGpu: false,
       autoYes: false,
       noOllamaAutostart: false,
+      experimentalProfile: null,
+    });
+  });
+
+  it("resolves the portable profile to deterministic unattended defaults", () => {
+    expect(resolve({ "experimental-profile": "portable" })).toMatchObject({
+      experimentalProfile: "portable",
+      nonInteractive: true,
+      fresh: true,
+      autoYes: true,
+      noOllamaAutostart: true,
     });
   });
 
@@ -255,6 +271,41 @@ describe("onboard command options", () => {
     });
 
     expect(runOnboard).toHaveBeenCalledWith(expect.objectContaining({ resume: true }));
+  });
+
+  it("prepares and scopes portable profile defaults around onboarding", async () => {
+    vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "previous-profile");
+    vi.stubEnv("NEMOCLAW_PROVIDER", "previous-provider");
+    vi.stubEnv("NEMOCLAW_MODEL", "previous-model");
+    vi.stubEnv("NEMOCLAW_OLLAMA_NO_AUTOSTART", "0");
+    const observed: Record<string, string | undefined> = {};
+    await runOnboardCommand({
+      flags: { "experimental-profile": "portable" },
+      env: {},
+      runOnboard: async () => {
+        for (const key of [
+          "NEMOCLAW_EXPERIMENTAL_PROFILE",
+          "NEMOCLAW_PROVIDER",
+          "NEMOCLAW_MODEL",
+          "NEMOCLAW_OLLAMA_NO_AUTOSTART",
+        ]) {
+          observed[key] = process.env[key];
+        }
+      },
+    });
+
+    expect(observed).toEqual({
+      NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
+      NEMOCLAW_PROVIDER: "ollama",
+      NEMOCLAW_MODEL: "qwen3-vl:4b",
+      NEMOCLAW_OLLAMA_NO_AUTOSTART: "1",
+    });
+    expect(process.env).toMatchObject({
+      NEMOCLAW_EXPERIMENTAL_PROFILE: "previous-profile",
+      NEMOCLAW_PROVIDER: "previous-provider",
+      NEMOCLAW_MODEL: "previous-model",
+      NEMOCLAW_OLLAMA_NO_AUTOSTART: "0",
+    });
   });
 
   it("treats a prompt EOF during onboarding as cancellation and exits non-zero (#5976)", async () => {

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -159,6 +159,16 @@ function resolveExperimentalProfile(flags: OnboardFlags): ExperimentalOnboardPro
     : null;
 }
 
+function validateExperimentalProfileLifecycle(
+  flags: OnboardFlags,
+  profile: ExperimentalOnboardProfile | null,
+  deps: ResolveOnboardOptionsDeps,
+): void {
+  if (profile && flags.resume === true) {
+    fail(deps, "  --resume cannot be combined with --experimental-profile portable.");
+  }
+}
+
 function withPortableDefault(
   requested: boolean | undefined,
   profile: ExperimentalOnboardProfile | null,
@@ -171,6 +181,7 @@ export function resolveOnboardOptions(
   deps: ResolveOnboardOptionsDeps,
 ): OnboardCommandOptions {
   const experimentalProfile = resolveExperimentalProfile(flags);
+  validateExperimentalProfileLifecycle(flags, experimentalProfile, deps);
   const agent = resolveAgent(flags.agent, deps);
   validateObservabilityAgent(flags.observability, agent, deps);
   let toolDisclosure: ToolDisclosure | null;

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -12,6 +12,11 @@ import {
 } from "../tool-disclosure";
 import { applyAgentsManifestEnv } from "./agents-manifest";
 import type { OnboardFlags } from "./command-support";
+import {
+  EXPERIMENTAL_PROFILE_ENV,
+  type ExperimentalOnboardProfile,
+  PORTABLE_EXPERIMENTAL_PROFILE,
+} from "./docker-driver-platform";
 import { GatewayManagementDeclarationError } from "./gateway-management";
 import { GatewayAuthorityError, gatewayAuthorityFailureLines } from "./gateway-teardown-authority";
 import { managedSandboxFeatureIssue } from "./managed-sandbox-feature";
@@ -38,6 +43,7 @@ export interface OnboardCommandOptions {
   noGpu: boolean;
   autoYes: boolean;
   noOllamaAutostart: boolean;
+  experimentalProfile: ExperimentalOnboardProfile | null;
 }
 
 export interface ResolveOnboardOptionsDeps {
@@ -147,10 +153,24 @@ function validateObservabilityAgent(
   }
 }
 
+function resolveExperimentalProfile(flags: OnboardFlags): ExperimentalOnboardProfile | null {
+  return flags["experimental-profile"] === PORTABLE_EXPERIMENTAL_PROFILE
+    ? PORTABLE_EXPERIMENTAL_PROFILE
+    : null;
+}
+
+function withPortableDefault(
+  requested: boolean | undefined,
+  profile: ExperimentalOnboardProfile | null,
+): boolean {
+  return requested === true || profile !== null;
+}
+
 export function resolveOnboardOptions(
   flags: OnboardFlags,
   deps: ResolveOnboardOptionsDeps,
 ): OnboardCommandOptions {
+  const experimentalProfile = resolveExperimentalProfile(flags);
   const agent = resolveAgent(flags.agent, deps);
   validateObservabilityAgent(flags.observability, agent, deps);
   let toolDisclosure: ToolDisclosure | null;
@@ -160,9 +180,9 @@ export function resolveOnboardOptions(
     fail(deps, `  ${error instanceof Error ? error.message : String(error)}`);
   }
   return {
-    nonInteractive: flags["non-interactive"] === true,
+    nonInteractive: withPortableDefault(flags["non-interactive"], experimentalProfile),
     resume: flags.resume === true,
-    fresh: flags.fresh === true,
+    fresh: withPortableDefault(flags.fresh, experimentalProfile),
     recreateSandbox: flags["recreate-sandbox"] === true,
     fromDockerfile: resolveFileOption("--from", flags.from, deps, true),
     sandboxName: flags.name ?? null,
@@ -177,8 +197,9 @@ export function resolveOnboardOptions(
     controlUiPort: flags["control-ui-port"] ?? null,
     gpu: flags.gpu === true,
     noGpu: flags["no-gpu"] === true,
-    autoYes: flags.yes === true,
-    noOllamaAutostart: flags["no-ollama-autostart"] === true,
+    autoYes: withPortableDefault(flags.yes, experimentalProfile),
+    noOllamaAutostart: withPortableDefault(flags["no-ollama-autostart"], experimentalProfile),
+    experimentalProfile,
   };
 }
 
@@ -224,8 +245,36 @@ function handleOnboardCommandError(error: unknown, deps: RunOnboardCommandDeps):
   fail(deps, "  Installation cancelled");
 }
 
+function applyPortableEnvironment(options: OnboardCommandOptions): () => void {
+  if (!options.experimentalProfile) return () => {};
+  const portableEnvDefaults = {
+    [EXPERIMENTAL_PROFILE_ENV]: options.experimentalProfile ?? undefined,
+    NEMOCLAW_PROVIDER: "ollama",
+    NEMOCLAW_MODEL: "qwen3-vl:4b",
+    NEMOCLAW_OLLAMA_NO_AUTOSTART: "1",
+  } as const;
+  const previousPortableEnv = new Map<string, string | undefined>();
+  const restore = () => {
+    for (const [key, value] of previousPortableEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+  try {
+    for (const [key, value] of Object.entries(portableEnvDefaults)) {
+      previousPortableEnv.set(key, process.env[key]);
+      if (value !== undefined) process.env[key] = value;
+    }
+  } catch (error) {
+    restore();
+    throw error;
+  }
+  return restore;
+}
+
 export async function runOnboardCommand(deps: RunOnboardCommandDeps): Promise<void> {
   const options = resolveOnboardOptions(deps.flags, deps);
+  const restorePortableEnvironment = applyPortableEnvironment(options);
   if (options.noOllamaAutostart) process.env.NEMOCLAW_OLLAMA_NO_AUTOSTART = "1";
   // Keep direct callers and the legacy monolithic onboard path on the same
   // canonical source. No value is written for the default so resume/rebuild
@@ -236,5 +285,7 @@ export async function runOnboardCommand(deps: RunOnboardCommandDeps): Promise<vo
     await deps.runOnboard(options);
   } catch (error) {
     handleOnboardCommandError(error, deps);
+  } finally {
+    restorePortableEnvironment();
   }
 }

--- a/src/lib/onboard/docker-driver-gateway-config.ts
+++ b/src/lib/onboard/docker-driver-gateway-config.ts
@@ -8,6 +8,7 @@ import {
   type DockerDriverGatewayJwtBundle,
   ensureDockerDriverGatewayJwtBundle,
 } from "./docker-driver-gateway-jwt-bundle";
+import { PORTABLE_HOST_GATEWAY_IP } from "./docker-driver-platform";
 
 export type { DockerDriverGatewayJwtBundle } from "./docker-driver-gateway-jwt-bundle";
 export { ensureDockerDriverGatewayJwtBundle } from "./docker-driver-gateway-jwt-bundle";
@@ -73,9 +74,11 @@ export function buildDockerDriverGatewayConfigToml(
   jwtBundle?: DockerDriverGatewayJwtBundle | null,
   gatewayId = "nemoclaw",
 ): string {
+  const driver = gatewayEnv.OPENSHELL_DRIVERS === "podman" ? "podman" : "docker";
   const localTlsDir = jwtBundle ? gatewayLocalTlsDir(gatewayEnv) : undefined;
   const dockerEntries: [string, string | undefined][] = [
     ["grpc_endpoint", gatewayEnv.OPENSHELL_GRPC_ENDPOINT],
+    ["host_gateway_ip", driver === "podman" ? PORTABLE_HOST_GATEWAY_IP : undefined],
     ["network_name", gatewayEnv.OPENSHELL_DOCKER_NETWORK_NAME],
     ["supervisor_image", gatewayEnv.OPENSHELL_DOCKER_SUPERVISOR_IMAGE],
     ["supervisor_bin", sandboxBin ?? undefined],
@@ -95,7 +98,7 @@ export function buildDockerDriverGatewayConfigToml(
     "version = 1",
     "",
     "[openshell.gateway]",
-    'compute_drivers = ["docker"]',
+    `compute_drivers = [${tomlString(driver)}]`,
     "disable_tls = false",
     "",
   ];
@@ -125,7 +128,7 @@ export function buildDockerDriverGatewayConfigToml(
     );
   }
 
-  sections.push("[openshell.drivers.docker]");
+  sections.push(`[openshell.drivers.${driver}]`);
   if (dockerConfig) sections.push(dockerConfig);
   sections.push("");
 

--- a/src/lib/onboard/docker-driver-gateway-env.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.test.ts
@@ -68,6 +68,7 @@ describe("buildDockerDriverGatewayEnv", () => {
 
   it("builds the exact rootless gateway network contract for the portable profile", () => {
     vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+    vi.stubEnv("CONTAINERS_CONF", "/tmp/nemoclaw-portable/containers.conf");
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-gateway-"));
     try {
       const env = buildDockerDriverGatewayEnv({
@@ -78,6 +79,7 @@ describe("buildDockerDriverGatewayEnv", () => {
       });
       expect(env).toMatchObject({
         OPENSHELL_DRIVERS: "podman",
+        CONTAINERS_CONF: "/tmp/nemoclaw-portable/containers.conf",
         OPENSHELL_BIND_ADDRESS: "0.0.0.0",
         OPENSHELL_GRPC_ENDPOINT: "https://169.254.1.2:8080",
         NETAVARK_FW: "iptables",

--- a/src/lib/onboard/docker-driver-gateway-env.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.test.ts
@@ -65,6 +65,32 @@ describe("buildDockerDriverGatewayEnv", () => {
     expect(env.OPENSHELL_VM_DRIVER_STATE_DIR).toBeUndefined();
     expect(env.OPENSHELL_DRIVER_DIR).toBeUndefined();
   });
+
+  it("builds the exact rootless gateway network contract for the portable profile", () => {
+    vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-gateway-"));
+    try {
+      const env = buildDockerDriverGatewayEnv({
+        platform: "linux",
+        stateDir,
+        getDockerSupervisorImage: () => "supervisor:test",
+        resolveSandboxBin: () => "/usr/bin/openshell-sandbox",
+      });
+      expect(env).toMatchObject({
+        OPENSHELL_DRIVERS: "podman",
+        OPENSHELL_BIND_ADDRESS: "0.0.0.0",
+        OPENSHELL_GRPC_ENDPOINT: "https://169.254.1.2:8080",
+        NETAVARK_FW: "iptables",
+      });
+      const toml = fs.readFileSync(env.OPENSHELL_GATEWAY_CONFIG, "utf-8");
+      expect(toml).toContain('compute_drivers = ["podman"]');
+      expect(toml).toContain("[openshell.drivers.podman]");
+      expect(toml).toContain('host_gateway_ip = "169.254.1.2"');
+    } finally {
+      vi.unstubAllEnvs();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("buildDockerGatewayDebEnvFile", () => {

--- a/src/lib/onboard/docker-driver-gateway-env.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.ts
@@ -33,6 +33,7 @@ import { isPortableExperimentalProfile, PORTABLE_HOST_GATEWAY_IP } from "./docke
 export { getGatewayHttpsEndpoint, startPackageManagedDockerDriverGateway };
 
 export const DOCKER_DRIVER_GATEWAY_RUNTIME_ENV_KEYS = [
+  "CONTAINERS_CONF",
   "DOCKER_HOST",
   "OPENSHELL_DRIVERS",
   "OPENSHELL_BIND_ADDRESS",
@@ -236,7 +237,11 @@ export function buildDockerDriverGatewayEnv({
     OPENSHELL_DOCKER_NETWORK_NAME: dockerNetworkName,
     OPENSHELL_DOCKER_SUPERVISOR_IMAGE: getDockerSupervisorImage(),
   };
-  if (portable) env.NETAVARK_FW = "iptables";
+  if (portable) {
+    env.NETAVARK_FW = "iptables";
+    const containersConf = process.env.CONTAINERS_CONF?.trim();
+    if (containersConf) env.CONTAINERS_CONF = containersConf;
+  }
   if (platform === "linux") {
     const sandboxBin = resolveSandboxBin();
     if (sandboxBin) {

--- a/src/lib/onboard/docker-driver-gateway-env.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.ts
@@ -28,6 +28,7 @@ import {
   startPackageManagedDockerDriverGateway,
   stopOpenShellGatewayUserService,
 } from "./docker-driver-gateway-service";
+import { isPortableExperimentalProfile, PORTABLE_HOST_GATEWAY_IP } from "./docker-driver-platform";
 
 export { getGatewayHttpsEndpoint, startPackageManagedDockerDriverGateway };
 
@@ -49,6 +50,7 @@ export const DOCKER_DRIVER_GATEWAY_RUNTIME_ENV_KEYS = [
   "OPENSHELL_GATEWAY_CONFIG",
   "OPENSHELL_VM_DRIVER_STATE_DIR",
   "OPENSHELL_DRIVER_DIR",
+  "NETAVARK_FW",
 ] as const;
 
 export interface BuildDockerDriverGatewayEnvOptions {
@@ -70,14 +72,17 @@ export type PackageManagedDockerDriverGatewayWithEnvOverrideOptions = Omit<
 };
 
 export function getGatewayPortCheckOptions(): { host: string } {
-  return { host: GATEWAY_BIND_ADDRESS };
+  return {
+    host: isPortableExperimentalProfile() ? WILDCARD_GATEWAY_BIND_ADDRESS : GATEWAY_BIND_ADDRESS,
+  };
 }
 
 export function getGatewayStartNetworkEnv(
   gatewayPort: number = GATEWAY_PORT,
 ): Record<string, string> {
+  const portable = isPortableExperimentalProfile();
   return {
-    OPENSHELL_BIND_ADDRESS: GATEWAY_BIND_ADDRESS,
+    OPENSHELL_BIND_ADDRESS: portable ? WILDCARD_GATEWAY_BIND_ADDRESS : GATEWAY_BIND_ADDRESS,
     OPENSHELL_SERVER_PORT: String(gatewayPort),
     OPENSHELL_SSH_GATEWAY_HOST: getGatewayConnectHost(),
     OPENSHELL_SSH_GATEWAY_PORT: String(gatewayPort),
@@ -86,6 +91,13 @@ export function getGatewayStartNetworkEnv(
 
 export function assertDockerDriverGatewayBindAddressSafe(gatewayEnv: Record<string, string>): void {
   if (gatewayEnv.OPENSHELL_BIND_ADDRESS !== WILDCARD_GATEWAY_BIND_ADDRESS) return;
+  if (
+    gatewayEnv.OPENSHELL_DRIVERS === "podman" &&
+    gatewayEnv.OPENSHELL_GRPC_ENDPOINT ===
+      `https://${PORTABLE_HOST_GATEWAY_IP}:${gatewayEnv.OPENSHELL_SERVER_PORT}`
+  ) {
+    return;
+  }
   throw new Error(
     "NEMOCLAW_GATEWAY_BIND_ADDRESS=0.0.0.0 is not supported for the OpenShell Docker-driver gateway while gateway JWT auth is active. Remove the override, or use NEMOCLAW_DASHBOARD_BIND for dashboard exposure.",
   );
@@ -212,15 +224,19 @@ export function buildDockerDriverGatewayEnv({
   getDockerSupervisorImage,
   resolveSandboxBin,
 }: BuildDockerDriverGatewayEnvOptions): Record<string, string> {
+  const portable = isPortableExperimentalProfile();
   const env: Record<string, string> = {
-    OPENSHELL_DRIVERS: "docker",
+    OPENSHELL_DRIVERS: portable ? "podman" : "docker",
     ...getGatewayStartNetworkEnv(gatewayPort),
     ...buildDockerDriverGatewayLocalTlsEnv(stateDir),
     OPENSHELL_DB_URL: `sqlite:${path.join(stateDir, "openshell.db")}`,
-    OPENSHELL_GRPC_ENDPOINT: getDockerDriverGatewayEndpoint(gatewayPort),
+    OPENSHELL_GRPC_ENDPOINT: portable
+      ? `https://${PORTABLE_HOST_GATEWAY_IP}:${gatewayPort}`
+      : getDockerDriverGatewayEndpoint(gatewayPort),
     OPENSHELL_DOCKER_NETWORK_NAME: dockerNetworkName,
     OPENSHELL_DOCKER_SUPERVISOR_IMAGE: getDockerSupervisorImage(),
   };
+  if (portable) env.NETAVARK_FW = "iptables";
   if (platform === "linux") {
     const sandboxBin = resolveSandboxBin();
     if (sandboxBin) {

--- a/src/lib/onboard/docker-driver-gateway-local-tls.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-local-tls.test.ts
@@ -224,6 +224,27 @@ describe("docker-driver-gateway-local-tls", () => {
     }
   });
 
+  it("adds the rootless host gateway SAN for the portable profile", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-tls-"));
+    const calls: string[][] = [];
+    try {
+      expect(() =>
+        ensureDockerDriverGatewayLocalTlsBundle({
+          env: { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
+          gatewayBin: "/opt/openshell/openshell-gateway",
+          stateDir,
+          spawnSyncImpl: ((_command: string, args: string[]) => {
+            calls.push(args);
+            return { status: 0, stdout: "", stderr: "" };
+          }) as never,
+        }),
+      ).toThrow("did not create a complete");
+      expect(calls[0]).toEqual(expect.arrayContaining(["--server-san", "169.254.1.2"]));
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves an existing complete mTLS bundle without regenerating certs", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-tls-"));
     const contents = writeBundle(stateDir, TEST_CERT_PEM, TEST_KEY_PEM);

--- a/src/lib/onboard/docker-driver-gateway-local-tls.ts
+++ b/src/lib/onboard/docker-driver-gateway-local-tls.ts
@@ -6,6 +6,8 @@ import { createPrivateKey, createPublicKey, type KeyObject, X509Certificate } fr
 import fs from "node:fs";
 import path from "node:path";
 
+import { isPortableExperimentalProfile, PORTABLE_HOST_GATEWAY_IP } from "./docker-driver-platform";
+
 // See docs/security/openshell-0.0.72-compatibility-review.mdx for the source-of-truth review.
 export const DOCKER_DRIVER_GATEWAY_LOCAL_TLS_DIR_NAME = "tls";
 
@@ -47,7 +49,10 @@ export function getDockerDriverGatewayLocalTlsBundle(
   };
 }
 
-export function dockerDriverGatewayLocalTlsBundleIsComplete(stateDir: string): boolean {
+export function dockerDriverGatewayLocalTlsBundleIsComplete(
+  stateDir: string,
+  requiredServerIpSans: readonly string[] = REQUIRED_SERVER_IP_SANS,
+): boolean {
   const bundle = getDockerDriverGatewayLocalTlsBundle(stateDir);
   const expectedFiles = [
     bundle.caPath,
@@ -74,7 +79,7 @@ export function dockerDriverGatewayLocalTlsBundleIsComplete(stateDir: string): b
     certificateMatchesPrivateKey(clientCert, clientKey) &&
     certificateVerifiesAgainstCa(serverCert, ca) &&
     certificateVerifiesAgainstCa(clientCert, ca) &&
-    certificateHasRequiredServerSubjectAltNames(serverCert)
+    certificateHasRequiredServerSubjectAltNames(serverCert, requiredServerIpSans)
   );
 }
 
@@ -156,7 +161,10 @@ function certificateVerifiesAgainstCa(certificate: X509Certificate, ca: X509Cert
   }
 }
 
-function certificateHasRequiredServerSubjectAltNames(certificate: X509Certificate): boolean {
+function certificateHasRequiredServerSubjectAltNames(
+  certificate: X509Certificate,
+  requiredServerIpSans: readonly string[],
+): boolean {
   const subjectAltNames = new Set(
     (certificate.subjectAltName ?? "")
       .split(",")
@@ -165,7 +173,7 @@ function certificateHasRequiredServerSubjectAltNames(certificate: X509Certificat
   );
   return (
     REQUIRED_SERVER_DNS_SANS.every((dnsName) => subjectAltNames.has(`dns:${dnsName}`)) &&
-    REQUIRED_SERVER_IP_SANS.every(
+    requiredServerIpSans.every(
       (ipAddress) =>
         subjectAltNames.has(`ip address:${ipAddress}`) || subjectAltNames.has(`ip:${ipAddress}`),
     )
@@ -186,9 +194,12 @@ export function ensureDockerDriverGatewayLocalTlsBundle({
   stateDir,
 }: EnsureDockerDriverGatewayLocalTlsBundleOptions): DockerDriverGatewayLocalTlsBundle {
   const bundle = getDockerDriverGatewayLocalTlsBundle(stateDir);
+  const requiredServerIpSans = isPortableExperimentalProfile(env)
+    ? [...REQUIRED_SERVER_IP_SANS, PORTABLE_HOST_GATEWAY_IP]
+    : REQUIRED_SERVER_IP_SANS;
   fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   fs.chmodSync(stateDir, 0o700);
-  if (dockerDriverGatewayLocalTlsBundleIsComplete(stateDir)) {
+  if (dockerDriverGatewayLocalTlsBundleIsComplete(stateDir, requiredServerIpSans)) {
     normalizeDockerDriverGatewayLocalTlsBundlePermissions(bundle);
     return bundle;
   }
@@ -205,6 +216,7 @@ export function ensureDockerDriverGatewayLocalTlsBundle({
       "localhost",
       "--server-san",
       "127.0.0.1",
+      ...(isPortableExperimentalProfile(env) ? ["--server-san", PORTABLE_HOST_GATEWAY_IP] : []),
     ],
     {
       encoding: "utf-8",
@@ -229,7 +241,7 @@ export function ensureDockerDriverGatewayLocalTlsBundle({
     const detail = sanitizeDockerDriverGatewayLocalTlsErrorDetail(rawDetail, bundle, stateDir);
     throw new Error(`OpenShell gateway certificate generation failed: ${detail}`);
   }
-  if (!dockerDriverGatewayLocalTlsBundleIsComplete(stateDir)) {
+  if (!dockerDriverGatewayLocalTlsBundleIsComplete(stateDir, requiredServerIpSans)) {
     const detail = sanitizeDockerDriverGatewayLocalTlsErrorDetail(
       `incomplete mTLS bundle in ${bundle.localTlsDir}`,
       bundle,

--- a/src/lib/onboard/docker-driver-gateway-runtime.ts
+++ b/src/lib/onboard/docker-driver-gateway-runtime.ts
@@ -278,6 +278,7 @@ export function createDockerDriverGatewayRuntimeHelpers(deps: DockerDriverGatewa
     if (!env) return false;
     return (
       env.OPENSHELL_DRIVERS === "docker" ||
+      env.OPENSHELL_DRIVERS === "podman" ||
       Boolean(env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE) ||
       env.OPENSHELL_GRPC_ENDPOINT ===
         dockerDriverGatewayEnv.getDockerDriverGatewayEndpoint(currentGatewayPort())

--- a/src/lib/onboard/docker-driver-platform.ts
+++ b/src/lib/onboard/docker-driver-platform.ts
@@ -5,6 +5,25 @@ import { resolveCurrentOpenShellComputePlan, usesManagedDockerGateway } from "./
 
 export { resolveCurrentOpenShellComputePlan } from "./compute/plan";
 
+export const EXPERIMENTAL_PROFILE_ENV = "NEMOCLAW_EXPERIMENTAL_PROFILE";
+export const PORTABLE_EXPERIMENTAL_PROFILE = "portable";
+export const PORTABLE_HOST_GATEWAY_IP = "169.254.1.2";
+export const PORTABLE_LOCAL_REGISTRY = "localhost:5000";
+
+export type ExperimentalOnboardProfile = typeof PORTABLE_EXPERIMENTAL_PROFILE;
+
+export function resolveExperimentalOnboardProfile(
+  env: NodeJS.ProcessEnv = process.env,
+): ExperimentalOnboardProfile | null {
+  return env[EXPERIMENTAL_PROFILE_ENV] === PORTABLE_EXPERIMENTAL_PROFILE
+    ? PORTABLE_EXPERIMENTAL_PROFILE
+    : null;
+}
+
+export function isPortableExperimentalProfile(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveExperimentalOnboardProfile(env) === PORTABLE_EXPERIMENTAL_PROFILE;
+}
+
 export function isLinuxDockerDriverGatewayEnabled(
   platform: NodeJS.Platform = process.platform,
   arch: NodeJS.Architecture = process.arch,

--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { preparePortableExperimentalHost } from "./portable-host-preparation";
+
+type SpawnResult = ReturnType<typeof spawnSync>;
+
+function result(status = 0, stdout = ""): SpawnResult {
+  return { status, stdout, stderr: "" } as SpawnResult;
+}
+
+describe("preparePortableExperimentalHost", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const tempDir of tempDirs) fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("does nothing unless the portable profile is explicit", () => {
+    const systemctl = vi.fn();
+    const docker = vi.fn();
+    const env: NodeJS.ProcessEnv = {};
+
+    preparePortableExperimentalHost(env, { docker, systemctl });
+
+    expect(env.DOCKER_HOST).toBeUndefined();
+    expect(systemctl).not.toHaveBeenCalled();
+    expect(docker).not.toHaveBeenCalled();
+  });
+
+  it("prepares the rootless socket and managed loopback registry deterministically", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
+    tempDirs.push(home);
+    const systemctl = vi.fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>(() =>
+      result(),
+    );
+    const docker = vi
+      .fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>()
+      .mockReturnValueOnce(result(1))
+      .mockReturnValueOnce(result());
+    const env: NodeJS.ProcessEnv = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
+
+    preparePortableExperimentalHost(env, {
+      platform: "linux",
+      home,
+      uid: 1001,
+      systemctl,
+      docker,
+    });
+
+    expect(env).toMatchObject({
+      DOCKER_HOST: "unix:///run/user/1001/podman/podman.sock",
+      NETAVARK_FW: "iptables",
+    });
+    expect(systemctl.mock.calls.map(([args]) => args)).toEqual([
+      ["--user", "set-environment", "NETAVARK_FW=iptables"],
+      ["--user", "try-restart", "podman.service"],
+      ["--user", "enable", "--now", "podman.socket"],
+    ]);
+    expect(docker.mock.calls[1]?.[0]).toEqual([
+      "run",
+      "-d",
+      "--name",
+      "nemoclaw-portable-registry",
+      "--label",
+      "com.nvidia.nemoclaw.portable=1",
+      "-p",
+      "127.0.0.1:5000:5000",
+      "--restart=always",
+      "docker.io/library/registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373",
+    ]);
+    const registryConfig = path.join(
+      home,
+      ".config/containers/registries.conf.d/99-nemoclaw-portable.conf",
+    );
+    expect(fs.readFileSync(registryConfig, "utf-8")).toContain('location = "localhost:5000"');
+    expect(fs.statSync(registryConfig).mode & 0o777).toBe(0o600);
+  });
+
+  it("refuses to replace an unmanaged registry container", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
+    tempDirs.push(home);
+    const env: NodeJS.ProcessEnv = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
+
+    expect(() =>
+      preparePortableExperimentalHost(env, {
+        platform: "linux",
+        home,
+        uid: 1001,
+        systemctl: () => result(),
+        docker: () => result(0, "unexpected-owner"),
+      }),
+    ).toThrow(/unmanaged container/);
+  });
+});

--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -92,7 +92,6 @@ describe("preparePortableExperimentalHost", () => {
     expect(fs.readFileSync(containersConf, "utf-8")).toContain(
       'default_rootless_network_cmd = "pasta"',
     );
-    expect(fs.readFileSync(containersConf, "utf-8")).toContain('pasta_options = ["--map-gw"]');
     expect(fs.readFileSync(containersConf, "utf-8")).toContain('env = ["NETAVARK_FW=iptables"]');
     expect(fs.statSync(containersConf).mode & 0o777).toBe(0o600);
   });

--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -56,11 +56,17 @@ describe("preparePortableExperimentalHost", () => {
     });
 
     expect(env).toMatchObject({
+      CONTAINERS_CONF: path.join(home, ".config/nemoclaw/portable/containers.conf"),
       DOCKER_HOST: "unix:///run/user/1001/podman/podman.sock",
       NETAVARK_FW: "iptables",
     });
     expect(systemctl.mock.calls.map(([args]) => args)).toEqual([
-      ["--user", "set-environment", "NETAVARK_FW=iptables"],
+      [
+        "--user",
+        "set-environment",
+        "NETAVARK_FW=iptables",
+        `CONTAINERS_CONF=${path.join(home, ".config/nemoclaw/portable/containers.conf")}`,
+      ],
       ["--user", "try-restart", "podman.service"],
       ["--user", "enable", "--now", "podman.socket"],
     ]);
@@ -82,6 +88,13 @@ describe("preparePortableExperimentalHost", () => {
     );
     expect(fs.readFileSync(registryConfig, "utf-8")).toContain('location = "localhost:5000"');
     expect(fs.statSync(registryConfig).mode & 0o777).toBe(0o600);
+    const containersConf = path.join(home, ".config/nemoclaw/portable/containers.conf");
+    expect(fs.readFileSync(containersConf, "utf-8")).toContain(
+      'default_rootless_network_cmd = "pasta"',
+    );
+    expect(fs.readFileSync(containersConf, "utf-8")).toContain('pasta_options = ["--map-gw"]');
+    expect(fs.readFileSync(containersConf, "utf-8")).toContain('env = ["NETAVARK_FW=iptables"]');
+    expect(fs.statSync(containersConf).mode & 0o777).toBe(0o600);
   });
 
   it("refuses to replace an unmanaged registry container", () => {

--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -111,4 +111,38 @@ describe("preparePortableExperimentalHost", () => {
       }),
     ).toThrow(/unmanaged container/);
   });
+
+  it("reports a bounded registry inspection failure before attempting startup", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
+    tempDirs.push(home);
+    const timeout = Object.assign(new Error("registry inspection timed out"), {
+      code: "ETIMEDOUT",
+    });
+    const docker = vi.fn(
+      () =>
+        ({
+          error: timeout,
+          output: [null, "", ""],
+          pid: 1234,
+          signal: "SIGKILL",
+          status: null,
+          stderr: "",
+          stdout: "",
+        }) as SpawnResult,
+    );
+
+    expect(() =>
+      preparePortableExperimentalHost(
+        { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
+        {
+          platform: "linux",
+          home,
+          uid: 1001,
+          systemctl: () => result(),
+          docker,
+        },
+      ),
+    ).toThrow(/Inspecting the managed portable registry failed: registry inspection timed out/);
+    expect(docker).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/onboard/experimental/portable-host-preparation.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { dockerSpawnSync } from "../../adapters/docker/exec";
+import { openRegularFileNoFollow } from "../../adapters/fs/regular-file";
+import { ensureConfigDir } from "../../state/config-io";
+import { isPortableExperimentalProfile, PORTABLE_LOCAL_REGISTRY } from "../docker-driver-platform";
+
+const REGISTRY_CONTAINER = "nemoclaw-portable-registry";
+const REGISTRY_LABEL = "com.nvidia.nemoclaw.portable=1";
+const REGISTRY_IMAGE =
+  "docker.io/library/registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373";
+const REGISTRY_FRAGMENT = `[[registry]]
+location = "${PORTABLE_LOCAL_REGISTRY}"
+insecure = true
+`;
+
+type SpawnResult = ReturnType<typeof spawnSync>;
+
+export interface PortableHostPreparationDeps {
+  platform?: NodeJS.Platform;
+  home?: string;
+  uid?: number;
+  systemctl?: (args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult;
+  docker?: (args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult;
+}
+
+function commandDetail(result: SpawnResult): string {
+  if (result.error) return result.error.message;
+  const stderr = String(result.stderr ?? "").trim();
+  const stdout = String(result.stdout ?? "").trim();
+  return stderr || stdout || `exit ${String(result.status)}`;
+}
+
+function requireCommand(result: SpawnResult, description: string): void {
+  if (result.status === 0) return;
+  throw new Error(`${description} failed: ${commandDetail(result)}`);
+}
+
+function writeRegistryFragment(home: string, env: NodeJS.ProcessEnv): void {
+  const configHome = env.XDG_CONFIG_HOME?.trim() || path.join(home, ".config");
+  const fragmentDir = path.join(configHome, "containers", "registries.conf.d");
+  const fragmentPath = path.join(fragmentDir, "99-nemoclaw-portable.conf");
+  ensureConfigDir(fragmentDir);
+  let file;
+  try {
+    file = openRegularFileNoFollow(fragmentPath, { writable: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    file = openRegularFileNoFollow(fragmentPath, {
+      create: true,
+      mode: 0o600,
+      writable: true,
+    });
+  }
+  try {
+    file.replaceUtf8(REGISTRY_FRAGMENT, 0o600);
+  } finally {
+    file.close();
+  }
+}
+
+function ensureRegistryContainer(
+  env: NodeJS.ProcessEnv,
+  docker: NonNullable<PortableHostPreparationDeps["docker"]>,
+): void {
+  const inspection = docker(
+    [
+      "inspect",
+      "--format",
+      '{{ index .Config.Labels "com.nvidia.nemoclaw.portable" }}',
+      REGISTRY_CONTAINER,
+    ],
+    env,
+  );
+  const exists = inspection.status === 0;
+  if (exists && String(inspection.stdout ?? "").trim() !== "1") {
+    throw new Error(
+      `Refusing to replace existing unmanaged container '${REGISTRY_CONTAINER}'. Rename or remove it and retry.`,
+    );
+  }
+  if (exists) {
+    requireCommand(
+      docker(["rm", "-f", REGISTRY_CONTAINER], env),
+      "Removing the previous managed portable registry",
+    );
+  }
+  requireCommand(
+    docker(
+      [
+        "run",
+        "-d",
+        "--name",
+        REGISTRY_CONTAINER,
+        "--label",
+        REGISTRY_LABEL,
+        "-p",
+        "127.0.0.1:5000:5000",
+        "--restart=always",
+        REGISTRY_IMAGE,
+      ],
+      env,
+    ),
+    "Starting the managed portable registry",
+  );
+}
+
+/** Prepare the user-scoped rootless runtime required by the hidden portable profile. */
+export function preparePortableExperimentalHost(
+  env: NodeJS.ProcessEnv = process.env,
+  deps: PortableHostPreparationDeps = {},
+): void {
+  if (!isPortableExperimentalProfile(env)) return;
+  if ((deps.platform ?? process.platform) !== "linux") {
+    throw new Error("The portable experimental profile requires Linux.");
+  }
+  const uid = deps.uid ?? process.getuid?.();
+  if (!Number.isInteger(uid) || Number(uid) < 0) {
+    throw new Error("The portable experimental profile could not resolve the current user ID.");
+  }
+  const home = deps.home ?? env.HOME ?? os.homedir();
+  env.NETAVARK_FW = "iptables";
+  env.DOCKER_HOST = `unix:///run/user/${String(uid)}/podman/podman.sock`;
+  writeRegistryFragment(home, env);
+
+  const systemctl =
+    deps.systemctl ??
+    ((args, childEnv) => spawnSync("systemctl", [...args], { encoding: "utf-8", env: childEnv }));
+  requireCommand(
+    systemctl(["--user", "set-environment", "NETAVARK_FW=iptables"], env),
+    "Configuring the rootless container service environment",
+  );
+  requireCommand(
+    systemctl(["--user", "try-restart", "podman.service"], env),
+    "Refreshing the rootless container service",
+  );
+  requireCommand(
+    systemctl(["--user", "enable", "--now", "podman.socket"], env),
+    "Starting the rootless container socket",
+  );
+
+  const docker =
+    deps.docker ??
+    ((args, childEnv) => dockerSpawnSync(args, { encoding: "utf-8", env: childEnv }));
+  ensureRegistryContainer(env, docker);
+}
+
+export const portableHostPreparationInternals = {
+  REGISTRY_CONTAINER,
+  REGISTRY_IMAGE,
+  REGISTRY_FRAGMENT,
+};

--- a/src/lib/onboard/experimental/portable-host-preparation.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.ts
@@ -19,6 +19,14 @@ const REGISTRY_FRAGMENT = `[[registry]]
 location = "${PORTABLE_LOCAL_REGISTRY}"
 insecure = true
 `;
+const PORTABLE_CONTAINERS_CONF = `[network]
+default_rootless_network_cmd = "pasta"
+firewall_driver = "iptables"
+pasta_options = ["--map-gw"]
+
+[engine]
+env = ["NETAVARK_FW=iptables"]
+`;
 
 type SpawnResult = ReturnType<typeof spawnSync>;
 
@@ -42,27 +50,35 @@ function requireCommand(result: SpawnResult, description: string): void {
   throw new Error(`${description} failed: ${commandDetail(result)}`);
 }
 
-function writeRegistryFragment(home: string, env: NodeJS.ProcessEnv): void {
-  const configHome = env.XDG_CONFIG_HOME?.trim() || path.join(home, ".config");
-  const fragmentDir = path.join(configHome, "containers", "registries.conf.d");
-  const fragmentPath = path.join(fragmentDir, "99-nemoclaw-portable.conf");
-  ensureConfigDir(fragmentDir);
+function writePrivateConfig(filePath: string, value: string): void {
+  ensureConfigDir(path.dirname(filePath));
   let file;
   try {
-    file = openRegularFileNoFollow(fragmentPath, { writable: true });
+    file = openRegularFileNoFollow(filePath, { writable: true });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-    file = openRegularFileNoFollow(fragmentPath, {
+    file = openRegularFileNoFollow(filePath, {
       create: true,
       mode: 0o600,
       writable: true,
     });
   }
   try {
-    file.replaceUtf8(REGISTRY_FRAGMENT, 0o600);
+    file.replaceUtf8(value, 0o600);
   } finally {
     file.close();
   }
+}
+
+function writePortableRuntimeConfig(home: string, env: NodeJS.ProcessEnv): string {
+  const configHome = env.XDG_CONFIG_HOME?.trim() || path.join(home, ".config");
+  writePrivateConfig(
+    path.join(configHome, "containers", "registries.conf.d", "99-nemoclaw-portable.conf"),
+    REGISTRY_FRAGMENT,
+  );
+  const containersConf = path.join(configHome, "nemoclaw", "portable", "containers.conf");
+  writePrivateConfig(containersConf, PORTABLE_CONTAINERS_CONF);
+  return containersConf;
 }
 
 function ensureRegistryContainer(
@@ -126,13 +142,21 @@ export function preparePortableExperimentalHost(
   const home = deps.home ?? env.HOME ?? os.homedir();
   env.NETAVARK_FW = "iptables";
   env.DOCKER_HOST = `unix:///run/user/${String(uid)}/podman/podman.sock`;
-  writeRegistryFragment(home, env);
+  env.CONTAINERS_CONF = writePortableRuntimeConfig(home, env);
 
   const systemctl =
     deps.systemctl ??
     ((args, childEnv) => spawnSync("systemctl", [...args], { encoding: "utf-8", env: childEnv }));
   requireCommand(
-    systemctl(["--user", "set-environment", "NETAVARK_FW=iptables"], env),
+    systemctl(
+      [
+        "--user",
+        "set-environment",
+        "NETAVARK_FW=iptables",
+        `CONTAINERS_CONF=${env.CONTAINERS_CONF}`,
+      ],
+      env,
+    ),
     "Configuring the rootless container service environment",
   );
   requireCommand(
@@ -154,4 +178,5 @@ export const portableHostPreparationInternals = {
   REGISTRY_CONTAINER,
   REGISTRY_IMAGE,
   REGISTRY_FRAGMENT,
+  PORTABLE_CONTAINERS_CONF,
 };

--- a/src/lib/onboard/experimental/portable-host-preparation.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -15,6 +14,8 @@ const REGISTRY_CONTAINER = "nemoclaw-portable-registry";
 const REGISTRY_LABEL = "com.nvidia.nemoclaw.portable=1";
 const REGISTRY_IMAGE =
   "docker.io/library/registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373";
+const HOST_COMMAND_TIMEOUT_MS = 30_000;
+const REGISTRY_COMMAND_TIMEOUT_MS = 300_000;
 const REGISTRY_FRAGMENT = `[[registry]]
 location = "${PORTABLE_LOCAL_REGISTRY}"
 insecure = true
@@ -93,6 +94,9 @@ function ensureRegistryContainer(
     ],
     env,
   );
+  if (inspection.error) {
+    requireCommand(inspection, "Inspecting the managed portable registry");
+  }
   const exists = inspection.status === 0;
   if (exists && String(inspection.stdout ?? "").trim() !== "1") {
     throw new Error(
@@ -145,7 +149,12 @@ export function preparePortableExperimentalHost(
 
   const systemctl =
     deps.systemctl ??
-    ((args, childEnv) => spawnSync("systemctl", [...args], { encoding: "utf-8", env: childEnv }));
+    ((args, childEnv) =>
+      spawnSync("systemctl", [...args], {
+        encoding: "utf-8",
+        env: childEnv,
+        timeout: HOST_COMMAND_TIMEOUT_MS,
+      }));
   requireCommand(
     systemctl(
       [
@@ -169,7 +178,12 @@ export function preparePortableExperimentalHost(
 
   const docker =
     deps.docker ??
-    ((args, childEnv) => dockerSpawnSync(args, { encoding: "utf-8", env: childEnv }));
+    ((args, childEnv) =>
+      dockerSpawnSync(args, {
+        encoding: "utf-8",
+        env: childEnv,
+        timeout: REGISTRY_COMMAND_TIMEOUT_MS,
+      }));
   ensureRegistryContainer(env, docker);
 }
 

--- a/src/lib/onboard/experimental/portable-host-preparation.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.ts
@@ -22,7 +22,6 @@ insecure = true
 const PORTABLE_CONTAINERS_CONF = `[network]
 default_rootless_network_cmd = "pasta"
 firewall_driver = "iptables"
-pasta_options = ["--map-gw"]
 
 [engine]
 env = ["NETAVARK_FW=iptables"]

--- a/src/lib/onboard/fatal-runtime-preflight.test.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.test.ts
@@ -51,4 +51,15 @@ describe("rejectUnsupportedContainerRuntime (#7320)", () => {
     rejectUnsupportedContainerRuntime(hostWithRuntime("docker"), exit as never);
     expect(exit).not.toHaveBeenCalled();
   });
+
+  it.skipIf(!isLinuxDockerDriverGatewayEnabled())(
+    "allows Podman only when the portable profile is explicit",
+    () => {
+      vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+      const exit = vi.fn();
+      rejectUnsupportedContainerRuntime(hostWithRuntime("podman"), exit as never);
+      expect(exit).not.toHaveBeenCalled();
+      vi.unstubAllEnvs();
+    },
+  );
 });

--- a/src/lib/onboard/fatal-runtime-preflight.test.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.test.ts
@@ -2,8 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ preparePortableExperimentalHost: vi.fn() }));
+
+vi.mock("./experimental/portable-host-preparation", () => ({
+  preparePortableExperimentalHost: mocks.preparePortableExperimentalHost,
+}));
+
 import { isLinuxDockerDriverGatewayEnabled } from "./docker-driver-platform";
-import { rejectUnsupportedContainerRuntime } from "./fatal-runtime-preflight";
+import {
+  rejectUnsupportedContainerRuntime,
+  runFatalOnboardRuntimePreflight,
+} from "./fatal-runtime-preflight";
 import type { HostAssessment } from "./preflight";
 
 function hostWithRuntime(runtime: HostAssessment["runtime"]): HostAssessment {
@@ -62,4 +72,17 @@ describe("rejectUnsupportedContainerRuntime (#7320)", () => {
       vi.unstubAllEnvs();
     },
   );
+});
+
+describe("runFatalOnboardRuntimePreflight", () => {
+  it("prepares the portable host before probing the container runtime", () => {
+    mocks.preparePortableExperimentalHost.mockImplementationOnce(() => {
+      throw new Error("portable host prepared");
+    });
+
+    expect(() => runFatalOnboardRuntimePreflight({}, { nonInteractive: true })).toThrow(
+      "portable host prepared",
+    );
+    expect(mocks.preparePortableExperimentalHost).toHaveBeenCalledWith(process.env);
+  });
 });

--- a/src/lib/onboard/fatal-runtime-preflight.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.ts
@@ -7,6 +7,7 @@ import {
   isLinuxDockerDriverGatewayEnabled,
   isPortableExperimentalProfile,
 } from "./docker-driver-platform";
+import { preparePortableExperimentalHost } from "./experimental/portable-host-preparation";
 import { warnIfHostProxyMissesLoopback } from "./http-proxy-preflight";
 import {
   assertCdiNvidiaGpuSpecPresent,
@@ -22,8 +23,6 @@ import {
   validateSandboxGpuPreflight,
 } from "./sandbox-gpu-preflight";
 import type { OnboardOptions } from "./types";
-
-export { preparePortableExperimentalHost } from "./experimental/portable-host-preparation";
 
 export type FatalRuntimePreflightOptions = Pick<
   OnboardOptions,
@@ -57,12 +56,13 @@ export function rejectUnsupportedContainerRuntime(
   }
 }
 
-/** Run the non-mutating runtime gates shared by fresh, resume, and rebuild onboarding. */
+/** Prepare and run the runtime gates shared by fresh, resume, and rebuild onboarding. */
 export function runFatalOnboardRuntimePreflight(
   options: FatalRuntimePreflightOptions,
   context: FatalRuntimePreflightContext,
 ): FatalRuntimePreflightResult {
   const exitProcess = context.exitProcess ?? exitProcessByDefault;
+  preparePortableExperimentalHost(process.env);
   const host = assessHost();
   if (!host.dockerReachable) {
     printDockerNotReachableError();

--- a/src/lib/onboard/fatal-runtime-preflight.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.ts
@@ -3,7 +3,10 @@
 
 import { detectGpu, type GpuDetection } from "../inference/nim";
 import { assertDockerBridgeAndContainerDnsHealthy } from "./bridge-dns-preflight";
-import { isLinuxDockerDriverGatewayEnabled } from "./docker-driver-platform";
+import {
+  isLinuxDockerDriverGatewayEnabled,
+  isPortableExperimentalProfile,
+} from "./docker-driver-platform";
 import { warnIfHostProxyMissesLoopback } from "./http-proxy-preflight";
 import {
   assertCdiNvidiaGpuSpecPresent,
@@ -19,6 +22,8 @@ import {
   validateSandboxGpuPreflight,
 } from "./sandbox-gpu-preflight";
 import type { OnboardOptions } from "./types";
+
+export { preparePortableExperimentalHost } from "./experimental/portable-host-preparation";
 
 export type FatalRuntimePreflightOptions = Pick<
   OnboardOptions,
@@ -46,6 +51,7 @@ export function rejectUnsupportedContainerRuntime(
   exitProcess: (code: number) => never = exitProcessByDefault,
 ): void {
   if (isLinuxDockerDriverGatewayEnabled() && host.runtime === "podman") {
+    if (isPortableExperimentalProfile()) return;
     printUnsupportedRuntimeError();
     exitProcess(1);
   }

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -369,7 +369,17 @@ describe("sandbox BuildKit prebuild", () => {
   it("publishes portable-profile builds to the managed loopback registry", async () => {
     const { buildCtx, createArgs } = createBuildContext();
     const buildImage = vi.fn(async () => 0);
-    const publishImage = vi.fn(async () => 0);
+    let credentialConfig = "";
+    const publishImage = vi.fn(async (_args, options) => {
+      credentialConfig = String(options.env.DOCKER_CONFIG);
+      expect(credentialConfig).toContain("nemoclaw-portable-docker-config-");
+      expect(fs.statSync(credentialConfig).mode & 0o777).toBe(0o700);
+      expect(
+        JSON.parse(fs.readFileSync(path.join(credentialConfig, "config.json"), "utf-8")),
+      ).toEqual({ auths: {} });
+      expect(fs.statSync(path.join(credentialConfig, "config.json")).mode & 0o777).toBe(0o600);
+      return 0;
+    });
     const result = await prebuildSandboxImageIfEligible({
       buildCtx,
       buildId: BUILD_ID,
@@ -389,6 +399,7 @@ describe("sandbox BuildKit prebuild", () => {
       expect.objectContaining({ stdio: "inherit" }),
     );
     expect(result.imageRef).toBe("localhost:5000/nemoclaw-sandbox-local:alpha-1234567890");
+    expect(fs.existsSync(credentialConfig)).toBe(false);
   });
 
   it("routes default Docker build stdout only while JSONL owns stdout (#6403)", async () => {

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -373,6 +373,7 @@ describe("sandbox BuildKit prebuild", () => {
     const publishImage = vi.fn(async (_args, options) => {
       credentialConfig = String(options.env.DOCKER_CONFIG);
       expect(credentialConfig).toContain("nemoclaw-portable-docker-config-");
+      expect(options.env.REGISTRY_AUTH_FILE).toBe(path.join(credentialConfig, "config.json"));
       expect(fs.statSync(credentialConfig).mode & 0o777).toBe(0o700);
       expect(
         JSON.parse(fs.readFileSync(path.join(credentialConfig, "config.json"), "utf-8")),
@@ -397,6 +398,10 @@ describe("sandbox BuildKit prebuild", () => {
     expect(publishImage).toHaveBeenCalledWith(
       ["push", "localhost:5000/nemoclaw-sandbox-local:alpha-1234567890"],
       expect.objectContaining({ stdio: "inherit" }),
+    );
+    expect(buildImage).toHaveBeenCalledWith(
+      expect.arrayContaining(["build", "localhost:5000/nemoclaw-sandbox-local:alpha-1234567890"]),
+      expect.objectContaining({ env: expect.not.objectContaining({ DOCKER_BUILDKIT: "1" }) }),
     );
     expect(result.imageRef).toBe("localhost:5000/nemoclaw-sandbox-local:alpha-1234567890");
     expect(fs.existsSync(credentialConfig)).toBe(false);

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -56,6 +56,7 @@ describe("sandbox BuildKit prebuild", () => {
   it("keeps Docker runtime settings while dropping secrets and control-plane state", () => {
     vi.stubEnv("PATH", "/usr/bin");
     vi.stubEnv("HOME", "/home/user");
+    vi.stubEnv("CONTAINERS_CONF", "/home/user/.config/nemoclaw/portable/containers.conf");
     vi.stubEnv("DOCKER_HOST", "unix:///var/run/docker.sock");
     vi.stubEnv("DOCKER_CONFIG", "/home/user/.docker-ci");
     vi.stubEnv("DOCKER_CONTEXT", "remote-builder");
@@ -76,6 +77,7 @@ describe("sandbox BuildKit prebuild", () => {
     expect(env).toMatchObject({
       PATH: "/usr/bin",
       HOME: "/home/user",
+      CONTAINERS_CONF: "/home/user/.config/nemoclaw/portable/containers.conf",
       DOCKER_HOST: "unix:///var/run/docker.sock",
       DOCKER_CONFIG: "/home/user/.docker-ci",
       DOCKER_CONTEXT: "remote-builder",

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -366,6 +366,31 @@ describe("sandbox BuildKit prebuild", () => {
     });
   });
 
+  it("publishes portable-profile builds to the managed loopback registry", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    const buildImage = vi.fn(async () => 0);
+    const publishImage = vi.fn(async () => 0);
+    const result = await prebuildSandboxImageIfEligible({
+      buildCtx,
+      buildId: BUILD_ID,
+      origin: "generated",
+      createArgs,
+      sandboxName: "alpha",
+      dockerDriverGateway: true,
+      env: { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
+      buildImage,
+      publishImage,
+      inspectImageId: () => IMAGE_ID,
+      log: () => {},
+    });
+
+    expect(publishImage).toHaveBeenCalledWith(
+      ["push", "localhost:5000/nemoclaw-sandbox-local:alpha-1234567890"],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+    expect(result.imageRef).toBe("localhost:5000/nemoclaw-sandbox-local:alpha-1234567890");
+  });
+
   it("routes default Docker build stdout only while JSONL owns stdout (#6403)", async () => {
     const { buildCtx, createArgs } = createBuildContext();
     mocks.dockerSpawn.mockImplementation(() => {

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -62,6 +62,17 @@ interface TrustedStagedBuildContext {
   dockerfile: string;
 }
 
+function createCredentialFreeDockerConfig(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-docker-config-"));
+  fs.chmodSync(directory, 0o700);
+  fs.writeFileSync(path.join(directory, "config.json"), '{"auths":{}}\n', {
+    encoding: "utf-8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  return directory;
+}
+
 /**
  * Resolve the private staged context before handing it to the host Docker daemon.
  * The context stagers create direct children of the OS temp directory with this
@@ -244,14 +255,20 @@ export async function prebuildSandboxImageIfEligible(
     const publishImage = input.publishImage ?? buildImage;
     log("  Publishing sandbox image to the managed local registry...");
     let publishStatus: number | null;
+    const credentialFreeDockerConfig = createCredentialFreeDockerConfig();
     try {
       publishStatus = await publishImage(["push", imageRef], {
-        env: dockerBuildSubprocessEnv(),
+        env: {
+          ...dockerBuildSubprocessEnv(),
+          DOCKER_CONFIG: credentialFreeDockerConfig,
+        },
         stdio: "inherit",
       });
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(`Managed local registry publish could not start: ${detail}`);
+    } finally {
+      fs.rmSync(credentialFreeDockerConfig, { recursive: true, force: true });
     }
     if (publishStatus !== 0) {
       const detail =

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -8,17 +8,20 @@ import path from "node:path";
 import { dockerImageInspectFormat } from "../adapters/docker";
 import { dockerSpawn } from "../adapters/docker/exec";
 import { redirectInheritedChildStdoutToStderr } from "../cli/stdout-guard";
-import { LOCAL_SANDBOX_IMAGE_REPO } from "../domain/sandbox/image-tag";
+import {
+  LOCAL_SANDBOX_IMAGE_REPO,
+  PORTABLE_LOCAL_SANDBOX_IMAGE_REPO,
+} from "../domain/sandbox/image-tag";
 import {
   SANDBOX_BUILD_CONTEXT_PREFIX,
   type SandboxBuildContextOrigin,
 } from "../sandbox/build-context";
 import { buildSubprocessEnv } from "../subprocess-env";
+import { isPortableExperimentalProfile } from "./docker-driver-platform";
 import { isImmutableDockerImageId } from "./openshell-docker-sandbox-containers";
 
 const TRUTHY_FLAG_VALUES = new Set(["1", "true", "yes", "on"]);
 const FALSY_FLAG_VALUES = new Set(["0", "false", "no", "off"]);
-const LOCAL_IMAGE_REPO = LOCAL_SANDBOX_IMAGE_REPO;
 const DOCKER_ENV_NAMES = [
   "DOCKER_API_VERSION",
   "DOCKER_CERT_PATH",
@@ -36,6 +39,10 @@ export interface SandboxPrebuildInput {
   origin: SandboxBuildContextOrigin;
   env?: NodeJS.ProcessEnv;
   buildImage?: (
+    args: readonly string[],
+    options: { env: NodeJS.ProcessEnv; stdio: "inherit" },
+  ) => Promise<number | null>;
+  publishImage?: (
     args: readonly string[],
     options: { env: NodeJS.ProcessEnv; stdio: "inherit" },
   ) => Promise<number | null>;
@@ -131,7 +138,11 @@ export function resolveSandboxPrebuildEnabled(
   return !env.VITEST && env.NODE_ENV !== "test";
 }
 
-export function sandboxLocalImageRef(sandboxName: string, buildId: string): string {
+export function sandboxLocalImageRef(
+  sandboxName: string,
+  buildId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
   const sanitize = (value: string) =>
     value
       .toLowerCase()
@@ -139,7 +150,10 @@ export function sandboxLocalImageRef(sandboxName: string, buildId: string): stri
       .replace(/^[-.]+/, "");
   const buildPart = sanitize(buildId).slice(-32) || "build";
   const namePart = sanitize(sandboxName).slice(0, 127 - buildPart.length) || "sandbox";
-  return `${LOCAL_IMAGE_REPO}:${namePart}-${buildPart}`;
+  const repository = isPortableExperimentalProfile(env)
+    ? PORTABLE_LOCAL_SANDBOX_IMAGE_REPO
+    : LOCAL_SANDBOX_IMAGE_REPO;
+  return `${repository}:${namePart}-${buildPart}`;
 }
 
 /**
@@ -190,7 +204,7 @@ export async function prebuildSandboxImageIfEligible(
     return { createArgs, imageRef: null, imageId: null };
   }
 
-  const imageRef = sandboxLocalImageRef(input.sandboxName, input.buildId);
+  const imageRef = sandboxLocalImageRef(input.sandboxName, input.buildId, env);
   const buildImage =
     input.buildImage ??
     ((args, options) =>
@@ -224,6 +238,26 @@ export async function prebuildSandboxImageIfEligible(
     const detail = status === null ? " without an exit status" : ` (exit ${status})`;
     log(`  Local BuildKit build failed${detail}; using the gateway builder instead.`);
     return { createArgs, imageRef: null, imageId: null };
+  }
+
+  if (isPortableExperimentalProfile(env)) {
+    const publishImage = input.publishImage ?? buildImage;
+    log("  Publishing sandbox image to the managed local registry...");
+    let publishStatus: number | null;
+    try {
+      publishStatus = await publishImage(["push", imageRef], {
+        env: dockerBuildSubprocessEnv(),
+        stdio: "inherit",
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Managed local registry publish could not start: ${detail}`);
+    }
+    if (publishStatus !== 0) {
+      const detail =
+        publishStatus === null ? " without an exit status" : ` (exit ${publishStatus})`;
+      throw new Error(`Managed local registry publish failed${detail}`);
+    }
   }
 
   createArgs[fromIndex + 1] = imageRef;

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -24,6 +24,7 @@ import { isImmutableDockerImageId } from "./openshell-docker-sandbox-containers"
 const TRUTHY_FLAG_VALUES = new Set(["1", "true", "yes", "on"]);
 const FALSY_FLAG_VALUES = new Set(["0", "false", "no", "off"]);
 const DOCKER_ENV_NAMES = [
+  "CONTAINERS_CONF",
   "DOCKER_API_VERSION",
   "DOCKER_CERT_PATH",
   "DOCKER_CONFIG",

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -71,6 +72,25 @@ function createCredentialFreeDockerConfig(): string {
     mode: 0o600,
   });
   return directory;
+}
+
+function createHostImageCommand(
+  command: "docker" | "podman",
+): NonNullable<SandboxPrebuildInput["buildImage"]> {
+  return (args, options) =>
+    new Promise<number | null>((resolve, reject) => {
+      const spawnOptions = {
+        ...options,
+        stdio: redirectInheritedChildStdoutToStderr(options.stdio),
+        shell: false,
+      } as const;
+      const child =
+        command === "podman"
+          ? spawn(command, [...args], spawnOptions)
+          : dockerSpawn(args, spawnOptions);
+      child.once("error", reject);
+      child.once("close", resolve);
+    });
 }
 
 /**
@@ -168,9 +188,10 @@ export function sandboxLocalImageRef(
 }
 
 /**
- * Build a NemoClaw-generated staged context with BuildKit on the shared local
- * Docker daemon. User-supplied Dockerfiles stay on the OpenShell gateway
- * builder trust boundary, and any failure preserves that original build path.
+ * Build a NemoClaw-generated staged context with the shared local container
+ * runtime. Docker uses BuildKit; the portable profile uses native rootless
+ * Podman. User-supplied Dockerfiles stay on the OpenShell gateway builder trust
+ * boundary, and any failure preserves that original build path.
  * Remove this bridge once OpenShell uses BuildKit for this local-driver path;
  * extraction and observable retirement criteria are tracked by #6258.
  */
@@ -216,42 +237,38 @@ export async function prebuildSandboxImageIfEligible(
   }
 
   const imageRef = sandboxLocalImageRef(input.sandboxName, input.buildId, env);
-  const buildImage =
-    input.buildImage ??
-    ((args, options) =>
-      new Promise<number | null>((resolve, reject) => {
-        const child = dockerSpawn(args, {
-          ...options,
-          stdio: redirectInheritedChildStdoutToStderr(options.stdio),
-          shell: false,
-        });
-        child.once("error", reject);
-        child.once("close", resolve);
-      }));
-  log("  Building sandbox image with BuildKit (skips the slower in-gateway builder)...");
+  const portable = isPortableExperimentalProfile(env);
+  const builderName = portable ? "rootless Podman" : "BuildKit";
+  const buildImage = input.buildImage ?? createHostImageCommand(portable ? "podman" : "docker");
+  log(`  Building sandbox image with ${builderName} (skips the slower in-gateway builder)...`);
 
   let status: number | null;
   try {
     status = await buildImage(
       ["build", "-t", imageRef, "-f", trustedContext.dockerfile, trustedContext.buildCtx],
       {
-        env: { ...dockerBuildSubprocessEnv(), DOCKER_BUILDKIT: "1" },
+        env: {
+          ...dockerBuildSubprocessEnv(),
+          ...(portable ? {} : { DOCKER_BUILDKIT: "1" }),
+        },
         stdio: "inherit",
       },
     );
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    log(`  Local BuildKit build could not start (${detail}); using the gateway builder instead.`);
+    log(
+      `  Local ${builderName} build could not start (${detail}); using the gateway builder instead.`,
+    );
     return { createArgs, imageRef: null, imageId: null };
   }
 
   if (status !== 0) {
     const detail = status === null ? " without an exit status" : ` (exit ${status})`;
-    log(`  Local BuildKit build failed${detail}; using the gateway builder instead.`);
+    log(`  Local ${builderName} build failed${detail}; using the gateway builder instead.`);
     return { createArgs, imageRef: null, imageId: null };
   }
 
-  if (isPortableExperimentalProfile(env)) {
+  if (portable) {
     const publishImage = input.publishImage ?? buildImage;
     log("  Publishing sandbox image to the managed local registry...");
     let publishStatus: number | null;
@@ -261,6 +278,7 @@ export async function prebuildSandboxImageIfEligible(
         env: {
           ...dockerBuildSubprocessEnv(),
           DOCKER_CONFIG: credentialFreeDockerConfig,
+          REGISTRY_AUTH_FILE: path.join(credentialFreeDockerConfig, "config.json"),
         },
         stdio: "inherit",
       });

--- a/src/lib/onboard/types.ts
+++ b/src/lib/onboard/types.ts
@@ -142,4 +142,5 @@ export type OnboardOptions = {
   gpu?: boolean;
   noGpu?: boolean;
   autoYes?: boolean;
+  experimentalProfile?: import("./docker-driver-platform").ExperimentalOnboardProfile | null;
 };

--- a/test/e2e/live/portable-profile-rootless-linux.test.ts
+++ b/test/e2e/live/portable-profile-rootless-linux.test.ts
@@ -8,31 +8,32 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 
-import * as importedGatewayEnv from "../../src/lib/onboard/docker-driver-gateway-env.ts";
-import * as importedPortableHostPreparation from "../../src/lib/onboard/experimental/portable-host-preparation.ts";
-import * as importedSandboxPrebuild from "../../src/lib/onboard/sandbox-prebuild.ts";
-import * as importedBuildContext from "../../src/lib/sandbox/build-context.ts";
+import * as importedGatewayEnv from "../../../src/lib/onboard/docker-driver-gateway-env.ts";
+import * as importedPortableHostPreparation from "../../../src/lib/onboard/experimental/portable-host-preparation.ts";
+import * as importedSandboxPrebuild from "../../../src/lib/onboard/sandbox-prebuild.ts";
+import * as importedBuildContext from "../../../src/lib/sandbox/build-context.ts";
+import { test } from "../fixtures/e2e-test.ts";
 
 const gatewayEnvModule = (
   "default" in importedGatewayEnv && importedGatewayEnv.default
     ? importedGatewayEnv.default
     : importedGatewayEnv
-) as typeof import("../../src/lib/onboard/docker-driver-gateway-env.ts");
+) as typeof import("../../../src/lib/onboard/docker-driver-gateway-env.ts");
 const portableHostPreparationModule = (
   "default" in importedPortableHostPreparation && importedPortableHostPreparation.default
     ? importedPortableHostPreparation.default
     : importedPortableHostPreparation
-) as typeof import("../../src/lib/onboard/experimental/portable-host-preparation.ts");
+) as typeof import("../../../src/lib/onboard/experimental/portable-host-preparation.ts");
 const sandboxPrebuildModule = (
   "default" in importedSandboxPrebuild && importedSandboxPrebuild.default
     ? importedSandboxPrebuild.default
     : importedSandboxPrebuild
-) as typeof import("../../src/lib/onboard/sandbox-prebuild.ts");
+) as typeof import("../../../src/lib/onboard/sandbox-prebuild.ts");
 const buildContextModule = (
   "default" in importedBuildContext && importedBuildContext.default
     ? importedBuildContext.default
     : importedBuildContext
-) as typeof import("../../src/lib/sandbox/build-context.ts");
+) as typeof import("../../../src/lib/sandbox/build-context.ts");
 
 const { buildDockerDriverGatewayEnv } = gatewayEnvModule;
 const { preparePortableExperimentalHost } = portableHostPreparationModule;
@@ -41,13 +42,20 @@ const { SANDBOX_BUILD_CONTEXT_PREFIX } = buildContextModule;
 
 const BASE_IMAGE =
   "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467";
+const PORTABLE_PROFILE_E2E_PHASES = [
+  "prepare the rootless container runtime",
+  "build and publish the sandbox image",
+  "verify the fixed host route",
+  "record portable environment completion",
+] as const;
 
-function run(command: string, args: readonly string[], timeout = 60_000): string {
+function run(command: string, args: readonly string[]): string {
   const result = spawnSync(command, [...args], {
     encoding: "utf-8",
     env: process.env,
+    killSignal: "SIGKILL",
     stdio: ["ignore", "pipe", "pipe"],
-    timeout,
+    timeout: 55_000,
   });
   assert.equal(
     result.status,
@@ -120,7 +128,7 @@ esac
   );
 }
 
-async function main(): Promise<void> {
+async function main(progress: { phase: (phase: string) => void }): Promise<void> {
   assert.equal(process.platform, "linux", "portable profile E2E requires Linux");
   assert.notEqual(process.getuid?.(), 0, "portable profile E2E must run without root privileges");
 
@@ -144,6 +152,7 @@ async function main(): Promise<void> {
   });
 
   try {
+    progress.phase("prepare the rootless container runtime");
     preparePortableExperimentalHost(process.env);
     assert.equal(process.env.DOCKER_HOST, `unix://${runtimeDir}/podman/podman.sock`);
     assert.match(
@@ -156,6 +165,7 @@ async function main(): Promise<void> {
     run("docker", ["version"]);
     await waitForRegistry();
 
+    progress.phase("build and publish the sandbox image");
     const buildCtx = fs.mkdtempSync(path.join(os.tmpdir(), SANDBOX_BUILD_CONTEXT_PREFIX));
     fs.chmodSync(buildCtx, 0o700);
     const dockerfile = path.join(buildCtx, "Dockerfile");
@@ -195,6 +205,7 @@ async function main(): Promise<void> {
       "nemoclaw-portable-registry",
     ]);
 
+    progress.phase("verify the fixed host route");
     const gatewayEnv = buildDockerDriverGatewayEnv({
       platform: "linux",
       gatewayPort: 5000,
@@ -217,34 +228,35 @@ async function main(): Promise<void> {
       'grep -F "200 OK" <<<"$response"',
     ].join("; ");
     assert.equal(
-      run(
-        "podman",
-        [
-          "run",
-          "--rm",
-          "--network",
-          "openshell-docker",
-          prebuild.imageRef,
-          "timeout",
-          "15",
-          "bash",
-          "-lc",
-          routeProof,
-        ],
-        20_000,
-      ),
+      run("podman", [
+        "run",
+        "--rm",
+        "--network",
+        "openshell-docker",
+        prebuild.imageRef,
+        "timeout",
+        "15",
+        "bash",
+        "-lc",
+        routeProof,
+      ]),
       "HTTP/1.1 200 OK",
     );
 
+    progress.phase("record portable environment completion");
     console.log("Portable profile rootless environment E2E passed.");
   } finally {
     spawnSync("podman", ["rm", "--force", "nemoclaw-portable-registry"], {
       env: process.env,
+      killSignal: "SIGKILL",
       stdio: "ignore",
+      timeout: 15_000,
     });
     spawnSync("podman", ["system", "reset", "--force"], {
       env: process.env,
+      killSignal: "SIGKILL",
       stdio: "ignore",
+      timeout: 15_000,
     });
     const pidFile = path.join(runtimeDir, "nemoclaw-podman-service.pid");
     if (fs.existsSync(pidFile)) {
@@ -259,4 +271,9 @@ async function main(): Promise<void> {
   }
 }
 
-await main();
+test("portable profile rootless environment completes the local image and fixed-host route contracts", {
+  meta: { e2ePhases: PORTABLE_PROFILE_E2E_PHASES },
+  timeout: 120_000,
+}, async ({ progress }) => {
+  await main(progress);
+});

--- a/test/e2e/live/portable-profile-rootless-linux.test.ts
+++ b/test/e2e/live/portable-profile-rootless-linux.test.ts
@@ -65,23 +65,24 @@ function run(command: string, args: readonly string[]): string {
   return String(result.stdout).trim();
 }
 
-async function waitForRegistry(): Promise<void> {
-  for (let attempt = 0; attempt < 60; attempt += 1) {
-    const ready = await new Promise<boolean>((resolve) => {
-      const request = http.get("http://127.0.0.1:5000/v2/", (response) => {
-        response.resume();
-        response.once("end", () => resolve(response.statusCode === 200));
-      });
-      request.once("error", () => resolve(false));
-      request.setTimeout(500, () => {
-        request.destroy();
-        resolve(false);
-      });
+async function waitForRegistry(attempt = 0): Promise<void> {
+  assert.ok(attempt < 60, "The managed local registry did not become ready.");
+  const ready = await new Promise<boolean>((resolve) => {
+    const request = http.get("http://127.0.0.1:5000/v2/", (response) => {
+      response.resume();
+      response.once("end", () => resolve(response.statusCode === 200));
     });
-    if (ready) return;
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  throw new Error("The managed local registry did not become ready.");
+    request.once("error", () => resolve(false));
+    request.setTimeout(500, () => {
+      request.destroy();
+      resolve(false);
+    });
+  });
+  return ready
+    ? undefined
+    : new Promise<void>((resolve) => setTimeout(resolve, 250)).then(() =>
+        waitForRegistry(attempt + 1),
+      );
 }
 
 function writeSystemctlShim(binDir: string): void {
@@ -259,10 +260,13 @@ async function main(progress: { phase: (phase: string) => void }): Promise<void>
       timeout: 15_000,
     });
     const pidFile = path.join(runtimeDir, "nemoclaw-podman-service.pid");
-    if (fs.existsSync(pidFile)) {
-      const pid = Number(fs.readFileSync(pidFile, "utf-8").trim());
-      if (Number.isInteger(pid)) process.kill(pid, "SIGTERM");
-    }
+    const pid = fs.existsSync(pidFile)
+      ? Number(fs.readFileSync(pidFile, "utf-8").trim())
+      : Number.NaN;
+    const terminateService = Number.isInteger(pid)
+      ? () => process.kill(pid, "SIGTERM")
+      : () => undefined;
+    terminateService();
     try {
       fs.rmSync(root, { recursive: true, force: true });
     } catch (error) {

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -3,6 +3,15 @@
   "version": 1,
   "entries": [
     {
+      "live": "test/e2e/live/portable-profile-rootless-linux.test.ts",
+      "fast": [
+        "src/lib/onboard/command.test.ts",
+        "src/lib/onboard/docker-driver-gateway-env.test.ts",
+        "src/lib/onboard/experimental/portable-host-preparation.test.ts",
+        "src/lib/onboard/sandbox-prebuild.test.ts"
+      ]
+    },
+    {
       "live": "test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts",
       "fast": [
         "test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts",

--- a/test/e2e/portable-profile-rootless-linux.mts
+++ b/test/e2e/portable-profile-rootless-linux.mts
@@ -40,7 +40,7 @@ const { prebuildSandboxImageIfEligible } = sandboxPrebuildModule;
 const { SANDBOX_BUILD_CONTEXT_PREFIX } = buildContextModule;
 
 const BASE_IMAGE =
-  "docker.io/library/ubuntu@sha256:7f622ca8766bccb22f04242ecb6f19f770b2f08827dc4b8c707de5e78a6da7ab";
+  "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467";
 
 function run(command: string, args: readonly string[]): string {
   const result = spawnSync(command, [...args], {
@@ -232,12 +232,20 @@ async function main(): Promise<void> {
       env: process.env,
       stdio: "ignore",
     });
+    spawnSync("podman", ["system", "reset", "--force"], {
+      env: process.env,
+      stdio: "ignore",
+    });
     const pidFile = path.join(runtimeDir, "nemoclaw-podman-service.pid");
     if (fs.existsSync(pidFile)) {
       const pid = Number(fs.readFileSync(pidFile, "utf-8").trim());
       if (Number.isInteger(pid)) process.kill(pid, "SIGTERM");
     }
-    fs.rmSync(root, { recursive: true, force: true });
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(`Portable E2E temporary cleanup was incomplete: ${String(error)}`);
+    }
   }
 }
 

--- a/test/e2e/portable-profile-rootless-linux.mts
+++ b/test/e2e/portable-profile-rootless-linux.mts
@@ -143,7 +143,6 @@ async function main(): Promise<void> {
     NEMOCLAW_SANDBOX_PREBUILD: "1",
   });
 
-  let server: http.Server | undefined;
   try {
     preparePortableExperimentalHost(process.env);
     assert.equal(process.env.DOCKER_HOST, `unix://${runtimeDir}/podman/podman.sock`);
@@ -186,39 +185,36 @@ async function main(): Promise<void> {
       run("podman", ["image", "inspect", "--format", "{{.Id}}", prebuild.imageRef]),
       /^(?:sha256:)?[a-f0-9]{64}$/,
     );
-    run("podman", ["network", "create", "openshell-docker"]);
-
-    server = http.createServer((_request, response) => {
-      response.writeHead(200, { "content-type": "text/plain" });
-      response.end("portable-profile-ok\n");
-    });
-    await new Promise<void>((resolve, reject) => {
-      server?.once("error", reject);
-      server?.listen(0, "0.0.0.0", resolve);
-    });
-    const address = server.address();
-    assert(address && typeof address === "object");
+    run("podman", ["network", "create", "--subnet", "169.254.1.0/24", "openshell-docker"]);
+    run("podman", [
+      "network",
+      "connect",
+      "--ip",
+      "169.254.1.2",
+      "openshell-docker",
+      "nemoclaw-portable-registry",
+    ]);
 
     const gatewayEnv = buildDockerDriverGatewayEnv({
       platform: "linux",
-      gatewayPort: address.port,
+      gatewayPort: 5000,
       stateDir,
       getDockerSupervisorImage: () => "supervisor:e2e-not-launched",
       resolveSandboxBin: () => null,
     });
     assert.equal(gatewayEnv.OPENSHELL_DRIVERS, "podman");
     assert.equal(gatewayEnv.OPENSHELL_BIND_ADDRESS, "0.0.0.0");
-    assert.equal(gatewayEnv.OPENSHELL_GRPC_ENDPOINT, `https://169.254.1.2:${address.port}`);
+    assert.equal(gatewayEnv.OPENSHELL_GRPC_ENDPOINT, "https://169.254.1.2:5000");
     assert.match(
       fs.readFileSync(gatewayEnv.OPENSHELL_GATEWAY_CONFIG, "utf-8"),
       /host_gateway_ip = "169\.254\.1\.2"/,
     );
 
     const routeProof = [
-      `exec 3<>/dev/tcp/169.254.1.2/${address.port}`,
-      "printf 'GET / HTTP/1.1\\r\\nHost: portable-profile\\r\\nConnection: close\\r\\n\\r\\n' >&3",
+      "exec 3<>/dev/tcp/169.254.1.2/5000",
+      "printf 'GET /v2/ HTTP/1.1\\r\\nHost: portable-profile\\r\\nConnection: close\\r\\n\\r\\n' >&3",
       "response=$(cat <&3)",
-      'grep -F portable-profile-ok <<<"$response"',
+      'grep -F "200 OK" <<<"$response"',
     ].join("; ");
     assert.equal(
       run(
@@ -237,12 +233,11 @@ async function main(): Promise<void> {
         ],
         20_000,
       ),
-      "portable-profile-ok",
+      "HTTP/1.1 200 OK",
     );
 
     console.log("Portable profile rootless environment E2E passed.");
   } finally {
-    server?.close();
     spawnSync("podman", ["rm", "--force", "nemoclaw-portable-registry"], {
       env: process.env,
       stdio: "ignore",

--- a/test/e2e/portable-profile-rootless-linux.mts
+++ b/test/e2e/portable-profile-rootless-linux.mts
@@ -8,10 +8,36 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 
-import { buildDockerDriverGatewayEnv } from "../../src/lib/onboard/docker-driver-gateway-env";
-import { preparePortableExperimentalHost } from "../../src/lib/onboard/experimental/portable-host-preparation";
-import { prebuildSandboxImageIfEligible } from "../../src/lib/onboard/sandbox-prebuild";
-import { SANDBOX_BUILD_CONTEXT_PREFIX } from "../../src/lib/sandbox/build-context";
+import * as importedGatewayEnv from "../../src/lib/onboard/docker-driver-gateway-env.ts";
+import * as importedPortableHostPreparation from "../../src/lib/onboard/experimental/portable-host-preparation.ts";
+import * as importedSandboxPrebuild from "../../src/lib/onboard/sandbox-prebuild.ts";
+import * as importedBuildContext from "../../src/lib/sandbox/build-context.ts";
+
+const gatewayEnvModule = (
+  "default" in importedGatewayEnv && importedGatewayEnv.default
+    ? importedGatewayEnv.default
+    : importedGatewayEnv
+) as typeof import("../../src/lib/onboard/docker-driver-gateway-env.ts");
+const portableHostPreparationModule = (
+  "default" in importedPortableHostPreparation && importedPortableHostPreparation.default
+    ? importedPortableHostPreparation.default
+    : importedPortableHostPreparation
+) as typeof import("../../src/lib/onboard/experimental/portable-host-preparation.ts");
+const sandboxPrebuildModule = (
+  "default" in importedSandboxPrebuild && importedSandboxPrebuild.default
+    ? importedSandboxPrebuild.default
+    : importedSandboxPrebuild
+) as typeof import("../../src/lib/onboard/sandbox-prebuild.ts");
+const buildContextModule = (
+  "default" in importedBuildContext && importedBuildContext.default
+    ? importedBuildContext.default
+    : importedBuildContext
+) as typeof import("../../src/lib/sandbox/build-context.ts");
+
+const { buildDockerDriverGatewayEnv } = gatewayEnvModule;
+const { preparePortableExperimentalHost } = portableHostPreparationModule;
+const { prebuildSandboxImageIfEligible } = sandboxPrebuildModule;
+const { SANDBOX_BUILD_CONTEXT_PREFIX } = buildContextModule;
 
 const BASE_IMAGE =
   "docker.io/library/ubuntu@sha256:7f622ca8766bccb22f04242ecb6f19f770b2f08827dc4b8c707de5e78a6da7ab";

--- a/test/e2e/portable-profile-rootless-linux.mts
+++ b/test/e2e/portable-profile-rootless-linux.mts
@@ -42,16 +42,17 @@ const { SANDBOX_BUILD_CONTEXT_PREFIX } = buildContextModule;
 const BASE_IMAGE =
   "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467";
 
-function run(command: string, args: readonly string[]): string {
+function run(command: string, args: readonly string[], timeout = 60_000): string {
   const result = spawnSync(command, [...args], {
     encoding: "utf-8",
     env: process.env,
     stdio: ["ignore", "pipe", "pipe"],
+    timeout,
   });
   assert.equal(
     result.status,
     0,
-    `${command} ${args.join(" ")} failed:\n${String(result.stderr || result.stdout)}`,
+    `${command} ${args.join(" ")} failed:\n${String(result.error?.message || result.stderr || result.stdout)}`,
   );
   return String(result.stdout).trim();
 }
@@ -88,7 +89,7 @@ pid_file="\${runtime_dir}/nemoclaw-podman-service.pid"
 log_file="\${runtime_dir}/nemoclaw-podman-service.log"
 
 case "$*" in
-  "--user set-environment NETAVARK_FW=iptables")
+  "--user set-environment NETAVARK_FW=iptables CONTAINERS_CONF="*)
     exit 0
     ;;
   "--user try-restart podman.service")
@@ -129,13 +130,7 @@ async function main(): Promise<void> {
   const stateDir = path.join(root, "gateway-state");
   const configHome = path.join(home, ".config");
   const runtimeDir = `/run/user/${String(process.getuid?.())}`;
-  fs.mkdirSync(path.join(configHome, "containers"), { recursive: true, mode: 0o700 });
   fs.mkdirSync(binDir, { recursive: true, mode: 0o700 });
-  fs.writeFileSync(
-    path.join(configHome, "containers", "containers.conf"),
-    '[network]\ndefault_rootless_network_cmd = "pasta"\n',
-    { encoding: "utf-8", mode: 0o600 },
-  );
   writeSystemctlShim(binDir);
 
   Object.assign(process.env, {
@@ -152,6 +147,10 @@ async function main(): Promise<void> {
   try {
     preparePortableExperimentalHost(process.env);
     assert.equal(process.env.DOCKER_HOST, `unix://${runtimeDir}/podman/podman.sock`);
+    assert.match(
+      fs.readFileSync(String(process.env.CONTAINERS_CONF), "utf-8"),
+      /pasta_options = \["--map-gw"\]/,
+    );
 
     const podmanInfo = JSON.parse(run("podman", ["info", "--format", "json"]));
     assert.equal(podmanInfo.host?.security?.rootless, true, "Podman must be rootless");
@@ -187,6 +186,7 @@ async function main(): Promise<void> {
       run("podman", ["image", "inspect", "--format", "{{.Id}}", prebuild.imageRef]),
       /^(?:sha256:)?[a-f0-9]{64}$/,
     );
+    run("podman", ["network", "create", "openshell-docker"]);
 
     server = http.createServer((_request, response) => {
       response.writeHead(200, { "content-type": "text/plain" });
@@ -221,7 +221,20 @@ async function main(): Promise<void> {
       'grep -F portable-profile-ok <<<"$response"',
     ].join("; ");
     assert.equal(
-      run("podman", ["run", "--rm", prebuild.imageRef, "bash", "-lc", routeProof]),
+      run(
+        "podman",
+        [
+          "run",
+          "--rm",
+          "--network",
+          "openshell-docker",
+          prebuild.imageRef,
+          "bash",
+          "-lc",
+          routeProof,
+        ],
+        20_000,
+      ),
       "portable-profile-ok",
     );
 

--- a/test/e2e/portable-profile-rootless-linux.mts
+++ b/test/e2e/portable-profile-rootless-linux.mts
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { buildDockerDriverGatewayEnv } from "../../src/lib/onboard/docker-driver-gateway-env";
+import { preparePortableExperimentalHost } from "../../src/lib/onboard/experimental/portable-host-preparation";
+import { prebuildSandboxImageIfEligible } from "../../src/lib/onboard/sandbox-prebuild";
+import { SANDBOX_BUILD_CONTEXT_PREFIX } from "../../src/lib/sandbox/build-context";
+
+const BASE_IMAGE =
+  "docker.io/library/ubuntu@sha256:7f622ca8766bccb22f04242ecb6f19f770b2f08827dc4b8c707de5e78a6da7ab";
+
+function run(command: string, args: readonly string[]): string {
+  const result = spawnSync(command, [...args], {
+    encoding: "utf-8",
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  assert.equal(
+    result.status,
+    0,
+    `${command} ${args.join(" ")} failed:\n${String(result.stderr || result.stdout)}`,
+  );
+  return String(result.stdout).trim();
+}
+
+async function waitForRegistry(): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const ready = await new Promise<boolean>((resolve) => {
+      const request = http.get("http://127.0.0.1:5000/v2/", (response) => {
+        response.resume();
+        response.once("end", () => resolve(response.statusCode === 200));
+      });
+      request.once("error", () => resolve(false));
+      request.setTimeout(500, () => {
+        request.destroy();
+        resolve(false);
+      });
+    });
+    if (ready) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("The managed local registry did not become ready.");
+}
+
+function writeSystemctlShim(binDir: string): void {
+  const shim = path.join(binDir, "systemctl");
+  fs.writeFileSync(
+    shim,
+    `#!/usr/bin/env bash
+set -euo pipefail
+runtime_dir="\${XDG_RUNTIME_DIR:?}"
+service_dir="\${runtime_dir}/podman"
+socket_path="\${service_dir}/podman.sock"
+pid_file="\${runtime_dir}/nemoclaw-podman-service.pid"
+log_file="\${runtime_dir}/nemoclaw-podman-service.log"
+
+case "$*" in
+  "--user set-environment NETAVARK_FW=iptables")
+    exit 0
+    ;;
+  "--user try-restart podman.service")
+    if [[ -f "\${pid_file}" ]]; then
+      kill "$(<"\${pid_file}")" 2>/dev/null || true
+      rm -f "\${pid_file}" "\${socket_path}"
+    fi
+    exit 0
+    ;;
+  "--user enable --now podman.socket")
+    mkdir -p "\${service_dir}"
+    nohup podman system service --time=0 "unix://\${socket_path}" >"\${log_file}" 2>&1 &
+    echo $! >"\${pid_file}"
+    for _ in $(seq 1 100); do
+      [[ -S "\${socket_path}" ]] && exit 0
+      sleep 0.1
+    done
+    cat "\${log_file}" >&2 || true
+    exit 1
+    ;;
+  *)
+    echo "unexpected user-service command: $*" >&2
+    exit 64
+    ;;
+esac
+`,
+    { encoding: "utf-8", mode: 0o700 },
+  );
+}
+
+async function main(): Promise<void> {
+  assert.equal(process.platform, "linux", "portable profile E2E requires Linux");
+  assert.notEqual(process.getuid?.(), 0, "portable profile E2E must run without root privileges");
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-e2e-"));
+  const home = path.join(root, "home");
+  const binDir = path.join(root, "bin");
+  const stateDir = path.join(root, "gateway-state");
+  const configHome = path.join(home, ".config");
+  const runtimeDir = `/run/user/${String(process.getuid?.())}`;
+  fs.mkdirSync(path.join(configHome, "containers"), { recursive: true, mode: 0o700 });
+  fs.mkdirSync(binDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(
+    path.join(configHome, "containers", "containers.conf"),
+    '[network]\ndefault_rootless_network_cmd = "pasta"\n',
+    { encoding: "utf-8", mode: 0o600 },
+  );
+  writeSystemctlShim(binDir);
+
+  Object.assign(process.env, {
+    HOME: home,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    XDG_CONFIG_HOME: configHome,
+    XDG_DATA_HOME: path.join(home, ".local", "share"),
+    XDG_RUNTIME_DIR: runtimeDir,
+    NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
+    NEMOCLAW_SANDBOX_PREBUILD: "1",
+  });
+
+  let server: http.Server | undefined;
+  try {
+    preparePortableExperimentalHost(process.env);
+    assert.equal(process.env.DOCKER_HOST, `unix://${runtimeDir}/podman/podman.sock`);
+
+    const podmanInfo = JSON.parse(run("podman", ["info", "--format", "json"]));
+    assert.equal(podmanInfo.host?.security?.rootless, true, "Podman must be rootless");
+    run("docker", ["version"]);
+    await waitForRegistry();
+
+    const buildCtx = fs.mkdtempSync(path.join(os.tmpdir(), SANDBOX_BUILD_CONTEXT_PREFIX));
+    fs.chmodSync(buildCtx, 0o700);
+    const dockerfile = path.join(buildCtx, "Dockerfile");
+    fs.writeFileSync(
+      dockerfile,
+      `FROM ${BASE_IMAGE}\nRUN printf 'portable-profile-image\\n' >/etc/nemoclaw-profile\n`,
+      { encoding: "utf-8", mode: 0o600 },
+    );
+    const prebuild = await prebuildSandboxImageIfEligible({
+      buildCtx,
+      buildId: "rootless-e2e",
+      createArgs: ["--from", dockerfile, "--name", "portable-e2e"],
+      sandboxName: "portable-e2e",
+      dockerDriverGateway: true,
+      env: process.env,
+      origin: "generated",
+      log: console.log,
+    });
+    assert.equal(
+      prebuild.imageRef,
+      "localhost:5000/nemoclaw-sandbox-local:portable-e2e-rootless-e2e",
+    );
+
+    run("podman", ["image", "rm", "--force", prebuild.imageRef]);
+    run("podman", ["pull", prebuild.imageRef]);
+    assert.match(
+      run("podman", ["image", "inspect", "--format", "{{.Id}}", prebuild.imageRef]),
+      /^sha256:/,
+    );
+
+    server = http.createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("portable-profile-ok\n");
+    });
+    await new Promise<void>((resolve, reject) => {
+      server?.once("error", reject);
+      server?.listen(0, "0.0.0.0", resolve);
+    });
+    const address = server.address();
+    assert(address && typeof address === "object");
+
+    const gatewayEnv = buildDockerDriverGatewayEnv({
+      platform: "linux",
+      gatewayPort: address.port,
+      stateDir,
+      getDockerSupervisorImage: () => "supervisor:e2e-not-launched",
+      resolveSandboxBin: () => null,
+    });
+    assert.equal(gatewayEnv.OPENSHELL_DRIVERS, "podman");
+    assert.equal(gatewayEnv.OPENSHELL_BIND_ADDRESS, "0.0.0.0");
+    assert.equal(gatewayEnv.OPENSHELL_GRPC_ENDPOINT, `https://169.254.1.2:${address.port}`);
+    assert.match(
+      fs.readFileSync(gatewayEnv.OPENSHELL_GATEWAY_CONFIG, "utf-8"),
+      /host_gateway_ip = "169\.254\.1\.2"/,
+    );
+
+    const routeProof = [
+      `exec 3<>/dev/tcp/169.254.1.2/${address.port}`,
+      "printf 'GET / HTTP/1.1\\r\\nHost: portable-profile\\r\\nConnection: close\\r\\n\\r\\n' >&3",
+      "response=$(cat <&3)",
+      'grep -F portable-profile-ok <<<"$response"',
+    ].join("; ");
+    assert.equal(
+      run("podman", ["run", "--rm", prebuild.imageRef, "bash", "-lc", routeProof]),
+      "portable-profile-ok",
+    );
+
+    console.log("Portable profile rootless environment E2E passed.");
+  } finally {
+    server?.close();
+    spawnSync("podman", ["rm", "--force", "nemoclaw-portable-registry"], {
+      env: process.env,
+      stdio: "ignore",
+    });
+    const pidFile = path.join(runtimeDir, "nemoclaw-podman-service.pid");
+    if (fs.existsSync(pidFile)) {
+      const pid = Number(fs.readFileSync(pidFile, "utf-8").trim());
+      if (Number.isInteger(pid)) process.kill(pid, "SIGTERM");
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/test/e2e/portable-profile-rootless-linux.mts
+++ b/test/e2e/portable-profile-rootless-linux.mts
@@ -149,7 +149,7 @@ async function main(): Promise<void> {
     assert.equal(process.env.DOCKER_HOST, `unix://${runtimeDir}/podman/podman.sock`);
     assert.match(
       fs.readFileSync(String(process.env.CONTAINERS_CONF), "utf-8"),
-      /pasta_options = \["--map-gw"\]/,
+      /default_rootless_network_cmd = "pasta"/,
     );
 
     const podmanInfo = JSON.parse(run("podman", ["info", "--format", "json"]));
@@ -229,6 +229,8 @@ async function main(): Promise<void> {
           "--network",
           "openshell-docker",
           prebuild.imageRef,
+          "timeout",
+          "15",
           "bash",
           "-lc",
           routeProof,

--- a/test/e2e/portable-profile-rootless-linux.mts
+++ b/test/e2e/portable-profile-rootless-linux.mts
@@ -185,7 +185,7 @@ async function main(): Promise<void> {
     run("podman", ["pull", prebuild.imageRef]);
     assert.match(
       run("podman", ["image", "inspect", "--format", "{{.Id}}", prebuild.imageRef]),
-      /^sha256:/,
+      /^(?:sha256:)?[a-f0-9]{64}$/,
     );
 
     server = http.createServer((_request, response) => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add a hidden `--experimental-profile portable` onboarding route for deterministic rootless Linux onboarding. The route reproduces the validated Podman networking and image-distribution requirements without changing defaults or depending on unmerged branches or unpublished assets.

## Changes

- Add a value-constrained hidden profile that selects unattended Ollama setup with `qwen3-vl:4b`, while restoring the caller environment after onboarding.
- Prepare a user-scoped Podman socket, force the known-compatible netavark firewall backend, and start an ownership-labeled loopback registry from a digest-pinned released image.
- Generate the Podman gateway contract with `169.254.1.2` container-to-host routing, an exact TLS SAN, authenticated wildcard binding, and runtime-drift recognition.
- Publish locally built sandbox images to the managed registry so the gateway can resolve them without an in-flight image asset.
- Use native rootless Podman for profile-scoped image builds and isolated credential-free registry pushes, while leaving the normal Docker BuildKit path unchanged.
- Add a dedicated Ubuntu rootless E2E that provisions released packages, invokes the production host-preparation and prebuild paths, exercises the real API socket and digest-pinned registry, deletes and re-pulls the image, and proves fixed link-local reachability on the named bridge.
- Keep the behavior profile-scoped because changing the normal Docker path would expose a wildcard listener and insecure loopback registry where they are not required. Command, host-preparation, gateway, TLS, prebuild, and environment E2E tests protect the compatibility route.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The experimental flag is intentionally hidden from public help and documentation until the path is ready to launch.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [Maintainer SOL merge authorization](https://github.com/NVIDIA/NemoClaw/pull/8376#issuecomment-5196996367).
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: Optional Nemotron second-opinion advisor failed after external HTTP 429/403; the primary advisor passed with zero blockers. [Maintainer acceptance](https://github.com/NVIDIA/NemoClaw/pull/8376#issuecomment-5196996367); external service ownership, so no code follow-up issue was filed.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed head d8fefc391. The value-constrained portable profile remains hidden, explicit-only, and excluded from public usage/help. The final follow-up only records the required fast/live parity mapping for the repository-owned unbranded portable E2E. It changes no product behavior, user procedure, documentation, or documentation code sample.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d8fefc391 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Focused Vitest validation passed (62 tests across the 4 fast parity-mapped files; broader profile suite: 89 tests across 9 files); CLI incremental typecheck, exact Vitest project membership, E2E semantic-phase validation, formatting, repository checks, and local hooks passed. The exact-head [E2E / Portable Profile](https://github.com/NVIDIA/NemoClaw/actions/runs/31040722778) passed its real rootless build/push/pull and fixed-link-local reachability scenario.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Exact-head [CI / Pull Request](https://github.com/NVIDIA/NemoClaw/actions/runs/31040723186) passed on retry after an unrelated setup-hook timeout; [E2E / PR Gate / Rollup](https://github.com/NVIDIA/NemoClaw/actions/runs/31042675438) passed all eight selected live scenarios.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental portable onboarding profile for Linux environments.
  * Portable setup supports rootless Podman, local registry configuration, and host gateway connectivity.
  * Portable onboarding can run unattended with fresh setup, automatic confirmation, and managed runtime defaults.
  * Locally built sandbox images are published to a managed local registry for portable environments.
* **Bug Fixes**
  * Improved gateway configuration and TLS validation for portable networking.
  * Unsupported runtime checks remain enforced outside the portable profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
