### PR TITLE
feat(inference): verify acquired llama.cpp GGUF

### DIFF
--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -499,7 +499,10 @@ function validateCandidateCheckout(invocation: QualificationInvocation): string 
   return root;
 }
 
-function hashModelFile(modelHostPath: string, plan: QualificationPlan): VerifiedLocalModelArtifact {
+export function hashModelFile(
+  modelHostPath: string,
+  plan: QualificationPlan,
+): VerifiedLocalModelArtifact {
   if (path.basename(modelHostPath) !== plan.recipe.model.file.path) {
     throw new Error("model file name does not match the qualification plan");
   }
@@ -507,35 +510,39 @@ function hashModelFile(modelHostPath: string, plan: QualificationPlan): Verified
   if (realPath !== modelHostPath) throw new Error("model file path must not use symlinks");
   const descriptor = fs.openSync(modelHostPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
   try {
-    const before = fs.fstatSync(descriptor);
+    const before = fs.fstatSync(descriptor, { bigint: true });
+    const expectedSize = BigInt(plan.recipe.model.file.sizeBytes);
     if (
       !before.isFile() ||
-      before.size !== plan.recipe.model.file.sizeBytes ||
-      before.size < 1 ||
-      before.size > maximumModelBytes
+      before.size !== expectedSize ||
+      before.size < 1n ||
+      before.size > BigInt(maximumModelBytes)
     ) {
       throw new Error("model file size does not match the bounded qualification plan");
     }
     const hash = createHash("sha256");
     const buffer = Buffer.allocUnsafe(8 * 1024 * 1024);
+    const sizeBytes = Number(before.size);
     let position = 0;
-    while (position < before.size) {
+    while (position < sizeBytes) {
       const read = fs.readSync(
         descriptor,
         buffer,
         0,
-        Math.min(buffer.length, before.size - position),
+        Math.min(buffer.length, sizeBytes - position),
         position,
       );
       if (read < 1) throw new Error("model file changed during verification");
       hash.update(buffer.subarray(0, read));
       position += read;
     }
-    const after = fs.fstatSync(descriptor);
+    const after = fs.fstatSync(descriptor, { bigint: true });
     if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
       before.size !== after.size ||
-      before.mtimeMs !== after.mtimeMs ||
-      before.ctimeMs !== after.ctimeMs
+      before.mtimeNs !== after.mtimeNs ||
+      before.ctimeNs !== after.ctimeNs
     ) {
       throw new Error("model file changed during verification");
     }
@@ -543,7 +550,18 @@ function hashModelFile(modelHostPath: string, plan: QualificationPlan): Verified
     if (digest !== plan.recipe.model.file.digest) {
       throw new Error("model file digest does not match the qualification plan");
     }
-    return { digest, hostPath: modelHostPath, sizeBytes: after.size };
+    return {
+      digest,
+      filesystemIdentity: {
+        ctimeNs: after.ctimeNs,
+        dev: after.dev,
+        ino: after.ino,
+        mtimeNs: after.mtimeNs,
+        size: after.size,
+      },
+      hostPath: modelHostPath,
+      sizeBytes,
+    };
   } finally {
     fs.closeSync(descriptor);
   }

--- a/src/lib/inference/llama-cpp/gguf-acquisition.test.ts
+++ b/src/lib/inference/llama-cpp/gguf-acquisition.test.ts
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import { lstat, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { HuggingFaceModelAcquisitionRequest } from "../model-acquisition/hugging-face";
+import { acquireVerifiedLlamaCppGguf, verifyLlamaCppGgufCacheEntry } from "./gguf-acquisition";
+import type { LlamaCppGgufCachePlan } from "./gguf-cache-plan";
+
+const CONTENT = Buffer.from("verified GGUF fixture\n", "utf8");
+const DIGEST = `sha256:${createHash("sha256").update(CONTENT).digest("hex")}`;
+const REPOSITORY = "nvidia/test-gguf";
+const REVISION = "a".repeat(40);
+const FILENAME = "model.Q4_K_M.gguf";
+
+function plan(
+  overrides: {
+    readonly digest?: string;
+    readonly filename?: string;
+    readonly repository?: string;
+    readonly revision?: string;
+    readonly sizeBytes?: number;
+  } = {},
+): LlamaCppGgufCachePlan {
+  const file = {
+    path: overrides.filename ?? FILENAME,
+    digest: overrides.digest ?? DIGEST,
+    sizeBytes: overrides.sizeBytes ?? CONTENT.length,
+  };
+  const repository = overrides.repository ?? REPOSITORY;
+  const revision = overrides.revision ?? REVISION;
+  return {
+    schemaVersion: 1,
+    recipeId: "test.llama.recipe",
+    acquisition: {
+      ref: "hugging-face-exact-file/v1",
+      url: `https://huggingface.co/${repository}/resolve/${revision}/${file.path}`,
+      authentication: { mode: "optional", environment: "HF_TOKEN" },
+      source: { repository, revision, file },
+    },
+    cache: {
+      ref: "llama-cpp.gguf-content-addressed/v1",
+      receiptRef: "llama-cpp.gguf-cache-entry.receipt/v1",
+      root: "user-cache",
+      key: `sha256-${"b".repeat(64)}`,
+      quotaBytes: 4096,
+      stagingHeadroomBytes: 1024,
+      staging: "same-filesystem",
+      publication: "atomic-no-clobber",
+      reuse: "verified-only-offline",
+      sharing: "owner-only",
+      cleanup: "receipt-owner-only",
+    },
+    planDigest: `sha256:${"c".repeat(64)}`,
+  };
+}
+
+function modelCacheRoot(cacheRoot: string): string {
+  return path.join(cacheRoot, "hub", "models--nvidia--test-gguf");
+}
+
+function snapshotEntry(cacheRoot: string, revision = REVISION): string {
+  return path.join(modelCacheRoot(cacheRoot), "snapshots", revision, FILENAME);
+}
+
+async function createSnapshot(
+  cacheRoot: string,
+  content: Buffer = CONTENT,
+  revision = REVISION,
+): Promise<{ blob: string; entry: string }> {
+  const modelRoot = modelCacheRoot(cacheRoot);
+  const blob = path.join(modelRoot, "blobs", "fixture-blob");
+  const entry = snapshotEntry(cacheRoot, revision);
+  await mkdir(path.dirname(blob), { recursive: true });
+  await mkdir(path.dirname(entry), { recursive: true });
+  await writeFile(blob, content);
+  await symlink(path.relative(path.dirname(entry), blob), entry);
+  return { blob, entry };
+}
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryCache(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "nemoclaw-gguf-acquisition-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function filesystemIdentity(file: string) {
+  const status = await lstat(file, { bigint: true });
+  return {
+    ctimeNs: status.ctimeNs,
+    dev: status.dev,
+    ino: status.ino,
+    mtimeNs: status.mtimeNs,
+    size: status.size,
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("llama.cpp GGUF acquisition", () => {
+  it("passes the exact compiled repository, revision, and filename to Hugging Face (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    const { blob } = await createSnapshot(cacheRoot);
+    const acquire = vi.fn().mockResolvedValue({ ok: true });
+    const execution = {
+      credentialEnv: { HF_TOKEN: "hf_test_token" },
+      dockerEnv: { DOCKER_HOST: "ssh://spark.example.test" },
+      downloaderImage: `nvcr.io/nvidia/vllm@sha256:${"d".repeat(64)}`,
+      hostCacheDir: cacheRoot,
+      spawnDocker: vi.fn(),
+      userIdentity: "1001:1001",
+    } satisfies Omit<HuggingFaceModelAcquisitionRequest, "filename" | "repository" | "revision">;
+    const observer = { logLine: vi.fn(), onRateLimit: vi.fn() };
+
+    await expect(
+      acquireVerifiedLlamaCppGguf(
+        { execution, observer, plan: plan() },
+        { acquireHuggingFaceModel: acquire },
+      ),
+    ).resolves.toEqual({
+      digest: DIGEST,
+      filesystemIdentity: await filesystemIdentity(blob),
+      hostPath: await realpath(blob),
+      sizeBytes: CONTENT.length,
+    });
+    expect(acquire).toHaveBeenCalledWith(
+      {
+        ...execution,
+        filename: FILENAME,
+        repository: REPOSITORY,
+        revision: REVISION,
+      },
+      observer,
+    );
+  });
+
+  it("resolves the standard snapshot symlink to its canonical regular blob (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    const { blob } = await createSnapshot(cacheRoot);
+
+    await expect(verifyLlamaCppGgufCacheEntry(plan(), cacheRoot)).resolves.toEqual({
+      digest: DIGEST,
+      filesystemIdentity: await filesystemIdentity(blob),
+      hostPath: await realpath(blob),
+      sizeBytes: CONTENT.length,
+    });
+  });
+
+  it("accepts a compiler-valid 64-character immutable revision (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    const revision = "d".repeat(64);
+    const { blob } = await createSnapshot(cacheRoot, CONTENT, revision);
+
+    await expect(verifyLlamaCppGgufCacheEntry(plan({ revision }), cacheRoot)).resolves.toEqual({
+      digest: DIGEST,
+      filesystemIdentity: await filesystemIdentity(blob),
+      hostPath: await realpath(blob),
+      sizeBytes: CONTENT.length,
+    });
+  });
+
+  it("rejects a snapshot symlink that resolves outside its model cache (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    const outside = path.join(cacheRoot, "outside.gguf");
+    const entry = snapshotEntry(cacheRoot);
+    await mkdir(path.dirname(entry), { recursive: true });
+    await writeFile(outside, CONTENT);
+    await symlink(path.relative(path.dirname(entry), outside), entry);
+
+    await expect(verifyLlamaCppGgufCacheEntry(plan(), cacheRoot)).rejects.toThrow(
+      "resolves outside its model cache",
+    );
+  });
+
+  it("rejects a model cache that resolves outside the configured cache root (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    const outsideModelCache = await temporaryCache();
+    await mkdir(path.join(cacheRoot, "hub"), { recursive: true });
+    await symlink(outsideModelCache, modelCacheRoot(cacheRoot), "dir");
+
+    await expect(verifyLlamaCppGgufCacheEntry(plan(), cacheRoot)).rejects.toThrow(
+      "resolves outside the configured cache root",
+    );
+  });
+
+  it("rejects a path-bearing filename before acquisition (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    const acquire = vi.fn();
+    const execution = {
+      dockerEnv: {},
+      downloaderImage: `nvcr.io/nvidia/vllm@sha256:${"d".repeat(64)}`,
+      hostCacheDir: cacheRoot,
+      spawnDocker: vi.fn(),
+      userIdentity: "1001:1001",
+    } satisfies Omit<HuggingFaceModelAcquisitionRequest, "filename" | "repository" | "revision">;
+
+    await expect(
+      acquireVerifiedLlamaCppGguf(
+        {
+          execution,
+          observer: { logLine: vi.fn(), onRateLimit: vi.fn() },
+          plan: plan({ filename: "nested/model.gguf" }),
+        },
+        { acquireHuggingFaceModel: acquire },
+      ),
+    ).rejects.toThrow("invalid model identity");
+    expect(acquire).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid repository before direct cache verification (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+
+    await expect(
+      verifyLlamaCppGgufCacheEntry(plan({ repository: "nvidia/model/foreign" }), cacheRoot),
+    ).rejects.toThrow("invalid model identity");
+  });
+
+  it("rejects a cache entry that is not a regular file (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    await mkdir(snapshotEntry(cacheRoot), { recursive: true });
+
+    await expect(verifyLlamaCppGgufCacheEntry(plan(), cacheRoot)).rejects.toThrow(
+      "does not resolve to the opened regular file",
+    );
+  });
+
+  it("rejects a GGUF whose size differs from the compiled size (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    await createSnapshot(cacheRoot);
+
+    await expect(
+      verifyLlamaCppGgufCacheEntry(plan({ sizeBytes: CONTENT.length + 1 }), cacheRoot),
+    ).rejects.toThrow("size does not match");
+  });
+
+  it("rejects a GGUF whose SHA-256 differs from the compiled digest (#8279)", async () => {
+    const cacheRoot = await temporaryCache();
+    await createSnapshot(cacheRoot);
+
+    await expect(
+      verifyLlamaCppGgufCacheEntry(plan({ digest: `sha256:${"0".repeat(64)}` }), cacheRoot),
+    ).rejects.toThrow("digest does not match");
+  });
+});

--- a/src/lib/inference/llama-cpp/gguf-acquisition.ts
+++ b/src/lib/inference/llama-cpp/gguf-acquisition.ts
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import { type BigIntStats, constants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  acquireHuggingFaceModel,
+  type HuggingFaceModelAcquisitionObserver,
+  type HuggingFaceModelAcquisitionRequest,
+  isValidHuggingFaceRepositoryId,
+} from "../model-acquisition/hugging-face";
+import type { LlamaCppGgufCachePlan } from "./gguf-cache-plan";
+import type { VerifiedLocalModelArtifact } from "./host-local-runtime";
+
+const GGUF_FILENAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,249}\.gguf$/u;
+const IMMUTABLE_HUGGING_FACE_REVISION = /^[0-9a-f]{40,64}$/u;
+const SHA256_DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const HASH_BUFFER_BYTES = 1024 * 1024;
+
+type HuggingFaceExecutionRequest = Omit<
+  HuggingFaceModelAcquisitionRequest,
+  "filename" | "repository" | "revision"
+>;
+
+export interface LlamaCppGgufAcquisitionRequest {
+  readonly execution: HuggingFaceExecutionRequest;
+  readonly observer: HuggingFaceModelAcquisitionObserver;
+  readonly plan: LlamaCppGgufCachePlan;
+}
+
+export interface LlamaCppGgufAcquisitionDependencies {
+  readonly acquireHuggingFaceModel?: typeof acquireHuggingFaceModel;
+}
+
+export class LlamaCppGgufAcquisitionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LlamaCppGgufAcquisitionError";
+  }
+}
+
+function fail(message: string): never {
+  throw new LlamaCppGgufAcquisitionError(message);
+}
+
+function validatePlanSource(plan: LlamaCppGgufCachePlan): void {
+  const { file, repository, revision } = plan.acquisition.source;
+  if (
+    plan.acquisition.ref !== "hugging-face-exact-file/v1" ||
+    !isValidHuggingFaceRepositoryId(repository) ||
+    !IMMUTABLE_HUGGING_FACE_REVISION.test(revision) ||
+    !GGUF_FILENAME.test(file.path) ||
+    !SHA256_DIGEST.test(file.digest) ||
+    !Number.isSafeInteger(file.sizeBytes) ||
+    file.sizeBytes < 1
+  ) {
+    fail("The llama.cpp GGUF acquisition plan has an invalid model identity.");
+  }
+}
+
+function isDescendant(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return (
+    relative.length > 0 &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function sameFileIdentity(left: BigIntStats, right: BigIntStats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameFileState(left: BigIntStats, right: BigIntStats): boolean {
+  return (
+    sameFileIdentity(left, right) &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+async function requireCanonicalDirectory(directory: string, label: string): Promise<string> {
+  let canonical: string;
+  let status: BigIntStats;
+  try {
+    canonical = await realpath(directory);
+    status = await lstat(canonical, { bigint: true });
+  } catch {
+    fail(`${label} is unavailable.`);
+  }
+  if (!status.isDirectory()) fail(`${label} is not a directory.`);
+  return canonical;
+}
+
+async function hashOpenFile(
+  handle: Awaited<ReturnType<typeof open>>,
+): Promise<{ digest: string; sizeBytes: number }> {
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(HASH_BUFFER_BYTES);
+  let sizeBytes = 0;
+  for (;;) {
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+    if (bytesRead === 0) break;
+    hash.update(buffer.subarray(0, bytesRead));
+    sizeBytes += bytesRead;
+    if (!Number.isSafeInteger(sizeBytes)) {
+      fail("The acquired GGUF size exceeds the JavaScript safe-integer range.");
+    }
+  }
+  return { digest: `sha256:${hash.digest("hex")}`, sizeBytes };
+}
+
+function modelCacheEntryPath(plan: LlamaCppGgufCachePlan, hostCacheDir: string): string {
+  const { file, repository, revision } = plan.acquisition.source;
+  const modelCacheKey = `models--${repository.replaceAll("/", "--")}`;
+  return path.join(hostCacheDir, "hub", modelCacheKey, "snapshots", revision, file.path);
+}
+
+/** Verify one exact GGUF in the Hugging Face Hub cache by hashing it in 1 MiB chunks. */
+export async function verifyLlamaCppGgufCacheEntry(
+  plan: LlamaCppGgufCachePlan,
+  hostCacheDir: string,
+): Promise<VerifiedLocalModelArtifact> {
+  validatePlanSource(plan);
+  const cacheRoot = await requireCanonicalDirectory(hostCacheDir, "The Hugging Face cache root");
+  const modelCachePath = path.join(
+    hostCacheDir,
+    "hub",
+    `models--${plan.acquisition.source.repository.replaceAll("/", "--")}`,
+  );
+  const modelCacheRoot = await requireCanonicalDirectory(
+    modelCachePath,
+    "The Hugging Face model cache",
+  );
+  if (!isDescendant(cacheRoot, modelCacheRoot)) {
+    fail("The Hugging Face model cache resolves outside the configured cache root.");
+  }
+
+  const snapshotEntry = modelCacheEntryPath(plan, hostCacheDir);
+  let canonicalTarget: string;
+  try {
+    canonicalTarget = await realpath(snapshotEntry);
+  } catch {
+    fail("The acquired GGUF cache entry is unavailable.");
+  }
+  if (!isDescendant(modelCacheRoot, canonicalTarget)) {
+    fail("The acquired GGUF cache entry resolves outside its model cache.");
+  }
+
+  let handle: Awaited<ReturnType<typeof open>>;
+  if (typeof constants.O_NOFOLLOW !== "number" || typeof constants.O_NONBLOCK !== "number") {
+    fail("The host does not provide the file flags required for GGUF verification.");
+  }
+  try {
+    handle = await open(
+      canonicalTarget,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+    );
+  } catch {
+    fail("The acquired GGUF cache entry is not a readable regular file.");
+  }
+
+  try {
+    const beforeDescriptor = await handle.stat({ bigint: true });
+    const beforePath = await lstat(canonicalTarget, { bigint: true });
+    if (
+      !beforeDescriptor.isFile() ||
+      !beforePath.isFile() ||
+      !sameFileIdentity(beforeDescriptor, beforePath)
+    ) {
+      fail("The acquired GGUF cache entry does not resolve to the opened regular file.");
+    }
+
+    const expectedSize = BigInt(plan.acquisition.source.file.sizeBytes);
+    if (beforeDescriptor.size !== expectedSize) {
+      fail("The acquired GGUF size does not match the declarative model identity.");
+    }
+
+    const actual = await hashOpenFile(handle);
+    const afterDescriptor = await handle.stat({ bigint: true });
+    let afterPath: BigIntStats;
+    let targetAfterVerification: string;
+    let cacheRootAfterVerification: string;
+    let modelCacheRootAfterVerification: string;
+    try {
+      afterPath = await lstat(canonicalTarget, { bigint: true });
+      targetAfterVerification = await realpath(snapshotEntry);
+      cacheRootAfterVerification = await realpath(hostCacheDir);
+      modelCacheRootAfterVerification = await realpath(modelCachePath);
+    } catch {
+      fail("The acquired GGUF cache entry changed during verification.");
+    }
+    if (
+      !afterPath.isFile() ||
+      !sameFileState(beforeDescriptor, afterDescriptor) ||
+      !sameFileState(afterDescriptor, afterPath) ||
+      targetAfterVerification !== canonicalTarget ||
+      cacheRootAfterVerification !== cacheRoot ||
+      modelCacheRootAfterVerification !== modelCacheRoot
+    ) {
+      fail("The acquired GGUF cache entry changed during verification.");
+    }
+    if (actual.sizeBytes !== plan.acquisition.source.file.sizeBytes) {
+      fail("The acquired GGUF size does not match the declarative model identity.");
+    }
+    if (actual.digest !== plan.acquisition.source.file.digest) {
+      fail("The acquired GGUF digest does not match the declarative model identity.");
+    }
+
+    return {
+      digest: actual.digest,
+      filesystemIdentity: {
+        ctimeNs: afterDescriptor.ctimeNs,
+        dev: afterDescriptor.dev,
+        ino: afterDescriptor.ino,
+        mtimeNs: afterDescriptor.mtimeNs,
+        size: afterDescriptor.size,
+      },
+      hostPath: canonicalTarget,
+      sizeBytes: actual.sizeBytes,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Acquire the plan-selected Hugging Face file and return its verified local artifact. */
+export async function acquireVerifiedLlamaCppGguf(
+  request: LlamaCppGgufAcquisitionRequest,
+  dependencies: LlamaCppGgufAcquisitionDependencies = {},
+): Promise<VerifiedLocalModelArtifact> {
+  validatePlanSource(request.plan);
+  const acquire = dependencies.acquireHuggingFaceModel ?? acquireHuggingFaceModel;
+  const { file, repository, revision } = request.plan.acquisition.source;
+  const result = await acquire(
+    {
+      ...request.execution,
+      filename: file.path,
+      repository,
+      revision,
+    },
+    request.observer,
+  );
+  if (!result.ok) fail(`Hugging Face model acquisition failed: ${result.reason}`);
+  return verifyLlamaCppGgufCacheEntry(request.plan, request.execution.hostCacheDir);
+}

--- a/src/lib/inference/llama-cpp/host-local-runtime.test.ts
+++ b/src/lib/inference/llama-cpp/host-local-runtime.test.ts
@@ -1,7 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import {
+  lstatSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   buildLlamaCppHostLocalDockerArgv,
@@ -11,6 +23,31 @@ import {
 
 const MODEL_DIGEST = `sha256:${"a".repeat(64)}`;
 const IMAGE = `ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"b".repeat(64)}`;
+const MODEL_CONTENT = Buffer.alloc(64, 0x61);
+const MODEL_FILENAME = "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
+let modelRoot = "";
+let modelPath = "";
+
+function filesystemIdentity() {
+  const status = lstatSync(modelPath, { bigint: true });
+  return {
+    ctimeNs: status.ctimeNs,
+    dev: status.dev,
+    ino: status.ino,
+    mtimeNs: status.mtimeNs,
+    size: status.size,
+  };
+}
+
+beforeEach(() => {
+  modelRoot = realpathSync(mkdtempSync(path.join(os.tmpdir(), "nemoclaw-llama-runtime-")));
+  modelPath = path.join(modelRoot, MODEL_FILENAME);
+  writeFileSync(modelPath, MODEL_CONTENT);
+});
+
+afterEach(() => {
+  rmSync(modelRoot, { force: true, recursive: true });
+});
 
 function contract(): LlamaCppHostLocalLaunchContract {
   return {
@@ -18,8 +55,8 @@ function contract(): LlamaCppHostLocalLaunchContract {
       servedName: "nvidia-nemotron-3-nano-30b-a3b",
       file: {
         digest: MODEL_DIGEST,
-        path: "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
-        sizeBytes: 22_833_947_424,
+        path: MODEL_FILENAME,
+        sizeBytes: MODEL_CONTENT.length,
       },
     },
     policy: {
@@ -70,8 +107,9 @@ function bindings(): LlamaCppHostLocalRuntimeBindings {
     imageReference: IMAGE,
     model: {
       digest: MODEL_DIGEST,
-      hostPath: `/home/nvidia/.cache/huggingface/hub/blobs/${"c".repeat(64)}`,
-      sizeBytes: 22_833_947_424,
+      filesystemIdentity: filesystemIdentity(),
+      hostPath: modelPath,
+      sizeBytes: MODEL_CONTENT.length,
     },
     network: { isolation: "docker-internal", name: "nemoclaw-llama-cpp-internal" },
     ownerLabel: { name: "io.nvidia.nemoclaw.llama-cpp-owner", value: "gateway.primary" },
@@ -227,6 +265,62 @@ describe("llama.cpp host-local runtime materializer", () => {
         model: { ...bindings().model, sizeBytes: 1 },
       }),
     ).toThrow("verified model artifact does not match");
+  });
+
+  it("rejects a replacement at a previously verified model path (#8279)", () => {
+    const runtime = bindings();
+    renameSync(modelPath, `${modelPath}.verified`);
+    writeFileSync(modelPath, MODEL_CONTENT);
+
+    expect(() => buildLlamaCppHostLocalDockerArgv(contract(), runtime)).toThrow(
+      "does not match its verified filesystem identity",
+    );
+  });
+
+  it("rejects changed state on the previously verified inode (#8279)", () => {
+    const runtime = bindings();
+    writeFileSync(modelPath, Buffer.alloc(MODEL_CONTENT.length, 0x62));
+    const future = new Date(Date.now() + 10_000);
+    utimesSync(modelPath, future, future);
+
+    expect(() => buildLlamaCppHostLocalDockerArgv(contract(), runtime)).toThrow(
+      "does not match its verified filesystem identity",
+    );
+  });
+
+  it.each([
+    "dev",
+    "ino",
+    "size",
+    "mtimeNs",
+    "ctimeNs",
+  ] as const)("rejects a forged %s field in the verified filesystem identity (#8279)", (field) => {
+    const runtime = bindings();
+    expect(() =>
+      buildLlamaCppHostLocalDockerArgv(contract(), {
+        ...runtime,
+        model: {
+          ...runtime.model,
+          filesystemIdentity: {
+            ...runtime.model.filesystemIdentity,
+            [field]: runtime.model.filesystemIdentity[field] + 1n,
+          },
+        },
+      }),
+    ).toThrow("does not match its verified filesystem identity");
+  });
+
+  it("rejects a forged artifact that omits filesystem identity (#8279)", () => {
+    const runtime = bindings();
+    expect(() =>
+      buildLlamaCppHostLocalDockerArgv(contract(), {
+        ...runtime,
+        model: {
+          ...runtime.model,
+          filesystemIdentity: undefined,
+        } as unknown as typeof runtime.model,
+      }),
+    ).toThrow("does not match its verified filesystem identity");
   });
 
   it("rejects inputs that violate host-local isolation (#8144)", () => {

--- a/src/lib/inference/llama-cpp/host-local-runtime.ts
+++ b/src/lib/inference/llama-cpp/host-local-runtime.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type BigIntStats, lstatSync, realpathSync } from "node:fs";
 import path from "node:path";
 
 import { isSafeLlamaCppServedModelAlias } from "./contract";
@@ -92,6 +93,14 @@ export interface LlamaCppHostLocalRuntimeBindings {
 
 export interface VerifiedLocalModelArtifact {
   readonly digest: string;
+  /** Executor-only identity captured from the descriptor that verified this file. */
+  readonly filesystemIdentity: {
+    readonly ctimeNs: bigint;
+    readonly dev: bigint;
+    readonly ino: bigint;
+    readonly mtimeNs: bigint;
+    readonly size: bigint;
+  };
   readonly hostPath: string;
   readonly sizeBytes: number;
 }
@@ -174,6 +183,35 @@ function validateBindings(
   ) {
     throw new Error(
       "llama.cpp verified model artifact does not match the declarative GGUF identity",
+    );
+  }
+  let canonicalModelPath: string;
+  let modelStatus: BigIntStats;
+  try {
+    canonicalModelPath = realpathSync(bindings.model.hostPath);
+    modelStatus = lstatSync(bindings.model.hostPath, { bigint: true });
+  } catch {
+    throw new Error("llama.cpp verified model artifact is unavailable");
+  }
+  const identity = bindings.model.filesystemIdentity;
+  if (
+    !identity ||
+    typeof identity.dev !== "bigint" ||
+    typeof identity.ino !== "bigint" ||
+    typeof identity.size !== "bigint" ||
+    typeof identity.mtimeNs !== "bigint" ||
+    typeof identity.ctimeNs !== "bigint" ||
+    canonicalModelPath !== bindings.model.hostPath ||
+    !modelStatus.isFile() ||
+    modelStatus.dev !== identity.dev ||
+    modelStatus.ino !== identity.ino ||
+    modelStatus.size !== identity.size ||
+    modelStatus.mtimeNs !== identity.mtimeNs ||
+    modelStatus.ctimeNs !== identity.ctimeNs ||
+    modelStatus.size !== BigInt(bindings.model.sizeBytes)
+  ) {
+    throw new Error(
+      "llama.cpp verified model artifact does not match its verified filesystem identity",
     );
   }
   if (

--- a/src/lib/inference/llama-cpp/index.ts
+++ b/src/lib/inference/llama-cpp/index.ts
@@ -14,6 +14,7 @@ import {
 } from "./contract";
 
 export * from "./contract";
+export * from "./gguf-acquisition";
 export * from "./gguf-cache-plan";
 export * from "./gguf-cache-receipt";
 export * from "./host-local-runtime";

--- a/src/lib/inference/model-acquisition/hugging-face.ts
+++ b/src/lib/inference/model-acquisition/hugging-face.ts
@@ -120,9 +120,9 @@ function exactFilenameArgs(filename: string | undefined): string[] {
   return [filename];
 }
 
-function repositoryArg(repository: string): string {
+export function isValidHuggingFaceRepositoryId(repository: string): boolean {
   const components = repository.split("/");
-  if (
+  return !(
     repository.length === 0 ||
     repository.length > HF_REPOSITORY_ID_MAX_LENGTH ||
     components.length > 2 ||
@@ -130,7 +130,11 @@ function repositoryArg(repository: string): string {
     repository.includes("--") ||
     repository.includes("..") ||
     repository.endsWith(".git")
-  ) {
+  );
+}
+
+function repositoryArg(repository: string): string {
+  if (!isValidHuggingFaceRepositoryId(repository)) {
     throw new Error("Hugging Face repository must be one valid repository ID");
   }
   return repository;

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -13,6 +14,7 @@ import {
   buildServerContainerArgv,
   expectedRegistryName,
   expectedRegistryOwner,
+  hashModelFile,
   parseNvidiaSmi,
   parseQualificationInvocation,
   type QualificationInvocation,
@@ -97,6 +99,23 @@ function mutatedPlan(mutate: (value: Record<string, any>) => void): [string, str
 
 function valuesAfter(argv: string[], option: string): string[] {
   return argv.flatMap((value, index) => (argv[index - 1] === option ? [value] : []));
+}
+
+function qualificationPlanForModel(content: Buffer): QualificationPlan {
+  return {
+    ...plan,
+    recipe: {
+      ...plan.recipe,
+      model: {
+        ...plan.recipe.model,
+        file: {
+          ...plan.recipe.model.file,
+          digest: `sha256:${createHash("sha256").update(content).digest("hex")}`,
+          sizeBytes: content.length,
+        },
+      },
+    },
+  } as unknown as QualificationPlan;
 }
 
 describe("trusted llama.cpp DGX Spark qualification runner", () => {
@@ -248,86 +267,98 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
   });
 
   it("constructs a read-only bounded one-GPU server without putting the key on argv (#8260)", () => {
-    const argv = buildServerContainerArgv(plan, {
-      apiKeyHostPath: "/work/tmp/api-key",
-      containerName: "qualified-server",
-      imageReference: `localhost:5000/repo@sha256:${"d".repeat(64)}`,
-      model: {
-        digest: plan.recipe.model.file.digest,
-        hostPath: MODEL_PATH,
-        sizeBytes: plan.recipe.model.file.sizeBytes,
-      },
-      networkName: "qualified-internal",
-      registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
-      runtimeGid: 1001,
-      runtimeUid: 1001,
-    });
-    expect(argv).toEqual(
-      expect.arrayContaining([
-        "--read-only",
-        "--cap-drop",
-        "ALL",
-        "no-new-privileges=true",
-        "--gpus",
-        "1",
-        "--gpu-layers",
-        "all",
-        "--ctx-size",
-        String(plan.recipe.serve.contextSize),
-        "--batch-size",
-        String(plan.recipe.serve.batchSize),
-        "--ubatch-size",
-        String(plan.recipe.serve.microBatchSize),
-        "--cache-type-k",
-        plan.recipe.serve.kvCache.key,
-        "--cache-type-v",
-        plan.recipe.serve.kvCache.value,
-        "--flash-attn",
-        "on",
-        "--metrics",
-        "--no-ui",
-        "--no-slots",
-        "--no-mmproj",
-        "--no-agent",
-      ]),
+    const content = Buffer.from("qualification model fixture\n", "utf8");
+    const testPlan = qualificationPlanForModel(content);
+    const modelRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-qualification-model-")),
     );
-    expect(valuesAfter(argv, "--publish")).toEqual(["127.0.0.1::8081"]);
-    expect(valuesAfter(argv, "--network")).toEqual(["qualified-internal"]);
-    expect(valuesAfter(argv, "--user")).toEqual(["1001:1001"]);
-    expect(valuesAfter(argv, "--api-key-file")).toEqual(["/run/secrets/llama-cpp-api-key"]);
-    expect(argv).not.toContain("--api-key");
-    expect(valuesAfter(argv, "--mount")).toEqual([
-      `type=bind,source=${MODEL_PATH},target=/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf,readonly`,
-      "type=bind,source=/work/tmp/api-key,target=/run/secrets/llama-cpp-api-key,readonly",
-    ]);
-    expect(valuesAfter(argv, "--memory")).toEqual([
-      `${plan.recipe.runtime.resources.memoryBytes}b`,
-    ]);
-    expect(valuesAfter(argv, "--memory-swap")).toEqual([
-      `${plan.recipe.runtime.resources.memoryBytes}b`,
-    ]);
-    expect(valuesAfter(argv, "--pids-limit")).toEqual([
-      String(plan.recipe.runtime.resources.pidsLimit),
-    ]);
-    expect(valuesAfter(argv, "--tmpfs")).toEqual([
-      `/tmp:rw,noexec,nosuid,nodev,size=${plan.recipe.runtime.resources.writableStorageBytes},uid=1001,gid=1001,mode=1777`,
-    ]);
-    expect(() =>
-      buildServerContainerArgv(plan, {
+    const modelHostPath = path.join(modelRoot, testPlan.recipe.model.file.path);
+    fs.writeFileSync(modelHostPath, content);
+    try {
+      const model = hashModelFile(modelHostPath, testPlan);
+      const modelStatus = fs.lstatSync(modelHostPath, { bigint: true });
+      expect(model.filesystemIdentity).toEqual({
+        ctimeNs: modelStatus.ctimeNs,
+        dev: modelStatus.dev,
+        ino: modelStatus.ino,
+        mtimeNs: modelStatus.mtimeNs,
+        size: modelStatus.size,
+      });
+      const argv = buildServerContainerArgv(testPlan, {
         apiKeyHostPath: "/work/tmp/api-key",
         containerName: "qualified-server",
         imageReference: `localhost:5000/repo@sha256:${"d".repeat(64)}`,
-        model: {
-          digest: plan.recipe.model.file.digest,
-          hostPath: MODEL_PATH,
-          sizeBytes: plan.recipe.model.file.sizeBytes,
-        },
+        model,
         networkName: "qualified-internal",
         registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
         runtimeGid: 1001,
-        runtimeUid: 0,
-      }),
-    ).toThrow(/runtime uid/u);
+        runtimeUid: 1001,
+      });
+      expect(argv).toEqual(
+        expect.arrayContaining([
+          "--read-only",
+          "--cap-drop",
+          "ALL",
+          "no-new-privileges=true",
+          "--gpus",
+          "1",
+          "--gpu-layers",
+          "all",
+          "--ctx-size",
+          String(testPlan.recipe.serve.contextSize),
+          "--batch-size",
+          String(testPlan.recipe.serve.batchSize),
+          "--ubatch-size",
+          String(testPlan.recipe.serve.microBatchSize),
+          "--cache-type-k",
+          testPlan.recipe.serve.kvCache.key,
+          "--cache-type-v",
+          testPlan.recipe.serve.kvCache.value,
+          "--flash-attn",
+          "on",
+          "--metrics",
+          "--no-ui",
+          "--no-slots",
+          "--no-mmproj",
+          "--no-agent",
+        ]),
+      );
+      expect(valuesAfter(argv, "--publish")).toEqual(["127.0.0.1::8081"]);
+      expect(valuesAfter(argv, "--network")).toEqual(["qualified-internal"]);
+      expect(valuesAfter(argv, "--user")).toEqual(["1001:1001"]);
+      expect(valuesAfter(argv, "--api-key-file")).toEqual(["/run/secrets/llama-cpp-api-key"]);
+      expect(argv).not.toContain("--api-key");
+      expect(valuesAfter(argv, "--mount")).toEqual([
+        `type=bind,source=${modelHostPath},target=/models/${testPlan.recipe.model.file.path},readonly`,
+        "type=bind,source=/work/tmp/api-key,target=/run/secrets/llama-cpp-api-key,readonly",
+      ]);
+      expect(valuesAfter(argv, "--memory")).toEqual([
+        `${testPlan.recipe.runtime.resources.memoryBytes}b`,
+      ]);
+      expect(valuesAfter(argv, "--memory-swap")).toEqual([
+        `${testPlan.recipe.runtime.resources.memoryBytes}b`,
+      ]);
+      expect(valuesAfter(argv, "--pids-limit")).toEqual([
+        String(testPlan.recipe.runtime.resources.pidsLimit),
+      ]);
+      expect(valuesAfter(argv, "--tmpfs")).toEqual([
+        `/tmp:rw,noexec,nosuid,nodev,size=${testPlan.recipe.runtime.resources.writableStorageBytes},uid=1001,gid=1001,mode=1777`,
+      ]);
+      expect(() =>
+        buildServerContainerArgv(testPlan, {
+          apiKeyHostPath: "/work/tmp/api-key",
+          containerName: "qualified-server",
+          imageReference: `localhost:5000/repo@sha256:${"d".repeat(64)}`,
+          model,
+          networkName: "qualified-internal",
+          registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
+          runtimeGid: 1001,
+          runtimeUid: 0,
+        }),
+      ).toThrow(/runtime uid/u);
+    } finally {
+      fs.rmSync(modelRoot, { force: true, recursive: true });
+    }
   });
 
   it("requires unambiguous full GPU offload and rejects CPU fallback warnings (#8260)", () => {


### PR DESCRIPTION
## Summary

Add the internal acquisition boundary that resolves the exact declarative llama.cpp GGUF through the shared Hugging Face flow and verifies the standard cache entry before it can become a host-local runtime binding. The verified artifact now carries descriptor-derived filesystem identity so replacement or mutation is rejected before Docker arguments are materialized.

## Related Issue

Part of #8279

## Changes

- Reuse the existing Hugging Face acquisition implementation for the exact repository, immutable revision, and GGUF filename compiled from YAML.
- Resolve and stream-verify the standard Hugging Face cache entry against its declared size and SHA-256 without adding another downloader or cache.
- Carry executor-only filesystem identity from the verifying descriptor into the existing host-local runtime abstraction and revalidate it before producing Docker argv.
- Update the DGX Spark qualification producer and add cache-boundary, invalid-input, replacement, mutation, and forged-identity tests. The abstraction is required because acquisition and launch are separate lifecycle stages; direct pathname handoff would lose the verified-file claim. The focused acquisition, runtime, and qualification suites protect this boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This slice adds an internal acquisition and verification boundary without activating or changing a CLI, YAML contract, lifecycle or onboarding workflow, default, or supported product surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent security review passed with no findings after descriptor-derived identity and adversarial replacement and mutation coverage were added.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change adds internal GGUF acquisition, pre-launch filesystem-identity revalidation, and qualification-runner coverage for #8279. It does not activate or change a CLI, YAML contract, lifecycle or onboarding workflow, default, or supported product surface. Focused tests pass, and the committed diff check passes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 317e62634131a62ed8a1b71808f2fd609349ce80 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70934b540c404d3939e3321f5c7558 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 70/70 affected CLI tests and 27/27 qualification runner and contract tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure acquisition and verification of plan-selected Hugging Face GGUF model files.
  * Added validation for repository, revision, filename, file size, checksum, cache location, and file integrity.
  * Added protection against model replacement or modification before runtime use.
  * Added verified local model metadata for safer runtime binding.

* **Bug Fixes**
  * Prevented invalid, altered, non-regular, or mismatched model files from being used.

* **Tests**
  * Expanded coverage for cache verification, file integrity, security checks, and runtime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->