### PR TITLE
ci(e2e): retry failed main jobs twice

### DIFF
--- a/.github/workflows/e2e-main-retry.yaml
+++ b/.github/workflows/e2e-main-retry.yaml
@@ -1,51 +1,44 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Hosted Runner Recovery
+name: E2E / Main Retry
 
-run-name: Hosted runner recovery for source run ${{ github.event.workflow_run.id }}
+run-name: E2E retry evidence for source run ${{ github.event.workflow_run.id }} attempt ${{ github.event.workflow_run.run_attempt }}
 
 on:
   workflow_run:
     workflows:
-      - E2E / WSL
-      - E2E / macOS
-      - CI / Platform Vitest Main Watch
+      - E2E
     types:
       - completed
 
 permissions: {}
 
 jobs:
-  recover:
+  evaluate:
     if: >-
       ${{
       github.run_attempt == 1 &&
       github.repository == 'NVIDIA/NemoClaw' &&
-      github.event.workflow_run.run_attempt == 1 &&
       github.event.workflow_run.status == 'completed' &&
-      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.path == '.github/workflows/e2e.yaml' &&
+      github.event.workflow_run.display_title == 'E2E main' &&
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.head_repository.full_name == 'NVIDIA/NemoClaw' &&
-      github.event.workflow_run.event == 'push' &&
-      (
-      github.event.workflow_run.path == '.github/workflows/wsl-e2e.yaml' ||
-      github.event.workflow_run.path == '.github/workflows/macos-e2e.yaml' ||
-      github.event.workflow_run.path == '.github/workflows/platform-vitest-main.yaml'
-      )
+      github.event.workflow_run.run_attempt >= 1 &&
+      github.event.workflow_run.run_attempt <= 3
       }}
     concurrency:
-      group: hosted-runner-recovery-${{ github.event.workflow_run.workflow_id }}
-      queue: max
+      group: e2e-main-retry-${{ github.event.workflow_run.id }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     permissions:
       actions: write
-      checks: read
       contents: read
     steps:
-      - name: Checkout trusted recovery controller
+      - name: Checkout trusted retry controller
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.workflow_sha }}
@@ -56,18 +49,20 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Evaluate exact hosted-runner-loss evidence
+      - name: Evaluate main E2E retry
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          RETRY_EVIDENCE_PATH: ${{ runner.temp }}/e2e-main-retry-evidence.json
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
         run: >-
           node --experimental-strip-types --no-warnings
-          tools/e2e/hosted-runner-recovery.mts
+          tools/e2e/main-run-retry.mts
 
-      - name: Record static recovery policy
+      - name: Upload retry evidence
         if: ${{ always() }}
-        shell: bash
-        run: >-
-          printf '%s\n'
-          'Hosted-runner recovery evaluated the fail-closed latest-eligible main-run policy.'
-          >> "$GITHUB_STEP_SUMMARY"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-main-retry-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          path: ${{ runner.temp }}/e2e-main-retry-evidence.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -775,6 +775,31 @@
       "file": "test/wechat-runtime-audit-workflow.test.ts",
       "test": "makes the trusted audit required in PR and main workflows",
       "category": "security"
+    },
+    {
+      "file": "test/e2e-main-retry-workflow.test.ts",
+      "test": "subscribes only to completed E2E workflow runs",
+      "category": "security"
+    },
+    {
+      "file": "test/e2e-main-retry-workflow.test.ts",
+      "test": "accepts only trusted main push attempts one through three",
+      "category": "security"
+    },
+    {
+      "file": "test/e2e-main-retry-workflow.test.ts",
+      "test": "uses one source-run concurrency identity and least privileges",
+      "category": "security"
+    },
+    {
+      "file": "test/e2e-main-retry-workflow.test.ts",
+      "test": "checks out trusted controller code and invokes the bounded helper",
+      "category": "security"
+    },
+    {
+      "file": "test/e2e-main-retry-workflow.test.ts",
+      "test": "runs the bounded evidence-upload step after evaluation failure",
+      "category": "security"
     }
   ]
 }

--- a/test/e2e-main-retry-workflow.test.ts
+++ b/test/e2e-main-retry-workflow.test.ts
@@ -64,6 +64,8 @@ describe("main E2E retry workflow", () => {
     }
     expect(guard).not.toContain("pull_request");
     expect(guard).not.toContain("workflow_dispatch");
+    expect(guard).not.toContain("||");
+    expect(guard.match(/&&/gu)).toHaveLength(9);
   });
 
   // source-shape-contract: security -- Source-run serialization and least privilege prevent concurrent or broader GitHub mutations

--- a/test/e2e-main-retry-workflow.test.ts
+++ b/test/e2e-main-retry-workflow.test.ts
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import YAML from "yaml";
+import { describe, expect, it } from "vitest";
+
+type Step = {
+  name?: string;
+  uses?: string;
+  if?: string;
+  env?: Record<string, string>;
+  run?: string;
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  name: string;
+  on: { workflow_run: { workflows: string[]; types: string[] } };
+  permissions: Record<string, string>;
+  jobs: {
+    evaluate: {
+      if: string;
+      concurrency: Record<string, unknown>;
+      permissions: Record<string, string>;
+      steps: Step[];
+    };
+  };
+};
+
+function workflow(): Workflow {
+  return YAML.parse(fs.readFileSync(".github/workflows/e2e-main-retry.yaml", "utf8")) as Workflow;
+}
+
+function step(name: string): Step {
+  return workflow().jobs.evaluate.steps.find((candidate) => candidate.name === name)!;
+}
+
+describe("main E2E retry workflow", () => {
+  // source-shape-contract: security -- The write-capable retry controller must subscribe only to the reviewed E2E workflow completion event
+  it("subscribes only to completed E2E workflow runs", () => {
+    const value = workflow();
+    expect(value.name).toBe("E2E / Main Retry");
+    expect(value.on).toEqual({ workflow_run: { workflows: ["E2E"], types: ["completed"] } });
+    expect(value.permissions).toEqual({});
+  });
+
+  // source-shape-contract: security -- Source identity and attempt guards prevent fork, PR, manual, and out-of-range retry writes
+  it("accepts only trusted main push attempts one through three", () => {
+    const guard = workflow().jobs.evaluate.if;
+    for (const fragment of [
+      "github.run_attempt == 1",
+      "github.repository == 'NVIDIA/NemoClaw'",
+      "github.event.workflow_run.status == 'completed'",
+      "github.event.workflow_run.event == 'push'",
+      "github.event.workflow_run.path == '.github/workflows/e2e.yaml'",
+      "github.event.workflow_run.display_title == 'E2E main'",
+      "github.event.workflow_run.head_branch == 'main'",
+      "github.event.workflow_run.head_repository.full_name == 'NVIDIA/NemoClaw'",
+      "github.event.workflow_run.run_attempt >= 1",
+      "github.event.workflow_run.run_attempt <= 3",
+    ]) {
+      expect(guard).toContain(fragment);
+    }
+    expect(guard).not.toContain("pull_request");
+    expect(guard).not.toContain("workflow_dispatch");
+  });
+
+  // source-shape-contract: security -- Source-run serialization and least privilege prevent concurrent or broader GitHub mutations
+  it("uses one source-run concurrency identity and least privileges", () => {
+    const job = workflow().jobs.evaluate;
+    expect(job.concurrency).toEqual({
+      group: "e2e-main-retry-${{ github.event.workflow_run.id }}",
+      "cancel-in-progress": false,
+    });
+    expect(job.permissions).toEqual({ actions: "write", contents: "read" });
+  });
+
+  // source-shape-contract: security -- Trusted default-branch controller code must run before any write-capable GitHub request
+  it("checks out trusted controller code and invokes the bounded helper", () => {
+    expect(step("Checkout trusted retry controller")).toMatchObject({
+      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      with: { ref: "${{ github.workflow_sha }}", "persist-credentials": false },
+    });
+    expect(step("Evaluate main E2E retry")).toMatchObject({
+      env: {
+        GITHUB_TOKEN: "${{ github.token }}",
+        RETRY_EVIDENCE_PATH: "${{ runner.temp }}/e2e-main-retry-evidence.json",
+        SOURCE_RUN_ID: "${{ github.event.workflow_run.id }}",
+      },
+    });
+    expect(step("Evaluate main E2E retry").run).toContain("tools/e2e/main-run-retry.mts");
+  });
+
+  // source-shape-contract: security -- The bounded upload step must run after evaluation failure without widening artifact paths
+  it("runs the bounded evidence-upload step after evaluation failure", () => {
+    expect(step("Upload retry evidence")).toMatchObject({
+      if: "${{ always() }}",
+      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      with: {
+        name: "e2e-main-retry-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}",
+        path: "${{ runner.temp }}/e2e-main-retry-evidence.json",
+        "if-no-files-found": "warn",
+        "retention-days": 14,
+      },
+    });
+  });
+});

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -13,6 +13,8 @@ before those targets run; local runners must provide it themselves.
 - `.github/workflows/hosted-runner-recovery.yaml` evaluates first-attempt
   failures from approved `main` workflows and requests one full rerun only when
   every non-passing job has authenticated GitHub-hosted runner-loss evidence.
+- `.github/workflows/e2e-main-retry.yaml` evaluates eligible `E2E main` push
+  attempts, requests at most two failed-job reruns, and uploads attempt evidence.
 - The `staging-brev-launchable` job in `.github/workflows/e2e.yaml` validates
   the baked candidate without installing or copying NemoClaw source.
 - Platform workflows such as macOS, WSL, sandbox image, and regression E2E
@@ -443,7 +445,7 @@ environment approval. The job uses the non-cancelling
 `staging-brev-launchable-cpu` group with `queue: max`, so pending Launchable E2E
 runs remain queued instead of replacing one another.
 
-### Hosted-runner recovery
+### Hosted-Runner Recovery
 
 Hosted Runner Recovery can request one full rerun for eligible WSL, macOS, and
 platform-watch push runs. It does not handle `E2E main`. The complete non-passing
@@ -693,7 +695,15 @@ Pull requests retain deterministic CI, including the `e2e-support` Vitest projec
 Each push to `main` triggers the default E2E suite.
 The central workflow has no scheduled trigger.
 
-When an `E2E main` job fails, `E2E / Main Retry` asks GitHub Actions to rerun failed jobs. The controller permits two retries but does not verify that GitHub schedules a different runner. After evaluation succeeds, it uploads an artifact named for the current attempt. The artifact contains every source attempt through that attempt and the cumulative runner-minutes. A later successful attempt sets `action` to `passed-after-retry` and `flaky` to `true`. The controller does not retry manual PR runs or a run superseded by a newer `main` push.
+When an eligible `E2E main` push workflow concludes with `failure`,
+`E2E / Main Retry` asks GitHub Actions to rerun the failed jobs. The controller
+permits two retries but does not verify that GitHub schedules a different runner.
+After evaluation succeeds, it uploads an artifact named for the current attempt.
+The artifact contains one `attempts` summary for each source attempt through the
+current attempt. The `totalRunnerMinutes` field contains the cumulative runner
+time for those summaries. A later successful attempt sets `action` to
+`passed-after-retry` and `flaky` to `true`. The controller does not retry manual
+PR runs or a run superseded by a newer `main` push.
 
 A repository maintainer or administrator can manually run the same default suite against the current exact head of an open internal or fork pull request.
 The trusted workflow definition remains on `main` and binds the candidate head to the current PR base SHA.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -445,49 +445,28 @@ runs remain queued instead of replacing one another.
 
 ### Hosted-runner recovery
 
-The trusted recovery workflow can request one full rerun of the latest eligible
-first attempt for these source workflows:
+Hosted Runner Recovery can request one full rerun for eligible WSL, macOS, and
+platform-watch push runs. It does not handle `E2E main`. The complete non-passing
+job listing must contain only authenticated hosted-runner-loss evidence for the
+workflow's approved runner labels. An ordinary assertion failure, mixed failure
+set, incomplete listing, custom or self-hosted label, changed evidence, or
+ambiguous pagination prevents recovery.
 
-- push or manually dispatched `E2E main`;
-- `E2E / WSL` pushes to `main`;
-- `E2E / macOS` pushes to `main`; and
-- `CI / Platform Vitest Main Watch` pushes to `main`.
+For eligible `E2E main` push runs, `E2E / Main Retry` asks GitHub Actions to
+rerun failed jobs after a workflow failure. It can request two retries. The
+controller does not verify that GitHub schedules a different runner, so do not
+treat a retry as evidence of a fresh host. It ignores manual runs and source runs
+superseded by a newer `main` push. The controller checks out only trusted
+default-branch code and receives no repository secrets.
 
-The controller authenticates the active workflow name and path, repository,
-head repository, branch, run name, event, run URL, and first-attempt failure.
-It ignores E2E PR child runs and an eligible source run that has a newer
-eligible run for the same workflow.
-
-The complete non-passing job listing must contain only exact hosted-runner-loss
-markers for that workflow's approved runner labels.
-The E2E policy accepts only `ubuntu-latest`.
-The WSL and macOS policies accept only `cancelled` jobs with their exact
-platform label and exact GitHub internal-error annotation.
-The platform-watch policy applies those platform contracts to Windows and
-macOS jobs and the authenticated hosted-runner-loss contract to Ubuntu jobs.
-An ordinary assertion failure, mixed failure set, incomplete listing, custom or
-self-hosted label, changed evidence, or ambiguous pagination prevents recovery.
-
-The controller collects and fingerprints the complete source, workflow,
-latest-run, job, check, annotation, and optional log evidence twice.
-It requests the full GitHub Actions rerun only when both snapshots match.
-The rerun executes every job in attempt two, not only the failed jobs.
-Neither a source attempt two nor a recovery-controller rerun can request
-another source rerun.
-
-The recovery job checks out only the trusted default-branch controller and does
-not check out source-run code.
-It receives no repository secrets and holds `actions: write` only for the
-bounded rerun request.
-
-The runner-allocation and internal-error failures originate in the
-GitHub-hosted Actions service, outside repository-controlled workflow code, so
-this controller contains the failure without claiming to repair its source.
-Remove the recovery workflow and controller after the supported source
-workflows record 30 consecutive days with no first-attempt failure accepted by
-the exact recovery classifier, or when those workflows stop using
-GitHub-hosted runners. Any accepted recovery request resets that observation
-window.
+The runner-allocation and internal-error failures handled by Hosted Runner
+Recovery originate in GitHub Actions, outside repository-controlled workflow
+code. Hosted Runner Recovery contains these failures without claiming to repair
+their source. Remove `.github/workflows/hosted-runner-recovery.yaml` and its
+controller only after the three platform workflows record 30 consecutive days
+with no first-attempt failure accepted by the recovery classifier, or after those
+workflows stop using GitHub-hosted runners. Each accepted Hosted Runner Recovery
+request resets that observation window.
 
 ### Runner comparison telemetry
 
@@ -606,10 +585,9 @@ unavailable. Separately, the adjacent progress/stall resource line falls back
 to the portable free-memory value and labels that value as `memory free`.
 
 The comparison time series is diagnostic-only and is not an input to terminal
-classification or retry policy. Low available or free memory never implies an
-OOM. OOM classification or attribution still requires the existing positive
-OOM evidence, and the single retry remains limited to positive runner-loss
-evidence.
+classification or retry policy. Runner-comparison telemetry does not affect
+`E2E / Main Retry` decisions. Hosted Runner Recovery remains limited to
+authenticated runner-loss evidence for its three platform workflows.
 
 Treat a missing summary as unavailable evidence, not as low utilization. A
 hard runner loss can prevent finalization or artifact upload. When you compare
@@ -710,10 +688,12 @@ a custom, copied, or no-op adapter.
 
 ## Push and Manual PR E2E
 
-Live E2E does not run automatically for pull requests.
+E2E does not run automatically for pull requests.
 Pull requests retain deterministic CI, including the `e2e-support` Vitest project.
-Each push to `main` triggers the default live E2E suite.
+Each push to `main` triggers the default E2E suite.
 The central workflow has no scheduled trigger.
+
+When an `E2E main` job fails, `E2E / Main Retry` asks GitHub Actions to rerun failed jobs. The controller permits two retries but does not verify that GitHub schedules a different runner. After evaluation succeeds, it uploads an artifact named for the current attempt. The artifact contains every source attempt through that attempt and the cumulative runner-minutes. A later successful attempt sets `action` to `passed-after-retry` and `flaky` to `true`. The controller does not retry manual PR runs or a run superseded by a newer `main` push.
 
 A repository maintainer or administrator can manually run the same default suite against the current exact head of an open internal or fork pull request.
 The trusted workflow definition remains on `main` and binds the candidate head to the current PR base SHA.

--- a/test/e2e/docs/README.md
+++ b/test/e2e/docs/README.md
@@ -132,14 +132,22 @@ npm run test:live-e2e -- --silent=false --reporter=default
 npm run test:runtime-audit -- e2e-artifacts/run-1 e2e-artifacts/run-2
 ```
 
-The aggregate live command rebuilds the CLI before Vitest starts and runs live
-test files serially.
-Live E2E projects do not retry an entire failed test.
-These tests mutate host, Docker, gateway, and sandbox state, so re-entering one
-on the same runner can replace the original failure with stale-lock,
-storage-exhaustion, or ownership noise. A target may retry a transient operation
-only inside its own cleanup boundary.
-Retry a full target by starting a fresh workflow run and runner.
+The aggregate local command rebuilds the CLI before Vitest starts and runs E2E
+test files serially. It does not retry a failed test.
+
+After an eligible `E2E main` push workflow fails, `E2E / Main Retry` asks
+GitHub Actions to rerun its failed jobs. It can request two reruns, for three total
+attempts. The controller does not verify that GitHub schedules a different runner,
+so do not treat a retry as evidence of a fresh host. If a later attempt succeeds,
+the source workflow concludes with `success`. The evidence sets `action` to
+`passed-after-retry` and `flaky` to `true`.
+
+After the controller evaluates attempt N, it uploads an artifact named for that
+attempt. The artifact contains one `attempts` entry for each source attempt through
+N. `totalRunnerMinutes` is the sum across those entries. If evaluation or file
+creation fails, the upload step warns that the file is missing and publishes no
+evidence artifact. The controller does not retry manual PR runs or a run
+superseded by a newer `main` push.
 
 During fixture teardown, every passing or failing live test writes
 `test-progress.json` beside its other target artifacts. The runtime audit

--- a/test/e2e/support/main-run-retry.test.ts
+++ b/test/e2e/support/main-run-retry.test.ts
@@ -165,4 +165,21 @@ describe("main E2E retry controller", () => {
       }),
     ).rejects.toThrow("source run is not a completed trusted E2E main push");
   });
+  it("rejects a truncated attempt job listing", async () => {
+    const fixture = setup({ attempt: 1, conclusion: "failure" });
+    const request = async (path: string, init?: { method?: "GET" | "POST" }) =>
+      path.includes("/attempts/1/jobs")
+        ? { total_count: 2, jobs: [job(1, "failure")] }
+        : fixture.request(path, init);
+
+    await expect(
+      evaluateMainRunRetry({
+        repository: REPOSITORY,
+        token: "token",
+        sourceRunId: RUN_ID,
+        controllerAttempt: 1,
+        request,
+      }),
+    ).rejects.toThrow("GitHub returned an invalid or truncated E2E job list");
+  });
 });

--- a/test/e2e/support/main-run-retry.test.ts
+++ b/test/e2e/support/main-run-retry.test.ts
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  E2E_MAX_ATTEMPTS,
+  E2E_MAX_RETRIES,
+  evaluateMainRunRetry,
+} from "../../../tools/e2e/main-run-retry.mts";
+
+const REPOSITORY = "NVIDIA/NemoClaw";
+const RUN_ID = 12345;
+const WORKFLOW_ID = 678;
+const SHA = "a".repeat(40);
+
+function sourceRun(attempt: number, conclusion: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id: RUN_ID,
+    workflow_id: WORKFLOW_ID,
+    run_attempt: attempt,
+    status: "completed",
+    conclusion,
+    event: "push",
+    path: ".github/workflows/e2e.yaml",
+    display_title: "E2E main",
+    head_branch: "main",
+    head_sha: SHA,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}`,
+    repository: { full_name: REPOSITORY },
+    head_repository: { full_name: REPOSITORY },
+    ...overrides,
+  };
+}
+
+function job(attempt: number, conclusion = "success") {
+  return {
+    id: attempt * 100,
+    name: `E2E job ${attempt}`,
+    run_attempt: attempt,
+    status: "completed",
+    conclusion,
+    started_at: `2026-08-06T00:0${attempt}:00Z`,
+    completed_at: `2026-08-06T00:0${attempt + 5}:00Z`,
+  };
+}
+
+function setup(options: { attempt: number; conclusion: string; latestRunId?: number }) {
+  const requests: Array<{ method: string; path: string }> = [];
+  const run = sourceRun(options.attempt, options.conclusion);
+  const request = async (path: string, init?: { method?: "GET" | "POST" }) => {
+    const method = init?.method ?? "GET";
+    requests.push({ method, path });
+    if (method === "POST") return undefined;
+    if (path.endsWith(`/actions/runs/${RUN_ID}`)) return run;
+    if (path.includes(`/actions/workflows/${WORKFLOW_ID}/runs?`)) {
+      return {
+        total_count: 1,
+        workflow_runs: [
+          sourceRun(options.attempt, options.conclusion, {
+            id: options.latestRunId ?? RUN_ID,
+          }),
+        ],
+      };
+    }
+    const attemptMatch = /\/attempts\/(\d+)\/jobs/u.exec(path);
+    if (attemptMatch) {
+      const attempt = Number(attemptMatch[1]);
+      return {
+        total_count: 1,
+        jobs: [job(attempt, attempt === options.attempt ? options.conclusion : "failure")],
+      };
+    }
+    throw new Error(`unexpected request ${method} ${path}`);
+  };
+  return { request, requests };
+}
+
+async function evaluate(options: { attempt: number; conclusion: string; latestRunId?: number }) {
+  const fixture = setup(options);
+  const evidence = await evaluateMainRunRetry({
+    repository: REPOSITORY,
+    token: "token",
+    sourceRunId: RUN_ID,
+    controllerAttempt: 1,
+    request: fixture.request,
+  });
+  return { evidence, requests: fixture.requests };
+}
+
+describe("main E2E retry controller", () => {
+  it.each([1, 2])("requests retry %s before the attempt limit", async (attempt) => {
+    const { evidence, requests } = await evaluate({ attempt, conclusion: "failure" });
+
+    expect(E2E_MAX_RETRIES).toBe(2);
+    expect(E2E_MAX_ATTEMPTS).toBe(3);
+    expect(evidence).toMatchObject({
+      action: "retry-requested",
+      flaky: false,
+      sourceAttempt: attempt,
+    });
+    expect(requests).toContainEqual({
+      method: "POST",
+      path: `repos/${REPOSITORY}/actions/runs/${RUN_ID}/rerun-failed-jobs`,
+    });
+  });
+
+  it("stops after the third failed attempt", async () => {
+    const { evidence, requests } = await evaluate({ attempt: 3, conclusion: "failure" });
+
+    expect(evidence.action).toBe("failed-after-retries");
+    expect(requests.some((request) => request.method === "POST")).toBe(false);
+  });
+
+  it("reports a successful retry as flaky and includes every attempt cost", async () => {
+    const { evidence, requests } = await evaluate({ attempt: 2, conclusion: "success" });
+
+    expect(evidence).toMatchObject({
+      action: "passed-after-retry",
+      flaky: true,
+      sourceAttempt: 2,
+      totalRunnerMinutes: 10,
+    });
+    expect(evidence.attempts).toHaveLength(2);
+    expect(requests.some((request) => request.method === "POST")).toBe(false);
+  });
+
+  it("reports a first-attempt pass without flaky evidence", async () => {
+    const { evidence } = await evaluate({ attempt: 1, conclusion: "success" });
+
+    expect(evidence).toMatchObject({ action: "passed-first-attempt", flaky: false });
+  });
+
+  it("does not retry a run superseded by a newer main push", async () => {
+    const { evidence, requests } = await evaluate({
+      attempt: 1,
+      conclusion: "failure",
+      latestRunId: RUN_ID + 1,
+    });
+
+    expect(evidence).toMatchObject({ action: "ignored", reason: "a newer E2E main push exists" });
+    expect(requests.some((request) => request.method === "POST")).toBe(false);
+  });
+
+  it("rejects manual workflow runs", async () => {
+    const fixture = setup({ attempt: 1, conclusion: "failure" });
+    const originalRequest = fixture.request;
+    const request = async (path: string, init?: { method?: "GET" | "POST" }) => {
+      const response = await originalRequest(path, init);
+      return path.endsWith(`/actions/runs/${RUN_ID}`)
+        ? { ...(response as Record<string, unknown>), event: "workflow_dispatch" }
+        : response;
+    };
+
+    await expect(
+      evaluateMainRunRetry({
+        repository: REPOSITORY,
+        token: "token",
+        sourceRunId: RUN_ID,
+        controllerAttempt: 1,
+        request,
+      }),
+    ).rejects.toThrow("source run is not a completed trusted E2E main push");
+  });
+});

--- a/test/e2e/support/main-run-retry.test.ts
+++ b/test/e2e/support/main-run-retry.test.ts
@@ -51,27 +51,30 @@ function setup(options: { attempt: number; conclusion: string; latestRunId?: num
   const request = async (path: string, init?: { method?: "GET" | "POST" }) => {
     const method = init?.method ?? "GET";
     requests.push({ method, path });
-    if (method === "POST") return undefined;
-    if (path.endsWith(`/actions/runs/${RUN_ID}`)) return run;
-    if (path.includes(`/actions/workflows/${WORKFLOW_ID}/runs?`)) {
-      return {
-        total_count: 1,
-        workflow_runs: [
-          sourceRun(options.attempt, options.conclusion, {
-            id: options.latestRunId ?? RUN_ID,
-          }),
-        ],
-      };
+    switch (true) {
+      case method === "POST":
+        return undefined;
+      case path.endsWith(`/actions/runs/${RUN_ID}`):
+        return run;
+      case path.includes(`/actions/workflows/${WORKFLOW_ID}/runs?`):
+        return {
+          total_count: 1,
+          workflow_runs: [
+            sourceRun(options.attempt, options.conclusion, {
+              id: options.latestRunId ?? RUN_ID,
+            }),
+          ],
+        };
+      case /\/attempts\/(\d+)\/jobs/u.test(path): {
+        const attempt = Number(/\/attempts\/(\d+)\/jobs/u.exec(path)![1]);
+        return {
+          total_count: 1,
+          jobs: [job(attempt, attempt === options.attempt ? options.conclusion : "failure")],
+        };
+      }
+      default:
+        throw new Error(`unexpected request ${method} ${path}`);
     }
-    const attemptMatch = /\/attempts\/(\d+)\/jobs/u.exec(path);
-    if (attemptMatch) {
-      const attempt = Number(attemptMatch[1]);
-      return {
-        total_count: 1,
-        jobs: [job(attempt, attempt === options.attempt ? options.conclusion : "failure")],
-      };
-    }
-    throw new Error(`unexpected request ${method} ${path}`);
   };
   return { request, requests };
 }

--- a/test/e2e/support/main-run-retry.test.ts
+++ b/test/e2e/support/main-run-retry.test.ts
@@ -115,7 +115,7 @@ describe("main E2E retry controller", () => {
     expect(requests.some((request) => request.method === "POST")).toBe(false);
   });
 
-  it("reports a successful retry as flaky and includes every attempt cost", async () => {
+  it("reports a successful retry as flaky and sums runner minutes across attempts", async () => {
     const { evidence, requests } = await evaluate({ attempt: 2, conclusion: "success" });
 
     expect(evidence).toMatchObject({
@@ -181,5 +181,23 @@ describe("main E2E retry controller", () => {
         request,
       }),
     ).rejects.toThrow("GitHub returned an invalid or truncated E2E job list");
+  });
+
+  it("rejects an unbounded job name before evidence serialization", async () => {
+    const fixture = setup({ attempt: 1, conclusion: "failure" });
+    const request = async (path: string, init?: { method?: "GET" | "POST" }) =>
+      path.includes("/attempts/1/jobs")
+        ? { total_count: 1, jobs: [{ ...job(1, "failure"), name: "x".repeat(257) }] }
+        : fixture.request(path, init);
+
+    await expect(
+      evaluateMainRunRetry({
+        repository: REPOSITORY,
+        token: "token",
+        sourceRunId: RUN_ID,
+        controllerAttempt: 1,
+        request,
+      }),
+    ).rejects.toThrow("GitHub returned invalid E2E job identity");
   });
 });

--- a/test/e2e/support/main-run-retry.test.ts
+++ b/test/e2e/support/main-run-retry.test.ts
@@ -200,4 +200,22 @@ describe("main E2E retry controller", () => {
       }),
     ).rejects.toThrow("GitHub returned invalid E2E job identity");
   });
+
+  it("rejects an empty successful attempt job listing", async () => {
+    const fixture = setup({ attempt: 1, conclusion: "success" });
+    const request = async (path: string, init?: { method?: "GET" | "POST" }) =>
+      path.includes("/attempts/1/jobs")
+        ? { total_count: 0, jobs: [] }
+        : fixture.request(path, init);
+
+    await expect(
+      evaluateMainRunRetry({
+        repository: REPOSITORY,
+        token: "token",
+        sourceRunId: RUN_ID,
+        controllerAttempt: 1,
+        request,
+      }),
+    ).rejects.toThrow("GitHub returned an invalid or truncated E2E job list");
+  });
 });

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -148,6 +148,10 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     testsToRun: runTests("test/pr-review-advisor-openshell-workflow-boundary.test.ts"),
   },
   {
+    pattern: /(?:^|\/)\.github\/workflows\/e2e-main-retry\.yaml$/,
+    testsToRun: runTests("test/e2e-main-retry-workflow.test.ts"),
+  },
+  {
     pattern:
       /(?:^|\/)\.github\/workflows\/(?:hosted-runner-recovery|wsl-e2e|macos-e2e|platform-vitest-main)\.yaml$/,
     testsToRun: runTests("test/hosted-runner-recovery-workflow.test.ts"),

--- a/test/hosted-runner-recovery-workflow.test.ts
+++ b/test/hosted-runner-recovery-workflow.test.ts
@@ -59,12 +59,12 @@ function collectStrings(value: unknown): string[] {
 }
 
 describe("hosted-runner recovery workflow boundary", () => {
-  it("subscribes only to completed runs from the four approved workflows (#7140)", () => {
+  it("subscribes only to completed runs from the three platform workflows (#7140)", () => {
     const value = workflow();
     expect(value.name).toBe("Hosted Runner Recovery");
     expect(value.on).toEqual({
       workflow_run: {
-        workflows: ["E2E", "E2E / WSL", "E2E / macOS", "CI / Platform Vitest Main Watch"],
+        workflows: ["E2E / WSL", "E2E / macOS", "CI / Platform Vitest Main Watch"],
         types: ["completed"],
       },
     });
@@ -96,12 +96,7 @@ describe("hosted-runner recovery workflow boundary", () => {
     expect(wsl).not.toHaveProperty("run-name");
     expect(macos).not.toHaveProperty("run-name");
     expect(platform).not.toHaveProperty("run-name");
-    expect(workflow().on.workflow_run.workflows).toEqual([
-      e2e.name,
-      wsl.name,
-      macos.name,
-      platform.name,
-    ]);
+    expect(workflow().on.workflow_run.workflows).toEqual([wsl.name, macos.name, platform.name]);
   });
 
   it("fails closed on controller, source, repository, branch, event, path, and title (#7140)", () => {
@@ -114,11 +109,6 @@ describe("hosted-runner recovery workflow boundary", () => {
       "github.event.workflow_run.conclusion == 'failure'",
       "github.event.workflow_run.head_branch == 'main'",
       "github.event.workflow_run.head_repository.full_name == 'NVIDIA/NemoClaw'",
-      "github.event.workflow_run.path == '.github/workflows/e2e.yaml'",
-      "github.event.workflow_run.event == 'push'",
-      "github.event.workflow_run.event == 'workflow_dispatch'",
-      "github.event.workflow_run.display_title == 'E2E main'",
-      "github.event.workflow_run.event == 'push'",
       "github.event.workflow_run.path == '.github/workflows/wsl-e2e.yaml'",
       "github.event.workflow_run.path == '.github/workflows/macos-e2e.yaml'",
       "github.event.workflow_run.path == '.github/workflows/platform-vitest-main.yaml'",

--- a/tools/e2e/main-run-retry.mts
+++ b/tools/e2e/main-run-retry.mts
@@ -136,6 +136,55 @@ function validateLatestRun(value: unknown, source: SourceRun): boolean {
   return eligible?.id === source.id;
 }
 
+const JOB_CONCLUSIONS = new Set([
+  "action_required",
+  "cancelled",
+  "failure",
+  "neutral",
+  "skipped",
+  "stale",
+  "startup_failure",
+  "success",
+  "timed_out",
+]);
+
+type ValidatedJob = {
+  name: string;
+  conclusion: string;
+  startedAt: string | null;
+  completedAt: string | null;
+};
+
+function validateJob(value: unknown, attempt: number): ValidatedJob {
+  const job = record(value);
+  const name = job.name;
+  const conclusion = job.conclusion;
+  if (
+    typeof name !== "string" ||
+    name.length < 1 ||
+    name.length > 256 ||
+    /[\u0000-\u001f\u007f]/u.test(name) ||
+    typeof conclusion !== "string" ||
+    !JOB_CONCLUSIONS.has(conclusion) ||
+    job.run_attempt !== attempt ||
+    job.status !== "completed"
+  ) {
+    throw new Error("GitHub returned invalid E2E job identity");
+  }
+  const startedAt = typeof job.started_at === "string" ? job.started_at : null;
+  const completedAt = typeof job.completed_at === "string" ? job.completed_at : null;
+  if (
+    conclusion !== "skipped" &&
+    (!startedAt ||
+      !TIMESTAMP_PATTERN.test(startedAt) ||
+      !completedAt ||
+      !TIMESTAMP_PATTERN.test(completedAt))
+  ) {
+    throw new Error("GitHub returned invalid E2E job timestamps");
+  }
+  return { name, conclusion, startedAt, completedAt };
+}
+
 function validateAttemptEvidence(value: unknown, attempt: number): AttemptEvidence {
   const response = record(value);
   if (
@@ -146,20 +195,10 @@ function validateAttemptEvidence(value: unknown, attempt: number): AttemptEviden
   ) {
     throw new Error("GitHub returned an invalid or truncated E2E job list");
   }
-  const jobs = response.jobs.map(record);
-  if (jobs.some((job) => job.run_attempt !== attempt)) {
-    throw new Error("GitHub returned jobs from a different run attempt");
-  }
-  const active = jobs.filter(
-    (job) =>
-      job.conclusion !== "skipped" &&
-      typeof job.started_at === "string" &&
-      TIMESTAMP_PATTERN.test(job.started_at) &&
-      typeof job.completed_at === "string" &&
-      TIMESTAMP_PATTERN.test(job.completed_at),
-  );
+  const jobs = response.jobs.map((job) => validateJob(job, attempt));
+  const active = jobs.filter((job) => job.conclusion !== "skipped");
   const runnerMilliseconds = active.reduce((total, job) => {
-    const duration = Date.parse(job.completed_at as string) - Date.parse(job.started_at as string);
+    const duration = Date.parse(job.completedAt!) - Date.parse(job.startedAt!);
     if (!Number.isFinite(duration) || duration < 0) throw new Error("GitHub returned invalid job timing");
     return total + duration;
   }, 0);
@@ -167,7 +206,7 @@ function validateAttemptEvidence(value: unknown, attempt: number): AttemptEviden
     attempt,
     failedJobs: active
       .filter((job) => job.conclusion !== "success")
-      .map((job) => String(job.name))
+      .map((job) => job.name)
       .sort(),
     nonSkippedJobs: active.length,
     runnerMinutes: Number((runnerMilliseconds / 60_000).toFixed(2)),
@@ -267,19 +306,26 @@ function integerEnvironment(name: string): number {
 }
 
 function writeRetryEvidence(file: string, evidence: MainRunRetryEvidence): void {
-  const descriptor = fs.openSync(
-    file,
-    fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
-    0o600,
-  );
+  const temporaryFile = `${file}.partial.${process.pid}`;
+  let descriptor: number | null = null;
   try {
-    // lgtm[js/network-data-to-file] The controller serializes bounded, validated
-    // GitHub run and job fields to a fixed runner-owned path through an exclusive
-    // 0600 descriptor. The artifact uploader treats the JSON as data and never executes it.
+    descriptor = fs.openSync(
+      temporaryFile,
+      fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+      0o600,
+    );
+    // lgtm[js/network-data-to-file] GitHub run and job fields pass type, enum,
+    // count, and length limits before the controller writes them to a fixed
+    // runner-owned path through an exclusive 0600 descriptor.
     // lgtm[js/http-to-file-access]
     fs.writeFileSync(descriptor, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
-  } finally {
+    fs.fsyncSync(descriptor);
     fs.closeSync(descriptor);
+    descriptor = null;
+    fs.linkSync(temporaryFile, file);
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+    fs.rmSync(temporaryFile, { force: true });
   }
 }
 

--- a/tools/e2e/main-run-retry.mts
+++ b/tools/e2e/main-run-retry.mts
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import { githubApi } from "../advisors/github.mts";
+
+const TRUSTED_REPOSITORY = "NVIDIA/NemoClaw";
+const WORKFLOW_PATH = ".github/workflows/e2e.yaml";
+const DISPLAY_TITLE = "E2E main";
+const SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/u;
+export const E2E_MAX_RETRIES = 2;
+export const E2E_MAX_ATTEMPTS = E2E_MAX_RETRIES + 1;
+
+export type MainRunRetryAction =
+  | "failed-after-retries"
+  | "ignored"
+  | "passed-after-retry"
+  | "passed-first-attempt"
+  | "retry-requested";
+
+type ApiRequest = (path: string, options?: { method?: "GET" | "POST" }) => Promise<unknown>;
+
+type SourceRun = {
+  id: number;
+  workflowId: number;
+  attempt: number;
+  status: "completed";
+  conclusion: string;
+  event: "push";
+  path: typeof WORKFLOW_PATH;
+  displayTitle: typeof DISPLAY_TITLE;
+  headBranch: "main";
+  headSha: string;
+  repository: typeof TRUSTED_REPOSITORY;
+  headRepository: typeof TRUSTED_REPOSITORY;
+  url: string;
+};
+
+type AttemptEvidence = {
+  attempt: number;
+  failedJobs: string[];
+  nonSkippedJobs: number;
+  runnerMinutes: number;
+};
+
+export type MainRunRetryEvidence = {
+  schemaVersion: 1;
+  sourceRunId: number;
+  sourceSha: string;
+  sourceAttempt: number;
+  sourceConclusion: string;
+  sourceUrl: string;
+  action: MainRunRetryAction;
+  reason: string;
+  flaky: boolean;
+  maxRetries: typeof E2E_MAX_RETRIES;
+  attempts: AttemptEvidence[];
+  totalRunnerMinutes: number;
+};
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("GitHub returned a non-object response");
+  }
+  return value as Record<string, unknown>;
+}
+
+function positiveInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw new Error(`${field} must be a positive safe integer`);
+  }
+  return value as number;
+}
+
+function validateSourceRun(value: unknown): SourceRun {
+  const run = record(value);
+  const repository = record(run.repository);
+  const headRepository = record(run.head_repository);
+  if (
+    run.status !== "completed" ||
+    typeof run.conclusion !== "string" ||
+    run.event !== "push" ||
+    run.path !== WORKFLOW_PATH ||
+    run.display_title !== DISPLAY_TITLE ||
+    run.head_branch !== "main" ||
+    typeof run.head_sha !== "string" ||
+    !SHA_PATTERN.test(run.head_sha) ||
+    repository.full_name !== TRUSTED_REPOSITORY ||
+    headRepository.full_name !== TRUSTED_REPOSITORY ||
+    typeof run.html_url !== "string"
+  ) {
+    throw new Error("source run is not a completed trusted E2E main push");
+  }
+  const id = positiveInteger(run.id, "source run ID");
+  const expectedUrl = `https://github.com/${TRUSTED_REPOSITORY}/actions/runs/${id}`;
+  if (run.html_url !== expectedUrl) throw new Error("source run URL does not match its identity");
+  const attempt = positiveInteger(run.run_attempt, "source run attempt");
+  if (attempt > E2E_MAX_ATTEMPTS) throw new Error("source run exceeds the retry attempt limit");
+  return {
+    id,
+    workflowId: positiveInteger(run.workflow_id, "workflow ID"),
+    attempt,
+    status: "completed",
+    conclusion: run.conclusion,
+    event: "push",
+    path: WORKFLOW_PATH,
+    displayTitle: DISPLAY_TITLE,
+    headBranch: "main",
+    headSha: run.head_sha,
+    repository: TRUSTED_REPOSITORY,
+    headRepository: TRUSTED_REPOSITORY,
+    url: run.html_url,
+  };
+}
+
+function validateLatestRun(value: unknown, source: SourceRun): boolean {
+  const response = record(value);
+  if (!Array.isArray(response.workflow_runs)) throw new Error("GitHub returned no workflow run list");
+  const eligible = response.workflow_runs
+    .map((item) => record(item))
+    .find(
+      (run) =>
+        run.workflow_id === source.workflowId &&
+        run.event === "push" &&
+        run.path === WORKFLOW_PATH &&
+        run.display_title === DISPLAY_TITLE &&
+        run.head_branch === "main" &&
+        record(run.repository).full_name === TRUSTED_REPOSITORY &&
+        record(run.head_repository).full_name === TRUSTED_REPOSITORY,
+    );
+  return eligible?.id === source.id;
+}
+
+function validateAttemptEvidence(value: unknown, attempt: number): AttemptEvidence {
+  const response = record(value);
+  if (!Array.isArray(response.jobs) || response.jobs.length > 100) {
+    throw new Error("GitHub returned an invalid E2E job list");
+  }
+  const jobs = response.jobs.map(record);
+  if (jobs.some((job) => job.run_attempt !== attempt)) {
+    throw new Error("GitHub returned jobs from a different run attempt");
+  }
+  const active = jobs.filter(
+    (job) =>
+      job.conclusion !== "skipped" &&
+      typeof job.started_at === "string" &&
+      TIMESTAMP_PATTERN.test(job.started_at) &&
+      typeof job.completed_at === "string" &&
+      TIMESTAMP_PATTERN.test(job.completed_at),
+  );
+  const runnerMilliseconds = active.reduce((total, job) => {
+    const duration = Date.parse(job.completed_at as string) - Date.parse(job.started_at as string);
+    if (!Number.isFinite(duration) || duration < 0) throw new Error("GitHub returned invalid job timing");
+    return total + duration;
+  }, 0);
+  return {
+    attempt,
+    failedJobs: active
+      .filter((job) => job.conclusion !== "success")
+      .map((job) => String(job.name))
+      .sort(),
+    nonSkippedJobs: active.length,
+    runnerMinutes: Number((runnerMilliseconds / 60_000).toFixed(2)),
+  };
+}
+
+export function decideMainRunRetry(source: SourceRun): { action: MainRunRetryAction; reason: string } {
+  if (source.conclusion === "success") {
+    return source.attempt === 1
+      ? { action: "passed-first-attempt", reason: "E2E passed on its first attempt" }
+      : { action: "passed-after-retry", reason: `E2E passed on attempt ${source.attempt}` };
+  }
+  if (source.conclusion !== "failure") {
+    return { action: "ignored", reason: `E2E concluded with ${source.conclusion}` };
+  }
+  return source.attempt < E2E_MAX_ATTEMPTS
+    ? { action: "retry-requested", reason: `E2E failed on attempt ${source.attempt}` }
+    : { action: "failed-after-retries", reason: "E2E failed on its third attempt" };
+}
+
+export async function evaluateMainRunRetry(options: {
+  repository: string;
+  token: string;
+  sourceRunId: number;
+  controllerAttempt: number;
+  request?: ApiRequest;
+}): Promise<MainRunRetryEvidence> {
+  if (options.repository !== TRUSTED_REPOSITORY) {
+    throw new Error(`E2E retry is restricted to ${TRUSTED_REPOSITORY}`);
+  }
+  if (!options.token) throw new Error("GitHub token is required");
+  positiveInteger(options.sourceRunId, "source run ID");
+  if (positiveInteger(options.controllerAttempt, "controller attempt") !== 1) {
+    throw new Error("controller reruns cannot request E2E retries");
+  }
+  const request =
+    options.request ??
+    ((path, requestOptions) =>
+      githubApi<unknown>(path, options.token, {
+        method: requestOptions?.method ?? "GET",
+        userAgent: "nemoclaw-e2e-main-retry",
+      }));
+  const runPath = `repos/${options.repository}/actions/runs/${options.sourceRunId}`;
+  const source = validateSourceRun(await request(runPath));
+  const latestPath = `repos/${options.repository}/actions/workflows/${source.workflowId}/runs?branch=main&event=push&per_page=20`;
+  const isLatest = validateLatestRun(await request(latestPath), source);
+  const attempts: AttemptEvidence[] = [];
+  for (let attempt = 1; attempt <= source.attempt; attempt += 1) {
+    attempts.push(
+      validateAttemptEvidence(
+        await request(`${runPath}/attempts/${attempt}/jobs?per_page=100`),
+        attempt,
+      ),
+    );
+  }
+  const decision = isLatest
+    ? decideMainRunRetry(source)
+    : { action: "ignored" as const, reason: "a newer E2E main push exists" };
+  if (decision.action === "retry-requested") {
+    const confirmed = validateSourceRun(await request(runPath));
+    if (JSON.stringify(confirmed) !== JSON.stringify(source)) {
+      throw new Error("source run changed before retry request");
+    }
+    if (!validateLatestRun(await request(latestPath), source)) {
+      throw new Error("a newer E2E main push appeared before retry request");
+    }
+    await request(`${runPath}/rerun-failed-jobs`, { method: "POST" });
+  }
+  return {
+    schemaVersion: 1,
+    sourceRunId: source.id,
+    sourceSha: source.headSha,
+    sourceAttempt: source.attempt,
+    sourceConclusion: source.conclusion,
+    sourceUrl: source.url,
+    action: decision.action,
+    reason: decision.reason,
+    flaky: decision.action === "passed-after-retry",
+    maxRetries: E2E_MAX_RETRIES,
+    attempts,
+    totalRunnerMinutes: Number(
+      attempts.reduce((total, attempt) => total + attempt.runnerMinutes, 0).toFixed(2),
+    ),
+  };
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function integerEnvironment(name: string): number {
+  const value = requiredEnvironment(name);
+  if (!/^[1-9][0-9]*$/u.test(value)) throw new Error(`${name} must be a positive integer`);
+  return Number(value);
+}
+
+async function main(): Promise<void> {
+  const evidence = await evaluateMainRunRetry({
+    repository: requiredEnvironment("GITHUB_REPOSITORY"),
+    token: requiredEnvironment("GITHUB_TOKEN"),
+    sourceRunId: integerEnvironment("SOURCE_RUN_ID"),
+    controllerAttempt: integerEnvironment("GITHUB_RUN_ATTEMPT"),
+  });
+  writeFileSync(requiredEnvironment("RETRY_EVIDENCE_PATH"), `${JSON.stringify(evidence, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  const message = `${evidence.reason}; ${evidence.totalRunnerMinutes} runner-minutes across ${evidence.sourceAttempt} attempt(s)`;
+  if (evidence.flaky) console.log(`::warning title=E2E passed after retry::${message}`);
+  else console.log(`::notice title=E2E retry decision::${message}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/tools/e2e/main-run-retry.mts
+++ b/tools/e2e/main-run-retry.mts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { writeFileSync } from "node:fs";
+import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import { githubApi } from "../advisors/github.mts";
@@ -266,6 +266,24 @@ function integerEnvironment(name: string): number {
   return Number(value);
 }
 
+function writeRetryEvidence(file: string, evidence: MainRunRetryEvidence): void {
+  const descriptor = fs.openSync(
+    file,
+    fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+    0o600,
+  );
+  try {
+    // lgtm[js/network-data-to-file] The controller serializes bounded, validated
+    // GitHub run and job fields to a fixed runner-owned path through an exclusive
+    // 0600 descriptor. The artifact uploader treats the JSON as data and never executes it.
+    // lgtm[js/http-to-file-access]
+    fs.writeFileSync(descriptor, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+
 async function main(): Promise<void> {
   const evidence = await evaluateMainRunRetry({
     repository: requiredEnvironment("GITHUB_REPOSITORY"),
@@ -273,11 +291,7 @@ async function main(): Promise<void> {
     sourceRunId: integerEnvironment("SOURCE_RUN_ID"),
     controllerAttempt: integerEnvironment("GITHUB_RUN_ATTEMPT"),
   });
-  writeFileSync(requiredEnvironment("RETRY_EVIDENCE_PATH"), `${JSON.stringify(evidence, null, 2)}\n`, {
-    encoding: "utf8",
-    flag: "wx",
-    mode: 0o600,
-  });
+  writeRetryEvidence(requiredEnvironment("RETRY_EVIDENCE_PATH"), evidence);
   const message = `${evidence.reason}; ${evidence.totalRunnerMinutes} runner-minutes across ${evidence.sourceAttempt} attempt(s)`;
   if (evidence.flaky) console.log(`::warning title=E2E passed after retry::${message}`);
   else console.log(`::notice title=E2E retry decision::${message}`);

--- a/tools/e2e/main-run-retry.mts
+++ b/tools/e2e/main-run-retry.mts
@@ -318,8 +318,7 @@ function writeRetryEvidence(file: string, evidence: MainRunRetryEvidence): void 
     // lgtm[js/network-data-to-file] GitHub run and job fields pass type, enum,
     // count, and length limits before the controller writes them to a fixed
     // runner-owned path through an exclusive 0600 descriptor.
-    // lgtm[js/http-to-file-access]
-    fs.writeFileSync(descriptor, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+    fs.writeFileSync(descriptor, `${JSON.stringify(evidence, null, 2)}\n`, "utf8"); // lgtm[js/http-to-file-access]
     fs.fsyncSync(descriptor);
     fs.closeSync(descriptor);
     descriptor = null;

--- a/tools/e2e/main-run-retry.mts
+++ b/tools/e2e/main-run-retry.mts
@@ -138,8 +138,13 @@ function validateLatestRun(value: unknown, source: SourceRun): boolean {
 
 function validateAttemptEvidence(value: unknown, attempt: number): AttemptEvidence {
   const response = record(value);
-  if (!Array.isArray(response.jobs) || response.jobs.length > 100) {
-    throw new Error("GitHub returned an invalid E2E job list");
+  if (
+    !Array.isArray(response.jobs) ||
+    response.jobs.length > 100 ||
+    !Number.isSafeInteger(response.total_count) ||
+    response.total_count !== response.jobs.length
+  ) {
+    throw new Error("GitHub returned an invalid or truncated E2E job list");
   }
   const jobs = response.jobs.map(record);
   if (jobs.some((job) => job.run_attempt !== attempt)) {

--- a/tools/e2e/main-run-retry.mts
+++ b/tools/e2e/main-run-retry.mts
@@ -189,6 +189,7 @@ function validateAttemptEvidence(value: unknown, attempt: number): AttemptEviden
   const response = record(value);
   if (
     !Array.isArray(response.jobs) ||
+    response.jobs.length === 0 ||
     response.jobs.length > 100 ||
     !Number.isSafeInteger(response.total_count) ||
     response.total_count !== response.jobs.length


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add trusted retry automation for failed `E2E main` push jobs. GitHub Actions may rerun failed jobs twice, while attempt-scoped artifacts retain cumulative cost and flaky-pass evidence.

## Related Issue

Related to #7922.

## Changes

- Add `E2E / Main Retry` for completed, trusted `main` push runs only.
- Permit two failed-job reruns, for three total source attempts.
- Ignore manual PR runs, controller reruns, out-of-range attempts, and runs superseded by a newer `main` push.
- Revalidate source identity and latest-run state immediately before the write-capable GitHub API request.
- Record each observed attempt, failed job names, non-skipped job counts, per-attempt runner-minutes, cumulative runner-minutes, and `passed-after-retry` flaky evidence.
- Keep platform runner-loss recovery scoped to WSL, macOS, and platform-watch workflows.
- Update internal E2E procedures and opaque-input test routing.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: A nine-category review of commit `013959b43b00c468fe76455b00431e98262cfd30` found no findings. The workflow uses default-branch code, validates repository/workflow/event/branch/SHA/attempt identity, serializes each source run, rechecks state before mutation, scopes `actions: write` to one job, and exposes no repository secret.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Independent current-head review passed after verifying retry behavior, nonempty and complete job evidence, atomic publication, bounded fields, exact GitHub API semantics, and documentation claims.
- Agent: Pi CLI
<!-- docs-review-head-sha: 37e0a462d4df2073f4f49d6f2a0e8e93202e5079 -->
<!-- docs-review-agents-blob-sha: c69aad4d563f774afb9924b33122b9485a48cdeb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 72 focused retry, workflow-boundary, hosted-recovery, and watch-trigger tests passed; CLI typecheck, repository checks, semantic phase validation, conditional-growth checks, source-shape checks, and normal hooks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: GitHub CI is authoritative for broad validation.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation:

- `npm run typecheck:cli`
- `npm run checks:repository`
- `npm run test:e2e-phases:check`
- `npm run source-shape:check`

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic retries for failed main-branch end-to-end runs, with up to two retries.
  - Added retry evidence, per-attempt artifacts, and cumulative runner-minute reporting.
  - Reports recovered runs as successful when retries resolve failures.

- **Bug Fixes**
  - Refined hosted-runner recovery to supported platform workflows and authenticated failure evidence.
  - Excludes manual, superseded, and untrusted runs from automatic retries.

- **Documentation**
  - Updated end-to-end testing documentation with retry behavior, limits, artifacts, and reporting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->