### PR TITLE
refactor(cli): extract recovery command transport

### DIFF
--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { dockerSpawnSync } from "../../adapters/docker";
 import { stripAnsi } from "../../adapters/openshell/client";
@@ -21,7 +20,6 @@ import {
   isDirectSandboxFallbackUnavailableError,
   privilegedSandboxExecArgv,
 } from "../../sandbox/privileged-exec";
-import { createTempSshConfig } from "../../sandbox/temp-ssh-config";
 import { withTimerBoundShieldsMutationLock } from "../../shields/timer-bound-lock";
 import * as registry from "../../state/registry";
 import { buildSubprocessEnv } from "../../subprocess-env";
@@ -54,6 +52,14 @@ import {
   processRecoveryMcpReconciliationRefusal,
 } from "./mcp-bridge-recovery";
 import {
+  type CommandTransportDependencies,
+  DEFAULT_SANDBOX_EXEC_TIMEOUT_MS,
+  executeSandboxCommandTransport,
+  executeSandboxExecCommandTransport,
+  type SandboxCommandResult,
+  type SandboxExecCommandOptions,
+} from "./process-recovery/command-transport";
+import {
   buildSandboxExecMarkedCommand,
   extractSandboxExecCommandStdout,
 } from "./sandbox-exec-output";
@@ -78,17 +84,22 @@ export type {
 
 export { buildSandboxExecMarkedCommand } from "./sandbox-exec-output";
 
-export type SandboxCommandResult = {
-  status: number;
-  stdout: string;
-  stderr: string;
-};
+export type { SandboxCommandResult, SandboxExecCommandOptions };
 
-export type SandboxExecCommandOptions = {
-  allowLocalDockerFallback?: boolean;
-};
-
-const DEFAULT_SANDBOX_EXEC_TIMEOUT_MS = 15000;
+function commandTransportDependencies(): CommandTransportDependencies {
+  return {
+    buildSandboxExecMarkedCommand,
+    buildSubprocessEnv,
+    captureSandboxSshConfig,
+    dockerSpawnSync,
+    extractSandboxExecCommandStdout,
+    getOpenshellBinary,
+    isDirectSandboxFallbackUnavailableError,
+    openshellProbeTimeoutMs: OPENSHELL_PROBE_TIMEOUT_MS,
+    privilegedSandboxExecArgv,
+    root: ROOT,
+  };
+}
 
 type AuxiliaryRecoveryResult = {
   label: string;
@@ -107,11 +118,6 @@ function anyAuxiliaryRecovered(results: AuxiliaryRecoveryResult[]): boolean {
   return results.some((result) => result.recovered === true);
 }
 
-function resolveSandboxExecTimeout(timeout = DEFAULT_SANDBOX_EXEC_TIMEOUT_MS): number {
-  const timeoutOverride = Number(process.env.NEMOCLAW_SANDBOX_EXEC_TIMEOUT_MS || "");
-  return Number.isFinite(timeoutOverride) && timeoutOverride > 0 ? timeoutOverride : timeout;
-}
-
 function getSandboxHealthProbeUrl(sandboxName: string): string {
   const agent = agentRuntime.getSessionAgent(sandboxName);
   if (agent && agentRuntime.hasGatewayRuntime(agent)) return agentRuntime.getHealthProbeUrl(agent);
@@ -126,94 +132,7 @@ export function executeSandboxCommand(
   sandboxName: string,
   command: string,
 ): SandboxCommandResult | null {
-  const sshConfigResult = captureSandboxSshConfig(sandboxName, {
-    ignoreError: true,
-    timeout: OPENSHELL_PROBE_TIMEOUT_MS,
-  });
-  if (sshConfigResult.status !== 0) return null;
-  if (!sshConfigResult.output.trim()) return null;
-
-  const tmpSshConfig = createTempSshConfig(sshConfigResult.output, "nemoclaw-ssh-");
-  try {
-    const result = spawnSync(
-      "ssh",
-      [
-        "-F",
-        tmpSshConfig.file,
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
-        "-o",
-        "ConnectTimeout=5",
-        "-o",
-        "LogLevel=ERROR",
-        `openshell-${sandboxName}`,
-        command,
-      ],
-      {
-        encoding: "utf-8",
-        env: buildSubprocessEnv(),
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: 15000,
-      },
-    );
-    return {
-      status: result.status ?? 1,
-      stdout: (result.stdout || "").trim(),
-      stderr: (result.stderr || "").trim(),
-    };
-  } catch {
-    return null;
-  } finally {
-    tmpSshConfig.cleanup();
-  }
-}
-
-function parseSandboxCommandResult(
-  result: ReturnType<typeof spawnSync>,
-): SandboxCommandResult | null {
-  if (result.error) return null;
-  const stdout = typeof result.stdout === "string" ? result.stdout : String(result.stdout || "");
-  const stderr = typeof result.stderr === "string" ? result.stderr : String(result.stderr || "");
-  const commandStdout = extractSandboxExecCommandStdout(stdout);
-  if (commandStdout === null) return null;
-  return {
-    status: result.status ?? 1,
-    stdout: commandStdout,
-    stderr: stderr.trim(),
-  };
-}
-
-function executeLocalDockerSandboxCommand(
-  sandboxName: string,
-  markedCommand: string,
-  timeout: number,
-): SandboxCommandResult | null {
-  let argv: string[];
-  try {
-    argv = privilegedSandboxExecArgv(sandboxName, ["sh", "-c", markedCommand]);
-  } catch (error) {
-    // Docker discovery failure or a stopped/nonexistent direct container means
-    // there is no local fallback. Identity refusals, unsupported drivers,
-    // registry corruption, and ambiguous matches are security-boundary
-    // diagnostics: let callers surface them instead of collapsing them into an
-    // inconclusive OpenShell transport result.
-    if (isDirectSandboxFallbackUnavailableError(error)) return null;
-    throw error;
-  }
-
-  try {
-    const result = dockerSpawnSync(argv, {
-      encoding: "utf-8",
-      env: buildSubprocessEnv(),
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout,
-    });
-    return parseSandboxCommandResult(result);
-  } catch {
-    return null;
-  }
+  return executeSandboxCommandTransport(commandTransportDependencies(), sandboxName, command);
 }
 
 /** Run one root controller argv against the registry-pinned direct container. */
@@ -244,29 +163,13 @@ export function executeSandboxExecCommand(
   timeout = DEFAULT_SANDBOX_EXEC_TIMEOUT_MS,
   options: SandboxExecCommandOptions = {},
 ): SandboxCommandResult | null {
-  const markedCommand = buildSandboxExecMarkedCommand(command);
-  const effectiveTimeout = resolveSandboxExecTimeout(timeout);
-  try {
-    const result = spawnSync(
-      getOpenshellBinary(),
-      ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", markedCommand],
-      {
-        cwd: ROOT,
-        encoding: "utf-8",
-        env: buildSubprocessEnv(),
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: effectiveTimeout,
-      },
-    );
-    const parsed = parseSandboxCommandResult(result);
-    if (parsed !== null) return parsed;
-  } catch {
-    // OpenShell transport failed; try the trusted direct-container fallback.
-  }
-  if (options.allowLocalDockerFallback === false) return null;
-  // Keep the fallback outside the OpenShell try/catch so a fail-closed identity
-  // refusal cannot be caught and retried against changing container state.
-  return executeLocalDockerSandboxCommand(sandboxName, markedCommand, effectiveTimeout);
+  return executeSandboxExecCommandTransport(
+    commandTransportDependencies(),
+    sandboxName,
+    command,
+    timeout,
+    options,
+  );
 }
 
 function executeGatewaySupervisorActionPinned(

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -12,6 +12,14 @@ import {
   isCommandTimeout,
 } from "../../adapters/openshell/runtime";
 import { OPENSHELL_PROBE_TIMEOUT_MS } from "../../adapters/openshell/timeouts";
+import {
+  type CommandTransportDependencies,
+  DEFAULT_SANDBOX_EXEC_TIMEOUT_MS,
+  executeSandboxCommandTransport,
+  executeSandboxExecCommandTransport,
+  type SandboxCommandResult,
+  type SandboxExecCommandOptions,
+} from "../../adapters/sandbox/command-transport";
 import * as agentRuntime from "../../agent/runtime";
 import { G, R } from "../../cli/terminal-style";
 import { sleepSeconds, waitUntil } from "../../core/wait";
@@ -51,14 +59,6 @@ import {
   inspectHermesMcpReconciliationRefusal,
   processRecoveryMcpReconciliationRefusal,
 } from "./mcp-bridge-recovery";
-import {
-  type CommandTransportDependencies,
-  DEFAULT_SANDBOX_EXEC_TIMEOUT_MS,
-  executeSandboxCommandTransport,
-  executeSandboxExecCommandTransport,
-  type SandboxCommandResult,
-  type SandboxExecCommandOptions,
-} from "./process-recovery/command-transport";
 import {
   buildSandboxExecMarkedCommand,
   extractSandboxExecCommandStdout,

--- a/src/lib/actions/sandbox/process-recovery/command-transport.ts
+++ b/src/lib/actions/sandbox/process-recovery/command-transport.ts
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { createTempSshConfig } from "../../../sandbox/temp-ssh-config";
+
+export type SandboxCommandResult = {
+  status: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type SandboxExecCommandOptions = {
+  allowLocalDockerFallback?: boolean;
+};
+
+export type CommandTransportDependencies = {
+  buildSandboxExecMarkedCommand: (command: string) => string;
+  buildSubprocessEnv: () => NodeJS.ProcessEnv;
+  captureSandboxSshConfig: (
+    sandboxName: string,
+    options: { ignoreError: boolean; timeout: number },
+  ) => { output: string; status: number | null };
+  dockerSpawnSync: (
+    args: readonly string[],
+    options: Parameters<typeof spawnSync>[2],
+  ) => ReturnType<typeof spawnSync>;
+  extractSandboxExecCommandStdout: (output: string) => string | null;
+  getOpenshellBinary: () => string;
+  isDirectSandboxFallbackUnavailableError: (error: unknown) => boolean;
+  openshellProbeTimeoutMs: number;
+  privilegedSandboxExecArgv: (sandboxName: string, command: string[]) => string[];
+  root: string;
+};
+
+export const DEFAULT_SANDBOX_EXEC_TIMEOUT_MS = 15000;
+
+function resolveSandboxExecTimeout(timeout: number): number {
+  const timeoutOverride = Number(process.env.NEMOCLAW_SANDBOX_EXEC_TIMEOUT_MS || "");
+  return Number.isFinite(timeoutOverride) && timeoutOverride > 0 ? timeoutOverride : timeout;
+}
+
+export function executeSandboxCommandTransport(
+  deps: CommandTransportDependencies,
+  sandboxName: string,
+  command: string,
+): SandboxCommandResult | null {
+  const sshConfigResult = deps.captureSandboxSshConfig(sandboxName, {
+    ignoreError: true,
+    timeout: deps.openshellProbeTimeoutMs,
+  });
+  if (sshConfigResult.status !== 0) return null;
+  if (!sshConfigResult.output.trim()) return null;
+
+  const tmpSshConfig = createTempSshConfig(sshConfigResult.output, "nemoclaw-ssh-");
+  try {
+    const result = spawnSync(
+      "ssh",
+      [
+        "-F",
+        tmpSshConfig.file,
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "LogLevel=ERROR",
+        `openshell-${sandboxName}`,
+        command,
+      ],
+      {
+        encoding: "utf-8",
+        env: deps.buildSubprocessEnv(),
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 15000,
+      },
+    );
+    return {
+      status: result.status ?? 1,
+      stdout: (result.stdout || "").trim(),
+      stderr: (result.stderr || "").trim(),
+    };
+  } catch {
+    return null;
+  } finally {
+    tmpSshConfig.cleanup();
+  }
+}
+
+function parseSandboxCommandResult(
+  deps: CommandTransportDependencies,
+  result: ReturnType<typeof spawnSync>,
+): SandboxCommandResult | null {
+  if (result.error) return null;
+  const stdout = typeof result.stdout === "string" ? result.stdout : String(result.stdout || "");
+  const stderr = typeof result.stderr === "string" ? result.stderr : String(result.stderr || "");
+  const commandStdout = deps.extractSandboxExecCommandStdout(stdout);
+  if (commandStdout === null) return null;
+  return {
+    status: result.status ?? 1,
+    stdout: commandStdout,
+    stderr: stderr.trim(),
+  };
+}
+
+function executeLocalDockerSandboxCommand(
+  deps: CommandTransportDependencies,
+  sandboxName: string,
+  markedCommand: string,
+  timeout: number,
+): SandboxCommandResult | null {
+  let argv: string[];
+  try {
+    argv = deps.privilegedSandboxExecArgv(sandboxName, ["sh", "-c", markedCommand]);
+  } catch (error) {
+    // Docker discovery failure or a stopped/nonexistent direct container means
+    // there is no local fallback. Identity refusals, unsupported drivers,
+    // registry corruption, and ambiguous matches are security-boundary
+    // diagnostics: let callers surface them instead of collapsing them into an
+    // inconclusive OpenShell transport result.
+    if (deps.isDirectSandboxFallbackUnavailableError(error)) return null;
+    throw error;
+  }
+
+  try {
+    const result = deps.dockerSpawnSync(argv, {
+      encoding: "utf-8",
+      env: deps.buildSubprocessEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout,
+    });
+    return parseSandboxCommandResult(deps, result);
+  } catch {
+    return null;
+  }
+}
+
+export function executeSandboxExecCommandTransport(
+  deps: CommandTransportDependencies,
+  sandboxName: string,
+  command: string,
+  timeout: number,
+  options: SandboxExecCommandOptions,
+): SandboxCommandResult | null {
+  const markedCommand = deps.buildSandboxExecMarkedCommand(command);
+  const effectiveTimeout = resolveSandboxExecTimeout(timeout);
+  try {
+    const result = spawnSync(
+      deps.getOpenshellBinary(),
+      ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", markedCommand],
+      {
+        cwd: deps.root,
+        encoding: "utf-8",
+        env: deps.buildSubprocessEnv(),
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: effectiveTimeout,
+      },
+    );
+    const parsed = parseSandboxCommandResult(deps, result);
+    if (parsed !== null) return parsed;
+  } catch {
+    // OpenShell transport failed; try the trusted direct-container fallback.
+  }
+  if (options.allowLocalDockerFallback === false) return null;
+  // Keep the fallback outside the OpenShell try/catch so a fail-closed identity
+  // refusal cannot be caught and retried against changing container state.
+  return executeLocalDockerSandboxCommand(deps, sandboxName, markedCommand, effectiveTimeout);
+}

--- a/src/lib/adapters/sandbox/command-transport.ts
+++ b/src/lib/adapters/sandbox/command-transport.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import { createTempSshConfig } from "../../../sandbox/temp-ssh-config";
+import { createTempSshConfig } from "../../sandbox/temp-ssh-config";
 
 export type SandboxCommandResult = {
   status: number;
@@ -74,7 +74,7 @@ export function executeSandboxCommandTransport(
         encoding: "utf-8",
         env: deps.buildSubprocessEnv(),
         stdio: ["ignore", "pipe", "pipe"],
-        timeout: 15000,
+        timeout: DEFAULT_SANDBOX_EXEC_TIMEOUT_MS,
       },
     );
     return {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Extracts private sandbox recovery command transport from `process-recovery.ts` while retaining its existing named exports as a compatibility facade. This reduces the module's responsibilities without changing SSH, OpenShell, direct-Docker fallback, timeout, error, or recovery behavior.

## Changes

- Move command result types, timeout resolution, SSH execution, OpenShell marked execution, and trusted direct-Docker fallback into a private transport module.
- Keep call-time wrappers on the existing `process-recovery.ts` exports because current policy-channel consumers and tests spy on those named functions.
- Leave privileged execution, supervisor classification and waiting, OpenShell re-registration, and recovery result shaping unchanged.
- Protect the transport contract with the existing process-recovery, sandbox-exec output, policy-channel lifecycle, and privileged-exec tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: 190 focused recovery, transport, lifecycle, and privileged-exec tests pass against the finalized commit.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is a private, behavior-preserving extraction with no public API, CLI, configuration, workflow, default, or error change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: an independent Codex security review found no findings; environment sanitization, exact marker parsing, fail-closed errors, and opt-in trusted Docker fallback remain unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed; the private extraction preserves all user-visible behavior, and the existing timeout documentation remains accurate. Focused tests, CLI typecheck, and repository checks passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 32827299a -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 84 CLI, 57 core integration, and 49 managed-recovery tests passed (190 total); `npm run typecheck:cli` and `npm run checks:repository` also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to this narrow private-module refactor. An exploratory `npm test` run reported 26,610 passed, 77 skipped, and 16 unrelated environment/package-lane failures.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when executing commands in sandboxes across SSH, OpenShell, and Docker environments.
  * Standardized command output and handling for unavailable sandbox states.
  * Ensured temporary connection settings are cleaned up after execution.
  * Added support for configurable sandbox command timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
