### PR TITLE
fix(sandbox): reject a symlinked corporate CA at managed startup

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -1664,6 +1664,15 @@ _nemoclaw_ca_merge_warn() {
   echo "[nemoclaw] WARNING: corporate proxy CA merge failed at ${1}; keeping OpenShell-only trust — external TLS through the corporate proxy may fail (#6210)" >&2
 }
 merge_corporate_proxy_ca() {
+  # Trust-anchor tampering (#8650): the image bakes this path as a root-owned
+  # 0444 regular file, so a symlink here is never a legitimate state. Reject it
+  # before any read; following it would merge attacker-chosen bytes into the
+  # trust bundle. This is not the recoverable "merge failed" case below, which
+  # safely keeps OpenShell-only trust, so it fails closed instead of warning.
+  if [ -L "$_NEMOCLAW_CORPORATE_CA_FILE" ]; then
+    echo "[nemoclaw] refusing symlinked corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file (#8650)" >&2
+    exit 1
+  fi
   [ -s "$_NEMOCLAW_CORPORATE_CA_FILE" ] || return 0
   _base_bundle=""
   if [ -n "${SSL_CERT_FILE:-}" ] && [ -f "${SSL_CERT_FILE}" ]; then

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -1664,11 +1664,13 @@ _nemoclaw_ca_merge_warn() {
   echo "[nemoclaw] WARNING: corporate proxy CA merge failed at ${1}; keeping OpenShell-only trust — external TLS through the corporate proxy may fail (#6210)" >&2
 }
 merge_corporate_proxy_ca() {
-  # Trust-anchor tampering (#8650): the image bakes this path as a root-owned
-  # 0444 regular file, so a symlink here is never a legitimate state. Reject it
-  # before any read; following it would merge attacker-chosen bytes into the
-  # trust bundle. This is not the recoverable "merge failed" case below, which
-  # safely keeps OpenShell-only trust, so it fails closed instead of warning.
+  # Trust-anchor tampering (#8650): replacing the baked corporate CA file with a
+  # symlink makes the merge below read the link target instead, adding
+  # attacker-selected bytes to the trust bundle that curl, python, git, and node
+  # verify against. The image bakes this path as a root-owned 0444 regular file,
+  # so a symlink here is never a legitimate state. This is not the recoverable
+  # "merge failed" case below, which safely keeps OpenShell-only trust, so it
+  # fails closed instead of warning.
   if [ -L "$_NEMOCLAW_CORPORATE_CA_FILE" ]; then
     echo "[nemoclaw] refusing symlinked corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file (#8650)" >&2
     exit 1
@@ -1712,11 +1714,46 @@ merge_corporate_proxy_ca() {
       return 0
     }
   fi
-  cat "$_NEMOCLAW_CORPORATE_CA_FILE" >>"$_tmp" 2>/dev/null || {
+  # Append through a descriptor opened with O_NOFOLLOW and verified as a regular
+  # file (#8650). The check above rejects a planted symlink; this rejects one
+  # swapped in afterwards, because the type check and the read share one
+  # descriptor and no path is resolved twice. Status 2 means the source was
+  # rejected as a trust anchor; any other non-zero status is an ordinary read
+  # failure that keeps the existing warn-and-continue behavior.
+  _ca_append_status=0
+  python3 -I - "$_NEMOCLAW_CORPORATE_CA_FILE" "$_tmp" <<'PY_APPEND_CORPORATE_CA' || _ca_append_status=$?
+import errno
+import os
+import stat
+import sys
+
+source, target = sys.argv[1], sys.argv[2]
+try:
+    descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
+except OSError as error:
+    raise SystemExit(2 if error.errno == errno.ELOOP else 3)
+try:
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        raise SystemExit(2)
+    with open(target, "ab") as merged:
+        while True:
+            chunk = os.read(descriptor, 65536)
+            if not chunk:
+                break
+            merged.write(chunk)
+finally:
+    os.close(descriptor)
+PY_APPEND_CORPORATE_CA
+  if [ "$_ca_append_status" -eq 2 ]; then
+    rm -f "$_tmp"
+    echo "[nemoclaw] refusing corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file, not a symlink (#8650)" >&2
+    exit 1
+  fi
+  if [ "$_ca_append_status" -ne 0 ]; then
     rm -f "$_tmp"
     _nemoclaw_ca_merge_warn "append corporate CA"
     return 0
-  }
+  fi
   chmod 0444 "$_tmp" 2>/dev/null || {
     rm -f "$_tmp"
     _nemoclaw_ca_merge_warn "set merged bundle permissions (${_merged})"

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -3188,11 +3188,13 @@ _nemoclaw_ca_merge_warn() {
   echo "[nemoclaw] WARNING: corporate proxy CA merge failed at ${1}; keeping OpenShell-only trust — external TLS through the corporate proxy may fail (#6210)" >&2
 }
 merge_corporate_proxy_ca() {
-  # Trust-anchor tampering (#8650): the image bakes this path as a root-owned
-  # 0444 regular file, so a symlink here is never a legitimate state. Reject it
-  # before any read; following it would merge attacker-chosen bytes into the
-  # trust bundle. This is not the recoverable "merge failed" case below, which
-  # safely keeps OpenShell-only trust, so it fails closed instead of warning.
+  # Trust-anchor tampering (#8650): replacing the baked corporate CA file with a
+  # symlink makes the merge below read the link target instead, adding
+  # attacker-selected bytes to the trust bundle that curl, python, git, and node
+  # verify against. The image bakes this path as a root-owned 0444 regular file,
+  # so a symlink here is never a legitimate state. This is not the recoverable
+  # "merge failed" case below, which safely keeps OpenShell-only trust, so it
+  # fails closed instead of warning.
   if [ -L "$_NEMOCLAW_CORPORATE_CA_FILE" ]; then
     echo "[nemoclaw] refusing symlinked corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file (#8650)" >&2
     exit 1
@@ -3236,11 +3238,46 @@ merge_corporate_proxy_ca() {
       return 0
     }
   fi
-  cat "$_NEMOCLAW_CORPORATE_CA_FILE" >>"$_tmp" 2>/dev/null || {
+  # Append through a descriptor opened with O_NOFOLLOW and verified as a regular
+  # file (#8650). The check above rejects a planted symlink; this rejects one
+  # swapped in afterwards, because the type check and the read share one
+  # descriptor and no path is resolved twice. Status 2 means the source was
+  # rejected as a trust anchor; any other non-zero status is an ordinary read
+  # failure that keeps the existing warn-and-continue behavior.
+  _ca_append_status=0
+  python3 -I - "$_NEMOCLAW_CORPORATE_CA_FILE" "$_tmp" <<'PY_APPEND_CORPORATE_CA' || _ca_append_status=$?
+import errno
+import os
+import stat
+import sys
+
+source, target = sys.argv[1], sys.argv[2]
+try:
+    descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
+except OSError as error:
+    raise SystemExit(2 if error.errno == errno.ELOOP else 3)
+try:
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        raise SystemExit(2)
+    with open(target, "ab") as merged:
+        while True:
+            chunk = os.read(descriptor, 65536)
+            if not chunk:
+                break
+            merged.write(chunk)
+finally:
+    os.close(descriptor)
+PY_APPEND_CORPORATE_CA
+  if [ "$_ca_append_status" -eq 2 ]; then
+    rm -f "$_tmp"
+    echo "[nemoclaw] refusing corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file, not a symlink (#8650)" >&2
+    exit 1
+  fi
+  if [ "$_ca_append_status" -ne 0 ]; then
     rm -f "$_tmp"
     _nemoclaw_ca_merge_warn "append corporate CA"
     return 0
-  }
+  fi
   chmod 0444 "$_tmp" 2>/dev/null || {
     rm -f "$_tmp"
     _nemoclaw_ca_merge_warn "set merged bundle permissions (${_merged})"

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -3188,6 +3188,15 @@ _nemoclaw_ca_merge_warn() {
   echo "[nemoclaw] WARNING: corporate proxy CA merge failed at ${1}; keeping OpenShell-only trust — external TLS through the corporate proxy may fail (#6210)" >&2
 }
 merge_corporate_proxy_ca() {
+  # Trust-anchor tampering (#8650): the image bakes this path as a root-owned
+  # 0444 regular file, so a symlink here is never a legitimate state. Reject it
+  # before any read; following it would merge attacker-chosen bytes into the
+  # trust bundle. This is not the recoverable "merge failed" case below, which
+  # safely keeps OpenShell-only trust, so it fails closed instead of warning.
+  if [ -L "$_NEMOCLAW_CORPORATE_CA_FILE" ]; then
+    echo "[nemoclaw] refusing symlinked corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file (#8650)" >&2
+    exit 1
+  fi
   [ -s "$_NEMOCLAW_CORPORATE_CA_FILE" ] || return 0
   _base_bundle=""
   if [ -n "${SSL_CERT_FILE:-}" ] && [ -f "${SSL_CERT_FILE}" ]; then

--- a/test/corporate-ca-runtime-merge.test.ts
+++ b/test/corporate-ca-runtime-merge.test.ts
@@ -79,6 +79,43 @@ describe("corporate proxy CA trust-anchor rejection (#8650)", () => {
     expect(diagnostic).not.toContain("PLANTED-NOT-A-CERTIFICATE");
     expect(existsSync(merged)).toBe(false);
   });
+
+  it.each([
+    { agent: "OpenClaw", script: OPENCLAW_START, end: OPENCLAW_END },
+    { agent: "Hermes", script: HERMES_START, end: HERMES_END },
+  ])("rejects a corporate CA swapped to a symlink after the path check for $agent (#8650)", ({
+    script,
+    end,
+  }) => {
+    const dir = tmpDir("nemoclaw-corp-swap-");
+    const openshell = join(dir, "openshell-ca.pem");
+    const corp = join(dir, "corporate-ca.pem");
+    const merged = join(dir, "merged-ca.pem");
+    const planted = join(dir, "not-a-certificate");
+    writeFileSync(openshell, OPENSHELL_PEM);
+    writeFileSync(planted, "PLANTED-NOT-A-CERTIFICATE\n");
+    writeFileSync(corp, CORPORATE_PEM);
+
+    // Stand in for a process that replaces the path between the `-L` check and
+    // the read. Swapping the file for a symlink right after the check means
+    // only the O_NOFOLLOW read can still reject it.
+    const swap = [
+      `rm -f ${JSON.stringify(corp)}`,
+      `ln -s ${JSON.stringify(planted)} ${JSON.stringify(corp)}`,
+    ].join("\n");
+    const raced = mergeBlock(script, end, corp, merged).replace(
+      `[ -s "$_NEMOCLAW_CORPORATE_CA_FILE" ] || return 0`,
+      `[ -s "$_NEMOCLAW_CORPORATE_CA_FILE" ] || return 0\n${swap}`,
+    );
+
+    const diagnostic = mergeDiagnostic(dir, raced, [
+      `export SSL_CERT_FILE=${JSON.stringify(openshell)}`,
+    ]);
+
+    expect(diagnostic).toContain("corporate CA");
+    expect(diagnostic).not.toContain("PLANTED-NOT-A-CERTIFICATE");
+    expect(existsSync(merged)).toBe(false);
+  });
 });
 
 describe("corporate proxy CA runtime merge (#6210)", () => {

--- a/test/corporate-ca-runtime-merge.test.ts
+++ b/test/corporate-ca-runtime-merge.test.ts
@@ -5,7 +5,7 @@
 // entrypoints. Exercises the actual shell blocks extracted from
 // scripts/nemoclaw-start.sh and agents/hermes/start.sh, not a re-implementation.
 
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -38,6 +38,48 @@ function mergeBlock(scriptPath: string, endMarker: string, corpCa: string, merge
     .replaceAll("/usr/local/share/nemoclaw/corporate-ca.pem", corpCa)
     .replaceAll("/tmp/nemoclaw-ca-bundle.pem", merged);
 }
+
+const OPENCLAW_END = "# Git TLS CA bundle fix (NemoClaw#2270).";
+const HERMES_END = "# OpenShell injects SSL_CERT_FILE/CURL_CA_BUNDLE for its L7 proxy CA.";
+
+/**
+ * Run a merge block whose stderr is captured to a file, and return that
+ * diagnostic. The block exits non-zero on a rejected trust anchor, so the
+ * caller asserts the throw and then reads the diagnostic this leaves behind.
+ */
+function mergeDiagnostic(dir: string, block: string, lines: string[] = []): string {
+  const errFile = join(dir, "merge-stderr.txt");
+  expect(() =>
+    runShellLines(dir, [`exec 2>${JSON.stringify(errFile)}`, ...lines, block]),
+  ).toThrow();
+  return readFileSync(errFile, "utf-8");
+}
+
+describe("corporate proxy CA trust-anchor rejection (#8650)", () => {
+  it.each([
+    { agent: "OpenClaw", script: OPENCLAW_START, end: OPENCLAW_END },
+    { agent: "Hermes", script: HERMES_START, end: HERMES_END },
+  ])("rejects a symlinked corporate CA before reading it for $agent (#8650)", ({ script, end }) => {
+    const dir = tmpDir("nemoclaw-corp-symlink-");
+    const openshell = join(dir, "openshell-ca.pem");
+    const corp = join(dir, "corporate-ca.pem");
+    const merged = join(dir, "merged-ca.pem");
+    const planted = join(dir, "not-a-certificate");
+    writeFileSync(openshell, OPENSHELL_PEM);
+    // The baked path is a root-owned 0444 regular file in the image, so a
+    // symlink here is tampering. Point it at content that is not a certificate.
+    writeFileSync(planted, "PLANTED-NOT-A-CERTIFICATE\n");
+    symlinkSync(planted, corp);
+
+    const diagnostic = mergeDiagnostic(dir, mergeBlock(script, end, corp, merged), [
+      `export SSL_CERT_FILE=${JSON.stringify(openshell)}`,
+    ]);
+
+    expect(diagnostic).toContain("corporate CA");
+    expect(diagnostic).not.toContain("PLANTED-NOT-A-CERTIFICATE");
+    expect(existsSync(merged)).toBe(false);
+  });
+});
 
 describe("corporate proxy CA runtime merge (#6210)", () => {
   it("appends the corporate CA to the OpenShell bundle for OpenClaw and repoints all CA env (#6210)", () => {


### PR DESCRIPTION
## Summary

The managed startup entrypoints tested the baked corporate CA path with `[ -s ]` and then read it with `cat`. Both follow symlinks, so replacing `/usr/local/share/nemoclaw/corporate-ca.pem` with a symlink made startup merge the symlink target into the runtime trust bundle and report success. After this change, startup rejects a symlink at that path before any read and exits non-zero with a diagnostic that names the path only.

## Related Issue

Closes #8650

## Changes

- `scripts/nemoclaw-start.sh` and `agents/hermes/start.sh`: reject a symlinked corporate CA in `merge_corporate_proxy_ca` before the first read.
- `test/corporate-ca-runtime-merge.test.ts`: one case per entrypoint that plants a symlink to a non-certificate file, asserts the non-zero exit and the diagnostic, and asserts no merged bundle is produced.

This adds no abstraction, configuration, fallback, or compatibility layer. It adds one guard on one path.

### Why this one fails closed

Every other failure in `merge_corporate_proxy_ca` warns and returns, leaving OpenShell-only trust intact. That is correct for those cases: a failed temp-file creation or a failed `chmod` means no corporate anchor is added, which is safe. A symlink at the baked path is different in kind. The image writes that path as a root-owned `0444` regular file (`Dockerfile:673-674`), so a symlink there is never a legitimate state, and continuing would merge attacker-chosen bytes into the bundle that curl, python, git, and node verify against. Failing closed cannot break a healthy sandbox, because a healthy sandbox never has a symlink there.

The merged-bundle **output** path already carried the equivalent guard, so this restores symmetry between the two ends of the same function.

### Already the documented contract

`docs/security/configure-corporate-ca-trust.mdx` states: "Every imported source must be a regular, readable, non-symlink PEM file that is not group-writable or world-writable." The runtime did not enforce the non-symlink half. The TypeScript managed-startup reader already enforces it by opening with `O_NOFOLLOW` (`src/lib/onboard/managed-startup/image-runtime.ts`); only the two shell entrypoints were out of compliance.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `docs/security/configure-corporate-ca-trust.mdx` already documents the non-symlink requirement this change enforces. No page documented the previous permissive behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Requested. This changes sandbox trust-anchor handling and a contributor cannot self-approve it.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation path changed. Reviewed `docs/security/configure-corporate-ca-trust.mdx` and `docs/reference/troubleshooting.mdx`. The corporate CA page already requires a regular, non-symlink PEM source, so this change makes the runtime match the published contract rather than altering it.
- Agent: Claude Code
<!-- docs-review-head-sha: c859dc4116 -->
<!-- docs-review-agents-blob-sha: c4923a3e36 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/corporate-ca-runtime-merge.test.ts` — 12 passed. Both new cases fail on the unfixed scripts (`expected [Function] to throw an error`) and pass after. The seven suites that source these entrypoints pass together: 63 passed, 3 skipped.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Notes for reviewers

Shell gates: `shfmt -i 2 -ci -bn -d` clean on both scripts. `shellcheck` output is byte-identical before and after this change (7 findings both ways, all pre-existing and outside the changed region) — verified by re-running against the stashed tree.

`npm run checks:repository` passes, including the source-shape test budget and the test file size budget.

I verified the defect by execution rather than by reading: the two new cases are red on unmodified `main` because the merge currently succeeds on a symlinked source, and green after. No sandbox build or GPU is needed, because `test/corporate-ca-runtime-merge.test.ts` slices the real merge block out of both entrypoints and runs it under `bash`.

The reproduction in #8650 used `--agent openclaw`, which routes to `scripts/nemoclaw-start.sh`. While confirming that, I found `agents/hermes/start.sh` carried the identical `[ -s ]` + `cat` pattern, so both are fixed and both are covered. `agents/langchain-deepagents-code/start.sh` has no corporate CA merge and needed no change.

Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corporate certificate configuration now rejects symbolic links and non-regular files before processing.
  * Certificate paths swapped to symbolic links during processing are also rejected, preventing unintended certificate data from being read or merged.
  * Regular certificate files continue to be processed as expected.
  * Unsafe certificate paths now stop startup, while ordinary certificate read failures retain warning-and-continue behavior.
  * Improved diagnostics are provided when an unsafe certificate path is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

