### PR TITLE
fix(ci): paginate final merge-gate checks

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
+++ b/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
@@ -2854,9 +2854,11 @@ function fetchFinalPrSnapshot(
   const [owner, name, extra] = repo.split("/");
   if (!owner || !name || extra) return null;
 
-  const response = ghJson([
+  const args = [
     "api",
     "graphql",
+    "--paginate",
+    "--slurp",
     "-F",
     `owner=${owner}`,
     "-F",
@@ -2864,7 +2866,7 @@ function fetchFinalPrSnapshot(
     "-F",
     `number=${number}`,
     "-f",
-    `query=query FinalPrSnapshot($owner: String!, $name: String!, $number: Int!) {
+    `query=query FinalPrSnapshot($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
       repository(owner: $owner, name: $name) {
         pullRequest(number: $number) {
           title
@@ -2886,9 +2888,9 @@ function fetchFinalPrSnapshot(
               commit {
                 oid
                 statusCheckRollup {
-                  contexts(first: 100) {
+                  contexts(first: 100, after: $endCursor) {
                     totalCount
-                    pageInfo { hasNextPage }
+                    pageInfo { hasNextPage endCursor }
                     nodes {
                       __typename
                       ... on CheckRun {
@@ -2914,45 +2916,143 @@ function fetchFinalPrSnapshot(
         }
       }
     }`,
-  ]) as {
-    data?: { repository?: { pullRequest?: Record<string, unknown> } };
-  } | null;
-  const record = response?.data?.repository?.pullRequest;
-  if (!record) return null;
+  ];
+  const firstPages = ghJson(args);
+  const finalPages = ghJson(args);
+  if (!isDeepStrictEqual(firstPages, finalPages)) return null;
+  return parseFinalPrSnapshotPages(finalPages);
+}
 
-  const headRepository = parseHeadRepository(record.headRepository, record.headRepositoryOwner);
-  const baseRef =
-    typeof record.baseRef === "object" && record.baseRef !== null && !Array.isArray(record.baseRef)
-      ? (record.baseRef as Record<string, unknown>)
-      : null;
-  const target =
-    typeof baseRef?.target === "object" && baseRef.target !== null && !Array.isArray(baseRef.target)
-      ? (baseRef.target as Record<string, unknown>)
-      : null;
-  const currentBaseSha = target?.oid;
-  if (
-    typeof record.title !== "string" ||
-    typeof record.body !== "string" ||
-    typeof record.state !== "string" ||
-    typeof record.isDraft !== "boolean" ||
-    typeof record.mergeable !== "string" ||
-    typeof record.mergeStateStatus !== "string" ||
-    typeof record.headRefOid !== "string" ||
-    !/^[0-9a-f]{40}$/iu.test(record.headRefOid) ||
-    typeof record.baseRefOid !== "string" ||
-    !/^[0-9a-f]{40}$/iu.test(record.baseRefOid) ||
-    typeof record.headRefName !== "string" ||
-    typeof record.baseRefName !== "string" ||
-    typeof currentBaseSha !== "string" ||
-    !/^[0-9a-f]{40}$/iu.test(currentBaseSha) ||
-    !headRepository
-  ) {
-    return null;
-  }
-  const statusCheckRollup = parseFinalStatusCheckRollup(record.commits, record.headRefOid);
-  if (!statusCheckRollup) return null;
-  return {
-    revision: {
+function parseFinalPrSnapshotPages(
+  pagesValue: unknown,
+): { revision: PrRevisionSnapshot; currentBaseSha: string } | null {
+  if (!Array.isArray(pagesValue) || pagesValue.length === 0) return null;
+
+  let canonicalIdentity: Record<string, unknown> | null = null;
+  let canonicalRecord: Record<string, unknown> | null = null;
+  let contextTotalCount: number | null = null;
+  const contextNodes: unknown[] = [];
+  const seenEndCursors = new Set<string>();
+
+  for (const [pageIndex, pageValue] of pagesValue.entries()) {
+    if (typeof pageValue !== "object" || pageValue === null || Array.isArray(pageValue)) {
+      return null;
+    }
+    const dataValue = (pageValue as Record<string, unknown>).data;
+    if (typeof dataValue !== "object" || dataValue === null || Array.isArray(dataValue))
+      return null;
+    const repositoryValue = (dataValue as Record<string, unknown>).repository;
+    if (
+      typeof repositoryValue !== "object" ||
+      repositoryValue === null ||
+      Array.isArray(repositoryValue)
+    ) {
+      return null;
+    }
+    const recordValue = (repositoryValue as Record<string, unknown>).pullRequest;
+    if (typeof recordValue !== "object" || recordValue === null || Array.isArray(recordValue)) {
+      return null;
+    }
+    const record = recordValue as Record<string, unknown>;
+
+    const headRepository = parseHeadRepository(record.headRepository, record.headRepositoryOwner);
+    const baseRef =
+      typeof record.baseRef === "object" &&
+      record.baseRef !== null &&
+      !Array.isArray(record.baseRef)
+        ? (record.baseRef as Record<string, unknown>)
+        : null;
+    const target =
+      typeof baseRef?.target === "object" &&
+      baseRef.target !== null &&
+      !Array.isArray(baseRef.target)
+        ? (baseRef.target as Record<string, unknown>)
+        : null;
+    const currentBaseSha = target?.oid;
+    if (
+      typeof record.title !== "string" ||
+      typeof record.body !== "string" ||
+      typeof record.state !== "string" ||
+      typeof record.isDraft !== "boolean" ||
+      typeof record.mergeable !== "string" ||
+      typeof record.mergeStateStatus !== "string" ||
+      typeof record.headRefOid !== "string" ||
+      !/^[0-9a-f]{40}$/iu.test(record.headRefOid) ||
+      typeof record.baseRefOid !== "string" ||
+      !/^[0-9a-f]{40}$/iu.test(record.baseRefOid) ||
+      typeof record.headRefName !== "string" ||
+      typeof record.baseRefName !== "string" ||
+      typeof currentBaseSha !== "string" ||
+      !/^[0-9a-f]{40}$/iu.test(currentBaseSha) ||
+      !headRepository
+    ) {
+      return null;
+    }
+
+    const commitsValue = record.commits;
+    if (typeof commitsValue !== "object" || commitsValue === null || Array.isArray(commitsValue)) {
+      return null;
+    }
+    const commits = commitsValue as Record<string, unknown>;
+    if (
+      typeof commits.totalCount !== "number" ||
+      !Number.isInteger(commits.totalCount) ||
+      commits.totalCount < 1 ||
+      !Array.isArray(commits.nodes) ||
+      commits.nodes.length !== 1
+    ) {
+      return null;
+    }
+    const commitNode = commits.nodes[0];
+    if (typeof commitNode !== "object" || commitNode === null || Array.isArray(commitNode)) {
+      return null;
+    }
+    const commitValue = (commitNode as Record<string, unknown>).commit;
+    if (typeof commitValue !== "object" || commitValue === null || Array.isArray(commitValue)) {
+      return null;
+    }
+    const commit = commitValue as Record<string, unknown>;
+    if (commit.oid !== record.headRefOid) return null;
+    const rollupValue = commit.statusCheckRollup;
+    if (typeof rollupValue !== "object" || rollupValue === null || Array.isArray(rollupValue)) {
+      return null;
+    }
+    const contextsValue = (rollupValue as Record<string, unknown>).contexts;
+    if (
+      typeof contextsValue !== "object" ||
+      contextsValue === null ||
+      Array.isArray(contextsValue)
+    ) {
+      return null;
+    }
+    const contexts = contextsValue as Record<string, unknown>;
+    const pageInfoValue = contexts.pageInfo;
+    if (
+      typeof contexts.totalCount !== "number" ||
+      !Number.isInteger(contexts.totalCount) ||
+      contexts.totalCount < 0 ||
+      !Array.isArray(contexts.nodes) ||
+      typeof pageInfoValue !== "object" ||
+      pageInfoValue === null ||
+      Array.isArray(pageInfoValue)
+    ) {
+      return null;
+    }
+    const pageInfo = pageInfoValue as Record<string, unknown>;
+    const isLastPage = pageIndex === pagesValue.length - 1;
+    if (pageInfo.hasNextPage !== !isLastPage) return null;
+    if (!isLastPage) {
+      if (
+        typeof pageInfo.endCursor !== "string" ||
+        pageInfo.endCursor.length === 0 ||
+        seenEndCursors.has(pageInfo.endCursor)
+      ) {
+        return null;
+      }
+      seenEndCursors.add(pageInfo.endCursor);
+    }
+
+    const identity = {
       title: record.title,
       body: record.body,
       state: record.state,
@@ -2964,9 +3064,58 @@ function fetchFinalPrSnapshot(
       headRefName: record.headRefName,
       baseRefName: record.baseRefName,
       headRepository,
+      currentBaseSha,
+      commitTotalCount: commits.totalCount,
+      contextTotalCount: contexts.totalCount,
+    };
+    if (canonicalIdentity && !isDeepStrictEqual(canonicalIdentity, identity)) return null;
+    canonicalIdentity = identity;
+    canonicalRecord ??= record;
+    contextTotalCount ??= contexts.totalCount;
+    contextNodes.push(...contexts.nodes);
+  }
+
+  if (!canonicalIdentity || !canonicalRecord || contextTotalCount !== contextNodes.length) {
+    return null;
+  }
+  const aggregateCommits = {
+    totalCount: canonicalIdentity.commitTotalCount,
+    nodes: [
+      {
+        commit: {
+          oid: canonicalIdentity.headRefOid,
+          statusCheckRollup: {
+            contexts: {
+              totalCount: contextTotalCount,
+              pageInfo: { hasNextPage: false },
+              nodes: contextNodes,
+            },
+          },
+        },
+      },
+    ],
+  };
+  const statusCheckRollup = parseFinalStatusCheckRollup(
+    aggregateCommits,
+    canonicalIdentity.headRefOid as string,
+  );
+  if (!statusCheckRollup) return null;
+  return {
+    revision: {
+      title: canonicalRecord.title as string,
+      body: canonicalRecord.body as string,
+      state: canonicalRecord.state as string,
+      isDraft: canonicalRecord.isDraft as boolean,
+      mergeable: canonicalRecord.mergeable as string,
+      mergeStateStatus: canonicalRecord.mergeStateStatus as string,
+      headRefOid: canonicalRecord.headRefOid as string,
+      baseRefOid: canonicalRecord.baseRefOid as string,
+      headRefName: canonicalRecord.headRefName as string,
+      baseRefName: canonicalRecord.baseRefName as string,
+      headRepository: canonicalIdentity.headRepository as string,
       statusCheckRollup,
     },
-    currentBaseSha,
+    currentBaseSha: canonicalIdentity.currentBaseSha as string,
   };
 }
 

--- a/test/skills/check-gates-final-snapshot.test.ts
+++ b/test/skills/check-gates-final-snapshot.test.ts
@@ -48,6 +48,51 @@ describe("maintainer merge-gate final PR snapshot", () => {
     expect(output.allPass).toBe(false);
   });
 
+  it("verifies every final status context when the rollup spans multiple pages", () => {
+    const statusChecks = [
+      ...successfulRequiredChecks(),
+      ...Array.from({ length: 95 }, (_, index) => ({
+        __typename: "StatusContext",
+        context: `optional-context-${index + 1}`,
+        state: "SUCCESS",
+        startedAt: "2026-01-01T00:00:00Z",
+      })),
+    ];
+    const output = JSON.parse(
+      runGate({
+        body: "Signed-off-by: Example User <user@example.com>",
+        verified: true,
+        statusChecks,
+        finalStatusCheckPageSize: 100,
+      }).stdout,
+    );
+
+    expect(output).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it("fails closed when the complete final status snapshot changes between reads", () => {
+    const output = JSON.parse(
+      runGate({
+        body: "Signed-off-by: Example User <user@example.com>",
+        verified: true,
+        finalStatusChecksAfterFirstRead: successfulRequiredChecks().map((check) =>
+          check.name === "checks"
+            ? { ...check, status: "IN_PROGRESS", conclusion: undefined }
+            : check,
+        ),
+      }).stdout,
+    );
+
+    expect(output.gates.ci).toMatchObject({
+      pass: false,
+      details: "Unable to verify the final PR checks",
+    });
+    expect(output.allPass).toBe(false);
+  });
+
   it("accepts a multi-commit PR when the final snapshot returns the PR commit SHA", () => {
     const output = JSON.parse(
       runGate({

--- a/test/skills/check-gates-test-fixtures.ts
+++ b/test/skills/check-gates-test-fixtures.ts
@@ -98,22 +98,24 @@ interface CoordinatorRunPartitionFixture {
   finalRunOverrides?: Record<string, Partial<ActionRunFixture>>;
 }
 
+interface StatusCheckFixture {
+  __typename?: string;
+  name?: string;
+  context?: string;
+  workflowName?: string;
+  startedAt?: string;
+  completedAt?: string;
+  detailsUrl?: string;
+  status?: string;
+  conclusion?: string;
+  state?: string;
+}
+
 interface ComplianceFixture {
   body: string;
   checkConclusions?: Record<string, string>;
   checkNames?: string[];
-  statusChecks?: Array<{
-    __typename?: string;
-    name?: string;
-    context?: string;
-    workflowName?: string;
-    startedAt?: string;
-    completedAt?: string;
-    detailsUrl?: string;
-    status?: string;
-    conclusion?: string;
-    state?: string;
-  }>;
+  statusChecks?: StatusCheckFixture[];
   commitOutput?: string;
   commitAuthorLogins?: string[];
   contributorCommitPages?: Array<
@@ -163,6 +165,8 @@ interface ComplianceFixture {
   finalStatusContextTotalCount?: number;
   finalStatusCheckCommitOid?: string;
   finalStatusCheckHasNextPage?: boolean;
+  finalStatusCheckPageSize?: number;
+  finalStatusChecksAfterFirstRead?: StatusCheckFixture[];
 }
 
 interface ComparatorFixture extends ComplianceFixture {
@@ -493,56 +497,75 @@ function runGate(fixture: ComplianceFixture) {
     fixture.finalCurrentBaseSha === undefined
       ? fixture.currentBaseSha
       : fixture.finalCurrentBaseSha;
-  const finalStatusCheckNodes = finalPrAfterFinalCi.statusCheckRollup.map(
-    ({ workflowName, ...check }) => ({
+  const buildFinalPrSnapshotOutput = (statusChecks: StatusCheckFixture[]) => {
+    const nodes = statusChecks.map(({ workflowName, ...check }) => ({
       ...check,
       ...(workflowName
         ? { checkSuite: { workflowRun: { workflow: { name: workflowName } } } }
         : {}),
-    }),
-  );
-  const finalPrSnapshotOutput = JSON.stringify({
-    data: {
-      repository: {
-        pullRequest: {
-          title: finalPrAfterFinalCi.title,
-          body: finalPrAfterFinalCi.body,
-          state: finalPrAfterFinalCi.state,
-          isDraft: finalPrAfterFinalCi.isDraft,
-          mergeable: finalPrAfterFinalCi.mergeable,
-          mergeStateStatus: finalPrAfterFinalCi.mergeStateStatus,
-          headRefOid: finalPrAfterFinalCi.headRefOid,
-          baseRefOid: finalPrAfterFinalCi.baseRefOid,
-          headRefName: finalPrAfterFinalCi.headRefName,
-          baseRefName: finalPrAfterFinalCi.baseRefName,
-          headRepository: finalPrAfterFinalCi.headRepository,
-          headRepositoryOwner: finalPrAfterFinalCi.headRepositoryOwner,
-          baseRef:
-            finalCurrentBaseSha === null
-              ? null
-              : { target: { oid: finalCurrentBaseSha ?? BASE_SHA } },
-          commits: {
-            totalCount: fixture.finalCommitTotalCount ?? 1,
-            nodes: [
-              {
-                commit: {
-                  oid: fixture.finalStatusCheckCommitOid ?? finalPrAfterFinalCi.headRefOid,
-                  statusCheckRollup: {
-                    contexts: {
-                      totalCount:
-                        fixture.finalStatusContextTotalCount ?? finalStatusCheckNodes.length,
-                      pageInfo: { hasNextPage: fixture.finalStatusCheckHasNextPage ?? false },
-                      nodes: finalStatusCheckNodes,
+    }));
+    const pageSize = fixture.finalStatusCheckPageSize ?? Math.max(1, nodes.length);
+    const nodePages =
+      nodes.length === 0
+        ? [[]]
+        : Array.from({ length: Math.ceil(nodes.length / pageSize) }, (_, index) =>
+            nodes.slice(index * pageSize, (index + 1) * pageSize),
+          );
+    return JSON.stringify(
+      nodePages.map((pageNodes, pageIndex) => {
+        const isLastPage = pageIndex === nodePages.length - 1;
+        const hasNextPage = !isLastPage || fixture.finalStatusCheckHasNextPage === true;
+        return {
+          data: {
+            repository: {
+              pullRequest: {
+                title: finalPrAfterFinalCi.title,
+                body: finalPrAfterFinalCi.body,
+                state: finalPrAfterFinalCi.state,
+                isDraft: finalPrAfterFinalCi.isDraft,
+                mergeable: finalPrAfterFinalCi.mergeable,
+                mergeStateStatus: finalPrAfterFinalCi.mergeStateStatus,
+                headRefOid: finalPrAfterFinalCi.headRefOid,
+                baseRefOid: finalPrAfterFinalCi.baseRefOid,
+                headRefName: finalPrAfterFinalCi.headRefName,
+                baseRefName: finalPrAfterFinalCi.baseRefName,
+                headRepository: finalPrAfterFinalCi.headRepository,
+                headRepositoryOwner: finalPrAfterFinalCi.headRepositoryOwner,
+                baseRef:
+                  finalCurrentBaseSha === null
+                    ? null
+                    : { target: { oid: finalCurrentBaseSha ?? BASE_SHA } },
+                commits: {
+                  totalCount: fixture.finalCommitTotalCount ?? 1,
+                  nodes: [
+                    {
+                      commit: {
+                        oid: fixture.finalStatusCheckCommitOid ?? finalPrAfterFinalCi.headRefOid,
+                        statusCheckRollup: {
+                          contexts: {
+                            totalCount: fixture.finalStatusContextTotalCount ?? nodes.length,
+                            pageInfo: {
+                              hasNextPage,
+                              endCursor: hasNextPage ? `cursor-${pageIndex + 1}` : null,
+                            },
+                            nodes: pageNodes,
+                          },
+                        },
+                      },
                     },
-                  },
+                  ],
                 },
               },
-            ],
+            },
           },
-        },
-      },
-    },
-  });
+        };
+      }),
+    );
+  };
+  const finalPrSnapshotOutput = buildFinalPrSnapshotOutput(finalPrAfterFinalCi.statusCheckRollup);
+  const finalPrSnapshotAfterFirstReadOutput = buildFinalPrSnapshotOutput(
+    fixture.finalStatusChecksAfterFirstRead ?? finalPrAfterFinalCi.statusCheckRollup,
+  );
   const issueEventPages = fixture.issueEventPages ?? [[]];
   const coordinationCheckPages = fixture.coordinationCheckPages ?? [
     {
@@ -765,6 +788,7 @@ function runGate(fixture: ComplianceFixture) {
     .join("\n");
   const coordinationCheckMarker = path.join(tmp, "coordination-checks-seen");
   const formerCoordinationCheckMarker = path.join(tmp, "former-coordination-checks-seen");
+  const finalPrFirstReadMarker = path.join(tmp, "final-pr-first-read");
   const finalPrReadMarker = path.join(tmp, "final-pr-read");
 
   fs.writeFileSync(
@@ -780,7 +804,7 @@ case "$*" in
   *"ContributorCommits"*) printf '%s' ${shellSingleQuote(contributorCommitOutput)} ;;
   *"ContributorReviews"*) printf '%s' ${shellSingleQuote(contributorReviewOutput)} ;;
   *"CurrentBaseRef"*) mkdir -p ${shellSingleQuote(path.join(tmp, "current-base-seen"))}; printf '%s' ${shellSingleQuote(currentBaseOutput)} ;;
-  *"FinalPrSnapshot"*) mkdir -p ${shellSingleQuote(finalPrReadMarker)}; printf '%s' ${shellSingleQuote(finalPrSnapshotOutput)} ;;
+  *"FinalPrSnapshot"*) if mkdir ${shellSingleQuote(finalPrFirstReadMarker)} 2>/dev/null; then printf '%s' ${shellSingleQuote(finalPrSnapshotOutput)}; else mkdir -p ${shellSingleQuote(finalPrReadMarker)}; printf '%s' ${shellSingleQuote(finalPrSnapshotAfterFirstReadOutput)}; fi ;;
   "api graphql"*) printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
   "api repos/NVIDIA/NemoClaw/issues/42/comments"*) printf '%s' '{"id":1,"body":"ordinary comment","user":{"login":"reviewer"},"updated_at":"2026-01-01T00:00:00Z"}' ;;
   "api repos/NVIDIA/NemoClaw/pulls/42/commits"*) printf '%s' ${shellSingleQuote(commitOutput)} ;;
@@ -894,9 +918,9 @@ export {
   E2E_COORDINATION_NAME,
   e2eChecks,
   e2eCoordinatorRun,
-  e2eManualCoordinatorRun,
   e2eGateCheck,
   e2eJobs,
+  e2eManualCoordinatorRun,
   e2eRunFixture,
   exactDiffGateRun,
   HEAD_SHA,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Final merge-gate snapshots now inspect every GitHub status context instead of stopping at the first 100. The checker reads the complete connection twice and fails closed if any page, PR identity, count, cursor chain, or snapshot differs.

## Changes

- Paginate the final GraphQL status-context connection with GitHub CLI cursor handling.
- Require two identical complete page sets before trusting the final PR revision and checks.
- Validate each page against one PR, head commit, base tip, commit count, context count, and non-repeating cursor chain.
- Add regression coverage for more than 100 contexts and for a status change between the two final reads.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This aligns an internal maintainer checker with its existing documented fail-closed contract; it changes no command, configuration, output schema, supported workflow, or product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: A nine-category security review passed with no findings for `540521476c0de5476b7c432500a60edc8b7f408a`: https://github.com/NVIDIA/NemoClaw/pull/8413#pullrequestreview-4869816874
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: No waiver.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change is limited to an internal merge-gate implementation and regression fixtures. Existing maintainer documentation already requires stable PR state and fail-closed handling for missing, malformed, contradictory, or changing evidence.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 540521476c0d -->
<!-- docs-review-agents-blob-sha: 3dd7c2425b70 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` does not change.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — the worktree merge hook could not resolve `COMMIT_EDITMSG`; direct commitlint passed and post-commit `npm run check:diff` passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — final-snapshot tests passed 7/7; the merge-gate suite passed 255 tests together, and its single load-related timeout passed alone, covering all 256 cases.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — `npm run check` is pending; no waiver is recorded.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — not applicable; no documentation changes.
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only) — not applicable; no documentation changes.
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — not applicable; no new page.

---

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Improved validation of pull request status snapshots, including paginated results and revision metadata.
* Prevented evaluations from proceeding when repeated status checks return inconsistent results.
* Ensured all available status checks are included in the final rollup.

* **Tests**
* Added coverage for multi-page status results.
* Added tests confirming that changing status snapshots fail safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->