### PR TITLE
fix(inference): admit remediable Spark storage

### DIFF
--- a/src/lib/inference/serving/resolver.test.ts
+++ b/src/lib/inference/serving/resolver.test.ts
@@ -722,6 +722,23 @@ describe("managed inference resolver", () => {
     ).toMatchObject({ outcome: "rejected", code: "invalid-readiness" });
   });
 
+  it("rejects remediation when another fatal finding remains (#8246)", () => {
+    const report = storageRemediableReadinessReport([
+      {
+        id: "host.gpu.unavailable",
+        severity: "fatal",
+        summary: "No supported GPU is available.",
+        capabilityIds: ["host.gpu.available"],
+      },
+    ]);
+
+    expect(
+      resolveManagedInferenceServing(
+        resolverInput({ readinessReports: [{ nodeId: "spark-head", report }] }),
+      ),
+    ).toMatchObject({ outcome: "rejected", code: "invalid-readiness" });
+  });
+
   it("rejects a storage conflict without the remediation capability (#8246)", () => {
     const remediable = storageRemediableReadinessReport();
     const report = {

--- a/src/lib/inference/serving/resolver.test.ts
+++ b/src/lib/inference/serving/resolver.test.ts
@@ -177,6 +177,34 @@ function readinessSources(): ManagedInferenceReadinessSource[] {
   ];
 }
 
+function storageRemediableReadinessReport(
+  extraFindings: SystemReadinessReport["findings"] = [],
+): SystemReadinessReport {
+  const report = readinessReport();
+  return {
+    ...report,
+    capabilities: [
+      ...report.capabilities.map((capability) =>
+        capability.id === "host.docker.storage_compatible"
+          ? { ...capability, state: "absent" as const }
+          : capability,
+      ),
+      { id: "host.docker.storage_remediation_available", state: "present" },
+    ],
+    findings: [
+      {
+        id: "host.docker.storage_incompatible",
+        severity: "blocking",
+        summary: "The Docker storage configuration requires lifecycle remediation.",
+        capabilityIds: ["host.docker.storage_compatible"],
+      },
+      ...extraFindings,
+    ],
+    status: "incompatible",
+    exitCode: 2,
+  };
+}
+
 function topology(
   overrides: Partial<ManagedInferenceTopologyQualification<ManagedClusterTopologyOutput>> = {},
 ): ManagedInferenceTopologyQualification<ManagedClusterTopologyOutput> {
@@ -658,6 +686,57 @@ describe("managed inference resolver", () => {
 
     expect(
       resolveManagedInferenceServing(resolverInput({ readinessReports: sources })),
+    ).toMatchObject({ outcome: "rejected", code: "invalid-readiness" });
+  });
+
+  it("admits a storage conflict that the public lifecycle can remediate (#8246)", () => {
+    const catalog = hostLocalFixtureCatalog();
+    const presetId = catalog.presets[0]!.metadata.id;
+    const result = resolveManagedInferenceServing(
+      {
+        readinessReports: [{ nodeId: "spark-head", report: storageRemediableReadinessReport() }],
+        topologyQualifications: [],
+        intent: { preset: presetId },
+        now: NOW,
+      },
+      catalog,
+    );
+
+    expect(result).toMatchObject({ outcome: "selected", selection: "explicit" });
+  });
+
+  it("rejects remediation when another blocking finding remains (#8246)", () => {
+    const report = storageRemediableReadinessReport([
+      {
+        id: "host.gpu.container_toolkit_missing",
+        severity: "blocking",
+        summary: "NVIDIA Container Toolkit is missing.",
+        capabilityIds: ["host.gpu.container_toolkit_available"],
+      },
+    ]);
+
+    expect(
+      resolveManagedInferenceServing(
+        resolverInput({ readinessReports: [{ nodeId: "spark-head", report }] }),
+      ),
+    ).toMatchObject({ outcome: "rejected", code: "invalid-readiness" });
+  });
+
+  it("rejects a storage conflict without the remediation capability (#8246)", () => {
+    const remediable = storageRemediableReadinessReport();
+    const report = {
+      ...remediable,
+      capabilities: remediable.capabilities.map((capability) =>
+        capability.id === "host.docker.storage_remediation_available"
+          ? { ...capability, state: "absent" as const }
+          : capability,
+      ),
+    };
+
+    expect(
+      resolveManagedInferenceServing(
+        resolverInput({ readinessReports: [{ nodeId: "spark-head", report }] }),
+      ),
     ).toMatchObject({ outcome: "rejected", code: "invalid-readiness" });
   });
 

--- a/src/lib/inference/serving/resolver.ts
+++ b/src/lib/inference/serving/resolver.ts
@@ -19,8 +19,8 @@ import type {
   ManagedInferenceReadinessRequirement,
   ManagedInferenceReadinessSource,
   ManagedInferenceResolution,
-  ManagedInferenceRuntimeServingRecipe,
   ManagedInferenceResolverInput,
+  ManagedInferenceRuntimeServingRecipe,
   ManagedInferenceSelectionIntent,
   ManagedInferenceServingPreset,
   ManagedInferenceServingRecipe,
@@ -71,6 +71,35 @@ function explicitIntentWithoutPreset(intent: ManagedInferenceSelectionIntent): b
   );
 }
 
+const STORAGE_COMPATIBLE_CAPABILITY = "host.docker.storage_compatible";
+const STORAGE_REMEDIATION_CAPABILITY = "host.docker.storage_remediation_available";
+const STORAGE_INCOMPATIBLE_FINDING = "host.docker.storage_incompatible";
+
+function capabilityState(
+  report: ManagedInferenceReadinessSource["report"],
+  id: string,
+): "present" | "absent" | "unknown" | undefined {
+  const matches = report.capabilities.filter((capability) => capability.id === id);
+  return matches.length === 1 ? matches[0]!.state : undefined;
+}
+
+function hasRemediableStorageConflict(report: ManagedInferenceReadinessSource["report"]): boolean {
+  const blocking = report.findings.filter(
+    ({ severity }) => severity === "fatal" || severity === "blocking",
+  );
+  return (
+    report.status === "incompatible" &&
+    report.exitCode === 2 &&
+    blocking.length === 1 &&
+    blocking[0]!.id === STORAGE_INCOMPATIBLE_FINDING &&
+    blocking[0]!.severity === "blocking" &&
+    blocking[0]!.capabilityIds?.length === 1 &&
+    blocking[0]!.capabilityIds[0] === STORAGE_COMPATIBLE_CAPABILITY &&
+    capabilityState(report, STORAGE_COMPATIBLE_CAPABILITY) === "absent" &&
+    capabilityState(report, STORAGE_REMEDIATION_CAPABILITY) === "present"
+  );
+}
+
 function readinessError(
   source: ManagedInferenceReadinessSource,
   nowMs: number,
@@ -94,10 +123,14 @@ function readinessError(
   }
   const referenceErrors = getSystemReadinessReferenceErrors(report);
   if (referenceErrors.length > 0) return `${nodeId}: ${referenceErrors[0]}`;
-  if (report.status !== "supported" || report.exitCode !== 0) {
+  const remediableStorage = hasRemediableStorageConflict(report);
+  if ((report.status !== "supported" || report.exitCode !== 0) && !remediableStorage) {
     return `${nodeId}: readiness status is ${report.status}`;
   }
-  if (report.findings.some(({ severity }) => severity === "fatal" || severity === "blocking")) {
+  if (
+    report.findings.some(({ severity }) => severity === "fatal" || severity === "blocking") &&
+    !remediableStorage
+  ) {
     return `${nodeId}: readiness report contains a blocking finding`;
   }
   return undefined;
@@ -175,7 +208,13 @@ function readinessRequirementMatches(
     const collection =
       requirement.kind === "observation" ? report.observations : report.capabilities;
     const matches = collection.filter(({ id }) => id === requirement.id);
-    return matches.length === 1 && matches[0]!.state === requirement.state;
+    if (matches.length === 1 && matches[0]!.state === requirement.state) return true;
+    return (
+      requirement.kind === "capability" &&
+      requirement.id === STORAGE_COMPATIBLE_CAPABILITY &&
+      requirement.state === "present" &&
+      hasRemediableStorageConflict(report)
+    );
   });
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed serving selection now accepts the exact Docker storage conflict that NemoClaw's public lifecycle can remediate. The readiness report remains incompatible and `host.docker.storage_compatible` remains absent; selection admits it only when `host.docker.storage_remediation_available` is present and no other blocker exists.

## Related Issue

Refs #8246
Parent epic: #8379

## Changes

- Recognize the canonical, blocking `host.docker.storage_incompatible` finding as remediable only with the exact storage capability states produced by host readiness.
- Allow a `host.docker.storage_compatible` lifecycle requirement to use the documented remediation alternative without changing the public readiness report.
- Continue to reject missing remediation, additional blocking findings, fatal findings, malformed references, or any other incompatible readiness result.
- Add focused resolver coverage for successful admission and both fail-closed cases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `docs/reference/system-readiness.mdx` already specifies that lifecycle admission accepts either native storage compatibility or the remediation capability while preserving incompatible probe status and rejecting every other blocker.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing `docs/reference/system-readiness.mdx` already documents the implemented storage remediation admission contract. The committed diff and 33 focused resolver tests passed review with no findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 53b67c4fa -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass — `src/lib/inference/serving/resolver.test.ts`: 33/33 passed.
- [x] Applicable broad gates passed — `npm run typecheck:cli` and `npm run checks:repository` passed.
- [x] Read-only physical Spark probe reproduced the exact admitted shape: incompatible/exit 2, storage-compatible absent, remediation-available present, and the sole blocker `host.docker.storage_incompatible`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness validation for environments with an incompatible Docker storage configuration when automatic remediation is available.
  * Ensured host-local selection is allowed only when storage remediation is supported and no other blocking issues remain.
* **Tests**
  * Added coverage for successful remediation, unsupported remediation, and additional blocking readiness findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->