### PR TITLE
ci: remove full E2E PR merge gate

### DIFF
--- a/.github/actions/ci-installer-hash-check/action.yaml
+++ b/.github/actions/ci-installer-hash-check/action.yaml
@@ -17,23 +17,3 @@ runs:
       env:
         NEMOCLAW_INSTALLER_HASH_REPO_ROOT: ${{ inputs.repo-root }}
       run: bash "${{ github.action_path }}/../../../scripts/check-installer-hash.sh"
-
-    - name: Require exact-head OpenShell E2E qualification
-      if: ${{ github.event_name == 'pull_request' }}
-      shell: bash
-      env:
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
-        GITHUB_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-        REPOSITORY: ${{ github.repository }}
-      run: >-
-        node --experimental-strip-types --no-warnings
-        "${{ github.action_path }}/../../../scripts/checks/verify-openshell-e2e-qualification.mts"
-        --repository "$REPOSITORY"
-        --pr-number "$PR_NUMBER"
-        --base-root "${{ github.action_path }}/../../.."
-        --candidate-root "${{ inputs.repo-root }}"
-        --candidate-sha "$CANDIDATE_SHA"
-        --base-sha "$BASE_SHA"
-        --workflow-sha "$BASE_SHA"

--- a/.github/workflows/installer-hash-check.yaml
+++ b/.github/workflows/installer-hash-check.yaml
@@ -29,16 +29,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
-  checks: read
   contents: read
-  pull-requests: read
 
 jobs:
   check-hash:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Set up trusted installer hash parser runtime
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -70,15 +67,9 @@ jobs:
           path: .trusted-installer-hash
           persist-credentials: false
           sparse-checkout: |
-            .github/workflows/e2e.yaml
             .github/actions/ci-installer-hash-check
-            nemoclaw-blueprint/blueprint.yaml
-            scripts/brev-launchable-ci-cpu.sh
             scripts/check-installer-hash.sh
             scripts/checks/extract-installer-pins.mts
-            scripts/checks/verify-openshell-e2e-qualification.mts
-            scripts/install-openshell.sh
-            scripts/scorecard/read-artifact-zip.mts
           sparse-checkout-cone-mode: false
 
       - name: Detect base-trusted installer hash action

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -588,7 +588,7 @@
     },
     {
       "file": "test/openshell-e2e-qualification-workflow.test.ts",
-      "test": "keeps OpenShell E2E qualification inside the trusted composite action",
+      "test": "keeps installer verification independent from full E2E qualification",
       "category": "security"
     },
     {

--- a/test/openshell-e2e-qualification-workflow.test.ts
+++ b/test/openshell-e2e-qualification-workflow.test.ts
@@ -35,9 +35,7 @@ describe("installer hash workflow", () => {
 
     expect(workflow.permissions).toEqual({ contents: "read" });
     const sparseCheckout = baseCheckout.with?.["sparse-checkout"];
-    if (typeof sparseCheckout !== "string") {
-      throw new TypeError("Installer hash sparse checkout must be a string");
-    }
+    assert(typeof sparseCheckout === "string");
     expect(sparseCheckout.trim().split("\n")).toEqual([
       ".github/actions/ci-installer-hash-check",
       "scripts/check-installer-hash.sh",

--- a/test/openshell-e2e-qualification-workflow.test.ts
+++ b/test/openshell-e2e-qualification-workflow.test.ts
@@ -28,15 +28,28 @@ describe("installer hash workflow", () => {
 
   // source-shape-contract: security -- Installer integrity verification must remain independent from unrelated full E2E completion
   it("keeps installer verification independent from full E2E qualification", () => {
+    const checkHashJob = workflow.jobs["check-hash"];
     const baseCheckout = requiredWorkflowStep(
-      workflow.jobs["check-hash"],
+      checkHashJob,
       "Checkout base-trusted installer hash action",
+    );
+    const bootstrapCheckout = requiredWorkflowStep(
+      checkHashJob,
+      "Checkout immutable installer hash bootstrap",
     );
 
     expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(checkHashJob["timeout-minutes"]).toBe(5);
     const sparseCheckout = baseCheckout.with?.["sparse-checkout"];
     assert(typeof sparseCheckout === "string");
     expect(sparseCheckout.trim().split("\n")).toEqual([
+      ".github/actions/ci-installer-hash-check",
+      "scripts/check-installer-hash.sh",
+      "scripts/checks/extract-installer-pins.mts",
+    ]);
+    const bootstrapSparseCheckout = bootstrapCheckout.with?.["sparse-checkout"];
+    assert(typeof bootstrapSparseCheckout === "string");
+    expect(bootstrapSparseCheckout.trim().split("\n")).toEqual([
       ".github/actions/ci-installer-hash-check",
       "scripts/check-installer-hash.sh",
       "scripts/checks/extract-installer-pins.mts",

--- a/test/openshell-e2e-qualification-workflow.test.ts
+++ b/test/openshell-e2e-qualification-workflow.test.ts
@@ -5,93 +5,50 @@ import assert from "node:assert/strict";
 
 import { describe, expect, it } from "vitest";
 
-import {
-  type CompositeAction,
-  readYaml,
-  type WorkflowJob,
-  type WorkflowStep,
-} from "./helpers/e2e-workflow-contract";
+import { type CompositeAction, readYaml, type WorkflowJob } from "./helpers/e2e-workflow-contract";
 
 type InstallerHashWorkflow = {
   permissions?: Record<string, string>;
   jobs: Record<string, WorkflowJob>;
 };
 
-type InstallerHashAction = CompositeAction & {
-  inputs?: Record<string, { required?: boolean }>;
-};
+type InstallerHashAction = CompositeAction & { inputs?: Record<string, { required?: boolean }> };
 
-function requiredActionStep(action: CompositeAction, name: string): WorkflowStep {
-  const step = action.runs.steps.find((candidate) => candidate.name === name);
-  assert(step, `Missing action step: ${name}`);
-  return step;
-}
-
-function requiredWorkflowStep(job: WorkflowJob, name: string): WorkflowStep {
+function requiredWorkflowStep(job: WorkflowJob, name: string) {
   const step = job.steps?.find((candidate) => candidate.name === name);
   assert(step, `Missing workflow step: ${name}`);
   return step;
 }
 
-describe("OpenShell exact-head qualification workflow", () => {
+describe("installer hash workflow", () => {
   const workflow = readYaml<InstallerHashWorkflow>(".github/workflows/installer-hash-check.yaml");
   const action = readYaml<InstallerHashAction>(
     ".github/actions/ci-installer-hash-check/action.yaml",
   );
 
-  // source-shape-contract: security -- OpenShell-sensitive PRs require exact-head live evidence through base-trusted code
-  it("keeps OpenShell E2E qualification inside the trusted composite action", () => {
+  // source-shape-contract: security -- Installer integrity verification must remain independent from unrelated full E2E completion
+  it("keeps installer verification independent from full E2E qualification", () => {
     const baseCheckout = requiredWorkflowStep(
       workflow.jobs["check-hash"],
       "Checkout base-trusted installer hash action",
     );
-    const qualification = requiredActionStep(
-      action,
-      "Require exact-head OpenShell E2E qualification",
-    );
 
-    expect(workflow.permissions).toEqual({
-      actions: "read",
-      checks: "read",
-      contents: "read",
-      "pull-requests": "read",
-    });
-    for (const trustedPath of [
-      ".github/workflows/e2e.yaml",
-      "nemoclaw-blueprint/blueprint.yaml",
-      "scripts/brev-launchable-ci-cpu.sh",
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    const sparseCheckout = baseCheckout.with?.["sparse-checkout"];
+    if (typeof sparseCheckout !== "string") {
+      throw new TypeError("Installer hash sparse checkout must be a string");
+    }
+    expect(sparseCheckout.trim().split("\n")).toEqual([
+      ".github/actions/ci-installer-hash-check",
       "scripts/check-installer-hash.sh",
       "scripts/checks/extract-installer-pins.mts",
-      "scripts/checks/verify-openshell-e2e-qualification.mts",
-      "scripts/install-openshell.sh",
-      "scripts/scorecard/read-artifact-zip.mts",
-    ]) {
-      expect(baseCheckout.with?.["sparse-checkout"], trustedPath).toContain(trustedPath);
-    }
+    ]);
     expect(action.inputs?.["repo-root"]?.required).toBe(true);
-    expect(qualification.if).toBe("${{ github.event_name == 'pull_request' }}");
-    expect(qualification.env).toEqual({
-      BASE_SHA: "${{ github.event.pull_request.base.sha }}",
-      CANDIDATE_SHA: "${{ github.event.pull_request.head.sha }}",
-      GITHUB_TOKEN: "${{ github.token }}",
-      PR_NUMBER: "${{ github.event.pull_request.number }}",
-      REPOSITORY: "${{ github.repository }}",
-    });
-    expect(qualification.run).toContain(
-      '"${{ github.action_path }}/../../../scripts/checks/verify-openshell-e2e-qualification.mts"',
-    );
-    expect(qualification.run).toContain('--base-root "${{ github.action_path }}/../../.."');
-    expect(qualification.run).toContain('--candidate-root "${{ inputs.repo-root }}"');
-    expect(qualification.run).toContain('--candidate-sha "$CANDIDATE_SHA"');
-    expect(qualification.run).toContain('--base-sha "$BASE_SHA"');
-    expect(qualification.run).toContain('--workflow-sha "$BASE_SHA"');
-    expect(qualification.run).not.toContain("$GITHUB_TOKEN");
-    expect(
-      action.runs.steps.findIndex((step) => step.name === "Verify installer hashes are current"),
-    ).toBeLessThan(
-      action.runs.steps.findIndex(
-        (step) => step.name === "Require exact-head OpenShell E2E qualification",
-      ),
+    expect(action.runs.steps.map((step) => step.name)).toEqual([
+      "Verify installer hashes are current",
+    ]);
+    expect(JSON.stringify({ action, workflow })).not.toContain(
+      "verify-openshell-e2e-qualification",
     );
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restores the installer hash check to its installer-integrity scope. Pull requests no longer require the full default E2E matrix to complete before merge; targeted, protected, and release E2E workflows remain available independently.

## Changes

- Remove exact-head full E2E qualification from the base-trusted installer hash composite action.
- Restore the installer hash workflow's read-only permission set, five-minute timeout, and narrow trusted checkout.
- Replace the qualification-enforcement source-shape contract with one that rejects coupling installer verification to full E2E qualification.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal CI merge policy only; no user-facing product behavior or documented command changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed rollback; focused workflow contracts and the full PR validation suite pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The diff changes only internal installer-hash CI policy and its regression contract. No user or contributor documentation describes the removed E2E coupling.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 2ccf84983 -->
<!-- docs-review-agents-blob-sha: c4923a3e -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/openshell-e2e-qualification-workflow.test.ts test/pr-workflow-contract.test.ts test/openshell-e2e-qualification.test.ts --coverage=false` (41 passed); `npm run source-shape:check`; `npm run typecheck:cli`; and Biome check passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Installer hash verification now runs independently from full end-to-end qualification.
  - Workflow access is limited to read-only repository contents.
  - Verification uses only the required trusted files, reducing unnecessary access.

- **Reliability**
  - Installer verification now completes within a five-minute limit.
  - Validation confirms that only the required verification step runs.
  - Security checks more clearly distinguish installer verification from broader end-to-end testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->