### PR TITLE
fix(hermes): repair legacy dashboard startup

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -1442,6 +1442,9 @@ start_socat_forwarder() {
 }
 
 build_hermes_dashboard_args() {
+  # HERMES_DASHBOARD_HOME is a dedicated profile for privilege separation.
+  # Hermes otherwise treats a profiles/<name> launch as a request for its
+  # unified machine dashboard and re-execs outside this prepared profile.
   HERMES_DASHBOARD_ARGS=(
     dashboard
     --host
@@ -1450,6 +1453,7 @@ build_hermes_dashboard_args() {
     "$DASHBOARD_INTERNAL_PORT"
     --skip-build
     --no-open
+    --isolated
   )
   if hermes_dashboard_tui_enabled; then
     HERMES_DASHBOARD_ARGS+=(--tui)

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -848,14 +848,14 @@ describe("agents/hermes/start.sh port validation", () => {
     expect(invalidOverride.stderr).toContain("Invalid NEMOCLAW_DASHBOARD_PORT");
   });
 
-  it("keeps the in-browser Hermes TUI opt-in", () => {
+  it("keeps the managed dashboard isolated and its in-browser Hermes TUI opt-in", () => {
     const defaultArgs = runHermesDashboardArgs();
     expect(defaultArgs.status).toBe(0);
     expect(defaultArgs.stdout.split("\n")).not.toContain("--tui");
 
     const optInArgs = runHermesDashboardArgs("1");
     expect(optInArgs.status).toBe(0);
-    expect(optInArgs.stdout.split("\n")).toContain("--tui");
+    expect(optInArgs.stdout.split("\n")).toEqual(expect.arrayContaining(["--isolated", "--tui"]));
   });
 
   it("rejects cross-collisions between API and dashboard ports", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Keep the managed Hermes Dashboard inside NemoClaw's prepared, privilege-separated profile by passing upstream Hermes' `--isolated` flag.
- Prevent Hermes from treating `profiles/dashboard-home` as a request to re-exec into its unified machine-level Dashboard.
- Extend the existing Dashboard argument contract without changing ports, credentials, migration, permissions, or retry behavior.

## Affected main evidence

- Run: https://github.com/NVIDIA/NemoClaw/actions/runs/31171807086
- Job: `sandbox-images-and-e2e / test-hermes-sandbox-image` (92846562212)
- Candidate: `c31724f4e66e4d9abd0baab2ff68181830a4750a`
- Scenario: `hermes root-entrypoint smoke preserves runtime layout and legacy state migration`
- Signal: after the legacy profile is migrated and seeded, the Dashboard service owner exits before binding `127.0.0.1:19119`; the container exits 1.

## Root cause

Hermes v2026.7.20 infers a named profile from a `HERMES_HOME` path under `profiles/<name>`. Without `--isolated`, `hermes dashboard` routes that launch to its unified machine-level Dashboard and leaves NemoClaw's prepared profile boundary. The legacy-state variant populates that profile before launch, exposing the route and causing the Dashboard owner to exit before the internal port binds.

## Ownership search

- No open PR matches the exact bind-exit text, port `19119`, or `start_socat_forwarder` path.
- No open PR edits `agents/hermes/start.sh` or `test/e2e/live/hermes-root-entrypoint-smoke.test.ts`.
- #8229 concerns the Dashboard WhatsApp session path and does not touch this startup boundary.

## Validation

- `npx vitest run --project integration test/hermes-start.test.ts test/hermes-dashboard-credential-launch.test.ts test/hermes-dashboard-profile-migration-security.test.ts` (47 passed)
- `npm run build:cli`
- `npm run validate:pr`
- The three failing cases in `test/seed-hermes-dashboard-config.test.ts` reproduce unchanged on `main`; they are outside this patch and this root cause.

## Security review

- `--isolated` keeps the Dashboard in the sandbox-owned profile that NemoClaw already prepares and permission-separates.
- Loopback host/bind, gateway credential handoff, fail-closed migration, and filesystem permissions are unchanged.
- No timeout, retry, test-coverage, or network-policy weakening; no E2E workflow was manually dispatched.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes dashboard startup reliability by running the dashboard in isolated mode.
  * Prevented unintended dashboard re-execution in unified environments.

* **Tests**
  * Added coverage confirming isolated dashboard behavior.
  * Preserved the opt-in behavior of the Hermes TUI flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->