### PR TITLE
fix(e2e): attest protected candidate checkout

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2589,7 +2589,7 @@ jobs:
       E2E_WORKLOAD_SOURCE: "managed-image"
       RELEASE_E2E_ACTIVATION_PATH: ci/protected-managed-image-runtime-activation-v1.json
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
-      NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha }}
+      NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha || github.sha }}
       NEMOCLAW_E2E_SHARD: linux-amd64-gpu
       NEMOCLAW_E2E_TESTED_ROOT: ${{ github.workspace }}/.candidate-runtime
       NEMOCLAW_NON_INTERACTIVE: "1"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2589,7 +2589,9 @@ jobs:
       E2E_WORKLOAD_SOURCE: "managed-image"
       RELEASE_E2E_ACTIVATION_PATH: ci/protected-managed-image-runtime-activation-v1.json
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
+      NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha }}
       NEMOCLAW_E2E_SHARD: linux-amd64-gpu
+      NEMOCLAW_E2E_TESTED_ROOT: ${{ github.workspace }}/.candidate-runtime
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA: ${{ inputs.base_sha || github.event.before || github.sha }}
       NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE: ${{ github.workspace }}/.protected-managed-image-build-cache/linux-amd64

--- a/test/e2e-risk-signal-reporter.test.ts
+++ b/test/e2e-risk-signal-reporter.test.ts
@@ -111,6 +111,22 @@ describe("E2E risk signal reporter", () => {
     expect(() => configuredEnvironment(env, () => "c".repeat(40))).toThrow(/checked-out HEAD/u);
   });
 
+  it("attests an explicit tested root when trusted code runs beside the candidate checkout", () => {
+    const env = {
+      E2E_ARTIFACT_DIR: "/tmp/e2e-risk-signal-test",
+      E2E_TARGET_ID: "managed-image-protected-runtime",
+      GITHUB_WORKSPACE: "/workspace/trusted",
+      NEMOCLAW_E2E_EXPECTED_SHA: EXPECTED_SHA,
+      NEMOCLAW_E2E_CORRELATION_ID: CORRELATION_ID,
+      NEMOCLAW_E2E_SHARD: "linux-amd64-gpu",
+      NEMOCLAW_E2E_TESTED_ROOT: "/workspace/trusted/.candidate-runtime",
+    };
+    const resolveHead = vi.fn(() => EXPECTED_SHA);
+
+    expect(configuredEnvironment(env, resolveHead)?.testedSha).toBe(EXPECTED_SHA);
+    expect(resolveHead).toHaveBeenCalledWith("/workspace/trusted/.candidate-runtime");
+  });
+
   it("writes pass, failure, skip, and pending counts for the tested commit", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-signal-"));
     try {

--- a/test/e2e-risk-signal-reporter.test.ts
+++ b/test/e2e-risk-signal-reporter.test.ts
@@ -127,6 +127,21 @@ describe("E2E risk signal reporter", () => {
     expect(resolveHead).toHaveBeenCalledWith("/workspace/trusted/.candidate-runtime");
   });
 
+  it("rejects a relative tested root before resolving its HEAD", () => {
+    const env = {
+      E2E_ARTIFACT_DIR: "/tmp/e2e-risk-signal-test",
+      E2E_TARGET_ID: "managed-image-protected-runtime",
+      NEMOCLAW_E2E_EXPECTED_SHA: EXPECTED_SHA,
+      NEMOCLAW_E2E_CORRELATION_ID: CORRELATION_ID,
+      NEMOCLAW_E2E_SHARD: "linux-amd64-gpu",
+      NEMOCLAW_E2E_TESTED_ROOT: ".candidate-runtime",
+    };
+    const resolveHead = vi.fn(() => EXPECTED_SHA);
+
+    expect(() => configuredEnvironment(env, resolveHead)).toThrow(/absolute tested root/u);
+    expect(resolveHead).not.toHaveBeenCalled();
+  });
+
   it("writes pass, failure, skip, and pending counts for the tested commit", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-risk-signal-"));
     try {

--- a/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
+++ b/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
@@ -50,6 +50,16 @@ describe("protected managed-image runtime workflow boundary", () => {
     expect(validateManagedImageProtectedRuntimeWorkflow(value)).toEqual([]);
   });
 
+  it("binds protected risk evidence to the isolated exact candidate checkout", () => {
+    const value = workflow();
+    const jobEnv = runtimeJob(value).env as Record<string, unknown>;
+    jobEnv.NEMOCLAW_E2E_TESTED_ROOT = "${{ github.workspace }}";
+
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
+      "managed-image-protected-runtime env must bind NEMOCLAW_E2E_TESTED_ROOT to ${{ github.workspace }}/.candidate-runtime",
+    );
+  });
+
   it("does not record manual PR risk signals on main pushes", () => {
     const value = workflow();
     const jobEnv = multiarchJob(value).env as Record<string, unknown>;

--- a/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
+++ b/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
@@ -60,6 +60,16 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
+  it("binds protected candidate identity on ordinary main runs", () => {
+    const value = workflow();
+    const jobEnv = runtimeJob(value).env as Record<string, unknown>;
+    jobEnv.NEMOCLAW_E2E_EXPECTED_SHA = "${{ inputs.checkout_sha }}";
+
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
+      "managed-image-protected-runtime env must bind NEMOCLAW_E2E_EXPECTED_SHA to ${{ inputs.checkout_sha || github.sha }}",
+    );
+  });
+
   it("does not record manual PR risk signals on main pushes", () => {
     const value = workflow();
     const jobEnv = multiarchJob(value).env as Record<string, unknown>;

--- a/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
+++ b/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
@@ -114,7 +114,7 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     E2E_TARGET_ID: JOB_ID,
     E2E_WORKLOAD_SOURCE: "managed-image",
     RELEASE_E2E_ACTIVATION_PATH: ACTIVATION_PATH,
-    NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha }}",
+    NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha || github.sha }}",
     NEMOCLAW_E2E_SHARD: "linux-amd64-gpu",
     NEMOCLAW_E2E_TESTED_ROOT: "${{ github.workspace }}/.candidate-runtime",
     NEMOCLAW_NON_INTERACTIVE: "1",

--- a/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
+++ b/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
@@ -114,7 +114,9 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     E2E_TARGET_ID: JOB_ID,
     E2E_WORKLOAD_SOURCE: "managed-image",
     RELEASE_E2E_ACTIVATION_PATH: ACTIVATION_PATH,
+    NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha }}",
     NEMOCLAW_E2E_SHARD: "linux-amd64-gpu",
+    NEMOCLAW_E2E_TESTED_ROOT: "${{ github.workspace }}/.candidate-runtime",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_PROTECTED_MANAGED_IMAGE_BASE_SHA:
       "${{ inputs.base_sha || github.event.before || github.sha }}",

--- a/tools/e2e/risk-signal.ts
+++ b/tools/e2e/risk-signal.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync } from "node:child_process";
+import path from "node:path";
 
 export const RISK_SIGNAL_FILE = "risk-signal.json";
 
@@ -73,7 +74,11 @@ export function configuredRiskSignalEnvironment(
   if (!CORRELATION_PATTERN.test(values.correlationId)) {
     throw new Error("risk signal requires a lowercase UUIDv4 correlation id");
   }
-  const testedSha = resolveHead(env.GITHUB_WORKSPACE ?? process.cwd());
+  const testedRoot = env.NEMOCLAW_E2E_TESTED_ROOT ?? env.GITHUB_WORKSPACE ?? process.cwd();
+  if (!path.isAbsolute(testedRoot)) {
+    throw new Error("risk signal requires an absolute tested root");
+  }
+  const testedSha = resolveHead(testedRoot);
   if (!SHA_PATTERN.test(testedSha) || testedSha !== values.expectedSha) {
     throw new Error("risk signal checked-out HEAD does not match the expected SHA");
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Protected managed-image GPU qualification runs trusted workflow code beside an exact candidate checkout, but the risk reporter resolved `HEAD` from the trusted workspace while expecting the candidate SHA. This binds the reporter to the explicit isolated candidate root so protected evidence attests the code actually under test.

## Related Issue

Prerequisite for #8058.

## Changes

- Allow the risk reporter to resolve an explicitly provided absolute tested-root path while retaining the existing workspace fallback for other jobs.
- Bind the protected managed-image GPU job to `${{ github.workspace }}/.candidate-runtime` and the exact candidate SHA.
- Add reporter and workflow-boundary tests proving the trusted workspace cannot be mistaken for the candidate checkout.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This corrects internal protected-E2E evidence identity; it changes no user command, configuration, default, API, or supported runtime behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-approved prerequisite scope for #8058. The change narrows evidence identity to the explicitly checked-out candidate, requires an absolute tested root, retains exact-SHA equality, and adds negative workflow-contract coverage; it does not change credentials, permissions, checkout provenance, or runtime code.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This prerequisite and follow-up change only internal protected E2E commit attestation, relative-root rejection, and their workflow/source contracts. They add no user-facing command, configuration, default, API, or supported behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9c18039dda8c300bb8d3740a4d4cf6d10a371918 -->
<!-- docs-review-agents-blob-sha: c4923a3e367681ea6f796fb595f3b97497d92fa0 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `test/e2e-risk-signal-reporter.test.ts` and `test/e2e/support/managed-image-protected-runtime-workflow.test.ts`: 36/36 passed; `npm run typecheck:cli`, Biome, workflow/config validation, test-conditionals, source-shape, test-size, pre-commit, commit-msg, and pre-push gates passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the five-file change is limited to one protected workflow identity binding and focused executable contract tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end validation to consistently identify the correct tested checkout and commit.
  * Ensured protected runtime evidence is tied to the isolated candidate runtime.
  * Added safeguards for absolute checkout paths and expected commit values.

* **Tests**
  * Added coverage for separated trusted and candidate runtimes.
  * Added boundary tests for runtime-root and checkout-commit configuration.
  * Verified commit selection works with both manual checkout values and the current commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->