### PR TITLE
fix(onboard): harden portable Ollama recovery

### DIFF
--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -22,7 +22,7 @@ NemoClaw detects Ollama on the host and can install, start, or upgrade it on sup
 
 ## Install or Upgrade Ollama
 
-If Ollama is installed but not started, NemoClaw starts it for you.
+During onboarding, if Ollama is installed but not started, NemoClaw starts it for you.
 On macOS and Linux, the wizard can offer to install Ollama when it is not present.
 
 When either the Ollama CLI or running daemon is below the minimum version for the starter models, currently `0.7.0`, the wizard displays an explicit **Upgrade Ollama** entry.
@@ -57,10 +57,12 @@ For ordinary user-local installs, restart the daemon manually after a reboot.
 For a sandbox created with the portable experimental profile, `$$nemoclaw <name> connect --probe-only` and `$$nemoclaw <name> recover` can restart the user-local daemon that NemoClaw installed.
 Before it decides whether to start Ollama, recovery probes `http://127.0.0.1:11434/api/tags`.
 If the API is unhealthy, recovery starts Ollama only when the sandbox records `ollama-local` and a valid ownership receipt names the fixed regular executable.
+NemoClaw releases that predate this receipt do not claim an existing executable after an upgrade.
+To authorize recovery for a previous NemoClaw user-local install, first verify that `${HOME}/.local/bin/ollama` is the executable you want NemoClaw to manage, then run `NEMOCLAW_PORTABLE_OLLAMA_REENROLL=1 nemoclaw <name> recover` once.
+The command rejects a symlink or non-executable file before it records ownership.
 It refuses to launch a duplicate when another `ollama` process exists but the API is unhealthy.
 After it launches the daemon, it waits up to 30 seconds for `/api/tags` to return valid JSON with a `models` array.
-Recovery then requires a trusted reachable result from the sandbox `inference.local` route.
-When route repair needs the local Ollama dependency check, it verifies or recovers the authenticated proxy before it retries `inference.local`.
+Recovery then verifies the authenticated proxy and requires HTTP 2xx from the sandbox `inference.local/v1/models` route.
 If Ollama does not become healthy within 30 seconds, the command identifies the exact receipt-bound executable and its `serve` argument, then tells you to retry recovery.
 The command exits non-zero with recovery guidance when startup or route validation fails.
 It does not start, stop, or replace a system service or another user-managed Ollama daemon.

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -132,13 +132,17 @@ Other workflows, including onboarding, rebuild, and `doctor --fix`, can explicit
 For a portable experimental-profile sandbox with the recorded `ollama-local` provider, `connect --probe-only` and `recover` also verify the host-side inference chain.
 Before it decides whether to start Ollama, the command probes `http://127.0.0.1:11434/api/tags` and leaves a healthy daemon unchanged.
 When that API is unhealthy, it starts the fixed user-local executable only if NemoClaw has a valid ownership receipt.
+NemoClaw releases that predate this receipt do not claim an existing executable after an upgrade.
+To authorize recovery for a previous NemoClaw user-local install, first verify that `${HOME}/.local/bin/ollama` is the executable you want NemoClaw to manage.
+Then run `NEMOCLAW_PORTABLE_OLLAMA_REENROLL=1 nemoclaw <name> recover` once.
+The command rejects a symbolic link or non-executable file before it records ownership.
 It refuses to launch a duplicate when another `ollama` process exists but the API remains unhealthy.
 After a launch, recovery waits up to 30 seconds for `/api/tags` to return valid JSON with a `models` array.
 It does not take over a system service or an unrelated user-managed daemon.
 It refuses a symbolic link, non-regular file, or non-executable file at the receipt path.
 
-The command also requires a trusted reachable route probe at `https://inference.local/v1/models` before it reports success.
-When route repair needs the local Ollama dependency check, it verifies or recovers the authenticated proxy on port `11435` before it retries the route.
+On every `ollama-local` completion path, the command verifies the authenticated proxy on port `11435`.
+It also requires HTTP 2xx from `https://inference.local/v1/models` before it reports success.
 If Ollama does not become healthy within 30 seconds, the command identifies the exact receipt-bound executable and its `serve` argument, then tells you to retry recovery.
 An Ollama startup or route failure exits non-zero and prints the available recovery guidance.
 </AgentOnly>

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -139,7 +139,7 @@ The command rejects a symbolic link or non-executable file before it records own
 It refuses to launch a duplicate when another `ollama` process exists but the API remains unhealthy.
 After a launch, recovery waits up to 30 seconds for `/api/tags` to return valid JSON with a `models` array.
 It does not take over a system service or an unrelated user-managed daemon.
-It refuses a symbolic link, non-regular file, or non-executable file at the receipt path.
+It refuses a symbolic link, non-regular file, or non-executable file at the receipt-bound executable path.
 
 On every `ollama-local` completion path, the command verifies the authenticated proxy on port `11435`.
 It also requires HTTP 2xx from `https://inference.local/v1/models` before it reports success.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1394,7 +1394,8 @@ $$nemoclaw my-assistant recover
 
 <AgentOnly variant="openclaw">
 
-For a portable experimental-profile sandbox with the recorded `ollama-local` provider, `recover` also runs the ownership-bound Ollama and `inference.local` route reachability checks described for [`connect --probe-only`](#$$nemoclaw-name-connect).
+For a portable experimental-profile sandbox with the recorded `ollama-local` provider, `recover` also runs the ownership-bound Ollama checks described for [`connect --probe-only`](#$$nemoclaw-name-connect).
+Before it reports success, every completion path verifies the authenticated proxy on port `11435` and requires HTTP 2xx from `inference.local/v1/models`.
 
 </AgentOnly>
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1020,17 +1020,20 @@ Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `$$nemoclaw <name> rebuild` hint.
 If another terminal is already connected to the sandbox, `connect` prints a note with the number of existing sessions before proceeding. Multiple concurrent sessions are allowed.
 
-`connect` does not pull a model itself, but it does inspect managed-vLLM install variables such as `NEMOCLAW_VLLM_MODEL` and `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` if you exported them in the same shell.
+Without `--probe-only`, `connect` does not pull a model itself, but it does inspect managed-vLLM install variables such as `NEMOCLAW_VLLM_MODEL` and `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` if you exported them in the same shell.
 An unknown model slug, malformed extra-args JSON, or a gated model (for example `deepseek-r1-distill-70b`) with no `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` exits non-zero with the same error the installer would emit, before any sandbox readiness probe or SSH attach.
-Unset the managed-vLLM variable, or fix the value, before retrying.
+Unset the managed-vLLM variable, or fix the value, before retrying a regular connection.
+`connect --probe-only` skips this install preflight so stale managed-vLLM variables cannot block recovery.
 
 <AgentOnly variant="openclaw">
 For a portable experimental-profile sandbox with the recorded `ollama-local` provider, `connect --probe-only` probes `http://127.0.0.1:11434/api/tags` before it decides whether to start Ollama.
 If the API is unhealthy and the ownership receipt is valid, it starts the fixed user-local Ollama executable with `serve`.
+An installation made before the ownership receipt was introduced is not claimed automatically.
+After you verify that `${HOME}/.local/bin/ollama` is the executable you intend NemoClaw to manage, run `NEMOCLAW_PORTABLE_OLLAMA_REENROLL=1 nemoclaw <name> recover` once to record it explicitly.
+The command rejects a symlink or non-executable file before it records ownership.
 It refuses to launch a duplicate when another `ollama` process exists but the API remains unhealthy.
 After a launch, it waits up to 30 seconds for valid `/api/tags` JSON with a `models` array.
-It then requires the existing sandbox `inference.local` route probe to return a trusted reachable result before it exits successfully.
-When route repair needs the local Ollama dependency check, it verifies or recovers the authenticated proxy before it retries `inference.local`.
+It then verifies the authenticated proxy and requires HTTP 2xx from the sandbox `inference.local/v1/models` route before it exits successfully.
 If Ollama does not become healthy within 30 seconds, the command identifies the exact receipt-bound executable and its `serve` argument, then tells you to retry recovery.
 The command does not take over a system service or an unrelated user-managed Ollama daemon.
 </AgentOnly>
@@ -4496,7 +4499,10 @@ The following flags change defaults for commands that manage existing sandboxes.
 | `NEMOCLAW_CONFIG_ACCEPT_NEW_PATH` | Exactly `"1"` to opt in (`true`, `yes`, `on` are not accepted) | Allows `$$nemoclaw <name> config set` to write a dotpath that does not already exist in the sandbox config, without the interactive confirmation. Equivalent to passing `--config-accept-new-path`, and it takes precedence over `NEMOCLAW_NON_INTERACTIVE=1`. Without it, a run without a TTY refuses the write instead. |
 </AgentOnly>
 | `NEMOCLAW_CONFIRM_LEGACY_MANAGED_RECREATE` | Exact JSON array of sandbox names | Confirms to the installer that the exact listed set of pre-fingerprint OpenClaw or Hermes sandboxes used NemoClaw-managed images, allowing recovery onto the current managed image. The normalized names must exactly match the installer's printed array. Set it only after verifying every named sandbox. Recorded custom-image evidence remains blocked. |
-| `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips the automatic DNS-proxy repair for stale `inference.local` routes during `$$nemoclaw <name> connect` and `$$nemoclaw <name> connect --probe-only`. Use only as a troubleshooting escape hatch. |
+| `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips automatic DNS-proxy mutation for stale `inference.local` routes during `$$nemoclaw <name> connect` and `$$nemoclaw <name> connect --probe-only`. The command still probes the route and exits non-zero when the provider-specific requirement fails. An `ollama-local` route still requires a healthy authenticated proxy and HTTP 2xx from `inference.local/v1/models`. Use only as a troubleshooting escape hatch. |
+<AgentOnly variant="openclaw">
+| `NEMOCLAW_PORTABLE_OLLAMA_REENROLL` | Exactly `1` for one recovery run | After you verify `${HOME}/.local/bin/ollama`, explicitly records that regular executable as NemoClaw-managed for a portable experimental-profile sandbox whose recorded provider is `ollama-local`. Use this once for a user-local Ollama that NemoClaw installed before ownership receipts existed. It never claims a system Ollama, symlink, non-executable file, or non-Ollama sandbox. |
+</AgentOnly>
 | `NEMOCLAW_DISABLE_SUPERVISOR_RELAUNCH` | `1` to enable | Skips the automatic trusted container recreation during `$$nemoclaw <name> recover` when two managed scans find no supervisor while PID 1 remains stable. Use only as a troubleshooting escape hatch; recovery then falls back to the rebuild or re-onboard guidance. |
 | `NEMOCLAW_SHIELDS_ACCEPT_LEGACY_BASELINE` | `1` to opt in | Allows advanced immutable-config verification to trust the current on-disk bytes for older or partial content baselines. Use only after you have rebuilt or manually inspected the sandbox state and accepted that the baseline is operator-approved. |
 | `NEMOCLAW_SHIELDS_SETTLE_MS` | milliseconds (default `750`, clamped to `0` to `10000`) | Settle window NemoClaw waits after re-applying a config lockdown (during shields auto-restore and `$$nemoclaw <name> shields up` drift remediation) before re-confirming the lock still holds. Detects when an in-sandbox reconciler changes config file permissions after lockdown and re-applies the lock; if NemoClaw cannot re-confirm the lock within the retry budget, shields stay down. This narrows the window in which a reconciler can revert permissions rather than eliminating it. The best-effort `chattr +i` immutable bit remains the only fully durable lock. Raise it on hosts where the gateway settles slowly. |

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -296,6 +296,47 @@ describe("connectSandbox flow", () => {
     );
   });
 
+  it.each([
+    401, 403, 404,
+  ])("rejects HTTP %i from inference.local for an Ollama recovery path (#8502)", async (httpStatus) => {
+    const response = `OK ${String(httpStatus)}`;
+    const harness = createConnectHarness({
+      inferenceGetOutput: "Provider: ollama-local\nModel: qwen3-vl:4b\n",
+      inferenceProbeResponses: [response, response],
+      registryEntry: { provider: "ollama-local", model: "qwen3-vl:4b" },
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(harness.errorSpy.mock.calls.flat().join("\n")).toContain(
+      "inference.local/v1/models must return HTTP 2xx",
+    );
+    expect(harness.probeLocalProviderHealthSpy).toHaveBeenCalledWith("ollama-local", {
+      skipOllamaAuthProxySubprobe: true,
+    });
+    expect(harness.probeOllamaAuthProxyHealthSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("rechecks HTTP 2xx after repairing an Ollama inference route (#8502)", async () => {
+    const harness = createConnectHarness({
+      inferenceGetOutput: "Provider: ollama-local\nModel: qwen3-vl:4b\n",
+      inferenceProbeResponses: ["BROKEN 503", "OK 401", "OK 401"],
+      registryEntry: { provider: "ollama-local", model: "qwen3-vl:4b" },
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(harness.runSetupDnsProxySpy).toHaveBeenCalled();
+    expect(harness.errorSpy.mock.calls.flat().join("\n")).toContain(
+      "inference.local/v1/models must return HTTP 2xx",
+    );
+  });
+
   it("fails closed with actionable diagnostics when the initial route probe is inconclusive (#6192)", async () => {
     const longProbeDetail = `route probe unavailable NVIDIA_API_KEY=super-secret ${"x".repeat(400)}`;
     const harness = createConnectHarness({

--- a/src/lib/actions/sandbox/connect-route-repair.test.ts
+++ b/src/lib/actions/sandbox/connect-route-repair.test.ts
@@ -105,19 +105,20 @@ function makeRepairDeps(
 }
 
 describe("sandbox connect route repair unit flow", () => {
-  it("skips work when route repair is disabled", () => {
-    const { calls, deps } = makeRepairDeps([], {
+  it("still probes and fails closed when route repair is disabled (#8502)", () => {
+    const { calls, deps } = makeRepairDeps([broken()], {
       isRepairDisabled: () => true,
     });
 
     const result = repairSandboxInferenceRouteWithDeps("demo", sandbox(), {}, deps);
 
     expect(result).toEqual({
-      healthy: true,
+      healthy: false,
       repairAttempted: false,
-      detail: "route repair disabled",
+      detail: "route repair disabled; BROKEN 503",
     });
-    expect(calls.probeOptions).toEqual([]);
+    expect(calls.probeOptions).toEqual([undefined]);
+    expect(calls.legacyRepairs).toEqual([]);
   });
 
   it("does not repair a healthy initial probe", () => {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -108,6 +108,7 @@ type SandboxListProbe = {
 export type SandboxInferenceRouteProbe = {
   healthy: boolean;
   broken: boolean;
+  httpStatus?: number;
   detail: string;
 };
 
@@ -412,6 +413,7 @@ function probeSandboxInferenceRoute(
     lastProbe = {
       healthy: parsed.healthy,
       broken: parsed.broken,
+      httpStatus: parsed.httpStatus,
       detail: parsed.detail,
     };
     if (lastProbe.healthy || attempt === boundedAttempts) return lastProbe;
@@ -462,13 +464,17 @@ export function repairSandboxInferenceRouteWithDeps(
 ): SandboxInferenceRouteRepairResult {
   const log = deps.log ?? console.log;
   const error = deps.error ?? console.error;
-  if (deps.isRepairDisabled?.()) {
-    return { healthy: true, repairAttempted: false, detail: "route repair disabled" };
-  }
   deps.assertRouteCompatible?.(sandboxName, sb);
   const initialProbe = deps.probe(sandboxName);
   if (initialProbe.healthy) {
     return { healthy: true, repairAttempted: false, detail: initialProbe.detail };
+  }
+  if (deps.isRepairDisabled?.()) {
+    return {
+      healthy: false,
+      repairAttempted: false,
+      detail: `route repair disabled; ${initialProbe.detail}`,
+    };
   }
   if (!initialProbe.broken) {
     return { healthy: false, repairAttempted: false, detail: initialProbe.detail };
@@ -809,14 +815,37 @@ function ensureSandboxInferenceRouteUnlocked(
       }
       return { sandbox: sb, routeHealthy: false };
     }
-    if (!repairResult.healthy && repairResult.repairAttempted) {
-      const resetResult = resetManagedInferenceRoute(sandboxName, sb, agent, gatewayName, {
+    let routeReady = repairResult.healthy;
+    if (!routeReady && repairResult.repairAttempted) {
+      routeReady = resetManagedInferenceRoute(sandboxName, sb, agent, gatewayName, {
         detail: repairResult.detail,
         quiet,
       });
-      return { sandbox: sb, routeHealthy: resetResult };
+      if (!routeReady) return { sandbox: sb, routeHealthy: false };
     }
-    return { sandbox: sb, routeHealthy: repairResult.healthy };
+    if (provider === "ollama-local") {
+      if (!verifyLocalInferenceRouteDependencies(provider, { quiet })) {
+        return { sandbox: sb, routeHealthy: false };
+      }
+      const finalProbe = probeSandboxInferenceRoute(sandboxName, agent);
+      const strictRouteHealthy =
+        finalProbe.healthy &&
+        finalProbe.httpStatus !== undefined &&
+        finalProbe.httpStatus >= 200 &&
+        finalProbe.httpStatus < 300;
+      if (!strictRouteHealthy) {
+        if (!quiet) {
+          printUnrecoverableInferenceRoute(
+            sandboxName,
+            `${sanitizeRouteValueForDisplay(provider)}/${sanitizeRouteValueForDisplay(model)}`,
+            `inference.local/v1/models must return HTTP 2xx; ${finalProbe.detail}`,
+            { repairAttempted: repairResult.repairAttempted },
+          );
+        }
+        return { sandbox: sb, routeHealthy: false };
+      }
+    }
+    return { sandbox: sb, routeHealthy: routeReady };
   } catch (error) {
     if (!sb || inference?.kind !== "configured") return { sandbox: sb, routeHealthy: null };
     if (error instanceof OpenShellGatewayEndpointOverrideError) {

--- a/src/lib/onboard/experimental/ollama-user-local-runtime.test.ts
+++ b/src/lib/onboard/experimental/ollama-user-local-runtime.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   loadUserLocalOllamaOwnership,
@@ -27,6 +27,7 @@ function createFixture(): { homeDir: string; stateDir: string; binPath: string }
 }
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   for (const directory of temporaryDirectories.splice(0)) {
     fs.rmSync(directory, { force: true, recursive: true });
   }
@@ -62,6 +63,43 @@ describe("user-local Ollama ownership receipt", () => {
     );
 
     expect(() => loadUserLocalOllamaOwnership(fixture)).toThrow("ownership receipt is invalid");
+  });
+
+  it("rejects a receipt that is not valid JSON (#8502)", () => {
+    const fixture = createFixture();
+    const receipt = userLocalOllamaOwnershipInternals.receiptPath(fixture);
+    fs.mkdirSync(path.dirname(receipt), { recursive: true });
+    fs.writeFileSync(receipt, "{not json", { mode: 0o600 });
+
+    expect(() => loadUserLocalOllamaOwnership(fixture)).toThrow("ownership receipt is malformed");
+  });
+
+  it("refuses a receipt path that is a symbolic link (#8502)", () => {
+    const fixture = createFixture();
+    const receipt = userLocalOllamaOwnershipInternals.receiptPath(fixture);
+    const plantedReceipt = path.join(fixture.homeDir, "planted-receipt.json");
+    fs.mkdirSync(path.dirname(receipt), { recursive: true });
+    fs.writeFileSync(
+      plantedReceipt,
+      `${JSON.stringify({ schemaVersion: 1, binPath: fixture.binPath })}\n`,
+      { mode: 0o600 },
+    );
+    fs.symlinkSync(plantedReceipt, receipt);
+
+    expect(() => loadUserLocalOllamaOwnership(fixture)).toThrow();
+  });
+
+  it("refuses a symbolic-link receipt directory before loading or removing (#8502)", () => {
+    const fixture = createFixture();
+    const receiptDirectory = path.dirname(userLocalOllamaOwnershipInternals.receiptPath(fixture));
+    const plantedDirectory = path.join(fixture.homeDir, "planted-ollama-state");
+    fs.mkdirSync(path.dirname(receiptDirectory), { recursive: true });
+    fs.mkdirSync(plantedDirectory, { mode: 0o700 });
+    fs.symlinkSync(plantedDirectory, receiptDirectory);
+    vi.stubEnv("HOME", fixture.homeDir);
+
+    expect(() => loadUserLocalOllamaOwnership(fixture)).toThrow("is a symbolic link");
+    expect(() => removeUserLocalOllamaOwnership(fixture)).toThrow("is a symbolic link");
   });
 
   it("removes obsolete ownership after a system installation (#8502)", () => {

--- a/src/lib/onboard/experimental/ollama-user-local-runtime.ts
+++ b/src/lib/onboard/experimental/ollama-user-local-runtime.ts
@@ -59,7 +59,7 @@ function parseReceipt(
   return receipt as unknown as UserLocalOllamaOwnershipReceipt;
 }
 
-/** Record the fixed user-local binary only after NemoClaw starts it successfully. */
+/** Record ownership after installation or explicit operator re-enrollment validates the fixed binary. */
 export function recordUserLocalOllamaOwnership(
   binPath: string,
   deps: UserLocalOllamaOwnershipDeps = {},

--- a/src/lib/onboard/experimental/ollama-user-local-runtime.ts
+++ b/src/lib/onboard/experimental/ollama-user-local-runtime.ts
@@ -69,6 +69,7 @@ export function recordUserLocalOllamaOwnership(
   }
   const target = receiptPath(deps);
   ensureConfigDir(path.dirname(target));
+  rejectSymlinksOnPath(path.dirname(target));
   let file;
   try {
     file = openRegularFileNoFollow(target, { writable: true });

--- a/src/lib/onboard/experimental/ollama-user-local-runtime.ts
+++ b/src/lib/onboard/experimental/ollama-user-local-runtime.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 
 import { openRegularFileNoFollow } from "../../adapters/fs/regular-file";
 import { OLLAMA_PORT } from "../../core/ports";
-import { ensureConfigDir } from "../../state/config-io";
+import { ensureConfigDir, rejectSymlinksOnPath } from "../../state/config-io";
 
 export { OLLAMA_PORT };
 
@@ -88,9 +88,11 @@ export function recordUserLocalOllamaOwnership(
 export function loadUserLocalOllamaOwnership(
   deps: UserLocalOllamaOwnershipDeps = {},
 ): string | null {
+  const target = receiptPath(deps);
+  rejectSymlinksOnPath(path.dirname(target));
   let file;
   try {
-    file = openRegularFileNoFollow(receiptPath(deps));
+    file = openRegularFileNoFollow(target);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw error;
@@ -110,8 +112,10 @@ export function loadUserLocalOllamaOwnership(
 
 /** Remove stale user-local ownership after a successful system installation. */
 export function removeUserLocalOllamaOwnership(deps: UserLocalOllamaOwnershipDeps = {}): void {
+  const target = receiptPath(deps);
+  rejectSymlinksOnPath(path.dirname(target));
   try {
-    fs.unlinkSync(receiptPath(deps));
+    fs.unlinkSync(target);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -621,10 +621,13 @@ describe("portable demo sandbox lifecycle", () => {
     const binPath = createManagedOllamaBinary(stateDir);
     recordUserLocalOllamaOwnership(binPath, { homeDir: stateDir, stateDir });
     let ollamaStarted = false;
-    const captureHost = vi.fn((command: string) => {
-      if (command === "pgrep") return { status: 1 };
-      return ollamaStarted ? { status: 0, stdout: JSON.stringify({ models: [] }) } : { status: 7 };
-    });
+    const captureHost = vi.fn((command: string) =>
+      command === "pgrep"
+        ? { status: 1 }
+        : ollamaStarted
+          ? { status: 0, stdout: JSON.stringify({ models: [] }) }
+          : { status: 7 },
+    );
     const launchHost = vi.fn(
       (_command: string, _args: readonly string[], _env: NodeJS.ProcessEnv, descriptor: number) => {
         fs.renameSync(binPath, `${binPath}.validated`);

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -595,10 +595,15 @@ describe("portable demo sandbox lifecycle", () => {
         },
       ),
     ).toEqual({ kind: "already-running" });
-    expect(launchHost).toHaveBeenCalledWith(binPath, ["serve"], {
-      HOME: stateDir,
-      OLLAMA_HOST: "127.0.0.1:11434",
-    });
+    expect(launchHost).toHaveBeenCalledWith(
+      "/proc/self/fd/3",
+      ["serve"],
+      {
+        HOME: stateDir,
+        OLLAMA_HOST: "127.0.0.1:11434",
+      },
+      expect.any(Number),
+    );
     expect(log).toHaveBeenCalledWith(
       "  Portable demo lifecycle restarted NemoClaw-managed Ollama.",
     );
@@ -606,6 +611,50 @@ describe("portable demo sandbox lifecycle", () => {
       "curl",
       expect.arrayContaining(["--noproxy", "127.0.0.1"]),
       5000,
+    );
+  });
+
+  it("launches the validated Ollama identity when its pathname is replaced (#8502)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime.podman);
+    const binPath = createManagedOllamaBinary(stateDir);
+    recordUserLocalOllamaOwnership(binPath, { homeDir: stateDir, stateDir });
+    let ollamaStarted = false;
+    const captureHost = vi.fn((command: string) => {
+      if (command === "pgrep") return { status: 1 };
+      return ollamaStarted ? { status: 0, stdout: JSON.stringify({ models: [] }) } : { status: 7 };
+    });
+    const launchHost = vi.fn(
+      (_command: string, _args: readonly string[], _env: NodeJS.ProcessEnv, descriptor: number) => {
+        fs.renameSync(binPath, `${binPath}.validated`);
+        fs.writeFileSync(binPath, "#!/bin/sh\n# replacement\n", { mode: 0o755 });
+        expect(fs.readFileSync(descriptor, "utf8")).toBe("#!/bin/sh\n");
+        ollamaStarted = true;
+      },
+    );
+
+    expect(
+      recoverPortableDemoSandboxLifecycle(
+        "alpha",
+        { agent: "openclaw", gatewayName: "nemoclaw", provider: "ollama-local" },
+        {
+          platform: "linux",
+          env: { HOME: stateDir },
+          stateDir,
+          podman: runtime.podman,
+          captureOpenshell: (args) =>
+            args.includes("curl") ? { status: 0, stdout: "200" } : { status: 0 },
+          captureHost,
+          launchHost,
+        },
+      ),
+    ).toEqual({ kind: "already-running" });
+    expect(launchHost).toHaveBeenCalledWith(
+      "/proc/self/fd/3",
+      ["serve"],
+      expect.objectContaining({ OLLAMA_HOST: "127.0.0.1:11434" }),
+      expect.any(Number),
     );
   });
 
@@ -645,10 +694,15 @@ describe("portable demo sandbox lifecycle", () => {
         fs.readFileSync(path.join(stateDir, "ollama", "user-local-ownership.json"), "utf8"),
       ),
     ).toMatchObject({ binPath });
-    expect(launchHost).toHaveBeenCalledWith(binPath, ["serve"], {
-      HOME: stateDir,
-      OLLAMA_HOST: "127.0.0.1:11434",
-    });
+    expect(launchHost).toHaveBeenCalledWith(
+      "/proc/self/fd/3",
+      ["serve"],
+      {
+        HOME: stateDir,
+        OLLAMA_HOST: "127.0.0.1:11434",
+      },
+      expect.any(Number),
+    );
   });
 
   it("rejects Ollama re-enrollment for a non-Ollama sandbox (#8502)", () => {

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -696,6 +696,36 @@ describe("portable demo sandbox lifecycle", () => {
     expect(fs.existsSync(path.join(stateDir, "ollama", "user-local-ownership.json"))).toBe(false);
   });
 
+  it("rejects a symlinked receipt directory during explicit Ollama re-enrollment (#8502)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime.podman);
+    createManagedOllamaBinary(stateDir);
+    const plantedDirectory = path.join(stateDir, "planted-ollama-state");
+    const receiptDirectory = path.join(stateDir, "ollama");
+    fs.mkdirSync(plantedDirectory, { mode: 0o700 });
+    fs.symlinkSync(plantedDirectory, receiptDirectory);
+    vi.stubEnv("HOME", stateDir);
+    const launchHost = vi.fn();
+
+    expect(() =>
+      recoverPortableDemoSandboxLifecycle(
+        "alpha",
+        { agent: "openclaw", gatewayName: "nemoclaw", provider: "ollama-local" },
+        {
+          platform: "linux",
+          env: { HOME: stateDir, NEMOCLAW_PORTABLE_OLLAMA_REENROLL: "1" },
+          stateDir,
+          podman: runtime.podman,
+          captureOpenshell: () => ({ status: 0 }),
+          launchHost,
+        },
+      ),
+    ).toThrow("is a symbolic link");
+    expect(fs.existsSync(path.join(plantedDirectory, "user-local-ownership.json"))).toBe(false);
+    expect(launchHost).not.toHaveBeenCalled();
+  });
+
   it("does not inspect ownership or launch Ollama when the local API is already healthy (#8502)", () => {
     const stateDir = temporaryStateDir();
     const runtime = createPodman();

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SandboxEntry } from "../../state/registry";
+import { recordUserLocalOllamaOwnership } from "./ollama-user-local-runtime";
 import {
   installPortableDemoSandboxLifecycle,
   portableDemoLifecycleInternals,
@@ -558,6 +559,7 @@ describe("portable demo sandbox lifecycle", () => {
     const runtime = createPodman();
     installReceipt(stateDir, runtime.podman);
     const binPath = createManagedOllamaBinary(stateDir);
+    recordUserLocalOllamaOwnership(binPath, { homeDir: stateDir, stateDir });
     let ollamaStarted = false;
     const captureHost = vi.fn((command: string) => {
       switch (command) {
@@ -589,7 +591,6 @@ describe("portable demo sandbox lifecycle", () => {
             args.includes("curl") ? { status: 0, stdout: "200" } : { status: 0 },
           captureHost,
           launchHost,
-          loadManagedOllama: () => binPath,
           log,
         },
       ),
@@ -601,6 +602,98 @@ describe("portable demo sandbox lifecycle", () => {
     expect(log).toHaveBeenCalledWith(
       "  Portable demo lifecycle restarted NemoClaw-managed Ollama.",
     );
+    expect(captureHost).toHaveBeenCalledWith(
+      "curl",
+      expect.arrayContaining(["--noproxy", "127.0.0.1"]),
+      5000,
+    );
+  });
+
+  it("records an explicitly re-enrolled pre-receipt Ollama before recovery (#8502)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime.podman);
+    const binPath = createManagedOllamaBinary(stateDir);
+    let ollamaStarted = false;
+    const launchHost = vi.fn(() => {
+      ollamaStarted = true;
+    });
+
+    expect(
+      recoverPortableDemoSandboxLifecycle(
+        "alpha",
+        { agent: "openclaw", gatewayName: "nemoclaw", provider: "ollama-local" },
+        {
+          platform: "linux",
+          env: { HOME: stateDir, NEMOCLAW_PORTABLE_OLLAMA_REENROLL: "1" },
+          stateDir,
+          podman: runtime.podman,
+          captureOpenshell: (args) =>
+            args.includes("curl") ? { status: 0, stdout: "200" } : { status: 0 },
+          captureHost: (command) =>
+            command === "pgrep"
+              ? { status: 1 }
+              : ollamaStarted
+                ? { status: 0, stdout: JSON.stringify({ models: [] }) }
+                : { status: 7 },
+          launchHost,
+        },
+      ),
+    ).toEqual({ kind: "already-running" });
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(stateDir, "ollama", "user-local-ownership.json"), "utf8"),
+      ),
+    ).toMatchObject({ binPath });
+    expect(launchHost).toHaveBeenCalledWith(binPath, ["serve"], {
+      HOME: stateDir,
+      OLLAMA_HOST: "127.0.0.1:11434",
+    });
+  });
+
+  it("rejects Ollama re-enrollment for a non-Ollama sandbox (#8502)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime.podman);
+
+    expect(() =>
+      recoverPortableDemoSandboxLifecycle(
+        "alpha",
+        { agent: "openclaw", gatewayName: "nemoclaw", provider: "nvidia" },
+        {
+          platform: "linux",
+          env: { HOME: stateDir, NEMOCLAW_PORTABLE_OLLAMA_REENROLL: "1" },
+          stateDir,
+          podman: runtime.podman,
+          captureOpenshell: () => ({ status: 0 }),
+        },
+      ),
+    ).toThrow("requires a portable sandbox with the recorded ollama-local provider");
+  });
+
+  it("rejects a symlink before recording explicit Ollama re-enrollment (#8502)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime.podman);
+    const binPath = createManagedOllamaBinary(stateDir);
+    const targetPath = path.join(stateDir, "ollama-target");
+    fs.renameSync(binPath, targetPath);
+    fs.symlinkSync(targetPath, binPath);
+
+    expect(() =>
+      recoverPortableDemoSandboxLifecycle(
+        "alpha",
+        { agent: "openclaw", gatewayName: "nemoclaw", provider: "ollama-local" },
+        {
+          platform: "linux",
+          env: { HOME: stateDir, NEMOCLAW_PORTABLE_OLLAMA_REENROLL: "1" },
+          stateDir,
+          podman: runtime.podman,
+          captureOpenshell: () => ({ status: 0 }),
+        },
+      ),
+    ).toThrow("is not a regular executable");
+    expect(fs.existsSync(path.join(stateDir, "ollama", "user-local-ownership.json"))).toBe(false);
   });
 
   it("does not inspect ownership or launch Ollama when the local API is already healthy (#8502)", () => {

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.ts
@@ -10,7 +10,11 @@ import path from "node:path";
 import { openRegularFileNoFollow } from "../../adapters/fs/regular-file";
 import { ensureConfigDir } from "../../state/config-io";
 import { isPortableExperimentalProfile } from "../docker-driver-platform";
-import { loadUserLocalOllamaOwnership, OLLAMA_PORT } from "./ollama-user-local-runtime";
+import {
+  loadUserLocalOllamaOwnership,
+  OLLAMA_PORT,
+  recordUserLocalOllamaOwnership,
+} from "./ollama-user-local-runtime";
 
 const RECEIPT_DIRECTORY = "portable-demo-lifecycle";
 const MAX_RECEIPT_BYTES = 4096;
@@ -20,6 +24,7 @@ const EXEC_READY_TIMEOUT_MS = 90_000;
 const STARTUP_STOP_TIMEOUT_MS = 30_000;
 const STARTUP_TIMEOUT_MS = 90_000;
 const OLLAMA_STARTUP_TIMEOUT_MS = 30_000;
+const PORTABLE_OLLAMA_REENROLL_ENV = "NEMOCLAW_PORTABLE_OLLAMA_REENROLL";
 const POLL_INTERVAL_MS = 1_000;
 const CONTAINER_ID_PATTERN = /^[a-f0-9]{64}$/u;
 const SANDBOX_ID_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/u;
@@ -431,6 +436,8 @@ function ollamaIsHealthy(
     "curl",
     [
       "-fsS",
+      "--noproxy",
+      "127.0.0.1",
       "--max-time",
       String(Math.max(1, Math.ceil(Math.min(PROBE_TIMEOUT_MS, timeoutMs) / 1_000))),
       `http://127.0.0.1:${String(OLLAMA_PORT)}/api/tags`,
@@ -469,13 +476,29 @@ function recoverManagedOllama(
   timing: Required<Pick<PortableDemoLifecycleDeps, "now" | "sleep">>,
   deps: PortableDemoLifecycleDeps,
 ): void {
-  if (context.provider !== "ollama-local") return;
+  const reenrollRequested = commandEnv[PORTABLE_OLLAMA_REENROLL_ENV] === "1";
+  const homeDir = commandEnv.HOME ?? os.homedir();
+  if (context.provider !== "ollama-local") {
+    if (reenrollRequested) {
+      throw new Error(
+        `${PORTABLE_OLLAMA_REENROLL_ENV}=1 requires a portable sandbox with the recorded ollama-local provider`,
+      );
+    }
+    return;
+  }
+  if (reenrollRequested) {
+    const binPath = path.join(homeDir, ".local", "bin", "ollama");
+    assertManagedOllamaBinary(binPath);
+    recordUserLocalOllamaOwnership(binPath, { homeDir, stateDir });
+    (deps.log ?? console.log)(
+      "  Portable demo lifecycle recorded the explicitly re-enrolled user-local Ollama.",
+    );
+  }
   const captureHost =
     deps.captureHost ??
     ((command, args, timeoutMs) => defaultCaptureHost(command, args, timeoutMs, commandEnv));
   if (ollamaIsHealthy(captureHost, PROBE_TIMEOUT_MS)) return;
 
-  const homeDir = commandEnv.HOME ?? os.homedir();
   const binPath = deps.loadManagedOllama
     ? deps.loadManagedOllama()
     : loadUserLocalOllamaOwnership({ homeDir, stateDir });
@@ -494,11 +517,13 @@ function recoverManagedOllama(
 
   const launchHost =
     deps.launchHost ?? ((command, args, env) => defaultLaunchHost(command, args, env));
-  launchHost(binPath, ["serve"], {
+  const launchEnv: NodeJS.ProcessEnv = {
     ...commandEnv,
     HOME: homeDir,
     OLLAMA_HOST: `127.0.0.1:${String(OLLAMA_PORT)}`,
-  });
+  };
+  delete launchEnv[PORTABLE_OLLAMA_REENROLL_ENV];
+  launchHost(binPath, ["serve"], launchEnv);
   const recovered = waitFor(OLLAMA_STARTUP_TIMEOUT_MS, timing, (remainingMs) =>
     ollamaIsHealthy(captureHost, remainingMs),
   );

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.ts
@@ -25,6 +25,7 @@ const STARTUP_STOP_TIMEOUT_MS = 30_000;
 const STARTUP_TIMEOUT_MS = 90_000;
 const OLLAMA_STARTUP_TIMEOUT_MS = 30_000;
 const PORTABLE_OLLAMA_REENROLL_ENV = "NEMOCLAW_PORTABLE_OLLAMA_REENROLL";
+const MANAGED_EXECUTABLE_CHILD_FD = 3;
 const POLL_INTERVAL_MS = 1_000;
 const CONTAINER_ID_PATTERN = /^[a-f0-9]{64}$/u;
 const SANDBOX_ID_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/u;
@@ -68,7 +69,12 @@ export interface PortableDemoLifecycleDeps {
   captureOpenshell?: (args: readonly string[], timeoutMs: number) => CommandResult;
   launchOpenshell?: (args: readonly string[]) => void;
   captureHost?: (command: string, args: readonly string[], timeoutMs: number) => CommandResult;
-  launchHost?: (command: string, args: readonly string[], env: NodeJS.ProcessEnv) => void;
+  launchHost?: (
+    command: string,
+    args: readonly string[],
+    env: NodeJS.ProcessEnv,
+    executableFd: number,
+  ) => void;
   loadManagedOllama?: () => string | null;
   sleep?: (milliseconds: number) => void;
   now?: () => number;
@@ -139,12 +145,17 @@ function defaultCaptureHost(
   });
 }
 
-function defaultLaunchHost(command: string, args: readonly string[], env: NodeJS.ProcessEnv): void {
+function defaultLaunchHost(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  executableFd: number,
+): void {
   const child = spawn(command, [...args], {
     detached: true,
     env,
     shell: false,
-    stdio: "ignore",
+    stdio: ["ignore", "ignore", "ignore", executableFd],
   });
   child.once("error", () => undefined);
   child.unref();
@@ -453,20 +464,62 @@ function ollamaIsHealthy(
   }
 }
 
-function assertManagedOllamaBinary(binPath: string): void {
-  let stats: fs.Stats;
+interface OpenManagedOllamaBinary {
+  descriptor: number;
+  close(): void;
+}
+
+function openManagedOllamaBinary(binPath: string): OpenManagedOllamaBinary {
+  if (typeof fs.constants.O_NOFOLLOW !== "number") {
+    throw new Error("O_NOFOLLOW is unavailable");
+  }
+  const nonblock = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
+  let descriptor: number;
   try {
-    stats = fs.lstatSync(binPath);
-  } catch {
+    descriptor = fs.openSync(binPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | nonblock);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw new Error(
+        `NemoClaw-managed Ollama binary '${binPath}' is not a regular executable; reinstall Ollama through nemoclaw onboard`,
+      );
+    }
     throw new Error(
       `NemoClaw-managed Ollama binary '${binPath}' is missing; reinstall Ollama through nemoclaw onboard`,
     );
   }
-  if (stats.isSymbolicLink() || !stats.isFile() || (stats.mode & 0o111) === 0) {
+  try {
+    const descriptorStats = fs.fstatSync(descriptor);
+    const pathStats = fs.lstatSync(binPath);
+    if (
+      !descriptorStats.isFile() ||
+      (descriptorStats.mode & 0o111) === 0 ||
+      pathStats.isSymbolicLink() ||
+      !pathStats.isFile() ||
+      descriptorStats.dev !== pathStats.dev ||
+      descriptorStats.ino !== pathStats.ino
+    ) {
+      throw new Error("invalid executable identity");
+    }
+  } catch {
+    fs.closeSync(descriptor);
     throw new Error(
       `NemoClaw-managed Ollama binary '${binPath}' is not a regular executable; reinstall Ollama through nemoclaw onboard`,
     );
   }
+  let closed = false;
+  return {
+    descriptor,
+    close: () => {
+      if (closed) return;
+      closed = true;
+      fs.closeSync(descriptor);
+    },
+  };
+}
+
+function assertManagedOllamaBinary(binPath: string): void {
+  const executable = openManagedOllamaBinary(binPath);
+  executable.close();
 }
 
 function recoverManagedOllama(
@@ -503,27 +556,37 @@ function recoverManagedOllama(
     ? deps.loadManagedOllama()
     : loadUserLocalOllamaOwnership({ homeDir, stateDir });
   if (!binPath) return;
-  assertManagedOllamaBinary(binPath);
+  const executable = openManagedOllamaBinary(binPath);
 
-  const processProbe = captureHost("pgrep", ["-x", "ollama"], PROBE_TIMEOUT_MS);
-  if (processProbe.status === 0 && !processProbe.error) {
-    throw new Error(
-      `An Ollama process already exists, but http://127.0.0.1:${String(OLLAMA_PORT)}/api/tags is unavailable; NemoClaw refused to launch a duplicate`,
+  try {
+    const processProbe = captureHost("pgrep", ["-x", "ollama"], PROBE_TIMEOUT_MS);
+    if (processProbe.status === 0 && !processProbe.error) {
+      throw new Error(
+        `An Ollama process already exists, but http://127.0.0.1:${String(OLLAMA_PORT)}/api/tags is unavailable; NemoClaw refused to launch a duplicate`,
+      );
+    }
+    if (processProbe.status !== 1 || processProbe.error) {
+      throw new Error(
+        `Ollama process state could not be determined: ${commandDetail(processProbe)}`,
+      );
+    }
+
+    const launchHost = deps.launchHost ?? defaultLaunchHost;
+    const launchEnv: NodeJS.ProcessEnv = {
+      ...commandEnv,
+      HOME: homeDir,
+      OLLAMA_HOST: `127.0.0.1:${String(OLLAMA_PORT)}`,
+    };
+    delete launchEnv[PORTABLE_OLLAMA_REENROLL_ENV];
+    launchHost(
+      `/proc/self/fd/${String(MANAGED_EXECUTABLE_CHILD_FD)}`,
+      ["serve"],
+      launchEnv,
+      executable.descriptor,
     );
+  } finally {
+    executable.close();
   }
-  if (processProbe.status !== 1 || processProbe.error) {
-    throw new Error(`Ollama process state could not be determined: ${commandDetail(processProbe)}`);
-  }
-
-  const launchHost =
-    deps.launchHost ?? ((command, args, env) => defaultLaunchHost(command, args, env));
-  const launchEnv: NodeJS.ProcessEnv = {
-    ...commandEnv,
-    HOME: homeDir,
-    OLLAMA_HOST: `127.0.0.1:${String(OLLAMA_PORT)}`,
-  };
-  delete launchEnv[PORTABLE_OLLAMA_REENROLL_ENV];
-  launchHost(binPath, ["serve"], launchEnv);
   const recovered = waitFor(OLLAMA_STARTUP_TIMEOUT_MS, timing, (remainingMs) =>
     ollamaIsHealthy(captureHost, remainingMs),
   );

--- a/test/cli/connect-recovery.test.ts
+++ b/test/cli/connect-recovery.test.ts
@@ -219,6 +219,7 @@ describe("CLI connect recovery process contracts", () => {
           "fi",
           'if [ "$1" = "sandbox" ] && [ "$2" = "exec" ] && [ "$3" = "--name" ] && [ "$4" = "alpha" ]; then',
           '  cmd="$8"',
+          '  if [[ "$*" == *"inference.local/v1/models"* ]]; then echo "OK 200"; exit 0; fi',
           '  case "$cmd" in',
           "    *'curl -so'*)",
           "      echo '__NEMOCLAW_SANDBOX_EXEC_STARTED__'",
@@ -250,7 +251,7 @@ describe("CLI connect recovery process contracts", () => {
           PATH: `${localBin}:${process.env.PATH || ""}`,
         });
 
-        expect(result.code).toBe(0);
+        expect(result.code, result.out).toBe(0);
         expect(result.out).toContain(expectedOutput);
         expect(result.out).not.toContain(unexpectedOutput);
         const calls = fs.readFileSync(markerFile, "utf8").trim().split("\n").filter(Boolean);
@@ -300,6 +301,7 @@ describe("CLI connect recovery process contracts", () => {
           "fi",
           'if [ "$1" = "sandbox" ] && [ "$2" = "exec" ] && [ "$3" = "--name" ] && [ "$4" = "alpha" ]; then',
           '  cmd="$8"',
+          '  if [[ "$*" == *"inference.local/v1/models"* ]]; then echo "OK 200"; exit 0; fi',
           '  if [[ "$cmd" == *"curl -so"* ]]; then',
           "    echo '__NEMOCLAW_SANDBOX_EXEC_STARTED__'",
           '    if [ "$(cat "$state_file")" = recovered ]; then echo RUNNING; else echo STOPPED; fi',
@@ -370,6 +372,7 @@ describe("CLI connect recovery process contracts", () => {
         "fi",
         'if [ "$1" = "sandbox" ] && [ "$2" = "exec" ] && [ "$3" = "--name" ] && [ "$4" = "alpha" ]; then',
         '  cmd="$8"',
+        '  if [[ "$*" == *"inference.local/v1/models"* ]]; then echo "OK 200"; exit 0; fi',
         '  if [[ "$cmd" == *"curl -so"* ]]; then',
         "    echo '__NEMOCLAW_SANDBOX_EXEC_STARTED__'",
         '    if [ "$(cat "$state_file")" = recovered ]; then echo RUNNING; else echo STOPPED; fi',
@@ -397,7 +400,7 @@ describe("CLI connect recovery process contracts", () => {
         PATH: `${localBin}:${process.env.PATH || ""}`,
       });
 
-      expect(result.code).toBe(0);
+      expect(result.code, result.out).toBe(0);
       expect(result.out).toContain("Probe complete: recovered Hermes Agent gateway");
       const openshellLog = fs.readFileSync(openshellCalls, "utf8");
       expect(openshellLog).toContain("sandbox exec --name alpha -- sh -c");

--- a/test/sandbox-connect-inference/route-swap-repair.test.ts
+++ b/test/sandbox-connect-inference/route-swap-repair.test.ts
@@ -26,7 +26,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
       );
 
       const result = runConnect(tmpDir, sandboxName);
-      expect(result.status).toBe(0);
+      expect(result.status, `${result.stdout || ""}${result.stderr || ""}`).toBe(0);
 
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
       expect(state.inferenceGetCalls).toEqual([["-g", "nemoclaw"]]);
@@ -69,6 +69,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
             'BROKEN 503 {"error":"upstream unavailable"}',
             'BROKEN 503 {"error":"upstream unavailable"}',
             "OK 200",
+            "OK 200",
           ],
         },
       );
@@ -80,7 +81,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
         http_proxy: "http://127.0.0.1:9",
         no_proxy: "",
       });
-      expect(result.status).toBe(0);
+      expect(result.status, `${result.stdout || ""}${result.stderr || ""}`).toBe(0);
 
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
       const curlCalls = state.curlCalls as string[][];
@@ -138,6 +139,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
             'BROKEN 503 {"error":"upstream unavailable"}',
             'BROKEN 503 {"error":"upstream unavailable"}',
             "OK 200",
+            "OK 200",
           ],
           writeOllamaProxyState: false,
         },
@@ -158,7 +160,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
         WSL_DISTRO_NAME: "Ubuntu",
         no_proxy: "",
       });
-      expect(result.status).toBe(0);
+      expect(result.status, `${result.stdout || ""}${result.stderr || ""}`).toBe(0);
 
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
       const curlCalls = state.curlCalls as string[][];

--- a/test/support/connect-flow-test-harness.ts
+++ b/test/support/connect-flow-test-harness.ts
@@ -32,6 +32,8 @@ export type ConnectHarness = {
   errorSpy: MockInstance;
   logSpy: MockInstance;
   preflightVllmSpy: MockInstance;
+  probeLocalProviderHealthSpy: MockInstance;
+  probeOllamaAuthProxyHealthSpy: MockInstance;
   readSandboxConfigSpy: MockInstance;
   recoverPortableDemoLifecycleSpy: MockInstance;
   registryEntries: SandboxEntry[];
@@ -114,6 +116,7 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   const gatewayFailureClassifier = requireDist(
     "../../src/lib/actions/sandbox/gateway-failure-classifier.js",
   );
+  const localInference = requireDist("../../src/lib/inference/local.js");
   const ollamaProxy = requireDist("../../src/lib/inference/ollama/proxy.js");
   const gatewayRouteMutationLock = requireDist(
     "../../src/lib/inference/gateway-route-mutation-lock.js",
@@ -192,6 +195,13 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   const ensureOllamaAuthProxySpy = vi
     .spyOn(ollamaProxy, "ensureOllamaAuthProxy")
     .mockImplementation(() => undefined);
+  vi.spyOn(localInference, "findReachableOllamaHost").mockReturnValue("127.0.0.1");
+  const probeLocalProviderHealthSpy = vi
+    .spyOn(localInference, "probeLocalProviderHealth")
+    .mockReturnValue({ ok: true });
+  const probeOllamaAuthProxyHealthSpy = vi
+    .spyOn(ollamaProxy, "probeOllamaAuthProxyHealth")
+    .mockReturnValue({ ok: true });
   const primaryRegistryEntry: SandboxEntry = {
     name: "alpha",
     agent: options.agentName ?? "openclaw",
@@ -265,6 +275,8 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
     errorSpy,
     logSpy,
     preflightVllmSpy,
+    probeLocalProviderHealthSpy,
+    probeOllamaAuthProxyHealthSpy,
     readSandboxConfigSpy,
     recoverPortableDemoLifecycleSpy,
     registryEntries,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Harden the portable Ollama recovery shipped in #8506 so recovery cannot report success until the receipt-owned backend, authenticated proxy, and sandbox `inference.local/v1/models` route are usable. This follow-up contains the automated-review fixes that were not included when #8506 merged at its earlier head.

## Related Issue

Fixes #8502

Follow-up to #8506.

## Changes

- Ignore ambient proxy variables for the loopback `/api/tags` readiness probe and reject symlinked ownership-receipt parent paths.
- Always verify the semantic Ollama backend and authenticated proxy, then require HTTP 2xx from `inference.local/v1/models` before an `ollama-local` recovery succeeds.
- Keep route probing fail-closed when `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR=1`; the flag now disables mutation, not verification.
- Add one-time, explicit `NEMOCLAW_PORTABLE_OLLAMA_REENROLL=1` ownership enrollment for NemoClaw user-local installs that predate the receipt, with fixed-path regular-executable validation before any receipt write.
- Bind launch to the no-follow opened Ollama file identity through an inherited descriptor so a pathname replacement after validation cannot change the executed program.
- Add regressions for proxy bypass, `401`/`403`/`404`, post-repair strict verification, malformed and symlinked receipts, explicit re-enrollment, executable replacement, and disabled-repair failure.
- Clarify the recovery and lifecycle-flag documentation.

Product root cause: #8462 restored the Podman container, managed OpenClaw startup, and dashboard, while #8506 added Ollama restart ownership. Final review identified that the completion boundary still accepted non-2xx `inference.local` responses, could bypass probing with the repair-disable flag, and had no safe path for pre-receipt installations.

Detection gap: route tests treated every trusted `200`-`499` response as reachable and did not exercise provider-specific completion requirements. Receipt tests did not cover parent symlinks or explicit migration of a pre-receipt fixed executable.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the ownership, filesystem, process-launch, proxy, and inference completion boundaries. The receipt remains credential-free, fixed-path, owner-only, and no-follow; explicit re-enrollment validates the executable before writing; launch uses exact argv without a shell and executes the already-opened validated file identity; readiness is bounded and fail-closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/set-up-ollama.mdx`, `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx`, `docs/reference/commands.mdx`
- Agent: Codex Desktop `/root/docs_review_8509_final`
<!-- docs-review-head-sha: 40509912b -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused lifecycle suite: 2 files and 39 tests passed; `npm run test:changed`: 42 files and 566 tests passed after the final behavior change; final CI fixture regression: 2 files and 8 tests passed
- [ ] Applicable broad gate passed — not applicable; focused affected-suite, CLI build, CLI type-check, repository checks, and normal hooks passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 pre-existing Fern warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
