### PR TITLE
feat(voice): add experimental committed-turn gateway

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -12,7 +12,7 @@
       "src/lib/adapters/openshell/timeouts.ts": 37,
       "src/lib/agent/defs.ts": 32,
       "src/lib/cli/branding.ts": 87,
-      "src/lib/cli/nemoclaw-oclif-command.ts": 104,
+      "src/lib/cli/nemoclaw-oclif-command.ts": 105,
       "src/lib/cli/terminal-style.ts": 45,
       "src/lib/core/json-types.ts": 37,
       "src/lib/core/ports.ts": 88,

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3789,16 +3789,15 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 ## Internal Commands
 
 NemoClaw registers a hidden `internal` command namespace. These commands are
-compatibility entrypoints for repo-owned scripts, such as the installer, the
-uninstaller, DNS setup, and developer tooling. They are not part of the
-supported public CLI surface.
+compatibility entrypoints for repo-owned scripts and experimental services.
+They are not part of the supported public CLI surface.
 
 Each command class sets `hidden = true`, so the commands stay out of
 `$$nemoclaw --help`. They remain registered and routable, which is why they are
 listed here for reference. Treat their names, flags, and output as
 implementation details. They exist to back `install.sh`, `uninstall.sh`, and
-related automation, and they may change or be removed without notice. Most run
-indirectly through those scripts rather than being typed by hand.
+related automation, and they may change or be removed without notice.
+Most run indirectly through those scripts rather than being typed by hand.
 
 For contributor guidance on how these command files are structured, refer to
 `src/commands/internal/README.md`.
@@ -3814,11 +3813,69 @@ For contributor guidance on how these command files are structured, refer to
 | `$$nemoclaw internal dns setup-proxy` | onboarding / sandbox setup | Configure the DNS forwarder bridge inside a sandbox pod. |
 | `$$nemoclaw internal dns fix-coredns` | onboarding / sandbox setup | Patch CoreDNS to use a non-loopback upstream resolver. |
 | `$$nemoclaw internal dev npm-link-or-shim` | `scripts/npm-link-or-shim.sh` (development) | Run `npm link`, falling back to a user-local NemoClaw development shim. |
+<AgentOnly variant="openclaw">
+| `$$nemoclaw internal voice-gateway serve` | Operator-started foreground service | Start the loopback-only experimental committed-turn gateway for one configured OpenClaw agent. |
+</AgentOnly>
 
 These commands do not appear in the command-level parity check, which compares
 `$$nemoclaw --help` against the public command headings in this reference; hidden
 commands are excluded from both. The table above is the canonical reference for
 the family.
+
+<AgentOnly variant="openclaw">
+
+### Experimental Voice Gateway
+
+The voice gateway is a private experimental runtime adapter for one configured OpenClaw agent.
+It is not a public protocol or a VoiceClaw, ElevenLabs, Hermes, Deep Agents, or general voice support claim.
+An operator starts it as a foreground service.
+NemoClaw does not install, start, restart, or supervise it, and onboarding and managed startup do not launch it.
+
+Before startup, provision separate deployment admission and OpenClaw agent gateway credentials at absolute paths outside the repository.
+Each file must be a current-user-owned regular file that group and other users cannot access.
+User-owned parent directories must not be writable by group or other users.
+The service rejects symbolic-link files and symbolic-link parent directories.
+Each credential contains 32–4,096 printable non-whitespace ASCII bytes; one trailing newline is accepted.
+NemoClaw does not create, distribute, rotate, recover, or delete these files. The files persist until the operator removes them. Removing a file does not revoke a value already loaded by the running process; rotation requires stopping and restarting the service.
+The runtime uses the deployment admission credential only to create a session and never receives the OpenClaw agent gateway credential.
+The runtime keeps its raw session grant in process memory. NemoClaw stores only its hash and removes the binding on close or expiry.
+
+Set `NEMOCLAW_EXPERIMENTAL_VOICE_GATEWAY=1` exactly.
+Any other value fails before the service reads credentials or creates a listener.
+Run the command with all required operator-controlled values:
+
+```bash
+NEMOCLAW_EXPERIMENTAL_VOICE_GATEWAY=1 $$nemoclaw internal voice-gateway serve \
+  --admission-credential-file /absolute/path/admission \
+  --openclaw-credential-file /absolute/path/openclaw \
+  --openclaw-endpoint ws://127.0.0.1:18789/ws \
+  --runtime-id local-runtime \
+  --runtime-profile pinned-profile \
+  --sandbox my-sandbox \
+  --agent main
+```
+
+The service binds only to `127.0.0.1`.
+The required running endpoint form is `ws://127.0.0.1:<port>/ws`.
+The optional `--listen-port` defaults to `18800` and accepts `1024`–`65535`.
+The optional `--session-lifetime-ms` defaults to `300000` and accepts `1`–`900000`.
+The optional `--turn-timeout-ms` defaults to `90000` and accepts `1`–`120000`.
+This slice allows one in-memory voice session and one committed turn.
+
+Verify listener responsiveness:
+
+```bash
+curl --silent --show-error --output /dev/null --write-out '%{http_code}\n' \
+  http://127.0.0.1:18800/healthz
+```
+
+The expected output is `204`.
+This check confirms listener responsiveness only, not agent compatibility.
+Send `SIGINT` or `SIGTERM` to stop the process; process exit removes in-memory session state.
+The service emits structured lifecycle diagnostics without credentials or conversational content.
+
+</AgentOnly>
+
 
 ## Environment Variables
 

--- a/src/commands/internal/README.md
+++ b/src/commands/internal/README.md
@@ -3,7 +3,7 @@
 
 # Internal commands
 
-Hidden `nemoclaw internal ...` commands are compatibility entrypoints for repo-owned scripts and migration helpers. They are not a public API.
+Hidden `nemoclaw internal ...` commands are compatibility entrypoints for repo-owned scripts, migration helpers, and explicitly gated experimental foreground services. They remain hidden and outside the supported public CLI.
 
 Keep command files thin:
 

--- a/src/commands/internal/voice-gateway/serve.ts
+++ b/src/commands/internal/voice-gateway/serve.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flags } from "@oclif/core";
+import {
+  DEFAULT_VOICE_GATEWAY_PORT,
+  runVoiceGatewayAction,
+} from "../../../lib/actions/voice-gateway/serve";
+import {
+  VOICE_MAX_SESSION_LIFETIME_MS,
+  VOICE_MAX_TURN_TIMEOUT_MS,
+} from "../../../lib/domain/voice/session-service";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
+
+export default class InternalVoiceGatewayServeCommand extends NemoClawCommand {
+  static hidden = true;
+  static strict = true;
+  static summary = "Internal: serve the experimental voice gateway";
+  static description =
+    "Serve the loopback-only runtime-to-agent boundary for one configured OpenClaw agent.";
+  static usage = [
+    "internal voice-gateway serve --admission-credential-file <path> --openclaw-credential-file <path> --openclaw-endpoint <url> --runtime-id <id> --runtime-profile <profile> --sandbox <name> --agent <id>",
+  ];
+  static flags = {
+    "admission-credential-file": Flags.string({
+      required: true,
+      description: "Owner-only deployment credential file",
+    }),
+    "openclaw-credential-file": Flags.string({
+      required: true,
+      description: "Owner-only OpenClaw credential file",
+    }),
+    "openclaw-endpoint": Flags.string({
+      required: true,
+      description: "Configured loopback OpenClaw WebSocket endpoint",
+    }),
+    "runtime-id": Flags.string({
+      required: true,
+      description: "Configured runtime deployment identity",
+    }),
+    "runtime-profile": Flags.string({ required: true, description: "Configured runtime profile" }),
+    sandbox: Flags.string({ required: true, description: "Configured sandbox" }),
+    agent: Flags.string({ required: true, description: "Configured OpenClaw agent" }),
+    "listen-port": Flags.integer({
+      default: DEFAULT_VOICE_GATEWAY_PORT,
+      min: 1024,
+      max: 65_535,
+      description: "Loopback HTTP listener port",
+    }),
+    "session-lifetime-ms": Flags.integer({
+      min: 1,
+      max: VOICE_MAX_SESSION_LIFETIME_MS,
+      description: "Voice session lifetime in milliseconds",
+    }),
+    "turn-timeout-ms": Flags.integer({
+      min: 1,
+      max: VOICE_MAX_TURN_TIMEOUT_MS,
+      description: "Committed-turn deadline in milliseconds",
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(InternalVoiceGatewayServeCommand);
+    await runVoiceGatewayAction({
+      admissionCredentialFile: flags["admission-credential-file"],
+      openClawCredentialFile: flags["openclaw-credential-file"],
+      openClawEndpoint: flags["openclaw-endpoint"],
+      runtimeId: flags["runtime-id"],
+      runtimeProfile: flags["runtime-profile"],
+      sandbox: flags.sandbox,
+      agent: flags.agent,
+      listenPort: flags["listen-port"],
+      sessionLifetimeMs: flags["session-lifetime-ms"],
+      turnTimeoutMs: flags["turn-timeout-ms"],
+    });
+  }
+}

--- a/src/lib/actions/voice-gateway/serve.test.ts
+++ b/src/lib/actions/voice-gateway/serve.test.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EventEmitter } from "node:events";
+import { createServer } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { runVoiceGatewayAction, VOICE_GATEWAY_FEATURE_FLAG } from "./serve";
+
+const options = {
+  admissionCredentialFile: "/private/admission",
+  openClawCredentialFile: "/private/openclaw",
+  openClawEndpoint: "ws://127.0.0.1:18789/ws",
+  runtimeId: "runtime-a",
+  runtimeProfile: "voiceclaw-pinned",
+  sandbox: "sandbox-a",
+  agent: "main",
+  listenPort: 18_801,
+};
+
+describe("experimental voice gateway action", () => {
+  it("fails before reading credentials or creating a listener when disabled (#8378)", async () => {
+    const readCredential = vi.fn();
+    const createGatewayServer = vi.fn();
+
+    await expect(
+      runVoiceGatewayAction(options, {
+        environment: {},
+        readCredential,
+        createServer: createGatewayServer,
+      }),
+    ).rejects.toThrow(VOICE_GATEWAY_FEATURE_FLAG);
+    expect(readCredential).not.toHaveBeenCalled();
+    expect(createGatewayServer).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    undefined,
+    "",
+    "true",
+    "yes",
+    "0",
+    "01",
+  ])("does not accept another experimental flag value %s (#8378)", async (value) => {
+    await expect(
+      runVoiceGatewayAction(options, {
+        environment: value === undefined ? {} : { [VOICE_GATEWAY_FEATURE_FLAG]: value },
+        readCredential: vi.fn(),
+      }),
+    ).rejects.toThrow("disabled");
+  });
+
+  it("reads separate credentials after the exact feature gate passes (#8378)", async () => {
+    const events = new EventEmitter();
+    const readCredential = vi
+      .fn()
+      .mockReturnValueOnce("deployment-admission-credential-value-123456")
+      .mockReturnValueOnce("openclaw-gateway-credential-value-12345678");
+    const server = createServer();
+    const createGatewayServer = vi.fn(() => server);
+    const running = runVoiceGatewayAction(options, {
+      environment: { [VOICE_GATEWAY_FEATURE_FLAG]: "1", NEMOCLAW_EXPERIMENTAL_OTHER: "1" },
+      readCredential,
+      createServer: createGatewayServer,
+      processEvents: events,
+      log: vi.fn(),
+    });
+    await vi.waitFor(() => expect(server.listening).toBe(true));
+    events.emit("SIGTERM");
+    await running;
+
+    expect(readCredential.mock.calls).toEqual([
+      ["/private/admission", "Voice deployment credential"],
+      ["/private/openclaw", "OpenClaw agent gateway credential"],
+    ]);
+    expect(createGatewayServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        admissionCredential: "deployment-admission-credential-value-123456",
+      }),
+    );
+  });
+});

--- a/src/lib/actions/voice-gateway/serve.ts
+++ b/src/lib/actions/voice-gateway/serve.ts
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Server } from "node:http";
+
+import { readPrivateCredentialFile } from "../../adapters/fs/private-credential";
+import { createVoiceGatewayServer } from "../../adapters/http/voice-gateway";
+import { OpenClawVoiceAgentClient } from "../../adapters/openclaw/voice-agent-client";
+import { type VoiceDiagnostic, VoiceSessionService } from "../../domain/voice/session-service";
+
+export const VOICE_GATEWAY_FEATURE_FLAG = "NEMOCLAW_EXPERIMENTAL_VOICE_GATEWAY";
+export const DEFAULT_VOICE_GATEWAY_PORT = 18_800;
+export const DEFAULT_VOICE_SESSION_LIFETIME_MS = 5 * 60_000;
+export const DEFAULT_VOICE_TURN_TIMEOUT_MS = 90_000;
+const LOOPBACK_ADDRESS = "127.0.0.1";
+
+type VoiceGatewaySignal = "SIGINT" | "SIGTERM";
+
+interface ProcessEvents {
+  once(event: VoiceGatewaySignal, listener: () => void): unknown;
+  removeListener(event: VoiceGatewaySignal, listener: () => void): unknown;
+}
+
+export interface VoiceGatewayActionOptions {
+  admissionCredentialFile: string;
+  openClawCredentialFile: string;
+  openClawEndpoint: string;
+  listenPort?: number;
+  runtimeId: string;
+  runtimeProfile: string;
+  sandbox: string;
+  agent: string;
+  sessionLifetimeMs?: number;
+  turnTimeoutMs?: number;
+}
+
+export interface VoiceGatewayActionDeps {
+  environment?: NodeJS.ProcessEnv;
+  readCredential?: typeof readPrivateCredentialFile;
+  createServer?: typeof createVoiceGatewayServer;
+  createAgentClient?: () => OpenClawVoiceAgentClient;
+  processEvents?: ProcessEvents;
+  log?: (message: string) => void;
+}
+
+function validatePort(value: number): void {
+  if (!Number.isInteger(value) || value < 1024 || value > 65_535) {
+    throw new Error("Voice gateway listen port must be an integer between 1024 and 65535.");
+  }
+}
+
+function validateTrustedName(value: string, label: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(value)) {
+    throw new Error(`${label} is invalid.`);
+  }
+}
+
+function listen(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(port, LOOPBACK_ADDRESS, () => {
+      server.removeListener("error", onError);
+      resolve();
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+export async function runVoiceGatewayAction(
+  options: VoiceGatewayActionOptions,
+  deps: VoiceGatewayActionDeps = {},
+): Promise<void> {
+  const environment = deps.environment ?? process.env;
+  if (environment[VOICE_GATEWAY_FEATURE_FLAG] !== "1") {
+    throw new Error(
+      `Experimental voice gateway is disabled. Set ${VOICE_GATEWAY_FEATURE_FLAG}=1 to enable it.`,
+    );
+  }
+
+  const listenPort = options.listenPort ?? DEFAULT_VOICE_GATEWAY_PORT;
+  const sessionLifetimeMs = options.sessionLifetimeMs ?? DEFAULT_VOICE_SESSION_LIFETIME_MS;
+  const turnTimeoutMs = options.turnTimeoutMs ?? DEFAULT_VOICE_TURN_TIMEOUT_MS;
+  validatePort(listenPort);
+  validateTrustedName(options.runtimeId, "Voice runtime identity");
+  validateTrustedName(options.runtimeProfile, "Voice runtime profile");
+  validateTrustedName(options.sandbox, "Voice sandbox");
+  validateTrustedName(options.agent, "Voice agent");
+
+  const readCredential = deps.readCredential ?? readPrivateCredentialFile;
+  const admissionCredential = readCredential(
+    options.admissionCredentialFile,
+    "Voice deployment credential",
+  );
+  const openClawCredential = readCredential(
+    options.openClawCredentialFile,
+    "OpenClaw agent gateway credential",
+  );
+  const diagnostic = (value: VoiceDiagnostic) => {
+    (deps.log ?? console.log)(
+      JSON.stringify({ component: "experimental-voice-gateway", ...value }),
+    );
+  };
+  const sessionService = new VoiceSessionService({
+    runtimeId: options.runtimeId,
+    runtimeProfile: options.runtimeProfile,
+    sandbox: options.sandbox,
+    agent: options.agent,
+    sessionLifetimeMs,
+    turnTimeoutMs,
+    diagnostic,
+    createAgentClient:
+      deps.createAgentClient ??
+      (() =>
+        new OpenClawVoiceAgentClient({
+          endpoint: options.openClawEndpoint,
+          credential: openClawCredential,
+          requestTimeoutMs: turnTimeoutMs,
+        })),
+  });
+  const server = (deps.createServer ?? createVoiceGatewayServer)({
+    admissionCredential,
+    sessionService,
+  });
+  const processEvents = deps.processEvents ?? process;
+  let resolveShutdown: () => void = () => {};
+  let rejectShutdown: (error: Error) => void = () => {};
+  const shutdown = new Promise<void>((resolve, reject) => {
+    resolveShutdown = resolve;
+    rejectShutdown = reject;
+  });
+  const onSignal = () => resolveShutdown();
+  const onClose = () => resolveShutdown();
+  const onError = (error: Error) => rejectShutdown(error);
+  processEvents.once("SIGINT", onSignal);
+  processEvents.once("SIGTERM", onSignal);
+  try {
+    await listen(server, listenPort);
+    server.once("close", onClose);
+    server.once("error", onError);
+    diagnostic({ event: "service.started", state: "experimental" });
+    await shutdown;
+  } finally {
+    processEvents.removeListener("SIGINT", onSignal);
+    processEvents.removeListener("SIGTERM", onSignal);
+    server.removeListener("close", onClose);
+    server.removeListener("error", onError);
+    await close(server);
+  }
+}

--- a/src/lib/adapters/fs/private-credential.test.ts
+++ b/src/lib/adapters/fs/private-credential.test.ts
@@ -71,8 +71,13 @@ describe("private voice credential files", () => {
         readPrivateCredentialFile(path.join(linkDirectory, "credential"), "Voice credential"),
       ).toThrow("symlink");
     } finally {
-      if (originalHome === undefined) delete process.env.HOME;
-      else process.env.HOME = originalHome;
+      const restoreHome =
+        originalHome === undefined
+          ? () => delete process.env.HOME
+          : () => {
+              process.env.HOME = originalHome;
+            };
+      restoreHome();
       fs.rmSync(item.directory, { recursive: true, force: true });
     }
   });

--- a/src/lib/adapters/fs/private-credential.test.ts
+++ b/src/lib/adapters/fs/private-credential.test.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { readPrivateCredentialFile } from "./private-credential";
+
+const value = "owner-only-credential-value-with-32-bytes";
+
+function fixture(mode = 0o600) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-voice-credential-"));
+  const file = path.join(directory, "credential");
+  fs.writeFileSync(file, `${value}\n`, { mode });
+  return { directory, file };
+}
+
+describe("private voice credential files", () => {
+  it("reads an owner-only regular file with one trailing newline (#8378)", () => {
+    const item = fixture();
+    try {
+      expect(readPrivateCredentialFile(item.file, "Voice credential")).toBe(value);
+    } finally {
+      fs.rmSync(item.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects symbolic links and group-readable files (#8378)", () => {
+    const item = fixture(0o640);
+    const link = path.join(item.directory, "link");
+    fs.symlinkSync(item.file, link);
+    try {
+      expect(() => readPrivateCredentialFile(item.file, "Voice credential")).toThrow(
+        "group or others",
+      );
+      expect(() => readPrivateCredentialFile(link, "Voice credential")).toThrow(
+        "must not be a symbolic link",
+      );
+    } finally {
+      fs.rmSync(item.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects relative, malformed, and oversized values (#8378)", () => {
+    const item = fixture();
+    try {
+      expect(() => readPrivateCredentialFile("relative", "Voice credential")).toThrow("absolute");
+      fs.writeFileSync(item.file, "short", { mode: 0o600 });
+      expect(() => readPrivateCredentialFile(item.file, "Voice credential")).toThrow("malformed");
+      fs.writeFileSync(item.file, "a".repeat(5000), { mode: 0o600 });
+      expect(() => readPrivateCredentialFile(item.file, "Voice credential")).toThrow(
+        "invalid size",
+      );
+    } finally {
+      fs.rmSync(item.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a credential reached through a symbolic-link directory (#8378)", () => {
+    const item = fixture();
+    const originalHome = process.env.HOME;
+    process.env.HOME = item.directory;
+    const realDirectory = path.join(item.directory, "real-parent");
+    const linkDirectory = path.join(item.directory, "linked-parent");
+    fs.mkdirSync(realDirectory);
+    fs.writeFileSync(path.join(realDirectory, "credential"), value, { mode: 0o600 });
+    fs.symlinkSync(realDirectory, linkDirectory);
+    try {
+      expect(() =>
+        readPrivateCredentialFile(path.join(linkDirectory, "credential"), "Voice credential"),
+      ).toThrow("symlink");
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      fs.rmSync(item.directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/adapters/fs/private-credential.test.ts
+++ b/src/lib/adapters/fs/private-credential.test.ts
@@ -59,8 +59,6 @@ describe("private voice credential files", () => {
 
   it("rejects a credential reached through a symbolic-link directory (#8378)", () => {
     const item = fixture();
-    const originalHome = process.env.HOME;
-    process.env.HOME = item.directory;
     const realDirectory = path.join(item.directory, "real-parent");
     const linkDirectory = path.join(item.directory, "linked-parent");
     fs.mkdirSync(realDirectory);
@@ -71,13 +69,6 @@ describe("private voice credential files", () => {
         readPrivateCredentialFile(path.join(linkDirectory, "credential"), "Voice credential"),
       ).toThrow("symlink");
     } finally {
-      const restoreHome =
-        originalHome === undefined
-          ? () => delete process.env.HOME
-          : () => {
-              process.env.HOME = originalHome;
-            };
-      restoreHome();
       fs.rmSync(item.directory, { recursive: true, force: true });
     }
   });

--- a/src/lib/adapters/fs/private-credential.ts
+++ b/src/lib/adapters/fs/private-credential.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+export const MAX_PRIVATE_CREDENTIAL_BYTES = 4096;
+
+function validateCredential(value: string, label: string): void {
+  if (
+    Buffer.byteLength(value) < 32 ||
+    Buffer.byteLength(value) > MAX_PRIVATE_CREDENTIAL_BYTES ||
+    !/^[\x21-\x7e]+$/u.test(value)
+  ) {
+    throw new Error(`${label} is malformed.`);
+  }
+}
+
+function validateCredentialDirectoryChain(directory: string, label: string): void {
+  let current = directory;
+  while (current !== path.dirname(current)) {
+    const stat = fs.lstatSync(current);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`${label} directory must not be a symlink.`);
+    }
+    if (!stat.isDirectory()) throw new Error(`${label} parent path is not a directory.`);
+    if (typeof process.getuid !== "function" || stat.uid !== process.getuid()) break;
+    if ((stat.mode & 0o022) !== 0) {
+      throw new Error(`${label} directory must not be writable by group or others.`);
+    }
+    current = path.dirname(current);
+  }
+}
+
+/** Read one owner-only credential without following its final path component. */
+export function readPrivateCredentialFile(filePath: string, label: string): string {
+  if (!path.isAbsolute(filePath)) throw new Error(`${label} file path must be absolute.`);
+  validateCredentialDirectoryChain(path.dirname(filePath), label);
+  if (typeof fs.constants.O_NOFOLLOW !== "number") {
+    throw new Error(
+      "This platform does not support opening credential files without following symbolic links.",
+    );
+  }
+  let descriptor: number | undefined;
+  try {
+    try {
+      descriptor = fs.openSync(
+        filePath,
+        fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | (fs.constants.O_NONBLOCK ?? 0),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+        throw new Error(`${label} file must not be a symbolic link.`);
+      }
+      throw error;
+    }
+    const stat = fs.fstatSync(descriptor);
+    if (!stat.isFile()) throw new Error(`${label} path is not a regular file.`);
+    if ((stat.mode & 0o077) !== 0) {
+      throw new Error(`${label} file must not be accessible by group or others.`);
+    }
+    if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+      throw new Error(`${label} file is not owned by the current user.`);
+    }
+    if (stat.size < 1 || stat.size > MAX_PRIVATE_CREDENTIAL_BYTES + 1) {
+      throw new Error(`${label} file has an invalid size.`);
+    }
+    const buffer = Buffer.alloc(MAX_PRIVATE_CREDENTIAL_BYTES + 2);
+    const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
+    if (bytesRead > MAX_PRIVATE_CREDENTIAL_BYTES + 1) {
+      throw new Error(`${label} file has an invalid size.`);
+    }
+    const contents = buffer.subarray(0, bytesRead).toString("utf8");
+    const value = contents.endsWith("\n") ? contents.slice(0, -1) : contents;
+    validateCredential(value, label);
+    return value;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}

--- a/src/lib/adapters/http/voice-gateway.test.ts
+++ b/src/lib/adapters/http/voice-gateway.test.ts
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type VoiceAgentClient, VoiceSessionService } from "../../domain/voice/session-service";
+import { createVoiceGatewayServer } from "./voice-gateway";
+
+const admission = "deployment-admission-credential-value-123456";
+const servers: ReturnType<typeof createVoiceGatewayServer>[] = [];
+
+function makeService(invoke?: VoiceAgentClient["invoke"]) {
+  return new VoiceSessionService({
+    runtimeId: "runtime-a",
+    runtimeProfile: "voiceclaw-pinned",
+    sandbox: "sandbox-a",
+    agent: "main",
+    sessionLifetimeMs: 60_000,
+    turnTimeoutMs: 1_000,
+    createAgentClient: () => ({
+      close: vi.fn(),
+      invoke:
+        invoke ??
+        (async (request) => {
+          request.onRun("expected-run");
+          request.onText("fixture output");
+        }),
+    }),
+  });
+}
+
+async function start(service = makeService()) {
+  const server = createVoiceGatewayServer({
+    admissionCredential: admission,
+    sessionService: service,
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return { service, base: `http://127.0.0.1:${port}` };
+}
+
+async function create(
+  base: string,
+  credential = admission,
+  body: Record<string, unknown> = { runtimeConversationId: "conversation-a" },
+) {
+  const response = await fetch(`${base}/v1/voice-sessions`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { response, body: (await response.json()) as Record<string, string> };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+});
+
+describe("experimental voice HTTP adapter", () => {
+  it("keeps the health check content-free without authenticating (#8378)", async () => {
+    const { base } = await start();
+    const response = await fetch(`${base}/healthz`);
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+  });
+
+  it("requires the deployment credential before session admission (#8378)", async () => {
+    const { base, service } = await start();
+    const missing = await fetch(`${base}/v1/voice-sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runtimeConversationId: "conversation-a" }),
+    });
+    const incorrect = await create(base, "incorrect-credential-value-with-32-bytes");
+
+    expect(missing.status).toBe(401);
+    expect(incorrect.response.status).toBe(401);
+    expect(service.getBindingForTest()).toBeUndefined();
+  });
+
+  it("rejects runtime-selected forwarding and agent fields (#8378)", async () => {
+    const { base, service } = await start();
+    const result = await create(base, admission, {
+      runtimeConversationId: "conversation-a",
+      agent: "attacker-agent",
+      openClawEndpoint: "ws://attacker.example",
+    });
+
+    expect(result.response.status).toBe(400);
+    expect(result.body).toEqual({ error: "invalid_request" });
+    expect(service.getBindingForTest()).toBeUndefined();
+  });
+
+  it("streams normalized NDJSON and does not expose OpenClaw credentials or frames (#8378)", async () => {
+    const { base } = await start();
+    const admitted = await create(base);
+    const response = await fetch(
+      `${base}/v1/voice-sessions/${admitted.body.voiceSessionId}/turns`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${admitted.body.grant}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ commitId: "commit-a", text: "repository status" }),
+      },
+    );
+    const text = await response.text();
+    const events = text
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/x-ndjson");
+    expect(events.map((event) => event.type)).toEqual([
+      "response.started",
+      "response.text.delta",
+      "response.completed",
+    ]);
+    expect(text).not.toContain("chat.send");
+    expect(text).not.toContain("expected-run");
+    expect(text).not.toContain(admission);
+  });
+
+  it("scopes the session grant and returns bounded conflict results (#8378)", async () => {
+    let finish!: () => void;
+    const invoke = vi.fn<VoiceAgentClient["invoke"]>(
+      () => new Promise<void>((resolve) => (finish = resolve)),
+    );
+    const { base } = await start(makeService(invoke));
+    const admitted = await create(base);
+    const turnUrl = `${base}/v1/voice-sessions/${admitted.body.voiceSessionId}/turns`;
+    const first = fetch(turnUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${admitted.body.grant}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ commitId: "commit-a", text: "first" }),
+    });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    const overlapping = await fetch(turnUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${admitted.body.grant}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ commitId: "commit-b", text: "second" }),
+    });
+
+    expect(overlapping.status).toBe(409);
+    finish();
+    await first;
+    const duplicate = await fetch(turnUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${admitted.body.grant}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ commitId: "commit-a", text: "first" }),
+    });
+    expect(duplicate.status).toBe(409);
+    expect(invoke).toHaveBeenCalledOnce();
+  });
+
+  it("rejects oversized turn requests before invoking the agent (#8378)", async () => {
+    const invoke = vi.fn<VoiceAgentClient["invoke"]>();
+    const { base } = await start(makeService(invoke));
+    const admitted = await create(base);
+    const response = await fetch(
+      `${base}/v1/voice-sessions/${admitted.body.voiceSessionId}/turns`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${admitted.body.grant}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ commitId: "commit-a", text: "x".repeat(21 * 1024) }),
+      },
+    );
+
+    expect(response.status).toBe(413);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("revokes the grant when the runtime closes the session (#8378)", async () => {
+    const { base, service } = await start();
+    const admitted = await create(base);
+    const response = await fetch(`${base}/v1/voice-sessions/${admitted.body.voiceSessionId}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${admitted.body.grant}` },
+    });
+    const reuse = await fetch(`${base}/v1/voice-sessions/${admitted.body.voiceSessionId}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${admitted.body.grant}` },
+    });
+
+    expect(response.status).toBe(204);
+    expect(reuse.status).toBe(404);
+    expect(service.getBindingForTest()).toBeUndefined();
+  });
+});

--- a/src/lib/adapters/http/voice-gateway.ts
+++ b/src/lib/adapters/http/voice-gateway.ts
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from "node:crypto";
+import http from "node:http";
+import {
+  type VoiceResponseEvent,
+  VoiceSessionError,
+  type VoiceSessionService,
+} from "../../domain/voice/session-service";
+
+const MAX_HEADER_BYTES = 16 * 1024;
+const MAX_SESSION_BODY_BYTES = 1024;
+const MAX_TURN_BODY_BYTES = 20 * 1024;
+const BODY_TIMEOUT_MS = 10_000;
+const MAX_STREAM_BUFFER_BYTES = 64 * 1024;
+
+class VoiceHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+  ) {
+    super(code);
+  }
+}
+
+function hashCredential(value: string): Buffer {
+  return crypto.createHash("sha256").update(value).digest();
+}
+
+function parseBearer(value: string | string[] | undefined): string {
+  if (typeof value !== "string") return "";
+  return /^Bearer ([^\s]+)$/u.exec(value)?.[1] ?? "";
+}
+
+function bearerMatches(header: string | string[] | undefined, expectedHash: Buffer): boolean {
+  return crypto.timingSafeEqual(hashCredential(parseBearer(header)), expectedHash);
+}
+
+function sendJson(response: http.ServerResponse, status: number, value: unknown): void {
+  if (response.destroyed) return;
+  const body = Buffer.from(JSON.stringify(value));
+  response.writeHead(status, {
+    "cache-control": "no-store",
+    "content-type": "application/json",
+    "content-length": String(body.length),
+    ...(status >= 400 ? { connection: "close" } : {}),
+  });
+  response.end(body);
+}
+
+function sendEmpty(response: http.ServerResponse, status: number): void {
+  if (response.destroyed) return;
+  response.writeHead(status, {
+    "cache-control": "no-store",
+    "content-length": "0",
+    ...(status >= 400 ? { connection: "close" } : {}),
+  });
+  response.end();
+}
+
+function sendError(response: http.ServerResponse, error: unknown): void {
+  if (error instanceof VoiceHttpError || error instanceof VoiceSessionError) {
+    sendJson(response, error.status, { error: error.code });
+    return;
+  }
+  sendJson(response, 500, { error: "internal_error" });
+}
+
+function readJsonBody(
+  request: http.IncomingMessage,
+  maxBytes: number,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    if (request.headers["content-type"]?.split(";", 1)[0]?.trim() !== "application/json") {
+      reject(new VoiceHttpError(415, "unsupported_media_type"));
+      return;
+    }
+    const rawLength = request.headers["content-length"];
+    if (Array.isArray(rawLength)) {
+      reject(new VoiceHttpError(400, "invalid_request"));
+      return;
+    }
+    const contentLength = rawLength === undefined ? undefined : Number(rawLength);
+    if (
+      contentLength !== undefined &&
+      (!Number.isSafeInteger(contentLength) || contentLength < 0)
+    ) {
+      reject(new VoiceHttpError(400, "invalid_request"));
+      return;
+    }
+    if (contentLength !== undefined && contentLength > maxBytes) {
+      reject(new VoiceHttpError(413, "request_too_large"));
+      return;
+    }
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) {
+        reject(error);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          throw new Error("not an object");
+        }
+        resolve(parsed as Record<string, unknown>);
+      } catch {
+        reject(new VoiceHttpError(400, "invalid_request"));
+      }
+    };
+    const timer = setTimeout(
+      () => finish(new VoiceHttpError(408, "request_timeout")),
+      BODY_TIMEOUT_MS,
+    );
+    request.on("data", (chunk: Buffer | string) => {
+      if (settled) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      bytes += value.length;
+      if (bytes > maxBytes) finish(new VoiceHttpError(413, "request_too_large"));
+      else chunks.push(value);
+    });
+    request.once("aborted", () => finish(new VoiceHttpError(400, "invalid_request")));
+    request.once("error", () => finish(new VoiceHttpError(400, "invalid_request")));
+    request.once("end", () => finish());
+  });
+}
+
+function pathParts(requestUrl: string | undefined): string[] | undefined {
+  if (!requestUrl?.startsWith("/") || requestUrl.startsWith("//")) return undefined;
+  let url: URL;
+  try {
+    url = new URL(requestUrl, "http://127.0.0.1");
+  } catch {
+    return undefined;
+  }
+  if (url.search || url.hash || requestUrl !== url.pathname) return undefined;
+  return url.pathname.split("/").filter(Boolean);
+}
+
+export interface VoiceGatewayServerOptions {
+  admissionCredential: string;
+  sessionService: VoiceSessionService;
+}
+
+export function createVoiceGatewayServer(options: VoiceGatewayServerOptions): http.Server {
+  const admissionHash = hashCredential(options.admissionCredential);
+  const server = http.createServer(
+    { maxHeaderSize: MAX_HEADER_BYTES },
+    async (request, response) => {
+      try {
+        const parts = pathParts(request.url);
+        if (!parts) throw new VoiceHttpError(404, "not_found");
+        if (request.method === "GET" && parts.length === 1 && parts[0] === "healthz") {
+          sendEmpty(response, 204);
+          return;
+        }
+        if (request.method === "POST" && parts.join("/") === "v1/voice-sessions") {
+          if (!bearerMatches(request.headers.authorization, admissionHash)) {
+            throw new VoiceHttpError(401, "unauthorized");
+          }
+          const body = await readJsonBody(request, MAX_SESSION_BODY_BYTES);
+          const allowed = new Set(["runtimeConversationId"]);
+          if (Object.keys(body).some((key) => !allowed.has(key))) {
+            throw new VoiceHttpError(400, "invalid_request");
+          }
+          const created = options.sessionService.createSession(body.runtimeConversationId);
+          sendJson(response, 201, {
+            voiceSessionId: created.voiceSessionId,
+            grant: created.grant,
+            expiresAt: created.expiresAt,
+          });
+          return;
+        }
+        if (parts[0] !== "v1" || parts[1] !== "voice-sessions") {
+          throw new VoiceHttpError(404, "not_found");
+        }
+        const voiceSessionId = parts[2] ?? "";
+        const grant = parseBearer(request.headers.authorization);
+        if (request.method === "DELETE" && parts.length === 3) {
+          options.sessionService.closeSession(voiceSessionId, grant);
+          sendEmpty(response, 204);
+          return;
+        }
+        if (request.method !== "POST" || parts.length !== 4 || parts[3] !== "turns") {
+          throw new VoiceHttpError(404, "not_found");
+        }
+        const body = await readJsonBody(request, MAX_TURN_BODY_BYTES);
+        const allowed = new Set(["commitId", "text"]);
+        if (Object.keys(body).some((key) => !allowed.has(key))) {
+          throw new VoiceHttpError(400, "invalid_request");
+        }
+        let deliveryOpen = true;
+        let streamStarted = false;
+        response.once("close", () => {
+          deliveryOpen = false;
+          if (!response.writableFinished) options.sessionService.disconnectTurn(voiceSessionId);
+        });
+        const deliver = (event: VoiceResponseEvent): boolean => {
+          if (!deliveryOpen || response.destroyed || response.writableEnded) return false;
+          if (!streamStarted) {
+            streamStarted = true;
+            response.writeHead(200, {
+              "cache-control": "no-store",
+              "content-type": "application/x-ndjson",
+              "x-content-type-options": "nosniff",
+            });
+          }
+          response.write(`${JSON.stringify(event)}\n`);
+          if (response.writableLength > MAX_STREAM_BUFFER_BYTES) {
+            deliveryOpen = false;
+            options.sessionService.disconnectTurn(voiceSessionId);
+            response.destroy();
+            return false;
+          }
+          return true;
+        };
+        await options.sessionService.startTurn(
+          voiceSessionId,
+          grant,
+          body.commitId,
+          body.text,
+          deliver,
+        );
+        if (!response.destroyed) response.end();
+      } catch (error) {
+        if (response.headersSent) {
+          response.destroy();
+          return;
+        }
+        sendError(response, error);
+      }
+    },
+  );
+  server.headersTimeout = 5_000;
+  server.requestTimeout = 15_000;
+  server.keepAliveTimeout = 5_000;
+  server.on("connect", (_request, socket) => socket.destroy());
+  server.on("upgrade", (_request, socket) => socket.destroy());
+  server.on("clientError", (_error, socket) => {
+    if (socket.writable) {
+      socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+    }
+  });
+  return server;
+}

--- a/src/lib/adapters/http/voice-gateway.ts
+++ b/src/lib/adapters/http/voice-gateway.ts
@@ -125,9 +125,11 @@ function readJsonBody(
       if (bytes > maxBytes) finish(new VoiceHttpError(413, "request_too_large"));
       else chunks.push(value);
     });
-    request.once("aborted", () => finish(new VoiceHttpError(400, "invalid_request")));
     request.once("error", () => finish(new VoiceHttpError(400, "invalid_request")));
     request.once("end", () => finish());
+    request.once("close", () => {
+      if (!request.readableEnded) finish(new VoiceHttpError(400, "invalid_request"));
+    });
   });
 }
 
@@ -199,7 +201,9 @@ export function createVoiceGatewayServer(options: VoiceGatewayServerOptions): ht
         let streamStarted = false;
         response.once("close", () => {
           deliveryOpen = false;
-          if (!response.writableFinished) options.sessionService.disconnectTurn(voiceSessionId);
+          if (streamStarted && !response.writableFinished) {
+            options.sessionService.disconnectTurn(voiceSessionId, grant);
+          }
         });
         const deliver = (event: VoiceResponseEvent): boolean => {
           if (!deliveryOpen || response.destroyed || response.writableEnded) return false;
@@ -214,7 +218,7 @@ export function createVoiceGatewayServer(options: VoiceGatewayServerOptions): ht
           response.write(`${JSON.stringify(event)}\n`);
           if (response.writableLength > MAX_STREAM_BUFFER_BYTES) {
             deliveryOpen = false;
-            options.sessionService.disconnectTurn(voiceSessionId);
+            options.sessionService.disconnectTurn(voiceSessionId, grant);
             response.destroy();
             return false;
           }

--- a/src/lib/adapters/openclaw/voice-agent-client.test.ts
+++ b/src/lib/adapters/openclaw/voice-agent-client.test.ts
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import { OpenClawVoiceAgentClient } from "./voice-agent-client";
+
+class FakeSocket extends EventTarget {
+  static readonly OPEN = 1;
+  readyState = FakeSocket.OPEN;
+  sent: Record<string, unknown>[] = [];
+  close = vi.fn();
+
+  send(value: string) {
+    const frame = JSON.parse(value) as Record<string, unknown>;
+    this.sent.push(frame);
+    const method = frame.method;
+    const payload = method === "chat.send" ? { runId: "expected-run" } : { type: "hello-ok" };
+    queueMicrotask(() =>
+      this.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({ type: "res", id: frame.id, ok: true, payload }),
+        }),
+      ),
+    );
+    if (method === "chat.send")
+      queueMicrotask(() => {
+        for (const event of [
+          {
+            sessionKey: "other-session",
+            runId: "expected-run",
+            seq: 1,
+            state: "delta",
+            deltaText: "discard-session",
+          },
+          {
+            sessionKey: "agent:main:voice:session",
+            runId: "other-run",
+            seq: 1,
+            state: "delta",
+            deltaText: "discard-run",
+          },
+          {
+            sessionKey: "agent:main:voice:session",
+            runId: "expected-run",
+            seq: 1,
+            state: "delta",
+            deltaText: "ordered ",
+          },
+          {
+            sessionKey: "agent:main:voice:session",
+            runId: "expected-run",
+            seq: 2,
+            state: "delta",
+            deltaText: "result",
+          },
+          { sessionKey: "agent:main:voice:session", runId: "expected-run", seq: 9, state: "final" },
+        ])
+          this.dispatchEvent(
+            new MessageEvent("message", {
+              data: JSON.stringify({ type: "event", event: "chat", payload: event }),
+            }),
+          );
+      });
+  }
+}
+
+describe("OpenClaw voice agent client", () => {
+  it("uses read and write scopes, chat.send, and exact session and run filtering (#8378)", async () => {
+    const socket = new FakeSocket();
+    const client = new OpenClawVoiceAgentClient({
+      endpoint: "ws://127.0.0.1:18789/ws",
+      credential: "openclaw-secret-value-with-at-least-32-bytes",
+      requestTimeoutMs: 1_000,
+      createSocket: () => socket as never,
+    });
+    queueMicrotask(() => {
+      socket.dispatchEvent(new Event("open"));
+      socket.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "event",
+            event: "connect.challenge",
+            payload: { nonce: "challenge" },
+          }),
+        }),
+      );
+    });
+    const text: string[] = [];
+    const runs: string[] = [];
+
+    await client.invoke({
+      agentSessionKey: "agent:main:voice:session",
+      idempotencyKey: "derived-idempotency-key",
+      text: "committed text",
+      signal: new AbortController().signal,
+      onText: (value) => text.push(value),
+      onRun: (value) => runs.push(value),
+    });
+
+    const connect = socket.sent.find((frame) => frame.method === "connect") as {
+      params: { scopes: string[]; auth: { token: string } };
+    };
+    const send = socket.sent.find((frame) => frame.method === "chat.send") as {
+      params: Record<string, unknown>;
+    };
+    expect(connect.params.scopes).toEqual(["operator.read", "operator.write"]);
+    expect(connect.params).toMatchObject({
+      role: "operator",
+      client: { id: "gateway-client", mode: "backend" },
+    });
+    expect(connect.params).not.toHaveProperty("device");
+    expect(connect.params.auth.token).toBe("openclaw-secret-value-with-at-least-32-bytes");
+    expect(send.params).toMatchObject({
+      sessionKey: "agent:main:voice:session",
+      message: "committed text",
+      deliver: false,
+      idempotencyKey: "derived-idempotency-key",
+    });
+    expect(runs).toEqual(["expected-run"]);
+    expect(text).toEqual(["ordered result"]);
+  });
+
+  it("ignores queued data after the first terminal frame (#8378)", async () => {
+    class TerminalSocket extends FakeSocket {
+      override send(value: string) {
+        const frame = JSON.parse(value) as Record<string, unknown>;
+        this.sent.push(frame);
+        if (frame.method === "connect") {
+          queueMicrotask(() =>
+            this.dispatchEvent(
+              new MessageEvent("message", {
+                data: JSON.stringify({
+                  type: "res",
+                  id: frame.id,
+                  ok: true,
+                  payload: { type: "hello-ok" },
+                }),
+              }),
+            ),
+          );
+          return;
+        }
+        for (const payload of [
+          { sessionKey: "agent:main:voice:session", runId: "expected-run", seq: 1, state: "final" },
+          {
+            sessionKey: "agent:main:voice:session",
+            runId: "expected-run",
+            seq: 2,
+            state: "delta",
+            deltaText: "must-not-deliver",
+          },
+        ])
+          this.dispatchEvent(
+            new MessageEvent("message", {
+              data: JSON.stringify({ type: "event", event: "chat", payload }),
+            }),
+          );
+        queueMicrotask(() =>
+          this.dispatchEvent(
+            new MessageEvent("message", {
+              data: JSON.stringify({
+                type: "res",
+                id: frame.id,
+                ok: true,
+                payload: { runId: "expected-run" },
+              }),
+            }),
+          ),
+        );
+      }
+    }
+    const socket = new TerminalSocket();
+    const onText = vi.fn();
+    const client = new OpenClawVoiceAgentClient({
+      endpoint: "ws://127.0.0.1:18789/ws",
+      credential: "openclaw-secret-value-with-at-least-32-bytes",
+      requestTimeoutMs: 1_000,
+      createSocket: () => socket as never,
+    });
+    queueMicrotask(() =>
+      socket.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "event",
+            event: "connect.challenge",
+            payload: { nonce: "challenge" },
+          }),
+        }),
+      ),
+    );
+    await client.invoke({
+      agentSessionKey: "agent:main:voice:session",
+      idempotencyKey: "key",
+      text: "text",
+      signal: new AbortController().signal,
+      onText,
+      onRun: vi.fn(),
+    });
+    expect(onText).not.toHaveBeenCalled();
+  });
+
+  it("rejects projected response text above the bounded limit (#8378)", async () => {
+    class OversizedSocket extends FakeSocket {
+      override send(value: string) {
+        const frame = JSON.parse(value) as Record<string, unknown>;
+        this.sent.push(frame);
+        if (frame.method === "connect") {
+          queueMicrotask(() =>
+            this.dispatchEvent(
+              new MessageEvent("message", {
+                data: JSON.stringify({
+                  type: "res",
+                  id: frame.id,
+                  ok: true,
+                  payload: { type: "hello-ok" },
+                }),
+              }),
+            ),
+          );
+          return;
+        }
+        queueMicrotask(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", {
+              data: JSON.stringify({
+                type: "res",
+                id: frame.id,
+                ok: true,
+                payload: { runId: "expected-run" },
+              }),
+            }),
+          );
+          queueMicrotask(() => {
+            for (const seq of [1, 2]) {
+              this.dispatchEvent(
+                new MessageEvent("message", {
+                  data: JSON.stringify({
+                    type: "event",
+                    event: "chat",
+                    payload: {
+                      sessionKey: "agent:main:voice:session",
+                      runId: "expected-run",
+                      seq,
+                      state: "delta",
+                      deltaText: "x".repeat(1_100_000),
+                    },
+                  }),
+                }),
+              );
+            }
+          });
+        });
+      }
+    }
+    const socket = new OversizedSocket();
+    const client = new OpenClawVoiceAgentClient({
+      endpoint: "ws://127.0.0.1:18789/ws",
+      credential: "openclaw-secret-value-with-at-least-32-bytes",
+      requestTimeoutMs: 1_000,
+      createSocket: () => socket as never,
+    });
+    queueMicrotask(() =>
+      socket.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "event",
+            event: "connect.challenge",
+            payload: { nonce: "challenge" },
+          }),
+        }),
+      ),
+    );
+    await expect(
+      client.invoke({
+        agentSessionKey: "agent:main:voice:session",
+        idempotencyKey: "key",
+        text: "text",
+        signal: new AbortController().signal,
+        onText: vi.fn(),
+        onRun: vi.fn(),
+      }),
+    ).rejects.toMatchObject({ reason: "agent_response_limit" });
+  });
+
+  it.each([
+    "ws://example.com:18789/ws",
+    "wss://127.0.0.1:18789/ws",
+    "ws://token@127.0.0.1:18789/ws",
+  ])("rejects an untrusted configured endpoint %s (#8378)", (endpoint) => {
+    expect(
+      () =>
+        new OpenClawVoiceAgentClient({ endpoint, credential: "credential", requestTimeoutMs: 100 }),
+    ).toThrow("loopback WebSocket URL");
+  });
+});

--- a/src/lib/adapters/openclaw/voice-agent-client.test.ts
+++ b/src/lib/adapters/openclaw/voice-agent-client.test.ts
@@ -22,45 +22,54 @@ class FakeSocket extends EventTarget {
         }),
       ),
     );
-    if (method === "chat.send")
-      queueMicrotask(() => {
-        for (const event of [
-          {
-            sessionKey: "other-session",
-            runId: "expected-run",
-            seq: 1,
-            state: "delta",
-            deltaText: "discard-session",
-          },
-          {
-            sessionKey: "agent:main:voice:session",
-            runId: "other-run",
-            seq: 1,
-            state: "delta",
-            deltaText: "discard-run",
-          },
-          {
-            sessionKey: "agent:main:voice:session",
-            runId: "expected-run",
-            seq: 1,
-            state: "delta",
-            deltaText: "ordered ",
-          },
-          {
-            sessionKey: "agent:main:voice:session",
-            runId: "expected-run",
-            seq: 2,
-            state: "delta",
-            deltaText: "result",
-          },
-          { sessionKey: "agent:main:voice:session", runId: "expected-run", seq: 9, state: "final" },
-        ])
-          this.dispatchEvent(
-            new MessageEvent("message", {
-              data: JSON.stringify({ type: "event", event: "chat", payload: event }),
-            }),
-          );
-      });
+    const events =
+      method === "chat.send"
+        ? [
+            {
+              sessionKey: "other-session",
+              runId: "expected-run",
+              seq: 1,
+              state: "delta",
+              deltaText: "discard-session",
+            },
+            {
+              sessionKey: "agent:main:voice:session",
+              runId: "other-run",
+              seq: 1,
+              state: "delta",
+              deltaText: "discard-run",
+            },
+            {
+              sessionKey: "agent:main:voice:session",
+              runId: "expected-run",
+              seq: 1,
+              state: "delta",
+              deltaText: "ordered ",
+            },
+            {
+              sessionKey: "agent:main:voice:session",
+              runId: "expected-run",
+              seq: 2,
+              state: "delta",
+              deltaText: "result",
+            },
+            {
+              sessionKey: "agent:main:voice:session",
+              runId: "expected-run",
+              seq: 9,
+              state: "final",
+            },
+          ]
+        : [];
+    queueMicrotask(() => {
+      for (const event of events) {
+        this.dispatchEvent(
+          new MessageEvent("message", {
+            data: JSON.stringify({ type: "event", event: "chat", payload: event }),
+          }),
+        );
+      }
+    });
   }
 }
 
@@ -125,48 +134,57 @@ describe("OpenClaw voice agent client", () => {
       override send(value: string) {
         const frame = JSON.parse(value) as Record<string, unknown>;
         this.sent.push(frame);
-        if (frame.method === "connect") {
-          queueMicrotask(() =>
-            this.dispatchEvent(
-              new MessageEvent("message", {
-                data: JSON.stringify({
-                  type: "res",
-                  id: frame.id,
-                  ok: true,
-                  payload: { type: "hello-ok" },
+        const handlers: Record<string, () => void> = {
+          connect: () =>
+            queueMicrotask(() =>
+              this.dispatchEvent(
+                new MessageEvent("message", {
+                  data: JSON.stringify({
+                    type: "res",
+                    id: frame.id,
+                    ok: true,
+                    payload: { type: "hello-ok" },
+                  }),
                 }),
-              }),
+              ),
             ),
-          );
-          return;
-        }
-        for (const payload of [
-          { sessionKey: "agent:main:voice:session", runId: "expected-run", seq: 1, state: "final" },
-          {
-            sessionKey: "agent:main:voice:session",
-            runId: "expected-run",
-            seq: 2,
-            state: "delta",
-            deltaText: "must-not-deliver",
+          "chat.send": () => {
+            for (const payload of [
+              {
+                sessionKey: "agent:main:voice:session",
+                runId: "expected-run",
+                seq: 1,
+                state: "final",
+              },
+              {
+                sessionKey: "agent:main:voice:session",
+                runId: "expected-run",
+                seq: 2,
+                state: "delta",
+                deltaText: "must-not-deliver",
+              },
+            ]) {
+              this.dispatchEvent(
+                new MessageEvent("message", {
+                  data: JSON.stringify({ type: "event", event: "chat", payload }),
+                }),
+              );
+            }
+            queueMicrotask(() =>
+              this.dispatchEvent(
+                new MessageEvent("message", {
+                  data: JSON.stringify({
+                    type: "res",
+                    id: frame.id,
+                    ok: true,
+                    payload: { runId: "expected-run" },
+                  }),
+                }),
+              ),
+            );
           },
-        ])
-          this.dispatchEvent(
-            new MessageEvent("message", {
-              data: JSON.stringify({ type: "event", event: "chat", payload }),
-            }),
-          );
-        queueMicrotask(() =>
-          this.dispatchEvent(
-            new MessageEvent("message", {
-              data: JSON.stringify({
-                type: "res",
-                id: frame.id,
-                ok: true,
-                payload: { runId: "expected-run" },
-              }),
-            }),
-          ),
-        );
+        };
+        handlers[String(frame.method)]?.();
       }
     }
     const socket = new TerminalSocket();
@@ -204,52 +222,54 @@ describe("OpenClaw voice agent client", () => {
       override send(value: string) {
         const frame = JSON.parse(value) as Record<string, unknown>;
         this.sent.push(frame);
-        if (frame.method === "connect") {
-          queueMicrotask(() =>
-            this.dispatchEvent(
-              new MessageEvent("message", {
-                data: JSON.stringify({
-                  type: "res",
-                  id: frame.id,
-                  ok: true,
-                  payload: { type: "hello-ok" },
-                }),
-              }),
-            ),
-          );
-          return;
-        }
-        queueMicrotask(() => {
-          this.dispatchEvent(
-            new MessageEvent("message", {
-              data: JSON.stringify({
-                type: "res",
-                id: frame.id,
-                ok: true,
-                payload: { runId: "expected-run" },
-              }),
-            }),
-          );
-          queueMicrotask(() => {
-            for (const seq of [1, 2]) {
+        const handlers: Record<string, () => void> = {
+          connect: () =>
+            queueMicrotask(() =>
               this.dispatchEvent(
                 new MessageEvent("message", {
                   data: JSON.stringify({
-                    type: "event",
-                    event: "chat",
-                    payload: {
-                      sessionKey: "agent:main:voice:session",
-                      runId: "expected-run",
-                      seq,
-                      state: "delta",
-                      deltaText: "x".repeat(1_100_000),
-                    },
+                    type: "res",
+                    id: frame.id,
+                    ok: true,
+                    payload: { type: "hello-ok" },
+                  }),
+                }),
+              ),
+            ),
+          "chat.send": () =>
+            queueMicrotask(() => {
+              this.dispatchEvent(
+                new MessageEvent("message", {
+                  data: JSON.stringify({
+                    type: "res",
+                    id: frame.id,
+                    ok: true,
+                    payload: { runId: "expected-run" },
                   }),
                 }),
               );
-            }
-          });
-        });
+              queueMicrotask(() => {
+                for (const seq of [1, 2]) {
+                  this.dispatchEvent(
+                    new MessageEvent("message", {
+                      data: JSON.stringify({
+                        type: "event",
+                        event: "chat",
+                        payload: {
+                          sessionKey: "agent:main:voice:session",
+                          runId: "expected-run",
+                          seq,
+                          state: "delta",
+                          deltaText: "x".repeat(1_100_000),
+                        },
+                      }),
+                    }),
+                  );
+                }
+              });
+            }),
+        };
+        handlers[String(frame.method)]?.();
       }
     }
     const socket = new OversizedSocket();

--- a/src/lib/adapters/openclaw/voice-agent-client.test.ts
+++ b/src/lib/adapters/openclaw/voice-agent-client.test.ts
@@ -302,6 +302,118 @@ describe("OpenClaw voice agent client", () => {
     ).rejects.toMatchObject({ reason: "agent_response_limit" });
   });
 
+  it("does not publish a run id after a protocol failure settled the turn (#8378)", async () => {
+    class LateAckSocket extends FakeSocket {
+      override send(value: string) {
+        const frame = JSON.parse(value) as Record<string, unknown>;
+        this.sent.push(frame);
+        const handlers: Record<string, () => void> = {
+          connect: () =>
+            queueMicrotask(() =>
+              this.dispatchEvent(
+                new MessageEvent("message", {
+                  data: JSON.stringify({
+                    type: "res",
+                    id: frame.id,
+                    ok: true,
+                    payload: { type: "hello-ok" },
+                  }),
+                }),
+              ),
+            ),
+          "chat.send": () => {
+            for (let seq = 1; seq <= 65; seq += 1) {
+              this.dispatchEvent(
+                new MessageEvent("message", {
+                  data: JSON.stringify({
+                    type: "event",
+                    event: "chat",
+                    payload: {
+                      sessionKey: "agent:main:voice:session",
+                      runId: "expected-run",
+                      seq,
+                      state: "delta",
+                      deltaText: "queued",
+                    },
+                  }),
+                }),
+              );
+            }
+            queueMicrotask(() =>
+              this.dispatchEvent(
+                new MessageEvent("message", {
+                  data: JSON.stringify({
+                    type: "res",
+                    id: frame.id,
+                    ok: true,
+                    payload: { runId: "expected-run" },
+                  }),
+                }),
+              ),
+            );
+          },
+        };
+        handlers[String(frame.method)]?.();
+      }
+    }
+    const socket = new LateAckSocket();
+    const onRun = vi.fn();
+    const client = new OpenClawVoiceAgentClient({
+      endpoint: "ws://127.0.0.1:18789/ws",
+      credential: "openclaw-secret-value-with-at-least-32-bytes",
+      requestTimeoutMs: 1_000,
+      createSocket: () => socket as never,
+    });
+    queueMicrotask(() =>
+      socket.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "event",
+            event: "connect.challenge",
+            payload: { nonce: "challenge" },
+          }),
+        }),
+      ),
+    );
+
+    await expect(
+      client.invoke({
+        agentSessionKey: "agent:main:voice:session",
+        idempotencyKey: "key",
+        text: "text",
+        signal: new AbortController().signal,
+        onText: vi.fn(),
+        onRun,
+      }),
+    ).rejects.toMatchObject({ reason: "agent_protocol_error" });
+    await Promise.resolve();
+    expect(onRun).not.toHaveBeenCalled();
+  });
+
+  it("rejects an already-aborted turn before sending a request (#8378)", async () => {
+    const socket = new FakeSocket();
+    const controller = new AbortController();
+    controller.abort();
+    const client = new OpenClawVoiceAgentClient({
+      endpoint: "ws://127.0.0.1:18789/ws",
+      credential: "openclaw-secret-value-with-at-least-32-bytes",
+      requestTimeoutMs: 1_000,
+      createSocket: () => socket as never,
+    });
+
+    await expect(
+      client.invoke({
+        agentSessionKey: "agent:main:voice:session",
+        idempotencyKey: "key",
+        text: "text",
+        signal: controller.signal,
+        onText: vi.fn(),
+        onRun: vi.fn(),
+      }),
+    ).rejects.toMatchObject({ reason: "agent_connection_failed" });
+    expect(socket.sent).toEqual([]);
+  });
+
   it.each([
     "ws://example.com:18789/ws",
     "wss://127.0.0.1:18789/ws",

--- a/src/lib/adapters/openclaw/voice-agent-client.ts
+++ b/src/lib/adapters/openclaw/voice-agent-client.ts
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { WebSocket } from "undici";
+import {
+  type AgentTurnRequest,
+  type VoiceAgentClient,
+  VoiceAgentError,
+} from "../../domain/voice/session-service";
+import { VOICE_MAX_RESPONSE_TEXT_BYTES } from "../../domain/voice/session-service";
+
+const OPENCLAW_PROTOCOL_VERSION = 4;
+const MAX_NATIVE_FRAME_BYTES = 2 * 1024 * 1024;
+const MAX_QUEUED_CHAT_FRAMES = 64;
+const MAX_QUEUED_CHAT_BYTES = 256 * 1024;
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export interface OpenClawVoiceAgentClientOptions {
+  endpoint: string;
+  credential: string;
+  requestTimeoutMs: number;
+  createSocket?: (endpoint: string) => WebSocket;
+}
+
+function parseFixedLoopbackEndpoint(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Voice agent gateway endpoint is invalid.");
+  }
+  if (
+    url.protocol !== "ws:" ||
+    url.hostname !== "127.0.0.1" ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/ws" ||
+    url.search ||
+    url.hash ||
+    !url.port
+  ) {
+    throw new Error(
+      "Voice agent gateway endpoint must be a credential-free loopback WebSocket URL.",
+    );
+  }
+  return url.toString();
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export class OpenClawVoiceAgentClient implements VoiceAgentClient {
+  private socket?: WebSocket;
+  private requestSequence = 0;
+  private readonly pending = new Map<string, PendingRequest>();
+  private closed = false;
+
+  constructor(private readonly options: OpenClawVoiceAgentClientOptions) {
+    parseFixedLoopbackEndpoint(options.endpoint);
+    if (!Number.isInteger(options.requestTimeoutMs) || options.requestTimeoutMs < 1) {
+      throw new Error("Voice agent gateway timeout must be a positive integer.");
+    }
+  }
+
+  async invoke(request: AgentTurnRequest): Promise<void> {
+    const socket = await this.connect(request.signal);
+    let expectedRunId: string | undefined;
+    let lastSequence: number | undefined;
+    let projectedText = "";
+    let terminal = false;
+    let settled = false;
+    const queuedChatFrames: Record<string, unknown>[] = [];
+    let queuedChatBytes = 0;
+
+    await new Promise<void>((resolve, reject) => {
+      const finish = (error?: VoiceAgentError) => {
+        if (settled) return;
+        settled = true;
+        request.signal.removeEventListener("abort", onAbort);
+        socket.removeEventListener("message", onMessage);
+        socket.removeEventListener("close", onClose);
+        if (error) reject(error);
+        else resolve();
+      };
+      const onAbort = () => {
+        this.close();
+        finish(new VoiceAgentError("agent_unavailable"));
+      };
+      const onClose = () => {
+        if (!terminal) finish(new VoiceAgentError("agent_connection_failed"));
+      };
+      const consumeChatFrame = (frame: Record<string, unknown>) => {
+        const payload = objectValue(frame.payload);
+        if (!payload || payload.sessionKey !== request.agentSessionKey) return;
+        if (typeof payload.runId !== "string" || payload.runId !== expectedRunId) return;
+        if (
+          typeof payload.seq !== "number" ||
+          !Number.isInteger(payload.seq) ||
+          payload.seq < 0 ||
+          (lastSequence !== undefined && payload.seq <= lastSequence)
+        ) {
+          this.close();
+          finish(new VoiceAgentError("agent_protocol_error"));
+          return;
+        }
+        lastSequence = payload.seq;
+        if (payload.state === "delta") {
+          if (typeof payload.deltaText !== "string") {
+            this.close();
+            finish(new VoiceAgentError("agent_protocol_error"));
+            return;
+          }
+          const projectedBytes =
+            payload.replace === true
+              ? Buffer.byteLength(payload.deltaText)
+              : Buffer.byteLength(projectedText) + Buffer.byteLength(payload.deltaText);
+          if (projectedBytes > VOICE_MAX_RESPONSE_TEXT_BYTES) {
+            this.close();
+            finish(new VoiceAgentError("agent_response_limit"));
+            return;
+          }
+          projectedText =
+            payload.replace === true ? payload.deltaText : `${projectedText}${payload.deltaText}`;
+          return;
+        }
+        if (payload.state === "final") {
+          if (projectedText) request.onText(projectedText);
+          terminal = true;
+          finish();
+        } else if (payload.state === "error" || payload.state === "aborted") {
+          terminal = true;
+          finish(new VoiceAgentError("agent_unavailable"));
+        } else {
+          this.close();
+          finish(new VoiceAgentError("agent_protocol_error"));
+        }
+      };
+      const onMessage = (event: MessageEvent) => {
+        const raw = typeof event.data === "string" ? event.data : "";
+        if (!raw || Buffer.byteLength(raw) > MAX_NATIVE_FRAME_BYTES) {
+          this.close();
+          finish(new VoiceAgentError("agent_protocol_error"));
+          return;
+        }
+        let frame: Record<string, unknown>;
+        try {
+          frame = objectValue(JSON.parse(raw)) ?? {};
+        } catch {
+          this.close();
+          finish(new VoiceAgentError("agent_protocol_error"));
+          return;
+        }
+        this.resolveRequestFrame(frame);
+        if (frame.type !== "event" || frame.event !== "chat") return;
+        if (!expectedRunId) {
+          const payload = objectValue(frame.payload);
+          if (!payload || payload.sessionKey !== request.agentSessionKey) return;
+          queuedChatBytes += Buffer.byteLength(raw);
+          if (
+            queuedChatFrames.length >= MAX_QUEUED_CHAT_FRAMES ||
+            queuedChatBytes > MAX_QUEUED_CHAT_BYTES
+          ) {
+            this.close();
+            finish(new VoiceAgentError("agent_protocol_error"));
+            return;
+          }
+          queuedChatFrames.push(frame);
+        } else {
+          consumeChatFrame(frame);
+        }
+      };
+
+      request.signal.addEventListener("abort", onAbort, { once: true });
+      socket.addEventListener("message", onMessage);
+      socket.addEventListener("close", onClose);
+      this.request(
+        "chat.send",
+        {
+          sessionKey: request.agentSessionKey,
+          message: request.text,
+          deliver: false,
+          timeoutMs: this.options.requestTimeoutMs,
+          idempotencyKey: request.idempotencyKey,
+        },
+        request.signal,
+      )
+        .then((value) => {
+          const response = objectValue(value);
+          const runId = typeof response?.runId === "string" ? response.runId : undefined;
+          if (!runId) {
+            finish(new VoiceAgentError("agent_protocol_error"));
+            return;
+          }
+          expectedRunId = runId;
+          request.onRun(runId);
+          for (const frame of queuedChatFrames.splice(0)) {
+            if (settled) break;
+            consumeChatFrame(frame);
+          }
+        })
+        .catch((error) =>
+          finish(
+            error instanceof VoiceAgentError ? error : new VoiceAgentError("agent_unavailable"),
+          ),
+        );
+    });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.socket?.close(1000, "voice session closed");
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new VoiceAgentError("agent_connection_failed"));
+    }
+    this.pending.clear();
+  }
+
+  private connect(signal: AbortSignal): Promise<WebSocket> {
+    if (this.closed) return Promise.reject(new VoiceAgentError("agent_connection_failed"));
+    if (this.socket?.readyState === WebSocket.OPEN) return Promise.resolve(this.socket);
+    const endpoint = parseFixedLoopbackEndpoint(this.options.endpoint);
+    const socket = this.options.createSocket?.(endpoint) ?? new WebSocket(endpoint);
+    this.socket = socket;
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      let challengeReceived = false;
+      const finish = (error?: VoiceAgentError) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        signal.removeEventListener("abort", onAbort);
+        socket.removeEventListener("message", onMessage);
+        socket.removeEventListener("error", onError);
+        socket.removeEventListener("close", onClose);
+        if (error) reject(error);
+        else resolve(socket);
+      };
+      const fail = (reason: "agent_connection_failed" | "agent_authentication_failed") =>
+        finish(new VoiceAgentError(reason));
+      const onAbort = () => {
+        socket.close();
+        fail("agent_connection_failed");
+      };
+      const onError = () => fail("agent_connection_failed");
+      const onClose = () => fail("agent_connection_failed");
+      const onMessage = (event: MessageEvent) => {
+        if (
+          typeof event.data !== "string" ||
+          Buffer.byteLength(event.data) > MAX_NATIVE_FRAME_BYTES
+        ) {
+          fail("agent_connection_failed");
+          return;
+        }
+        let frame: Record<string, unknown>;
+        try {
+          frame = objectValue(JSON.parse(event.data)) ?? {};
+        } catch {
+          fail("agent_connection_failed");
+          return;
+        }
+        this.resolveRequestFrame(frame);
+        if (frame.type !== "event" || frame.event !== "connect.challenge") return;
+        const payload = objectValue(frame.payload);
+        if (challengeReceived || typeof payload?.nonce !== "string" || !payload.nonce.trim()) {
+          fail("agent_connection_failed");
+          return;
+        }
+        challengeReceived = true;
+        this.request(
+          "connect",
+          {
+            minProtocol: OPENCLAW_PROTOCOL_VERSION,
+            maxProtocol: OPENCLAW_PROTOCOL_VERSION,
+            client: {
+              id: "gateway-client",
+              displayName: "NemoClaw experimental voice gateway",
+              version: "1",
+              platform: process.platform,
+              mode: "backend",
+            },
+            caps: [],
+            role: "operator",
+            scopes: ["operator.read", "operator.write"],
+            auth: { token: this.options.credential },
+          },
+          signal,
+        )
+          .then(() => finish())
+          .catch(() => fail("agent_authentication_failed"));
+      };
+      const timer = setTimeout(() => {
+        socket.close();
+        fail("agent_connection_failed");
+      }, this.options.requestTimeoutMs);
+      timer.unref();
+      signal.addEventListener("abort", onAbort, { once: true });
+      socket.addEventListener("message", onMessage);
+      socket.addEventListener("error", onError);
+      socket.addEventListener("close", onClose);
+    });
+  }
+
+  private request(
+    method: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal,
+  ): Promise<unknown> {
+    const socket = this.socket;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new VoiceAgentError("agent_connection_failed"));
+    }
+    const id = `voice-${++this.requestSequence}`;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new VoiceAgentError("agent_unavailable"));
+      }, this.options.requestTimeoutMs);
+      timer.unref();
+      const abort = () => {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(new VoiceAgentError("agent_unavailable"));
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      this.pending.set(id, {
+        timer,
+        resolve: (value) => {
+          signal.removeEventListener("abort", abort);
+          resolve(value);
+        },
+        reject: (error) => {
+          signal.removeEventListener("abort", abort);
+          reject(error);
+        },
+      });
+      socket.send(JSON.stringify({ type: "req", id, method, params }));
+    });
+  }
+
+  private resolveRequestFrame(frame: Record<string, unknown>): void {
+    if (frame.type !== "res" || typeof frame.id !== "string") return;
+    const pending = this.pending.get(frame.id);
+    if (!pending) return;
+    this.pending.delete(frame.id);
+    clearTimeout(pending.timer);
+    if (frame.ok === false || frame.error) {
+      pending.reject(new VoiceAgentError("agent_unavailable"));
+    } else {
+      pending.resolve(frame.payload ?? frame.result ?? frame);
+    }
+  }
+}

--- a/src/lib/adapters/openclaw/voice-agent-client.ts
+++ b/src/lib/adapters/openclaw/voice-agent-client.ts
@@ -193,6 +193,7 @@ export class OpenClawVoiceAgentClient implements VoiceAgentClient {
         request.signal,
       )
         .then((value) => {
+          if (settled) return;
           const response = objectValue(value);
           const runId = typeof response?.runId === "string" ? response.runId : undefined;
           if (!runId) {
@@ -226,7 +227,9 @@ export class OpenClawVoiceAgentClient implements VoiceAgentClient {
   }
 
   private connect(signal: AbortSignal): Promise<WebSocket> {
-    if (this.closed) return Promise.reject(new VoiceAgentError("agent_connection_failed"));
+    if (signal.aborted || this.closed) {
+      return Promise.reject(new VoiceAgentError("agent_connection_failed"));
+    }
     if (this.socket?.readyState === WebSocket.OPEN) return Promise.resolve(this.socket);
     const endpoint = parseFixedLoopbackEndpoint(this.options.endpoint);
     const socket = this.options.createSocket?.(endpoint) ?? new WebSocket(endpoint);
@@ -318,6 +321,9 @@ export class OpenClawVoiceAgentClient implements VoiceAgentClient {
     const socket = this.socket;
     if (!socket || socket.readyState !== WebSocket.OPEN) {
       return Promise.reject(new VoiceAgentError("agent_connection_failed"));
+    }
+    if (signal.aborted) {
+      return Promise.reject(new VoiceAgentError("agent_unavailable"));
     }
     const id = `voice-${++this.requestSequence}`;
     return new Promise((resolve, reject) => {

--- a/src/lib/domain/voice/session-service.test.ts
+++ b/src/lib/domain/voice/session-service.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type VoiceAgentClient,
   VoiceAgentError,
@@ -64,6 +64,7 @@ function collect() {
 }
 
 describe("experimental voice session state", () => {
+  afterEach(() => vi.useRealTimers());
   it("binds trusted runtime and agent configuration to an opaque session (#8378)", () => {
     const h = harness();
     const created = create(h);
@@ -77,8 +78,27 @@ describe("experimental voice session state", () => {
       agent: "main",
       agentSessionKey: "agent:main:voice:opaque-2",
     });
-    expect(created.grant).toHaveLength(42);
     expect(h.service.getBindingForTest()).not.toHaveProperty("grant");
+  });
+
+  it("issues unique high-entropy grants with the default generator (#8378)", () => {
+    const createAgentClient = () => ({ close: vi.fn(), invoke: vi.fn() });
+    const service = new VoiceSessionService({
+      runtimeId: "runtime-a",
+      runtimeProfile: "voiceclaw-pinned",
+      sandbox: "sandbox-a",
+      agent: "main",
+      sessionLifetimeMs: 60_000,
+      turnTimeoutMs: 1_000,
+      createAgentClient,
+    });
+    const first = service.createSession("conversation-a");
+    service.closeSession(first.voiceSessionId, first.grant);
+    const second = service.createSession("conversation-b");
+
+    expect(first.grant).toMatch(/^[A-Za-z0-9_-]{43}$/u);
+    expect(second.grant).toMatch(/^[A-Za-z0-9_-]{43}$/u);
+    expect(second.grant).not.toBe(first.grant);
   });
 
   it("streams one ordered response with one terminal outcome (#8378)", async () => {
@@ -169,7 +189,6 @@ describe("experimental voice session state", () => {
       expect.objectContaining({ code: "session_not_found" }),
     );
     expect(h.close).toHaveBeenCalled();
-    vi.useRealTimers();
   });
 
   it("bounds a running turn with a stable content-free failure (#8378)", async () => {
@@ -197,7 +216,6 @@ describe("experimental voice session state", () => {
 
     expect(output.events.at(-1)).toMatchObject({ type: "response.failed", reason: "turn_timeout" });
     expect(JSON.stringify(h.diagnostics)).not.toContain("secret transcript");
-    vi.useRealTimers();
   });
 
   it("stops response delivery after the runtime disconnects (#8378)", async () => {
@@ -223,6 +241,25 @@ describe("experimental voice session state", () => {
     expect(events.map((event) => event.type)).toEqual(["response.started", "response.text.delta"]);
   });
 
+  it("does not disconnect active work for an invalid session grant (#8378)", async () => {
+    const running = deferred<void>();
+    const h = harness(() => running.promise);
+    const created = create(h);
+    const turn = h.service.startTurn(
+      created.voiceSessionId,
+      created.grant,
+      "commit-a",
+      "text",
+      () => true,
+    );
+    await vi.waitFor(() => expect(h.service.getBindingForTest()).toBeDefined());
+
+    h.service.disconnectTurn(created.voiceSessionId, "invalid-grant-value");
+    expect(h.close).not.toHaveBeenCalled();
+    running.resolve();
+    await turn;
+  });
+
   it("closes active agent work when response delivery disconnects (#8378)", async () => {
     const running = deferred<void>();
     const h = harness(() => running.promise);
@@ -236,7 +273,7 @@ describe("experimental voice session state", () => {
     );
     await vi.waitFor(() => expect(h.service.getBindingForTest()).toBeDefined());
 
-    h.service.disconnectTurn(created.voiceSessionId);
+    h.service.disconnectTurn(created.voiceSessionId, created.grant);
     expect(h.close).toHaveBeenCalled();
     running.resolve();
     await turn;

--- a/src/lib/domain/voice/session-service.test.ts
+++ b/src/lib/domain/voice/session-service.test.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  type VoiceAgentClient,
+  VoiceAgentError,
+  type VoiceResponseEvent,
+  VoiceSessionError,
+  VoiceSessionService,
+} from "./session-service";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function harness(
+  invoke?: VoiceAgentClient["invoke"],
+  options: { lifetime?: number; timeout?: number } = {},
+) {
+  const close = vi.fn();
+  const invokeAgent = vi.fn(
+    invoke ??
+      (async (request) => {
+        request.onRun("run-1");
+        request.onText("known ");
+        request.onText("state");
+      }),
+  );
+  const client: VoiceAgentClient = {
+    close,
+    invoke: invokeAgent,
+  };
+  let id = 0;
+  const diagnostics: unknown[] = [];
+  const service = new VoiceSessionService({
+    runtimeId: "runtime-a",
+    runtimeProfile: "voiceclaw-pinned",
+    sandbox: "sandbox-a",
+    agent: "main",
+    sessionLifetimeMs: options.lifetime ?? 60_000,
+    turnTimeoutMs: options.timeout ?? 1_000,
+    createAgentClient: () => client,
+    randomId: () => `opaque-${++id}`,
+    randomGrant: () => "session-grant-value-with-at-least-32-bytes",
+    diagnostic: (value) => diagnostics.push(value),
+  });
+  return { service, client, close, diagnostics };
+}
+
+function create(h: ReturnType<typeof harness>) {
+  return h.service.createSession("runtime-conversation-a");
+}
+
+function collect() {
+  const events: VoiceResponseEvent[] = [];
+  return { events, deliver: (event: VoiceResponseEvent) => (events.push(event), true) };
+}
+
+describe("experimental voice session state", () => {
+  it("binds trusted runtime and agent configuration to an opaque session (#8378)", () => {
+    const h = harness();
+    const created = create(h);
+
+    expect(created).toMatchObject({
+      voiceSessionId: "opaque-1",
+      runtimeId: "runtime-a",
+      runtimeProfile: "voiceclaw-pinned",
+      runtimeConversationId: "runtime-conversation-a",
+      sandbox: "sandbox-a",
+      agent: "main",
+      agentSessionKey: "agent:main:voice:opaque-2",
+    });
+    expect(created.grant).toHaveLength(42);
+    expect(h.service.getBindingForTest()).not.toHaveProperty("grant");
+  });
+
+  it("streams one ordered response with one terminal outcome (#8378)", async () => {
+    const h = harness();
+    const created = create(h);
+    const output = collect();
+
+    await h.service.startTurn(
+      created.voiceSessionId,
+      created.grant,
+      "runtime-commit-a",
+      "show repository status",
+      output.deliver,
+    );
+
+    expect(output.events.map((event) => event.type)).toEqual([
+      "response.started",
+      "response.text.delta",
+      "response.text.delta",
+      "response.completed",
+    ]);
+    expect(output.events.map((event) => event.sequence)).toEqual([1, 2, 3, 4]);
+    expect(output.events[1]).toMatchObject({
+      text: "known ",
+      turnId: "opaque-3",
+      responseId: "opaque-4",
+    });
+    expect(h.client.invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: "agent:main:voice:opaque-2",
+        idempotencyKey: expect.not.stringContaining("runtime-commit-a"),
+      }),
+    );
+    expect(h.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects duplicate and overlapping runtime commits without another invocation (#8378)", async () => {
+    const running = deferred<void>();
+    const invoke = vi.fn<VoiceAgentClient["invoke"]>((request) => {
+      request.onRun("run-1");
+      return running.promise;
+    });
+    const h = harness(invoke);
+    const created = create(h);
+    const output = collect();
+    const first = h.service.startTurn(
+      created.voiceSessionId,
+      created.grant,
+      "commit-a",
+      "text",
+      output.deliver,
+    );
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+
+    expect(() =>
+      h.service.startTurn(
+        created.voiceSessionId,
+        created.grant,
+        "commit-a",
+        "text",
+        output.deliver,
+      ),
+    ).toThrowError(expect.objectContaining({ code: "duplicate_turn" }));
+    expect(() =>
+      h.service.startTurn(
+        created.voiceSessionId,
+        created.grant,
+        "commit-b",
+        "text",
+        output.deliver,
+      ),
+    ).toThrowError(expect.objectContaining({ code: "turn_in_progress" }));
+    running.resolve();
+    await first;
+    expect(invoke).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a grant for another or expired voice session (#8378)", () => {
+    vi.useFakeTimers();
+    const h = harness(undefined, { lifetime: 50 });
+    const created = create(h);
+
+    expect(() => h.service.authorize("another-session", created.grant)).toThrowError(
+      expect.objectContaining({ code: "session_not_found" }),
+    );
+    vi.advanceTimersByTime(51);
+    expect(() => h.service.authorize(created.voiceSessionId, created.grant)).toThrowError(
+      expect.objectContaining({ code: "session_not_found" }),
+    );
+    expect(h.close).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("bounds a running turn with a stable content-free failure (#8378)", async () => {
+    vi.useFakeTimers();
+    const h = harness(
+      (request) =>
+        new Promise((_resolve, reject) => {
+          request.signal.addEventListener("abort", () =>
+            reject(new VoiceAgentError("agent_unavailable")),
+          );
+        }),
+      { timeout: 25 },
+    );
+    const created = create(h);
+    const output = collect();
+    const turn = h.service.startTurn(
+      created.voiceSessionId,
+      created.grant,
+      "commit-a",
+      "secret transcript",
+      output.deliver,
+    );
+    await vi.advanceTimersByTimeAsync(26);
+    await turn;
+
+    expect(output.events.at(-1)).toMatchObject({ type: "response.failed", reason: "turn_timeout" });
+    expect(JSON.stringify(h.diagnostics)).not.toContain("secret transcript");
+    vi.useRealTimers();
+  });
+
+  it("stops response delivery after the runtime disconnects (#8378)", async () => {
+    const h = harness(async (request) => {
+      request.onRun("run-1");
+      request.onText("first");
+      request.onText("must-not-deliver");
+    });
+    const created = create(h);
+    const events: VoiceResponseEvent[] = [];
+
+    await h.service.startTurn(
+      created.voiceSessionId,
+      created.grant,
+      "commit-a",
+      "text",
+      (event) => {
+        events.push(event);
+        return event.type !== "response.text.delta";
+      },
+    );
+
+    expect(events.map((event) => event.type)).toEqual(["response.started", "response.text.delta"]);
+  });
+
+  it("closes active agent work when response delivery disconnects (#8378)", async () => {
+    const running = deferred<void>();
+    const h = harness(() => running.promise);
+    const created = create(h);
+    const turn = h.service.startTurn(
+      created.voiceSessionId,
+      created.grant,
+      "commit-a",
+      "text",
+      () => true,
+    );
+    await vi.waitFor(() => expect(h.service.getBindingForTest()).toBeDefined());
+
+    h.service.disconnectTurn(created.voiceSessionId);
+    expect(h.close).toHaveBeenCalled();
+    running.resolve();
+    await turn;
+  });
+
+  it("reports stable reasons without agent error content (#8378)", async () => {
+    const h = harness(async () => {
+      throw new Error("native payload contains transcript and credential");
+    });
+    const created = create(h);
+    const output = collect();
+
+    await h.service.startTurn(
+      created.voiceSessionId,
+      created.grant,
+      "commit-a",
+      "sensitive prompt",
+      output.deliver,
+    );
+
+    expect(output.events.at(-1)).toMatchObject({
+      type: "response.failed",
+      reason: "agent_unavailable",
+    });
+    expect(JSON.stringify(output.events)).not.toContain("native payload");
+    expect(JSON.stringify(h.diagnostics)).not.toContain("sensitive prompt");
+    expect(JSON.stringify(h.diagnostics)).not.toContain("credential");
+  });
+
+  it("closes the agent connection and revokes state when the session closes (#8378)", () => {
+    const h = harness();
+    const created = create(h);
+    h.service.closeSession(created.voiceSessionId, created.grant);
+
+    expect(h.service.getBindingForTest()).toBeUndefined();
+    expect(h.close).toHaveBeenCalledOnce();
+    expect(() => h.service.authorize(created.voiceSessionId, created.grant)).toThrow(
+      VoiceSessionError,
+    );
+  });
+  it("rejects duration values above the security maxima (#8378)", () => {
+    expect(() => harness(undefined, { lifetime: 900_001 })).toThrow("between 1 and 900000");
+    expect(() => harness(undefined, { timeout: 120_001 })).toThrow("between 1 and 120000");
+  });
+});

--- a/src/lib/domain/voice/session-service.ts
+++ b/src/lib/domain/voice/session-service.ts
@@ -1,0 +1,455 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from "node:crypto";
+
+export const VOICE_MAX_COMMIT_ID_BYTES = 256;
+export const VOICE_MAX_TURN_TEXT_BYTES = 16 * 1024;
+export const VOICE_MAX_RESPONSE_TEXT_BYTES = 2 * 1024 * 1024;
+export const VOICE_MAX_SESSION_LIFETIME_MS = 15 * 60_000;
+export const VOICE_MAX_TURN_TIMEOUT_MS = 2 * 60_000;
+
+export type VoiceFailureReason =
+  | "agent_authentication_failed"
+  | "agent_connection_failed"
+  | "agent_protocol_error"
+  | "agent_response_limit"
+  | "agent_unavailable"
+  | "session_closed"
+  | "session_expired"
+  | "turn_timeout";
+
+export type VoiceResponseEvent =
+  | {
+      type: "response.started";
+      sequence: number;
+      voiceSessionId: string;
+      turnId: string;
+      responseId: string;
+    }
+  | {
+      type: "response.text.delta";
+      sequence: number;
+      voiceSessionId: string;
+      turnId: string;
+      responseId: string;
+      text: string;
+    }
+  | {
+      type: "response.completed";
+      sequence: number;
+      voiceSessionId: string;
+      turnId: string;
+      responseId: string;
+    }
+  | {
+      type: "response.failed";
+      sequence: number;
+      voiceSessionId: string;
+      turnId: string;
+      responseId: string;
+      reason: VoiceFailureReason;
+    };
+
+export interface AgentTurnRequest {
+  agentSessionKey: string;
+  idempotencyKey: string;
+  text: string;
+  signal: AbortSignal;
+  onText: (text: string) => void;
+  onRun: (runId: string) => void;
+}
+
+export interface VoiceAgentClient {
+  invoke(request: AgentTurnRequest): Promise<void>;
+  close(): void;
+}
+
+export interface VoiceSessionBinding {
+  voiceSessionId: string;
+  runtimeId: string;
+  runtimeProfile: string;
+  runtimeConversationId: string;
+  sandbox: string;
+  agent: string;
+  agentSessionKey: string;
+  expiresAt: string;
+}
+
+export interface VoiceDiagnostic {
+  event: string;
+  state: string;
+  voiceSessionId?: string;
+  turnId?: string;
+  responseId?: string;
+  openClawRunId?: string;
+  reason?: string;
+  durationMs?: number;
+}
+
+export class VoiceSessionError extends Error {
+  constructor(
+    readonly code:
+      | "duplicate_turn"
+      | "invalid_grant"
+      | "invalid_request"
+      | "session_expired"
+      | "session_in_progress"
+      | "session_not_found"
+      | "turn_in_progress",
+    readonly status: number,
+  ) {
+    super(code);
+  }
+}
+
+interface SessionRecord extends VoiceSessionBinding {
+  grantHash: Buffer;
+  expiresAtMs: number;
+  expiryTimer: NodeJS.Timeout;
+  agentClient: VoiceAgentClient;
+  acceptedCommitId?: string;
+  active?: {
+    turnId: string;
+    responseId: string;
+    startedAt: number;
+    controller: AbortController;
+    timedOut: boolean;
+    responseLimitExceeded?: boolean;
+    expiryReason?: "session_closed" | "session_expired";
+    runId?: string;
+  };
+}
+
+export interface VoiceSessionServiceOptions {
+  runtimeId: string;
+  runtimeProfile: string;
+  sandbox: string;
+  agent: string;
+  sessionLifetimeMs: number;
+  turnTimeoutMs: number;
+  createAgentClient: () => VoiceAgentClient;
+  diagnostic?: (diagnostic: VoiceDiagnostic) => void;
+  now?: () => number;
+  randomId?: () => string;
+  randomGrant?: () => string;
+}
+
+function hashCredential(value: string): Buffer {
+  return crypto.createHash("sha256").update(value).digest();
+}
+
+function equalCredential(value: string, expectedHash: Buffer): boolean {
+  return crypto.timingSafeEqual(hashCredential(value), expectedHash);
+}
+
+function requireBoundedString(value: unknown, label: string, maxBytes: number): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    Buffer.byteLength(value) > maxBytes ||
+    /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(value)
+  ) {
+    throw new VoiceSessionError("invalid_request", 400);
+  }
+  if (label === "text" && value.trim().length === 0) {
+    throw new VoiceSessionError("invalid_request", 400);
+  }
+  return value;
+}
+
+export class VoiceSessionService {
+  private session?: SessionRecord;
+  private readonly now: () => number;
+  private readonly randomId: () => string;
+  private readonly randomGrant: () => string;
+  private readonly diagnostic: (diagnostic: VoiceDiagnostic) => void;
+
+  constructor(private readonly options: VoiceSessionServiceOptions) {
+    this.now = options.now ?? Date.now;
+    this.randomId = options.randomId ?? crypto.randomUUID;
+    this.randomGrant = options.randomGrant ?? (() => crypto.randomBytes(32).toString("base64url"));
+    this.diagnostic = options.diagnostic ?? (() => {});
+    if (
+      !Number.isInteger(options.sessionLifetimeMs) ||
+      options.sessionLifetimeMs < 1 ||
+      options.sessionLifetimeMs > VOICE_MAX_SESSION_LIFETIME_MS
+    ) {
+      throw new Error(
+        `Voice session lifetime must be an integer between 1 and ${VOICE_MAX_SESSION_LIFETIME_MS}.`,
+      );
+    }
+    if (
+      !Number.isInteger(options.turnTimeoutMs) ||
+      options.turnTimeoutMs < 1 ||
+      options.turnTimeoutMs > VOICE_MAX_TURN_TIMEOUT_MS
+    ) {
+      throw new Error(
+        `Voice turn timeout must be an integer between 1 and ${VOICE_MAX_TURN_TIMEOUT_MS}.`,
+      );
+    }
+  }
+
+  createSession(runtimeConversationIdValue: unknown): VoiceSessionBinding & { grant: string } {
+    this.expireIfNeeded();
+    if (this.session) throw new VoiceSessionError("session_in_progress", 409);
+    const runtimeConversationId = requireBoundedString(
+      runtimeConversationIdValue,
+      "runtimeConversationId",
+      256,
+    );
+    const voiceSessionId = this.randomId();
+    const grant = this.randomGrant();
+    const expiresAtMs = this.now() + this.options.sessionLifetimeMs;
+    const agentClient = this.options.createAgentClient();
+    const binding: VoiceSessionBinding = {
+      voiceSessionId,
+      runtimeId: this.options.runtimeId,
+      runtimeProfile: this.options.runtimeProfile,
+      runtimeConversationId,
+      sandbox: this.options.sandbox,
+      agent: this.options.agent,
+      agentSessionKey: `agent:${this.options.agent}:voice:${this.randomId()}`,
+      expiresAt: new Date(expiresAtMs).toISOString(),
+    };
+    const expiryTimer = setTimeout(
+      () => this.clearSession("session_expired"),
+      this.options.sessionLifetimeMs,
+    );
+    expiryTimer.unref();
+    this.session = {
+      ...binding,
+      grantHash: hashCredential(grant),
+      expiresAtMs,
+      expiryTimer,
+      agentClient,
+    };
+    this.diagnostic({ event: "session.created", state: "active", voiceSessionId });
+    return { ...binding, grant };
+  }
+
+  getBindingForTest(): VoiceSessionBinding | undefined {
+    if (!this.session) return undefined;
+    const {
+      grantHash: _grantHash,
+      expiresAtMs: _expiresAtMs,
+      expiryTimer: _expiryTimer,
+      agentClient: _agentClient,
+      active: _active,
+      acceptedCommitId: _acceptedCommitId,
+      ...binding
+    } = this.session;
+    return binding;
+  }
+
+  authorize(voiceSessionId: string, grant: string): SessionRecord {
+    this.expireIfNeeded();
+    const session = this.session;
+    if (!session || session.voiceSessionId !== voiceSessionId) {
+      throw new VoiceSessionError("session_not_found", 404);
+    }
+    if (!equalCredential(grant, session.grantHash)) {
+      throw new VoiceSessionError("invalid_grant", 401);
+    }
+    return session;
+  }
+
+  closeSession(voiceSessionId: string, grant: string): void {
+    this.authorize(voiceSessionId, grant);
+    this.clearSession("session_closed");
+  }
+
+  disconnectTurn(voiceSessionId: string): void {
+    const session = this.session;
+    if (!session || session.voiceSessionId !== voiceSessionId || !session.active) return;
+    session.active.controller.abort();
+    session.agentClient.close();
+  }
+
+  startTurn(
+    voiceSessionId: string,
+    grant: string,
+    commitIdValue: unknown,
+    textValue: unknown,
+    deliver: (event: VoiceResponseEvent) => boolean,
+  ): Promise<void> {
+    const session = this.authorize(voiceSessionId, grant);
+    const commitId = requireBoundedString(commitIdValue, "commitId", VOICE_MAX_COMMIT_ID_BYTES);
+    const text = requireBoundedString(textValue, "text", VOICE_MAX_TURN_TEXT_BYTES);
+    if (session.acceptedCommitId === commitId) {
+      throw new VoiceSessionError("duplicate_turn", 409);
+    }
+    if (session.active) throw new VoiceSessionError("turn_in_progress", 409);
+    if (session.acceptedCommitId) throw new VoiceSessionError("duplicate_turn", 409);
+
+    session.acceptedCommitId = commitId;
+    const turnId = this.randomId();
+    const responseId = this.randomId();
+    const controller = new AbortController();
+    session.active = {
+      turnId,
+      responseId,
+      startedAt: this.now(),
+      controller,
+      timedOut: false,
+    };
+    return Promise.resolve().then(() => this.runTurn(session, text, deliver));
+  }
+
+  private async runTurn(
+    session: SessionRecord,
+    text: string,
+    deliver: (event: VoiceResponseEvent) => boolean,
+  ): Promise<void> {
+    const active = session.active;
+    if (!active) return;
+    let sequence = 0;
+    let terminal = false;
+    let responseBytes = 0;
+    let deliveryOpen = deliver({
+      type: "response.started",
+      sequence: ++sequence,
+      voiceSessionId: session.voiceSessionId,
+      turnId: active.turnId,
+      responseId: active.responseId,
+    });
+    this.diagnostic({
+      event: "response.started",
+      state: "running",
+      voiceSessionId: session.voiceSessionId,
+      turnId: active.turnId,
+      responseId: active.responseId,
+    });
+
+    const emitTerminal = (reason?: VoiceFailureReason) => {
+      if (terminal) return;
+      terminal = true;
+      if (deliveryOpen) {
+        deliveryOpen = deliver(
+          reason
+            ? {
+                type: "response.failed",
+                sequence: ++sequence,
+                voiceSessionId: session.voiceSessionId,
+                turnId: active.turnId,
+                responseId: active.responseId,
+                reason,
+              }
+            : {
+                type: "response.completed",
+                sequence: ++sequence,
+                voiceSessionId: session.voiceSessionId,
+                turnId: active.turnId,
+                responseId: active.responseId,
+              },
+        );
+      }
+      this.diagnostic({
+        event: reason ? "response.failed" : "response.completed",
+        state: reason ? "failed" : "completed",
+        voiceSessionId: session.voiceSessionId,
+        turnId: active.turnId,
+        responseId: active.responseId,
+        openClawRunId: active.runId,
+        reason,
+        durationMs: Math.max(0, this.now() - active.startedAt),
+      });
+    };
+
+    const timeout = setTimeout(() => {
+      active.timedOut = true;
+      active.controller.abort();
+      session.agentClient.close();
+    }, this.options.turnTimeoutMs);
+    timeout.unref();
+
+    try {
+      await session.agentClient.invoke({
+        agentSessionKey: session.agentSessionKey,
+        idempotencyKey: hashCredential(active.turnId).toString("base64url"),
+        text,
+        signal: active.controller.signal,
+        onRun: (runId) => {
+          active.runId = runId;
+        },
+        onText: (delta) => {
+          if (terminal || active.controller.signal.aborted || delta.length === 0) return;
+          responseBytes += Buffer.byteLength(delta);
+          if (responseBytes > VOICE_MAX_RESPONSE_TEXT_BYTES) {
+            active.responseLimitExceeded = true;
+            active.controller.abort();
+            session.agentClient.close();
+            return;
+          }
+          if (!deliveryOpen) return;
+          deliveryOpen = deliver({
+            type: "response.text.delta",
+            sequence: ++sequence,
+            voiceSessionId: session.voiceSessionId,
+            turnId: active.turnId,
+            responseId: active.responseId,
+            text: delta,
+          });
+        },
+      });
+      if (responseBytes > VOICE_MAX_RESPONSE_TEXT_BYTES) emitTerminal("agent_response_limit");
+      else if (active.expiryReason) emitTerminal(active.expiryReason);
+      else if (active.timedOut) emitTerminal("turn_timeout");
+      else emitTerminal();
+    } catch (error) {
+      const reason =
+        active.expiryReason ??
+        (active.responseLimitExceeded
+          ? "agent_response_limit"
+          : active.timedOut
+            ? "turn_timeout"
+            : isVoiceFailureReason(error)
+              ? error.reason
+              : "agent_unavailable");
+      emitTerminal(reason);
+    } finally {
+      clearTimeout(timeout);
+      session.agentClient.close();
+      if (session.active === active) session.active = undefined;
+    }
+  }
+
+  private expireIfNeeded(): void {
+    if (this.session && this.now() >= this.session.expiresAtMs) {
+      this.clearSession("session_expired");
+    }
+  }
+
+  private clearSession(reason: "session_closed" | "session_expired"): void {
+    const session = this.session;
+    if (!session) return;
+    this.session = undefined;
+    clearTimeout(session.expiryTimer);
+    if (session.active) {
+      session.active.expiryReason = reason;
+      session.active.controller.abort();
+    }
+    session.agentClient.close();
+    this.diagnostic({
+      event: reason === "session_expired" ? "session.expired" : "session.closed",
+      state: reason === "session_expired" ? "expired" : "closed",
+      voiceSessionId: session.voiceSessionId,
+      reason,
+    });
+  }
+}
+
+export class VoiceAgentError extends Error {
+  constructor(
+    readonly reason: Exclude<
+      VoiceFailureReason,
+      "session_closed" | "session_expired" | "turn_timeout"
+    >,
+  ) {
+    super(reason);
+  }
+}
+
+function isVoiceFailureReason(error: unknown): error is VoiceAgentError {
+  return error instanceof VoiceAgentError;
+}

--- a/src/lib/domain/voice/session-service.ts
+++ b/src/lib/domain/voice/session-service.ts
@@ -259,9 +259,14 @@ export class VoiceSessionService {
     this.clearSession("session_closed");
   }
 
-  disconnectTurn(voiceSessionId: string): void {
-    const session = this.session;
-    if (!session || session.voiceSessionId !== voiceSessionId || !session.active) return;
+  disconnectTurn(voiceSessionId: string, grant: string): void {
+    let session: SessionRecord;
+    try {
+      session = this.authorize(voiceSessionId, grant);
+    } catch {
+      return;
+    }
+    if (!session.active) return;
     session.active.controller.abort();
     session.agentClient.close();
   }
@@ -356,6 +361,14 @@ export class VoiceSessionService {
       });
     };
 
+    const failureReason = (): VoiceFailureReason | undefined =>
+      active.expiryReason ??
+      (active.responseLimitExceeded
+        ? "agent_response_limit"
+        : active.timedOut
+          ? "turn_timeout"
+          : undefined);
+
     const timeout = setTimeout(() => {
       active.timedOut = true;
       active.controller.abort();
@@ -392,21 +405,11 @@ export class VoiceSessionService {
           });
         },
       });
-      if (responseBytes > VOICE_MAX_RESPONSE_TEXT_BYTES) emitTerminal("agent_response_limit");
-      else if (active.expiryReason) emitTerminal(active.expiryReason);
-      else if (active.timedOut) emitTerminal("turn_timeout");
-      else emitTerminal();
+      emitTerminal(failureReason());
     } catch (error) {
-      const reason =
-        active.expiryReason ??
-        (active.responseLimitExceeded
-          ? "agent_response_limit"
-          : active.timedOut
-            ? "turn_timeout"
-            : isVoiceFailureReason(error)
-              ? error.reason
-              : "agent_unavailable");
-      emitTerminal(reason);
+      emitTerminal(
+        failureReason() ?? (isVoiceFailureReason(error) ? error.reason : "agent_unavailable"),
+      );
     } finally {
       clearTimeout(timeout);
       session.agentClient.close();

--- a/test/internal-cli.test.ts
+++ b/test/internal-cli.test.ts
@@ -97,6 +97,19 @@ describe("internal oclif namespace", () => {
     });
   });
 
+  it("routes the experimental voice gateway through its internal command ID (#8378)", () => {
+    const result = spawnSync(
+      process.execPath,
+      [CLI, "internal", "voice-gateway", "serve", "--help"],
+      { encoding: "utf-8" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Internal: serve the experimental voice gateway");
+    expect(result.stdout).toContain("--admission-credential-file");
+    expect(result.stdout).toContain("--openclaw-credential-file");
+  });
+
   it("exposes installer ref and env normalization helpers through oclif routing", () => {
     const ref = spawnSync(
       process.execPath,

--- a/test/internal-commands-docs.test.ts
+++ b/test/internal-commands-docs.test.ts
@@ -89,11 +89,24 @@ describe("internal command documentation (#3782)", () => {
     expect(internalIds.length).toBeGreaterThanOrEqual(9);
   });
 
-  it.each(references)("documents every hidden internal command in $name", ({ text, binary }) => {
-    const undocumented = internalIds.filter(
-      (id) => !text.includes(spaceFormInvocation(binary, id)),
-    );
+  it.each(references)("documents every generally applicable hidden internal command in $name", ({
+    text,
+    binary,
+  }) => {
+    const undocumented = internalIds
+      .filter((id) => id !== "internal:voice-gateway:serve")
+      .filter((id) => !text.includes(spaceFormInvocation(binary, id)));
     expect(undocumented).toEqual([]);
+  });
+
+  it("publishes the experimental voice gateway only in the OpenClaw reference", () => {
+    const commandId = "internal:voice-gateway:serve";
+    expect(renderedCommandReferences[0].text).toContain(
+      spaceFormInvocation(renderedCommandReferences[0].binary, commandId),
+    );
+    for (const reference of renderedCommandReferences.slice(1)) {
+      expect(reference.text).not.toContain(spaceFormInvocation(reference.binary, commandId));
+    }
   });
 
   it.each(references)("keeps internal commands out of the public command headings in $name", ({

--- a/test/package-contract/cli/oclif-metadata.test.ts
+++ b/test/package-contract/cli/oclif-metadata.test.ts
@@ -26,6 +26,13 @@ describe("oclif metadata lookup", () => {
     );
   });
 
+  it("includes the hidden experimental voice gateway command in the compiled package (#8378)", () => {
+    expect(getRegisteredOclifCommandMetadata("internal:voice-gateway:serve")).toMatchObject({
+      hidden: true,
+      summary: "Internal: serve the experimental voice gateway",
+    });
+  });
+
   it("keeps generated manifest command IDs aligned with oclif Config", async () => {
     const config = await OclifConfig.load(process.cwd());
     const expectedIds = config.commands.map((command) => command.id).sort();

--- a/test/voice-gateway-integration.test.ts
+++ b/test/voice-gateway-integration.test.ts
@@ -40,65 +40,70 @@ class FakeOpenClawSocket extends EventTarget {
       params: Record<string, unknown>;
     };
     this.invocations.push(request.params);
-    const payload =
-      request.method === "chat.send" ? { runId: "fixture-run" } : { type: "hello-ok" };
-    queueMicrotask(() => {
-      this.dispatchEvent(
-        new MessageEvent("message", {
-          data: JSON.stringify({ type: "res", id: request.id, ok: true, payload }),
-        }),
-      );
-    });
-    if (request.method !== "chat.send") return;
-    const sessionKey = request.params.sessionKey;
-    queueMicrotask(() => {
-      for (const event of [
-        {
-          sessionKey: "other-session",
-          runId: "fixture-run",
-          seq: 1,
-          state: "delta",
-          deltaText: "discarded session",
-        },
-        {
-          sessionKey,
-          runId: "other-run",
-          seq: 1,
-          state: "delta",
-          deltaText: "discarded run",
-        },
-        {
-          sessionKey,
-          runId: "fixture-run",
-          seq: 1,
-          state: "delta",
-          deltaText: "branch: fixture\n",
-        },
-        {
-          sessionKey,
-          runId: "fixture-run",
-          seq: 4,
-          state: "delta",
-          deltaText: "branch: wrong\nstatus: dirty",
-          replace: true,
-        },
-        {
-          sessionKey,
-          runId: "fixture-run",
-          seq: 7,
-          state: "delta",
-          deltaText: "branch: fixture\nstatus: clean",
-          replace: true,
-        },
-        { sessionKey, runId: "fixture-run", seq: 9, state: "final" },
-      ]) {
+    const respond = (payload: Record<string, unknown>) =>
+      queueMicrotask(() => {
         this.dispatchEvent(
           new MessageEvent("message", {
-            data: JSON.stringify({ type: "event", event: "chat", payload: event }),
+            data: JSON.stringify({ type: "res", id: request.id, ok: true, payload }),
           }),
         );
-      }
-    });
+      });
+    const sessionKey = request.params.sessionKey;
+    const handlers: Record<string, () => void> = {
+      connect: () => respond({ type: "hello-ok" }),
+      "chat.send": () => {
+        respond({ runId: "fixture-run" });
+        queueMicrotask(() => {
+          for (const event of [
+            {
+              sessionKey: "other-session",
+              runId: "fixture-run",
+              seq: 1,
+              state: "delta",
+              deltaText: "discarded session",
+            },
+            {
+              sessionKey,
+              runId: "other-run",
+              seq: 1,
+              state: "delta",
+              deltaText: "discarded run",
+            },
+            {
+              sessionKey,
+              runId: "fixture-run",
+              seq: 1,
+              state: "delta",
+              deltaText: "branch: fixture\n",
+            },
+            {
+              sessionKey,
+              runId: "fixture-run",
+              seq: 4,
+              state: "delta",
+              deltaText: "branch: wrong\nstatus: dirty",
+              replace: true,
+            },
+            {
+              sessionKey,
+              runId: "fixture-run",
+              seq: 7,
+              state: "delta",
+              deltaText: "branch: fixture\nstatus: clean",
+              replace: true,
+            },
+            { sessionKey, runId: "fixture-run", seq: 9, state: "final" },
+          ]) {
+            this.dispatchEvent(
+              new MessageEvent("message", {
+                data: JSON.stringify({ type: "event", event: "chat", payload: event }),
+              }),
+            );
+          }
+        });
+      },
+    };
+    handlers[request.method]?.();
   }
 }
 
@@ -165,10 +170,9 @@ describe("composed experimental voice gateway", () => {
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line));
-    const runtimeOutput: string[] = [];
-    for (const event of events) {
-      if (event.type === "response.text.delta") runtimeOutput.push(event.text);
-    }
+    const runtimeOutput = events
+      .filter((event) => event.type === "response.text.delta")
+      .map((event) => event.text);
 
     expect(runtimeOutput.join("")).toBe("branch: fixture\nstatus: clean");
     expect(events.filter((event) => event.type === "response.completed")).toHaveLength(1);

--- a/test/voice-gateway-integration.test.ts
+++ b/test/voice-gateway-integration.test.ts
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVoiceGatewayServer } from "../src/lib/adapters/http/voice-gateway";
+import { OpenClawVoiceAgentClient } from "../src/lib/adapters/openclaw/voice-agent-client";
+import { VoiceSessionService } from "../src/lib/domain/voice/session-service";
+
+const admission = "deployment-admission-credential-value-123456";
+const openClawCredential = "openclaw-gateway-credential-value-12345678";
+const httpServers: ReturnType<typeof createServer>[] = [];
+
+class FakeOpenClawSocket extends EventTarget {
+  static readonly OPEN = 1;
+  readyState = FakeOpenClawSocket.OPEN;
+  close = vi.fn();
+  readonly invocations: Record<string, unknown>[] = [];
+
+  start(): void {
+    queueMicrotask(() => {
+      this.dispatchEvent(new Event("open"));
+      this.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "event",
+            event: "connect.challenge",
+            payload: { nonce: "fixture-challenge" },
+          }),
+        }),
+      );
+    });
+  }
+
+  send(data: string): void {
+    const request = JSON.parse(data) as {
+      id: string;
+      method: string;
+      params: Record<string, unknown>;
+    };
+    this.invocations.push(request.params);
+    const payload =
+      request.method === "chat.send" ? { runId: "fixture-run" } : { type: "hello-ok" };
+    queueMicrotask(() => {
+      this.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({ type: "res", id: request.id, ok: true, payload }),
+        }),
+      );
+    });
+    if (request.method !== "chat.send") return;
+    const sessionKey = request.params.sessionKey;
+    queueMicrotask(() => {
+      for (const event of [
+        {
+          sessionKey: "other-session",
+          runId: "fixture-run",
+          seq: 1,
+          state: "delta",
+          deltaText: "discarded session",
+        },
+        {
+          sessionKey,
+          runId: "other-run",
+          seq: 1,
+          state: "delta",
+          deltaText: "discarded run",
+        },
+        {
+          sessionKey,
+          runId: "fixture-run",
+          seq: 1,
+          state: "delta",
+          deltaText: "branch: fixture\n",
+        },
+        {
+          sessionKey,
+          runId: "fixture-run",
+          seq: 4,
+          state: "delta",
+          deltaText: "branch: wrong\nstatus: dirty",
+          replace: true,
+        },
+        {
+          sessionKey,
+          runId: "fixture-run",
+          seq: 7,
+          state: "delta",
+          deltaText: "branch: fixture\nstatus: clean",
+          replace: true,
+        },
+        { sessionKey, runId: "fixture-run", seq: 9, state: "final" },
+      ]) {
+        this.dispatchEvent(
+          new MessageEvent("message", {
+            data: JSON.stringify({ type: "event", event: "chat", payload: event }),
+          }),
+        );
+      }
+    });
+  }
+}
+
+async function fixture() {
+  const socket = new FakeOpenClawSocket();
+  const service = new VoiceSessionService({
+    runtimeId: "trusted-runtime",
+    runtimeProfile: "voiceclaw-pinned-fixture",
+    sandbox: "fixture-sandbox",
+    agent: "main",
+    sessionLifetimeMs: 60_000,
+    turnTimeoutMs: 5_000,
+    createAgentClient: () =>
+      new OpenClawVoiceAgentClient({
+        endpoint: "ws://127.0.0.1:18789/ws",
+        credential: openClawCredential,
+        requestTimeoutMs: 2_000,
+        createSocket: () => {
+          socket.start();
+          return socket as never;
+        },
+      }),
+  });
+  const gateway = createVoiceGatewayServer({
+    admissionCredential: admission,
+    sessionService: service,
+  });
+  httpServers.push(gateway);
+  await new Promise<void>((resolve) => gateway.listen(0, "127.0.0.1", resolve));
+  return {
+    base: `http://127.0.0.1:${(gateway.address() as AddressInfo).port}`,
+    invocations: socket.invocations,
+  };
+}
+
+async function createSession(base: string) {
+  const response = await fetch(`${base}/v1/voice-sessions`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${admission}`, "content-type": "application/json" },
+    body: JSON.stringify({ runtimeConversationId: "fixture-conversation" }),
+  });
+  return (await response.json()) as { voiceSessionId: string; grant: string };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    httpServers
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+});
+
+describe("composed experimental voice gateway", () => {
+  it("routes a committed fixture turn into the runtime output path without exposing OpenClaw credentials (#8378)", async () => {
+    const { base, invocations } = await fixture();
+    const session = await createSession(base);
+    const response = await fetch(`${base}/v1/voice-sessions/${session.voiceSessionId}/turns`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${session.grant}`, "content-type": "application/json" },
+      body: JSON.stringify({ commitId: "fixture-commit", text: "report repository status" }),
+    });
+    const raw = await response.text();
+    const events = raw
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const runtimeOutput: string[] = [];
+    for (const event of events) {
+      if (event.type === "response.text.delta") runtimeOutput.push(event.text);
+    }
+
+    expect(runtimeOutput.join("")).toBe("branch: fixture\nstatus: clean");
+    expect(events.filter((event) => event.type === "response.completed")).toHaveLength(1);
+    expect(events.filter((event) => event.type === "response.failed")).toHaveLength(0);
+    expect(invocations[0]).toMatchObject({ scopes: ["operator.read", "operator.write"] });
+    expect(invocations[1]).toMatchObject({ message: "report repository status", deliver: false });
+    expect(raw).not.toContain(openClawCredential);
+    expect(raw).not.toContain("fixture-run");
+    expect(raw).not.toContain("chat.send");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the first experimental voice-gateway capability slice: one authenticated local runtime can create an expiring session and stream one committed text turn through a NemoClaw-owned OpenClaw boundary. The service remains hidden, foreground-only, loopback-only, OpenClaw-specific, and outside supported VoiceClaw or general voice claims.

## Related Issue

Fixes #8378
Parent: #8275

## Changes

- Add hidden `nemoclaw internal voice-gateway serve` routing behind the exact `NEMOCLAW_EXPERIMENTAL_VOICE_GATEWAY=1` gate.
- Separate private credential loading, HTTP/NDJSON transport, in-memory session and turn state, OpenClaw WebSocket protocol handling, and foreground service lifetime.
- Enforce owner-controlled credential files, random session grants, fixed operator configuration, loopback-only destinations, `operator.read`/`operator.write`, bounded inputs/queues/responses/deadlines, exact session/run correlation, duplicate and overlap rejection, cleanup, and content-free diagnostics.
- Add deterministic domain, adapter, composed integration, command-routing, variant-doc, and package-contract evidence.
- Document the OpenClaw-only experimental operational and credential-lifecycle contract.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent final nine-category review passed commit `0eb18814bf378105a96259277d2aad77b6127a10` with no findings after credential-path, OpenClaw protocol, queue, response, duration, and backpressure hardening.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/commands.mdx`; `src/commands/internal/README.md`
- Agent: Pi CLI
<!-- docs-review-head-sha: 0eb18814b -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 60 focused CLI, integration, internal-command, documentation-routing, and package-contract tests passed after rebasing to current `origin/main`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Focused behavior tests, `npm run build:cli`, `npm run typecheck:cli`, `npm run checks:repository`, `npm run validate:pr`, `npm run docs`, production `npm audit`, and `git diff --check` passed. Full live runtime validation remains for CI/E2E selection.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — build passed with 0 errors; two existing Fern warnings remain.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an opt-in, hidden experimental voice gateway with loopback-only access.
  - Supports authenticated sessions, streamed voice turns, health checks, bounded timeouts, and graceful shutdown.
  - Added secure private credential-file validation and OpenClaw voice-agent connectivity.

- **Documentation**
  - Documented setup, credentials, limits, diagnostics, and compatibility use cases.

- **Tests**
  - Added comprehensive unit, integration, security, CLI, and documentation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

