### PR TITLE
fix(e2e): accept push publication preflight

### DIFF
--- a/test/e2e/support/base-image-publication.test.ts
+++ b/test/e2e/support/base-image-publication.test.ts
@@ -14,6 +14,7 @@ import {
   type FirstParentHistory,
   githubRequest,
   type PublicationRun,
+  isBaseImagePublicationEvent,
   parseBaseImagePushPaths,
   resolveFirstParentHistory,
   selectPublicationRun,
@@ -161,6 +162,18 @@ function successfulJobs(overrides: { runAttempt?: number } = {}): Record<string,
 }
 
 describe("base-image publication evidence", () => {
+  it.each(["push", "workflow_dispatch"])("accepts %s publication preflight events", (eventName) => {
+    expect(isBaseImagePublicationEvent(eventName)).toBe(true);
+  });
+
+  it.each([
+    "schedule",
+    "pull_request",
+    undefined,
+  ])("rejects unsupported %s publication preflight events", (eventName) => {
+    expect(isBaseImagePublicationEvent(eventName)).toBe(false);
+  });
+
   it("extracts literal paths and the reviewed managed-image input families (#7372)", () => {
     const source = fs.readFileSync(
       path.resolve(import.meta.dirname, "../../../.github/workflows/base-image.yaml"),

--- a/tools/e2e/base-image-publication.mts
+++ b/tools/e2e/base-image-publication.mts
@@ -709,6 +709,10 @@ function parseDurationArgument(argv: string[], name: string, defaultSeconds: num
   return seconds;
 }
 
+export function isBaseImagePublicationEvent(eventName: string | undefined): boolean {
+  return eventName === "push" || eventName === "workflow_dispatch";
+}
+
 export async function main(argv = process.argv.slice(2), env = process.env): Promise<void> {
   const known = new Set(["--wait-seconds", "--poll-seconds"]);
   for (let index = 0; index < argv.length; index += 2) {
@@ -736,8 +740,8 @@ export async function main(argv = process.argv.slice(2), env = process.env): Pro
   if (env.GITHUB_REF !== "refs/heads/main") {
     throw new Error("GITHUB_REF must be refs/heads/main");
   }
-  if (env.GITHUB_EVENT_NAME !== "schedule" && env.GITHUB_EVENT_NAME !== "workflow_dispatch") {
-    throw new Error("GITHUB_EVENT_NAME must be schedule or workflow_dispatch");
+  if (!isBaseImagePublicationEvent(env.GITHUB_EVENT_NAME)) {
+    throw new Error("GITHUB_EVENT_NAME must be push or workflow_dispatch");
   }
   if (env.GITHUB_SHA !== expectedSha) {
     throw new Error("EXPECTED_SHA must match GITHUB_SHA");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The first push-triggered E2E run after #8445 failed before matrix generation because the base-image publication preflight accepted only the retired schedule event and manual dispatches. Accept trusted pushes to `main` while retaining manual dispatch support and rejecting scheduled, pull-request, or missing events.

## Changes

- Recognize `push` and `workflow_dispatch` as the only base-image publication preflight events.
- Keep repository, `main` ref, and exact `GITHUB_SHA` binding unchanged.
- Add focused positive and negative event regression cases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This aligns an internal E2E publication preflight with the trusted workflow event. It does not change a user-facing command, configuration, or supported product workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: A nine-category review of commit `c01c7146b4c7105756eb936d7d11efd608a50858` found no findings. The change does not alter token flow, repository/ref/SHA binding, dependencies, logging, cryptography, or privileges; negative tests retain rejection of schedule, pull-request, and missing events.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independent review confirmed this internal preflight alignment changes no public command, configuration, user workflow, agent-runtime behavior, guide variant, or support claim. Changed files: `tools/e2e/base-image-publication.mts` and `test/e2e/support/base-image-publication.test.ts`.
- Agent: Pi CLI
<!-- docs-review-head-sha: c01c7146b4c7105756eb936d7d11efd608a50858 -->
<!-- docs-review-agents-blob-sha: c69aad4d563f774afb9924b33122b9485a48cdeb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/base-image-publication.test.ts test/e2e/support/base-image-publication-workflow-boundary.test.ts`: 66 tests passed after formatting.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: GitHub CI is authoritative for broad validation.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Base image publication workflows now run only for supported `push` and manual trigger events.
  * Scheduled and pull request events are no longer accepted for base image publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->