### PR TITLE
test(onboard): add an in-memory machine runtime fixture

### DIFF
--- a/src/lib/onboard/machine/flow-phases/agent-policy-finalization.test.ts
+++ b/src/lib/onboard/machine/flow-phases/agent-policy-finalization.test.ts
@@ -3,14 +3,6 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  createSession,
-  filterSafeUpdates,
-  MACHINE_SNAPSHOT_VERSION,
-  normalizeSession,
-  type Session,
-  type SessionUpdates,
-} from "../../../state/onboard-session";
 import type { OnboardFlowContext } from "../flow-context";
 import { advanceTo, completeOnboardMachine } from "../result";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "../runtime";
@@ -22,6 +14,18 @@ import {
   createPoliciesPhase,
   createPostVerifyPhase,
 } from "./agent-policy-finalization";
+import {
+  MACHINE_SNAPSHOT_VERSION,
+  type Session,
+  type SessionUpdates,
+  cloneSession,
+  createSession,
+  createTestRuntime,
+} from "../../../../../test/helpers/onboard-machine-runtime-fixture";
+
+function createRuntime(initialSession: Session = createSession()) {
+  return createTestRuntime(initialSession, { now: () => "2026-05-29T00:00:00.000Z" });
+}
 
 function context(): OnboardFlowContext<null, null, null> {
   return {
@@ -50,51 +54,6 @@ function context(): OnboardFlowContext<null, null, null> {
     sandboxGpuConfig: null,
     gpuPassthrough: false,
   };
-}
-
-function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
-}
-
-function createRuntime(initialSession: Session = createSession()) {
-  let session = cloneSession(initialSession);
-  const updateSession = (mutator: (value: Session) => Session | void): Session => {
-    session = cloneSession(mutator(cloneSession(session)) ?? session);
-    return cloneSession(session);
-  };
-  const deps: OnboardRuntimeDeps = {
-    loadSession: () => cloneSession(session),
-    createSession,
-    saveSession: (next) => {
-      session = cloneSession(next);
-      return cloneSession(session);
-    },
-    updateSession,
-    markStepStarted: () => cloneSession(session),
-    markStepComplete: (_stepName, updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        return current;
-      }),
-    markStepSkipped: () => cloneSession(session),
-    markStepFailed: (stepName, message) =>
-      updateSession((current) => {
-        current.steps[stepName].status = "failed";
-        current.steps[stepName].error = message ?? null;
-        return current;
-      }),
-    completeSession: (updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        current.status = "complete";
-        current.resumable = false;
-        return current;
-      }),
-    filterSafeUpdates,
-    emitEvent: () => undefined,
-    now: () => "2026-05-29T00:00:00.000Z",
-  };
-  return new OnboardRuntime(deps);
 }
 
 describe("agent/policy/finalization phases", () => {

--- a/src/lib/onboard/machine/flow-sequence.test.ts
+++ b/src/lib/onboard/machine/flow-sequence.test.ts
@@ -3,20 +3,24 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  createSession,
-  filterSafeUpdates,
-  MACHINE_SNAPSHOT_VERSION,
-  normalizeSession,
-  type Session,
-  type SessionUpdates,
-} from "../../state/onboard-session";
 import type { OnboardFlowContext, OnboardFlowPhaseResult } from "./flow-context";
 import { onboardFlowPhaseResult } from "./flow-context";
 import { buildOnboardFlowPhaseSequence } from "./flow-sequence";
 import { advanceTo, branchTo, completeOnboardMachine } from "./result";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "./runtime";
 import { runOnboardSequenceWithRunner } from "./sequence-runner";
+import {
+  MACHINE_SNAPSHOT_VERSION,
+  type Session,
+  type SessionUpdates,
+  cloneSession,
+  createSession,
+  createTestRuntime,
+} from "../../../../test/helpers/onboard-machine-runtime-fixture";
+
+function createRuntime(initialSession: Session = createSession()) {
+  return createTestRuntime(initialSession, { now: () => "2026-05-29T00:00:00.000Z" });
+}
 
 type Context = OnboardFlowContext<null, { type: string }, { mode: string }>;
 
@@ -55,51 +59,6 @@ function result(
   next: ReturnType<typeof advanceTo>["next"],
 ): OnboardFlowPhaseResult<Context> {
   return onboardFlowPhaseResult(ctx, advanceTo(next));
-}
-
-function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
-}
-
-function createRuntime(initialSession: Session = createSession()) {
-  let session = cloneSession(initialSession);
-  const updateSession = (mutator: (value: Session) => Session | void): Session => {
-    session = cloneSession(mutator(cloneSession(session)) ?? session);
-    return cloneSession(session);
-  };
-  const deps: OnboardRuntimeDeps = {
-    loadSession: () => cloneSession(session),
-    createSession,
-    saveSession: (next) => {
-      session = cloneSession(next);
-      return cloneSession(session);
-    },
-    updateSession,
-    markStepStarted: () => cloneSession(session),
-    markStepComplete: (_stepName, updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        return current;
-      }),
-    markStepSkipped: () => cloneSession(session),
-    markStepFailed: (stepName, message) =>
-      updateSession((current) => {
-        current.steps[stepName].status = "failed";
-        current.steps[stepName].error = message ?? null;
-        return current;
-      }),
-    completeSession: (updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        current.status = "complete";
-        current.resumable = false;
-        return current;
-      }),
-    filterSafeUpdates,
-    emitEvent: () => undefined,
-    now: () => "2026-05-29T00:00:00.000Z",
-  };
-  return new OnboardRuntime(deps);
 }
 
 describe("onboard flow phase sequence", () => {

--- a/src/lib/onboard/machine/flow-slices.test.ts
+++ b/src/lib/onboard/machine/flow-slices.test.ts
@@ -3,14 +3,6 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  createSession,
-  filterSafeUpdates,
-  MACHINE_SNAPSHOT_VERSION,
-  normalizeSession,
-  type Session,
-  type SessionUpdates,
-} from "../../state/onboard-session";
 import type { OnboardFlowContext } from "./flow-context";
 import {
   coreOnboardFlowPhases,
@@ -23,10 +15,14 @@ import {
 import { advanceTo, branchTo, completeOnboardMachine } from "./result";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "./runtime";
 import type { OnboardSequencePhase } from "./sequence-runner";
-
-function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
-}
+import {
+  MACHINE_SNAPSHOT_VERSION,
+  type Session,
+  type SessionUpdates,
+  cloneSession,
+  createSession,
+  filterSafeUpdates,
+} from "../../../../test/helpers/onboard-machine-runtime-fixture";
 
 function runtime(initialSession: Session = createSession()) {
   let session = cloneSession(initialSession);

--- a/src/lib/onboard/machine/runner-sequence.test.ts
+++ b/src/lib/onboard/machine/runner-sequence.test.ts
@@ -3,14 +3,6 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  createSession,
-  filterSafeUpdates,
-  MACHINE_SNAPSHOT_VERSION,
-  normalizeSession,
-  type Session,
-  type SessionUpdates,
-} from "../../state/onboard-session";
 import { advanceTo, branchTo, completeOnboardMachine, failOnboardMachine, retryTo } from "./result";
 import {
   EmptyOnboardStateHandlerResultError,
@@ -21,56 +13,18 @@ import {
   runOnboardMachine,
 } from "./runner";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "./runtime";
+import {
+  MACHINE_SNAPSHOT_VERSION,
+  type Session,
+  type SessionUpdates,
+  cloneSession,
+  createSession,
+  createTestRuntime as createRuntime,
+} from "../../../../test/helpers/onboard-machine-runtime-fixture";
 
 interface RunnerContext {
   attempts: number;
   visited: string[];
-}
-
-function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
-}
-
-function createRuntime(initialSession: Session = createSession()) {
-  let session = cloneSession(initialSession);
-  const updateSession = (mutator: (value: Session) => Session | void): Session => {
-    const next = mutator(cloneSession(session)) ?? session;
-    session = cloneSession(next);
-    return cloneSession(session);
-  };
-  const deps: OnboardRuntimeDeps = {
-    loadSession: () => cloneSession(session),
-    createSession,
-    saveSession: (next) => {
-      session = cloneSession(next);
-      return cloneSession(session);
-    },
-    updateSession,
-    markStepStarted: () => cloneSession(session),
-    markStepComplete: (_stepName, updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        return current;
-      }),
-    markStepSkipped: () => cloneSession(session),
-    markStepFailed: (stepName, message) =>
-      updateSession((current) => {
-        current.steps[stepName].status = "failed";
-        current.steps[stepName].error = message ?? null;
-        return current;
-      }),
-    completeSession: (updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        current.status = "complete";
-        current.resumable = false;
-        return current;
-      }),
-    filterSafeUpdates,
-    emitEvent: () => undefined,
-    now: () => "2026-05-28T00:00:00.000Z",
-  };
-  return new OnboardRuntime(deps);
 }
 
 describe("runOnboardMachine result sequences", () => {

--- a/src/lib/onboard/machine/runner.test.ts
+++ b/src/lib/onboard/machine/runner.test.ts
@@ -4,14 +4,6 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  createSession,
-  filterSafeUpdates,
-  MACHINE_SNAPSHOT_VERSION,
-  normalizeSession,
-  type Session,
-  type SessionUpdates,
-} from "../../state/onboard-session";
-import {
   advanceTo,
   branchTo,
   completeOnboardMachine,
@@ -26,56 +18,18 @@ import {
   runOnboardMachine,
 } from "./runner";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "./runtime";
+import {
+  MACHINE_SNAPSHOT_VERSION,
+  type Session,
+  type SessionUpdates,
+  cloneSession,
+  createSession,
+  createTestRuntime as createRuntime,
+} from "../../../../test/helpers/onboard-machine-runtime-fixture";
 
 interface RunnerContext {
   attempts: number;
   visited: string[];
-}
-
-function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
-}
-
-function createRuntime(initialSession: Session = createSession()) {
-  let session = cloneSession(initialSession);
-  const updateSession = (mutator: (value: Session) => Session | void): Session => {
-    const next = mutator(cloneSession(session)) ?? session;
-    session = cloneSession(next);
-    return cloneSession(session);
-  };
-  const deps: OnboardRuntimeDeps = {
-    loadSession: () => cloneSession(session),
-    createSession,
-    saveSession: (next) => {
-      session = cloneSession(next);
-      return cloneSession(session);
-    },
-    updateSession,
-    markStepStarted: () => cloneSession(session),
-    markStepComplete: (_stepName, updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        return current;
-      }),
-    markStepSkipped: () => cloneSession(session),
-    markStepFailed: (stepName, message) =>
-      updateSession((current) => {
-        current.steps[stepName].status = "failed";
-        current.steps[stepName].error = message ?? null;
-        return current;
-      }),
-    completeSession: (updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        current.status = "complete";
-        current.resumable = false;
-        return current;
-      }),
-    filterSafeUpdates,
-    emitEvent: () => undefined,
-    now: () => "2026-05-28T00:00:00.000Z",
-  };
-  return new OnboardRuntime(deps);
 }
 
 describe("runOnboardMachine", () => {

--- a/src/lib/onboard/machine/runtime.test.ts
+++ b/src/lib/onboard/machine/runtime.test.ts
@@ -3,13 +3,6 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  createSession,
-  filterSafeUpdates,
-  normalizeSession,
-  type Session,
-  type SessionUpdates,
-} from "../../state/onboard-session";
 import type { OnboardMachineEvent } from "./events";
 import {
   advanceTo,
@@ -21,10 +14,13 @@ import {
 } from "./result";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "./runtime";
 import { InvalidOnboardMachineTransitionError } from "./transitions";
-
-function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
-}
+import {
+  type Session,
+  type SessionUpdates,
+  cloneSession,
+  createSession,
+  filterSafeUpdates,
+} from "../../../../test/helpers/onboard-machine-runtime-fixture";
 
 function createHarness(initialSession: Session | null = createSession()) {
   let session = initialSession ? cloneSession(initialSession) : null;

--- a/src/lib/onboard/machine/sequence-runner.test.ts
+++ b/src/lib/onboard/machine/sequence-runner.test.ts
@@ -3,13 +3,6 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  createSession,
-  filterSafeUpdates,
-  normalizeSession,
-  type Session,
-  type SessionUpdates,
-} from "../../state/onboard-session";
 import { advanceTo, branchTo, completeOnboardMachine, retryTo } from "./result";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "./runtime";
 import {
@@ -18,55 +11,21 @@ import {
   type OnboardSequencePhase,
   runOnboardSequenceWithRunner,
 } from "./sequence-runner";
+import {
+  type Session,
+  type SessionUpdates,
+  cloneSession,
+  createSession,
+  createTestRuntime,
+} from "../../../../test/helpers/onboard-machine-runtime-fixture";
+
+function createRuntime(initialSession: Session = createSession()) {
+  return createTestRuntime(initialSession, { now: () => "2026-05-29T00:00:00.000Z" });
+}
 
 interface SequenceContext {
   attempt: number;
   log: string[];
-}
-
-function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
-}
-
-function createRuntime(initialSession: Session = createSession()) {
-  let session = cloneSession(initialSession);
-  const updateSession = (mutator: (value: Session) => Session | void): Session => {
-    session = cloneSession(mutator(cloneSession(session)) ?? session);
-    return cloneSession(session);
-  };
-  const deps: OnboardRuntimeDeps = {
-    loadSession: () => cloneSession(session),
-    createSession,
-    saveSession: (next) => {
-      session = cloneSession(next);
-      return cloneSession(session);
-    },
-    updateSession,
-    markStepStarted: () => cloneSession(session),
-    markStepComplete: (_stepName, updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        return current;
-      }),
-    markStepSkipped: () => cloneSession(session),
-    markStepFailed: (stepName, message) =>
-      updateSession((current) => {
-        current.steps[stepName].status = "failed";
-        current.steps[stepName].error = message ?? null;
-        return current;
-      }),
-    completeSession: (updates: SessionUpdates = {}) =>
-      updateSession((current) => {
-        Object.assign(current, filterSafeUpdates(updates));
-        current.status = "complete";
-        current.resumable = false;
-        return current;
-      }),
-    filterSafeUpdates,
-    emitEvent: () => undefined,
-    now: () => "2026-05-29T00:00:00.000Z",
-  };
-  return new OnboardRuntime(deps);
 }
 
 function phase(

--- a/src/lib/onboard/machine/transition-traces.test.ts
+++ b/src/lib/onboard/machine/transition-traces.test.ts
@@ -14,16 +14,6 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  createSession,
-  filterSafeUpdates,
-  MACHINE_SNAPSHOT_VERSION,
-  normalizeSession,
-  type OnboardMachineSnapshot,
-  type Session,
-  type SessionUpdates,
-  type StepState,
-} from "../../state/onboard-session";
 import type { OnboardMachineEvent } from "./events";
 import { handleSandboxState } from "./handlers/sandbox";
 import { baseOptions, bindJournaledRecreate, createDeps } from "./handlers/sandbox-test-fixtures";
@@ -31,12 +21,17 @@ import { advanceTo, branchTo, completeOnboardMachine, failOnboardMachine } from 
 import { type OnboardStateHandlers, runOnboardMachine } from "./runner";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "./runtime";
 import type { OnboardMachineState } from "./types";
+import type { OnboardMachineSnapshot, StepState } from "../../state/onboard-session";
+import {
+  MACHINE_SNAPSHOT_VERSION,
+  type Session,
+  type SessionUpdates,
+  cloneSession,
+  createSession,
+  filterSafeUpdates,
+} from "../../../../test/helpers/onboard-machine-runtime-fixture";
 
 const NOW = "2026-07-04T00:00:00.000Z";
-
-function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
-}
 
 function machineAt(state: OnboardMachineState, revision = 0): OnboardMachineSnapshot {
   return { version: MACHINE_SNAPSHOT_VERSION, state, stateEnteredAt: NOW, revision };

--- a/test/helpers/onboard-machine-runtime-fixture.ts
+++ b/test/helpers/onboard-machine-runtime-fixture.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  createSession,
+  filterSafeUpdates,
+  normalizeSession,
+  type Session,
+  type SessionUpdates,
+} from "../../src/lib/state/onboard-session";
+import { OnboardRuntime, type OnboardRuntimeDeps } from "../../src/lib/onboard/machine/runtime";
+
+export {
+  createSession,
+  filterSafeUpdates,
+  MACHINE_SNAPSHOT_VERSION,
+} from "../../src/lib/state/onboard-session";
+export type { Session, SessionUpdates } from "../../src/lib/state/onboard-session";
+
+/**
+ * In-memory onboarding-machine runtime for the machine test suites. The
+ * fixture owns the session store mechanics the suites previously each
+ * declared inline; scenario sessions, timestamps that assertions depend on,
+ * and behavior expectations stay in each test. Every call returns fresh
+ * state, and nothing outside the returned runtime is touched.
+ */
+
+/** A deep session copy that survives independent mutation. */
+export function cloneSession(session: Session): Session {
+  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
+}
+
+/** Behavior options for createTestRuntime. */
+export interface TestRuntimeOptions {
+  /** The deterministic clock the runtime stamps sessions with. */
+  now?: () => string;
+}
+
+/**
+ * An OnboardRuntime over an in-memory session store. Step transitions
+ * mutate the stored session the way the suites' inline copies did; the
+ * clock defaults to a fixed timestamp and is overridable where assertions
+ * depend on a specific value.
+ */
+export function createTestRuntime(
+  initialSession: Session = createSession(),
+  options?: TestRuntimeOptions,
+): OnboardRuntime {
+  let session = cloneSession(initialSession);
+  const updateSession = (mutator: (value: Session) => Session | void): Session => {
+    session = cloneSession(mutator(cloneSession(session)) ?? session);
+    return cloneSession(session);
+  };
+  const deps: OnboardRuntimeDeps = {
+    loadSession: () => cloneSession(session),
+    createSession,
+    saveSession: (next) => {
+      session = cloneSession(next);
+      return cloneSession(session);
+    },
+    updateSession,
+    markStepStarted: () => cloneSession(session),
+    markStepComplete: (_stepName, updates: SessionUpdates = {}) =>
+      updateSession((current) => {
+        Object.assign(current, filterSafeUpdates(updates));
+        return current;
+      }),
+    markStepSkipped: () => cloneSession(session),
+    markStepFailed: (stepName, message) =>
+      updateSession((current) => {
+        current.steps[stepName].status = "failed";
+        current.steps[stepName].error = message ?? null;
+        return current;
+      }),
+    completeSession: (updates: SessionUpdates = {}) =>
+      updateSession((current) => {
+        Object.assign(current, filterSafeUpdates(updates));
+        current.status = "complete";
+        current.resumable = false;
+        return current;
+      }),
+    filterSafeUpdates,
+    emitEvent: () => undefined,
+    now: options?.now ?? (() => "2026-05-28T00:00:00.000Z"),
+  };
+  return new OnboardRuntime(deps);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Five onboarding-machine suites each declared the same in-memory OnboardRuntime over a session store, and eight duplicated the deep `cloneSession` helper byte for byte. This is sequential PR 2 of issue #8289: it moves both into `test/helpers/onboard-machine-runtime-fixture.ts` and migrates the eight suites. The deterministic clock is overridable where assertions depend on a specific timestamp, and `flow-slices` keeps its intentionally inert `markStepFailed` and `completeSession` behavior local rather than growing the fixture behavior options.

## Related Issue

Refs #8289 (sequential PR 2 of 4; PR 1 is #8537)

## Changes

- Add `test/helpers/onboard-machine-runtime-fixture.ts`: `cloneSession`, `createTestRuntime(initialSession?, { now? })`, and a re-export of the session helpers the suites consume. The `test/helpers/` placement follows the existing shared-fixture convention (`base-image-test-harness`, `messaging-conflict-fixtures`, `env-test-helpers`) and keeps the source-architecture fan-in budget for `onboard-session.ts` untouched; the eight suites drop their direct runtime imports of `onboard-session` in the process. Requirement and consumers: the eight machine suites below. A direct change cannot remove the duplication because each suite owns an inline copy; the protecting tests are the migrated suites themselves. The fixture holds no filesystem or global state, so the PR 1 review convention about registering workspace cleanup does not apply here.
- Migrate `runner`, `runner-sequence`, `sequence-runner`, `flow-sequence`, and `flow-phases/agent-policy-finalization` to the shared runtime; the two clock families keep their asserted timestamps at their call sites.
- Migrate `runtime`, `flow-slices`, and `transition-traces` to the shared `cloneSession` only.
- Every migrated file has a negative line delta (net -139 across the PR).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: test-only consolidation; the eight migrated suites are the protected behavior and pass unchanged (63 tests).
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test fixture only; no user-facing surface or documented behavior changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: test-only fixture and suite migrations; no user-facing surface changes. Docstrings on the new fixture reviewed against the writing rules.
- Agent: Claude Code
<!-- docs-review-head-sha: 18924fa -->
<!-- docs-review-agents-blob-sha: c69aad4 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — ran `npm run validate:pr`; every hook passes except hadolint, which reports a pre-existing info-level finding (`Dockerfile:1543 SC2015`) that is byte-identical on unmodified `main`; this PR changes no Dockerfile
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli` on the eight migrated suites; 8 files, 63 tests pass in normal and shuffled order. `tsc -p tsconfig.cli.json` and `npm run checks:repository` pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: JulienAu <16043912+JulienAu@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized onboarding flow and runtime tests on a shared test fixture.
  * Improved test isolation through consistent session cloning, persistence, lifecycle handling, and event simulation.
  * Added configurable fixed timestamps for more deterministic test execution.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->