### PR TITLE
fix(e2e): preserve protected main dispatch identity

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1979,6 +1979,7 @@ jobs:
       E2E_TARGET_ID: "managed-image-multiarch-startup"
       RELEASE_E2E_ACTIVATION_PATH: ci/protected-managed-image-multiarch-activation-v1.json
       NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha }}
+      NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA: ${{ inputs.checkout_sha || github.sha }}
       NEMOCLAW_E2E_SHARD: ${{ matrix.shard }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: ${{ inputs.base_sha || github.event.before || github.sha }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE: ${{ github.workspace }}/.protected-managed-image-build-cache/${{ matrix.shard }}
@@ -2401,6 +2402,7 @@ jobs:
       NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha }}
       NEMOCLAW_E2E_SHARD: linux-arm64-gpu-dgx-spark-gb10
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_BASE_SHA: ${{ inputs.base_sha || github.event.before || github.sha }}
+      NEMOCLAW_LLAMA_CPP_QUALIFICATION_HEAD_SHA: ${{ inputs.checkout_sha || github.sha }}
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_CANDIDATE_ROOT: ${{ github.workspace }}/.candidate-llama-cpp
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_EVIDENCE: ${{ github.workspace }}/e2e-artifacts/live/llama-cpp-dgx-spark-qualification/evidence.json
       NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN: ${{ github.workspace }}/.llama-cpp-qualification/plan.json

--- a/test/e2e/live/llama-cpp-dgx-spark-qualification-helpers.ts
+++ b/test/e2e/live/llama-cpp-dgx-spark-qualification-helpers.ts
@@ -35,7 +35,7 @@ function positiveIntegerEnvironment(name: string): number {
 export function llamaCppDgxSparkQualificationEnvironment(): LlamaCppDgxSparkQualificationEnvironment {
   const identity = {
     baseSha: requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_BASE_SHA"),
-    headSha: requiredEnvironment("NEMOCLAW_E2E_EXPECTED_SHA"),
+    headSha: requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_HEAD_SHA"),
     runAttempt: positiveIntegerEnvironment("GITHUB_RUN_ATTEMPT"),
     runId: positiveIntegerEnvironment("GITHUB_RUN_ID"),
     workflowSha: requiredEnvironment("NEMOCLAW_LLAMA_CPP_QUALIFICATION_WORKFLOW_SHA"),

--- a/test/e2e/live/managed-image-multiarch-startup-helpers.ts
+++ b/test/e2e/live/managed-image-multiarch-startup-helpers.ts
@@ -42,7 +42,7 @@ function positiveIntegerEnvironment(name: string): number {
 export function protectedManagedImageDispatchEnvironment(): ProtectedManagedImageDispatchEnvironment {
   const platform = requiredEnvironment("NEMOCLAW_PROTECTED_MANAGED_IMAGE_PLATFORM");
   const cohort = requiredEnvironment("NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT");
-  const headSha = requiredEnvironment("NEMOCLAW_E2E_EXPECTED_SHA");
+  const headSha = requiredEnvironment("NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA");
   const baseSha = requiredEnvironment("NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA");
   const workflowSha = requiredEnvironment("NEMOCLAW_PROTECTED_MANAGED_IMAGE_WORKFLOW_SHA");
 

--- a/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
+++ b/test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts
@@ -73,6 +73,16 @@ describe("llama.cpp DGX Spark qualification workflow boundary (#8260)", () => {
     );
   });
 
+  it("binds qualification candidate identity on ordinary main runs", () => {
+    const value = workflow();
+    const jobEnv = job(value, "llama-cpp-dgx-spark-qualification").env as Record<string, unknown>;
+    jobEnv.NEMOCLAW_LLAMA_CPP_QUALIFICATION_HEAD_SHA = "${{ inputs.checkout_sha }}";
+
+    expect(validateLlamaCppDgxSparkQualificationWorkflow(value)).toContain(
+      "llama-cpp-dgx-spark-qualification env must bind NEMOCLAW_LLAMA_CPP_QUALIFICATION_HEAD_SHA to ${{ inputs.checkout_sha || github.sha }}",
+    );
+  });
+
   it("rejects bypassing the declarative protected-runner plan", () => {
     const value = workflow();
     job(value, "llama-cpp-dgx-spark-qualification")["runs-on"] = "self-hosted";

--- a/test/e2e/support/managed-image-multiarch-startup-helpers.test.ts
+++ b/test/e2e/support/managed-image-multiarch-startup-helpers.test.ts
@@ -23,11 +23,11 @@ beforeEach(() => {
   vi.stubEnv("GITHUB_RUN_ATTEMPT", "1");
   vi.stubEnv("GITHUB_RUN_ID", "123");
   vi.stubEnv("GITHUB_WORKSPACE", temporaryRoot);
-  vi.stubEnv("NEMOCLAW_E2E_EXPECTED_SHA", sha);
   vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA", sha);
   vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT", "protected-123-1");
   vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT", path.join(artifacts, "contract.json"));
   vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_EVIDENCE", path.join(artifacts, "evidence.json"));
+  vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA", sha);
   vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_PLATFORM", "linux/amd64");
   vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_WORKFLOW_SHA", sha);
 });
@@ -54,6 +54,15 @@ describe("protected managed-image startup helpers", () => {
     vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT", "other-123-1");
     expect(() => protectedManagedImageDispatchEnvironment()).toThrow(
       "protected managed-image dispatch identity is invalid",
+    );
+  });
+
+  it("requires an explicit protected candidate head independent of PR risk signals", () => {
+    vi.stubEnv("NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA", "");
+    vi.stubEnv("NEMOCLAW_E2E_EXPECTED_SHA", sha);
+
+    expect(() => protectedManagedImageDispatchEnvironment()).toThrow(
+      "NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA is required",
     );
   });
 

--- a/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
+++ b/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
@@ -60,6 +60,16 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
+  it("binds protected candidate identity on ordinary main runs", () => {
+    const value = workflow();
+    const jobEnv = multiarchJob(value).env as Record<string, unknown>;
+    jobEnv.NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA = "${{ inputs.checkout_sha }}";
+
+    expect(validateManagedImageMultiarchWorkflow(value)).toContain(
+      "managed-image-multiarch-startup env must bind NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA to ${{ inputs.checkout_sha || github.sha }}",
+    );
+  });
+
   it("ships the exact activation contract consumed by the trusted lane (#7744)", () => {
     const activation = JSON.parse(
       fs.readFileSync(

--- a/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
+++ b/tools/e2e/llama-cpp-dgx-spark-qualification-workflow-boundary.mts
@@ -258,6 +258,7 @@ export function validateLlamaCppDgxSparkQualificationWorkflow(workflow: RecordVa
     NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha }}",
     NEMOCLAW_LLAMA_CPP_QUALIFICATION_BASE_SHA:
       "${{ inputs.base_sha || github.event.before || github.sha }}",
+    NEMOCLAW_LLAMA_CPP_QUALIFICATION_HEAD_SHA: "${{ inputs.checkout_sha || github.sha }}",
     NEMOCLAW_LLAMA_CPP_QUALIFICATION_PLAN:
       "${{ github.workspace }}/.llama-cpp-qualification/plan.json",
     NEMOCLAW_LLAMA_CPP_QUALIFICATION_WORKFLOW_SHA:

--- a/tools/e2e/managed-image-multiarch-workflow-boundary.mts
+++ b/tools/e2e/managed-image-multiarch-workflow-boundary.mts
@@ -157,6 +157,7 @@ export function validateManagedImageMultiarchWorkflow(workflow: WorkflowRecord):
       "protected-managed-image-build-cache-${{ github.run_id }}-${{ inputs.checkout_sha || github.sha }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_COHORT:
       "protected-${{ github.run_id }}-${{ github.run_attempt }}",
+    NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA: "${{ inputs.checkout_sha || github.sha }}",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_CONTRACT:
       "${{ github.workspace }}/e2e-artifacts/live/managed-image-multiarch-startup/${{ matrix.shard }}/contracts.json",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_EVIDENCE:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Ordinary main E2E dispatches now provide candidate identity to protected managed-image and DGX Spark qualification without enabling manual-PR risk signals. Before this change, both managed-image architecture jobs failed before qualification because their candidate SHA was empty.

## Changes

- Add lane-specific candidate SHA variables that resolve to `checkout_sha` for PR runs and `github.sha` for ordinary main runs.
- Keep `NEMOCLAW_E2E_EXPECTED_SHA` bound only to `checkout_sha` so main runs do not emit manual-PR risk evidence.
- Validate both contracts in the workflow boundaries and cover the ordinary-main identity path in E2E-support tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This repairs internal E2E candidate identity and does not change public commands, configuration, workflow inputs, defaults, or operator procedures.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Workflow boundary tests preserve the PR-only risk signal and require exact candidate identity for each protected lane.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Repairs internal E2E candidate-SHA plumbing and its boundary tests; no public CLI, configuration, workflow input, default, or operator procedure changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e99c73b2d -->
<!-- docs-review-agents-blob-sha: 12ad395bb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec -- vitest run --project e2e-support test/e2e/support/managed-image-protected-runtime-workflow.test.ts test/e2e/support/managed-image-multiarch-startup-helpers.test.ts test/e2e/support/llama-cpp-dgx-spark-qualification-workflow.test.ts` passed 39 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow validation for protected managed-image startup and qualification runs.
  * Ensured jobs consistently use the selected checkout revision, falling back to the workflow commit when needed.
  * Prevented dispatch validation from relying on legacy revision settings.

* **Tests**
  * Added end-to-end coverage for checkout revision binding and invalid workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->