### PR TITLE
ci(e2e): gate hardware jobs behind opt-in flags

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -135,7 +135,9 @@ npm run release:e2e-evidence -- \
 ```
 
 The preflight derives every required execution from one empty-selector dispatch.
-The full run includes every workflow E2E and `Exact staging Brev Launchable`.
+The full run includes every default-selected workflow E2E plus `Exact staging Brev Launchable`.
+Accepted release evidence requires `allow_jetson_runner_queue=false` and `allow_dgx_spark_runner_queue=false`.
+The required denominator excludes `jetson-nvmap-gpu`, `llama-cpp-dgx-spark-plan`, and `llama-cpp-dgx-spark-qualification`.
 Each job that declares `RELEASE_E2E_ACTIVATION_PATH` requires that path at the candidate SHA.
 A missing activation path is a preflight failure.
 
@@ -146,7 +148,7 @@ Monitor the dispatched correlation ID with one bounded status query.
 Before accepting full-mode exact Brev evidence, require:
 
 - the workflow `head_sha` to equal the plan candidate SHA;
-- the trusted dispatch receipt to prove empty selectors and `include_staging_brev_launchable=true`;
+- the trusted dispatch receipt to prove empty selectors, `include_staging_brev_launchable=true`, `allowJetsonRunnerQueue: false`, and `allowDgxSparkRunnerQueue: false`;
 - the workflow conclusion to be `success`;
 - the `Exact staging Brev Launchable` job conclusion to be `success`;
 - the job URL and selected successful Launchable job attempt;

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts
@@ -89,6 +89,11 @@ const DEFAULT_WORKFLOW_PATH = path.join(REPO_ROOT, ".github", "workflows", "e2e.
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const SAFE_REPO_PATH_PATTERN = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[^\\]+$/u;
 const MATRIX_EXPRESSION_PATTERN = /\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/gu;
+const OPT_IN_HARDWARE_JOB_IDS = new Set([
+  "jetson-nvmap-gpu",
+  "llama-cpp-dgx-spark-plan",
+  "llama-cpp-dgx-spark-qualification",
+]);
 
 function record(value: unknown, label: string): JsonRecord {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -250,11 +255,6 @@ function isLaunchableE2eJob(jobId: string, job: JsonRecord): boolean {
   );
 }
 
-function requiresConfirmedJetsonRunner(job: JsonRecord): boolean {
-  const runsOn = job["runs-on"];
-  return typeof runsOn === "string" && runsOn.includes("inputs.allow_jetson_runner_queue");
-}
-
 function releaseActivationPath(job: JsonRecord, jobId: string): string | undefined {
   const rawEnvironment = job.env;
   if (rawEnvironment === undefined) return undefined;
@@ -307,7 +307,9 @@ export function buildReleaseE2ePreflight(input: {
   const inventory = readFreeStandingJobsInventory(workflowPath);
   const plan = input.plan ?? buildE2eWorkflowPlan();
   const pathExists = input.candidatePathExists ?? candidatePathExists;
-  const defaultJobIds = inventory.workflowJobs.filter((jobId) => jobId !== "shared-e2e");
+  const defaultJobIds = inventory.workflowJobs.filter(
+    (jobId) => jobId !== "shared-e2e" && !OPT_IN_HARDWARE_JOB_IDS.has(jobId),
+  );
   for (const jobId of defaultJobIds) {
     const activationPath = releaseActivationPath(
       record(jobs[jobId], `workflow.jobs.${jobId}`),
@@ -428,6 +430,16 @@ export function buildReleaseE2eLedger(
       booleanField(dispatch, "includeStagingBrevLaunchable", `${label}.dispatch`),
       true,
       `${label}.dispatch.includeStagingBrevLaunchable`,
+    );
+    requireEqual(
+      booleanField(dispatch, "allowJetsonRunnerQueue", `${label}.dispatch`),
+      false,
+      `${label}.dispatch.allowJetsonRunnerQueue`,
+    );
+    requireEqual(
+      booleanField(dispatch, "allowDgxSparkRunnerQueue", `${label}.dispatch`),
+      false,
+      `${label}.dispatch.allowDgxSparkRunnerQueue`,
     );
 
     const selectedExecutions = preflight.executions;

--- a/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
+++ b/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
@@ -67,8 +67,8 @@ Fail closed when identity, state, or timing evidence is missing, malformed, stal
 ### Live E2E
 
 Live E2E does not run automatically for pull requests and is not a merge gate.
-Each push to `main` selects every workflow E2E in `.github/workflows/e2e.yaml`.
-A selected job can remain queued until its configured runner is available.
+Each push to `main` selects the default workflow E2E jobs in `.github/workflows/e2e.yaml`.
+Push runs skip the Jetson nvmap and DGX Spark llama.cpp jobs because push events cannot set their required workflow dispatch flags.
 The workflow has no scheduled trigger.
 
 Use the manual PR mode only when a maintainer requests live evidence before merge.
@@ -85,7 +85,9 @@ After a failure, inspect the artifacts and remove resources that target cleanup 
 
 Dispatch the trusted `main` workflow with the current PR number, lowercase 40-character head SHA, head repository, lowercase 40-character base SHA, trusted workflow SHA, and a review reason containing 10 to 500 printable characters.
 Leave job and target selectors empty and keep Launchable disabled.
-If GitHub pauses `llama-cpp-dgx-spark-qualification` for the `approve-dgx-spark-image-qualification` environment, an authorized environment reviewer must approve it before qualification starts.
+Keep `allow_jetson_runner_queue=false` and `allow_dgx_spark_runner_queue=false` for the default PR revision selection.
+If the DGX Spark flag is `true`, GitHub can pause `llama-cpp-dgx-spark-qualification` for the `approve-dgx-spark-image-qualification` environment.
+An authorized environment reviewer must approve it before qualification starts.
 The trusted pre-checkout step requires current `maintain` or `admin` access and validates the exact open PR before candidate code runs.
 
 The manual run is advisory.

--- a/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
@@ -9,7 +9,9 @@ description: Dispatches and verifies trusted GitHub Actions E2E for NemoClaw mai
 # Run Maintainer E2E
 
 Use `.github/workflows/e2e.yaml` from trusted `main`.
-Every push to `main` selects every workflow E2E. A selected job can remain queued until its configured runner is available. No E2E job is excluded from trusted `main` push selection. Pre-tag evidence still requires the full `workflow_dispatch` mode described below.
+Every push to `main` selects the default workflow E2E jobs.
+Push runs skip `jetson-nvmap-gpu`, `llama-cpp-dgx-spark-plan`, and `llama-cpp-dgx-spark-qualification` because push events cannot set the required workflow dispatch flags.
+Pre-tag evidence still requires the full `workflow_dispatch` mode described below.
 Do not substitute local `npm run test:live-e2e` unless the maintainer explicitly requests local execution.
 
 ## Manual PR E2E
@@ -63,9 +65,10 @@ Require a review reason containing 10 to 500 printable characters.
 Choose exactly one mode:
 
 - For a PR revision run, leave `E2E_JOBS` empty. The run selects:
-  - every free-standing workflow E2E except `Exact staging Brev Launchable`;
+  - every default-selected free-standing workflow E2E except `Exact staging Brev Launchable`;
   - every shared credential-free test; and
   - these controller-selected registry targets: `ubuntu-policy-custom-missing-presets-negative`, `ubuntu-repo-cloud-langchain-deepagents-code`, `ubuntu-repo-cloud-openclaw`, and `ubuntu-repo-docker-post-reboot-recovery`.
+  The run skips `jetson-nvmap-gpu`, `llama-cpp-dgx-spark-plan`, and `llama-cpp-dgx-spark-qualification` unless their separate runner-queue flags are `true`.
 - For protected managed-image runtime qualification, set `E2E_JOBS=managed-image-protected-runtime`. The exact candidate must contain `ci/protected-managed-image-multiarch-activation-v1.json` and `ci/protected-managed-image-runtime-activation-v1.json`.
 
 Leave `targets` empty and keep Launchable disabled:
@@ -85,6 +88,8 @@ gh workflow run .github/workflows/e2e.yaml \
   -f "jobs=${E2E_JOBS}" \
   -f inference_mode=mock \
   -f include_staging_brev_launchable=false \
+  -f allow_jetson_runner_queue=false \
+  -f allow_dgx_spark_runner_queue=false \
   -f "pr_number=${PR_NUMBER}" \
   -f "checkout_sha=${HEAD_SHA}" \
   -f "checkout_repository=${HEAD_REPOSITORY}" \
@@ -152,9 +157,10 @@ A generic E2E request must not authorize the Brev Launchable path.
 Do not infer full mode from words such as “all” or “complete.”
 Ask for clarification only when the request contains conflicting mode phrases.
 
-Ordinary mode selects every workflow E2E except `Exact staging Brev Launchable`.
+Ordinary mode selects every default-selected workflow E2E except `Exact staging Brev Launchable`.
 Launchable mode runs only `Exact staging Brev Launchable`.
-Full mode selects every workflow E2E, including `Exact staging Brev Launchable`, in the same workflow run.
+Full mode adds `Exact staging Brev Launchable` to the default E2E selection in the same workflow run.
+The documented invocations for all three modes keep both hardware runner-queue flags set to `false`.
 
 ## Resolve the Candidate
 
@@ -191,6 +197,8 @@ gh workflow run .github/workflows/e2e.yaml \
   -f jobs= \
   -f inference_mode=mock \
   -f include_staging_brev_launchable=false \
+  -f allow_jetson_runner_queue=false \
+  -f allow_dgx_spark_runner_queue=false \
   -f "correlation_id=${CORRELATION_ID}"
 ```
 
@@ -204,6 +212,8 @@ gh workflow run .github/workflows/e2e.yaml \
   -f jobs=staging-brev-launchable \
   -f inference_mode=mock \
   -f include_staging_brev_launchable=false \
+  -f allow_jetson_runner_queue=false \
+  -f allow_dgx_spark_runner_queue=false \
   -f "correlation_id=${CORRELATION_ID}"
 ```
 
@@ -217,16 +227,29 @@ gh workflow run .github/workflows/e2e.yaml \
   -f jobs= \
   -f inference_mode=mock \
   -f include_staging_brev_launchable=true \
+  -f allow_jetson_runner_queue=false \
+  -f allow_dgx_spark_runner_queue=false \
   -f "correlation_id=${CORRELATION_ID}"
 ```
 
 Do not set `jobs=staging-brev-launchable` for full mode.
-Empty `jobs` and `targets` select every workflow E2E except `Exact staging Brev Launchable`.
-The boolean input adds the Launchable E2E job to that same run.
+Empty `jobs` and `targets` select every default-selected workflow E2E except `Exact staging Brev Launchable`.
+The `include_staging_brev_launchable` input adds the Launchable E2E job to that same run.
 The trusted `main` workflow verifies that the dispatching and rerunning actors have
 repository `maintain` or `admin` permission before the Launchable path's source
 checkout. That role check is the authorization.
-Every push and every empty-selector manual run selects `llama-cpp-dgx-spark-qualification`. If GitHub pauses the job for the `approve-dgx-spark-image-qualification` environment, an authorized environment reviewer must approve it before qualification starts. `Exact staging Brev Launchable` does not require environment approval.
+A user permitted to dispatch this workflow may set
+`allow_jetson_runner_queue=true` to add `jetson-nvmap-gpu` to an empty-selector
+manual run or enable its explicit selection. Set it only after a repository
+administrator confirms an online Jetson runner in the authoritative runner
+inventory.
+A permitted dispatcher may set `allow_dgx_spark_runner_queue=true` to add
+`llama-cpp-dgx-spark-plan` and `llama-cpp-dgx-spark-qualification` to an
+empty-selector manual run or enable explicit qualification selection. Set it
+only after a repository administrator confirms an online DGX Spark runner in
+the authoritative runner inventory.
+If GitHub pauses the qualification job for the `approve-dgx-spark-image-qualification` environment, an authorized environment reviewer must approve it before qualification starts.
+`Exact staging Brev Launchable` does not require environment approval.
 
 Find the run by its unique title:
 
@@ -324,7 +347,7 @@ node --experimental-strip-types --no-warnings \
 The validator requires:
 
 - the workflow run to succeed for the selected SHA;
-- `dispatch.json` to bind the same run, empty selectors, `include_staging_brev_launchable=true`, and the selected successful Launchable job attempt;
+- `dispatch.json` to bind the same run, empty selectors, `include_staging_brev_launchable=true`, `allowJetsonRunnerQueue: false`, `allowDgxSparkRunnerQueue: false`, and the selected successful Launchable job attempt;
 - `Exact staging Brev Launchable` to conclude `success` in the selected current or earlier attempt of the same workflow run;
 - `launchable-e2e.json` to identify the selected SHA in the repository and provision records;
 - the booted repository to be unmodified;
@@ -351,7 +374,7 @@ If the release candidate SHA changes, discard the earlier full run and dispatch 
 No release-note-only delta exception is currently defined.
 
 When `nemoclaw-maintainer-cut-release-tag` invokes this skill, return the validated fields for its pre-tag E2E evidence ledger.
-The trusted `dispatch.json` receipt proves that full mode used empty selectors and included `Exact staging Brev Launchable`.
+The trusted `dispatch.json` receipt proves that full mode used empty selectors, included `Exact staging Brev Launchable`, and disabled both optional hardware paths.
 The release evidence ledger proves the result of each workflow E2E.
 Do not ask for the release confirmation phrase in this skill.
 

--- a/.agents/skills/nemoclaw-maintainer-e2e/scripts/validate-full-e2e-evidence.mts
+++ b/.agents/skills/nemoclaw-maintainer-e2e/scripts/validate-full-e2e-evidence.mts
@@ -26,6 +26,8 @@ export interface FullE2eEvidenceSummary {
     workspaceName: string;
   };
   dispatch: {
+    allowDgxSparkRunnerQueue: false;
+    allowJetsonRunnerQueue: false;
     emptySelectors: true;
     includeStagingBrevLaunchable: true;
   };
@@ -121,6 +123,8 @@ export function validateFullE2eEvidence(input: FullE2eEvidenceInput): FullE2eEvi
     true,
     "dispatch.includeStagingBrevLaunchable",
   );
+  requireEqual(dispatch.allowJetsonRunnerQueue, false, "dispatch.allowJetsonRunnerQueue");
+  requireEqual(dispatch.allowDgxSparkRunnerQueue, false, "dispatch.allowDgxSparkRunnerQueue");
   requireEqual(dispatch.emptySelectors, true, "dispatch.emptySelectors");
 
   const matchingJobs = jobRecords(input.jobs).filter(
@@ -186,6 +190,8 @@ export function validateFullE2eEvidence(input: FullE2eEvidenceInput): FullE2eEvi
       workspaceName,
     },
     dispatch: {
+      allowDgxSparkRunnerQueue: false,
+      allowJetsonRunnerQueue: false,
       emptySelectors: true,
       includeStagingBrevLaunchable: true,
     },

--- a/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
@@ -56,11 +56,13 @@ Before asking for the release confirmation phrase, build and show an evidence le
 - Require every declared `RELEASE_E2E_ACTIVATION_PATH` to exist at the candidate SHA. A missing path is a preflight failure.
 - Require the workflow-produced trusted dispatch receipt to bind the accepted run candidate SHA, run ID, attempt, and selector inputs.
 - Run `nemoclaw-maintainer-e2e` in full mode when the ledger lacks complete evidence for the candidate SHA.
-- Require one completed, successful full workflow run that selects every workflow E2E, including `Exact staging Brev Launchable`.
+- Require one completed, successful full workflow run for all default-selected workflow E2E jobs and the full-mode additions, including `Exact staging Brev Launchable`.
+- Require the trusted dispatch receipt to record `allowJetsonRunnerQueue: false` and `allowDgxSparkRunnerQueue: false`.
+- Exclude `jetson-nvmap-gpu`, `llama-cpp-dgx-spark-plan`, and `llama-cpp-dgx-spark-qualification` from the required denominator.
 - Require the trusted dispatch receipt to bind the workflow run and an attempt no later than the run's latest attempt. The receipt must record empty selectors and `include_staging_brev_launchable=true`.
 - Require the Launchable E2E receipt to identify the candidate SHA in the repository and provision records.
 - Require the cleanup receipt to identify the qualified workspace and report `ABSENT`.
-- Every E2E execution declared by the workflow must have at least one completed, successful execution for the candidate SHA.
+- Every E2E execution selected by the accepted dispatch must have at least one completed, successful execution for the candidate SHA.
 - Treat each expanded matrix execution as a separate ledger entry. Use its matrix `id`, or all distinguishing matrix dimensions when no single ID exists, in the test identifier so results for distinct expansions are never collapsed under the parent job.
 - Successful evidence may accumulate across rerun attempts of that workflow run. Evidence from another workflow run does not satisfy the ledger. A later failure does not erase an earlier successful execution for the same test and SHA.
 - Skipped, unexecuted, queued, in-progress, cancelled, and failing results do not count as successful evidence.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ on:
         default: ""
         type: string
       jobs:
-        description: "Optional comma-separated E2E test IDs. On trusted main runs, empty jobs and targets select every workflow E2E except Exact staging Brev Launchable; set include_staging_brev_launchable to include it. PR revision runs use the trusted controller target matrix and exclude Launchable."
+        description: "Optional comma-separated E2E test IDs. Empty selectors choose the default suite. Set include_staging_brev_launchable for Launchable. Jetson and DGX Spark require their queue flags. PR revisions use the trusted controller matrix."
         required: false
         default: ""
         type: string
@@ -34,7 +34,12 @@ on:
           - internal-nvidia
           - public-nvidia
       allow_jetson_runner_queue:
-        description: "Repository administrators only: before setting true for jetson-nvmap-gpu, confirm an online Jetson runner in the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory; queued jobs do not honor timeout-minutes before assignment."
+        description: "Before setting true for jetson-nvmap-gpu, obtain repository administrator confirmation of an online Jetson runner in the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory; queued jobs do not honor timeout-minutes before assignment."
+        required: false
+        default: false
+        type: boolean
+      allow_dgx_spark_runner_queue:
+        description: "Before setting true for llama-cpp-dgx-spark-qualification, obtain repository administrator confirmation of an online DGX Spark runner in the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory; queued jobs do not honor timeout-minutes before assignment."
         required: false
         default: false
         type: boolean
@@ -563,6 +568,7 @@ jobs:
       - name: Record trusted E2E dispatch receipt
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
+          ALLOW_DGX_SPARK_RUNNER_QUEUE: ${{ inputs.allow_dgx_spark_runner_queue && 'true' || 'false' }}
           ALLOW_JETSON_RUNNER_QUEUE: ${{ inputs.allow_jetson_runner_queue && 'true' || 'false' }}
           CANDIDATE_SHA: ${{ inputs.checkout_sha || github.sha }}
           DISPATCH_JOBS: ${{ inputs.jobs }}
@@ -576,6 +582,7 @@ jobs:
           set -euo pipefail
           install -d -m 0700 "$DISPATCH_RECEIPT_DIR"
           jq -n \
+            --argjson allowDgxSparkRunnerQueue "$ALLOW_DGX_SPARK_RUNNER_QUEUE" \
             --arg candidateSha "$CANDIDATE_SHA" \
             --arg eventName "$EVENT_NAME" \
             --arg jobs "$DISPATCH_JOBS" \
@@ -592,6 +599,7 @@ jobs:
               workflowRunAttempt: $workflowRunAttempt,
               jobs: $jobs,
               targets: $targets,
+              allowDgxSparkRunnerQueue: $allowDgxSparkRunnerQueue,
               allowJetsonRunnerQueue: $allowJetsonRunnerQueue,
               includeStagingBrevLaunchable: $includeStagingBrevLaunchable,
               emptySelectors: ($jobs == "" and $targets == "")
@@ -2292,7 +2300,7 @@ jobs:
   llama-cpp-dgx-spark-plan:
     name: Compile protected llama.cpp DGX Spark plan
     needs: generate-matrix
-    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.jobs == '' && inputs.targets == '') || contains(format(',{0},', inputs.jobs), ',llama-cpp-dgx-spark-qualification,') || contains(format(',{0},', inputs.targets), ',llama-cpp-dgx-spark-qualification,')) }}
+    if: ${{ inputs.allow_dgx_spark_runner_queue && github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.jobs == '' && inputs.targets == '') || contains(format(',{0},', inputs.jobs), ',llama-cpp-dgx-spark-qualification,') || contains(format(',{0},', inputs.targets), ',llama-cpp-dgx-spark-qualification,')) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -2374,12 +2382,12 @@ jobs:
             scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts \
             --source-root "$CANDIDATE_ROOT"
 
-  # Every main push evaluates the trusted llama.cpp plan. Qualification runs
-  # only when that plan reports execution=enabled.
+  # The opt-in flag prevents assignment to an unavailable DGX Spark runner.
+  # Qualification runs only when the trusted plan reports execution=enabled.
   llama-cpp-dgx-spark-qualification:
     name: Protected llama.cpp on NVIDIA DGX Spark
     needs: [generate-matrix, llama-cpp-dgx-spark-plan]
-    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.jobs == '' && inputs.targets == '') || contains(format(',{0},', inputs.jobs), ',llama-cpp-dgx-spark-qualification,') || contains(format(',{0},', inputs.targets), ',llama-cpp-dgx-spark-qualification,')) && needs.llama-cpp-dgx-spark-plan.outputs.execution == 'enabled' }}
+    if: ${{ inputs.allow_dgx_spark_runner_queue && github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.jobs == '' && inputs.targets == '') || contains(format(',{0},', inputs.jobs), ',llama-cpp-dgx-spark-qualification,') || contains(format(',{0},', inputs.targets), ',llama-cpp-dgx-spark-qualification,')) && needs.llama-cpp-dgx-spark-plan.outputs.execution == 'enabled' }}
     runs-on: ${{ needs.llama-cpp-dgx-spark-plan.outputs.runner }}
     environment:
       name: ${{ needs.llama-cpp-dgx-spark-plan.outputs.environment }}
@@ -4803,11 +4811,9 @@ jobs:
 
   jetson-nvmap-gpu:
     needs: generate-matrix
-    # Every main push queues the repository-owned Jetson runner. GitHub starts
-    # timeout-minutes only after runner assignment. Maintainers must keep the
-    # configured runner label online.
-    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && ((github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',jetson-nvmap-gpu,') || contains(format(',{0},', inputs.targets), ',jetson-nvmap-gpu,')) }}
-    runs-on: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '') || inputs.allow_jetson_runner_queue) && (vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1') || 'ubuntu-latest' }}
+    # The opt-in flag prevents assignment to an unavailable Jetson runner.
+    if: ${{ inputs.allow_jetson_runner_queue && github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && ((github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',jetson-nvmap-gpu,') || contains(format(',{0},', inputs.targets), ',jetson-nvmap-gpu,')) }}
+    runs-on: ${{ vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1' }}
     timeout-minutes: 60
     env:
       E2E_JOB: "1"
@@ -4827,18 +4833,6 @@ jobs:
           repository: ${{ inputs.checkout_repository || github.repository }}
           ref: ${{ inputs.checkout_sha || github.sha }}
           persist-credentials: false
-
-      - name: Guard Jetson runner dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.jobs != '' || inputs.targets != '') && !inputs.allow_jetson_runner_queue }}
-        env:
-          JETSON_E2E_RUNNER_LABEL: ${{ vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1' }}
-        run: |
-          set -euo pipefail
-          echo "::error::jetson-nvmap-gpu was selected without allow_jetson_runner_queue=true."
-          echo "::error::GitHub Actions does not apply timeout-minutes while a self-hosted job is queued before runner assignment."
-          echo "::error::A repository administrator must confirm the runner is online in the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory before enabling queueing."
-          echo "::error::Confirm an online runner with label ${JETSON_E2E_RUNNER_LABEL}, then re-run with allow_jetson_runner_queue=true."
-          exit 1
 
       - *dockerhub-auth
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -8,8 +8,10 @@ Direct E2E coverage runs through Vitest.
 Interactive TUI targets require `expect`. The unified workflow installs it
 before those targets run; local runners must provide it themselves.
 
-- `.github/workflows/e2e.yaml` selects every workflow E2E on each push to `main`
-  and supports trusted manual dispatches for specific PR head commits.
+- `.github/workflows/e2e.yaml` selects the default workflow E2E jobs on each push
+  to `main` and supports trusted manual dispatches for specific PR head commits.
+  Push runs skip the Jetson nvmap and DGX Spark llama.cpp jobs because their
+  required workflow dispatch flags cannot be set by a push event.
 - `.github/workflows/hosted-runner-recovery.yaml` evaluates first-attempt
   failures from approved `main` workflows and requests one full rerun only when
   every non-passing job has authenticated GitHub-hosted runner-loss evidence.
@@ -160,7 +162,7 @@ and exact-staging Launchable job own its product coverage:
 | `gpu` | Unified E2E | `gpu-e2e` runs on the dedicated GPU runner. |
 | `all` | Retired | The selector only duplicated `credential-sanitization` and `telegram-injection`. |
 
-The retired nightly caller no longer runs. Each push to `main` starts a workflow that selects every workflow E2E.
+The retired nightly caller no longer runs. Each push to `main` starts a workflow that selects the default workflow E2E jobs.
 Manual GPU validation must use `gpu-e2e`.
 It must not provision a generic Brev VM.
 
@@ -435,7 +437,7 @@ A manual run with `jobs=staging-brev-launchable` runs only `Exact staging Brev
 Launchable`. Each push run also selects this job as part of the complete main run.
 
 A manual run with `include_staging_brev_launchable=true` and empty `jobs` and
-`targets` selectors runs every workflow E2E, including the Launchable E2E job.
+`targets` selectors runs the default workflow E2E selection plus the Launchable E2E job.
 This is the full run required for pre-tag evidence. Each full dispatch uses
 `github.run_id` in its workflow concurrency identity, so another full dispatch
 cannot supersede it while it waits. The trusted `main` workflow dispatch
@@ -445,6 +447,21 @@ role check authorizes `staging-brev-launchable`; the job does not use GitHub
 environment approval. The job uses the non-cancelling
 `staging-brev-launchable-cpu` group with `queue: max`, so pending Launchable E2E
 runs remain queued instead of replacing one another.
+
+The Jetson nvmap and DGX Spark llama.cpp jobs remain excluded from ordinary and
+full runs unless their independent runner-queue flags are `true`.
+A user permitted to dispatch this workflow may set either flag, but only after
+a repository administrator confirms the corresponding runner is online in the
+authoritative repository runner inventory.
+Set `allow_jetson_runner_queue=true` to select `jetson-nvmap-gpu`.
+Set `allow_dgx_spark_runner_queue=true` to select both
+`llama-cpp-dgx-spark-plan` and `llama-cpp-dgx-spark-qualification`.
+GitHub can pause the qualification job for the
+`approve-dgx-spark-image-qualification` environment before it reaches the DGX
+Spark runner.
+Pre-tag evidence requires both runner-queue flags to remain `false`.
+Results from opt-in hardware runs do not enter the required pre-tag E2E
+denominator.
 
 ### Hosted-Runner Recovery
 
@@ -699,7 +716,8 @@ a custom, copied, or no-op adapter.
 
 E2E does not run automatically for pull requests.
 Pull requests retain deterministic CI, including the `e2e-support` Vitest project.
-Each push to `main` selects every workflow E2E. A selected job can remain queued until its configured runner is available.
+Each push to `main` selects the default workflow E2E jobs.
+The central workflow skips the Jetson nvmap and DGX Spark llama.cpp jobs on push.
 The central workflow has no scheduled trigger.
 
 The main-push selection includes:
@@ -708,14 +726,12 @@ The main-push selection includes:
 - the OpenShell gateway authentication contract;
 - the development MCP bridge;
 - managed-image startup on AMD64 and ARM64;
-- llama.cpp qualification on NVIDIA DGX Spark;
 - managed-image GPU, Ollama, NVIDIA NIM, and vLLM behavior;
-- Hermes GPU startup; and
-- Jetson nvmap behavior.
+- Hermes GPU startup.
 
-These jobs retain their runner, credential, evidence, and cleanup boundaries. A
-main push can queue repository-owned GPU and Jetson runners and can create Brev
-resources. The retry workflow reruns failed jobs at most twice.
+These jobs retain their runner, credential, evidence, and cleanup boundaries.
+A main push can queue repository-owned GPU runners and can create Brev resources.
+The retry workflow reruns failed jobs at most twice.
 
 Each trusted push to `main` selects `Exact staging Brev Launchable`. The job reads
 these credentials from repository Actions secrets:
@@ -743,9 +759,13 @@ The controller does not retry manual PR runs or a run superseded by a newer `mai
 
 For a PR revision run, a repository maintainer or administrator leaves `jobs` and `targets` empty. The run selects:
 
-- every free-standing workflow E2E except `Exact staging Brev Launchable`;
+- every default-selected free-standing workflow E2E except `Exact staging Brev Launchable`;
 - every shared credential-free test; and
 - these controller-selected registry targets: `ubuntu-policy-custom-missing-presets-negative`, `ubuntu-repo-cloud-langchain-deepagents-code`, `ubuntu-repo-cloud-openclaw`, and `ubuntu-repo-docker-post-reboot-recovery`.
+
+The run skips `jetson-nvmap-gpu`, `llama-cpp-dgx-spark-plan`, and
+`llama-cpp-dgx-spark-qualification` unless their separate runner-queue flags
+are `true`.
 The trusted workflow definition remains on `main` and binds the candidate head to the current PR base SHA.
 It does not run GitHub's synthetic merge commit.
 
@@ -774,7 +794,9 @@ For `managed-image-protected-runtime`, the workflow supplies the long-lived `NVI
 
 For a manual PR run, provide the current PR number, lowercase 40-character head SHA, head repository, lowercase 40-character base SHA, trusted `main` workflow SHA, and a review reason containing 10 to 500 printable characters.
 Leave `jobs` and `targets` empty and keep `include_staging_brev_launchable=false` to use this PR revision selection.
-The empty-selector run selects `llama-cpp-dgx-spark-qualification`. If GitHub pauses the job for the `approve-dgx-spark-image-qualification` environment, an authorized environment reviewer must approve it before qualification starts.
+Keep `allow_jetson_runner_queue=false` and `allow_dgx_spark_runner_queue=false` for the default PR revision selection.
+If `allow_dgx_spark_runner_queue=true`, GitHub can pause the qualification job for the `approve-dgx-spark-image-qualification` environment.
+An authorized environment reviewer must approve it before qualification starts.
 To select the protected managed-image runtime qualification, set `jobs=managed-image-protected-runtime`.
 Leave `targets` empty.
 Keep `include_staging_brev_launchable=false`.

--- a/test/e2e/docs/README.md
+++ b/test/e2e/docs/README.md
@@ -289,23 +289,27 @@ test/e2e/
   used by PR Review Advisor. It maps changed runtime surfaces to invariant
   families and canonical `e2e.yaml` jobs; it does not dispatch E2E.
 
-- `.github/workflows/e2e.yaml` selects every workflow E2E on each push to `main`.
-  A selected job can remain queued until its configured runner is available.
-  The workflow inventory rejects any job excluded from `main`. Runner, credential, evidence,
-  and cleanup requirements remain job-specific.
+- `.github/workflows/e2e.yaml` selects the default workflow E2E jobs on each push
+  to `main`.
+  Push runs skip `jetson-nvmap-gpu`, `llama-cpp-dgx-spark-plan`, and
+  `llama-cpp-dgx-spark-qualification` because a push event cannot set their
+  required workflow dispatch flags.
+  Runner, credential, evidence, and cleanup requirements remain job-specific.
   A maintainer can also dispatch the trusted `main` workflow against the exact
   head of an open internal or fork PR. The manual path validates the actor, PR
   number, head repository, head SHA, base SHA, workflow SHA, review reason, and
   selected mode before candidate checkout. For a PR revision run, leave `jobs` and
-  `targets` empty. The run selects every free-standing workflow E2E except `Exact
-  staging Brev Launchable`. It also selects all shared credential-free tests and
+  `targets` empty. The run selects every default-selected free-standing workflow
+  E2E except `Exact staging Brev Launchable`. It also selects all shared credential-free tests and
   these controller-selected registry targets:
   `ubuntu-policy-custom-missing-presets-negative`,
   `ubuntu-repo-cloud-langchain-deepagents-code`, `ubuntu-repo-cloud-openclaw`, and
-  `ubuntu-repo-docker-post-reboot-recovery`. If GitHub pauses
-  `llama-cpp-dgx-spark-qualification` for the
-  `approve-dgx-spark-image-qualification` environment, an authorized environment
-  reviewer must approve it before qualification starts. The only accepted nonempty
+  `ubuntu-repo-docker-post-reboot-recovery`. Keep
+  `allow_jetson_runner_queue=false` and `allow_dgx_spark_runner_queue=false` for
+  this default selection. If the DGX Spark flag is `true`, GitHub can pause the
+  qualification job for the `approve-dgx-spark-image-qualification` environment.
+  An authorized environment reviewer must approve it before qualification starts.
+  The only accepted nonempty
   `jobs` value is `managed-image-protected-runtime`; `targets` must remain empty.
   Refer to [NemoClaw E2E CI](../README.md).
 

--- a/test/e2e/support/jetson-workflow-boundary.test.ts
+++ b/test/e2e/support/jetson-workflow-boundary.test.ts
@@ -17,7 +17,7 @@ function validateWorkflowMutation(
 }
 
 describe("Jetson nvmap GPU E2E workflow boundary", () => {
-  it("rejects unsafe runner opt-in, routing, and guard ordering drift (#6430)", () => {
+  it("rejects a permissive Jetson runner opt-in", () => {
     const inputErrors = validateWorkflowMutation((workflow) => {
       const triggers = (workflow.on ?? workflow[true as unknown as string]) as {
         workflow_dispatch?: {
@@ -33,7 +33,7 @@ describe("Jetson nvmap GPU E2E workflow boundary", () => {
       expect.arrayContaining([
         "workflow_dispatch allow_jetson_runner_queue input must be boolean",
         "workflow_dispatch allow_jetson_runner_queue input must default to false",
-        "workflow_dispatch allow_jetson_runner_queue input must identify repository administrators and NVIDIA/NemoClaw Settings -> Actions -> Runners as the authoritative runner inventory, and document queued timeout behavior",
+        "workflow_dispatch allow_jetson_runner_queue input must require repository administrator confirmation from the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory and document queued timeout behavior",
       ]),
     );
 
@@ -41,57 +41,35 @@ describe("Jetson nvmap GPU E2E workflow boundary", () => {
       const job = (workflow.jobs as Record<string, unknown>)["jetson-nvmap-gpu"] as {
         "runs-on"?: string;
         if?: string;
-        steps?: Array<{ if?: string; name?: string; uses?: string }>;
+        steps?: Array<{ name?: string }>;
       };
       job["runs-on"] = "self-hosted";
       job.if = "${{ true }}";
-      const steps = job.steps!;
-      const guardIndex = steps.findIndex((step) => step.name === "Guard Jetson runner dispatch");
-      const [guard] = steps.splice(guardIndex, 1);
-      guard!.if = "always()";
-      const authIndex = steps.findIndex((step) => step.name === "Authenticate to Docker Hub");
-      steps.splice(authIndex + 1, 0, guard!);
+      job.steps!.push({ name: "Guard Jetson runner dispatch" });
     });
     expect(guardErrors).toEqual(
       expect.arrayContaining([
-        "jetson-nvmap-gpu job must queue the configured runner for main and default manual runs",
-        "jetson-nvmap-gpu job must use the trusted-main selector condition",
-        "jetson-nvmap-gpu dispatch guard must run before Docker Hub auth",
-        "jetson-nvmap-gpu dispatch guard must reject unconfirmed selective queueing",
+        "jetson-nvmap-gpu job must require allow_jetson_runner_queue before runner assignment and retain trusted-main selectors",
+        "jetson-nvmap-gpu job must use the configured runner only after job-level opt-in",
+        "jetson-nvmap-gpu must enforce opt-in before runner assignment, not in a step",
       ]),
     );
   });
 
-  it("rejects a Jetson guard that only prints the fallback runner label (#6430)", () => {
+  it("requires the Jetson flag at the job boundary", () => {
     const errors = validateWorkflowMutation((workflow) => {
       const job = (workflow.jobs as Record<string, unknown>)["jetson-nvmap-gpu"] as {
-        steps?: Array<{
-          env?: Record<string, string>;
-          name?: string;
-          run?: string;
-        }>;
+        if?: string;
       };
-      const guard = job.steps?.find((step) => step.name === "Guard Jetson runner dispatch");
-      expect(guard).toBeDefined();
-      guard!.env = {
-        JETSON_E2E_RUNNER_LABEL: "linux-arm64-gpu-jetson-orin-latest-1",
-      };
-      guard!.run = guard!.run?.replace(
-        "${JETSON_E2E_RUNNER_LABEL}",
-        "linux-arm64-gpu-jetson-orin-latest-1",
-      );
+      job.if = job.if?.replace("inputs.allow_jetson_runner_queue && ", "");
     });
 
-    expect(errors).toEqual(
-      expect.arrayContaining([
-        "jetson-nvmap-gpu dispatch guard must receive the configured Jetson runner label",
-        "step 'Guard Jetson runner dispatch' run script must include ${JETSON_E2E_RUNNER_LABEL}",
-        "step 'Guard Jetson runner dispatch' run script must not include linux-arm64-gpu-jetson-orin-latest-1",
-      ]),
+    expect(errors).toContain(
+      "jetson-nvmap-gpu job must require allow_jetson_runner_queue before runner assignment and retain trusted-main selectors",
     );
   });
 
-  it("accepts the real workflow without Jetson queue contract errors (#6430)", () => {
+  it("accepts the real workflow without Jetson queue contract errors", () => {
     const errors = validateE2eWorkflowBoundary();
     expect(errors.filter((error) => /jetson|allow_jetson_runner_queue/iu.test(error))).toEqual([]);
     expect(errors).toEqual([]);

--- a/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
+++ b/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
@@ -37,6 +37,32 @@ describe("llama.cpp DGX Spark qualification workflow boundary (#8260)", () => {
     expect(validateLlamaCppDgxSparkQualificationWorkflow(workflow())).toEqual([]);
   });
 
+  it("requires DGX Spark opt-in before protected runner assignment", () => {
+    const value = workflow();
+    const triggers = value.on as {
+      workflow_dispatch: {
+        inputs: Record<string, Record<string, unknown>>;
+      };
+    };
+    const input = triggers.workflow_dispatch.inputs.allow_dgx_spark_runner_queue!;
+    input.type = "string";
+    input.default = true;
+    input.description = "Queue the runner";
+    job(value, "llama-cpp-dgx-spark-plan").if = "${{ true }}";
+    job(value, "llama-cpp-dgx-spark-qualification").if =
+      "${{ needs.llama-cpp-dgx-spark-plan.outputs.execution == 'enabled' }}";
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toEqual(
+      expect.arrayContaining([
+        "workflow_dispatch allow_dgx_spark_runner_queue input must be boolean",
+        "workflow_dispatch allow_dgx_spark_runner_queue input must default to false",
+        "workflow_dispatch allow_dgx_spark_runner_queue input must require repository administrator confirmation from the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory and document queued timeout behavior",
+        "llama-cpp-dgx-spark-plan must require allow_dgx_spark_runner_queue and retain manual selectors",
+        "llama-cpp-dgx-spark-qualification must require allow_dgx_spark_runner_queue after the trusted plan is enabled",
+      ]),
+    );
+  });
+
   it("does not record manual PR risk signals on main pushes", () => {
     const value = workflow();
     const jobEnv = job(value, "llama-cpp-dgx-spark-qualification").env as Record<string, unknown>;

--- a/test/maintainer-e2e-skill.test.ts
+++ b/test/maintainer-e2e-skill.test.ts
@@ -18,6 +18,8 @@ function validEvidence() {
       workspaceName: "nclaw-e2e-100-2",
     },
     dispatch: {
+      allowDgxSparkRunnerQueue: false,
+      allowJetsonRunnerQueue: false,
       candidateSha,
       emptySelectors: true,
       eventName: "workflow_dispatch",
@@ -77,6 +79,8 @@ describe("nemoclaw-maintainer-e2e evidence validation", () => {
         workspaceName: "nclaw-e2e-100-2",
       },
       dispatch: {
+        allowDgxSparkRunnerQueue: false,
+        allowJetsonRunnerQueue: false,
         emptySelectors: true,
         includeStagingBrevLaunchable: true,
       },
@@ -128,6 +132,20 @@ describe("nemoclaw-maintainer-e2e evidence validation", () => {
         evidence.dispatch.jobs = "staging-brev-launchable";
       },
       "dispatch.jobs",
+    ],
+    [
+      "a full dispatch that opts into the Jetson runner queue",
+      (evidence: ReturnType<typeof validEvidence>) => {
+        evidence.dispatch.allowJetsonRunnerQueue = true;
+      },
+      "dispatch.allowJetsonRunnerQueue",
+    ],
+    [
+      "a full dispatch that opts into the DGX Spark runner queue",
+      (evidence: ReturnType<typeof validEvidence>) => {
+        evidence.dispatch.allowDgxSparkRunnerQueue = true;
+      },
+      "dispatch.allowDgxSparkRunnerQueue",
     ],
     [
       "a skipped Launchable E2E job",

--- a/test/release-e2e-evidence.test.ts
+++ b/test/release-e2e-evidence.test.ts
@@ -41,6 +41,7 @@ function runEvidence(
   const selectors: string[] = [];
   return {
     dispatch: {
+      allowDgxSparkRunnerQueue: false,
       allowJetsonRunnerQueue: false,
       candidateSha,
       emptySelectors: true,
@@ -88,6 +89,13 @@ describe("release E2E evidence", () => {
     });
     expect(plan.launchableE2eJobId).toBe("staging-brev-launchable");
     expect(plan.exceptionsRequired).toEqual([]);
+    expect(plan.executions.map((execution) => execution.jobId)).not.toEqual(
+      expect.arrayContaining([
+        "jetson-nvmap-gpu",
+        "llama-cpp-dgx-spark-plan",
+        "llama-cpp-dgx-spark-qualification",
+      ]),
+    );
   });
 
   it("rejects a missing activation path for a default E2E", () => {
@@ -181,6 +189,17 @@ describe("release E2E evidence", () => {
     expect(() => buildReleaseE2eLedger(plan, [evidence])).toThrow(
       "runs[0].dispatch.includeStagingBrevLaunchable must equal true",
     );
+  });
+
+  it.each([
+    ["allowJetsonRunnerQueue", "runs[0].dispatch.allowJetsonRunnerQueue must equal false"],
+    ["allowDgxSparkRunnerQueue", "runs[0].dispatch.allowDgxSparkRunnerQueue must equal false"],
+  ])("rejects release evidence that opts into %s", (field, message) => {
+    const plan = preflight();
+    const evidence = runEvidence(plan, "default");
+    (evidence.dispatch as Record<string, unknown>)[field] = true;
+
+    expect(() => buildReleaseE2eLedger(plan, [evidence])).toThrow(message);
   });
 
   it("reports a failed matrix row without collapsing its successful siblings", () => {

--- a/tools/e2e/cli-artifact-workflow-boundary.mts
+++ b/tools/e2e/cli-artifact-workflow-boundary.mts
@@ -40,7 +40,7 @@ const CLI_ARTIFACT_PROVENANCE_STEP = "Record CLI artifact provenance";
 const CANDIDATE_CHECKOUT_STEP_CONTENT_SHA256 =
   "3578a053cede863f7aa4814d8399b4ca21ea0b77cee712e6d549c684818f11dd";
 const CLI_ARTIFACT_WORKFLOW_CONTRACT_SHA256 =
-  "5d09301f3d37c6d2f588379fa8c94ef33d00efb8e25dc475bcfba24377fd8365";
+  "3576771c69b3d838cf75e25782548ee20c560be58c528224adf7f3d228facc32";
 const CLI_ARTIFACT_CONSUMER_JOB_NAMES = [
   "agent-turn-latency",
   "bedrock-runtime-compatible-anthropic",

--- a/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
+++ b/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
@@ -18,8 +18,9 @@ type WorkflowStep = RecordValue & {
 };
 
 const PLAN_JOB_ID = "llama-cpp-dgx-spark-plan";
-const SELECTOR = `\${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.jobs == '' && inputs.targets == '') || contains(format(',{0},', inputs.jobs), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},')) }}`;
-const QUALIFICATION_SELECTOR = `\${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.jobs == '' && inputs.targets == '') || contains(format(',{0},', inputs.jobs), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},')) && needs.${PLAN_JOB_ID}.outputs.execution == 'enabled' }}`;
+const RUNNER_QUEUE_INPUT = "allow_dgx_spark_runner_queue";
+const SELECTOR = `\${{ inputs.${RUNNER_QUEUE_INPUT} && github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.jobs == '' && inputs.targets == '') || contains(format(',{0},', inputs.jobs), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},')) }}`;
+const QUALIFICATION_SELECTOR = `\${{ inputs.${RUNNER_QUEUE_INPUT} && github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.jobs == '' && inputs.targets == '') || contains(format(',{0},', inputs.jobs), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},') || contains(format(',{0},', inputs.targets), ',${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID},')) && needs.${PLAN_JOB_ID}.outputs.execution == 'enabled' }}`;
 const CHECKOUT = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
 const BUILDX = "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c";
 const PREPARE =
@@ -35,6 +36,35 @@ function steps(value: unknown): WorkflowStep[] {
 
 function text(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function validateRunnerQueueInput(errors: string[], workflow: RecordValue): void {
+  const triggers = record(workflow.on ?? workflow[true as unknown as string]);
+  const dispatch = record(triggers.workflow_dispatch);
+  const inputs = record(dispatch.inputs);
+  const input = record(inputs[RUNNER_QUEUE_INPUT]);
+  if (Object.keys(input).length === 0) {
+    errors.push(`workflow_dispatch must define ${RUNNER_QUEUE_INPUT}`);
+    return;
+  }
+  if (input.type !== "boolean") {
+    errors.push(`workflow_dispatch ${RUNNER_QUEUE_INPUT} input must be boolean`);
+  }
+  if (input.default !== false) {
+    errors.push(`workflow_dispatch ${RUNNER_QUEUE_INPUT} input must default to false`);
+  }
+  const description = text(input.description);
+  if (
+    !description.includes("repository administrator confirmation") ||
+    !description.includes("DGX Spark runner") ||
+    !description.includes("authoritative") ||
+    !description.includes("NVIDIA/NemoClaw Settings -> Actions -> Runners") ||
+    !description.includes("timeout-minutes")
+  ) {
+    errors.push(
+      `workflow_dispatch ${RUNNER_QUEUE_INPUT} input must require repository administrator confirmation from the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory and document queued timeout behavior`,
+    );
+  }
 }
 
 function requireStep(
@@ -88,6 +118,7 @@ function requireOrderedSteps(
 
 export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordValue): string[] {
   const errors: string[] = [];
+  validateRunnerQueueInput(errors, workflow);
   const jobs = record(workflow.jobs);
   const planJob = record(jobs[PLAN_JOB_ID]);
   const qualificationJob = record(jobs[LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID]);
@@ -101,7 +132,7 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
     errors.push(`${PLAN_JOB_ID} must depend on generate-matrix`);
   }
   if (planJob.if !== SELECTOR)
-    errors.push(`${PLAN_JOB_ID} must run on main pushes and retain manual selectors`);
+    errors.push(`${PLAN_JOB_ID} must require ${RUNNER_QUEUE_INPUT} and retain manual selectors`);
   if (planJob["runs-on"] !== "ubuntu-24.04") {
     errors.push(`${PLAN_JOB_ID} must run on a standard trusted planner`);
   }
@@ -195,7 +226,7 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
   }
   if (qualificationJob.if !== QUALIFICATION_SELECTOR) {
     errors.push(
-      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must run on main pushes after the trusted plan is enabled`,
+      `${LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID} must require ${RUNNER_QUEUE_INPUT} after the trusted plan is enabled`,
     );
   }
   if (qualificationJob["runs-on"] !== `\${{ needs.${PLAN_JOB_ID}.outputs.runner }}`) {

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -2575,24 +2575,20 @@ function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): 
     const authIndex = steps.indexOf(auth);
     const cleanupIndex = steps.indexOf(cleanup);
     const expectedAuthIndex =
-      jobName === "jetson-nvmap-gpu"
-        ? checkoutIndex + 2
-        : jobName === "hermes-gpu-startup"
-          ? checkoutIndex + 3
-          : jobName === "managed-image-protected-runtime"
-            ? protectedCacheDownloadIndex + 1
-            : checkoutIndex + 1;
+      jobName === "hermes-gpu-startup"
+        ? checkoutIndex + 3
+        : jobName === "managed-image-protected-runtime"
+          ? protectedCacheDownloadIndex + 1
+          : checkoutIndex + 1;
     if (
       checkoutIndex < 0 ||
       (jobName === "managed-image-protected-runtime" && protectedCacheDownloadIndex < 0) ||
       authIndex !== expectedAuthIndex
     ) {
       errors.push(
-        jobName === "jetson-nvmap-gpu"
-          ? `${jobName} Docker Hub auth must run immediately after the Jetson dispatch guard`
-          : jobName === "managed-image-protected-runtime"
-            ? `${jobName} Docker Hub auth must run immediately after the protected cache download`
-            : `${jobName} Docker Hub auth must run immediately after checkout`,
+        jobName === "managed-image-protected-runtime"
+          ? `${jobName} Docker Hub auth must run immediately after the protected cache download`
+          : `${jobName} Docker Hub auth must run immediately after checkout`,
       );
     }
     if (authIndex < 0 || cleanupIndex <= authIndex) {
@@ -3938,72 +3934,40 @@ function validateAllowJetsonRunnerQueueInput(
   }
   const description = stringValue(input.description);
   if (
-    !description.includes("Repository administrators") ||
+    !description.includes("repository administrator confirmation") ||
     !description.includes("Jetson runner") ||
     !description.includes("authoritative") ||
     !description.includes("NVIDIA/NemoClaw Settings -> Actions -> Runners") ||
     !description.includes("timeout-minutes")
   ) {
     errors.push(
-      "workflow_dispatch allow_jetson_runner_queue input must identify repository administrators and NVIDIA/NemoClaw Settings -> Actions -> Runners as the authoritative runner inventory, and document queued timeout behavior",
+      "workflow_dispatch allow_jetson_runner_queue input must require repository administrator confirmation from the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory and document queued timeout behavior",
     );
   }
 }
 
-function validateJetsonRunnerDispatchGuard(errors: string[], jobs: WorkflowRecord): void {
+function validateJetsonJobOptInBoundary(errors: string[], jobs: WorkflowRecord): void {
   const job = asRecord(jobs["jetson-nvmap-gpu"]);
   if (job.needs !== "generate-matrix") {
     errors.push("jetson-nvmap-gpu job must depend on generate-matrix");
   }
   const trustedSelector =
-    "${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && ((github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',jetson-nvmap-gpu,') || contains(format(',{0},', inputs.targets), ',jetson-nvmap-gpu,')) }}";
+    "${{ inputs.allow_jetson_runner_queue && github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && ((github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',jetson-nvmap-gpu,') || contains(format(',{0},', inputs.targets), ',jetson-nvmap-gpu,')) }}";
   if (job.if !== trustedSelector) {
-    errors.push("jetson-nvmap-gpu job must use the trusted-main selector condition");
-  }
-  const guardedRunsOn =
-    "${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '') || inputs.allow_jetson_runner_queue) && (vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1') || 'ubuntu-latest' }}";
-  if (job["runs-on"] !== guardedRunsOn) {
     errors.push(
-      "jetson-nvmap-gpu job must queue the configured runner for main and default manual runs",
+      "jetson-nvmap-gpu job must require allow_jetson_runner_queue before runner assignment and retain trusted-main selectors",
     );
+  }
+  const configuredRunsOn =
+    "${{ vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1' }}";
+  if (job["runs-on"] !== configuredRunsOn) {
+    errors.push("jetson-nvmap-gpu job must use the configured runner only after job-level opt-in");
   }
 
   const steps = asSteps(job.steps);
-  const guard = namedStep(steps, "Guard Jetson runner dispatch");
-  const checkoutIndex = steps.findIndex((step) =>
-    stringValue(step.uses).startsWith("actions/checkout@"),
-  );
-  const guardIndex = steps.findIndex((step) => step.name === "Guard Jetson runner dispatch");
-  const dockerAuthIndex = steps.findIndex((step) => step.name === DOCKER_HUB_AUTH_STEP);
-  if (!guard) {
-    errors.push("jetson-nvmap-gpu job missing step: Guard Jetson runner dispatch");
-    return;
+  if (steps.some((step) => step.name === "Guard Jetson runner dispatch")) {
+    errors.push("jetson-nvmap-gpu must enforce opt-in before runner assignment, not in a step");
   }
-  if (checkoutIndex < 0 || guardIndex <= checkoutIndex) {
-    errors.push("jetson-nvmap-gpu dispatch guard must run after checkout");
-  }
-  if (dockerAuthIndex >= 0 && guardIndex >= dockerAuthIndex) {
-    errors.push("jetson-nvmap-gpu dispatch guard must run before Docker Hub auth");
-  }
-  if (
-    guard.if !==
-    "${{ github.event_name == 'workflow_dispatch' && (inputs.jobs != '' || inputs.targets != '') && !inputs.allow_jetson_runner_queue }}"
-  ) {
-    errors.push("jetson-nvmap-gpu dispatch guard must reject unconfirmed selective queueing");
-  }
-  if (
-    asRecord(guard.env).JETSON_E2E_RUNNER_LABEL !==
-    "${{ vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1' }}"
-  ) {
-    errors.push("jetson-nvmap-gpu dispatch guard must receive the configured Jetson runner label");
-  }
-  requireRunContains(errors, guard, "allow_jetson_runner_queue=true");
-  requireRunContains(errors, guard, "timeout-minutes");
-  requireRunContains(errors, guard, "repository administrator");
-  requireRunContains(errors, guard, "authoritative");
-  requireRunContains(errors, guard, "NVIDIA/NemoClaw Settings -> Actions -> Runners");
-  requireRunContains(errors, guard, "${JETSON_E2E_RUNNER_LABEL}");
-  requireRunDoesNotContain(errors, guard, "linux-arm64-gpu-jetson-orin-latest-1");
 }
 
 export function validateJetsonRunnerDispatchBoundary(workflow: unknown): string[] {
@@ -4013,7 +3977,7 @@ export function validateJetsonRunnerDispatchBoundary(workflow: unknown): string[
   const errors: string[] = [];
 
   validateAllowJetsonRunnerQueueInput(errors, asRecord(workflowDispatch.inputs));
-  validateJetsonRunnerDispatchGuard(errors, asRecord(workflowRecord.jobs));
+  validateJetsonJobOptInBoundary(errors, asRecord(workflowRecord.jobs));
   return errors;
 }
 
@@ -4289,6 +4253,7 @@ function validateTrustedE2eDispatchReceipt(
   }
   const dispatchReceiptEnv = asRecord(dispatchReceipt?.env);
   const expectedDispatchReceiptEnv = {
+    ALLOW_DGX_SPARK_RUNNER_QUEUE: "${{ inputs.allow_dgx_spark_runner_queue && 'true' || 'false' }}",
     ALLOW_JETSON_RUNNER_QUEUE: "${{ inputs.allow_jetson_runner_queue && 'true' || 'false' }}",
     CANDIDATE_SHA: "${{ inputs.checkout_sha || github.sha }}",
     DISPATCH_JOBS: "${{ inputs.jobs }}",
@@ -4313,6 +4278,7 @@ function validateTrustedE2eDispatchReceipt(
     "workflowRunAttempt: $workflowRunAttempt",
     "jobs: $jobs",
     "targets: $targets",
+    "allowDgxSparkRunnerQueue: $allowDgxSparkRunnerQueue",
     "allowJetsonRunnerQueue: $allowJetsonRunnerQueue",
     "includeStagingBrevLaunchable: $includeStagingBrevLaunchable",
     'emptySelectors: ($jobs == "" and $targets == "")',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The default E2E suite currently queues Jetson and DGX Spark jobs even when their self-hosted runners are unavailable, so those jobs can wait indefinitely before `timeout-minutes` applies. This change keeps both hardware lanes out of ordinary and full E2E runs unless a dispatcher explicitly enables the independent flag for that runner.

## Changes

- Add default-false `allow_jetson_runner_queue` and `allow_dgx_spark_runner_queue` workflow-dispatch inputs.
- Gate Jetson before runner assignment and gate both the DGX Spark planner and protected qualification job behind the DGX Spark flag.
- Record both flags in `dispatch.json`; require both to be false for standard/full release evidence, and exclude the optional hardware jobs from the required release denominator.
- Update workflow boundary tests, release-evidence tests, and maintainer E2E guidance for the two opt-in lanes.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact job-boundary selectors, receipt/release validators, focused tests, and an independent commit-wide documentation-writer review cover the runner and release-evidence behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md`, `.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md`, `.agents/skills/nemoclaw-maintainer-e2e/SKILL.md`, `.agents/skills/nemoclaw-maintainer-policies/references/release-train.md`, `test/e2e/README.md`, `test/e2e/docs/README.md`
- Agent: Codex Desktop
<!-- docs-review-head-sha: fc3aae938 -->
<!-- docs-review-agents-blob-sha: 12ad395bb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: E2E-support workflow suites passed (4 files, 103 tests); maintainer/release evidence suites passed (3 files, 58 tests).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm test` was attempted after successful builds but showed widespread unrelated local timing and filesystem failures across untouched CLI areas; CI is the broad signal for this PR.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in controls for Jetson and DGX Spark hardware E2E jobs, disabled by default.
  * Updated workflow receipts and validation to record hardware queue settings.
  * Main-branch E2E runs now use a default job set, with hardware jobs selected separately.

* **Documentation**
  * Clarified hardware runner requirements, administrator approval, selectors, and qualification workflows.

* **Tests**
  * Added and updated coverage for hardware queue controls, workflow validation, and release evidence requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->