### PR TITLE
ci(checks): reject Vitest test registration outside test files

### DIFF
--- a/scripts/checks/run.mts
+++ b/scripts/checks/run.mts
@@ -98,6 +98,11 @@ export const CHECKS: readonly CheckCommand[] = [
     command: TSX,
     args: ["scripts/checks/no-unit-blocks-in-live-e2e.mts"],
   },
+  {
+    name: "test-registration-boundary",
+    command: TSX,
+    args: ["scripts/checks/test-registration-boundary.mts"],
+  },
 ];
 
 type RunChecksOptions = {

--- a/scripts/checks/test-registration-boundary.mts
+++ b/scripts/checks/test-registration-boundary.mts
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import ts from "typescript";
+
+export type TestRegistrationViolation = {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+  readonly call: string;
+};
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_SCAN_ROOTS = Object.freeze([
+  "bin",
+  "nemoclaw/src",
+  "scripts",
+  "src",
+  "test",
+  "tools",
+]);
+const SOURCE_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/;
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/;
+const SUITE_FILE_PATTERN = /-suite\.(?:[cm]?[jt]sx?)$/;
+const SKIP_DIRS = new Set([".git", ".venv", "coverage", "dist", "node_modules"]);
+const REGISTRATION_NAMES = new Set(["describe", "it", "suite", "test"]);
+const REGISTRATION_MODIFIERS = new Set([
+  "concurrent",
+  "each",
+  "fails",
+  "for",
+  "only",
+  "runIf",
+  "scoped",
+  "sequential",
+  "skip",
+  "skipIf",
+  "todo",
+]);
+
+type CallChain = {
+  readonly rootName: string;
+  readonly rootNode: ts.Identifier;
+  readonly members: readonly string[];
+};
+
+type VitestBindings = {
+  readonly registrations: ReadonlyMap<string, string>;
+  readonly namespaces: ReadonlySet<string>;
+};
+
+function scriptKindFor(filePath: string): ts.ScriptKind {
+  if (/\.tsx$/i.test(filePath)) return ts.ScriptKind.TSX;
+  if (/\.jsx$/i.test(filePath)) return ts.ScriptKind.JSX;
+  if (/\.[cm]?js$/i.test(filePath)) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function collectVitestBindings(sourceFile: ts.SourceFile): VitestBindings {
+  const registrations = new Map<string, string>();
+  const namespaces = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== "vitest"
+    ) {
+      continue;
+    }
+    const importClause = statement.importClause;
+    if (importClause === undefined || importClause.isTypeOnly) continue;
+
+    const bindings = importClause.namedBindings;
+    if (bindings === undefined) continue;
+    if (ts.isNamespaceImport(bindings)) {
+      namespaces.add(bindings.name.text);
+      continue;
+    }
+    for (const element of bindings.elements) {
+      if (element.isTypeOnly) continue;
+      const importedName = element.propertyName?.text ?? element.name.text;
+      if (REGISTRATION_NAMES.has(importedName)) {
+        registrations.set(element.name.text, importedName);
+      }
+    }
+  }
+
+  return { registrations, namespaces };
+}
+
+function callChain(expression: ts.Expression): CallChain | null {
+  if (ts.isIdentifier(expression)) {
+    return { rootName: expression.text, rootNode: expression, members: [] };
+  }
+  if (ts.isPropertyAccessExpression(expression)) {
+    const inner = callChain(expression.expression);
+    if (inner === null) return null;
+    return { ...inner, members: [...inner.members, expression.name.text] };
+  }
+  if (ts.isCallExpression(expression)) return callChain(expression.expression);
+  return null;
+}
+
+function registrationCall(chain: CallChain, bindings: VitestBindings): string | null {
+  const imported = bindings.registrations.get(chain.rootName);
+  const name = imported ?? (bindings.namespaces.has(chain.rootName) ? chain.members[0] : undefined);
+  const modifiers = imported === undefined ? chain.members.slice(1) : chain.members;
+  if (name === undefined || !REGISTRATION_NAMES.has(name)) return null;
+  if (!modifiers.every((modifier) => REGISTRATION_MODIFIERS.has(modifier))) return null;
+  return [chain.rootName, ...chain.members].join(".");
+}
+
+export function scanTestRegistrations(
+  file: string,
+  source: string,
+): readonly TestRegistrationViolation[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(file),
+  );
+  const bindings = collectVitestBindings(sourceFile);
+  if (bindings.registrations.size === 0 && bindings.namespaces.size === 0) return [];
+
+  const violations: TestRegistrationViolation[] = [];
+  const reported = new Set<number>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      const chain = callChain(node.expression);
+      const call = chain === null ? null : registrationCall(chain, bindings);
+      if (chain !== null && call !== null) {
+        const start = chain.rootNode.getStart(sourceFile);
+        if (!reported.has(start)) {
+          reported.add(start);
+          const location = sourceFile.getLineAndCharacterOfPosition(start);
+          violations.push({
+            file,
+            line: location.line + 1,
+            column: location.character + 1,
+            call,
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return violations;
+}
+
+export function isScannedModule(file: string): boolean {
+  const name = path.basename(file);
+  return (
+    SOURCE_FILE_PATTERN.test(name) &&
+    !TEST_FILE_PATTERN.test(name) &&
+    !SUITE_FILE_PATTERN.test(name)
+  );
+}
+
+function isSkipped(absolutePath: string): boolean {
+  const segments = path.relative(REPO_ROOT, absolutePath).split(path.sep);
+  return segments.some((segment) => SKIP_DIRS.has(segment));
+}
+
+function* walkModules(directory: string): Generator<string> {
+  if (!existsSync(directory) || isSkipped(directory)) return;
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) continue;
+    const absolutePath = path.join(directory, entry.name);
+    if (isSkipped(absolutePath)) continue;
+    if (entry.isDirectory()) {
+      yield* walkModules(absolutePath);
+    } else if (entry.isFile() && isScannedModule(entry.name)) {
+      yield absolutePath;
+    }
+  }
+}
+
+export function findTestRegistrationViolations(
+  roots: readonly string[] = DEFAULT_SCAN_ROOTS,
+): readonly TestRegistrationViolation[] {
+  const violations: TestRegistrationViolation[] = [];
+  for (const root of roots) {
+    const absoluteRoot = path.resolve(REPO_ROOT, root);
+    for (const absolutePath of walkModules(absoluteRoot)) {
+      const file = path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/");
+      violations.push(...scanTestRegistrations(file, readFileSync(absolutePath, "utf8")));
+    }
+  }
+  return violations;
+}
+
+export function formatViolations(violations: readonly TestRegistrationViolation[]): string {
+  const lines = [
+    "Test registration boundary check failed.",
+    "",
+    "These modules register Vitest tests, but Vitest does not collect them as test",
+    "files. Their cases run only when a collected test file imports the module, and",
+    "not at all when nothing imports it. Either way the cases stay outside the",
+    "vitest-project-overlap, test file size budget, and test-title-style checks.",
+    "",
+    "Fix: move each registration into a collected test file — root test/**/*.test.ts,",
+    "a co-located src/**/*.test.ts, or test/e2e/support/**. Rename the module to",
+    "*-suite.ts only when a collected test file imports it to register shared tests.",
+    "",
+  ];
+  for (const violation of violations) {
+    lines.push(`- ${violation.file}:${violation.line}:${violation.column} ${violation.call}(...)`);
+  }
+  return lines.join("\n");
+}
+
+function main(): void {
+  const violations = findTestRegistrationViolations();
+  if (violations.length === 0) {
+    console.log("Test registration boundary check passed.");
+    return;
+  }
+
+  console.error(formatViolations(violations));
+  console.error(`Found ${violations.length} test registration violation(s).`);
+  process.exitCode = 1;
+}
+
+const invokedPath = process.argv[1];
+if (
+  invokedPath !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(invokedPath)).href
+) {
+  main();
+}

--- a/scripts/checks/test-registration-boundary.mts
+++ b/scripts/checks/test-registration-boundary.mts
@@ -26,6 +26,16 @@ const DEFAULT_SCAN_ROOTS = Object.freeze([
 const SOURCE_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/;
 const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/;
 const SUITE_FILE_PATTERN = /-suite\.(?:[cm]?[jt]sx?)$/;
+const SOURCE_EXTENSIONS = Object.freeze([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
 const SKIP_DIRS = new Set([".git", ".venv", "coverage", "dist", "node_modules"]);
 const REGISTRATION_NAMES = new Set(["describe", "it", "suite", "test"]);
 const REGISTRATION_MODIFIERS = new Set([
@@ -49,8 +59,8 @@ type CallChain = {
 };
 
 type VitestBindings = {
-  readonly registrations: ReadonlyMap<string, string>;
-  readonly namespaces: ReadonlySet<string>;
+  readonly registrations: ReadonlyMap<ts.Symbol, string>;
+  readonly namespaces: ReadonlySet<ts.Symbol>;
 };
 
 function scriptKindFor(filePath: string): ts.ScriptKind {
@@ -60,9 +70,43 @@ function scriptKindFor(filePath: string): ts.ScriptKind {
   return ts.ScriptKind.TS;
 }
 
-function collectVitestBindings(sourceFile: ts.SourceFile): VitestBindings {
-  const registrations = new Map<string, string>();
-  const namespaces = new Set<string>();
+function bindSourceFile(file: string, source: string): {
+  readonly checker: ts.TypeChecker;
+  readonly sourceFile: ts.SourceFile;
+} {
+  const fileName = path.resolve(file);
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(fileName),
+  );
+  const host: ts.CompilerHost = {
+    fileExists: (candidate) => path.resolve(candidate) === fileName,
+    getCanonicalFileName: (candidate) => candidate,
+    getCurrentDirectory: () => path.dirname(fileName),
+    getDefaultLibFileName: () => "lib.d.ts",
+    getNewLine: () => "\n",
+    getSourceFile: (candidate) => (path.resolve(candidate) === fileName ? sourceFile : undefined),
+    readFile: (candidate) => (path.resolve(candidate) === fileName ? source : undefined),
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => undefined,
+  };
+  const program = ts.createProgram(
+    [fileName],
+    { allowJs: true, noLib: true, noResolve: true, target: ts.ScriptTarget.Latest },
+    host,
+  );
+  return { checker: program.getTypeChecker(), sourceFile };
+}
+
+function collectVitestBindings(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+): VitestBindings {
+  const registrations = new Map<ts.Symbol, string>();
+  const namespaces = new Set<ts.Symbol>();
 
   for (const statement of sourceFile.statements) {
     if (
@@ -78,14 +122,16 @@ function collectVitestBindings(sourceFile: ts.SourceFile): VitestBindings {
     const bindings = importClause.namedBindings;
     if (bindings === undefined) continue;
     if (ts.isNamespaceImport(bindings)) {
-      namespaces.add(bindings.name.text);
+      const symbol = checker.getSymbolAtLocation(bindings.name);
+      if (symbol !== undefined) namespaces.add(symbol);
       continue;
     }
     for (const element of bindings.elements) {
       if (element.isTypeOnly) continue;
       const importedName = element.propertyName?.text ?? element.name.text;
       if (REGISTRATION_NAMES.has(importedName)) {
-        registrations.set(element.name.text, importedName);
+        const symbol = checker.getSymbolAtLocation(element.name);
+        if (symbol !== undefined) registrations.set(symbol, importedName);
       }
     }
   }
@@ -102,13 +148,20 @@ function callChain(expression: ts.Expression): CallChain | null {
     if (inner === null) return null;
     return { ...inner, members: [...inner.members, expression.name.text] };
   }
+  if (ts.isTaggedTemplateExpression(expression)) return callChain(expression.tag);
   if (ts.isCallExpression(expression)) return callChain(expression.expression);
   return null;
 }
 
-function registrationCall(chain: CallChain, bindings: VitestBindings): string | null {
-  const imported = bindings.registrations.get(chain.rootName);
-  const name = imported ?? (bindings.namespaces.has(chain.rootName) ? chain.members[0] : undefined);
+function registrationCall(
+  chain: CallChain,
+  bindings: VitestBindings,
+  checker: ts.TypeChecker,
+): string | null {
+  const symbol = checker.getSymbolAtLocation(chain.rootNode);
+  if (symbol === undefined) return null;
+  const imported = bindings.registrations.get(symbol);
+  const name = imported ?? (bindings.namespaces.has(symbol) ? chain.members[0] : undefined);
   const modifiers = imported === undefined ? chain.members.slice(1) : chain.members;
   if (name === undefined || !REGISTRATION_NAMES.has(name)) return null;
   if (!modifiers.every((modifier) => REGISTRATION_MODIFIERS.has(modifier))) return null;
@@ -119,14 +172,9 @@ export function scanTestRegistrations(
   file: string,
   source: string,
 ): readonly TestRegistrationViolation[] {
-  const sourceFile = ts.createSourceFile(
-    file,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindFor(file),
-  );
-  const bindings = collectVitestBindings(sourceFile);
+  if (!source.includes("vitest")) return [];
+  const { checker, sourceFile } = bindSourceFile(file, source);
+  const bindings = collectVitestBindings(sourceFile, checker);
   if (bindings.registrations.size === 0 && bindings.namespaces.size === 0) return [];
 
   const violations: TestRegistrationViolation[] = [];
@@ -135,7 +183,7 @@ export function scanTestRegistrations(
   function visit(node: ts.Node): void {
     if (ts.isCallExpression(node)) {
       const chain = callChain(node.expression);
-      const call = chain === null ? null : registrationCall(chain, bindings);
+      const call = chain === null ? null : registrationCall(chain, bindings, checker);
       if (chain !== null && call !== null) {
         const start = chain.rootNode.getStart(sourceFile);
         if (!reported.has(start)) {
@@ -157,12 +205,12 @@ export function scanTestRegistrations(
   return violations;
 }
 
-export function isScannedModule(file: string): boolean {
+export function isScannedModule(file: string, suiteImportedByTest = false): boolean {
   const name = path.basename(file);
   return (
     SOURCE_FILE_PATTERN.test(name) &&
     !TEST_FILE_PATTERN.test(name) &&
-    !SUITE_FILE_PATTERN.test(name)
+    (!SUITE_FILE_PATTERN.test(name) || !suiteImportedByTest)
   );
 }
 
@@ -171,7 +219,7 @@ function isSkipped(absolutePath: string): boolean {
   return segments.some((segment) => SKIP_DIRS.has(segment));
 }
 
-function* walkModules(directory: string): Generator<string> {
+function* walkSourceModules(directory: string): Generator<string> {
   if (!existsSync(directory) || isSkipped(directory)) return;
 
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
@@ -179,23 +227,79 @@ function* walkModules(directory: string): Generator<string> {
     const absolutePath = path.join(directory, entry.name);
     if (isSkipped(absolutePath)) continue;
     if (entry.isDirectory()) {
-      yield* walkModules(absolutePath);
-    } else if (entry.isFile() && isScannedModule(entry.name)) {
+      yield* walkSourceModules(absolutePath);
+    } else if (entry.isFile() && SOURCE_FILE_PATTERN.test(entry.name)) {
       yield absolutePath;
     }
   }
+}
+
+function staticModuleSpecifiers(sourceFile: ts.SourceFile): readonly string[] {
+  const specifiers: string[] = [];
+  for (const statement of sourceFile.statements) {
+    if (
+      (ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement)) &&
+      statement.moduleSpecifier !== undefined &&
+      ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      specifiers.push(statement.moduleSpecifier.text);
+    }
+  }
+  return specifiers;
+}
+
+function resolveRelativeModule(
+  importer: string,
+  specifier: string,
+  modules: ReadonlySet<string>,
+): string | null {
+  if (!specifier.startsWith(".")) return null;
+  const base = path.resolve(path.dirname(importer), specifier);
+  const extension = path.extname(base);
+  const stem = SOURCE_EXTENSIONS.includes(extension) ? base.slice(0, -extension.length) : base;
+  const candidates = new Set([base, ...SOURCE_EXTENSIONS.map((suffix) => `${stem}${suffix}`)]);
+  for (const candidate of candidates) {
+    if (modules.has(candidate)) return candidate;
+  }
+  return null;
+}
+
+function importedSuiteModules(modules: ReadonlySet<string>): ReadonlySet<string> {
+  const importedSuites = new Set<string>();
+  for (const importer of modules) {
+    if (!TEST_FILE_PATTERN.test(path.basename(importer))) continue;
+    const source = readFileSync(importer, "utf8");
+    const sourceFile = ts.createSourceFile(
+      importer,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      scriptKindFor(importer),
+    );
+    for (const specifier of staticModuleSpecifiers(sourceFile)) {
+      const resolved = resolveRelativeModule(importer, specifier, modules);
+      if (resolved !== null && SUITE_FILE_PATTERN.test(path.basename(resolved))) {
+        importedSuites.add(resolved);
+      }
+    }
+  }
+  return importedSuites;
 }
 
 export function findTestRegistrationViolations(
   roots: readonly string[] = DEFAULT_SCAN_ROOTS,
 ): readonly TestRegistrationViolation[] {
   const violations: TestRegistrationViolation[] = [];
+  const modules = new Set<string>();
   for (const root of roots) {
     const absoluteRoot = path.resolve(REPO_ROOT, root);
-    for (const absolutePath of walkModules(absoluteRoot)) {
-      const file = path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/");
-      violations.push(...scanTestRegistrations(file, readFileSync(absolutePath, "utf8")));
-    }
+    for (const absolutePath of walkSourceModules(absoluteRoot)) modules.add(absolutePath);
+  }
+  const importedSuites = importedSuiteModules(modules);
+  for (const absolutePath of modules) {
+    if (!isScannedModule(absolutePath, importedSuites.has(absolutePath))) continue;
+    const file = path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/");
+    violations.push(...scanTestRegistrations(file, readFileSync(absolutePath, "utf8")));
   }
   return violations;
 }

--- a/test/checks-runner.test.ts
+++ b/test/checks-runner.test.ts
@@ -25,6 +25,14 @@ describe("checks runner", () => {
     });
   });
 
+  it("registers the test registration boundary check", () => {
+    expect(CHECKS).toContainEqual({
+      name: "test-registration-boundary",
+      command: process.platform === "win32" ? "tsx.cmd" : "tsx",
+      args: ["scripts/checks/test-registration-boundary.mts"],
+    });
+  });
+
   it("runs Windows command shims through cmd.exe", () => {
     expect(
       buildCheckSpawnInvocation(sampleCheck, "win32", {

--- a/test/test-registration-boundary.test.ts
+++ b/test/test-registration-boundary.test.ts
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  findTestRegistrationViolations,
+  formatViolations,
+  isScannedModule,
+  scanTestRegistrations,
+} from "../scripts/checks/test-registration-boundary.mts";
+
+function scan(source: string, file = "test/helpers/example-helper.ts") {
+  return scanTestRegistrations(file, source);
+}
+
+describe("test registration boundary scanner", () => {
+  it("flags a helper module that registers a suite", () => {
+    const violations = scan(
+      [
+        'import { describe, expect, it } from "vitest";',
+        "",
+        "export function registerExampleTests() {",
+        '  describe("example", () => {',
+        '    it("holds", () => expect(1).toBe(1));',
+        "  });",
+        "}",
+      ].join("\n"),
+    );
+
+    expect(violations).toEqual([
+      { file: "test/helpers/example-helper.ts", line: 4, column: 3, call: "describe" },
+      { file: "test/helpers/example-helper.ts", line: 5, column: 5, call: "it" },
+    ]);
+  });
+
+  it("flags the describe, it, suite, and test registrations", () => {
+    const violations = scan(
+      [
+        'import { describe, it, suite, test } from "vitest";',
+        "",
+        'describe("a", () => {});',
+        'it("b", () => {});',
+        'suite("c", () => {});',
+        'test("d", () => {});',
+      ].join("\n"),
+    );
+
+    expect(violations.map(({ call }) => call)).toEqual(["describe", "it", "suite", "test"]);
+  });
+
+  it("flags modifier chains on a registration binding", () => {
+    const violations = scan(
+      [
+        'import { describe, it, test } from "vitest";',
+        "",
+        'describe.each([1, 2])("each %i", () => {});',
+        'it.only("only", () => {});',
+        'it.skip("skip", () => {});',
+        'test.skipIf(false)("skipIf", () => {});',
+        'test.runIf(true)("runIf", () => {});',
+        'describe.concurrent("concurrent", () => {});',
+      ].join("\n"),
+    );
+
+    expect(violations.map(({ call }) => call)).toEqual([
+      "describe.each",
+      "it.only",
+      "it.skip",
+      "test.skipIf",
+      "test.runIf",
+      "describe.concurrent",
+    ]);
+  });
+
+  it("reports a chained registration once at the root binding", () => {
+    const violations = scan(
+      ['import { it } from "vitest";', "", 'it.skipIf(false)("chained", () => {});'].join("\n"),
+    );
+
+    expect(violations).toEqual([
+      { file: "test/helpers/example-helper.ts", line: 3, column: 1, call: "it.skipIf" },
+    ]);
+  });
+
+  it("resolves a renamed registration import", () => {
+    const violations = scan(
+      [
+        'import { describe as group, it as scenario } from "vitest";',
+        "",
+        'group("renamed", () => {',
+        '  scenario("case", () => {});',
+        "});",
+      ].join("\n"),
+    );
+
+    expect(violations.map(({ call }) => call)).toEqual(["group", "scenario"]);
+  });
+
+  it("resolves registrations reached through a namespace import", () => {
+    const violations = scan(
+      [
+        'import * as vitest from "vitest";',
+        "",
+        'vitest.describe.only("namespaced", () => {});',
+      ].join("\n"),
+    );
+
+    expect(violations.map(({ call }) => call)).toEqual(["vitest.describe.only"]);
+  });
+
+  it("does not flag fixture extension", () => {
+    const violations = scan(
+      [
+        'import { test as base, describe, expect } from "vitest";',
+        "",
+        "export const test = base.extend({",
+        "  resource: async ({}, use) => {",
+        "    await use({});",
+        "  },",
+        "});",
+        "",
+        "export { describe, expect };",
+      ].join("\n"),
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it("does not flag registration names inside comments and strings", () => {
+    const violations = scan(
+      [
+        'import { describe } from "vitest";',
+        "",
+        '// describe("commented", () => {});',
+        '/* it("blocked", () => {}); */',
+        "export const label = 'test(\"quoted\", () => {})';",
+      ].join("\n"),
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it("does not flag a locally declared registration name", () => {
+    const violations = scan(
+      [
+        'import { expect } from "vitest";',
+        "",
+        "function it(title: string, body: () => void) {",
+        "  return { title, body };",
+        "}",
+        "",
+        'export const recorded = it("local", () => expect(true).toBe(true));',
+      ].join("\n"),
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it("does not flag a type-only Vitest import", () => {
+    const violations = scan(
+      [
+        'import type { TestContext } from "vitest";',
+        "",
+        "export function describe(context: TestContext) {",
+        "  return context;",
+        "}",
+        "",
+        "export const described = describe({} as TestContext);",
+      ].join("\n"),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});
+
+describe("test registration boundary module selection", () => {
+  it("selects modules that Vitest does not collect as test files", () => {
+    expect(isScannedModule("test/helpers/example-helper.ts")).toBe(true);
+    expect(isScannedModule("src/lib/example.mts")).toBe(true);
+    expect(isScannedModule("bin/example.js")).toBe(true);
+  });
+
+  it("does not select test or spec files", () => {
+    expect(isScannedModule("src/lib/example.test.ts")).toBe(false);
+    expect(isScannedModule("test/example.spec.js")).toBe(false);
+  });
+
+  it("does not select a shared suite module", () => {
+    expect(isScannedModule("test/local-credential-helper-suite.ts")).toBe(false);
+    expect(isScannedModule("test/openclaw-integrity-pin-suite.ts")).toBe(false);
+  });
+
+  it("does not select files that are not JavaScript or TypeScript", () => {
+    expect(isScannedModule("docs/example.mdx")).toBe(false);
+    expect(isScannedModule("scripts/example.sh")).toBe(false);
+  });
+});
+
+describe("test registration boundary diagnostics", () => {
+  it("names the file, position, and remediation for each violation", () => {
+    const report = formatViolations([
+      { file: "test/helpers/example-helper.ts", line: 4, column: 3, call: "describe" },
+    ]);
+
+    expect(report).toContain("test/helpers/example-helper.ts:4:3 describe(...)");
+    expect(report).toContain("*.test.ts");
+    expect(report).toContain("*-suite.ts");
+  });
+});
+
+describe("test registration boundary repository state", () => {
+  it("reports no test registration outside test and suite files", () => {
+    expect(findTestRegistrationViolations()).toEqual([]);
+  });
+});

--- a/test/test-registration-boundary.test.ts
+++ b/test/test-registration-boundary.test.ts
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -109,6 +112,25 @@ describe("test registration boundary scanner", () => {
     expect(violations.map(({ call }) => call)).toEqual(["vitest.describe.only"]);
   });
 
+  it("flags tagged-template registrations through direct, renamed, and namespace imports", () => {
+    const violations = scan(
+      [
+        'import { describe, test as scenario } from "vitest";',
+        'import * as vitest from "vitest";',
+        "",
+        'describe.each`value | expected\n${1} | ${1}`("direct", () => {});',
+        'scenario.each`value\n${2}`("renamed", () => {});',
+        'vitest.suite.each`value\n${3}`("namespaced", () => {});',
+      ].join("\n"),
+    );
+
+    expect(violations.map(({ call }) => call)).toEqual([
+      "describe.each",
+      "scenario.each",
+      "vitest.suite.each",
+    ]);
+  });
+
   it("does not flag fixture extension", () => {
     const violations = scan(
       [
@@ -157,6 +179,23 @@ describe("test registration boundary scanner", () => {
     expect(violations).toEqual([]);
   });
 
+  it("resolves a nested registration parameter instead of the imported binding", () => {
+    const violations = scan(
+      [
+        'import { it } from "vitest";',
+        "",
+        'it("imported", () => {});',
+        "function invoke(it: (title: string, body: () => void) => unknown) {",
+        '  it("local", () => {});',
+        "}",
+      ].join("\n"),
+    );
+
+    expect(violations).toEqual([
+      { file: "test/helpers/example-helper.ts", line: 3, column: 1, call: "it" },
+    ]);
+  });
+
   it("does not flag a type-only Vitest import", () => {
     const violations = scan(
       [
@@ -186,9 +225,10 @@ describe("test registration boundary module selection", () => {
     expect(isScannedModule("test/example.spec.js")).toBe(false);
   });
 
-  it("does not select a shared suite module", () => {
-    expect(isScannedModule("test/local-credential-helper-suite.ts")).toBe(false);
-    expect(isScannedModule("test/openclaw-integrity-pin-suite.ts")).toBe(false);
+  it("selects an orphan suite module but exempts one imported by a test", () => {
+    expect(isScannedModule("test/orphan-suite.ts")).toBe(true);
+    expect(isScannedModule("test/local-credential-helper-suite.ts", true)).toBe(false);
+    expect(isScannedModule("test/openclaw-integrity-pin-suite.ts", true)).toBe(false);
   });
 
   it("does not select files that are not JavaScript or TypeScript", () => {
@@ -210,6 +250,28 @@ describe("test registration boundary diagnostics", () => {
 });
 
 describe("test registration boundary repository state", () => {
+  it("exempts an imported suite module and reports an orphan suite module", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "nemoclaw-test-registration-boundary-"));
+    try {
+      writeFileSync(path.join(root, "collected.test.ts"), 'import "./imported-suite";\n');
+      writeFileSync(
+        path.join(root, "imported-suite.ts"),
+        'import { it } from "vitest";\nit("imported", () => {});\n',
+      );
+      writeFileSync(
+        path.join(root, "orphan-suite.ts"),
+        'import { it } from "vitest";\nit("orphan", () => {});\n',
+      );
+
+      const violations = findTestRegistrationViolations([root]);
+
+      expect(violations).toHaveLength(1);
+      expect(path.basename(violations[0]?.file ?? "")).toBe("orphan-suite.ts");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("reports no test registration outside test and suite files", () => {
     expect(findTestRegistrationViolations()).toEqual([]);
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Repository checks now reject Vitest test registration from helper and other modules that Vitest does not collect as suites. Before, a helper could register cases that ran only through a side-effect import, which kept them outside project membership, file-size, and title checks. Such a registration now fails the check with the file, position, and remediation.

## Related Issue
Resolves #8358
Closes #8354, resolved by #8444
Closes #8356, resolved by #8436

## Changes
- Add `scripts/checks/test-registration-boundary.mts`: a TypeScript-AST scan that resolves bindings imported from `vitest`, then flags calls to `describe`, `it`, `test`, and `suite` through those bindings, including renamed imports, namespace imports, and modifier chains such as `each`, `only`, `skip`, `skipIf`, `runIf`, and `concurrent`. Discoverable `*.test.*` and `*.spec.*` files and explicitly named `*-suite.*` registrars stay out of scope, as does fixture extension through `base.extend(...)`. The scan carries no allowlist.
- Wire the check into `scripts/checks/run.mts` beside the other test-boundary checks, so `npm run checks:repository` runs it.
- Add `test/test-registration-boundary.test.ts` covering registration, modifier chains, renamed and namespace imports, comments and string literals, fixture extension, locally declared names, type-only imports, module selection, and the zero-violation state of the repository.
- Assert the new runner entry in `test/checks-runner.test.ts`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the change adds a repository check and touches no user-visible surface. No documentation page names an individual repository check; a search of `*.md`, `*.mdx`, `*.yaml`, and `*.yml` for `no-unit-blocks-in-live-e2e` and `test-title-style` returns no match.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation path changed. The reviewer confirmed that the only Markdown references to this surface are the `npm run checks:repository` command name in `CONTRIBUTING.md` and `AGENTS.md`, neither of which enumerates individual checks, and that the change alters no public API, CLI command, configuration, UI, documented workflow, default, or supported product behavior. The review returned two blocking findings on the contributor-facing text, both fixed in this commit: the failure message used `suite` for both a Vitest collection unit and the `*-suite.ts` module convention, which made the rename read as a way to get the module collected, and one test title claimed coverage of every Vitest registration primitive while the check covers `describe`, `it`, `suite`, and `test`. The maintainer follow-up changes only the internal repository scanner and its tests; it alters no shipped product surface. A Codex Desktop documentation review confirmed that the generic `checks:repository` contributor guidance remains accurate and no documentation source needs changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: db9565f8a -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/test-registration-boundary.test.ts test/checks-runner.test.ts` — 2 files, 25 tests passed. `npm run checks:repository`, `npm run test:projects:check`, `npm run test:titles:check`, `npm run test-size:check`, and `npm run typecheck:cli` each exit 0. The guard was also exercised end to end: a temporary registrar at `test/helpers/registration-probe.ts` made the check exit 1 and report both registration lines; renaming it to `-suite.ts` returned exit 0; the file was then removed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run check` exits 1 at the `hadolint` hook, which reports 30 pre-existing findings across `Dockerfile`, `Dockerfile.base`, `agents/hermes/Dockerfile`, `agents/langchain-deepagents-code/Dockerfile`, and four test Dockerfiles. This commit changes no Dockerfile. Every other pre-commit hook passes, including `Repository checks`, which runs the new check. The `hadolint` exit stops the chain before the manual stage runs, so that stage is unverified here.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated check to detect Vitest test registrations in non-test application modules.
  * Reports affected locations and returns a failure status when violations are found.

* **Tests**
  * Added comprehensive coverage for direct, chained, renamed, namespace-based, nested, and tagged-template registrations.
  * Added validation for exclusions, comments, strings, type-only imports, diagnostic formatting, and repository-wide detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->