### PR TITLE
fix(sandbox): scope registry recovery to the target gateway

### DIFF
--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -325,7 +325,15 @@ async function recoverRegistryFromLiveGateway(
 
   let recoveredFromGateway = 0;
   const ephemeralSandboxes: RecoveredSandboxEntry[] = [];
-  const liveList = captureOpenshell(["sandbox", "list"], {
+  // Scope the live-sandbox list to the gateway this recovery targets. An
+  // unscoped `sandbox list` returns every sandbox on the host. On a host
+  // running two NemoClaw gateways, recovery therefore registered the sibling
+  // gateway's sandboxes under this gateway, and every later sandbox-scoped
+  // status and exec command resolved that binding and reported the sandbox as
+  // Provisioning or absent from the live gateway (#7105). `-g` targets the
+  // named gateway without selecting it, matching the readiness poll in
+  // `connect` and `captureNamedGatewaySandboxListReadOnly`.
+  const liveList = captureOpenshell(["sandbox", "list", "-g", gatewayName], {
     ignoreError: true,
     timeout: OPENSHELL_PROBE_TIMEOUT_MS,
   });

--- a/src/lib/registry-recovery-seeded-paths.test.ts
+++ b/src/lib/registry-recovery-seeded-paths.test.ts
@@ -303,4 +303,63 @@ describe("recoverRegistryEntries seeded recovery paths", () => {
     expect(deps.calls.appendAuditEntry).not.toHaveBeenCalled();
     expect(deps.calls.restartSandboxGateway).not.toHaveBeenCalled();
   });
+
+  it("recovers only the targeted gateway's sandboxes, not a sibling gateway's (#7105)", async () => {
+    // An unscoped `sandbox list` returns every sandbox on the host. This stub
+    // answers as OpenShell does: unscoped lists both gateways' sandboxes, `-g`
+    // lists only the named gateway's. Registering the sibling gateway's sandbox
+    // here binds it to the wrong gateway, and every later status and exec
+    // command follows that binding.
+    vi.mocked(captureOpenshell).mockImplementation(
+      (args: string[]) =>
+        ({
+          output: args.includes("-g") ? "scoped-list" : "host-wide-list",
+          status: 0,
+        }) as never,
+    );
+    vi.mocked(parseLiveSandboxEntries).mockImplementation((output?: string) =>
+      output === "scoped-list" ? [] : [{ name: "hermes-station", phase: "Ready" }],
+    );
+    mockRegistryState.sandboxes.gamma = gammaEntry([]);
+    mockRegistryState.defaultSandbox = "gamma";
+
+    const result = await recoverRegistryEntries({ requestedSandboxName: "hermes-station" });
+
+    expect(mockRegistryState.sandboxes["hermes-station"]).toBeUndefined();
+    expect(result.recoveredFromGateway).toBe(0);
+    expect(captureOpenshell).toHaveBeenCalledWith(
+      ["sandbox", "list", "-g", "nemoclaw"],
+      expect.anything(),
+    );
+  });
+
+  it("scopes the unseeded display-only recovery to the resolved gateway too (#7105)", async () => {
+    // The unseeded #5714 `list` path reads the same list and must be scoped as
+    // well, or a plain `nemoclaw list` advertises a sibling gateway's sandbox
+    // that the next sandbox-scoped command cannot act on.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(captureOpenshell).mockImplementation(
+      (args: string[]) =>
+        ({
+          output: args.includes("-g") ? "scoped-list" : "host-wide-list",
+          status: 0,
+        }) as never,
+    );
+    vi.mocked(parseLiveSandboxEntries).mockImplementation((output?: string) =>
+      output === "scoped-list"
+        ? [{ name: "target-sandbox", phase: "Ready" }]
+        : [{ name: "sibling-sandbox", phase: "Ready" }],
+    );
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.sandboxes.map((sandbox) => sandbox.name)).toEqual(["target-sandbox"]);
+    // Unseeded recovery is display-only, so neither name is persisted.
+    expect(mockRegistryState.sandboxes["target-sandbox"]).toBeUndefined();
+    expect(mockRegistryState.sandboxes["sibling-sandbox"]).toBeUndefined();
+    expect(captureOpenshell).toHaveBeenCalledWith(
+      ["sandbox", "list", "-g", "nemoclaw"],
+      expect.anything(),
+    );
+  });
 });

--- a/test/cli/dispatch-basics.test.ts
+++ b/test/cli/dispatch-basics.test.ts
@@ -433,7 +433,11 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("CONNECTED_LIOST");
     expect(r.out).not.toContain("Unknown command: liost");
     const calls = fs.readFileSync(path.join(home, "openshell-calls.log"), "utf8").split("\n");
-    expect(calls).toContain("sandbox list");
+    // Every sandbox list in this flow is gateway-scoped, including registry
+    // recovery's. An unscoped list returns every sandbox on the host, so on a
+    // two-gateway host recovery would bind a sibling gateway's sandbox to the
+    // selected gateway (#7105).
+    expect(calls).not.toContain("sandbox list");
     expect(calls).toContain("sandbox list -g nemoclaw");
   });
 


### PR DESCRIPTION
## Summary

`openshell sandbox list` without `-g` returns every sandbox on the host, not only the selected gateway's. On a host running two NemoClaw gateways, registry recovery listed the sibling gateway's sandboxes and registered them bound to the current gateway. Every later sandbox-scoped `status` or `exec` then resolved that binding, selected the wrong gateway, and reported the sandbox as `Provisioning` or absent from the live gateway. Recovery now scopes its list to the gateway it targets, so a sibling gateway's sandbox is never registered under this one.

## Related Issue

Refs: #7105

Deliberately `Refs:`, not `Fixes:` — see "Limits" below for what this does not close.

## Changes

- `src/lib/registry-recovery-action.ts` — the live-sandbox list in `recoverRegistryFromLiveGateway` now runs `sandbox list -g <gatewayName>` instead of the unscoped `sandbox list`. `-g` targets the named gateway without selecting it, so this adds no gateway-state mutation to either recovery path. The form is already this repository's standard for the problem: `connect`'s readiness poll (`src/lib/actions/sandbox/connect.ts:971`, whose comment reads "so a same-named sandbox on a sibling gateway cannot satisfy readiness") and `captureNamedGatewaySandboxListReadOnly` (`src/lib/openshell-sandbox-list.ts:134`) both use it.
- `src/lib/registry-recovery-seeded-paths.test.ts` — two tests through the real entry point `recoverRegistryEntries`, one per consumer of the changed list (seeded and unseeded).
- `test/cli/dispatch-basics.test.ts` — an existing assertion required the unscoped call (`expect(calls).toContain("sandbox list")`). It encoded the behavior being fixed, so it now asserts that no unscoped list is issued. That test's behavioral assertions (exit 0, `CONNECTED_LIOST`, no typo suggestion) are unchanged and still pass, so recovery still works; it is only scoped now.

No abstraction, configuration, fallback, migration, or compatibility path is added.

### Why recovery is the writer, not onboarding

QA's root-cause line reads "after onboarding sandbox B on port 8090, the local registry entry ... contained `gatewayName: nemoclaw`", which sounds like an onboarding-time registration defect. It is worth stating why I concluded otherwise, since it is the obvious first question.

The sandbox registry file is per gateway port. `nemoclawStateRoot` (`src/lib/state/state-root.ts:12`) returns `~/.nemoclaw` for the default port and `~/.nemoclaw/gateways/<port>` for any other, and `REGISTRY_FILE` (`src/lib/state/registry/persistence.ts:49`) is that root plus `sandboxes.json`. So onboarding under `NEMOCLAW_GATEWAY_PORT=8090` writes only `~/.nemoclaw/gateways/8090/sandboxes.json`, and it writes the correct binding there — `onboard.ts` passes `gatewayName: GATEWAY_NAME, gatewayPort: GATEWAY_PORT`, both resolved from the requested port.

QA's unqualified `nemoclaw hermes-v2c-6471144 status` reads the *default* root and found the sandbox there ("registered locally, but is not present in the live OpenShell gateway"). Onboarding under 8090 cannot have written that file. The writer that can is registry recovery, which runs on exactly that unqualified path (`public-dispatch.ts` → `recoverRegistryEntries`), listed the whole host, and registered the row under the assumed current gateway.

I cannot confirm this on QA's host, so I have not claimed the issue is closed.

### Scoping is safe on both recovery paths

Both paths establish which gateway they mean before the list runs:

- Seeded path: `canInspectLiveGatewayViaRecovery()` recovers and selects the named gateway first.
- Unseeded `list` path (#5714): `canInspectLiveGatewayReadOnly()` returns true only for `healthy_named` — "the active gateway IS the NemoClaw gateway this process resolves/targets" (`registry-recovery-action.ts:311-312`). That comment already flagged the ambiguity this fixes: "`openshell sandbox list` may be scoped to the active gateway". `-g` removes the guess.

`-g` support is not a compatibility risk: `nemoclaw-blueprint/blueprint.yaml` pins both `min_openshell_version` and `max_openshell_version` to `0.0.85`, and `connect` already ships `-g` against that version.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no user-visible string, flag, default, or command surface changes. The fix restores a contract the docs already state — `docs/reference/troubleshooting.mdx:398`, "Every later command reads the state root that its own `NEMOCLAW_GATEWAY_PORT` selects" — rather than changing one.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: @apurvvkumaria completed an independent nine-category security audit of this revision and recorded APPROVE, no security findings — https://github.com/NVIDIA/NemoClaw/pull/8486#issuecomment-5207961584
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed. The reviewer swept `docs/` for registry recovery, multi-gateway and `NEMOCLAW_GATEWAY_PORT` operation, and the "registered locally but missing from the gateway" behavior. Every tracked `openshell sandbox list` mention is a user-run diagnostic, not this internal list, and `docs/changelog/2026-06-28.mdx:11` ("recovery can rediscover live sandboxes when the local registry is empty") stays accurate because only the scope narrowed.
- Agent: Claude Code
<!-- docs-review-head-sha: 85f81dc5d -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: see below
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; this is a one-line behavior change with targeted coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Red then green

Both tests drive `recoverRegistryEntries`, the function `public-dispatch.ts` calls. The stub answers as OpenShell does: an unscoped list returns both gateways' sandboxes, `-g` returns only the named gateway's.

Against the unchanged source, both fail, and the seeded one produces the exact row QA reported:

```
 × recovers only the targeted gateway's sandboxes, not a sibling gateway's (#7105)
 × scopes the unseeded display-only recovery to the resolved gateway too (#7105)
      Tests  2 failed | 8 passed (10)

AssertionError: expected { name: 'hermes-station', …(9) } to be undefined
+ Received:
{
  "gatewayName": "nemoclaw",
  "name": "hermes-station",
  ...
}
```

With the fix:

```
npx vitest run --project cli --no-file-parallelism src/lib/registry-recovery-seeded-paths.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

### Blast radius

Grepped the whole repository for the changed argv literal `["sandbox", "list"]` and ran every match's suite, in both projects, with `--no-file-parallelism`. Note `npm run test:changed` does not run the `integration` project, and that project is what caught the one real regression (`dispatch-basics.test.ts`) described above.

```
npx vitest run --project cli --no-file-parallelism \
  src/lib/registry-recovery-seeded-paths.test.ts src/lib/registry-recovery-action.test.ts \
  src/lib/openshell-sandbox-list.test.ts src/lib/actions/sandbox/rebuild-gateway-drift.test.ts \
  src/lib/actions/sandbox/destroy-gateway-cleanup.test.ts src/lib/actions/sandbox/doctor-flow.test.ts \
  src/lib/inventory/index.test.ts src/commands/global-oclif-command-adapters.test.ts \
  src/commands/simple-global-oclif-adapters.test.ts src/lib/actions/sandbox/connect-flow.test.ts \
  src/lib/actions/sandbox/connect-probe-observe.test.ts
 Test Files  11 passed (11)
      Tests  170 passed (170)

npx vitest run --project integration --no-file-parallelism \
  test/cli-oclif-compatibility.test.ts test/cli/dispatch-basics.test.ts \
  test/repro-2666-silent-list-status.test.ts test/cli/list-inference.test.ts \
  test/registry.test.ts test/nemoclaw-cli-recovery.test.ts
 Test Files  6 passed (6)
      Tests  143 passed (143)
```

`npm run typecheck:cli`, `npx biome check`, and `npm run checks:repository` all pass.

## Limits a reviewer should know

- **This does not close #7105, and I have not marked it `Fixes:`.** It removes the writer I could identify and prove. QA should re-verify on the two-gateway DGX Station before the issue is closed.
- **Already-wrong registry rows are not repaired.** The fix stops a wrong binding from being written. A row an affected host already has — QA's `hermes-station` with `gatewayName: nemoclaw` in the default state root — stays wrong after upgrade, because recovery is skipped entirely once the registry holds the name. Those hosts still need the row removed by hand. Repairing existing rows means reconciling across per-port state roots, which is a larger change and a separate decision.
- **Proof is against a stubbed OpenShell boundary, not a real two-gateway host.** I do not have the DGX Station setup QA used. The stub encodes the documented `-g` semantics.
- **Other unscoped `sandbox list` / `sandbox get` call sites are left alone,** so this is not a claim that the whole surface is scoped. The ones I found: `src/lib/onboard/sandbox-lifecycle.ts:49` (`sandboxExistsInGateway`, which feeds onboard's reuse/recreate decision — the most consequential of these), `src/lib/onboard/sandbox-create-step.ts:123`, `src/lib/onboard/docker-gpu-sandbox-create.ts:522`, `src/lib/onboard/docker-gpu-supervisor-reconnect.ts:97`, `src/lib/onboard/sandbox-gpu-create-attempt.ts:183`, `src/lib/onboard/sandbox-gpu-create-run-attempt.ts:160,212`, `src/lib/onboard/docker-gpu-patch.ts:425`, `src/lib/actions/sandbox/snapshot.ts:400,416,558`, `src/lib/actions/sandbox/doctor.ts:255`, `src/lib/actions/sandbox/destroy-gateway-cleanup.ts:67`. Happy to open a follow-up issue if maintainers want them swept.

---

Signed-off-by: harjoth <harjoth.khara@gmail.com>
