### PR TITLE
fix(hermes): restore dashboard runtime permissions

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -1608,13 +1608,13 @@ wait_for_hermes_gateway_internal() {
 
 restore_hermes_config_permissions_after_dashboard_start() {
   [ "$(id -u)" -eq 0 ] || return 0
-  # Hermes dashboard startup may tighten HERMES_HOME to 0700 because it runs as
-  # the sandbox owner. The gateway process runs as the separate gateway user and
-  # reads config via sandbox-group membership, so restore NemoClaw's shared
-  # mutable-root mode after the dashboard has performed its startup checks.
+  # Hermes dashboard startup may tighten HERMES_HOME and its runtime directories
+  # to 0700 because it runs as the sandbox owner. The gateway process runs as the
+  # separate gateway user and relies on sandbox-group membership, so restore the
+  # complete bounded writable layout after the dashboard startup checks.
   local attempts=0
   while [ "$attempts" -lt 5 ]; do
-    ensure_hermes_config_root_mode || return 1
+    repair_hermes_startup_layout || return 1
     attempts=$((attempts + 1))
     sleep 1
   done

--- a/test/hermes-dashboard-permission-restore.test.ts
+++ b/test/hermes-dashboard-permission-restore.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { extractShellFunction } from "./support/hermes-shell-harness";
+
+const START_SCRIPT = path.join(import.meta.dirname, "..", "agents", "hermes", "start.sh");
+
+describe("Hermes post-Dashboard permission restore", () => {
+  it("reasserts the complete writable layout throughout the bounded startup window", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-dashboard-repair-"));
+    const scriptPath = path.join(tmpDir, "run.sh");
+    const src = fs.readFileSync(START_SCRIPT, "utf-8");
+    fs.writeFileSync(
+      scriptPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        extractShellFunction(src, "restore_hermes_config_permissions_after_dashboard_start"),
+        'id() { [ "${1:-}" = "-u" ] && printf "0\\n"; }',
+        'repair_hermes_startup_layout() { printf "repair-layout\\n"; }',
+        "sleep() { :; }",
+        "restore_hermes_config_permissions_after_dashboard_start",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+
+    try {
+      const result = spawnSync("bash", [scriptPath], {
+        encoding: "utf-8",
+        timeout: 5000,
+        env: process.env,
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim().split("\n")).toEqual(Array(5).fill("repair-layout"));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Restore the gateway-writable Hermes runtime-directory contract after Dashboard startup tightens the state tree.
- Keep the existing strict root-entrypoint E2E assertion; do not add delay or retry to the test.

## Failure ownership

- Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/31162755941
- Affected job: `sandbox-images-and-e2e / test-hermes-sandbox-image`, job 92818398291
- Failure: the gateway write probe received `Permission denied` for `/sandbox/.hermes/hooks/.nemoclaw-write-test` after clean root-entrypoint startup.
- Duplicate search: no open PR matched the failure text, `hermes-root-entrypoint-smoke`, `/sandbox/.hermes/hooks`, or the affected post-Dashboard repair. Open PRs touching Hermes Dockerfiles do not modify this startup boundary.

## Root cause

Hermes Dashboard can recursively tighten the state tree to mode 0700. The post-start repair currently restores only `/sandbox/.hermes` to 3770, leaving `hooks`, `image_cache`, `audio_cache`, and `logs/curator` inaccessible to the separate gateway user.

## Validation

- [x] Added a focused regression for the full post-Dashboard layout repair.
- [x] Affected permission/startup suites pass: 72 tests across four files.
- [x] `npm run build:cli`, CLI typecheck, and full `npm run validate:pr` pass.
- [x] Security review found no blocker in the cross-UID ownership and mode boundary.
- [x] No E2E workflow was manually dispatched.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes startup recovery after dashboard launch by fully restoring the required writable layout.
  * Helps prevent permission-related startup issues during the dashboard startup window.

* **Tests**
  * Added integration coverage to verify repeated permission repairs occur as expected during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->