### PR TITLE
fix(skills): enforce issue plan report contract

### DIFF
--- a/.agents/skills/nemoclaw-contributor-plan-issue/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-plan-issue/SKILL.md
@@ -18,7 +18,9 @@ For every successful issue-planning invocation, including the bare trigger `plan
 the final response must use the exact report structure in [Report the plan](#report-the-plan).
 Do not replace its headings with free-form prose, implementation code, "Safety Considerations," or
 "Next Steps." Complete research first, then render the report once. Start the final response with
-`# Issue #<number>: <title>` and include every applicable section through `## GitHub writes`.
+`# Issue #<number>: <title>` and include every defined top-level section through
+`## GitHub writes`. Keep an empty required section and report `none` or `none found`; only the
+acceptance categories may be omitted when they do not apply, with the reason stated.
 
 ## Route the request
 

--- a/.agents/skills/nemoclaw-contributor-plan-issue/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-plan-issue/SKILL.md
@@ -12,6 +12,14 @@ Produce an evidence-based issue plan before implementation starts. Refine the re
 an accepted issue or accepted design decision. Divide delivery into independently valuable capability
 slices. Do not edit source, implement a slice, push a branch, or publish a pull request in this workflow.
 
+## Required response contract
+
+For every successful issue-planning invocation, including the bare trigger `plan issue <issue-url>`,
+the final response must use the exact report structure in [Report the plan](#report-the-plan).
+Do not replace its headings with free-form prose, implementation code, "Safety Considerations," or
+"Next Steps." Complete research first, then render the report once. Start the final response with
+`# Issue #<number>: <title>` and include every applicable section through `## GitHub writes`.
+
 ## Route the request
 
 Use this workflow for an explicit request to plan, refine, scope, divide, or define acceptance for
@@ -108,7 +116,8 @@ implementation or pull request publication.
 
 ## Report the plan
 
-Use this structure:
+Use this structure exactly. Keep the headings unchanged so users and automated checks can identify
+the planning result reliably:
 
 ```markdown
 # Issue #<number>: <title>

--- a/.agents/skills/nemoclaw-contributor-plan-issue/agents/openai.yaml
+++ b/.agents/skills/nemoclaw-contributor-plan-issue/agents/openai.yaml
@@ -4,4 +4,4 @@
 interface:
   display_name: "Plan a NemoClaw Issue"
   short_description: "Refine issues into valuable capability slices"
-  default_prompt: "Use $nemoclaw-contributor-plan-issue to research this issue and propose independently valuable capability slices without implementing or publishing them."
+  default_prompt: "Use $nemoclaw-contributor-plan-issue to research this issue and return its exact required report headings with independently valuable capability slices, without implementing or publishing them."

--- a/.agents/skills/nemoclaw-contributor-plan-issue/evals/evals.json
+++ b/.agents/skills/nemoclaw-contributor-plan-issue/evals/evals.json
@@ -20,6 +20,11 @@
     "expected_behavior": [
       "Uses `nemoclaw-contributor-plan-issue`.",
       "Starts with `# Issue #8378:` and preserves every required level-two report heading through `## GitHub writes`.",
+      "Names the requested outcome, confirmed scope authority, current behavior owner, and assigned implementation owner.",
+      "Provides security-boundary risks, controls, and required negative evidence rather than leaving the section empty.",
+      "Provides Allowed, Denied, Ambiguous, and Failure or recovery acceptance examples with observable results and test evidence, or states why a category does not apply.",
+      "For each capability slice, provides the outcome, acceptance evidence, dependencies and decisions, test plan, and deferred scope.",
+      "Names the first capability slice, later deferrals, and stop conditions in delivery order.",
       "Reports `Not authorized; plan only` under GitHub writes.",
       "Does not emit implementation code, a Safety Considerations substitute, or a Next Steps substitute."
     ]

--- a/.agents/skills/nemoclaw-contributor-plan-issue/evals/evals.json
+++ b/.agents/skills/nemoclaw-contributor-plan-issue/evals/evals.json
@@ -13,6 +13,18 @@
     ]
   },
   {
+    "id": "positive-bare-plan-trigger",
+    "question": "plan issue https://github.com/NVIDIA/NemoClaw/issues/8378",
+    "expected_skill": "nemoclaw-contributor-plan-issue",
+    "ground_truth": "The documented bare trigger loads the planning workflow and returns the exact structured report rather than free-form prose or implementation code.",
+    "expected_behavior": [
+      "Uses `nemoclaw-contributor-plan-issue`.",
+      "Starts with `# Issue #8378:` and preserves every required level-two report heading through `## GitHub writes`.",
+      "Reports `Not authorized; plan only` under GitHub writes.",
+      "Does not emit implementation code, a Safety Considerations substitute, or a Next Steps substitute."
+    ]
+  },
+  {
     "id": "negative-implementation",
     "question": "Implement NVIDIA/NemoClaw issue #8378 and add the tests. Do not spend time writing a plan.",
     "expected_skill": null,

--- a/test/skills-frontmatter.test.ts
+++ b/test/skills-frontmatter.test.ts
@@ -134,6 +134,11 @@ describe("repo skill markdown files", () => {
     expect(skill).toContain("Authorization to plan does not authorize GitHub writes");
     expect(skill).toMatch(/This workflow never authorizes source\s+implementation/u);
     expect(skill).toContain("Current behavior owner");
+    expect(skill).toContain("including the bare trigger `plan issue <issue-url>`");
+    expect(skill).toContain("the final response must use the exact report structure");
+    expect(skill.indexOf("## Required response contract")).toBeLessThan(
+      skill.indexOf("## Route the request"),
+    );
 
     expect(skill).toContain("Assigned implementation owner");
     expect(skill).toContain("First capability slice");
@@ -143,6 +148,7 @@ describe("repo skill markdown files", () => {
 
     expect(evals.map(({ id }) => id)).toEqual([
       "positive-explicit-plan",
+      "positive-bare-plan-trigger",
       "negative-implementation",
       "negative-pr-publication",
       "negative-maintainer-loop",
@@ -153,6 +159,9 @@ describe("repo skill markdown files", () => {
       "adversarial-untrusted-issue-content",
     ]);
     expect(evals.find(({ id }) => id === "positive-explicit-plan")?.expected_skill).toBe(
+      "nemoclaw-contributor-plan-issue",
+    );
+    expect(evals.find(({ id }) => id === "positive-bare-plan-trigger")?.expected_skill).toBe(
       "nemoclaw-contributor-plan-issue",
     );
     expect(evals.find(({ id }) => id === "clean-context-refinement")?.expected_skill).toBe(

--- a/test/skills-frontmatter.test.ts
+++ b/test/skills-frontmatter.test.ts
@@ -136,9 +136,11 @@ describe("repo skill markdown files", () => {
     expect(skill).toContain("Current behavior owner");
     expect(skill).toContain("including the bare trigger `plan issue <issue-url>`");
     expect(skill).toContain("the final response must use the exact report structure");
-    expect(skill.indexOf("## Required response contract")).toBeLessThan(
-      skill.indexOf("## Route the request"),
-    );
+    const responseContractIndex = skill.indexOf("## Required response contract");
+    const routeRequestIndex = skill.indexOf("## Route the request");
+    expect(responseContractIndex).toBeGreaterThanOrEqual(0);
+    expect(routeRequestIndex).toBeGreaterThanOrEqual(0);
+    expect(responseContractIndex).toBeLessThan(routeRequestIndex);
 
     expect(skill).toContain("Assigned implementation owner");
     expect(skill).toContain("First capability slice");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Make the contributor issue-planning skill return its required structured report for the bare `plan issue <url>` trigger. The response contract is now stated before routing, reinforced in the agent prompt, and protected by a dedicated evaluation and repository test.

## Related Issue
Fixes #8549

## Changes
- Add an early, explicit response contract for every successful issue-planning invocation.
- Require the exact report headings instead of free-form substitutes.
- Align the OpenAI agent prompt with the skill contract.
- Add a bare-trigger evaluation and contract assertions.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `.agents/skills/nemoclaw-contributor-plan-issue/SKILL.md` and `.agents/skills/nemoclaw-contributor-plan-issue/agents/openai.yaml`; exact headings, trigger wording, links, and the NemoClaw writing rules were reviewed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 631ee0e22 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/skills-frontmatter.test.ts` (35 passed)
- [x] Applicable broad gate passed — `npm run validate:pr` passed, including markdownlint, skills YAML, repository checks, TypeScript, and commitlint.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>
