### PR TITLE
fix(hermes): support atomic profile migration on macOS

### DIFF
--- a/agents/hermes/seed-dashboard-config.py
+++ b/agents/hermes/seed-dashboard-config.py
@@ -98,19 +98,26 @@ def _rename_no_replace_at(src_fd: int, name: str, dst_fd: int) -> None:
     import ctypes
 
     libc = ctypes.CDLL(None, use_errno=True)
-    renameat2 = getattr(libc, "renameat2", None)
-    if renameat2 is None:
-        raise OSError(errno.ENOSYS, "renameat2 is unavailable")
-    renameat2.argtypes = [
+    if sys.platform == "darwin":
+        rename_no_replace = getattr(libc, "renameatx_np", None)
+        rename_flag = 0x00000004  # RENAME_EXCL from Darwin sys/stdio.h.
+        unavailable_message = "renameatx_np is unavailable"
+    else:
+        rename_no_replace = getattr(libc, "renameat2", None)
+        rename_flag = 1  # RENAME_NOREPLACE from Linux stdio.h.
+        unavailable_message = "renameat2 is unavailable"
+    if rename_no_replace is None:
+        raise OSError(errno.ENOSYS, unavailable_message)
+    rename_no_replace.argtypes = [
         ctypes.c_int,
         ctypes.c_char_p,
         ctypes.c_int,
         ctypes.c_char_p,
         ctypes.c_uint,
     ]
-    renameat2.restype = ctypes.c_int
+    rename_no_replace.restype = ctypes.c_int
     encoded = os.fsencode(name)
-    if renameat2(src_fd, encoded, dst_fd, encoded, 1) != 0:
+    if rename_no_replace(src_fd, encoded, dst_fd, encoded, rename_flag) != 0:
         error_number = ctypes.get_errno()
         raise OSError(error_number, os.strerror(error_number))
 

--- a/test/hermes-dashboard-profile-migration-security.test.ts
+++ b/test/hermes-dashboard-profile-migration-security.test.ts
@@ -52,6 +52,56 @@ describe("Hermes dashboard profile migration security", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("moves between anchored directories without replacing a peer", () => {
+    const sourceDir = path.join(tmpDir, "source");
+    const destinationDir = path.join(tmpDir, "destination");
+    fs.mkdirSync(sourceDir);
+    fs.mkdirSync(destinationDir);
+    fs.writeFileSync(path.join(sourceDir, "state"), "legacy\n");
+
+    const harness = `
+import errno
+import importlib.util
+import os
+import sys
+
+spec = importlib.util.spec_from_file_location("seed_dashboard_config", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+source_fd = module._open_directory_no_follow(sys.argv[2])
+destination_fd = module._open_directory_no_follow(sys.argv[3])
+try:
+    module._rename_no_replace_at(source_fd, "state", destination_fd)
+    source_state_fd = os.open(
+        "state", os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=source_fd
+    )
+    try:
+        os.write(source_state_fd, b"retry\\n")
+    finally:
+        os.close(source_state_fd)
+    try:
+        module._rename_no_replace_at(source_fd, "state", destination_fd)
+    except OSError as exc:
+        if exc.errno != errno.EEXIST:
+            raise
+    else:
+        raise AssertionError("no-clobber rename replaced the destination")
+finally:
+    os.close(destination_fd)
+    os.close(source_fd)
+`;
+    const res = spawnSync("python3", ["-c", harness, SCRIPT_PATH, sourceDir, destinationDir], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 10_000,
+    });
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(fs.readFileSync(path.join(sourceDir, "state"), "utf-8")).toBe("retry\n");
+    expect(fs.readFileSync(path.join(destinationDir, "state"), "utf-8")).toBe("legacy\n");
+  });
+
   it("does not replace a destination recreated before the whole-profile move (#7200)", () => {
     const hermesHome = path.join(tmpDir, ".hermes");
     const legacyHome = path.join(hermesHome, "dashboard-home");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes dashboard-profile migration now uses Darwin's native atomic no-clobber rename instead of failing with `ENOSYS` on macOS. Linux keeps its existing `renameat2(RENAME_NOREPLACE)` behavior, and the migration keeps the security invariants established by #7892.

## Changes

- Select `renameatx_np(RENAME_EXCL)` on Darwin while retaining `renameat2(RENAME_NOREPLACE)` on Linux.
- Keep failures fail-closed when the required native symbol or operation is unavailable. The repair adds no fallback, exists-before-rename sequence, copy/delete path, or overwrite path.
- Add a real-process native-boundary test that moves between validated directory descriptors, requires `EEXIST` on collision, and verifies that both source and destination remain unchanged.
- Preserve the existing behavior tests for legacy migration, profile-path swaps, ambiguous profiles, disjoint merges, collisions, symlinks, and both rollback paths.
- Close the detection gap from #7892: rollback tests could accept an initial unsupported-native-operation failure without directly proving that the platform no-clobber move succeeded.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This repair restores the documented #7892 behavior on macOS. It does not change a command, configuration, path, workflow, default, recovery instruction, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent correctness/security and release reviews passed all nine security categories with no findings on commit `96d7d43d1` against base `6514e72c3`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `96d7d43d1` restores the existing documented Hermes dashboard-profile migration on macOS by selecting Darwin `renameatx_np(RENAME_EXCL)` while retaining Linux `renameat2(RENAME_NOREPLACE)`. It does not change a command, configuration, path, workflow, default, recovery instruction, or supported behavior. The public documentation added with #7892 already describes legacy-state preservation, the canonical `.hermes/profiles/dashboard-home/` path, refusal of unsafe or dual-populated migrations, disjoint restore merging, and incomplete-restore handling. The reviewer checked the complete diff, changed comments, error text, and test title for terminology, claim accuracy, structure, and voice. The macOS SDK confirms `RENAME_EXCL` and `renameatx_np` in `sys/stdio.h`. On Darwin arm64, supported Python 3.12.13 with PyYAML 6.0.3 passed `test/seed-hermes-dashboard-config.test.ts` and `test/hermes-dashboard-profile-migration-security.test.ts`: 44 of 44 tests passed with exit status 0. Source-shape and test-title checks passed, and commit hooks passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 96d7d43d1 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: On Darwin arm64, `npx vitest run --project integration test/seed-hermes-dashboard-config.test.ts test/hermes-dashboard-profile-migration-security.test.ts` used Python 3.12.13 and PyYAML 6.0.3; 2 files and 44 tests passed. `npm run source-shape:check` and `npm run test:titles:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this two-file platform-boundary repair has focused real-process tests and does not change shared test or repository validation behavior.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform file moves to prevent existing destination files from being overwritten.
  * Added clearer errors when the required operating-system rename capability is unavailable.

* **Tests**
  * Added coverage confirming safe retry behavior and preservation of both source and destination files when a move is attempted twice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->