### PR TITLE
fix(e2e): restore CLI artifact for security posture

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5168,6 +5168,11 @@ jobs:
         with:
           build-cli: "false"
 
+      - name: Restore exact-commit CLI artifact
+        uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@c246409193a31133cab10c8a3589001cc0d59eb3
+        with:
+          provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
+
       - name: Initialize runner comparison telemetry
         if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && inputs.checkout_sha == '' && matrix.agent == 'hermes' }}
         continue-on-error: true

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -526,7 +526,8 @@ larger runner.
 Each execution writes one bounded, ordered v2 time series to the canonical
 `runner-comparison.jsonl` ledger. It contains:
 
-- an `initialize` endpoint after exact-commit artifact restoration, or after workspace preparation for `security-posture`; the rebuild jobs initialize after their fixed-capacity swap;
+- an `initialize` endpoint after exact-commit artifact restoration; the rebuild
+  jobs initialize after their fixed-capacity swap;
 - a distinct `scenario-start` for every test handled by the execution;
 - a `periodic` sample on an approximately 15-second fixed cadence for
   `rebuild-hermes` and `rebuild-hermes-stale-base`, and an approximately
@@ -581,10 +582,10 @@ following procfs observation and may differ when a live process changes memory.
 
 The finalizer validates the complete ledger before writing
 `runner-comparison-summary.json`. The v2 summary reports the sampled window from
-`initialize` until immediately before artifact scanning or upload. For artifact-using
-jobs, initialization follows artifact restoration and any required rebuild swap. For
-the Hermes `security-posture` shard, initialization follows workspace preparation,
-so the window includes OpenShell installation and installer-backed NemoClaw setup.
+`initialize` until immediately before artifact scanning or upload. Initialization
+follows artifact restoration and any required rebuild swap. For the Hermes
+`security-posture` shard, the window includes OpenShell installation and
+installer-backed NemoClaw setup, but not workspace preparation or artifact restoration.
 The summary reports CPU average and busiest interval; one-minute load;
 available, cached, reclaimable, swap, root-cgroup current/peak/limit, and
 endpoint OOM-counter evidence; memory and I/O pressure; workspace bytes and

--- a/test/e2e/support/cli-artifact-workflow-boundary.test.ts
+++ b/test/e2e/support/cli-artifact-workflow-boundary.test.ts
@@ -714,6 +714,7 @@ describe("exact-commit CLI artifact workflow boundary", () => {
       CONTENT_ADDRESSED_ARTIFACT_NAME,
       UNBOUND_ARTIFACT_NAME,
     );
+    packageStep.run = packageStep.run!.replace("sandbox-name.cjs", "missing-boundary.cjs");
     const uploadStep = requireStep(workflow, "generate-matrix", CLI_ARTIFACT_PUBLISH_STEP);
     uploadStep.uses = "actions/upload-artifact@v7";
 
@@ -722,6 +723,7 @@ describe("exact-commit CLI artifact workflow boundary", () => {
         "generate-matrix must expose exact cli_artifact_provenance provenance",
         "CLI artifact package step must bind candidate and trusted workflow identities explicitly",
         `CLI artifact package step must contain ${CONTENT_ADDRESSED_ARTIFACT_NAME}`,
+        "CLI artifact package step must contain sandbox-name.cjs",
         "CLI artifact upload must use the immutable content-addressed upload contract",
       ]),
     );
@@ -898,6 +900,7 @@ describe("exact-commit CLI artifact workflow boundary", () => {
       const actionPath = path.join(directory, "action.yaml");
       const source = readRepoText(".github/actions/restore-e2e-cli-artifact/action.yaml")
         .replace("tar --no-same-owner --no-same-permissions", "tar")
+        .replace("sandbox-name.cjs", "missing-boundary.cjs")
         .replace('[[ "$actual_payload_sha256" == "$PAYLOAD_SHA256" ]]', '[[ -s "$payload" ]]');
       fs.writeFileSync(actionPath, source);
 
@@ -905,6 +908,7 @@ describe("exact-commit CLI artifact workflow boundary", () => {
         expect.arrayContaining([
           "CLI artifact restore action must match its immutable workflow pin",
           'CLI artifact payload verification must contain tar --no-same-owner --no-same-permissions -xf "$payload" -C "$restore_dir"',
+          "CLI artifact payload verification must contain sandbox-name.cjs",
           'CLI artifact payload verification must contain [[ "$actual_payload_sha256" == "$PAYLOAD_SHA256" ]]',
         ]),
       );
@@ -924,13 +928,14 @@ describe("exact-commit CLI artifact workflow boundary", () => {
     );
   });
 
-  it("excludes installer-backed jobs from the shared CLI artifact", () => {
+  it("requires security posture to restore the shared CLI modules", () => {
     const workflow = workflowFixture();
-    const inheritedRestore = requireStep(workflow, "sandbox-operations", CLI_ARTIFACT_RESTORE_STEP);
-    workflow.jobs["security-posture"].steps!.push(inheritedRestore);
+    workflow.jobs["security-posture"].steps = workflow.jobs["security-posture"].steps!.filter(
+      (step) => step.name !== CLI_ARTIFACT_RESTORE_STEP,
+    );
 
     expect(validateCliArtifactWorkflowBoundary(workflow)).toContain(
-      "security-posture must not consume the shared CLI artifact",
+      "security-posture must verify and restore the exact CLI artifact exactly once",
     );
   });
 });

--- a/test/e2e/support/runner-comparison-workflow-boundary.test.ts
+++ b/test/e2e/support/runner-comparison-workflow-boundary.test.ts
@@ -162,9 +162,7 @@ describe("runner comparison E2E workflow boundary (#7140)", () => {
     ];
     const expectedInitializeError = REBUILD_JOBS.includes(jobId as (typeof REBUILD_JOBS)[number])
       ? `${jobId} must establish rebuild swap before initializing runner comparison telemetry`
-      : jobId === "security-posture"
-        ? `${jobId} must initialize runner comparison telemetry immediately after workspace preparation`
-        : `${jobId} must initialize runner comparison telemetry immediately after CLI artifact restore`;
+      : `${jobId} must initialize runner comparison telemetry immediately after CLI artifact restore`;
     expect(validateRunnerComparisonWorkflow(lateInitialize)).toContain(expectedInitializeError);
 
     const afterPublication = loadWorkflow();

--- a/tools/e2e/cli-artifact-workflow-boundary.mts
+++ b/tools/e2e/cli-artifact-workflow-boundary.mts
@@ -40,7 +40,7 @@ const CLI_ARTIFACT_PROVENANCE_STEP = "Record CLI artifact provenance";
 const CANDIDATE_CHECKOUT_STEP_CONTENT_SHA256 =
   "3578a053cede863f7aa4814d8399b4ca21ea0b77cee712e6d549c684818f11dd";
 const CLI_ARTIFACT_WORKFLOW_CONTRACT_SHA256 =
-  "f46080a39df2db871cfc2638dc3c7b2fa93ee0bb64702e3e405fe52a8e6ba50e";
+  "ba3ab24550161d5d229511a0c679be0a3c6442b1ccd3d998d934ad2ca147e678";
 const CLI_ARTIFACT_CONSUMER_JOB_NAMES = [
   "agent-turn-latency",
   "bedrock-runtime-compatible-anthropic",
@@ -97,6 +97,7 @@ const CLI_ARTIFACT_CONSUMER_JOB_NAMES = [
   "retired-selector-compatibility",
   "sandbox-operations",
   "sandbox-survival",
+  "security-posture",
   "sessions-agents-cli",
   "shared-e2e",
   "skill-agent",
@@ -270,6 +271,7 @@ export function validateCliArtifactRestoreAction(
     'restore_dir="$(mktemp -d',
     'tar --no-same-owner --no-same-permissions -xf "$payload" -C "$restore_dir"',
     '[[ -f "$cli_entrypoint" && ! -L "$cli_entrypoint" && -s "$cli_entrypoint" ]]',
+    "sandbox-name.cjs",
     '[[ -f "$boundary_path" && ! -L "$boundary_path" && -s "$boundary_path" ]]',
 
     ".sourceRevision == $candidateSha",
@@ -332,6 +334,7 @@ function validateProducer(errors: string[], producer: WorkflowRecord): void {
     'git rev-parse --verify HEAD)" == "$CANDIDATE_SHA"',
     "for required_file in dist/nemoclaw.js dist/build-identity.json; do",
     '[[ -f "$required_file" && ! -L "$required_file" && -s "$required_file" ]]',
+    "sandbox-name.cjs",
     '[[ -f "$boundary_path" && ! -L "$boundary_path" && -s "$boundary_path" ]]',
 
     ".sourceRevision == $candidateSha",

--- a/tools/e2e/prepare-e2e-workflow-boundary.mts
+++ b/tools/e2e/prepare-e2e-workflow-boundary.mts
@@ -30,7 +30,6 @@ export const PREPARE_E2E_NO_BUILD_JOBS = new Set([
   "llama-cpp-dgx-spark-qualification",
   "managed-image-multiarch-startup",
   "ollama-auth-proxy",
-  "security-posture",
   "shields-config",
   "snapshot-commands",
   "spark-install",

--- a/tools/e2e/runner-comparison-workflow-boundary.mts
+++ b/tools/e2e/runner-comparison-workflow-boundary.mts
@@ -195,7 +195,6 @@ export function validateRunnerComparisonWorkflow(workflowValue: unknown): string
 
     const prepare = jobSteps.findIndex((step) => step.name === PREPARE_E2E_STEP);
     const restore = jobSteps.findIndex((step) => step.name === CLI_ARTIFACT_RESTORE_STEP);
-    // security-posture installs the CLI after workspace preparation and does not restore the artifact.
     const bootstrapEnd = restore >= 0 ? restore : prepare;
     const initializationBoundary = restore >= 0 ? "CLI artifact restore" : "workspace preparation";
     const initializeIndex = jobSteps.indexOf(initialize);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

The trusted `security-posture` job now restores the exact candidate CLI artifact produced by `generate-matrix` before telemetry, installation, and live testing. This supplies `nemoclaw/dist/shared/sandbox-name.cjs` while retaining the existing receipt, provenance, digest, and security-posture gates.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- Restore the pinned, content-addressed CLI artifact immediately after the no-build `prepare-e2e` step in `security-posture`.
- Register `security-posture` as an exact-artifact consumer and require `sandbox-name.cjs` at both producer and restore contract boundaries.
- Update workflow tests, runner-comparison ordering coverage, and the internal E2E telemetry description.
- Root cause: `prepare-e2e` skipped the CLI build for `security-posture`, while the artifact-consumer registry also excluded that job even though `generate-matrix` packaged the required shared module. The former contract test encoded that exclusion, so it did not catch the missing restore. The failure is visible in [current-main run 31243363889](https://github.com/NVIDIA/NemoClaw/actions/runs/31243363889/job/93077846620).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: No user-facing behavior changes; the internal `test/e2e/README.md` was updated to match the trusted workflow ordering.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent frozen-diff security and correctness review passed for `4c2e1db90`; receipt, provenance, credential scope, failure ordering, and security-posture controls remain intact.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `test/e2e/README.md` to document artifact restoration before telemetry and the resulting `security-posture` measurement window.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4c2e1db90 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Four focused E2E-support files passed 78 tests; the `origin/main` path-scoped selection passed 397 tests across 36 files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security-posture end-to-end workflow reliability by restoring the exact CLI artifact before telemetry and tests run.
  * Ensured required shared CLI components are included during packaging and restoration.
  * Updated workflow validation to enforce consistent artifact and telemetry initialization behavior.

* **Documentation**
  * Clarified artifact restoration and telemetry initialization timing in end-to-end testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->