### PR TITLE
fix(onboard): authorize managed loopback vLLM endpoints

### DIFF
--- a/src/lib/onboard/setup-nim-vllm.test.ts
+++ b/src/lib/onboard/setup-nim-vllm.test.ts
@@ -167,6 +167,7 @@ describe("setupNim vLLM route containment", () => {
   });
 
   it("fails closed for a managed endpoint that is neither loopback nor operator-trusted private", async () => {
+    const queryVllmModels = vi.fn(() => JSON.stringify({ data: [{ id: "served/model" }] }));
     const validateOpenAiLikeSelection = vi.fn(async () => ({ ok: true }));
     const handler = createSetupNimVllmHandler(
       deps({
@@ -176,12 +177,13 @@ describe("setupNim vLLM route containment", () => {
           baseUrl: "http://93.184.216.34:8000/v1",
           apiKey: "a".repeat(64),
         }),
-        queryVllmModels: () => JSON.stringify({ data: [{ id: "served/model" }] }),
+        queryVllmModels,
         validateOpenAiLikeSelection,
       }),
     );
 
     await expect(handler(state(null))).rejects.toThrow("exit 1");
+    expect(queryVllmModels).not.toHaveBeenCalled();
     expect(validateOpenAiLikeSelection).not.toHaveBeenCalled();
     expect(console.error).toHaveBeenCalledWith(
       "  Managed vLLM endpoint authorization could not be verified.",

--- a/src/lib/onboard/setup-nim-vllm.test.ts
+++ b/src/lib/onboard/setup-nim-vllm.test.ts
@@ -134,6 +134,60 @@ describe("setupNim vLLM route containment", () => {
     expect(renderedOutput).not.toContain("localhost:8000");
   });
 
+  it("authorizes a managed loopback endpoint without a trusted-private capability (#8539)", async () => {
+    const apiKey = "a".repeat(64);
+    const queryVllmModels = vi.fn(() => JSON.stringify({ data: [{ id: "served/model" }] }));
+    const validateOpenAiLikeSelection = vi.fn(async () => ({
+      ok: true,
+      api: "openai-completions",
+    }));
+    const handler = createSetupNimVllmHandler(
+      deps({
+        getLocalProviderBaseUrl: () => "http://127.0.0.1:8000/v1",
+        getLocalProviderValidationBaseUrl: () => "http://127.0.0.1:8000/v1",
+        getManagedVllmProviderBinding: () => ({
+          baseUrl: "http://127.0.0.1:8000/v1",
+          apiKey,
+        }),
+        queryVllmModels,
+        validateOpenAiLikeSelection,
+      }),
+    );
+
+    await expect(handler(state(null))).resolves.toBe("selected");
+    expect(validateOpenAiLikeSelection).toHaveBeenCalledWith(
+      "Local vLLM",
+      "http://127.0.0.1:8000/v1",
+      "served/model",
+      null,
+      undefined,
+      undefined,
+      { apiKey, pinnedAddresses: [], trustedPrivateCapability: undefined },
+    );
+  });
+
+  it("fails closed for a managed endpoint that is neither loopback nor operator-trusted private", async () => {
+    const validateOpenAiLikeSelection = vi.fn(async () => ({ ok: true }));
+    const handler = createSetupNimVllmHandler(
+      deps({
+        getLocalProviderBaseUrl: () => "http://93.184.216.34:8000/v1",
+        getLocalProviderValidationBaseUrl: () => "http://93.184.216.34:8000/v1",
+        getManagedVllmProviderBinding: () => ({
+          baseUrl: "http://93.184.216.34:8000/v1",
+          apiKey: "a".repeat(64),
+        }),
+        queryVllmModels: () => JSON.stringify({ data: [{ id: "served/model" }] }),
+        validateOpenAiLikeSelection,
+      }),
+    );
+
+    await expect(handler(state(null))).rejects.toThrow("exit 1");
+    expect(validateOpenAiLikeSelection).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "  Managed vLLM endpoint authorization could not be verified.",
+    );
+  });
+
   it("rejects a root-matched alias with topology-neutral recovery for a managed dual endpoint", async () => {
     const selection = state("required/model");
     const validateOpenAiLikeSelection = vi.fn(async () => ({ ok: true }));

--- a/src/lib/onboard/setup-nim-vllm.ts
+++ b/src/lib/onboard/setup-nim-vllm.ts
@@ -271,6 +271,16 @@ export function createSetupNimVllmHandler(
         ? "  ✓ Using managed vLLM endpoint"
         : `  ✓ Using existing vLLM on localhost:${deps.VLLM_PORT}`,
     );
+    let managedValidationOptions: Awaited<ReturnType<typeof managedVllmValidationOptions>> | null =
+      null;
+    if (apiKey) {
+      try {
+        managedValidationOptions = await managedVllmValidationOptions(validationBaseUrl, apiKey);
+      } catch {
+        console.error("  Managed vLLM endpoint authorization could not be verified.");
+        deps.exitProcess(1);
+      }
+    }
     const raw = apiKey
       ? deps.queryVllmModels(validationBaseUrl, apiKey)
       : deps.runCapture(["curl", "-sf", `${validationBaseUrl}/models`], {
@@ -338,16 +348,6 @@ export function createSetupNimVllmHandler(
     }
 
     const validationModel = deps.requireValue(state.model, "Expected a detected vLLM model");
-    let managedValidationOptions: Awaited<ReturnType<typeof managedVllmValidationOptions>> | null =
-      null;
-    if (apiKey) {
-      try {
-        managedValidationOptions = await managedVllmValidationOptions(validationBaseUrl, apiKey);
-      } catch {
-        console.error("  Managed vLLM endpoint authorization could not be verified.");
-        deps.exitProcess(1);
-      }
-    }
     const validation = apiKey
       ? await deps.validateOpenAiLikeSelection(
           "Local vLLM",

--- a/src/lib/onboard/setup-nim-vllm.ts
+++ b/src/lib/onboard/setup-nim-vllm.ts
@@ -3,9 +3,11 @@
 
 import {
   assertEndpointResolvesPublic,
+  isTrustedPrivateEndpointCapability,
   type TrustedPrivateEndpointCapability,
 } from "../inference/endpoint-ssrf-preflight";
 import { VLLM_MODELS } from "../inference/vllm-models";
+import { isLoopbackHostname } from "../private-networks";
 import { cliName } from "./branding";
 import type { SetupNimSelectionResult, SetupNimSelectionState } from "./setup-nim-flow";
 
@@ -77,7 +79,13 @@ async function managedVllmValidationOptions(baseUrl: string, apiKey: string) {
   const preflight = await assertEndpointResolvesPublic(baseUrl, undefined, {
     trustedPrivateHosts: [hostname],
   });
-  if (!preflight.ok || !preflight.trustedPrivateCapability) {
+  if (!preflight.ok) {
+    throw new Error("Managed vLLM endpoint authorization failed.");
+  }
+  if (
+    !isLoopbackHostname(hostname) &&
+    !isTrustedPrivateEndpointCapability(preflight.trustedPrivateCapability)
+  ) {
     throw new Error("Managed vLLM endpoint authorization failed.");
   }
   return {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

The managed host-local vLLM runtime always publishes on `127.0.0.1`, and the shared SSRF preflight admits an explicit loopback host without minting a trusted-private capability, so onboarding's unconditional capability demand could never pass and every managed vLLM install exited before creating a sandbox. A loopback managed endpoint now satisfies the check on its own, while any other host still requires a provenance-checked capability.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

Fixes #8539

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- `managedVllmValidationOptions` in `src/lib/onboard/setup-nim-vllm.ts` splits one condition into two. A preflight rejection still fails closed. The trusted-private capability is now demanded only when the endpoint host is not loopback, because `assertEndpointResolvesPublic` returns early for an explicit loopback host and issues no capability for it — a capability records which private addresses may appear in a curl `--resolve` pin, and loopback needs no pin. The truthiness test is replaced by `isTrustedPrivateEndpointCapability`, so a forged object no longer satisfies the check.
- `pinnedAddresses` keeps passing `preflight.addresses ?? []`. The empty array is load-bearing: `src/lib/adapters/http/probe.ts` treats a defined value, including `[]`, as proof that the preflight ran and strips every proxy environment variable, so the credentialed loopback probe is not routed through an ambient proxy.
- Two tests in `src/lib/onboard/setup-nim-vllm.test.ts`. The first drives a loopback managed binding through the handler and asserts the validation options it forwards; it fails against the unfixed code. The second holds the other side of the gate by asserting that a managed endpoint which is neither loopback nor operator-trusted private still fails closed. Neither test resolves DNS.
- The gate is scoped to loopback rather than to the preflight's `trustedPrivateEndpoint` flag. Gating on that flag would also have admitted a managed endpoint on a public address, which the previous code rejected. There are three managed-binding producers, and the managed-cluster one derives its base URL from a discovered fabric interface address that is not constrained to private space, so that widening would have been a real behaviour change rather than a theoretical one. Scoping to loopback fixes this defect and widens nothing.
- No production behaviour changes for the DGX Station or managed-cluster endpoints, which resolve to routed private addresses and still mint and require a capability. That path is covered by the pre-existing test using `10.40.0.1`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no flag, prompt, configuration key, default, or success-path output changes. The fix restores the onboarding flow the documentation already describes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [Nine-category maintainer security review](https://github.com/NVIDIA/NemoClaw/pull/8548#issuecomment-5216200716) passed with no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed. The review checked the "When to Update Docs" triggers in `docs/CONTRIBUTING.md` and found none met: no flag is added, removed, or renamed, no default or configuration changes, and the pages describe the flow this fix restores rather than describing it incorrectly. It found the error string absent from `docs/`, with the only near hit in `docs/reference/troubleshooting.mdx` being an unrelated WSL message, and no vLLM onboarding-failure entry to stay consistent with. It confirmed that the managed-endpoint address statements in `docs/inference/choose-local-inference-server.mdx` and `docs/inference/set-up-vllm.mdx` describe where the server is published rather than an authorization rule, and that the trusted-private posture in `docs/inference/custom-endpoint-security.mdx` is scoped to custom endpoints and disclaims managed provider defaults, so no published claim is contradicted. It also checked `docs/reference/commands.mdx`, the remaining `docs/inference/` vLLM pages, all pages under `docs/security/`, and `docs/get-started/`, and confirmed that neither `CONTRIBUTING.md` nor `AGENTS.md` documents the preflight capability pattern, so nothing there is stale. The review additionally rejected an earlier version of this change that gated on `trustedPrivateEndpoint`, and its finding produced the loopback-scoped gate in this commit.
- Agent: Codex Desktop Documentation Writer
<!-- docs-review-head-sha: 57bc91b2d -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/setup-nim-vllm.test.ts` — 34 passed. `npx vitest run --project cli` across the eight further suites reaching this handler, including `setup-nim-flow`, `vllm-menu`, `provider-selection`, `inference-providers/vllm-local`, both `provider-inference` handlers, and `rebuild-local-provider-recreate` — 123 passed. `npx vitest run --project integration test/onboard-selection-vllm.test.ts` — 7 passed. `npx vitest run --project installer-integration test/install-express-prompt.test.ts` — 84 passed. `npm run typecheck:cli` and `npm run build:cli` — clean. `test/vllm-docker-storage.test.ts` skips without Docker and was not run.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable. This changes one private function in a single onboarding module and adds no harness mechanics — no Vitest config, setup file, project glob, or registration topology. `npm run checks:repository` passed, including the layer import boundary, source architecture budget with zero cycles, and Vitest project membership.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization handling for managed vLLM endpoints.
  * Local loopback endpoints can proceed without additional private-endpoint permissions.
  * Non-loopback private endpoints remain protected and are rejected when authorization requirements are not met.
  * Authorization errors are now reported before endpoint validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
