### PR TITLE
fix(onboard): repair journaled rebuild image retirement

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -177,7 +177,6 @@ const {
   dockerInspect,
   dockerRemoveVolumesByPrefix,
   dockerRm,
-  dockerRmi,
   dockerStop,
 } = docker;
 const gatewayDrift: typeof import("./adapters/openshell/gateway-drift") = require("./adapters/openshell/gateway-drift");
@@ -2530,20 +2529,6 @@ async function createSandboxWithBaseImageResolution(
     // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
     if (recreateRuntime.beginDelete() === "source") { runSandboxProviderPreDeleteCleanup(sandboxName, { runOpenshell, redact }); runOpenshell(["sandbox", "delete", "-g", recreateRuntime.journaledGatewayName ?? GATEWAY_NAME, sandboxName], { ignoreError: true }); if (!waitForSandboxRecreateDeleteAbsence(sandboxName, recreateRuntime.journaledGatewayName ?? GATEWAY_NAME, note)) throw new Error(`Cannot continue sandbox '${sandboxName}' recreation: OpenShell did not confirm explicit source absence after delete.`); }
     recreateRuntime.confirmDeleted();
-    const replacementReusesPreviousImage =
-      replacementWorkload.source.kind === "managed-image" &&
-      replacementWorkload.source.reference === previousEntry?.imageTag;
-    if (
-      previousEntry?.imageTag &&
-      previousEntry.workload?.shared !== true &&
-      !replacementReusesPreviousImage
-    ) {
-      // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
-      const rmiResult = dockerRmi(previousEntry.imageTag, { ignoreError: true, suppressOutput: true });
-      if (rmiResult.status !== 0) {
-        console.warn(`  Warning: failed to remove old sandbox image '${previousEntry.imageTag}'.`);
-      }
-    }
     sandboxLifecycle.removeSandboxUnlessSessionReservation(previousEntry, sandboxName);
   }
   const preparedSandboxWorkload = await managedWorkloadRuntime.ensurePreparedWorkload();
@@ -2595,7 +2580,7 @@ async function createSandboxWithBaseImageResolution(
       createArgv,
       sandboxEnv,
       sandboxStartupCommand,
-      lifecycleRegistrationFields: recreateRuntime.registrationFields,
+      lifecycleGeneration: recreateRuntime.targetGeneration,
       prebuild,
       restoreBackupPath,
       terminalAgent: agentDefs.isTerminalAgent(agent),
@@ -2725,6 +2710,7 @@ async function createSandboxWithBaseImageResolution(
           hermesDashboardState: finalHermesDashboardState,
           dashboardPort: actualDashboardPort,
           ...lifecycleRegistrationFields,
+          ...recreateRuntime.registrationFields,
           gatewayName: GATEWAY_NAME,
           gatewayPort: GATEWAY_PORT,
         }),

--- a/src/lib/onboard/machine/handlers/sandbox-recreate-journal.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-recreate-journal.test.ts
@@ -161,6 +161,61 @@ it("journals not-ready repair on the selected non-default gateway (#6492)", asyn
   expect(session.checkpoint?.sandboxRecreate).toBeNull();
 });
 
+it.each([
+  "replacement-unproven",
+  "shared-image",
+  "authority-unproven",
+  "no-owned-image",
+  "image-reused",
+] as const)("reports the bounded %s image-retirement skip after journaled recreation", async (reason) => {
+  const session = createSession({ sandboxName: "saved", agent: "openclaw" });
+  const journal = bindJournaledRecreate(session);
+  const sourceEntry: SandboxEntry = {
+    name: "saved",
+    provider: "provider",
+    model: "model",
+    endpointUrl: null,
+    preferredInferenceApi: "openai-completions",
+    webSearchEnabled: false,
+    toolDisclosure: "progressive",
+    fromDockerfile: null,
+    hermesAuthMethod: null,
+    imageTag: "openshell/sandbox-from:old",
+    workload: {
+      schemaVersion: 1,
+      kind: "legacy-dockerfile",
+      reference: "openshell/sandbox-from:old",
+      shared: false,
+    },
+  };
+  const retireReplacedSandboxWorkload = vi.fn(() => ({
+    status: "skipped" as const,
+    reason,
+  }));
+  const { deps, calls } = createDeps(
+    {
+      getSandboxReuseState: () => "not_ready",
+      getSandboxRecreateObservation: journal.observe,
+      getSandboxRegistryEntry: () => sourceEntry,
+      createSandbox: journal.completeCreate,
+      retireReplacedSandboxWorkload,
+    },
+    session,
+  );
+
+  await handleSandboxState({
+    ...baseOptions(deps, session),
+    resume: true,
+    sandboxName: "saved",
+  });
+
+  const diagnostics = calls.note.mock.calls
+    .map(([message]) => message)
+    .filter((message) => message.startsWith("  Obsolete sandbox image retirement skipped:"));
+  expect(diagnostics).toEqual([`  Obsolete sandbox image retirement skipped: ${reason}`]);
+  expect(retireReplacedSandboxWorkload).toHaveBeenCalledOnce();
+});
+
 it("continues an outer rebuild journal after the outer rebuild deletes the source sandbox", async () => {
   const session = createSession({ sandboxName: "saved", agent: "openclaw" });
   session.steps.sandbox.status = "complete";

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -119,6 +119,19 @@ import {
   type SandboxResumeDecision,
 } from "./sandbox-resume";
 
+type SandboxRecreateWorkloadSkipReason = Extract<
+  ReplacedSandboxWorkloadCleanupResult,
+  { readonly status: "skipped" }
+>["reason"];
+
+const SANDBOX_RECREATE_WORKLOAD_SKIP_DIAGNOSTIC = {
+  "replacement-unproven": "  Obsolete sandbox image retirement skipped: replacement-unproven",
+  "shared-image": "  Obsolete sandbox image retirement skipped: shared-image",
+  "authority-unproven": "  Obsolete sandbox image retirement skipped: authority-unproven",
+  "no-owned-image": "  Obsolete sandbox image retirement skipped: no-owned-image",
+  "image-reused": "  Obsolete sandbox image retirement skipped: image-reused",
+} as const satisfies Record<SandboxRecreateWorkloadSkipReason, string>;
+
 function isAdvisoryPeerRouteDifference(
   result: Exclude<GatewayRouteCompatibilityResult, { ok: true }>,
   sandboxName: string,
@@ -1623,6 +1636,8 @@ class SandboxStateFlow<
       this.deps.note(
         `  Warning: failed to remove obsolete ${retired.engineDisplayName} image ${retired.reference}; run '${this.deps.cliName()} gc' to clean up.`,
       );
+    } else if (retired.status === "skipped") {
+      this.deps.note(SANDBOX_RECREATE_WORKLOAD_SKIP_DIAGNOSTIC[retired.reason]);
     }
   }
 

--- a/src/lib/onboard/runtime-provider/replaced-workload.test.ts
+++ b/src/lib/onboard/runtime-provider/replaced-workload.test.ts
@@ -15,6 +15,7 @@ const TARGET_IDENTITY = "target-identity";
 function entry(imageTag: string, generation: string): SandboxEntry {
   return {
     name: "alpha",
+    openshellDriver: "docker",
     imageTag,
     workload: {
       schemaVersion: 1,
@@ -149,6 +150,37 @@ describe("same-name replacement workload cleanup", () => {
         { runtimeProviders: providers(removeImage) },
       ),
     ).toEqual({ status: "skipped", reason: "replacement-unproven" });
+    expect(removeImage).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["provider identity", ({ openshellDriver: _provider, ...source }: SandboxEntry) => source],
+    ["workload receipt", ({ workload: _workload, ...source }: SandboxEntry) => source],
+    [
+      "matching workload receipt",
+      (source: SandboxEntry) => ({
+        ...source,
+        workload: {
+          schemaVersion: 1 as const,
+          kind: "legacy-dockerfile" as const,
+          reference: "openshell/sandbox-from:foreign",
+          shared: false as const,
+        },
+      }),
+    ],
+  ] as const)("does not remove the source image without its durable %s", (_field, mutate) => {
+    const removeImage = vi.fn(() => ({ status: 0 }));
+
+    expect(
+      retireReplacedSandboxWorkload(
+        "alpha",
+        "target",
+        TARGET_IDENTITY,
+        mutate(entry(SOURCE_IMAGE, "source")),
+        entry(REPLACEMENT_IMAGE, "target"),
+        { runtimeProviders: providers(removeImage) },
+      ),
+    ).toEqual({ status: "skipped", reason: "authority-unproven" });
     expect(removeImage).not.toHaveBeenCalled();
   });
 

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -680,21 +680,15 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
 
   it("configures the portable lifecycle after sandbox creation succeeds (#8441)", async () => {
     const input = createInput();
-    input.lifecycleRegistrationFields = {
-      lifecycleGeneration: "current-generation",
-      lifecycleLiveIdentityFingerprint: "current-fingerprint",
-    };
+    input.lifecycleGeneration = "current-generation";
     const deps = createDeps();
-    deps.installPortableDemoLifecycle = vi.fn(
-      () => input.lifecycleRegistrationFields?.lifecycleGeneration ?? null,
-    );
+    deps.installPortableDemoLifecycle = vi.fn(() => input.lifecycleGeneration ?? null);
 
-    await expect(runSandboxGpuCreateFlow(input, deps)).resolves.toMatchObject({
-      lifecycleRegistrationFields: {
-        lifecycleGeneration: "current-generation",
-        lifecycleLiveIdentityFingerprint: "current-fingerprint",
-      },
-      route: "native",
+    const result = await runSandboxGpuCreateFlow(input, deps);
+
+    expect(result.route).toBe("native");
+    expect(result.lifecycleRegistrationFields).toEqual({
+      lifecycleGeneration: "current-generation",
     });
 
     expect(deps.installPortableDemoLifecycle).toHaveBeenCalledWith(

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -682,7 +682,9 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
     const input = createInput();
     input.lifecycleGeneration = "current-generation";
     const deps = createDeps();
-    deps.installPortableDemoLifecycle = vi.fn(() => input.lifecycleGeneration ?? null);
+    deps.installPortableDemoLifecycle = vi.fn(
+      (_sandboxName, _startupCommand, _env, options) => options.registryGeneration ?? null,
+    );
 
     const result = await runSandboxGpuCreateFlow(input, deps);
 

--- a/src/lib/onboard/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.ts
@@ -66,10 +66,7 @@ function exitForManagedBootstrapRecovery(error: ManagedBootstrapRecoveryBlockedE
 type RunOpenshell = NonNullable<DockerGpuPatchDeps["runOpenshell"]>;
 type RunCaptureOpenshell = NonNullable<DockerGpuPatchDeps["runCaptureOpenshell"]>;
 type Sleep = NonNullable<DockerGpuPatchDeps["sleep"]>;
-type LifecycleRegistrationFields = Pick<
-  SandboxEntry,
-  "lifecycleGeneration" | "lifecycleLiveIdentityFingerprint"
->;
+type LifecycleRegistrationFields = Pick<SandboxEntry, "lifecycleGeneration">;
 
 export interface SandboxGpuCreateFlowInput {
   sandboxName: string;
@@ -84,7 +81,7 @@ export interface SandboxGpuCreateFlowInput {
   createArgv: string[];
   sandboxEnv: NodeJS.ProcessEnv;
   sandboxStartupCommand: string[];
-  lifecycleRegistrationFields?: LifecycleRegistrationFields;
+  lifecycleGeneration?: SandboxEntry["lifecycleGeneration"];
   prebuild: SandboxPrebuildResult;
   restoreBackupPath: string | null;
   terminalAgent: boolean;
@@ -264,9 +261,7 @@ export async function runSandboxGpuCreateFlow(
         input.sandboxStartupCommand,
         process.env,
         {
-          ...(input.lifecycleRegistrationFields?.lifecycleGeneration
-            ? { registryGeneration: input.lifecycleRegistrationFields.lifecycleGeneration }
-            : {}),
+          ...(input.lifecycleGeneration ? { registryGeneration: input.lifecycleGeneration } : {}),
         },
       ) ?? null;
   } catch (error) {
@@ -281,7 +276,7 @@ export async function runSandboxGpuCreateFlow(
     registryImageRef,
     lifecycleRegistrationFields: {
       ...(portableLifecycleGeneration ? { lifecycleGeneration: portableLifecycleGeneration } : {}),
-      ...input.lifecycleRegistrationFields,
+      ...(input.lifecycleGeneration ? { lifecycleGeneration: input.lifecycleGeneration } : {}),
     },
   };
 }

--- a/src/lib/onboard/sandbox-recreate-transaction.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.ts
@@ -82,6 +82,19 @@ export function retireReplacedSandboxWorkload(
   if (source.workload?.shared === true) {
     return { status: "skipped", reason: "shared-image" };
   }
+  if (!source.imageTag) {
+    return { status: "skipped", reason: "no-owned-image" };
+  }
+  if (
+    typeof source.openshellDriver !== "string" ||
+    source.openshellDriver.trim().length === 0 ||
+    source.workload?.schemaVersion !== 1 ||
+    source.workload.kind !== "legacy-dockerfile" ||
+    source.workload.shared !== false ||
+    source.workload.reference !== source.imageTag
+  ) {
+    return { status: "skipped", reason: "authority-unproven" };
+  }
 
   const cleanupSource = providerCleanupSource(source);
   const providers = deps.runtimeProviders ?? CURRENT_RUNTIME_PROVIDER_BUNDLES;

--- a/test/e2e/live/rebuild-hermes-image-state.ts
+++ b/test/e2e/live/rebuild-hermes-image-state.ts
@@ -8,8 +8,20 @@ import {
 } from "../../../src/lib/domain/sandbox/image-tag";
 
 export interface RebuildHermesRegistryImageState {
+  openshellDriver: "docker";
   imageTag: string;
   fromDockerfile: null;
+  workload: {
+    schemaVersion: 1;
+    kind: "legacy-dockerfile";
+    reference: string;
+    shared: false;
+  };
+}
+
+export interface RebuildHermesReplacementLifecycleReceipt {
+  lifecycleGeneration: string;
+  lifecycleLiveIdentityFingerprint: string;
 }
 
 export async function cleanupTrackedRebuildHermesImage(
@@ -31,6 +43,28 @@ export function requireRebuildHermesInitialImageTag(value: unknown, sandboxName:
   return imageTag;
 }
 
+export function requireRebuildHermesReplacementLifecycleReceipt(
+  value: Record<string, unknown>,
+): RebuildHermesReplacementLifecycleReceipt {
+  const lifecycleGeneration = value.lifecycleGeneration;
+  const lifecycleLiveIdentityFingerprint = value.lifecycleLiveIdentityFingerprint;
+  if (
+    typeof lifecycleGeneration !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(
+      lifecycleGeneration,
+    )
+  ) {
+    throw new Error("rebuilt Hermes registry is missing its journaled lifecycle generation");
+  }
+  if (
+    typeof lifecycleLiveIdentityFingerprint !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(lifecycleLiveIdentityFingerprint)
+  ) {
+    throw new Error("rebuilt Hermes registry is missing its live lifecycle identity fingerprint");
+  }
+  return { lifecycleGeneration, lifecycleLiveIdentityFingerprint };
+}
+
 export function rebuildHermesRegistryImageState(
   createOutput: string,
 ): RebuildHermesRegistryImageState {
@@ -42,5 +76,15 @@ export function rebuildHermesRegistryImageState(
       `old Hermes sandbox create must report an exact ${prefix}<build-id> image tag; got ${imageTag ?? "<missing>"}`,
     );
   }
-  return { imageTag, fromDockerfile: null };
+  return {
+    openshellDriver: "docker",
+    imageTag,
+    fromDockerfile: null,
+    workload: {
+      schemaVersion: 1,
+      kind: "legacy-dockerfile",
+      reference: imageTag,
+      shared: false,
+    },
+  };
 }

--- a/test/e2e/live/rebuild-hermes.test.ts
+++ b/test/e2e/live/rebuild-hermes.test.ts
@@ -55,6 +55,7 @@ import {
   type RebuildHermesRegistryImageState,
   rebuildHermesRegistryImageState,
   requireRebuildHermesInitialImageTag,
+  requireRebuildHermesReplacementLifecycleReceipt,
 } from "./rebuild-hermes-image-state.ts";
 import {
   REBUILD_HERMES_OLD_BASE_FIXTURE,
@@ -1268,6 +1269,10 @@ test(STALE_BASE_REBUILD
     resultText(oldImageInspect),
   ).toBe(true);
   expect(resultText(oldImageInspect)).toMatch(/No such (?:image|object)(?::|\s)/iu);
+  await artifacts.writeJson(
+    "phase-6-replacement-registry-lifecycle-receipt.json",
+    requireRebuildHermesReplacementLifecycleReceipt(rebuiltRegistry),
+  );
 
   progress.phase("validate upgraded state inference and backup hygiene");
   const restoredMarker = await host.command(

--- a/test/e2e/support/rebuild-hermes-image-state.test.ts
+++ b/test/e2e/support/rebuild-hermes-image-state.test.ts
@@ -6,6 +6,7 @@ import {
   cleanupTrackedRebuildHermesImage,
   rebuildHermesRegistryImageState,
   requireRebuildHermesInitialImageTag,
+  requireRebuildHermesReplacementLifecycleReceipt,
 } from "../live/rebuild-hermes-image-state.ts";
 
 describe("Hermes rebuild fixture image ownership", () => {
@@ -39,6 +40,24 @@ describe("Hermes rebuild fixture image ownership", () => {
     ).toThrow("owned");
   });
 
+  it("requires the replacement registry row to carry its journaled live identity", () => {
+    const receipt = {
+      lifecycleGeneration: "5f63a0a3-e0f0-4e41-847b-8bc7c1f135ad",
+      lifecycleLiveIdentityFingerprint: "a".repeat(64),
+    };
+
+    expect(requireRebuildHermesReplacementLifecycleReceipt(receipt)).toEqual(receipt);
+    expect(() => requireRebuildHermesReplacementLifecycleReceipt({})).toThrow(
+      "lifecycle generation",
+    );
+    expect(() =>
+      requireRebuildHermesReplacementLifecycleReceipt({
+        ...receipt,
+        lifecycleLiveIdentityFingerprint: "unproven",
+      }),
+    ).toThrow("live lifecycle identity");
+  });
+
   it("retains the exact OpenShell-derived tag in managed rebuild state", () => {
     expect(
       rebuildHermesRegistryImageState(
@@ -48,8 +67,15 @@ describe("Hermes rebuild fixture image ownership", () => {
         ].join("\n"),
       ),
     ).toEqual({
+      openshellDriver: "docker",
       imageTag: "openshell/sandbox-from:1784010200",
       fromDockerfile: null,
+      workload: {
+        schemaVersion: 1,
+        kind: "legacy-dockerfile",
+        reference: "openshell/sandbox-from:1784010200",
+        shared: false,
+      },
     });
   });
 

--- a/test/e2e/support/rebuild-hermes-image-state.test.ts
+++ b/test/e2e/support/rebuild-hermes-image-state.test.ts
@@ -53,6 +53,12 @@ describe("Hermes rebuild fixture image ownership", () => {
     expect(() =>
       requireRebuildHermesReplacementLifecycleReceipt({
         ...receipt,
+        lifecycleGeneration: "5f63a0a3-e0f0-1e41-847b-8bc7c1f135ad",
+      }),
+    ).toThrow("lifecycle generation");
+    expect(() =>
+      requireRebuildHermesReplacementLifecycleReceipt({
+        ...receipt,
         lifecycleLiveIdentityFingerprint: "unproven",
       }),
     ).toThrow("live lifecycle identity");

--- a/test/onboard-sandbox-recreation.test.ts
+++ b/test/onboard-sandbox-recreation.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -100,7 +101,7 @@ const { createSandbox } = require(${onboardPath});
   it.each([
     "balanced",
     "restricted",
-  ])("recreate-sandbox materializes and records the %s policy tier", {
+  ])("recreate-sandbox records the %s policy tier and late replacement identity", {
     timeout: 60_000,
   }, async (policyTier) => {
     const repoRoot = path.join(import.meta.dirname, "..");
@@ -118,19 +119,31 @@ const { createSandbox } = require(${onboardPath});
 const runner = require(${runnerPath});
 require(${onboardScriptMocksPath}).mockStandaloneGatewayTeardownAuthority();
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
-let _deleted = false;
+let _deleted = false; let _sandboxId = "sbx-4f2a91c0d7";
 const registry = require(${registryPath});
 const childProcess = require("node:child_process");
 const { EventEmitter } = require("node:events");
 
 const commands = []; let registeredSandbox = null;
+const sourceSandbox = {
+  name: "my-assistant",
+  gpuEnabled: false,
+  openshellDriver: "docker",
+  imageTag: "openshell/sandbox-from:source",
+  workload: {
+    schemaVersion: 1,
+    kind: "legacy-dockerfile",
+    reference: "openshell/sandbox-from:source",
+    shared: false,
+  },
+};
 runner.run = (command, opts = {}) => {
   _deleted = _deleted || _n(command).includes("sandbox delete");
   commands.push({ command: _n(command), env: opts.env || null });
   return { status: 0 };
 };
 runner.runCapture = (command) => {
-  if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return _deleted ? "" : ["my-assistant", "Id: sbx-4f2a91c0d7"].join(String.fromCharCode(10));
+  if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return _deleted ? "" : ["my-assistant", "Id: " + _sandboxId].join(String.fromCharCode(10));
   if (_n(command).includes("sandbox list")) return _deleted ? "" : "my-assistant Ready";
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   {
@@ -141,7 +154,7 @@ runner.runCapture = (command) => {
   }
   return "";
 };
-registry.getSandbox = () => ({ name: "my-assistant", gpuEnabled: false });
+registry.getSandbox = () => registeredSandbox || sourceSandbox;
 registry.registerSandbox = (entry) => { registeredSandbox = entry; return true; };
 registry.updateSandbox = () => true;
 registry.setDefault = () => true;
@@ -152,6 +165,7 @@ preflight.checkPortAvailable = async () => ({ ok: true });
 
 childProcess.spawn = (...args) => {
   _deleted = false;
+  _sandboxId = "sbx-8e6b10fd33";
   const child = new EventEmitter();
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
@@ -210,6 +224,21 @@ const { createSandbox } = require(${onboardPath});
         payload.registeredSandbox?.policyTier === policyTier,
       "should create a sandbox and persist its tier before policy finalization",
     );
+    assert.ok(
+      !payload.commands.some((entry: CommandEntry) =>
+        entry.command.includes("docker rmi openshell/sandbox-from:source"),
+      ),
+      "must defer source image retirement until replacement registration is proven",
+    );
+    const sourceFingerprint = createHash("sha256").update("sbx-4f2a91c0d7").digest("hex");
+    const replacementFingerprint = createHash("sha256").update("sbx-8e6b10fd33").digest("hex");
+    assert.match(payload.registeredSandbox?.lifecycleGeneration ?? "", /^[0-9a-f-]{36}$/);
+    assert.equal(
+      payload.registeredSandbox?.lifecycleLiveIdentityFingerprint,
+      replacementFingerprint,
+      "replacement registration must read the live identity after creation",
+    );
+    assert.notEqual(payload.registeredSandbox?.lifecycleLiveIdentityFingerprint, sourceFingerprint);
   });
   it("recreate-sandbox flag backs up and restores workspace state", {
     timeout: 60_000,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->
Journaled same-name rebuilds now register the replacement's live lifecycle identity after creation and retire an obsolete owned Docker image only after exact replacement and ownership proof. Skipped retirements emit bounded reason codes, and the Hermes rebuild fixture records exact provider, workload, and replacement lifecycle evidence.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Related: #8590

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- Preserve portable lifecycle generation before create while reading the journaled live identity only after replacement creation.
- Remove eager pre-replacement image deletion and require an explicit runtime provider plus an exact matching unshared legacy-Dockerfile receipt before retirement.
- Report every bounded retirement skip reason and add focused lifecycle, cleanup-authority, ordering, logging, and Hermes E2E-support regressions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The existing Recover and Rebuild Sandboxes page already documents post-registration owned-image retirement, retention, and fail-closed mismatch handling; the completed documentation review found no contract change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent security/correctness review approved full-index diff SHA-256 `1c296f8d6354658bb2317087dbdaf49516d8ac6db44d102c172ee7f9ab24cca5`; final commit-object/tree rebind passed for `9d85c318882ff4c88a5b12f3205732b725593b02`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx`; its existing identity, generation, owned-image retirement, retention, and fail-closed contract remains accurate.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9d85c3188 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Focused CLI tests passed 107/107; `test/onboard-sandbox-recreation.test.ts` passed 11/11; E2E support tests passed 5/5. `npm run typecheck:cli`, `npm run checks:repository`, title/project/size/source-shape checks, changed-path Biome checks, and `git diff --check` also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox recreation safety by validating workload ownership and identity before retiring replaced images.
  - Prevented cleanup when workload authority cannot be confirmed, reducing the risk of removing unrelated resources.
  - Ensured recreated sandboxes retain accurate lifecycle generation and replacement identity information.
  - Added clear, reason-specific diagnostics when image retirement is skipped.

- **Tests**
  - Expanded coverage for sandbox recreation, lifecycle receipts, image cleanup safeguards, and replacement identity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->