### PR TITLE
fix(ollama): probe Windows readiness from Docker

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -15,7 +15,7 @@
       "src/lib/cli/nemoclaw-oclif-command.ts": 106,
       "src/lib/cli/terminal-style.ts": 45,
       "src/lib/core/json-types.ts": 37,
-      "src/lib/core/ports.ts": 88,
+      "src/lib/core/ports.ts": 87,
       "src/lib/core/shell-quote.ts": 26,
       "src/lib/core/url-utils.ts": 28,
       "src/lib/core/wait.ts": 35,

--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -156,7 +156,8 @@ If you see "Cannot connect to the Docker daemon", confirm that Docker Desktop is
 
 ## Set Up Local Inference with Ollama (Optional)
 
-If you plan to select Ollama as your inference provider during onboarding, use one Ollama instance that WSL can reach.
+If you plan to select Ollama as your inference provider during onboarding, use one Ollama instance.
+It can run inside WSL or on Windows through Docker Desktop.
 Run this command to install Ollama inside WSL.
 
 ```bash
@@ -176,7 +177,8 @@ With native Docker Engine inside WSL, or when the Docker runtime is unavailable 
 An installed Windows-host Ollama that the container runtime cannot reach leaves the WSL-local install available, in both the onboarding menu and a requested `install-ollama` provider.
 When containers cannot reach host loopback, onboarding fronts that WSL-local daemon with the sandbox auth proxy.
 You can still decline the express prompt (or set `NEMOCLAW_NO_EXPRESS=1`) to choose a provider manually; the onboarding menu labels the Windows-host actions as requiring Docker Desktop integration.
-When Ollama runs on the Windows host, NemoClaw detects it from WSL through `host.docker.internal` and pulls missing models through the Ollama HTTP API.
+When Ollama runs on the Windows host, NemoClaw checks it from Docker Desktop through `host.docker.internal` and pulls missing models through the Ollama HTTP API.
+A direct request from WSL can fail because Docker Desktop defines this hostname in its container network context.
 Do not run both the Windows and WSL Ollama instances on port `11434` at the same time.
 Use one instance, or move one of them to a different port before running `$$nemoclaw onboard`.
 On Windows on Arm N1X systems with a Snapdragon X processor, let NemoClaw choose the Ollama starter model automatically.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -36,7 +36,7 @@ If sudo is unavailable in a non-interactive run, rerun interactively or upgrade 
 After an upgrade, NemoClaw probes the running daemon again and stops if its reported version remains below the minimum.
 Fresh installs skip this second probe because the bundled installers provide a daemon at or above the minimum.
 
-The version gate does not apply to Windows-host Ollama reached from WSL through `host.docker.internal`.
+The version gate does not apply to Windows-host Ollama reached from Docker Desktop through `host.docker.internal`.
 The Windows-host menu entries perform their own actions on the Windows side.
 
 ## Choose a Linux Install Mode
@@ -122,8 +122,9 @@ When NemoClaw runs in WSL, the provider menu can offer these Windows-host action
 - Start Ollama when it is installed but not running.
 - Install Ollama when it is not installed on Windows.
 
-The install and restart paths set `OLLAMA_HOST=0.0.0.0:11434` on Windows so Docker and WSL can reach the daemon through `host.docker.internal`.
-NemoClaw relaunches Ollama from the detected Windows tray application or verified `ollama.exe` path and waits for the endpoint to respond.
+The install and restart paths set `OLLAMA_HOST=0.0.0.0:11434` on Windows so Docker Desktop containers can reach the daemon through `host.docker.internal`.
+NemoClaw relaunches Ollama from the detected Windows tray application or verified `ollama.exe` path and checks the endpoint from Docker Desktop's network context.
+A direct request from WSL can fail because Docker Desktop defines this hostname for its containers.
 It pulls missing models through the Ollama HTTP API without requiring an Ollama CLI inside WSL.
 
 <Warning>

--- a/src/lib/adapters/docker/command.ts
+++ b/src/lib/adapters/docker/command.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { run, runCapture } from "../../runner";
+
+export type DockerRunOptions = Parameters<typeof run>[1];
+export type DockerCaptureOptions = Parameters<typeof runCapture>[1];
+export type DockerRunResult = ReturnType<typeof run>;
+
+export function dockerArgv(args: readonly string[]): string[] {
+  return ["docker", ...args];
+}
+
+export function dockerRun(args: readonly string[], opts: DockerRunOptions = {}): DockerRunResult {
+  return run(dockerArgv(args), opts);
+}
+
+export function dockerCapture(args: readonly string[], opts: DockerCaptureOptions = {}): string {
+  return runCapture(dockerArgv(args), opts);
+}

--- a/src/lib/adapters/docker/run.ts
+++ b/src/lib/adapters/docker/run.ts
@@ -1,19 +1,4 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { run, runCapture } from "../../runner";
-
-export type DockerRunOptions = Parameters<typeof run>[1];
-export type DockerCaptureOptions = Parameters<typeof runCapture>[1];
-export type DockerRunResult = ReturnType<typeof run>;
-export function dockerArgv(args: readonly string[]): string[] {
-  return ["docker", ...args];
-}
-
-export function dockerRun(args: readonly string[], opts: DockerRunOptions = {}): DockerRunResult {
-  return run(dockerArgv(args), opts);
-}
-
-export function dockerCapture(args: readonly string[], opts: DockerCaptureOptions = {}): string {
-  return runCapture(dockerArgv(args), opts);
-}
+export * from "./command";

--- a/src/lib/adapters/docker/run.ts
+++ b/src/lib/adapters/docker/run.ts
@@ -1,4 +1,26 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export * from "./command";
+import {
+  dockerArgv as commandDockerArgv,
+  dockerCapture as commandDockerCapture,
+  dockerRun as commandDockerRun,
+  type DockerCaptureOptions,
+  type DockerRunOptions,
+  type DockerRunResult,
+} from "./command";
+
+export type { DockerCaptureOptions, DockerRunOptions, DockerRunResult };
+
+// Keep own exports so CommonJS consumers can replace these functions.
+export function dockerArgv(args: readonly string[]): string[] {
+  return commandDockerArgv(args);
+}
+
+export function dockerRun(args: readonly string[], opts: DockerRunOptions = {}): DockerRunResult {
+  return commandDockerRun(args, opts);
+}
+
+export function dockerCapture(args: readonly string[], opts: DockerCaptureOptions = {}): string {
+  return commandDockerCapture(args, opts);
+}

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -32,6 +32,7 @@ import {
   getOllamaModelOptions,
   getOllamaProbeCommand,
   getOllamaWarmupCommand,
+  getWindowsHostOllamaDockerReachabilityArgs,
   isLocalProviderProbeOutputHealthy,
   isOllamaRunnerCrash,
   LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV,
@@ -105,6 +106,20 @@ describe("local inference helpers", () => {
       allowHostDockerInternal: true,
       probeFromDocker: { expectedPort: 11434 },
     });
+  });
+
+  it("builds a credential-free Docker Desktop probe for Windows-host Ollama (#8127)", () => {
+    expect(getWindowsHostOllamaDockerReachabilityArgs()).toEqual([
+      "run",
+      "--rm",
+      CONTAINER_REACHABILITY_IMAGE,
+      "-sf",
+      "--connect-timeout",
+      "2",
+      "--max-time",
+      "5",
+      "http://host.docker.internal:11434/api/tags",
+    ]);
   });
 
   it("returns the expected base URL for vllm-local", () => {

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -112,6 +112,7 @@ export type RunCaptureExFn = (cmd: string[]) => CaptureResult;
 export const OLLAMA_LOCALHOST = "127.0.0.1";
 export const OLLAMA_HOST_DOCKER_INTERNAL = "host.docker.internal";
 
+/** Build the credential-free Docker Desktop probe for Windows-host Ollama. */
 export function getWindowsHostOllamaDockerReachabilityArgs(): string[] {
   return [
     "run",

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -106,13 +106,25 @@ export {
 
 export type RunCaptureExFn = (cmd: string[]) => CaptureResult;
 
-// Hosts that the WSL-side onboard CLI tries when probing Ollama. Native Linux
-// and macOS only ever reach Ollama on the local loopback. WSL with Docker
-// Desktop can also reach a Windows-host Ollama through the docker-desktop
-// integration's `host.docker.internal` alias when that host explicitly exposes
-// Ollama outside Windows loopback.
+// Hosts that local-provider discovery may try when probing Ollama. The Windows
+// onboarding path separately checks host.docker.internal from Docker Desktop's
+// network context because the alias may not resolve from the WSL host.
 export const OLLAMA_LOCALHOST = "127.0.0.1";
 export const OLLAMA_HOST_DOCKER_INTERNAL = "host.docker.internal";
+
+export function getWindowsHostOllamaDockerReachabilityArgs(): string[] {
+  return [
+    "run",
+    "--rm",
+    CONTAINER_REACHABILITY_IMAGE,
+    "-sf",
+    "--connect-timeout",
+    "2",
+    "--max-time",
+    "5",
+    `http://${OLLAMA_HOST_DOCKER_INTERNAL}:${OLLAMA_PORT}/api/tags`,
+  ];
+}
 
 let _resolvedOllamaHost: string | null = null;
 

--- a/src/lib/inference/ollama/windows.test.ts
+++ b/src/lib/inference/ollama/windows.test.ts
@@ -8,6 +8,7 @@ const require = createRequire(import.meta.url);
 const WINDOWS_DIST_PATH = require.resolve("./windows");
 const RUNNER_PATH = require.resolve("../../runner");
 const childProcess = require("node:child_process");
+const WINDOWS_OLLAMA_TAGS_URL = "http://host.docker.internal:11434/api/tags";
 
 function commandText(command: string | string[]): string {
   return Array.isArray(command) ? command.join(" ") : String(command);
@@ -62,9 +63,8 @@ describe("Windows Ollama helper", () => {
         stopCommands.push(cmd);
         return "";
       }
-      if (cmd.includes("host.docker.internal:11434/api/tags")) {
-        return Array.isArray(command) &&
-          command[0] === "docker" &&
+      if (Array.isArray(command) && command.at(-1) === WINDOWS_OLLAMA_TAGS_URL) {
+        return command[0] === "docker" &&
           launchScripts.some((script) => script.includes(installedPath))
           ? JSON.stringify({ models: [] })
           : "";

--- a/src/lib/inference/ollama/windows.test.ts
+++ b/src/lib/inference/ollama/windows.test.ts
@@ -39,11 +39,12 @@ function loadWindowsOllamaWithMocks(
 }
 
 describe("Windows Ollama helper", () => {
-  it("falls back from a stale watcher path to the verified installed executable", () => {
+  it("falls back from a stale watcher path and checks readiness from Docker Desktop (#8127)", () => {
     const watcherPath = "C:\\Users\\tester\\AppData\\Local\\Programs\\Ollama\\ollama app.exe";
     const installedPath = "C:\\Users\\tester\\AppData\\Local\\Programs\\Ollama\\ollama.exe";
     const launchScripts: string[] = [];
     const stopCommands: string[] = [];
+    const dockerProbes: string[][] = [];
 
     const run = vi.fn((command: string[]) => {
       const script = command[2] || "";
@@ -62,11 +63,13 @@ describe("Windows Ollama helper", () => {
         stopCommands.push(cmd);
         return "";
       }
-      if (cmd.includes("host.docker.internal:11434/api/tags")) {
+      if (Array.isArray(command) && command[0] === "docker") {
+        dockerProbes.push(command);
         return launchScripts.some((script) => script.includes(installedPath))
           ? JSON.stringify({ models: [] })
           : "";
       }
+      if (cmd.includes("host.docker.internal:11434/api/tags")) return "";
       return "";
     });
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -90,5 +93,17 @@ describe("Windows Ollama helper", () => {
     ).toBe(false);
     expect(stopCommands[0]).toContain("Get-Process 'ollama app'");
     expect(stopCommands[1]).toContain("Get-Process ollama");
+    expect(dockerProbes.at(-1)).toEqual([
+      "docker",
+      "run",
+      "--rm",
+      "curlimages/curl:8.10.1",
+      "-sf",
+      "--connect-timeout",
+      "2",
+      "--max-time",
+      "5",
+      "http://host.docker.internal:11434/api/tags",
+    ]);
   });
 });

--- a/src/lib/inference/ollama/windows.test.ts
+++ b/src/lib/inference/ollama/windows.test.ts
@@ -44,7 +44,6 @@ describe("Windows Ollama helper", () => {
     const installedPath = "C:\\Users\\tester\\AppData\\Local\\Programs\\Ollama\\ollama.exe";
     const launchScripts: string[] = [];
     const stopCommands: string[] = [];
-    const dockerProbes: string[][] = [];
 
     const run = vi.fn((command: string[]) => {
       const script = command[2] || "";
@@ -63,13 +62,13 @@ describe("Windows Ollama helper", () => {
         stopCommands.push(cmd);
         return "";
       }
-      if (Array.isArray(command) && command[0] === "docker") {
-        dockerProbes.push(command);
-        return launchScripts.some((script) => script.includes(installedPath))
+      if (cmd.includes("host.docker.internal:11434/api/tags")) {
+        return Array.isArray(command) &&
+          command[0] === "docker" &&
+          launchScripts.some((script) => script.includes(installedPath))
           ? JSON.stringify({ models: [] })
           : "";
       }
-      if (cmd.includes("host.docker.internal:11434/api/tags")) return "";
       return "";
     });
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -93,17 +92,20 @@ describe("Windows Ollama helper", () => {
     ).toBe(false);
     expect(stopCommands[0]).toContain("Get-Process 'ollama app'");
     expect(stopCommands[1]).toContain("Get-Process ollama");
-    expect(dockerProbes.at(-1)).toEqual([
-      "docker",
-      "run",
-      "--rm",
-      "curlimages/curl:8.10.1",
-      "-sf",
-      "--connect-timeout",
-      "2",
-      "--max-time",
-      "5",
-      "http://host.docker.internal:11434/api/tags",
-    ]);
+    expect(runCapture).toHaveBeenCalledWith(
+      [
+        "docker",
+        "run",
+        "--rm",
+        "curlimages/curl:8.10.1",
+        "-sf",
+        "--connect-timeout",
+        "2",
+        "--max-time",
+        "5",
+        "http://host.docker.internal:11434/api/tags",
+      ],
+      { ignoreError: true },
+    );
   });
 });

--- a/src/lib/inference/ollama/windows.ts
+++ b/src/lib/inference/ollama/windows.ts
@@ -6,6 +6,7 @@
 // Detection lives in onboard.ts; this module owns the action side.
 
 const { spawn, spawnSync } = require("child_process");
+const { dockerCapture } = require("../../adapters/docker/command");
 const { run, runCapture } = require("../../runner");
 const {
   getWindowsHostOllamaDockerReachabilityArgs,
@@ -115,7 +116,7 @@ function awaitWindowsOllamaReady(): boolean {
   console.log("  Waiting for Ollama to respond on host.docker.internal...");
   for (let attempt = 0; attempt < 15; attempt++) {
     sleep(2);
-    const probe = runCapture(["docker", ...getWindowsHostOllamaDockerReachabilityArgs()], {
+    const probe = dockerCapture(getWindowsHostOllamaDockerReachabilityArgs(), {
       ignoreError: true,
     });
     if (probe) {

--- a/src/lib/inference/ollama/windows.ts
+++ b/src/lib/inference/ollama/windows.ts
@@ -7,7 +7,11 @@
 
 const { spawn, spawnSync } = require("child_process");
 const { run, runCapture } = require("../../runner");
-const { OLLAMA_HOST_DOCKER_INTERNAL, setResolvedOllamaHost } = require("../local");
+const {
+  getWindowsHostOllamaDockerReachabilityArgs,
+  OLLAMA_HOST_DOCKER_INTERNAL,
+  setResolvedOllamaHost,
+} = require("../local");
 const { OLLAMA_PORT } = require("../../core/ports");
 
 function sleep(seconds: number): void {
@@ -111,18 +115,9 @@ function awaitWindowsOllamaReady(): boolean {
   console.log("  Waiting for Ollama to respond on host.docker.internal...");
   for (let attempt = 0; attempt < 15; attempt++) {
     sleep(2);
-    const probe = runCapture(
-      [
-        "curl",
-        "-sf",
-        "--connect-timeout",
-        "2",
-        "--max-time",
-        "5",
-        `http://host.docker.internal:${OLLAMA_PORT}/api/tags`,
-      ],
-      { ignoreError: true },
-    );
+    const probe = runCapture(["docker", ...getWindowsHostOllamaDockerReachabilityArgs()], {
+      ignoreError: true,
+    });
     if (probe) {
       setResolvedOllamaHost(OLLAMA_HOST_DOCKER_INTERNAL);
       return true;
@@ -220,9 +215,7 @@ function printWindowsOllamaTimeoutDiagnostics(): void {
   console.error(
     '    powershell.exe -Command "Get-NetTCPConnection -LocalPort 11434 -State Listen -ErrorAction SilentlyContinue"',
   );
-  console.error(
-    `    curl -sS --connect-timeout 2 --max-time 5 http://host.docker.internal:${OLLAMA_PORT}/api/tags`,
-  );
+  console.error(`    docker ${getWindowsHostOllamaDockerReachabilityArgs().join(" ")}`);
 }
 
 module.exports = {

--- a/src/lib/onboard/provider-host-state.test.ts
+++ b/src/lib/onboard/provider-host-state.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
-
+import { getWindowsHostOllamaDockerRequirement } from "./local-inference-topology";
 import {
   type DetectInferenceProviderHostStateDeps,
   detectInferenceProviderHostState,
@@ -179,8 +179,11 @@ describe("detectInferenceProviderHostState", () => {
     );
   });
 
-  it("detects a reachable Windows-host Ollama beside WSL-local Ollama and warns outside mirrored networking", () => {
+  it("detects Windows-host Ollama from Docker Desktop when WSL cannot reach it (#8127)", () => {
     const logs: string[] = [];
+    const dockerCapture = vi.fn((command: string[]) =>
+      command.includes("http://host.docker.internal:11434/api/tags") ? "{}" : "",
+    );
     const deps = buildDeps({
       isWsl: vi.fn(() => true),
       findReachableOllamaHost: vi.fn(() => "127.0.0.1"),
@@ -191,10 +194,10 @@ describe("detectInferenceProviderHostState", () => {
       })),
       runCapture: vi.fn((command) => {
         const joined = command.join(" ");
-        if (joined.includes("host.docker.internal:11434/api/tags")) return "{}";
         if (joined.includes("wslinfo --networking-mode")) return "nat\n";
         return "";
       }),
+      dockerCapture,
     });
 
     const state = detectInferenceProviderHostState({
@@ -214,6 +217,20 @@ describe("detectInferenceProviderHostState", () => {
     expect(state.winOllamaInstalledPath).toMatch(/ollama\.exe$/);
     expect(logs.join("\n")).toContain("Ollama is running on both WSL and the Windows host");
     expect(deps.getWindowsHostOllamaDockerRequirement).toHaveBeenCalledWith("docker-desktop");
+    expect(dockerCapture).toHaveBeenCalledWith(
+      [
+        "run",
+        "--rm",
+        "curlimages/curl:8.10.1",
+        "-sf",
+        "--connect-timeout",
+        "2",
+        "--max-time",
+        "5",
+        "http://host.docker.internal:11434/api/tags",
+      ],
+      { ignoreError: true },
+    );
   });
 
   it("keeps WSL-local install available when Docker Desktop cannot reach Windows-host Ollama (#8199)", () => {
@@ -236,6 +253,22 @@ describe("detectInferenceProviderHostState", () => {
     expect(state.windowsOllamaReachable).toBe(false);
     expect(state.ollamaInstallMenu.entry?.key).toBe("install-ollama");
     expect(state.ollamaInstallMenu.entry?.label).toBe("Install Ollama (WSL Linux)");
+  });
+
+  it("does not run the Windows-host probe without Docker Desktop WSL integration (#8127)", () => {
+    const dockerCapture = vi.fn<DetectInferenceProviderHostStateDeps["dockerCapture"]>(() => "{}");
+    const deps = buildDeps({
+      isWsl: vi.fn(() => true),
+      dockerCapture,
+      getWindowsHostOllamaDockerRequirement: vi.fn(() =>
+        getWindowsHostOllamaDockerRequirement("docker"),
+      ),
+    });
+
+    const state = detectWithDeps(deps);
+
+    expect(state.windowsOllamaReachable).toBe(false);
+    expect(dockerCapture).not.toHaveBeenCalled();
   });
 
   it("passes injected platform and env through WSL detection", () => {
@@ -270,10 +303,12 @@ describe("detectInferenceProviderHostState", () => {
       })),
       runCapture: vi.fn((command) => {
         const joined = command.join(" ");
-        if (joined.includes("host.docker.internal:11434/api/tags")) return "{}";
         if (joined.includes("wslinfo --networking-mode")) return "mirrored\n";
         return "";
       }),
+      dockerCapture: vi.fn((command) =>
+        command.includes("http://host.docker.internal:11434/api/tags") ? "{}" : "",
+      ),
     });
 
     const state = detectInferenceProviderHostState({
@@ -293,6 +328,7 @@ describe("detectInferenceProviderHostState", () => {
 
   it("does not probe the Windows-host switch path when running Ollama already resolves to the Windows host", () => {
     const runCapture = vi.fn<DetectInferenceProviderHostStateDeps["runCapture"]>(() => "");
+    const dockerCapture = vi.fn<DetectInferenceProviderHostStateDeps["dockerCapture"]>(() => "");
     const deps = buildDeps({
       isWsl: vi.fn(() => true),
       findReachableOllamaHost: vi.fn(() => "host.docker.internal"),
@@ -302,16 +338,13 @@ describe("detectInferenceProviderHostState", () => {
         loopbackOnly: true,
       })),
       runCapture,
+      dockerCapture,
     });
 
     const state = detectWithDeps(deps);
 
     expect(state.isWindowsHostOllama).toBe(true);
     expect(state.windowsOllamaReachable).toBe(false);
-    expect(
-      runCapture.mock.calls.some(([command]) =>
-        command.join(" ").includes("host.docker.internal:11434/api/tags"),
-      ),
-    ).toBe(false);
+    expect(dockerCapture).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/onboard/provider-host-state.test.ts
+++ b/src/lib/onboard/provider-host-state.test.ts
@@ -9,6 +9,8 @@ import {
   type InferenceProviderHostGpu,
 } from "./provider-host-state";
 
+const WINDOWS_OLLAMA_TAGS_URL = "http://host.docker.internal:11434/api/tags";
+
 const SUPPORTED_WINDOWS_OLLAMA = {
   supported: true,
   detectedRuntime: "Docker Desktop",
@@ -182,7 +184,7 @@ describe("detectInferenceProviderHostState", () => {
   it("detects Windows-host Ollama from Docker Desktop when WSL cannot reach it (#8127)", () => {
     const logs: string[] = [];
     const dockerCapture = vi.fn((command: string[]) =>
-      command.includes("http://host.docker.internal:11434/api/tags") ? "{}" : "",
+      command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "",
     );
     const deps = buildDeps({
       isWsl: vi.fn(() => true),
@@ -227,7 +229,7 @@ describe("detectInferenceProviderHostState", () => {
         "2",
         "--max-time",
         "5",
-        "http://host.docker.internal:11434/api/tags",
+        WINDOWS_OLLAMA_TAGS_URL,
       ],
       { ignoreError: true },
     );
@@ -306,9 +308,7 @@ describe("detectInferenceProviderHostState", () => {
         if (joined.includes("wslinfo --networking-mode")) return "mirrored\n";
         return "";
       }),
-      dockerCapture: vi.fn((command) =>
-        command.includes("http://host.docker.internal:11434/api/tags") ? "{}" : "",
-      ),
+      dockerCapture: vi.fn((command) => (command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "")),
     });
 
     const state = detectInferenceProviderHostState({

--- a/src/lib/onboard/provider-host-state.ts
+++ b/src/lib/onboard/provider-host-state.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { dockerCapture as defaultDockerCapture } from "../adapters/docker";
-import { OLLAMA_PORT } from "../core/ports";
 import {
   findReachableOllamaHost,
   getLocalProviderAvailabilityEndpoint,
+  getWindowsHostOllamaDockerReachabilityArgs,
   isLocalProviderProbeOutputHealthy,
   OLLAMA_HOST_DOCKER_INTERNAL,
 } from "../inference/local";
@@ -142,18 +142,13 @@ function probeVllmRunning(deps: DetectInferenceProviderHostStateDeps): boolean {
 function probeWindowsOllamaReachable(input: {
   isWsl: boolean;
   isWindowsHostOllama: boolean;
-  runCapture: RunCapture;
+  dockerRequirementSupported: boolean;
+  dockerCapture: DockerCapture;
 }): boolean {
-  if (!input.isWsl || input.isWindowsHostOllama) return false;
-  return !!input.runCapture(
-    [
-      "curl",
-      "-sf",
-      ...LOCAL_PROVIDER_PROBE_CURL_ARGS,
-      `http://host.docker.internal:${OLLAMA_PORT}/api/tags`,
-    ],
-    { ignoreError: true },
-  );
+  if (!input.isWsl || input.isWindowsHostOllama || !input.dockerRequirementSupported) return false;
+  return !!input.dockerCapture(getWindowsHostOllamaDockerReachabilityArgs(), {
+    ignoreError: true,
+  });
 }
 
 function maybeWarnAboutDuplicateOllamaDaemons(input: {
@@ -207,7 +202,12 @@ export function detectInferenceProviderHostState(
   const windowsOllamaReachable =
     input.probeOllama === false
       ? false
-      : probeWindowsOllamaReachable({ isWsl, isWindowsHostOllama, runCapture: deps.runCapture });
+      : probeWindowsOllamaReachable({
+          isWsl,
+          isWindowsHostOllama,
+          dockerRequirementSupported: windowsHostOllamaDockerRequirement.supported,
+          dockerCapture: deps.dockerCapture,
+        });
 
   maybeWarnAboutDuplicateOllamaDaemons({
     isWsl,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Windows-host Ollama detection and startup readiness previously ran from WSL, where Docker Desktop's `host.docker.internal` alias can return HTTP 000 even when containers can reach Ollama. This change checks the endpoint from Docker Desktop's network context during both initial provider detection and the post-launch wait, preventing unnecessary restarts and readiness timeouts.

## Related Issue

Fixes #8127

## Changes

- Add one fixed, credential-free Docker reachability command consumed by the provider snapshot and Windows Ollama readiness wait. Both consumers need the same command so their network context cannot diverge again; `local.test.ts`, `windows.test.ts`, and `provider-host-state.test.ts` protect the contract.
- Skip the Windows-host probe when Docker Desktop WSL integration is unsupported, and print the Docker-context command in timeout diagnostics.
- Cover the QA-escaped WSL-failure/Docker-success topology and lower the exact source fan-in budget after removing the redundant port import.
- Clarify the owning Windows preparation and Ollama setup guides. The existing changelog already records Docker-context validation.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes — `npm run docs:sync-agent-variants` passed; `npm run docs` passed with 0 errors and 2 warnings.
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: contributor security review confirmed a fixed URL, image, and argv; no credentials, environment variables, mounts, or user input are forwarded; unsupported runtimes fail closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/get-started/windows-preparation.mdx` and `docs/inference/set-up-ollama.mdx`; reviewed the final Docker Desktop reachability implementation, diagnostics, tests, adapter compatibility update, and generated guide variants for code-to-doc accuracy.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7bdaefbd5 -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Ollama/provider tests (91 passed), adapter regression tests (26 passed), and compiled-artifact compatibility tests (35 passed).
- [x] Applicable broad gate passed — `npm run checks:repository` passed, including the source architecture budget and exact Vitest project membership.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>

