### PR TITLE
ci: stabilize CLI coverage shards

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -153,7 +153,7 @@ jobs:
         uses: ./.github/actions/ci-cli-coverage-shard
         with:
           shard: ${{ matrix.shard }}
-          shard-count: "8"
+          shard-count: "12"
 
   cli-tests:
     needs: cli-test-shards
@@ -191,10 +191,10 @@ jobs:
                 else
                   [.jobs[] |
                     select((.name | type) == "string") |
-                    select(.name | test("^cli-test-shards \\([1-8]\\)$")) |
+                    select(.name | test("^cli-test-shards \\(([1-9]|1[0-2])\\)$")) |
                     select(.conclusion != "success")] as $failed |
                   if ($failed | length) == 0 or
-                    ($failed | length) > 8 or
+                    ($failed | length) > 12 or
                     (($failed | map(.name) | unique | length) != ($failed | length))
                   then error("invalid failed CLI shard listing")
                   else
@@ -230,7 +230,7 @@ jobs:
       - name: Merge CLI coverage
         uses: ./.github/actions/ci-cli-coverage-merge
         with:
-          shard-count: "8"
+          shard-count: "12"
 
   plugin-tests:
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -254,7 +254,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -282,7 +282,7 @@ jobs:
         uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-shard
         with:
           shard: ${{ matrix.shard }}
-          shard-count: "8"
+          shard-count: "12"
 
   cli-tests:
     needs:
@@ -322,10 +322,10 @@ jobs:
                 else
                   [.jobs[] |
                     select((.name | type) == "string") |
-                    select(.name | test("^cli-test-shards \\([1-8]\\)$")) |
+                    select(.name | test("^cli-test-shards \\(([1-9]|1[0-2])\\)$")) |
                     select(.conclusion != "success")] as $failed |
                   if ($failed | length) == 0 or
-                    ($failed | length) > 8 or
+                    ($failed | length) > 12 or
                     (($failed | map(.name) | unique | length) != ($failed | length))
                   then error("invalid failed CLI shard listing")
                   else
@@ -377,7 +377,7 @@ jobs:
       - name: Merge CLI coverage
         uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-merge
         with:
-          shard-count: "8"
+          shard-count: "12"
 
   plugin-tests:
     needs: changes

--- a/src/lib/shields/legacy-hermes-compat.test.ts
+++ b/src/lib/shields/legacy-hermes-compat.test.ts
@@ -13,6 +13,7 @@ const INDEX_MODULE = "./index.js";
 const HERMES_PYTHON = "/opt/hermes/.venv/bin/python";
 const HERMES_GUARD = "/usr/local/lib/nemoclaw/hermes-runtime-config-guard.py";
 const LOCK_TOKEN = "a".repeat(64);
+const SETUP_TIMEOUT_MS = 30_000;
 const OLD_GUARD_HELP = "usage: guard {ensure-api-key,refresh-hashes,provider-placeholders}";
 const PARTIAL_GUARD_HELP = "begin-shields-transition --rollback-shields-mode";
 const PREVIOUS_SEALED_GUARD_HELP = [
@@ -158,7 +159,7 @@ describe("legacy Hermes shields compatibility", () => {
     );
 
     shields = requireSource(INDEX_MODULE);
-  });
+  }, SETUP_TIMEOUT_MS);
 
   afterEach(() => {
     for (const spy of spies) spy.mockRestore();

--- a/src/lib/shields/legacy-hermes-compat.test.ts
+++ b/src/lib/shields/legacy-hermes-compat.test.ts
@@ -8,6 +8,8 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
+import { testTimeout } from "../../../test/helpers/timeouts";
+
 const requireSource = createRequire(import.meta.url);
 const INDEX_MODULE = "./index.js";
 const HERMES_PYTHON = "/opt/hermes/.venv/bin/python";
@@ -159,7 +161,7 @@ describe("legacy Hermes shields compatibility", () => {
     );
 
     shields = requireSource(INDEX_MODULE);
-  }, SETUP_TIMEOUT_MS);
+  }, testTimeout(SETUP_TIMEOUT_MS));
 
   afterEach(() => {
     for (const spy of spies) spy.mockRestore();

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -59,6 +59,7 @@ let homeLocalBin: string;
 let openshellPath: string;
 let stateFile: string;
 let scriptFile: string;
+let installerInvocationsFile: string;
 
 function writeDefaultRegistry() {
   fs.writeFileSync(
@@ -248,9 +249,29 @@ beforeEach(() => {
   openshellPath = path.join(homeLocalBin, "openshell");
   stateFile = path.join(tmpDir, "state.json");
   scriptFile = path.join(tmpDir, "script.json");
+  installerInvocationsFile = path.join(tmpDir, "installer-invocations.log");
 
   fs.mkdirSync(homeLocalBin, { recursive: true });
   fs.mkdirSync(registryDir, { recursive: true });
+  fs.writeFileSync(installerInvocationsFile, "");
+  fs.writeFileSync(
+    path.join(homeLocalBin, "bash"),
+    `#!${process.execPath}
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] === ${JSON.stringify(
+      path.join(import.meta.dirname, "..", "scripts", "install-openshell.sh"),
+    )}) {
+  fs.appendFileSync(${JSON.stringify(installerInvocationsFile)}, "install\\n");
+  process.exit(0);
+}
+const result = spawnSync("/bin/bash", args, { env: process.env, stdio: "inherit" });
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);
+`,
+    { mode: 0o755 },
+  );
   writeDefaultRegistry();
   writeDefaultSession();
   fs.writeFileSync(
@@ -356,7 +377,16 @@ describe("connect preserves the registry so rebuild can recover in scenario 14 (
       },
     );
     const rebuildOut = `${rebuild.stdout || ""}\n${rebuild.stderr || ""}`;
+    const installerInvocations = fs
+      .readFileSync(installerInvocationsFile, "utf8")
+      .split("\n")
+      .filter(Boolean);
 
+    assert.equal(
+      installerInvocations.length,
+      0,
+      `rebuild must not invoke the OpenShell installer, got ${installerInvocations.length} invocation(s)`,
+    );
     assert.doesNotMatch(
       rebuildOut,
       /below minimum required version|Installing OpenShell/,

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -124,7 +124,7 @@ function emit(r) {
 }
 
 if (args[0] === "-V" || args[0] === "--version") {
-  process.stdout.write("openshell 0.0.99\\n");
+  process.stdout.write("openshell 0.0.101\\n");
   process.exit(0);
 }
 
@@ -180,7 +180,7 @@ process.exit(0);
       path.join(homeLocalBin, component),
       `#!${process.execPath}
 const requiredFeatures = "request-body-credential-rewrite websocket-credential-rewrite allow_all_known_mcp_methods";
-if (process.argv[2] === "-V" || process.argv[2] === "--version") process.stdout.write("${component} 0.0.99\\n");
+if (process.argv[2] === "-V" || process.argv[2] === "--version") process.stdout.write("${component} 0.0.101\\n");
 process.exit(0);
 `,
       { mode: 0o755 },
@@ -357,6 +357,11 @@ describe("connect preserves the registry so rebuild can recover in scenario 14 (
     );
     const rebuildOut = `${rebuild.stdout || ""}\n${rebuild.stderr || ""}`;
 
+    assert.doesNotMatch(
+      rebuildOut,
+      /below minimum required version|Installing OpenShell/,
+      `rebuild must use the fixture OpenShell binaries, got:\n${rebuildOut}`,
+    );
     assert.doesNotMatch(
       rebuildOut,
       /does not exist/,

--- a/test/mcp-lifecycle-lock.test.ts
+++ b/test/mcp-lifecycle-lock.test.ts
@@ -446,8 +446,16 @@ const releasePath = process.argv[3];
       })}\n`,
     );
 
+    let monotonicNow = 0;
     await expect(
-      lifecycleLock.withMcpLifecycleLock("alpha", () => undefined, options({ timeoutMs: 40 })),
+      lifecycleLock.withMcpLifecycleLock(
+        "alpha",
+        () => undefined,
+        options({
+          timeoutMs: 40,
+          monotonicNow: () => monotonicNow++,
+        }),
+      ),
     ).rejects.toThrow("Sandbox mutation containment is active");
     expect(fs.existsSync(deadlinePath)).toBe(true);
     expect(fs.existsSync(containmentPath)).toBe(true);

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -80,8 +80,7 @@ const trustedActionDirs = [
   ".github/actions/ci-installer-integration",
 ] as const;
 
-const cliShardMatrix = [1, 2, 3, 4, 5, 6, 7, 8] as const;
-const cliShardCount = String(cliShardMatrix.length);
+const cliShardCount = "12";
 
 function stepRuns(jobOrAction: WorkflowJob | CompositeAction): string[] {
   const steps = "runs" in jobOrAction ? jobOrAction.runs.steps : (jobOrAction.steps ?? []);
@@ -416,22 +415,30 @@ describe("pull request and main workflow contracts", () => {
     const temp = mkdtempSync(join(tmpdir(), "nemoclaw-cli-shard-validation-"));
     const marker = join(temp, "injected");
     const shellPayload = `$(touch ${marker})`;
+    const output = join(temp, "github-output");
 
     try {
+      const validShard = runWorkflowShellStep(shardValidationStep, {
+        CLI_SHARD: cliShardCount,
+        CLI_SHARD_COUNT: cliShardCount,
+        GITHUB_OUTPUT: output,
+      });
       const invalidShard = runWorkflowShellStep(shardValidationStep, {
         CLI_SHARD: shellPayload,
-        CLI_SHARD_COUNT: "8",
-        GITHUB_OUTPUT: join(temp, "github-output"),
+        CLI_SHARD_COUNT: cliShardCount,
+        GITHUB_OUTPUT: output,
       });
       const invalidRange = runWorkflowShellStep(shardValidationStep, {
-        CLI_SHARD: "9",
-        CLI_SHARD_COUNT: "8",
+        CLI_SHARD: "13",
+        CLI_SHARD_COUNT: cliShardCount,
         GITHUB_OUTPUT: join(temp, "github-output"),
       });
       const invalidCount = runWorkflowShellStep(mergeValidationStep, {
         CLI_SHARD_COUNT: shellPayload,
       });
 
+      expect(validShard.status).toBe(0);
+      expect(readFileSync(output, "utf8")).toContain("upload_build_artifact=false");
       expect(invalidShard.status).not.toBe(0);
       expect(invalidShard.stdout).toContain("Invalid CLI shard");
       expect(invalidRange.status).not.toBe(0);
@@ -530,7 +537,7 @@ describe("pull request and main workflow contracts", () => {
     const failedShards = workflowJobListing([
       workflowJob(101, "cli-test-shards (1)", "success"),
       workflowJob(102, "cli-test-shards (2)", "failure"),
-      workflowJob(108, "cli-test-shards (8)", "cancelled"),
+      workflowJob(112, "cli-test-shards (12)", "cancelled"),
       workflowJob(109, "plugin-tests", "success"),
     ]);
     const malformedShards = workflowJobListing([
@@ -572,7 +579,7 @@ describe("pull request and main workflow contracts", () => {
 
       expect(failure.status, `${workflowName}: ${failure.stderr}`).not.toBe(0);
       expect(failure.stdout).toContain(`${runUrl}/job/102`);
-      expect(failure.stdout).toContain(`${runUrl}/job/108`);
+      expect(failure.stdout).toContain(`${runUrl}/job/112`);
       expect(malformed.status).not.toBe(0);
       expect(malformed.stdout).toContain(`Details: ${runUrl}`);
       expect(malformed.stdout).not.toContain(`${runUrl}/job/`);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make CLI tests independent of scheduler timing and host OpenShell installation state. Increase CLI coverage from 8 to 12 shards; the measured run model lowers the slowest shard from 586.3 seconds to 344.3 seconds while issue #8669 tracks the underlying slow tests.

## Related Issue

Relates #8669.
Follow-up to #8512.

## Changes

- Inject a deterministic monotonic clock into the stale deadline-generation lifecycle-lock test.
- Keep the stale-rebuild fixture on supported OpenShell 0.0.101 binaries and directly verify that rebuild does not invoke the installer.
- Give the legacy Hermes compatibility fixture setup a 30-second hook timeout so an overloaded coverage shard does not fail Vitest’s default 10-second timeout.
- Run PR and main CLI coverage with 12 shards, merge 12 reports, and report failures from every shard.
- Exercise shard 12 as valid input, reject shard 13, and verify failed-shard links for shard 12.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal CI parallelism and deterministic test fixtures only; no supported product surface changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence:
  - The workflow changes only increase internal CLI coverage parallelism and update failed-shard validation.
  - The test changes make existing CI and lifecycle fixtures deterministic, including direct verification that rebuild does not invoke the OpenShell installer.
  - The legacy Hermes compatibility change only extends the heavy test-fixture setup timeout; it does not change production behavior.
  - No production command, configuration, user workflow, output contract, or supported product surface changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 01dc6e2cc -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — the two formerly flaky files passed five runs, 225 test executions; the updated installer probe passed five additional runs; the workflow contract passed 5/5; the source-shape budget passed. The legacy Hermes compatibility suite passed 18/18 tests in each of five normal runs and 18/18 once with V8 coverage; that coverage command exited only on unrelated whole-repository coverage thresholds.
- [ ] Applicable broad gate passed — `npm run check` passed every pre-commit check. Its CLI coverage lane completed 23,741 passing tests and found 27 unrelated DGX Spark host-state failures: an installed user service, a group-writable Codex workspace parent, and ARM64 Python executed in an amd64 container. An isolated HOME cleared all 24 service-related failures.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded CLI coverage testing from 8 to 12 parallel shards.
  * Updated coverage validation and reporting to include all 12 shards.
  * Improved test reliability with deterministic timing and extended setup timeouts.
  * Verified rebuilds avoid unnecessary installation attempts and related messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->