### PR TITLE
fix(inference): honor host-local serving recipe contracts

### DIFF
--- a/src/lib/inference/serving/resolver.test.ts
+++ b/src/lib/inference/serving/resolver.test.ts
@@ -499,7 +499,7 @@ describe("managed inference resolver", () => {
     ).toMatchObject({ outcome: "no-match", code: "requirements-not-met" });
   });
 
-  it("matches typed readiness observation comparisons (#8246)", () => {
+  it("selects a preset only when readiness observation comparisons match (#8246)", () => {
     const catalog = hostLocalFixtureCatalog();
     const preset = catalog.presets[0]!;
     const comparedPreset = {
@@ -572,27 +572,35 @@ describe("managed inference resolver", () => {
       ),
     ).toMatchObject({ outcome: "selected" });
 
-    reports[1] = {
-      nodeId: reports[1]!.nodeId,
-      report: readinessReport({
-        ...reports[1]!.report,
-        observations: reports[1]!.report.observations.map((observation) =>
-          observation.id === "host.gpu.driver_version"
-            ? { ...observation, value: "579.99.0" }
-            : observation,
-        ),
-      }),
-    };
-    expect(
-      resolveManagedInferenceServing(
-        resolverInput({
-          readinessReports: reports,
-          topologyQualifications: [],
-          intent: { preset: preset.metadata.id },
+    const nonmatchingObservations = [
+      ["equals", "host.os.platform", "windows"],
+      ["one-of", "host.os.architecture", "riscv64"],
+      ["at-least", "host.gpu.count", 0],
+      ["version-at-least", "host.gpu.driver_version", "579.99.0"],
+      ["malformed version-at-least", "host.gpu.driver_version", "580.65.x"],
+    ] as const;
+    for (const [caseName, id, value] of nonmatchingObservations) {
+      const rejectedReports = reports.map(({ nodeId, report }, index) => ({
+        nodeId,
+        report: readinessReport({
+          ...report,
+          observations: report.observations.map((observation) =>
+            index === 1 && observation.id === id ? { ...observation, value } : observation,
+          ),
         }),
-        comparedCatalog,
-      ),
-    ).toMatchObject({ outcome: "rejected", code: "requirements-not-met" });
+      }));
+      expect(
+        resolveManagedInferenceServing(
+          resolverInput({
+            readinessReports: rejectedReports,
+            topologyQualifications: [],
+            intent: { preset: preset.metadata.id },
+          }),
+          comparedCatalog,
+        ),
+        `${caseName} must reject a nonmatching observation`,
+      ).toMatchObject({ outcome: "rejected", code: "requirements-not-met" });
+    }
   });
 
   it("applies any-node readiness requirements as an existential match", () => {

--- a/src/lib/inference/serving/resolver.test.ts
+++ b/src/lib/inference/serving/resolver.test.ts
@@ -499,6 +499,102 @@ describe("managed inference resolver", () => {
     ).toMatchObject({ outcome: "no-match", code: "requirements-not-met" });
   });
 
+  it("matches typed readiness observation comparisons (#8246)", () => {
+    const catalog = hostLocalFixtureCatalog();
+    const preset = catalog.presets[0]!;
+    const comparedPreset = {
+      ...preset,
+      spec: {
+        ...preset.spec,
+        requirements: {
+          all: [
+            {
+              readiness: {
+                scope: "everyNode",
+                kind: "observation",
+                id: "host.os.platform",
+                comparison: { operator: "equals", value: "linux" },
+              },
+            },
+            {
+              readiness: {
+                scope: "everyNode",
+                kind: "observation",
+                id: "host.os.architecture",
+                comparison: { operator: "one-of", values: ["arm64", "amd64"] },
+              },
+            },
+            {
+              readiness: {
+                scope: "everyNode",
+                kind: "observation",
+                id: "host.gpu.count",
+                comparison: { operator: "at-least", value: 1 },
+              },
+            },
+            {
+              readiness: {
+                scope: "everyNode",
+                kind: "observation",
+                id: "host.gpu.driver_version",
+                comparison: { operator: "version-at-least", value: "580.65.6" },
+              },
+            },
+          ],
+        },
+      },
+    } as ManagedInferenceServingPreset;
+    const comparedCatalog: CompiledManagedInferenceCatalog = {
+      ...catalog,
+      presets: [comparedPreset],
+    };
+    const reports = readinessSources().map(({ nodeId, report }) => ({
+      nodeId,
+      report: readinessReport({
+        ...report,
+        observations: [
+          { id: "host.os.platform", state: "present", value: "linux" },
+          { id: "host.os.architecture", state: "present", value: "arm64" },
+          { id: "host.gpu.count", state: "present", value: 1 },
+          { id: "host.gpu.driver_version", state: "present", value: "580.65.06" },
+        ],
+      }),
+    }));
+
+    expect(
+      resolveManagedInferenceServing(
+        resolverInput({
+          readinessReports: reports,
+          topologyQualifications: [],
+          intent: { preset: preset.metadata.id },
+        }),
+        comparedCatalog,
+      ),
+    ).toMatchObject({ outcome: "selected" });
+
+    reports[1] = {
+      nodeId: reports[1]!.nodeId,
+      report: readinessReport({
+        ...reports[1]!.report,
+        observations: reports[1]!.report.observations.map((observation) =>
+          observation.id === "host.gpu.driver_version"
+            ? { ...observation, value: "579.99.0" }
+            : observation,
+        ),
+      }),
+    };
+    expect(
+      resolveManagedInferenceServing(
+        resolverInput({
+          readinessReports: reports,
+          topologyQualifications: [],
+          intent: { preset: preset.metadata.id },
+        }),
+        comparedCatalog,
+      ),
+    ).toMatchObject({ outcome: "rejected", code: "requirements-not-met" });
+  });
+
   it("applies any-node readiness requirements as an existential match", () => {
     const catalog = shippedCatalog();
     const preset = shippedPreset(catalog);

--- a/src/lib/inference/serving/resolver.ts
+++ b/src/lib/inference/serving/resolver.ts
@@ -19,8 +19,8 @@ import type {
   ManagedInferenceReadinessRequirement,
   ManagedInferenceReadinessSource,
   ManagedInferenceResolution,
-  ManagedInferenceRuntimeServingRecipe,
   ManagedInferenceResolverInput,
+  ManagedInferenceRuntimeServingRecipe,
   ManagedInferenceSelectionIntent,
   ManagedInferenceServingPreset,
   ManagedInferenceServingRecipe,
@@ -28,6 +28,7 @@ import type {
   ManagedInferenceTopologyRequirement,
   ResolvedHostLocalInferenceSelection,
   ResolvedManagedInferenceSelection,
+  ServingReadinessComparison,
 } from "./types.js";
 
 export const MANAGED_INFERENCE_READINESS_MAX_AGE_MS = 30_000;
@@ -162,6 +163,42 @@ function readinessScopeMatches(
   return false;
 }
 
+function compareNumericDottedVersions(left: string, right: string): number | undefined {
+  const parse = (value: string): number[] | undefined => {
+    if (!/^\d+(?:\.\d+)+$/u.test(value)) return undefined;
+    const parts = value.split(".").map(Number);
+    return parts.every(Number.isSafeInteger) ? parts : undefined;
+  };
+  const leftParts = parse(left);
+  const rightParts = parse(right);
+  if (!leftParts || !rightParts) return undefined;
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) return difference < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+function readinessComparisonMatches(
+  actual: unknown,
+  comparison: ServingReadinessComparison,
+): boolean {
+  switch (comparison.operator) {
+    case "equals":
+      return scalarEquals(actual, comparison.value);
+    case "one-of":
+      return comparison.values.some((candidate) => scalarEquals(actual, candidate));
+    case "at-least":
+      return typeof actual === "number" && actual >= comparison.value;
+    case "version-at-least": {
+      if (typeof actual !== "string") return false;
+      const order = compareNumericDottedVersions(actual, comparison.value);
+      return order !== undefined && order >= 0;
+    }
+  }
+}
+
 function readinessRequirementMatches(
   requirement: ManagedInferenceReadinessRequirement["readiness"],
   reports: readonly ManagedInferenceReadinessSource[],
@@ -171,7 +208,14 @@ function readinessRequirementMatches(
       const matches = report.qualifications.filter(({ id }) => id === requirement.id);
       return matches.length === 1 && matches[0]!.status === requirement.status;
     }
-    if ("comparison" in requirement) return false;
+    if ("comparison" in requirement) {
+      const matches = report.observations.filter(({ id }) => id === requirement.id);
+      return (
+        matches.length === 1 &&
+        matches[0]!.state === "present" &&
+        readinessComparisonMatches(matches[0]!.value, requirement.comparison)
+      );
+    }
     const collection =
       requirement.kind === "observation" ? report.observations : report.capabilities;
     const matches = collection.filter(({ id }) => id === requirement.id);

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -17,6 +17,22 @@ import {
 } from "./vllm-models";
 
 describe("vllm model registry", () => {
+  it("starts directly with setup when the serving environment is empty (#8246)", () => {
+    const command = buildVllmServeCommand({
+      id: "test/model",
+      label: "Test model",
+      envValue: "test-model",
+      downloadSizeBytes: 1,
+      maxModelLen: 4096,
+      modelArgs: [],
+      gated: false,
+      platforms: ["spark"],
+      serveEnv: {},
+    });
+
+    expect(command).toMatch(/^pip install vllm\[fastsafetensors\] && vllm serve/u);
+  });
+
   it("records a finite positive Hugging Face file size for every model", () => {
     for (const model of VLLM_MODELS) {
       expect(Number.isFinite(model.downloadSizeBytes)).toBe(true);

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -675,16 +675,17 @@ export function buildVllmServeCommand(
   model: VllmModelDef,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  const envPrefix = model.serveEnv
-    ? `${Object.entries(model.serveEnv)
-        .map(([key, value]) => {
-          if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key)) {
-            throw new Error(`Invalid vLLM serving environment variable name: ${key}`);
-          }
-          return `export ${key}=${shellQuote(value)}`;
-        })
-        .join(" && ")} && `
-    : "";
+  const envPrefix =
+    model.serveEnv && Object.keys(model.serveEnv).length > 0
+      ? `${Object.entries(model.serveEnv)
+          .map(([key, value]) => {
+            if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key)) {
+              throw new Error(`Invalid vLLM serving environment variable name: ${key}`);
+            }
+            return `export ${key}=${shellQuote(value)}`;
+          })
+          .join(" && ")} && `
+      : "";
   const args = [
     ...SHARED_VLLM_ARGS,
     "--max-model-len",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Serving presets can now evaluate schema-valid readiness observation comparisons. Host-local vLLM recipes with an empty runtime environment now produce a valid serving command instead of a leading `&&`.

## Related Issue

Refs #8246

## Changes

- Evaluate `equals`, `one-of`, `at-least`, and `version-at-least` observation comparisons against typed readiness values.
- Compare numeric dotted versions segment by segment and reject invalid version values.
- Omit the vLLM environment prefix when `runtime.environment` is empty.
- Add regression tests for matching and rejected readiness comparisons and for the empty-environment command.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change restores existing internal serving-catalog and vLLM command contracts. It adds no command, flag, schema field, default, or public workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The review of commit `d6491799c` found that the change restores existing internal behavior and does not change a documented user-facing surface. No terminology, structure, voice, or test-title findings were reported.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d6491799c -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/inference/serving/resolver.test.ts src/lib/inference/vllm-models.test.ts`: 2 files and 73 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; targeted source tests cover both changed behaviors.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Readiness requirements now correctly support string, membership, numeric minimum, and version minimum comparisons.
  * Version comparisons safely handle dotted numeric versions and reject insufficient or malformed values.
  * Serving commands no longer include an invalid command separator when no environment overrides are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->