### PR TITLE
ci: run DCO check on self-hosted runner

### DIFF
--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   dco-check:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 5
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Runs only the existing DCO check job on the known NVIDIA self-hosted Linux runner label. The trigger, permissions, steps, status context, and DCO behavior are unchanged.

## Changes

- Changes `.github/workflows/dco-check.yaml` from `ubuntu-latest` to `linux-amd64-cpu4`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: One-line runner-label pilot; validation is the live DCO job on this PR.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal CI runner routing only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Aaron Erickson requested this narrow live pilot.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact one-line DCO runner-label change; no documentation or product behavior changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: c06ee76cf -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Live DCO job on this PR is the requested validation.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated contribution sign-off check to run on a standardized build environment.
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- dco-self-hosted-pilot-retrigger -->