### PR TITLE
ci(qualification): bootstrap trusted draft gate

### DIFF
--- a/.github/workflows/openshell-0.0.101-pr-gate.yaml
+++ b/.github/workflows/openshell-0.0.101-pr-gate.yaml
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: OpenShell 0.0.101 PR Gate
+
+run-name: >-
+  ${{ format('OpenShell draft gate PR #{0} head {1} base {2}',
+  github.event.pull_request.number, github.event.pull_request.head.sha,
+  github.event.pull_request.base.sha) }}
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  classify:
+    name: Classify trusted qualification scope
+    if: >-
+      github.repository == 'NVIDIA/NemoClaw' &&
+      github.event.pull_request.base.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      required: ${{ steps.classify.outputs.required }}
+      same-repository: ${{ steps.classify.outputs.same-repository }}
+    steps:
+      - name: Set up base-trusted qualification runtime
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.19.0
+
+      - name: Checkout base-trusted qualification verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-openshell-qualification
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/checks/openshell-qualification-bootstrap-contract.mts
+            scripts/checks/openshell-qualification-io.mts
+            scripts/checks/openshell-qualification-paths.mts
+            scripts/checks/verify-openshell-qualification-pr-gate.mts
+          sparse-checkout-cone-mode: false
+
+      - name: Classify pull request from base-trusted code
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: >-
+          node --experimental-strip-types --no-warnings
+          .trusted-openshell-qualification/scripts/checks/verify-openshell-qualification-pr-gate.mts
+          classify
+          --repository "$REPOSITORY"
+          --pr-number "$PR_NUMBER"
+          --candidate-sha "$CANDIDATE_SHA"
+          --base-sha "$BASE_SHA"
+          --output "$GITHUB_OUTPUT"
+
+  verify-draft:
+    name: Verify inert draft transition
+    needs: classify
+    if: >-
+      needs.classify.result == 'success' &&
+      needs.classify.outputs.required == 'true' &&
+      needs.classify.outputs.same-repository == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up base-trusted qualification runtime
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.19.0
+
+      - name: Checkout base-trusted draft verifier and data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-openshell-qualification
+          persist-credentials: false
+          sparse-checkout: |
+            ci/openshell-0.0.101-qualification-v1.json
+            nemoclaw-blueprint/blueprint.yaml
+            scripts/checks/openshell-qualification-bootstrap-contract.mts
+            scripts/checks/openshell-qualification-io.mts
+            scripts/checks/openshell-qualification-paths.mts
+            scripts/checks/verify-openshell-qualification-pr-gate.mts
+          sparse-checkout-cone-mode: false
+
+      # This checkout contains declarative data only. Base-trusted code reads
+      # it through the draft schema and never executes candidate content.
+      - name: Checkout candidate qualification data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: .candidate-openshell-qualification
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
+          sparse-checkout: |
+            ci/openshell-0.0.101-qualification-v1.json
+            nemoclaw-blueprint/blueprint.yaml
+          sparse-checkout-cone-mode: false
+
+      - name: Verify draft through base-trusted code
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: >-
+          node --experimental-strip-types --no-warnings
+          .trusted-openshell-qualification/scripts/checks/verify-openshell-qualification-pr-gate.mts
+          verify-draft
+          --repository "$REPOSITORY"
+          --pr-number "$PR_NUMBER"
+          --candidate-sha "$CANDIDATE_SHA"
+          --base-sha "$BASE_SHA"
+          --base-root "$GITHUB_WORKSPACE/.trusted-openshell-qualification"
+          --candidate-root "$GITHUB_WORKSPACE/.candidate-openshell-qualification"
+
+  openshell-qualification:
+    name: openshell-qualification
+    if: always()
+    needs: [classify, verify-draft]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Report qualification decision
+        env:
+          CLASSIFY_RESULT: ${{ needs.classify.result }}
+          REQUIRED: ${{ needs.classify.outputs.required }}
+          SAME_REPOSITORY: ${{ needs.classify.outputs.same-repository }}
+          VERIFY_DRAFT_RESULT: ${{ needs.verify-draft.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$CLASSIFY_RESULT" != "success" ]]; then
+            echo "::error::Base-trusted OpenShell qualification classification failed."
+            exit 1
+          fi
+          if [[ "$REQUIRED" == "false" ]]; then
+            echo "OpenShell 0.0.101 qualification is not applicable to this pull request."
+            exit 0
+          fi
+          if [[ "$REQUIRED" != "true" ]]; then
+            echo "::error::The base-trusted qualification decision is missing or malformed."
+            exit 1
+          fi
+          if [[ "$SAME_REPOSITORY" == "false" ]]; then
+            echo "::error::Qualification-sensitive fork pull requests fail closed."
+            exit 1
+          fi
+          if [[ "$SAME_REPOSITORY" != "true" ]]; then
+            echo "::error::The base-trusted repository decision is missing or malformed."
+            exit 1
+          fi
+          if [[ "$VERIFY_DRAFT_RESULT" != "success" ]]; then
+            echo "::error::The base-trusted inert draft transition was not verified."
+            exit 1
+          fi
+          echo "The base-trusted inert OpenShell qualification draft transition is verified."

--- a/ci/openshell-0.0.101-qualification-v1.json
+++ b/ci/openshell-0.0.101-qualification-v1.json
@@ -1,0 +1,406 @@
+{
+  "schemaVersion": 1,
+  "scope": "NVIDIA/NemoClaw#8590",
+  "repository": "NVIDIA/NemoClaw",
+  "inventoryState": "draft",
+  "requiredWorkflowGate": null,
+  "retirementEvidence": null,
+  "requiredStatusRulesetId": 15735613,
+  "artifacts": [],
+  "nemoclawRepositoryBaselineSha": "02398f3433f8c8d4cc329328229854bde7f4ce77",
+  "nemoclawUserBaselineTag": "v0.0.104",
+  "nemoclawUserBaselineTagObjectSha": "fc9b7ecee4e81048ab0f2c73c513cd606313797a",
+  "nemoclawUserBaselineCommitSha": "f389c9d872775006ae069473f58250fa8f3ad40f",
+  "lifecycle": "bootstrap",
+  "openshellRepositoryBaselineVersion": "0.0.99",
+  "openshellRepositoryBaselineTag": "v0.0.99",
+  "openshellRepositoryBaselineCommitSha": "8c7dd148a9e6360c9d5b2830e339a0dc4b3f3032",
+  "openshellBaselineVersion": "0.0.85",
+  "openshellBaselineTag": "v0.0.85",
+  "openshellBaselineCommitSha": "3dee5570a46076a57a3b056f35f35ebc0861ac85",
+  "openshellTargetVersion": "0.0.101",
+  "openshellTargetTag": "v0.0.101",
+  "openshellTargetCommitSha": "8ddd98c3dff62619a3963f99ba1e055b67650e72",
+  "trustedProducerWorkflowPath": ".github/workflows/openshell-0.0.101-qualification.yaml",
+  "tests": [
+    {
+      "id": "openshell-00101-docker-clean-install",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8605],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "clean-install",
+        "exact-candidate-base",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00099-to-00101-docker-upgrade",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8605],
+      "phases": ["selector"],
+      "requiredCases": [
+        "exact-candidate-base",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket",
+        "upgrade-from-00099"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00085-to-00101-docker-upgrade",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8605],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "direct-public-v85",
+        "exact-candidate-base",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-rootless-podman-controlled",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8603],
+      "phases": ["selector"],
+      "requiredCases": [
+        "exact-candidate-base",
+        "no-docker-fallback",
+        "published-artifacts",
+        "real-prepared-socket",
+        "real-runtime",
+        "real-socket"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-rootless-podman-clean-install",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8603],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "clean-install",
+        "exact-candidate-base",
+        "no-docker-fallback",
+        "published-artifacts",
+        "real-prepared-socket",
+        "real-runtime",
+        "real-socket"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00099-to-00101-rootless-podman-upgrade",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8603, 8605],
+      "phases": ["selector"],
+      "requiredCases": [
+        "exact-candidate-base",
+        "no-docker-fallback",
+        "published-artifacts",
+        "real-prepared-socket",
+        "real-runtime",
+        "real-socket",
+        "upgrade-from-00099"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00085-to-00101-rootless-podman-upgrade",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8603, 8605],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "direct-public-v85",
+        "exact-candidate-base",
+        "no-docker-fallback",
+        "published-artifacts",
+        "real-prepared-socket",
+        "real-runtime",
+        "real-socket"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-keepalive",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8601],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "exact-candidate-base",
+        "idle-over-interval",
+        "long-running",
+        "proxy-policy-path",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket",
+        "reconnect"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-policy-credentials",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8602],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "child-visible-boundary",
+        "default-db-selected",
+        "exact-candidate-base",
+        "no-external-driver",
+        "no-new-egress-mount-privilege",
+        "policy-deny",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket",
+        "secret-negative"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-credential-store-lifecycle",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8602],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "create-update-refresh-delete",
+        "exact-candidate-base",
+        "legacy-inline-preserved",
+        "owner-only-kek",
+        "plaintext-negative",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket",
+        "restart-retry-crash-cleanup",
+        "secret-negative",
+        "touched-key-handle-transition"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-component-coherence",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8602],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "artifact-component-coherence",
+        "exact-candidate-base",
+        "no-egress-adapter",
+        "no-go-sdk",
+        "no-vm-driver",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-runtime-identity",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8604],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "exact-candidate-base",
+        "full-id",
+        "image-identity",
+        "labels",
+        "non-root",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket",
+        "ssh-alias",
+        "supervisor-argv-workdir",
+        "workspace-name"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-upgrade-recovery",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8605],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "delete-convergence",
+        "direct-public-v85",
+        "exact-candidate-base",
+        "interruption",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket",
+        "rollback-retry"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    },
+    {
+      "id": "openshell-00101-same-name-isolation",
+      "approvedExceptions": [],
+      "matrix": { "lanes": [] },
+      "ownerIssues": [8605],
+      "phases": ["selector", "final"],
+      "requiredCases": [
+        "exact-candidate-base",
+        "published-artifacts",
+        "real-runtime",
+        "real-socket",
+        "same-name-isolation"
+      ],
+      "requiredDimensions": [
+        "all-registered-agents",
+        "applicable-gpu",
+        "cpu",
+        "supported-architecture",
+        "supported-os"
+      ],
+      "mappings": {
+        "selector": { "status": "pending", "source": null },
+        "final": { "status": "pending", "source": null }
+      }
+    }
+  ]
+}

--- a/scripts/checks/openshell-qualification-bootstrap-contract.mts
+++ b/scripts/checks/openshell-qualification-bootstrap-contract.mts
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isDeepStrictEqual } from "node:util";
+
+export const QUALIFICATION_CONTRACT_PATH = "ci/openshell-0.0.101-qualification-v1.json" as const;
+export const QUALIFICATION_REQUIRED_WORKFLOW_PATH =
+  ".github/workflows/openshell-0.0.101-pr-gate.yaml" as const;
+export const QUALIFICATION_REQUIRED_WORKFLOW_REF = "refs/heads/main" as const;
+export const QUALIFICATION_REQUIRED_WORKFLOW_REPOSITORY_ID = 1182547092 as const;
+export const QUALIFICATION_MAX_JSON_BYTES = 2 * 1024 * 1024;
+
+const TOKEN_PATTERN = /^[a-z0-9][a-z0-9-]{0,127}$/u;
+const TOP_LEVEL_KEYS = [
+  "artifacts",
+  "inventoryState",
+  "lifecycle",
+  "nemoclawRepositoryBaselineSha",
+  "nemoclawUserBaselineCommitSha",
+  "nemoclawUserBaselineTag",
+  "nemoclawUserBaselineTagObjectSha",
+  "openshellBaselineCommitSha",
+  "openshellBaselineTag",
+  "openshellBaselineVersion",
+  "openshellRepositoryBaselineCommitSha",
+  "openshellRepositoryBaselineTag",
+  "openshellRepositoryBaselineVersion",
+  "openshellTargetCommitSha",
+  "openshellTargetTag",
+  "openshellTargetVersion",
+  "repository",
+  "requiredStatusRulesetId",
+  "requiredWorkflowGate",
+  "retirementEvidence",
+  "schemaVersion",
+  "scope",
+  "tests",
+  "trustedProducerWorkflowPath",
+] as const;
+const TEST_KEYS = [
+  "approvedExceptions",
+  "id",
+  "mappings",
+  "matrix",
+  "ownerIssues",
+  "phases",
+  "requiredCases",
+  "requiredDimensions",
+] as const;
+const FIXED_FIELDS = {
+  schemaVersion: 1,
+  scope: "NVIDIA/NemoClaw#8590",
+  repository: "NVIDIA/NemoClaw",
+  inventoryState: "draft",
+  retirementEvidence: null,
+  requiredStatusRulesetId: 15735613,
+  artifacts: [],
+  nemoclawRepositoryBaselineSha: "02398f3433f8c8d4cc329328229854bde7f4ce77",
+  nemoclawUserBaselineTag: "v0.0.104",
+  nemoclawUserBaselineTagObjectSha: "fc9b7ecee4e81048ab0f2c73c513cd606313797a",
+  nemoclawUserBaselineCommitSha: "f389c9d872775006ae069473f58250fa8f3ad40f",
+  lifecycle: "bootstrap",
+  openshellRepositoryBaselineVersion: "0.0.99",
+  openshellRepositoryBaselineTag: "v0.0.99",
+  openshellRepositoryBaselineCommitSha: "8c7dd148a9e6360c9d5b2830e339a0dc4b3f3032",
+  openshellBaselineVersion: "0.0.85",
+  openshellBaselineTag: "v0.0.85",
+  openshellBaselineCommitSha: "3dee5570a46076a57a3b056f35f35ebc0861ac85",
+  openshellTargetVersion: "0.0.101",
+  openshellTargetTag: "v0.0.101",
+  openshellTargetCommitSha: "8ddd98c3dff62619a3963f99ba1e055b67650e72",
+  trustedProducerWorkflowPath: ".github/workflows/openshell-0.0.101-qualification.yaml",
+} as const;
+
+export type QualificationRequiredWorkflowGate = {
+  organizationRulesetId: number;
+  repositoryId: typeof QUALIFICATION_REQUIRED_WORKFLOW_REPOSITORY_ID;
+  sourcePath: typeof QUALIFICATION_REQUIRED_WORKFLOW_PATH;
+  sourceRef: typeof QUALIFICATION_REQUIRED_WORKFLOW_REF;
+};
+
+type PendingMapping = { source: null; status: "pending" };
+
+export type BootstrapQualificationTest = {
+  approvedExceptions: [];
+  id: string;
+  mappings: { final: PendingMapping; selector: PendingMapping };
+  matrix: { lanes: [] };
+  ownerIssues: number[];
+  phases: ["selector"] | ["selector", "final"];
+  requiredCases: string[];
+  requiredDimensions: string[];
+};
+
+export type BootstrapQualificationContract = typeof FIXED_FIELDS & {
+  requiredWorkflowGate: QualificationRequiredWorkflowGate | null;
+  tests: BootstrapQualificationTest[];
+};
+
+export function failQualificationGate(message: string): never {
+  throw new Error(`OpenShell qualification PR gate failed: ${message}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (!isDeepStrictEqual(actual, wanted)) {
+    failQualificationGate(`${label} fields are invalid`);
+  }
+}
+
+function assertEmptyArray(value: unknown, label: string): asserts value is [] {
+  if (!Array.isArray(value) || value.length !== 0) {
+    failQualificationGate(`${label} must remain empty in draft`);
+  }
+}
+
+function validateUniqueTokens(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 128) {
+    failQualificationGate(`${label} must be a bounded nonempty list`);
+  }
+  const tokens = value.map((entry) => {
+    if (typeof entry !== "string" || !TOKEN_PATTERN.test(entry)) {
+      failQualificationGate(`${label} contains an invalid identifier`);
+    }
+    return entry;
+  });
+  if (new Set(tokens).size !== tokens.length) {
+    failQualificationGate(`${label} contains a duplicate identifier`);
+  }
+  return tokens;
+}
+
+function validatePendingMapping(value: unknown, label: string): PendingMapping {
+  if (!isRecord(value)) failQualificationGate(`${label} is not an object`);
+  assertExactKeys(value, ["source", "status"], label);
+  if (value.status !== "pending" || value.source !== null) {
+    failQualificationGate(`${label} must remain pending without a source`);
+  }
+  return { source: null, status: "pending" };
+}
+
+function validateTest(value: unknown): BootstrapQualificationTest {
+  if (!isRecord(value)) failQualificationGate("qualification test is not an object");
+  assertExactKeys(value, TEST_KEYS, "qualification test");
+  if (typeof value.id !== "string" || !TOKEN_PATTERN.test(value.id)) {
+    failQualificationGate("qualification test id is invalid");
+  }
+  assertEmptyArray(value.approvedExceptions, `qualification test ${value.id} exceptions`);
+  if (!isRecord(value.matrix)) {
+    failQualificationGate(`qualification test ${value.id} matrix is not an object`);
+  }
+  assertExactKeys(value.matrix, ["lanes"], `qualification test ${value.id} matrix`);
+  assertEmptyArray(value.matrix.lanes, `qualification test ${value.id} matrix lanes`);
+  if (!Array.isArray(value.ownerIssues) || value.ownerIssues.length === 0) {
+    failQualificationGate(`qualification test ${value.id} owner issues are invalid`);
+  }
+  const ownerIssues = value.ownerIssues.map((entry) => {
+    if (!Number.isSafeInteger(entry) || (entry as number) <= 0) {
+      failQualificationGate(`qualification test ${value.id} owner issue is invalid`);
+    }
+    return entry as number;
+  });
+  if (new Set(ownerIssues).size !== ownerIssues.length) {
+    failQualificationGate(`qualification test ${value.id} owner issues contain a duplicate`);
+  }
+  if (
+    !Array.isArray(value.phases) ||
+    (value.phases.length !== 1 && value.phases.length !== 2) ||
+    value.phases[0] !== "selector" ||
+    (value.phases.length === 2 && value.phases[1] !== "final")
+  ) {
+    failQualificationGate(`qualification test ${value.id} phases are invalid`);
+  }
+  if (!isRecord(value.mappings)) {
+    failQualificationGate(`qualification test ${value.id} mappings are not an object`);
+  }
+  assertExactKeys(value.mappings, ["final", "selector"], `qualification test ${value.id} mappings`);
+  const mappings = {
+    final: validatePendingMapping(
+      value.mappings.final,
+      `qualification test ${value.id} final mapping`,
+    ),
+    selector: validatePendingMapping(
+      value.mappings.selector,
+      `qualification test ${value.id} selector mapping`,
+    ),
+  };
+  return {
+    approvedExceptions: [],
+    id: value.id,
+    mappings,
+    matrix: { lanes: [] },
+    ownerIssues,
+    phases: value.phases as ["selector"] | ["selector", "final"],
+    requiredCases: validateUniqueTokens(
+      value.requiredCases,
+      `qualification test ${value.id} required cases`,
+    ),
+    requiredDimensions: validateUniqueTokens(
+      value.requiredDimensions,
+      `qualification test ${value.id} required dimensions`,
+    ),
+  };
+}
+
+function validateRequiredWorkflowGate(value: unknown): QualificationRequiredWorkflowGate | null {
+  if (value === null) return null;
+  if (!isRecord(value)) failQualificationGate("required workflow gate is not an object");
+  assertExactKeys(
+    value,
+    ["organizationRulesetId", "repositoryId", "sourcePath", "sourceRef"],
+    "required workflow gate",
+  );
+  if (
+    !Number.isSafeInteger(value.organizationRulesetId) ||
+    (value.organizationRulesetId as number) <= 0 ||
+    value.repositoryId !== QUALIFICATION_REQUIRED_WORKFLOW_REPOSITORY_ID ||
+    value.sourcePath !== QUALIFICATION_REQUIRED_WORKFLOW_PATH ||
+    value.sourceRef !== QUALIFICATION_REQUIRED_WORKFLOW_REF
+  ) {
+    failQualificationGate("required workflow gate authority is invalid");
+  }
+  return {
+    organizationRulesetId: value.organizationRulesetId as number,
+    repositoryId: QUALIFICATION_REQUIRED_WORKFLOW_REPOSITORY_ID,
+    sourcePath: QUALIFICATION_REQUIRED_WORKFLOW_PATH,
+    sourceRef: QUALIFICATION_REQUIRED_WORKFLOW_REF,
+  };
+}
+
+export function validateBootstrapQualificationContract(
+  value: unknown,
+): BootstrapQualificationContract {
+  if (!isRecord(value)) failQualificationGate("qualification contract is not an object");
+  assertExactKeys(value, TOP_LEVEL_KEYS, "qualification contract");
+  for (const [key, expected] of Object.entries(FIXED_FIELDS)) {
+    if (!isDeepStrictEqual(value[key], expected)) {
+      failQualificationGate(`qualification contract ${key} is invalid for draft bootstrap`);
+    }
+  }
+  if (!Array.isArray(value.tests) || value.tests.length === 0 || value.tests.length > 128) {
+    failQualificationGate("qualification tests must be a bounded nonempty list");
+  }
+  const tests = value.tests.map(validateTest);
+  if (new Set(tests.map((test) => test.id)).size !== tests.length) {
+    failQualificationGate("qualification test ids contain a duplicate");
+  }
+  return {
+    ...FIXED_FIELDS,
+    requiredWorkflowGate: validateRequiredWorkflowGate(value.requiredWorkflowGate),
+    tests,
+  };
+}
+
+export function validateBootstrapDraftTransition(
+  baseValue: unknown | null,
+  candidateValue: unknown | null,
+  versions: { baseVersion: string; candidateVersion: string },
+): BootstrapQualificationContract {
+  if (baseValue === null && candidateValue !== null) {
+    failQualificationGate(
+      "candidate contract cannot establish authority absent from the trusted base",
+    );
+  }
+  if (baseValue === null || candidateValue === null) {
+    failQualificationGate("draft bootstrap contract cannot be removed");
+  }
+  if (versions.baseVersion !== "0.0.99" || versions.candidateVersion !== "0.0.99") {
+    failQualificationGate("draft bootstrap cannot change the pinned OpenShell version");
+  }
+  const base = validateBootstrapQualificationContract(baseValue);
+  const candidate = validateBootstrapQualificationContract(candidateValue);
+  const comparableBase = { ...base, requiredWorkflowGate: null };
+  const comparableCandidate = { ...candidate, requiredWorkflowGate: null };
+  if (!isDeepStrictEqual(comparableBase, comparableCandidate)) {
+    failQualificationGate("draft bootstrap contract may change only required workflow authority");
+  }
+  if (
+    base.requiredWorkflowGate !== null &&
+    !isDeepStrictEqual(base.requiredWorkflowGate, candidate.requiredWorkflowGate)
+  ) {
+    failQualificationGate("established required workflow authority cannot change");
+  }
+  return candidate;
+}

--- a/scripts/checks/openshell-qualification-io.mts
+++ b/scripts/checks/openshell-qualification-io.mts
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  type BootstrapQualificationContract,
+  failQualificationGate as fail,
+  QUALIFICATION_CONTRACT_PATH,
+  QUALIFICATION_MAX_JSON_BYTES,
+  validateBootstrapQualificationContract,
+} from "./openshell-qualification-bootstrap-contract.mts";
+
+const MAX_JSON_DEPTH = 64;
+const MAX_JSON_ITEMS = 100_000;
+const QUALIFICATION_MAX_ARTIFACT_BYTES = 4 * 1024 * 1024;
+const SAFE_TEXT_PATTERN = /^[^\u0000-\u001f\u007f]{1,2048}$/u;
+
+function skipWhitespace(source: string, cursor: { index: number }): void {
+  while (/\s/u.test(source[cursor.index] ?? "")) cursor.index += 1;
+}
+
+function scanJsonString(source: string, cursor: { index: number }): string {
+  const start = cursor.index;
+  cursor.index += 1;
+  while (cursor.index < source.length) {
+    const character = source[cursor.index];
+    if (character === "\\") {
+      cursor.index += 2;
+      continue;
+    }
+    cursor.index += 1;
+    if (character === '"') {
+      try {
+        return JSON.parse(source.slice(start, cursor.index)) as string;
+      } catch {
+        fail("JSON contains a malformed string");
+      }
+    }
+  }
+  fail("JSON contains an unterminated string");
+}
+
+function scanJsonValue(
+  source: string,
+  cursor: { index: number; items: number },
+  depth: number,
+): void {
+  if (depth > MAX_JSON_DEPTH) fail("JSON nesting is too deep");
+  skipWhitespace(source, cursor);
+  const character = source[cursor.index];
+  if (character === "{") {
+    cursor.index += 1;
+    const keys = new Set<string>();
+    skipWhitespace(source, cursor);
+    if (source[cursor.index] === "}") {
+      cursor.index += 1;
+      return;
+    }
+    while (cursor.index < source.length) {
+      skipWhitespace(source, cursor);
+      if (source[cursor.index] !== '"') fail("JSON object key is malformed");
+      const key = scanJsonString(source, cursor);
+      if (keys.has(key)) fail(`JSON contains duplicate object key ${JSON.stringify(key)}`);
+      keys.add(key);
+      cursor.items += 1;
+      if (cursor.items > MAX_JSON_ITEMS) fail("JSON contains too many items");
+      skipWhitespace(source, cursor);
+      if (source[cursor.index] !== ":") fail("JSON object separator is malformed");
+      cursor.index += 1;
+      scanJsonValue(source, cursor, depth + 1);
+      skipWhitespace(source, cursor);
+      if (source[cursor.index] === "}") {
+        cursor.index += 1;
+        return;
+      }
+      if (source[cursor.index] !== ",") fail("JSON object delimiter is malformed");
+      cursor.index += 1;
+    }
+    fail("JSON object is unterminated");
+  }
+  if (character === "[") {
+    cursor.index += 1;
+    skipWhitespace(source, cursor);
+    if (source[cursor.index] === "]") {
+      cursor.index += 1;
+      return;
+    }
+    while (cursor.index < source.length) {
+      cursor.items += 1;
+      if (cursor.items > MAX_JSON_ITEMS) fail("JSON contains too many items");
+      scanJsonValue(source, cursor, depth + 1);
+      skipWhitespace(source, cursor);
+      if (source[cursor.index] === "]") {
+        cursor.index += 1;
+        return;
+      }
+      if (source[cursor.index] !== ",") fail("JSON array delimiter is malformed");
+      cursor.index += 1;
+    }
+    fail("JSON array is unterminated");
+  }
+  if (character === '"') {
+    scanJsonString(source, cursor);
+    return;
+  }
+  const start = cursor.index;
+  while (cursor.index < source.length && !/[\s,\]}]/u.test(source[cursor.index] ?? "")) {
+    cursor.index += 1;
+  }
+  if (cursor.index === start) fail("JSON value is malformed");
+  try {
+    JSON.parse(source.slice(start, cursor.index));
+  } catch {
+    fail("JSON primitive is malformed");
+  }
+}
+
+export function parseBoundedJson(source: string, label: string): unknown {
+  if (Buffer.byteLength(source, "utf8") > QUALIFICATION_MAX_JSON_BYTES) {
+    fail(`${label} is oversized`);
+  }
+  const cursor = { index: 0, items: 0 };
+  scanJsonValue(source, cursor, 0);
+  skipWhitespace(source, cursor);
+  if (cursor.index !== source.length) fail(`${label} has trailing content`);
+  try {
+    return JSON.parse(source) as unknown;
+  } catch {
+    fail(`${label} is not valid JSON`);
+  }
+}
+
+export function readBoundedRegularFileBytes(
+  filePath: string,
+  label: string,
+  limits: { maximumBytes: number; minimumBytes?: number },
+): Buffer {
+  if (
+    typeof filePath !== "string" ||
+    !SAFE_TEXT_PATTERN.test(filePath) ||
+    path.normalize(filePath) !== filePath
+  ) {
+    fail(`${label} path is invalid or non-canonical`);
+  }
+  const minimumBytes = limits.minimumBytes ?? 0;
+  if (
+    !Number.isSafeInteger(minimumBytes) ||
+    minimumBytes < 0 ||
+    !Number.isSafeInteger(limits.maximumBytes) ||
+    limits.maximumBytes > QUALIFICATION_MAX_ARTIFACT_BYTES ||
+    limits.maximumBytes < minimumBytes
+  ) {
+    fail(`${label} byte limits are invalid`);
+  }
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (!Number.isSafeInteger(noFollow) || noFollow === 0) {
+    fail(`${label} cannot be authenticated without no-follow file access`);
+  }
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK | noFollow);
+  } catch {
+    fail(`${label} is missing or is not a regular non-link file`);
+  }
+  try {
+    const before = fs.fstatSync(descriptor, { bigint: true });
+    if (
+      !before.isFile() ||
+      before.size < BigInt(minimumBytes) ||
+      before.size > BigInt(limits.maximumBytes)
+    ) {
+      fail(`${label} must be a bounded regular non-link file`);
+    }
+    const buffer = Buffer.allocUnsafe(limits.maximumBytes + 1);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const count = fs.readSync(descriptor, buffer, bytesRead, buffer.length - bytesRead, null);
+      if (count === 0) break;
+      bytesRead += count;
+    }
+    const after = fs.fstatSync(descriptor, { bigint: true });
+    if (
+      bytesRead !== Number(before.size) ||
+      after.dev !== before.dev ||
+      after.ino !== before.ino ||
+      after.mode !== before.mode ||
+      after.nlink !== before.nlink ||
+      after.size !== before.size ||
+      after.mtimeNs !== before.mtimeNs ||
+      after.ctimeNs !== before.ctimeNs
+    ) {
+      fail(`${label} changed while it was being read`);
+    }
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+export function readBoundedRegularFile(
+  filePath: string,
+  label: string,
+  limits: { maximumBytes: number; minimumBytes?: number } = {
+    maximumBytes: QUALIFICATION_MAX_JSON_BYTES,
+  },
+): string {
+  return readBoundedRegularFileBytes(filePath, label, limits).toString("utf8");
+}
+
+export function readBoundedRegularFileFromRoot(
+  root: string,
+  relativePath: string,
+  label: string,
+  limits: { maximumBytes: number; minimumBytes?: number },
+): Buffer {
+  if (
+    typeof root !== "string" ||
+    root.length === 0 ||
+    typeof relativePath !== "string" ||
+    relativePath.length === 0 ||
+    path.isAbsolute(relativePath) ||
+    path.posix.normalize(relativePath) !== relativePath ||
+    relativePath.split("/").some((part) => part === "" || part === "." || part === "..")
+  ) {
+    fail(`${label} root or relative path is invalid`);
+  }
+  const absoluteRoot = path.resolve(root);
+  let rootStats: fs.Stats;
+  try {
+    rootStats = fs.lstatSync(absoluteRoot);
+  } catch {
+    fail(`${label} root is missing`);
+  }
+  if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) {
+    fail(`${label} root must be a real directory`);
+  }
+  const canonicalRoot = fs.realpathSync(absoluteRoot);
+  const parts = relativePath.split("/");
+  let cursor = canonicalRoot;
+  for (const part of parts.slice(0, -1)) {
+    cursor = path.join(cursor, part);
+    let stats: fs.Stats;
+    try {
+      stats = fs.lstatSync(cursor);
+    } catch {
+      fail(`${label} is missing`);
+    }
+    if (stats.isSymbolicLink()) fail(`${label} path crosses a symbolic link`);
+    if (!stats.isDirectory()) fail(`${label} path has an invalid parent`);
+    const resolvedParent = fs.realpathSync(cursor);
+    if (resolvedParent !== cursor || !resolvedParent.startsWith(`${canonicalRoot}${path.sep}`)) {
+      fail(`${label} path escapes its root or crosses a symbolic link`);
+    }
+    cursor = resolvedParent;
+  }
+  return readBoundedRegularFileBytes(path.join(cursor, parts.at(-1) as string), label, limits);
+}
+
+export function loadBootstrapQualificationContractFromRoot(
+  root: string,
+): BootstrapQualificationContract {
+  return validateBootstrapQualificationContract(
+    parseBoundedJson(
+      readBoundedRegularFileFromRoot(root, QUALIFICATION_CONTRACT_PATH, "qualification contract", {
+        maximumBytes: QUALIFICATION_MAX_JSON_BYTES,
+        minimumBytes: 1,
+      }).toString("utf8"),
+      "qualification contract",
+    ),
+  );
+}

--- a/scripts/checks/openshell-qualification-paths.mts
+++ b/scripts/checks/openshell-qualification-paths.mts
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+import { failQualificationGate as fail } from "./openshell-qualification-bootstrap-contract.mts";
+
+const SAFE_PATH_PATTERN = /^[^\u0000-\u001f\u007f\\]{1,4096}$/u;
+const MAX_PR_FILE_PAGES = 30;
+const PAGE_SIZE = 100;
+
+const KNOWN_FILE_STATUSES = new Set([
+  "added",
+  "changed",
+  "copied",
+  "modified",
+  "removed",
+  "renamed",
+  "unchanged",
+]);
+
+const SENSITIVE_EXACT_PATHS = new Set([
+  ".dockerignore",
+  ".agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md",
+  ".agents/skills/nemoclaw-maintainer-cut-release-tag/scripts/release-e2e-evidence.mts",
+  ".github/workflows/managed-images.yaml",
+  ".github/workflows/openshell-0.0.101-pr-gate.yaml",
+  ".github/workflows/openshell-0.0.101-qualification.yaml",
+  ".github/workflows/podman-cpu-proof.yaml",
+  "Dockerfile",
+  "ci/openshell-0.0.101-qualification-v1.json",
+  "nemoclaw-blueprint/blueprint.yaml",
+  "nemoclaw/src/shared/openshell-policy-boundary.cts",
+  "schemas/blueprint.schema.json",
+  "scripts/brev-launchable-ci-cpu.sh",
+  "scripts/checks/dependency-pins.mts",
+  "scripts/checks/managed-image-protected-runtime-contract.ts",
+  "scripts/checks/openshell-qualification-bootstrap-contract.mts",
+  "scripts/checks/openshell-qualification-contract.mts",
+  "scripts/checks/openshell-qualification-core.mts",
+  "scripts/checks/openshell-qualification-github.mts",
+  "scripts/checks/openshell-qualification-io.mts",
+  "scripts/checks/openshell-qualification-matrix.mts",
+  "scripts/checks/openshell-qualification-paths.mts",
+  "scripts/checks/openshell-qualification-schema.mts",
+  "scripts/checks/verify-openshell-qualification-producer-workflow.mts",
+  "scripts/checks/verify-openshell-qualification-pr-gate.mts",
+  "scripts/install-openshell.sh",
+  "scripts/install.sh",
+  "scripts/nemoclaw-start.sh",
+  "scripts/release-cut-tag.sh",
+  "scripts/scorecard/read-artifact-zip.mts",
+  "src/lib/adapters/container-engine.ts",
+  "src/lib/gateway-runtime-action.ts",
+  "src/lib/inference/serving/managed-runtime-receipts.ts",
+  "src/lib/onboard/experimental/portable-demo-lifecycle.test.ts",
+  "src/lib/onboard/experimental/portable-demo-lifecycle.ts",
+  "src/lib/onboard/gateway-host-runtime.ts",
+  "tools/e2e/openshell-gateway-upgrade-workflow-boundary.mts",
+]);
+
+const SENSITIVE_PREFIXES = [
+  "agents/hermes/",
+  "agents/langchain-deepagents-code/",
+  "agents/openclaw/",
+  "nemoclaw-blueprint/model-specific-setup/",
+  "nemoclaw-blueprint/openclaw-plugins/",
+  "nemoclaw/src/blueprint/",
+  "scripts/lib/openshell-",
+  "src/lib/adapters/openshell/",
+  "src/lib/adapters/podman/",
+  "src/lib/adapters/sandbox/command-transport",
+  "src/lib/onboard/managed-bootstrap/",
+  "src/lib/onboard/managed-startup",
+  "src/lib/onboard/openshell-",
+  "src/lib/onboard/runtime-provider/podman",
+  "src/lib/sandbox/version",
+  "test/e2e/live/managed-image-activation-e2e",
+  "test/e2e/live/openshell-gateway-upgrade",
+  "test/e2e/live/podman-cpu-lifecycle",
+  "test/e2e/support/openshell-gateway-upgrade",
+  "test/e2e/support/podman-cpu-proof-workflow",
+] as const;
+
+export type PullRequestFile = {
+  filename: string;
+  previousFilename?: string;
+  status: string;
+};
+
+export type PullRequestReader = {
+  getPullRequestFilesPage(repository: string, prNumber: number, page: number): Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function validateRepositoryPath(value: unknown, label = "path"): string {
+  if (typeof value !== "string" || !SAFE_PATH_PATTERN.test(value)) {
+    fail(`${label} is invalid`);
+  }
+  if (
+    value.startsWith("/") ||
+    value.endsWith("/") ||
+    value.split("/").some((part) => part === "" || part === "." || part === "..") ||
+    path.posix.normalize(value) !== value
+  ) {
+    fail(`${label} is not a canonical repository-relative path`);
+  }
+  return value;
+}
+
+export function validatePullRequestFile(value: unknown): PullRequestFile {
+  if (!isRecord(value)) fail("pull-request files response contains a non-object entry");
+  const filename = validateRepositoryPath(value.filename, "pull-request filename");
+  if (typeof value.status !== "string" || !KNOWN_FILE_STATUSES.has(value.status)) {
+    fail(`pull-request file ${filename} has unknown status`);
+  }
+  if (value.status === "renamed") {
+    const previousFilename = validateRepositoryPath(
+      value.previous_filename,
+      "renamed pull-request previous_filename",
+    );
+    if (previousFilename === filename) fail(`renamed pull-request file ${filename} did not move`);
+    return { filename, previousFilename, status: value.status };
+  }
+  if (value.previous_filename !== undefined) {
+    fail(`non-renamed pull-request file ${filename} unexpectedly has previous_filename`);
+  }
+  return { filename, status: value.status };
+}
+
+export function pathsForFile(file: PullRequestFile): string[] {
+  return file.previousFilename ? [file.previousFilename, file.filename] : [file.filename];
+}
+
+function matchesExactOrPrefix(
+  candidatePath: string,
+  exact: ReadonlySet<string>,
+  prefixes: readonly string[],
+): boolean {
+  return exact.has(candidatePath) || prefixes.some((prefix) => candidatePath.startsWith(prefix));
+}
+
+export function isOpenShellQualificationSensitivePath(candidatePath: string): boolean {
+  validateRepositoryPath(candidatePath, "qualification candidate path");
+  if (matchesExactOrPrefix(candidatePath, SENSITIVE_EXACT_PATHS, SENSITIVE_PREFIXES)) return true;
+  if (/^agents\/[^/]+\/(?:manifest\.yaml|state-lock-plan\.json)$/u.test(candidatePath)) return true;
+  if (
+    /^src\/lib\/actions\/sandbox\/openshell-child-visible-credentials\.v[^/]+\.json$/u.test(
+      candidatePath,
+    )
+  ) {
+    return true;
+  }
+  if (
+    /^src\/lib\/(?:actions\/sandbox|onboard)\/[^/]*(?:gateway|supervisor)[^/]*\.(?:ts|json)$/u.test(
+      candidatePath,
+    )
+  ) {
+    return true;
+  }
+  if (
+    /^\.github\/workflows\/[^/]*(?:openshell|runtime|qualification)[^/]*\.ya?ml$/u.test(
+      candidatePath,
+    )
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function classifyQualification(files: readonly PullRequestFile[]): {
+  required: boolean;
+  sensitivePaths: string[];
+} {
+  const allPaths = files.flatMap(pathsForFile);
+  const sensitivePaths = [
+    ...new Set(allPaths.filter(isOpenShellQualificationSensitivePath)),
+  ].sort();
+  return { required: sensitivePaths.length > 0, sensitivePaths };
+}
+
+export async function loadPullRequestFiles(
+  api: PullRequestReader,
+  repository: string,
+  prNumber: number,
+): Promise<PullRequestFile[]> {
+  const files: PullRequestFile[] = [];
+  const filenames = new Set<string>();
+  for (let page = 1; page <= MAX_PR_FILE_PAGES; page += 1) {
+    const value = await api.getPullRequestFilesPage(repository, prNumber, page);
+    if (!Array.isArray(value) || value.length > PAGE_SIZE) {
+      fail(`pull-request files page ${page} is malformed`);
+    }
+    for (const item of value) {
+      const file = validatePullRequestFile(item);
+      if (filenames.has(file.filename)) {
+        fail(`pull-request filename ${file.filename} is duplicated`);
+      }
+      filenames.add(file.filename);
+      files.push(file);
+    }
+    if (value.length < PAGE_SIZE) return files;
+  }
+  fail("pull-request files pagination is incomplete or exceeds GitHub's 3,000-file limit");
+}

--- a/scripts/checks/verify-openshell-qualification-pr-gate.mts
+++ b/scripts/checks/verify-openshell-qualification-pr-gate.mts
@@ -1,0 +1,444 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  failQualificationGate as fail,
+  validateBootstrapDraftTransition,
+} from "./openshell-qualification-bootstrap-contract.mts";
+import {
+  loadBootstrapQualificationContractFromRoot,
+  readBoundedRegularFileFromRoot,
+} from "./openshell-qualification-io.mts";
+import {
+  classifyQualification,
+  loadPullRequestFiles,
+  type PullRequestReader,
+} from "./openshell-qualification-paths.mts";
+
+const QUALIFICATION_REPOSITORY = "NVIDIA/NemoClaw";
+const MAX_GITHUB_JSON_BYTES = 16 * 1024 * 1024;
+const MAX_BLUEPRINT_BYTES = 1024 * 1024;
+const GITHUB_TIMEOUT_MILLISECONDS = 10_000;
+const REVIEWED_BLUEPRINT_SHA256 =
+  "a69e56022d7f5973f330e13dccfcef0c997f933f851da218a8f2f73cdcc9c20f";
+const SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/u;
+
+type PullRequestIdentity = {
+  baseRef: "main";
+  baseSha: string;
+  candidateRepository: string;
+  candidateSha: string;
+  number: number;
+  repository: typeof QUALIFICATION_REPOSITORY;
+  state: "open";
+};
+
+export type GateInputs = {
+  baseSha: string;
+  candidateSha: string;
+  prNumber: number;
+  repository: typeof QUALIFICATION_REPOSITORY;
+};
+
+type GateGitHubReader = PullRequestReader & {
+  getPullRequest(repository: string, prNumber: number): Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readNestedString(
+  value: Record<string, unknown>,
+  first: string,
+  second: string,
+  third?: string,
+): string {
+  const firstValue = value[first];
+  if (!isRecord(firstValue)) fail("pull-request identity is malformed");
+  const secondValue = firstValue[second];
+  if (third === undefined) {
+    if (typeof secondValue !== "string") fail("pull-request identity is malformed");
+    return secondValue;
+  }
+  if (!isRecord(secondValue) || typeof secondValue[third] !== "string") {
+    fail("pull-request identity is malformed");
+  }
+  return secondValue[third];
+}
+
+function validateSha(value: unknown, label: string): string {
+  if (typeof value !== "string" || !SHA_PATTERN.test(value)) {
+    fail(`${label} must be a lowercase 40-character SHA`);
+  }
+  return value;
+}
+
+function validateRepository(value: unknown): typeof QUALIFICATION_REPOSITORY {
+  if (value !== QUALIFICATION_REPOSITORY) {
+    fail("repository identity is outside the qualification boundary");
+  }
+  return QUALIFICATION_REPOSITORY;
+}
+
+function validatePositiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) fail(`${label} is invalid`);
+  return value as number;
+}
+
+function validateInputs(inputs: GateInputs): GateInputs {
+  return {
+    baseSha: validateSha(inputs.baseSha, "base SHA"),
+    candidateSha: validateSha(inputs.candidateSha, "candidate SHA"),
+    prNumber: validatePositiveInteger(inputs.prNumber, "pull-request number"),
+    repository: validateRepository(inputs.repository),
+  };
+}
+
+function validatePullRequestIdentity(value: unknown, expected: GateInputs): PullRequestIdentity {
+  if (!isRecord(value)) fail("pull-request response is not an object");
+  if (value.state !== "open") fail("pull request is not open");
+  const baseRef = readNestedString(value, "base", "ref");
+  if (baseRef !== "main") fail("pull request no longer targets main");
+  const identity: PullRequestIdentity = {
+    baseRef,
+    baseSha: validateSha(readNestedString(value, "base", "sha"), "live base SHA"),
+    candidateRepository: readNestedString(value, "head", "repo", "full_name"),
+    candidateSha: validateSha(readNestedString(value, "head", "sha"), "live candidate SHA"),
+    number: validatePositiveInteger(value.number, "live pull-request number"),
+    repository: validateRepository(readNestedString(value, "base", "repo", "full_name")),
+    state: value.state,
+  };
+  if (
+    identity.number !== expected.prNumber ||
+    identity.baseSha !== expected.baseSha ||
+    identity.candidateSha !== expected.candidateSha
+  ) {
+    fail("pull-request identity changed or does not match the workflow event");
+  }
+  return identity;
+}
+
+function parseContentLength(value: string | null, label: string): number | null {
+  if (value === null) return null;
+  if (!/^(?:0|[1-9][0-9]*)$/u.test(value)) fail(`${label} content length is invalid`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) fail(`${label} content length is invalid`);
+  return parsed;
+}
+
+export async function readBoundedJsonResponse(
+  response: Response,
+  label: string,
+  maximumBytes = MAX_GITHUB_JSON_BYTES,
+): Promise<unknown> {
+  if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 1) {
+    fail(`${label} byte limit is invalid`);
+  }
+  const declared = parseContentLength(response.headers.get("content-length"), label);
+  if (declared !== null && declared > maximumBytes) fail(`${label} response is oversized`);
+  if (!response.ok) fail(`${label} request failed with HTTP ${response.status}`);
+  if (response.body === null) fail(`${label} response has no body`);
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maximumBytes) {
+        await reader.cancel();
+        fail(`${label} response is oversized`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = Buffer.concat(chunks, total);
+  let source: string;
+  try {
+    source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail(`${label} response is not valid UTF-8`);
+  }
+  try {
+    return JSON.parse(source) as unknown;
+  } catch {
+    fail(`${label} response is not valid JSON`);
+  }
+}
+
+export function createGitHubReader(token: string): GateGitHubReader {
+  if (!token) fail("GITHUB_TOKEN is unavailable");
+  const request = async (url: string, label: string): Promise<unknown> => {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "nemoclaw-openshell-qualification-pr-gate",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      redirect: "error",
+      signal: AbortSignal.timeout(GITHUB_TIMEOUT_MILLISECONDS),
+    });
+    return readBoundedJsonResponse(response, label);
+  };
+  return {
+    getPullRequest(repository: string, prNumber: number): Promise<unknown> {
+      validateRepository(repository);
+      validatePositiveInteger(prNumber, "pull-request number");
+      return request(
+        `https://api.github.com/repos/NVIDIA/NemoClaw/pulls/${prNumber}`,
+        "pull-request",
+      );
+    },
+    getPullRequestFilesPage(repository: string, prNumber: number, page: number): Promise<unknown> {
+      validateRepository(repository);
+      validatePositiveInteger(prNumber, "pull-request number");
+      validatePositiveInteger(page, "pull-request files page");
+      return request(
+        `https://api.github.com/repos/NVIDIA/NemoClaw/pulls/${prNumber}/files?per_page=100&page=${page}`,
+        "pull-request files",
+      );
+    },
+  };
+}
+
+async function loadStablePullRequest(
+  api: GateGitHubReader,
+  inputs: GateInputs,
+): Promise<{
+  files: Awaited<ReturnType<typeof loadPullRequestFiles>>;
+  identity: PullRequestIdentity;
+}> {
+  const expected = validateInputs(inputs);
+  const before = validatePullRequestIdentity(
+    await api.getPullRequest(expected.repository, expected.prNumber),
+    expected,
+  );
+  const files = await loadPullRequestFiles(api, expected.repository, expected.prNumber);
+  const after = validatePullRequestIdentity(
+    await api.getPullRequest(expected.repository, expected.prNumber),
+    expected,
+  );
+  if (before.candidateRepository !== after.candidateRepository) {
+    fail("pull-request repository identity changed while the gate was running");
+  }
+  return { files, identity: after };
+}
+
+export async function classifyPullRequestGate(
+  inputs: GateInputs,
+  api: GateGitHubReader,
+): Promise<{ required: boolean; sameRepository: boolean; sensitivePaths: string[] }> {
+  const { files, identity } = await loadStablePullRequest(api, inputs);
+  const classification = classifyQualification(files);
+  return {
+    ...classification,
+    sameRepository: identity.candidateRepository === QUALIFICATION_REPOSITORY,
+  };
+}
+
+function validateRoot(root: string, label: string): string {
+  if (typeof root !== "string" || root.length === 0) fail(`${label} is invalid`);
+  const absolute = path.resolve(root);
+  let stats: fs.Stats;
+  try {
+    stats = fs.lstatSync(absolute);
+  } catch {
+    fail(`${label} is missing`);
+  }
+  if (!stats.isDirectory() || stats.isSymbolicLink()) fail(`${label} must be a real directory`);
+  return fs.realpathSync(absolute);
+}
+
+export function readBlueprintVersion(root: string): string {
+  const bytes = readBoundedRegularFileFromRoot(
+    root,
+    "nemoclaw-blueprint/blueprint.yaml",
+    "OpenShell version blueprint",
+    { maximumBytes: MAX_BLUEPRINT_BYTES, minimumBytes: 1 },
+  );
+  if (createHash("sha256").update(bytes).digest("hex") !== REVIEWED_BLUEPRINT_SHA256) {
+    fail("trusted OpenShell version blueprint does not match the reviewed baseline");
+  }
+  return "0.0.99";
+}
+
+function validateBlueprintPair(baseRoot: string, candidateRoot: string): string {
+  const baseBytes = readBoundedRegularFileFromRoot(
+    baseRoot,
+    "nemoclaw-blueprint/blueprint.yaml",
+    "trusted OpenShell version blueprint",
+    { maximumBytes: MAX_BLUEPRINT_BYTES, minimumBytes: 1 },
+  );
+  const candidateBytes = readBoundedRegularFileFromRoot(
+    candidateRoot,
+    "nemoclaw-blueprint/blueprint.yaml",
+    "candidate OpenShell version blueprint",
+    { maximumBytes: MAX_BLUEPRINT_BYTES, minimumBytes: 1 },
+  );
+  if (createHash("sha256").update(baseBytes).digest("hex") !== REVIEWED_BLUEPRINT_SHA256) {
+    fail("trusted OpenShell version blueprint does not match the reviewed baseline");
+  }
+  if (!baseBytes.equals(candidateBytes)) {
+    fail("candidate OpenShell version blueprint must remain byte-identical to the trusted base");
+  }
+  return "0.0.99";
+}
+
+export async function verifyDraftPullRequestGate(
+  inputs: GateInputs & { baseRoot: string; candidateRoot: string },
+  api: GateGitHubReader,
+): Promise<void> {
+  const { files, identity } = await loadStablePullRequest(api, inputs);
+  if (identity.candidateRepository !== QUALIFICATION_REPOSITORY) {
+    fail("sensitive qualification changes require a same-repository candidate");
+  }
+  if (!classifyQualification(files).required) {
+    fail("draft verification was requested without a sensitive qualification change");
+  }
+  const baseRoot = validateRoot(inputs.baseRoot, "trusted base checkout");
+  const candidateRoot = validateRoot(inputs.candidateRoot, "candidate data checkout");
+  const blueprintVersion = validateBlueprintPair(baseRoot, candidateRoot);
+  validateBootstrapDraftTransition(
+    loadBootstrapQualificationContractFromRoot(baseRoot),
+    loadBootstrapQualificationContractFromRoot(candidateRoot),
+    {
+      baseVersion: blueprintVersion,
+      candidateVersion: blueprintVersion,
+    },
+  );
+  const after = validatePullRequestIdentity(
+    await api.getPullRequest(inputs.repository, inputs.prNumber),
+    validateInputs(inputs),
+  );
+  if (after.candidateRepository !== identity.candidateRepository) {
+    fail("pull-request repository identity changed while draft data was being verified");
+  }
+}
+
+function parseCli(argv: readonly string[]): { command: string; values: Map<string, string> } {
+  const command = argv[0] ?? "";
+  const values = new Map<string, string>();
+  for (let index = 1; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined || values.has(key)) {
+      fail("CLI arguments are malformed or duplicated");
+    }
+    values.set(key, value);
+  }
+  return { command, values };
+}
+
+function requireCliValues(values: Map<string, string>, expected: readonly string[]): void {
+  const allowed = new Set(expected);
+  if (values.size !== allowed.size || [...values.keys()].some((key) => !allowed.has(key))) {
+    fail(`CLI requires exactly: ${expected.join(", ")}`);
+  }
+}
+
+function requiredCliValue(values: Map<string, string>, key: string): string {
+  const value = values.get(key);
+  if (value === undefined) fail(`CLI argument ${key} is missing`);
+  return value;
+}
+
+function parsePositiveInteger(value: string, label: string): number {
+  if (!POSITIVE_INTEGER_PATTERN.test(value)) fail(`${label} is invalid`);
+  return validatePositiveInteger(Number(value), label);
+}
+
+function cliInputs(values: Map<string, string>): GateInputs {
+  return validateInputs({
+    baseSha: requiredCliValue(values, "--base-sha"),
+    candidateSha: requiredCliValue(values, "--candidate-sha"),
+    prNumber: parsePositiveInteger(requiredCliValue(values, "--pr-number"), "pull-request number"),
+    repository: validateRepository(requiredCliValue(values, "--repository")),
+  });
+}
+
+function appendGitHubOutput(filePath: string, values: Record<string, string>): void {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (!Number.isSafeInteger(noFollow) || noFollow === 0 || path.normalize(filePath) !== filePath) {
+    fail("GitHub output path is invalid");
+  }
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(filePath, fs.constants.O_WRONLY | fs.constants.O_APPEND | noFollow);
+  } catch {
+    fail("GitHub output file is unavailable");
+  }
+  try {
+    if (!fs.fstatSync(descriptor).isFile()) fail("GitHub output destination is not a regular file");
+    const source = Object.entries(values)
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join("");
+    fs.writeSync(descriptor, source, null, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+export async function runCli(
+  argv: readonly string[] = process.argv.slice(2),
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const { command, values } = parseCli(argv);
+  const api = createGitHubReader(environment.GITHUB_TOKEN ?? "");
+  if (command === "classify") {
+    requireCliValues(values, [
+      "--base-sha",
+      "--candidate-sha",
+      "--output",
+      "--pr-number",
+      "--repository",
+    ]);
+    const result = await classifyPullRequestGate(cliInputs(values), api);
+    appendGitHubOutput(requiredCliValue(values, "--output"), {
+      required: String(result.required),
+      "same-repository": String(result.sameRepository),
+      "sensitive-paths": JSON.stringify(result.sensitivePaths),
+    });
+    return;
+  }
+  if (command === "verify-draft") {
+    requireCliValues(values, [
+      "--base-root",
+      "--base-sha",
+      "--candidate-root",
+      "--candidate-sha",
+      "--pr-number",
+      "--repository",
+    ]);
+    await verifyDraftPullRequestGate(
+      {
+        ...cliInputs(values),
+        baseRoot: requiredCliValue(values, "--base-root"),
+        candidateRoot: requiredCliValue(values, "--candidate-root"),
+      },
+      api,
+    );
+    return;
+  }
+  fail("CLI command must be classify or verify-draft");
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  runCli().catch((error: unknown) => {
+    const message =
+      error instanceof Error ? error.message : "OpenShell qualification PR gate failed";
+    console.error(message);
+    process.exitCode = 1;
+  });
+}

--- a/test/openshell-qualification-bootstrap-contract.test.ts
+++ b/test/openshell-qualification-bootstrap-contract.test.ts
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  QUALIFICATION_REQUIRED_WORKFLOW_PATH,
+  QUALIFICATION_REQUIRED_WORKFLOW_REF,
+  QUALIFICATION_REQUIRED_WORKFLOW_REPOSITORY_ID,
+  validateBootstrapDraftTransition,
+  validateBootstrapQualificationContract,
+} from "../scripts/checks/openshell-qualification-bootstrap-contract.mts";
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CONTRACT_PATH = path.join(REPO_ROOT, "ci/openshell-0.0.101-qualification-v1.json");
+const VERSIONS = { baseVersion: "0.0.99", candidateVersion: "0.0.99" };
+const VALID_CONTRACT = validateBootstrapQualificationContract(
+  JSON.parse(fs.readFileSync(CONTRACT_PATH, "utf8")) as unknown,
+);
+
+function contract(): Record<string, unknown> {
+  return structuredClone(VALID_CONTRACT) as unknown as Record<string, unknown>;
+}
+
+describe("OpenShell qualification draft bootstrap contract", () => {
+  it("ships a full inert draft inventory without workflow authority (#8590)", () => {
+    const parsed = validateBootstrapQualificationContract(contract());
+
+    expect(parsed.lifecycle).toBe("bootstrap");
+    expect(parsed.inventoryState).toBe("draft");
+    expect(parsed.requiredWorkflowGate).toBeNull();
+    expect(parsed.retirementEvidence).toBeNull();
+    expect(parsed.artifacts).toEqual([]);
+    expect(parsed.tests).toHaveLength(14);
+    expect(
+      parsed.tests.every(
+        (test) =>
+          test.approvedExceptions.length === 0 &&
+          test.matrix.lanes.length === 0 &&
+          test.mappings.selector.status === "pending" &&
+          test.mappings.selector.source === null &&
+          test.mappings.final.status === "pending" &&
+          test.mappings.final.source === null,
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts trusted-base draft staging and later exact workflow authority (#8590)", () => {
+    const base = contract();
+    const unchangedCandidate = contract();
+    const governedCandidate = contract();
+    governedCandidate.requiredWorkflowGate = {
+      organizationRulesetId: 24680,
+      repositoryId: QUALIFICATION_REQUIRED_WORKFLOW_REPOSITORY_ID,
+      sourcePath: QUALIFICATION_REQUIRED_WORKFLOW_PATH,
+      sourceRef: QUALIFICATION_REQUIRED_WORKFLOW_REF,
+    };
+
+    expect(validateBootstrapDraftTransition(base, unchangedCandidate, VERSIONS)).toBeTruthy();
+    expect(validateBootstrapDraftTransition(base, governedCandidate, VERSIONS)).toMatchObject({
+      requiredWorkflowGate: {
+        organizationRulesetId: 24680,
+        repositoryId: QUALIFICATION_REQUIRED_WORKFLOW_REPOSITORY_ID,
+        sourcePath: QUALIFICATION_REQUIRED_WORKFLOW_PATH,
+        sourceRef: QUALIFICATION_REQUIRED_WORKFLOW_REF,
+      },
+    });
+  });
+
+  it("rejects candidate authority when the trusted base has no contract (#8590)", () => {
+    expect(() => validateBootstrapDraftTransition(null, contract(), VERSIONS)).toThrow(
+      "absent from the trusted base",
+    );
+  });
+
+  it("rejects draft removal, version movement, and an authority rewrite (#8590)", () => {
+    const governedBase = contract();
+    governedBase.requiredWorkflowGate = {
+      organizationRulesetId: 24680,
+      repositoryId: QUALIFICATION_REQUIRED_WORKFLOW_REPOSITORY_ID,
+      sourcePath: QUALIFICATION_REQUIRED_WORKFLOW_PATH,
+      sourceRef: QUALIFICATION_REQUIRED_WORKFLOW_REF,
+    };
+    const rewritten = structuredClone(governedBase);
+    (rewritten.requiredWorkflowGate as { organizationRulesetId: number }).organizationRulesetId =
+      13579;
+
+    expect(() => validateBootstrapDraftTransition(contract(), null, VERSIONS)).toThrow(
+      "cannot be removed",
+    );
+    expect(() =>
+      validateBootstrapDraftTransition(contract(), contract(), {
+        baseVersion: "0.0.99",
+        candidateVersion: "0.0.101",
+      }),
+    ).toThrow("cannot change the pinned OpenShell version");
+    expect(() => validateBootstrapDraftTransition(governedBase, rewritten, VERSIONS)).toThrow(
+      "cannot change",
+    );
+  });
+
+  it.each([
+    ["a frozen inventory", { inventoryState: "frozen" }],
+    ["a release lifecycle", { lifecycle: "final" }],
+    ["an artifact", { artifacts: [{ name: "receipt" }] }],
+    ["retirement evidence", { retirementEvidence: { releaseTag: "v0.0.101" } }],
+    ["receipt acceptance", { qualificationReceipt: { result: "success" } }],
+  ])("rejects %s in the bootstrap contract (#8590)", (_label, replacement) => {
+    expect(() =>
+      validateBootstrapQualificationContract({ ...contract(), ...replacement }),
+    ).toThrow();
+  });
+
+  it("rejects active mappings, matrix lanes, and draft exceptions (#8590)", () => {
+    const active = contract();
+    const lane = contract();
+    const exception = contract();
+    const activeTests = active.tests as Array<Record<string, unknown>>;
+    const laneTests = lane.tests as Array<Record<string, unknown>>;
+    const exceptionTests = exception.tests as Array<Record<string, unknown>>;
+    activeTests[0].mappings = {
+      final: { source: null, status: "pending" },
+      selector: { source: { workflowId: 1 }, status: "active" },
+    };
+    laneTests[0].matrix = { lanes: [{ id: "live" }] };
+    exceptionTests[0].approvedExceptions = [{ reason: "skip" }];
+
+    expect(() => validateBootstrapQualificationContract(active)).toThrow("must remain pending");
+    expect(() => validateBootstrapQualificationContract(lane)).toThrow("must remain empty");
+    expect(() => validateBootstrapQualificationContract(exception)).toThrow("must remain empty");
+  });
+});

--- a/test/openshell-qualification-io.test.ts
+++ b/test/openshell-qualification-io.test.ts
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  loadBootstrapQualificationContractFromRoot,
+  parseBoundedJson,
+  readBoundedRegularFileBytes,
+} from "../scripts/checks/openshell-qualification-io.mts";
+
+const tempRoots: string[] = [];
+
+function tempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openshell-qualification-io-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of tempRoots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
+});
+
+describe("OpenShell qualification descriptor-pinned reads", () => {
+  it("rejects links, directories, empty input, and oversized input (#8590)", () => {
+    const root = tempRoot();
+    const source = path.join(root, "source.txt");
+    const linked = path.join(root, "linked.txt");
+    const empty = path.join(root, "empty.txt");
+    const oversized = path.join(root, "oversized.txt");
+    fs.writeFileSync(source, "trusted");
+    fs.symlinkSync(source, linked);
+    fs.writeFileSync(empty, "");
+    fs.writeFileSync(oversized, "12345");
+
+    expect(() =>
+      readBoundedRegularFileBytes(linked, "linked input", {
+        maximumBytes: 7,
+        minimumBytes: 1,
+      }),
+    ).toThrow("regular non-link file");
+    expect(() =>
+      readBoundedRegularFileBytes(root, "directory input", {
+        maximumBytes: 7,
+        minimumBytes: 1,
+      }),
+    ).toThrow("bounded regular non-link file");
+    expect(() =>
+      readBoundedRegularFileBytes(empty, "empty input", {
+        maximumBytes: 7,
+        minimumBytes: 1,
+      }),
+    ).toThrow("bounded regular non-link file");
+    expect(() =>
+      readBoundedRegularFileBytes(oversized, "oversized input", {
+        maximumBytes: 4,
+        minimumBytes: 1,
+      }),
+    ).toThrow("bounded regular non-link file");
+  });
+
+  it("keeps bytes pinned to the opened descriptor when the path is swapped (#8590)", () => {
+    const root = tempRoot();
+    const source = path.join(root, "source.txt");
+    const opened = path.join(root, "opened.txt");
+    fs.writeFileSync(source, "trusted");
+    const openSync = fs.openSync.bind(fs);
+    vi.spyOn(fs, "openSync").mockImplementation((filePath, flags, mode) => {
+      const descriptor = openSync(filePath, flags, mode);
+      fs.renameSync(source, opened);
+      fs.writeFileSync(source, "replacement");
+      return descriptor;
+    });
+
+    expect(
+      readBoundedRegularFileBytes(source, "swapped input", {
+        maximumBytes: 32,
+        minimumBytes: 1,
+      }).toString("utf8"),
+    ).toBe("trusted");
+    expect(fs.readFileSync(source, "utf8")).toBe("replacement");
+  });
+
+  it("rejects input that grows beyond the bound after descriptor authentication (#8590)", () => {
+    const root = tempRoot();
+    const source = path.join(root, "source.txt");
+    fs.writeFileSync(source, "1234");
+    const fstatSync = fs.fstatSync.bind(fs);
+    vi.spyOn(fs, "fstatSync")
+      .mockImplementationOnce((descriptor, options) => {
+        const stats = fstatSync(descriptor, options as { bigint: true });
+        fs.appendFileSync(source, "5");
+        return stats;
+      })
+      .mockImplementation((descriptor, options) =>
+        fstatSync(descriptor, options as { bigint: true }),
+      );
+
+    expect(() =>
+      readBoundedRegularFileBytes(source, "growing input", {
+        maximumBytes: 4,
+        minimumBytes: 1,
+      }),
+    ).toThrow("changed while it was being read");
+  });
+
+  it("rejects same-size input overwritten after descriptor authentication (#8590)", () => {
+    const root = tempRoot();
+    const source = path.join(root, "source.txt");
+    fs.writeFileSync(source, "SAFE");
+    const fstatSync = fs.fstatSync.bind(fs);
+    vi.spyOn(fs, "fstatSync")
+      .mockImplementationOnce((descriptor, options) => {
+        const stats = fstatSync(descriptor, options as { bigint: true });
+        fs.writeFileSync(source, "EVIL");
+        return stats;
+      })
+      .mockImplementation((descriptor, options) =>
+        fstatSync(descriptor, options as { bigint: true }),
+      );
+
+    expect(() =>
+      readBoundedRegularFileBytes(source, "overwritten input", {
+        maximumBytes: 8,
+        minimumBytes: 1,
+      }),
+    ).toThrow("changed while it was being read");
+  });
+
+  it("closes the descriptor after successful and rejected reads (#8590)", () => {
+    const root = tempRoot();
+    const source = path.join(root, "source.txt");
+    fs.writeFileSync(source, "trusted");
+    const closeSync = vi.spyOn(fs, "closeSync");
+
+    expect(
+      readBoundedRegularFileBytes(source, "valid input", {
+        maximumBytes: 8,
+        minimumBytes: 1,
+      }).toString("utf8"),
+    ).toBe("trusted");
+    expect(() =>
+      readBoundedRegularFileBytes(source, "oversized input", {
+        maximumBytes: 3,
+        minimumBytes: 1,
+      }),
+    ).toThrow("bounded regular non-link file");
+    expect(closeSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects duplicate JSON keys and symbolic contract components (#8590)", () => {
+    expect(() => parseBoundedJson('{"scope":1,"scope":2}', "duplicate JSON")).toThrow(
+      "duplicate object key",
+    );
+
+    const root = tempRoot();
+    const outside = tempRoot();
+    fs.mkdirSync(path.join(outside, "ci"));
+    fs.writeFileSync(path.join(outside, "ci", "openshell-0.0.101-qualification-v1.json"), "{}");
+    fs.symlinkSync(path.join(outside, "ci"), path.join(root, "ci"));
+    expect(() => loadBootstrapQualificationContractFromRoot(root)).toThrow(
+      "crosses a symbolic link",
+    );
+  });
+});

--- a/test/openshell-qualification-paths.test.ts
+++ b/test/openshell-qualification-paths.test.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyQualification,
+  isOpenShellQualificationSensitivePath,
+  loadPullRequestFiles,
+  type PullRequestReader,
+  validatePullRequestFile,
+} from "../scripts/checks/openshell-qualification-paths.mts";
+
+const REPOSITORY = "NVIDIA/NemoClaw";
+
+function prFile(filename: string, status = "modified") {
+  return { filename, status };
+}
+
+describe("OpenShell qualification-sensitive path classification", () => {
+  it.each([
+    "nemoclaw-blueprint/blueprint.yaml",
+    "scripts/install-openshell.sh",
+    "agents/hermes/manifest.yaml",
+    "agents/langchain-deepagents-code/managed-dcode-runtime.py",
+    "src/lib/onboard/docker-driver-gateway-runtime.ts",
+    "src/lib/adapters/container-engine.ts",
+    "src/lib/adapters/podman/podman-driver.ts",
+    "src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.99.json",
+    "nemoclaw/src/blueprint/runner.ts",
+    ".github/workflows/openshell-0.0.101-pr-gate.yaml",
+    ".github/workflows/openshell-0.0.101-qualification.yaml",
+    "scripts/checks/openshell-qualification-bootstrap-contract.mts",
+    "scripts/checks/openshell-qualification-contract.mts",
+    "scripts/checks/openshell-qualification-github.mts",
+    "scripts/checks/verify-openshell-qualification-producer-workflow.mts",
+    "scripts/checks/verify-openshell-qualification-pr-gate.mts",
+    "scripts/release-cut-tag.sh",
+  ])("keeps draft staging path %s inside the trusted gate (#8590)", (candidatePath) => {
+    expect(isOpenShellQualificationSensitivePath(candidatePath)).toBe(true);
+  });
+
+  it.each([
+    "docs/index.mdx",
+    "nemoclaw/README.md",
+    "agents/foo/README.md",
+    "scripts/generate-unrelated-report.mjs",
+    "src/lib/messaging/README.md",
+    "src/lib/security/credential-hash.ts",
+  ])("does not require the OpenShell gate for unrelated path %s (#8590)", (candidatePath) => {
+    expect(classifyQualification([validatePullRequestFile(prFile(candidatePath))])).toEqual({
+      required: false,
+      sensitivePaths: [],
+    });
+  });
+
+  it("classifies both sides of a rename without trusting candidate metadata (#8590)", () => {
+    const renamed = validatePullRequestFile({
+      filename: "docs/retired.mdx",
+      previous_filename: "scripts/install-openshell.sh",
+      status: "renamed",
+    });
+
+    expect(classifyQualification([renamed])).toEqual({
+      required: true,
+      sensitivePaths: ["scripts/install-openshell.sh"],
+    });
+  });
+
+  it.each([
+    [{ filename: "a", status: "mystery" }, "unknown status"],
+    [{ filename: "a", status: "renamed" }, "previous_filename"],
+    [{ filename: "a", previous_filename: "b", status: "modified" }, "unexpectedly"],
+    [{ filename: "../escape", status: "modified" }, "canonical"],
+    [{ filename: "scripts\\escape.mts", status: "modified" }, "invalid"],
+  ])("rejects malformed pull-request file metadata %# (#8590)", (value, message) => {
+    expect(() => validatePullRequestFile(value)).toThrow(message);
+  });
+
+  it("paginates through the supported pull-request file bound (#8590)", async () => {
+    const api: PullRequestReader = {
+      getPullRequestFilesPage: async (_repository, _prNumber, page) =>
+        page === 1
+          ? Array.from({ length: 100 }, (_, index) => prFile(`docs/${index}.md`))
+          : [prFile("scripts/install-openshell.sh")],
+    };
+
+    const files = await loadPullRequestFiles(api, REPOSITORY, 1);
+    expect(files).toHaveLength(101);
+    expect(classifyQualification(files)).toEqual({
+      required: true,
+      sensitivePaths: ["scripts/install-openshell.sh"],
+    });
+  });
+
+  it("rejects duplicate files and pagination beyond the supported bound (#8590)", async () => {
+    const duplicate: PullRequestReader = {
+      getPullRequestFilesPage: async () => [prFile("docs/a.md"), prFile("docs/a.md")],
+    };
+    const unbounded: PullRequestReader = {
+      getPullRequestFilesPage: async (_repository, _prNumber, page) =>
+        Array.from({ length: 100 }, (_, index) => prFile(`docs/${page}-${index}.md`)),
+    };
+
+    await expect(loadPullRequestFiles(duplicate, REPOSITORY, 1)).rejects.toThrow("duplicated");
+    await expect(loadPullRequestFiles(unbounded, REPOSITORY, 1)).rejects.toThrow(
+      "pagination is incomplete",
+    );
+  });
+});

--- a/test/openshell-qualification-pr-gate-workflow.test.ts
+++ b/test/openshell-qualification-pr-gate-workflow.test.ts
@@ -32,12 +32,6 @@ function step(owner: WorkflowJob, name: string): WorkflowStep {
   return value;
 }
 
-function sparsePaths(owner: WorkflowJob, stepName: string): string[] {
-  const value = step(owner, stepName).with?.["sparse-checkout"];
-  assert(typeof value === "string", `${stepName} must declare sparse paths`);
-  return value.trim().split("\n");
-}
-
 describe("OpenShell qualification draft PR gate workflow", () => {
   it("validates the parsed trust boundary through an executable contract (#8590)", () => {
     const validation = spawnSync(

--- a/test/openshell-qualification-pr-gate-workflow.test.ts
+++ b/test/openshell-qualification-pr-gate-workflow.test.ts
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import { readYaml, type WorkflowJob, type WorkflowStep } from "./helpers/e2e-workflow-contract";
+
+type QualificationWorkflow = {
+  jobs: Record<string, WorkflowJob>;
+  name: string;
+  on: { pull_request_target: { types: string[] } };
+  permissions: Record<string, string>;
+  "run-name": string;
+};
+
+const workflow = readYaml<QualificationWorkflow>(
+  ".github/workflows/openshell-0.0.101-pr-gate.yaml",
+);
+
+function job(name: string): WorkflowJob {
+  const value = workflow.jobs[name];
+  assert(value, `missing workflow job ${name}`);
+  return value;
+}
+
+function step(owner: WorkflowJob, name: string): WorkflowStep {
+  const value = owner.steps?.find((candidate) => candidate.name === name);
+  assert(value, `missing workflow step ${name}`);
+  return value;
+}
+
+function sparsePaths(owner: WorkflowJob, stepName: string): string[] {
+  const value = step(owner, stepName).with?.["sparse-checkout"];
+  assert(typeof value === "string", `${stepName} must declare sparse paths`);
+  return value.trim().split("\n");
+}
+
+describe("OpenShell qualification draft PR gate workflow", () => {
+  it("validates the parsed trust boundary through an executable contract (#8590)", () => {
+    const validation = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `
+          import assert from "node:assert/strict";
+          import fs from "node:fs";
+          import YAML from "yaml";
+          const workflow = YAML.parse(fs.readFileSync(
+            ".github/workflows/openshell-0.0.101-pr-gate.yaml",
+            "utf8",
+          ));
+          assert.deepEqual(Object.keys(workflow.jobs), [
+            "classify", "verify-draft", "openshell-qualification",
+          ]);
+          assert.deepEqual(workflow.on.pull_request_target.types, [
+            "opened", "synchronize", "reopened", "edited",
+          ]);
+          assert.deepEqual(workflow.permissions, {
+            contents: "read", "pull-requests": "read",
+          });
+          const steps = Object.values(workflow.jobs).flatMap((job) => job.steps ?? []);
+          const setups = steps.filter((step) => step.uses?.startsWith("actions/setup-node@"));
+          const checkouts = steps.filter((step) => step.uses?.startsWith("actions/checkout@"));
+          assert.equal(setups.length, 2);
+          assert(setups.every((step) =>
+            step.uses === "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
+          ));
+          assert.equal(checkouts.length, 3);
+          assert(checkouts.every((step) =>
+            step.uses === "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+          ));
+          const byName = (jobName, stepName) => {
+            const found = workflow.jobs[jobName].steps.find((step) => step.name === stepName);
+            assert(found);
+            return found;
+          };
+          const paths = (jobName, stepName) =>
+            byName(jobName, stepName).with["sparse-checkout"].trim().split("\\n");
+          assert.deepEqual(paths("classify", "Checkout base-trusted qualification verifier"), [
+            "scripts/checks/openshell-qualification-bootstrap-contract.mts",
+            "scripts/checks/openshell-qualification-io.mts",
+            "scripts/checks/openshell-qualification-paths.mts",
+            "scripts/checks/verify-openshell-qualification-pr-gate.mts",
+          ]);
+          assert.deepEqual(paths("verify-draft", "Checkout candidate qualification data"), [
+            "ci/openshell-0.0.101-qualification-v1.json",
+            "nemoclaw-blueprint/blueprint.yaml",
+          ]);
+          const candidate = byName("verify-draft", "Checkout candidate qualification data");
+          assert.equal(candidate.with["persist-credentials"], false);
+          assert.equal(candidate.with["allow-unsafe-pr-checkout"], true);
+          assert.equal(workflow.jobs["openshell-qualification"].if, "always()");
+          assert(steps.filter((step) => step.run).every((step) =>
+            !step.run.includes(".candidate-openshell-qualification/scripts/")
+          ));
+        `,
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+
+    expect(validation.status, validation.stderr).toBe(0);
+  });
+
+  it.each([
+    {
+      disposition: "classification failure",
+      env: {
+        CLASSIFY_RESULT: "failure",
+        REQUIRED: "",
+        SAME_REPOSITORY: "",
+        VERIFY_DRAFT_RESULT: "skipped",
+      },
+      expectedStatus: 1,
+    },
+    {
+      disposition: "unrelated pull request",
+      env: {
+        CLASSIFY_RESULT: "success",
+        REQUIRED: "false",
+        SAME_REPOSITORY: "false",
+        VERIFY_DRAFT_RESULT: "skipped",
+      },
+      expectedStatus: 0,
+    },
+    {
+      disposition: "missing applicability output",
+      env: {
+        CLASSIFY_RESULT: "success",
+        REQUIRED: "",
+        SAME_REPOSITORY: "",
+        VERIFY_DRAFT_RESULT: "skipped",
+      },
+      expectedStatus: 1,
+    },
+    {
+      disposition: "malformed applicability output",
+      env: {
+        CLASSIFY_RESULT: "success",
+        REQUIRED: "unknown",
+        SAME_REPOSITORY: "true",
+        VERIFY_DRAFT_RESULT: "success",
+      },
+      expectedStatus: 1,
+    },
+    {
+      disposition: "sensitive fork",
+      env: {
+        CLASSIFY_RESULT: "success",
+        REQUIRED: "true",
+        SAME_REPOSITORY: "false",
+        VERIFY_DRAFT_RESULT: "skipped",
+      },
+      expectedStatus: 1,
+    },
+    {
+      disposition: "malformed repository output",
+      env: {
+        CLASSIFY_RESULT: "success",
+        REQUIRED: "true",
+        SAME_REPOSITORY: "unknown",
+        VERIFY_DRAFT_RESULT: "success",
+      },
+      expectedStatus: 1,
+    },
+    {
+      disposition: "rejected draft",
+      env: {
+        CLASSIFY_RESULT: "success",
+        REQUIRED: "true",
+        SAME_REPOSITORY: "true",
+        VERIFY_DRAFT_RESULT: "failure",
+      },
+      expectedStatus: 1,
+    },
+    {
+      disposition: "missing draft verification result",
+      env: {
+        CLASSIFY_RESULT: "success",
+        REQUIRED: "true",
+        SAME_REPOSITORY: "true",
+        VERIFY_DRAFT_RESULT: "",
+      },
+      expectedStatus: 1,
+    },
+    {
+      disposition: "verified inert draft",
+      env: {
+        CLASSIFY_RESULT: "success",
+        REQUIRED: "true",
+        SAME_REPOSITORY: "true",
+        VERIFY_DRAFT_RESULT: "success",
+      },
+      expectedStatus: 0,
+    },
+  ])("enforces $disposition behavior (#8590)", ({ env, expectedStatus }) => {
+    const report = step(job("openshell-qualification"), "Report qualification decision");
+    assert(report.run);
+    const result = spawnSync("bash", ["-c", report.run], {
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+    });
+
+    expect(result.status).toBe(expectedStatus);
+  });
+});

--- a/test/openshell-qualification-pr-gate.test.ts
+++ b/test/openshell-qualification-pr-gate.test.ts
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PullRequestReader } from "../scripts/checks/openshell-qualification-paths.mts";
+import {
+  classifyPullRequestGate,
+  createGitHubReader,
+  type GateInputs,
+  readBlueprintVersion,
+  readBoundedJsonResponse,
+  runCli,
+  verifyDraftPullRequestGate,
+} from "../scripts/checks/verify-openshell-qualification-pr-gate.mts";
+
+const REPOSITORY = "NVIDIA/NemoClaw" as const;
+const BASE_SHA = "b".repeat(40);
+const CANDIDATE_SHA = "a".repeat(40);
+const INPUTS: GateInputs = {
+  baseSha: BASE_SHA,
+  candidateSha: CANDIDATE_SHA,
+  prNumber: 42,
+  repository: REPOSITORY,
+};
+const tempRoots: string[] = [];
+
+type GateReader = PullRequestReader & {
+  getPullRequest(repository: string, prNumber: number): Promise<unknown>;
+};
+
+function pullRequest(
+  candidateRepository: string = REPOSITORY,
+  candidateSha = CANDIDATE_SHA,
+  state = "open",
+  baseRef = "main",
+) {
+  return {
+    base: { ref: baseRef, repo: { full_name: REPOSITORY }, sha: BASE_SHA },
+    head: { repo: { full_name: candidateRepository }, sha: candidateSha },
+    number: 42,
+    state,
+  };
+}
+
+function reader(
+  files: unknown[],
+  candidateRepository: string = REPOSITORY,
+  candidateSha = CANDIDATE_SHA,
+  state = "open",
+  baseRef = "main",
+): GateReader {
+  return {
+    getPullRequest: async () => pullRequest(candidateRepository, candidateSha, state, baseRef),
+    getPullRequestFilesPage: async (_repository, _prNumber, page) => (page === 1 ? files : []),
+  };
+}
+
+function tempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openshell-pr-gate-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function writeDraftRoot(root: string, contract: Record<string, unknown>): void {
+  fs.mkdirSync(path.join(root, "ci"), { recursive: true });
+  fs.mkdirSync(path.join(root, "nemoclaw-blueprint"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "ci/openshell-0.0.101-qualification-v1.json"),
+    JSON.stringify(contract),
+  );
+  fs.writeFileSync(
+    path.join(root, "nemoclaw-blueprint/blueprint.yaml"),
+    fs.readFileSync("nemoclaw-blueprint/blueprint.yaml"),
+  );
+}
+
+function draftContract(): Record<string, unknown> {
+  return JSON.parse(
+    fs.readFileSync("ci/openshell-0.0.101-qualification-v1.json", "utf8"),
+  ) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  for (const root of tempRoots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
+});
+
+describe("OpenShell base-trusted draft PR gate", () => {
+  it("classifies the live exact pull request and fails sensitive forks closed (#8590)", async () => {
+    const files = [{ filename: "scripts/install-openshell.sh", status: "modified" }];
+
+    await expect(classifyPullRequestGate(INPUTS, reader(files))).resolves.toEqual({
+      required: true,
+      sameRepository: true,
+      sensitivePaths: ["scripts/install-openshell.sh"],
+    });
+    await expect(
+      classifyPullRequestGate(INPUTS, reader(files, "attacker/fork")),
+    ).resolves.toMatchObject({ required: true, sameRepository: false });
+  });
+
+  it("rejects a live pull request whose exact head changed (#8590)", async () => {
+    await expect(
+      classifyPullRequestGate(
+        INPUTS,
+        reader([{ filename: "docs/index.mdx", status: "modified" }], REPOSITORY, "c".repeat(40)),
+      ),
+    ).rejects.toThrow("does not match the workflow event");
+  });
+
+  it.each([
+    ["closed", "main", "not open"],
+    ["open", "release", "no longer targets main"],
+  ])("rejects a %s pull request targeting %s (#8590)", async (state, baseRef, message) => {
+    await expect(
+      classifyPullRequestGate(
+        INPUTS,
+        reader(
+          [{ filename: "scripts/install-openshell.sh", status: "modified" }],
+          REPOSITORY,
+          CANDIDATE_SHA,
+          state,
+          baseRef,
+        ),
+      ),
+    ).rejects.toThrow(message);
+  });
+
+  it("rejects closure or retargeting between live identity reads (#8590)", async () => {
+    const identities = [pullRequest(), pullRequest(REPOSITORY, CANDIDATE_SHA, "closed", "main")];
+    const api: GateReader = {
+      getPullRequest: async () => identities.shift(),
+      getPullRequestFilesPage: async () => [
+        { filename: "scripts/install-openshell.sh", status: "modified" },
+      ],
+    };
+
+    await expect(classifyPullRequestGate(INPUTS, api)).rejects.toThrow("not open");
+  });
+
+  it("accepts the later multi-file candidate through draft data only (#8590)", async () => {
+    const baseRoot = tempRoot();
+    const candidateRoot = tempRoot();
+    const base = draftContract();
+    const candidate = draftContract();
+    candidate.requiredWorkflowGate = {
+      organizationRulesetId: 8642,
+      repositoryId: 1182547092,
+      sourcePath: ".github/workflows/openshell-0.0.101-pr-gate.yaml",
+      sourceRef: "refs/heads/main",
+    };
+    writeDraftRoot(baseRoot, base);
+    writeDraftRoot(candidateRoot, candidate);
+    const files = [
+      { filename: ".github/workflows/openshell-0.0.101-qualification.yaml", status: "added" },
+      { filename: "scripts/checks/openshell-qualification-contract.mts", status: "added" },
+      { filename: "scripts/checks/openshell-qualification-github.mts", status: "added" },
+      { filename: "src/lib/adapters/container-engine.ts", status: "modified" },
+    ];
+
+    await expect(
+      verifyDraftPullRequestGate({ ...INPUTS, baseRoot, candidateRoot }, reader(files)),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects candidate receipt state and OpenShell version movement (#8590)", async () => {
+    const baseRoot = tempRoot();
+    const candidateRoot = tempRoot();
+    const base = draftContract();
+    const candidate = draftContract();
+    candidate.artifacts = [{ name: "qualification receipt" }];
+    writeDraftRoot(baseRoot, base);
+    writeDraftRoot(candidateRoot, candidate);
+    const sensitive = reader([{ filename: "scripts/install-openshell.sh", status: "modified" }]);
+
+    await expect(
+      verifyDraftPullRequestGate({ ...INPUTS, baseRoot, candidateRoot }, sensitive),
+    ).rejects.toThrow("artifacts is invalid for draft bootstrap");
+
+    writeDraftRoot(candidateRoot, draftContract());
+    fs.writeFileSync(
+      path.join(candidateRoot, "nemoclaw-blueprint/blueprint.yaml"),
+      'min_openshell_version: "0.0.101"\nmax_openshell_version: "0.0.101"\n',
+    );
+    await expect(
+      verifyDraftPullRequestGate({ ...INPUTS, baseRoot, candidateRoot }, sensitive),
+    ).rejects.toThrow("must remain byte-identical to the trusted base");
+
+    fs.writeFileSync(
+      path.join(candidateRoot, "nemoclaw-blueprint/blueprint.yaml"),
+      'min_openshell_version: "0.0.99"\nmax_openshell_version: "0.0.99"\nmin_openshell_version: 0.0.101\n',
+    );
+    await expect(
+      verifyDraftPullRequestGate({ ...INPUTS, baseRoot, candidateRoot }, sensitive),
+    ).rejects.toThrow("must remain byte-identical to the trusted base");
+  });
+
+  it("rejects linked and oversized OpenShell version blueprints (#8590)", () => {
+    const root = tempRoot();
+    const blueprintDirectory = path.join(root, "nemoclaw-blueprint");
+    const blueprintPath = path.join(blueprintDirectory, "blueprint.yaml");
+    const targetPath = path.join(root, "target.yaml");
+    const source = fs.readFileSync("nemoclaw-blueprint/blueprint.yaml");
+    fs.mkdirSync(blueprintDirectory, { recursive: true });
+    fs.writeFileSync(blueprintPath, source);
+    expect(readBlueprintVersion(root)).toBe("0.0.99");
+    fs.renameSync(blueprintPath, targetPath);
+    fs.symlinkSync(targetPath, blueprintPath);
+    expect(() => readBlueprintVersion(root)).toThrow("regular non-link file");
+    fs.unlinkSync(blueprintPath);
+    fs.writeFileSync(blueprintPath, Buffer.alloc(1024 * 1024 + 1));
+    expect(() => readBlueprintVersion(root)).toThrow("bounded regular non-link file");
+  });
+
+  it("rejects an intermediate candidate blueprint directory link (#8590)", async () => {
+    const baseRoot = tempRoot();
+    const candidateRoot = tempRoot();
+    writeDraftRoot(baseRoot, draftContract());
+    writeDraftRoot(candidateRoot, draftContract());
+    fs.rmSync(path.join(candidateRoot, "nemoclaw-blueprint"), { recursive: true });
+    fs.symlinkSync(
+      path.join(baseRoot, "nemoclaw-blueprint"),
+      path.join(candidateRoot, "nemoclaw-blueprint"),
+    );
+
+    await expect(
+      verifyDraftPullRequestGate(
+        { ...INPUTS, baseRoot, candidateRoot },
+        reader([{ filename: "scripts/install-openshell.sh", status: "modified" }]),
+      ),
+    ).rejects.toThrow("path crosses a symbolic link");
+  });
+
+  it("bounds streamed GitHub JSON before parsing it (#8590)", async () => {
+    await expect(
+      readBoundedJsonResponse(new Response('{"ok":true}'), "GitHub test", 64),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      readBoundedJsonResponse(
+        new Response(new Uint8Array(65), { headers: { "content-length": "65" } }),
+        "GitHub test",
+        64,
+      ),
+    ).rejects.toThrow("oversized");
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(40));
+        controller.enqueue(new Uint8Array(40));
+        controller.close();
+      },
+    });
+    await expect(readBoundedJsonResponse(new Response(body), "GitHub test", 64)).rejects.toThrow(
+      "oversized",
+    );
+  });
+
+  it("uses fixed GitHub endpoints with timeout and redirect rejection (#8590)", async () => {
+    const timeoutSignal = new AbortController().signal;
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(pullRequest())))
+      .mockResolvedValueOnce(new Response("[]"));
+    vi.stubGlobal("fetch", fetchMock);
+    const api = createGitHubReader("token");
+
+    await api.getPullRequest(REPOSITORY, 42);
+    await api.getPullRequestFilesPage(REPOSITORY, 42, 1);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/repos/NVIDIA/NemoClaw/pulls/42",
+      expect.objectContaining({ redirect: "error", signal: timeoutSignal }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/NVIDIA/NemoClaw/pulls/42/files?per_page=100&page=1",
+      expect.objectContaining({ redirect: "error", signal: timeoutSignal }),
+    );
+    expect(timeout).toHaveBeenCalledWith(10_000);
+  });
+
+  it.each([
+    "verify",
+    "authority",
+    "produce",
+    "create-receipt",
+  ])("does not expose candidate receipt or authority command %s (#8590)", async (command) => {
+    await expect(runCli([command], { GITHUB_TOKEN: "token" })).rejects.toThrow(
+      "must be classify or verify-draft",
+    );
+  });
+});

--- a/test/openshell-qualification-sparse-bootstrap-bundle.test.ts
+++ b/test/openshell-qualification-sparse-bootstrap-bundle.test.ts
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readYaml, type WorkflowJob, type WorkflowStep } from "./helpers/e2e-workflow-contract";
+
+type QualificationWorkflow = { jobs: Record<string, WorkflowJob> };
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workflow = readYaml<QualificationWorkflow>(
+  ".github/workflows/openshell-0.0.101-pr-gate.yaml",
+);
+const tempRoots: string[] = [];
+
+function step(jobName: string, stepName: string): WorkflowStep {
+  const owner = workflow.jobs[jobName];
+  assert(owner, `missing workflow job ${jobName}`);
+  const value = owner.steps?.find((candidate) => candidate.name === stepName);
+  assert(value, `missing workflow step ${stepName}`);
+  return value;
+}
+
+function sparsePaths(jobName: string, stepName: string): string[] {
+  const value = step(jobName, stepName).with?.["sparse-checkout"];
+  assert(typeof value === "string", `${stepName} must declare sparse paths`);
+  return value.trim().split("\n");
+}
+
+function tempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openshell-sparse-bootstrap-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function constructBundle(paths: readonly string[]): string {
+  const root = tempRoot();
+  for (const relativePath of paths) {
+    const destination = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.join(REPO_ROOT, relativePath), destination);
+  }
+  return root;
+}
+
+function importVerifier(root: string) {
+  const verifier = pathToFileURL(
+    path.join(root, "scripts/checks/verify-openshell-qualification-pr-gate.mts"),
+  ).href;
+  return spawnSync(
+    process.execPath,
+    [
+      "--experimental-strip-types",
+      "--no-warnings",
+      "--input-type=module",
+      "--eval",
+      `await import(${JSON.stringify(verifier)})`,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+function bundleFiles(root: string): string[] {
+  return fs
+    .readdirSync(root, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.relative(root, path.join(entry.parentPath, entry.name)))
+    .sort();
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
+});
+
+describe("OpenShell qualification sparse bootstrap bundle", () => {
+  it("imports the real verifier from the workflow-declared trusted bundle (#8590)", () => {
+    const paths = sparsePaths("classify", "Checkout base-trusted qualification verifier");
+    const root = constructBundle(paths);
+    const result = importVerifier(root);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(bundleFiles(root)).toEqual([...paths].sort());
+  });
+
+  it("fails when a runtime dependency is absent from the trusted bundle (#8590)", () => {
+    const paths = sparsePaths("classify", "Checkout base-trusted qualification verifier");
+    const root = constructBundle(paths);
+    fs.unlinkSync(path.join(root, "scripts/checks/openshell-qualification-io.mts"));
+    const result = importVerifier(root);
+
+    expect(result.status).not.toBe(0);
+  });
+
+  it("constructs the verify bundle with contract and blueprint data (#8590)", () => {
+    const paths = sparsePaths("verify-draft", "Checkout base-trusted draft verifier and data");
+    const root = constructBundle(paths);
+
+    expect(importVerifier(root).status).toBe(0);
+    expect(bundleFiles(root)).toEqual([...paths].sort());
+  });
+
+  it("keeps the candidate bundle declarative and receipt-free (#8590)", () => {
+    const paths = sparsePaths("verify-draft", "Checkout candidate qualification data");
+    const root = constructBundle(paths);
+
+    expect(bundleFiles(root)).toEqual([
+      "ci/openshell-0.0.101-qualification-v1.json",
+      "nemoclaw-blueprint/blueprint.yaml",
+    ]);
+    expect(
+      [
+        ".github/workflows/openshell-0.0.101-qualification.yaml",
+        "scripts/checks/verify-openshell-qualification-producer-workflow.mts",
+        "scripts/release-cut-tag.sh",
+      ].every((relativePath) => !fs.existsSync(path.join(root, relativePath))),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Bootstrap a base-trusted, fail-closed pull-request gate and an inert draft qualification inventory for the OpenShell v0.0.101 program. This prerequisite records no compatibility result and does not activate the organization ruleset; every qualification mapping remains pending until separately accepted evidence and governance are available.

## Related Issue

Related #8590

## Changes

- Add a read-only `pull_request_target` workflow that classifies qualification-sensitive paths using executable code checked out from the exact base SHA.
- Restrict candidate checkout to declarative qualification data, disable persisted credentials, reject fork-sensitive transitions, and verify only the bounded draft transition.
- Add the draft qualification inventory with `requiredWorkflowGate`, retirement evidence, and artifacts unset and all selector/final mappings pending.
- Add bounded JSON, regular-file, repository-path, and GitHub identity helpers plus focused workflow, sparse-bundle, and failure-boundary coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is an internal inert CI/governance prerequisite; it changes no user-facing runtime, API, compatibility promise, or activation state.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head review at `4d5104c5127346bd08d9fa64c491786e66d1bd3d` verified read-only workflow permissions, immutable action pins, base-trusted executable code, declarative-only candidate checkout, disabled persisted credentials, bounded file/path/JSON parsing, and inert draft/null state. The reviewed bootstrap was rebound across a path-disjoint base move; 76 focused tests, the 10-test affected workflow suite after removing an unused helper, typecheck, repository gates, and gitleaks pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [ ] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Owner review found no changed documentation paths and no user-facing behavior; an independent documentation-writer review remains pending as advisory follow-up.
- Agent: Codex Desktop bootstrap owner
<!-- docs-review-head-sha: 4d5104c51 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration` over the six OpenShell bootstrap/gate suites: 76/76 pass; `npm run typecheck:cli`, source-shape, test-size, title, and project-membership gates pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request qualification checks for OpenShell changes.
  * Added a qualification manifest covering installation, upgrades, runtime behavior, credentials, and isolation scenarios.
  * Added secure validation for qualification data, repository paths, pull-request metadata, and draft transitions.
  * Added clear handling for applicable, inapplicable, malformed, forked, and failed-verification changes.

* **Tests**
  * Added comprehensive coverage for qualification workflows, security protections, path handling, contract validation, and draft verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->