### PR TITLE
test(inference): qualify llama.cpp security signals

### DIFF
--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -57,6 +57,9 @@ spec:
       probes:
         - health
         - models
+        - properties
+        - metrics
+        - disabled-surfaces
         - synchronous-chat
         - streaming-chat
         - usage
@@ -68,6 +71,7 @@ spec:
         - malformed-request
         - cancellation
         - client-timeout
+        - log-redaction
       probeBounds:
         cancellationMaxTokens: 4096
         clientTimeoutMilliseconds: 250

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -10,7 +10,7 @@ import YAML from "yaml";
 
 import {
   LLAMA_CPP_DGX_SPARK_AGENT_QUALIFICATION_PATH,
-  LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES,
   llamaCppDgxSparkExecutionPlanSha256,
   parseLlamaCppDgxSparkExecutionPlan,
 } from "./llama-cpp-dgx-spark-qualification-contract.mts";
@@ -479,7 +479,8 @@ export function loadLlamaCppImageConfig(
       fullOffload: true,
       vendor: "nvidia",
     }) ||
-    JSON.stringify(qualification?.probes) !== JSON.stringify(LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES)
+    JSON.stringify(qualification?.probes) !==
+      JSON.stringify(LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES)
   ) {
     throw new Error("invalid llama.cpp image publication contract");
   }

--- a/scripts/checks/llama-cpp-dgx-spark-protocol-qualification.mts
+++ b/scripts/checks/llama-cpp-dgx-spark-protocol-qualification.mts
@@ -3,6 +3,7 @@
 
 import {
   LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+  LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES,
   type LlamaCppDgxSparkExecutionPlan,
   type LlamaCppDgxSparkQualificationReceipt,
 } from "./llama-cpp-dgx-spark-qualification-contract.mts";
@@ -10,7 +11,7 @@ import {
 type ProtocolProbe = (typeof LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES)[number];
 
 type JsonRecord = Record<string, unknown>;
-type ProtocolEvidence = LlamaCppDgxSparkQualificationReceipt["probes"];
+type ProtocolEvidence = Omit<LlamaCppDgxSparkQualificationReceipt["probes"], "logRedaction">;
 type FetchImplementation = typeof fetch;
 
 type ToolCall = {
@@ -220,16 +221,72 @@ export function validateChatCompletionResponse(value: unknown, expectedModel: st
 export function validatePropertiesResponse(
   value: unknown,
   expectedContextSize: number,
-): ProtocolEvidence["contextWindow"] {
+  expectedModel: ProtocolEvidence["properties"]["model"],
+  expectedModelFile: ProtocolEvidence["properties"]["modelPath"],
+): {
+  readonly contextWindow: ProtocolEvidence["contextWindow"];
+  readonly disabledState: Pick<ProtocolEvidence["disabledSurfaces"], "multimodal">;
+  readonly properties: ProtocolEvidence["properties"];
+} {
+  const expectedModelPath = `/models/${expectedModelFile}`;
   if (
     !isRecord(value) ||
     value.total_slots !== 1 ||
     !isRecord(value.default_generation_settings) ||
-    value.default_generation_settings.n_ctx !== expectedContextSize
+    value.default_generation_settings.n_ctx !== expectedContextSize ||
+    value.model_alias !== expectedModel ||
+    value.model_path !== expectedModelPath ||
+    value.endpoint_metrics !== true ||
+    value.endpoint_slots !== false ||
+    value.endpoint_props !== false ||
+    value.ui !== false ||
+    value.cors_proxy_enabled !== false ||
+    value.is_sleeping !== false ||
+    !isRecord(value.modalities) ||
+    value.modalities.vision !== false ||
+    value.modalities.video !== false ||
+    value.modalities.audio !== false
   ) {
-    throw new Error("properties probe did not prove the declarative context window");
+    throw new Error("properties probe did not prove the declarative security and readiness state");
   }
-  return { contextSize: expectedContextSize, ok: true, slots: 1 };
+  return {
+    contextWindow: { contextSize: expectedContextSize, ok: true, slots: 1 },
+    disabledState: { multimodal: false },
+    properties: {
+      httpStatus: 200,
+      metrics: true,
+      model: expectedModel,
+      modelPath: expectedModelFile,
+      ok: true,
+    },
+  };
+}
+
+export function validateMetricsResponse(source: string): ProtocolEvidence["metrics"] {
+  if (source.length === 0 || /[\0\r]/u.test(source)) {
+    throw new Error("metrics probe returned an invalid Prometheus document");
+  }
+  const samples = new Map<string, number>();
+  for (const line of source.split("\n")) {
+    if (line === "" || line.startsWith("#")) continue;
+    const match =
+      /^(llamacpp:[a-z_]+)(?:\{[^{}\r\n]{1,4096}\})?\s+(-?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)$/u.exec(
+        line,
+      );
+    if (!match || !Number.isFinite(Number(match[2]))) {
+      throw new Error("metrics probe returned an invalid Prometheus sample");
+    }
+    samples.set(match[1] as string, Number(match[2]));
+  }
+  if (LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES.some((name) => !samples.has(name))) {
+    throw new Error("metrics probe did not return the required llama.cpp series");
+  }
+  return {
+    httpStatus: 200,
+    ok: true,
+    requiredSeries: LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES.length,
+    unauthenticatedHttpStatus: 401,
+  };
 }
 
 export function validateStructuredOutputResponse(value: unknown, expectedModel: string): void {
@@ -555,6 +612,7 @@ export async function runLlamaCppDgxSparkProtocolQualification(options: {
   const timeoutMilliseconds = plan.recipe.serve.limits.requestTimeoutSeconds * 1000;
   const chatUrl = `${baseUrl}/v1/chat/completions`;
   const executedProbes = new Set<ProtocolProbe>();
+  const rejectedAuthorization = `${authorization.slice(0, -1)}${authorization.endsWith("0") ? "1" : "0"}`;
 
   const healthResponse = await fetchImpl(`${baseUrl}/health`, {
     headers: { Authorization: authorization },
@@ -577,16 +635,75 @@ export async function runLlamaCppDgxSparkProtocolQualification(options: {
     headers: { Authorization: authorization },
     signal: requestSignal(timeoutMilliseconds),
   });
-  const contextWindow = validatePropertiesResponse(
+  const propertiesEvidence = validatePropertiesResponse(
     await readJson(propertiesResponse, 200, bounds.maxResponseBytes, "properties probe"),
     plan.recipe.serve.contextSize,
+    model,
+    plan.recipe.model.file.path,
   );
+  const { contextWindow } = propertiesEvidence;
   executedProbes.add("context-window");
+  executedProbes.add("properties");
+
+  const unauthenticatedMetricsResponse = await fetchImpl(`${baseUrl}/metrics`, {
+    headers: { Authorization: rejectedAuthorization },
+    signal: requestSignal(timeoutMilliseconds),
+  });
+  await expectStatus(
+    unauthenticatedMetricsResponse,
+    401,
+    bounds.maxResponseBytes,
+    "unauthenticated metrics probe",
+  );
+  const metricsResponse = await fetchImpl(`${baseUrl}/metrics`, {
+    headers: { Authorization: authorization },
+    signal: requestSignal(timeoutMilliseconds),
+  });
+  if (
+    metricsResponse.status !== 200 ||
+    !metricsResponse.headers.get("content-type")?.toLowerCase().includes("text/plain")
+  ) {
+    throw new Error("metrics probe did not return Prometheus text");
+  }
+  const metrics = validateMetricsResponse(
+    new TextDecoder("utf8", { fatal: true }).decode(
+      await readBoundedBytes(metricsResponse, bounds.maxResponseBytes),
+    ),
+  );
+  executedProbes.add("metrics");
+
+  const disabledSurfaceRequests: readonly {
+    readonly label: string;
+    readonly path: string;
+    readonly status: number;
+    readonly init?: RequestInit;
+  }[] = [
+    { label: "UI", path: "/", status: 404 },
+    { label: "slot inspection", path: "/slots", status: 501 },
+    { label: "MCP proxy", path: "/cors-proxy", status: 403 },
+    { label: "server tools", path: "/tools", status: 403 },
+    { label: "router", path: "/models/load", status: 404, init: { method: "POST" } },
+    { label: "properties mutation", path: "/props", status: 501, init: { method: "POST" } },
+  ];
+  for (const probe of disabledSurfaceRequests) {
+    const response = await fetchImpl(`${baseUrl}${probe.path}`, {
+      ...probe.init,
+      headers: { Authorization: authorization },
+      signal: requestSignal(timeoutMilliseconds),
+    });
+    await expectStatus(
+      response,
+      probe.status,
+      bounds.maxResponseBytes,
+      `${probe.label} disabled-surface probe`,
+    );
+  }
+  executedProbes.add("disabled-surfaces");
 
   const authenticationResponse = await fetchImpl(
     chatUrl,
     jsonRequest(
-      `${authorization.slice(0, -1)}${authorization.endsWith("0") ? "1" : "0"}`,
+      rejectedAuthorization,
       {
         max_tokens: 1,
         messages: [{ content: "This request must be rejected.", role: "user" }],
@@ -779,15 +896,27 @@ export async function runLlamaCppDgxSparkProtocolQualification(options: {
   executedProbes.add("cancellation");
   await clientTimeoutProbe(fetchImpl, chatUrl, authorization, plan, timeoutMilliseconds);
   executedProbes.add("client-timeout");
-  assertExecutedProbeInventory(plan.qualification.probes, executedProbes);
+  assertExecutedProbeInventory(LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES, executedProbes);
 
   return {
     authentication: { httpStatus: 401, ok: true },
     cancellation: { aborted: true, ok: true, recovered: true },
     contextWindow,
+    disabledSurfaces: {
+      corsProxyHttpStatus: 403,
+      multimodal: propertiesEvidence.disabledState.multimodal,
+      ok: true,
+      propertiesMutationHttpStatus: 501,
+      routerHttpStatus: 404,
+      slotsHttpStatus: 501,
+      toolsHttpStatus: 403,
+      uiHttpStatus: 404,
+    },
     health: { httpStatus: 200, ok: true },
     malformedRequest: { httpStatus: 400, ok: true },
     models: { httpStatus: 200, model, ok: true },
+    metrics,
+    properties: propertiesEvidence.properties,
     clientTimeout: {
       aborted: true,
       limitMilliseconds: bounds.clientTimeoutMilliseconds,

--- a/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
+++ b/scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts
@@ -42,6 +42,9 @@ export const LLAMA_CPP_DGX_SPARK_MINIMUM_DRIVER_VERSION = "580.65.06" as const;
 export const LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES = [
   "health",
   "models",
+  "properties",
+  "metrics",
+  "disabled-surfaces",
   "synchronous-chat",
   "streaming-chat",
   "usage",
@@ -53,6 +56,23 @@ export const LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES = [
   "malformed-request",
   "cancellation",
   "client-timeout",
+] as const;
+export const LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES = [
+  ...LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+  "log-redaction",
+] as const;
+export const LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES = [
+  "llamacpp:prompt_tokens_total",
+  "llamacpp:prompt_seconds_total",
+  "llamacpp:prompt_tokens_seconds",
+  "llamacpp:tokens_predicted_total",
+  "llamacpp:tokens_predicted_seconds_total",
+  "llamacpp:predicted_tokens_seconds",
+  "llamacpp:requests_processing",
+  "llamacpp:requests_deferred",
+  "llamacpp:n_tokens_max",
+  "llamacpp:n_decode_total",
+  "llamacpp:n_busy_slots_per_decode",
 ] as const;
 export const LLAMA_CPP_DGX_SPARK_AGENT_PROBES = [
   "synchronous-chat",
@@ -128,7 +148,7 @@ export type LlamaCppDgxSparkQualificationPlan = {
       readonly toolResultContinuation: number;
     };
   };
-  readonly probes: typeof LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES;
+  readonly probes: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES;
   readonly profile: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE;
   readonly recipeRef: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE;
   readonly required: true;
@@ -175,7 +195,7 @@ export type LlamaCppDgxSparkExecutionPlan = {
   readonly qualification: {
     readonly agentQualification: LlamaCppDgxSparkAgentQualificationPlan;
     readonly probeBounds: LlamaCppDgxSparkQualificationPlan["probeBounds"];
-    readonly probes: typeof LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES;
+    readonly probes: typeof LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES;
   };
   readonly recipe: {
     readonly capabilities: {
@@ -419,8 +439,21 @@ export type LlamaCppDgxSparkQualificationReceipt = {
       readonly ok: true;
       readonly slots: 1;
     };
+    readonly disabledSurfaces: {
+      readonly corsProxyHttpStatus: 403;
+      readonly multimodal: false;
+      readonly ok: true;
+      readonly propertiesMutationHttpStatus: 501;
+      readonly routerHttpStatus: 404;
+      readonly slotsHttpStatus: 501;
+      readonly toolsHttpStatus: 403;
+      readonly uiHttpStatus: 404;
+    };
     readonly health: {
       readonly httpStatus: 200;
+      readonly ok: true;
+    };
+    readonly logRedaction: {
       readonly ok: true;
     };
     readonly malformedRequest: {
@@ -430,6 +463,19 @@ export type LlamaCppDgxSparkQualificationReceipt = {
     readonly models: {
       readonly httpStatus: 200;
       readonly model: typeof LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID;
+      readonly ok: true;
+    };
+    readonly metrics: {
+      readonly httpStatus: 200;
+      readonly ok: true;
+      readonly requiredSeries: number;
+      readonly unauthenticatedHttpStatus: 401;
+    };
+    readonly properties: {
+      readonly httpStatus: 200;
+      readonly metrics: true;
+      readonly model: typeof LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID;
+      readonly modelPath: "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
       readonly ok: true;
     };
     readonly clientTimeout: {
@@ -893,7 +939,7 @@ export function parseLlamaCppDgxSparkQualificationPlan(
     gpu.cpuFallback !== "reject" ||
     model.id !== LLAMA_CPP_DGX_SPARK_MODEL_ID ||
     model.digest !== LLAMA_CPP_DGX_SPARK_MODEL_DIGEST ||
-    JSON.stringify(plan.probes) !== JSON.stringify(LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES)
+    JSON.stringify(plan.probes) !== JSON.stringify(LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES)
   ) {
     throw new Error("llama.cpp DGX Spark qualification plan is invalid");
   }
@@ -908,7 +954,7 @@ export function parseLlamaCppDgxSparkQualificationPlan(
     },
     platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
     probeBounds: parsedProbeBounds,
-    probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+    probes: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES,
     profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
     recipeRef: LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE,
     required: true,
@@ -937,7 +983,8 @@ export function parseLlamaCppDgxSparkExecutionPlan(
     "compiled protocol qualification",
   );
   if (
-    JSON.stringify(qualification.probes) !== JSON.stringify(LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES)
+    JSON.stringify(qualification.probes) !==
+    JSON.stringify(LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES)
   ) {
     throw new Error("compiled llama.cpp DGX Spark protocol probes are invalid");
   }
@@ -1299,7 +1346,7 @@ export function parseLlamaCppDgxSparkExecutionPlan(
     qualification: {
       agentQualification,
       probeBounds: protocolProbeBounds,
-      probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+      probes: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES,
     },
     recipe: {
       capabilities: {
@@ -1683,9 +1730,13 @@ export function parseLlamaCppDgxSparkQualificationReceipt(
       "authentication",
       "cancellation",
       "contextWindow",
+      "disabledSurfaces",
       "health",
+      "logRedaction",
       "malformedRequest",
+      "metrics",
       "models",
+      "properties",
       "clientTimeout",
       "streamingChat",
       "structuredOutput",
@@ -1698,8 +1749,45 @@ export function parseLlamaCppDgxSparkQualificationReceipt(
   );
   const health = record(probes.health, "llama.cpp DGX Spark health probe");
   requireExactKeys(health, ["httpStatus", "ok"], "health probe");
+  const logRedaction = record(probes.logRedaction, "llama.cpp DGX Spark log-redaction probe");
+  requireExactKeys(logRedaction, ["ok"], "log-redaction probe");
   const models = record(probes.models, "llama.cpp DGX Spark models probe");
   requireExactKeys(models, ["httpStatus", "model", "ok"], "models probe");
+  const metrics = record(probes.metrics, "llama.cpp DGX Spark metrics probe");
+  requireExactKeys(
+    metrics,
+    ["httpStatus", "ok", "requiredSeries", "unauthenticatedHttpStatus"],
+    "metrics probe",
+  );
+  const requiredSeries = safeInteger(
+    metrics.requiredSeries,
+    "required metrics series count",
+    LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES.length,
+  );
+  const properties = record(probes.properties, "llama.cpp DGX Spark properties probe");
+  requireExactKeys(
+    properties,
+    ["httpStatus", "metrics", "model", "modelPath", "ok"],
+    "properties probe",
+  );
+  const disabledSurfaces = record(
+    probes.disabledSurfaces,
+    "llama.cpp DGX Spark disabled-surfaces probe",
+  );
+  requireExactKeys(
+    disabledSurfaces,
+    [
+      "corsProxyHttpStatus",
+      "multimodal",
+      "ok",
+      "propertiesMutationHttpStatus",
+      "routerHttpStatus",
+      "slotsHttpStatus",
+      "toolsHttpStatus",
+      "uiHttpStatus",
+    ],
+    "disabled-surfaces probe",
+  );
   const synchronousChat = record(probes.synchronousChat, "synchronous chat probe");
   requireExactKeys(synchronousChat, ["httpStatus", "model", "ok"], "synchronous chat probe");
   const streamingChat = record(probes.streamingChat, "streaming chat probe");
@@ -1773,9 +1861,27 @@ export function parseLlamaCppDgxSparkQualificationReceipt(
   if (
     health.ok !== true ||
     health.httpStatus !== 200 ||
+    logRedaction.ok !== true ||
     models.ok !== true ||
     models.httpStatus !== 200 ||
     models.model !== LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID ||
+    metrics.ok !== true ||
+    metrics.httpStatus !== 200 ||
+    metrics.unauthenticatedHttpStatus !== 401 ||
+    requiredSeries !== LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES.length ||
+    properties.ok !== true ||
+    properties.httpStatus !== 200 ||
+    properties.metrics !== true ||
+    properties.model !== LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID ||
+    properties.modelPath !== "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf" ||
+    disabledSurfaces.ok !== true ||
+    disabledSurfaces.corsProxyHttpStatus !== 403 ||
+    disabledSurfaces.multimodal !== false ||
+    disabledSurfaces.propertiesMutationHttpStatus !== 501 ||
+    disabledSurfaces.routerHttpStatus !== 404 ||
+    disabledSurfaces.slotsHttpStatus !== 501 ||
+    disabledSurfaces.toolsHttpStatus !== 403 ||
+    disabledSurfaces.uiHttpStatus !== 404 ||
     synchronousChat.ok !== true ||
     synchronousChat.httpStatus !== 200 ||
     synchronousChat.model !== LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID ||
@@ -1865,11 +1971,35 @@ export function parseLlamaCppDgxSparkQualificationReceipt(
       authentication: { httpStatus: 401, ok: true },
       cancellation: { aborted: true, ok: true, recovered: true },
       contextWindow: { contextSize, ok: true, slots: 1 },
+      disabledSurfaces: {
+        corsProxyHttpStatus: 403,
+        multimodal: false,
+        ok: true,
+        propertiesMutationHttpStatus: 501,
+        routerHttpStatus: 404,
+        slotsHttpStatus: 501,
+        toolsHttpStatus: 403,
+        uiHttpStatus: 404,
+      },
       health: { httpStatus: 200, ok: true },
+      logRedaction: { ok: true },
       malformedRequest: { httpStatus: 400, ok: true },
+      metrics: {
+        httpStatus: 200,
+        ok: true,
+        requiredSeries: LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES.length,
+        unauthenticatedHttpStatus: 401,
+      },
       models: {
         httpStatus: 200,
         model: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+        ok: true,
+      },
+      properties: {
+        httpStatus: 200,
+        metrics: true,
+        model: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+        modelPath: "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
         ok: true,
       },
       clientTimeout: {

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -415,6 +415,36 @@ export function validateRuntimeLogRedaction(
   return { ok: true };
 }
 
+export function buildRuntimeLogForbiddenValues(
+  plan: QualificationPlan,
+  invocation: QualificationInvocation,
+  apiKey: string,
+  authorization: string,
+): readonly string[] {
+  const agentPlan = plan.qualification.agentQualification;
+  const rejectedAuthorization = `${authorization.slice(0, -1)}${authorization.endsWith("0") ? "1" : "0"}`;
+  return [
+    apiKey,
+    authorization,
+    rejectedAuthorization,
+    invocation.modelHostPath,
+    `/models/${plan.recipe.model.file.path}`,
+    "This request must be rejected.",
+    "Return one short readiness token.",
+    "Reply with exactly: ready",
+    "Reply with one token.",
+    "Count upward without stopping.",
+    "Report the requested qualification status.",
+    "Use the available tool to get the weather in Seattle.",
+    JSON.stringify({ conditions: "clear", temperature_c: 21 }),
+    JSON.stringify({ location: "Seattle" }),
+    agentPlan.prompts.normal,
+    agentPlan.prompts.tool,
+    agentPlan.prompts.continuation,
+    agentPlan.fixture.value,
+  ];
+}
+
 function compareVersions(left: string, right: string): number {
   const leftParts = left.split(".").map(Number);
   const rightParts = right.split(".").map(Number);
@@ -1034,19 +1064,7 @@ async function runQualification(
       runCommand("docker", ["logs", "--tail", "20000", names.containerName], {
         maximumBytes: 16 * 1024 * 1024,
       }).toString("utf8"),
-      [
-        apiKey,
-        authorization,
-        invocation.modelHostPath,
-        "Return one short readiness token.",
-        "Reply with exactly: ready",
-        "Report the requested qualification status.",
-        "Use the available tool to get the weather in Seattle.",
-        agentPlan.prompts.normal,
-        agentPlan.prompts.tool,
-        agentPlan.prompts.continuation,
-        agentPlan.fixture.value,
-      ],
+      buildRuntimeLogForbiddenValues(plan, invocation, apiKey, authorization),
     );
     successReceipt = {
       agentQualification,

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -399,6 +399,22 @@ export function validateStartupLog(log: string): {
   return counts[0] as { offloadedLayers: number; totalLayers: number };
 }
 
+export function validateRuntimeLogRedaction(
+  log: string,
+  forbiddenValues: readonly string[],
+): { readonly ok: true } {
+  if (Buffer.byteLength(log) < 1 || Buffer.byteLength(log) > 16 * 1024 * 1024) {
+    throw new Error("runtime log evidence is missing or exceeds the bounded log size");
+  }
+  if (
+    forbiddenValues.length < 1 ||
+    forbiddenValues.some((value) => value.length < 8 || log.includes(value))
+  ) {
+    throw new Error("runtime log evidence contains a credential, path, prompt, or response value");
+  }
+  return { ok: true };
+}
+
 function compareVersions(left: string, right: string): number {
   const leftParts = left.split(".").map(Number);
   const rightParts = right.split(".").map(Number);
@@ -1014,6 +1030,24 @@ async function runQualification(
         else process.env[baseUrlEnvironmentName] = priorBaseUrl;
       }
     }
+    const logRedaction = validateRuntimeLogRedaction(
+      runCommand("docker", ["logs", "--tail", "20000", names.containerName], {
+        maximumBytes: 16 * 1024 * 1024,
+      }).toString("utf8"),
+      [
+        apiKey,
+        authorization,
+        invocation.modelHostPath,
+        "Return one short readiness token.",
+        "Reply with exactly: ready",
+        "Report the requested qualification status.",
+        "Use the available tool to get the weather in Seattle.",
+        agentPlan.prompts.normal,
+        agentPlan.prompts.tool,
+        agentPlan.prompts.continuation,
+        agentPlan.fixture.value,
+      ],
+    );
     successReceipt = {
       agentQualification,
       baseSha: invocation.candidateBase,
@@ -1047,7 +1081,7 @@ async function runQualification(
         fullOffload: true,
         ...offload,
       },
-      probes,
+      probes: { ...probes, logRedaction },
     };
   } catch (error) {
     failure = error;

--- a/test/llama-cpp-dgx-spark-protocol-qualification.test.ts
+++ b/test/llama-cpp-dgx-spark-protocol-qualification.test.ts
@@ -6,16 +6,24 @@ import { describe, expect, it, vi } from "vitest";
 import { loadLlamaCppImageConfig } from "../scripts/checks/export-llama-cpp-image-config.mts";
 import {
   runLlamaCppDgxSparkProtocolQualification,
+  validateMetricsResponse,
   validatePropertiesResponse,
   validateStreamingChatResponse,
   validateStructuredOutputResponse,
   validateToolCallResponse,
   validateToolResultContinuationResponse,
 } from "../scripts/checks/llama-cpp-dgx-spark-protocol-qualification.mts";
-import { parseLlamaCppDgxSparkExecutionPlan } from "../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
+import {
+  LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES,
+  parseLlamaCppDgxSparkExecutionPlan,
+} from "../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
 
 const AUTHORIZATION = `Bearer ${"a".repeat(64)}`;
 const MODEL = "nvidia-nemotron-3-nano-30b-a3b";
+const MODEL_FILE = "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
+const METRICS = LLAMA_CPP_DGX_SPARK_REQUIRED_METRIC_SERIES.map(
+  (name, index) => `${name} ${String(index + 1)}`,
+).join("\n");
 
 const config = loadLlamaCppImageConfig();
 const compiledPlan = parseLlamaCppDgxSparkExecutionPlan(
@@ -46,6 +54,22 @@ function completion(content = "ready", usage = true): JsonObject {
     model: MODEL,
     object: "chat.completion",
     ...(usage ? { usage: { completion_tokens: 2, prompt_tokens: 5, total_tokens: 7 } } : {}),
+  };
+}
+
+function properties(contextSize = 262144): JsonObject {
+  return {
+    cors_proxy_enabled: false,
+    default_generation_settings: { n_ctx: contextSize },
+    endpoint_metrics: true,
+    endpoint_props: false,
+    endpoint_slots: false,
+    is_sleeping: false,
+    modalities: { audio: false, video: false, vision: false },
+    model_alias: MODEL,
+    model_path: `/models/${MODEL_FILE}`,
+    total_slots: 1,
+    ui: false,
   };
 }
 
@@ -137,16 +161,12 @@ describe("llama.cpp DGX Spark protocol qualification", () => {
         MODEL,
       ),
     ).not.toThrow();
-    expect(
-      validatePropertiesResponse(
-        { default_generation_settings: { n_ctx: 262144 }, total_slots: 1 },
-        262144,
-      ),
-    ).toEqual({
-      contextSize: 262144,
-      ok: true,
-      slots: 1,
+    expect(validatePropertiesResponse(properties(), 262144, MODEL, MODEL_FILE)).toMatchObject({
+      contextWindow: { contextSize: 262144, ok: true, slots: 1 },
+      disabledState: { multimodal: false },
+      properties: { metrics: true, model: MODEL, modelPath: MODEL_FILE },
     });
+    expect(validateMetricsResponse(METRICS)).toMatchObject({ requiredSeries: 11 });
   });
 
   it("rejects malformed or unbounded protocol evidence without exposing response content (#8144)", () => {
@@ -164,12 +184,23 @@ describe("llama.cpp DGX Spark protocol qualification", () => {
     expect(() =>
       validateStructuredOutputResponse(completion('{"status":"wrong"}', false), MODEL),
     ).toThrow("JSON schema");
+    expect(() => validatePropertiesResponse(properties(131072), 262144, MODEL, MODEL_FILE)).toThrow(
+      "security and readiness",
+    );
+    expect(() => validateMetricsResponse("llamacpp:requests_processing nope")).toThrow(
+      "invalid Prometheus sample",
+    );
+    expect(() =>
+      validateMetricsResponse(METRICS.replace("llamacpp:requests_processing 7\n", "")),
+    ).toThrow("required llama.cpp series");
     expect(() =>
       validatePropertiesResponse(
-        { default_generation_settings: { n_ctx: 131072 }, total_slots: 1 },
+        { ...properties(), endpoint_slots: true },
         262144,
+        MODEL,
+        MODEL_FILE,
       ),
-    ).toThrow("context window");
+    ).toThrow("security and readiness");
     expect(() =>
       validateToolCallResponse(
         {
@@ -245,12 +276,21 @@ describe("llama.cpp DGX Spark protocol qualification", () => {
         case "http://127.0.0.1:18081/v1/models":
           return jsonResponse({ data: [{ id: MODEL }], object: "list" });
         case "http://127.0.0.1:18081/props":
-          return jsonResponse({
-            default_generation_settings: {
-              n_ctx: plan.recipe.serve.contextSize,
-            },
-            total_slots: 1,
-          });
+          return init?.method === "POST"
+            ? jsonResponse({ error: {} }, 501)
+            : jsonResponse(properties(plan.recipe.serve.contextSize));
+        case "http://127.0.0.1:18081/metrics":
+          return new Headers(init?.headers).get("authorization") === AUTHORIZATION
+            ? new Response(METRICS, { headers: { "Content-Type": "text/plain" }, status: 200 })
+            : jsonResponse({ error: {} }, 401);
+        case "http://127.0.0.1:18081/":
+        case "http://127.0.0.1:18081/models/load":
+          return jsonResponse({ error: {} }, 404);
+        case "http://127.0.0.1:18081/slots":
+          return jsonResponse({ error: {} }, 501);
+        case "http://127.0.0.1:18081/cors-proxy":
+        case "http://127.0.0.1:18081/tools":
+          return jsonResponse({ error: {} }, 403);
         default:
           expect(url).toBe("http://127.0.0.1:18081/v1/chat/completions");
       }
@@ -346,7 +386,17 @@ describe("llama.cpp DGX Spark protocol qualification", () => {
       authentication: { httpStatus: 401, ok: true },
       cancellation: { aborted: true, ok: true, recovered: true },
       contextWindow: { contextSize: plan.recipe.serve.contextSize, slots: 1 },
+      disabledSurfaces: {
+        corsProxyHttpStatus: 403,
+        multimodal: false,
+        routerHttpStatus: 404,
+        slotsHttpStatus: 501,
+        toolsHttpStatus: 403,
+        uiHttpStatus: 404,
+      },
       malformedRequest: { httpStatus: 400, ok: true },
+      metrics: { requiredSeries: 11, unauthenticatedHttpStatus: 401 },
+      properties: { metrics: true, model: MODEL, modelPath: MODEL_FILE },
       clientTimeout: { limitMilliseconds: 10, recovered: true },
       streamingChat: { done: true, events: 3, model: MODEL },
       structuredOutput: { schemaMatched: true },

--- a/test/llama-cpp-dgx-spark-qualification-contract.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-contract.test.ts
@@ -19,12 +19,12 @@ import {
   LLAMA_CPP_DGX_SPARK_OPENCLAW_SANDBOX,
   LLAMA_CPP_DGX_SPARK_OPENCLAW_SOURCE_REVISION,
   LLAMA_CPP_DGX_SPARK_OWNED_IMAGE_REPOSITORY,
-  LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_ACTIVATION_PATH,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_IMAGE_REPOSITORY,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_JOB_ID,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_KIND,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
   LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE,
   LLAMA_CPP_DGX_SPARK_RUNNER_PATTERN,
@@ -127,7 +127,7 @@ function disabledPlan() {
     },
     platform: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PLATFORM,
     probeBounds: probeBounds(),
-    probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+    probes: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES,
     profile: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROFILE,
     recipeRef: LLAMA_CPP_DGX_SPARK_QUALIFICATION_RECIPE,
     required: true,
@@ -194,11 +194,35 @@ function receipt() {
       authentication: { httpStatus: 401, ok: true },
       cancellation: { aborted: true, ok: true, recovered: true },
       contextWindow: { contextSize: 262144, ok: true, slots: 1 },
+      disabledSurfaces: {
+        corsProxyHttpStatus: 403,
+        multimodal: false,
+        ok: true,
+        propertiesMutationHttpStatus: 501,
+        routerHttpStatus: 404,
+        slotsHttpStatus: 501,
+        toolsHttpStatus: 403,
+        uiHttpStatus: 404,
+      },
       health: { httpStatus: 200, ok: true },
+      logRedaction: { ok: true },
       malformedRequest: { httpStatus: 400, ok: true },
+      metrics: {
+        httpStatus: 200,
+        ok: true,
+        requiredSeries: 11,
+        unauthenticatedHttpStatus: 401,
+      },
       models: {
         httpStatus: 200,
         model: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+        ok: true,
+      },
+      properties: {
+        httpStatus: 200,
+        metrics: true,
+        model: LLAMA_CPP_DGX_SPARK_SERVED_MODEL_ID,
+        modelPath: "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
         ok: true,
       },
       clientTimeout: {
@@ -266,7 +290,7 @@ function executionPlan() {
     qualification: {
       agentQualification: agentQualification(),
       probeBounds: probeBounds(),
-      probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+      probes: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES,
     },
     recipe: {
       capabilities: {
@@ -463,7 +487,7 @@ describe("llama.cpp DGX Spark qualification contract", () => {
     expect(() =>
       parseLlamaCppDgxSparkQualificationPlan({
         ...enabledPlan(),
-        probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES.filter((probe) => probe !== "tool-call"),
+        probes: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES.filter((probe) => probe !== "tool-call"),
       }),
     ).toThrow("qualification plan is invalid");
     expect(() =>
@@ -632,7 +656,7 @@ describe("llama.cpp DGX Spark qualification contract", () => {
         ...value,
         qualification: {
           ...value.qualification,
-          probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES.slice(0, -1),
+          probes: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES.slice(0, -1),
         },
       }),
     ).toThrow("protocol probes are invalid");
@@ -859,6 +883,42 @@ describe("llama.cpp DGX Spark qualification contract", () => {
             ...receipt().probes,
             models: { ...receipt().probes.models, model: "/models/private.gguf" },
           },
+        },
+        evidenceIdentity(),
+      ),
+    ).toThrow("probes did not pass");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        {
+          ...receipt(),
+          probes: {
+            ...receipt().probes,
+            metrics: { ...receipt().probes.metrics, requiredSeries: 10 },
+          },
+        },
+        evidenceIdentity(),
+      ),
+    ).toThrow("probes did not pass");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        {
+          ...receipt(),
+          probes: {
+            ...receipt().probes,
+            disabledSurfaces: {
+              ...receipt().probes.disabledSurfaces,
+              toolsHttpStatus: 200,
+            },
+          },
+        },
+        evidenceIdentity(),
+      ),
+    ).toThrow("probes did not pass");
+    expect(() =>
+      parseLlamaCppDgxSparkQualificationReceipt(
+        {
+          ...receipt(),
+          probes: { ...receipt().probes, logRedaction: { ok: false } },
         },
         evidenceIdentity(),
       ),

--- a/test/llama-cpp-dgx-spark-qualification-plan.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-plan.test.ts
@@ -10,7 +10,7 @@ import YAML from "yaml";
 
 import { exportLlamaCppDgxSparkQualificationPlan } from "../scripts/checks/export-llama-cpp-dgx-spark-qualification-plan.mts";
 import {
-  LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+  LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES,
   parseLlamaCppDgxSparkExecutionPlan,
   parseLlamaCppDgxSparkQualificationPlan,
 } from "../scripts/checks/llama-cpp-dgx-spark-qualification-contract.mts";
@@ -128,7 +128,7 @@ describe("llama.cpp DGX Spark qualification plan export (#8260)", () => {
             toolResultContinuation: 64,
           },
         },
-        probes: LLAMA_CPP_DGX_SPARK_PROTOCOL_PROBES,
+        probes: LLAMA_CPP_DGX_SPARK_QUALIFICATION_PROBES,
       },
       recipe: {
         capabilities: {

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import { loadLlamaCppImageConfig } from "../scripts/checks/export-llama-cpp-image-config.mts";
 import {
   buildCandidateImageArgv,
+  buildRuntimeLogForbiddenValues,
   buildServerContainerArgv,
   expectedRegistryName,
   expectedRegistryOwner,
@@ -432,13 +433,35 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     }
   });
 
-  it("rejects credentials, host paths, prompts, and responses in bounded runtime logs (#8144)", () => {
-    const forbidden = [
-      "a".repeat(64),
-      MODEL_PATH,
-      "Return one short readiness token.",
-      "LLAMA_CPP_OPENCLAW_TOOL_OK",
-    ];
+  it("rejects every runner-derived credential, model path, prompt, and response in bounded runtime logs (#8144)", () => {
+    const apiKey = "a".repeat(64);
+    const authorization = `Bearer ${apiKey}`;
+    const forbidden = buildRuntimeLogForbiddenValues(
+      plan,
+      parsedInvocation(),
+      apiKey,
+      authorization,
+    );
+    expect(forbidden).toEqual(
+      expect.arrayContaining([
+        `${authorization.slice(0, -1)}0`,
+        MODEL_PATH,
+        `/models/${plan.recipe.model.file.path}`,
+        "This request must be rejected.",
+        "Return one short readiness token.",
+        "Reply with exactly: ready",
+        "Reply with one token.",
+        "Count upward without stopping.",
+        "Report the requested qualification status.",
+        "Use the available tool to get the weather in Seattle.",
+        '{"conditions":"clear","temperature_c":21}',
+        '{"location":"Seattle"}',
+        plan.qualification.agentQualification.prompts.normal,
+        plan.qualification.agentQualification.prompts.tool,
+        plan.qualification.agentQualification.prompts.continuation,
+        plan.qualification.agentQualification.fixture.value,
+      ]),
+    );
     expect(validateRuntimeLogRedaction("server request complete\n", forbidden)).toEqual({
       ok: true,
     });

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -25,6 +25,7 @@ import {
   validateModelsResponse,
   validateOpenClawQualificationImageLabels,
   validateQualificationPlan,
+  validateRuntimeLogRedaction,
   validateStartupLog,
 } from "../scripts/checks/run-llama-cpp-dgx-spark-qualification.mts";
 
@@ -428,6 +429,23 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
       "offloaded 57/57 layers to GPU\noffloaded 58/58 layers to GPU",
     ]) {
       expect(() => validateStartupLog(log)).toThrow();
+    }
+  });
+
+  it("rejects credentials, host paths, prompts, and responses in bounded runtime logs (#8144)", () => {
+    const forbidden = [
+      "a".repeat(64),
+      MODEL_PATH,
+      "Return one short readiness token.",
+      "LLAMA_CPP_OPENCLAW_TOOL_OK",
+    ];
+    expect(validateRuntimeLogRedaction("server request complete\n", forbidden)).toEqual({
+      ok: true,
+    });
+    for (const value of forbidden) {
+      expect(() => validateRuntimeLogRedaction(`server log: ${value}\n`, forbidden)).toThrow(
+        /credential, path, prompt, or response/u,
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

Strengthen the protected DGX Spark llama.cpp qualification lane with deterministic security and observability evidence derived from the declarative image recipe. This adds authenticated metrics validation, disabled-surface checks, exact runtime-property checks, and post-request log-redaction checks without changing onboarding, runtime selection, publication, or support state.

Physical DGX Spark execution and GPU telemetry remain deferred until hardware is available; this PR does not claim either result.

## Related Issue

Advances #8144

## Changes

- declare the qualification probe inventory in `managed-inference/images/llama-cpp/image.yaml`, which remains the authoritative source for runtime and serving values
- validate `/props`, authenticated `/metrics`, disabled HTTP surfaces, and post-request log redaction in the protected qualification runner
- keep receipts bounded and sanitized: only booleans and counts are retained, never tokens, prompts, model host paths, response bodies, or raw logs
- add focused contract, plan, runner, protocol, image, agent, publication-boundary, and workflow tests
- leave physical Spark evidence, GPU telemetry, publication, and support activation out of scope

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This only strengthens the internal protected qualification lane and sanitized receipt. It does not change public commands, onboarding, defaults, user-editable configuration, publication, or support state.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending PR review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This change only strengthens the internal protected DGX Spark llama.cpp qualification plan, probes, sanitized receipt, and tests. It does not change public commands, onboarding, defaults, user configuration, or support status; publication remains disabled.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 74e8038c0 -->
<!-- docs-review-agents-blob-sha: 12ad395bb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this change targets DGX Spark and physical execution is deferred until hardware is available.
- Station profile/scenario: Not applicable.
- Result: Not claimed.
- Supporting evidence: Not claimed.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 9 focused llama.cpp and workflow-support files, 120 tests passed
- [x] Applicable broad gate passed — `npm run build:policy-boundary`, `npm run build:cli`, `npm run typecheck`, `npm run typecheck:cli`, and `npm run checks:repository` passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded DGX Spark qualification checks to validate model properties, context windows, endpoint security, readiness, and disabled capabilities.
  * Added Prometheus metrics verification, including authentication behavior and required metric availability.
  * Added runtime log-redaction checks to prevent credentials, paths, prompts, and response data from appearing in logs.
  * Qualification results now provide detailed evidence for metrics, disabled surfaces, model properties, and log safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
