### PR TITLE
test(e2e): run runtime overrides as root

### DIFF
--- a/test/e2e/live/runtime-overrides.test.ts
+++ b/test/e2e/live/runtime-overrides.test.ts
@@ -158,6 +158,8 @@ function dockerRunArgs(image: string, env: Record<string, string>, script: strin
   return [
     "run",
     "--rm",
+    "--user",
+    "root",
     ...Object.entries(env).flatMap(([key, value]) => ["-e", `${key}=${value}`]),
     image,
     "bash",
@@ -174,7 +176,12 @@ async function runContainer(
   env: Record<string, string>,
   script: string,
 ): Promise<CommandResult> {
-  const result = await run("docker", dockerRunArgs(image, env, script), label);
+  const args = dockerRunArgs(image, env, script);
+  expect(
+    args.slice(0, 4),
+    "runtime overrides require root to mutate root-owned OpenClaw configuration",
+  ).toEqual(["run", "--rm", "--user", "root"]);
+  const result = await run("docker", args, label);
   dockerLog.push(formatLog(label, result));
   return result;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The direct-Docker runtime-overrides live test now selects the root entrypoint so it can mutate root-owned OpenClaw configuration. Before this change, the stock `sandbox` user caused valid overrides to remain unapplied. This test-only change preserves the stock non-root image default and production fail-closed rejection.

## Changes

- Pass `--user root` through the shared direct-Docker argument builder for every runtime-override case.
- Assert the constructed root-user command prefix immediately before the real Docker execution boundary.
- Preserve every existing valid, invalid, atomicity, configuration-hash, and managed-compaction assertion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This test-topology repair does not change a supported product behavior or public contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: An independent Codex Desktop review of `d849223eb1890f6e14dc6042c41d3a81b5347081` found no correctness, security, release-safety, or required-gate defects across all nine security categories.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Codex Desktop reviewed commit `d849223eb1890f6e14dc6042c41d3a81b5347081` against base `290eb94884eb29bc8aac89685e18525bb1292ed3`. The diff changes only `test/e2e/live/runtime-overrides.test.ts`. It selects the existing root entrypoint and asserts that test topology without changing the Dockerfile, production entrypoint, stock `USER sandbox` default, CLI, configuration contract, workflow gate, or another supported behavior. `docs/security/process-controls.mdx` already documents the stock non-root default and direct-runtime root override.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d849223eb -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/sandbox-images-workflow-boundary.test.ts` passed 42 tests. The exact live test could not complete locally: the image build failed during its locked npm install, and the downloaded exact-main image artifact could not load because the local Docker store had no free space. Normal PR CI is the authoritative post-fix platform evidence.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this one-file live-test topology repair.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation:

- Exact-main pre-fix evidence: run `31287812018`, job `93180501096`, artifact `9030504455`, base `290eb94884eb29bc8aac89685e18525bb1292ed3`.
- `npm run test:e2e-phases:check` — passed for 124 tests across 80 files.
- `npm run source-shape:check` — passed with no new source-shape cases.
- `npm run test:titles:check` — passed.
- `npm run test-size:check` — passed.
- `npm run test:projects:check` — passed.
- `npx biome check test/e2e/live/runtime-overrides.test.ts` — passed.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed.
- `npm run test:changed` — passed; no CLI, plugin, or E2E-support tests were selected for this live-test-only diff.
- GitHub reports commit `d849223eb1890f6e14dc6042c41d3a81b5347081` as `verified=true` with reason `valid`.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved runtime override test reliability by allowing test containers to modify root-owned configuration.
  * Added validation for container execution settings before tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->