### PR TITLE
docs: add v0.0.103 release notes

### DIFF
--- a/docs/changelog/2026-08-05.mdx
+++ b/docs/changelog/2026-08-05.mdx
@@ -1,0 +1,45 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.103
+
+NemoClaw v0.0.103 adds `nemoclaw launch <name>` and its agent-specific CLI variants so you can start an agent directly after the standard sandbox preflight and recovery checks.
+It improves onboarding, managed inference, installation, uninstall, snapshot, rebuild, and Shields failure handling with more accurate recovery behavior and diagnostics.
+It also strengthens endpoint validation, sandbox privilege separation, and the managed Hermes and LangChain Deep Agents Code lifecycle.
+
+- The new `nemoclaw launch <name>` command starts the sandbox agent in one host-side step while preserving the same preflight, process recovery, inference reconciliation, and pairing checks used by `connect`.
+  The command resolves the trusted interactive command from the selected agent manifest and supports OpenClaw, Hermes, and LangChain Deep Agents Code through their corresponding NemoClaw CLI variants.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Quickstart](/user-guide/openclaw/get-started/quickstart).
+- Managed vLLM onboarding now rejects a model before image or checkpoint download when the host GPU does not meet its minimum compute capability.
+  The readiness poller also stops a repeatedly restarting vLLM container instead of waiting for the full load timeout, and the DGX Spark Qwen profile no longer enables multi-token prediction by default.
+  Non-interactive onboarding preserves an explicit model selection when you switch providers.
+  For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm) and [Use Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama).
+- Windows Subsystem for Linux Express setup now waits until Node.js can read Docker Desktop configuration before selecting the Ollama provider.
+  Re-running the installer at the installed revision reuses a clean managed checkout instead of recloning it after dependency installation, and packaged-service teardown can complete through the expected standalone fallback.
+  Scoped uninstall also treats an already-removed sandbox as completed cleanup while retaining retry state for unreachable or rejected deletions.
+  For more information, refer to [Additional Setup for Windows Machines](/user-guide/openclaw/get-started/additional-setup/windows-preparation), [Gateway Lifecycle Authority](/user-guide/openclaw/deployment/gateway-lifecycle-authority), and [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw).
+- Onboarding and rebuild recovery now preserve the original container-start failure diagnosis, require journal-backed authority before repairing a not-ready sandbox, and print a structured safe-abort diagnostic for rebuild preflight failures.
+  Top-level CLI and MCP bridge destruction failures return one redacted error with a nonzero exit status instead of exposing an uncaught Node.js stack trace.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- A failed `snapshot create` now removes its incomplete capture so later list and restore operations do not treat it as complete.
+  Cross-sandbox restore keeps documented policy reconciliation best-effort, warns when preset mutation fails, and continues to gateway pairing when the restored sandbox remains usable.
+  The documentation also clarifies that OpenClaw snapshot persistence follows the manifest-defined `/sandbox/.openclaw/workspace` paths rather than arbitrary files under `/sandbox`.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots) and [Understand Sandbox State](/user-guide/openclaw/manage-sandboxes/state-and-backups/understand-sandbox-state).
+- Shields transitions now preserve independently managed MCP policy entries, retain a fresh OpenClaw sandbox's mutable-default rollback state, and reject corrupt persisted transition state before mutation.
+  A rejected policy transition no longer leaves `shields status` claiming a state that was not applied, and lock inspection remains bound to the verified descriptor.
+  For more information, refer to [Understand Runtime Changes](/user-guide/openclaw/manage-sandboxes/configure-sandboxes/understand-runtime-changes), [Manage MCP Servers](/user-guide/openclaw/manage-sandboxes/mcp-servers/manage-mcp-servers), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Hermes now stores dashboard state in the canonical `~/.hermes/profiles/dashboard-home` profile and safely migrates an existing legacy dashboard home when the destination is empty.
+  Rebuild restore keeps script-backed cron jobs undispatchable until restored state and scripts validate against the same gateway, and successful gateway recovery resets the consecutive health-failure budget.
+  Hermes build stages also apply configured corporate certificate authority trust before supported npm, uv, and Python dependency downloads.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/hermes/manage-sandboxes/state-and-backups/create-and-restore-snapshots), [Understand Runtime Changes](/user-guide/hermes/manage-sandboxes/configure-sandboxes/understand-runtime-changes), and [Configure Corporate CA Trust](/user-guide/hermes/security/configure-corporate-ca-trust).
+- Managed LangChain Deep Agents Code non-interactive failures now use a bounded error classification instead of exposing exception messages or reporting every failure as unknown.
+  Rebuilds reuse the published Deep Agents Code base image, while the documented recovery guidance reflects the classified failure and managed-image path.
+  For more information, refer to [Run LangChain Deep Agents Code](/user-guide/deepagents/manage-sandboxes/operate-sandboxes/run-deep-agents-code) and [Troubleshooting](/user-guide/deepagents/reference/troubleshooting).
+- CLI and plugin endpoint validation now share expanded special-purpose address protections and reject endpoint URLs containing embedded credentials before DNS resolution.
+  Managed images use the Debian-pinned `setpriv` implementation for reviewed user and group transitions and fail closed instead of starting an agent service as root when that transition is unavailable.
+  Shields-protected confidentiality roots remain unlistable while allowing the sandbox group to resolve an absent top-level path without breaking gateway startup.
+  For more information, refer to [Meet Custom Endpoint Security Requirements](/user-guide/openclaw/inference/custom-endpoints/custom-endpoint-security), [Review Sandbox Hardening](/user-guide/openclaw/manage-sandboxes/configure-sandboxes/review-sandbox-hardening), and [Security Best Practices](/user-guide/openclaw/security/best-practices).
+- Documentation now removes the unsupported `logs --audit` example, places network-policy walkthrough prerequisites before the command sequence, and clarifies snapshot restore selection and platform runtime validation.
+  For more information, refer to [Troubleshoot MCP Servers](/user-guide/openclaw/reference/troubleshoot-mcp-servers), [Approve Network Requests](/user-guide/openclaw/network-policy/approve-network-requests), and [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots).

--- a/docs/changelog/2026-08-05.mdx
+++ b/docs/changelog/2026-08-05.mdx
@@ -32,7 +32,7 @@ It also strengthens endpoint validation, sandbox privilege separation, and the m
   For more information, refer to [Understand Runtime Changes](/user-guide/openclaw/manage-sandboxes/configure-sandboxes/understand-runtime-changes), [Manage MCP Servers](/user-guide/openclaw/manage-sandboxes/mcp-servers/manage-mcp-servers), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
 - Hermes now stores dashboard state in the canonical `~/.hermes/profiles/dashboard-home` profile and safely migrates an existing legacy dashboard home when the destination is empty.
   Rebuild restore keeps script-backed cron jobs undispatchable until restored state and scripts validate against the same gateway, and successful gateway recovery resets the consecutive health-failure budget.
-  Hermes build stages also apply configured corporate certificate authority trust before supported npm, uv, and Python dependency downloads.
+  Hermes build stages also apply configured corporate certificate authority trust before supported `npm`, `uv`, and Python dependency downloads.
   For more information, refer to [Create and Restore Snapshots](/user-guide/hermes/manage-sandboxes/state-and-backups/create-and-restore-snapshots), [Understand Runtime Changes](/user-guide/hermes/manage-sandboxes/configure-sandboxes/understand-runtime-changes), and [Configure Corporate CA Trust](/user-guide/hermes/security/configure-corporate-ca-trust).
 - Managed LangChain Deep Agents Code non-interactive failures now use a bounded error classification instead of exposing exception messages or reporting every failure as unknown.
   Rebuilds reuse the published Deep Agents Code base image, while the documented recovery guidance reflects the classified failure and managed-image path.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the canonical dated changelog entry for the planned NemoClaw v0.0.103 release.
The new `docs/changelog/2026-08-05.mdx` entry uses the exact `## v0.0.103` heading and summarizes supported user-visible changes merged since v0.0.102.

## Changes

- Add the parser-safe MDX SPDX header, three-paragraph release summary, and detailed grouped bullets to `docs/changelog/2026-08-05.mdx`.
- Link each release-note group to the most specific published OpenClaw, Hermes, or Deep Agents documentation routes.
- Exclude dormant MXC and Podman foundations, internal managed-inference adapters, test-only changes, and maintainer tooling from the supported product narrative.

### Source summary

- [#8082](https://github.com/NVIDIA/NemoClaw/pull/8082) -> `docs/changelog/2026-08-05.mdx`: Document the new one-command agent launch flow.
- [#8314](https://github.com/NVIDIA/NemoClaw/pull/8314) -> `docs/changelog/2026-08-05.mdx`: Document managed vLLM host capability validation and restart handling.
- [#8248](https://github.com/NVIDIA/NemoClaw/pull/8248) -> `docs/changelog/2026-08-05.mdx`: Record the DGX Spark Qwen profile MTP default change.
- [#8223](https://github.com/NVIDIA/NemoClaw/pull/8223) -> `docs/changelog/2026-08-05.mdx`: Record explicit model preservation across provider switches.
- [#8209](https://github.com/NVIDIA/NemoClaw/pull/8209) -> `docs/changelog/2026-08-05.mdx`: Document corrected Windows WSL provider selection.
- [#8316](https://github.com/NVIDIA/NemoClaw/pull/8316) -> `docs/changelog/2026-08-05.mdx`: Record clean managed-checkout reuse after installation.
- [#8239](https://github.com/NVIDIA/NemoClaw/pull/8239) -> `docs/changelog/2026-08-05.mdx`: Record the packaged-service teardown fallback.
- [#8247](https://github.com/NVIDIA/NemoClaw/pull/8247) -> `docs/changelog/2026-08-05.mdx`: Document uninstall behavior for an already-removed sandbox.
- [#7998](https://github.com/NVIDIA/NemoClaw/pull/7998) -> `docs/changelog/2026-08-05.mdx`: Record preserved container-start diagnostics.
- [#8027](https://github.com/NVIDIA/NemoClaw/pull/8027) -> `docs/changelog/2026-08-05.mdx`: Record journal-backed not-ready repair authority.
- [#7812](https://github.com/NVIDIA/NemoClaw/pull/7812) -> `docs/changelog/2026-08-05.mdx`: Document actionable rebuild preflight diagnostics.
- [#8222](https://github.com/NVIDIA/NemoClaw/pull/8222) -> `docs/changelog/2026-08-05.mdx`: Record redacted top-level CLI failures.
- [#8313](https://github.com/NVIDIA/NemoClaw/pull/8313) -> `docs/changelog/2026-08-05.mdx`: Record structured MCP bridge destruction failures.
- [#8211](https://github.com/NVIDIA/NemoClaw/pull/8211) -> `docs/changelog/2026-08-05.mdx`: Document cleanup of incomplete snapshot captures.
- [#8212](https://github.com/NVIDIA/NemoClaw/pull/8212) -> `docs/changelog/2026-08-05.mdx`: Document best-effort post-restore policy reconciliation.
- [#8245](https://github.com/NVIDIA/NemoClaw/pull/8245) -> `docs/changelog/2026-08-05.mdx`: Clarify manifest-defined OpenClaw workspace persistence.
- [#8254](https://github.com/NVIDIA/NemoClaw/pull/8254) -> `docs/changelog/2026-08-05.mdx`: Include corrected snapshot restore selection guidance.
- [#8238](https://github.com/NVIDIA/NemoClaw/pull/8238) -> `docs/changelog/2026-08-05.mdx`: Document preservation of managed MCP policy entries.
- [#7568](https://github.com/NVIDIA/NemoClaw/pull/7568) -> `docs/changelog/2026-08-05.mdx`: Record mutable-default Shields rollback preservation.
- [#8200](https://github.com/NVIDIA/NemoClaw/pull/8200) -> `docs/changelog/2026-08-05.mdx`: Record truthful Shields state after a rejected transition.
- [#7895](https://github.com/NVIDIA/NemoClaw/pull/7895) -> `docs/changelog/2026-08-05.mdx`: Record descriptor-bound Shields lock inspection.
- [#7892](https://github.com/NVIDIA/NemoClaw/pull/7892) -> `docs/changelog/2026-08-05.mdx`: Document the canonical Hermes dashboard profile and migration.
- [#7871](https://github.com/NVIDIA/NemoClaw/pull/7871) -> `docs/changelog/2026-08-05.mdx`: Document fail-closed Hermes cron restore.
- [#7894](https://github.com/NVIDIA/NemoClaw/pull/7894) -> `docs/changelog/2026-08-05.mdx`: Record the reset Hermes health budget after recovery.
- [#8228](https://github.com/NVIDIA/NemoClaw/pull/8228) -> `docs/changelog/2026-08-05.mdx`: Document Hermes build-time corporate CA trust.
- [#8206](https://github.com/NVIDIA/NemoClaw/pull/8206) -> `docs/changelog/2026-08-05.mdx`: Document bounded Deep Agents Code failure classification.
- [#8297](https://github.com/NVIDIA/NemoClaw/pull/8297) -> `docs/changelog/2026-08-05.mdx`: Record reuse of the published Deep Agents Code base image.
- [#8321](https://github.com/NVIDIA/NemoClaw/pull/8321) -> `docs/changelog/2026-08-05.mdx`: Document aligned endpoint SSRF protections and userinfo rejection.
- [#8299](https://github.com/NVIDIA/NemoClaw/pull/8299) -> `docs/changelog/2026-08-05.mdx`: Document the fail-closed `setpriv` transition in managed images.
- [#7603](https://github.com/NVIDIA/NemoClaw/pull/7603) -> `docs/changelog/2026-08-05.mdx`: Record corrected confidentiality-root traversal.
- [#8334](https://github.com/NVIDIA/NemoClaw/pull/8334) -> `docs/changelog/2026-08-05.mdx`: Record removal of the unsupported logs audit example.
- [#8256](https://github.com/NVIDIA/NemoClaw/pull/8256) -> `docs/changelog/2026-08-05.mdx`: Record reordered network-policy walkthrough prerequisites.
- [#7767](https://github.com/NVIDIA/NemoClaw/pull/7767) -> `docs/changelog/2026-08-05.mdx`: Record platform runtime shape validation.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `npx vitest run test/changelog-docs.test.ts` passed all 6 tests.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-08-05.mdx` follows the release-prep and documentation writing rules. The changelog contract tests passed 6/6, and `npm run docs` completed with 0 errors and the repository's 2 existing Fern warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 66fcd800d -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/changelog-docs.test.ts`: 1 file and 6 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run for this doc-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — the native changelog uses the required parser-safe MDX SPDX comment and does not use page frontmatter.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.103.
  * Documented the new `nemoclaw launch` command.
  * Included updates covering onboarding, inference, installation, recovery, snapshots, security, integrations, endpoint validation, sandbox hardening, and related guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->