### PR TITLE
fix(hermes): preserve MCP rebuild restart evidence

### DIFF
--- a/src/lib/actions/sandbox/gateway-restart-mcp.test.ts
+++ b/src/lib/actions/sandbox/gateway-restart-mcp.test.ts
@@ -55,6 +55,8 @@ describe("Hermes MCP gateway restart", () => {
         ok: false,
         failureLayer: "MCP reconciliation refusal",
         detail: "Hermes MCP config does not match persisted managed intent",
+        restarted: true,
+        healthPassed: true,
       });
       expect(deps.ensureSandboxPortForward).not.toHaveBeenCalled();
     } finally {
@@ -75,6 +77,8 @@ describe("Hermes MCP gateway restart", () => {
         ok: false,
         failureLayer: "MCP reconciliation refusal",
         detail: "integrity pending FORGED SUCCESS <REDACTED>",
+        restarted: true,
+        healthPassed: true,
       });
       expect(deps.ensureSandboxPortForward).not.toHaveBeenCalled();
     } finally {
@@ -94,10 +98,13 @@ describe("Hermes MCP gateway restart", () => {
         })),
       });
 
-      expect(restartSandboxGateway("alpha", { quiet: true, deps })).toMatchObject({
+      const result = restartSandboxGateway("alpha", { quiet: true, deps });
+      expect(result).toMatchObject({
         ok: false,
         failureLayer: "MCP reconciliation refusal",
       });
+      expect(result).not.toHaveProperty("restarted");
+      expect(result).not.toHaveProperty("healthPassed");
       expect(deps.waitForRecoveredSandboxGateway).not.toHaveBeenCalled();
       const output = vi.mocked(console.error).mock.calls.flat().join("\n");
       expect(output).toContain("nemoclaw alpha mcp restart");

--- a/src/lib/actions/sandbox/gateway-restart.ts
+++ b/src/lib/actions/sandbox/gateway-restart.ts
@@ -69,6 +69,15 @@ export type GatewayRestartResult =
       ok: false;
       failureLayer: GatewayRestartFailureLayer;
       detail: string;
+      restarted?: never;
+      healthPassed?: never;
+    }
+  | {
+      ok: false;
+      failureLayer: "MCP reconciliation refusal";
+      detail: string;
+      restarted: true;
+      healthPassed: true;
     };
 
 type SandboxAgentLookup = (sandboxName: string) => { agent?: string | null } | null | undefined;
@@ -430,6 +439,8 @@ export function restartSandboxGatewayWithDeps(
         ok: false,
         failureLayer: "MCP reconciliation refusal",
         detail,
+        restarted: true,
+        healthPassed: true,
       };
     }
   }

--- a/src/lib/actions/sandbox/rebuild-hermes-post-restore.test.ts
+++ b/src/lib/actions/sandbox/rebuild-hermes-post-restore.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   ensureHermesGatewayAfterStateRestore,
   ensureHermesGatewayAfterStateRestoreForCronGate,
+  restartHermesGatewayAfterStateRestore,
   verifyHermesGatewayAfterStateRestore,
   verifyHermesGatewayAfterStateRestoreForCronGate,
 } from "./rebuild-hermes-post-restore";
@@ -24,6 +25,18 @@ const RESTART_FAILED = {
   ok: false,
   failureLayer: "health timeout",
   detail: "gateway did not become healthy",
+} as const;
+const RESTARTED_WITH_MCP_MISMATCH = {
+  ok: false,
+  failureLayer: "MCP reconciliation refusal",
+  detail: "Hermes MCP config does not match persisted managed intent",
+  restarted: true,
+  healthPassed: true,
+} as const;
+const MCP_REFUSED_BEFORE_RESTART = {
+  ok: false,
+  failureLayer: "MCP reconciliation refusal",
+  detail: "supervisor refused the restart before replacing the gateway",
 } as const;
 
 describe("binding the Hermes gateway to restored state", () => {
@@ -71,6 +84,57 @@ describe("binding the Hermes gateway to restored state", () => {
     });
 
     expect(state).toBe("recovered");
+  });
+
+  it("keeps restart evidence while rebuild restores the managed MCP projection (#8671)", () => {
+    const restartState = restartHermesGatewayAfterStateRestore("alpha", "hermes", {
+      restartSandboxGateway: () => RESTARTED_WITH_MCP_MISMATCH,
+    });
+
+    expect(restartState).toBe("restarted");
+    expect(
+      verifyHermesGatewayAfterStateRestore("alpha", "hermes", restartState, {
+        checkAndRecoverSandboxProcesses: () => ({
+          checked: true,
+          wasRunning: true,
+          recovered: false,
+        }),
+      }),
+    ).toBe("healthy");
+  });
+
+  it("rejects managed MCP drift that remains after rebuild restoration (#8671)", () => {
+    const restartState = restartHermesGatewayAfterStateRestore("alpha", "hermes", {
+      restartSandboxGateway: () => RESTARTED_WITH_MCP_MISMATCH,
+    });
+
+    expect(
+      verifyHermesGatewayAfterStateRestore("alpha", "hermes", restartState, {
+        checkAndRecoverSandboxProcesses: () => ({
+          checked: true,
+          wasRunning: true,
+          recovered: false,
+          mcpReconciliationRefused: true,
+        }),
+      }),
+    ).toBe("unverified");
+  });
+
+  it("preserves an MCP refusal before gateway replacement (#8671)", () => {
+    const restartState = restartHermesGatewayAfterStateRestore("alpha", "hermes", {
+      restartSandboxGateway: () => MCP_REFUSED_BEFORE_RESTART,
+    });
+
+    expect(restartState).toBe("restart-failed");
+    expect(
+      verifyHermesGatewayAfterStateRestore("alpha", "hermes", restartState, {
+        checkAndRecoverSandboxProcesses: () => ({
+          checked: true,
+          wasRunning: true,
+          recovered: false,
+        }),
+      }),
+    ).toBe("unverified");
   });
 
   it("leaves a non-Hermes rebuild without a gateway restart (#8184)", () => {

--- a/src/lib/actions/sandbox/rebuild-hermes-post-restore.ts
+++ b/src/lib/actions/sandbox/rebuild-hermes-post-restore.ts
@@ -164,7 +164,14 @@ export function restartHermesGatewayAfterStateRestore(
 ): HermesPostRestoreGatewayRestartState {
   if (agentName !== "hermes") return "not-applicable";
   const restart = deps.restartSandboxGateway ?? processRecovery.restartSandboxGateway;
-  return restart(sandboxName, { quiet: true }).ok ? "restarted" : "restart-failed";
+  const result = restart(sandboxName, { quiet: true });
+  if (result.ok) return "restarted";
+  const mcpRestoreCanSupersede =
+    result.failureLayer === "MCP reconciliation refusal" &&
+    result.restarted === true &&
+    result.healthPassed === true;
+  // Final verification still requires MCP reconciliation after restoration.
+  return mcpRestoreCanSupersede ? "restarted" : "restart-failed";
 }
 
 export function verifyHermesGatewayAfterStateRestore(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes rebuilds no longer fail after a healthy gateway replacement merely because the generic restart checks persisted MCP intent before the rebuild restores the managed adapter projection. The restart result now carries explicit process-replacement and health evidence, so only that expected transitional mismatch can be superseded by MCP restoration; final MCP reconciliation remains mandatory and fail-closed.

## Related Issue

Fixes #8671

## Changes

- Record `restarted: true` and `healthPassed: true` only when Hermes MCP reconciliation refuses after the supervisor restart marker and gateway health check have both passed.
- Preserve that proven restart evidence while the rebuild restores the registered MCP provider, policy, and adapter state.
- Keep pre-restart supervisor refusals classified as failed restarts, and keep final MCP drift, secret-boundary failures, process failures, and forward-recovery failures unverified.
- Add positive and negative regression coverage for the transitional mismatch, post-restore drift, and the pre-restart refusal boundary.

The result provenance is required because `MCP reconciliation refusal` is also used for supervisor-side failures that occur before process replacement. The rebuild consumer therefore requires both explicit proofs instead of weakening reconciliation based on the failure label alone.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This corrects an internal rebuild state transition. Existing rebuild and MCP pages already describe restart, managed MCP restoration, and final verification in the corrected order.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed with no findings; credential handling and the final fail-closed checks are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx` and `docs/manage-sandboxes/manage-mcp-servers.mdx` already document the corrected lifecycle and provider-backed MCP restoration.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 08709e9a0 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable; no DGX Station host preparation changes.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - CLI rebuild, reconciliation, and restart tests: 84 passed.
  - Hermes config transaction, integrity-state, and credential-boundary integration tests: 52 passed under the repository-locked Python 3.14 dependencies.
  - Hermes MCP E2E-support lifecycle tests: 2 passed.
  - `npm run typecheck:cli`: passed.
  - `npx prek run --from-ref main --to-ref HEAD`: passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this localized result-contract change. A local `npm run test:fast` attempt was not claimed because an isolated untouched DCode finalization test currently fails two unrelated preference-merge assertions.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The canonical live `mcp-bridge (hermes)` lane was not available for a PR branch because it requires the trusted main-only Hermes swap. CI and the next trusted-main lane provide the remaining process-level proof.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gateway recovery after managed MCP configuration mismatches.
  - Restarts are now recognized as successful when the gateway restarts and passes health checks, even if MCP reconciliation is refused.
  - MCP restoration and verification can continue after a healthy restart.
  - Persistent MCP drift after restoration is correctly rejected.
  - Recovery states now clearly distinguish verified success from unverified pre-restart refusals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->