### PR TITLE
fix(onboard): omit Docker-only Podman config

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -16,6 +16,7 @@ on:
       - "src/lib/onboard/**"
       - "src/lib/domain/sandbox/image-tag.ts"
       - "src/lib/sandbox/build-context.ts"
+      - "test/e2e/live/portable-profile-gateway-proof.ts"
       - "test/e2e/live/portable-profile-rootless-linux.test.ts"
   push:
     branches:
@@ -27,6 +28,7 @@ on:
       - "src/lib/onboard/**"
       - "src/lib/domain/sandbox/image-tag.ts"
       - "src/lib/sandbox/build-context.ts"
+      - "test/e2e/live/portable-profile-gateway-proof.ts"
       - "test/e2e/live/portable-profile-rootless-linux.test.ts"
 
 permissions:

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -13,11 +13,13 @@ on:
       - ".github/workflows/portable-profile-e2e.yaml"
       - "install.sh"
       - "scripts/install.sh"
+      - "scripts/install-openshell.sh"
       - "src/lib/onboard/**"
       - "src/lib/domain/sandbox/image-tag.ts"
       - "src/lib/sandbox/build-context.ts"
       - "test/e2e/live/portable-profile-gateway-proof.ts"
       - "test/e2e/live/portable-profile-rootless-linux.test.ts"
+      - "tools/e2e/check-semantic-phases.mts"
   push:
     branches:
       - main
@@ -25,11 +27,13 @@ on:
       - ".github/workflows/portable-profile-e2e.yaml"
       - "install.sh"
       - "scripts/install.sh"
+      - "scripts/install-openshell.sh"
       - "src/lib/onboard/**"
       - "src/lib/domain/sandbox/image-tag.ts"
       - "src/lib/sandbox/build-context.ts"
       - "test/e2e/live/portable-profile-gateway-proof.ts"
       - "test/e2e/live/portable-profile-rootless-linux.test.ts"
+      - "tools/e2e/check-semantic-phases.mts"
 
 permissions:
   contents: read

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -58,6 +58,11 @@ jobs:
       - name: Build shared policy boundary
         run: npm run build:policy-boundary
 
+      - name: Install pinned OpenShell
+        run: |
+          env -u GH_TOKEN -u GITHUB_TOKEN NEMOCLAW_NON_INTERACTIVE=1 bash scripts/install-openshell.sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Provision restricted rootless Linux runtime
         shell: bash
         run: |

--- a/src/lib/onboard/docker-driver-gateway-config.ts
+++ b/src/lib/onboard/docker-driver-gateway-config.ts
@@ -81,7 +81,10 @@ export function buildDockerDriverGatewayConfigToml(
     ["host_gateway_ip", driver === "podman" ? PORTABLE_HOST_GATEWAY_IP : undefined],
     ["network_name", gatewayEnv.OPENSHELL_DOCKER_NETWORK_NAME],
     ["supervisor_image", gatewayEnv.OPENSHELL_DOCKER_SUPERVISOR_IMAGE],
-    ["supervisor_bin", sandboxBin ?? undefined],
+    // OpenShell 0.0.85 accepts supervisor_bin only for the Docker driver.
+    // The Podman schema rejects the entire driver table when this Docker-only
+    // field is present, so portable onboarding must rely on supervisor_image.
+    ["supervisor_bin", driver === "docker" ? (sandboxBin ?? undefined) : undefined],
     ["guest_tls_ca", localTlsDir ? path.join(localTlsDir, "ca.crt") : undefined],
     ["guest_tls_cert", localTlsDir ? path.join(localTlsDir, "client", "tls.crt") : undefined],
     ["guest_tls_key", localTlsDir ? path.join(localTlsDir, "client", "tls.key") : undefined],

--- a/src/lib/onboard/docker-driver-gateway-env.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.test.ts
@@ -88,6 +88,7 @@ describe("buildDockerDriverGatewayEnv", () => {
       expect(toml).toContain('compute_drivers = ["podman"]');
       expect(toml).toContain("[openshell.drivers.podman]");
       expect(toml).toContain('host_gateway_ip = "169.254.1.2"');
+      expect(toml).not.toContain("supervisor_bin");
     } finally {
       vi.unstubAllEnvs();
       fs.rmSync(stateDir, { recursive: true, force: true });

--- a/test/e2e/live/portable-profile-gateway-proof.ts
+++ b/test/e2e/live/portable-profile-gateway-proof.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+
+import { spawnObservedChild } from "../fixtures/observed-child-process.ts";
+import type { TestProgress } from "../fixtures/progress.ts";
+import { stripAnsi } from "./json-envelope.ts";
+
+/** Prove the pinned gateway accepts the generated rootless Podman configuration. */
+export async function verifyPinnedPodmanGatewayStarts(
+  gatewayBin: string,
+  gatewayEnv: Record<string, string>,
+  progress: TestProgress,
+): Promise<void> {
+  const child = spawnObservedChild(gatewayBin, [], {
+    activityLabel: "command: pinned OpenShell Podman gateway",
+    progress,
+    spawn: {
+      env: { ...process.env, ...gatewayEnv },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  });
+  let output = "";
+  child.stdout?.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  try {
+    const deadline = Date.now() + 15_000;
+    let driverSeenAt = 0;
+    while (Date.now() < deadline) {
+      const plainOutput = stripAnsi(output);
+      if (/configuration error|invalid \[openshell\.drivers\.podman\] table/i.test(plainOutput)) {
+        assert.fail(`Pinned OpenShell rejected the generated Podman config:\n${output}`);
+      }
+      if (child.exitCode !== null) {
+        assert.fail(
+          `Pinned OpenShell Podman gateway exited with ${String(child.exitCode)}:\n${output}`,
+        );
+      }
+      if (/Using compute driver\s+driver=podman/.test(plainOutput)) {
+        if (driverSeenAt === 0) driverSeenAt = Date.now();
+        if (Date.now() - driverSeenAt >= 2_000) return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    assert.fail(`Pinned OpenShell did not keep the Podman driver healthy:\n${output}`);
+  } finally {
+    child.kill("SIGTERM");
+  }
+}

--- a/test/e2e/live/portable-profile-gateway-proof.ts
+++ b/test/e2e/live/portable-profile-gateway-proof.ts
@@ -7,7 +7,7 @@ import { spawnObservedChild } from "../fixtures/observed-child-process.ts";
 import type { TestProgress } from "../fixtures/progress.ts";
 import { stripAnsi } from "./json-envelope.ts";
 
-/** Prove the pinned gateway accepts the generated rootless Podman configuration. */
+/** Verify that the pinned gateway accepts the generated rootless Podman configuration. */
 export async function verifyPinnedPodmanGatewayStarts(
   gatewayBin: string,
   gatewayEnv: Record<string, string>,
@@ -34,7 +34,7 @@ export async function verifyPinnedPodmanGatewayStarts(
     while (Date.now() < deadline) {
       const plainOutput = stripAnsi(output);
       if (/configuration error|invalid \[openshell\.drivers\.podman\] table/i.test(plainOutput)) {
-        assert.fail(`Pinned OpenShell rejected the generated Podman config:\n${output}`);
+        assert.fail(`Pinned OpenShell rejected the generated Podman configuration:\n${output}`);
       }
       if (child.exitCode !== null) {
         assert.fail(
@@ -47,7 +47,9 @@ export async function verifyPinnedPodmanGatewayStarts(
       }
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
-    assert.fail(`Pinned OpenShell did not keep the Podman driver healthy:\n${output}`);
+    assert.fail(
+      `Pinned OpenShell did not report driver=podman and remain running for two seconds:\n${output}`,
+    );
   } finally {
     child.kill("SIGTERM");
   }

--- a/test/e2e/live/portable-profile-rootless-linux.test.ts
+++ b/test/e2e/live/portable-profile-rootless-linux.test.ts
@@ -9,16 +9,24 @@ import os from "node:os";
 import path from "node:path";
 
 import * as importedGatewayEnv from "../../../src/lib/onboard/docker-driver-gateway-env.ts";
+import * as importedGatewayLocalTls from "../../../src/lib/onboard/docker-driver-gateway-local-tls.ts";
 import * as importedPortableHostPreparation from "../../../src/lib/onboard/experimental/portable-host-preparation.ts";
 import * as importedSandboxPrebuild from "../../../src/lib/onboard/sandbox-prebuild.ts";
 import * as importedBuildContext from "../../../src/lib/sandbox/build-context.ts";
 import { test } from "../fixtures/e2e-test.ts";
+import { spawnObservedChild } from "../fixtures/observed-child-process.ts";
+import type { TestProgress } from "../fixtures/progress.ts";
 
 const gatewayEnvModule = (
   "default" in importedGatewayEnv && importedGatewayEnv.default
     ? importedGatewayEnv.default
     : importedGatewayEnv
 ) as typeof import("../../../src/lib/onboard/docker-driver-gateway-env.ts");
+const gatewayLocalTlsModule = (
+  "default" in importedGatewayLocalTls && importedGatewayLocalTls.default
+    ? importedGatewayLocalTls.default
+    : importedGatewayLocalTls
+) as typeof import("../../../src/lib/onboard/docker-driver-gateway-local-tls.ts");
 const portableHostPreparationModule = (
   "default" in importedPortableHostPreparation && importedPortableHostPreparation.default
     ? importedPortableHostPreparation.default
@@ -36,6 +44,7 @@ const buildContextModule = (
 ) as typeof import("../../../src/lib/sandbox/build-context.ts");
 
 const { buildDockerDriverGatewayEnv } = gatewayEnvModule;
+const { ensureDockerDriverGatewayLocalTlsBundle } = gatewayLocalTlsModule;
 const { preparePortableExperimentalHost } = portableHostPreparationModule;
 const { prebuildSandboxImageIfEligible } = sandboxPrebuildModule;
 const { SANDBOX_BUILD_CONTEXT_PREFIX } = buildContextModule;
@@ -46,6 +55,7 @@ const PORTABLE_PROFILE_E2E_PHASES = [
   "select the Podman-reported runtime socket",
   "prepare the rootless container runtime",
   "build and publish the sandbox image",
+  "start the pinned Podman gateway",
   "verify the fixed host route",
   "record portable environment completion",
 ] as const;
@@ -84,6 +94,50 @@ async function waitForRegistry(attempt = 0): Promise<void> {
     : new Promise<void>((resolve) => setTimeout(resolve, 250)).then(() =>
         waitForRegistry(attempt + 1),
       );
+}
+
+async function verifyPinnedPodmanGatewayStarts(
+  gatewayBin: string,
+  gatewayEnv: Record<string, string>,
+  progress: TestProgress,
+): Promise<void> {
+  const child = spawnObservedChild(gatewayBin, [], {
+    activityLabel: "command: pinned OpenShell Podman gateway",
+    progress,
+    spawn: {
+      env: { ...process.env, ...gatewayEnv },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  });
+  let output = "";
+  child.stdout?.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  try {
+    const deadline = Date.now() + 15_000;
+    let driverSeenAt = 0;
+    while (Date.now() < deadline) {
+      if (/configuration error|invalid \[openshell\.drivers\.podman\] table/i.test(output)) {
+        assert.fail(`Pinned OpenShell rejected the generated Podman config:\n${output}`);
+      }
+      if (child.exitCode !== null) {
+        assert.fail(
+          `Pinned OpenShell Podman gateway exited with ${String(child.exitCode)}:\n${output}`,
+        );
+      }
+      if (output.includes("Using compute driver driver=podman")) {
+        if (driverSeenAt === 0) driverSeenAt = Date.now();
+        if (Date.now() - driverSeenAt >= 2_000) return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    assert.fail(`Pinned OpenShell did not keep the Podman driver healthy:\n${output}`);
+  } finally {
+    child.kill("SIGTERM");
+  }
 }
 
 function writeSystemctlShim(binDir: string): void {
@@ -141,7 +195,7 @@ function selectInstallerPodmanRuntime(repoRoot: string): string {
   return run("bash", ["-c", script]);
 }
 
-async function main(progress: { phase: (phase: string) => void }): Promise<void> {
+async function main(progress: TestProgress): Promise<void> {
   assert.equal(process.platform, "linux", "portable profile E2E requires Linux");
   assert.notEqual(process.getuid?.(), 0, "portable profile E2E must run without root privileges");
 
@@ -222,21 +276,32 @@ async function main(progress: { phase: (phase: string) => void }): Promise<void>
       "nemoclaw-portable-registry",
     ]);
 
-    progress.phase("verify the fixed host route");
+    const gatewayBin = run("bash", ["-lc", "command -v openshell-gateway"]);
+    const sandboxBin = run("bash", ["-lc", "command -v openshell-sandbox"]);
     const gatewayEnv = buildDockerDriverGatewayEnv({
       platform: "linux",
-      gatewayPort: 5000,
+      gatewayPort: 8080,
       stateDir,
       getDockerSupervisorImage: () => "supervisor:e2e-not-launched",
-      resolveSandboxBin: () => null,
+      resolveSandboxBin: () => sandboxBin,
     });
     assert.equal(gatewayEnv.OPENSHELL_DRIVERS, "podman");
     assert.equal(gatewayEnv.OPENSHELL_BIND_ADDRESS, "0.0.0.0");
-    assert.equal(gatewayEnv.OPENSHELL_GRPC_ENDPOINT, "https://169.254.1.2:5000");
+    assert.equal(gatewayEnv.OPENSHELL_GRPC_ENDPOINT, "https://169.254.1.2:8080");
     assert.match(
       fs.readFileSync(gatewayEnv.OPENSHELL_GATEWAY_CONFIG, "utf-8"),
       /host_gateway_ip = "169\.254\.1\.2"/,
     );
+    assert.doesNotMatch(
+      fs.readFileSync(gatewayEnv.OPENSHELL_GATEWAY_CONFIG, "utf-8"),
+      /supervisor_bin/,
+    );
+
+    progress.phase("start the pinned Podman gateway");
+    ensureDockerDriverGatewayLocalTlsBundle({ gatewayBin, stateDir });
+    await verifyPinnedPodmanGatewayStarts(gatewayBin, gatewayEnv, progress);
+
+    progress.phase("verify the fixed host route");
 
     const routeProof = [
       "exec 3<>/dev/tcp/169.254.1.2/5000",

--- a/test/e2e/live/portable-profile-rootless-linux.test.ts
+++ b/test/e2e/live/portable-profile-rootless-linux.test.ts
@@ -16,6 +16,7 @@ import * as importedBuildContext from "../../../src/lib/sandbox/build-context.ts
 import { test } from "../fixtures/e2e-test.ts";
 import { spawnObservedChild } from "../fixtures/observed-child-process.ts";
 import type { TestProgress } from "../fixtures/progress.ts";
+import { stripAnsi } from "./json-envelope.ts";
 
 const gatewayEnvModule = (
   "default" in importedGatewayEnv && importedGatewayEnv.default
@@ -120,7 +121,8 @@ async function verifyPinnedPodmanGatewayStarts(
     const deadline = Date.now() + 15_000;
     let driverSeenAt = 0;
     while (Date.now() < deadline) {
-      if (/configuration error|invalid \[openshell\.drivers\.podman\] table/i.test(output)) {
+      const plainOutput = stripAnsi(output);
+      if (/configuration error|invalid \[openshell\.drivers\.podman\] table/i.test(plainOutput)) {
         assert.fail(`Pinned OpenShell rejected the generated Podman config:\n${output}`);
       }
       if (child.exitCode !== null) {
@@ -128,7 +130,7 @@ async function verifyPinnedPodmanGatewayStarts(
           `Pinned OpenShell Podman gateway exited with ${String(child.exitCode)}:\n${output}`,
         );
       }
-      if (output.includes("Using compute driver driver=podman")) {
+      if (/Using compute driver\s+driver=podman/.test(plainOutput)) {
         if (driverSeenAt === 0) driverSeenAt = Date.now();
         if (Date.now() - driverSeenAt >= 2_000) return;
       }

--- a/test/e2e/live/portable-profile-rootless-linux.test.ts
+++ b/test/e2e/live/portable-profile-rootless-linux.test.ts
@@ -14,9 +14,8 @@ import * as importedPortableHostPreparation from "../../../src/lib/onboard/exper
 import * as importedSandboxPrebuild from "../../../src/lib/onboard/sandbox-prebuild.ts";
 import * as importedBuildContext from "../../../src/lib/sandbox/build-context.ts";
 import { test } from "../fixtures/e2e-test.ts";
-import { spawnObservedChild } from "../fixtures/observed-child-process.ts";
 import type { TestProgress } from "../fixtures/progress.ts";
-import { stripAnsi } from "./json-envelope.ts";
+import { verifyPinnedPodmanGatewayStarts } from "./portable-profile-gateway-proof.ts";
 
 const gatewayEnvModule = (
   "default" in importedGatewayEnv && importedGatewayEnv.default
@@ -95,51 +94,6 @@ async function waitForRegistry(attempt = 0): Promise<void> {
     : new Promise<void>((resolve) => setTimeout(resolve, 250)).then(() =>
         waitForRegistry(attempt + 1),
       );
-}
-
-async function verifyPinnedPodmanGatewayStarts(
-  gatewayBin: string,
-  gatewayEnv: Record<string, string>,
-  progress: TestProgress,
-): Promise<void> {
-  const child = spawnObservedChild(gatewayBin, [], {
-    activityLabel: "command: pinned OpenShell Podman gateway",
-    progress,
-    spawn: {
-      env: { ...process.env, ...gatewayEnv },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  });
-  let output = "";
-  child.stdout?.on("data", (chunk) => {
-    output += String(chunk);
-  });
-  child.stderr?.on("data", (chunk) => {
-    output += String(chunk);
-  });
-  try {
-    const deadline = Date.now() + 15_000;
-    let driverSeenAt = 0;
-    while (Date.now() < deadline) {
-      const plainOutput = stripAnsi(output);
-      if (/configuration error|invalid \[openshell\.drivers\.podman\] table/i.test(plainOutput)) {
-        assert.fail(`Pinned OpenShell rejected the generated Podman config:\n${output}`);
-      }
-      if (child.exitCode !== null) {
-        assert.fail(
-          `Pinned OpenShell Podman gateway exited with ${String(child.exitCode)}:\n${output}`,
-        );
-      }
-      if (/Using compute driver\s+driver=podman/.test(plainOutput)) {
-        if (driverSeenAt === 0) driverSeenAt = Date.now();
-        if (Date.now() - driverSeenAt >= 2_000) return;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    assert.fail(`Pinned OpenShell did not keep the Podman driver healthy:\n${output}`);
-  } finally {
-    child.kill("SIGTERM");
-  }
 }
 
 function writeSystemctlShim(binDir: string): void {

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -715,8 +715,26 @@ describe("e2e workflow boundary", () => {
       jobs: Record<string, { env?: Record<string, string>; if?: string }>;
     };
     const workflowJobs = new Set(Object.keys(workflow.jobs));
+    const portableWorkflow = YAML.parse(
+      fs.readFileSync(
+        path.join(process.cwd(), ".github", "workflows", "portable-profile-e2e.yaml"),
+        "utf8",
+      ),
+    ) as {
+      on?: { pull_request?: { paths?: string[] }; push?: { paths?: string[] } };
+    };
+    const portableProofInputs = [
+      "scripts/install-openshell.sh",
+      "test/e2e/live/portable-profile-gateway-proof.ts",
+      "test/e2e/live/portable-profile-rootless-linux.test.ts",
+      "tools/e2e/check-semantic-phases.mts",
+    ];
 
     expect(validateFreeStandingWorkflowInventory()).toEqual([]);
+    expect(portableWorkflow.on?.pull_request?.paths).toEqual(
+      expect.arrayContaining(portableProofInputs),
+    );
+    expect(portableWorkflow.on?.push?.paths).toEqual(expect.arrayContaining(portableProofInputs));
     expect(inventory.allowedJobs).not.toHaveLength(0);
     expect(inventory.targetToJob.size).toBeGreaterThan(0);
     expect(inventory.workflowJobs.every((job) => workflowJobs.has(job))).toBe(true);

--- a/tools/e2e/check-semantic-phases.mts
+++ b/tools/e2e/check-semantic-phases.mts
@@ -388,6 +388,10 @@ const OBSERVED_CHILD_PROGRESS_POLICIES = new Map<string, ObservedChildProgressPo
   ],
   ["test/e2e/live/ollama-auth-proxy.test.ts#spawnLogged", { kind: "path", path: "progress" }],
   [
+    "test/e2e/live/portable-profile-rootless-linux.test.ts#verifyPinnedPodmanGatewayStarts",
+    { kind: "path", path: "progress" },
+  ],
+  [
     "test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts#runCommand",
     { kind: "path", path: "progress" },
   ],

--- a/tools/e2e/check-semantic-phases.mts
+++ b/tools/e2e/check-semantic-phases.mts
@@ -388,7 +388,7 @@ const OBSERVED_CHILD_PROGRESS_POLICIES = new Map<string, ObservedChildProgressPo
   ],
   ["test/e2e/live/ollama-auth-proxy.test.ts#spawnLogged", { kind: "path", path: "progress" }],
   [
-    "test/e2e/live/portable-profile-rootless-linux.test.ts#verifyPinnedPodmanGatewayStarts",
+    "test/e2e/live/portable-profile-gateway-proof.ts#verifyPinnedPodmanGatewayStarts",
     { kind: "path", path: "progress" },
   ],
   [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

Portable onboarding selected the Podman driver but wrote the Docker-only `supervisor_bin` field into `[openshell.drivers.podman]`. OpenShell 0.0.85 rejected that table before the gateway could start.

This change omits `supervisor_bin` for Podman and preserves the existing Docker configuration. It follows the portable runtime override restored by #8408.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- Omit `supervisor_bin` from the generated Podman driver table.
- Preserve `supervisor_bin` in the generated Docker driver table.
- Install pinned OpenShell 0.0.85 in the portable-profile E2E workflow.
- Start the real rootless Podman gateway and fail if OpenShell rejects the generated configuration or exits.
- Trigger the portable-profile workflow when its gateway-proof or pinned-runtime helpers change.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change repairs generated configuration for an existing hidden experimental profile. No supported public command, default, or workflow changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Aaron Erickson reviewed the driver-schema boundary. The [exact-head rootless runner](https://github.com/NVIDIA/NemoClaw/actions/runs/31062172724) installs pinned OpenShell 0.0.85 and starts the real Podman gateway.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Omits a Docker-only field from the generated configuration for an existing hidden experimental profile and adds pinned OpenShell E2E evidence. No supported public command, default, or workflow changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9403b99ef -->
<!-- docs-review-agents-blob-sha: 3dd7c2425 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: [E2E / Portable Profile](https://github.com/NVIDIA/NemoClaw/actions/runs/31062172724) passed on `91daf0836`; `npm run typecheck` and `npm run test:e2e-phases:check` passed locally.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: [CI / Pull Request](https://github.com/NVIDIA/NemoClaw/actions/runs/31062172715) passed on `91daf0836`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
