### PR TITLE
fix(hermes): preserve MCP reload and Discord handshake

### DIFF
--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -222,8 +222,9 @@ $$nemoclaw <sandbox-name> gateway-token --quiet
 ```
 
 Before post-restore repairs, NemoClaw verifies that the recreated sandbox still identifies as Hermes and exits nonzero if its identity does not match the rebuild target.
-After state restore, NemoClaw restores managed MCP configuration through the normal lifecycle, then restarts the Hermes gateway and verifies or recovers its health before performing final MCP reconciliation.
-The gateway starts during recreation and reads its durable state before the restore replaces it, so the restart is what binds the running gateway to the restored state.
+After state restore, NemoClaw restarts the Hermes gateway so it reads the restored durable state, then restores managed MCP configuration through the normal lifecycle.
+MCP restoration performs an acknowledged gateway reload, so NemoClaw finishes by verifying the final running gateway and its managed MCP state without replacing that verified process again.
+The gateway starts during recreation and reads its durable state before the restore replaces it, which is why the first post-restore restart must happen before managed MCP restoration.
 `rebuild` exits nonzero instead of reporting success when it cannot verify final gateway health or managed MCP state.
 Follow the printed recovery guidance, using `$$nemoclaw <sandbox-name> gateway restart` first for gateway health, `$$nemoclaw <sandbox-name> recover` when the restart does not restore verified health, and `$$nemoclaw <sandbox-name> mcp restart` for incomplete managed MCP restoration.
 

--- a/src/lib/actions/sandbox/rebuild-hermes-post-restore.test.ts
+++ b/src/lib/actions/sandbox/rebuild-hermes-post-restore.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   ensureHermesGatewayAfterStateRestore,
   ensureHermesGatewayAfterStateRestoreForCronGate,
+  verifyHermesGatewayAfterStateRestore,
+  verifyHermesGatewayAfterStateRestoreForCronGate,
 } from "./rebuild-hermes-post-restore";
 
 const RESTART_SUCCEEDED = {
@@ -164,6 +166,71 @@ describe("binding the Hermes gateway to restored state", () => {
     ).toEqual({ state: "unverified" });
     expect(observeHermesCronReplacement).toHaveBeenCalledTimes(2);
   });
+
+  it("verifies the final cron-bound gateway without restarting after MCP restoration (#8472)", () => {
+    const original = { pid: 41, start_time: 902, drain_token: "restore-token" };
+    const replacement = { pid: 77, start_time: 903, drain_token: "restore-token" };
+    const restartSandboxGateway = vi.fn(() => RESTART_SUCCEEDED);
+    const observeHermesCronReplacement = vi.fn(() => replacement);
+
+    expect(
+      verifyHermesGatewayAfterStateRestoreForCronGate("alpha", "hermes", "restarted", original, {
+        restartSandboxGateway,
+        observeHermesCronReplacement,
+        checkAndRecoverSandboxProcesses: () => ({
+          checked: true,
+          wasRunning: true,
+          recovered: false,
+        }),
+      }),
+    ).toEqual({ state: "healthy", replacementIdentity: replacement });
+    expect(restartSandboxGateway).not.toHaveBeenCalled();
+    expect(observeHermesCronReplacement).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects unstable final cron identity without restarting after MCP restoration (#8472)", () => {
+    const restartSandboxGateway = vi.fn(() => RESTART_SUCCEEDED);
+    const observeHermesCronReplacement = vi
+      .fn()
+      .mockReturnValueOnce({ pid: 77, start_time: 903, drain_token: "restore-token" })
+      .mockReturnValueOnce({ pid: 88, start_time: 904, drain_token: "restore-token" });
+
+    expect(
+      verifyHermesGatewayAfterStateRestoreForCronGate(
+        "alpha",
+        "hermes",
+        "restarted",
+        { pid: 41, start_time: 902, drain_token: "restore-token" },
+        {
+          restartSandboxGateway,
+          observeHermesCronReplacement,
+          checkAndRecoverSandboxProcesses: () => ({
+            checked: true,
+            wasRunning: true,
+            recovered: false,
+          }),
+        },
+      ),
+    ).toEqual({ state: "unverified" });
+    expect(restartSandboxGateway).not.toHaveBeenCalled();
+  });
+
+  it("preserves MCP reconciliation refusal during restart-free final verification (#7084)", () => {
+    const restartSandboxGateway = vi.fn(() => RESTART_SUCCEEDED);
+
+    expect(
+      verifyHermesGatewayAfterStateRestore("alpha", "hermes", "restarted", {
+        restartSandboxGateway,
+        checkAndRecoverSandboxProcesses: () => ({
+          checked: true,
+          wasRunning: true,
+          recovered: false,
+          mcpReconciliationRefused: true,
+        }),
+      }),
+    ).toBe("unverified");
+    expect(restartSandboxGateway).not.toHaveBeenCalled();
+  });
 });
 
 describe("Hermes gateway post-restore recheck", () => {
@@ -267,7 +334,7 @@ describe("Hermes rebuild post-restore verification", () => {
     expect(harness.restoreMcpBridgesAfterRebuildSpy).toHaveBeenCalledWith("alpha", [mcpEntry]);
   });
 
-  it("accepts restored MCP configuration only after final gateway recovery (#7084)", async () => {
+  it("restores MCP after gateway restart and before final health verification (#7084)", async () => {
     const mcpEntry = {
       server: "blender",
       providerName: "nemoclaw-mcp-alpha-blender",
@@ -276,9 +343,9 @@ describe("Hermes rebuild post-restore verification", () => {
       agentName: "hermes",
       checkAndRecoverSandboxProcesses: () => ({
         checked: true,
-        wasRunning: false,
-        recovered: true,
-        forwardRecovered: true,
+        wasRunning: true,
+        recovered: false,
+        forwardRecovered: false,
       }),
       mcpPreparation: {
         entries: [mcpEntry],
@@ -293,11 +360,14 @@ describe("Hermes rebuild post-restore verification", () => {
     ).resolves.toBeUndefined();
 
     expect(harness.restoreMcpBridgesAfterRebuildSpy).toHaveBeenCalledWith("alpha", [mcpEntry]);
+    expect(harness.restartSandboxGatewaySpy.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.restoreMcpBridgesAfterRebuildSpy.mock.invocationCallOrder[0],
+    );
     expect(harness.restoreMcpBridgesAfterRebuildSpy.mock.invocationCallOrder[0]).toBeLessThan(
       harness.checkAndRecoverSandboxProcessesSpy.mock.invocationCallOrder[0],
     );
     expect(harness.logSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Hermes gateway recovered after state restore"),
+      expect.stringContaining("Hermes gateway restarted and verified after state restore"),
     );
   });
 

--- a/src/lib/actions/sandbox/rebuild-hermes-post-restore.ts
+++ b/src/lib/actions/sandbox/rebuild-hermes-post-restore.ts
@@ -79,6 +79,11 @@ export type HermesPostRestoreGatewayState =
   | "recovered"
   | "unverified";
 
+export type HermesPostRestoreGatewayRestartState =
+  | "not-applicable"
+  | "restarted"
+  | "restart-failed";
+
 type GatewayRecoveryObservation = {
   checked: boolean;
   wasRunning: boolean | null;
@@ -116,20 +121,24 @@ export interface HermesPostRestoreGatewayVerification {
  * pre-restore result for the life of the process — the WhatsApp bridge reads
  * its paired session that way — so the gateway can be alive and healthy while
  * still serving the state the rebuild replaced. A liveness check cannot see
- * that difference, so restart first and let the check report on the process
- * that restart produced. `relaunchManagedSupervisorSession` already restarts
- * after its own restore for the same reason.
+ * that difference, so restart before runtime restoration and let the final
+ * check report on the process left by every intervening acknowledged reload.
+ * `relaunchManagedSupervisorSession` already restarts after its own restore
+ * for the same reason.
  *
- * A gated rebuild keeps the root-owned cron drain active while this function
- * replaces and verifies the gateway. The caller then completes the held
- * transaction against the replacement process before dispatch can resume.
+ * The split restart/verify exports let rebuild insert MCP restoration between
+ * those two steps. Hermes MCP restoration performs its own acknowledged
+ * gateway reload, so a later unconditional restart would discard the runtime
+ * identity whose MCP load just converged. A gated rebuild keeps the root-owned
+ * cron drain active across restart, MCP restoration, and final verification.
  */
 export function ensureHermesGatewayAfterStateRestore(
   sandboxName: string,
   agentName: string,
   deps: HermesPostRestoreGatewayDeps = {},
 ): HermesPostRestoreGatewayState {
-  return ensureHermesGatewayAfterStateRestoreImpl(sandboxName, agentName, deps).state;
+  const restartState = restartHermesGatewayAfterStateRestore(sandboxName, agentName, deps);
+  return verifyHermesGatewayAfterStateRestore(sandboxName, agentName, restartState, deps);
 }
 
 export function ensureHermesGatewayAfterStateRestoreForCronGate(
@@ -138,7 +147,49 @@ export function ensureHermesGatewayAfterStateRestoreForCronGate(
   originalIdentity: HermesCronRestoreIdentity,
   deps: HermesPostRestoreGatewayDeps = {},
 ): HermesPostRestoreGatewayVerification {
-  return ensureHermesGatewayAfterStateRestoreImpl(sandboxName, agentName, deps, originalIdentity);
+  const restartState = restartHermesGatewayAfterStateRestore(sandboxName, agentName, deps);
+  return verifyHermesGatewayAfterStateRestoreForCronGate(
+    sandboxName,
+    agentName,
+    restartState,
+    originalIdentity,
+    deps,
+  );
+}
+
+export function restartHermesGatewayAfterStateRestore(
+  sandboxName: string,
+  agentName: string,
+  deps: HermesPostRestoreGatewayDeps = {},
+): HermesPostRestoreGatewayRestartState {
+  if (agentName !== "hermes") return "not-applicable";
+  const restart = deps.restartSandboxGateway ?? processRecovery.restartSandboxGateway;
+  return restart(sandboxName, { quiet: true }).ok ? "restarted" : "restart-failed";
+}
+
+export function verifyHermesGatewayAfterStateRestore(
+  sandboxName: string,
+  agentName: string,
+  restartState: HermesPostRestoreGatewayRestartState,
+  deps: HermesPostRestoreGatewayDeps = {},
+): HermesPostRestoreGatewayState {
+  return verifyHermesGatewayAfterStateRestoreImpl(sandboxName, agentName, restartState, deps).state;
+}
+
+export function verifyHermesGatewayAfterStateRestoreForCronGate(
+  sandboxName: string,
+  agentName: string,
+  restartState: HermesPostRestoreGatewayRestartState,
+  originalIdentity: HermesCronRestoreIdentity,
+  deps: HermesPostRestoreGatewayDeps = {},
+): HermesPostRestoreGatewayVerification {
+  return verifyHermesGatewayAfterStateRestoreImpl(
+    sandboxName,
+    agentName,
+    restartState,
+    deps,
+    originalIdentity,
+  );
 }
 
 function sameGatewayIdentity(
@@ -148,15 +199,15 @@ function sameGatewayIdentity(
   return left.pid === right.pid && left.start_time === right.start_time;
 }
 
-function ensureHermesGatewayAfterStateRestoreImpl(
+function verifyHermesGatewayAfterStateRestoreImpl(
   sandboxName: string,
   agentName: string,
+  restartState: HermesPostRestoreGatewayRestartState,
   deps: HermesPostRestoreGatewayDeps,
   originalIdentity?: HermesCronRestoreIdentity,
 ): HermesPostRestoreGatewayVerification {
   if (agentName !== "hermes") return { state: "not-applicable" };
-  const restart = deps.restartSandboxGateway ?? processRecovery.restartSandboxGateway;
-  const restarted = restart(sandboxName, { quiet: true }).ok;
+  const restarted = restartState === "restarted";
   const checkAndRecover =
     deps.checkAndRecoverSandboxProcesses ?? processRecovery.checkAndRecoverSandboxProcesses;
   const observeReplacement = deps.observeHermesCronReplacement ?? observeHermesCronReplacement;

--- a/src/lib/actions/sandbox/rebuild-post-restore-phase.test.ts
+++ b/src/lib/actions/sandbox/rebuild-post-restore-phase.test.ts
@@ -58,13 +58,17 @@ describe("rebuild post-restore phase", () => {
       skipReason: "not-needed",
     } as never);
     vi.spyOn(rebuildMcp, "restoreMcpAfterRebuild").mockResolvedValue(true);
-    vi.spyOn(rebuildHermesPostRestore, "ensureHermesGatewayAfterStateRestore").mockImplementation(
+    vi.spyOn(rebuildHermesPostRestore, "restartHermesGatewayAfterStateRestore").mockImplementation(
+      (_sandboxName, targetAgentName) =>
+        targetAgentName === "hermes" ? "restarted" : "not-applicable",
+    );
+    vi.spyOn(rebuildHermesPostRestore, "verifyHermesGatewayAfterStateRestore").mockImplementation(
       (_sandboxName, targetAgentName) =>
         targetAgentName === "hermes" ? "healthy" : "not-applicable",
     );
     vi.spyOn(
       rebuildHermesPostRestore,
-      "ensureHermesGatewayAfterStateRestoreForCronGate",
+      "verifyHermesGatewayAfterStateRestoreForCronGate",
     ).mockReturnValue({
       state: "healthy",
       replacementIdentity: { pid: 77, start_time: 903, drain_token: "restore-token" },
@@ -135,17 +139,23 @@ describe("rebuild post-restore phase", () => {
     const events: string[] = [];
     let dispatchHeld = true;
     const attemptDispatch = () => events.push(dispatchHeld ? "dispatch-blocked" : "dispatch-ran");
+    vi.mocked(rebuildHermesPostRestore.restartHermesGatewayAfterStateRestore).mockImplementation(
+      () => {
+        events.push("restart");
+        attemptDispatch();
+        return "restarted";
+      },
+    );
     vi.mocked(rebuildMcp.restoreMcpAfterRebuild).mockImplementation(async () => {
       events.push("mcp");
       attemptDispatch();
       return true;
     });
     vi.mocked(
-      rebuildHermesPostRestore.ensureHermesGatewayAfterStateRestoreForCronGate,
+      rebuildHermesPostRestore.verifyHermesGatewayAfterStateRestoreForCronGate,
     ).mockImplementation(() => {
-      events.push("restart");
-      attemptDispatch();
       events.push("health-verified");
+      attemptDispatch();
       return {
         state: "healthy",
         replacementIdentity: { pid: 77, start_time: 903, drain_token: "restore-token" },
@@ -176,14 +186,16 @@ describe("rebuild post-restore phase", () => {
     await runRebuildPostRestorePhase(args);
 
     expect(events).toEqual([
-      "mcp",
-      "dispatch-blocked",
       "restart",
       "dispatch-blocked",
+      "mcp",
+      "dispatch-blocked",
       "health-verified",
+      "dispatch-blocked",
       "release",
       "dispatch-ran",
     ]);
+    expect(rebuildHermesPostRestore.restartHermesGatewayAfterStateRestore).toHaveBeenCalledOnce();
     expect(args.log).toHaveBeenCalledWith(
       "Hermes cron restore gate released: pid=77, startTime=903",
     );
@@ -200,7 +212,7 @@ describe("rebuild post-restore phase", () => {
   it("leaves the cron gate active when replacement verification fails (#8472)", async () => {
     agentName = "hermes";
     vi.mocked(
-      rebuildHermesPostRestore.ensureHermesGatewayAfterStateRestoreForCronGate,
+      rebuildHermesPostRestore.verifyHermesGatewayAfterStateRestoreForCronGate,
     ).mockReturnValue({ state: "unverified" });
     const args = {
       ...input(),
@@ -222,6 +234,45 @@ describe("rebuild post-restore phase", () => {
     expect(messagingHostForward.ensureMessagingHostForwardAfterRebuild).not.toHaveBeenCalled();
     expect(vi.mocked(console.error).mock.calls.flat().join("\n")).toContain(
       "Hermes cron dispatch remains drained",
+    );
+  });
+
+  it("keeps restart failure ahead of MCP repair and final verification (#8472)", async () => {
+    agentName = "hermes";
+    const events: string[] = [];
+    vi.mocked(rebuildHermesPostRestore.restartHermesGatewayAfterStateRestore).mockImplementation(
+      () => {
+        events.push("restart-failed");
+        return "restart-failed";
+      },
+    );
+    vi.mocked(rebuildMcp.restoreMcpAfterRebuild).mockImplementation(async () => {
+      events.push("mcp");
+      return true;
+    });
+    vi.mocked(
+      rebuildHermesPostRestore.verifyHermesGatewayAfterStateRestoreForCronGate,
+    ).mockImplementation((_sandboxName, _agentName, restartState) => {
+      events.push(`verify:${restartState}`);
+      return { state: "unverified" };
+    });
+    const args = {
+      ...input(),
+      hermesCronRestoreIdentity: {
+        pid: 41,
+        start_time: 902,
+        drain_token: "restore-token",
+      },
+    };
+
+    await runRebuildPostRestorePhase(args);
+
+    expect(events).toEqual(["restart-failed", "mcp", "verify:restart-failed"]);
+    expect(
+      rebuildHermesPostRestore.completeHermesCronRestoreAfterGatewayReplacement,
+    ).not.toHaveBeenCalled();
+    expect(args.bail).toHaveBeenCalledWith(
+      "Hermes cron restore validation failed; dispatch was not re-enabled.",
     );
   });
 
@@ -329,7 +380,7 @@ describe("rebuild post-restore phase", () => {
     agentName = "hermes";
     vi.mocked(rebuildMcp.restoreMcpAfterRebuild).mockResolvedValue(false);
     vi.mocked(
-      rebuildHermesPostRestore.ensureHermesGatewayAfterStateRestoreForCronGate,
+      rebuildHermesPostRestore.verifyHermesGatewayAfterStateRestoreForCronGate,
     ).mockReturnValue({ state: "unverified" });
     const args = {
       ...input(),
@@ -405,7 +456,7 @@ describe("rebuild post-restore phase", () => {
 
   it("does not print the Hermes API token notice when post-restore verification is incomplete (#7175)", async () => {
     agentName = "hermes";
-    vi.mocked(rebuildHermesPostRestore.ensureHermesGatewayAfterStateRestore).mockReturnValue(
+    vi.mocked(rebuildHermesPostRestore.verifyHermesGatewayAfterStateRestore).mockReturnValue(
       "unverified",
     );
     const args = input();
@@ -450,7 +501,7 @@ describe("rebuild post-restore phase", () => {
 
   it("prints the Hermes API token notice after gateway recovery (#7175)", async () => {
     agentName = "hermes";
-    vi.mocked(rebuildHermesPostRestore.ensureHermesGatewayAfterStateRestore).mockReturnValue(
+    vi.mocked(rebuildHermesPostRestore.verifyHermesGatewayAfterStateRestore).mockReturnValue(
       "recovered",
     );
     const args = input();
@@ -561,7 +612,7 @@ describe("rebuild post-restore phase", () => {
     const output = vi.mocked(console.log).mock.calls.flat().map(String).join("\n");
     // Every incomplete-recovery report this path can emit for an OpenClaw
     // rebuild. The Hermes gateway report is unreachable here because
-    // ensureHermesGatewayAfterStateRestore returns "not-applicable" for
+    // verifyHermesGatewayAfterStateRestore returns "not-applicable" for
     // OpenClaw; baseline exclusions are covered by the #7194 test above.
     const ordered = [
       "State restore was incomplete",

--- a/src/lib/actions/sandbox/rebuild-post-restore-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-post-restore-phase.ts
@@ -19,11 +19,12 @@ import type { RebuildBail, RebuildLog } from "./rebuild-credential-preflight";
 import type { RebuildSandboxEntry } from "./rebuild-flow-helpers";
 import {
   completeHermesCronRestoreAfterGatewayReplacement,
-  ensureHermesGatewayAfterStateRestore,
-  ensureHermesGatewayAfterStateRestoreForCronGate,
   type HermesCronRestoreIdentity,
   isHermesCronRestoreDrainMarkerRollbackFailure,
   printHermesGatewayRestoreRecovery,
+  restartHermesGatewayAfterStateRestore,
+  verifyHermesGatewayAfterStateRestore,
+  verifyHermesGatewayAfterStateRestoreForCronGate,
 } from "./rebuild-hermes-post-restore";
 import {
   type McpRebuildPreparation,
@@ -283,15 +284,27 @@ export async function runRebuildPostRestorePhase(
     }
   }
 
+  // Restart before restoring MCP. The Hermes MCP transaction performs an
+  // acknowledged reload of its own; restarting afterwards would replace the
+  // only runtime whose managed MCP configuration was proven to have loaded.
+  const hermesGatewayRestartState = restartHermesGatewayAfterStateRestore(
+    sandboxName,
+    targetAgentName,
+  );
   const mcpBridgeRestoreUnverified = !(await restoreMcpAfterRebuild(sandboxName, mcpEntries));
   const hermesGatewayVerification = hermesCronRestoreIdentity
-    ? ensureHermesGatewayAfterStateRestoreForCronGate(
+    ? verifyHermesGatewayAfterStateRestoreForCronGate(
         sandboxName,
         targetAgentName,
+        hermesGatewayRestartState,
         hermesCronRestoreIdentity,
       )
     : {
-        state: ensureHermesGatewayAfterStateRestore(sandboxName, targetAgentName),
+        state: verifyHermesGatewayAfterStateRestore(
+          sandboxName,
+          targetAgentName,
+          hermesGatewayRestartState,
+        ),
         replacementIdentity: undefined,
       };
   const hermesGatewayRestoreState = hermesGatewayVerification.state;

--- a/test/e2e/live/hermes-discord-proxy.ts
+++ b/test/e2e/live/hermes-discord-proxy.ts
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function hermesDiscordHttpProxyWebSocketUrl(host: string, port: number | string): string {
+  return `http://${host}:${port}/gateway`;
+}

--- a/test/e2e/live/hermes-discord.test.ts
+++ b/test/e2e/live/hermes-discord.test.ts
@@ -14,6 +14,7 @@ import { expect, test } from "../fixtures/e2e-test.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 import { buildProcessTokenProbe } from "../fixtures/process-token-probe.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import { hermesDiscordHttpProxyWebSocketUrl } from "./hermes-discord-proxy.ts";
 import { type FakeDockerApi, startFakeDockerApi } from "./messaging-providers-helpers.ts";
 import {
   runSecondaryCleanup as bestEffortLifecycleCleanup,
@@ -36,6 +37,10 @@ const DISCORD_ALLOWED_IDS = process.env.DISCORD_ALLOWED_IDS ?? "1005536447329222
 const DISCORD_REQUIRE_MENTION = process.env.DISCORD_REQUIRE_MENTION ?? "0";
 const HERMES_HEALTH_URL = "http://localhost:8642/health";
 const FAKE_DISCORD_HOST = "host.docker.internal";
+const HERMES_DISCORD_HTTP_PROXY_GATEWAY_TEMPLATE = hermesDiscordHttpProxyWebSocketUrl(
+  "{host}",
+  "{port}",
+);
 
 function commandEnv(apiKey?: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return phase6Env({
@@ -270,7 +275,12 @@ async def main():
     client.http._global_over.set()
     try:
         from_client = discord.gateway.DiscordWebSocket.from_client
-        kwargs = {"gateway": URL(f"ws://{host}:{port}/gateway")}
+        # aiohttp preserves the target scheme in the absolute-form request it
+        # sends to an HTTP proxy. OpenShell accepts WebSocket upgrades through
+        # that proxy as HTTP requests with Upgrade headers, matching the raw
+        # Node proof below; a ws:// absolute-form target is rejected with 400
+        # before it reaches the fake gateway.
+        kwargs = {"gateway": URL(f"${HERMES_DISCORD_HTTP_PROXY_GATEWAY_TEMPLATE}")}
         params = inspect.signature(from_client).parameters
         if "initial" in params:
             kwargs["initial"] = False

--- a/test/e2e/support/hermes-discord-proxy-request.test.ts
+++ b/test/e2e/support/hermes-discord-proxy-request.test.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { hermesDiscordHttpProxyWebSocketUrl } from "../live/hermes-discord-proxy.ts";
+
+describe("Hermes Discord proxy request", () => {
+  it("uses HTTP absolute-form for the native WebSocket upgrade through OpenShell", () => {
+    const gateway = new URL(hermesDiscordHttpProxyWebSocketUrl("host.docker.internal", 32_768));
+
+    expect(gateway.protocol).toBe("http:");
+    expect(gateway.host).toBe("host.docker.internal:32768");
+    expect(gateway.pathname).toBe("/gateway");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes rebuilds now restart the gateway before managed MCP restoration and verify the MCP-reloaded process before releasing the cron gate. The Hermes Discord E2E proof now uses an HTTP absolute-form target so aiohttp can complete its native WebSocket Upgrade through OpenShell.

## Changes

- Split Hermes post-restore gateway restart from final verification so managed MCP restoration runs between them.
- Preserve fail-closed MCP reconciliation, secret-boundary checks, and stable cron process identity validation before dispatch resumes.
- Change only the existing fake Discord gateway test client's target from `ws://` to `http://`; the fake server and Upgrade, credential rewrite, IDENTIFY, READY, and heartbeat assertions remain unchanged.
- Add focused rebuild-ordering, restart-free verification, and Discord proxy URL regression tests.
- Document the corrected Hermes rebuild lifecycle.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop performed a focused read-only review of gateway restart, MCP reload, reconciliation refusal, and cron identity ordering. The review found no actionable correctness or security issue, and focused tests cover the fail-closed paths.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx`; `npm run docs` completed with 0 errors and 2 existing Fern warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 82869f253 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/actions/sandbox/rebuild-hermes-post-restore.test.ts src/lib/actions/sandbox/rebuild-post-restore-phase.test.ts` passed 47 tests; the focused `e2e-support` Discord test passed 1 test.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — full `npm test` was not run. The rebuild-focused sweep passed 684 tests with 3 skips; one parallel 5-second timeout passed 38 tests when rerun alone.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox recovery by restarting the gateway before restoring managed MCP settings.
  * Added final health and configuration checks without unnecessarily replacing a verified gateway process.
  * Improved handling and reporting of gateway restart failures during recovery.

* **Documentation**
  * Updated sandbox recovery guidance to reflect the revised gateway and MCP restoration sequence.

* **Tests**
  * Expanded coverage for gateway identity changes, restart failures, MCP reconciliation, and recovery ordering.
  * Added end-to-end coverage for Discord gateway connections through HTTP proxy upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->