### PR TITLE
fix(e2e): pause supervisor during childless recovery

### DIFF
--- a/test/e2e/fixtures/shields-failed-startup.ts
+++ b/test/e2e/fixtures/shields-failed-startup.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const CONTAINER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/u;
+
+export interface FailedStartupProcessControlCommands {
+  pauseSupervisor: string[];
+  resumeSupervisor: string[];
+  terminateStartupChild: string[];
+}
+
+export function failedStartupProcessControlCommands(
+  containerId: string,
+  startupPid: number,
+): FailedStartupProcessControlCommands {
+  if (!CONTAINER_ID_PATTERN.test(containerId)) {
+    throw new Error("container id must be a safe Docker identifier");
+  }
+  if (!Number.isSafeInteger(startupPid) || startupPid <= 1) {
+    throw new Error("startup child pid must be a safe integer greater than 1");
+  }
+
+  const signal = (name: "CONT" | "STOP" | "TERM", pid: number): string[] => [
+    "exec",
+    "--user",
+    "0",
+    containerId,
+    "kill",
+    `-${name}`,
+    String(pid),
+  ];
+
+  return {
+    pauseSupervisor: signal("STOP", 1),
+    resumeSupervisor: signal("CONT", 1),
+    terminateStartupChild: signal("TERM", startupPid),
+  };
+}

--- a/test/e2e/fixtures/shields-failed-startup.ts
+++ b/test/e2e/fixtures/shields-failed-startup.ts
@@ -9,6 +9,13 @@ export interface FailedStartupProcessControlCommands {
   terminateStartupChild: string[];
 }
 
+export async function resumeSupervisorIfPaused(
+  paused: boolean,
+  resume: () => Promise<void>,
+): Promise<void> {
+  if (paused) await resume();
+}
+
 export function failedStartupProcessControlCommands(
   containerId: string,
   startupPid: number,

--- a/test/e2e/live/shields-config.test.ts
+++ b/test/e2e/live/shields-config.test.ts
@@ -30,7 +30,10 @@ import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 import { pollUntil } from "../fixtures/polling.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
-import { failedStartupProcessControlCommands } from "../fixtures/shields-failed-startup.ts";
+import {
+  failedStartupProcessControlCommands,
+  resumeSupervisorIfPaused,
+} from "../fixtures/shields-failed-startup.ts";
 import { stripAnsi } from "./json-envelope.ts";
 
 const CONFIG_PATH = "/sandbox/.openclaw/openclaw.json";
@@ -968,8 +971,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   );
   expect(liveCensus).toMatchObject({ count: 1, pid: expect.any(Number) });
   expect(liveCensus.pid).not.toBeNull();
-  const liveStartupPid = liveCensus.pid ?? 0;
-  const processControl = failedStartupProcessControlCommands(recoveryContainerId, liveStartupPid);
   const liveChildRefusal = await runInstalledFailedStartupUnlock(
     host,
     recoveryContainerId,
@@ -987,28 +988,38 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   // leave the sandbox supervisor runnable for cleanup.
   let supervisorPaused = false;
   cleanup.trackDisposable(`resume stopped supervisor for ${SANDBOX_NAME}`, async () => {
-    if (!supervisorPaused) return;
-    const resume = await docker(host, processControl.resumeSupervisor, {
-      artifactName: "cleanup-phase-12-resume-startup-supervisor",
-      timeoutMs: 30_000,
+    await resumeSupervisorIfPaused(supervisorPaused, async () => {
+      const resume = await docker(host, supervisorControl.resumeSupervisor, {
+        artifactName: "cleanup-phase-12-resume-startup-supervisor",
+        timeoutMs: 30_000,
+      });
+      expect(resume.exitCode, resultText(resume)).toBe(0);
     });
-    expect(resume.exitCode, resultText(resume)).toBe(0);
   });
-  const pauseSupervisor = await docker(host, processControl.pauseSupervisor, {
+  const supervisorControl = failedStartupProcessControlCommands(recoveryContainerId, 2);
+  const pauseSupervisor = await docker(host, supervisorControl.pauseSupervisor, {
     artifactName: "phase-12-pause-startup-supervisor",
     timeoutMs: 30_000,
   });
   expect(pauseSupervisor.exitCode, resultText(pauseSupervisor)).toBe(0);
   supervisorPaused = true;
 
+  const pausedCensus = await installedStartupCensus(
+    host,
+    recoveryContainerId,
+    "phase-12-paused-startup-census",
+  );
+  expect(pausedCensus).toMatchObject({ count: 1, pid: expect.any(Number) });
+  expect(pausedCensus.pid).not.toBeNull();
+  const processControl = failedStartupProcessControlCommands(
+    recoveryContainerId,
+    pausedCensus.pid ?? 0,
+  );
   const terminateChild = await docker(host, processControl.terminateStartupChild, {
     artifactName: "phase-12-terminate-startup-child",
     timeoutMs: 30_000,
   });
-  expect(
-    terminateChild.exitCode === 0 || /no such process/i.test(resultText(terminateChild)),
-    resultText(terminateChild),
-  ).toBe(true);
+  expect(terminateChild.exitCode, resultText(terminateChild)).toBe(0);
 
   await waitForChildlessStartup(host, recoveryContainerId);
   const childlessUnlock = await runInstalledFailedStartupUnlock(

--- a/test/e2e/live/shields-config.test.ts
+++ b/test/e2e/live/shields-config.test.ts
@@ -30,6 +30,7 @@ import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 import { pollUntil } from "../fixtures/polling.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import { failedStartupProcessControlCommands } from "../fixtures/shields-failed-startup.ts";
 import { stripAnsi } from "./json-envelope.ts";
 
 const CONFIG_PATH = "/sandbox/.openclaw/openclaw.json";
@@ -304,22 +305,7 @@ async function runInstalledFailedStartupUnlock(
   });
 }
 
-async function waitForChildlessStartup(
-  host: HostCliClient,
-  containerId: string,
-  startupPid: number,
-): Promise<void> {
-  expect(Number.isSafeInteger(startupPid) && startupPid > 1).toBe(true);
-  const terminate = await docker(
-    host,
-    ["exec", "--user", "0", containerId, "kill", "-TERM", String(startupPid)],
-    { artifactName: "phase-12-terminate-startup-child", timeoutMs: 30_000 },
-  );
-  expect(
-    terminate.exitCode === 0 || /no such process/i.test(resultText(terminate)),
-    resultText(terminate),
-  ).toBe(true);
-
+async function waitForChildlessStartup(host: HostCliClient, containerId: string): Promise<void> {
   await pollUntil({
     artifactPrefix: "phase-12-childless-census",
     attempts: 20,
@@ -983,6 +969,7 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   expect(liveCensus).toMatchObject({ count: 1, pid: expect.any(Number) });
   expect(liveCensus.pid).not.toBeNull();
   const liveStartupPid = liveCensus.pid ?? 0;
+  const processControl = failedStartupProcessControlCommands(recoveryContainerId, liveStartupPid);
   const liveChildRefusal = await runInstalledFailedStartupUnlock(
     host,
     recoveryContainerId,
@@ -995,7 +982,35 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
     owner: "root:root",
   });
 
-  await waitForChildlessStartup(host, recoveryContainerId, liveStartupPid);
+  // A running OpenShell PID 1 can restart its child while the recovery guard
+  // scans procfs. Register the fail-safe first so every later assertion can
+  // leave the sandbox supervisor runnable for cleanup.
+  let supervisorPaused = false;
+  cleanup.trackDisposable(`resume stopped supervisor for ${SANDBOX_NAME}`, async () => {
+    if (!supervisorPaused) return;
+    const resume = await docker(host, processControl.resumeSupervisor, {
+      artifactName: "cleanup-phase-12-resume-startup-supervisor",
+      timeoutMs: 30_000,
+    });
+    expect(resume.exitCode, resultText(resume)).toBe(0);
+  });
+  const pauseSupervisor = await docker(host, processControl.pauseSupervisor, {
+    artifactName: "phase-12-pause-startup-supervisor",
+    timeoutMs: 30_000,
+  });
+  expect(pauseSupervisor.exitCode, resultText(pauseSupervisor)).toBe(0);
+  supervisorPaused = true;
+
+  const terminateChild = await docker(host, processControl.terminateStartupChild, {
+    artifactName: "phase-12-terminate-startup-child",
+    timeoutMs: 30_000,
+  });
+  expect(
+    terminateChild.exitCode === 0 || /no such process/i.test(resultText(terminateChild)),
+    resultText(terminateChild),
+  ).toBe(true);
+
+  await waitForChildlessStartup(host, recoveryContainerId);
   const childlessUnlock = await runInstalledFailedStartupUnlock(
     host,
     recoveryContainerId,
@@ -1011,6 +1026,13 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   expect(
     await statPath(sandbox, `${CONFIG_DIR}/workspace`, "phase-12-state-tree-unlocked"),
   ).toMatchObject({ mode: "2770", owner: "sandbox:sandbox" });
+
+  const resumeSupervisor = await docker(host, processControl.resumeSupervisor, {
+    artifactName: "phase-12-resume-startup-supervisor",
+    timeoutMs: 30_000,
+  });
+  expect(resumeSupervisor.exitCode, resultText(resumeSupervisor)).toBe(0);
+  supervisorPaused = false;
 
   // Reconcile the host-side Shields receipt after the direct installed-guard
   // proof, then restart the failed sandbox and return cleanup to lockdown.

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -491,7 +491,8 @@
       "live": "test/e2e/live/shields-config.test.ts",
       "fast": [
         "test/e2e/support/e2e-cleanup-resources.test.ts",
-        "test/e2e/support/e2e-clients.test.ts"
+        "test/e2e/support/e2e-clients.test.ts",
+        "test/e2e/support/shields-failed-startup.test.ts"
       ]
     },
     {

--- a/test/e2e/support/shields-failed-startup.test.ts
+++ b/test/e2e/support/shields-failed-startup.test.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { failedStartupProcessControlCommands } from "../fixtures/shields-failed-startup.ts";
+
+describe("Shields failed-startup process control", () => {
+  it("pauses PID 1 before terminating its child and resumes the same supervisor", () => {
+    expect(failedStartupProcessControlCommands("abc123def456", 44)).toEqual({
+      pauseSupervisor: ["exec", "--user", "0", "abc123def456", "kill", "-STOP", "1"],
+      resumeSupervisor: ["exec", "--user", "0", "abc123def456", "kill", "-CONT", "1"],
+      terminateStartupChild: ["exec", "--user", "0", "abc123def456", "kill", "-TERM", "44"],
+    });
+  });
+
+  it.each([
+    0,
+    1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])("rejects unsafe startup child pid %s", (pid) => {
+    expect(() => failedStartupProcessControlCommands("abc123def456", pid)).toThrow(
+      "startup child pid must be a safe integer greater than 1",
+    );
+  });
+
+  it.each([
+    "",
+    "-latest",
+    "container id",
+    "container/id",
+  ])("rejects unsafe Docker container id %s", (containerId) => {
+    expect(() => failedStartupProcessControlCommands(containerId, 44)).toThrow(
+      "container id must be a safe Docker identifier",
+    );
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Shields failed-startup E2E proof now pauses the sandbox supervisor before terminating the startup child. This prevents PID 1 from racing the childless census and killing `docker exec` with exit 137.

## Changes

- Build validated Docker signal commands for the supervisor and startup child.
- Pause PID 1, prove stable childless guard recovery, then resume PID 1 before restart and relock checks.
- Register fail-safe resume cleanup before the supervisor is paused.
- Bind the live fixture change to focused E2E-support coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only an internal live E2E fixture and its support tests.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent review covered Docker command construction, signal status propagation, fail-safe cleanup registration, and cleanup ordering.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change only makes the existing Shields failed-startup E2E proof deterministic by pausing and resuming the sandbox supervisor. It does not change product behavior, commands, configuration, output, or documented procedures.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6f398d16e -->
<!-- docs-review-agents-blob-sha: 12ad395bb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:changed` and focused E2E-support coverage passed 9 tests; E2E phase, mock/live parity, integration parity, and repository checks also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when a service fails during startup.
  - Safely pauses and resumes supervisor processes while terminating failed startup processes.
  - Added safeguards against unsafe process IDs and invalid container identifiers.

- **Tests**
  - Added end-to-end coverage for startup failure recovery and process-control safety.
  - Added fast-test coverage for the updated recovery workflow and verified cleanup after recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->