### PR TITLE
fix(ci): align locked graph verification with production install

### DIFF
--- a/scripts/audit-reviewed-npm-graph.mts
+++ b/scripts/audit-reviewed-npm-graph.mts
@@ -233,13 +233,27 @@ function materializeLockedGraph(
   fs.copyFileSync(sourcePackage, path.join(destination, "package.json"));
   fs.copyFileSync(sourceLock, path.join(destination, "package-lock.json"));
   run("npm", ["ci", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund"], destination);
-  verifyInstalledNpmLock({
+  verifyMaterializedLockedGraph({ destination, expectedLockSha256, label: graph.label });
+  return destination;
+}
+
+export function verifyMaterializedLockedGraph({
+  destination,
+  expectedLockSha256,
+  label,
+}: Readonly<{
+  destination: string;
+  expectedLockSha256: string;
+  label: string;
+}>): readonly string[] {
+  const lockfilePath = path.join(destination, "package-lock.json");
+  return verifyInstalledNpmLock({
     expectedLockSha256,
     installRoot: destination,
-    label: graph.label,
-    lockfilePath: path.join(destination, "package-lock.json"),
+    label,
+    lockfilePath,
+    omitDev: true,
   });
-  return destination;
 }
 
 export function selectReviewedLockSha256(
@@ -510,13 +524,7 @@ function main(): void {
     const reports = [
       {
         label: SOURCE_GRAPH.label,
-        result: auditSourceGraph(
-          config,
-          tempRoot,
-          exceptionFile,
-          artifactDirectory,
-          npmVersion,
-        ),
+        result: auditSourceGraph(config, tempRoot, exceptionFile, artifactDirectory, npmVersion),
       },
       {
         label: "reviewed archive graph",

--- a/test/reviewed-npm-audit-workflow.test.ts
+++ b/test/reviewed-npm-audit-workflow.test.ts
@@ -15,6 +15,7 @@ import {
   normalizeOpenClawSignatureAlias,
   parseAuditConfig,
   selectReviewedLockSha256,
+  verifyMaterializedLockedGraph,
 } from "../scripts/audit-reviewed-npm-graph.mts";
 import { verifyInstalledNpmLock } from "../scripts/lib/reviewed-npm-archive.mts";
 import type { AuditPolicyResult } from "../scripts/lib/reviewed-npm-audit.mts";
@@ -430,6 +431,38 @@ esac
       expect(fs.readFileSync(path.join(destination, "package-lock.json"), "utf-8")).toBe(
         lockSource,
       );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts an omitted development-only package in a locked production install (#8394)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-locked-production-"));
+    const lockfilePath = path.join(root, "package-lock.json");
+    const lockSource = `${JSON.stringify(
+      {
+        lockfileVersion: 3,
+        packages: {
+          "": {
+            devDependencies: { "@types/node": "25.5.2" },
+            name: "locked-production-fixture",
+            version: "1.0.0",
+          },
+          "node_modules/@types/node": { dev: true, version: "25.5.2" },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+    try {
+      fs.writeFileSync(lockfilePath, lockSource);
+      expect(
+        verifyMaterializedLockedGraph({
+          destination: root,
+          expectedLockSha256: createHash("sha256").update(lockSource).digest("hex"),
+          label: "locked production fixture",
+        }),
+      ).toEqual([]);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The reviewed npm audit now validates the same production-only package set that `npm ci --omit=dev` installs. This fixes the post-#8394 required-check regression reported by jobs `92781507051` in run `31151347942` and `92781717854` in run `31151390584`, where the verifier incorrectly required dev-only `@types/node@25.5.2`.

## Changes

- Pass the production-only boundary to installed-lock verification for every configured locked graph.
- Add an executable regression fixture proving a dev-only locked package may be absent while the lock digest remains verified.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This corrects an internal CI verifier to match its existing production-only install boundary; user commands, configuration, output, schemas, and supported workflows are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed all nine security categories with PASS. Lock SHA-256 verification, registry and integrity checks, production dependency reachability, and rejection of production dependencies incorrectly marked `dev: true` remain fail closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Internal reviewed-npm CI verification now honors the existing production-only install boundary after `npm ci --omit=dev`; no user command, configuration, output, schema, supported workflow, or documented behavior changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 39e8f4ff6 -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/reviewed-npm-audit-workflow.test.ts` passed 1 file and 21 tests; `npm run source-shape:check` and `npm run test-conditionals:scan -- --top 25` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of production installations by correctly allowing development-only packages to be omitted.
  * Preserved lockfile integrity checks during materialized installation verification.

* **Tests**
  * Added coverage for production installs that exclude development-only type packages while retaining the expected lockfile checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->