### PR TITLE
fix(inference): accept iproute2 'from' source in managed-cluster route check

### DIFF
--- a/src/lib/inference/serving/managed-cluster-discovery-production.ts
+++ b/src/lib/inference/serving/managed-cluster-discovery-production.ts
@@ -985,7 +985,12 @@ function connectivityCheck(
   }
   if (!isRecordArray(routeValue) || routeValue.length !== 1) return failed("route");
   const route = routeValue[0]!;
-  const routeSource = route.prefsrc ?? route.src;
+  // `ip -j route get <peer> from <src> oif <dev>` echoes the source back as the
+  // `from` field on iproute2 6.1.0 (DGX Spark / DGX OS 7.5.0) instead of
+  // `prefsrc`/`src`, so the source must be read from `from` too or the route
+  // check fails on every healthy cluster (#8684; same field-shape class as the
+  // neighbor `dev`-omission fix in #8519/#8527).
+  const routeSource = route.prefsrc ?? route.src ?? route.from;
   if (
     route.dev !== request.netdev ||
     routeSource !== request.sourceAddress ||

--- a/src/lib/inference/serving/managed-cluster-discovery.test.ts
+++ b/src/lib/inference/serving/managed-cluster-discovery.test.ts
@@ -756,7 +756,11 @@ function connectivityTransport(
     execute: (argv) => {
       const routeResponse = () => ({
         status: 0,
-        stdout: JSON.stringify([{ dev: argv.at(-1), prefsrc: argv[6], scope: "link" }]),
+        // Real iproute2 6.1.0 output for `route get <peer> from <src> oif <dev>`
+        // echoes the source as `from` (no `prefsrc`/`scope`) — see #8684.
+        stdout: JSON.stringify([
+          { dst: argv[4], from: argv[6], dev: argv.at(-1), flags: [], uid: 1000, cache: [] },
+        ]),
         stderr: "",
       });
       const pingResponse = () => ({
@@ -920,9 +924,12 @@ describe("production pinned peer transport", () => {
           status: 0,
           stdout: JSON.stringify([
             {
+              dst: argv[4],
+              from: argv[6],
               dev: argv.at(-1),
-              prefsrc: argv[6],
-              scope: "link",
+              flags: [],
+              uid: 1000,
+              cache: [],
               ...(routedThroughGateway ? { gateway: "192.168.100.254" } : {}),
             },
           ]),
@@ -959,6 +966,50 @@ describe("production pinned peer transport", () => {
       check: "route",
       netdev: "enp1s0f0np0",
     });
+  });
+
+  it("accepts the route source when iproute2 6.1.0 echoes it as `from` on a healthy cluster (#8684)", () => {
+    const deps = createManagedClusterDiscoveryDeps(() => ({ status: 0, stdout: "", stderr: "" }));
+    const requests = connectivityRequests();
+    // Real DGX Spark output (iproute2 6.1.0, DGX OS 7.5.0): `route get <peer>
+    // from <src> oif <dev>` reports the source as `from`, with no
+    // `prefsrc`/`src`/`scope`. Before #8684 the route check read only
+    // `prefsrc ?? src`, so it rejected every healthy dual-Spark rail.
+    const transport: ManagedClusterReadOnlyHostTransport = {
+      execute: (argv) => {
+        const routeResponse = () => ({
+          status: 0,
+          stdout: JSON.stringify([
+            { dst: argv[4], from: argv[6], dev: argv.at(-1), flags: [], uid: 1000, cache: [] },
+          ]),
+          stderr: "",
+        });
+        const neighborResponse = () => {
+          const request = requests.find(({ peerAddress }) => peerAddress === argv[5])!;
+          return {
+            status: 0,
+            stdout: JSON.stringify([
+              {
+                dst: request.peerAddress,
+                dev: request.netdev,
+                lladdr: request.expectedPeerMac,
+                state: ["REACHABLE"],
+              },
+            ]),
+            stderr: "",
+          };
+        };
+        return argv[1] === "-j" && argv[2] === "route"
+          ? routeResponse()
+          : argv[0] === "ping"
+            ? { status: 0, stdout: "", stderr: "" }
+            : neighborResponse();
+      },
+      readFile: () => "",
+      readdir: () => [],
+    };
+
+    expect(deps.probeConnectivity(transport, requests)).toBeNull();
   });
 
   it("accepts a neighbor entry that omits the dev key filtered out by ip (#8519)", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The dual DGX Spark managed-vLLM onboard aborted at "[3/8] Configuring inference provider" (`The route check failed …`, exit 1) on verifiably healthy clusters. The connectivity route check ran `ip -j route get <peer> from <src> oif <dev>` and matched the source against `route.prefsrc ?? route.src`; on iproute2 6.1.0 (DGX OS 7.5.0) the `from <src>` argument makes iproute2 echo the source back as the JSON `from` field instead of `prefsrc`/`src`, so the source was `undefined` and every healthy rail failed the check. This reads the source from `from` as well, matching the sibling Python probe and the neighbor-check field-shape fix in #8519/#8527.

## Related Issue
Closes #8684

## Changes
- `src/lib/inference/serving/managed-cluster-discovery-production.ts`: in `connectivityCheck`, read the route source as `route.prefsrc ?? route.src ?? route.from` so the check accepts the source when iproute2 6.1.0 echoes it as `from`. One-field widening; no behavior change for outputs that carry `prefsrc`/`src`.
- `src/lib/inference/serving/managed-cluster-discovery.test.ts`: the two connectivity route mocks emitted an unrealistic `{ prefsrc, scope: "link" }` shape (with a `from` invocation) that hid the defect; update them to the real iproute2 6.1.0 shape (`{ dst, from, dev, flags, uid, cache }` — source as `from`, no `prefsrc`/`scope`), and add a `#8684` regression asserting a healthy dual-Spark cluster passes. With the mocks corrected, the existing healthy-path tests fail without the source fix.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal connectivity-probe parsing fix; it restores the already-documented dual DGX Spark managed-vLLM onboard to work as documented, with no new command, flag, option, or documented contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: `inference`/onboarding connectivity path. The change only widens the accepted iproute2 source field (`?? route.from`) to fix a false-negative route check; it does not weaken any check (dev/gateway/scope/source-match all still enforced) or touch credentials/policy. Same accepted field-shape class as #8519/#8527. Deferred to normal CODEOWNERS review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. The fix is an internal iproute2-output parsing correction in the managed-cluster connectivity probe; it makes the documented dual DGX Spark managed-vLLM onboard succeed on healthy clusters rather than changing any documented behavior, command, flag, or output.
- Agent: Claude Code
<!-- docs-review-head-sha: bcd7d2e7c -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/inference/serving/managed-cluster-discovery.test.ts` on a fresh clone on an Ubuntu host (Node v22.23.1, `npm ci` + plugin build) → 31 passed. Two-way check: reverting only `managed-cluster-discovery-production.ts` to `origin/main` (keeping the corrected tests) fails 4 healthy-cluster tests incl. the new #8684 regression (route source `undefined` = bug reproduced with the real iproute2 6.1.0 output shape the reporter captured).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route connectivity validation for environments using newer iproute2 output.
  * Connectivity checks now correctly recognize source addresses reported through the `from` field.
  * Prevented healthy dual-rail connections from being incorrectly flagged as unavailable.

* **Tests**
  * Added coverage for connectivity responses matching iproute2 6.1.0 output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->