### PR TITLE
fix(e2e): validate direct workload supervisor

### DIFF
--- a/test/e2e/fixtures/security-posture.ts
+++ b/test/e2e/fixtures/security-posture.ts
@@ -364,10 +364,15 @@ function requireExactIds(values: string[], expected: number, label: string): voi
   }
 }
 
-function requireExactSupplementaryGroups(values: string[], expected: number, label: string): void {
-  const exact = String(expected);
-  if (values.length !== 1 || values[0] !== exact) {
-    throw new Error(`${label} expected only ${exact}, got ${values.join(" ")}`);
+function requireExactSupplementaryGroups(
+  values: string[],
+  expected: readonly number[],
+  label: string,
+): void {
+  const exact = expected.map(String).sort();
+  const actual = [...values].sort();
+  if (actual.length !== exact.length || actual.some((value, index) => value !== exact[index])) {
+    throw new Error(`${label} expected exactly ${exact.join(" ")}, got ${values.join(" ")}`);
   }
 }
 
@@ -385,7 +390,7 @@ function canonicalNemoclawStartSupervisorArgv(argv: string[]): boolean {
   );
 }
 
-function validateSupervisor(process: ProcessSecurityIdentity): void {
+function validateSupervisor(process: ProcessSecurityIdentity, sandboxGid: number): void {
   if (process.pid !== 1 || process.ppid !== 0) {
     throw new Error(
       `OpenShell supervisor expected pid=1 ppid=0, got ${process.pid}/${process.ppid}`,
@@ -400,7 +405,11 @@ function validateSupervisor(process: ProcessSecurityIdentity): void {
   }
   requireExactIds(process.status.uid, 0, "OpenShell supervisor Uid");
   requireExactIds(process.status.gid, 0, "OpenShell supervisor Gid");
-  requireExactSupplementaryGroups(process.status.groups, 0, "OpenShell supervisor Groups");
+  requireExactSupplementaryGroups(
+    process.status.groups,
+    [0, sandboxGid],
+    "OpenShell supervisor Groups",
+  );
   for (const field of ["capInh", "capPrm", "capEff", "capBnd", "capAmb"] as const) {
     requireCapabilityHex(process.status[field], `OpenShell supervisor ${field}`);
   }
@@ -422,37 +431,76 @@ function validateSupervisor(process: ProcessSecurityIdentity): void {
   }
 }
 
-function validateNemoclawStartSupervisor(
+function validateNemoclawStartProcess(
   process: ProcessSecurityIdentity,
   sandboxUid: number,
   sandboxGid: number,
 ): void {
-  if (process.pid === 1 || process.ppid !== 1) {
-    throw new Error(
-      `nemoclaw-start child supervisor expected a direct PID 1 child, got pid=${process.pid} ppid=${process.ppid}`,
-    );
+  if (process.pid === 1) {
+    throw new Error("nemoclaw-start process must not replace the OpenShell supervisor at PID 1");
   }
   if (!canonicalNemoclawStartSupervisorArgv(process.argv)) {
-    throw new Error("nemoclaw-start child supervisor does not have the expected argv");
+    throw new Error("nemoclaw-start process does not have the expected argv");
   }
   if (!(SYSTEM_BASH_EXECUTABLES as readonly string[]).includes(process.executable)) {
     throw new Error(
-      `nemoclaw-start child supervisor expected the system Bash executable, got ${process.executable}`,
+      `nemoclaw-start process expected the system Bash executable, got ${process.executable}`,
     );
   }
-  requireExactIds(process.status.uid, sandboxUid, "nemoclaw-start child supervisor Uid");
-  requireExactIds(process.status.gid, sandboxGid, "nemoclaw-start child supervisor Gid");
+  requireExactIds(process.status.uid, sandboxUid, "nemoclaw-start process Uid");
+  requireExactIds(process.status.gid, sandboxGid, "nemoclaw-start process Gid");
   requireExactSupplementaryGroups(
     process.status.groups,
-    sandboxGid,
-    "nemoclaw-start child supervisor Groups",
+    [sandboxGid],
+    "nemoclaw-start process Groups",
   );
-  requireZeroCapabilities(process.status, "nemoclaw-start child supervisor");
+  requireZeroCapabilities(process.status, "nemoclaw-start process");
   if (process.status.noNewPrivs !== "1") {
     throw new Error(
-      `nemoclaw-start child supervisor expected NoNewPrivs=1, got ${process.status.noNewPrivs}`,
+      `nemoclaw-start process expected NoNewPrivs=1, got ${process.status.noNewPrivs}`,
     );
   }
+}
+
+function selectNemoclawStartSupervisor(
+  processes: ProcessSecurityIdentity[],
+): ProcessSecurityIdentity {
+  const byPid = new Map<number, ProcessSecurityIdentity>();
+  for (const process of processes) {
+    if (byPid.has(process.pid)) {
+      throw new Error(`nemoclaw-start process PID ${process.pid} appeared more than once`);
+    }
+    byPid.set(process.pid, process);
+  }
+
+  const direct = processes.filter((process) => process.ppid === 1);
+  if (direct.length !== 1) {
+    throw new Error(
+      `expected exactly one direct nemoclaw-start child supervisor, found ${direct.length}`,
+    );
+  }
+  const supervisor = direct[0]!;
+  for (const process of processes) {
+    if (process === supervisor) continue;
+    const visited = new Set<number>([process.pid]);
+    let current = process;
+    while (current.ppid !== 1) {
+      const parent = byPid.get(current.ppid);
+      if (!parent || visited.has(parent.pid)) {
+        throw new Error(
+          `nemoclaw-start process PID ${process.pid} is not a descendant of the direct child supervisor`,
+        );
+      }
+      visited.add(parent.pid);
+      current = parent;
+    }
+    if (current !== supervisor) {
+      throw new Error(
+        `nemoclaw-start process PID ${process.pid} is not a descendant of the direct child supervisor`,
+      );
+    }
+  }
+  return supervisor;
 }
 
 export function validateSplitProcessSecurityReport(value: unknown): SplitProcessSecurityReport {
@@ -475,13 +523,11 @@ export function validateSplitProcessSecurityReport(value: unknown): SplitProcess
   const childSupervisors = report.childSupervisors.map((entry, index) =>
     processIdentity(entry, `childSupervisors[${index}]`),
   );
-  if (childSupervisors.length !== 1) {
-    throw new Error(
-      `expected exactly one nemoclaw-start child supervisor, found ${childSupervisors.length}`,
-    );
+  validateSupervisor(supervisor, sandboxGid);
+  for (const process of childSupervisors) {
+    validateNemoclawStartProcess(process, sandboxUid, sandboxGid);
   }
-  validateSupervisor(supervisor);
-  validateNemoclawStartSupervisor(childSupervisors[0]!, sandboxUid, sandboxGid);
+  selectNemoclawStartSupervisor(childSupervisors);
   return {
     childSupervisors,
     observedProcEntries,
@@ -759,7 +805,7 @@ tail -n 20 "$log"
     rcFilesLocked: true,
     runtimeProxyEnvLocked: true,
     splitProcess: {
-      childSupervisor: splitProcess.childSupervisors[0]!,
+      childSupervisor: selectNemoclawStartSupervisor(splitProcess.childSupervisors),
       supervisor: splitProcess.supervisor,
     },
     startupLogClean: true,

--- a/test/e2e/support/security-posture.test.ts
+++ b/test/e2e/support/security-posture.test.ts
@@ -14,6 +14,7 @@ import {
   assertSecurityPosture,
   dockerRuntimeEndpointArgs,
   OPENSHELL_SUPERVISOR_CAPABILITY_MASK,
+  type ProcessSecurityIdentity,
   parseOpenShellContainerId,
   parseSplitProcessSecurityReport,
   SPLIT_PROCESS_SECURITY_PROBE,
@@ -43,6 +44,40 @@ function repeatedId(id: number): string[] {
   return Array.from({ length: 4 }, () => String(id));
 }
 
+function validNemoclawStartProcess({
+  pid = 42,
+  ppid = 1,
+  sandboxGid = 1000,
+  sandboxUid = 1000,
+  startTime = "202",
+}: {
+  pid?: number;
+  ppid?: number;
+  sandboxGid?: number;
+  sandboxUid?: number;
+  startTime?: string;
+} = {}): ProcessSecurityIdentity {
+  return {
+    argv: ["/usr/bin/bash", "/usr/local/bin/nemoclaw-start"],
+    executable: "/usr/bin/bash",
+    pid,
+    ppid,
+    state: "S",
+    startTime,
+    status: {
+      capAmb: ZERO_CAPABILITIES,
+      capBnd: ZERO_CAPABILITIES,
+      capEff: ZERO_CAPABILITIES,
+      capInh: ZERO_CAPABILITIES,
+      capPrm: ZERO_CAPABILITIES,
+      gid: repeatedId(sandboxGid),
+      groups: [String(sandboxGid)],
+      noNewPrivs: "1",
+      uid: repeatedId(sandboxUid),
+    },
+  };
+}
+
 function validReport(): SplitProcessSecurityReport {
   return {
     observedProcEntries: 12,
@@ -62,34 +97,25 @@ function validReport(): SplitProcessSecurityReport {
         capInh: ZERO_CAPABILITIES,
         capPrm: OPENSHELL_SUPERVISOR_CAPABILITY_MASK,
         gid: repeatedId(0),
-        groups: ["0"],
+        groups: ["0", "1000"],
         noNewPrivs: "1",
         uid: repeatedId(0),
       },
     },
     version: 1,
-    childSupervisors: [
-      {
-        argv: ["/usr/bin/bash", "/usr/local/bin/nemoclaw-start"],
-        executable: "/usr/bin/bash",
-        pid: 42,
-        ppid: 1,
-        state: "S",
-        startTime: "202",
-        status: {
-          capAmb: ZERO_CAPABILITIES,
-          capBnd: ZERO_CAPABILITIES,
-          capEff: ZERO_CAPABILITIES,
-          capInh: ZERO_CAPABILITIES,
-          capPrm: ZERO_CAPABILITIES,
-          gid: repeatedId(1000),
-          groups: ["1000"],
-          noNewPrivs: "1",
-          uid: repeatedId(1000),
-        },
-      },
-    ],
+    childSupervisors: [validNemoclawStartProcess()],
   };
+}
+
+function reportsWithEachNemoclawStartProcessFirst(): SplitProcessSecurityReport[] {
+  const directFirst = validReport();
+  const descendantFirst = validReport();
+  const direct = descendantFirst.childSupervisors[0]!;
+  descendantFirst.childSupervisors = [
+    validNemoclawStartProcess({ pid: 43, ppid: direct.pid, startTime: "203" }),
+    direct,
+  ];
+  return [directFirst, descendantFirst];
 }
 
 function successfulProbe(stdout = ""): ShellProbeResult {
@@ -191,6 +217,63 @@ describe("security posture fixture", () => {
     expect(parseSplitProcessSecurityReport(JSON.stringify(report))).toEqual(report);
   });
 
+  it("accepts the exact OpenShell supervisor groups in either report order", () => {
+    const report = validReport();
+    report.supervisor.status.groups.reverse();
+
+    expect(validateSplitProcessSecurityReport(report)).toEqual(report);
+  });
+
+  it.each([
+    {
+      agent: "OpenClaw",
+      observedProcEntries: 14,
+      processes: [
+        { pid: 453, ppid: 37, startTime: "58621" },
+        { pid: 463, ppid: 37, startTime: "58622" },
+        { pid: 473, ppid: 37, startTime: "58623" },
+        { pid: 37, ppid: 1, startTime: "58448" },
+      ],
+      sandboxGid: 998,
+    },
+    {
+      agent: "Hermes",
+      observedProcEntries: 16,
+      processes: [
+        { pid: 54_461, ppid: 38, startTime: "52022" },
+        { pid: 38, ppid: 1, startTime: "30812" },
+      ],
+      sandboxGid: 999,
+    },
+  ])("accepts the observed $agent process tree with one direct supervisor and secure descendants", ({
+    observedProcEntries,
+    processes,
+    sandboxGid,
+  }) => {
+    const report = validReport();
+    report.observedProcEntries = observedProcEntries;
+    report.sandboxUid = 998;
+    report.sandboxGid = sandboxGid;
+    report.supervisor.status.groups = ["0", String(sandboxGid)];
+    report.childSupervisors = processes.map(({ pid, ppid, startTime }) =>
+      validNemoclawStartProcess({ pid, ppid, sandboxGid, sandboxUid: 998, startTime }),
+    );
+
+    expect(validateSplitProcessSecurityReport(report)).toEqual(report);
+    expect(parseSplitProcessSecurityReport(JSON.stringify(report))).toEqual(report);
+  });
+
+  it("accepts a nested canonical descendant tree", () => {
+    const report = validReport();
+    report.childSupervisors = [
+      validNemoclawStartProcess({ pid: 44, ppid: 43, startTime: "204" }),
+      report.childSupervisors[0]!,
+      validNemoclawStartProcess({ pid: 43, ppid: 42, startTime: "203" }),
+    ];
+
+    expect(validateSplitProcessSecurityReport(report)).toEqual(report);
+  });
+
   it.each<ReportMutationCase>([
     {
       error: /expected pid=1 ppid=0/u,
@@ -228,11 +311,32 @@ describe("security posture fixture", () => {
       name: "group identity",
     },
     {
-      error: /supervisor Groups expected only 0/u,
+      error: /supervisor Groups expected exactly 0 1000/u,
+      mutate: (report) => {
+        report.supervisor.status.groups = ["0"];
+      },
+      name: "missing sandbox supplementary group",
+    },
+    {
+      error: /supervisor Groups expected exactly 0 1000/u,
       mutate: (report) => {
         report.supervisor.status.groups = ["0", "44"];
       },
-      name: "supplementary groups",
+      name: "wrong sandbox supplementary group",
+    },
+    {
+      error: /supervisor Groups expected exactly 0 1000/u,
+      mutate: (report) => {
+        report.supervisor.status.groups = ["0", "1000", "44"];
+      },
+      name: "extra supplementary group",
+    },
+    {
+      error: /supervisor Groups expected exactly 0 1000/u,
+      mutate: (report) => {
+        report.supervisor.status.groups = ["0", "0"];
+      },
+      name: "duplicate supplementary group",
     },
     {
       error: /supervisor\.state must be one of D, R, S/u,
@@ -291,25 +395,74 @@ describe("security posture fixture", () => {
   });
 
   it.each([
-    [0, /found 0/u],
-    [2, /found 2/u],
-  ])("rejects a census with %i nemoclaw-start child supervisors", (count, error) => {
+    {
+      directCount: 0,
+      mutate: (report: SplitProcessSecurityReport) => {
+        report.childSupervisors[0]!.ppid = 43;
+      },
+    },
+    {
+      directCount: 2,
+      mutate: (report: SplitProcessSecurityReport) => {
+        report.childSupervisors.push(
+          validNemoclawStartProcess({ pid: 43, ppid: 1, startTime: "203" }),
+        );
+      },
+    },
+  ])("rejects a census with $directCount direct nemoclaw-start child supervisors", ({
+    directCount,
+    mutate,
+  }) => {
     const report = validReport();
-    report.childSupervisors = Array.from(
-      { length: count },
-      () => validReport().childSupervisors[0]!,
-    );
+    mutate(report);
 
-    expect(() => validateSplitProcessSecurityReport(report)).toThrow(error);
+    expect(() => validateSplitProcessSecurityReport(report)).toThrow(
+      new RegExp(`found ${directCount}`, "u"),
+    );
+  });
+
+  it.each([
+    "202",
+    "303",
+  ])("rejects a repeated nemoclaw-start PID with reported start time %s", (startTime) => {
+    const report = validReport();
+    const duplicatePid = structuredClone(report.childSupervisors[0]!);
+    duplicatePid.startTime = startTime;
+    report.childSupervisors.push(duplicatePid);
+
+    expect(() => validateSplitProcessSecurityReport(report)).toThrow(
+      /PID 42 appeared more than once/u,
+    );
+  });
+
+  it.each([
+    {
+      name: "missing parent",
+      processes: [validNemoclawStartProcess({ pid: 43, ppid: 99, startTime: "203" })],
+    },
+    {
+      name: "parent cycle",
+      processes: [
+        validNemoclawStartProcess({ pid: 43, ppid: 44, startTime: "203" }),
+        validNemoclawStartProcess({ pid: 44, ppid: 43, startTime: "204" }),
+      ],
+    },
+  ])("rejects a canonical descendant with a $name", ({ processes }) => {
+    const report = validReport();
+    report.childSupervisors.push(...processes);
+
+    expect(() => validateSplitProcessSecurityReport(report)).toThrow(
+      /is not a descendant of the direct child supervisor/u,
+    );
   });
 
   it.each<ReportMutationCase>([
     {
-      error: /direct PID 1 child/u,
+      error: /must not replace the OpenShell supervisor at PID 1/u,
       mutate: (report) => {
-        report.childSupervisors[0]!.ppid = 10;
+        report.childSupervisors[0]!.pid = 1;
       },
-      name: "that is not a direct child of PID 1",
+      name: "at PID 1",
     },
     {
       error: /does not have the expected argv/u,
@@ -344,45 +497,46 @@ describe("security posture fixture", () => {
       name: "with a stopped or traced process state",
     },
     {
-      error: /child supervisor Uid expected 1000/u,
+      error: /nemoclaw-start process Uid expected 1000/u,
       mutate: (report) => {
         report.childSupervisors[0]!.status.uid = repeatedId(0);
       },
       name: "that runs as root",
     },
     {
-      error: /child supervisor Uid expected 1000/u,
+      error: /nemoclaw-start process Uid expected 1000/u,
       mutate: (report) => {
         report.childSupervisors[0]!.status.uid = repeatedId(1001);
       },
       name: "with a different non-root user",
     },
     {
-      error: /child supervisor Gid expected 1000/u,
+      error: /nemoclaw-start process Gid expected 1000/u,
       mutate: (report) => {
         report.childSupervisors[0]!.status.gid = repeatedId(1001);
       },
       name: "with a different non-root group",
     },
     {
-      error: /child supervisor Groups expected only 1000/u,
+      error: /nemoclaw-start process Groups expected exactly 1000/u,
       mutate: (report) => {
         report.childSupervisors[0]!.status.groups = ["0", "1000"];
       },
       name: "with a privileged supplementary group",
     },
     {
-      error: /child supervisor expected NoNewPrivs=1/u,
+      error: /nemoclaw-start process expected NoNewPrivs=1/u,
       mutate: (report) => {
         report.childSupervisors[0]!.status.noNewPrivs = "0";
       },
       name: "without NoNewPrivs",
     },
-  ])("rejects a nemoclaw-start child supervisor $name", ({ error, mutate }) => {
-    const report = validReport();
-    mutate(report);
+  ])("rejects every nemoclaw-start process $name", ({ error, mutate }) => {
+    for (const report of reportsWithEachNemoclawStartProcessFirst()) {
+      mutate(report);
 
-    expect(() => validateSplitProcessSecurityReport(report)).toThrow(error);
+      expect(() => validateSplitProcessSecurityReport(report)).toThrow(error);
+    }
   });
 
   it.each([
@@ -391,13 +545,14 @@ describe("security posture fixture", () => {
     "capEff",
     "capBnd",
     "capAmb",
-  ] as const)("rejects a nemoclaw-start child supervisor with a nonzero %s set", (field) => {
-    const report = validReport();
-    report.childSupervisors[0]!.status[field] = "0000000000000001";
+  ] as const)("rejects every nemoclaw-start process with a nonzero %s set", (field) => {
+    for (const report of reportsWithEachNemoclawStartProcessFirst()) {
+      report.childSupervisors[0]!.status[field] = "0000000000000001";
 
-    expect(() => validateSplitProcessSecurityReport(report)).toThrow(
-      new RegExp(`child supervisor\\.${field} expected 0`, "u"),
-    );
+      expect(() => validateSplitProcessSecurityReport(report)).toThrow(
+        new RegExp(`nemoclaw-start process\\.${field} expected 0`, "u"),
+      );
+    }
   });
 
   it("rejects malformed and overflowing split-process reports", () => {
@@ -475,6 +630,15 @@ describe("security posture fixture", () => {
     vi.stubEnv("DOCKER_TLS_VERIFY", "1");
     vi.stubEnv("DOCKER_CERT_PATH", "/tmp/untrusted-docker-certs");
     const report = validReport();
+    const directChildSupervisor = report.childSupervisors[0]!;
+    report.childSupervisors = [
+      validNemoclawStartProcess({
+        pid: 43,
+        ppid: directChildSupervisor.pid,
+        startTime: "203",
+      }),
+      directChildSupervisor,
+    ];
     const containerRow = `${CONTAINER_ID}\t${CONTAINER_NAME}\t${SANDBOX_ID}\tdefault\n`;
     const command = vi
       .fn<HostCliClient["command"]>()
@@ -519,7 +683,7 @@ describe("security posture fixture", () => {
       rcFilesLocked: true,
       runtimeProxyEnvLocked: true,
       splitProcess: {
-        childSupervisor: report.childSupervisors[0],
+        childSupervisor: directChildSupervisor,
         supervisor: report.supervisor,
       },
       startupLogClean: true,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Security-posture validation now selects the unique direct `nemoclaw-start` child of PID 1 while validating every canonical descendant. The validator also freezes the observed OpenShell supervisor group set, so duplicate, disconnected, privileged, or ambiguous process evidence fails closed. Automatic trusted-main run [31287291324](https://github.com/NVIDIA/NemoClaw/actions/runs/31287291324), OpenClaw job [93178468981](https://github.com/NVIDIA/NemoClaw/actions/runs/31287291324/job/93178468981), reproduced the prior four-record false failure on commit `c3bbad78306030ea650073372c0d9f8f82974a15`.

## Changes
- Validate every canonical `nemoclaw-start` process for the sandbox UID/GID, exact supplementary group, zero capabilities, and `NoNewPrivs=1`.
- Require one direct PID-1 child and a complete canonical ancestry tree; reject duplicate PIDs, missing parents, cycles, and disconnected matches.
- Require the OpenShell supervisor to retain exactly the root and sandbox supplementary groups.
- Add artifact-shaped OpenClaw and Hermes regression tests, including order-independent selection and privilege-drift failures for descendants.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal live-E2E validator and its support tests. It does not change a supported command, configuration, workflow, default, product error, or runtime behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed all categories with no finding.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The final diff changes only `test/e2e/fixtures/security-posture.ts` and `test/e2e/support/security-posture.test.ts`; no supported user-facing or documentation surface changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f6254ea95 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/security-posture.test.ts` passed 60 tests; `npm run test:changed` passed 60 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused two-file E2E validator repair. GitHub CI supplies the aggregate exact-commit evidence.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded security posture validation coverage for supplementary-group membership and process hierarchy rules.
  * Added checks for nested descendants, duplicate process IDs, missing parents, cycles, and invalid direct-child counts.
  * Improved report handling to reliably identify the supervisor regardless of process ordering.
  * Added integration coverage for nested child supervisors and multiple supported process identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->