### PR TITLE
fix(ci): scale PR E2E evidence traversal budget

### DIFF
--- a/test/pr-e2e-gate-evidence-limits.test.ts
+++ b/test/pr-e2e-gate-evidence-limits.test.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { evidenceEntryLimit } from "../tools/e2e/pr-e2e-gate.mts";
+
+describe("PR E2E gate evidence traversal limits", () => {
+  it("scales the entry budget with expected signals under a hard ceiling", () => {
+    expect(evidenceEntryLimit(1)).toBe(1_280);
+    expect(evidenceEntryLimit(28)).toBe(8_192);
+    expect(evidenceEntryLimit(1_000)).toBe(16_384);
+    expect(() => evidenceEntryLimit(0)).toThrow(/signal count is invalid/u);
+    expect(() => evidenceEntryLimit(Number.NaN)).toThrow(/signal count is invalid/u);
+  });
+});

--- a/tools/e2e/pr-e2e-gate.mts
+++ b/tools/e2e/pr-e2e-gate.mts
@@ -139,7 +139,9 @@ const EVIDENCE_DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
 const EVIDENCE_DOWNLOAD_KILL_GRACE_MS = 30_000;
 const EVIDENCE_LIMITS = {
   maxDepth: 8,
-  maxEntries: 4096,
+  baseEntries: 1024,
+  entriesPerExpectedSignal: 256,
+  maxEntries: 16_384,
 } as const;
 
 type ControllerPaths = {
@@ -3634,6 +3636,16 @@ export function findSignalFiles(
   return files.sort((left, right) => left.localeCompare(right));
 }
 
+export function evidenceEntryLimit(expectedSignalCount: number): number {
+  if (!Number.isSafeInteger(expectedSignalCount) || expectedSignalCount < 1) {
+    throw new Error("E2E expected signal count is invalid");
+  }
+  return Math.min(
+    EVIDENCE_LIMITS.maxEntries,
+    EVIDENCE_LIMITS.baseEntries + expectedSignalCount * EVIDENCE_LIMITS.entriesPerExpectedSignal,
+  );
+}
+
 export async function finishPrGate(options: {
   statePath: string;
   stateHash: string;
@@ -3737,7 +3749,8 @@ export async function finishPrGate(options: {
         throw error;
       }
       const signals = findSignalFiles(options.evidencePath, {
-        ...EVIDENCE_LIMITS,
+        maxDepth: EVIDENCE_LIMITS.maxDepth,
+        maxEntries: evidenceEntryLimit(expectedSignalCount),
         maxSignalFiles: expectedSignalCount + 1,
       }).map((file) => validateSignal(readRegularJson(file), state));
       verdict = classifyPrGateEvidence({


### PR DESCRIPTION
## Summary

- scale the trusted PR E2E evidence traversal budget with the number of expected risk signals
- retain the existing depth, symlink, signal-count, and hard 16,384-entry guards
- add focused coverage for normal, capped, and invalid signal counts

## Why

PR #8272 produced a successful protected child run with all 30 selected jobs green and a 4,447-entry extracted evidence tree. Its trusted coordinator runs from the base workflow SHA, where the fixed 4,096-entry ceiling rejected that valid evidence before classification.

This is a prerequisite for #8272 because the trusted controller intentionally executes from main rather than from untrusted PR-head code. For 28 expected signals, this patch permits 8,192 entries while preserving the 16,384 hard ceiling.

## Validation

- focused evidence-limit test: 1 passed
- pre-push TypeScript CLI check: passed

Evidence: protected child run 31061954929 succeeded; coordinator run 31061923643 failed only with E2E evidence exceeds the entry limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence processing limits now scale with the expected number of signals.
  * Increased the maximum evidence entry limit to support larger test runs.
  * Existing depth and signal-file safeguards remain in place.

* **Bug Fixes**
  * Invalid signal counts, including zero and `NaN`, are now rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- Refresh current signed PR metadata after stale DCO event replay. -->