### PR TITLE
test(inference): prove llama.cpp recovery diagnostics

### DIFF
--- a/src/lib/actions/sandbox/doctor-inference.test.ts
+++ b/src/lib/actions/sandbox/doctor-inference.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { ProviderHealthStatus } from "../../inference/health";
-import { collectInferenceChecks } from "./doctor-inference";
+import { collectInferenceChecks, collectManagedLlamaCppDoctorChecks } from "./doctor-inference";
 
 const endpoint = "https://inference.local/v1/models";
 
@@ -32,6 +32,39 @@ function upstream(overrides: Partial<ProviderHealthStatus> = {}): ProviderHealth
 }
 
 describe("doctor inference checks", () => {
+  it.each([
+    ["running", "ok", false],
+    ["preparing", "warn", true],
+    ["stopped", "warn", true],
+    ["absent", "fail", true],
+    ["conflict", "fail", true],
+    ["unknown", "fail", true],
+  ] as const)("maps managed llama.cpp %s to an actionable %s diagnostic", (state, status, hinted) => {
+    const checks = collectManagedLlamaCppDoctorChecks("spark-agent", 7443, {
+      inspectManagedLlamaCppStatusImpl: vi.fn(() => ({
+        recipeId: "llama-cpp.nemotron.spark.v1",
+        modelDigest: state === "preparing" ? null : `sha256:${"a".repeat(64)}`,
+        imageReference:
+          state === "preparing"
+            ? null
+            : `ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"b".repeat(64)}`,
+        endpoint: "https://inference.local/v1" as const,
+        state,
+        detail: `${state} managed runtime`,
+      })),
+    });
+
+    expect(checks).toHaveLength(2);
+    expect(checks[1]).toMatchObject({
+      label: "Managed llama.cpp runtime",
+      status,
+      detail: `${state}: ${state} managed runtime; endpoint https://inference.local/v1`,
+      ...(hinted
+        ? { hint: "re-run `nemoclaw onboard` for 'spark-agent' to recover the exact runtime" }
+        : {}),
+    });
+  });
+
   it("makes a broken inference.local route authoritative over a healthy upstream (#6192)", async () => {
     const checks = await collectInferenceChecks(
       "alpha",

--- a/src/lib/actions/sandbox/doctor-inference.test.ts
+++ b/src/lib/actions/sandbox/doctor-inference.test.ts
@@ -63,6 +63,11 @@ describe("doctor inference checks", () => {
         ? { hint: "re-run `nemoclaw onboard` for 'spark-agent' to recover the exact runtime" }
         : {}),
     });
+    expect(checks[1]?.hint).toBe(
+      hinted
+        ? "re-run `nemoclaw onboard` for 'spark-agent' to recover the exact runtime"
+        : undefined,
+    );
   });
 
   it("makes a broken inference.local route authoritative over a healthy upstream (#6192)", async () => {

--- a/src/lib/actions/sandbox/doctor-inference.ts
+++ b/src/lib/actions/sandbox/doctor-inference.ts
@@ -18,13 +18,21 @@ export type DoctorInferenceRoute = {
   effectiveReasoningEffort?: EffectiveReasoningEffort | null;
 };
 
+type ManagedLlamaCppDoctorDeps = {
+  inspectManagedLlamaCppStatusImpl?: typeof inspectManagedLlamaCppStatus;
+};
+
 export function collectManagedLlamaCppDoctorChecks(
   sandboxName: string,
   gatewayPort?: number | null,
+  deps: ManagedLlamaCppDoctorDeps = {},
 ): DoctorCheck[] {
-  const managed = inspectManagedLlamaCppStatus(sandboxName, {
-    ...(typeof gatewayPort === "number" ? { gatewayPort } : {}),
-  });
+  const managed = (deps.inspectManagedLlamaCppStatusImpl ?? inspectManagedLlamaCppStatus)(
+    sandboxName,
+    {
+      ...(typeof gatewayPort === "number" ? { gatewayPort } : {}),
+    },
+  );
   if (!managed) return [];
   const runtimeStatus =
     managed.state === "running"

--- a/src/lib/inference/llama-cpp/managed-status.test.ts
+++ b/src/lib/inference/llama-cpp/managed-status.test.ts
@@ -60,7 +60,7 @@ function engine(
   };
 }
 
-function publishState(homeDir: string, runtimeEngine: ContainerEngine): void {
+function reserveState(homeDir: string): void {
   const paths = managedLlamaCppStatePaths(homeDir);
   const catalog = loadManagedInferenceCatalog();
   const preset = catalog.presets.find(
@@ -79,6 +79,11 @@ function publishState(homeDir: string, runtimeEngine: ContainerEngine): void {
     recipeId: RECIPE_ID,
   });
   loadOrCreateManagedLlamaCppApiKey(paths);
+}
+
+function publishState(homeDir: string, runtimeEngine: ContainerEngine): void {
+  reserveState(homeDir);
+  const paths = managedLlamaCppStatePaths(homeDir);
   const engineAuthority = {
     schemaVersion: 1 as const,
     providerId: "docker",
@@ -143,6 +148,83 @@ function publishState(homeDir: string, runtimeEngine: ContainerEngine): void {
 }
 
 describe("managed llama.cpp status", () => {
+  it("reports reserved ownership without a receipt as preparing", () => {
+    const homeDir = temporaryHome();
+    reserveState(homeDir);
+
+    expect(inspectManagedLlamaCppStatus("spark-agent", { homeDir })).toEqual({
+      recipeId: RECIPE_ID,
+      modelDigest: null,
+      imageReference: null,
+      endpoint: "https://inference.local/v1",
+      state: "preparing",
+      detail: "ownership is reserved; no finalized runtime receipt is published",
+    });
+  });
+
+  it("reports the exact receipt-bound container as absent without further inspection", () => {
+    const inspectExact = vi.fn();
+    const probe = vi.fn();
+    const runtimeEngine = engine(
+      vi.fn(() => ({
+        status: 1,
+        stdout: "",
+        stderr: `Error response from daemon: No such container: ${RUNTIME_ID}`,
+      })),
+    );
+    const homeDir = temporaryHome();
+    publishState(homeDir, runtimeEngine);
+
+    expect(
+      inspectManagedLlamaCppStatus("spark-agent", {
+        homeDir,
+        engine: runtimeEngine,
+        inspectExact,
+        probe,
+      }),
+    ).toMatchObject({ state: "absent", detail: "the exact managed container is absent" });
+    expect(inspectExact).not.toHaveBeenCalled();
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("reports an exact stopped runtime without probing readiness", () => {
+    const inspectExact = vi.fn(() => ({ running: false, receipt: {} as never }));
+    const probe = vi.fn();
+    const runtimeEngine = engine(vi.fn(() => ({ status: 0, stdout: "[]", stderr: "" })));
+    const homeDir = temporaryHome();
+    publishState(homeDir, runtimeEngine);
+
+    expect(
+      inspectManagedLlamaCppStatus("spark-agent", {
+        homeDir,
+        engine: runtimeEngine,
+        inspectExact,
+        probe,
+      }),
+    ).toMatchObject({ state: "stopped", detail: "exact managed container is stopped" });
+    expect(inspectExact).toHaveBeenCalledOnce();
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("does not classify a different missing container as the receipt-bound absence", () => {
+    const runtimeEngine = engine(
+      vi.fn(() => ({
+        status: 1,
+        stdout: "",
+        stderr: "Error response from daemon: No such container: foreign-runtime",
+      })),
+    );
+    const homeDir = temporaryHome();
+    publishState(homeDir, runtimeEngine);
+
+    expect(
+      inspectManagedLlamaCppStatus("spark-agent", { homeDir, engine: runtimeEngine }),
+    ).toMatchObject({
+      state: "unknown",
+      detail: "Docker inspection failed",
+    });
+  });
+
   it("reports exact secret-free runtime identity and running state", () => {
     const inspectExact = vi.fn<NonNullable<ManagedLlamaCppStatusOptions["inspectExact"]>>(() => ({
       running: true,

--- a/src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.test-support.ts
+++ b/src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.test-support.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import { LLAMA_CPP_PORT } from "../../inference/llama-cpp/contract";
+import type { LlamaCppHostLocalLaunchContract } from "../../inference/llama-cpp/host-local-runtime";
+
+export const HOST_PORT = String(LLAMA_CPP_PORT);
+export const MODEL_DIGEST = `sha256:${"a".repeat(64)}`;
+export const IMAGE = `ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"c".repeat(64)}`;
+export const PROBE_IMAGE = `quay.io/curl/curl@sha256:${"d".repeat(64)}`;
+export const RUNTIME_ID = "e".repeat(64);
+export const NETWORK_ID = "7".repeat(64);
+export const TRANSACTION_ID = "9".repeat(64);
+export const RECEIPT_TARGET_SHA256 = "8".repeat(64);
+export const MODEL_CONTENT = Buffer.alloc(64, 0x61);
+export const MODEL_FILENAME = "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
+export const REVISION = "f".repeat(40);
+
+function canonical(value: unknown): unknown {
+  return Array.isArray(value)
+    ? value.map(canonical)
+    : value !== null && typeof value === "object"
+      ? Object.fromEntries(
+          Object.entries(value)
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([key, nested]) => [key, canonical(nested)]),
+        )
+      : value;
+}
+
+export function invariant(condition: unknown, message: string): asserts condition {
+  switch (Boolean(condition)) {
+    case false:
+      throw new Error(message);
+  }
+}
+
+export function digest(value: unknown): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(canonical(value)))
+    .digest("hex")}`;
+}
+
+export function rawDigest(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonical(value)))
+    .digest("hex");
+}
+
+export function contract(): LlamaCppHostLocalLaunchContract {
+  return {
+    model: {
+      servedName: "nvidia-nemotron-3-nano-30b-a3b",
+      file: {
+        digest: MODEL_DIGEST,
+        path: MODEL_FILENAME,
+        sizeBytes: MODEL_CONTENT.length,
+      },
+    },
+    policy: {
+      egress: "disabled",
+      modelDownloads: "disabled",
+      modelSource: "verified-local",
+    },
+    runtime: {
+      restartPolicy: "unless-stopped",
+      gpu: {
+        count: 1,
+        cpuFallback: "reject",
+        offload: "full",
+        vendor: "nvidia",
+      },
+      resources: {
+        memoryBytes: 51_539_607_552,
+        pidsLimit: 256,
+        writableStorageBytes: 1024,
+      },
+    },
+    serve: {
+      authentication: "bearer",
+      batchSize: 2048,
+      chatTemplate: "nemotron-v3-embedded",
+      contextSize: 262_144,
+      flashAttention: "enabled",
+      idleSleepSeconds: -1,
+      kvCache: { key: "f16", value: "f16" },
+      limits: { requestTimeoutSeconds: 900 },
+      microBatchSize: 512,
+      port: LLAMA_CPP_PORT,
+      protocol: "openai-completions",
+      slots: 1,
+      speculativeDecoding: "disabled",
+    },
+    surfaces: {
+      agentMode: "disabled",
+      mcpProxy: "disabled",
+      multimodalProjection: "disabled",
+      router: "disabled",
+      serverTools: "disabled",
+      slotInspection: "disabled",
+      ui: "disabled",
+    },
+  };
+}

--- a/src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.test.ts
@@ -11,15 +11,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContainerEngine } from "../../adapters/container-engine";
 import { LLAMA_CPP_PORT } from "../../inference/llama-cpp/contract";
 import type { LlamaCppGgufCachePlan } from "../../inference/llama-cpp/gguf-cache-plan";
-/* Test-only reconstruction of the exact immutable command for recovery fixtures. */
-import {
-  buildLlamaCppHostLocalServerArgv,
-  type LlamaCppHostLocalLaunchContract,
-} from "../../inference/llama-cpp/host-local-runtime";
+import { buildLlamaCppHostLocalServerArgv } from "../../inference/llama-cpp/host-local-runtime";
 import {
   createDockerLlamaCppManagedLifecycle,
   type DockerLlamaCppManagedLifecycleOptions,
 } from "./docker-llama-cpp-managed-lifecycle";
+import {
+  contract,
+  digest,
+  HOST_PORT,
+  IMAGE,
+  invariant,
+  MODEL_CONTENT,
+  MODEL_DIGEST,
+  MODEL_FILENAME,
+  NETWORK_ID,
+  PROBE_IMAGE,
+  RECEIPT_TARGET_SHA256,
+  REVISION,
+  RUNTIME_ID,
+  rawDigest,
+  TRANSACTION_ID,
+} from "./docker-llama-cpp-managed-lifecycle.test-support";
 import type {
   HostLocalCreateJournalExecutionLease,
   HostLocalCreateJournalRecord,
@@ -32,53 +45,11 @@ import {
 } from "./host-local-inference";
 import type { PersistedEngineAuthorityStore } from "./persisted-engine-authority";
 
-const HOST_PORT = String(LLAMA_CPP_PORT);
-const MODEL_DIGEST = `sha256:${"a".repeat(64)}`;
-const IMAGE = `ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"c".repeat(64)}`;
-const PROBE_IMAGE = `quay.io/curl/curl@sha256:${"d".repeat(64)}`;
-const RUNTIME_ID = "e".repeat(64);
-const NETWORK_ID = "7".repeat(64);
-const TRANSACTION_ID = "9".repeat(64);
-const RECEIPT_TARGET_SHA256 = "8".repeat(64);
-const MODEL_CONTENT = Buffer.alloc(64, 0x61);
-const MODEL_FILENAME = "Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf";
-const REVISION = "f".repeat(40);
 let temporaryRoot = "";
 let cacheRoot = "";
 let modelPath = "";
 let apiKeyRoot = "";
 let apiKeyPath = "";
-
-function canonical(value: unknown): unknown {
-  return Array.isArray(value)
-    ? value.map(canonical)
-    : value !== null && typeof value === "object"
-      ? Object.fromEntries(
-          Object.entries(value)
-            .sort(([left], [right]) => left.localeCompare(right))
-            .map(([key, nested]) => [key, canonical(nested)]),
-        )
-      : value;
-}
-
-function invariant(condition: unknown, message: string): asserts condition {
-  switch (Boolean(condition)) {
-    case false:
-      throw new Error(message);
-  }
-}
-
-function digest(value: unknown): string {
-  return `sha256:${createHash("sha256")
-    .update(JSON.stringify(canonical(value)))
-    .digest("hex")}`;
-}
-
-function rawDigest(value: unknown): string {
-  return createHash("sha256")
-    .update(JSON.stringify(canonical(value)))
-    .digest("hex");
-}
 
 function receiptWriter(
   writeExact: (serializedReceipt: string) => string = (serializedReceipt) => serializedReceipt,
@@ -111,62 +82,6 @@ beforeEach(() => {
 });
 
 afterEach(() => fs.rmSync(temporaryRoot, { force: true, recursive: true }));
-
-function contract(): LlamaCppHostLocalLaunchContract {
-  return {
-    model: {
-      servedName: "nvidia-nemotron-3-nano-30b-a3b",
-      file: {
-        digest: MODEL_DIGEST,
-        path: MODEL_FILENAME,
-        sizeBytes: MODEL_CONTENT.length,
-      },
-    },
-    policy: {
-      egress: "disabled",
-      modelDownloads: "disabled",
-      modelSource: "verified-local",
-    },
-    runtime: {
-      restartPolicy: "unless-stopped",
-      gpu: {
-        count: 1,
-        cpuFallback: "reject",
-        offload: "full",
-        vendor: "nvidia",
-      },
-      resources: {
-        memoryBytes: 51_539_607_552,
-        pidsLimit: 256,
-        writableStorageBytes: 1024,
-      },
-    },
-    serve: {
-      authentication: "bearer",
-      batchSize: 2048,
-      chatTemplate: "nemotron-v3-embedded",
-      contextSize: 262_144,
-      flashAttention: "enabled",
-      idleSleepSeconds: -1,
-      kvCache: { key: "f16", value: "f16" },
-      limits: { requestTimeoutSeconds: 900 },
-      microBatchSize: 512,
-      port: 8081,
-      protocol: "openai-completions",
-      slots: 1,
-      speculativeDecoding: "disabled",
-    },
-    surfaces: {
-      agentMode: "disabled",
-      mcpProxy: "disabled",
-      multimodalProjection: "disabled",
-      router: "disabled",
-      serverTools: "disabled",
-      slotInspection: "disabled",
-      ui: "disabled",
-    },
-  };
-}
 
 function plan(): LlamaCppGgufCachePlan {
   const payload = {
@@ -384,7 +299,9 @@ interface DockerFixture {
   readonly onAbsentNetworkInspect: (callback: () => void) => void;
   readonly onNetworkCreate: (callback: () => void) => void;
   readonly onStart: (callback: () => void) => void;
+  readonly onProbe: (callback: () => void) => void;
   readonly onCreate: (callback: () => void) => void;
+  readonly setContainerState: (running: boolean, status: string) => void;
   readonly seedNetwork: (journal: HostLocalCreateJournalRecord) => void;
   readonly seed: (journal: HostLocalCreateJournalRecord, running: boolean) => void;
 }
@@ -418,6 +335,7 @@ function dockerFixture(
   let absentNetworkInspectHook: (() => void) | undefined;
   let networkCreateHook: (() => void) | undefined;
   let startHook: (() => void) | undefined;
+  let probeHook: (() => void) | undefined;
   let createHook: (() => void) | undefined;
   let startedOnce = false;
   let container:
@@ -628,6 +546,7 @@ function dockerFixture(
         return { status: 0, stdout: RUNTIME_ID, stderr: "" };
       case "run":
         invariant(args[1] === "--rm", unexpected);
+        probeHook?.();
         return probeFails
           ? { status: 1, stdout: "", stderr: "not ready" }
           : { status: 0, stdout: "ok", stderr: "" };
@@ -672,7 +591,13 @@ function dockerFixture(
     onAbsentNetworkInspect: (callback) => (absentNetworkInspectHook = callback),
     onNetworkCreate: (callback) => (networkCreateHook = callback),
     onStart: (callback) => (startHook = callback),
+    onProbe: (callback) => (probeHook = callback),
     onCreate: (callback) => (createHook = callback),
+    setContainerState: (running, status) => {
+      invariant(container !== undefined, "cannot change an absent fixture container");
+      container.running = running;
+      container.status = status;
+    },
     seedNetwork: (journal) => {
       invariant(journal.networkId !== null, "seeded network identity is missing");
       networkId = journal.networkId;
@@ -824,6 +749,86 @@ describe("dormant Docker llama.cpp managed lifecycle", () => {
     expect(lifecycle.runtime.prepareDestroy(receipt)).toEqual(receipt);
     expect(lifecycle.runtime.destroy(receipt).status).toBe("removed");
     expect(lifecycle.runtime.destroy(receipt).status).toBe("already-absent");
+  });
+
+  it("resumes an already-running receipt without creating or starting resources (#8144)", () => {
+    const fixture = dockerFixture();
+    const lifecycle = controller(fixture);
+    const receipt = lifecycle.start(receiptWriter());
+    fixture.capture.mockClear();
+
+    expect(lifecycle.resume(receipt)).toEqual(receipt);
+    const calls = fixture.capture.mock.calls.map((call) => call[0]);
+    expect(calls).toContainEqual(expect.arrayContaining(["container", "inspect", RUNTIME_ID]));
+    expect(calls).toContainEqual(expect.arrayContaining(["run", "--rm"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["start"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["create"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["network", "create"]));
+  });
+
+  it("resumes only the receipt-bound stopped runtime and rechecks readiness (#8144)", () => {
+    const fixture = dockerFixture();
+    const lifecycle = controller(fixture);
+    const receipt = lifecycle.start(receiptWriter());
+    lifecycle.runtime.stopManaged(receipt);
+    fixture.capture.mockClear();
+
+    expect(lifecycle.resume(receipt)).toEqual(receipt);
+    const calls = fixture.capture.mock.calls.map((call) => call[0]);
+    expect(calls.filter((args) => args[0] === "start")).toEqual([["start", RUNTIME_ID]]);
+    expect(calls).toContainEqual(expect.arrayContaining(["run", "--rm"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["create"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["network", "create"]));
+  });
+
+  it("rejects a non-resumable exact runtime without lifecycle mutation (#8144)", () => {
+    const fixture = dockerFixture();
+    const lifecycle = controller(fixture);
+    const receipt = lifecycle.start(receiptWriter());
+    fixture.setContainerState(false, "paused");
+    fixture.capture.mockClear();
+
+    expect(() => lifecycle.resume(receipt)).toThrow("inconsistent runtime state");
+    const calls = fixture.capture.mock.calls.map((call) => call[0]);
+    expect(calls).not.toContainEqual(expect.arrayContaining(["start"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["create"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["network", "create"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["run", "--rm"]));
+  });
+
+  it.each([
+    [
+      "model filesystem",
+      (fixture: DockerFixture) => fixture.onProbe(() => fs.appendFileSync(modelPath, "drift")),
+      /filesystem identity/u,
+    ],
+    [
+      "API-key",
+      (fixture: DockerFixture) =>
+        fixture.onProbe(() => fs.writeFileSync(apiKeyPath, "changed-test-only-secret\n")),
+      /API-key/u,
+    ],
+    [
+      "network",
+      (fixture: DockerFixture) => fixture.onProbe(() => fixture.setNetworkId("6".repeat(64))),
+      /network identity/u,
+    ],
+  ] as const)("fails closed on post-readiness %s drift without replacement (#8144)", (_kind, drift, expected) => {
+    const fixture = dockerFixture();
+    const store = journalStore();
+    const lifecycle = controller(fixture, store);
+    const receipt = lifecycle.start(receiptWriter());
+    lifecycle.runtime.stopManaged(receipt);
+    drift(fixture);
+    fixture.capture.mockClear();
+
+    expect(() => lifecycle.resume(receipt)).toThrow(expected);
+    const calls = fixture.capture.mock.calls.map((call) => call[0]);
+    expect(calls.filter((args) => args[0] === "start")).toEqual([["start", RUNTIME_ID]]);
+    expect(calls).toContainEqual(expect.arrayContaining(["run", "--rm"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["create"]));
+    expect(calls).not.toContainEqual(expect.arrayContaining(["network", "create"]));
+    expect(store.load(TRANSACTION_ID)).toMatchObject({ phase: "finalized", runtimeId: RUNTIME_ID });
   });
   it.each([
     ["configured", "8082", undefined, /bound host port/u],

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -21,6 +21,11 @@ function trackedPaths(...pathspecs: readonly string[]): string[] {
 }
 
 const read = (relativePath: string): string => readFileSync(join(repoRoot, relativePath), "utf8");
+const isTestOnlySource = (path: string): boolean =>
+  path.endsWith(".test.ts") ||
+  path.endsWith(".test-support.ts") ||
+  path.includes("/test/") ||
+  path.startsWith("test/");
 
 let productionPaths: string[] = [];
 let bootstrapProtocolPaths: string[] = [];
@@ -61,7 +66,7 @@ beforeAll(() => {
     (path) =>
       (path === "src/lib/onboard.ts" || path.startsWith("src/lib/onboard/")) &&
       path.endsWith(".ts") &&
-      !path.endsWith(".test.ts") &&
+      !isTestOnlySource(path) &&
       !path.startsWith("src/lib/onboard/managed-bootstrap/"),
   );
   providerPaths = activationPaths.filter((path) =>
@@ -192,9 +197,7 @@ describe("runtime provider central source boundary", () => {
       .filter(
         (path) =>
           /\.[cm]?ts$/u.test(path) &&
-          !path.endsWith(".test.ts") &&
-          !path.includes("/test/") &&
-          !path.startsWith("test/") &&
+          !isTestOnlySource(path) &&
           path !== "src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.ts",
       )
       .map(read)


### PR DESCRIPTION
## Summary

Add hardware-independent regression evidence for the existing managed Docker llama.cpp recovery, status, and doctor paths. The tests prove exact receipt-bound resume behavior, post-readiness authority revalidation, fail-closed drift handling, and actionable lifecycle diagnostics without changing runtime behavior, declarative configuration, publication, or support state.

## Related Issue

Advances #8144

## Changes

- prove an already-running receipt creates or starts nothing and a stopped receipt starts only its immutable runtime ID before readiness checks
- prove model filesystem, API-key, and Docker network identity are revalidated after readiness and fail closed without replacement resources or state mutation
- cover preparing, exact absent, exact stopped, foreign-absence, running, conflict, and unknown managed status outcomes
- cover doctor severity and recovery hints for every managed llama.cpp lifecycle state through a behavior-neutral injected inspection dependency
- extract static lifecycle test fixtures into a test-support module so the existing test remains within the repository's 1,500-line budget
- keep established `.test-support.ts` fixtures excluded from production runtime-provider source-shape inventories

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This adds regression evidence and a test dependency seam only. Public commands, output, configuration, lifecycle behavior, publication, and support claims are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending PR review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact head `a17b77dfd` adds hardware-independent regression coverage for existing managed llama.cpp resume, status, and doctor behavior, including proof that a running runtime does not show a recovery hint. It also corrects the source-shape test classifier so `.test-support.ts` fixtures remain excluded from production provider inventories. The only production change is a test dependency seam; public commands, output, configuration, lifecycle behavior, and support claims are unchanged. No documentation files changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a17b77dfd -->
<!-- docs-review-agents-blob-sha: 12ad395bb -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this slice is hardware-independent and does not change DGX Station scripts.
- Station profile/scenario: Not applicable.
- Result: Not claimed.
- Supporting evidence: Not claimed.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 3 focused files, 70 tests passed; reviewer follow-up doctor suite passed 18/18; exact source-shape suite passed 9/9
- [x] Applicable broad gate passed — `npm run build:cli`, `npm run typecheck:cli`, `npm run checks:repository`, and `npm run test-size:check` passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
