### PR TITLE
test(sandbox): restore base layer budget guard

### DIFF
--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -457,6 +457,11 @@
       "category": "security"
     },
     {
+      "file": "test/sandbox-base-image-layout.test.ts",
+      "test": "keeps Dockerfile.base within the reviewed final-stage layer budget",
+      "category": "compatibility"
+    },
+    {
       "file": "test/source-architecture.test.ts",
       "test": "keeps removed step mutation APIs out of production source (#7703)",
       "category": "compatibility"

--- a/test/sandbox-base-image-layout.test.ts
+++ b/test/sandbox-base-image-layout.test.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("sandbox base image layout", () => {
+  // source-shape-contract: compatibility -- The exact instruction count preserves the reviewed final-stage layer budget
+  it("keeps Dockerfile.base within the reviewed final-stage layer budget", () => {
+    const dockerfile = readFileSync(new URL("../Dockerfile.base", import.meta.url), "utf8");
+    const stages = dockerfile.split(/(?=^FROM )/gmu).filter((stage) => stage.startsWith("FROM "));
+    const finalStage = stages.at(-1) ?? "";
+    const layerInstructions = finalStage.match(/^(?:ADD|COPY|RUN)\b/gmu) ?? [];
+
+    expect(layerInstructions).toHaveLength(24);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`Dockerfile.base` currently has 24 final-stage `ADD`, `COPY`, and `RUN` instructions. This follow-up restores an exact source-shape contract, so a later count change requires an explicit update to the expected count and reverses only #8632's deletion of this guard. It does not revert #8632's unrelated workflow or validator changes and does not block other repair or qualification work.

## Changes

- Add one integration test that requires exactly 24 final-stage `ADD`, `COPY`, and `RUN` instructions in `Dockerfile.base`.
- Register the compatibility contract in the source-shape budget.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores an internal regression contract. It changes no Dockerfile, runtime, CLI, configuration, workflow, default, security policy, or user-visible behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent correctness and nine-category security review completed for commit `3c5fcba30`; no waiver is used.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `3c5fcba30` adds one internal source-shape test for `Dockerfile.base` and registers it with the source-shape budget. It does not change `Dockerfile.base`, runtime, CLI, configuration, workflow, defaults, security policy, or user-visible behavior. The test title and annotation accurately state the exact final-stage instruction-count contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 3c5fcba30 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/sandbox-base-image-layout.test.ts` passes. A transient 24-to-25 mutation fails with actual count 24. Source-shape, repository, project-registration, test-title, test-size, Biome, diff, and CLI type checks pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run. This change adds one focused integration contract and its required source-shape allowance; targeted and path-triggered checks pass.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure the sandbox base image’s final build stage maintains the expected 24-layer limit.
* **Chores**
  * Recorded the new compatibility exception in the source-shape test budget configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->