### PR TITLE
fix(status): point SSH operators to dashboard-url for remote access

### DIFF
--- a/src/lib/actions/sandbox/status-flow.test.ts
+++ b/src/lib/actions/sandbox/status-flow.test.ts
@@ -675,6 +675,33 @@ describe("showSandboxStatus flow", () => {
     expect(output).not.toContain("Recovered NemoClaw gateway runtime");
   });
 
+  it("points SSH operators to dashboard-url for remote-access instructions when the gateway is running (#8465)", async () => {
+    vi.stubEnv("SSH_CONNECTION", "203.0.113.9 51000 198.51.100.2 22");
+    const harness = createStatusFlowHarness({ gatewayRunning: true });
+
+    await expect(harness.showSandboxStatus("alpha")).resolves.toBeUndefined();
+
+    const output = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("OpenClaw: ");
+    expect(output).toContain("running");
+    expect(output).toContain(
+      "Remote access: run `nemoclaw alpha dashboard-url` for SSH port-forward instructions.",
+    );
+  });
+
+  it("omits the remote-access pointer when the session is not over SSH (#8465)", async () => {
+    vi.stubEnv("SSH_CONNECTION", "");
+    vi.stubEnv("SSH_CLIENT", "");
+    vi.stubEnv("SSH_TTY", "");
+    const harness = createStatusFlowHarness({ gatewayRunning: true });
+
+    await expect(harness.showSandboxStatus("alpha")).resolves.toBeUndefined();
+
+    const output = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("running");
+    expect(output).not.toContain("Remote access: run");
+  });
+
   it("renders gateway-level handshake failures without removing registry state", async () => {
     const harness = createStatusFlowHarness({
       inferenceHealth: null,

--- a/src/lib/actions/sandbox/status-text.ts
+++ b/src/lib/actions/sandbox/status-text.ts
@@ -10,6 +10,7 @@ import { formatInferenceRouteDriftForDisplay } from "../../inference/config";
 import type { ProviderHealthStatus } from "../../inference/health";
 import * as nim from "../../inference/nim";
 import { getEffectiveReasoningEffort } from "../../inference/selection";
+import { isSshSession } from "../../onboard/ssh-forward-hint";
 import { getBaselineExclusionRuntimeStatus } from "../../policy";
 import {
   BASELINE_EXCLUSION_SUPPORT_IMPACT,
@@ -378,6 +379,17 @@ export function printSandboxDetails(context: SandboxStatusTextContext): SandboxS
   return { exitCode: inferenceExitCode ?? agentExitCode };
 }
 
+// On an SSH session the loopback-only dashboard needs a port forward to reach
+// from the operator's workstation. `status` does not print the dashboard URL,
+// so point to `dashboard-url`, which renders the copy-pastable `ssh -L` block.
+// This extends the #5925 remote-access guidance to the status surface (#8465).
+function printDashboardRemoteAccessHint(sandboxName: string): void {
+  if (!isSshSession()) return;
+  console.log(
+    `      Remote access: run \`${CLI_NAME} ${sandboxName} dashboard-url\` for SSH port-forward instructions.`,
+  );
+}
+
 async function printGatewayProcessStatus(context: SandboxStatusTextContext): Promise<void> {
   const { sandboxName, statusAgent } = context;
   const running = await isSandboxGatewayRunningForStatus(sandboxName);
@@ -385,6 +397,7 @@ async function printGatewayProcessStatus(context: SandboxStatusTextContext): Pro
   const agentName = statusAgent.agentDisplayName;
   if (running) {
     console.log(`    ${agentName}: ${G}running${R}`);
+    printDashboardRemoteAccessHint(sandboxName);
     return;
   }
   console.log(`    ${agentName}: ${RD}not running${R}`);

--- a/test/support/status-flow-test-harness.ts
+++ b/test/support/status-flow-test-harness.ts
@@ -30,6 +30,7 @@ export type StatusFlowHarness = {
   collectSandboxStatusSnapshotSpy: MockInstance;
   getActiveSandboxSessionsSpy: MockInstance;
   getSandboxDockerRuntimeSpy: MockInstance;
+  isSandboxGatewayRunningForStatusSpy: MockInstance;
   logSpy: MockInstance;
   removeSandboxSpy: MockInstance;
   showSandboxStatus: ShowSandboxStatus;
@@ -65,6 +66,7 @@ export type StatusFlowHarnessOptions = {
   baselineExclusionStatus?: BaselineExclusionRuntimeStatus;
   lookup?: SandboxGatewayState;
   lookupState?: "present" | "missing";
+  gatewayRunning?: boolean;
   preflight?: SandboxStatusPreflightResult;
   postRecoveryPreflight?: SandboxStatusPreflightResult;
   sandboxEntry?: Partial<Omit<typeof baseSandboxEntry, "agentVersion">> & {
@@ -201,7 +203,9 @@ export function createStatusFlowHarness(options: StatusFlowHarnessOptions = {}):
       health: "unhealthy",
       paused: false,
     });
-  vi.spyOn(statusProcessRecovery, "isSandboxGatewayRunningForStatus").mockResolvedValue(false);
+  const isSandboxGatewayRunningForStatusSpy = vi
+    .spyOn(statusProcessRecovery, "isSandboxGatewayRunningForStatus")
+    .mockResolvedValue(options.gatewayRunning ?? false);
   vi.spyOn(resolve, "resolveOpenshell").mockReturnValue("/usr/bin/openshell");
   vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue({ name: "openclaw" });
   vi.spyOn(agentRuntime, "getAgentDisplayName").mockReturnValue("OpenClaw");
@@ -248,6 +252,7 @@ export function createStatusFlowHarness(options: StatusFlowHarnessOptions = {}):
     collectSandboxStatusSnapshotSpy,
     getActiveSandboxSessionsSpy,
     getSandboxDockerRuntimeSpy,
+    isSandboxGatewayRunningForStatusSpy,
     logSpy,
     removeSandboxSpy,
     showSandboxStatus: requireDist(statusModulePath).showSandboxStatus,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`nemoclaw <sandbox> status` gave no remote-access guidance when run over SSH, so an operator on a remote host was left without a pointer to reach the loopback-only dashboard — unlike `dashboard-url` and the post-onboard block, which print an `ssh -L` port-forward example (#5925). When the gateway is running and the CLI is in an SSH session, status now prints a pointer to `nemoclaw <sandbox> dashboard-url`, which renders the copy-pastable port-forward block.

## Related Issue
Closes #8465

## Changes
- `src/lib/actions/sandbox/status-text.ts`: add `printDashboardRemoteAccessHint`, called in the running-gateway branch of `printGatewayProcessStatus`. It reuses the existing `isSshSession` helper from `ssh-forward-hint.ts` (#5925) and, only inside an SSH session, prints one line pointing to `nemoclaw <sandbox> dashboard-url`. Scoped to the gateway-runtime running path, so terminal-runtime sandboxes (which have no browser dashboard) are unaffected. This is a display-only status-output addition; it introduces no new abstraction, flag, or lifecycle behavior.
- `test/support/status-flow-test-harness.ts`: add an optional `gatewayRunning` option (default `false`, preserving every existing test) and expose the `isSandboxGatewayRunningForStatus` spy, so a test can drive the real running-gateway rendering path end-to-end.
- `src/lib/actions/sandbox/status-flow.test.ts`: add two tests — the pointer appears for a running gateway inside an SSH session, and is omitted when the session is not over SSH (SSH env controlled via `vi.stubEnv` so the result is deterministic even when the verifying host itself runs over SSH).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: adds a one-line SSH-gated pointer to the existing `dashboard-url` command; no new command, flag, or documented contract, and the remote-access/port-forward guidance it points to is already documented.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Display-only change under `actions/sandbox/` (status output rendering); it adds an SSH-gated guidance line and alters no sandbox lifecycle, credential, policy, or security behavior. Deferred to normal CODEOWNERS review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. The change adds a single SSH-gated status-output line pointing operators to the already-documented `nemoclaw <sandbox> dashboard-url` command; it introduces no new command, flag, configuration, or documented contract.
- Agent: Claude Code
<!-- docs-review-head-sha: da2270661 -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/actions/sandbox/status-flow.test.ts` on a fresh clone of this branch on an Ubuntu host (Node v22.23.1, `npm ci` + plugin build) → 35 passed. Two-way check: reverting only `status-text.ts` to `origin/main` (keeping the tests) fails exactly the new positive test (pointer absent = bug reproduced); the negative test still passes.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSH-aware sandbox status guidance.
  * When the sandbox gateway is running over SSH, status output now provides the dashboard port-forward command.
  * Local sessions continue to show streamlined status output without remote-access instructions.

* **Tests**
  * Added coverage to verify the guidance appears only for SSH sessions and is shown when the gateway is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->