### PR TITLE
test(inference): stage OpenClaw llama.cpp qualification

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2298,6 +2298,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      agent_qualification_execution: ${{ steps.plan.outputs.agent_qualification_execution }}
       environment: ${{ steps.plan.outputs.environment }}
       execution: ${{ steps.plan.outputs.execution }}
       model_host_path: ${{ steps.plan.outputs.model_host_path }}
@@ -2459,6 +2460,10 @@ jobs:
         uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@f6304bc25fc35bfaa441c8c2fbfee38f72805a75
         with:
           build-cli: "false"
+
+      - name: Install OpenShell CLI for declarative OpenClaw qualification
+        if: ${{ needs.llama-cpp-dgx-spark-plan.outputs.agent_qualification_execution == 'enabled' }}
+        run: env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_API_KEY -u NVIDIA_INFERENCE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
 
       - name: Materialize trusted llama.cpp qualification plan
         env:
@@ -7515,8 +7520,6 @@ jobs:
             if (!response.ok) {
               core.setFailed(`Slack webhook returned ${response.status}`);
             }
-
-
       - name: Upload E2E runtime summary
         if: ${{ always() && github.event_name == 'push' }}
         uses: NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@7768e15eb90d3ee2d33432f481dfe8747e4f6d57

--- a/managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml
+++ b/managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: AgentQualification
+
+metadata:
+  id: llama-cpp.openclaw.spark-single.v1
+
+spec:
+  execution: disabled
+  agent: openclaw
+  image:
+    reference: ghcr.io/nvidia/nemoclaw/openclaw-sandbox@sha256:3648441718cdd6c2bc4c8fe39fa0d04d3931656b2063af34215cc51841cd0d5e
+    sourceRevision: eb1d2f5700393892f227ac9fd56f485fc6718bce
+  runtimeProvider: docker
+  sandbox:
+    name: nemoclaw-llama-cpp-openclaw
+    gpuAccess: disabled
+  route:
+    provider: llama-cpp-local
+    api: openai-completions
+    routedBaseUrl: https://inference.local/v1
+    upstreamBaseUrl: http://host.openshell.internal:8081/v1
+  probes:
+    - synchronous-chat
+    - streaming-chat
+    - agent-normal-turn
+    - agent-tool-call
+    - agent-tool-result-continuation
+    - agent-multi-turn
+  bounds:
+    commandTimeoutSeconds: 420
+    maxResponseBytes: 16777216
+    maxStreamEvents: 512
+    maxTokens: 32
+  expectations:
+    normal: PONG
+  sessions:
+    normal: llama-cpp-openclaw-normal
+    tool: llama-cpp-openclaw-tool
+  prompts:
+    normal: "Reply with exactly one word: PONG"
+    tool: "Use the read tool to read /tmp/nemoclaw-llama-cpp-tool.txt. Reply with exactly the file contents: LLAMA_CPP_OPENCLAW_TOOL_OK"
+    continuation: "Repeat the exact value LLAMA_CPP_OPENCLAW_TOOL_OK from the file you read in the prior turn."
+  fixture:
+    path: /tmp/nemoclaw-llama-cpp-tool.txt
+    value: LLAMA_CPP_OPENCLAW_TOOL_OK
+  tool:
+    name: read

--- a/scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts
+++ b/scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts
@@ -48,12 +48,13 @@ export function exportLlamaCppDgxSparkQualificationPlan(sourceRoot: string) {
   ) {
     throw new Error("protected llama.cpp DGX Spark qualification is not enabled");
   }
-  parseLlamaCppDgxSparkExecutionPlan(
+  const executionPlan = parseLlamaCppDgxSparkExecutionPlan(
     JSON.parse(config.publication_qualification_plan) as unknown,
     config.publication_qualification_plan_sha256,
   );
 
   return {
+    agent_qualification_execution: executionPlan.qualification.agentQualification.execution,
     environment: qualification.environment,
     execution: qualification.execution,
     model_host_path: qualification.model.hostPath,
@@ -72,6 +73,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const output = githubOutput(exportLlamaCppDgxSparkQualificationPlan(args[1]));
   const githubOutputPath = process.env.GITHUB_OUTPUT;
   if (githubOutputPath)
-    fs.appendFileSync(githubOutputPath, output, { encoding: "utf8", mode: 0o600 });
+    fs.appendFileSync(githubOutputPath, output, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
   else process.stdout.write(output);
 }

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -151,6 +151,12 @@ type LlamaCppQualificationRecipe = {
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 const manifestPath = path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml");
+const agentQualificationPath = path.join(
+  repoRoot,
+  "managed-inference",
+  "qualifications",
+  "llama-cpp.openclaw.spark-single.v1.yaml",
+);
 const recipePath = path.join(
   repoRoot,
   "managed-inference",
@@ -251,13 +257,48 @@ function parseImageManifest(source: string): ServerImageManifest {
   return document.toJS({ maxAliasCount: 0 }) as ServerImageManifest;
 }
 
+function parseAgentQualificationDocument(source: string): unknown {
+  const document = YAML.parseDocument(source, {
+    strict: true,
+    uniqueKeys: true,
+  });
+  const issues = [...document.errors, ...document.warnings];
+  if (issues.length > 0) {
+    throw new Error(`invalid llama.cpp agent qualification YAML: ${issues.join("; ")}`);
+  }
+  const value = document.toJS({ maxAliasCount: 0 }) as unknown;
+  assertExactKeys(value, "agent qualification document", [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec",
+  ]);
+  const qualification = value as {
+    apiVersion?: unknown;
+    kind?: unknown;
+    metadata?: unknown;
+    spec?: unknown;
+  };
+  assertExactKeys(qualification.metadata, "agent qualification metadata", ["id"]);
+  if (
+    qualification.apiVersion !== "nemoclaw.nvidia.com/managed-inference/v1" ||
+    qualification.kind !== "AgentQualification" ||
+    (qualification.metadata as { id?: unknown }).id !== "llama-cpp.openclaw.spark-single.v1"
+  ) {
+    throw new Error("invalid llama.cpp agent qualification identity");
+  }
+  return qualification.spec;
+}
+
 export function loadLlamaCppImageConfig(
   source = fs.readFileSync(manifestPath, "utf8"),
   recipeSource = fs.readFileSync(recipePath, "utf8"),
   recipeSchemaSource = fs.readFileSync(recipeSchemaPath, "utf8"),
+  agentQualificationSource = fs.readFileSync(agentQualificationPath, "utf8"),
 ) {
   const manifest = parseImageManifest(source);
   const recipe = parseQualificationRecipe(recipeSource, recipeSchemaSource);
+  const agentQualification = parseAgentQualificationDocument(agentQualificationSource);
   assertExactKeys(manifest, "manifest", ["apiVersion", "kind", "metadata", "spec"]);
   assertExactKeys(manifest.metadata, "metadata", ["id"]);
   assertExactKeys(manifest.spec, "spec", [
@@ -674,6 +715,7 @@ export function loadLlamaCppImageConfig(
       },
     },
     qualification: {
+      agentQualification,
       probeBounds: qualification?.probeBounds,
       probes: qualification?.probes,
     },
@@ -868,6 +910,10 @@ export function loadLlamaCppImageConfigFromRoot(sourceRoot: string) {
       "managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
     ),
     fs.readFileSync(recipeSchemaPath, "utf8"),
+    readBoundedRegularFile(
+      root,
+      "managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml",
+    ),
   );
 }
 

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -9,6 +9,7 @@ import Ajv2020 from "ajv/dist/2020.js";
 import YAML from "yaml";
 
 import {
+  LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH,
   LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
   llamaCppDgxSparkExecutionPlanSha256,
   parseLlamaCppDgxSparkExecutionPlan,
@@ -151,12 +152,7 @@ type LlamaCppQualificationRecipe = {
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 const manifestPath = path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml");
-const agentQualificationPath = path.join(
-  repoRoot,
-  "managed-inference",
-  "qualifications",
-  "llama-cpp.openclaw.spark-single.v1.yaml",
-);
+const agentQualificationPath = path.join(repoRoot, LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH);
 const recipePath = path.join(
   repoRoot,
   "managed-inference",
@@ -910,10 +906,7 @@ export function loadLlamaCppImageConfigFromRoot(sourceRoot: string) {
       "managed-inference/recipes/llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
     ),
     fs.readFileSync(recipeSchemaPath, "utf8"),
-    readBoundedRegularFile(
-      root,
-      "managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml",
-    ),
+    readBoundedRegularFile(root, LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH),
   );
 }
 

--- a/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
+++ b/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
@@ -51,8 +51,29 @@ export const LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES = [
   "cancellation",
   "client-timeout",
 ] as const;
+export const LLAMA_CPP_DGX_SPARK_AGENT_PROBES = [
+  "synchronous-chat",
+  "streaming-chat",
+  "agent-normal-turn",
+  "agent-tool-call",
+  "agent-tool-result-continuation",
+  "agent-multi-turn",
+] as const;
+export const LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE =
+  "ghcr.io/nvidia/nemoclaw/openclaw-sandbox@sha256:3648441718cdd6c2bc4c8fe39fa0d04d3931656b2063af34215cc51841cd0d5e" as const;
+export const LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION =
+  "eb1d2f5700393892f227ac9fd56f485fc6718bce" as const;
+export const LLAMA_CPP_DGX_SPARK_OPENCLAW_NORMAL_PROMPT =
+  "Reply with exactly one word: PONG" as const;
+export const LLAMA_CPP_DGX_SPARK_OPENCLAW_TOOL_PROMPT =
+  "Use the read tool to read /tmp/nemoclaw-llama-cpp-tool.txt. Reply with exactly the file contents: LLAMA_CPP_OPENCLAW_TOOL_OK" as const;
+export const LLAMA_CPP_DGX_SPARK_OPENCLAW_CONTINUATION_PROMPT =
+  "Repeat the exact value LLAMA_CPP_OPENCLAW_TOOL_OK from the file you read in the prior turn." as const;
 
-const LLAMA_CPP_DGX_SPARK_CLIENT_TIMEOUT_RANGE = { maximum: 10_000, minimum: 10 } as const;
+const LLAMA_CPP_DGX_SPARK_CLIENT_TIMEOUT_RANGE = {
+  maximum: 10_000,
+  minimum: 10,
+} as const;
 const LLAMA_CPP_DGX_SPARK_CONTEXT_SIZE_RANGE = {
   maximum: 1024 * 1024,
   minimum: 1024,
@@ -148,6 +169,7 @@ export type LlamaCppDgxSparkExecutionPlan = {
     };
   };
   readonly qualification: {
+    readonly agentQualification: LlamaCppDgxSparkAgentQualificationPlan;
     readonly probeBounds: LlamaCppDgxSparkQualificationPlan["probeBounds"];
     readonly probes: typeof LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES;
   };
@@ -255,7 +277,97 @@ export type LlamaCppDgxSparkExecutionPlan = {
   };
 };
 
+export type LlamaCppDgxSparkAgentQualificationPlan = {
+  readonly agent: "openclaw";
+  readonly bounds: {
+    readonly commandTimeoutSeconds: number;
+    readonly maxResponseBytes: number;
+    readonly maxStreamEvents: number;
+    readonly maxTokens: number;
+  };
+  readonly execution: "disabled" | "enabled";
+  readonly fixture: {
+    readonly path: "/tmp/nemoclaw-llama-cpp-tool.txt";
+    readonly value: "LLAMA_CPP_OPENCLAW_TOOL_OK";
+  };
+  readonly image: {
+    readonly reference: typeof LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE;
+    readonly sourceRevision: typeof LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION;
+  };
+  readonly expectations: {
+    readonly normal: "PONG";
+  };
+  readonly probes: typeof LLAMA_CPP_DGX_SPARK_AGENT_PROBES;
+  readonly prompts: {
+    readonly continuation: typeof LLAMA_CPP_DGX_SPARK_OPENCLAW_CONTINUATION_PROMPT;
+    readonly normal: typeof LLAMA_CPP_DGX_SPARK_OPENCLAW_NORMAL_PROMPT;
+    readonly tool: typeof LLAMA_CPP_DGX_SPARK_OPENCLAW_TOOL_PROMPT;
+  };
+  readonly route: {
+    readonly api: "openai-completions";
+    readonly provider: "llama-cpp-local";
+    readonly routedBaseUrl: "https://inference.local/v1";
+    readonly upstreamBaseUrl: "http://host.openshell.internal:8081/v1";
+  };
+  readonly runtimeProvider: "docker";
+  readonly sandbox: {
+    readonly gpuAccess: "disabled";
+    readonly name: "nemoclaw-llama-cpp-openclaw";
+  };
+  readonly sessions: {
+    readonly normal: "llama-cpp-openclaw-normal";
+    readonly tool: "llama-cpp-openclaw-tool";
+  };
+  readonly tool: {
+    readonly name: "read";
+  };
+};
+
 export type LlamaCppDgxSparkQualificationReceipt = {
+  readonly agentQualification:
+    | { readonly execution: "disabled" }
+    | {
+        readonly agent: "openclaw";
+        readonly cleanup: {
+          readonly gatewayRemoved: true;
+          readonly networkRemoved: true;
+          readonly sandboxRemoved: true;
+          readonly stateRemoved: true;
+        };
+        readonly execution: "enabled";
+        readonly image: {
+          readonly reference: typeof LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE;
+          readonly sourceRevision: typeof LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION;
+        };
+        readonly model: {
+          readonly chatTemplate: "nemotron-v3-embedded";
+          readonly id: typeof LLAMA_CPP_DGX_SPARK_MODEL_ID;
+          readonly quantization: "UD-Q4_K_XL";
+          readonly servedName: typeof LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID;
+        };
+        readonly platform: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM;
+        readonly probes: {
+          readonly agentMultiTurn: true;
+          readonly agentNormalTurn: true;
+          readonly agentToolCall: {
+            readonly argumentsValid: true;
+            readonly name: "read";
+          };
+          readonly agentToolResultContinuation: true;
+          readonly streamingChat: {
+            readonly done: true;
+            readonly events: number;
+          };
+          readonly synchronousChat: true;
+        };
+        readonly route: {
+          readonly api: "openai-completions";
+          readonly provider: "llama-cpp-local";
+          readonly routedBaseUrl: "https://inference.local/v1";
+          readonly upstreamBaseUrl: "http://host.openshell.internal:8081/v1";
+        };
+        readonly runtimeProvider: "docker";
+      };
   readonly baseSha: string;
   readonly cleanup: {
     readonly containerRemoved: true;
@@ -402,7 +514,10 @@ function parseActivationYaml(source: string): unknown {
       "llama.cpp DGX Spark activation YAML is empty, exceeds 4096 bytes, or contains control characters",
     );
   }
-  const document = YAML.parseDocument(source, { strict: true, uniqueKeys: true });
+  const document = YAML.parseDocument(source, {
+    strict: true,
+    uniqueKeys: true,
+  });
   if (document.errors.length > 0 || document.warnings.length > 0) {
     throw new Error("llama.cpp DGX Spark activation YAML is invalid");
   }
@@ -503,6 +618,154 @@ function parseProtocolProbeBounds(
   };
 }
 
+function boundedText(value: unknown, label: string, maximum: number): string {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > maximum ||
+    /[\0\r\n]/u.test(value)
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function parseAgentQualification(value: unknown): LlamaCppDgxSparkAgentQualificationPlan {
+  const qualification = record(value, "llama.cpp DGX Spark agent qualification");
+  requireExactKeys(
+    qualification,
+    [
+      "agent",
+      "bounds",
+      "execution",
+      "expectations",
+      "fixture",
+      "image",
+      "probes",
+      "prompts",
+      "route",
+      "runtimeProvider",
+      "sandbox",
+      "sessions",
+      "tool",
+    ],
+    "llama.cpp DGX Spark agent qualification",
+  );
+  const bounds = record(qualification.bounds, "agent qualification bounds");
+  requireExactKeys(
+    bounds,
+    ["commandTimeoutSeconds", "maxResponseBytes", "maxStreamEvents", "maxTokens"],
+    "agent qualification bounds",
+  );
+  const fixture = record(qualification.fixture, "agent qualification fixture");
+  requireExactKeys(fixture, ["path", "value"], "agent qualification fixture");
+  const expectations = record(qualification.expectations, "agent qualification expectations");
+  requireExactKeys(expectations, ["normal"], "agent qualification expectations");
+  const image = record(qualification.image, "agent qualification image");
+  requireExactKeys(image, ["reference", "sourceRevision"], "agent qualification image");
+  const prompts = record(qualification.prompts, "agent qualification prompts");
+  requireExactKeys(prompts, ["continuation", "normal", "tool"], "agent qualification prompts");
+  const route = record(qualification.route, "agent qualification route");
+  requireExactKeys(
+    route,
+    ["api", "provider", "routedBaseUrl", "upstreamBaseUrl"],
+    "agent qualification route",
+  );
+  const sandbox = record(qualification.sandbox, "agent qualification sandbox");
+  requireExactKeys(sandbox, ["gpuAccess", "name"], "agent qualification sandbox");
+  const sessions = record(qualification.sessions, "agent qualification sessions");
+  requireExactKeys(sessions, ["normal", "tool"], "agent qualification sessions");
+  const tool = record(qualification.tool, "agent qualification tool");
+  requireExactKeys(tool, ["name"], "agent qualification tool");
+
+  const execution = qualification.execution;
+  const normalPrompt = boundedText(prompts.normal, "agent qualification normal prompt", 512);
+  const toolPrompt = boundedText(prompts.tool, "agent qualification tool prompt", 1024);
+  const continuationPrompt = boundedText(
+    prompts.continuation,
+    "agent qualification continuation prompt",
+    512,
+  );
+  if (
+    (execution !== "disabled" && execution !== "enabled") ||
+    qualification.agent !== "openclaw" ||
+    qualification.runtimeProvider !== "docker" ||
+    image.reference !== LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE ||
+    image.sourceRevision !== LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION ||
+    JSON.stringify(qualification.probes) !== JSON.stringify(LLAMA_CPP_DGX_SPARK_AGENT_PROBES) ||
+    fixture.path !== "/tmp/nemoclaw-llama-cpp-tool.txt" ||
+    fixture.value !== "LLAMA_CPP_OPENCLAW_TOOL_OK" ||
+    expectations.normal !== "PONG" ||
+    tool.name !== "read" ||
+    route.provider !== "llama-cpp-local" ||
+    route.api !== "openai-completions" ||
+    route.routedBaseUrl !== "https://inference.local/v1" ||
+    route.upstreamBaseUrl !== "http://host.openshell.internal:8081/v1" ||
+    sandbox.name !== "nemoclaw-llama-cpp-openclaw" ||
+    sandbox.gpuAccess !== "disabled" ||
+    sessions.normal !== "llama-cpp-openclaw-normal" ||
+    sessions.tool !== "llama-cpp-openclaw-tool" ||
+    normalPrompt !== LLAMA_CPP_DGX_SPARK_OPENCLAW_NORMAL_PROMPT ||
+    toolPrompt !== LLAMA_CPP_DGX_SPARK_OPENCLAW_TOOL_PROMPT ||
+    continuationPrompt !== LLAMA_CPP_DGX_SPARK_OPENCLAW_CONTINUATION_PROMPT
+  ) {
+    throw new Error("compiled llama.cpp DGX Spark agent qualification is invalid");
+  }
+  return {
+    agent: "openclaw",
+    bounds: {
+      commandTimeoutSeconds: boundedInteger(
+        bounds.commandTimeoutSeconds,
+        "agent qualification command timeout",
+        30,
+        900,
+      ),
+      maxResponseBytes: boundedInteger(
+        bounds.maxResponseBytes,
+        "agent qualification response bound",
+        64 * 1024,
+        64 * 1024 * 1024,
+      ),
+      maxStreamEvents: boundedInteger(
+        bounds.maxStreamEvents,
+        "agent qualification stream event bound",
+        8,
+        4096,
+      ),
+      maxTokens: boundedInteger(bounds.maxTokens, "agent qualification token bound", 1, 512),
+    },
+    execution,
+    expectations: { normal: "PONG" },
+    fixture: {
+      path: "/tmp/nemoclaw-llama-cpp-tool.txt",
+      value: "LLAMA_CPP_OPENCLAW_TOOL_OK",
+    },
+    image: {
+      reference: LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE,
+      sourceRevision: LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION,
+    },
+    probes: LLAMA_CPP_DGX_SPARK_AGENT_PROBES,
+    prompts: {
+      continuation: LLAMA_CPP_DGX_SPARK_OPENCLAW_CONTINUATION_PROMPT,
+      normal: LLAMA_CPP_DGX_SPARK_OPENCLAW_NORMAL_PROMPT,
+      tool: LLAMA_CPP_DGX_SPARK_OPENCLAW_TOOL_PROMPT,
+    },
+    route: {
+      api: "openai-completions",
+      provider: "llama-cpp-local",
+      routedBaseUrl: "https://inference.local/v1",
+      upstreamBaseUrl: "http://host.openshell.internal:8081/v1",
+    },
+    runtimeProvider: "docker",
+    sandbox: { gpuAccess: "disabled", name: "nemoclaw-llama-cpp-openclaw" },
+    sessions: {
+      normal: "llama-cpp-openclaw-normal",
+      tool: "llama-cpp-openclaw-tool",
+    },
+    tool: { name: "read" },
+  };
+}
+
 function requiredSha(value: unknown, label: string): string {
   if (typeof value !== "string" || !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(value)) {
     throw new Error(`${label} is invalid`);
@@ -530,7 +793,11 @@ function driverVersionAtLeast(actual: string, minimum: string): boolean {
 function parseInfrastructure(
   value: Record<string, unknown>,
   execution: "disabled" | "enabled",
-): { environment: string | null; hostPath: string | null; runner: string | null } {
+): {
+  environment: string | null;
+  hostPath: string | null;
+  runner: string | null;
+} {
   const environment = value.environment;
   const runner = value.runner;
   const model = record(value.model, "llama.cpp DGX Spark qualification model");
@@ -660,13 +927,18 @@ export function parseLlamaCppDgxSparkExecutionPlan(
   }
 
   const qualification = record(plan.qualification, "compiled protocol qualification");
-  requireExactKeys(qualification, ["probeBounds", "probes"], "compiled protocol qualification");
+  requireExactKeys(
+    qualification,
+    ["agentQualification", "probeBounds", "probes"],
+    "compiled protocol qualification",
+  );
   if (
     JSON.stringify(qualification.probes) !== JSON.stringify(LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES)
   ) {
     throw new Error("compiled llama.cpp DGX Spark protocol probes are invalid");
   }
   const protocolProbeBounds = parseProtocolProbeBounds(qualification.probeBounds);
+  const agentQualification = parseAgentQualification(qualification.agentQualification);
 
   const imageBuild = record(plan.imageBuild, "compiled qualification image build");
   requireExactKeys(
@@ -1021,6 +1293,7 @@ export function parseLlamaCppDgxSparkExecutionPlan(
       },
     },
     qualification: {
+      agentQualification,
       probeBounds: protocolProbeBounds,
       probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
     },
@@ -1070,7 +1343,12 @@ export function parseLlamaCppDgxSparkExecutionPlan(
           baseImage: LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE,
           minimumDriverVersion: recipeCuda.minimumDriverVersion,
         },
-        gpu: { vendor: "nvidia", count: 1, offload: "full", cpuFallback: "reject" },
+        gpu: {
+          vendor: "nvidia",
+          count: 1,
+          offload: "full",
+          cpuFallback: "reject",
+        },
         resources: { memoryBytes, writableStorageBytes, pidsLimit },
       },
       serve: {
@@ -1157,12 +1435,15 @@ export function parseLlamaCppDgxSparkQualificationEvidenceIdentity(
 export function parseLlamaCppDgxSparkQualificationReceipt(
   value: unknown,
   expectedValue: unknown,
+  expectedPlanValue: unknown,
 ): LlamaCppDgxSparkQualificationReceipt {
   const expected = parseLlamaCppDgxSparkQualificationEvidenceIdentity(expectedValue);
+  const expectedPlan = parseLlamaCppDgxSparkExecutionPlan(expectedPlanValue);
   const receipt = record(value, "llama.cpp DGX Spark qualification receipt");
   requireExactKeys(
     receipt,
     [
+      "agentQualification",
       "baseSha",
       "cleanup",
       "execution",
@@ -1189,6 +1470,141 @@ export function parseLlamaCppDgxSparkQualificationReceipt(
     !LLAMA_CPP_DGX_SPARK_SHA_PATTERN.test(String(receipt.workflowSha))
   ) {
     throw new Error("llama.cpp DGX Spark qualification receipt identity is invalid");
+  }
+
+  const agentQualification = record(
+    receipt.agentQualification,
+    "llama.cpp DGX Spark agent qualification receipt",
+  );
+  let parsedAgentQualification: LlamaCppDgxSparkQualificationReceipt["agentQualification"];
+  if (expectedPlan.qualification.agentQualification.execution === "disabled") {
+    if (agentQualification.execution !== "disabled") {
+      throw new Error("llama.cpp DGX Spark agent qualification ran without declarative activation");
+    }
+    requireExactKeys(agentQualification, ["execution"], "agent qualification receipt");
+    parsedAgentQualification = { execution: "disabled" };
+  } else {
+    requireExactKeys(
+      agentQualification,
+      [
+        "agent",
+        "cleanup",
+        "execution",
+        "image",
+        "model",
+        "platform",
+        "probes",
+        "route",
+        "runtimeProvider",
+      ],
+      "agent qualification receipt",
+    );
+    const agentImage = record(agentQualification.image, "agent qualification receipt image");
+    requireExactKeys(agentImage, ["reference", "sourceRevision"], "agent receipt image");
+    const agentModel = record(agentQualification.model, "agent qualification receipt model");
+    requireExactKeys(
+      agentModel,
+      ["chatTemplate", "id", "quantization", "servedName"],
+      "agent receipt model",
+    );
+    const agentRoute = record(agentQualification.route, "agent qualification receipt route");
+    requireExactKeys(
+      agentRoute,
+      ["api", "provider", "routedBaseUrl", "upstreamBaseUrl"],
+      "agent receipt route",
+    );
+    const agentProbes = record(agentQualification.probes, "agent qualification receipt probes");
+    requireExactKeys(
+      agentProbes,
+      [
+        "agentMultiTurn",
+        "agentNormalTurn",
+        "agentToolCall",
+        "agentToolResultContinuation",
+        "streamingChat",
+        "synchronousChat",
+      ],
+      "agent receipt probes",
+    );
+    const agentToolCall = record(agentProbes.agentToolCall, "agent tool-call probe");
+    requireExactKeys(agentToolCall, ["argumentsValid", "name"], "agent tool-call probe");
+    const agentStreaming = record(agentProbes.streamingChat, "agent streaming probe");
+    requireExactKeys(agentStreaming, ["done", "events"], "agent streaming probe");
+    const agentStreamingEvents = boundedInteger(
+      agentStreaming.events,
+      "agent streaming event count",
+      2,
+      expectedPlan.qualification.agentQualification.bounds.maxStreamEvents,
+    );
+    const agentCleanup = record(agentQualification.cleanup, "agent qualification cleanup");
+    requireExactKeys(
+      agentCleanup,
+      ["gatewayRemoved", "networkRemoved", "sandboxRemoved", "stateRemoved"],
+      "agent qualification cleanup",
+    );
+    const configured = expectedPlan.qualification.agentQualification;
+    if (
+      agentQualification.execution !== "enabled" ||
+      agentQualification.agent !== configured.agent ||
+      agentQualification.runtimeProvider !== configured.runtimeProvider ||
+      agentQualification.platform !== LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM ||
+      agentImage.reference !== configured.image.reference ||
+      agentImage.sourceRevision !== configured.image.sourceRevision ||
+      agentModel.id !== expectedPlan.recipe.model.id ||
+      agentModel.servedName !== expectedPlan.recipe.model.servedName ||
+      agentModel.quantization !== expectedPlan.recipe.model.file.quantization ||
+      agentModel.chatTemplate !== expectedPlan.recipe.serve.chatTemplate ||
+      agentRoute.provider !== configured.route.provider ||
+      agentRoute.api !== configured.route.api ||
+      agentRoute.routedBaseUrl !== configured.route.routedBaseUrl ||
+      agentRoute.upstreamBaseUrl !== configured.route.upstreamBaseUrl ||
+      agentProbes.synchronousChat !== true ||
+      agentProbes.agentNormalTurn !== true ||
+      agentProbes.agentMultiTurn !== true ||
+      agentProbes.agentToolResultContinuation !== true ||
+      agentStreaming.done !== true ||
+      agentToolCall.name !== configured.tool.name ||
+      agentToolCall.argumentsValid !== true ||
+      Object.values(agentCleanup).some((entry) => entry !== true)
+    ) {
+      throw new Error("llama.cpp DGX Spark agent qualification evidence is invalid");
+    }
+    parsedAgentQualification = {
+      agent: "openclaw",
+      cleanup: {
+        gatewayRemoved: true,
+        networkRemoved: true,
+        sandboxRemoved: true,
+        stateRemoved: true,
+      },
+      execution: "enabled",
+      image: {
+        reference: LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE,
+        sourceRevision: LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION,
+      },
+      model: {
+        chatTemplate: "nemotron-v3-embedded",
+        id: LLAMA_CPP_DGX_SPARK_MODEL_ID,
+        quantization: "UD-Q4_K_XL",
+        servedName: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+      },
+      platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+      probes: {
+        agentMultiTurn: true,
+        agentNormalTurn: true,
+        agentToolCall: { argumentsValid: true, name: "read" },
+        agentToolResultContinuation: true,
+        streamingChat: { done: true, events: agentStreamingEvents },
+        synchronousChat: true,
+      },
+      route: {
+        api: "openai-completions",
+        provider: "llama-cpp-local",
+        routedBaseUrl: "https://inference.local/v1",
+        upstreamBaseUrl: "http://host.openshell.internal:8081/v1",
+      },
+      runtimeProvider: "docker",
+    };
   }
 
   const run = record(receipt.run, "llama.cpp DGX Spark qualification receipt run");
@@ -1408,6 +1824,7 @@ export function parseLlamaCppDgxSparkQualificationReceipt(
   }
 
   return {
+    agentQualification: parsedAgentQualification,
     baseSha: expected.baseSha,
     cleanup: {
       containerRemoved: true,

--- a/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
+++ b/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
@@ -9,6 +9,8 @@ export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID =
   "llama-cpp-dgx-spark-qualification" as const;
 export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH =
   "ci/llama-cpp-dgx-spark-qualification-v1.yaml" as const;
+export const LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH =
+  "managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml" as const;
 export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND =
   "nemoclaw-llama-cpp-dgx-spark-qualification-v1" as const;
 export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE = "dgx-spark-gb10-single" as const;

--- a/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
+++ b/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
@@ -5,12 +5,13 @@ import { createHash } from "node:crypto";
 
 import YAML from "yaml";
 
+export {
+  LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
+} from "./llama-cpp-dgx-spark-qualification-paths.mts";
+
 export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID =
   "llama-cpp-dgx-spark-qualification" as const;
-export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH =
-  "ci/llama-cpp-dgx-spark-qualification-v1.yaml" as const;
-export const LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH =
-  "managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml" as const;
 export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND =
   "nemoclaw-llama-cpp-dgx-spark-qualification-v1" as const;
 export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE = "dgx-spark-gb10-single" as const;

--- a/scripts/checks/llama-cpp-dgx-spark-qualification-paths.mts
+++ b/scripts/checks/llama-cpp-dgx-spark-qualification-paths.mts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH =
+  "ci/llama-cpp-dgx-spark-qualification-v1.yaml" as const;
+export const LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH =
+  "managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml" as const;

--- a/scripts/checks/llama-cpp-openclaw-agent-qualification.mts
+++ b/scripts/checks/llama-cpp-openclaw-agent-qualification.mts
@@ -12,7 +12,7 @@ export type LlamaCppOpenClawAgentQualificationEvidence = {
   readonly agentNormalTurn: true;
   readonly agentToolCall: {
     readonly argumentsValid: true;
-    readonly name: "read";
+    readonly name: LlamaCppDgxSparkAgentQualificationPlan["tool"]["name"];
   };
   readonly agentToolResultContinuation: true;
   readonly streamingChat: {
@@ -22,10 +22,6 @@ export type LlamaCppOpenClawAgentQualificationEvidence = {
   readonly synchronousChat: true;
 };
 
-function detail(result: ManagedImageOpenShellE2eProbeResult): string {
-  return `${result.stdout}\n${result.stderr}`.replace(/\s+/gu, " ").trim().slice(-2_000);
-}
-
 function requireSuccess(
   result: ManagedImageOpenShellE2eProbeResult,
   label: string,
@@ -33,7 +29,9 @@ function requireSuccess(
 ): void {
   const bytes = Buffer.byteLength(result.stdout) + Buffer.byteLength(result.stderr);
   if (bytes > maximumBytes) throw new Error(`${label} exceeded the declarative response bound`);
-  if (result.status !== 0) throw new Error(`${label} failed: ${detail(result)}`);
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with status ${result.status ?? "unknown"}`);
+  }
 }
 
 function agentArgv(session: string, prompt: string): string[] {
@@ -257,7 +255,7 @@ export async function runLlamaCppOpenClawAgentQualification(
   return {
     agentMultiTurn: true,
     agentNormalTurn: true,
-    agentToolCall: { argumentsValid: true, name: "read" },
+    agentToolCall: { argumentsValid: true, name: config.tool.name },
     agentToolResultContinuation: true,
     streamingChat: { done: true, events },
     synchronousChat: true,

--- a/scripts/checks/llama-cpp-openclaw-agent-qualification.mts
+++ b/scripts/checks/llama-cpp-openclaw-agent-qualification.mts
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { LlamaCppDgxSparkAgentQualificationPlan } from "./llama-cpp-dgx-spark-qualification-contract.mts";
+import type {
+  ManagedImageOpenShellE2eProbeContext,
+  ManagedImageOpenShellE2eProbeResult,
+} from "./run-managed-image-openshell-e2e.ts";
+
+export type LlamaCppOpenClawAgentQualificationEvidence = {
+  readonly agentMultiTurn: true;
+  readonly agentNormalTurn: true;
+  readonly agentToolCall: {
+    readonly argumentsValid: true;
+    readonly name: "read";
+  };
+  readonly agentToolResultContinuation: true;
+  readonly streamingChat: {
+    readonly done: true;
+    readonly events: number;
+  };
+  readonly synchronousChat: true;
+};
+
+function detail(result: ManagedImageOpenShellE2eProbeResult): string {
+  return `${result.stdout}\n${result.stderr}`.replace(/\s+/gu, " ").trim().slice(-2_000);
+}
+
+function requireSuccess(
+  result: ManagedImageOpenShellE2eProbeResult,
+  label: string,
+  maximumBytes: number,
+): void {
+  const bytes = Buffer.byteLength(result.stdout) + Buffer.byteLength(result.stderr);
+  if (bytes > maximumBytes) throw new Error(`${label} exceeded the declarative response bound`);
+  if (result.status !== 0) throw new Error(`${label} failed: ${detail(result)}`);
+}
+
+function agentArgv(session: string, prompt: string): string[] {
+  return [
+    "openclaw",
+    "agent",
+    "--agent",
+    "main",
+    "--json",
+    "--thinking",
+    "off",
+    "--session-id",
+    session,
+    "-m",
+    prompt,
+  ];
+}
+
+const INFERENCE_PROBE_SOURCE = String.raw`
+const [completionUrl, mode, model, prompt, expected, maxTokensText, maxEventsText, maxBytesText] = process.argv.slice(1);
+const streaming = mode === "stream";
+const response = await fetch(completionUrl, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    model,
+    messages: [{ role: "user", content: prompt }],
+    max_tokens: Number.parseInt(maxTokensText, 10),
+    stream: streaming,
+  }),
+});
+if (!response.ok) throw new Error("inference.local returned HTTP " + response.status);
+const maximumBytes = Number.parseInt(maxBytesText, 10);
+const chunks = [];
+let responseBytes = 0;
+for await (const chunk of response.body) {
+  responseBytes += chunk.byteLength;
+  if (responseBytes > maximumBytes) throw new Error("inference.local response exceeded its bound");
+  chunks.push(Buffer.from(chunk));
+}
+const source = Buffer.concat(chunks).toString("utf8");
+if (!streaming) {
+  const body = JSON.parse(source);
+  const text = body?.choices?.[0]?.message?.content ?? body?.choices?.[0]?.text ?? "";
+  if (!String(text).includes(expected)) throw new Error("synchronous response mismatch");
+  process.stdout.write(JSON.stringify({ ok: true }));
+} else {
+  const events = source.split(/\r?\n/).filter((line) => line.startsWith("data: "));
+  const maximum = Number.parseInt(maxEventsText, 10);
+  if (events.length < 2 || events.length > maximum || !events.some((line) => line === "data: [DONE]")) {
+    throw new Error("streaming response framing mismatch");
+  }
+  const text = events
+    .filter((line) => line !== "data: [DONE]")
+    .map((line) => JSON.parse(line.slice(6))?.choices?.[0]?.delta?.content ?? "")
+    .join("");
+  if (!text.includes(expected)) throw new Error("streaming response mismatch");
+  process.stdout.write(JSON.stringify({ done: true, events: events.length }));
+}
+`;
+
+const SESSION_PROBE_SOURCE = String.raw`
+const fs = require("node:fs");
+const [sessionPath, toolName, fixturePath, fixtureValue] = process.argv.slice(1);
+const items = fs.readFileSync(sessionPath, "utf8").split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+const messages = items.filter((item) => item?.type === "message" && item?.message).map((item) => item.message);
+const blocks = messages.flatMap((message) => Array.isArray(message.content) ? message.content : []);
+const calls = blocks.filter((block) => block?.type === "toolCall");
+const exactCalls = calls.filter((call) =>
+  (call.name === toolName || call.toolName === toolName) &&
+  call.arguments && call.arguments.path === fixturePath
+);
+const results = messages.filter((message) => message?.role === "toolResult");
+const resultText = JSON.stringify(results);
+const users = messages.filter((message) => message?.role === "user");
+const finalAssistant = messages.at(-1)?.role === "assistant";
+if (exactCalls.length < 1 || results.length < 1 || !resultText.includes(fixtureValue) || users.length < 2 || !finalAssistant) {
+  throw new Error("OpenClaw session did not prove the declared tool-call continuation flow");
+}
+process.stdout.write(JSON.stringify({ calls: exactCalls.length, results: results.length, users: users.length }));
+`;
+
+function parseJson(value: string, label: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new Error(`${label} did not return bounded JSON evidence`);
+  }
+}
+
+export async function runLlamaCppOpenClawAgentQualification(
+  config: LlamaCppDgxSparkAgentQualificationPlan,
+  context: ManagedImageOpenShellE2eProbeContext,
+): Promise<LlamaCppOpenClawAgentQualificationEvidence> {
+  if (
+    config.execution !== "enabled" ||
+    context.input.agent !== config.agent ||
+    context.input.localProvider !== "llama-cpp" ||
+    context.input.model === undefined ||
+    context.input.sandbox !== config.sandbox.name ||
+    context.input.gpu === true
+  ) {
+    throw new Error("OpenClaw agent qualification invocation does not match its declarative plan");
+  }
+  const timeout = config.bounds.commandTimeoutSeconds * 1_000;
+  const run = (argv: readonly string[], label: string) => {
+    const result = context.runSandbox(argv, timeout);
+    requireSuccess(result, label, config.bounds.maxResponseBytes);
+    return result;
+  };
+
+  const synchronous = run(
+    [
+      "node",
+      "--input-type=module",
+      "-e",
+      INFERENCE_PROBE_SOURCE,
+      `${config.route.routedBaseUrl}/chat/completions`,
+      "sync",
+      context.input.model,
+      config.prompts.normal,
+      config.expectations.normal,
+      String(config.bounds.maxTokens),
+      String(config.bounds.maxStreamEvents),
+      String(config.bounds.maxResponseBytes),
+    ],
+    "inference.local synchronous probe",
+  );
+  const synchronousEvidence = parseJson(synchronous.stdout, "synchronous probe");
+  if (synchronousEvidence.ok !== true) throw new Error("synchronous probe evidence is invalid");
+
+  const streaming = run(
+    [
+      "node",
+      "--input-type=module",
+      "-e",
+      INFERENCE_PROBE_SOURCE,
+      `${config.route.routedBaseUrl}/chat/completions`,
+      "stream",
+      context.input.model,
+      config.prompts.normal,
+      config.expectations.normal,
+      String(config.bounds.maxTokens),
+      String(config.bounds.maxStreamEvents),
+      String(config.bounds.maxResponseBytes),
+    ],
+    "inference.local streaming probe",
+  );
+  const streamingEvidence = parseJson(streaming.stdout, "streaming probe");
+  const events = Number(streamingEvidence.events);
+  if (
+    streamingEvidence.done !== true ||
+    !Number.isSafeInteger(events) ||
+    events < 2 ||
+    events > config.bounds.maxStreamEvents
+  ) {
+    throw new Error("streaming probe evidence is invalid");
+  }
+
+  const normal = run(
+    agentArgv(config.sessions.normal, config.prompts.normal),
+    "OpenClaw normal agent turn",
+  );
+  if (!normal.stdout.includes(config.expectations.normal)) {
+    throw new Error("OpenClaw normal agent turn did not pass");
+  }
+
+  run(
+    [
+      "/bin/sh",
+      "-eu",
+      "-c",
+      'umask 077; printf "%s" "$1" > "$2"',
+      "fixture",
+      config.fixture.value,
+      config.fixture.path,
+    ],
+    "OpenClaw tool fixture creation",
+  );
+  const tool = run(
+    agentArgv(config.sessions.tool, config.prompts.tool),
+    "OpenClaw tool agent turn",
+  );
+  if (!tool.stdout.includes(config.fixture.value)) {
+    throw new Error("OpenClaw tool agent turn did not return the declared fixture value");
+  }
+  const continuation = run(
+    agentArgv(config.sessions.tool, config.prompts.continuation),
+    "OpenClaw tool-result continuation turn",
+  );
+  if (!continuation.stdout.includes(config.fixture.value)) {
+    throw new Error("OpenClaw tool-result continuation did not retain the prior result");
+  }
+
+  const session = run(
+    [
+      "node",
+      "-e",
+      SESSION_PROBE_SOURCE,
+      `/sandbox/.openclaw/agents/main/sessions/${config.sessions.tool}.jsonl`,
+      config.tool.name,
+      config.fixture.path,
+      config.fixture.value,
+    ],
+    "OpenClaw session structure probe",
+  );
+  const sessionEvidence = parseJson(session.stdout, "OpenClaw session structure probe");
+  if (
+    !Number.isSafeInteger(sessionEvidence.calls) ||
+    Number(sessionEvidence.calls) < 1 ||
+    !Number.isSafeInteger(sessionEvidence.results) ||
+    Number(sessionEvidence.results) < 1 ||
+    !Number.isSafeInteger(sessionEvidence.users) ||
+    Number(sessionEvidence.users) < 2
+  ) {
+    throw new Error("OpenClaw session structure evidence is invalid");
+  }
+
+  return {
+    agentMultiTurn: true,
+    agentNormalTurn: true,
+    agentToolCall: { argumentsValid: true, name: "read" },
+    agentToolResultContinuation: true,
+    streamingChat: { done: true, events },
+    synchronousChat: true,
+  };
+}

--- a/scripts/checks/managed-image-protected-runtime-contract.ts
+++ b/scripts/checks/managed-image-protected-runtime-contract.ts
@@ -12,20 +12,29 @@ export {
   parseProtectedManagedImageContracts,
 } from "./protected-managed-image-contract.ts";
 
-export const MANAGED_IMAGE_LOCAL_INFERENCE_KINDS = ["ollama", "nim", "vllm"] as const;
+export const MANAGED_IMAGE_LOCAL_INFERENCE_KINDS = ["llama-cpp", "ollama", "nim", "vllm"] as const;
 
 export type ManagedImageLocalInferenceKind = (typeof MANAGED_IMAGE_LOCAL_INFERENCE_KINDS)[number];
 
 export type ManagedImageLocalInferenceRoute = {
   readonly kind: ManagedImageLocalInferenceKind;
-  readonly providerName: "ollama-local" | "vllm-local";
-  readonly credentialEnv: "NEMOCLAW_OLLAMA_PROXY_TOKEN" | "NEMOCLAW_VLLM_LOCAL_TOKEN";
+  readonly providerName: "llama-cpp-local" | "ollama-local" | "vllm-local";
+  readonly credentialEnv:
+    | "NEMOCLAW_LLAMACPP_LOCAL_TOKEN"
+    | "NEMOCLAW_OLLAMA_PROXY_TOKEN"
+    | "NEMOCLAW_VLLM_LOCAL_TOKEN";
   readonly defaultBaseUrl: string;
 };
 
 const LOCAL_INFERENCE_ROUTES: Readonly<
   Record<ManagedImageLocalInferenceKind, ManagedImageLocalInferenceRoute>
 > = Object.freeze({
+  "llama-cpp": Object.freeze({
+    kind: "llama-cpp",
+    providerName: "llama-cpp-local",
+    credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+    defaultBaseUrl: "http://host.openshell.internal:8081/v1",
+  }),
   ollama: Object.freeze({
     kind: "ollama",
     providerName: "ollama-local",

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -17,7 +17,6 @@ import {
   validateChatCompletionResponse,
   validateModelsResponse,
 } from "./llama-cpp-dgx-spark-protocol-qualification.mts";
-import { resolveManagedImageLocalInferenceRoute } from "./managed-image-protected-runtime-contract.ts";
 import {
   LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY,
@@ -27,6 +26,7 @@ import {
   parseLlamaCppDgxSparkExecutionPlan,
 } from "./llama-cpp-dgx-spark-qualification-contract.mts";
 import { runLlamaCppOpenClawAgentQualification } from "./llama-cpp-openclaw-agent-qualification.mts";
+import { resolveManagedImageLocalInferenceRoute } from "./managed-image-protected-runtime-contract.ts";
 import { runManagedImageOpenShellE2e } from "./run-managed-image-openshell-e2e.ts";
 
 export { validateChatCompletionResponse, validateModelsResponse };
@@ -932,6 +932,11 @@ async function runQualification(
       plan.recipe.runtime.cuda.minimumDriverVersion,
     );
     await waitForHealth(loopbackPort, plan.recipe.readiness.timeoutSeconds);
+    const offload = validateStartupLog(
+      runCommand("docker", ["logs", "--tail", "20000", names.containerName], {
+        maximumBytes: 16 * 1024 * 1024,
+      }).toString("utf8"),
+    );
     const authorization = `Bearer ${apiKey}`;
     const probes = await runLlamaCppDgxSparkProtocolQualification({
       authorization,
@@ -1009,11 +1014,6 @@ async function runQualification(
         else process.env[baseUrlEnvironmentName] = priorBaseUrl;
       }
     }
-    const offload = validateStartupLog(
-      runCommand("docker", ["logs", "--tail", "20000", names.containerName], {
-        maximumBytes: 16 * 1024 * 1024,
-      }).toString("utf8"),
-    );
     successReceipt = {
       agentQualification,
       baseSha: invocation.candidateBase,

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -17,6 +17,7 @@ import {
   validateChatCompletionResponse,
   validateModelsResponse,
 } from "./llama-cpp-dgx-spark-protocol-qualification.mts";
+import { resolveManagedImageLocalInferenceRoute } from "./managed-image-protected-runtime-contract.ts";
 import {
   LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY,
@@ -25,6 +26,8 @@ import {
   type LlamaCppDgxSparkExecutionPlan,
   parseLlamaCppDgxSparkExecutionPlan,
 } from "./llama-cpp-dgx-spark-qualification-contract.mts";
+import { runLlamaCppOpenClawAgentQualification } from "./llama-cpp-openclaw-agent-qualification.mts";
+import { runManagedImageOpenShellE2e } from "./run-managed-image-openshell-e2e.ts";
 
 export { validateChatCompletionResponse, validateModelsResponse };
 
@@ -227,7 +230,14 @@ export function parseQualificationInvocation(
     throw new Error("registry ownership does not match this workflow run");
   }
   requireTrustedEnvironment(environment, runId, runAttempt);
-  if (cleanupOnly) return { cleanupOnly: true, registryName, registryOwner, runAttempt, runId };
+  if (cleanupOnly)
+    return {
+      cleanupOnly: true,
+      registryName,
+      registryOwner,
+      runAttempt,
+      runId,
+    };
 
   const workflowSha = requiredString(options.get("--workflow-sha"), "workflow SHA", gitShaPattern);
   requireTrustedEnvironment(environment, runId, runAttempt, workflowSha);
@@ -319,12 +329,14 @@ export function buildServerContainerArgv(
     registryOwner: string;
     runtimeGid: number;
     runtimeUid: number;
+    hostPort?: number;
   },
 ): string[] {
   return buildLlamaCppHostLocalDockerArgv(plan.recipe, {
     apiKeyHostPath: options.apiKeyHostPath,
     containerName: options.containerName,
     imageReference: options.imageReference,
+    ...(options.hostPort === undefined ? {} : { hostPort: options.hostPort }),
     model: options.model,
     network: { isolation: "docker-internal", name: options.networkName },
     ownerLabel: { name: registryOwnerLabel, value: options.registryOwner },
@@ -333,7 +345,32 @@ export function buildServerContainerArgv(
   });
 }
 
-export function validateStartupLog(log: string): { offloadedLayers: number; totalLayers: number } {
+export function validateOpenClawQualificationImageLabels(
+  source: string,
+  expectedRevision: string,
+): void {
+  let labels: unknown;
+  try {
+    labels = JSON.parse(source) as unknown;
+  } catch {
+    throw new Error("OpenClaw qualification image labels are invalid");
+  }
+  if (
+    !isRecord(labels) ||
+    labels["io.nvidia.nemoclaw.agent"] !== "openclaw" ||
+    labels["io.nvidia.nemoclaw.managed-image.contract"] !== "1" ||
+    labels["io.nvidia.nemoclaw.managed-image.platform"] !== "linux/arm64" ||
+    labels["org.opencontainers.image.source"] !== "https://github.com/NVIDIA/NemoClaw" ||
+    labels["org.opencontainers.image.revision"] !== expectedRevision
+  ) {
+    throw new Error("OpenClaw qualification image does not match the declarative identity");
+  }
+}
+
+export function validateStartupLog(log: string): {
+  offloadedLayers: number;
+  totalLayers: number;
+} {
   if (Buffer.byteLength(log) < 1 || Buffer.byteLength(log) > 16 * 1024 * 1024) {
     throw new Error("startup evidence is missing or exceeds the bounded log size");
   }
@@ -700,7 +737,9 @@ function inspectBuiltImage(
   });
   if (sha256Text(raw) !== digest)
     throw new Error("candidate manifest bytes do not match its digest");
-  runCommand("docker", ["pull", "--platform", "linux/arm64", reference], { capture: false });
+  runCommand("docker", ["pull", "--platform", "linux/arm64", reference], {
+    capture: false,
+  });
   const inspected = JSON.parse(
     runCommand("docker", ["image", "inspect", reference]).toString("utf8"),
   ) as unknown;
@@ -782,7 +821,10 @@ function writeReceipt(output: string, receipt: unknown, tempRoot: string): void 
     throw new Error("qualification receipt path must not be a symlink");
   }
   const temporary = `${output}.tmp-${process.pid}`;
-  fs.writeFileSync(temporary, `${JSON.stringify(receipt)}\n`, { encoding: "utf8", mode: 0o600 });
+  fs.writeFileSync(temporary, `${JSON.stringify(receipt)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
   fs.renameSync(temporary, output);
 }
 
@@ -811,6 +853,12 @@ async function runQualification(
   let cleanupEvidence: CleanupEvidence | undefined;
   try {
     if (await tcpOpen(5000)) throw new Error("refusing to reuse an existing localhost registry");
+    if (
+      plan.qualification.agentQualification.execution === "enabled" &&
+      (await tcpOpen(plan.recipe.serve.port))
+    ) {
+      throw new Error("refusing to reuse the declarative llama.cpp agent qualification port");
+    }
     startRegistry(names);
     await waitForRegistry();
     runCommand("docker", buildCandidateImageArgv(plan, invocation, metadataFile), {
@@ -822,7 +870,11 @@ async function runQualification(
     fs.mkdirSync(names.tempRoot, { mode: 0o700 });
     const model = hashModelFile(invocation.modelHostPath, plan);
     const apiKey = randomBytes(32).toString("hex");
-    fs.writeFileSync(apiKeyHostPath, apiKey, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    fs.writeFileSync(apiKeyHostPath, apiKey, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
     const hostUid = process.getuid?.();
     const hostGid = process.getgid?.();
     if (hostUid === undefined || hostGid === undefined) {
@@ -862,6 +914,9 @@ async function runQualification(
         registryOwner: names.registryOwner,
         runtimeGid,
         runtimeUid,
+        ...(plan.qualification.agentQualification.execution === "enabled"
+          ? { hostPort: plan.recipe.serve.port }
+          : {}),
       }),
       { capture: false },
     );
@@ -883,12 +938,84 @@ async function runQualification(
       baseUrl: `http://127.0.0.1:${loopbackPort}`,
       plan,
     });
+    let agentQualification: JsonRecord = { execution: "disabled" };
+    const agentPlan = plan.qualification.agentQualification;
+    if (agentPlan.execution === "enabled") {
+      if (loopbackPort !== plan.recipe.serve.port) {
+        throw new Error("agent qualification requires the declarative llama.cpp loopback port");
+      }
+      runCommand(
+        "docker",
+        ["pull", "--platform", plan.imageBuild.platform.platform, agentPlan.image.reference],
+        { capture: false },
+      );
+      validateOpenClawQualificationImageLabels(
+        runCommand("docker", [
+          "image",
+          "inspect",
+          "--format",
+          "{{json .Config.Labels}}",
+          agentPlan.image.reference,
+        ]).toString("utf8"),
+        agentPlan.image.sourceRevision,
+      );
+      const route = resolveManagedImageLocalInferenceRoute("llama-cpp");
+      if (
+        route.providerName !== agentPlan.route.provider ||
+        route.defaultBaseUrl !== agentPlan.route.upstreamBaseUrl
+      ) {
+        throw new Error("managed OpenClaw route does not match the declarative qualification");
+      }
+      const credentialName = "NEMOCLAW_LLAMACPP_LOCAL_TOKEN";
+      const baseUrlEnvironmentName = "NEMOCLAW_E2E_LOCAL_INFERENCE_BASE_URL";
+      const priorCredential = process.env[credentialName];
+      const priorBaseUrl = process.env[baseUrlEnvironmentName];
+      process.env[credentialName] = apiKey;
+      process.env[baseUrlEnvironmentName] = agentPlan.route.upstreamBaseUrl;
+      try {
+        const managedResult = await runManagedImageOpenShellE2e(
+          {
+            agent: agentPlan.agent,
+            image: agentPlan.image.reference,
+            localProvider: "llama-cpp",
+            model: plan.recipe.model.servedName,
+            sandbox: agentPlan.sandbox.name,
+          },
+          (context) => runLlamaCppOpenClawAgentQualification(agentPlan, context),
+        );
+        if (!managedResult.probeEvidence) {
+          throw new Error("OpenClaw qualification did not return bounded evidence");
+        }
+        agentQualification = {
+          agent: agentPlan.agent,
+          cleanup: managedResult.cleanup,
+          execution: "enabled",
+          image: agentPlan.image,
+          model: {
+            chatTemplate: plan.recipe.serve.chatTemplate,
+            id: plan.recipe.model.id,
+            quantization: plan.recipe.model.file.quantization,
+            servedName: plan.recipe.model.servedName,
+          },
+          platform: plan.imageBuild.platform.platform,
+          probes: managedResult.probeEvidence,
+          route: agentPlan.route,
+          runtimeProvider: agentPlan.runtimeProvider,
+        };
+      } finally {
+        if (priorCredential === undefined) delete process.env[credentialName];
+        else process.env[credentialName] = priorCredential;
+        if (priorBaseUrl === undefined) delete process.env[baseUrlEnvironmentName];
+        else process.env[baseUrlEnvironmentName] = priorBaseUrl;
+      }
+    }
     const offload = validateStartupLog(
       runCommand("docker", ["logs", "--tail", "20000", names.containerName], {
         maximumBytes: 16 * 1024 * 1024,
       }).toString("utf8"),
     );
     successReceipt = {
+      agentQualification,
       baseSha: invocation.candidateBase,
       headSha: invocation.candidateHead,
       kind: LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND,

--- a/scripts/checks/run-managed-image-openshell-e2e.ts
+++ b/scripts/checks/run-managed-image-openshell-e2e.ts
@@ -76,7 +76,7 @@ function redactProtectedGpuProof(value: string): string {
     .replace(/\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD))=([^\s]*)/giu, "$1=<REDACTED>");
 }
 
-type Inputs = {
+export type ManagedImageOpenShellE2eInputs = {
   agent: ManagedStartupAgent;
   image: string;
   sandbox: string;
@@ -85,6 +85,44 @@ type Inputs = {
   model?: string;
   failureInjection?: "bootstrap-completion";
 };
+
+export type ManagedImageOpenShellE2eProbeResult = {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+export type ManagedImageOpenShellE2eProbeContext = {
+  readonly input: Readonly<ManagedImageOpenShellE2eInputs>;
+  readonly runSandbox: (
+    argv: readonly string[],
+    timeoutMilliseconds?: number,
+  ) => ManagedImageOpenShellE2eProbeResult;
+};
+
+export type ManagedImageOpenShellE2eResult<T = never> = {
+  readonly cleanup: {
+    readonly gatewayRemoved: true;
+    readonly networkRemoved: true;
+    readonly sandboxRemoved: true;
+    readonly stateRemoved: true;
+  };
+  readonly probeEvidence?: T;
+};
+
+type Inputs = ManagedImageOpenShellE2eInputs;
+
+const MANAGED_IMAGE_E2E_ENVIRONMENT_KEYS = [
+  "NEMOCLAW_NON_INTERACTIVE",
+  "NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR",
+  "NEMOCLAW_GATEWAY_PORT",
+  "NEMOCLAW_DOCKER_GPU_SUPERVISOR_RECONNECT_TIMEOUT",
+  "OPENSHELL_DOCKER_NETWORK_NAME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "PATH",
+] as const;
 
 type OnboardModule = {
   openshellArgv(args: string[]): string[];
@@ -129,7 +167,7 @@ export function parseManagedImageOpenShellE2eInputs(argv: readonly string[]): In
     ? requiredValue(argv, "--local-provider")
     : null;
   if (localProviderValue && !isManagedImageLocalInferenceKind(localProviderValue)) {
-    throw new Error("--local-provider must be one of: ollama, nim, vllm");
+    throw new Error("--local-provider must be one of: llama-cpp, ollama, nim, vllm");
   }
   const model = argv.includes("--model") ? requiredValue(argv, "--model") : null;
   if (model && !/^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,255}$/u.test(model)) {
@@ -139,11 +177,16 @@ export function parseManagedImageOpenShellE2eInputs(argv: readonly string[]): In
   if (gpu && (!localProviderValue || !model)) {
     throw new Error("--gpu requires --local-provider and --model");
   }
-  if (!gpu && (localProviderValue || model)) {
-    throw new Error("--local-provider and --model require --gpu");
+  if (!gpu && (localProviderValue || model) && localProviderValue !== "llama-cpp") {
+    throw new Error("--local-provider and --model require --gpu except for llama-cpp");
   }
-  if (failureInjection && gpu) {
-    throw new Error("bootstrap failure injection cannot be combined with the GPU qualification");
+  if (localProviderValue === "llama-cpp" && (!model || gpu)) {
+    throw new Error("llama-cpp requires --model and must not grant direct sandbox GPU access");
+  }
+  if (failureInjection && (gpu || localProviderValue)) {
+    throw new Error(
+      "bootstrap failure injection cannot be combined with local-inference qualification",
+    );
   }
   return {
     agent: agentValue as ManagedStartupAgent,
@@ -648,10 +691,16 @@ function assertFailedSandboxAbsent(
   }
 }
 
-async function run(input: Inputs): Promise<void> {
+async function run<T = never>(
+  input: Inputs,
+  afterLocalInference?: (context: ManagedImageOpenShellE2eProbeContext) => Promise<T> | T,
+): Promise<ManagedImageOpenShellE2eResult<T>> {
   const stateParent = process.env.RUNNER_TEMP || os.tmpdir();
   const stateDir = fs.mkdtempSync(path.join(stateParent, "nemoclaw-managed-openshell-"));
   const networkName = `nemoclaw-managed-pr-${process.pid}-${Date.now().toString(36)}`;
+  const previousEnvironment = Object.fromEntries(
+    MANAGED_IMAGE_E2E_ENVIRONMENT_KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<(typeof MANAGED_IMAGE_E2E_ENVIRONMENT_KEYS)[number], string | undefined>;
   process.env.NEMOCLAW_NON_INTERACTIVE = "1";
   process.env.NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR = stateDir;
   process.env.NEMOCLAW_GATEWAY_PORT = String(GATEWAY_PORT);
@@ -666,6 +715,7 @@ async function run(input: Inputs): Promise<void> {
   let ownedContainerId: string | null = null;
   let initialSandboxPolicy: InitialSandboxPolicy | null = null;
   let failureInjectionQualified = false;
+  let probeEvidence: T | undefined;
   let primaryError: unknown;
   let hasPrimaryError = false;
   const cleanupErrors: string[] = [];
@@ -732,7 +782,11 @@ async function run(input: Inputs): Promise<void> {
       openshellArgv: onboard.openshellArgv,
       managedStartupRootApplyRequest: rootApplyRequest,
     });
-    const prebuild = { createArgs: [...createArgs], imageRef: null, imageId: null };
+    const prebuild = {
+      createArgs: [...createArgs],
+      imageRef: null,
+      imageId: null,
+    };
     if (
       launch.createArgv.filter((value) => value === "--from").length !== 1 ||
       launch.createArgv[launch.createArgv.indexOf("--from") + 1] !== input.image ||
@@ -823,7 +877,9 @@ async function run(input: Inputs): Promise<void> {
           openshellArgv: onboard.openshellArgv,
           verifyDirectSandboxGpu,
           ...(input.failureInjection
-            ? { createManagedBootstrapAdapter: () => failureInjectingAdapter(onboard!) }
+            ? {
+                createManagedBootstrapAdapter: () => failureInjectingAdapter(onboard!),
+              }
             : {}),
         },
       );
@@ -862,13 +918,35 @@ async function run(input: Inputs): Promise<void> {
 
       await waitForCommittedSandboxProbe(onboard, input, launch.sandboxEnv, !gpuEnabled);
       ownedContainerId = assertExactSandboxImage(input, networkName, launch.sandboxEnv);
-      if (gpuEnabled) {
+      if (input.localProvider && !afterLocalInference) {
         assertProtectedLocalInference(onboard, input, launch.sandboxEnv);
+      }
+      if (gpuEnabled) {
         await flow.runtimePatch.commitAfterReady();
         await waitForCommittedSandboxProbe(onboard, input, launch.sandboxEnv);
       }
+      if (afterLocalInference) {
+        if (!input.localProvider) {
+          throw new Error("managed-image post-route probe requires protected local inference");
+        }
+        probeEvidence = await afterLocalInference({
+          input,
+          runSandbox(argv, timeoutMilliseconds = 210_000) {
+            const result = commandResult(
+              onboard!.openshellArgv(["sandbox", "exec", "--name", input.sandbox, "--", ...argv]),
+              launch.sandboxEnv,
+              timeoutMilliseconds,
+            );
+            return {
+              status: result.status,
+              stdout: String(result.stdout ?? ""),
+              stderr: String(result.stderr ?? ""),
+            };
+          },
+        });
+      }
       process.stdout.write(
-        `OpenShell launched exact ${input.agent} PR image ${input.image} through the production managed-bootstrap sequence${gpuEnabled ? ` with real NVIDIA GPU access and ${input.localProvider} inference.local completion` : ""}.\n`,
+        `OpenShell launched exact ${input.agent} PR image ${input.image} through the production managed-bootstrap sequence${input.localProvider ? ` with ${gpuEnabled ? "real NVIDIA GPU access and " : ""}${input.localProvider} inference.local completion` : ""}.\n`,
       );
     }
   } catch (error) {
@@ -971,6 +1049,11 @@ async function run(input: Inputs): Promise<void> {
     } catch (error) {
       cleanupErrors.push(error instanceof Error ? error.message : String(error));
     }
+    for (const key of MANAGED_IMAGE_E2E_ENVIRONMENT_KEYS) {
+      const previousValue = previousEnvironment[key];
+      if (previousValue === undefined) delete process.env[key];
+      else process.env[key] = previousValue;
+    }
   }
 
   const cleanupDetail =
@@ -981,7 +1064,9 @@ async function run(input: Inputs): Promise<void> {
     if (cleanupDetail) {
       const primaryDetail =
         primaryError instanceof Error ? primaryError.message : String(primaryError);
-      throw new Error(`${primaryDetail}; ${cleanupDetail}`, { cause: primaryError });
+      throw new Error(`${primaryDetail}; ${cleanupDetail}`, {
+        cause: primaryError,
+      });
     }
     throw primaryError;
   }
@@ -993,6 +1078,15 @@ async function run(input: Inputs): Promise<void> {
       `Managed-bootstrap failure injection left no sandbox, container, network, or harness state orphan for ${input.agent}.\n`,
     );
   }
+  return {
+    cleanup: {
+      gatewayRemoved: true,
+      networkRemoved: true,
+      sandboxRemoved: true,
+      stateRemoved: true,
+    },
+    ...(probeEvidence === undefined ? {} : { probeEvidence }),
+  };
 }
 
 if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {

--- a/scripts/checks/run-managed-image-openshell-e2e.ts
+++ b/scripts/checks/run-managed-image-openshell-e2e.ts
@@ -100,7 +100,13 @@ export type ManagedImageOpenShellE2eProbeContext = {
   ) => ManagedImageOpenShellE2eProbeResult;
 };
 
-export type ManagedImageOpenShellE2eResult<T = never> = {
+export type ManagedImageOpenShellE2eLocalInferenceEvidence = {
+  readonly synchronousChat: true;
+};
+
+export type ManagedImageOpenShellE2eResult<
+  T extends ManagedImageOpenShellE2eLocalInferenceEvidence = never,
+> = {
   readonly cleanup: {
     readonly gatewayRemoved: true;
     readonly networkRemoved: true;
@@ -247,19 +253,24 @@ function readGatewayPid(stateDir: string): number | null {
   }
 }
 
-function stopProcess(pid: number | null): void {
-  if (!pid) return;
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stopProcess(pid: number | null): boolean {
+  if (!pid || !processExists(pid)) return true;
   try {
     process.kill(pid, "SIGTERM");
   } catch {
-    return;
+    return !processExists(pid);
   }
   for (let attempt = 0; attempt < 50; attempt += 1) {
-    try {
-      process.kill(pid, 0);
-    } catch {
-      return;
-    }
+    if (!processExists(pid)) return true;
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
   }
   try {
@@ -267,6 +278,11 @@ function stopProcess(pid: number | null): void {
   } catch {
     // The process exited between the liveness probe and the final signal.
   }
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (!processExists(pid)) return true;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+  }
+  return !processExists(pid);
 }
 
 function createProtectedAuthorityStore(stateDir: string): ManagedBootstrapAuthorityStore {
@@ -691,7 +707,7 @@ function assertFailedSandboxAbsent(
   }
 }
 
-async function run<T = never>(
+async function run<T extends ManagedImageOpenShellE2eLocalInferenceEvidence = never>(
   input: Inputs,
   afterLocalInference?: (context: ManagedImageOpenShellE2eProbeContext) => Promise<T> | T,
 ): Promise<ManagedImageOpenShellE2eResult<T>> {
@@ -944,6 +960,11 @@ async function run<T = never>(
             };
           },
         });
+        if (!probeEvidence || probeEvidence.synchronousChat !== true) {
+          throw new Error(
+            "managed-image post-route probe did not prove protected synchronous inference",
+          );
+        }
       }
       process.stdout.write(
         `OpenShell launched exact ${input.agent} PR image ${input.image} through the production managed-bootstrap sequence${input.localProvider ? ` with ${gpuEnabled ? "real NVIDIA GPU access and " : ""}${input.localProvider} inference.local completion` : ""}.\n`,
@@ -960,9 +981,19 @@ async function run<T = never>(
         15_000,
       );
     }
-    stopProcess(readGatewayPid(stateDir));
+    const gatewayPid = readGatewayPid(stateDir);
+    if (!stopProcess(gatewayPid)) {
+      cleanupErrors.push(`OpenShell gateway process ${String(gatewayPid)} did not stop`);
+    }
     if (onboard) {
-      commandResult(onboard.openshellArgv(["gateway", "remove", "nemoclaw"]), process.env, 15_000);
+      const removeGateway = commandResult(
+        onboard.openshellArgv(["gateway", "remove", "nemoclaw"]),
+        process.env,
+        15_000,
+      );
+      if (removeGateway.status !== 0) {
+        cleanupErrors.push(`OpenShell gateway removal failed: ${commandDetail(removeGateway)}`);
+      }
     }
     try {
       const resolved = exactHarnessContainerIds(input, networkName, process.env);

--- a/test/e2e-recommendations.test.ts
+++ b/test/e2e-recommendations.test.ts
@@ -75,6 +75,7 @@ describe("E2E recommendation normalizer", () => {
         "tools/advisors/e2e-text.mts",
         "tools/advisors/json.mts",
         "tools/advisors/risk-plan.mts",
+        "scripts/checks/llama-cpp-dgx-spark-qualification-paths.mts",
         "scripts/checks/protected-managed-image-contract.ts",
         "tools/e2e/module-tags.mts",
         ".github/workflows/e2e.yaml",

--- a/test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts
+++ b/test/e2e/live/llama-cpp-dgx-spark-qualification.test.ts
@@ -38,12 +38,10 @@ test("binds the exact NemoClaw-built llama.cpp image candidate to protected NVID
     environment.planFile,
     path.dirname(environment.planFile),
   );
-  expect(() =>
-    parseLlamaCppDgxSparkExecutionPlan(
-      JSON.parse(plan.toString("utf8")) as unknown,
-      environment.planSha256,
-    ),
-  ).not.toThrow();
+  const parsedPlan = parseLlamaCppDgxSparkExecutionPlan(
+    JSON.parse(plan.toString("utf8")) as unknown,
+    environment.planSha256,
+  );
 
   progress.phase("validate exact DGX Spark execution and cleanup evidence");
   const evidence = readLlamaCppQualificationArtifact(
@@ -54,6 +52,7 @@ test("binds the exact NemoClaw-built llama.cpp image candidate to protected NVID
     parseLlamaCppDgxSparkQualificationReceipt(
       JSON.parse(evidence.toString("utf8")) as unknown,
       environment.identity,
+      parsedPlan,
     ),
   ).not.toThrow();
 });

--- a/test/e2e/support/e2e-cross-runtime-compatibility.test.ts
+++ b/test/e2e/support/e2e-cross-runtime-compatibility.test.ts
@@ -45,7 +45,7 @@ describe("cross-runtime foundation compatibility", () => {
     ];
 
     expect(digestOutput(cases.map(buildRiskPlan))).toBe(
-      "323a6eab7df534424f3b94a7f43c92234750b680855d8b67354941f6eb8a4a7a",
+      "33947044389a5e021c36273a187ab2e631def9e57ed3602a32d9263416b8015e",
     );
   });
 });

--- a/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
+++ b/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
@@ -173,6 +173,20 @@ describe("llama.cpp DGX Spark qualification workflow boundary (#8260)", () => {
     );
   });
 
+  it("rejects installing OpenShell through candidate-controlled code", () => {
+    const value = workflow();
+    const install = namedStep(
+      value,
+      "llama-cpp-dgx-spark-qualification",
+      "Install OpenShell CLI for declarative OpenClaw qualification",
+    );
+    install.run = `${String(install.run)}\nbash .candidate-llama-cpp/scripts/install-openshell.sh`;
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification must install OpenShell only from trusted helper code",
+    );
+  });
+
   it("rejects qualification before the trusted plan is materialized", () => {
     const value = workflow();
     const protectedJob = job(value, "llama-cpp-dgx-spark-qualification");

--- a/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
+++ b/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
@@ -160,6 +160,19 @@ describe("llama.cpp DGX Spark qualification workflow boundary (#8260)", () => {
     );
   });
 
+  it("rejects installing OpenShell outside declarative agent activation", () => {
+    const value = workflow();
+    namedStep(
+      value,
+      "llama-cpp-dgx-spark-qualification",
+      "Install OpenShell CLI for declarative OpenClaw qualification",
+    ).if = "always()";
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification must gate OpenShell installation on the declarative agent qualification",
+    );
+  });
+
   it("rejects qualification before the trusted plan is materialized", () => {
     const value = workflow();
     const protectedJob = job(value, "llama-cpp-dgx-spark-qualification");

--- a/test/llama-cpp-dgx-spark-qualification-contract.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-contract.test.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 
 import {
+  LLAMA_CPP_DGX_SPARK_AGENT_PROBES,
   LLAMA_CPP_DGX_SPARK_CUDA_DEVELOPMENT_BASE,
   LLAMA_CPP_DGX_SPARK_CUDA_RUNTIME_BASE,
   LLAMA_CPP_DGX_SPARK_DIGEST_PATTERN,
@@ -14,6 +15,8 @@ import {
   LLAMA_CPP_DGX_SPARK_MODEL_DIGEST,
   LLAMA_CPP_DGX_SPARK_MODEL_ID,
   LLAMA_CPP_DGX_SPARK_MODEL_PATH_PATTERN,
+  LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE,
+  LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION,
   LLAMA_CPP_DGX_SPARK_OWNED_IMAGE_REPOSITORY,
   LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
@@ -34,7 +37,7 @@ import {
   parseLlamaCppDgxSparkQualificationActivation,
   parseLlamaCppDgxSparkQualificationEvidenceIdentity,
   parseLlamaCppDgxSparkQualificationPlan,
-  parseLlamaCppDgxSparkQualificationReceipt,
+  parseLlamaCppDgxSparkQualificationReceipt as parseQualificationReceiptWithPlan,
   verifyLlamaCppDgxSparkExecutionPlanSha256,
 } from "../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
 
@@ -66,6 +69,48 @@ function activation() {
     jobId: LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
     platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
     profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
+  };
+}
+
+function agentQualification() {
+  return {
+    agent: "openclaw",
+    bounds: {
+      commandTimeoutSeconds: 420,
+      maxResponseBytes: 16777216,
+      maxStreamEvents: 512,
+      maxTokens: 32,
+    },
+    execution: "disabled",
+    expectations: { normal: "PONG" },
+    fixture: {
+      path: "/tmp/nemoclaw-llama-cpp-tool.txt",
+      value: "LLAMA_CPP_OPENCLAW_TOOL_OK",
+    },
+    image: {
+      reference: LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE,
+      sourceRevision: LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION,
+    },
+    probes: LLAMA_CPP_DGX_SPARK_AGENT_PROBES,
+    prompts: {
+      continuation:
+        "Repeat the exact value LLAMA_CPP_OPENCLAW_TOOL_OK from the file you read in the prior turn.",
+      normal: "Reply with exactly one word: PONG",
+      tool: "Use the read tool to read /tmp/nemoclaw-llama-cpp-tool.txt. Reply with exactly the file contents: LLAMA_CPP_OPENCLAW_TOOL_OK",
+    },
+    route: {
+      api: "openai-completions",
+      provider: "llama-cpp-local",
+      routedBaseUrl: "https://inference.local/v1",
+      upstreamBaseUrl: "http://host.openshell.internal:8081/v1",
+    },
+    runtimeProvider: "docker",
+    sandbox: { gpuAccess: "disabled", name: "nemoclaw-llama-cpp-openclaw" },
+    sessions: {
+      normal: "llama-cpp-openclaw-normal",
+      tool: "llama-cpp-openclaw-tool",
+    },
+    tool: { name: "read" },
   };
 }
 
@@ -111,6 +156,7 @@ function evidenceIdentity() {
 
 function receipt() {
   return {
+    agentQualification: { execution: "disabled" },
     baseSha: BASE_SHA,
     cleanup: {
       containerRemoved: true,
@@ -217,6 +263,7 @@ function executionPlan() {
       },
     },
     qualification: {
+      agentQualification: agentQualification(),
       probeBounds: probeBounds(),
       probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
     },
@@ -308,6 +355,10 @@ function executionPlan() {
       },
     },
   };
+}
+
+function parseLlamaCppDgxSparkQualificationReceipt(value: unknown, identity: unknown) {
+  return parseQualificationReceiptWithPlan(value, identity, executionPlan());
 }
 
 describe("llama.cpp DGX Spark qualification contract", () => {
@@ -590,6 +641,65 @@ describe("llama.cpp DGX Spark qualification contract", () => {
     expect(parseLlamaCppDgxSparkQualificationReceipt(receipt(), evidenceIdentity())).toEqual(
       receipt(),
     );
+  });
+
+  it("binds enabled OpenClaw evidence to the exact YAML-authored tuple", () => {
+    const plan = executionPlan();
+    plan.qualification.agentQualification.execution = "enabled";
+    const value = {
+      ...receipt(),
+      agentQualification: {
+        agent: "openclaw",
+        cleanup: {
+          gatewayRemoved: true,
+          networkRemoved: true,
+          sandboxRemoved: true,
+          stateRemoved: true,
+        },
+        execution: "enabled",
+        image: {
+          reference: LLAMA_CPP_DGX_SPARK_OPENCLAW_IMAGE,
+          sourceRevision: LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION,
+        },
+        model: {
+          chatTemplate: "nemotron-v3-embedded",
+          id: LLAMA_CPP_DGX_SPARK_MODEL_ID,
+          quantization: "UD-Q4_K_XL",
+          servedName: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+        },
+        platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+        probes: {
+          agentMultiTurn: true,
+          agentNormalTurn: true,
+          agentToolCall: { argumentsValid: true, name: "read" },
+          agentToolResultContinuation: true,
+          streamingChat: { done: true, events: 7 },
+          synchronousChat: true,
+        },
+        route: plan.qualification.agentQualification.route,
+        runtimeProvider: "docker",
+      },
+    };
+
+    expect(
+      parseQualificationReceiptWithPlan(value, evidenceIdentity(), plan).agentQualification,
+    ).toEqual(value.agentQualification);
+    expect(() =>
+      parseQualificationReceiptWithPlan(value, evidenceIdentity(), executionPlan()),
+    ).toThrow(/without declarative activation/u);
+    expect(() =>
+      parseQualificationReceiptWithPlan(
+        {
+          ...value,
+          agentQualification: {
+            ...value.agentQualification,
+            route: { ...value.agentQualification.route, provider: "vllm-local" },
+          },
+        },
+        evidenceIdentity(),
+        plan,
+      ),
+    ).toThrow(/evidence is invalid/u);
   });
 
   it("rejects stale workflow identity and extra sensitive receipt fields (#8260)", () => {

--- a/test/llama-cpp-dgx-spark-qualification-plan.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-plan.test.ts
@@ -22,8 +22,10 @@ function candidateRoot(options: { activation?: string; enabled?: boolean } = {})
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-llama-cpp-plan-"));
   temporaryRoots.push(root);
   const imageDirectory = path.join(root, "managed-inference", "images", "llama-cpp");
+  const qualificationDirectory = path.join(root, "managed-inference", "qualifications");
   const recipeDirectory = path.join(root, "managed-inference", "recipes");
   fs.mkdirSync(imageDirectory, { recursive: true });
+  fs.mkdirSync(qualificationDirectory, { recursive: true });
   fs.mkdirSync(recipeDirectory, { recursive: true });
 
   const sourceImage = fs.readFileSync(
@@ -60,6 +62,15 @@ function candidateRoot(options: { activation?: string; enabled?: boolean } = {})
     ),
     path.join(recipeDirectory, "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml"),
   );
+  fs.copyFileSync(
+    path.join(
+      repoRoot,
+      "managed-inference",
+      "qualifications",
+      "llama-cpp.openclaw.spark-single.v1.yaml",
+    ),
+    path.join(qualificationDirectory, "llama-cpp.openclaw.spark-single.v1.yaml"),
+  );
   for (const activation of options.activation === undefined ? [] : [options.activation]) {
     const activationPath = path.join(root, "ci", "llama-cpp-dgx-spark-qualification-v1.yaml");
     fs.mkdirSync(path.dirname(activationPath), { recursive: true });
@@ -87,6 +98,7 @@ describe("llama.cpp DGX Spark qualification plan export (#8260)", () => {
     );
 
     expect(output.execution).toBe("enabled");
+    expect(output.agent_qualification_execution).toBe("disabled");
     expect(output.runner).toBe("linux-arm64-gpu-dgx-spark-gb10-protected-1");
     expect(parseLlamaCppDgxSparkQualificationPlan(JSON.parse(output.qualification))).toMatchObject({
       execution: "enabled",
@@ -98,6 +110,11 @@ describe("llama.cpp DGX Spark qualification plan export (#8260)", () => {
     ).toMatchObject({
       contractVersion: 1,
       qualification: {
+        agentQualification: {
+          agent: "openclaw",
+          execution: "disabled",
+          runtimeProvider: "docker",
+        },
         probeBounds: {
           cancellationMaxTokens: 4096,
           clientTimeoutMilliseconds: 250,

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -23,6 +23,7 @@ import {
   validateCandidateDockerfile,
   validateChatCompletionResponse,
   validateModelsResponse,
+  validateOpenClawQualificationImageLabels,
   validateQualificationPlan,
   validateStartupLog,
 } from "../scripts/checks/run-llama-cpp-dgx-spark-qualification.mts";
@@ -337,6 +338,18 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         ]),
       );
       expect(valuesAfter(argv, "--publish")).toEqual(["127.0.0.1::8081"]);
+      const agentQualificationArgv = buildServerContainerArgv(testPlan, {
+        apiKeyHostPath: "/work/tmp/api-key",
+        containerName: "qualified-server",
+        hostPort: 8081,
+        imageReference: `localhost:5000/repo@sha256:${"d".repeat(64)}`,
+        model,
+        networkName: "qualified-internal",
+        registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
+        runtimeGid: 1001,
+        runtimeUid: 1001,
+      });
+      expect(valuesAfter(agentQualificationArgv, "--publish")).toEqual(["127.0.0.1:8081:8081"]);
       expect(valuesAfter(argv, "--network")).toEqual(["qualified-internal"]);
       expect(valuesAfter(argv, "--user")).toEqual(["1001:1001"]);
       expect(valuesAfter(argv, "--api-key-file")).toEqual(["/run/secrets/llama-cpp-api-key"]);
@@ -372,6 +385,28 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     } finally {
       fs.rmSync(modelRoot, { force: true, recursive: true });
     }
+  });
+
+  it("accepts only the exact NVIDIA OpenClaw ARM64 managed-image labels", () => {
+    const labels = {
+      "io.nvidia.nemoclaw.agent": "openclaw",
+      "io.nvidia.nemoclaw.managed-image.contract": "1",
+      "io.nvidia.nemoclaw.managed-image.platform": "linux/arm64",
+      "org.opencontainers.image.revision": "eb1d2f5700393892f227ac9fd56f485fc6718bce",
+      "org.opencontainers.image.source": "https://github.com/NVIDIA/NemoClaw",
+    };
+    expect(() =>
+      validateOpenClawQualificationImageLabels(
+        JSON.stringify(labels),
+        "eb1d2f5700393892f227ac9fd56f485fc6718bce",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateOpenClawQualificationImageLabels(
+        JSON.stringify({ ...labels, "io.nvidia.nemoclaw.agent": "hermes" }),
+        "eb1d2f5700393892f227ac9fd56f485fc6718bce",
+      ),
+    ).toThrow(/declarative identity/u);
   });
 
   it("requires unambiguous full GPU offload and rejects CPU fallback warnings (#8260)", () => {
@@ -411,7 +446,10 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     ).not.toThrow();
     expect(() =>
       validateModelsResponse(
-        { data: [{ id: EXPECTED_MODEL }, { id: "unexpected" }], object: "list" },
+        {
+          data: [{ id: EXPECTED_MODEL }, { id: "unexpected" }],
+          object: "list",
+        },
         EXPECTED_MODEL,
       ),
     ).toThrow();

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -407,6 +407,12 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         "eb1d2f5700393892f227ac9fd56f485fc6718bce",
       ),
     ).toThrow(/declarative identity/u);
+    expect(() =>
+      validateOpenClawQualificationImageLabels(JSON.stringify(labels), "f".repeat(40)),
+    ).toThrow(/declarative identity/u);
+    expect(() => validateOpenClawQualificationImageLabels("{", "f".repeat(40))).toThrow(
+      /labels are invalid/u,
+    );
   });
 
   it("requires unambiguous full GPU offload and rejects CPU fallback warnings (#8260)", () => {

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -20,6 +20,12 @@ const recipePath = path.join(
   "recipes",
   "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
 );
+const agentQualificationPath = path.join(
+  repoRoot,
+  "managed-inference",
+  "qualifications",
+  "llama-cpp.openclaw.spark-single.v1.yaml",
+);
 const exporterPath = path.join(repoRoot, "scripts", "checks", "export-llama-cpp-image-config.mts");
 
 type ImageManifest = {
@@ -68,6 +74,7 @@ type ImageManifest = {
         gpu?: { cpuFallback?: string; fullOffload?: boolean; vendor?: string };
         model?: { digest?: string; hostPath?: string | null; id?: string };
         platform?: string;
+        probeBounds?: Record<string, unknown>;
         probes?: string[];
         profile?: string;
         recipeRef?: string;
@@ -135,7 +142,10 @@ function configureQualification(
 }
 
 function enablePublication(source: string): string {
-  return configureQualification(source, { execution: "enabled", publicationEnabled: true });
+  return configureQualification(source, {
+    execution: "enabled",
+    publicationEnabled: true,
+  });
 }
 
 describe("declarative llama.cpp server image", () => {
@@ -216,6 +226,24 @@ describe("declarative llama.cpp server image", () => {
       imageBuild: {
         platform: { cudaArchitectures: "121a-real", platform: "linux/arm64" },
         source: { revision: manifest.spec?.source?.revision },
+      },
+      qualification: {
+        agentQualification: {
+          execution: "disabled",
+          image: {
+            reference:
+              "ghcr.io/nvidia/nemoclaw/openclaw-sandbox@sha256:3648441718cdd6c2bc4c8fe39fa0d04d3931656b2063af34215cc51841cd0d5e",
+            sourceRevision: "eb1d2f5700393892f227ac9fd56f485fc6718bce",
+          },
+          probes: [
+            "synchronous-chat",
+            "streaming-chat",
+            "agent-normal-turn",
+            "agent-tool-call",
+            "agent-tool-result-continuation",
+            "agent-multi-turn",
+          ],
+        },
       },
       recipe: {
         id: "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
@@ -408,6 +436,40 @@ describe("declarative llama.cpp server image", () => {
     expect(reordered.publication_qualification_plan_sha256).toBe(
       baseline.publication_qualification_plan_sha256,
     );
+  });
+
+  it("uses only the strict agent-qualification YAML to activate OpenClaw probes", () => {
+    const recipeSource = fs.readFileSync(recipePath, "utf8");
+    const qualificationSource = fs.readFileSync(agentQualificationPath, "utf8");
+    const enabled = loadLlamaCppImageConfig(
+      manifestSource,
+      recipeSource,
+      undefined,
+      qualificationSource.replace("execution: disabled", "execution: enabled"),
+    );
+
+    expect(JSON.parse(enabled.publication_qualification_plan)).toMatchObject({
+      qualification: { agentQualification: { execution: "enabled" } },
+    });
+    expect(() =>
+      loadLlamaCppImageConfig(
+        manifestSource,
+        recipeSource,
+        undefined,
+        qualificationSource.replace("provider: llama-cpp-local", "provider: vllm-local"),
+      ),
+    ).toThrow(/agent qualification is invalid/u);
+    expect(() =>
+      loadLlamaCppImageConfig(
+        manifestSource,
+        recipeSource,
+        undefined,
+        qualificationSource.replace(
+          "kind: AgentQualification",
+          "kind: AgentQualification\nextra: true",
+        ),
+      ),
+    ).toThrow(/agent qualification document fields/u);
   });
 
   it("rejects YAML parser warnings in image and recipe inputs (#8260)", () => {

--- a/test/llama-cpp-openclaw-agent-qualification.test.ts
+++ b/test/llama-cpp-openclaw-agent-qualification.test.ts
@@ -104,8 +104,8 @@ describe("llama.cpp OpenClaw qualification probe", () => {
     await expect(
       runLlamaCppOpenClawAgentQualification(
         config,
-        context([{ status: 1, stdout: "", stderr: "probe failed" }], invocations),
+        context([{ status: 1, stdout: "", stderr: "TOKEN=do-not-log" }], invocations),
       ),
-    ).rejects.toThrow(/synchronous probe failed/u);
+    ).rejects.toThrow(/^inference[.]local synchronous probe failed with status 1$/u);
   });
 });

--- a/test/llama-cpp-openclaw-agent-qualification.test.ts
+++ b/test/llama-cpp-openclaw-agent-qualification.test.ts
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { loadLlamaCppImageConfig } from "../scripts/checks/export-llama-cpp-image-config.mts";
+import { parseLlamaCppDgxSparkExecutionPlan } from "../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
+import { runLlamaCppOpenClawAgentQualification } from "../scripts/checks/llama-cpp-openclaw-agent-qualification.mts";
+import type { ManagedImageOpenShellE2eProbeContext } from "../scripts/checks/run-managed-image-openshell-e2e.ts";
+
+function enabledConfig() {
+  const output = loadLlamaCppImageConfig();
+  const plan = parseLlamaCppDgxSparkExecutionPlan(
+    JSON.parse(output.publication_qualification_plan) as unknown,
+  );
+  return {
+    ...plan.qualification.agentQualification,
+    execution: "enabled" as const,
+  };
+}
+
+function context(
+  outputs: readonly { status: number; stdout: string; stderr?: string }[],
+  invocations: string[][],
+  localProvider: "llama-cpp" | "vllm" = "llama-cpp",
+): ManagedImageOpenShellE2eProbeContext {
+  let index = 0;
+  return {
+    input: {
+      agent: "openclaw",
+      image: enabledConfig().image.reference,
+      localProvider,
+      model: "nvidia-nemotron-3-nano-30b-a3b",
+      sandbox: "nemoclaw-llama-cpp-openclaw",
+    },
+    runSandbox(argv) {
+      invocations.push([...argv]);
+      const output = outputs[index++];
+      if (!output) throw new Error("unexpected qualification invocation");
+      return {
+        status: output.status,
+        stdout: output.stdout,
+        stderr: output.stderr ?? "",
+      };
+    },
+  };
+}
+
+describe("llama.cpp OpenClaw qualification probe", () => {
+  it("executes every YAML-authored probe and emits only bounded structural evidence", async () => {
+    const invocations: string[][] = [];
+    const evidence = await runLlamaCppOpenClawAgentQualification(
+      enabledConfig(),
+      context(
+        [
+          { status: 0, stdout: '{"ok":true}' },
+          { status: 0, stdout: '{"done":true,"events":7}' },
+          { status: 0, stdout: '{"payloads":[{"text":"PONG"}]}' },
+          { status: 0, stdout: "" },
+          {
+            status: 0,
+            stdout: '{"payloads":[{"text":"LLAMA_CPP_OPENCLAW_TOOL_OK"}]}',
+          },
+          {
+            status: 0,
+            stdout: '{"payloads":[{"text":"LLAMA_CPP_OPENCLAW_TOOL_OK"}]}',
+          },
+          { status: 0, stdout: '{"calls":1,"results":1,"users":2}' },
+        ],
+        invocations,
+      ),
+    );
+
+    expect(evidence).toEqual({
+      agentMultiTurn: true,
+      agentNormalTurn: true,
+      agentToolCall: { argumentsValid: true, name: "read" },
+      agentToolResultContinuation: true,
+      streamingChat: { done: true, events: 7 },
+      synchronousChat: true,
+    });
+    expect(invocations).toHaveLength(7);
+    expect(invocations[0]).toContain("https://inference.local/v1/chat/completions");
+    expect(invocations[2]).toContain("llama-cpp-openclaw-normal");
+    expect(invocations[4]).toContain("llama-cpp-openclaw-tool");
+    expect(invocations[5]).toContain("llama-cpp-openclaw-tool");
+    expect(invocations[6]).toContain(
+      "/sandbox/.openclaw/agents/main/sessions/llama-cpp-openclaw-tool.jsonl",
+    );
+    expect(JSON.stringify(evidence)).not.toContain("LLAMA_CPP_OPENCLAW_TOOL_OK");
+  });
+
+  it("fails closed on unplanned runtime selection or failed probe evidence", async () => {
+    const config = enabledConfig();
+    const invocations: string[][] = [];
+    const wrongRuntime = context([], invocations, "vllm");
+    await expect(runLlamaCppOpenClawAgentQualification(config, wrongRuntime)).rejects.toThrow(
+      /does not match its declarative plan/u,
+    );
+
+    await expect(
+      runLlamaCppOpenClawAgentQualification(
+        config,
+        context([{ status: 1, stdout: "", stderr: "probe failed" }], invocations),
+      ),
+    ).rejects.toThrow(/synchronous probe failed/u);
+  });
+});

--- a/test/llama-cpp-openclaw-agent-qualification.test.ts
+++ b/test/llama-cpp-openclaw-agent-qualification.test.ts
@@ -35,8 +35,11 @@ function context(
     },
     runSandbox(argv) {
       invocations.push([...argv]);
-      const output = outputs[index++];
-      if (!output) throw new Error("unexpected qualification invocation");
+      const output = outputs[index++] ?? {
+        status: 1,
+        stderr: "unexpected qualification invocation",
+        stdout: "",
+      };
       return {
         status: output.status,
         stdout: output.stdout,

--- a/test/managed-image-protected-runtime-contract.test.ts
+++ b/test/managed-image-protected-runtime-contract.test.ts
@@ -24,6 +24,7 @@ const IMAGE = `localhost:5000/nemoclaw-managed-protected/openclaw@sha256:${"a".r
 
 describe("protected managed-image runtime contract", () => {
   it.each([
+    ["llama-cpp", "llama-cpp-local", "NEMOCLAW_LLAMACPP_LOCAL_TOKEN", 8081],
     ["ollama", "ollama-local", "NEMOCLAW_OLLAMA_PROXY_TOKEN", 11435],
     ["nim", "vllm-local", "NEMOCLAW_VLLM_LOCAL_TOKEN", 8000],
     ["vllm", "vllm-local", "NEMOCLAW_VLLM_LOCAL_TOKEN", 8000],
@@ -31,7 +32,11 @@ describe("protected managed-image runtime contract", () => {
     const route = resolveManagedImageLocalInferenceRoute(kind);
 
     expect(MANAGED_IMAGE_LOCAL_INFERENCE_KINDS).toContain(kind);
-    expect(route).toMatchObject({ kind, providerName: provider, credentialEnv: credential });
+    expect(route).toMatchObject({
+      kind,
+      providerName: provider,
+      credentialEnv: credential,
+    });
     expect(new URL(route.defaultBaseUrl)).toMatchObject({
       hostname: "host.openshell.internal",
       port: String(port),
@@ -138,6 +143,56 @@ describe("protected managed-image runtime contract", () => {
         "--gpu",
       ]),
     ).toThrow(/--gpu requires/u);
+  });
+
+  it("allows only llama.cpp local inference without direct sandbox GPU access", () => {
+    expect(
+      parseManagedImageOpenShellE2eInputs([
+        "--agent",
+        "openclaw",
+        "--image",
+        IMAGE,
+        "--sandbox",
+        "managed-openclaw-llama-cpp",
+        "--local-provider",
+        "llama-cpp",
+        "--model",
+        "nvidia-nemotron-3-nano-30b-a3b",
+      ]),
+    ).toMatchObject({
+      agent: "openclaw",
+      localProvider: "llama-cpp",
+      model: "nvidia-nemotron-3-nano-30b-a3b",
+    });
+    expect(() =>
+      parseManagedImageOpenShellE2eInputs([
+        "--agent",
+        "openclaw",
+        "--image",
+        IMAGE,
+        "--sandbox",
+        "managed-openclaw-vllm",
+        "--local-provider",
+        "vllm",
+        "--model",
+        "nvidia/nemotron-3-nano",
+      ]),
+    ).toThrow(/require --gpu/u);
+    expect(() =>
+      parseManagedImageOpenShellE2eInputs([
+        "--agent",
+        "openclaw",
+        "--image",
+        IMAGE,
+        "--sandbox",
+        "managed-openclaw-llama-cpp",
+        "--local-provider",
+        "llama-cpp",
+        "--model",
+        "nvidia-nemotron-3-nano-30b-a3b",
+        "--inject-bootstrap-completion-failure",
+      ]),
+    ).toThrow(/cannot be combined/u);
   });
 
   it("keeps rollback cleanup distinct from initial readiness", () => {

--- a/test/managed-image-protected-runtime-contract.test.ts
+++ b/test/managed-image-protected-runtime-contract.test.ts
@@ -190,6 +190,33 @@ describe("protected managed-image runtime contract", () => {
         "llama-cpp",
         "--model",
         "nvidia-nemotron-3-nano-30b-a3b",
+        "--gpu",
+      ]),
+    ).toThrow(/must not grant direct sandbox GPU access/u);
+    expect(() =>
+      parseManagedImageOpenShellE2eInputs([
+        "--agent",
+        "openclaw",
+        "--image",
+        IMAGE,
+        "--sandbox",
+        "managed-openclaw-llama-cpp",
+        "--local-provider",
+        "llama-cpp",
+      ]),
+    ).toThrow(/requires --model/u);
+    expect(() =>
+      parseManagedImageOpenShellE2eInputs([
+        "--agent",
+        "openclaw",
+        "--image",
+        IMAGE,
+        "--sandbox",
+        "managed-openclaw-llama-cpp",
+        "--local-provider",
+        "llama-cpp",
+        "--model",
+        "nvidia-nemotron-3-nano-30b-a3b",
         "--inject-bootstrap-completion-failure",
       ]),
     ).toThrow(/cannot be combined/u);

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -491,6 +491,11 @@ describe("deterministic PR risk plan", () => {
       "llama-cpp-dgx-spark-qualification",
     );
     expect(
+      riskPlanRequiredJobIds(
+        plan("managed-inference/qualifications/llama-cpp.other.spark-single.v1.yaml"),
+      ),
+    ).not.toContain("llama-cpp-dgx-spark-qualification");
+    expect(
       dormantImplementation.families.some(
         (family) => family.id === "llama-cpp-dgx-spark-qualification",
       ),

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -86,7 +86,7 @@ describe("deterministic PR risk plan", () => {
     const second = plan("src/lib/onboard.ts", "src/lib/state/registry.ts");
 
     expect(first).toEqual(second);
-    expect(first.version).toBe(16);
+    expect(first.version).toBe(17);
     expect(first.headSha).toBe(HEAD_SHA);
     expect(first.planHash).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.changedFiles).toEqual(["src/lib/onboard.ts", "src/lib/state/registry.ts"]);
@@ -471,6 +471,8 @@ describe("deterministic PR risk plan", () => {
 
   it("keeps protected llama.cpp DGX Spark qualification activation-only until trusted (#8260)", () => {
     const activation = "ci/llama-cpp-dgx-spark-qualification-v1.yaml";
+    const agentQualification =
+      "managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml";
     const result = plan(activation);
     const dormantImplementation = plan(
       "scripts/checks/run-llama-cpp-dgx-spark-qualification.mts",
@@ -485,6 +487,9 @@ describe("deterministic PR risk plan", () => {
       }),
     );
     expect(riskPlanRequiredJobIds(result)).toEqual(["llama-cpp-dgx-spark-qualification"]);
+    expect(riskPlanRequiredJobIds(plan(agentQualification))).toContain(
+      "llama-cpp-dgx-spark-qualification",
+    );
     expect(
       dormantImplementation.families.some(
         (family) => family.id === "llama-cpp-dgx-spark-qualification",

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -18,7 +18,7 @@ const protectedManagedImageContract = (
 const { PROTECTED_MANAGED_IMAGE_ACTIVATION_PATH, PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID } =
   protectedManagedImageContract;
 
-export const RISK_PLAN_VERSION = 16 as const;
+export const RISK_PLAN_VERSION = 17 as const;
 
 export const PR_E2E_TYPED_TARGET_IDS = [
   "ubuntu-repo-cloud-langchain-deepagents-code",
@@ -97,6 +97,8 @@ const MANAGED_IMAGE_PROTECTED_RUNTIME_INPUT_PREFIXES = [
   "test/e2e/live/managed-image-protected-runtime.",
 ] as const;
 const LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION = "ci/llama-cpp-dgx-spark-qualification-v1.yaml";
+const LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION =
+  "managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml";
 const LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID = "llama-cpp-dgx-spark-qualification" as const;
 // The activation-only phase is complete. Any input that can change bytes or
 // startup policy in a shipped managed image must requalify the exact all-agent
@@ -315,7 +317,10 @@ export function focusedPrE2eJobsForChangedFiles(
           },
         ]
       : []),
-    ...MANAGED_STARTUP_E2E_JOB_IDS.map((id) => ({ id, matchedFiles: managedStartupFiles })),
+    ...MANAGED_STARTUP_E2E_JOB_IDS.map((id) => ({
+      id,
+      matchedFiles: managedStartupFiles,
+    })),
     ...HERMES_CLI_ADAPTER_E2E_JOB_IDS.map((id) => ({
       id,
       matchedFiles: hermesCliAdapterFiles,
@@ -550,7 +555,9 @@ export const RISK_RULES: readonly RiskRule[] = [
     // The trusted workflow and validators land while dormant. A later YAML-only
     // activation candidate selects this protected lane after the Spark runner,
     // approval environment, and verified local model path are provisioned.
-    matches: (file) => file === LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION,
+    matches: (file) =>
+      file === LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION ||
+      file === LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION,
   },
   {
     id: "sandbox-boundary",

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createHash } from "node:crypto";
-
+import * as importedLlamaCppDgxSparkQualificationContract from "../../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
 import * as importedProtectedManagedImageContract from "../../scripts/checks/protected-managed-image-contract.ts";
 
 // The root TypeScript package is exposed as CJS under the exact
@@ -15,8 +15,16 @@ const protectedManagedImageContract = (
     : importedProtectedManagedImageContract
 ) as typeof import("../../scripts/checks/protected-managed-image-contract.ts");
 
+const llamaCppDgxSparkQualificationContract = (
+  "default" in importedLlamaCppDgxSparkQualificationContract &&
+  importedLlamaCppDgxSparkQualificationContract.default
+    ? importedLlamaCppDgxSparkQualificationContract.default
+    : importedLlamaCppDgxSparkQualificationContract
+) as typeof import("../../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts");
+
 const { PROTECTED_MANAGED_IMAGE_ACTIVATION_PATH, PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID } =
   protectedManagedImageContract;
+const { LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH } = llamaCppDgxSparkQualificationContract;
 
 export const RISK_PLAN_VERSION = 17 as const;
 
@@ -97,8 +105,6 @@ const MANAGED_IMAGE_PROTECTED_RUNTIME_INPUT_PREFIXES = [
   "test/e2e/live/managed-image-protected-runtime.",
 ] as const;
 const LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION = "ci/llama-cpp-dgx-spark-qualification-v1.yaml";
-const LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION =
-  "managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml";
 const LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID = "llama-cpp-dgx-spark-qualification" as const;
 // The activation-only phase is complete. Any input that can change bytes or
 // startup policy in a shipped managed image must requalify the exact all-agent
@@ -557,7 +563,7 @@ export const RISK_RULES: readonly RiskRule[] = [
     // approval environment, and verified local model path are provisioned.
     matches: (file) =>
       file === LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION ||
-      file === LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION,
+      file === LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH,
   },
   {
     id: "sandbox-boundary",

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createHash } from "node:crypto";
-import * as importedLlamaCppDgxSparkQualificationContract from "../../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
+import {
+  LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
+} from "../../scripts/checks/llama-cpp-dgx-spark-qualification-paths.mts";
 import * as importedProtectedManagedImageContract from "../../scripts/checks/protected-managed-image-contract.ts";
 
 // The root TypeScript package is exposed as CJS under the exact
@@ -15,19 +18,8 @@ const protectedManagedImageContract = (
     : importedProtectedManagedImageContract
 ) as typeof import("../../scripts/checks/protected-managed-image-contract.ts");
 
-const llamaCppDgxSparkQualificationContract = (
-  "default" in importedLlamaCppDgxSparkQualificationContract &&
-  importedLlamaCppDgxSparkQualificationContract.default
-    ? importedLlamaCppDgxSparkQualificationContract.default
-    : importedLlamaCppDgxSparkQualificationContract
-) as typeof import("../../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts");
-
 const { PROTECTED_MANAGED_IMAGE_ACTIVATION_PATH, PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID } =
   protectedManagedImageContract;
-const {
-  LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH,
-  LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
-} = llamaCppDgxSparkQualificationContract;
 
 export const RISK_PLAN_VERSION = 17 as const;
 

--- a/tools/advisors/risk-plan.mts
+++ b/tools/advisors/risk-plan.mts
@@ -24,7 +24,10 @@ const llamaCppDgxSparkQualificationContract = (
 
 const { PROTECTED_MANAGED_IMAGE_ACTIVATION_PATH, PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID } =
   protectedManagedImageContract;
-const { LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH } = llamaCppDgxSparkQualificationContract;
+const {
+  LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
+} = llamaCppDgxSparkQualificationContract;
 
 export const RISK_PLAN_VERSION = 17 as const;
 
@@ -104,7 +107,6 @@ const MANAGED_IMAGE_PROTECTED_RUNTIME_INPUT_PREFIXES = [
   "src/lib/onboard/workload/",
   "test/e2e/live/managed-image-protected-runtime.",
 ] as const;
-const LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION = "ci/llama-cpp-dgx-spark-qualification-v1.yaml";
 const LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID = "llama-cpp-dgx-spark-qualification" as const;
 // The activation-only phase is complete. Any input that can change bytes or
 // startup policy in a shipped managed image must requalify the exact all-agent
@@ -562,7 +564,7 @@ export const RISK_RULES: readonly RiskRule[] = [
     // activation candidate selects this protected lane after the Spark runner,
     // approval environment, and verified local model path are provisioned.
     matches: (file) =>
-      file === LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION ||
+      file === LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH ||
       file === LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH,
   },
   {

--- a/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
+++ b/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
@@ -351,6 +351,11 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
     "-u GITHUB_TOKEN",
     "bash scripts/install-openshell.sh",
   ]);
+  if (text(installOpenShell?.run).includes(".candidate-llama-cpp/scripts")) {
+    errors.push(
+      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must install OpenShell only from trusted helper code`,
+    );
+  }
   const materialize = requireStep(
     errors,
     LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,

--- a/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
+++ b/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
@@ -113,6 +113,7 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
   }
   const expectedOutputs = Object.fromEntries(
     [
+      "agent_qualification_execution",
       "environment",
       "execution",
       "model_host_path",
@@ -327,6 +328,29 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
       `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must use trusted no-build preparation`,
     );
   }
+  const installOpenShell = requireStep(
+    errors,
+    LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
+    qualificationSteps,
+    "Install OpenShell CLI for declarative OpenClaw qualification",
+  );
+  if (
+    installOpenShell?.if !==
+    `\${{ needs.${PLAN_JOB_ID}.outputs.agent_qualification_execution == 'enabled' }}`
+  ) {
+    errors.push(
+      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must gate OpenShell installation on the declarative agent qualification`,
+    );
+  }
+  requireFragments(errors, LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID, installOpenShell, [
+    "env -u DOCKER_CONFIG",
+    "-u DOCKERHUB_USERNAME",
+    "-u DOCKERHUB_TOKEN",
+    "-u NVIDIA_API_KEY",
+    "-u NVIDIA_INFERENCE_API_KEY",
+    "-u GITHUB_TOKEN",
+    "bash scripts/install-openshell.sh",
+  ]);
   const materialize = requireStep(
     errors,
     LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
@@ -408,6 +432,7 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
     "Checkout trusted llama.cpp qualification",
     "Checkout exact llama.cpp qualification candidate",
     "Prepare E2E workspace",
+    "Install OpenShell CLI for declarative OpenClaw qualification",
     "Materialize trusted llama.cpp qualification plan",
     "Build and qualify exact llama.cpp candidate",
     "Remove protected llama.cpp qualification resources",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Stages the execution-disabled, YAML-authored qualification path for running OpenClaw against the existing llama.cpp/Nemotron single-DGX-Spark recipe through `inference.local`. This lands the trusted compiler, protected runner wiring, and evidence contract without claiming support; the shipped recipe still declares `agents: []`, and a later YAML-only activation can exercise the tuple after this code is on `main`.

## Related Issue

Advances #8144.

## Changes

- Adds a strict standalone `AgentQualification` YAML that pins the OpenClaw image digest, Docker runtime, route, bounds, prompts, sessions, tool fixture, and required probes while keeping execution disabled.
- Extends the trusted DGX Spark plan and runner to conditionally install OpenShell, route the already-qualified llama.cpp server through `inference.local`, execute synchronous/streaming and real agent/tool/multi-turn probes, and emit sanitized identity-bound evidence.
- Keeps the existing llama.cpp image manifest and shipped recipe unchanged, preserves the trusted-main/candidate-config boundary, restores operation-scoped process state, and requires exact cleanup.
- Updates risk selection and focused tests so changing the qualification YAML selects the protected Spark lane and cannot silently bypass the declarative plan.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: execution remains disabled, the shipped recipe still declares no qualified agents, and current docs already state that support requires protected qualification and activation.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: author threat review covered strict candidate parsing, trusted-main execution, credential non-disclosure, immutable image/model identities, loopback-only host exposure, no direct sandbox GPU access, bounded evidence, and exact cleanup; automated security and review advisors remain required before merge.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This PR adds an execution-disabled protected OpenClaw and llama.cpp qualification path and strengthens its evidence, cleanup, and trusted-workflow controls. The shipped recipe still declares no qualified agents, and existing documentation already states that support requires protected qualification and activation.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 39b66e930 -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm run typecheck -- --pretty false`; 233 focused qualification, workflow, and risk tests.
- [ ] Applicable broad gate passed — GitHub's broad Linux CI is required; the local macOS aggregate run was stopped after unrelated watcher tests exceeded their existing time budgets.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OpenClaw agent qualification for llama.cpp managed inference.
  * Added declarative chat, streaming, tool-use, and continuation probes.
  * Added local llama.cpp routing and protected runtime support.
  * Qualification results now include structured agent evidence and execution details.
  * CI now conditionally installs required sandbox tooling and exposes qualification status.

* **Bug Fixes**
  * Improved validation of image identity, revisions, routes, cleanup, and runtime behavior.
  * Prevented unauthorized or incorrectly configured qualification execution.

* **Tests**
  * Expanded end-to-end coverage for qualification workflows, probes, routing, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->