### PR TITLE
fix(onboard): allow model router cold starts to finish

### DIFF
--- a/src/lib/onboard/model-router.ts
+++ b/src/lib/onboard/model-router.ts
@@ -40,7 +40,9 @@ export {
   type ModelRouterCommandProvisioner,
 } from "./model-router-command";
 
-const ROUTER_HEALTH_RETRIES = 15;
+// The prefill router loads its routing model before it serves /health.
+// Allow that model load to finish while keeping the startup wait bounded.
+const ROUTER_HEALTH_RETRIES = 60;
 const ROUTER_HEALTH_INTERVAL_MS = 2000;
 const MODEL_ROUTER_RELATIVE_DIR = path.join("nemoclaw-blueprint", "router", "llm-router");
 const MODEL_ROUTER_VENV_DIR = path.join(

--- a/test/onboard-model-router.test.ts
+++ b/test/onboard-model-router.test.ts
@@ -379,6 +379,83 @@ describe("onboard Model Router setup", () => {
     );
   });
 
+  it("starts a Model Router whose health check passes after 16 retry intervals", async () => {
+    const pid = 12_345;
+    const sleep = vi.fn(async () => undefined);
+    const terminateProcess = vi.fn();
+    let healthProbe = 0;
+
+    const startedPid = await startModelRouter(
+      { port: 45_679, pool_config_path: "router/test-pool.yaml" },
+      {
+        rootDir: "/test/repo",
+        homeDir: "/test/home",
+        ensureModelRouterCommand: () => "/test/model-router",
+        mkdirSync: () => undefined,
+        runProxyConfig: () => ({ status: 0 }),
+        spawnProxy: () => ({
+          pid,
+          onError: () => undefined,
+          onExit: () => undefined,
+          unref: () => undefined,
+        }),
+        resolveProviderCredential: () => null,
+        buildSubprocessEnv: () => ({}),
+        isRouterHealthy: async () => {
+          healthProbe += 1;
+          return healthProbe > 16;
+        },
+        sleep,
+        isProcessAlive: () => true,
+        terminateProcess,
+        getProviderKey: () => "",
+      },
+    );
+
+    assert.equal(startedPid, pid);
+    assert.equal(healthProbe, 17);
+    assert.equal(sleep.mock.calls.length, 16);
+    assert.equal(terminateProcess.mock.calls.length, 0);
+  });
+
+  it("requests termination for a Model Router that stays unhealthy after 60 retry intervals", async () => {
+    const pid = 12_345;
+    const sleep = vi.fn(async () => undefined);
+    const terminateProcess = vi.fn();
+    const isRouterHealthy = vi.fn(async () => false);
+
+    await assert.rejects(
+      startModelRouter(
+        { port: 45_680, pool_config_path: "router/test-pool.yaml" },
+        {
+          rootDir: "/test/repo",
+          homeDir: "/test/home",
+          ensureModelRouterCommand: () => "/test/model-router",
+          mkdirSync: () => undefined,
+          runProxyConfig: () => ({ status: 0 }),
+          spawnProxy: () => ({
+            pid,
+            onError: () => undefined,
+            onExit: () => undefined,
+            unref: () => undefined,
+          }),
+          resolveProviderCredential: () => null,
+          buildSubprocessEnv: () => ({}),
+          isRouterHealthy,
+          sleep,
+          isProcessAlive: () => true,
+          terminateProcess,
+          getProviderKey: () => "",
+        },
+      ),
+      /failed to become healthy on port 45680 after 60 attempts/,
+    );
+
+    assert.equal(isRouterHealthy.mock.calls.length, 61);
+    assert.equal(sleep.mock.calls.length, 60);
+    assert.deepEqual(terminateProcess.mock.calls, [[pid]]);
+  });
+
   it("writes router state beneath the selected nondefault gateway root", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-router-port-"));
     tempDirs.add(tmpDir);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Model Router startup now allows a longer bounded window for the prefill router to load its routing model before the health gate fails. The change preserves the existing process-liveness and health requirements and adds regression coverage across the former retry boundary.

## Changes
- Increase the bounded Model Router health retry budget from 15 to 60 probes. The upstream prefill router loads its Qwen routing model before it serves `/health`, and a cold load can outlast the former budget while the child process remains alive.
- Add a regression test that becomes healthy only after the former 15-retry limit and confirms startup succeeds without requesting termination.
- Add terminal-path coverage that confirms an unhealthy router still fails after the new bounded limit and requests child termination.
- Current-main evidence: [the first trusted run failed at the 15-attempt limit](https://github.com/NVIDIA/NemoClaw/actions/runs/31267050727/job/93127146573), while [the same trusted SHA and artifact passed on retry](https://github.com/NVIDIA/NemoClaw/actions/runs/31267050727/job/93133708726). This identifies cold-start timing as the escaped condition; the previous tests did not cross the old retry boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the internal bounded health-check retry budget. The owning setup page already states that onboarding waits for the Model Router health endpoint.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent security and correctness review of commit `4f146d391` passed all nine categories with no actionable findings. The retry remains bounded, process-liveness-gated, and fail-closed; credential handling is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `4f146d391` extends only the internal bounded Model Router health-check retry budget. `docs/inference/set-up-model-router.mdx` already documents that onboarding waits for the health endpoint.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4f146d391 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host preparation path changed.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/onboard-model-router.test.ts --coverage=false` passed 15 tests.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Broad runtime and test-harness gates are not triggered by this two-file change. Path-triggered repository checks, source-shape, test-size, test-title, test-project, test-conditional, formatting, and CLI type-check gates passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional path-triggered verification:

- `npm run checks:repository`
- `npm run test-size:check`
- `npm run source-shape:check`
- `npm run test-conditionals:scan -- --root test --min-score 8 --top 5`
- `npm run test:titles:check`
- `npm run test:projects:check`
- `npm run typecheck:cli`
- `npx @biomejs/biome check src/lib/onboard/model-router.ts test/onboard-model-router.test.ts`
- `git diff --check`

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model startup reliability by allowing additional time for health checks to succeed.
  * Preserved bounded failure behavior when the model does not become ready.

* **Tests**
  * Added coverage for delayed successful startup and failure after all retry attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->