### PR TITLE
chore(portable): recover known-good Portable baseline

### DIFF
--- a/scripts/security/build-perl-security-packages.sh
+++ b/scripts/security/build-perl-security-packages.sh
@@ -54,6 +54,29 @@ tar -xJf "${source_archive}" -C "${source_dir}" --strip-components=1
     -Dman3dir=none
   make -j"$(nproc)"
   make test_prep
+  readonly extutils_constant_test='../cpan/ExtUtils-Constant/t/Constant.t'
+  readonly -a raw_icmp_tests=(
+    '../dist/Net-Ping/t/001_new.t'
+    '../dist/Net-Ping/t/110_icmp_inst.t'
+    '../dist/Net-Ping/t/500_ping_icmp.t'
+    '../dist/Net-Ping/t/520_icmp_ttl.t'
+  )
+  parallel_test_exclusion='--nre=^[.][.]/cpan/ExtUtils-Constant/t/Constant[.]t$'
+  : >"${build_root}/perl-tests-capability-skipped"
+  # Rootless Podman maps the build user to effective UID 0 inside its user
+  # namespace without granting CAP_NET_RAW. Net::Ping treats UID 0 as proof
+  # that raw ICMP sockets are available, so these four upstream cases attempt
+  # privileged socket creation and fail with EPERM. Probe the actual capability:
+  # full-capability builders still run every test, while rootless builders omit
+  # only the cases that cannot execute in their namespace.
+  if ! env -C t ./perl -MNet::Ping -e 'Net::Ping->new("icmp")' >/dev/null 2>&1; then
+    parallel_test_exclusion='--nre=^(?:[.][.]/cpan/ExtUtils-Constant/t/Constant[.]t|[.][.]/dist/Net-Ping/t/(?:001_new|110_icmp_inst|500_ping_icmp|520_icmp_ttl)[.]t)$'
+    env -C t ./perl harness -dumptests "${raw_icmp_tests[@]}" \
+      >"${build_root}/perl-tests-capability-skipped"
+    printf '%s\n' \
+      'Skipping four Net::Ping raw-ICMP tests because this build namespace lacks CAP_NET_RAW.' \
+      >&2
+  fi
   # ExtUtils::Constant's test recursively invokes make and produced an incomplete
   # TAP plan when it overlapped another test locally, so run it alone first and
   # exclude exactly that already-passed file from the parallel pass.
@@ -63,16 +86,17 @@ tar -xJf "${source_archive}" -C "${source_dir}" --strip-components=1
   env -C t PERL_TEST_HARNESS_ASAP=1 ./perl harness -dumptests \
     >"${build_root}/perl-tests-full"
   env -C t ./perl harness -dumptests \
-    ../cpan/ExtUtils-Constant/t/Constant.t \
+    "${extutils_constant_test}" \
     >"${build_root}/perl-tests-serial"
   env -C t PERL_TEST_HARNESS_ASAP=1 ./perl harness -dumptests \
-    '--nre=^[.][.]/cpan/ExtUtils-Constant/t/Constant[.]t$' \
+    "${parallel_test_exclusion}" \
     >"${build_root}/perl-tests-parallel"
   sort "${build_root}/perl-tests-full" \
     >"${build_root}/perl-tests-full.sorted"
   sort \
     "${build_root}/perl-tests-serial" \
     "${build_root}/perl-tests-parallel" \
+    "${build_root}/perl-tests-capability-skipped" \
     >"${build_root}/perl-tests-combined.sorted"
   cmp \
     "${build_root}/perl-tests-full.sorted" \
@@ -87,11 +111,11 @@ tar -xJf "${source_archive}" -C "${source_dir}" --strip-components=1
   # scheduler use each native runner efficiently instead of serializing every
   # script in QEMU.
   TEST_JOBS=1 \
-    TEST_ARGS='../cpan/ExtUtils-Constant/t/Constant.t' \
+    TEST_ARGS="${extutils_constant_test}" \
     make test_harness
   TEST_JOBS="$(nproc)" \
   PERL_TEST_HARNESS_ASAP=1 \
-  TEST_ARGS='--nre=^[.][.]/cpan/ExtUtils-Constant/t/Constant[.]t$' \
+  TEST_ARGS="${parallel_test_exclusion}" \
     make -j"$(nproc)" test_harness
   make install DESTDIR="${perl_root}"
 )


### PR DESCRIPTION
## Purpose

This draft pins a validation branch to the exact NemoClaw source tree that was installed on the Portable profile before the successful August 6 recording.

- Historical installed source: 1af9bbace024bff84d92a257e69afb30b6d992b6
- Baseline marker: f5e0a00e94f9ba3aeaf63f0a16a061a76bdb1628
- The two commits have the same Git tree.
- OpenShell remains pinned to 0.0.85.
- No remote-inference changes are included yet.

The first step is to validate this unchanged baseline on the existing Portable profile. Only after that succeeds will the narrowly scoped remote-inference changes be applied. OpenShell upgrades and the experimental Podman-storage/lifecycle work are explicitly out of scope.

Signed-off-by: Aaron Erickson <aaronerickson@nvidia.com>