### PR TITLE
fix(uninstall): stop deleting third-party OpenClaw Docker resources

### DIFF
--- a/scripts/smoke-macos-install.sh
+++ b/scripts/smoke-macos-install.sh
@@ -253,10 +253,14 @@ verify_cleanup() {
   fi
 
   if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    # Mirrors the uninstall selection in src/lib/actions/uninstall/run-plan.ts.
+    # `openclaw` is deliberately absent from both: uninstall does not remove the
+    # separate OpenClaw project's containers, so reporting them here would fail
+    # the smoke run on any host that also runs OpenClaw (#8496).
     local related_containers
     related_containers="$(
       docker ps -a --format '{{.Image}} {{.Names}}' 2>/dev/null \
-        | awk 'BEGIN { IGNORECASE=1 } /openshell-cluster|openshell|openclaw|nemoclaw/ { print }'
+        | awk 'BEGIN { IGNORECASE=1 } /openshell-cluster|openshell|nemoclaw/ { print }'
     )"
     if [ -n "$related_containers" ]; then
       warn "Related Docker containers remain after uninstall:"

--- a/scripts/smoke-macos-install.sh
+++ b/scripts/smoke-macos-install.sh
@@ -257,10 +257,14 @@ verify_cleanup() {
     # `openclaw` is deliberately absent from both: uninstall does not remove the
     # separate OpenClaw project's containers, so reporting them here would fail
     # the smoke run on any host that also runs OpenClaw (#8496).
+    # `tolower($0) ~` rather than `BEGIN { IGNORECASE=1 }`: IGNORECASE is a gawk
+    # extension. macOS ships BWK awk and Ubuntu defaults to mawk, and both accept
+    # the assignment and then match case-sensitively, so the mirror silently
+    # disagreed with the case-insensitive filter it mirrors.
     local related_containers
     related_containers="$(
       docker ps -a --format '{{.Image}} {{.Names}}' 2>/dev/null \
-        | awk 'BEGIN { IGNORECASE=1 } /openshell-cluster|openshell|nemoclaw/ { print }'
+        | awk 'tolower($0) ~ /openshell-cluster|openshell|nemoclaw/ { print }'
     )"
     if [ -n "$related_containers" ]; then
       warn "Related Docker containers remain after uninstall:"

--- a/src/lib/actions/uninstall/run-plan-docker-scope.test.ts
+++ b/src/lib/actions/uninstall/run-plan-docker-scope.test.ts
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type RunResult,
+  runUninstallPlan as runUninstallPlanBase,
+  type UninstallRunDeps,
+  type UninstallRunOptions,
+} from "./run-plan";
+
+function ok(stdout = ""): RunResult {
+  return { status: 0, stdout, stderr: "" };
+}
+
+function runUninstallPlan(options: UninstallRunOptions, deps: UninstallRunDeps) {
+  return runUninstallPlanBase(options, {
+    resolveGatewayTeardownAuthority: ({ gatewayName, gatewayPort }) => ({
+      gatewayName,
+      gatewayPort,
+      mode: "nemoclaw-managed",
+      source: gatewayPort === 8080 ? "packaged-service" : "standalone",
+      endpoint: null,
+      stateDir: null,
+      supervisor: null,
+      requiredCapabilities: [],
+    }),
+    ...deps,
+  });
+}
+
+// A host that also runs the separate OpenClaw project. `docker ps` reports
+// `{{.ID}} {{.Image}} {{.Names}}`, so the OpenClaw workload contributes both an
+// unrelated container name and an unrelated image reference; `docker images`
+// reports `{{.ID}} {{.Repository}}:{{.Tag}}`.
+const PS_OUTPUT = [
+  "c-cluster nemoclaw-cluster:native openshell-cluster-nemoclaw",
+  "c-sandbox nemoclaw-sandbox-local:build-1 openshell-my-assistant",
+  // Probe containers run with `--rm` and no `--name`, so an interrupted run
+  // leaves a randomly named container that only its image identifies.
+  "c-probe nemoclaw-hermes-sandbox-base-local:image-abc nostalgic_curie",
+  "c-openclaw ghcr.io/openclaw/openclaw:latest my-openclaw-test",
+  "c-unrelated redis:7 cache",
+].join("\n");
+
+const IMAGES_OUTPUT = [
+  "i-nemoclaw ghcr.io/nvidia/nemoclaw:test",
+  "i-openclaw ghcr.io/openclaw/openclaw:latest",
+  "i-unrelated redis:7",
+].join("\n");
+
+function collectDockerCalls(): { calls: string[][]; runDocker: UninstallRunDeps["runDocker"] } {
+  const calls: string[][] = [];
+  const dockerResponses: Record<string, RunResult> = {
+    ps: ok(`${PS_OUTPUT}\n`),
+    images: ok(`${IMAGES_OUTPUT}\n`),
+  };
+  const runDocker = vi.fn((args: string[]) => {
+    calls.push(args);
+    return dockerResponses[args[0] ?? ""] ?? ok();
+  });
+  return { calls, runDocker };
+}
+
+function runWithDockerInventory(): string[][] {
+  const { calls, runDocker } = collectDockerCalls();
+  const run = vi.fn((command: string, args: string[]) => {
+    const stubbed: Record<string, RunResult> = {
+      "-c": ok("/fake/bin/tool\n"),
+      "-f": ok(""),
+    };
+    return (
+      stubbed[args[0] ?? ""] ??
+      (command === "openshell" && args[0] === "gateway" && args[1] === "list"
+        ? ok(JSON.stringify([{ name: "nemoclaw" }]))
+        : ok())
+    );
+  });
+
+  const result = runUninstallPlan(
+    { assumeYes: true, deleteModels: false, keepOpenShell: true },
+    {
+      commandExists: () => true,
+      env: {
+        HOME: "/tmp/nemoclaw-uninstall-docker-scope",
+        NEMOCLAW_AGENT: "",
+        TMPDIR: "/tmp/nemoclaw-uninstall-docker-scope",
+      } as NodeJS.ProcessEnv,
+      existsSync: () => false,
+      isTty: false,
+      kill: () => true,
+      log: () => undefined,
+      rmSync: vi.fn(),
+      run,
+      runDocker,
+    },
+  );
+
+  expect(result.exitCode).toBe(0);
+  return calls;
+}
+
+describe("uninstall Docker resource scope", () => {
+  it("keeps containers belonging to the separate OpenClaw project (#8496)", () => {
+    const calls = runWithDockerInventory();
+
+    expect(calls).not.toContainEqual(["rm", "-f", "c-openclaw"]);
+    expect(calls).not.toContainEqual(["rm", "-f", "c-unrelated"]);
+  });
+
+  it("keeps images belonging to the separate OpenClaw project (#8496)", () => {
+    const calls = runWithDockerInventory();
+
+    expect(calls).not.toContainEqual(["rmi", "-f", "i-openclaw"]);
+    expect(calls).not.toContainEqual(["rmi", "-f", "i-unrelated"]);
+  });
+
+  it("still removes the gateway and sandbox containers it owns by name", () => {
+    const calls = runWithDockerInventory();
+
+    expect(calls).toContainEqual(["rm", "-f", "c-cluster"]);
+    expect(calls).toContainEqual(["rm", "-f", "c-sandbox"]);
+  });
+
+  it("still reclaims a randomly named probe container by its NemoClaw image", () => {
+    const calls = runWithDockerInventory();
+
+    expect(calls).toContainEqual(["rm", "-f", "c-probe"]);
+  });
+
+  it("still removes NemoClaw images published under a registry path", () => {
+    const calls = runWithDockerInventory();
+
+    expect(calls).toContainEqual(["rmi", "-f", "i-nemoclaw"]);
+  });
+});

--- a/src/lib/actions/uninstall/run-plan-docker-scope.test.ts
+++ b/src/lib/actions/uninstall/run-plan-docker-scope.test.ts
@@ -46,6 +46,9 @@ const PS_OUTPUT = [
 
 const IMAGES_OUTPUT = [
   "i-nemoclaw ghcr.io/nvidia/nemoclaw:test",
+  // The gateway builds sandbox images under this repository, so the `openshell`
+  // half of the filter selects real resources and must stay covered.
+  "i-openshell openshell/sandbox-from:1780294581",
   "i-openclaw ghcr.io/openclaw/openclaw:latest",
   "i-unrelated redis:7",
 ].join("\n");
@@ -133,5 +136,11 @@ describe("uninstall Docker resource scope", () => {
     const calls = runWithDockerInventory();
 
     expect(calls).toContainEqual(["rmi", "-f", "i-nemoclaw"]);
+  });
+
+  it("still removes gateway-built OpenShell sandbox images", () => {
+    const calls = runWithDockerInventory();
+
+    expect(calls).toContainEqual(["rmi", "-f", "i-openshell"]);
   });
 });

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -1570,7 +1570,16 @@ function removeDockerContainers(runtime: UninstallRuntime, gatewayName?: string)
         if (MANAGED_INFERENCE_CONTAINER_NAME_PATTERN.test(name)) {
           return false;
         }
-        return /openshell-cluster|openshell|openclaw|nemoclaw/i.test(line);
+        // `openclaw` is deliberately absent: NemoClaw's containers are
+        // `openshell-*` (cluster and sandbox) and `nemoclaw-*` (gateway compat
+        // and managed inference), so that term only ever selected the separate
+        // OpenClaw project's containers for `docker rm -f` (#8496).
+        // The whole `{{.ID}} {{.Image}} {{.Names}}` line is still matched
+        // rather than the name alone, because probe containers run with `--rm`
+        // and no `--name` (e.g. hermesBaseImageSupportsMcp) take a random
+        // Docker name; their NemoClaw image reference is the only way to
+        // reclaim one orphaned by an interrupted run.
+        return /openshell-cluster|openshell|nemoclaw/i.test(line);
       }
       return (
         name === `openshell-cluster-${gatewayName}` ||
@@ -1597,7 +1606,11 @@ function removeDockerImages(runtime: UninstallRuntime): void {
     env: runtime.env,
   });
   const ids = splitNonEmptyLines(result.stdout)
-    .filter((line) => /openshell|openclaw|nemoclaw/i.test(line))
+    // `openclaw` is deliberately absent: NemoClaw builds no image under that
+    // name, so the term only ever selected the separate OpenClaw project's
+    // images — including any `ghcr.io/openclaw/*` pulled by an unrelated
+    // workload — for `docker rmi -f` (#8496).
+    .filter((line) => /openshell|nemoclaw/i.test(line))
     .map((line) => line.split(/\s+/)[0]);
   if (ids.length === 0) {
     runtime.log(`No ${runtimeBranding(runtime).display}/OpenShell Docker images found`);

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -1574,11 +1574,11 @@ function removeDockerContainers(runtime: UninstallRuntime, gatewayName?: string)
         // `openshell-*` (cluster and sandbox) and `nemoclaw-*` (gateway compat
         // and managed inference), so that term only ever selected the separate
         // OpenClaw project's containers for `docker rm -f` (#8496).
-        // The whole `{{.ID}} {{.Image}} {{.Names}}` line is still matched
-        // rather than the name alone, because probe containers run with `--rm`
-        // and no `--name` (e.g. hermesBaseImageSupportsMcp) take a random
-        // Docker name; their NemoClaw image reference is the only way to
-        // reclaim one orphaned by an interrupted run.
+        // The whole `{{.ID}} {{.Image}} {{.Names}}` line is matched rather than
+        // the name alone. Probe containers that run with `--rm` and no
+        // `--name`, such as `hermesBaseImageSupportsMcp`, take a random Docker
+        // name. Their NemoClaw image reference is the only way to reclaim one
+        // that an interrupted run orphaned.
         return /openshell-cluster|openshell|nemoclaw/i.test(line);
       }
       return (


### PR DESCRIPTION
## Summary

`nemoclaw uninstall` selected Docker containers and images for forced removal by a substring alternation that included `openclaw`. NemoClaw creates no Docker resource under that name, so on a host that also runs the separate [OpenClaw](https://openclaw.ai) project, uninstall force-removed that project's containers and images. This drops `openclaw` from both filters so uninstall only reclaims resources NemoClaw owns.

## Related Issue

Refs #8496

## Changes

- `src/lib/actions/uninstall/run-plan.ts` — remove the `openclaw` alternative from the container filter in `removeDockerContainers` and the image filter in `removeDockerImages`, and record why the term must not return.
- `src/lib/actions/uninstall/run-plan-docker-scope.test.ts` (new) — regression coverage for both filters. Added as a sibling file because `run-plan.test.ts` is at 1484 lines against the 1500-line `defaultMaxLines` budget in `ci/test-file-size-budget.json`.
- `scripts/smoke-macos-install.sh` — `verify_cleanup` mirrors the same selection to report leftovers. Left unchanged it would report OpenClaw containers as leftovers and fail the smoke run for resources uninstall is now correct to leave alone. The check only warns; it removes nothing.

No abstraction, configuration, fallback, migration, or compatibility path is added.

### Why the whole-line match is retained

The container filter tests the whole `{{.ID}} {{.Image}} {{.Names}}` line rather than the extracted name. Narrowing to the name alone looks cleaner and would also address the report's "over-matches on registry/repository path segments" wording, but it regresses cleanup: probe containers run with `docker run --rm` and no `--name` (for example `hermesBaseImageSupportsMcp` at `src/lib/agent/base-image.ts:244-256`) take a random Docker name, so one orphaned by an interrupted run is identifiable only by its NemoClaw image reference.

Anchoring the image filter to owned repositories was also considered and rejected here: it would stop removing `ghcr.io/nvidia/nemoclaw:test`, which `src/lib/actions/uninstall/run-plan.test.ts:102` currently asserts uninstall does remove. Changing that asserted contract is a scope decision for maintainers, so this PR uses `Refs` rather than `Closes` and leaves the ownership-scoped selection the issue suggests to a follow-up.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no page enumerates the Docker resources uninstall selects. `docs/manage-sandboxes/uninstall-nemoclaw.mdx`, `docs/reference/commands.mdx`, and `docs/reference/host-files-and-state.mdx` describe removal only in NemoClaw-ownership terms, so no sentence becomes inaccurate and none was inaccurate before. No command, flag, output field, or documented default changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security and correctness review passed with no findings: https://github.com/NVIDIA/NemoClaw/pull/8517#pullrequestreview-4880291858
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The current revision changes the full-uninstall Docker selection, its macOS leftover check, and regression coverage without changing commands, flags, output, configuration, or documented procedures. Existing uninstall docs already scope removal to NemoClaw/OpenShell-managed runtime resources and recorded sandbox images. Preserving a separate OpenClaw deployment therefore aligns implementation with the published contract. `npm run docs` passed with 0 errors and 2 nonblocking Fern warnings.
- Agent: Codex Desktop (`/root/docs_8517`)
<!-- docs-review-head-sha: 3038d0073ef14f1afa24198f0d17b951c877cda6 -->
<!-- docs-review-agents-blob-sha: c69aad4d563f774afb9924b33122b9485a48cdeb -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/actions/uninstall/` → 15 files / 171 tests passed. The new file was confirmed to fail on the pre-fix code (`rm -f` and `rmi -f` both issued for the OpenClaw resources) and pass after, while its three non-regression cases pass on both revisions.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Note on the broad gate

`npm run test:fast` on this host reports failures that are unrelated to this change and reproduce without it. I ran the implicated uninstall files three times on each revision: with the fix 3/4/1 failures, without it 2/3/3. Every failure is `Test timed out in 5000ms` under load, and the `test/e2e/support` cluster fails on `jq: command not found`, which is not installed here. CI is the authority for the broad gate.

---

Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Docker cleanup during uninstall to target only NemoClaw and OpenShell containers and images.
  - OpenClaw and unrelated Docker resources are now preserved.
  - Cleanup now handles named and automatically generated NemoClaw containers, including resources identified through images and registry paths.
  - Added safeguards to ensure uninstall removes only resources owned by NemoClaw.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
