### PR TITLE
test(plugin): consolidate migration and blueprint-runner test fixtures

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -2,7 +2,7 @@
   "$comment": "SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\nSPDX-License-Identifier: Apache-2.0",
   "defaultMaxLines": 1500,
   "legacyMaxLines": {
-    "nemoclaw/src/commands/migration-state.test.ts": 1562,
+    "nemoclaw/src/commands/migration-state.test.ts": 1301,
     "src/lib/inference/nim.test.ts": 2068,
     "src/lib/onboard/preflight.test.ts": 1904,
     "test/generate-openclaw-config.test.ts": 1941,

--- a/nemoclaw/src/blueprint/runner-identity.test.ts
+++ b/nemoclaw/src/blueprint/runner-identity.test.ts
@@ -2,54 +2,45 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type fs from "node:fs";
-import { resolve } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
 
-interface FsEntry {
-  type: "file" | "dir";
-  content?: string;
-}
+import {
+  createRunnerFsStore,
+  FAKE_HOME,
+  FIXED_RUN_UUID,
+  inMemoryFsMethods,
+  resolvedEndpointFor,
+} from "./runner-mock-fixtures.js";
+import {
+  MATCHING_INFERENCE_PROVIDER_LISTING,
+  MATCHING_INFERENCE_ROUTE_LISTING,
+  MATCHING_RUNTIME_PROVIDER_LISTING,
+  providersV2EnabledResult,
+  successResult,
+} from "./runner-test-fixtures.js";
 
-const store = new Map<string, FsEntry>();
+const { store } = createRunnerFsStore();
 const realpaths = new Map<string, string>();
 const mockExeca = vi.fn();
-const missingEntry = (path: string): never => {
-  throw new Error(`ENOENT: ${path}`);
-};
 
 vi.mock("node:os", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:os")>();
-  return { ...original, homedir: () => "/fakehome" };
+  return { ...original, homedir: () => FAKE_HOME };
 });
-vi.mock("node:crypto", () => ({ randomUUID: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }));
+vi.mock("node:crypto", () => ({ randomUUID: () => FIXED_RUN_UUID }));
 vi.mock("node:fs", async (importOriginal) => {
   const original = await importOriginal<typeof fs>();
+  const memory = inMemoryFsMethods(store, { realpaths, spy: vi.fn });
   return {
     ...original,
-    mkdirSync: vi.fn((path: string) => store.set(path, { type: "dir" })),
-    readFileSync: (path: string) => {
-      const entry = store.get(path);
-      return entry?.type === "file" ? (entry.content ?? "") : missingEntry(path);
-    },
-    writeFileSync: vi.fn((path: string, content: string) =>
-      store.set(path, { type: "file", content }),
-    ),
-    readdirSync: (path: string) => {
-      const prefix = path.endsWith("/") ? path : `${path}/`;
-      const entries = [...store.keys()]
-        .filter((key) => key.startsWith(prefix))
-        .map((key) => key.slice(prefix.length).split("/")[0]);
-      return entries.length > 0 || store.has(path) ? [...new Set(entries)] : missingEntry(path);
-    },
-    realpathSync: (path: string) => {
-      const resolved = resolve(path);
-      return realpaths.get(resolved) ?? (store.has(resolved) ? resolved : missingEntry(resolved));
-    },
-    statSync: (path: string) => ({
-      isFile: () => store.get(resolve(path))?.type === "file",
-    }),
+    mkdirSync: memory.mkdirSync,
+    readFileSync: memory.readFileSync,
+    writeFileSync: memory.writeFileSync,
+    readdirSync: memory.readdirSync,
+    realpathSync: memory.realpathSync,
+    statSync: memory.statSync,
   };
 });
 vi.mock("execa", () => ({ execa: (...args: unknown[]) => mockExeca(...args) }));
@@ -57,13 +48,7 @@ vi.mock("./ssrf.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./ssrf.js")>();
   return {
     ...actual,
-    validateEndpointUrl: vi.fn(async (url: string) => ({
-      url,
-      pinnedUrl: url,
-      protocol: "https:",
-      hostname: new URL(url).hostname,
-      dnsResolved: false,
-    })),
+    validateEndpointUrl: vi.fn(async (url: string) => resolvedEndpointFor(url)),
   };
 });
 
@@ -71,42 +56,12 @@ const { actionApply, actionPlan, actionRollback, actionStatus, loadBlueprint } =
   "./runner.js"
 );
 
-const matchingProvider = [
-  "Name: acme-okta-runtime",
-  "Type: okta-runtime-v1",
-  "Credential keys: OKTA_ACCESS_TOKEN",
-  "Config keys: <none>",
-  "",
-].join("\n");
+const matchingProvider = MATCHING_RUNTIME_PROVIDER_LISTING;
+const matchingInferenceProvider = MATCHING_INFERENCE_PROVIDER_LISTING;
+const matchingInferenceRoute = MATCHING_INFERENCE_ROUTE_LISTING;
 
-const matchingInferenceProvider = [
-  "Name: test-provider",
-  "Type: openai",
-  "Credential keys: <none>",
-  "Config keys: OPENAI_BASE_URL",
-  "",
-].join("\n");
-
-const matchingInferenceRoute = [
-  "Gateway inference:",
-  "",
-  "  Provider: test-provider",
-  "  Model: test-model",
-  "  Version: 1",
-  "  Timeout: 180s",
-  "",
-].join("\n");
-
-const success = { exitCode: 0, stdout: "", stderr: "" };
-const providersV2Enabled = {
-  exitCode: 0,
-  stdout: JSON.stringify({
-    scope: "global",
-    settings_revision: 1,
-    settings: { providers_v2_enabled: "true" },
-  }),
-  stderr: "",
-};
+const success = successResult();
+const providersV2Enabled = providersV2EnabledResult();
 
 function responseQueue(
   overrides: Array<[string, Array<{ exitCode?: number; stdout: string; stderr: string }>]>,

--- a/nemoclaw/src/blueprint/runner-identity.test.ts
+++ b/nemoclaw/src/blueprint/runner-identity.test.ts
@@ -14,6 +14,7 @@ import {
   resolvedEndpointFor,
 } from "./runner-mock-fixtures.js";
 import {
+  failureResult,
   MATCHING_INFERENCE_PROVIDER_LISTING,
   MATCHING_INFERENCE_ROUTE_LISTING,
   MATCHING_RUNTIME_PROVIDER_LISTING,
@@ -67,8 +68,8 @@ function responseQueue(
   overrides: Array<[string, Array<{ exitCode?: number; stdout: string; stderr: string }>]>,
 ) {
   const responses = new Map([
-    ["sandbox get test-sandbox", [{ exitCode: 1, stdout: "", stderr: "sandbox not found" }]],
-    ["provider get test-provider", [{ exitCode: 1, stdout: "", stderr: "provider not found" }]],
+    ["sandbox get test-sandbox", [failureResult("sandbox not found")]],
+    ["provider get test-provider", [failureResult("provider not found")]],
     ["inference get", [{ exitCode: 0, stdout: matchingInferenceRoute, stderr: "" }]],
     ...overrides,
   ]);
@@ -228,7 +229,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
         ],
       ],
@@ -295,7 +296,7 @@ describe("blueprint identity wrapper", () => {
     process.env.OKTA_REFRESH_TOKEN = "refresh-secret";
     process.env.OKTA_CLIENT_SECRET = "client-secret";
     responseQueue([
-      ["provider get acme-okta-runtime", [{ exitCode: 1, stdout: "", stderr: "not found" }]],
+      ["provider get acme-okta-runtime", [failureResult("not found")]],
       [
         "provider create --name acme-okta-runtime --type okta-runtime-v1 --runtime-credentials",
         [{ exitCode: undefined, stdout: "", stderr: "terminated by SIGTERM" }],
@@ -317,10 +318,7 @@ describe("blueprint identity wrapper", () => {
     process.env.OKTA_REFRESH_TOKEN = "refresh-secret";
     process.env.OKTA_CLIENT_SECRET = "client-secret";
     responseQueue([
-      [
-        "sandbox get test-sandbox",
-        [{ exitCode: 1, stdout: "", stderr: "gateway configuration not found" }],
-      ],
+      ["sandbox get test-sandbox", [failureResult("gateway configuration not found")]],
     ]);
 
     await expect(actionApply("default", blueprint({ identity: oktaIdentity() }))).rejects.toThrow(
@@ -357,7 +355,7 @@ describe("blueprint identity wrapper", () => {
   it.each([
     [
       "cannot be inspected",
-      { exitCode: 1, stdout: "", stderr: "gateway route unavailable" },
+      failureResult("gateway route unavailable"),
       /Failed to inspect sandbox 'test-sandbox' after concurrent creation.*gateway route unavailable/,
     ],
     [
@@ -370,14 +368,11 @@ describe("blueprint identity wrapper", () => {
     process.env.OKTA_REFRESH_TOKEN = "refresh-secret";
     process.env.OKTA_CLIENT_SECRET = "client-secret";
     responseQueue([
-      [
-        "sandbox get test-sandbox",
-        [{ exitCode: 1, stdout: "", stderr: "sandbox not found" }, racedSandbox],
-      ],
+      ["sandbox get test-sandbox", [failureResult("sandbox not found"), racedSandbox]],
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           ...Array.from({ length: 4 }, () => ({
             exitCode: 0,
             stdout: matchingProvider,
@@ -387,7 +382,7 @@ describe("blueprint identity wrapper", () => {
       ],
       [
         "sandbox create --from openclaw --name test-sandbox --forward 18789",
-        [{ exitCode: 1, stdout: "", stderr: "sandbox already exists" }],
+        [failureResult("sandbox already exists")],
       ],
     ]);
 
@@ -410,10 +405,7 @@ describe("blueprint identity wrapper", () => {
         "sandbox get test-sandbox",
         [{ exitCode: 0, stdout: "Name: test-sandbox\nPhase: Ready", stderr: "" }],
       ],
-      [
-        "provider get test-provider",
-        [{ exitCode: 1, stdout: "", stderr: "gateway configuration not found" }],
-      ],
+      ["provider get test-provider", [failureResult("gateway configuration not found")]],
     ]);
 
     await expect(actionApply("default", blueprint({ identity: oktaIdentity() }))).rejects.toThrow(
@@ -472,10 +464,7 @@ describe("blueprint identity wrapper", () => {
         "provider get test-provider",
         [{ exitCode: 0, stdout: matchingInferenceProvider, stderr: "" }],
       ],
-      [
-        "inference get",
-        [{ exitCode: 1, stdout: "", stderr: "gateway route inspection unavailable" }],
-      ],
+      ["inference get", [failureResult("gateway route inspection unavailable")]],
     ]);
 
     await expect(actionApply("default", blueprint({ identity: oktaIdentity() }))).rejects.toThrow(
@@ -511,7 +500,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           ...Array.from({ length: 4 }, () => ({
             exitCode: 0,
             stdout: matchingProvider,
@@ -554,7 +543,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           ...Array.from({ length: 4 }, () => ({
             exitCode: 0,
             stdout: matchingProvider,
@@ -589,7 +578,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           ...Array.from({ length: 4 }, () => ({
             exitCode: 0,
             stdout: matchingProvider,
@@ -619,7 +608,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get test-provider",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           {
             exitCode: 0,
             stdout: matchingInferenceProvider.replace("Type: openai", "Type: anthropic"),
@@ -630,7 +619,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
@@ -638,7 +627,7 @@ describe("blueprint identity wrapper", () => {
       ],
       [
         "provider create --name test-provider --type openai --config OPENAI_BASE_URL=https://api.example.com/v1",
-        [{ exitCode: 1, stdout: "", stderr: "provider already exists" }],
+        [failureResult("provider already exists")],
       ],
     ]);
 
@@ -671,7 +660,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
@@ -679,7 +668,7 @@ describe("blueprint identity wrapper", () => {
       ],
       [
         "inference set --provider test-provider --model test-model",
-        [{ exitCode: 1, stdout: "", stderr: "route failed" }],
+        [failureResult("route failed")],
       ],
     ]);
 
@@ -718,16 +707,13 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
         ],
       ],
-      [
-        "policy get --base test-sandbox",
-        [{ exitCode: 1, stdout: "", stderr: "policy read rejected" }],
-      ],
+      ["policy get --base test-sandbox", [failureResult("policy read rejected")]],
     ]);
 
     await expect(
@@ -784,7 +770,7 @@ describe("blueprint identity wrapper", () => {
     responseQueue([
       [
         "inference set --provider test-provider --model test-model",
-        [{ exitCode: 1, stdout: "", stderr: "route failed" }],
+        [failureResult("route failed")],
       ],
     ]);
 
@@ -813,7 +799,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           ...Array.from({ length: 4 }, () => ({
             exitCode: 0,
             stdout: matchingProvider,
@@ -887,11 +873,11 @@ describe("blueprint identity wrapper", () => {
         "sandbox get test-sandbox",
         [{ exitCode: 0, stdout: "Name: test-sandbox\nPhase: Ready", stderr: "" }],
       ],
-      ["provider get test-provider", [{ exitCode: 1, stdout: "", stderr: "provider not found" }]],
+      ["provider get test-provider", [failureResult("provider not found")]],
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           { exitCode: 0, stdout: matchingProvider, stderr: "" },
         ],
       ],
@@ -945,9 +931,7 @@ describe("blueprint identity wrapper", () => {
         sandbox_created_by_apply: true,
       }),
     });
-    responseQueue([
-      ["sandbox remove owned-sandbox", [{ exitCode: 1, stdout: "", stderr: "remove denied" }]],
-    ]);
+    responseQueue([["sandbox remove owned-sandbox", [failureResult("remove denied")]]]);
 
     await expect(actionRollback("failed-sandbox-removal")).rejects.toThrow(
       /Failed to remove owned sandbox 'owned-sandbox': remove denied/,
@@ -966,12 +950,7 @@ describe("blueprint identity wrapper", () => {
         inference: { provider_name: "test-provider" },
       }),
     });
-    responseQueue([
-      [
-        "provider delete test-provider",
-        [{ exitCode: 1, stdout: "", stderr: "provider delete denied" }],
-      ],
-    ]);
+    responseQueue([["provider delete test-provider", [failureResult("provider delete denied")]]]);
 
     await expect(actionRollback("failed-inference-provider-removal")).rejects.toThrow(
       /Failed to remove owned inference provider 'test-provider': provider delete denied/,
@@ -1006,7 +985,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           ...Array.from({ length: 5 }, () => ({
             exitCode: 0,
             stdout: matchingProvider,
@@ -1016,14 +995,11 @@ describe("blueprint identity wrapper", () => {
       ],
       [
         "provider delete acme-okta-runtime",
-        [
-          { exitCode: 1, stdout: "", stderr: "delete denied" },
-          { exitCode: 0, stdout: "", stderr: "" },
-        ],
+        [failureResult("delete denied"), { exitCode: 0, stdout: "", stderr: "" }],
       ],
       [
         "inference set --provider test-provider --model test-model",
-        [{ exitCode: 1, stdout: "", stderr: "route failed" }],
+        [failureResult("route failed")],
       ],
     ]);
 
@@ -1053,7 +1029,7 @@ describe("blueprint identity wrapper", () => {
       [
         "provider get acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "provider not found" },
+          failureResult("provider not found"),
           ...Array.from({ length: 3 }, () => ({
             exitCode: 0,
             stdout: matchingProvider,
@@ -1063,13 +1039,13 @@ describe("blueprint identity wrapper", () => {
       ],
       [
         "provider refresh rotate acme-okta-runtime --credential-key OKTA_ACCESS_TOKEN",
-        [{ exitCode: 1, stdout: "", stderr: "rotate failed" }],
+        [failureResult("rotate failed")],
       ],
       [
         "provider delete acme-okta-runtime",
         [
-          { exitCode: 1, stdout: "", stderr: "first delete denied" },
-          { exitCode: 1, stdout: "", stderr: "second delete denied" },
+          failureResult("first delete denied"),
+          failureResult("second delete denied"),
           { exitCode: 0, stdout: "", stderr: "" },
         ],
       ],

--- a/nemoclaw/src/blueprint/runner-mock-fixtures.ts
+++ b/nemoclaw/src/blueprint/runner-mock-fixtures.ts
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolve } from "node:path";
+
+/**
+ * Shared mock mechanics for the blueprint runner test suites. Data builders
+ * for blueprints live in runner-test-fixtures.ts; this module owns the
+ * in-memory filesystem, stdout capture, and endpoint-validation shapes the
+ * suites previously each declared inline. Helpers return fresh state per call
+ * and never import vitest: tests pass their own spy wrapper where call
+ * tracking is asserted.
+ */
+
+export interface RunnerFsEntry {
+  type: "file" | "dir";
+  content?: string;
+}
+
+export const FAKE_HOME = "/fakehome";
+
+export const FIXED_RUN_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+export interface RunnerFsStore {
+  store: Map<string, RunnerFsEntry>;
+  addFile: (path: string, content: string) => void;
+  addDir: (path: string) => void;
+}
+
+export function createRunnerFsStore(): RunnerFsStore {
+  const store = new Map<string, RunnerFsEntry>();
+  return {
+    store,
+    addFile: (path, content) => void store.set(path, { type: "file", content }),
+    addDir: (path) => void store.set(path, { type: "dir" }),
+  };
+}
+
+function missingEntry(path: string): never {
+  throw new Error(`ENOENT: ${path}`);
+}
+
+export interface InMemoryFsOptions {
+  /** Canonical-path overrides consulted by realpathSync before the store. */
+  realpaths?: Map<string, string>;
+  /** Wrapper applied to mutating methods so tests can track calls (pass vi.fn). */
+  spy?: <T extends (...args: never[]) => unknown>(fn: T) => T;
+}
+
+/**
+ * The full in-memory method set backed by store. Suites spread only the
+ * methods they previously overrode, so untouched fs behavior stays real.
+ */
+export function inMemoryFsMethods(store: Map<string, RunnerFsEntry>, options?: InMemoryFsOptions) {
+  const spy = options?.spy ?? (<T>(fn: T): T => fn);
+  return {
+    existsSync: (p: string) => store.has(p),
+    mkdirSync: spy((p: string) => void store.set(p, { type: "dir" })),
+    readFileSync: (p: string) => {
+      const entry = store.get(p);
+      return entry?.type === "file" ? (entry.content ?? "") : missingEntry(p);
+    },
+    writeFileSync: spy((p: string, data: string) => {
+      store.set(p, { type: "file", content: String(data) });
+    }),
+    readdirSync: (p: string) => {
+      const prefix = p.endsWith("/") ? p : `${p}/`;
+      const entries = new Set(
+        [...store.keys()]
+          .filter((k) => k.startsWith(prefix))
+          .map((k) => k.slice(prefix.length).split("/")[0])
+          .filter((first): first is string => Boolean(first)),
+      );
+      return entries.size === 0 && !store.has(p) ? missingEntry(p) : [...entries].sort();
+    },
+    realpathSync: (p: string) => {
+      const resolved = resolve(p);
+      const mapped = options?.realpaths?.get(resolved);
+      return mapped ?? (store.has(resolved) ? resolved : missingEntry(resolved));
+    },
+    statSync: (p: string) => ({
+      isFile: () => store.get(resolve(p))?.type === "file",
+    }),
+  };
+}
+
+/** The resolution shape the runner's endpoint validator produces for url. */
+export function resolvedEndpointFor(url: string) {
+  return {
+    url,
+    pinnedUrl: url,
+    protocol: url.startsWith("http:") ? ("http:" as const) : ("https:" as const),
+    hostname: new URL(url).hostname,
+    dnsResolved: false,
+  };
+}
+
+/**
+ * Collects process.stdout writes. The test owns the spy:
+ * vi.spyOn(process.stdout, "write").mockImplementation(capture.write).
+ */
+export interface StdoutCapture {
+  write: (chunk: string | Uint8Array) => boolean;
+  text: () => string;
+  /** Parsed JSON payload with RUN_ID: and PROGRESS: progress lines removed. */
+  jsonOutput: <T = unknown>() => T;
+  reset: () => void;
+}
+
+export function createStdoutCapture(): StdoutCapture {
+  const chunks: string[] = [];
+  const text = (): string => chunks.join("");
+  return {
+    write: (chunk) => {
+      chunks.push(String(chunk));
+      return true;
+    },
+    text,
+    jsonOutput: <T>(): T => {
+      const json = text()
+        .split("\n")
+        .filter((line) => line && !line.startsWith("RUN_ID:") && !line.startsWith("PROGRESS:"))
+        .join("\n");
+      return JSON.parse(json) as T;
+    },
+    reset: () => {
+      chunks.length = 0;
+    },
+  };
+}

--- a/nemoclaw/src/blueprint/runner-mock-fixtures.ts
+++ b/nemoclaw/src/blueprint/runner-mock-fixtures.ts
@@ -12,21 +12,26 @@ import { resolve } from "node:path";
  * tracking is asserted.
  */
 
+/** One entry in the in-memory filesystem store. */
 export interface RunnerFsEntry {
   type: "file" | "dir";
   content?: string;
 }
 
+/** The home directory every runner suite mocks os.homedir() to. */
 export const FAKE_HOME = "/fakehome";
 
+/** The deterministic UUID every runner suite mocks crypto.randomUUID() to. */
 export const FIXED_RUN_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
+/** An in-memory filesystem store with its seeding helpers. */
 export interface RunnerFsStore {
   store: Map<string, RunnerFsEntry>;
   addFile: (path: string, content: string) => void;
   addDir: (path: string) => void;
 }
 
+/** Creates a fresh in-memory filesystem store for one suite. */
 export function createRunnerFsStore(): RunnerFsStore {
   const store = new Map<string, RunnerFsEntry>();
   return {
@@ -40,6 +45,7 @@ function missingEntry(path: string): never {
   throw new Error(`ENOENT: ${path}`);
 }
 
+/** Behavior options for inMemoryFsMethods. */
 export interface InMemoryFsOptions {
   /** Canonical-path overrides consulted by realpathSync before the store. */
   realpaths?: Map<string, string>;
@@ -107,6 +113,7 @@ export interface StdoutCapture {
   reset: () => void;
 }
 
+/** Creates a fresh stdout capture for one suite. */
 export function createStdoutCapture(): StdoutCapture {
   const chunks: string[] = [];
   const text = (): string => chunks.join("");

--- a/nemoclaw/src/blueprint/runner-name-validation.test.ts
+++ b/nemoclaw/src/blueprint/runner-name-validation.test.ts
@@ -8,61 +8,36 @@
 import type fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-interface FsEntry {
-  type: "file" | "dir";
-  content?: string;
-}
+import {
+  createRunnerFsStore,
+  createStdoutCapture,
+  FAKE_HOME,
+  FIXED_RUN_UUID,
+  inMemoryFsMethods,
+  resolvedEndpointFor,
+} from "./runner-mock-fixtures.js";
+import { minimalBlueprint, successResult } from "./runner-test-fixtures.js";
 
-/** Throw from an expression position so the fake fs stays branch-free. */
-function raise(message: string): never {
-  throw new Error(message);
-}
-
-const store = new Map<string, FsEntry>();
-
-function addFile(p: string, content: string): void {
-  store.set(p, { type: "file", content });
-}
-
-function addDir(p: string): void {
-  store.set(p, { type: "dir" });
-}
-
-const FAKE_HOME = "/fakehome";
+const { store, addFile, addDir } = createRunnerFsStore();
 
 vi.mock("node:os", () => ({
   homedir: () => FAKE_HOME,
 }));
 
 vi.mock("node:crypto", () => ({
-  randomUUID: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  randomUUID: () => FIXED_RUN_UUID,
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
   const original = await importOriginal<typeof fs>();
+  const memory = inMemoryFsMethods(store, { spy: vi.fn });
   return {
     ...original,
-    existsSync: (p: string) => store.has(p),
-    mkdirSync: vi.fn((p: string) => {
-      addDir(p);
-    }),
-    readFileSync: (p: string) => {
-      const entry = store.get(p);
-      return entry?.type === "file" ? (entry.content ?? "") : raise(`ENOENT: ${p}`);
-    },
-    writeFileSync: vi.fn((p: string, data: string) => {
-      store.set(p, { type: "file", content: data });
-    }),
-    readdirSync: (p: string) => {
-      const prefix = p.endsWith("/") ? p : `${p}/`;
-      const entries = new Set(
-        [...store.keys()]
-          .filter((k) => k.startsWith(prefix))
-          .map((k) => k.slice(prefix.length).split("/")[0])
-          .filter((first): first is string => Boolean(first)),
-      );
-      return entries.size === 0 && !store.has(p) ? raise(`ENOENT: ${p}`) : [...entries].sort();
-    },
+    existsSync: memory.existsSync,
+    mkdirSync: memory.mkdirSync,
+    readFileSync: memory.readFileSync,
+    writeFileSync: memory.writeFileSync,
+    readdirSync: memory.readdirSync,
   };
 });
 
@@ -75,51 +50,13 @@ vi.mock("./ssrf.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./ssrf.js")>();
   return {
     ...actual,
-    validateEndpointUrl: vi.fn(async (url: string) => ({
-      url,
-      pinnedUrl: url,
-      protocol: url.startsWith("http:") ? "http:" : "https:",
-      hostname: new URL(url).hostname,
-      dnsResolved: false,
-    })),
+    validateEndpointUrl: vi.fn(async (url: string) => resolvedEndpointFor(url)),
   };
 });
 
 const { actionApply, actionRollback } = await import("./runner.js");
 
-const stdoutChunks: string[] = [];
-
-function captureStdout(): void {
-  vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
-    stdoutChunks.push(String(chunk));
-    return true;
-  });
-}
-
-function minimalBlueprint(): Record<string, unknown> {
-  return {
-    version: "1.0",
-    components: {
-      inference: {
-        profiles: {
-          default: {
-            provider_type: "openai",
-            provider_name: "my-provider",
-            endpoint: "https://api.example.com/v1",
-            model: "gpt-4",
-            credential_env: "MY_API_KEY",
-          },
-        },
-      },
-      sandbox: {
-        image: "openclaw",
-        name: "test-sandbox",
-        forward_ports: [18789],
-      },
-      policy: { additions: {} },
-    },
-  };
-}
+const stdout = createStdoutCapture();
 
 function createCalls(): unknown[] {
   return mockExeca.mock.calls.filter(
@@ -174,10 +111,10 @@ describe("blueprint name validation (fail-closed integration)", () => {
 
   beforeEach(() => {
     store.clear();
-    stdoutChunks.length = 0;
+    stdout.reset();
     vi.clearAllMocks();
-    captureStdout();
-    mockExeca.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    vi.spyOn(process.stdout, "write").mockImplementation(stdout.write);
+    mockExeca.mockResolvedValue(successResult());
   });
 
   afterEach(() => {

--- a/nemoclaw/src/blueprint/runner-openshell-072-policy.test.ts
+++ b/nemoclaw/src/blueprint/runner-openshell-072-policy.test.ts
@@ -6,29 +6,32 @@ import type fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
 
-type FsEntry = { type: "file" | "dir"; content?: string };
+import {
+  createRunnerFsStore,
+  FAKE_HOME,
+  FIXED_RUN_UUID,
+  inMemoryFsMethods,
+  resolvedEndpointFor,
+} from "./runner-mock-fixtures.js";
 
-const store = new Map<string, FsEntry>();
+const { store } = createRunnerFsStore();
 const mockExeca = vi.fn();
 
 vi.mock("node:crypto", () => ({
-  randomUUID: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  randomUUID: () => FIXED_RUN_UUID,
 }));
 
 vi.mock("node:os", () => ({
-  homedir: () => "/fakehome",
+  homedir: () => FAKE_HOME,
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
   const original = await importOriginal<typeof fs>();
+  const memory = inMemoryFsMethods(store, { spy: vi.fn });
   return {
     ...original,
-    mkdirSync: vi.fn((path: string) => {
-      store.set(path, { type: "dir" });
-    }),
-    writeFileSync: vi.fn((path: string, data: string) => {
-      store.set(path, { type: "file", content: String(data) });
-    }),
+    mkdirSync: memory.mkdirSync,
+    writeFileSync: memory.writeFileSync,
   };
 });
 
@@ -40,13 +43,7 @@ vi.mock("./ssrf.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./ssrf.js")>();
   return {
     ...actual,
-    validateEndpointUrl: vi.fn(async (url: string) => ({
-      url,
-      pinnedUrl: url,
-      protocol: url.startsWith("http:") ? "http:" : "https:",
-      hostname: new URL(url).hostname,
-      dnsResolved: false,
-    })),
+    validateEndpointUrl: vi.fn(async (url: string) => resolvedEndpointFor(url)),
   };
 });
 
@@ -262,7 +259,9 @@ describe("OpenShell 0.0.72 blueprint policy round-trip", () => {
     }));
 
     await actionApply("default", blueprint());
-    const merged = mergedPolicy() as { network_policies: Record<string, unknown> };
+    const merged = mergedPolicy() as {
+      network_policies: Record<string, unknown>;
+    };
     expect(merged.network_policies).not.toHaveProperty("_provider_unexpected");
     expect(merged.network_policies).toHaveProperty("existing_mcp");
     expect(merged.network_policies).toHaveProperty("existing_json_rpc");
@@ -277,7 +276,9 @@ describe("OpenShell 0.0.72 blueprint policy round-trip", () => {
 
     await actionApply("default", blueprintWithReservedAddition);
 
-    const merged = mergedPolicy() as { network_policies: Record<string, unknown> };
+    const merged = mergedPolicy() as {
+      network_policies: Record<string, unknown>;
+    };
     expect(merged.network_policies).not.toHaveProperty("_provider_injected");
     expect(merged.network_policies).toHaveProperty("nim_service");
   });

--- a/nemoclaw/src/blueprint/runner-test-fixtures.ts
+++ b/nemoclaw/src/blueprint/runner-test-fixtures.ts
@@ -82,3 +82,57 @@ export function resultForCommandFailure(
     ? { exitCode: 1, stdout: "", stderr }
     : { exitCode: 0, stdout: "", stderr: "" };
 }
+
+export function successResult(): {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+} {
+  return { exitCode: 0, stdout: "", stderr: "" };
+}
+
+/** The `provider get` listing for the sandbox's matching runtime identity provider. */
+export const MATCHING_RUNTIME_PROVIDER_LISTING = [
+  "Name: acme-okta-runtime",
+  "Type: okta-runtime-v1",
+  "Credential keys: OKTA_ACCESS_TOKEN",
+  "Config keys: <none>",
+  "",
+].join("\n");
+
+/** The `provider get` listing for the blueprint's matching inference provider. */
+export const MATCHING_INFERENCE_PROVIDER_LISTING = [
+  "Name: test-provider",
+  "Type: openai",
+  "Credential keys: <none>",
+  "Config keys: OPENAI_BASE_URL",
+  "",
+].join("\n");
+
+/** The `inference get` listing for the gateway route the blueprint expects. */
+export const MATCHING_INFERENCE_ROUTE_LISTING = [
+  "Gateway inference:",
+  "",
+  "  Provider: test-provider",
+  "  Model: test-model",
+  "  Version: 1",
+  "  Timeout: 180s",
+  "",
+].join("\n");
+
+/** A `settings get` payload with gateway providers v2 enabled. */
+export function providersV2EnabledResult(): {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+} {
+  return {
+    exitCode: 0,
+    stdout: JSON.stringify({
+      scope: "global",
+      settings_revision: 1,
+      settings: { providers_v2_enabled: "true" },
+    }),
+    stderr: "",
+  };
+}

--- a/nemoclaw/src/blueprint/runner-test-fixtures.ts
+++ b/nemoclaw/src/blueprint/runner-test-fixtures.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/** The smallest valid blueprint: one inference profile, one sandbox, empty policy. */
 export function minimalBlueprint(overrides?: Record<string, unknown>): Record<string, unknown> {
   return {
     version: "1.0",
@@ -27,6 +28,7 @@ export function minimalBlueprint(overrides?: Record<string, unknown>): Record<st
   };
 }
 
+/** A valid blueprint routed through the local router profile. */
 export function routedBlueprint(): Record<string, unknown> {
   return {
     version: "1.0",
@@ -59,6 +61,7 @@ export function routedBlueprint(): Record<string, unknown> {
   };
 }
 
+/** minimalBlueprint with the given policy additions substituted in. */
 export function blueprintWithPolicyAdditions(
   additions: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -73,6 +76,7 @@ export function blueprintWithPolicyAdditions(
   };
 }
 
+/** Fails the given two-word command with stderr; every other command succeeds. */
 export function resultForCommandFailure(
   args: readonly string[],
   command: readonly [string, string],
@@ -83,12 +87,22 @@ export function resultForCommandFailure(
     : { exitCode: 0, stdout: "", stderr: "" };
 }
 
+/** An empty successful command result. */
 export function successResult(): {
   exitCode: number;
   stdout: string;
   stderr: string;
 } {
   return { exitCode: 0, stdout: "", stderr: "" };
+}
+
+/** A failed command result carrying only stderr. */
+export function failureResult(stderr: string): {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+} {
+  return { exitCode: 1, stdout: "", stderr };
 }
 
 /** The `provider get` listing for the sandbox's matching runtime identity provider. */

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -5,6 +5,14 @@ import type fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
 import {
+  createRunnerFsStore,
+  createStdoutCapture,
+  FAKE_HOME,
+  FIXED_RUN_UUID,
+  inMemoryFsMethods,
+  resolvedEndpointFor,
+} from "./runner-mock-fixtures.js";
+import {
   blueprintWithPolicyAdditions,
   minimalBlueprint,
   resultForCommandFailure,
@@ -13,62 +21,26 @@ import {
 
 // ── In-memory filesystem ────────────────────────────────────────
 
-interface FsEntry {
-  type: "file" | "dir";
-  content?: string;
-}
-
-const store = new Map<string, FsEntry>();
-
-function addFile(p: string, content: string): void {
-  store.set(p, { type: "file", content });
-}
-
-function addDir(p: string): void {
-  store.set(p, { type: "dir" });
-}
-
-const FAKE_HOME = "/fakehome";
+const { store, addFile, addDir } = createRunnerFsStore();
 
 vi.mock("node:os", () => ({
   homedir: () => FAKE_HOME,
 }));
 
 vi.mock("node:crypto", () => ({
-  randomUUID: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  randomUUID: () => FIXED_RUN_UUID,
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
   const original = await importOriginal<typeof fs>();
+  const memory = inMemoryFsMethods(store, { spy: vi.fn });
   return {
     ...original,
-    existsSync: (p: string) => store.has(p),
-    mkdirSync: vi.fn((p: string) => {
-      addDir(p);
-    }),
-    readFileSync: (p: string) => {
-      const entry = store.get(p);
-      if (entry?.type !== "file") throw new Error(`ENOENT: ${p}`);
-      return entry.content ?? "";
-    },
-    writeFileSync: vi.fn((p: string, data: string) => {
-      store.set(p, { type: "file", content: data });
-    }),
-    readdirSync: (p: string) => {
-      const prefix = p.endsWith("/") ? p : p + "/";
-      const entries = new Set<string>();
-      for (const k of store.keys()) {
-        if (k.startsWith(prefix)) {
-          const rest = k.slice(prefix.length);
-          const first = rest.split("/")[0];
-          if (first) entries.add(first);
-        }
-      }
-      if (entries.size === 0 && !store.has(p)) {
-        throw new Error(`ENOENT: ${p}`);
-      }
-      return [...entries].sort();
-    },
+    existsSync: memory.existsSync,
+    mkdirSync: memory.mkdirSync,
+    readFileSync: memory.readFileSync,
+    writeFileSync: memory.writeFileSync,
+    readdirSync: memory.readdirSync,
   };
 });
 
@@ -81,13 +53,7 @@ vi.mock("./ssrf.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./ssrf.js")>();
   return {
     ...actual,
-    validateEndpointUrl: vi.fn(async (url: string) => ({
-      url,
-      pinnedUrl: url,
-      protocol: url.startsWith("http:") ? "http:" : "https:",
-      hostname: new URL(url).hostname,
-      dnsResolved: false,
-    })),
+    validateEndpointUrl: vi.fn(async (url: string) => resolvedEndpointFor(url)),
   };
 });
 
@@ -99,25 +65,12 @@ const { emitRunId, loadBlueprint, actionPlan, actionApply, actionStatus, actionR
 
 // ── Helpers ─────────────────────────────────────────────────────
 
-const stdoutChunks: string[] = [];
+const stdoutCapture = createStdoutCapture();
+const stdoutText = stdoutCapture.text;
+const capturedJsonOutput = stdoutCapture.jsonOutput;
 
 function captureStdout(): void {
-  vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
-    stdoutChunks.push(String(chunk));
-    return true;
-  });
-}
-
-function stdoutText(): string {
-  return stdoutChunks.join("");
-}
-
-function capturedJsonOutput<T = unknown>(): T {
-  const json = stdoutText()
-    .split("\n")
-    .filter((line) => line && !line.startsWith("RUN_ID:") && !line.startsWith("PROGRESS:"))
-    .join("\n");
-  return JSON.parse(json) as T;
+  vi.spyOn(process.stdout, "write").mockImplementation(stdoutCapture.write);
 }
 
 function seedBlueprintFile(bp?: Record<string, unknown>): void {
@@ -143,7 +96,7 @@ function mockCurrentPolicy(stdout: string): void {
 describe("runner", () => {
   beforeEach(() => {
     store.clear();
-    stdoutChunks.length = 0;
+    stdoutCapture.reset();
     vi.clearAllMocks();
     delete process.env.NEMOCLAW_BLUEPRINT_PATH;
   });
@@ -480,7 +433,9 @@ describe("runner", () => {
       process.env.SECRET_KEY = "real-secret-value";
       try {
         const plan = await actionPlan("secrets", bp);
-        const rendered = capturedJsonOutput<{ inference: Record<string, unknown> }>();
+        const rendered = capturedJsonOutput<{
+          inference: Record<string, unknown>;
+        }>();
         const out = stdoutText();
 
         expect(plan.inference).not.toHaveProperty("credential_env");

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./runner-mock-fixtures.js";
 import {
   blueprintWithPolicyAdditions,
+  failureResult,
   minimalBlueprint,
   resultForCommandFailure,
   routedBlueprint,
@@ -794,7 +795,7 @@ describe("runner", () => {
     });
 
     it("reuses sandbox when 'already exists' error", async () => {
-      mockExeca.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "already exists" });
+      mockExeca.mockResolvedValueOnce(failureResult("already exists"));
       // Subsequent calls succeed
       mockExeca.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
 
@@ -803,7 +804,7 @@ describe("runner", () => {
     });
 
     it("throws when sandbox creation fails with other error", async () => {
-      mockExeca.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "disk full" });
+      mockExeca.mockResolvedValueOnce(failureResult("disk full"));
 
       await expect(actionApply("default", minimalBlueprint())).rejects.toThrow(
         /Failed to create sandbox.*disk full/,

--- a/nemoclaw/src/commands/migration-state-test-fixtures.ts
+++ b/nemoclaw/src/commands/migration-state-test-fixtures.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HostOpenClawState, SnapshotManifest } from "./migration-state.js";
+
+/**
+ * Data builders for the migration-state test suites. Each builder returns the
+ * ordinary valid baseline with fresh nested arrays and objects; tests override
+ * only the fields their scenario changes. The sanitizer module mock lives in
+ * migration-state-sanitizer-test-fixture.ts.
+ */
+
+/** The detected host state for a standard ~/.openclaw installation. */
+export function makeHostOpenClawState(overrides?: Partial<HostOpenClawState>): HostOpenClawState {
+  return {
+    exists: true,
+    homeDir: "/home/user",
+    stateDir: "/home/user/.openclaw",
+    configDir: "/home/user/.openclaw",
+    configPath: "/home/user/.openclaw/openclaw.json",
+    workspaceDir: null,
+    extensionsDir: null,
+    skillsDir: null,
+    hooksDir: null,
+    externalRoots: [],
+    warnings: [],
+    errors: [],
+    hasExternalConfig: false,
+    ...overrides,
+  };
+}
+
+/** A version 2 snapshot manifest for the standard ~/.openclaw installation. */
+export function makeSnapshotManifest(overrides?: Partial<SnapshotManifest>): SnapshotManifest {
+  return {
+    version: 2,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    homeDir: "/home/user",
+    stateDir: "/home/user/.openclaw",
+    configPath: null,
+    hasExternalConfig: false,
+    externalRoots: [],
+    warnings: [],
+    ...overrides,
+  };
+}

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -4,6 +4,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginLogger } from "../index.js";
 import { setConfigValue } from "./migration-state.js";
+import { makeHostOpenClawState, makeSnapshotManifest } from "./migration-state-test-fixtures.js";
 
 // fs mock — thin in-memory store keyed by absolute path
 type FsEntry = { type: "file" | "dir" | "symlink"; content?: string };
@@ -501,21 +502,12 @@ describe("commands/migration-state", () => {
   describe("createSnapshotBundle", () => {
     it("returns null when stateDir is missing", () => {
       const logger = makeLogger();
-      const hostState: HostOpenClawState = {
+      const hostState = makeHostOpenClawState({
         exists: false,
-        homeDir: "/home/user",
         stateDir: null,
         configDir: null,
         configPath: null,
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      });
       expect(createSnapshotBundle(hostState, logger, { persist: false })).toBeNull();
       expect(logger.error).toHaveBeenCalled();
     });
@@ -525,21 +517,7 @@ describe("commands/migration-state", () => {
       addDir("/home/user/.openclaw");
       addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({ version: 1 }));
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
-        configPath: "/home/user/.openclaw/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      const hostState = makeHostOpenClawState();
 
       const bundle = createSnapshotBundle(hostState, logger, { persist: true });
       if (bundle === null) {
@@ -556,23 +534,14 @@ describe("commands/migration-state", () => {
       addDir("/home/user/.openclaw");
       addFile("/etc/openclaw.json", JSON.stringify({ external: true }));
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
+      const hostState = makeHostOpenClawState({
         configPath: "/etc/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
         hasExternalConfig: true,
-      };
+      });
 
-      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      const bundle = createSnapshotBundle(hostState, logger, {
+        persist: false,
+      });
       if (bundle === null) {
         expect.unreachable("bundle should not be null");
         return;
@@ -586,16 +555,8 @@ describe("commands/migration-state", () => {
       addDir("/home/user/.openclaw");
       addDir("/external/ws");
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
+      const hostState = makeHostOpenClawState({
         configPath: null,
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
         externalRoots: [
           {
             id: "workspaces-ws",
@@ -608,12 +569,11 @@ describe("commands/migration-state", () => {
             bindings: [{ configPath: "agents.list[0].workspace" }],
           },
         ],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      });
 
-      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      const bundle = createSnapshotBundle(hostState, logger, {
+        persist: false,
+      });
       if (bundle === null) {
         expect.unreachable("bundle should not be null");
         return;
@@ -637,23 +597,11 @@ describe("commands/migration-state", () => {
         JSON.stringify({ name: "main" }),
       );
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
-        configPath: "/home/user/.openclaw/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      const hostState = makeHostOpenClawState();
 
-      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      const bundle = createSnapshotBundle(hostState, logger, {
+        persist: false,
+      });
       if (bundle === null) {
         expect.unreachable("bundle should not be null");
         return;
@@ -682,23 +630,11 @@ describe("commands/migration-state", () => {
         }),
       );
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
-        configPath: "/home/user/.openclaw/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      const hostState = makeHostOpenClawState();
 
-      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      const bundle = createSnapshotBundle(hostState, logger, {
+        persist: false,
+      });
       if (bundle === null) {
         expect.unreachable("bundle should not be null");
         return;
@@ -737,23 +673,11 @@ describe("commands/migration-state", () => {
         }),
       );
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
-        configPath: "/home/user/.openclaw/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      const hostState = makeHostOpenClawState();
 
-      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      const bundle = createSnapshotBundle(hostState, logger, {
+        persist: false,
+      });
       if (bundle === null) {
         expect.unreachable("bundle should not be null");
         return;
@@ -778,21 +702,7 @@ describe("commands/migration-state", () => {
       addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({ version: 1 }));
       addFile("/test/blueprint.yaml", "version: 0.1.0\ndigest: ''\n");
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
-        configPath: "/home/user/.openclaw/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      const hostState = makeHostOpenClawState();
 
       const bundle = createSnapshotBundle(hostState, logger, {
         persist: false,
@@ -811,23 +721,11 @@ describe("commands/migration-state", () => {
       addDir("/home/user/.openclaw");
       addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({ version: 1 }));
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
-        configPath: "/home/user/.openclaw/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      const hostState = makeHostOpenClawState();
 
-      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      const bundle = createSnapshotBundle(hostState, logger, {
+        persist: false,
+      });
       if (bundle === null) {
         expect.unreachable("bundle should not be null");
         return;
@@ -840,21 +738,7 @@ describe("commands/migration-state", () => {
       addDir("/home/user/.openclaw");
       addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({ version: 1 }));
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
-        configPath: "/home/user/.openclaw/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      const hostState = makeHostOpenClawState();
 
       // /test/nonexistent.yaml does not exist in store
       const bundle = createSnapshotBundle(hostState, logger, {
@@ -877,23 +761,11 @@ describe("commands/migration-state", () => {
         }),
       );
 
-      const hostState: HostOpenClawState = {
-        exists: true,
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configDir: "/home/user/.openclaw",
-        configPath: "/home/user/.openclaw/openclaw.json",
-        workspaceDir: null,
-        extensionsDir: null,
-        skillsDir: null,
-        hooksDir: null,
-        externalRoots: [],
-        warnings: [],
-        errors: [],
-        hasExternalConfig: false,
-      };
+      const hostState = makeHostOpenClawState();
 
-      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      const bundle = createSnapshotBundle(hostState, logger, {
+        persist: false,
+      });
       if (bundle === null) {
         expect.unreachable("bundle should not be null");
         return;
@@ -969,13 +841,7 @@ describe("commands/migration-state", () => {
 
   describe("loadSnapshotManifest", () => {
     it("reads and parses snapshot.json", () => {
-      const manifest: SnapshotManifest = {
-        version: 2,
-        createdAt: "2026-03-01T00:00:00.000Z",
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configPath: null,
-        hasExternalConfig: false,
+      const manifest = makeSnapshotManifest({
         externalRoots: [
           {
             id: "workspace-root",
@@ -989,7 +855,7 @@ describe("commands/migration-state", () => {
           },
         ],
         warnings: ["workspace root was remapped"],
-      };
+      });
       addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
       const loaded = loadSnapshotManifest("/snapshots/snap1");
       expect(loaded).toEqual(manifest);
@@ -1032,16 +898,7 @@ describe("commands/migration-state", () => {
   describe("restoreSnapshotToHost", () => {
     it("returns false when snapshot openclaw dir is missing", () => {
       const logger = makeLogger();
-      const manifest: SnapshotManifest = {
-        version: 2,
-        createdAt: "2026-03-01T00:00:00.000Z",
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configPath: null,
-        hasExternalConfig: false,
-        externalRoots: [],
-        warnings: [],
-      };
+      const manifest = makeSnapshotManifest();
       addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
       // Don't add /snapshots/snap1/openclaw
       const result = restoreSnapshotToHost("/snapshots/snap1", logger);
@@ -1054,16 +911,7 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
-        };
+        const manifest = makeSnapshotManifest();
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
         addFile("/snapshots/snap1/openclaw/openclaw.json", JSON.stringify({ restored: true }));
@@ -1089,16 +937,10 @@ describe("commands/migration-state", () => {
       process.env.HOME = "/home/user";
       process.env.OPENCLAW_CONFIG_PATH = "/etc/openclaw.json";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
+        const manifest = makeSnapshotManifest({
           configPath: "/etc/openclaw.json",
           hasExternalConfig: true,
-          externalRoots: [],
-          warnings: [],
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
         addFile("/snapshots/snap1/config/openclaw.json", JSON.stringify({ external: true }));
@@ -1125,16 +967,10 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
+        const manifest = makeSnapshotManifest({
           homeDir: "/tmp/evil",
           stateDir: "/tmp/evil/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
 
@@ -1155,16 +991,9 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
+        const manifest = makeSnapshotManifest({
           stateDir: "/tmp/evil/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
 
@@ -1187,16 +1016,7 @@ describe("commands/migration-state", () => {
       process.env.HOME = "/home/user";
       process.env.OPENCLAW_STATE_DIR = "/home/user/.custom-state";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
-        };
+        const manifest = makeSnapshotManifest();
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
 
@@ -1224,16 +1044,7 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: true,
-          externalRoots: [],
-          warnings: [],
-        };
+        const manifest = makeSnapshotManifest({ hasExternalConfig: true });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
 
@@ -1254,16 +1065,10 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
+        const manifest = makeSnapshotManifest({
           configPath: "/tmp/evil/openclaw.json",
           hasExternalConfig: true,
-          externalRoots: [],
-          warnings: [],
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
 
@@ -1286,16 +1091,10 @@ describe("commands/migration-state", () => {
       process.env.HOME = "/home/user";
       process.env.OPENCLAW_CONFIG_PATH = "/home/user/my-config.json";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
+        const manifest = makeSnapshotManifest({
           configPath: "/etc/openclaw.json",
           hasExternalConfig: true,
-          externalRoots: [],
-          warnings: [],
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
 
@@ -1329,21 +1128,7 @@ describe("commands/migration-state", () => {
         // First create a snapshot with blueprintPath to get the real digest
         addDir("/home/user/.openclaw");
         addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({ version: 1 }));
-        const hostState: HostOpenClawState = {
-          exists: true,
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configDir: "/home/user/.openclaw",
-          configPath: "/home/user/.openclaw/openclaw.json",
-          workspaceDir: null,
-          extensionsDir: null,
-          skillsDir: null,
-          hooksDir: null,
-          externalRoots: [],
-          warnings: [],
-          errors: [],
-          hasExternalConfig: false,
-        };
+        const hostState = makeHostOpenClawState();
         const bundle = createSnapshotBundle(hostState, logger, {
           persist: false,
           blueprintPath: "/test/blueprint.yaml",
@@ -1357,17 +1142,10 @@ describe("commands/migration-state", () => {
 
         // Now set up for restore with matching digest
         store.clear();
-        const manifest: SnapshotManifest = {
+        const manifest = makeSnapshotManifest({
           version: 3,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
           blueprintDigest: digest,
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
         addFile("/snapshots/snap1/openclaw/openclaw.json", JSON.stringify({ restored: true }));
@@ -1391,17 +1169,10 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
+        const manifest = makeSnapshotManifest({
           version: 3,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
           blueprintDigest: "wrong-hash-value",
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
         addFile("/test/blueprint.yaml", "version: 0.1.0\n");
@@ -1425,17 +1196,10 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
+        const manifest = makeSnapshotManifest({
           version: 3,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
           blueprintDigest: "",
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
 
@@ -1458,17 +1222,10 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
+        const manifest = makeSnapshotManifest({
           version: 3,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
           blueprintDigest: "abc123",
-        };
+        });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
 
@@ -1491,17 +1248,8 @@ describe("commands/migration-state", () => {
       const origHome = process.env.HOME;
       process.env.HOME = "/home/user";
       try {
-        const manifest: SnapshotManifest = {
-          version: 2,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
-          // no blueprintDigest field
-        };
+        // no blueprintDigest field
+        const manifest = makeSnapshotManifest();
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
         addFile("/snapshots/snap1/openclaw/openclaw.json", JSON.stringify({ restored: true }));
@@ -1523,17 +1271,8 @@ describe("commands/migration-state", () => {
       process.env.HOME = "/home/user";
       try {
         // v3 manifest with no blueprintDigest field — created without a blueprint
-        const manifest: SnapshotManifest = {
-          version: 3,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          homeDir: "/home/user",
-          stateDir: "/home/user/.openclaw",
-          configPath: null,
-          hasExternalConfig: false,
-          externalRoots: [],
-          warnings: [],
-          // blueprintDigest intentionally omitted
-        };
+        // blueprintDigest intentionally omitted
+        const manifest = makeSnapshotManifest({ version: 3 });
         addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
         addDir("/snapshots/snap1/openclaw");
         addFile("/snapshots/snap1/openclaw/openclaw.json", JSON.stringify({ restored: true }));


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The four blueprint runner suites each declared their own copy of the same in-memory filesystem, fixed run UUID, fake home directory, execa wiring, endpoint-validation result shape, and stdout capture, and the migration-state suite declared 28 inline copies of the host-state and snapshot-manifest baselines. This change moves the shared mock mechanics into `runner-mock-fixtures.ts` and the ordinary valid baselines into `migration-state-test-fixtures.ts` and `runner-test-fixtures.ts`, then migrates the six suites to consume them. Net delta is minus 183 lines with test titles, assertions, and scenario values unchanged.

## Related Issue

Fixes #8290

## Changes

- Add `src/blueprint/runner-mock-fixtures.ts`: in-memory fs store and method set, fixed UUID and fake home constants, endpoint-validation result builder, and a stdout capture. Helpers never import vitest; suites pass `vi.fn` as a spy wrapper and keep ownership of `vi.mock` and `vi.spyOn` calls. Each suite spreads only the fs methods it previously overrode, so untouched fs behavior stays real.
- Extend `src/blueprint/runner-test-fixtures.ts` with the sandbox identity listings, the success result, and the providers-v2 settings payload that runner-identity previously declared inline.
- Add `src/commands/migration-state-test-fixtures.ts`: `makeHostOpenClawState` and `makeSnapshotManifest` builders returning the ordinary valid baseline with fresh nested state; tests override only the fields their scenario changes.
- Migrate `runner.test.ts`, `runner-identity.test.ts`, `runner-name-validation.test.ts`, `runner-openshell-072-policy.test.ts`, and `migration-state.test.ts` to the shared fixtures. `migration-state-security.test.ts` keeps its explicit real-filesystem malicious path and symlink setup, and per-test command expectations stay local per the acceptance criteria.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: test-only consolidation with no production behavior change; all six affected suites pass unchanged (217 tests), in order and shuffled.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test fixtures only, no user-facing behavior change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: nine-category security review PASS with no findings: https://github.com/NVIDIA/NemoClaw/pull/8489#issuecomment-5208017540
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Validation

```
npx vitest run src/commands/migration-state.test.ts src/commands/migration-state-security.test.ts src/blueprint/runner.test.ts src/blueprint/runner-identity.test.ts src/blueprint/runner-name-validation.test.ts src/blueprint/runner-openshell-072-policy.test.ts
6 files, 217 tests passed (matches the pre-change baseline), also passing with --sequence.shuffle
npm run lint, npm run format:check: clean
tsc --noEmit -p tsconfig.json: clean
```

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: test-only fixture consolidation; no user-facing surface or documented behavior changes. Docstrings on the new fixtures reviewed against the writing rules.
- Agent: Codex independent documentation reviewer
<!-- docs-review-head-sha: c276e00a70f14b4849c7191c84cdcd798d2e10b7 -->
<!-- docs-review-agents-blob-sha: c69aad4 -->

---

Signed-off-by: JulienAu <16043912+JulienAu@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated reusable test fixtures for runner workflows, filesystem behavior, command results, endpoint resolution, and migration state.
  * Simplified blueprint and migration tests by replacing duplicated setup with shared deterministic fixtures.
  * Improved consistency across test scenarios with standardized command outputs, provider listings, host state, and snapshot data.
  * Preserved existing test behavior and assertions while updating test-size budgeting to reflect the streamlined coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->