### PR TITLE
fix(installer): resolve the CLI through the user-local shim

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2241,26 +2241,17 @@ verify_nemoclaw() {
     fi
   fi
 
-  # The npm prefix active now can differ from the prefix the CLI was installed
-  # under — a Homebrew npm shadowing the installer's nvm npm, for example — which
-  # leaves the user-local shim as the only working entry point. Probe it here
-  # rather than only listing it in the diagnostic below, so a working install is
-  # not reported as a failure (#8311).
-  #
-  # NEMOCLAW_READY_NOW deliberately stays false for the same reason as the
-  # npm-prefix branch above: this shell still cannot resolve $_CLI_BIN by name,
-  # so print_done() must keep emitting the PATH-refresh hint.
+  # The active npm prefix can differ from the CLI installation prefix. The
+  # user-local shim can remain executable when the active prefix has no CLI.
+  # Probe the shim before reporting that installation failed (#8311).
   if [[ -x "$NEMOCLAW_SHIM_DIR/$_CLI_BIN" ]] \
     && is_real_nemoclaw_cli "$NEMOCLAW_SHIM_DIR/$_CLI_BIN" "$_CLI_BIN"; then
     _CLI_PATH="$NEMOCLAW_SHIM_DIR/$_CLI_BIN"
     record_cli_resolution_state "$_CLI_PATH" "$npm_bin"
 
-    # record_cli_resolution_state clears the refresh flag as soon as the shim
-    # directory sits on the initial PATH, which is the whole story only when the
-    # name resolves to this shim. A rejected binary earlier on PATH still
-    # shadows it, so re-check and keep the hint when it does — otherwise
-    # print_done() reports a clean install for a shell where $_CLI_BIN still
-    # runs the binary this function just refused.
+    # record_cli_resolution_state clears the refresh flag when the shim
+    # directory is on the initial PATH. A different command can resolve first.
+    # In that case, NEMOCLAW_READY_NOW must remain false.
     if [[ "$(command -v "$_CLI_BIN" 2>/dev/null)" -ef "$_CLI_PATH" ]]; then
       NEMOCLAW_READY_NOW=true
       info "Verified: ${_CLI_BIN} is available at $_CLI_PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2241,6 +2241,40 @@ verify_nemoclaw() {
     fi
   fi
 
+  # The npm prefix active now can differ from the prefix the CLI was installed
+  # under — a Homebrew npm shadowing the installer's nvm npm, for example — which
+  # leaves the user-local shim as the only working entry point. Probe it here
+  # rather than only listing it in the diagnostic below, so a working install is
+  # not reported as a failure (#8311).
+  #
+  # NEMOCLAW_READY_NOW deliberately stays false for the same reason as the
+  # npm-prefix branch above: this shell still cannot resolve $_CLI_BIN by name,
+  # so print_done() must keep emitting the PATH-refresh hint.
+  if [[ -x "$NEMOCLAW_SHIM_DIR/$_CLI_BIN" ]] \
+    && is_real_nemoclaw_cli "$NEMOCLAW_SHIM_DIR/$_CLI_BIN" "$_CLI_BIN"; then
+    _CLI_PATH="$NEMOCLAW_SHIM_DIR/$_CLI_BIN"
+    record_cli_resolution_state "$_CLI_PATH" "$npm_bin"
+
+    # record_cli_resolution_state clears the refresh flag as soon as the shim
+    # directory sits on the initial PATH, which is the whole story only when the
+    # name resolves to this shim. A rejected binary earlier on PATH still
+    # shadows it, so re-check and keep the hint when it does — otherwise
+    # print_done() reports a clean install for a shell where $_CLI_BIN still
+    # runs the binary this function just refused.
+    if [[ "$(command -v "$_CLI_BIN" 2>/dev/null)" -ef "$_CLI_PATH" ]]; then
+      NEMOCLAW_READY_NOW=true
+      info "Verified: ${_CLI_BIN} is available at $_CLI_PATH"
+      return 0
+    fi
+
+    NEMOCLAW_CURRENT_SHELL_NEEDS_PATH_REFRESH=true
+    NEMOCLAW_RECOVERY_EXPORT_DIR="${NEMOCLAW_RECOVERY_EXPORT_DIR:-$NEMOCLAW_SHIM_DIR}"
+    NEMOCLAW_RECOVERY_PROFILE="${NEMOCLAW_RECOVERY_PROFILE:-$(detect_shell_profile)}"
+    warn "Found ${_CLI_BIN} at $_CLI_PATH but this shell's PATH does not yet resolve it."
+    warn "Running onboarding via the absolute path; refresh your shell PATH afterwards (commands below)."
+    return 0
+  fi
+
   # Single warn header, then plain printf for each bullet. warn() prefixes
   # every line with "[warn]" + colour codes, which would render the bulleted
   # diagnostic table as six separate warnings rather than one structured block.

--- a/test/install-npm-resolution.test.ts
+++ b/test/install-npm-resolution.test.ts
@@ -102,6 +102,69 @@ function isLinuxRoot(): boolean {
   );
 }
 
+/**
+ * Builds an install tree where the active npm prefix bin has no CLI but the
+ * user-local shim is present and working, and the shim directory is absent
+ * from PATH. Callers that need the no-shim control remove `shimPath`.
+ */
+function createStaleNpmPrefixTree(): {
+  tmp: string;
+  fakeBin: string;
+  prefix: string;
+  shimPath: string;
+} {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-shim-probe-"));
+  const fakeBin = path.join(tmp, "bin");
+  const prefix = path.join(tmp, "prefix");
+  const shimPath = path.join(tmp, ".local", "bin", "nemoclaw");
+
+  fs.mkdirSync(fakeBin);
+  fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+  fs.mkdirSync(path.dirname(shimPath), { recursive: true });
+
+  writeExecutable(
+    path.join(fakeBin, "node"),
+    `#!/usr/bin/env bash
+exit 0
+`,
+  );
+  writeExecutable(
+    path.join(fakeBin, "npm"),
+    `#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
+  echo "$ACTIVE_NPM_PREFIX"
+  exit 0
+fi
+exit 99
+`,
+  );
+  writeExecutable(
+    shimPath,
+    `#!/usr/bin/env bash
+echo "nemoclaw v0.1.0"
+`,
+  );
+
+  return { tmp, fakeBin, prefix, shimPath };
+}
+
+function runVerifyNemoclaw(
+  tree: ReturnType<typeof createStaleNpmPrefixTree>,
+  extraEnv: Record<string, string> = {},
+) {
+  return runInstallerFunction(
+    "_CLI_BIN=nemoclaw; verify_nemoclaw; " +
+      "printf 'CLI_PATH=%s\\nREFRESH=%s\\nREADY=%s\\n' " +
+      '"$_CLI_PATH" "$NEMOCLAW_CURRENT_SHELL_NEEDS_PATH_REFRESH" "$NEMOCLAW_READY_NOW"',
+    tree.fakeBin,
+    {
+      ACTIVE_NPM_PREFIX: tree.prefix,
+      HOME: tree.tmp,
+      ...extraEnv,
+    },
+  );
+}
+
 describe("installer npm resolution", () => {
   it("creates user-local shims for every packaged CLI alias during the default install path", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-package-shims-"));
@@ -333,5 +396,64 @@ exit 98
 
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe("WRITABLE");
+  });
+
+  it("verifies through the user-local shim when the active npm prefix has no CLI (#8311)", () => {
+    const tree = createStaleNpmPrefixTree();
+
+    const result = runVerifyNemoclaw(tree);
+
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    expect(normalizeShellPathForAssert(result.stdout)).toContain(
+      `CLI_PATH=${normalizeShellPathForAssert(tree.shimPath)}`,
+    );
+    expect(result.stdout).toContain("REFRESH=true");
+    expect(result.stdout).toContain("READY=false");
+  });
+
+  it("keeps the PATH-refresh hint when a rejected binary still shadows the shim (#8311)", () => {
+    const tree = createStaleNpmPrefixTree();
+    writeExecutable(
+      path.join(tree.fakeBin, "nemoclaw"),
+      `#!/usr/bin/env bash
+echo "placeholder package"
+`,
+    );
+
+    const result = runVerifyNemoclaw(tree, {
+      PATH: [tree.fakeBin, path.dirname(tree.shimPath), TEST_SYSTEM_PATH].join(path.delimiter),
+    });
+
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    expect(normalizeShellPathForAssert(result.stdout)).toContain(
+      `CLI_PATH=${normalizeShellPathForAssert(tree.shimPath)}`,
+    );
+    expect(result.stdout).toContain("REFRESH=true");
+    expect(result.stdout).toContain("READY=false");
+  });
+
+  it("reports the CLI as ready when the shim itself resolves on PATH (#8311)", () => {
+    const tree = createStaleNpmPrefixTree();
+
+    const result = runVerifyNemoclaw(tree, {
+      PATH: [path.dirname(tree.shimPath), tree.fakeBin, TEST_SYSTEM_PATH].join(path.delimiter),
+    });
+
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    expect(normalizeShellPathForAssert(result.stdout)).toContain(
+      `CLI_PATH=${normalizeShellPathForAssert(tree.shimPath)}`,
+    );
+    expect(result.stdout).toContain("READY=true");
+    expect(result.stdout).toContain("REFRESH=false");
+  });
+
+  it("still fails the install when neither the npm prefix nor the shim has a CLI (#8311)", () => {
+    const tree = createStaleNpmPrefixTree();
+    fs.rmSync(tree.shimPath);
+
+    const result = runVerifyNemoclaw(tree);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("nemoclaw binary not found");
   });
 });

--- a/test/install-npm-resolution.test.ts
+++ b/test/install-npm-resolution.test.ts
@@ -135,6 +135,10 @@ if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
   echo "$ACTIVE_NPM_PREFIX"
   exit 0
 fi
+if [ "$1" = "uninstall" ] && [ "$2" = "-g" ] && [ "$3" = "nemoclaw" ] && [ -n "$NPM_UNINSTALL_TARGET" ]; then
+  rm -f -- "$NPM_UNINSTALL_TARGET"
+  exit 0
+fi
 exit 99
 `,
   );
@@ -160,6 +164,7 @@ function runVerifyNemoclaw(
     {
       ACTIVE_NPM_PREFIX: tree.prefix,
       HOME: tree.tmp,
+      NPM_UNINSTALL_TARGET: "",
       ...extraEnv,
     },
   );
@@ -440,6 +445,30 @@ echo "placeholder package"
     });
 
     expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    expect(normalizeShellPathForAssert(result.stdout)).toContain(
+      `CLI_PATH=${normalizeShellPathForAssert(tree.shimPath)}`,
+    );
+    expect(result.stdout).toContain("READY=true");
+    expect(result.stdout).toContain("REFRESH=false");
+  });
+
+  it("resolves the CLI name to the user-local shim after npm removes a rejected PATH command (#8311)", () => {
+    const tree = createStaleNpmPrefixTree();
+    const shadowPath = path.join(tree.fakeBin, "nemoclaw");
+    writeExecutable(
+      shadowPath,
+      `#!/usr/bin/env bash
+echo "placeholder package"
+`,
+    );
+
+    const result = runVerifyNemoclaw(tree, {
+      NPM_UNINSTALL_TARGET: shadowPath,
+      PATH: [tree.fakeBin, path.dirname(tree.shimPath), TEST_SYSTEM_PATH].join(path.delimiter),
+    });
+
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    expect(fs.existsSync(shadowPath)).toBe(false);
     expect(normalizeShellPathForAssert(result.stdout)).toContain(
       `CLI_PATH=${normalizeShellPathForAssert(tree.shimPath)}`,
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fixes installer verification when npm prefix changes leave NemoClaw available only through the user-local shim. The installer now probes the shim after the npm-prefix checks and records whether the calling shell needs a PATH refresh.

This replacement preserves Dongni Yang's original commit from #8440 and adds the missing regression coverage.

## Related Issue

Closes #8311

## Changes

- Probe the user-local shim when the active npm prefix does not expose the CLI.
- Re-check command resolution before recording readiness so a rejected binary that shadows the shim keeps the PATH-refresh guidance.
- Cover stale-prefix, shadowing, shim-on-PATH, npm-uninstall, and missing-shim behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `docs/reference/troubleshooting.mdx` already explains how to source the shell profile and add `~/.local/bin` to `PATH`. The removed installer failure was not documented.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: An independent review passed all nine security categories for PR commit `d2b1ea5139076b45bf366dcec04a3a75dd8cf49e` against base SHA `2f297843b8fddad80b046eaf34f2987bdd922711`. The existing shim trust boundary does not change.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: No waiver is recorded.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed `scripts/install.sh`, `test/install-npm-resolution.test.ts`, and the existing user-local shim recovery in `docs/reference/troubleshooting.mdx` for PR commit `d2b1ea5139076b45bf366dcec04a3a75dd8cf49e` against base SHA `2f297843b8fddad80b046eaf34f2987bdd922711`. The change removes an undocumented failure and retains the documented recovery action. The review covered repository terminology, test titles, comments, security wording, and documentation ownership; no documentation or code sample changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d2b1ea5139076b45bf366dcec04a3a75dd8cf49e -->
<!-- docs-review-agents-blob-sha: c69aad4d563f774afb9924b33122b9485a48cdeb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` does not change.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub — both contributor commits and the current-main refresh commit are GitHub Verified.
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — normal hooks passed for the contributor fix, remediation, and current-main refresh.
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — GitHub Actions is authoritative; no standalone local test suite ran for the reviewed replacement commit.
- [ ] Applicable broad gate passed — GitHub Actions has not completed for the replacement PR.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — not applicable; no documentation changes.
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only) — not applicable; no documentation changes.
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — not applicable; no new page.

---

Signed-off-by: Dongni Yang <dongniy@nvidia.com>
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI detection when the active npm installation path does not contain the command.
  * Added support for valid user-local CLI shims.
  * Provides clearer onboarding guidance when PATH needs refreshing.
  * Correctly resolves valid shims and removes conflicting invalid command entries.
  * Reports a clear failure when no usable CLI installation is found.

* **Tests**
  * Added coverage for local shim discovery, PATH handling, conflicting binaries, and missing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->