### PR TITLE
fix(onboard): keep the portable firewall driver in the Podman search path

### DIFF
--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -101,6 +101,31 @@ describe("preparePortableExperimentalHost", () => {
     expect(fs.statSync(containersConf).mode & 0o777).toBe(0o600);
   });
 
+  it("keeps the portable firewall driver in the podman default search path (#8441)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
+    tempDirs.push(home);
+    const systemctl = vi.fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>(() =>
+      result(),
+    );
+    const docker = vi
+      .fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>()
+      .mockReturnValueOnce(result(1))
+      .mockReturnValueOnce(result());
+    const podman = vi.fn(() => result(0, "/run/user/1001/podman/podman.sock\n"));
+
+    preparePortableExperimentalHost(
+      { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
+      { platform: "linux", home, uid: 1001, systemctl, podman, docker },
+    );
+
+    const dropIn = path.join(
+      home,
+      ".config/containers/containers.conf.d/99-nemoclaw-portable.conf",
+    );
+    expect(fs.readFileSync(dropIn, "utf-8")).toContain('firewall_driver = "iptables"');
+    expect(fs.statSync(dropIn).mode & 0o777).toBe(0o600);
+  });
+
   it("refuses to replace an unmanaged registry container", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
     tempDirs.push(home);

--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -101,7 +101,7 @@ describe("preparePortableExperimentalHost", () => {
     expect(fs.statSync(containersConf).mode & 0o777).toBe(0o600);
   });
 
-  it("keeps the portable firewall driver in the podman default search path (#8441)", () => {
+  it("keeps the portable firewall driver in the Podman default search path (#8441)", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
     tempDirs.push(home);
     const systemctl = vi.fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>(() =>

--- a/src/lib/onboard/experimental/portable-host-preparation.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.ts
@@ -87,14 +87,14 @@ function writePortableRuntimeConfig(home: string, env: NodeJS.ProcessEnv): strin
     path.join(configHome, "containers", "registries.conf.d", "99-nemoclaw-portable.conf"),
     REGISTRY_FRAGMENT,
   );
-  // Podman reads `containers.conf.d` drop-ins from its own default search path, so this copy
+  // Podman reads `containers.conf.d` drop-ins from its own default search path, so this drop-in
   // keeps `firewall_driver` in effect for a shell that starts without CONTAINERS_CONF. The
   // `systemctl --user set-environment` values below last only until the user manager restarts.
   writePrivateConfig(
     path.join(configHome, "containers", "containers.conf.d", "99-nemoclaw-portable.conf"),
     PORTABLE_CONTAINERS_CONF,
   );
-  // Read through CONTAINERS_CONF by the OpenShell gateway service environment.
+  // The OpenShell gateway service and sandbox prebuild read this file through CONTAINERS_CONF.
   const containersConf = path.join(configHome, "nemoclaw", "portable", "containers.conf");
   writePrivateConfig(containersConf, PORTABLE_CONTAINERS_CONF);
   return containersConf;

--- a/src/lib/onboard/experimental/portable-host-preparation.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.ts
@@ -87,6 +87,14 @@ function writePortableRuntimeConfig(home: string, env: NodeJS.ProcessEnv): strin
     path.join(configHome, "containers", "registries.conf.d", "99-nemoclaw-portable.conf"),
     REGISTRY_FRAGMENT,
   );
+  // Podman reads `containers.conf.d` drop-ins from its own default search path, so this copy
+  // keeps `firewall_driver` in effect for a shell that starts without CONTAINERS_CONF. The
+  // `systemctl --user set-environment` values below last only until the user manager restarts.
+  writePrivateConfig(
+    path.join(configHome, "containers", "containers.conf.d", "99-nemoclaw-portable.conf"),
+    PORTABLE_CONTAINERS_CONF,
+  );
+  // Read through CONTAINERS_CONF by the OpenShell gateway service environment.
   const containersConf = path.join(configHome, "nemoclaw", "portable", "containers.conf");
   writePrivateConfig(containersConf, PORTABLE_CONTAINERS_CONF);
   return containersConf;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The hidden portable Podman profile lost its network settings after a user session or host restart, so the sandbox container could no longer start. Podman ignores every other config file when `CONTAINERS_CONF` is set, and the variable that pointed at the portable config did not survive a systemd user-manager restart. This writes the same settings to the `containers.conf.d` drop-in that Podman already reads from its own default search path, so `firewall_driver` stays in effect in a new shell without any environment variable.

## Related Issue

Refs #8441

## Changes

- Write the portable network settings to `$XDG_CONFIG_HOME/containers/containers.conf.d/99-nemoclaw-portable.conf`, next to the `registries.conf.d` fragment the same function already writes.
- Add a test that the drop-in carries `firewall_driver = "iptables"` at mode `0600`.

This is not a new fallback layer. It is the config path Podman documents as its own default for rootless users: `containers.conf.5` states that a rootless engine reads `$XDG_CONFIG_HOME/containers/containers.conf` and `$XDG_CONFIG_HOME/containers/containers.conf.d/*.conf`, and that "if the `CONTAINERS_CONF` environment variable is set, all system and user config files are ignored and only the specified config file will be loaded". The existing private copy at `~/.config/nemoclaw/portable/containers.conf` is kept because two current consumers read it through `CONTAINERS_CONF`: the OpenShell gateway service environment (`src/lib/onboard/docker-driver-gateway-env.ts:242`) and the sandbox prebuild subprocess environment (`src/lib/onboard/sandbox-prebuild.ts:27`). The new test protects the drop-in; the existing "prepares the rootless socket and managed loopback registry deterministically" test protects the private copy.

### Scope

This fixes the container-start half of #8441 only, which is repro steps 4-8. Steps 9-11 stay broken: the restarted container returns without `openshell.ai/*` labels and without the `nemoclaw-start` supervisor, so lifecycle recovery still reports `privileged control unavailable`. That authority belongs to the OpenShell provider and to epic #7744, so this uses `Refs` rather than a closing keyword.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `--experimental-profile portable` is a hidden flag with zero occurrences in `docs/` and `fern/`, and the published support statements say the opposite of activation (`docs/reference/platform-support.mdx:167` lists Podman as unsupported; `docs/changelog/2026-08-03.mdx:37` states the portable work "does not register Podman, activate buildless onboarding, or add a new supported runtime provider"). Documenting it would establish an unapproved product surface under the Product Scope Gate. The sibling `registries.conf.d` fragment written by the same function is likewise undocumented.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Onboarding path. The change adds one `writePrivateConfig` call that reuses the existing helper, which creates the file with `O_NOFOLLOW` through `openRegularFileNoFollow` and sets mode `0600`. It writes a fixed, non-secret TOML constant to a fixed path, takes no external input, and runs only when `isPortableExperimentalProfile(env)` is true. No credential, policy, or network-egress surface changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. The reviewer confirmed the flag is registered `hidden: true` at `src/lib/onboard/command-support.ts:155`, and confirmed zero hits across `docs/` and `fern/` for `experimental-profile`, `containers.conf`, `NETAVARK`, and `firewall_driver`. The published support statements say the opposite of activation (`docs/reference/platform-support.mdx:167`; `docs/reference/troubleshooting.mdx:2936`), so no page describes this behavior incorrectly and the Product Scope Gate blocks documenting the profile as canonical. The reviewer independently verified both `CONTAINERS_CONF` readers named in the added comment (`src/lib/onboard/docker-driver-gateway-env.ts:242` and `src/lib/onboard/sandbox-prebuild.ts:27`) and found no third reader; the first draft named only one, and commit `68dd8d698` corrects that. No dated changelog entry is required, because `docs/CONTRIBUTING.md:85` scopes `docs/changelog/` to pre-tag release entries.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4dbd170f4 -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/onboard/experimental/portable-host-preparation.test.ts` → 6/6 passed. Neighboring lanes `docker-driver-gateway-env.test.ts` and `fatal-runtime-preflight.test.ts` → 15/15 passed. `npm run checks:repository` passed, including the source-shape test budget and test file size budget. `npx biome check src/lib/onboard/experimental/` clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### `pre-push` hook status

Resolved. The earlier `TypeScript (CLI)` failure was a duplicate `readinessComparisonMatches` implementation in `src/lib/inference/serving/resolver.ts` on `main` itself, not in this branch. #8437 removed it, and this branch now carries that fix through the merge from `main`.

Full validation passes at head `4dbd170f4` against merge base `2f297843b`:

```text
prek --stage pre-commit -> all Passed (hadolint and shellcheck skip: no matching files)
commitlint --from 2f297843b --to HEAD -> exit 0
prek --stage pre-push -> TypeScript (CLI) Passed, package.json <-> git tag version sync Passed
```

When reproducing, diff against the merge base rather than a fork `main`. A stale fork `main` widens the hook range to unrelated files and trips `hadolint` on Dockerfiles this branch does not touch.

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portable host preparation now configures Podman to use the iptables firewall driver.
  * Applies secure permissions to the generated container configuration.
* **Tests**
  * Added coverage confirming the configuration file is created with the expected firewall setting and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
