### PR TITLE
test(onboard): opt generated fixtures into local prebuild

### DIFF
--- a/test/onboard-extra-provider-reconciliation.test.ts
+++ b/test/onboard-extra-provider-reconciliation.test.ts
@@ -145,6 +145,7 @@ const { createSandbox } = require(${onboardPath});
           PATH: `${fakeBin}:${process.env.PATH || ""}`,
           NEMOCLAW_NON_INTERACTIVE: "1",
           NEMOCLAW_TEST_MANAGED_IMAGE_FALLBACK: "1",
+          NEMOCLAW_SANDBOX_PREBUILD: "1",
           OPENSHELL_GATEWAY_ENDPOINT: undefined,
         },
       });

--- a/test/onboard-installer-restore-intent.test.ts
+++ b/test/onboard-installer-restore-intent.test.ts
@@ -184,6 +184,7 @@ const MARKER_SHA = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852
       PATH: `${fakeBin}:${process.env.PATH || ""}`,
       NEMOCLAW_NON_INTERACTIVE: "1",
       NEMOCLAW_TEST_MANAGED_IMAGE_FALLBACK: "1",
+      NEMOCLAW_SANDBOX_PREBUILD: "1",
     };
     delete env["NEMOCLAW_RECREATE_SANDBOX"];
     const result = spawnSync(process.execPath, [scriptPath], {

--- a/test/onboard-messaging.test.ts
+++ b/test/onboard-messaging.test.ts
@@ -46,6 +46,7 @@ const onboardScriptMocksPath = JSON.stringify(
 );
 beforeEach(() => {
   vi.stubEnv("NEMOCLAW_TEST_MANAGED_IMAGE_FALLBACK", "1");
+  vi.stubEnv("NEMOCLAW_SANDBOX_PREBUILD", "1");
 });
 describe("onboard messaging", () => {
   it("creates providers for messaging tokens and attaches them to the sandbox", {
@@ -513,7 +514,7 @@ const childProcess = require("node:child_process");
 const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
 
-const commands = [];
+const commands = []; let dockerfileContent;
 const registerCalls = [];
 registry.registerSandbox({
   name: "my-assistant",
@@ -556,15 +557,15 @@ childProcess.spawn = (...args) => {
   child.pid = 4242;
   const command = _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]);
   const entry = { command, env: args[2]?.env || null };
-  const dockerfileMatch = command.match(/--from ([^ ]+Dockerfile)/);
+  const dockerfileMatch = command.match(/(?:--from|-f) ([^ ]+Dockerfile)/);
   if (dockerfileMatch) {
     try {
-      entry.dockerfileContent = fs.readFileSync(dockerfileMatch[1], "utf-8");
+      entry.dockerfileContent = dockerfileContent = fs.readFileSync(dockerfileMatch[1], "utf-8");
     } catch (error) {
       entry.dockerfileReadError = String(error);
     }
   }
-  commands.push(entry);
+  commands.push({ ...entry, dockerfileContent: entry.dockerfileContent ?? dockerfileContent });
   process.nextTick(() => {
     child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
     child.emit("close", 0);
@@ -628,7 +629,6 @@ const { createSandbox } = require(${onboardPath});
     assert.match(createCommand.command, /--provider my-assistant-discord-bridge/);
     assert.match(createCommand.command, /--provider my-assistant-slack-bridge/);
     assert.match(createCommand.command, /--provider my-assistant-slack-app/);
-
     assert.deepEqual(activeChannelsFromDockerfile(createCommand.dockerfileContent), [
       "discord",
       "slack",
@@ -674,7 +674,7 @@ const childProcess = require("node:child_process");
 const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
 
-const commands = [];
+const commands = []; let dockerfileContent;
 const registerCalls = [];
 registry.registerSandbox({
   name: "my-assistant",
@@ -715,15 +715,15 @@ childProcess.spawn = (...args) => {
   child.pid = 4242;
   const command = _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]);
   const entry = { command, env: args[2]?.env || null };
-  const dockerfileMatch = command.match(/--from ([^ ]+Dockerfile)/);
+  const dockerfileMatch = command.match(/(?:--from|-f) ([^ ]+Dockerfile)/);
   if (dockerfileMatch) {
     try {
-      entry.dockerfileContent = fs.readFileSync(dockerfileMatch[1], "utf-8");
+      entry.dockerfileContent = dockerfileContent = fs.readFileSync(dockerfileMatch[1], "utf-8");
     } catch (error) {
       entry.dockerfileReadError = String(error);
     }
   }
-  commands.push(entry);
+  commands.push({ ...entry, dockerfileContent: entry.dockerfileContent ?? dockerfileContent });
   process.nextTick(() => {
     child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
     child.emit("close", 0);
@@ -827,7 +827,7 @@ const childProcess = require("node:child_process");
 const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
 
-const commands = [];
+const commands = []; let dockerfileContent;
 const registerCalls = [];
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
@@ -863,15 +863,15 @@ childProcess.spawn = (...args) => {
   child.pid = 4242;
   const command = _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]);
   const entry = { command, env: args[2]?.env || null };
-  const dockerfileMatch = command.match(/--from ([^ ]+Dockerfile)/);
+  const dockerfileMatch = command.match(/(?:--from|-f) ([^ ]+Dockerfile)/);
   if (dockerfileMatch) {
     try {
-      entry.dockerfileContent = fs.readFileSync(dockerfileMatch[1], "utf-8");
+      entry.dockerfileContent = dockerfileContent = fs.readFileSync(dockerfileMatch[1], "utf-8");
     } catch (error) {
       entry.dockerfileReadError = String(error);
     }
   }
-  commands.push(entry);
+  commands.push({ ...entry, dockerfileContent: entry.dockerfileContent ?? dockerfileContent });
   process.nextTick(() => {
     child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
     child.emit("close", 0);
@@ -982,7 +982,7 @@ registry.registerSandbox({
   messaging: { schemaVersion: 1, plan: ${messagingPlanLiteral(["whatsapp"], ["whatsapp"])} },
 });
 
-const commands = [];
+const commands = []; let dockerfileContent;
 const registerCalls = [];
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
@@ -1018,15 +1018,15 @@ childProcess.spawn = (...args) => {
   child.pid = 4242;
   const command = _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]);
   const entry = { command, env: args[2]?.env || null };
-  const dockerfileMatch = command.match(/--from ([^ ]+Dockerfile)/);
+  const dockerfileMatch = command.match(/(?:--from|-f) ([^ ]+Dockerfile)/);
   if (dockerfileMatch) {
     try {
-      entry.dockerfileContent = fs.readFileSync(dockerfileMatch[1], "utf-8");
+      entry.dockerfileContent = dockerfileContent = fs.readFileSync(dockerfileMatch[1], "utf-8");
     } catch (error) {
       entry.dockerfileReadError = String(error);
     }
   }
-  commands.push(entry);
+  commands.push({ ...entry, dockerfileContent: entry.dockerfileContent ?? dockerfileContent });
   process.nextTick(() => {
     child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
     child.emit("close", 0);

--- a/test/onboard-reservation-recreate.test.ts
+++ b/test/onboard-reservation-recreate.test.ts
@@ -139,6 +139,7 @@ const { createSandbox } = require(${onboardPath});
       env: workspaceEnv(workspace, {
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_TEST_MANAGED_IMAGE_FALLBACK: "1",
+        NEMOCLAW_SANDBOX_PREBUILD: "1",
       }),
     });
 

--- a/test/onboard-sandbox-build.test.ts
+++ b/test/onboard-sandbox-build.test.ts
@@ -18,6 +18,7 @@ import {
 
 beforeEach(() => {
   vi.stubEnv("NEMOCLAW_TEST_MANAGED_IMAGE_FALLBACK", "1");
+  vi.stubEnv("NEMOCLAW_SANDBOX_PREBUILD", "1");
 });
 
 describe("onboard helpers", () => {
@@ -448,7 +449,7 @@ sandboxBaseImage.resolveSandboxBaseImage = (options) => {
   };
 };
 buildContext.stageOptimizedSandboxBuildContext = () => {
-  const buildCtx = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-build-"));
+  const buildCtx = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-"));
   const stagedDockerfile = path.join(buildCtx, "Dockerfile");
   fs.writeFileSync(
     stagedDockerfile,

--- a/test/onboard-sandbox-recreation.test.ts
+++ b/test/onboard-sandbox-recreation.test.ts
@@ -13,6 +13,7 @@ import { type CommandEntry, onboardScriptMocksPath } from "./helpers/onboard-spl
 
 beforeEach(() => {
   vi.stubEnv("NEMOCLAW_TEST_MANAGED_IMAGE_FALLBACK", "1");
+  vi.stubEnv("NEMOCLAW_SANDBOX_PREBUILD", "1");
 });
 
 describe("onboard helpers", () => {
@@ -1189,6 +1190,9 @@ const { createSandbox } = require(${onboardPath});
     const credentialsPath = JSON.stringify(
       path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
     );
+    const dockerExecPath = JSON.stringify(
+      path.join(repoRoot, "src", "lib", "adapters", "docker", "exec.ts"),
+    );
 
     fs.mkdirSync(fakeBin, { recursive: true });
     writeOkOpenshell(fakeBin);
@@ -1203,6 +1207,12 @@ const preflight = require(${preflightPath});
 const credentials = require(${credentialsPath});
 const childProcess = require("node:child_process");
 const { EventEmitter } = require("node:events");
+const dockerExec = require(${dockerExecPath});
+dockerExec.dockerSpawn = () => {
+  const child = new EventEmitter();
+  process.nextTick(() => child.emit("close", 0));
+  return child;
+};
 const fs = require("node:fs");
 
 const commands = [];


### PR DESCRIPTION
## Summary
Generated-sandbox integration fixtures now opt into the required local-prebuild path introduced by #8651. Before this change, 25 existing assertions failed before reaching their intended behavior; the repaired fixtures now exercise the BuildKit boundary and all 40 focused tests pass.

## Related Issue
Fixes #8652

## Changes
- Opt the six affected generated-sandbox fixture environments into local prebuild with `NEMOCLAW_SANDBOX_PREBUILD=1`.
- Preserve messaging-plan assertions by capturing the Dockerfile at the BuildKit `-f` boundary.
- Keep staged-context and never-closing create-stream fixtures faithful to the trusted BuildKit and sandbox child-process boundaries.
- Leave production prebuild enforcement and fallback behavior unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Test fixtures changed; production behavior and public interfaces are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Fixture-only self-review confirmed production trust boundaries are unchanged; 64 existing local-prebuild and sandbox-launch boundary tests pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change updates integration-test fixtures only. Production source, public interfaces, supported behavior, and documentation are unchanged. Focused integration and prebuild boundary tests pass.
- Agent: Pi CLI
<!-- docs-review-head-sha: a4b4c2c1ea94 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/onboard-extra-provider-reconciliation.test.ts test/onboard-installer-restore-intent.test.ts test/onboard-messaging.test.ts test/onboard-reservation-recreate.test.ts test/onboard-sandbox-build.test.ts test/onboard-sandbox-recreation.test.ts` — 6 files and 40 tests passed. `npx vitest run --project cli src/lib/onboard/sandbox-prebuild.test.ts src/lib/onboard/sandbox-create-launch.test.ts src/lib/onboard/sandbox-create-launch-observability.test.ts` — 3 files and 64 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
