### PR TITLE
fix(sandbox): restore reviewed runtime build contexts

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -893,6 +893,43 @@ To silence the warning when the host is intentionally small, set `NEMOCLAW_IGNOR
 
 <AgentOnly variant="openclaw,hermes">
 
+### Managed Sandbox Image Build Requires Local BuildKit
+
+On a local Docker-driver gateway, NemoClaw builds each generated OpenClaw or Hermes sandbox image with host-side BuildKit.
+The generated Dockerfiles include BuildKit-only file-mode, per-step network, and mount controls.
+NemoClaw stops before sandbox creation in these cases:
+
+- The local build is disabled.
+- The staged build context fails trust validation.
+- Docker cannot start the build.
+- The build exits with an error.
+
+It does not send that generated Dockerfile to the OpenShell gateway's classic Docker API builder because that builder cannot enforce the same instructions.
+
+Keep the local prebuild enabled, and verify that the host Docker installation provides BuildKit:
+
+```bash
+unset NEMOCLAW_SANDBOX_PREBUILD
+docker info
+docker buildx version
+```
+
+Repair Docker access or the Docker Buildx plugin when either Docker command fails.
+Then rerun the original onboarding or rebuild command.
+For a resumable onboarding session, run:
+
+```bash
+$$nemoclaw onboard --resume
+```
+
+A passing recovery completes the local BuildKit build before sandbox creation starts.
+If NemoClaw rejects the staged build context trust boundary, do not change its permissions or move its Dockerfile.
+Rerun the command so NemoClaw creates a new private staged context.
+If the new context is also rejected, preserve the complete error and stop instead of forcing the gateway builder.
+
+This requirement does not change user-supplied `--from` contexts, which continue to use the OpenShell gateway builder.
+It also preserves the gateway fallback when a generated LangChain Deep Agents Code image does not complete its local prebuild.
+
 ### Re-onboard fails because port 18789 is held by SSH
 
 After destroying a sandbox and gateway, the SSH port-forward process for the dashboard can be left running.

--- a/src/lib/adapters/fs/regular-file.test.ts
+++ b/src/lib/adapters/fs/regular-file.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { openRegularFileNoFollow } from "./regular-file";
 
@@ -66,6 +66,91 @@ describe("regular file adapter", () => {
       } finally {
         file.close();
       }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("reads bounded bytes without changing their representation", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-regular-file-"));
+    const filePath = path.join(tmp, "runtime.bundle");
+    const expected = Buffer.from([0x00, 0xff, 0x7f, 0x0a]);
+    fs.writeFileSync(filePath, expected);
+
+    try {
+      const file = openRegularFileNoFollow(filePath);
+      try {
+        expect(file.readBytes(expected.length)).toEqual(expected);
+        expect(() => file.readBytes(expected.length - 1)).toThrow(RangeError);
+      } finally {
+        file.close();
+      }
+      expect(fs.readFileSync(filePath)).toEqual(expected);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a hard-linked regular file without changing either link", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-regular-file-"));
+    const filePath = path.join(tmp, "runtime.bundle");
+    const aliasPath = path.join(tmp, "runtime-alias.bundle");
+    const expected = Buffer.from("reviewed runtime\n");
+    fs.writeFileSync(filePath, expected);
+    fs.linkSync(filePath, aliasPath);
+
+    try {
+      expect(() => openRegularFileNoFollow(filePath)).toThrow(/changed during validation/);
+      expect(fs.readFileSync(filePath)).toEqual(expected);
+      expect(fs.readFileSync(aliasPath)).toEqual(expected);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a replaced path when reading bytes from its original descriptor", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-regular-file-"));
+    const filePath = path.join(tmp, "runtime.bundle");
+    const openedPath = path.join(tmp, "opened-runtime.bundle");
+    fs.writeFileSync(filePath, "reviewed\n");
+
+    try {
+      const file = openRegularFileNoFollow(filePath);
+      try {
+        fs.renameSync(filePath, openedPath);
+        fs.writeFileSync(filePath, "replacement\n");
+        expect(() => file.readBytes(64)).toThrow(/changed during validation/);
+      } finally {
+        file.close();
+      }
+      expect(fs.readFileSync(openedPath, "utf8")).toBe("reviewed\n");
+      expect(fs.readFileSync(filePath, "utf8")).toBe("replacement\n");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects descriptor metadata changes during a byte read", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-regular-file-"));
+    const filePath = path.join(tmp, "runtime.bundle");
+    const expected = Buffer.from("reviewed runtime\n");
+    fs.writeFileSync(filePath, expected, { mode: 0o644 });
+    fs.chmodSync(filePath, 0o644);
+
+    try {
+      const file = openRegularFileNoFollow(filePath);
+      const originalReadSync = fs.readSync.bind(fs);
+      const readSpy = vi.spyOn(fs, "readSync").mockImplementation(((...args: unknown[]) => {
+        fs.chmodSync(filePath, 0o600);
+        return Reflect.apply(originalReadSync, fs, args);
+      }) as typeof fs.readSync);
+      try {
+        expect(() => file.readBytes(expected.length)).toThrow(/changed while reading/);
+      } finally {
+        readSpy.mockRestore();
+        file.close();
+      }
+      expect(fs.readFileSync(filePath)).toEqual(expected);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/lib/adapters/fs/regular-file.ts
+++ b/src/lib/adapters/fs/regular-file.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 
 export interface OpenRegularFile {
   close(): void;
+  readBytes(maxBytes: number): Buffer;
   readUtf8(maxBytes?: number): string;
   replaceUtf8(contents: string, mode: number): void;
 }
@@ -33,7 +34,7 @@ export function openRegularFileNoFollow(
     closed = true;
     fs.closeSync(descriptor);
   };
-  const assertPathIdentity = () => {
+  const assertPathIdentity = (): fs.Stats => {
     const descriptorStats = fs.fstatSync(descriptor);
     const pathStats = fs.lstatSync(target);
     if (
@@ -47,6 +48,7 @@ export function openRegularFileNoFollow(
     ) {
       throw new Error(`regular file changed during validation: ${target}`);
     }
+    return descriptorStats;
   };
   try {
     const descriptorStats = fs.fstatSync(descriptor);
@@ -61,8 +63,38 @@ export function openRegularFileNoFollow(
     close();
     throw error;
   }
+  const readBytes = (maxBytes: number): Buffer => {
+    if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+      throw new RangeError(`regular file read limit must be a non-negative integer: ${target}`);
+    }
+    const beforeRead = assertPathIdentity();
+    if (beforeRead.size > maxBytes) {
+      throw new RangeError(`regular file exceeds the ${maxBytes}-byte read limit: ${target}`);
+    }
+    const bytes = Buffer.alloc(beforeRead.size);
+    let offset = 0;
+    while (offset < beforeRead.size) {
+      const read = fs.readSync(descriptor, bytes, offset, beforeRead.size - offset, offset);
+      if (read === 0) throw new Error(`short read from regular file: ${target}`);
+      offset += read;
+    }
+    const afterRead = assertPathIdentity();
+    if (
+      beforeRead.dev !== afterRead.dev ||
+      beforeRead.ino !== afterRead.ino ||
+      beforeRead.nlink !== afterRead.nlink ||
+      beforeRead.mode !== afterRead.mode ||
+      beforeRead.size !== afterRead.size ||
+      beforeRead.mtimeMs !== afterRead.mtimeMs ||
+      beforeRead.ctimeMs !== afterRead.ctimeMs
+    ) {
+      throw new Error(`regular file changed while reading: ${target}`);
+    }
+    return bytes;
+  };
   return {
     close,
+    readBytes,
     readUtf8: (maxBytes) => {
       const size = fs.fstatSync(descriptor).size;
       if (maxBytes !== undefined && size > maxBytes) {

--- a/src/lib/onboard/sandbox-create-launch.test.ts
+++ b/src/lib/onboard/sandbox-create-launch.test.ts
@@ -627,11 +627,44 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     expect(buildImage).toHaveBeenCalledOnce();
   });
 
-  it("renders the original Dockerfile for Hermes after a local build failure", async () => {
+  it.each([
+    ["OpenClaw", null],
+    ["Hermes", { name: "hermes" }],
+  ])("fails closed for a generated %s image after a local BuildKit failure", async (_agentName, agent) => {
+    const buildCtx = createTrustedBuildContext();
+    const dockerfile = path.join(buildCtx, "Dockerfile");
+
+    await expect(
+      prepareSandboxCreateLaunchWithPrebuild({
+        agent: agent as any,
+        chatUiUrl: "",
+        createArgs: ["--from", dockerfile, "--name", "demo"],
+        env: {},
+        extraPlaceholderKeys: [],
+        getDashboardForwardPort: () => "0",
+        hermesDashboardState: disabledHermesDashboardState,
+        manageDashboard: false,
+        openshellShellCommand: (args) => args.join(" "),
+        sandboxName: "demo",
+        buildEnv: () => ({}),
+        prebuild: {
+          buildCtx,
+          buildId: "build-123",
+          dockerDriverGateway: true,
+          env: { NEMOCLAW_SANDBOX_PREBUILD: "1" },
+          buildImage: async () => 1,
+          log: vi.fn(),
+          origin: "generated",
+        },
+      }),
+    ).rejects.toThrow("Local BuildKit build failed (exit 1)");
+  });
+
+  it("preserves the gateway builder for generated Deep Agents Code images", async () => {
     const buildCtx = createTrustedBuildContext();
     const dockerfile = path.join(buildCtx, "Dockerfile");
     const result = await prepareSandboxCreateLaunchWithPrebuild({
-      agent: { name: "hermes" } as any,
+      agent: { name: "langchain-deepagents-code" } as any,
       chatUiUrl: "",
       createArgs: ["--from", dockerfile, "--name", "demo"],
       env: {},
@@ -660,5 +693,41 @@ describe("prepareSandboxCreateLaunchWithPrebuild", () => {
     });
     expect(result.createCommand).toContain(`sandbox create --from ${dockerfile} --name demo`);
     expect(result.createCommand).not.toContain("nemoclaw-sandbox-local");
+  });
+
+  it("preserves the rootless gateway path for a generated portable Hermes image", async () => {
+    const buildCtx = createTrustedBuildContext();
+    const dockerfile = path.join(buildCtx, "Dockerfile");
+    const result = await prepareSandboxCreateLaunchWithPrebuild({
+      agent: { name: "hermes" } as any,
+      chatUiUrl: "",
+      createArgs: ["--from", dockerfile, "--name", "demo"],
+      env: {},
+      extraPlaceholderKeys: [],
+      getDashboardForwardPort: () => "0",
+      hermesDashboardState: disabledHermesDashboardState,
+      manageDashboard: false,
+      openshellShellCommand: (args) => args.join(" "),
+      sandboxName: "demo",
+      buildEnv: () => ({}),
+      prebuild: {
+        buildCtx,
+        buildId: "build-123",
+        dockerDriverGateway: true,
+        env: {
+          NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
+          NEMOCLAW_SANDBOX_PREBUILD: "1",
+        },
+        buildImage: async () => 1,
+        log: vi.fn(),
+        origin: "generated",
+      },
+    });
+
+    expect(result.prebuild).toEqual({
+      createArgs: ["--from", dockerfile, "--name", "demo"],
+      imageRef: null,
+      imageId: null,
+    });
   });
 });

--- a/src/lib/onboard/sandbox-create-launch.ts
+++ b/src/lib/onboard/sandbox-create-launch.ts
@@ -338,9 +338,13 @@ export async function prepareSandboxCreateLaunchWithPrebuild(
   input: SandboxCreateLaunchWithPrebuildInput,
 ): Promise<SandboxCreateLaunchWithPrebuild> {
   const { prebuild: prebuildInput, ...launchInput } = input;
+  const requiresLocalBuildKit =
+    prebuildInput.origin === "generated" &&
+    (input.agent == null || input.agent.name === "openclaw" || input.agent.name === "hermes");
   const prebuild = await prebuildSandboxImageIfEligible({
     ...prebuildInput,
     createArgs: input.createArgs,
+    requiresLocalBuildKit,
     sandboxName: input.sandboxName,
   });
   return {

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -390,6 +390,7 @@ describe("sandbox BuildKit prebuild", () => {
       createArgs,
       sandboxName: "alpha",
       dockerDriverGateway: true,
+      requiresLocalBuildKit: true,
       env: { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
       buildImage,
       publishImage,
@@ -445,6 +446,131 @@ describe("sandbox BuildKit prebuild", () => {
       expect.arrayContaining(["build", "nemoclaw-sandbox-local:alpha-1234567890"]),
       expect.objectContaining({ shell: false, stdio: ["inherit", process.stderr, "inherit"] }),
     );
+  });
+
+  it("rejects disabling a required local BuildKit build", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        requiresLocalBuildKit: true,
+        env: { NEMOCLAW_SANDBOX_PREBUILD: "0" },
+        log: () => {},
+      }),
+    ).rejects.toThrow("Local BuildKit is required for this generated sandbox image");
+  });
+
+  it("rejects an untrusted context instead of handing a required build to the gateway", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    fs.chmodSync(buildCtx, 0o770);
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        requiresLocalBuildKit: true,
+        env: {},
+        log: () => {},
+      }),
+    ).rejects.toThrow("Local BuildKit rejected the staged build context trust boundary");
+  });
+
+  it("preserves a required staged-context inspection diagnosis", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    vi.spyOn(fs, "openSync").mockImplementation(() => {
+      throw new Error("descriptor limit reached");
+    });
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        requiresLocalBuildKit: true,
+        env: {},
+        log: () => {},
+      }),
+    ).rejects.toThrow(
+      "Local BuildKit could not inspect the staged build context: descriptor limit reached",
+    );
+  });
+
+  it("rejects mismatched create arguments for a required build", async () => {
+    const { buildCtx } = createBuildContext();
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs: ["--from", "/other/Dockerfile"],
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        requiresLocalBuildKit: true,
+        env: {},
+        log: () => {},
+      }),
+    ).rejects.toThrow("Local BuildKit requires the generated staged Dockerfile");
+  });
+
+  it.each([
+    ["a nonzero result", async () => 1, "Local BuildKit build failed (exit 1)"],
+    [
+      "a missing exit status",
+      async () => null,
+      "Local BuildKit build failed without an exit status",
+    ],
+  ])("fails closed after %s from a required build", async (_label, buildImage, message) => {
+    const { buildCtx, createArgs } = createBuildContext();
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        requiresLocalBuildKit: true,
+        env: {},
+        buildImage,
+        log: () => {},
+      }),
+    ).rejects.toThrow(message);
+  });
+
+  it("preserves a required builder startup diagnosis", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        requiresLocalBuildKit: true,
+        env: {},
+        buildImage: async () => {
+          throw new Error("builder unavailable");
+        },
+        log: () => {},
+      }),
+    ).rejects.toThrow("Local BuildKit build could not start: builder unavailable");
   });
 
   it.each([

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -39,6 +39,8 @@ export interface SandboxPrebuildInput {
   sandboxName: string;
   dockerDriverGateway: boolean;
   origin: SandboxBuildContextOrigin;
+  /** The selected generated Dockerfile cannot be built by OpenShell's classic Docker builder. */
+  requiresLocalBuildKit?: boolean;
   env?: NodeJS.ProcessEnv;
   buildImage?: (
     args: readonly string[],
@@ -192,7 +194,10 @@ export function sandboxLocalImageRef(
  * Build a NemoClaw-generated staged context with the shared local container
  * runtime. Docker uses BuildKit; the portable profile uses native rootless
  * Podman. User-supplied Dockerfiles stay on the OpenShell gateway builder trust
- * boundary, and any failure preserves that original build path.
+ * boundary. Generated OpenClaw and Hermes Dockerfiles fail closed when their
+ * required local BuildKit build cannot complete because the gateway's classic
+ * Docker builder cannot preserve their archive-mode, per-step network, and
+ * mount contracts.
  * Remove this bridge once OpenShell uses BuildKit for this local-driver path;
  * extraction and observable retirement criteria are tracked by #6258.
  */
@@ -202,7 +207,16 @@ export async function prebuildSandboxImageIfEligible(
   const createArgs = [...input.createArgs];
   const env = input.env ?? process.env;
   const log = input.log ?? console.log;
+  const portable = isPortableExperimentalProfile(env);
+  const requiresLocalBuildKit =
+    input.origin === "generated" &&
+    input.requiresLocalBuildKit === true &&
+    input.dockerDriverGateway &&
+    !portable;
   if (!resolveSandboxPrebuildEnabled(env, input.dockerDriverGateway)) {
+    if (requiresLocalBuildKit) {
+      throw new Error("Local BuildKit is required for this generated sandbox image");
+    }
     return { createArgs, imageRef: null, imageId: null };
   }
   if (input.origin !== "generated") {
@@ -218,6 +232,9 @@ export async function prebuildSandboxImageIfEligible(
     !fromDockerfile ||
     path.resolve(fromDockerfile) !== path.resolve(input.buildCtx, "Dockerfile")
   ) {
+    if (requiresLocalBuildKit) {
+      throw new Error("Local BuildKit requires the generated staged Dockerfile");
+    }
     return { createArgs, imageRef: null, imageId: null };
   }
   let trustedContext: TrustedStagedBuildContext | null;
@@ -225,12 +242,20 @@ export async function prebuildSandboxImageIfEligible(
     trustedContext = resolveTrustedStagedBuildContext(input.buildCtx);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
+    if (requiresLocalBuildKit) {
+      throw new Error(`Local BuildKit could not inspect the staged build context: ${detail}`, {
+        cause: error,
+      });
+    }
     log(
       `  Local BuildKit build skipped: staged build context could not be inspected (${detail}); using the gateway builder instead.`,
     );
     return { createArgs, imageRef: null, imageId: null };
   }
   if (!trustedContext) {
+    if (requiresLocalBuildKit) {
+      throw new Error("Local BuildKit rejected the staged build context trust boundary");
+    }
     log(
       "  Local BuildKit build skipped: staged build context failed trust validation; using the gateway builder instead.",
     );
@@ -238,7 +263,6 @@ export async function prebuildSandboxImageIfEligible(
   }
 
   const imageRef = sandboxLocalImageRef(input.sandboxName, input.buildId, env);
-  const portable = isPortableExperimentalProfile(env);
   const builderName = portable ? "rootless Podman" : "BuildKit";
   const buildImage = input.buildImage ?? createHostImageCommand(portable ? "podman" : "docker");
   log(`  Building sandbox image with ${builderName} (skips the slower in-gateway builder)...`);
@@ -257,6 +281,9 @@ export async function prebuildSandboxImageIfEligible(
     );
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
+    if (requiresLocalBuildKit) {
+      throw new Error(`Local BuildKit build could not start: ${detail}`, { cause: error });
+    }
     log(
       `  Local ${builderName} build could not start (${detail}); using the gateway builder instead.`,
     );
@@ -265,6 +292,9 @@ export async function prebuildSandboxImageIfEligible(
 
   if (status !== 0) {
     const detail = status === null ? " without an exit status" : ` (exit ${status})`;
+    if (requiresLocalBuildKit) {
+      throw new Error(`Local BuildKit build failed${detail}`);
+    }
     log(`  Local ${builderName} build failed${detail}; using the gateway builder instead.`);
     return { createArgs, imageRef: null, imageId: null };
   }

--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -5,6 +5,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { openRegularFileNoFollow } from "../adapters/fs/regular-file";
+
 export const SANDBOX_BUILD_CONTEXT_PREFIX = "nemoclaw-build-";
 export type SandboxBuildContextOrigin = "custom" | "generated";
 
@@ -19,6 +21,8 @@ export interface BuildContextStats {
 }
 
 type BuildContextStatsFilter = (entryPath: string) => boolean;
+
+const MAX_REVIEWED_RUNTIME_ARTIFACT_BYTES = 8 * 1024 * 1024;
 
 function createBuildContextDir(tmpDir: string = os.tmpdir()): string {
   return fs.mkdtempSync(path.join(tmpDir, SANDBOX_BUILD_CONTEXT_PREFIX));
@@ -37,6 +41,27 @@ function normalizeReadModesForDockerCopy(rootDir: string): void {
   if (stat.isFile()) {
     const mode = stat.mode & 0o777;
     fs.chmodSync(rootDir, (mode & ~0o022) | 0o444 | (mode & 0o111 ? 0o111 : 0));
+  }
+}
+
+function copyReviewedRegularFileSync(
+  sourceRoot: string,
+  relativePath: string,
+  target: string,
+): void {
+  const source = path.join(sourceRoot, relativePath);
+  const opened = openRegularFileNoFollow(source);
+  try {
+    const bytes = opened.readBytes(MAX_REVIEWED_RUNTIME_ARTIFACT_BYTES);
+    const resolvedRoot = fs.realpathSync(sourceRoot);
+    const resolvedSource = fs.realpathSync(source);
+    if (path.relative(resolvedRoot, resolvedSource) !== path.normalize(relativePath)) {
+      throw new Error(`reviewed runtime artifact escapes its source directory: ${source}`);
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, bytes, { flag: "wx", mode: 0o644 });
+  } finally {
+    opened.close();
   }
 }
 
@@ -91,6 +116,16 @@ function stageMcpToolDiscoveryRuntime(rootDir: string, buildCtx: string): void {
       mode: fs.constants.COPYFILE_FICLONE,
       recursive: true,
     });
+  }
+  for (const relativePath of [
+    "managed-startup-image-runtime.bundle",
+    path.join("mcp-tool-discovery", "BUNDLED_PACKAGES.json"),
+    path.join("mcp-tool-discovery", "THIRD_PARTY_LICENSES.txt"),
+    path.join("mcp-tool-discovery", "mcp-tool-discovery.bundle"),
+  ]) {
+    const reviewedRuntimeDir = path.join(sourceDir, "reviewed-runtime-bundle");
+    const target = path.join(stagedDir, "reviewed-runtime-bundle", relativePath);
+    copyReviewedRegularFileSync(reviewedRuntimeDir, relativePath, target);
   }
   normalizeReadModesForDockerCopy(path.join(buildCtx, "tools"));
 }

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -1,17 +1,69 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-
+import { dockerSpawnSync } from "../src/lib/adapters/docker/exec";
+import { createAgentSandbox } from "../src/lib/agent/base-image";
+import type { AgentDefinition } from "../src/lib/agent/defs";
+import { isWsl } from "../src/lib/platform";
 import {
   collectBuildContextStats,
   normalizeReadModesForDockerCopy,
   stageLegacySandboxBuildContext,
   stageOptimizedSandboxBuildContext,
 } from "../src/lib/sandbox/build-context";
+
+interface BuildxCommand {
+  command: string;
+  args: string[];
+}
+
+function resolveBuildxCommand(): BuildxCommand | null {
+  return (
+    [
+      { command: "docker", args: ["buildx"] },
+      { command: "docker-buildx", args: [] },
+    ].find((candidate) => {
+      const args = [...candidate.args, "version"];
+      const result =
+        candidate.command === "docker"
+          ? dockerSpawnSync(args, { encoding: "utf8" })
+          : spawnSync(candidate.command, args, { encoding: "utf8" });
+      return result.status === 0;
+    }) ?? null
+  );
+}
+
+const SUPPORTED_BUILDX_HOST = process.platform === "linux" && !isWsl();
+const BUILDX_COMMAND = SUPPORTED_BUILDX_HOST ? resolveBuildxCommand() : null;
+const DOCKER_CAPABLE_LINUX_CI = process.env.CI === "true" && SUPPORTED_BUILDX_HOST;
+
+function buildTarget(
+  buildx: BuildxCommand,
+  stagedDockerfile: string,
+  buildCtx: string,
+  target: string,
+  outputDir: string,
+) {
+  const args = [
+    ...buildx.args,
+    "build",
+    "--progress=plain",
+    `--target=${target}`,
+    `--output=type=local,dest=${outputDir}`,
+    "--file",
+    stagedDockerfile,
+    buildCtx,
+  ];
+  const options = { encoding: "utf8" as const, maxBuffer: 20 * 1024 * 1024 };
+  return buildx.command === "docker"
+    ? dockerSpawnSync(args, options)
+    : spawnSync(buildx.command, args, options);
+}
 
 describe("sandbox build context staging", () => {
   function runtimeManifestFixture(runtimeName: string, fileName: string) {
@@ -82,6 +134,25 @@ describe("sandbox build context staging", () => {
     for (const seedDirectory of ["mcp-runtime-npm-cache-seed", "npm-cache-seed"]) {
       writeFixture(path.join("tools", "mcp-tool-discovery-runtime", seedDirectory, ".gitkeep"));
     }
+    for (const relativePath of [
+      "managed-startup-image-runtime.bundle",
+      path.join("mcp-tool-discovery", "BUNDLED_PACKAGES.json"),
+      path.join("mcp-tool-discovery", "THIRD_PARTY_LICENSES.txt"),
+      path.join("mcp-tool-discovery", "mcp-tool-discovery.bundle"),
+    ]) {
+      writeFixture(
+        path.join("tools", "mcp-tool-discovery-runtime", "reviewed-runtime-bundle", relativePath),
+        `reviewed fixture: ${relativePath}\n`,
+      );
+    }
+    writeFixture(
+      path.join(
+        "tools",
+        "mcp-tool-discovery-runtime",
+        "reviewed-runtime-bundle",
+        "unreviewed-runtime.bundle",
+      ),
+    );
     for (const fileName of [
       "package.json",
       "package-lock.json",
@@ -313,6 +384,7 @@ describe("sandbox build context staging", () => {
       "npm-ci-locked.sh",
       "package-lock.json",
       "package.json",
+      "reviewed-runtime-bundle",
       "streamable-http-client.test.ts",
       "tool-discovery-core.ts",
       "tsconfig.json",
@@ -352,6 +424,36 @@ describe("sandbox build context staging", () => {
       expect(fs.readFileSync(path.join(stagedSeedDirectory, sourceEntries[0]))).toEqual(
         fs.readFileSync(path.join(sourceSeedDirectory, sourceEntries[0])),
       );
+    }
+
+    const reviewedRuntimeDir = path.join(runtimeDir, "reviewed-runtime-bundle");
+    expect(fs.readdirSync(reviewedRuntimeDir).sort()).toEqual([
+      "managed-startup-image-runtime.bundle",
+      "mcp-tool-discovery",
+    ]);
+    const reviewedRuntimeFiles = [
+      "managed-startup-image-runtime.bundle",
+      path.join("mcp-tool-discovery", "BUNDLED_PACKAGES.json"),
+      path.join("mcp-tool-discovery", "THIRD_PARTY_LICENSES.txt"),
+      path.join("mcp-tool-discovery", "mcp-tool-discovery.bundle"),
+    ];
+    expect(fs.readdirSync(path.join(reviewedRuntimeDir, "mcp-tool-discovery")).sort()).toEqual([
+      "BUNDLED_PACKAGES.json",
+      "THIRD_PARTY_LICENSES.txt",
+      "mcp-tool-discovery.bundle",
+    ]);
+    for (const relativePath of reviewedRuntimeFiles) {
+      const stagedPath = path.join(reviewedRuntimeDir, relativePath);
+      const sourcePath = path.join(
+        sourceRoot,
+        "tools",
+        "mcp-tool-discovery-runtime",
+        "reviewed-runtime-bundle",
+        relativePath,
+      );
+      expect(fs.lstatSync(stagedPath).isFile(), relativePath).toBe(true);
+      expect(fs.readFileSync(stagedPath), relativePath).toEqual(fs.readFileSync(sourcePath));
+      expect((fs.statSync(stagedPath).mode & 0o777).toString(8), relativePath).toBe("644");
     }
   }
 
@@ -600,6 +702,51 @@ describe("sandbox build context staging", () => {
     }
   });
 
+  it("rejects a symlinked reviewed runtime artifact", () => {
+    const sourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-source-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-symlink-"));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-reviewed-runtime-outside-"));
+
+    try {
+      writeBuildContextFixture(sourceRoot);
+      const outsideTarget = path.join(outsideDir, "outside-license.txt");
+      const outsideContents = "outside target must remain unchanged\n";
+      fs.writeFileSync(outsideTarget, outsideContents);
+      const reviewedArtifact = path.join(
+        sourceRoot,
+        "tools",
+        "mcp-tool-discovery-runtime",
+        "reviewed-runtime-bundle",
+        "mcp-tool-discovery",
+        "THIRD_PARTY_LICENSES.txt",
+      );
+      fs.rmSync(reviewedArtifact);
+      fs.symlinkSync(outsideTarget, reviewedArtifact);
+
+      expect(() => stageOptimizedSandboxBuildContext(sourceRoot, tmpDir)).toThrow();
+      expect(fs.readFileSync(outsideTarget, "utf8")).toBe(outsideContents);
+      const stagedDirectories = fs.readdirSync(tmpDir);
+      expect(stagedDirectories).toHaveLength(1);
+      expect(
+        fs.existsSync(
+          path.join(
+            tmpDir,
+            stagedDirectories[0],
+            "tools",
+            "mcp-tool-discovery-runtime",
+            "reviewed-runtime-bundle",
+            "mcp-tool-discovery",
+            "THIRD_PARTY_LICENSES.txt",
+          ),
+        ),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(sourceRoot, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it("optimized staging excludes blueprint .venv and extra scripts while preserving required files", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-opt-"));
@@ -767,6 +914,112 @@ describe("sandbox build context staging", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it.runIf(DOCKER_CAPABLE_LINUX_CI)("provides Buildx on Docker-capable Linux CI", () => {
+    expect(BUILDX_COMMAND).not.toBeNull();
+  });
+
+  it.skipIf(!SUPPORTED_BUILDX_HOST || BUILDX_COMMAND === null)(
+    "generated build contexts import reviewed runtime artifacts through BuildKit",
+    {
+      timeout: 120_000,
+    },
+    () => {
+      const buildx = BUILDX_COMMAND as BuildxCommand;
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-reviewed-runtime-build-"));
+      const reviewedRuntimeSource = path.join(
+        repoRoot,
+        "tools",
+        "mcp-tool-discovery-runtime",
+        "reviewed-runtime-bundle",
+      );
+      const hermesAgent = {
+        name: "hermes",
+        displayName: "Hermes",
+        dockerfileBasePath: null,
+        dockerfilePath: path.join(repoRoot, "agents", "hermes", "Dockerfile"),
+      } as AgentDefinition;
+      const hermesBuild = createAgentSandbox(hermesAgent, { rootDir: repoRoot });
+
+      try {
+        for (const [name, staged] of [
+          ["openclaw", stageOptimizedSandboxBuildContext(repoRoot, tmpDir)],
+          ["hermes", hermesBuild],
+        ] as const) {
+          const { buildCtx, stagedDockerfile } = staged;
+          const mcpOutput = path.join(tmpDir, `${name}-mcp-output`);
+          const mcpBuild = buildTarget(
+            buildx,
+            stagedDockerfile,
+            buildCtx,
+            "mcp-tool-discovery-runtime",
+            mcpOutput,
+          );
+          expect(mcpBuild.status, `${mcpBuild.stdout}\n${mcpBuild.stderr}`).toBe(0);
+
+          for (const [sourceRelativePath, outputRelativePath] of [
+            [
+              path.join("mcp-tool-discovery", "BUNDLED_PACKAGES.json"),
+              path.join("opt", "mcp-tool-discovery-runtime", "dist", "BUNDLED_PACKAGES.json"),
+            ],
+            [
+              path.join("mcp-tool-discovery", "THIRD_PARTY_LICENSES.txt"),
+              path.join("opt", "mcp-tool-discovery-runtime", "dist", "THIRD_PARTY_LICENSES.txt"),
+            ],
+            [
+              path.join("mcp-tool-discovery", "mcp-tool-discovery.bundle"),
+              path.join("opt", "mcp-tool-discovery-runtime", "dist", "mcp-tool-discovery.mjs"),
+            ],
+          ] as const) {
+            expect(fs.readFileSync(path.join(mcpOutput, outputRelativePath))).toEqual(
+              fs.readFileSync(path.join(reviewedRuntimeSource, sourceRelativePath)),
+            );
+          }
+
+          const startupOutput = path.join(tmpDir, `${name}-startup-output`);
+          const startupBuild = buildTarget(
+            buildx,
+            stagedDockerfile,
+            buildCtx,
+            "managed-startup-runtime-builder",
+            startupOutput,
+          );
+          expect(startupBuild.status, `${startupBuild.stdout}\n${startupBuild.stderr}`).toBe(0);
+          expect(
+            fs.readFileSync(path.join(startupOutput, "out", "managed-startup-image-runtime.cjs")),
+          ).toEqual(
+            fs.readFileSync(
+              path.join(reviewedRuntimeSource, "managed-startup-image-runtime.bundle"),
+            ),
+          );
+        }
+
+        const incomplete = stageOptimizedSandboxBuildContext(repoRoot, tmpDir);
+        fs.rmSync(
+          path.join(
+            incomplete.buildCtx,
+            "tools",
+            "mcp-tool-discovery-runtime",
+            "reviewed-runtime-bundle",
+            "mcp-tool-discovery",
+            "THIRD_PARTY_LICENSES.txt",
+          ),
+        );
+        const incompleteBuild = buildTarget(
+          buildx,
+          incomplete.stagedDockerfile,
+          incomplete.buildCtx,
+          "mcp-tool-discovery-runtime",
+          path.join(tmpDir, "incomplete-output"),
+        );
+        expect(incompleteBuild.status).not.toBe(0);
+      } finally {
+        fs.rmSync(hermesBuild.buildCtx, { recursive: true, force: true });
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("build context stats honor filters without descending into excluded directories", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-stats-"));


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Restores the reviewed runtime bundle, license, and package artifacts to both supported sparse build-context paths. Generated OpenClaw and Hermes contexts now require a trusted local BuildKit or rootless Podman prebuild instead of falling through to an incompatible classic builder, while DCode and genuinely custom classic-compatible contexts retain their existing fallback.

## Related Issue
Refs #8590.

## Changes
- Stage `mcp-tool-discovery.bundle`, `managed-startup-image-runtime.bundle`, `THIRD_PARTY_LICENSES.txt`, and `BUNDLED_PACKAGES.json` through the regular-file and sandbox prebuild paths.
- Require the local prebuild path for generated OpenClaw and Hermes contexts whose Dockerfiles need BuildKit semantics, while preserving the gateway/classic fallback for DCode and custom compatible contexts.
- Add focused behavior coverage for sparse staging and builder selection, plus troubleshooting guidance for unsupported local builders.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent exact-head nine-category security review passed with no blocker; the Epic manager accepted the receipt.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/troubleshooting.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: dd5e324a7 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: focused CLI suite 69/69; focused reviewed-runtime integration suite 14 passed with two intentional unsupported-Darwin skips; root, CLI, and plugin type checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: no successful local aggregate is claimed; official PR CI remains required.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for safely staging reviewed runtime artifacts during sandbox setup.
  - Added bounded binary file reads with integrity checks.

- **Bug Fixes**
  - Sandbox builds that require local BuildKit now fail clearly instead of silently falling back when BuildKit is unavailable, misconfigured, or unsuccessful.
  - Improved detection of changed, oversized, incomplete, or unsafe files during sandbox preparation.

- **Documentation**
  - Added troubleshooting guidance for local Docker BuildKit requirements, recovery steps, and common setup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->