### PR TITLE
fix(e2e): revert direct Ollama harness commits

### DIFF
--- a/test/e2e/live/gpu-e2e-helpers.ts
+++ b/test/e2e/live/gpu-e2e-helpers.ts
@@ -204,45 +204,14 @@ export async function cleanupOllama(
   host: HostCliClient,
   artifactName: string,
 ): Promise<ShellProbeResult> {
-  return await host.command("bash", ["-lc", ollamaCleanupScript()], {
-    artifactName,
-    env: env(),
-    timeoutMs: 30_000,
-  });
-}
-
-export function ollamaCleanupScript(): string {
-  return `set -euo pipefail
-sudo_prefix=()
-if [ "$(id -u)" -eq 0 ]; then
-  sudo_prefix=()
-elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-  sudo_prefix=(sudo -n)
-fi
-
-if command -v systemctl >/dev/null 2>&1; then
-  systemctl --user stop ollama.service >/dev/null 2>&1 || true
-  if [ "$(id -u)" -eq 0 ] || [ "\${#sudo_prefix[@]}" -gt 0 ]; then
-    "\${sudo_prefix[@]}" systemctl stop ollama.service >/dev/null 2>&1 || true
-  fi
-fi
-pkill -f '[o]llama-auth-proxy' >/dev/null 2>&1 || true
-pkill -f '[o]llama serve' >/dev/null 2>&1 || true
-if [ "\${#sudo_prefix[@]}" -gt 0 ]; then
-  "\${sudo_prefix[@]}" pkill -f '[o]llama serve' >/dev/null 2>&1 || true
-fi
-
-for _ in $(seq 1 20); do
-  if ! pgrep -f '[o]llama serve' >/dev/null 2>&1 &&
-    ! curl -fsS --connect-timeout 1 --max-time 2 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
-    exit 0
-  fi
-  sleep 1
-done
-
-echo 'Ollama cleanup left a daemon process or listener on 127.0.0.1:11434' >&2
-pgrep -af '[o]llama serve' >&2 || true
-exit 1`;
+  return await host.command(
+    "bash",
+    [
+      "-lc",
+      "systemctl --user stop ollama 2>/dev/null || true; systemctl stop ollama 2>/dev/null || true; pkill -f '[o]llama serve' 2>/dev/null || true; pkill -f '[o]llama-auth-proxy' 2>/dev/null || true",
+    ],
+    { artifactName, env: env(), timeoutMs: 30_000 },
+  );
 }
 
 export function assertNvidiaAvailable(

--- a/test/e2e/live/gpu-e2e-helpers.ts
+++ b/test/e2e/live/gpu-e2e-helpers.ts
@@ -213,34 +213,36 @@ export async function cleanupOllama(
 
 export function ollamaCleanupScript(): string {
   return `set -euo pipefail
+sudo_prefix=()
+if [ "$(id -u)" -eq 0 ]; then
+  sudo_prefix=()
+elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  sudo_prefix=(sudo -n)
+fi
+
 if command -v systemctl >/dev/null 2>&1; then
   systemctl --user stop ollama.service >/dev/null 2>&1 || true
-  if systemctl cat ollama.service >/dev/null 2>&1; then
-    if [ "$(id -u)" -eq 0 ]; then
-      systemctl stop ollama.service
-    elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-      sudo -n systemctl stop ollama.service
-    else
-      echo 'Ollama system service exists but passwordless sudo is unavailable' >&2
-      exit 1
-    fi
+  if [ "$(id -u)" -eq 0 ] || [ "\${#sudo_prefix[@]}" -gt 0 ]; then
+    "\${sudo_prefix[@]}" systemctl stop ollama.service >/dev/null 2>&1 || true
   fi
 fi
 pkill -f '[o]llama-auth-proxy' >/dev/null 2>&1 || true
 pkill -f '[o]llama serve' >/dev/null 2>&1 || true
-if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-  sudo -n pkill -f '[o]llama serve' >/dev/null 2>&1 || true
+if [ "\${#sudo_prefix[@]}" -gt 0 ]; then
+  "\${sudo_prefix[@]}" pkill -f '[o]llama serve' >/dev/null 2>&1 || true
 fi
 
-if pgrep -f '[o]llama serve' >/dev/null 2>&1; then
-  echo 'Ollama cleanup left a daemon process' >&2
-  pgrep -af '[o]llama serve' >&2 || true
-  exit 1
-fi
-if curl -fsS --connect-timeout 1 --max-time 2 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
-  echo 'Ollama cleanup left a listener on 127.0.0.1:11434' >&2
-  exit 1
-fi`;
+for _ in $(seq 1 20); do
+  if ! pgrep -f '[o]llama serve' >/dev/null 2>&1 &&
+    ! curl -fsS --connect-timeout 1 --max-time 2 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+    exit 0
+  fi
+  sleep 1
+done
+
+echo 'Ollama cleanup left a daemon process or listener on 127.0.0.1:11434' >&2
+pgrep -af '[o]llama serve' >&2 || true
+exit 1`;
 }
 
 export function assertNvidiaAvailable(

--- a/test/e2e/live/managed-image-protected-runtime-helpers.ts
+++ b/test/e2e/live/managed-image-protected-runtime-helpers.ts
@@ -126,72 +126,20 @@ async function qualifyEveryAgent(
   }
 }
 
-export function protectedOllamaStartScript(logPath: string): string {
-  if (!path.isAbsolute(logPath) || /[\0\r\n]/u.test(logPath)) {
-    throw new Error(`protected Ollama log path must be absolute: ${JSON.stringify(logPath)}`);
-  }
-  const logPathLiteral = JSON.stringify(logPath);
-  return `set -euo pipefail
-log_path=${logPathLiteral}
-: >"$log_path"
-restart_mode=''
-sudo_prefix=()
-if [ "$(id -u)" -eq 0 ]; then
-  sudo_prefix=()
-elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-  sudo_prefix=(sudo -n)
-fi
-
-if command -v systemctl >/dev/null 2>&1 &&
-  { [ "$(id -u)" -eq 0 ] || [ "\${#sudo_prefix[@]}" -gt 0 ]; } &&
-  "\${sudo_prefix[@]}" systemctl restart ollama.service; then
-  restart_mode=system
-elif command -v systemctl >/dev/null 2>&1 && systemctl --user restart ollama.service; then
-  restart_mode=user
-else
-  nohup setsid -f env OLLAMA_HOST=127.0.0.1:11434 ollama serve >"$log_path" 2>&1
-  restart_mode=manual
-fi
-
-diagnose_ollama() {
-  tail -n 200 "$log_path" >&2 || true
-  if [ "$restart_mode" = system ]; then
-    "\${sudo_prefix[@]}" journalctl -u ollama.service --no-pager -n 200 >&2 || true
-  elif [ "$restart_mode" = user ]; then
-    journalctl --user -u ollama.service --no-pager -n 200 >&2 || true
-  fi
-}
-
-for _ in $(seq 1 120); do
-  if curl -fsS --connect-timeout 2 --max-time 5 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
-    printf 'restart_mode=%s\n' "$restart_mode"
-    exit 0
-  fi
-  if [ "$restart_mode" = system ] &&
-    "\${sudo_prefix[@]}" systemctl is-failed --quiet ollama.service; then
-    echo 'Ollama system service failed before becoming ready' >&2
-    diagnose_ollama
-    exit 1
-  fi
-  sleep 1
-done
-
-echo 'Ollama did not become ready on 127.0.0.1:11434' >&2
-diagnose_ollama
-exit 1`;
-}
-
 async function startProtectedOllama(host: HostCliClient): Promise<string> {
   await ensureOllama(host);
-  const preCleanup = await cleanupOllama(host, "pre-cleanup-managed-image-ollama");
-  expect(preCleanup.exitCode, resultText(preCleanup)).toBe(0);
+  await cleanupOllama(host, "pre-cleanup-managed-image-ollama");
   const start = await host.command(
     "bash",
     [
       "-lc",
-      protectedOllamaStartScript(
-        path.join(process.env.RUNNER_TEMP ?? "/tmp", "managed-image-ollama.log"),
-      ),
+      `set -euo pipefail
+OLLAMA_HOST=127.0.0.1:11434 nohup ollama serve >"${process.env.RUNNER_TEMP ?? "/tmp"}/managed-image-ollama.log" 2>&1 &
+for _ in $(seq 1 120); do
+  curl -fsS --connect-timeout 2 http://127.0.0.1:11434/api/tags >/dev/null 2>&1 && exit 0
+  sleep 1
+done
+exit 1`,
     ],
     {
       artifactName: "start-managed-image-ollama",
@@ -408,8 +356,7 @@ export async function qualifyProtectedManagedImageRuntime(
   });
   cleanup.trackDisposable("stop protected Ollama runtime", async () => {
     killStaleProxy();
-    const result = await cleanupOllama(host, "cleanup-managed-image-ollama");
-    expect(result.exitCode, resultText(result)).toBe(0);
+    await cleanupOllama(host, "cleanup-managed-image-ollama");
   });
 
   let activePhase = "validate protected host runtime";
@@ -437,8 +384,7 @@ export async function qualifyProtectedManagedImageRuntime(
     });
     await proveOllamaGpuPlacement(host);
     killStaleProxy();
-    const ollamaCleanup = await cleanupOllama(host, "stop-ollama-before-vllm");
-    expect(ollamaCleanup.exitCode, resultText(ollamaCleanup)).toBe(0);
+    await cleanupOllama(host, "stop-ollama-before-vllm");
 
     activePhase = "qualify all managed agents with GPU-backed vLLM";
     progress.phase("qualify all managed agents with GPU-backed vLLM");

--- a/test/e2e/live/managed-image-protected-runtime-helpers.ts
+++ b/test/e2e/live/managed-image-protected-runtime-helpers.ts
@@ -183,6 +183,8 @@ exit 1`;
 
 async function startProtectedOllama(host: HostCliClient): Promise<string> {
   await ensureOllama(host);
+  const preCleanup = await cleanupOllama(host, "pre-cleanup-managed-image-ollama");
+  expect(preCleanup.exitCode, resultText(preCleanup)).toBe(0);
   const start = await host.command(
     "bash",
     [

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -12,10 +12,8 @@ import {
   assertAgentExecutionSucceeded,
   env,
   hasExactReadyPhase,
-  ollamaCleanupScript,
   openClawModelConfigProjectionScript,
 } from "../live/gpu-e2e-helpers.ts";
-import { protectedOllamaStartScript } from "../live/managed-image-protected-runtime-helpers.ts";
 
 const GPU_MODEL = "qwen3.5:9b";
 
@@ -118,67 +116,6 @@ const invalidExecutionProofs: Array<{
 ];
 
 describe("GPU E2E helpers", () => {
-  it("stops the privileged Ollama service and proves the listener is gone", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-cleanup-"));
-    try {
-      const bin = path.join(root, "bin");
-      const calls = path.join(root, "calls.log");
-      mkdirSync(bin);
-      for (const [command, body] of [
-        ["sudo", 'printf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
-        ["systemctl", 'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
-        ["pkill", "exit 1\n"],
-        ["pgrep", "exit 1\n"],
-        ["curl", "exit 7\n"],
-      ] as const) {
-        const commandPath = path.join(bin, command);
-        writeFileSync(commandPath, `#!/bin/sh\n${body}`);
-        chmodSync(commandPath, 0o755);
-      }
-
-      execFileSync("bash", ["-c", ollamaCleanupScript()], {
-        env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
-      });
-      const commandLog = readFileSync(calls, "utf8");
-      expect(commandLog).toContain("systemctl --user stop ollama.service");
-      expect(commandLog).toContain("sudo -n systemctl stop ollama.service");
-      expect(commandLog).toContain("sudo -n pkill -f [o]llama serve");
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("restarts the protected Ollama daemon through its installed system service", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-start-"));
-    try {
-      const bin = path.join(root, "bin");
-      const calls = path.join(root, "calls.log");
-      const logPath = path.join(root, "ollama.log");
-      mkdirSync(bin);
-      const sudoPath = path.join(bin, "sudo");
-      writeFileSync(
-        sudoPath,
-        '#!/bin/sh\nprintf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\ncase "$*" in\n  "-n systemctl is-failed --quiet ollama.service") exit 1 ;;\n  *) exit 0 ;;\nesac\n',
-      );
-      chmodSync(sudoPath, 0o755);
-      const curlPath = path.join(bin, "curl");
-      writeFileSync(curlPath, "#!/bin/sh\nexit 0\n");
-      chmodSync(curlPath, 0o755);
-      const systemctlPath = path.join(bin, "systemctl");
-      writeFileSync(systemctlPath, "#!/bin/sh\nexit 0\n");
-      chmodSync(systemctlPath, 0o755);
-
-      const stdout = execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
-        encoding: "utf8",
-        env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
-      });
-      expect(stdout).toBe("restart_mode=system\n");
-      expect(readFileSync(calls, "utf8")).toContain("sudo -n systemctl restart ollama.service");
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
   it("forwards the workflow-owned Ollama model pull timeout", () => {
     expect(env({}, { NEMOCLAW_OLLAMA_PULL_TIMEOUT: "2400" }).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe(
       "2400",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe
before-and-after behavior when it applies. Follow the NemoClaw Writing
Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not
add unrelated prose cleanup. -->

This PR reverts the two remaining direct `main` commits made outside the intended #8058 PR workflow. It restores only the three affected E2E files for review and does not claim that the restored protected E2E harness behavior is correct.

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration,
fallback, migration, or compatibility path, name its current requirement
and consumer, explain why a direct change is insufficient, and identify
the test that protects it. -->

- Revert `ebbbc91c005d07cf2a52cf8673b1e4f795490e3f` (`fix(e2e): require Ollama service cleanup`).
- Revert `5722e63901fa7187f761993e1679ff98dce44e5b` (`fix(e2e): use installed Ollama service in protected run`).
- Restore the affected paths to their exact contents before `5722e63901fa7187f761993e1679ff98dce44e5b`.
- Preserve unrelated commit `37f54757a680a26cc63fc0b2a2c816b15aae57c0` and its complete diff.
- Do not duplicate the existing verified `main` revert `fad771aa3296c8df47994602bb41ec69d9492e12`, which already reverts `11ae5a69d2930b4092ed0e7ec6de3249806599df`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The semantic E2E phase check and the focused GPU E2E helper suite pass for the restored file tree.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This PR restores internal E2E harness and test files without changing a supported user surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed exact source reversion; the affected paths match the pre-`5722e639` contents and add no behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The diff changes only three internal E2E harness and test files. It does not change a supported CLI, API, configuration, default, user workflow, or documentation surface.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 37ce69ccd0 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes.
Maintainers must review the linked evidence before approving or merging.
This is human-reviewed evidence, not authenticated hardware provenance.
Exceptional bypasses use existing repository governance and must be documented in the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later behavior-affecting edits or hook autofixes. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:e2e-phases:check` passed for 122 tests across 79 files; `npx vitest run --project e2e-support test/e2e/support/gpu-e2e-helpers.test.ts` passed 24 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit
must appear as Verified in GitHub. Run: git config user.name && git
config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved GPU end-to-end test setup and teardown reliability.
  * Simplified runtime startup and cleanup behavior to reduce test-environment failures.
  * Removed obsolete coverage for deprecated service-management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->