### PR TITLE
test(e2e): read flat Hermes cron runtime state

### DIFF
--- a/test/e2e/live/rebuild-hermes-cron-restore.ts
+++ b/test/e2e/live/rebuild-hermes-cron-restore.ts
@@ -121,15 +121,20 @@ function parseCronJob(text: string, jobId: string, label: string): JsonObject {
   );
 }
 
-function cronJobState(job: JsonObject, label: string): JsonObject {
-  return requireObject(job.state, `${label} state`);
-}
-
-function completedRuns(job: JsonObject, label: string): number {
-  const repeat = requireObject(cronJobState(job, label).repeat, `${label} repeat state`);
-  return typeof repeat.completed === "number"
-    ? repeat.completed
-    : fail(`${label} completed run count is unavailable`);
+export function hermesCronJobRuntimeState(job: JsonObject, label: string) {
+  const repeat = requireObject(job.repeat, `${label} repeat state`);
+  const state = typeof job.state === "string" ? job.state : fail(`${label} state is not a string`);
+  const completed =
+    typeof repeat.completed === "number"
+      ? repeat.completed
+      : fail(`${label} completed run count is unavailable`);
+  return {
+    completed,
+    lastRunAt: job.last_run_at ?? null,
+    lastStatus: job.last_status ?? null,
+    nextRunAt: job.next_run_at,
+    state,
+  };
 }
 
 function assertFutureCronJob(job: JsonObject, seed: SeededCronJob): void {
@@ -141,12 +146,13 @@ function assertFutureCronJob(job: JsonObject, seed: SeededCronJob): void {
     schedule: { kind: "interval" },
     script: seed.scriptName,
   });
-  const state = cronJobState(job, `cron job ${seed.id}`);
-  expect(state.last_run_at ?? null).toBeNull();
-  expect(state.last_status ?? null).toBeNull();
-  expect(completedRuns(job, `cron job ${seed.id}`)).toBe(0);
+  const runtime = hermesCronJobRuntimeState(job, `cron job ${seed.id}`);
+  expect(runtime.state).toBe("scheduled");
+  expect(runtime.lastRunAt).toBeNull();
+  expect(runtime.lastStatus).toBeNull();
+  expect(runtime.completed).toBe(0);
   expect(
-    normalizeTimestampMs(state.next_run_at, `cron job ${seed.id} next run`),
+    normalizeTimestampMs(runtime.nextRunAt, `cron job ${seed.id} next run`),
     "seeded recurring cron job must remain well in the future during rebuild",
   ).toBeGreaterThan(Date.now() + 60 * 60_000);
 }
@@ -305,13 +311,13 @@ export function createRebuildHermesCronRestoreFixture({
     for (let attempt = 1; attempt <= EXECUTION_POLL_ATTEMPTS; attempt += 1) {
       const job = await readCronJob(seed.id, `${artifactPrefix}-job-attempt-${attempt}`);
       const count = await executionCount(seed, `${artifactPrefix}-marker-attempt-${attempt}`);
-      const state = cronJobState(job, `cron job ${seed.id}`);
-      const completed = completedRuns(job, `cron job ${seed.id}`);
-      lastEvidence = JSON.stringify({ completed, count, last_status: state.last_status });
+      const runtime = hermesCronJobRuntimeState(job, `cron job ${seed.id}`);
+      const completed = runtime.completed;
+      lastEvidence = JSON.stringify({ completed, count, last_status: runtime.lastStatus });
       if (completed > 1 || count > 1) {
         fail(`Hermes cron job ${seed.id} executed more than once: ${lastEvidence}`);
       }
-      if (completed === 1 && count === 1 && state.last_status === "ok") return;
+      if (completed === 1 && count === 1 && runtime.lastStatus === "ok") return;
       await sleep(POLL_INTERVAL_MS);
     }
     fail(`Hermes cron job ${seed.id} did not complete exactly once: ${lastEvidence}`);

--- a/test/e2e/live/rebuild-hermes-cron-restore.ts
+++ b/test/e2e/live/rebuild-hermes-cron-restore.ts
@@ -125,7 +125,9 @@ export function hermesCronJobRuntimeState(job: JsonObject, label: string) {
   const repeat = requireObject(job.repeat, `${label} repeat state`);
   const state = typeof job.state === "string" ? job.state : fail(`${label} state is not a string`);
   const completed =
-    typeof repeat.completed === "number"
+    typeof repeat.completed === "number" &&
+    Number.isSafeInteger(repeat.completed) &&
+    repeat.completed >= 0
       ? repeat.completed
       : fail(`${label} completed run count is unavailable`);
   return {

--- a/test/e2e/live/rebuild-hermes-cron-restore.ts
+++ b/test/e2e/live/rebuild-hermes-cron-restore.ts
@@ -54,7 +54,7 @@ interface GatewayEvidence {
   start_time: number;
 }
 
-interface CronControlReceipt {
+export interface CronControlReceipt {
   action: "begin";
   active_agents: number;
   disposition: string;
@@ -137,6 +137,25 @@ export function hermesCronJobRuntimeState(job: JsonObject, label: string) {
     nextRunAt: job.next_run_at,
     state,
   };
+}
+
+export function parseHermesCronBeginReceipt(text: string): CronControlReceipt {
+  const lines = text.split(/\r?\n/u).filter((line) => line.startsWith(RECEIPT_PREFIX));
+  if (lines.length !== 1) fail(`Hermes cron begin returned ${lines.length} receipts`);
+  const payload = parseJsonObject(lines[0].slice(RECEIPT_PREFIX.length), "cron begin receipt");
+  expect(payload).toMatchObject({
+    action: "begin",
+    active_agents: 0,
+    disposition: "drain-acquired",
+    drain_acquired: true,
+    drain_token: "<REDACTED>",
+    operator_drain_active: false,
+    version: 1,
+  });
+  if (!Number.isSafeInteger(payload.pid) || !Number.isSafeInteger(payload.start_time)) {
+    fail("Hermes cron begin receipt identity is invalid");
+  }
+  return payload as unknown as CronControlReceipt;
 }
 
 function assertFutureCronJob(job: JsonObject, seed: SeededCronJob): void {
@@ -397,29 +416,6 @@ export function createRebuildHermesCronRestoreFixture({
     fail(`Hermes gateway did not reach ${state}: ${lastEvidence}`);
   }
 
-  function parseBeginReceipt(text: string): CronControlReceipt {
-    const lines = text.split(/\r?\n/u).filter((line) => line.startsWith(RECEIPT_PREFIX));
-    if (lines.length !== 1) fail(`Hermes cron begin returned ${lines.length} receipts`);
-    const payload = parseJsonObject(lines[0].slice(RECEIPT_PREFIX.length), "cron begin receipt");
-    expect(payload).toMatchObject({
-      action: "begin",
-      active_agents: 0,
-      disposition: "drain-acquired",
-      drain_acquired: true,
-      operator_drain_active: false,
-      version: 1,
-    });
-    if (
-      !Number.isSafeInteger(payload.pid) ||
-      !Number.isSafeInteger(payload.start_time) ||
-      typeof payload.drain_token !== "string" ||
-      payload.drain_token.length !== 32
-    ) {
-      fail("Hermes cron begin receipt identity is invalid");
-    }
-    return payload as unknown as CronControlReceipt;
-  }
-
   async function exerciseStateRootSubstitutionAttack(
     seed: SeededCronJob,
     expectedGateway: Pick<GatewayEvidence, "pid" | "start_time">,
@@ -545,7 +541,7 @@ export function createRebuildHermesCronRestoreFixture({
         "phase-8-acquire-stranded-hermes-cron-restore-gate",
       );
       expectExitZero(begin, "acquire stranded Hermes cron restore gate");
-      const receipt = parseBeginReceipt(begin.stdout);
+      const receipt = parseHermesCronBeginReceipt(begin.stdout);
       await assertControlMarker(true, "phase-8-verify-cron-restore-marker-before-restart");
 
       const recoverySeed = await seedCronJob("recovery");

--- a/test/e2e/support/rebuild-hermes-cron-restore.test.ts
+++ b/test/e2e/support/rebuild-hermes-cron-restore.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { hermesCronJobRuntimeState } from "../live/rebuild-hermes-cron-restore.ts";
+
+describe("Hermes rebuild cron restore evidence", () => {
+  it("reads the flat runtime state emitted by Hermes", () => {
+    expect(
+      hermesCronJobRuntimeState(
+        {
+          last_run_at: null,
+          last_status: null,
+          next_run_at: "2026-08-06T19:41:01.000Z",
+          repeat: { completed: 0, times: null },
+          state: "scheduled",
+        },
+        "cron job fixture",
+      ),
+    ).toEqual({
+      completed: 0,
+      lastRunAt: null,
+      lastStatus: null,
+      nextRunAt: "2026-08-06T19:41:01.000Z",
+      state: "scheduled",
+    });
+  });
+
+  it("rejects the nested state shape that hid the live rebuild contract", () => {
+    expect(() =>
+      hermesCronJobRuntimeState(
+        {
+          state: {
+            last_run_at: null,
+            last_status: null,
+            next_run_at: "2026-08-06T19:41:01.000Z",
+            repeat: { completed: 0, times: null },
+          },
+        },
+        "cron job fixture",
+      ),
+    ).toThrow("cron job fixture repeat state is not an object");
+  });
+});

--- a/test/e2e/support/rebuild-hermes-cron-restore.test.ts
+++ b/test/e2e/support/rebuild-hermes-cron-restore.test.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { hermesCronJobRuntimeState } from "../live/rebuild-hermes-cron-restore.ts";
+import {
+  hermesCronJobRuntimeState,
+  parseHermesCronBeginReceipt,
+} from "../live/rebuild-hermes-cron-restore.ts";
 
 describe("Hermes rebuild cron restore evidence", () => {
   it("reads the flat runtime state emitted by Hermes", () => {
@@ -53,5 +56,17 @@ describe("Hermes rebuild cron restore evidence", () => {
         "cron job fixture",
       ),
     ).toThrow("cron job fixture completed run count is unavailable");
+  });
+
+  it("accepts the redacted cron drain receipt returned by shell probes", () => {
+    expect(
+      parseHermesCronBeginReceipt(
+        'NEMOCLAW_HERMES_CRON_RESTORE_V1:{"action":"begin","active_agents":0,"disposition":"drain-acquired","drain_acquired":true,"drain_token":"<REDACTED>","operator_drain_active":false,"pid":263,"start_time":47767,"version":1}\n',
+      ),
+    ).toMatchObject({
+      drain_token: "<REDACTED>",
+      pid: 263,
+      start_time: 47767,
+    });
   });
 });

--- a/test/e2e/support/rebuild-hermes-cron-restore.test.ts
+++ b/test/e2e/support/rebuild-hermes-cron-restore.test.ts
@@ -41,4 +41,17 @@ describe("Hermes rebuild cron restore evidence", () => {
       ),
     ).toThrow("cron job fixture repeat state is not an object");
   });
+
+  it.each([-1, 0.5])("rejects invalid completed run count %s", (completed) => {
+    expect(() =>
+      hermesCronJobRuntimeState(
+        {
+          next_run_at: "2026-08-06T19:41:01.000Z",
+          repeat: { completed, times: null },
+          state: "scheduled",
+        },
+        "cron job fixture",
+      ),
+    ).toThrow("cron job fixture completed run count is unavailable");
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Align the Hermes cron rebuild E2E fixture with Hermes's flat `jobs.json` runtime schema. The live target now restores the captured top-level runtime fields instead of constructing a nested state object that Hermes does not accept.

## Changes

- Export a focused helper that derives Hermes cron runtime state from a captured job.
- Restore `state`, `repeat`, `next_run_at`, `last_run_at`, and `last_status` at the top level.
- Add E2E-support regression coverage using the schema captured from the failed release run and reject the obsolete nested shape.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is a test-only correction to the live E2E fixture; production behavior and user-facing contracts are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Test-only fix aligns Hermes rebuild evidence with the flat jobs.json runtime schema and the shell probe's sanitized drain receipt, with regression coverage for both; production and user-facing behavior are unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8190f95e2ddb -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/rebuild-hermes-cron-restore.test.ts` (4/4 passed); `git diff --check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for cron restore evidence and runtime-state validation.
  * Added validation for malformed nested state and invalid completed-run counts.
  * Added coverage for accepting redacted cron drain receipts from shell probes.
  * Improved cron execution checks using normalized runtime data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->