### PR TITLE
fix(e2e): keep protected GPU risk reporting PR-only

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2684,7 +2684,7 @@ jobs:
       E2E_WORKLOAD_SOURCE: "managed-image"
       RELEASE_E2E_ACTIVATION_PATH: ci/protected-managed-image-runtime-activation-v1.json
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
-      NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha || github.sha }}
+      NEMOCLAW_E2E_EXPECTED_SHA: ${{ inputs.checkout_sha }}
       NEMOCLAW_E2E_SHARD: linux-amd64-gpu
       NEMOCLAW_E2E_TESTED_ROOT: ${{ github.workspace }}/.candidate-runtime
       NEMOCLAW_NON_INTERACTIVE: "1"

--- a/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
+++ b/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
@@ -60,13 +60,13 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("binds protected candidate identity on ordinary main runs", () => {
+  it("does not activate protected PR risk reporting for ordinary main runs (#8664)", () => {
     const value = workflow();
     const jobEnv = runtimeJob(value).env as Record<string, unknown>;
-    jobEnv.NEMOCLAW_E2E_EXPECTED_SHA = "${{ inputs.checkout_sha }}";
+    jobEnv.NEMOCLAW_E2E_EXPECTED_SHA = "${{ inputs.checkout_sha || github.sha }}";
 
     expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
-      "managed-image-protected-runtime env must bind NEMOCLAW_E2E_EXPECTED_SHA to ${{ inputs.checkout_sha || github.sha }}",
+      "managed-image-protected-runtime env must bind NEMOCLAW_E2E_EXPECTED_SHA to ${{ inputs.checkout_sha }}",
     );
   });
 

--- a/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
+++ b/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
@@ -114,7 +114,7 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     E2E_TARGET_ID: JOB_ID,
     E2E_WORKLOAD_SOURCE: "managed-image",
     RELEASE_E2E_ACTIVATION_PATH: ACTIVATION_PATH,
-    NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha || github.sha }}",
+    NEMOCLAW_E2E_EXPECTED_SHA: "${{ inputs.checkout_sha }}",
     NEMOCLAW_E2E_SHARD: "linux-amd64-gpu",
     NEMOCLAW_E2E_TESTED_ROOT: "${{ github.workspace }}/.candidate-runtime",
     NEMOCLAW_NON_INTERACTIVE: "1",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Protected managed-image GPU qualification no longer starts PR risk reporting for ordinary `main` pushes or non-PR dispatches. Exact-PR dispatches retain their exact SHA, isolated checkout, correlation ID, and tested-root evidence binding, while candidate identity remains available for image and cache operations on every supported event.

## Related Issue

Fixes #8664

## Changes

- Bind the protected runtime job's `NEMOCLAW_E2E_EXPECTED_SHA` only to `inputs.checkout_sha`, matching the established PR-only reporting contract.
- Keep the separate candidate identity path unchanged for checkout, image construction, activation validation, and cache selection.
- Update the workflow boundary and regression test so `${{ inputs.checkout_sha || github.sha }}` is rejected if it returns.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is an internal CI workflow contract correction with no supported CLI, configuration, API, policy, or user-facing runtime change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop security-review subagent reviewed the current three-file diff on `6ad7ea6c`; no security or correctness findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation files changed; the correction only changes internal GitHub Actions risk-report activation and its workflow-boundary contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 88c6b4573 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/managed-image-protected-runtime-workflow.test.ts` (20/20); `npx vitest run --project integration test/e2e-risk-signal-reporter.test.ts` (20/20); `npm run typecheck:cli` (pass); `npx prek run --from-ref main --to-ref HEAD` (pass).
- [ ] Applicable broad gate passed — Not applicable; this is a narrow workflow environment-binding and boundary-test correction.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protected runtime validation by requiring the explicitly provided checkout revision.
  * Prevented ordinary main-branch runs from using an unintended fallback revision.
  * Updated end-to-end validation to enforce the corrected workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->