### PR TITLE
fix(maintainer): authenticate fork Advisor runs

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
+++ b/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
@@ -1865,40 +1865,6 @@ function currentCheckRollup(
     return { runId: segments[4], jobId: segments[6] };
   };
 
-  const isAuthenticatedAdvisoryPrReviewCheck = (check: StatusCheck): boolean => {
-    const checkName = check.name ?? "";
-    if (
-      check.__typename !== "CheckRun" ||
-      check.workflowName !== PR_REVIEW_ADVISOR_WORKFLOW_NAME ||
-      !ADVISORY_PR_REVIEW_ADVISOR_JOB_NAMES.has(checkName)
-    ) {
-      return false;
-    }
-    const identity = actionRunJobIdentity(check);
-    if (!identity) return false;
-    const run = actionRunMetadata(identity.runId);
-    const job = latestAttemptJobs(identity.runId)?.get(identity.jobId);
-    const checkStatus = check.status?.toUpperCase() ?? null;
-    const checkConclusion = check.conclusion?.toUpperCase() ?? null;
-    return Boolean(
-      run &&
-        job &&
-        run.event === "pull_request_target" &&
-        run.path === PR_REVIEW_ADVISOR_WORKFLOW_PATH &&
-        run.hasPullRequests === true &&
-        run.exactDiff === true &&
-        job.name === checkName &&
-        job.status === checkStatus &&
-        job.conclusion === checkConclusion,
-    );
-  };
-
-  const isTrustedCustomE2eCheck = (check: StatusCheck): boolean =>
-    e2eCoordinationEvidence.trustedCustomCheckId !== undefined &&
-    check.name === "E2E / PR Gate" &&
-    check.detailsUrl?.match(/\/runs\/(\d+)(?:[/?#]|$)/u)?.[1] ===
-      String(e2eCoordinationEvidence.trustedCustomCheckId);
-
   const associationLessHeadBinding = (
     metadata: ActionRunMetadata,
   ): "current" | "other" | "unknown" => {
@@ -1921,6 +1887,45 @@ function currentCheckRollup(
       ? "current"
       : "unknown";
   };
+
+  const isAuthenticatedAdvisoryPrReviewCheck = (check: StatusCheck): boolean => {
+    const checkName = check.name ?? "";
+    if (
+      check.__typename !== "CheckRun" ||
+      check.workflowName !== PR_REVIEW_ADVISOR_WORKFLOW_NAME ||
+      !ADVISORY_PR_REVIEW_ADVISOR_JOB_NAMES.has(checkName)
+    ) {
+      return false;
+    }
+    const identity = actionRunJobIdentity(check);
+    if (!identity) return false;
+    const run = actionRunMetadata(identity.runId);
+    const job = latestAttemptJobs(identity.runId)?.get(identity.jobId);
+    const checkStatus = check.status?.toUpperCase() ?? null;
+    const checkConclusion = check.conclusion?.toUpperCase() ?? null;
+    const currentPrBinding =
+      run?.hasPullRequests === true && run.exactDiff === true
+        ? true
+        : exactDiff.headRepository !== repo &&
+          run !== null &&
+          associationLessHeadBinding(run) === "current";
+    return Boolean(
+      run &&
+        job &&
+        run.event === "pull_request_target" &&
+        run.path === PR_REVIEW_ADVISOR_WORKFLOW_PATH &&
+        currentPrBinding &&
+        job.name === checkName &&
+        job.status === checkStatus &&
+        job.conclusion === checkConclusion,
+    );
+  };
+
+  const isTrustedCustomE2eCheck = (check: StatusCheck): boolean =>
+    e2eCoordinationEvidence.trustedCustomCheckId !== undefined &&
+    check.name === "E2E / PR Gate" &&
+    check.detailsUrl?.match(/\/runs\/(\d+)(?:[/?#]|$)/u)?.[1] ===
+      String(e2eCoordinationEvidence.trustedCustomCheckId);
 
   function runIdentityEvidence(
     runId: string,

--- a/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
+++ b/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
@@ -1908,6 +1908,8 @@ function currentCheckRollup(
         ? true
         : exactDiff.headRepository !== repo &&
           run !== null &&
+          run.status === "COMPLETED" &&
+          run.conclusion !== null &&
           associationLessHeadBinding(run) === "current";
     return Boolean(
       run &&

--- a/test/skills/check-gates-actions-evidence.test.ts
+++ b/test/skills/check-gates-actions-evidence.test.ts
@@ -183,6 +183,8 @@ describe("maintainer merge-gate contributor compliance", () => {
           headBranch: "feature-branch",
           headRepository: forkRepository,
           pullRequests: [],
+          status: "completed",
+          conclusion: "failure",
         }),
       },
     });
@@ -190,6 +192,41 @@ describe("maintainer merge-gate contributor compliance", () => {
     expect(JSON.parse(result.stdout)).toMatchObject({
       allPass: true,
       gates: { ci: { pass: true } },
+    });
+  });
+
+  it.each([
+    {
+      evidence: "the workflow run is in progress",
+      run: { status: "in_progress", conclusion: "failure" },
+    },
+    {
+      evidence: "the completed workflow run has no conclusion",
+      run: { status: "completed", conclusion: null },
+    },
+  ])("keeps an association-less fork Advisor lane merge-relevant when $evidence", ({ run }) => {
+    const runId = 9005;
+    const jobId = 9105;
+    const forkRepository = "contributor/NemoClaw";
+    const result = runGate({
+      body: "Signed-off-by: Example User <user@example.com>",
+      verified: true,
+      headRepository: forkRepository,
+      statusChecks: [...successfulRequiredChecks(), advisorCheck(runId, jobId)],
+      actionRunAttempts: {
+        [String(runId)]: advisorRun(jobId, {
+          headSha: HEAD_SHA,
+          headBranch: "feature-branch",
+          headRepository: forkRepository,
+          pullRequests: [],
+          ...run,
+        }),
+      },
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
     });
   });
 

--- a/test/skills/check-gates-actions-evidence.test.ts
+++ b/test/skills/check-gates-actions-evidence.test.ts
@@ -35,6 +35,9 @@ interface AdvisorRunOptions {
   jobName?: string;
   path?: string;
   event?: string;
+  headSha?: string;
+  headBranch?: string;
+  headRepository?: string;
   pullRequests?: unknown[];
   status?: string;
   conclusion?: string | null;
@@ -162,6 +165,64 @@ describe("maintainer merge-gate contributor compliance", () => {
     expect(JSON.parse(result.stdout)).toMatchObject({
       allPass: true,
       gates: { ci: { pass: true } },
+    });
+  });
+
+  it("keeps a current fork Advisor lane advisory without a REST PR association", () => {
+    const runId = 9003;
+    const jobId = 9103;
+    const forkRepository = "contributor/NemoClaw";
+    const result = runGate({
+      body: "Signed-off-by: Example User <user@example.com>",
+      verified: true,
+      headRepository: forkRepository,
+      statusChecks: [...successfulRequiredChecks(), advisorCheck(runId, jobId)],
+      actionRunAttempts: {
+        [String(runId)]: advisorRun(jobId, {
+          headSha: HEAD_SHA,
+          headBranch: "feature-branch",
+          headRepository: forkRepository,
+          pullRequests: [],
+        }),
+      },
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: true,
+      gates: { ci: { pass: true } },
+    });
+  });
+
+  it.each([
+    { evidence: "the head SHA differs", run: { headSha: BASE_SHA } },
+    { evidence: "the head ref differs", run: { headBranch: "other-branch" } },
+    {
+      evidence: "the head repository differs",
+      run: { headRepository: "attacker/NemoClaw" },
+    },
+  ])("keeps an association-less fork Advisor lane merge-relevant when $evidence", ({ run }) => {
+    const runId = 9004;
+    const jobId = 9104;
+    const forkRepository = "contributor/NemoClaw";
+    const result = runGate({
+      body: "Signed-off-by: Example User <user@example.com>",
+      verified: true,
+      headRepository: forkRepository,
+      statusChecks: [...successfulRequiredChecks(), advisorCheck(runId, jobId)],
+      actionRunAttempts: {
+        [String(runId)]: advisorRun(jobId, {
+          headSha: HEAD_SHA,
+          headBranch: "feature-branch",
+          headRepository: forkRepository,
+          pullRequests: [],
+          ...run,
+        }),
+      },
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      allPass: false,
+      gates: { ci: { pass: false } },
     });
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The maintainer merge gate currently rejects a successful PR Review Advisor run for a fork pull request when GitHub Actions omits the run's pull-request association, even though the run otherwise identifies the current fork branch revision. This change accepts that narrow GitHub payload shape only after validating the current revision, branch, source repository, trusted workflow identity, event, job URL, latest attempt, status, and conclusion.

## Changes

- Permit association-less Advisor evidence only for cross-repository pull requests whose current revision, branch, and source repository all match the workflow run.
- Keep same-repository runs and any mismatched, stale, untrusted, incomplete, or failed evidence blocked.
- Add positive coverage for the current fork payload shape and negative coverage for mismatched revision, branch, source repository, and incomplete workflow-run data.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes internal maintainer evidence authentication and does not change user-facing commands, configuration, or workflows.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [independent review receipt](https://github.com/NVIDIA/NemoClaw/pull/8587#issuecomment-5222467089); all nine categories passed with no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: the change is confined to internal maintainer gate authentication, with no user-facing behavior or documentation contract change.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7a04b67d8 -->
<!-- docs-review-agents-blob-sha: 12ad395bb5 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal commit and push hooks passed
- [x] Targeted tests pass for changed behavior — all 83 maintainer gate tests pass, including hostile and latest-attempt cases
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification: CLI build and type checking pass; whitespace and diff checks pass.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of pull request workflow runs without an associated pull request.
  * Correctly recognizes matching fork runs using commit, branch, and repository details.
  * Prevents runs with mismatched status, conclusion, commit, branch, or repository metadata from being treated as advisory.

* **Tests**
  * Added coverage for matching and mismatching association-less fork workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->