### PR TITLE
fix(installer): select portable Podman override before preflight

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -11,6 +11,8 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/portable-profile-e2e.yaml"
+      - "install.sh"
+      - "scripts/install.sh"
       - "src/lib/onboard/**"
       - "src/lib/domain/sandbox/image-tag.ts"
       - "src/lib/sandbox/build-context.ts"
@@ -20,6 +22,8 @@ on:
       - main
     paths:
       - ".github/workflows/portable-profile-e2e.yaml"
+      - "install.sh"
+      - "scripts/install.sh"
       - "src/lib/onboard/**"
       - "src/lib/domain/sandbox/image-tag.ts"
       - "src/lib/sandbox/build-context.ts"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5009,7 +5009,7 @@ main() {
   [[ -z "$expect_experimental_profile" ]] \
     || error "Missing value for --experimental-profile (expected: portable)."
   case "$EXPERIMENTAL_PROFILE" in
-    "") ;;
+    "") unset NEMOCLAW_EXPERIMENTAL_PROFILE ;;
     portable) export NEMOCLAW_EXPERIMENTAL_PROFILE="$EXPERIMENTAL_PROFILE" ;;
     *) error "Unknown experimental profile: $EXPERIMENTAL_PROFILE (expected: portable)." ;;
   esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3069,6 +3069,9 @@ run_onboard() {
   show_usage_notice
   info "Running ${_CLI_BIN} onboard…"
   local -a onboard_cmd=(onboard)
+  if [[ "${NEMOCLAW_EXPERIMENTAL_PROFILE:-}" == "portable" ]]; then
+    onboard_cmd+=(--experimental-profile portable)
+  fi
   local installer_auto_fresh_receipt_generation=""
   local session_file
   session_file="$(nemoclaw_state_dir)/onboard-session.json"
@@ -3427,6 +3430,37 @@ ensure_docker() {
   if ! docker info >/dev/null 2>&1; then
     error "Docker is installed but not reachable. Try: sudo systemctl start docker"
   fi
+}
+
+# Select the rootless Podman API socket reported for the current user. This
+# must run before ensure_docker and the installer host preflight: both use
+# the Docker CLI, with DOCKER_HOST overriding its daemon to Podman's user
+# socket. The CLI's portable host preparation later applies the networking and
+# local-registry configuration required by the OpenShell Podman driver.
+prepare_portable_experimental_runtime_override() {
+  [[ "${NEMOCLAW_EXPERIMENTAL_PROFILE:-}" == "portable" ]] || return 0
+  [[ "$(uname -s)" == "Linux" ]] \
+    || error "The portable experimental profile requires Linux."
+  command_exists podman \
+    || error "The portable experimental profile requires rootless Podman on PATH."
+  command_exists docker \
+    || error "The portable experimental profile requires the Docker CLI on PATH."
+  command_exists systemctl \
+    || error "The portable experimental profile requires systemctl --user to manage the rootless Podman socket."
+
+  systemctl --user enable --now podman.socket >/dev/null \
+    || error "Could not start the rootless Podman API socket with 'systemctl --user enable --now podman.socket'."
+
+  local podman_socket=""
+  podman_socket="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null)" \
+    || error "Could not resolve the rootless Podman API socket with 'podman info'."
+  case "$podman_socket" in
+    unix:///*) export DOCKER_HOST="$podman_socket" ;;
+    /*) export DOCKER_HOST="unix://${podman_socket}" ;;
+    *) error "Podman reported an invalid rootless API socket path: ${podman_socket:-empty}" ;;
+  esac
+
+  info "Portable profile selected rootless Podman through DOCKER_HOST=${DOCKER_HOST}."
 }
 
 is_wsl_host() {
@@ -4674,6 +4708,7 @@ prepare_installer_host() {
   # Intentional ordering: Station preparation owns the reboot boundary before
   # generic Docker bootstrap; ensure_station_express_host is a no-op elsewhere.
   ensure_station_express_host
+  prepare_portable_experimental_runtime_override
   ensure_docker
   ensure_openshell_build_deps
 }
@@ -4936,7 +4971,14 @@ main() {
   FRESH=""
   STATION_DEEPSEEK=""
   FORCE_STATION_INSTALL=""
+  EXPERIMENTAL_PROFILE="${NEMOCLAW_EXPERIMENTAL_PROFILE:-}"
+  local expect_experimental_profile=""
   for arg in "$@"; do
+    if [[ "$expect_experimental_profile" == "1" ]]; then
+      EXPERIMENTAL_PROFILE="$arg"
+      expect_experimental_profile=""
+      continue
+    fi
     case "$arg" in
       --non-interactive)
         NON_INTERACTIVE=1
@@ -4946,6 +4988,8 @@ main() {
       --fresh) FRESH=1 ;;
       --station-deepseek) STATION_DEEPSEEK=1 ;;
       --force-station-install) FORCE_STATION_INSTALL=1 ;;
+      --experimental-profile) expect_experimental_profile=1 ;;
+      --experimental-profile=*) EXPERIMENTAL_PROFILE="${arg#*=}" ;;
       --version | -v)
         local version_suffix
         version_suffix="$(installer_version_for_display)"
@@ -4962,6 +5006,13 @@ main() {
         ;;
     esac
   done
+  [[ -z "$expect_experimental_profile" ]] \
+    || error "Missing value for --experimental-profile (expected: portable)."
+  case "$EXPERIMENTAL_PROFILE" in
+    "") ;;
+    portable) export NEMOCLAW_EXPERIMENTAL_PROFILE="$EXPERIMENTAL_PROFILE" ;;
+    *) error "Unknown experimental profile: $EXPERIMENTAL_PROFILE (expected: portable)." ;;
+  esac
   # Also honor env var
   NON_INTERACTIVE="${NON_INTERACTIVE:-${NEMOCLAW_NON_INTERACTIVE:-}}"
   if [ "${NON_INTERACTIVE:-}" = "1" ] && [ -z "${NON_INTERACTIVE_SOURCE:-}" ]; then

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -123,6 +123,8 @@ describe("onboard command options", () => {
       fresh: true,
       autoYes: true,
       noOllamaAutostart: true,
+      noGpu: false,
+      sandboxGpu: null,
     });
   });
 

--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -45,19 +45,23 @@ describe("preparePortableExperimentalHost", () => {
       .fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>()
       .mockReturnValueOnce(result(1))
       .mockReturnValueOnce(result());
-    const env: NodeJS.ProcessEnv = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
+    const podman = vi.fn(() => result(0, "/run/user/1001/custom/podman.sock\n"));
+    const env: NodeJS.ProcessEnv = {
+      NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
+    };
 
     preparePortableExperimentalHost(env, {
       platform: "linux",
       home,
       uid: 1001,
       systemctl,
+      podman,
       docker,
     });
 
     expect(env).toMatchObject({
       CONTAINERS_CONF: path.join(home, ".config/nemoclaw/portable/containers.conf"),
-      DOCKER_HOST: "unix:///run/user/1001/podman/podman.sock",
+      DOCKER_HOST: "unix:///run/user/1001/custom/podman.sock",
       NETAVARK_FW: "iptables",
     });
     expect(systemctl.mock.calls.map(([args]) => args)).toEqual([
@@ -70,6 +74,7 @@ describe("preparePortableExperimentalHost", () => {
       ["--user", "try-restart", "podman.service"],
       ["--user", "enable", "--now", "podman.socket"],
     ]);
+    expect(podman).toHaveBeenCalledWith(["info", "--format", "{{.Host.RemoteSocket.Path}}"], env);
     expect(docker.mock.calls[1]?.[0]).toEqual([
       "run",
       "-d",
@@ -99,7 +104,9 @@ describe("preparePortableExperimentalHost", () => {
   it("refuses to replace an unmanaged registry container", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
     tempDirs.push(home);
-    const env: NodeJS.ProcessEnv = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
+    const env: NodeJS.ProcessEnv = {
+      NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
+    };
 
     expect(() =>
       preparePortableExperimentalHost(env, {
@@ -107,6 +114,7 @@ describe("preparePortableExperimentalHost", () => {
         home,
         uid: 1001,
         systemctl: () => result(),
+        podman: () => result(0, "/run/user/1001/podman/podman.sock"),
         docker: () => result(0, "unexpected-owner"),
       }),
     ).toThrow(/unmanaged container/);
@@ -139,10 +147,30 @@ describe("preparePortableExperimentalHost", () => {
           home,
           uid: 1001,
           systemctl: () => result(),
+          podman: () => result(0, "/run/user/1001/podman/podman.sock"),
           docker,
         },
       ),
     ).toThrow(/Inspecting the managed portable registry failed: registry inspection timed out/);
     expect(docker).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when Podman does not report an absolute local socket", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
+    tempDirs.push(home);
+
+    expect(() =>
+      preparePortableExperimentalHost(
+        { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
+        {
+          platform: "linux",
+          home,
+          uid: 1001,
+          systemctl: () => result(),
+          podman: () => result(0, "tcp://127.0.0.1:1234"),
+          docker: vi.fn(),
+        },
+      ),
+    ).toThrow(/invalid socket path/);
   });
 });

--- a/src/lib/onboard/experimental/portable-host-preparation.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.ts
@@ -35,6 +35,7 @@ export interface PortableHostPreparationDeps {
   home?: string;
   uid?: number;
   systemctl?: (args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult;
+  podman?: (args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult;
   docker?: (args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult;
 }
 
@@ -48,6 +49,16 @@ function commandDetail(result: SpawnResult): string {
 function requireCommand(result: SpawnResult, description: string): void {
   if (result.status === 0) return;
   throw new Error(`${description} failed: ${commandDetail(result)}`);
+}
+
+function resolvePodmanDockerHost(result: SpawnResult): string {
+  requireCommand(result, "Resolving the rootless Podman API socket");
+  const socket = String(result.stdout ?? "").trim();
+  if (socket.startsWith("unix:///")) return socket;
+  if (socket.startsWith("/")) return `unix://${socket}`;
+  throw new Error(
+    `Resolving the rootless Podman API socket failed: invalid socket path '${socket || "empty"}'`,
+  );
 }
 
 function writePrivateConfig(filePath: string, value: string): void {
@@ -144,7 +155,6 @@ export function preparePortableExperimentalHost(
   }
   const home = deps.home ?? env.HOME ?? os.homedir();
   env.NETAVARK_FW = "iptables";
-  env.DOCKER_HOST = `unix:///run/user/${String(uid)}/podman/podman.sock`;
   env.CONTAINERS_CONF = writePortableRuntimeConfig(home, env);
 
   const systemctl =
@@ -176,6 +186,18 @@ export function preparePortableExperimentalHost(
     "Starting the rootless container socket",
   );
 
+  const podman =
+    deps.podman ??
+    ((args, childEnv) =>
+      spawnSync("podman", [...args], {
+        encoding: "utf-8",
+        env: childEnv,
+        timeout: HOST_COMMAND_TIMEOUT_MS,
+      }));
+  env.DOCKER_HOST = resolvePodmanDockerHost(
+    podman(["info", "--format", "{{.Host.RemoteSocket.Path}}"], env),
+  );
+
   const docker =
     deps.docker ??
     ((args, childEnv) =>
@@ -192,4 +214,5 @@ export const portableHostPreparationInternals = {
   REGISTRY_IMAGE,
   REGISTRY_FRAGMENT,
   PORTABLE_CONTAINERS_CONF,
+  resolvePodmanDockerHost,
 };

--- a/test/e2e/live/portable-profile-rootless-linux.test.ts
+++ b/test/e2e/live/portable-profile-rootless-linux.test.ts
@@ -43,6 +43,7 @@ const { SANDBOX_BUILD_CONTEXT_PREFIX } = buildContextModule;
 const BASE_IMAGE =
   "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467";
 const PORTABLE_PROFILE_E2E_PHASES = [
+  "select the Podman-reported runtime socket",
   "prepare the rootless container runtime",
   "build and publish the sandbox image",
   "verify the fixed host route",
@@ -129,6 +130,17 @@ esac
   );
 }
 
+function selectInstallerPodmanRuntime(repoRoot: string): string {
+  const payload = path.join(repoRoot, "scripts", "install.sh");
+  const script = [
+    `source "${payload}" >/dev/null 2>&1 || true`,
+    'export NEMOCLAW_EXPERIMENTAL_PROFILE="portable"',
+    "prepare_portable_experimental_runtime_override >&2",
+    'printf "%s" "$DOCKER_HOST"',
+  ].join("\n");
+  return run("bash", ["-c", script]);
+}
+
 async function main(progress: { phase: (phase: string) => void }): Promise<void> {
   assert.equal(process.platform, "linux", "portable profile E2E requires Linux");
   assert.notEqual(process.getuid?.(), 0, "portable profile E2E must run without root privileges");
@@ -153,6 +165,10 @@ async function main(progress: { phase: (phase: string) => void }): Promise<void>
   });
 
   try {
+    progress.phase("select the Podman-reported runtime socket");
+    const installerDockerHost = selectInstallerPodmanRuntime(process.cwd());
+    assert.equal(installerDockerHost, `unix://${runtimeDir}/podman/podman.sock`);
+
     progress.phase("prepare the rootless container runtime");
     preparePortableExperimentalHost(process.env);
     assert.equal(process.env.DOCKER_HOST, `unix://${runtimeDir}/podman/podman.sock`);

--- a/test/install-onboard-yes.test.ts
+++ b/test/install-onboard-yes.test.ts
@@ -154,7 +154,11 @@ function runFailedSessionRecovery(mode: FailedPromptMode, agent: FailedSessionAg
   fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
   fs.writeFileSync(
     path.join(home, ".nemoclaw", "onboard-session.json"),
-    JSON.stringify({ status: "failed", resumable: true, failure: { step: "inference" } }),
+    JSON.stringify({
+      status: "failed",
+      resumable: true,
+      failure: { step: "inference" },
+    }),
   );
   fs.writeFileSync(promptInput, "");
   fs.writeFileSync(cliBin, `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > "${argvLog}"\n`, {
@@ -196,7 +200,11 @@ function runFailedSessionRecovery(mode: FailedPromptMode, agent: FailedSessionAg
       PROMPT_MODE: mode,
     },
   });
-  return { argvLog, output: `${result.stdout}${result.stderr}`, status: result.status };
+  return {
+    argvLog,
+    output: `${result.stdout}${result.stderr}`,
+    status: result.status,
+  };
 }
 
 describe("install.sh run_onboard — session classification (#5626)", () => {
@@ -408,7 +416,12 @@ describe("install.sh run_onboard — session classification (#5626)", () => {
   it("does not resume or reset a completed session", () => {
     const argv = runOnboardWithSession(
       { NON_INTERACTIVE: "1" },
-      { version: 1, status: "complete", resumable: false, sandboxName: "my-assistant" },
+      {
+        version: 1,
+        status: "complete",
+        resumable: false,
+        sandboxName: "my-assistant",
+      },
     );
     expect(argv).toContain("onboard");
     expect(argv).not.toContain("--resume");
@@ -462,8 +475,16 @@ describe("install.sh run_onboard — session classification (#5626)", () => {
 
 describe("install.sh run_onboard — failed-session recovery", () => {
   it.each([
-    { mode: "unreadable-tty", name: "no prompt TTY is readable", error: "no TTY" },
-    { mode: "read-failure", name: "reading prompt input fails", error: "Could not read" },
+    {
+      mode: "unreadable-tty",
+      name: "no prompt TTY is readable",
+      error: "no TTY",
+    },
+    {
+      mode: "read-failure",
+      name: "reading prompt input fails",
+      error: "Could not read",
+    },
   ] as const)("shows both recovery commands when $name", ({ mode, error }) => {
     const { argvLog, output, status } = runFailedSessionRecovery(mode);
     expect(status).not.toBe(0);
@@ -510,6 +531,14 @@ describe("install.sh run_onboard", () => {
     });
     expect(argv).toContain("--yes-i-accept-third-party-software");
     expect(argv).toContain("--yes");
+  });
+
+  it("forwards the portable profile to the actual onboard command", () => {
+    const argv = runOnboardWithMockCli({
+      NON_INTERACTIVE: "1",
+      NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
+    });
+    expect(argv).toEqual(expect.arrayContaining(["onboard", "--experimental-profile", "portable"]));
   });
 });
 

--- a/test/install-portable-profile.test.ts
+++ b/test/install-portable-profile.test.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
+
+function runPortableOverride(profile = "portable"): ReturnType<typeof spawnSync> {
+  const snippet = `
+    set -e
+    source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1 || true
+    NEMOCLAW_EXPERIMENTAL_PROFILE="${profile}"
+    export NEMOCLAW_EXPERIMENTAL_PROFILE
+    command_exists() { return 0; }
+    uname() { printf 'Linux\\n'; }
+    systemctl() { printf 'SYSTEMCTL=%s\\n' "$*" >&2; }
+    podman() {
+      printf 'PODMAN=%s\\n' "$*" >&2
+      printf '/run/user/4242/selected/podman.sock\\n'
+    }
+    info() { printf 'INFO=%s\\n' "$*"; }
+    error() { printf 'ERROR=%s\\n' "$*" >&2; return 1; }
+    prepare_portable_experimental_runtime_override
+    printf 'DOCKER_HOST=%s\\n' "\${DOCKER_HOST:-}"
+  `;
+  return spawnSync("bash", ["-c", snippet], {
+    encoding: "utf-8",
+    env: { ...process.env },
+  });
+}
+
+describe("installer portable profile runtime override", () => {
+  it("selects the Podman-reported rootless socket before installer preflight", () => {
+    const result = runPortableOverride();
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("SYSTEMCTL=--user enable --now podman.socket");
+    expect(result.stdout).toContain("DOCKER_HOST=unix:///run/user/4242/selected/podman.sock");
+  });
+
+  it("does not touch the runtime without the explicit portable profile", () => {
+    const result = runPortableOverride("");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("DOCKER_HOST=\n");
+    expect(result.stderr).toBe("");
+  });
+});

--- a/test/install-portable-profile.test.ts
+++ b/test/install-portable-profile.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
 
-function runPortableOverride(profile = "portable"): ReturnType<typeof spawnSync> {
+function runPortableOverride(profile = "portable", dockerHost = ""): ReturnType<typeof spawnSync> {
   const snippet = `
     set -e
     source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1 || true
@@ -28,7 +28,7 @@ function runPortableOverride(profile = "portable"): ReturnType<typeof spawnSync>
   `;
   return spawnSync("bash", ["-c", snippet], {
     encoding: "utf-8",
-    env: { ...process.env },
+    env: { ...process.env, DOCKER_HOST: dockerHost },
   });
 }
 
@@ -41,9 +41,9 @@ describe("installer portable profile runtime override", () => {
   });
 
   it("does not touch the runtime without the explicit portable profile", () => {
-    const result = runPortableOverride("");
+    const result = runPortableOverride("", "unix:///preexisting.sock");
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe("DOCKER_HOST=\n");
+    expect(result.stdout).toBe("DOCKER_HOST=unix:///preexisting.sock\n");
     expect(result.stderr).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
Portable installer runs were reaching ordinary Docker bootstrap and host preflight before the hidden profile could select rootless Podman. This change applies the same Podman socket override used by the working Portable setup before those gates, then forwards the hidden profile into onboarding without disabling GPU.

## Related Issue
Follow-up to #8376.

## Changes
- Accept the existing hidden portable profile at the installer boundary and forward it to the actual onboard command.
- Start the rootless Podman user socket and derive DOCKER_HOST from podman info before Docker bootstrap and installer host preflight.
- Make CLI host preparation use the Podman-reported socket instead of assuming a UID-derived path.
- Exercise the installer selector in the rootless portable E2E and trigger that workflow for installer changes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Repairs installer forwarding and rootless Podman socket selection for an existing hidden experimental profile; no supported public workflow changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed urgent corrective follow-up to merged #8376.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The profile remains hidden; no docs paths changed. Reviewer-requested help text and historical wording were removed before commit; the follow-up edge-case fix, final GPU regression assertion, and required current-main merge were re-reviewed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f7a264477 -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `76` CLI tests and `21` installer integration tests passed; `npm run typecheck` and semantic E2E phase validation passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an experimental portable profile for Linux environments using rootless Podman.
  - Automatically detects and uses Podman’s runtime socket.
  - Added validation for required tools, services, socket paths, and profile values.
  - The portable profile is forwarded during onboarding and runtime preparation.

- **Bug Fixes**
  - Installation now stops when runtime socket discovery returns an invalid path.

- **Tests**
  - Expanded coverage for portable profile setup, socket selection, onboarding, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


