### PR TITLE
docs: add v0.0.104 release notes

### DIFF
--- a/docs/changelog/2026-08-06.mdx
+++ b/docs/changelog/2026-08-06.mdx
@@ -5,13 +5,10 @@
 
 ## v0.0.104
 
-NemoClaw v0.0.104 adds fixed local model serving profiles for vLLM and llama.cpp on DGX Spark, trusted private endpoint configuration, and a selectable Personal network policy tier.
+NemoClaw v0.0.104 adds trusted private endpoint configuration and a selectable Personal network policy tier.
 It makes agent manifests authoritative for persistent state and strengthens gateway, rebuild, registry, and uninstall recovery.
 It also improves Hermes configuration safety, MCP diagnostics, credential isolation, and host installation guidance.
 
-- The feature-gated fixed local model profile for DGX Spark now supports the explicit `--local-model-runtime=vllm` and `--local-model-runtime=llama-cpp` onboarding choices with a fixed model catalog, loopback-only authenticated endpoints, and ownership-aware cleanup.
-  Durable serving receipts preserve lifecycle provenance across recovery, DGX Spark storage admission reports remediable capacity problems, and a public llama.cpp `/v1/models` route is accepted only when `/props` remains protected.
-  For more information, refer to [Choose a Local Inference Server](/user-guide/openclaw/inference/local-inference/choose-local-inference-server), [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm), and [Understand Host Files and State](/user-guide/openclaw/reference/host-files-and-state).
 - Custom inference endpoints, MCP servers, and custom policy presets can now opt in to explicitly trusted private hosts.
   NemoClaw keeps exact host allowlists, pins generated `allowed_ips`, preserves those pins across restart and rebuild, and applies configured certificate authority trust without widening the endpoint policy.
   For more information, refer to [Meet Custom Endpoint Security Requirements](/user-guide/openclaw/inference/custom-endpoints/custom-endpoint-security), [Create Custom Policy Presets](/user-guide/openclaw/network-policy/configure-policies/create-custom-policy-presets), and [Configure Corporate CA Trust](/user-guide/openclaw/security/configure-corporate-ca-trust).

--- a/docs/changelog/2026-08-06.mdx
+++ b/docs/changelog/2026-08-06.mdx
@@ -1,0 +1,40 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.104
+
+NemoClaw v0.0.104 adds fixed local model serving profiles for vLLM and llama.cpp on DGX Spark, trusted private endpoint configuration, and a selectable Personal network policy tier.
+It makes agent manifests authoritative for persistent state and strengthens gateway, rebuild, registry, and uninstall recovery.
+It also improves Hermes configuration safety, MCP diagnostics, credential isolation, and host installation guidance.
+
+- The feature-gated fixed local model profile for DGX Spark now supports the explicit `--local-model-runtime=vllm` and `--local-model-runtime=llama-cpp` onboarding choices with a fixed model catalog, loopback-only authenticated endpoints, and ownership-aware cleanup.
+  Durable serving receipts preserve lifecycle provenance across recovery, DGX Spark storage admission reports remediable capacity problems, and a public llama.cpp `/v1/models` route is accepted only when `/props` remains protected.
+  For more information, refer to [Choose a Local Inference Server](/user-guide/openclaw/inference/local-inference/choose-local-inference-server), [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm), and [Understand Host Files and State](/user-guide/openclaw/reference/host-files-and-state).
+- Custom inference endpoints, MCP servers, and custom policy presets can now opt in to explicitly trusted private hosts.
+  NemoClaw keeps exact host allowlists, pins generated `allowed_ips`, preserves those pins across restart and rebuild, and applies configured certificate authority trust without widening the endpoint policy.
+  For more information, refer to [Meet Custom Endpoint Security Requirements](/user-guide/openclaw/inference/custom-endpoints/custom-endpoint-security), [Create Custom Policy Presets](/user-guide/openclaw/network-policy/configure-policies/create-custom-policy-presets), and [Configure Corporate CA Trust](/user-guide/openclaw/security/configure-corporate-ca-trust).
+- Onboarding now offers a Personal network policy tier for trusted single-user environments that need broad TCP access on ports 80 and 443.
+  The tier continues to block unspecified, loopback, and link-local destinations, and the documentation calls out its larger trust boundary so users can choose it deliberately.
+  For more information, refer to [Network Policies Reference](/user-guide/openclaw/reference/network-policies) and [Security Best Practices](/user-guide/openclaw/security/best-practices).
+- The selected agent manifest is now the canonical definition of persistent state for backup, restore, wipe, and Shields operations.
+  State operations fail closed when stored authority drifts from the manifest, and lifecycle lock timeouts remain side-effect free.
+  For more information, refer to [Create and Restore Snapshots](/user-guide/openclaw/manage-sandboxes/state-and-backups/create-and-restore-snapshots), [Security Best Practices](/user-guide/openclaw/security/best-practices), and [Trusted Computing Base](/user-guide/openclaw/security/trusted-computing-base).
+- Gateway and sandbox recovery now waits for the managed gateway lease, resumes journaled rebuild recreation, and applies compatibility decisions before rejecting a restored sandbox as not ready.
+  Malformed sandbox registry data fails closed, gateways that never served receive bounded boot-grace recovery, and registry repair remains scoped to the target gateway.
+  For more information, refer to [Understand Gateway Lifecycle Control](/user-guide/openclaw/manage-sandboxes/configure-sandboxes/understand-gateway-lifecycle-control), [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- Scoped uninstall now deletes the sandbox before removing its unit and preserves the gateway and unit when sandbox deletion fails, leaving a retryable state instead of partial teardown.
+  Desktop metadata no longer blocks uninstall when the managed runtime state is otherwise valid.
+  For more information, refer to [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Hermes configuration now comes from one typed policy, keeps the dashboard token only in the process environment, and recalculates the context window when the selected model changes.
+  WhatsApp setup reports the gateway and dashboard sessions separately, while the managed Hermes image and dependency checks include the reviewed security updates.
+  For more information, refer to [Switch Models](/user-guide/hermes/inference/manage-inference/switch-models), [Set Up WhatsApp](/user-guide/hermes/manage-sandboxes/messaging-channels/set-up-whatsapp), and [Credential Storage](/user-guide/hermes/security/credential-storage).
+- OpenClaw MCP discovery now has a bounded `tools/list` timeout that can be tuned from 1500 to 10000 milliseconds with `NEMOCLAW_MCP_TOOLS_LIST_TIMEOUT_MS`.
+  Opt-in `NEMOCLAW_MCP_SHADOW_DIAGNOSTICS=1` diagnostics report redacted operation timings and rolling latency summaries without changing MCP behavior.
+  For more information, refer to [Troubleshoot MCP Servers](/user-guide/openclaw/reference/troubleshoot-mcp-servers) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Onboarding now blocks raw Brave and Tavily web-search credentials from entering the sandbox and directs users to the supported credential flow.
+  Preflight remediation includes stable advisory identifiers, and malformed registry diagnostics remain redacted.
+  For more information, refer to [Credential Storage](/user-guide/openclaw/security/credential-storage) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- Installation now resolves `nemoclaw` through the user-local shim when required, and remote network-policy guidance opens the sandbox terminal with `openshell term` before running approval commands.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Approve Network Requests](/user-guide/openclaw/network-policy/approve-network-requests).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the canonical dated changelog entry required before cutting `v0.0.104`.
The entry reconciles user-facing changes merged from `v0.0.103` through `8d2b86aaf44968b4f7bc3b714222a73bd28e0403` while excluding hidden and experimental product surfaces.

## Changes

- Added `docs/changelog/2026-08-06.mdx` with the exact `## v0.0.104` heading and release themes for private endpoints, network policy, state authority, lifecycle recovery, uninstall, Hermes, MCP diagnostics, credential safety, and installation guidance.
- Source summary links:
  - [#8272](https://github.com/NVIDIA/NemoClaw/pull/8272) -> `docs/changelog/2026-08-06.mdx`: explicitly trusted private endpoints with stable policy pins and CA trust.
  - [#8431](https://github.com/NVIDIA/NemoClaw/pull/8431) -> `docs/changelog/2026-08-06.mdx`: Personal onboarding policy tier and its trust boundary.
  - [#8143](https://github.com/NVIDIA/NemoClaw/pull/8143) -> `docs/changelog/2026-08-06.mdx`: manifest-derived state authority.
  - [#7859](https://github.com/NVIDIA/NemoClaw/pull/7859) -> `docs/changelog/2026-08-06.mdx`: side-effect-free lifecycle lock timeouts.
  - [#8262](https://github.com/NVIDIA/NemoClaw/pull/8262) -> `docs/changelog/2026-08-06.mdx`: managed gateway lease waiting.
  - [#8339](https://github.com/NVIDIA/NemoClaw/pull/8339) -> `docs/changelog/2026-08-06.mdx`: continued journaled rebuild recreation.
  - [#8373](https://github.com/NVIDIA/NemoClaw/pull/8373) -> `docs/changelog/2026-08-06.mdx`: restore readiness after compatibility decisions.
  - [#8443](https://github.com/NVIDIA/NemoClaw/pull/8443) -> `docs/changelog/2026-08-06.mdx`: fail-closed malformed registry handling.
  - [#8419](https://github.com/NVIDIA/NemoClaw/pull/8419) -> `docs/changelog/2026-08-06.mdx`: bounded recovery for a gateway that never served.
  - [#8486](https://github.com/NVIDIA/NemoClaw/pull/8486) -> `docs/changelog/2026-08-06.mdx`: target-scoped registry recovery.
  - [#8259](https://github.com/NVIDIA/NemoClaw/pull/8259) -> `docs/changelog/2026-08-06.mdx`: scoped uninstall ordering and retry safety.
  - [#8457](https://github.com/NVIDIA/NemoClaw/pull/8457) -> `docs/changelog/2026-08-06.mdx`: desktop metadata exclusion during uninstall.
  - [#8026](https://github.com/NVIDIA/NemoClaw/pull/8026) -> `docs/changelog/2026-08-06.mdx`: typed Hermes configuration policy.
  - [#8242](https://github.com/NVIDIA/NemoClaw/pull/8242) -> `docs/changelog/2026-08-06.mdx`: Hermes WhatsApp session diagnostics.
  - [#8344](https://github.com/NVIDIA/NemoClaw/pull/8344) -> `docs/changelog/2026-08-06.mdx`: patched Hermes image and dependency checks.
  - [#8491](https://github.com/NVIDIA/NemoClaw/pull/8491) -> `docs/changelog/2026-08-06.mdx`: bounded MCP discovery timeout.
  - [#8490](https://github.com/NVIDIA/NemoClaw/pull/8490) -> `docs/changelog/2026-08-06.mdx`: MCP shadow diagnostics.
  - [#7619](https://github.com/NVIDIA/NemoClaw/pull/7619) -> `docs/changelog/2026-08-06.mdx`: web-search credential isolation.
  - [#8476](https://github.com/NVIDIA/NemoClaw/pull/8476) -> `docs/changelog/2026-08-06.mdx`: stable preflight advisory identifiers.
  - [#8452](https://github.com/NVIDIA/NemoClaw/pull/8452) -> `docs/changelog/2026-08-06.mdx`: user-local CLI resolution.
  - [#8481](https://github.com/NVIDIA/NemoClaw/pull/8481) -> `docs/changelog/2026-08-06.mdx`: remote network-policy terminal guidance.
- Product-scope exclusions: fixed local model profile work [#8399](https://github.com/NVIDIA/NemoClaw/pull/8399), [#8418](https://github.com/NVIDIA/NemoClaw/pull/8418), [#8422](https://github.com/NVIDIA/NemoClaw/pull/8422), [#8402](https://github.com/NVIDIA/NemoClaw/pull/8402), [#8391](https://github.com/NVIDIA/NemoClaw/pull/8391), [#8401](https://github.com/NVIDIA/NemoClaw/pull/8401), and [#8322](https://github.com/NVIDIA/NemoClaw/pull/8322) remains gated pending the activation decision and physical qualification tracked by [#8144](https://github.com/NVIDIA/NemoClaw/issues/8144); [#8429](https://github.com/NVIDIA/NemoClaw/pull/8429) remains experimental; [#8261](https://github.com/NVIDIA/NemoClaw/pull/8261) remains feature-gated; and portable-profile changes [#8408](https://github.com/NVIDIA/NemoClaw/pull/8408), [#8415](https://github.com/NVIDIA/NemoClaw/pull/8415), [#8446](https://github.com/NVIDIA/NemoClaw/pull/8446), [#8458](https://github.com/NVIDIA/NemoClaw/pull/8458), [#8462](https://github.com/NVIDIA/NemoClaw/pull/8462), and [#8506](https://github.com/NVIDIA/NemoClaw/pull/8506) are not promoted as supported product surfaces.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `npx vitest run test/changelog-docs.test.ts` passed 6/6 and validates dated changelog structure and published links.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-08-06.mdx`; release-range scope, Product Scope Gate exclusions, writing rules, documentation style, skip terms, exact names, threat-boundary wording, and published routes reviewed after the final correction; changelog tests and docs build passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 84db20b44 -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host preparation script changed.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6/6.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to a single changelog entry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The new dated changelog file includes the required parser-safe SPDX header and intentionally has no frontmatter, matching the changelog contract and existing entries.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.104.
  * Documented support for trusted private endpoints and the Personal network policy tier.
  * Added guidance on manifest-authoritative state, recovery and uninstall behavior, Hermes safety updates, MCP diagnostics, credential isolation, and installation.
  * Included information about fixes for local model runtimes and related operational improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
