### PR TITLE
fix(inference): restore qualification loopback publish

### DIFF
--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -326,14 +326,27 @@ export function insertQualificationLoopbackPublishArgv(
     imageReference: string;
   },
 ): string[] {
-  if (argv.includes("--publish")) {
-    throw new Error("llama.cpp qualification materializer must not publish a Docker port");
-  }
   const imageIndex = argv.indexOf(options.imageReference);
   if (imageIndex < 0 || imageIndex !== argv.lastIndexOf(options.imageReference)) {
     throw new Error(
       "llama.cpp qualification requires exactly one Docker image reference in the materialized argument vector",
     );
+  }
+  const materializedDockerOptions = argv.slice(0, imageIndex);
+  if (
+    materializedDockerOptions.some(
+      (argument) =>
+        argument === "--publish" ||
+        argument.startsWith("--publish=") ||
+        argument === "--publish-all" ||
+        argument.startsWith("--publish-all=") ||
+        argument === "-p" ||
+        (argument.startsWith("-p") && argument.length > 2) ||
+        argument === "-P" ||
+        argument.startsWith("-P="),
+    )
+  ) {
+    throw new Error("llama.cpp qualification materializer must not publish a Docker port");
   }
   const containerPort = requiredInteger(
     options.containerPort,

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -318,6 +318,41 @@ export function buildCandidateImageArgv(
   ];
 }
 
+export function insertQualificationLoopbackPublishArgv(
+  argv: readonly string[],
+  options: {
+    containerPort: number;
+    hostPort?: number;
+    imageReference: string;
+  },
+): string[] {
+  if (argv.includes("--publish")) {
+    throw new Error("llama.cpp qualification materializer must not publish a Docker port");
+  }
+  const imageIndex = argv.indexOf(options.imageReference);
+  if (imageIndex < 0 || imageIndex !== argv.lastIndexOf(options.imageReference)) {
+    throw new Error(
+      "llama.cpp qualification requires exactly one Docker image reference in the materialized argument vector",
+    );
+  }
+  const containerPort = requiredInteger(
+    options.containerPort,
+    "qualification container port",
+    1,
+    65_535,
+  );
+  const hostPort =
+    options.hostPort === undefined
+      ? ""
+      : String(requiredInteger(options.hostPort, "qualification host port", 1, 65_535));
+  return [
+    ...argv.slice(0, imageIndex),
+    "--publish",
+    `127.0.0.1:${hostPort}:${String(containerPort)}`,
+    ...argv.slice(imageIndex),
+  ];
+}
+
 export function buildServerContainerArgv(
   plan: QualificationPlan,
   options: {
@@ -346,14 +381,11 @@ export function buildServerContainerArgv(
     runtimeGid: options.runtimeGid,
     runtimeUid: options.runtimeUid,
   });
-  const entrypointIndex = argv.indexOf("--entrypoint");
-  const hostPort = options.hostPort === undefined ? "" : String(options.hostPort);
-  return [
-    ...argv.slice(0, entrypointIndex),
-    "--publish",
-    `127.0.0.1:${hostPort}:${String(plan.recipe.serve.port)}`,
-    ...argv.slice(entrypointIndex),
-  ];
+  return insertQualificationLoopbackPublishArgv(argv, {
+    containerPort: plan.recipe.serve.port,
+    ...(options.hostPort === undefined ? {} : { hostPort: options.hostPort }),
+    imageReference: options.imageReference,
+  });
 }
 
 export function validateOpenClawQualificationImageLabels(

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -460,12 +460,30 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     expect(() =>
       insertQualificationLoopbackPublishArgv(["run", imageReference, imageReference], options),
     ).toThrow(/exactly one Docker image reference/u);
-    expect(() =>
-      insertQualificationLoopbackPublishArgv(
-        ["run", "--publish", "127.0.0.1::8081", imageReference],
-        options,
-      ),
-    ).toThrow(/must not publish/u);
+    for (const publishArgv of [
+      ["--publish", "0.0.0.0:8081:8081"],
+      ["--publish=0.0.0.0:8081:8081"],
+      ["-p", "0.0.0.0:8081:8081"],
+      ["-p0.0.0.0:8081:8081"],
+      ["--publish-all"],
+      ["--publish-all=true"],
+      ["-P"],
+      ["-P=true"],
+    ]) {
+      expect(() =>
+        insertQualificationLoopbackPublishArgv(["run", ...publishArgv, imageReference], options),
+      ).toThrow(/must not publish/u);
+    }
+    expect(
+      insertQualificationLoopbackPublishArgv(["run", imageReference, "-p", "guard-value"], options),
+    ).toEqual([
+      "run",
+      "--publish",
+      `127.0.0.1::${String(containerPort)}`,
+      imageReference,
+      "-p",
+      "guard-value",
+    ]);
   });
 
   it("accepts only the exact NVIDIA OpenClaw ARM64 managed-image labels", () => {

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -16,6 +16,7 @@ import {
   expectedRegistryName,
   expectedRegistryOwner,
   hashModelFile,
+  insertQualificationLoopbackPublishArgv,
   parseNvidiaSmi,
   parseQualificationInvocation,
   type QualificationInvocation,
@@ -282,7 +283,7 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     }
   });
 
-  it("activates the YAML-bound guard without putting the key on argv (#8260)", () => {
+  it("publishes the YAML-bound guard on loopback without putting the key on argv (#8667)", () => {
     const content = Buffer.from("qualification model fixture\n", "utf8");
     const testPlan = qualificationPlanForModel(content);
     const modelRoot = fs.realpathSync(
@@ -300,24 +301,24 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         mtimeNs: modelStatus.mtimeNs,
         size: modelStatus.size,
       });
-      const argv = buildServerContainerArgv(testPlan, {
+      const imageReference = `localhost:5000/repo@sha256:${"d".repeat(64)}`;
+      const containerOptions = {
         apiKeyHostPath: "/work/tmp/api-key",
         containerName: "qualified-server",
-        imageReference: `localhost:5000/repo@sha256:${"d".repeat(64)}`,
+        imageReference,
         model,
         networkName: "qualified-internal",
         registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
         runtimeGid: 1001,
         runtimeUid: 1001,
-      });
+      } as const;
+      const argv = buildServerContainerArgv(testPlan, containerOptions);
       expect(argv).toEqual(
         expect.arrayContaining([
           "--read-only",
           "--cap-drop",
           "ALL",
           "no-new-privileges=true",
-          "--gpus",
-          "1",
           "--gpu-layers",
           "all",
           "--ctx-size",
@@ -339,7 +340,15 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
           "--no-agent",
         ]),
       );
-      expect(valuesAfter(argv, "--publish")).toEqual(["127.0.0.1::8081"]);
+      const publishMappings = valuesAfter(argv, "--publish");
+      expect(publishMappings).toEqual([`127.0.0.1::${String(testPlan.recipe.serve.port)}`]);
+      expect(publishMappings.some((mapping) => mapping.startsWith("0.0.0.0:"))).toBe(false);
+      const imageIndex = argv.indexOf(imageReference);
+      expect(argv.slice(imageIndex - 2, imageIndex + 1)).toEqual([
+        "--publish",
+        publishMappings[0],
+        imageReference,
+      ]);
       expect(valuesAfter(argv, "--entrypoint")).toEqual([
         "/usr/local/bin/nemoclaw-llama-cpp-request-guard",
       ]);
@@ -372,19 +381,33 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         String(testPlan.recipe.serve.limits.maxOutputTokens),
       ]);
       const agentQualificationArgv = buildServerContainerArgv(testPlan, {
-        apiKeyHostPath: "/work/tmp/api-key",
-        containerName: "qualified-server",
-        hostPort: 8081,
-        imageReference: `localhost:5000/repo@sha256:${"d".repeat(64)}`,
-        model,
-        networkName: "qualified-internal",
-        registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
-        runtimeGid: 1001,
-        runtimeUid: 1001,
+        ...containerOptions,
+        hostPort: testPlan.recipe.serve.port,
       });
-      expect(valuesAfter(agentQualificationArgv, "--publish")).toEqual(["127.0.0.1:8081:8081"]);
+      expect(valuesAfter(agentQualificationArgv, "--publish")).toEqual([
+        `127.0.0.1:${String(testPlan.recipe.serve.port)}:${String(testPlan.recipe.serve.port)}`,
+      ]);
+      const alternateContainerPort = 9_081;
+      // The adapter must use its validated plan input instead of duplicating the current recipe port.
+      const alternatePortPlan = {
+        ...testPlan,
+        recipe: {
+          ...testPlan.recipe,
+          serve: { ...testPlan.recipe.serve, port: alternateContainerPort },
+        },
+      } as unknown as QualificationPlan;
+      const alternatePortArgv = buildServerContainerArgv(alternatePortPlan, containerOptions);
+      expect(valuesAfter(alternatePortArgv, "--publish")).toEqual([
+        `127.0.0.1::${String(alternateContainerPort)}`,
+      ]);
+      expect(valuesAfter(alternatePortArgv, "--listen-port")).toEqual([
+        String(alternateContainerPort),
+      ]);
       expect(valuesAfter(argv, "--network")).toEqual(["qualified-internal"]);
       expect(valuesAfter(argv, "--user")).toEqual(["1001:1001"]);
+      expect(valuesAfter(argv, "--gpus")).toEqual(["driver=nvidia,count=1"]);
+      expect(valuesAfter(argv, "--cap-drop")).toEqual(["ALL"]);
+      expect(valuesAfter(argv, "--security-opt")).toEqual(["no-new-privileges=true"]);
       expect(valuesAfter(argv, "--api-key-file")).toEqual(["/run/secrets/llama-cpp-api-key"]);
       expect(argv).not.toContain("--api-key");
       expect(valuesAfter(argv, "--mount")).toEqual([
@@ -418,6 +441,31 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     } finally {
       fs.rmSync(modelRoot, { force: true, recursive: true });
     }
+  });
+
+  it("inserts one loopback publish option before exactly one image reference and rejects an existing publish option (#8667)", () => {
+    const imageReference = `localhost:5000/repo@sha256:${"d".repeat(64)}`;
+    const containerPort = 9_081;
+    const options = { containerPort, imageReference };
+
+    expect(insertQualificationLoopbackPublishArgv(["run", imageReference], options)).toEqual([
+      "run",
+      "--publish",
+      `127.0.0.1::${String(containerPort)}`,
+      imageReference,
+    ]);
+    expect(() => insertQualificationLoopbackPublishArgv(["run"], options)).toThrow(
+      /exactly one Docker image reference/u,
+    );
+    expect(() =>
+      insertQualificationLoopbackPublishArgv(["run", imageReference, imageReference], options),
+    ).toThrow(/exactly one Docker image reference/u);
+    expect(() =>
+      insertQualificationLoopbackPublishArgv(
+        ["run", "--publish", "127.0.0.1::8081", imageReference],
+        options,
+      ),
+    ).toThrow(/must not publish/u);
   });
 
   it("accepts only the exact NVIDIA OpenClaw ARM64 managed-image labels", () => {

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -283,7 +283,7 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     }
   });
 
-  it("publishes the YAML-bound guard on loopback without putting the key on argv (#8667)", () => {
+  it("publishes the recipe-selected request guard on the loopback address without putting the API key in Docker arguments (#8667)", () => {
     const content = Buffer.from("qualification model fixture\n", "utf8");
     const testPlan = qualificationPlanForModel(content);
     const modelRoot = fs.realpathSync(
@@ -443,7 +443,7 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     }
   });
 
-  it("inserts one loopback publish option before exactly one image reference and rejects an existing publish option (#8667)", () => {
+  it("rejects Docker publish aliases before inserting one loopback mapping at the image boundary (#8667)", () => {
     const imageReference = `localhost:5000/repo@sha256:${"d".repeat(64)}`;
     const containerPort = 9_081;
     const options = { containerPort, imageReference };


### PR DESCRIPTION
## Summary

The llama.cpp qualification runner launches Docker directly and cannot rely on the normal lifecycle provider to publish its guarded port. This change completes the qualification-only loopback adapter by placing exactly one declarative mapping immediately before the image reference and failing closed when the materialized argument boundary conflicts, while the shared materializer and product lifecycle remain unchanged.

## Related Issue

Fixes #8667

## Changes

- Replace the qualification runner's `--entrypoint` position heuristic with an adapter that requires exactly one image-reference boundary, validates the host and container ports, and rejects long, short, attached, and publish-all Docker publication options before the image.
- Emit `127.0.0.1::<container-port>` for ephemeral qualification and `127.0.0.1:<host-port>:<container-port>` for fixed-port agent qualification, with the container port derived from the validated recipe.
- Keep the shared host-local materializer non-publishing and leave the normal Docker lifecycle provider unchanged; ordinary launches use that provider, while this protected runner calls `docker run`, `docker port`, and the live probe directly.
- Expand behavior coverage for mapping count, loopback-only binding, declarative port authority, Docker option ordering, image-boundary failures, request-guard arguments, and existing runtime hardening.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the protected qualification adapter; the documented product lifecycle and fixed authenticated loopback listener remain unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the final nine-category review; no blocker, public binding, authentication bypass, port-authority drift, or normal-launch change was found. The protected live-run gap is recorded below.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation files changed. `docs/inference/set-up-llama-cpp.mdx` remains accurate for the normal managed runtime.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a32183bbd -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/llama-cpp-dgx-spark-qualification-runner.test.ts test/llama-cpp-dgx-spark-qualification-contract.test.ts` (31 passed); `npx vitest run --project cli src/lib/inference/llama-cpp/host-local-runtime.test.ts src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.test.ts` (57 passed); `npm run typecheck:cli` and `npx prek run --from-ref main --to-ref HEAD` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Full PR CI reached a terminal state with 38 passed, 14 skipped, and one unrelated root failure plus two downstream aggregators. CLI shard 5 reproduced the deterministic current-main regression tracked in #8674 on both its initial run and one retry: the stale-recovery fixture upgrades OpenShell 0.0.99 to 0.0.101, then stops on its live-route mismatch before reaching the expected assertion. No maintainer acceptance is recorded, so the non-success checkbox remains unchecked.

Protected DGX Spark qualification was not run pre-merge. The local host is Darwin/ARM64 without the required GB10 GPU or model, and the protected PR workflow deliberately executes this runner script from trusted `main` rather than the candidate checkout. A trusted-main protected run after merge remains the live validation step for `docker port` resolution and the health probe.

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
