### PR TITLE
fix(inference): restore loopback port publishing in the llama.cpp qualification runner

### DIFF
--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -318,6 +318,28 @@ export function buildCandidateImageArgv(
   ];
 }
 
+/**
+ * The qualification runner launches the container directly instead of through
+ * the Docker lifecycle provider, so it owns its loopback bridge. The shared
+ * host-local materializer deliberately publishes nothing (#8615).
+ */
+function withQualificationLoopbackPublish(
+  argv: string[],
+  imageReference: string,
+  containerPort: number,
+): string[] {
+  const imageIndex = argv.indexOf(imageReference);
+  if (imageIndex < 0) {
+    throw new Error("qualification container arguments are missing the candidate image reference");
+  }
+  return [
+    ...argv.slice(0, imageIndex),
+    "--publish",
+    `127.0.0.1::${String(containerPort)}`,
+    ...argv.slice(imageIndex),
+  ];
+}
+
 export function buildServerContainerArgv(
   plan: QualificationPlan,
   options: {
@@ -335,7 +357,7 @@ export function buildServerContainerArgv(
   if (plan.qualification.requestGuard !== "required") {
     throw new Error("llama.cpp qualification requires the declarative request guard");
   }
-  return buildLlamaCppRequestGuardDockerArgv(plan.recipe, {
+  const argv = buildLlamaCppRequestGuardDockerArgv(plan.recipe, {
     apiKeyHostPath: options.apiKeyHostPath,
     containerName: options.containerName,
     imageReference: options.imageReference,
@@ -346,6 +368,14 @@ export function buildServerContainerArgv(
     runtimeGid: options.runtimeGid,
     runtimeUid: options.runtimeUid,
   });
+  if (options.hostPort === undefined) {
+    return withQualificationLoopbackPublish(
+      argv,
+      options.imageReference,
+      plan.recipe.serve.port,
+    );
+  }
+  return argv;
 }
 
 export function validateOpenClawQualificationImageLabels(

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -321,7 +321,9 @@ export function buildCandidateImageArgv(
 /**
  * The qualification runner launches the container directly instead of through
  * the Docker lifecycle provider, so it owns its loopback bridge. The shared
- * host-local materializer deliberately publishes nothing (#8615).
+ * host-local materializer deliberately publishes nothing (#8615). An absent
+ * `hostPort` yields an ephemeral loopback mapping; a present one yields the
+ * fixed loopback port that agent qualification requires.
  */
 function withQualificationLoopbackPublish(
   argv: string[],
@@ -337,12 +339,7 @@ function withQualificationLoopbackPublish(
     hostPort === undefined
       ? `127.0.0.1::${String(containerPort)}`
       : `127.0.0.1:${String(hostPort)}:${String(containerPort)}`;
-  return [
-    ...argv.slice(0, imageIndex),
-    "--publish",
-    mapping,
-    ...argv.slice(imageIndex),
-  ];
+  return [...argv.slice(0, imageIndex), "--publish", mapping, ...argv.slice(imageIndex)];
 }
 
 export function buildServerContainerArgv(
@@ -865,7 +862,7 @@ function resolveLoopbackPort(containerName: string, containerPort: number): numb
     .toString("utf8")
     .trim();
   const match = /^127\.0\.0\.1:([1-9][0-9]{3,4})$/u.exec(value);
-  if (!match) throw new Error("model server did not receive one loopback-only ephemeral port");
+  if (!match) throw new Error("model server did not receive one loopback-only port");
   return requiredInteger(Number.parseInt(match[1] ?? "0", 10), "loopback port", 1024, 65_535);
 }
 

--- a/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
+++ b/scripts/checks/run-llama-cpp-dgx-spark-qualification.mts
@@ -327,15 +327,20 @@ function withQualificationLoopbackPublish(
   argv: string[],
   imageReference: string,
   containerPort: number,
+  hostPort?: number,
 ): string[] {
   const imageIndex = argv.indexOf(imageReference);
   if (imageIndex < 0) {
     throw new Error("qualification container arguments are missing the candidate image reference");
   }
+  const mapping =
+    hostPort === undefined
+      ? `127.0.0.1::${String(containerPort)}`
+      : `127.0.0.1:${String(hostPort)}:${String(containerPort)}`;
   return [
     ...argv.slice(0, imageIndex),
     "--publish",
-    `127.0.0.1::${String(containerPort)}`,
+    mapping,
     ...argv.slice(imageIndex),
   ];
 }
@@ -368,14 +373,12 @@ export function buildServerContainerArgv(
     runtimeGid: options.runtimeGid,
     runtimeUid: options.runtimeUid,
   });
-  if (options.hostPort === undefined) {
-    return withQualificationLoopbackPublish(
-      argv,
-      options.imageReference,
-      plan.recipe.serve.port,
-    );
-  }
-  return argv;
+  return withQualificationLoopbackPublish(
+    argv,
+    options.imageReference,
+    plan.recipe.serve.port,
+    options.hostPort,
+  );
 }
 
 export function validateOpenClawQualificationImageLabels(

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -340,6 +340,10 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         ]),
       );
       expect(valuesAfter(argv, "--publish")).toEqual(["127.0.0.1::8081"]);
+      expect(argv.indexOf("--publish")).toBeLessThan(
+        argv.indexOf(`localhost:5000/repo@sha256:${"d".repeat(64)}`),
+      );
+      expect(argv.filter((argument) => argument === "--publish")).toHaveLength(1);
       expect(valuesAfter(argv, "--entrypoint")).toEqual([
         "/usr/local/bin/nemoclaw-llama-cpp-request-guard",
       ]);

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -466,7 +466,7 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         expect(imageIndex).toBeGreaterThan(0);
         expect(argv.slice(imageIndex - 2, imageIndex)).toEqual(["--publish", expectedMapping]);
         expect(argv.filter((argument) => argument === "--publish")).toHaveLength(1);
-        const [publishedHost, , publishedContainerPort] = expectedMapping.split(":");
+        const [publishedHost, , publishedContainerPort] = argv[imageIndex - 1].split(":");
         expect([publishedHost, publishedContainerPort]).toEqual(["127.0.0.1", servePort]);
       }
     } finally {

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -282,7 +282,7 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     }
   });
 
-  it("activates the YAML-bound guard without putting the key on argv (#8260)", () => {
+  it("activates the YAML-bound guard without putting the key on argv (#8260, #8667)", () => {
     const content = Buffer.from("qualification model fixture\n", "utf8");
     const testPlan = qualificationPlanForModel(content);
     const modelRoot = fs.realpathSync(
@@ -387,9 +387,6 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         runtimeUid: 1001,
       });
       expect(valuesAfter(agentQualificationArgv, "--publish")).toEqual(["127.0.0.1:8081:8081"]);
-      expect(valuesAfter(agentQualificationArgv, "--publish")).not.toEqual(
-        valuesAfter(argv, "--publish"),
-      );
       expect(valuesAfter(argv, "--network")).toEqual(["qualified-internal"]);
       expect(valuesAfter(argv, "--user")).toEqual(["1001:1001"]);
       expect(valuesAfter(argv, "--api-key-file")).toEqual(["/run/secrets/llama-cpp-api-key"]);

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -386,7 +386,10 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         runtimeGid: 1001,
         runtimeUid: 1001,
       });
-      expect(valuesAfter(agentQualificationArgv, "--publish")).toEqual([]);
+      expect(valuesAfter(agentQualificationArgv, "--publish")).toEqual(["127.0.0.1:8081:8081"]);
+      expect(valuesAfter(agentQualificationArgv, "--publish")).not.toEqual(
+        valuesAfter(argv, "--publish"),
+      );
       expect(valuesAfter(argv, "--network")).toEqual(["qualified-internal"]);
       expect(valuesAfter(argv, "--user")).toEqual(["1001:1001"]);
       expect(valuesAfter(argv, "--api-key-file")).toEqual(["/run/secrets/llama-cpp-api-key"]);

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -466,8 +466,6 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
         expect(imageIndex).toBeGreaterThan(0);
         expect(argv.slice(imageIndex - 2, imageIndex)).toEqual(["--publish", expectedMapping]);
         expect(argv.filter((argument) => argument === "--publish")).toHaveLength(1);
-        const [publishedHost, , publishedContainerPort] = argv[imageIndex - 1].split(":");
-        expect([publishedHost, publishedContainerPort]).toEqual(["127.0.0.1", servePort]);
       }
     } finally {
       fs.rmSync(modelRoot, { force: true, recursive: true });

--- a/test/llama-cpp-dgx-spark-qualification-runner.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-runner.test.ts
@@ -427,6 +427,53 @@ describe("trusted llama.cpp DGX Spark qualification runner", () => {
     }
   });
 
+  it("splices one loopback mapping directly before the qualification image reference (#8667)", () => {
+    const content = Buffer.from("qualification publish fixture\n", "utf8");
+    const testPlan = qualificationPlanForModel(content);
+    const modelRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-qualification-publish-")),
+    );
+    const modelHostPath = path.join(modelRoot, testPlan.recipe.model.file.path);
+    fs.writeFileSync(modelHostPath, content);
+    const servePort = String(testPlan.recipe.serve.port);
+    const imageReference = `localhost:5000/repo@sha256:${"d".repeat(64)}`;
+    try {
+      const bindings = {
+        apiKeyHostPath: "/work/tmp/api-key",
+        containerName: "qualified-server",
+        imageReference,
+        model: hashModelFile(modelHostPath, testPlan),
+        networkName: "qualified-internal",
+        registryOwner: expectedRegistryOwner(RUN_ID, RUN_ATTEMPT),
+        runtimeGid: 1001,
+        runtimeUid: 1001,
+      };
+      for (const [argv, expectedMapping] of [
+        [buildServerContainerArgv(testPlan, bindings), `127.0.0.1::${servePort}`],
+        [
+          buildServerContainerArgv(testPlan, {
+            ...bindings,
+            hostPort: testPlan.recipe.serve.port,
+          }),
+          `127.0.0.1:${servePort}:${servePort}`,
+        ],
+        [
+          buildServerContainerArgv(testPlan, { ...bindings, hostPort: 18_081 }),
+          `127.0.0.1:18081:${servePort}`,
+        ],
+      ] as const) {
+        const imageIndex = argv.indexOf(imageReference);
+        expect(imageIndex).toBeGreaterThan(0);
+        expect(argv.slice(imageIndex - 2, imageIndex)).toEqual(["--publish", expectedMapping]);
+        expect(argv.filter((argument) => argument === "--publish")).toHaveLength(1);
+        const [publishedHost, , publishedContainerPort] = expectedMapping.split(":");
+        expect([publishedHost, publishedContainerPort]).toEqual(["127.0.0.1", servePort]);
+      }
+    } finally {
+      fs.rmSync(modelRoot, { force: true, recursive: true });
+    }
+  });
+
   it("accepts only the exact NVIDIA OpenClaw ARM64 managed-image labels", () => {
     const labels = {
       "io.nvidia.nemoclaw.agent": "openclaw",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The DGX Spark llama.cpp qualification runner builds its server container arguments with no `--publish` entry, so `docker port` cannot resolve a loopback address and the runner cannot probe the server it just launched. This adds a qualification-only loopback mapping in the runner itself: an ephemeral `127.0.0.1::8081` by default, and the requested fixed `127.0.0.1:8081:8081` when the runner asks for a deterministic port. The shared host-local materializer and the Docker lifecycle provider are unchanged, so ordinary product launches still leave host bridging to the lifecycle provider.

## Related Issue

Fixes #8667

## Changes

- `scripts/checks/run-llama-cpp-dgx-spark-qualification.mts`: add module-private `withQualificationLoopbackPublish()`, which splices one `--publish <mapping>` pair into the argv returned by the shared request-guard builder, immediately before the image reference. `buildServerContainerArgv()` wraps the shared result and forwards its optional `hostPort`.
- `scripts/checks/run-llama-cpp-dgx-spark-qualification.mts`: drop the word `ephemeral` from `resolveLoopbackPort()`'s error message, which this change makes inaccurate on the fixed-port path.
- `test/llama-cpp-dgx-spark-qualification-runner.test.ts`: pin both mapping forms, the mapping's position ahead of the image reference, and that exactly one mapping is emitted.

This adds no configuration, fallback, migration, or compatibility layer. `withQualificationLoopbackPublish()` is one private helper with one current consumer, `buildServerContainerArgv()`, and the tests named under Verification protect its contract. The `hostPort` option it reads already existed on `buildServerContainerArgv()` and is still forwarded into the shared `LlamaCppHostLocalRuntimeBindings`, where `positiveInteger(bindings.hostPort, "llama.cpp host port", 65_535)` continues to bound it.

Why the runner needs its own argument rather than a change to the shared materializer: #8615 deliberately removed publishing from the shared path because product launches delegate host bridging to the Docker lifecycle provider, which rejects a container that publishes ports (the `must not publish` ownership rollback from #8544). The qualification runner does not use that provider — it runs `docker run` directly, then `docker port`, then probes the resolved port. Publishing therefore belongs to the runner alone. Both emitted mapping strings are byte-identical to what the pre-#8615 materializer produced, and the runner already created its network with `--internal` at that time, so this restores a configuration this repository's CI is known to have run rather than introducing a new one.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the qualification runner is CI-internal, invoked only from `.github/workflows/e2e.yaml` behind `allow_dgx_spark_runner_queue` or manual dispatch. It is not a CLI, configuration, default, or other supported product surface. A documentation writer subagent independently confirmed that no `docs/` page references the script or its functions, and that every `docs/` occurrence of "qualification" refers to host and platform hardware qualification or the protected qualification and activation gates, which are separate already-documented concepts.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requesting maintainer review. The change touches the inference qualification runner. It publishes only to `127.0.0.1`, adds no egress, and leaves the credential path untouched — the API key is still delivered by bind-mounted file, and the test continues to assert the key never appears on argv.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed. The reviewer searched `docs/` for `run-llama-cpp-dgx-spark-qualification`, `withQualificationLoopbackPublish`, `resolveLoopbackPort`, and `qualification`, finding no page that owns this script; confirmed from `.github/workflows/e2e.yaml` that the runner is CI-internal; and reviewed the changed prose against `WRITING.md` and the controlled word list — the helper's doc comment, `resolveLoopbackPort()`'s amended error message, the test titles, and the commit subjects. No blocking findings.
- Agent: Claude Code
<!-- docs-review-head-sha: 7af908ab4 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result:
  - `npx vitest run --project integration test/llama-cpp-dgx-spark-qualification-runner.test.ts` — 12/12 pass. Without this change the suite fails with `expected [] to deeply equal [ '127.0.0.1::8081' ]`.
  - `npx vitest run --project cli src/lib/inference/llama-cpp/host-local-runtime.test.ts` — 16/16 pass, confirming the shared materializer still publishes nothing, including when `hostPort` is set.
  - `npx vitest run --project cli src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.test.ts` — 41/41 pass, confirming the lifecycle provider's `must not publish` rollback is undisturbed.
  - `npm run checks:repository` — all checks pass, including `test-title-style`.
  - `npm run validate:pr` — exit 0, no autofixes.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable. This change is confined to one CI-only check script and its test, and alters no runtime or test-harness behavior. For transparency: a local `npm test` attempt on the development host produced 37 timeout failures out of 14,702 in the `cli` project, all `Test timed out in 5000ms` under memory pressure on an 8 GB machine with cumulative setup time of 1,113 s. The affected files pass 53/53 in 13.66 s when run in isolation, and none of them import either changed file. Deferring the broad gate to CI.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Notes for Reviewers

Two items found during this work that are outside the fix and are not addressed here:

1. The `prek` `biome-format` hook's `files` pattern ends in `.*\.ts$`, which does not match a `.mts` extension, while `biome.json` includes `**/*.mts`. `npm run validate:pr` and the `prek run --from-ref` invocation in `.github/workflows/pr.yaml` therefore both pass over formatting in every `.mts` file under `scripts/checks/` and `tools/e2e/`. This branch's helper was left unformatted by that gap until it was caught by review and corrected in `7af908ab4`; `npm run format` is now a no-op on the file. Happy to open a separate issue if maintainers agree it is worth fixing.
2. `resolveLoopbackPort()` parses `docker port` output with `/^127\.0\.0\.1:([1-9][0-9]{3,4})$/u`, which accepts only 4-and-5-digit ports, while `positiveInteger(contract.serve.port, ..., 65_535)` permits any port from 1. A recipe declaring a shorter port would publish successfully and then fail to resolve. Not reachable today — the pinned recipe declares `port: 8081` — and deliberately not changed here to keep this fix minimal.

The fixed-port availability race called out in the issue's acceptance criteria is likewise not addressed here, as the issue directs. The runner's existing pre-flight `tcpOpen(plan.recipe.serve.port)` refusal already narrows it to a TOCTOU window.

Signed-off-by: Azeel Sajjad <aasajjad05@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container qualification networking by ensuring required loopback access is configured reliably.
  * Added support for automatic, configured, and custom host-port mappings.
  * Resolved an issue affecting request-guard validation during qualification runs.

* **Tests**
  * Expanded coverage for container argument ordering, loopback publishing, and host-port configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->