### PR TITLE
ci(images): retry transient manifest registry reads

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -536,7 +536,7 @@ jobs:
             fi
             source="$IMAGE@sha256:$digest"
             source_platform="$(
-              docker buildx imagetools inspect "$source" \
+              scripts/checks/retry-docker-imagetools-inspect.sh "$source" \
                 --format '{{.Image.OS}}/{{.Image.Architecture}}'
             )"
             if [ "$source_platform" != "linux/$expected_arch" ]; then
@@ -577,7 +577,7 @@ jobs:
           fi
           reference="$IMAGE@$digest"
           actual_platforms="$(
-            docker buildx imagetools inspect "$reference" --raw \
+            scripts/checks/retry-docker-imagetools-inspect.sh "$reference" --raw \
               | jq -r '.manifests[] | select(.platform.os == "linux") | .platform.architecture' \
               | sort -u \
               | paste -sd, -
@@ -705,7 +705,7 @@ jobs:
             fi
             source="$IMAGE@sha256:$digest"
             source_platform="$(
-              docker buildx imagetools inspect "$source" \
+              scripts/checks/retry-docker-imagetools-inspect.sh "$source" \
                 --format '{{.Image.OS}}/{{.Image.Architecture}}'
             )"
             if [ "$source_platform" != "linux/$expected_arch" ]; then
@@ -746,7 +746,7 @@ jobs:
           fi
           reference="$IMAGE@$digest"
           actual_platforms="$(
-            docker buildx imagetools inspect "$reference" --raw \
+            scripts/checks/retry-docker-imagetools-inspect.sh "$reference" --raw \
               | jq -r '.manifests[] | select(.platform.os == "linux") | .platform.architecture' \
               | sort -u \
               | paste -sd, -
@@ -876,7 +876,7 @@ jobs:
             fi
             source="$IMAGE@sha256:$digest"
             source_platform="$(
-              docker buildx imagetools inspect "$source" \
+              scripts/checks/retry-docker-imagetools-inspect.sh "$source" \
                 --format '{{.Image.OS}}/{{.Image.Architecture}}'
             )"
             if [ "$source_platform" != "linux/$expected_arch" ]; then
@@ -917,7 +917,7 @@ jobs:
           fi
           reference="$IMAGE@$digest"
           actual_platforms="$(
-            docker buildx imagetools inspect "$reference" --raw \
+            scripts/checks/retry-docker-imagetools-inspect.sh "$reference" --raw \
               | jq -r '.manifests[] | select(.platform.os == "linux") | .platform.architecture' \
               | sort -u \
               | paste -sd, -

--- a/scripts/checks/retry-docker-imagetools-inspect.sh
+++ b/scripts/checks/retry-docker-imagetools-inspect.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <image-reference> [imagetools-inspect-arguments...]" >&2
+  exit 2
+fi
+
+attempts=5
+retry_seconds=5
+
+error_log="$(mktemp "${TMPDIR:-/tmp}/nemoclaw-imagetools-inspect.XXXXXX")"
+trap 'rm -f "$error_log"' EXIT
+
+status=1
+for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+  : >"$error_log"
+  if output="$(docker buildx imagetools inspect "$@" 2>"$error_log")"; then
+    cat "$error_log" >&2
+    printf '%s\n' "$output"
+    exit 0
+  else
+    status="$?"
+  fi
+  cat "$error_log" >&2
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "WARN: image registry read failed on attempt $attempt/$attempts; retrying in ${retry_seconds}s." >&2
+    sleep "$retry_seconds"
+  fi
+done
+
+echo "ERROR: image registry read failed after $attempts attempts." >&2
+exit "$status"

--- a/scripts/checks/validate-managed-base-index.sh
+++ b/scripts/checks/validate-managed-base-index.sh
@@ -33,7 +33,7 @@ for arch in amd64 arm64; do
     arm64) source_digest="$source_arm64" ;;
   esac
   source_reference="$image@$source_digest"
-  source_json="$(docker buildx imagetools inspect "$source_reference" --raw)"
+  source_json="$(scripts/checks/retry-docker-imagetools-inspect.sh "$source_reference" --raw)"
 
   mapfile -t workload_digests < <(
     jq -r --arg arch "$arch" \
@@ -96,7 +96,7 @@ for arch in amd64 arm64; do
   )"
 done
 
-index_json="$(docker buildx imagetools inspect "$reference" --raw)"
+index_json="$(scripts/checks/retry-docker-imagetools-inspect.sh "$reference" --raw)"
 if ! jq -e \
   '
     .schemaVersion == 2

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -605,6 +605,13 @@ describe("base-image publication behavior", () => {
       expect(manifestScript).toContain('"${#digest_files[@]}" -ne 2');
       expect(manifestScript).toContain("^(amd64|arm64)-([0-9a-f]{64})$");
       expect(manifestScript).toContain("--format '{{.Image.OS}}/{{.Image.Architecture}}'");
+      expect(manifestScript).toContain(
+        'scripts/checks/retry-docker-imagetools-inspect.sh "$source"',
+      );
+      expect(manifestScript).toContain(
+        'scripts/checks/retry-docker-imagetools-inspect.sh "$reference" --raw',
+      );
+      expect(manifestScript).not.toContain("docker buildx imagetools inspect");
       expect(manifestScript).toContain('if [ "$source_platform" != "linux/$expected_arch" ]; then');
       expect(manifestScript).toContain("duplicate platform digest");
       expect(manifestScript).toContain("declare -A source_digests=()");

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -106,6 +106,15 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     testsToRun: runTests("test/validate-managed-base-index.test.ts"),
   },
   {
+    pattern: /(?:^|\/)scripts\/checks\/retry-docker-imagetools-inspect\.sh$/,
+    testsToRun: runTests(
+      "test/retry-docker-imagetools-inspect.test.ts",
+      "test/validate-managed-base-index.test.ts",
+      "test/managed-image-publication-workflow.test.ts",
+      "test/dcode-base-image-workflow.test.ts",
+    ),
+  },
+  {
     pattern: /(?:^|\/)scripts\/e2e\/sanitize-trace-timing\.py$/,
     testsToRun: runTests(
       "test/e2e/support/e2e-scorecard.test.ts",

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -406,6 +406,11 @@ describe("complete managed-image publication workflow", () => {
       expect(manifest.run).toContain('reference="$IMAGE@$digest"');
       expect(manifest.run).toContain('.["containerimage.descriptor"].digest');
       expect(manifest.run).toContain('--metadata-file "$candidate_metadata"');
+      expect(manifestRun).toContain('scripts/checks/retry-docker-imagetools-inspect.sh "$source"');
+      expect(manifestRun).toContain(
+        'scripts/checks/retry-docker-imagetools-inspect.sh "$reference" --raw',
+      );
+      expect(manifestRun).not.toContain("docker buildx imagetools inspect");
       expect(manifest.run).toContain("scripts/checks/validate-managed-base-index.sh");
       expect(manifest.run).toContain("declare -A source_digests=()");
       expect(manifest.run).toContain('"${source_digests[linux/amd64]}"');

--- a/test/retry-docker-imagetools-inspect.test.ts
+++ b/test/retry-docker-imagetools-inspect.test.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const inspector = path.join(repoRoot, "scripts/checks/retry-docker-imagetools-inspect.sh");
+const reference = `ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:${"a".repeat(64)}`;
+
+function runInspector(failures: number) {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-image-inspect-"));
+  const fakeBin = path.join(temporaryRoot, "bin");
+  const countFile = path.join(temporaryRoot, "count");
+  const argsFile = path.join(temporaryRoot, "args");
+  fs.mkdirSync(fakeBin);
+  fs.writeFileSync(
+    path.join(fakeBin, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [ -f "$COUNT_FILE" ]; then
+  count="$(cat "$COUNT_FILE")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$COUNT_FILE"
+printf '%s\n' "$*" >>"$ARGS_FILE"
+if [ "$count" -le "$FAILURES" ]; then
+  echo "failed to authorize: token request returned 403 Forbidden" >&2
+  exit 42
+fi
+printf '{"schemaVersion":2}\n'
+`,
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(path.join(fakeBin, "sleep"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+
+  try {
+    const result = spawnSync(inspector, [reference, "--raw"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ARGS_FILE: argsFile,
+        COUNT_FILE: countFile,
+        FAILURES: String(failures),
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      },
+    });
+    return {
+      ...result,
+      args: fs.readFileSync(argsFile, "utf8").trim().split("\n"),
+      count: Number(fs.readFileSync(countFile, "utf8").trim()),
+    };
+  } finally {
+    fs.rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+}
+
+describe("retry-docker-imagetools-inspect", () => {
+  it("recovers from a transient registry authorization failure", () => {
+    const result = runInspector(2);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe('{"schemaVersion":2}\n');
+    expect(result.count).toBe(3);
+    expect(result.args).toEqual(
+      Array.from({ length: 3 }, () => `buildx imagetools inspect ${reference} --raw`),
+    );
+    expect(result.stderr).toContain("attempt 1/5");
+    expect(result.stderr).toContain("attempt 2/5");
+  });
+
+  it("returns the registry failure after the bounded attempts", () => {
+    const result = runInspector(5);
+
+    expect(result.status).toBe(42);
+    expect(result.count).toBe(5);
+    expect(result.stderr).toContain("failed after 5 attempts");
+  });
+});

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -139,6 +139,12 @@ describe("Vitest opaque-input watch triggers", () => {
     expect(triggeredBy("scripts/checks/validate-managed-base-index.sh")).toEqual([
       "test/validate-managed-base-index.test.ts",
     ]);
+    expect(triggeredBy("scripts/checks/retry-docker-imagetools-inspect.sh")).toEqual([
+      "test/retry-docker-imagetools-inspect.test.ts",
+      "test/validate-managed-base-index.test.ts",
+      "test/managed-image-publication-workflow.test.ts",
+      "test/dcode-base-image-workflow.test.ts",
+    ]);
     expect(triggeredBy("scripts/e2e/sanitize-trace-timing.py")).toEqual([
       "test/e2e/support/e2e-scorecard.test.ts",
       "test/e2e/support/sanitize-trace-timing.test.ts",


### PR DESCRIPTION
## Summary

Base-image publication can fail immediately after pushing a candidate manifest when GHCR's token endpoint transiently returns `403 Forbidden` to the first manifest read. This change gives registry reads five bounded attempts while preserving the existing digest, platform, and provenance verification.

The failure was observed in main E2E run 31184501275, job 92888376997, propagated from Base Images run 31184501811, job 92886728421 (`Build and push Hermes base image`).

## Changes

- Route base-image manifest reads through one fixed-policy retry helper.
- Preserve the final Docker exit status after five unsuccessful attempts.
- Keep all existing source-digest, platform, candidate-manifest, and publication checks unchanged.
- Add focused helper, workflow-shape, and opaque-input trigger coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only internal GitHub Actions registry-read reliability; no user-facing command, configuration, default, or supported product behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer nine-category review passed. The retry is bounded, arguments remain quoted, terminal failures propagate, temporary stderr is removed, credential handling is unchanged, and digest/platform/provenance verification remains fail-closed.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: `PR exact all-agent managed runtime activation` failed in [run 31186757641, job 92896129767](https://github.com/NVIDIA/NemoClaw/actions/runs/31186757641/job/92896129767) on the existing OpenShell v0.0.85 Hermes sandbox-creation path. Accepted issue #8497 owns that v0.0.85 activation failure, and PR #8523's v0.0.99 activation passed in [run 31186050945, job 92893723945](https://github.com/NVIDIA/NemoClaw/actions/runs/31186050945/job/92893723945). The classification is recorded in [#8560](https://github.com/NVIDIA/NemoClaw/pull/8560#issuecomment-5218409078) and routed to [#8523](https://github.com/NVIDIA/NemoClaw/pull/8523#issuecomment-5218408856).

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change only adds bounded retries to internal GitHub Actions base-image registry reads. It does not change a user-facing command, configuration, default, or supported product behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 069dbd48e -->
<!-- docs-review-agents-blob-sha: 12ad395bb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/retry-docker-imagetools-inspect.test.ts test/dcode-base-image-workflow.test.ts test/managed-image-publication-workflow.test.ts test/vitest-watch-triggers.test.ts` (4 files, 30 tests passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this narrow internal workflow retry. Normal repository checks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The existing `validate-managed-base-index` suite requires Bash associative arrays. This macOS host has only Bash 3.2, so that suite could not execute locally; required Linux CI remains authoritative for that integration path.

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
