### PR TITLE
test(rebuild): align stale recovery fixture with OpenShell 0.0.101

### DIFF
--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -20,6 +20,7 @@ import { testTimeout } from "./helpers/timeouts";
 
 const TIMEOUT_MS = testTimeout(60_000);
 const SANDBOX_NAME = "my-assistant";
+const OPENSHELL_FIXTURE_VERSION = "0.0.101";
 
 // Output fixtures that mirror real OpenShell CLI output.
 const GATEWAY_INFO_NEMOCLAW =
@@ -124,7 +125,7 @@ function emit(r) {
 }
 
 if (args[0] === "-V" || args[0] === "--version") {
-  process.stdout.write("openshell 0.0.99\\n");
+  process.stdout.write("openshell ${OPENSHELL_FIXTURE_VERSION}\\n");
   process.exit(0);
 }
 
@@ -180,7 +181,7 @@ process.exit(0);
       path.join(homeLocalBin, component),
       `#!${process.execPath}
 const requiredFeatures = "request-body-credential-rewrite websocket-credential-rewrite allow_all_known_mcp_methods";
-if (process.argv[2] === "-V" || process.argv[2] === "--version") process.stdout.write("${component} 0.0.99\\n");
+if (process.argv[2] === "-V" || process.argv[2] === "--version") process.stdout.write("${component} ${OPENSHELL_FIXTURE_VERSION}\\n");
 process.exit(0);
 `,
       { mode: 0o755 },
@@ -357,6 +358,16 @@ describe("connect preserves the registry so rebuild can recover in scenario 14 (
     );
     const rebuildOut = `${rebuild.stdout || ""}\n${rebuild.stderr || ""}`;
 
+    assert.doesNotMatch(
+      rebuildOut,
+      /below minimum.*upgrading|missing provider credential rewrite or MCP L7 policy support.*reinstalling/i,
+      `rebuild must not enter the OpenShell upgrade or repair path, got:\n${rebuildOut}`,
+    );
+    assert.doesNotMatch(
+      rebuildOut,
+      /Installing OpenShell from release/,
+      `rebuild must not enter the OpenShell install path, got:\n${rebuildOut}`,
+    );
     assert.doesNotMatch(
       rebuildOut,
       /does not exist/,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Align the stale gateway recovery test fixture with the supported OpenShell 0.0.101 release so the test remains hermetic. The test now fails explicitly if rebuild enters OpenShell upgrade, repair, or installation instead of exercising stale-state recovery.

## Related Issue

Fixes #8674

## Changes

- Use one named OpenShell 0.0.101 fixture constant for the CLI, gateway, and sandbox stubs.
- Retain the credential-rewrite and MCP L7 feature signals required by the OpenShell feature gate.
- Assert that rebuild does not enter an OpenShell upgrade, repair, or install path before checking the complete #4497 stale-recovery contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes one test fixture and its assertions; production behavior and user-facing output are unchanged, and the existing sandbox recovery guide already documents continuing creation when the recorded gateway reports the source sandbox as absent.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `test/gateway-state-reconcile-2276.test.ts` is the only changed path; the change corrects test-fixture identity and adds hermetic-path assertions without changing production behavior. `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx` already documents the preserved recovery behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 43e46a995 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/gateway-state-reconcile-2276.test.ts test/rebuild-stale-recovery.test.ts test/rebuild-credential-preflight.test.ts test/install-openshell-version-check.test.ts test/install-openshell-version-pin.test.ts` passed 12/12 assigned integration tests; `npx vitest run --project installer-integration test/install-openshell-version-check.test.ts test/install-openshell-version-pin.test.ts` passed 44 tests with 1 existing skip; `npm run typecheck:cli` passed; `npx prek run --from-ref main --to-ref HEAD` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this changes a single self-contained integration fixture, and the targeted integration and installer lanes cover its boundary.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to use OpenShell version 0.0.101.
  * Expanded rebuild recovery coverage to verify that rebuilds do not trigger unnecessary upgrades, repairs, or installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->