### PR TITLE
fix(e2e): align Windows MXC process container harness

### DIFF
--- a/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
+++ b/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
@@ -425,6 +425,14 @@ export function allowlistedWindowsProcessEnvironment(
   return allowed;
 }
 
+export function withoutOpenShellGatewaySelection(
+  environment: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const isolated = { ...environment };
+  delete isolated.OPENSHELL_GATEWAY;
+  return isolated;
+}
+
 function tomlString(value: string): string {
   return JSON.stringify(value.replaceAll("\\", "/"));
 }
@@ -831,7 +839,8 @@ export function normalizeReportedVersion(output: string): string | null {
   const normalized = output
     .trim()
     .replace(/^openclaw(?:\s+version)?\s+/iu, "")
-    .replace(/^v(?=[0-9])/u, "");
+    .replace(/^v(?=[0-9])/u, "")
+    .replace(/\s+\([0-9a-f]{7,40}\)$/iu, "");
   return VERSION_PATTERN.test(normalized) ? normalized : null;
 }
 
@@ -1019,7 +1028,7 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
     mode: 0o600,
   });
 
-  const gatewayEnvironment: NodeJS.ProcessEnv = {
+  const gatewayEnvironment: NodeJS.ProcessEnv = withoutOpenShellGatewaySelection({
     ...allowlistedWindowsProcessEnvironment(environment),
     NEMOCLAW_MXC_E2E_DENY_PATH: denyPath,
     NEMOCLAW_MXC_E2E_ENTRY: inputs.openClaw.entryPath,
@@ -1034,11 +1043,10 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
     NEMOCLAW_MXC_E2E_STOP_PATH: stopPath,
     NEMOCLAW_MXC_E2E_TOKEN: token,
     OPENSHELL_DRIVERS: "mxc",
-    OPENSHELL_GATEWAY: "",
     OPENSHELL_GATEWAY_CONFIG: gatewayConfigPath,
     XDG_CONFIG_HOME: configDirectory,
     XDG_STATE_HOME: stateDirectory,
-  };
+  });
   const controlEnvironment: NodeJS.ProcessEnv = {
     ...gatewayEnvironment,
     NEMOCLAW_MXC_E2E_TOKEN: undefined,
@@ -1154,17 +1162,7 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
     assertExactArtifactIdentities(inputs);
     sandboxCreateStarted = true;
     const create = await runOpenShellCommand(
-      [
-        "sandbox",
-        "create",
-        "--name",
-        sandboxName,
-        "--policy",
-        policyPath,
-        "--no-tty",
-        "--",
-        "exit",
-      ],
+      ["sandbox", "create", "--name", sandboxName, "--policy", policyPath, "--no-tty"],
       "command: windows-mxc-sandbox-create",
       READY_TIMEOUT_MS,
     );

--- a/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
+++ b/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
@@ -428,8 +428,10 @@ export function allowlistedWindowsProcessEnvironment(
 export function withoutOpenShellGatewaySelection(
   environment: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
-  const isolated = { ...environment };
-  delete isolated.OPENSHELL_GATEWAY;
+  const isolated: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(environment)) {
+    if (name.toLowerCase() !== "openshell_gateway") isolated[name] = value;
+  }
   return isolated;
 }
 

--- a/test/e2e/support/e2e-semantic-phase-check.test.ts
+++ b/test/e2e/support/e2e-semantic-phase-check.test.ts
@@ -87,6 +87,20 @@ describe("semantic E2E phase checker", () => {
     ]);
   });
 
+  test("rejects in-sandbox exec when a later Windows MXC create omits it", () => {
+    const source = `
+      async function qualify(cli, env, progress, sandboxName) {
+        await runCommand(cli, ["sandbox", "create", "--", "exit"], env, progress, "create");
+        await runCommand(cli, ["sandbox", "create", "--name", sandboxName], env, progress, "retry");
+        await runCommand(cli, ["sandbox", "delete", sandboxName], env, progress, "delete");
+      }
+    `;
+
+    expect(validateWindowsMxcControlBoundarySource(source)).toEqual([
+      "OpenShell process_container create must not request in-sandbox exec",
+    ]);
+  });
+
   // source-shape-contract: compatibility -- Generated policy output must precede semantic collection and remain shared with the canonical CLI build
   test("builds the policy boundary before semantic collection and CLI compilation", () => {
     const scripts = (

--- a/test/e2e/support/e2e-semantic-phase-check.test.ts
+++ b/test/e2e/support/e2e-semantic-phase-check.test.ts
@@ -74,6 +74,19 @@ describe("semantic E2E phase checker", () => {
     ]);
   });
 
+  test("rejects in-sandbox exec after Windows MXC process_container creation", () => {
+    const source = `
+      async function qualify(cli, env, progress, sandboxName) {
+        await runCommand(cli, ["sandbox", "create", "--", "exit"], env, progress, "create");
+        await runCommand(cli, ["sandbox", "delete", sandboxName], env, progress, "delete");
+      }
+    `;
+
+    expect(validateWindowsMxcControlBoundarySource(source)).toEqual([
+      "OpenShell process_container create must not request in-sandbox exec",
+    ]);
+  });
+
   // source-shape-contract: compatibility -- Generated policy output must precede semantic collection and remain shared with the canonical CLI build
   test("builds the policy boundary before semantic collection and CLI compilation", () => {
     const scripts = (

--- a/test/e2e/support/e2e-semantic-phase-check.test.ts
+++ b/test/e2e/support/e2e-semantic-phase-check.test.ts
@@ -76,9 +76,9 @@ describe("semantic E2E phase checker", () => {
 
   test("rejects in-sandbox exec after Windows MXC process_container creation", () => {
     const source = `
-      async function qualify(cli, env, progress, sandboxName) {
-        await runCommand(cli, ["sandbox", "create", "--", "exit"], env, progress, "create");
-        await runCommand(cli, ["sandbox", "delete", sandboxName], env, progress, "delete");
+      async function qualify(sandboxName) {
+        await runOpenShellCommand(["sandbox", "create", "--", "exit"], "create");
+        await runOpenShellCommand(["sandbox", "delete", sandboxName], "delete");
       }
     `;
 

--- a/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
@@ -138,6 +138,14 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
     ).toThrow(/does not match/u);
     expect(normalizeReportedVersion("OpenClaw 2026.7.1\n")).toBe("2026.7.1");
     expect(normalizeReportedVersion("OpenClaw 2026.7.1 (2d2ddc4)\n")).toBe("2026.7.1");
+    expect(
+      normalizeReportedVersion("OpenClaw 2026.7.1 (0123456789abcdef0123456789abcdef01234567)\n"),
+    ).toBe("2026.7.1");
+    expect(normalizeReportedVersion("OpenClaw 2026.7.1 (2d2ddc)\n")).toBeNull();
+    expect(
+      normalizeReportedVersion("OpenClaw 2026.7.1 (0123456789abcdef0123456789abcdef012345678)\n"),
+    ).toBeNull();
+    expect(normalizeReportedVersion("OpenClaw 2026.7.1 (2d2ddcZ)\n")).toBeNull();
     expect(normalizeReportedVersion("2026.7.10\n")).toBe("2026.7.10");
     expect(normalizeReportedVersion("OpenClaw 2026.7.1 (local)\n")).toBeNull();
     expect(normalizeReportedVersion("OpenClaw version 2026.7.1 extra\n")).toBeNull();
@@ -299,7 +307,7 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
   it("does not override the gateway selected in the isolated CLI state (#8178)", () => {
     expect(
       withoutOpenShellGatewaySelection({
-        OPENSHELL_GATEWAY: "",
+        OpenShell_Gateway: "unexpected-gateway",
         OPENSHELL_GATEWAY_CONFIG: "C:\\probe\\gateway.toml",
       }),
     ).toEqual({ OPENSHELL_GATEWAY_CONFIG: "C:\\probe\\gateway.toml" });

--- a/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
@@ -24,6 +24,7 @@ import {
   sandboxListContainsExactName,
   sha256File,
   shouldRetrySandboxDelete,
+  withoutOpenShellGatewaySelection,
 } from "../live/windows-mxc-openclaw-process-container-helpers.ts";
 
 const roots: string[] = [];
@@ -136,7 +137,9 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
       }),
     ).toThrow(/does not match/u);
     expect(normalizeReportedVersion("OpenClaw 2026.7.1\n")).toBe("2026.7.1");
+    expect(normalizeReportedVersion("OpenClaw 2026.7.1 (2d2ddc4)\n")).toBe("2026.7.1");
     expect(normalizeReportedVersion("2026.7.10\n")).toBe("2026.7.10");
+    expect(normalizeReportedVersion("OpenClaw 2026.7.1 (local)\n")).toBeNull();
     expect(normalizeReportedVersion("OpenClaw version 2026.7.1 extra\n")).toBeNull();
   });
 
@@ -291,6 +294,15 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
     });
 
     expect(allowed).toEqual({ Path: "C:\\Windows\\System32", SystemRoot: "C:\\Windows" });
+  });
+
+  it("does not override the gateway selected in the isolated CLI state (#8178)", () => {
+    expect(
+      withoutOpenShellGatewaySelection({
+        OPENSHELL_GATEWAY: "",
+        OPENSHELL_GATEWAY_CONFIG: "C:\\probe\\gateway.toml",
+      }),
+    ).toEqual({ OPENSHELL_GATEWAY_CONFIG: "C:\\probe\\gateway.toml" });
   });
 
   it("fails closed when a Windows process query fails without output (#8178)", () => {

--- a/tools/e2e/check-semantic-phases.mts
+++ b/tools/e2e/check-semantic-phases.mts
@@ -166,7 +166,7 @@ export function validateWindowsMxcControlBoundarySource(source: string): string[
       const separatorIndex = args.elements.findIndex(
         (element) => ts.isStringLiteralLike(element) && element.text === "--",
       );
-      createRequestsExec = separatorIndex >= 0 && separatorIndex < args.elements.length - 1;
+      createRequestsExec ||= separatorIndex >= 0 && separatorIndex < args.elements.length - 1;
       return "create";
     }
     if (

--- a/tools/e2e/check-semantic-phases.mts
+++ b/tools/e2e/check-semantic-phases.mts
@@ -129,6 +129,7 @@ export function validateWindowsMxcControlBoundarySource(source: string): string[
     "spawnSync",
   ]);
   let createPosition: number | null = null;
+  let createRequestsExec = false;
   const deletePositions: number[] = [];
 
   function containsWxcExecPath(node: ts.Node): boolean {
@@ -161,7 +162,13 @@ export function validateWindowsMxcControlBoundarySource(source: string): string[
     const [scope, action, target] = args.elements;
     if (!ts.isStringLiteralLike(scope) || scope.text !== "sandbox") return null;
     if (!ts.isStringLiteralLike(action)) return null;
-    if (action.text === "create") return "create";
+    if (action.text === "create") {
+      const separatorIndex = args.elements.findIndex(
+        (element) => ts.isStringLiteralLike(element) && element.text === "--",
+      );
+      createRequestsExec = separatorIndex >= 0 && separatorIndex < args.elements.length - 1;
+      return "create";
+    }
     if (
       action.text === "delete" &&
       target !== undefined &&
@@ -191,6 +198,9 @@ export function validateWindowsMxcControlBoundarySource(source: string): string[
   inspect(sourceFile);
 
   if (createPosition === null) failures.push("OpenShell sandbox create command is missing");
+  if (createRequestsExec) {
+    failures.push("OpenShell process_container create must not request in-sandbox exec");
+  }
   if (deletePositions.length === 0) failures.push("OpenShell sandbox delete command is missing");
   const observedCreatePosition = createPosition;
   if (


### PR DESCRIPTION
## Summary

Correct the inactive Windows MXC OpenClaw qualification harness for the current `process_container` contract. The harness now accepts OpenClaw's exact-version banner with a hexadecimal build suffix, relies on isolated CLI state instead of an empty gateway override, and creates the configured one-shot workload without requesting unsupported in-sandbox exec.

## Related Issue

Refs #8178

## Changes

- Normalize only parenthesized 7–40 character hexadecimal OpenClaw build suffixes while retaining exact artifact digest checks.
- Remove `OPENSHELL_GATEWAY` from the isolated process environment so the explicitly selected test gateway remains authoritative.
- Create the MXC `process_container` workload through OpenShell without a trailing exec command.
- Extend the semantic control-boundary check to reject any Windows MXC sandbox create that requests in-sandbox exec, including multi-create source flows.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only an inactive, opt-in live qualification harness and its repository guard; no supported CLI, configuration, onboarding workflow, or product behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head nine-category security review passed with no findings for `07995f6254f4fac438d418e75f749bc99fe7367b` against base `b148bc13ee53b7a1f612d07e42275ec732e71877`: https://github.com/NVIDIA/NemoClaw/pull/8388#pullrequestreview-4868603812
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No supported user-facing surface changed; the inactive harness behavior is covered by focused tests and existing E2E guidance remains accurate.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 07995f6254f4fac438d418e75f749bc99fe7367b -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70934b540c404d3939e3321f5c7558 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub — all 7 commits appear as `Verified`.
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/windows-mxc-openclaw-process-container.test.ts test/e2e/support/e2e-semantic-phase-check.test.ts` passed 38 tests; `npm run test:e2e-phases:check` covered 118 tests across 75 files.
- [x] Applicable broad gate passed — Not applicable; this is a four-file inactive E2E harness and source-shape guard correction covered by the focused project and semantic inventory.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows sandbox command validation to detect and reject unsupported in-sandbox execution requests.
  - Refined gateway startup environment handling for more reliable process-container behavior.
  - Improved version parsing to support parenthesized build identifiers while rejecting unsupported local metadata.

- **Tests**
  - Added coverage for initial and retry sandbox creation scenarios, gateway selection cleanup, version parsing, and Windows-specific validation boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->