### PR TITLE
test(onboard): preserve runtime fixture isolation

### DIFF
--- a/test/helpers/onboard-machine-runtime-fixture.test.ts
+++ b/test/helpers/onboard-machine-runtime-fixture.test.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { cloneSession, createSession } from "./onboard-machine-runtime-fixture";
+
+describe("cloneSession", () => {
+  it("isolates invalid session state when normalization rejects the copy", () => {
+    const session = createSession();
+    session.version = 0;
+
+    const copy = cloneSession(session);
+
+    expect(copy).not.toBe(session);
+    expect(copy.steps).not.toBe(session.steps);
+
+    copy.status = "failed";
+    copy.steps.preflight.status = "failed";
+
+    expect(session.status).toBe("in_progress");
+    expect(session.steps.preflight.status).toBe("pending");
+  });
+});

--- a/test/helpers/onboard-machine-runtime-fixture.ts
+++ b/test/helpers/onboard-machine-runtime-fixture.ts
@@ -27,7 +27,8 @@ export type { Session, SessionUpdates } from "../../src/lib/state/onboard-sessio
 
 /** A deep session copy that survives independent mutation. */
 export function cloneSession(session: Session): Session {
-  return normalizeSession(JSON.parse(JSON.stringify(session))) ?? session;
+  const copy = JSON.parse(JSON.stringify(session)) as Session;
+  return normalizeSession(copy) ?? copy;
 }
 
 /** Behavior options for createTestRuntime. */


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`cloneSession` from #8546 returned the caller-owned session when normalization rejected its serialized copy. This follow-up keeps the serialized copy as the fallback so fixture mutations cannot alter caller-owned top-level or nested state.

## Changes

- Use the serialized session copy as both the normalization input and fallback.
- Add a regression test with an invalid session version. The test proves that normalization rejection still returns independent top-level and nested state.
- Record the detection gap: #8546 exercised valid sessions only, so normalization always succeeded and did not reach the aliasing fallback.
- Close the complete #8546 review set. The CodeRabbit isolation finding is fixed. The docstring-coverage warning is advisory because local exports have JSDoc and re-export documentation remains source-owned. The PR Review Advisor reported no findings and failed only because its model request returned HTTP 429.
- Inspect the equivalent local clone helpers in `test/helpers/onboard-final-flow-phases.ts`, `src/lib/onboard/resume-machine-repair.test.ts`, `src/lib/onboard/runtime-boundary-step-result.test.ts`, and `src/lib/onboard/runtime-boundary.test.ts`. Their callers construct valid sessions and do not expose #8546's independent-mutation contract, so this PR does not change them.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes an internal test fixture and its regression coverage. No CLI, configuration, output, workflow, default, API, policy schema, or supported user behavior changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: the completed diff changes only `test/helpers/onboard-machine-runtime-fixture.ts` and `test/helpers/onboard-machine-runtime-fixture.test.ts`. The reviewer found no user-visible behavior or documentation impact and approved the test title and existing JSDoc ownership.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 64c19cf70 -->
<!-- docs-review-agents-blob-sha: c69aad4d5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` does not change.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/helpers/onboard-machine-runtime-fixture.test.ts` passed 1/1; the eight #8546 CLI suites passed 63/63; `npm run typecheck:cli` passed; `npm run test:projects:check` reported exact membership for 2,231 candidate files across seven projects.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable. The change updates one fixture fallback and adds one focused test; targeted validation covers every #8546 consumer.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cloning so copied sessions remain independent even when normalization fails.
  * Prevented changes to a cloned session from affecting the original session.

* **Tests**
  * Added regression coverage for cloning invalid-version sessions and nested steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->