### PR TITLE
test(inference): activate OpenClaw llama.cpp qualification

### DIFF
--- a/managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml
+++ b/managed-inference/qualifications/llama-cpp.openclaw.spark-single.v1.yaml
@@ -8,7 +8,7 @@ metadata:
   id: llama-cpp.openclaw.spark-single.v1
 
 spec:
-  execution: disabled
+  execution: enabled
   agent: openclaw
   image:
     reference: ghcr.io/nvidia/nemoclaw/openclaw-sandbox@sha256:3648441718cdd6c2bc4c8fe39fa0d04d3931656b2063af34215cc51841cd0d5e

--- a/test/llama-cpp-dgx-spark-qualification-plan.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-plan.test.ts
@@ -98,7 +98,7 @@ describe("llama.cpp DGX Spark qualification plan export (#8260)", () => {
     );
 
     expect(output.execution).toBe("enabled");
-    expect(output.agent_qualification_execution).toBe("disabled");
+    expect(output.agent_qualification_execution).toBe("enabled");
     expect(output.runner).toBe("linux-arm64-gpu-dgx-spark-gb10-protected-1");
     expect(parseLlamaCppDgxSparkQualificationPlan(JSON.parse(output.qualification))).toMatchObject({
       execution: "enabled",
@@ -112,7 +112,7 @@ describe("llama.cpp DGX Spark qualification plan export (#8260)", () => {
       qualification: {
         agentQualification: {
           agent: "openclaw",
-          execution: "disabled",
+          execution: "enabled",
           runtimeProvider: "docker",
         },
         probeBounds: {
@@ -146,6 +146,7 @@ describe("llama.cpp DGX Spark qualification plan export (#8260)", () => {
     const output = exportLlamaCppDgxSparkQualificationPlan(repoRoot);
 
     expect(output).toMatchObject({
+      agent_qualification_execution: "enabled",
       environment: "approve-dgx-spark-image-qualification",
       execution: "enabled",
       model_host_path: "/var/lib/nemoclaw/models/Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -229,7 +229,7 @@ describe("declarative llama.cpp server image", () => {
       },
       qualification: {
         agentQualification: {
-          execution: "disabled",
+          execution: "enabled",
           image: {
             reference:
               "ghcr.io/nvidia/nemoclaw/openclaw-sandbox@sha256:3648441718cdd6c2bc4c8fe39fa0d04d3931656b2063af34215cc51841cd0d5e",
@@ -445,7 +445,7 @@ describe("declarative llama.cpp server image", () => {
       manifestSource,
       recipeSource,
       undefined,
-      qualificationSource.replace("execution: disabled", "execution: enabled"),
+      qualificationSource,
     );
 
     expect(JSON.parse(enabled.publication_qualification_plan)).toMatchObject({


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Enable the already-declared OpenClaw agent qualification in the protected NVIDIA DGX Spark llama.cpp lane. This produces physical evidence for the exact YAML-defined OpenClaw, Nemotron GGUF, runtime, image, and probe tuple without changing onboarding defaults, enabling image publication, or advertising agent support in the serving recipe.

## Related Issue

Closes #8260
Advances #8144

## Changes

- Change the repository-owned `AgentQualification` manifest from dormant to enabled.
- Keep the serving recipe authoritative and unchanged, including `capabilities.agents: []` until the protected evidence is accepted.
- Update the plan and image compiler tests to require the checked-in enabled qualification state directly from YAML.
- Preserve the existing trusted-main workflow, protected runner/environment, exact-head binding, fail-closed validation, and cleanup behavior without adding runtime code or hidden defaults.

## Operational Acceptance

- The repository environment `approve-dgx-spark-image-qualification` exists and is selected declaratively by the image manifest.
- This PR must not merge until `llama-cpp-dgx-spark-qualification` starts on `linux-arm64-gpu-dgx-spark-gb10-protected-1` and passes for the exact head. Job assignment and environment entry establish that those two external prerequisites are live.
- The protected runner verifies the declared local GGUF path and exact SHA-256 before launch or qualification. A passing exact-head job is the required evidence that the model prerequisite is staged; a missing or mismatched artifact fails closed.
- No repository-only test can prove external runner assignment or host filesystem state, so the protected job is the acceptance gate rather than a mocked substitute.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this activates protected qualification evidence only; the public recipe still declares `agents: []`, image publication remains disabled, and no support claim, command, default, or user-facing configuration changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This slice enables protected DGX Spark qualification evidence only. The serving recipe still declares no qualified agents, image publication remains disabled, and no user-facing behavior or support claim changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d26d3979b7e7274413e9108048ccf83aeed59bac -->
<!-- docs-review-agents-blob-sha: 12ad395bb57fef895b67dbb11703894e5475e502 -->

## DGX Station Hardware Evidence

<!-- Not applicable: scripts/prepare-dgx-station-host.sh is unchanged. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `218/218` focused integration tests and `19/19` E2E support/workflow-boundary tests passed.
- [x] Applicable broad gate passed — `npm run checks:repository`, `npm run typecheck:cli`, `npm run validate:configs`, and `npm run catalog:check` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
