### PR TITLE
fix(uninstall): ignore desktop metadata in the gateway scan

### DIFF
--- a/src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts
+++ b/src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts
@@ -75,65 +75,65 @@ function makeHome(prefix: string, entries: readonly string[]): { home: string; s
   return { home, shims };
 }
 
+/**
+ * Runs the plan and reports which shims are still on disk afterwards. Removal
+ * goes through the real filesystem, restricted to the temporary home, so the
+ * assertions read the outcome rather than the calls a test double recorded.
+ */
 function uninstall(home: string, shims: readonly string[]) {
   const logs: string[] = [];
-  const removed: string[] = [];
   const result = runUninstallPlan(
     { assumeYes: true, deleteModels: false, keepOpenShell: false },
     {
       commandExists: (command) => command !== "docker" && command !== "lsof" && command !== "pgrep",
       env: { HOME: home } as NodeJS.ProcessEnv,
-      existsSync: (target) => shims.includes(target),
+      existsSync: (target) => shims.includes(target) && fs.existsSync(target),
       isTty: false,
       log: (line) => logs.push(line),
-      rmSync: vi.fn((target: fs.PathLike) => {
-        removed.push(String(target));
+      rmSync: vi.fn((target: fs.PathLike, options?: fs.RmOptions) => {
+        String(target).startsWith(home) ? fs.rmSync(target, options) : undefined;
       }),
       run: vi.fn(okWithKnownGatewayList),
       runDocker: () => ok(""),
     },
   );
-  return { result, logs, removed };
+  return { result, logs, survivors: shims.filter((shim) => fs.existsSync(shim)) };
 }
 
 describe("uninstall gateway-directory scan", () => {
-  it("removes the CLI shims when the gateways directory holds only desktop metadata (#7905)", () => {
-    const { home, shims } = makeHome("nemoclaw-uninstall-dsstore-", [".DS_Store"]);
+  it.each([
+    [".DS_Store"],
+    [".localized"],
+    ["._sandboxes.json"],
+  ])("removes the CLI shims when the gateways directory holds only %s (#7905)", (entry) => {
+    const { home, shims } = makeHome("nemoclaw-uninstall-metadata-", [entry]);
 
     try {
-      const { result, logs, removed } = uninstall(home, shims);
+      const { result, logs, survivors } = uninstall(home, shims);
 
       expect(result.exitCode).toBe(0);
       expect(logs).not.toContain(SCOPED_RETENTION_LOG);
-      expect(removed).toEqual(expect.arrayContaining(shims));
+      expect(survivors).toEqual([]);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it("keeps the CLI shims when the gateways directory holds an unidentified entry (#7905)", () => {
-    const { home, shims } = makeHome("nemoclaw-uninstall-unknown-", ["not-a-port"]);
+  // "._" carries no name, and a directory or symlink is a shape that may hide
+  // live gateway state, so each of these keeps the conservative treatment.
+  it.each([
+    ["not-a-port"],
+    ["._"],
+    [".DS_Store/"],
+  ])("keeps the CLI shims when the gateways directory holds %s (#7905)", (entry) => {
+    const { home, shims } = makeHome("nemoclaw-uninstall-conservative-", [entry]);
 
     try {
-      const { result, logs, removed } = uninstall(home, shims);
+      const { result, logs, survivors } = uninstall(home, shims);
 
       expect(result.exitCode).toBe(0);
       expect(logs).toContain(SCOPED_RETENTION_LOG);
-      expect(removed).not.toEqual(expect.arrayContaining(shims));
-    } finally {
-      fs.rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps the CLI shims when a directory carries a desktop metadata name (#7905)", () => {
-    const { home, shims } = makeHome("nemoclaw-uninstall-dsstore-dir-", [".DS_Store/"]);
-
-    try {
-      const { result, logs, removed } = uninstall(home, shims);
-
-      expect(result.exitCode).toBe(0);
-      expect(logs).toContain(SCOPED_RETENTION_LOG);
-      expect(removed).not.toEqual(expect.arrayContaining(shims));
+      expect(survivors).toEqual(shims);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts
+++ b/src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts
@@ -138,4 +138,22 @@ describe("uninstall gateway-directory scan", () => {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
+
+  it("keeps the CLI shims for a desktop-metadata symlink (#7905)", () => {
+    const { home, shims } = makeHome("nemoclaw-uninstall-conservative-", []);
+    fs.symlinkSync(
+      "concealed-gateway-state",
+      path.join(home, ".nemoclaw", "gateways", ".DS_Store"),
+    );
+
+    try {
+      const { result, logs, survivors } = uninstall(home, shims);
+
+      expect(result.exitCode).toBe(0);
+      expect(logs).toContain(SCOPED_RETENTION_LOG);
+      expect(survivors).toEqual(shims);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts
+++ b/src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type RunResult,
+  runUninstallPlan as runUninstallPlanBase,
+  type UninstallRunDeps,
+  type UninstallRunOptions,
+} from "./run-plan";
+
+function ok(stdout = ""): RunResult {
+  return { status: 0, stdout, stderr: "" };
+}
+
+function runUninstallPlan(options: UninstallRunOptions, deps: UninstallRunDeps) {
+  return runUninstallPlanBase(options, {
+    resolveGatewayTeardownAuthority: ({ gatewayName, gatewayPort }) => ({
+      gatewayName,
+      gatewayPort,
+      mode: "nemoclaw-managed",
+      source: gatewayPort === 8080 ? "packaged-service" : "standalone",
+      endpoint: null,
+      stateDir: null,
+      supervisor: null,
+      requiredCapabilities: [],
+    }),
+    ...deps,
+  });
+}
+
+function okWithKnownGatewayList(command: string, args: readonly string[]): RunResult {
+  return command === "openshell" && args[0] === "gateway" && args[1] === "list"
+    ? ok(JSON.stringify([{ name: "nemoclaw" }]))
+    : ok();
+}
+
+const SCOPED_RETENTION_LOG =
+  "Sibling gateways remain; kept the shared NemoClaw CLI and shell shims.";
+
+function managedWrapper(binName: string): string {
+  return [
+    "#!/usr/bin/env bash",
+    'export PATH="/tmp/node-bin:$PATH"',
+    `exec "/tmp/prefix/bin/${binName}" "$@"`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Builds a home whose gateways directory holds only the named entries, plus a
+ * managed wrapper shim for every CLI alias. Returns the shim paths so a test
+ * can assert on removal.
+ */
+function makeHome(prefix: string, entries: readonly string[]): { home: string; shims: string[] } {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const gatewaysDir = path.join(home, ".nemoclaw", "gateways");
+  fs.mkdirSync(gatewaysDir, { recursive: true });
+  for (const entry of entries) {
+    fs.writeFileSync(path.join(gatewaysDir, entry), "");
+  }
+  const userBin = path.join(home, ".local", "bin");
+  fs.mkdirSync(userBin, { recursive: true });
+  const shims = ["nemoclaw", "nemohermes", "nemo-deepagents"].map((binName) => {
+    const shimPath = path.join(userBin, binName);
+    fs.writeFileSync(shimPath, managedWrapper(binName), { mode: 0o755 });
+    return shimPath;
+  });
+  return { home, shims };
+}
+
+function uninstall(home: string, shims: readonly string[]) {
+  const logs: string[] = [];
+  const removed: string[] = [];
+  const result = runUninstallPlan(
+    { assumeYes: true, deleteModels: false, keepOpenShell: false },
+    {
+      commandExists: (command) => command !== "docker" && command !== "lsof" && command !== "pgrep",
+      env: { HOME: home } as NodeJS.ProcessEnv,
+      existsSync: (target) => shims.includes(target),
+      isTty: false,
+      log: (line) => logs.push(line),
+      rmSync: vi.fn((target: fs.PathLike) => {
+        removed.push(String(target));
+      }),
+      run: vi.fn(okWithKnownGatewayList),
+      runDocker: () => ok(""),
+    },
+  );
+  return { result, logs, removed };
+}
+
+describe("uninstall gateway-directory scan", () => {
+  it("removes the CLI shims when the gateways directory holds only Finder metadata (#7905)", () => {
+    const { home, shims } = makeHome("nemoclaw-uninstall-dsstore-", [".DS_Store"]);
+
+    try {
+      const { result, logs, removed } = uninstall(home, shims);
+
+      expect(result.exitCode).toBe(0);
+      expect(logs).not.toContain(SCOPED_RETENTION_LOG);
+      expect(removed).toEqual(expect.arrayContaining(shims));
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the CLI shims when the gateways directory holds an unrecognized entry (#7905)", () => {
+    const { home, shims } = makeHome("nemoclaw-uninstall-unknown-", ["not-a-port"]);
+
+    try {
+      const { result, logs, removed } = uninstall(home, shims);
+
+      expect(result.exitCode).toBe(0);
+      expect(logs).toContain(SCOPED_RETENTION_LOG);
+      expect(removed).not.toEqual(expect.arrayContaining(shims));
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts
+++ b/src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts
@@ -54,15 +54,16 @@ function managedWrapper(binName: string): string {
 
 /**
  * Builds a home whose gateways directory holds only the named entries, plus a
- * managed wrapper shim for every CLI alias. Returns the shim paths so a test
- * can assert on removal.
+ * managed wrapper shim for every CLI alias. An entry ending in "/" is created
+ * as a directory. Returns the shim paths so a test can assert on removal.
  */
 function makeHome(prefix: string, entries: readonly string[]): { home: string; shims: string[] } {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   const gatewaysDir = path.join(home, ".nemoclaw", "gateways");
   fs.mkdirSync(gatewaysDir, { recursive: true });
   for (const entry of entries) {
-    fs.writeFileSync(path.join(gatewaysDir, entry), "");
+    const target = path.join(gatewaysDir, entry.replace(/\/$/, ""));
+    entry.endsWith("/") ? fs.mkdirSync(target) : fs.writeFileSync(target, "");
   }
   const userBin = path.join(home, ".local", "bin");
   fs.mkdirSync(userBin, { recursive: true });
@@ -96,7 +97,7 @@ function uninstall(home: string, shims: readonly string[]) {
 }
 
 describe("uninstall gateway-directory scan", () => {
-  it("removes the CLI shims when the gateways directory holds only Finder metadata (#7905)", () => {
+  it("removes the CLI shims when the gateways directory holds only desktop metadata (#7905)", () => {
     const { home, shims } = makeHome("nemoclaw-uninstall-dsstore-", [".DS_Store"]);
 
     try {
@@ -110,8 +111,22 @@ describe("uninstall gateway-directory scan", () => {
     }
   });
 
-  it("keeps the CLI shims when the gateways directory holds an unrecognized entry (#7905)", () => {
+  it("keeps the CLI shims when the gateways directory holds an unidentified entry (#7905)", () => {
     const { home, shims } = makeHome("nemoclaw-uninstall-unknown-", ["not-a-port"]);
+
+    try {
+      const { result, logs, removed } = uninstall(home, shims);
+
+      expect(result.exitCode).toBe(0);
+      expect(logs).toContain(SCOPED_RETENTION_LOG);
+      expect(removed).not.toEqual(expect.arrayContaining(shims));
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the CLI shims when a directory carries a desktop metadata name (#7905)", () => {
+    const { home, shims } = makeHome("nemoclaw-uninstall-dsstore-dir-", [".DS_Store/"]);
 
     try {
       const { result, logs, removed } = uninstall(home, shims);

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -1651,6 +1651,12 @@ function inspectOtherGatewayEnvironments(
   );
 }
 
+// Names a desktop environment writes beside real content: Finder's .DS_Store
+// and .localized, and the ._ companion a macOS copy leaves for a resource fork.
+function isDesktopMetadataEntry(name: string): boolean {
+  return name === ".DS_Store" || name === ".localized" || name.startsWith("._");
+}
+
 function discoverOtherGatewayEnvironments(
   paths: UninstallPaths,
   runtime: UninstallRuntime,
@@ -1721,6 +1727,12 @@ function discoverOtherGatewayEnvironments(
     for (const entry of fs.readdirSync(gatewaysDir, { withFileTypes: true })) {
       const candidate = path.resolve(gatewaysDir, entry.name);
       if (candidate === selectedRoot) continue;
+      // A plain file the desktop environment drops into any directory it shows
+      // holds no gateway state. Counting one as unidentified scopes the whole
+      // uninstall, which keeps the CLI and shell shims on PATH after a run that
+      // reports success (#7905). Only regular files match, so a directory or a
+      // symlink wearing the same name still gets the conservative treatment.
+      if (entry.isFile() && isDesktopMetadataEntry(entry.name)) continue;
       // Never follow or dismiss a symlink or non-directory: a surprising shape
       // may hide live gateway state, so keep the conservative treatment.
       if (entry.isSymbolicLink() || !entry.isDirectory()) {

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -1651,8 +1651,9 @@ function inspectOtherGatewayEnvironments(
   );
 }
 
-// Names a desktop environment writes beside real content: Finder's .DS_Store
-// and .localized, and the ._ companion a macOS copy leaves for a resource fork.
+// Names a desktop environment writes into a directory it displays. macOS writes
+// .DS_Store and .localized, and ._<name> to carry a resource fork and extended
+// attributes on a filesystem that lacks them. None of them hold gateway state.
 function isDesktopMetadataEntry(name: string): boolean {
   return name === ".DS_Store" || name === ".localized" || name.startsWith("._");
 }
@@ -1727,11 +1728,10 @@ function discoverOtherGatewayEnvironments(
     for (const entry of fs.readdirSync(gatewaysDir, { withFileTypes: true })) {
       const candidate = path.resolve(gatewaysDir, entry.name);
       if (candidate === selectedRoot) continue;
-      // A plain file the desktop environment drops into any directory it shows
-      // holds no gateway state. Counting one as unidentified scopes the whole
-      // uninstall, which keeps the CLI and shell shims on PATH after a run that
-      // reports success (#7905). Only regular files match, so a directory or a
-      // symlink wearing the same name still gets the conservative treatment.
+      // Counting desktop metadata as unidentified scopes the whole uninstall,
+      // which keeps the CLI and shell shims on PATH after a run that reports
+      // success (#7905). Only a regular file matches, so a directory or a
+      // symlink with the same name still gets the conservative treatment.
       if (entry.isFile() && isDesktopMetadataEntry(entry.name)) continue;
       // Never follow or dismiss a symlink or non-directory: a surprising shape
       // may hide live gateway state, so keep the conservative treatment.

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -1655,7 +1655,10 @@ function inspectOtherGatewayEnvironments(
 // .DS_Store and .localized, and ._<name> to carry a resource fork and extended
 // attributes on a filesystem that lacks them. None of them hold gateway state.
 function isDesktopMetadataEntry(name: string): boolean {
-  return name === ".DS_Store" || name === ".localized" || name.startsWith("._");
+  // "._" alone names no file it could carry, so it stays conservative.
+  return (
+    name === ".DS_Store" || name === ".localized" || (name.startsWith("._") && name.length > 2)
+  );
 }
 
 function discoverOtherGatewayEnvironments(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The gateway-directory scan counted any non-directory entry under `~/.nemoclaw/gateways` as an unidentified sibling gateway, which scopes the uninstall to the selected gateway. That path skips CLI and shell-shim removal entirely and still exits 0, so `nemoclaw`, `nemohermes`, and `nemo-deepagents` stayed on PATH after a run that reported success. A `.DS_Store`, which macOS writes into a directory it displays, was enough to trigger it. The scan now skips a regular file whose name is desktop metadata.

## Related Issue
Refs #7905

## Changes
- `src/lib/actions/uninstall/run-plan.ts`: add `isDesktopMetadataEntry` and skip a regular file named `.DS_Store`, `.localized`, or `._<name>` before the conservative non-directory branch in `discoverOtherGatewayEnvironments`.
- The conservatism is deliberate and stays intact for every other shape. Only `entry.isFile()` matches, so a directory or a symlink with the same name still sets `unidentified`, and an unrecognized entry such as `not-a-port` still scopes the uninstall.
- `src/lib/actions/uninstall/run-plan-gateway-scan-entries.test.ts` (new): cover the reported metadata-file behavior and guard conservative handling for unidentified entries, the bare `._` boundary, metadata-named directories, and metadata-named symlinks. A new focused file rather than an addition to `run-plan-gateway-segregation.test.ts`, which is at 1392 of the 1500-line budget.

No new abstraction: `isDesktopMetadataEntry` is a single local predicate with one call site. `src/lib/build-context.ts:33` filters `.DS_Store` and `._` for a different purpose and with a different contract (no symlink conservatism, no `.localized`), so the two are deliberately not shared.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The published contract already says uninstall removes the shared CLI when no sibling gateway remains (`docs/manage-sandboxes/uninstall-nemoclaw.mdx:88`, `docs/reference/commands.mdx`), and no page ever defined a stray file as a sibling gateway. This makes the code match the documented contract rather than changing a documented surface. `rg` over `docs/` for "Sibling gateways remain", "shell shims", and ".DS_Store" returns zero hits. Per `docs/CONTRIBUTING.md:83-102` a dated changelog entry belongs to the pre-tag release-note PR.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer security review PASS at `a8c993902`. The change skips only recognized regular metadata files. Directories, symlinks, malformed names, and unknown entries remain conservative. The nine-category review found no secrets, unsafe input handling, authorization changes, dependency risk, sensitive logging, cryptography changes, insecure configuration, test regressions, or broader security-posture degradation. The added symlink regression strengthens negative coverage for the resource-retention boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independent review of the completed branch confirmed the focused symlink regression does not change user-visible behavior or documentation requirements. The existing contract pages remain accurate and no `docs/` file changed.
- Agent: Codex documentation writer
<!-- docs-review-head-sha: a8c993902 -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused gateway-scan tests pass 7/7. `npm run build:cli`, `npm run typecheck:cli`, Biome, source-shape, test-size, test-title, and Vitest project-overlap checks pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

### Scope note

`Refs #7905` rather than `Closes`, because this is very likely not the reporter's cause. Their steps describe a default-port onboard, and `~/.nemoclaw/gateways/` is only created for a non-default gateway port (`src/lib/state/state-root.ts:16`), so on that host the directory would not exist and this scan returns early. Reaching this bug needs a host that used a non-default port at some point, leaving the directory behind for a desktop environment to write into.

The reporter is on v0.0.97, whose scan lacked the `port === GATEWAY_PORT` guard, so the selected gateway counted itself a sibling and took the same retention path. That is #7987, fixed by #7993 and shipped in v0.0.101, after this report. A separate follow-up on the issue asks for the uninstall output to confirm which path they hit.

Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall scanning by ignoring common desktop metadata files.
  * Prevents managed CLI shims from being removed when only harmless metadata is present.
  * Continues to protect unidentified entries and metadata directories or symlinks from removal.

* **Tests**
  * Added coverage for uninstall scanning and safe shim cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
