### PR TITLE
test(hermes): align dashboard credential boundary

### DIFF
--- a/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
+++ b/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
@@ -294,7 +294,7 @@ async function assertDashboardHome(probe: DockerProbe, container: string): Promi
   await expectContainerSh(
     probe,
     container,
-    "Hermes dashboard profile was not seeded with sandbox-owned 0700/0600 allowlisted config",
+    "Hermes dashboard profile did not preserve ownership, file modes, or the API credential boundary",
     String.raw`
 set -eu
 for _ in $(seq 1 30); do
@@ -313,7 +313,6 @@ from pathlib import Path
 allowed = {
     "API_SERVER_HOST",
     "API_SERVER_PORT",
-    "API_SERVER_KEY",
     "NEMOCLAW_HERMES_TOOL_GATEWAY_BROKER",
     "FIRECRAWL_GATEWAY_URL",
     "OPENAI_AUDIO_GATEWAY_URL",
@@ -330,8 +329,10 @@ for raw_line in env_path.read_text(encoding="utf-8").splitlines():
     if line.startswith("export "):
         line = line[len("export "):].lstrip()
     keys.add(line.split("=", 1)[0].strip())
+if "API_SERVER_KEY" in keys:
+    raise SystemExit("dashboard .env contains API_SERVER_KEY")
 extra = sorted(keys - allowed)
-missing = sorted({"API_SERVER_HOST", "API_SERVER_PORT", "API_SERVER_KEY"} - keys)
+missing = sorted({"API_SERVER_HOST", "API_SERVER_PORT"} - keys)
 if extra or missing:
     raise SystemExit(f"dashboard .env allowlist mismatch extra={extra} missing={missing}")
 config_text = Path("/sandbox/.hermes/profiles/dashboard-home/config.yaml").read_text(encoding="utf-8")
@@ -478,7 +479,7 @@ test("hermes root-entrypoint smoke preserves runtime layout and legacy state mig
       "gateway.pid is stored as a regular file below the writable runtime directory",
       "gateway user cannot remove config.yaml from sticky config root",
       "Hermes API denies missing/wrong bearer tokens and accepts API_SERVER_KEY",
-      "dashboard profile is sandbox-owned 0700 with 0600 allowlisted config/env",
+      "dashboard profile is sandbox-owned, and its allowlisted .env excludes API_SERVER_KEY",
       "legacy gateway.pid symlink/state shape is repaired and booted",
       "legacy dashboard profile state is moved into profiles/dashboard-home",
     ],

--- a/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
+++ b/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
@@ -479,7 +479,7 @@ test("hermes root-entrypoint smoke preserves runtime layout and legacy state mig
       "gateway.pid is stored as a regular file below the writable runtime directory",
       "gateway user cannot remove config.yaml from sticky config root",
       "Hermes API denies missing/wrong bearer tokens and accepts API_SERVER_KEY",
-      "dashboard profile is sandbox-owned, and its allowlisted .env excludes API_SERVER_KEY",
+      "dashboard profile is sandbox-owned, and its .env allowlist excludes API_SERVER_KEY",
       "legacy gateway.pid symlink/state shape is repaired and booted",
       "legacy dashboard profile state is moved into profiles/dashboard-home",
     ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes policy refactor stopped copying `API_SERVER_KEY` into the dashboard profile, but the root-entrypoint image smoke test still required the copied key. This change makes the live assertion enforce the dashboard `.env` credential boundary instead of failing the intended image behavior.

## Changes

- Remove `API_SERVER_KEY` from the dashboard `.env` allowlist and required-key set in the Hermes root-entrypoint image smoke test.
- Fail explicitly if the dashboard profile writes `API_SERVER_KEY` to its `.env` file.
- Update the E2E contract text to state the tested credential boundary.
- Preserve the existing gateway bearer-auth assertion. Focused tests cover the dashboard process-environment handoff, but the live image assertion still encoded the previous persistence behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This test-only correction matches the existing credential boundary documented in `docs/security/credential-storage.mdx`; it does not change user-visible behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Pi CLI security review of `7baf6ea2b` passed all nine repository rubric categories with no findings. The diff changes only live credential-boundary evidence; runtime credential handling is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Pi CLI reviewed committed head `7baf6ea2b`, the proposed PR description, and `docs/security/credential-storage.mdx`. The test-only change requires no public documentation update.
- Agent: Pi CLI
<!-- docs-review-head-sha: 7baf6ea2b -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable; this change does not modify `scripts/prepare-dgx-station-host.sh`.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/hermes-managed-policy.test.ts test/seed-hermes-dashboard-config.test.ts test/hermes-dashboard-credential-launch.test.ts` passed 49 tests on `b3f711c1c` before the verified merge from `main`; `npm run test:e2e-phases:check` passed for 122 tests across 79 files; Biome passed for the changed file. The failing main run 31159156686 provides the pre-fix live reproduction; local live E2E was not run because it mutates Docker state.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
