### PR TITLE
fix(ci): exclude draft PRs from conflict fixer

### DIFF
--- a/test/pr-merge-conflict-fixer.test.ts
+++ b/test/pr-merge-conflict-fixer.test.ts
@@ -189,6 +189,7 @@ function createResolutionPatch(
 
 function pullRequest(input: {
   baseRef?: string;
+  draft?: boolean;
   headRef?: string;
   headRepository?: string;
   number: number;
@@ -198,6 +199,7 @@ function pullRequest(input: {
   const repository = input.repository ?? "NVIDIA/NemoClaw";
   return {
     base: { ref: input.baseRef ?? "main" },
+    draft: input.draft ?? false,
     head: {
       ref: input.headRef ?? `branch-${input.number}`,
       repo:
@@ -237,16 +239,15 @@ describe("PR merge conflict fixer", () => {
     expect(checkConflict).toHaveBeenCalledTimes(1);
   });
 
-  it("selects draft and non-draft same-repository conflicts without labels (#7542)", () => {
-    const draft = { ...pullRequest({ number: 1 }), draft: true } as PullRequest;
+  it("skips draft same-repository conflicts (#7542)", () => {
     const selected = selectConflictingPullRequests(
-      [draft, pullRequest({ number: 2 })],
+      [pullRequest({ draft: true, number: 1 }), pullRequest({ number: 2 })],
       "NVIDIA/NemoClaw",
       "b".repeat(40),
       { checkConflict: () => ["conflict.txt"] },
     );
 
-    expect(selected.map((item) => item.pr_number)).toEqual([1, 2]);
+    expect(selected.map((item) => item.pr_number)).toEqual([2]);
   });
 
   it("skips GitHub workflow conflicts before model selection (#7542)", () => {
@@ -333,6 +334,7 @@ describe("PR merge conflict fixer", () => {
         ref: "feature",
         repo: { full_name: "NVIDIA/NemoClaw" },
       },
+      draft: false,
       state: "open",
     };
 
@@ -346,6 +348,37 @@ describe("PR merge conflict fixer", () => {
         object: { sha: entry.base_sha },
       }),
     ).not.toThrow();
+  });
+
+  it("rejects publication when the pull request becomes a draft after discovery (#7542)", () => {
+    const entry: ConflictMatrixEntry = {
+      base_sha: "a".repeat(40),
+      conflict_paths: ["conflict.txt"],
+      head_ref: "feature",
+      head_sha: "b".repeat(40),
+      pr_number: 42,
+    };
+    expect(() =>
+      validatePublicationState(
+        entry,
+        "NVIDIA/NemoClaw",
+        {
+          base: {
+            ref: "main",
+            repo: { full_name: "NVIDIA/NemoClaw", node_id: "R_repo" },
+          },
+          head: {
+            ref: "feature",
+            repo: { full_name: "NVIDIA/NemoClaw" },
+          },
+          draft: true,
+          state: "open",
+        },
+        {
+          object: { sha: entry.base_sha },
+        },
+      ),
+    ).toThrow(/draft/u);
   });
 
   it("creates a verified commit from a main-relative tree before the atomic head update (#7542)", async () => {
@@ -377,6 +410,7 @@ describe("PR merge conflict fixer", () => {
           ref: entry.head_ref,
           repo: { full_name: "NVIDIA/NemoClaw" },
         },
+        draft: false,
         state: "open",
       }),
       "/repos/NVIDIA/NemoClaw/git/ref/heads/main": () => ({

--- a/tools/pr-merge-conflict-fixer/discover.mts
+++ b/tools/pr-merge-conflict-fixer/discover.mts
@@ -11,6 +11,7 @@ import { ConflictFixerError, prepareMerge, requireSha } from "./merge.mts";
 
 export type PullRequest = {
   base: { ref: string };
+  draft: boolean;
   head: {
     ref: string;
     repo: { full_name: string } | null;
@@ -61,6 +62,7 @@ export function eligibleSameRepositoryPullRequests(
   return pullRequests.filter(
     (pullRequest) =>
       pullRequest.state === "open" &&
+      !pullRequest.draft &&
       pullRequest.base.ref === "main" &&
       pullRequest.head.repo?.full_name === repository,
   );

--- a/tools/pr-merge-conflict-fixer/publish.mts
+++ b/tools/pr-merge-conflict-fixer/publish.mts
@@ -28,6 +28,7 @@ type LivePullRequest = {
     ref: string;
     repo: { full_name: string } | null;
   };
+  draft: boolean;
   state: string;
 };
 
@@ -58,6 +59,7 @@ export function validatePublicationState(
   mainRef: LiveRef,
 ): void {
   if (pullRequest.state !== "open") throw new ConflictFixerError("The pull request is not open");
+  if (pullRequest.draft) throw new ConflictFixerError("The pull request is a draft");
   if (pullRequest.base.ref !== "main") {
     throw new ConflictFixerError("The pull request no longer targets main");
   }


### PR DESCRIPTION
## Summary

Draft pull requests are no longer eligible for automatic conflict-resolution commits. Publication also rechecks draft state so a pull request that becomes a draft after discovery cannot be updated.

## Changes

- Exclude draft pull requests during conflict-fixer discovery.
- Reject publication when the live pull request is a draft.
- Cover both the normal exclusion and discovery-to-publication race.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This only changes internal conflict-fixer automation.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change only excludes draft pull requests from internal conflict-fixer discovery and revalidates draft state before publication. No public CLI, API, configuration, supported workflow, documentation page, or code sample changed. Changed error text, terminology, test titles, structure, and voice were reviewed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 58c94c2fe -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `vitest run --project integration test/pr-merge-conflict-fixer.test.ts` (13 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Pre-commit and commit-msg hooks passed. The local pre-push TypeScript gate could not resolve generated `dist/` modules in the fresh worktree; the focused suite above passed against the committed head.

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft pull requests are now excluded from conflict-resolution selection.
  * Draft pull requests can no longer have resolution changes published.
  * Pull request publication status is checked before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->