### PR TITLE
test(ci): stabilize coverage and image isolation checks

### DIFF
--- a/src/lib/shields/flow.test.ts
+++ b/src/lib/shields/flow.test.ts
@@ -112,7 +112,7 @@ describe("shields command flow", () => {
   });
 
   it("shieldsDown captures policy, unlocks config, saves state, and skips timer on request", {
-    timeout: 15_000,
+    timeout: 30_000,
   }, () => {
     const harness = createHarness();
 

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -49,7 +49,7 @@ fi
 
 # Helper: run a command inside the container as the sandbox user
 run_as_sandbox() {
-  docker run --rm --entrypoint "" "$IMAGE" /usr/bin/setpriv \
+  docker run --rm --user root --entrypoint "" "$IMAGE" /usr/bin/setpriv \
     --reuid=sandbox --regid=sandbox --init-groups -- bash -c "$1" 2>&1
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Stabilize the coverage-heavy Shields test and preserve the gateway-isolation helper after the image default changed to `USER sandbox`. The checks now complete without changing their assertions or product behavior.

## Changes

- Give `shieldsDown captures policy, unlocks config, saves state, and skips timer on request` the same 30-second bound used by coverage-heavy test setup.
- Select root explicitly before the gateway-isolation helper uses `setpriv` for its existing root-to-sandbox transition.
- Preserve every Shields assertion and runtime path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change only adjusts a test timeout. Product behavior and user workflows do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Nine-category self-review of commit `43cb4744c7eab757f5906c51a4d916c81ea25126` found no changed security control. The same assertions and root-to-sandbox identity transition still run; neither test change skips, weakens, or reorders them.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The commit under review changes one Vitest timeout and one E2E test helper invocation. Both changes affect test execution only; no test title, product behavior, user workflow, or documentation surface changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 43cb4744c -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:changed` passed 35 tests for the timeout change; `bash -n test/e2e-gateway-isolation.sh` and `shellcheck test/e2e-gateway-isolation.sh` passed for the helper change. Protected CI runs the complete image test.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for the initial shield-flow test to improve reliability in slower environments.
  * Improved end-to-end gateway isolation test setup while preserving sandbox command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->