### PR TITLE
test(e2e): stabilize gateway guard recovery disruption

### DIFF
--- a/test/e2e/fixtures/clients/sandbox.ts
+++ b/test/e2e/fixtures/clients/sandbox.ts
@@ -193,9 +193,9 @@ export class SandboxClient {
   }
 
   /**
-   * Disruption helper: kill the entire openclaw process tree inside the
-   * sandbox (gateway + launcher + supervisor watchdog). Used after
-   * `wipeGuardChain` to force the recovery path to relaunch from scratch.
+   * Disruption helper: kill the observed OpenClaw process tree inside the
+   * sandbox. Used after `wipeGuardChain` to force the managed watchdog or
+   * recovery path to relaunch from scratch.
    *
    * The bracket pattern `[o]penclaw` is the standard pgrep/pkill trick to
    * avoid matching the matcher process itself.
@@ -207,12 +207,10 @@ export class SandboxClient {
     options: ShellProbeRunOptions = {},
   ): Promise<ShellProbeResult> {
     validateSandboxName(name);
-    // Two-phase kill: SIGKILL the tree, sleep, then verify nothing came back.
-    // Mirrors the bash test's pkill -9 + verify pattern.
-    const script =
-      "pkill -9 -f '[o]penclaw' 2>/dev/null || true; " +
-      "sleep 2; " +
-      "pgrep -af '[o]penclaw' >/dev/null 2>&1 && exit 1 || exit 0";
+    // Require an initial gateway process, then kill it. Do not assert that the
+    // process stays absent: PID 1 is expected to respawn the gateway, and the
+    // live scenario verifies the replacement PID and restored guard chain.
+    const script = "pkill -9 -f '[o]penclaw'";
     const result = await this.exec(name, ["sh", "-c", script], {
       artifactName: `sandbox-kill-gateway-tree-${name}`,
       env: openshellProbeEnv(),

--- a/test/e2e/live/gateway-guard-recovery.test.ts
+++ b/test/e2e/live/gateway-guard-recovery.test.ts
@@ -43,7 +43,6 @@
  * #2701 guard-chain assertion.
  */
 
-import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
@@ -51,6 +50,7 @@ import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import { pollUntil } from "../fixtures/polling.ts";
 import { ubuntuRepoDocker } from "../registry/matrix.ts";
 
 // Reuses the standard ubuntu-repo-docker environment with the
@@ -150,22 +150,18 @@ async function waitForSandboxExecAfterContainerRestart(
   host: HostCliClient,
   sandboxName: string,
 ): Promise<void> {
-  let lastResult = "no OpenShell exec attempt completed";
-  for (let attempt = 1; attempt <= 12; attempt += 1) {
-    const result = await host.command(
-      "openshell",
-      ["sandbox", "exec", "-n", sandboxName, "--", "true"],
-      {
-        artifactName: `legacy-restart-openshell-ready-${attempt}`,
+  await pollUntil({
+    artifactPrefix: "legacy-restart-openshell-ready",
+    attempts: 12,
+    delayMs: 3_000,
+    probe: async (_attempt, artifactName) =>
+      await host.command("openshell", ["sandbox", "exec", "-n", sandboxName, "--", "true"], {
+        artifactName,
         env: buildAvailabilityProbeEnv(),
         timeoutMs: 30_000,
-      },
-    );
-    if (result.exitCode === 0) return;
-    lastResult = resultText(result);
-    await sleep(3_000);
-  }
-  throw new Error(`OpenShell did not accept the restarted legacy sandbox:\n${lastResult}`);
+      }),
+    accept: (result) => result.exitCode === 0,
+  });
 }
 
 test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)", {

--- a/test/e2e/live/gateway-guard-recovery.test.ts
+++ b/test/e2e/live/gateway-guard-recovery.test.ts
@@ -51,6 +51,7 @@ import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { pollUntil } from "../fixtures/polling.ts";
+import type { TestProgress } from "../fixtures/progress.ts";
 import { ubuntuRepoDocker } from "../registry/matrix.ts";
 
 // Reuses the standard ubuntu-repo-docker environment with the
@@ -149,19 +150,30 @@ async function inspectStartupCommand(
 async function waitForSandboxExecAfterContainerRestart(
   host: HostCliClient,
   sandboxName: string,
+  progress: TestProgress,
 ): Promise<void> {
   await pollUntil({
     artifactPrefix: "legacy-restart-openshell-ready",
     attempts: 12,
     delayMs: 3_000,
     probe: async (_attempt, artifactName) =>
-      await host.command("openshell", ["sandbox", "exec", "-n", sandboxName, "--", "true"], {
-        artifactName,
-        env: buildAvailabilityProbeEnv(),
-        timeoutMs: 30_000,
-      }),
-    accept: (result) => result.exitCode === 0,
+      await host.command(
+        host.openshellCommandPath,
+        ["sandbox", "exec", "-n", sandboxName, "--", "true"],
+        {
+          artifactName,
+          env: buildAvailabilityProbeEnv(),
+          timeoutMs: 30_000,
+        },
+      ),
+    accept: (result, attempt) =>
+      result.exitCode === 0 ? true : reportReadinessRetry(progress, attempt),
   });
+}
+
+function reportReadinessRetry(progress: TestProgress, attempt: number): false {
+  progress.event(`OpenShell sandbox readiness retry ${attempt}`);
+  return false;
 }
 
 test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)", {
@@ -437,7 +449,7 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
     timeoutMs: 120_000,
   });
   expect(legacyRestart.exitCode, resultText(legacyRestart)).toBe(0);
-  await waitForSandboxExecAfterContainerRestart(host, instance.sandboxName);
+  await waitForSandboxExecAfterContainerRestart(host, instance.sandboxName, progress);
 
   progress.phase("recover legacy managed supervisor and inference");
   const legacyCredentialCanary = "nemoclaw-e2e-recovery-secret-6635";

--- a/test/e2e/live/gateway-guard-recovery.test.ts
+++ b/test/e2e/live/gateway-guard-recovery.test.ts
@@ -43,6 +43,7 @@
  * #2701 guard-chain assertion.
  */
 
+import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
@@ -143,6 +144,28 @@ async function inspectStartupCommand(
   });
   expect(result.exitCode, resultText(result)).toBe(0);
   return result.stdout.trim();
+}
+
+async function waitForSandboxExecAfterContainerRestart(
+  host: HostCliClient,
+  sandboxName: string,
+): Promise<void> {
+  let lastResult = "no OpenShell exec attempt completed";
+  for (let attempt = 1; attempt <= 12; attempt += 1) {
+    const result = await host.command(
+      "openshell",
+      ["sandbox", "exec", "-n", sandboxName, "--", "true"],
+      {
+        artifactName: `legacy-restart-openshell-ready-${attempt}`,
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    if (result.exitCode === 0) return;
+    lastResult = resultText(result);
+    await sleep(3_000);
+  }
+  throw new Error(`OpenShell did not accept the restarted legacy sandbox:\n${lastResult}`);
 }
 
 test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)", {
@@ -418,6 +441,7 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
     timeoutMs: 120_000,
   });
   expect(legacyRestart.exitCode, resultText(legacyRestart)).toBe(0);
+  await waitForSandboxExecAfterContainerRestart(host, instance.sandboxName);
 
   progress.phase("recover legacy managed supervisor and inference");
   const legacyCredentialCanary = "nemoclaw-e2e-recovery-secret-6635";

--- a/test/e2e/support/e2e-recovery-helpers.test.ts
+++ b/test/e2e/support/e2e-recovery-helpers.test.ts
@@ -398,7 +398,7 @@ describe("SandboxClient disruption helpers (#2701)", () => {
     await expect(sandbox.wipeGuardChain("e2e-2701")).rejects.toThrow(/wipe guard chain/);
   });
 
-  it("killGatewayTree pkills the openclaw tree and verifies nothing remains", async () => {
+  it("killGatewayTree kills the observed OpenClaw tree without racing its watchdog", async () => {
     const runner = new ScriptedRunner();
     const sandbox = new SandboxClient(runner);
 
@@ -406,11 +406,10 @@ describe("SandboxClient disruption helpers (#2701)", () => {
 
     const args = runner.calls[0]?.args ?? [];
     const script = args[args.length - 1];
-    expect(script).toContain("pkill -9 -f '[o]penclaw'");
-    expect(script).toContain("pgrep -af '[o]penclaw'");
+    expect(script).toBe("pkill -9 -f '[o]penclaw'");
   });
 
-  it("killGatewayTree throws if openclaw processes survive the kill", async () => {
+  it("killGatewayTree throws when no OpenClaw process was killed", async () => {
     const runner = new ScriptedRunner();
     runner.queue({ exitCode: 1 });
     const sandbox = new SandboxClient(runner);

--- a/test/e2e/support/e2e-recovery-helpers.test.ts
+++ b/test/e2e/support/e2e-recovery-helpers.test.ts
@@ -404,6 +404,7 @@ describe("SandboxClient disruption helpers (#2701)", () => {
 
     await sandbox.killGatewayTree("e2e-2701");
 
+    expect(runner.calls).toHaveLength(1);
     const args = runner.calls[0]?.args ?? [];
     const script = args[args.length - 1];
     expect(script).toBe("pkill -9 -f '[o]penclaw'");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Stabilize the gateway guard recovery live E2E target around the two expected lifecycle transitions it disrupts. The fixture no longer mistakes PID 1's watchdog relaunch for a failed kill, and the legacy-container leg waits for OpenShell to re-register the restarted sandbox before invoking recovery.

## Changes

- Require the disruption command to kill an observed OpenClaw process without asserting that the watchdog cannot relaunch it.
- Add bounded OpenShell exec-readiness polling after the test directly restarts the legacy keepalive container.
- Preserve the live target's strict assertions for a new gateway PID, restored guards, managed topology, forwarding health, and inference.
- Update E2E-support regression coverage for the corrected disruption contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only E2E disruption and readiness timing; production recovery and sandbox behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Nine-category review passed for `2e35050a882af6ee881de1d59d250a7e3fe85fad`: https://github.com/NVIDIA/NemoClaw/pull/8398#pullrequestreview-4869025741
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This PR changes only live E2E recovery timing, observability, and disruption-helper assertions. It does not change NemoClaw commands, configuration, defaults, user workflows, supported behavior, or published documentation.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 2e35050a882a -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-recovery-helpers.test.ts` (32/32 passed); `npm run test-conditionals:scan -- --top 25` passed; `git diff --check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>
