### PR TITLE
test(images): keep glibc cleanup mocks linear

### DIFF
--- a/src/lib/sandbox-base-image/image-compatibility.test.ts
+++ b/src/lib/sandbox-base-image/image-compatibility.test.ts
@@ -20,6 +20,38 @@ import {
   versionGte,
 } from "./image-compatibility";
 
+function mockProbeOutputs(outputs: readonly string[]): void {
+  let probeIndex = 0;
+  mocks.dockerCapture.mockImplementation((args: readonly string[]) =>
+    args[0] === "run" ? (outputs[probeIndex++] ?? "") : "",
+  );
+}
+
+function mockRetainedProbeContainer(): void {
+  let retainedContainerName = "";
+  mocks.dockerCapture.mockImplementation((args: readonly string[]) => {
+    switch (args[0]) {
+      case "run":
+        retainedContainerName = String(args[3]);
+        return "";
+      case "container":
+        return retainedContainerName;
+      default:
+        return "";
+    }
+  });
+}
+
+function throwCleanupVerificationError(): never {
+  throw new Error("Docker daemon unavailable during cleanup verification");
+}
+
+function mockCleanupVerificationFailure(): void {
+  mocks.dockerCapture.mockImplementation((args: readonly string[]) =>
+    args[0] === "run" ? "" : throwCleanupVerificationError(),
+  );
+}
+
 describe("sandbox base-image glibc compatibility", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -71,12 +103,7 @@ describe("sandbox base-image glibc compatibility", () => {
   });
 
   it("retries a probe with missing output and removes its retained container (#8375)", () => {
-    let probeCount = 0;
-    mocks.dockerCapture.mockImplementation((args: readonly string[]) => {
-      if (args[0] !== "run") return "";
-      probeCount += 1;
-      return probeCount === 1 ? "" : "ldd (Debian GLIBC 2.41-12+deb13u3) 2.41";
-    });
+    mockProbeOutputs(["", "ldd (Debian GLIBC 2.41-12+deb13u3) 2.41"]);
 
     expect(getImageGlibcVersion("nemoclaw:cold")).toBe("2.41");
 
@@ -125,16 +152,11 @@ describe("sandbox base-image glibc compatibility", () => {
   });
 
   it("accepts a failed removal only when the retained container is already absent (#8375)", () => {
-    let probeCount = 0;
     mocks.dockerForceRm.mockReturnValue({ error: undefined, status: 1 });
-    mocks.dockerCapture.mockImplementation((args: readonly string[]) => {
-      if (args[0] !== "run") return "";
-      probeCount += 1;
-      return probeCount === 1 ? "" : "ldd (GNU libc) 2.41";
-    });
+    mockProbeOutputs(["", "ldd (GNU libc) 2.41"]);
 
     expect(getImageGlibcVersion("nemoclaw:cold")).toBe("2.41");
-    expect(probeCount).toBe(2);
+    expect(mocks.dockerCapture.mock.calls.filter((call) => call[0]?.[0] === "run")).toHaveLength(2);
   });
 
   it.each([
@@ -144,15 +166,8 @@ describe("sandbox base-image glibc compatibility", () => {
       "failed before returning an exit status",
     ],
   ])("stops before retry when cleanup %s leaves the retained container present (#8375)", (removal, expectedStatus) => {
-    let retainedContainerName = "";
     mocks.dockerForceRm.mockReturnValue(removal);
-    mocks.dockerCapture.mockImplementation((args: readonly string[]) => {
-      if (args[0] === "run") {
-        retainedContainerName = String(args[3]);
-        return "";
-      }
-      return args[0] === "container" ? retainedContainerName : "";
-    });
+    mockRetainedProbeContainer();
 
     expect(() => getImageGlibcVersion("nemoclaw:cold")).toThrow(
       new RegExp(`cleanup ${expectedStatus}; container nemoclaw-glibc-probe-.+ is still present`),
@@ -161,10 +176,7 @@ describe("sandbox base-image glibc compatibility", () => {
   });
 
   it("stops before retry when retained-container absence cannot be verified (#8375)", () => {
-    mocks.dockerCapture.mockImplementation((args: readonly string[]) => {
-      if (args[0] === "run") return "";
-      throw new Error("Docker daemon unavailable during cleanup verification");
-    });
+    mockCleanupVerificationFailure();
 
     expect(() => getImageGlibcVersion("nemoclaw:cold")).toThrow(
       "Docker daemon unavailable during cleanup verification",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

PR #8389 merged its cleanup behavior while the test-conditionals guardrail was still finishing.
This follow-up keeps the same assertions while moving mock command branching into named helpers.

## Related Work

- Follow-up to #8389
- Failed run: https://github.com/NVIDIA/NemoClaw/actions/runs/31158388224
- Failed job: https://github.com/NVIDIA/NemoClaw/actions/runs/31158388224/job/92802902551

## Changes

- Move probe-output sequencing into a named mock helper.
- Move retained-container command handling into a named mock helper.
- Move cleanup-verification failure setup into a named mock helper.
- Assert two attempts through observable Docker `run` calls instead of a local counter.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only test mock organization and one equivalent assertion. Production, workflow, public error, configuration, schema, default, compatibility, and documented behavior are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Not applicable; no production sensitive path changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: No waiver is recorded.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Test-only refactoring moves Docker probe mock branching into named helpers and replaces a local counter with an observable Docker run-call assertion. Production, workflow, and documented behavior are unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6480cdbeb -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` does not change.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub — the single commit is `Verified`.
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — normal hooks passed, including source-shape and test-file-size checks.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 21 focused tests pass; one opt-in live Docker test is skipped locally as designed. CLI type-check, test-conditionals scan, and test-title validation pass.
- [x] Applicable broad gate passed — all GitHub Actions checks passed for the current commit; no waiver is recorded.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — not applicable; no documentation file changed.
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only) — not applicable.
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — not applicable.

## GitHub Actions

GitHub Actions is authoritative for commit `6480cdbeb1c400b3e387554eadd68a83bfd2017d` against base `cc4b816c78c024b743b55d345cf54681de4fe268`.
All checks passed.
Both PR Review Advisor lanes completed with zero findings, and no check waiver is recorded.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for container cleanup and cleanup-verification failures.
  * Added reusable test utilities for simulating probe outputs.
  * Updated retry and cleanup scenarios while preserving existing behavior checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->