### PR TITLE
fix(sandbox): install dos2unix in the Deep Agents Code base image

### DIFF
--- a/agents/langchain-deepagents-code/Dockerfile.base
+++ b/agents/langchain-deepagents-code/Dockerfile.base
@@ -94,6 +94,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         util-linux=2.41-5 \
         procps=2:4.0.4-9 \
         e2fsprogs=1.47.2-3+b11 \
+        "dos2unix=7.5.2-1*" \
         openssh-sftp-server=1:10.0p1-7+deb13u4 \
         ripgrep=14.1.1-1+b4 \
     && if [ -n "${NEMOCLAW_CORPORATE_CA_B64:-}" ]; then \

--- a/test/sandbox-base-runtime-tools.test.ts
+++ b/test/sandbox-base-runtime-tools.test.ts
@@ -82,7 +82,7 @@ describe("sandbox base runtime tools", () => {
 
   it.each(
     MANAGED_BASE_DOCKERFILES,
-  )("%s installs dos2unix under a version prefix pin that resolves on arm64 (#8691)", (dockerfile) => {
+  )("%s declares dos2unix as a version-prefix pin rather than an exact pin (#8691)", (dockerfile) => {
     const source = fs.readFileSync(dockerfile, "utf-8");
 
     expect(source).toContain('"dos2unix=7.5.2-1*"');

--- a/test/sandbox-base-runtime-tools.test.ts
+++ b/test/sandbox-base-runtime-tools.test.ts
@@ -80,6 +80,14 @@ describe("sandbox base runtime tools", () => {
     expect(source).not.toMatch(/\bgosu\b/u);
   });
 
+  it.each(
+    MANAGED_BASE_DOCKERFILES,
+  )("%s installs dos2unix under a version prefix pin that resolves on arm64 (#8691)", (dockerfile) => {
+    const source = fs.readFileSync(dockerfile, "utf-8");
+
+    expect(source).toContain('"dos2unix=7.5.2-1*"');
+  });
+
   it("installs the required process, filesystem, and SFTP tools", () => {
     const { calls, result } = runBaseAptLayer("nemoclaw-base-apt-");
 

--- a/test/sandbox-base-runtime-tools.test.ts
+++ b/test/sandbox-base-runtime-tools.test.ts
@@ -80,14 +80,6 @@ describe("sandbox base runtime tools", () => {
     expect(source).not.toMatch(/\bgosu\b/u);
   });
 
-  it.each(
-    MANAGED_BASE_DOCKERFILES,
-  )("%s declares dos2unix as a version-prefix pin rather than an exact pin (#8691)", (dockerfile) => {
-    const source = fs.readFileSync(dockerfile, "utf-8");
-
-    expect(source).toContain('"dos2unix=7.5.2-1*"');
-  });
-
   it("installs the required process, filesystem, and SFTP tools", () => {
     const { calls, result } = runBaseAptLayer("nemoclaw-base-apt-");
 

--- a/test/sandbox-base-security-packages.test.ts
+++ b/test/sandbox-base-security-packages.test.ts
@@ -182,6 +182,40 @@ describe("sandbox base security packages", () => {
 
   it.each(
     SECURITY_CASES,
+  )("installs dos2unix from the runtime apt layer for %s on %s (#8691)", (_name, architecture, image) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-dos2unix-"));
+    const prepared = sandboxSecurityCommand(image, tmp);
+
+    try {
+      const { calls, result } = runLoggedDockerShell(
+        prepared.command,
+        tmp,
+        [
+          "perl_base_installed=0",
+          "perl_installed=0",
+          'apt-get() { printf "apt-get %s\\n" "$*" >> "$call_log"; [[ "$*" != *"/perl-base.deb"* ]] || perl_base_installed=1; [[ "$*" != *"/perl.deb"* ]] || perl_installed=1; }',
+          'install() { [[ "$#" -eq 8 && "$1" == "-d" && "$2" == "-o" && "$3" == "root" && "$4" == "-g" && "$5" == "root" && "$6" == "-m" && "$7" == "0755" ]] || return 64; mkdir -p "$8"; }',
+          'chown() { [[ "$#" -eq 2 && "$1" == "root:root" ]] || return 64; }',
+          ...useRealPatchedParser(baseAptSecurityFunctions(architecture), prepared.pythonShim),
+        ],
+        { timeoutMs: 15_000 },
+      );
+
+      expect({ status: result.status, stderr: result.stderr }).toEqual({ status: 0, stderr: "" });
+      expect(
+        calls
+          .split("\n")
+          .filter((line) => line.startsWith("apt-get install"))
+          .flatMap((line) => line.split(" "))
+          .filter((argument) => argument.startsWith("dos2unix")),
+      ).toEqual(["dos2unix=7.5.2-1*"]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it.each(
+    SECURITY_CASES,
   )("executes the completed-image package contract for %s on %s", (_name, architecture, image) => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-final-security-"));
     const prepared = completedImageSecurityCommand(image, tmp, architecture);


### PR DESCRIPTION
## Summary

A fresh DCode sandbox has no `dos2unix`, while OpenClaw and Hermes sandboxes do. This adds the package to the Deep Agents Code base image with the same pinned form the other two images already use.

## Related Issue

Closes #8691

## Root Cause

`dos2unix` reached the OpenClaw and Hermes base images in #3091 (2026-05-07) as a plain-apt entry. `agents/langchain-deepagents-code/Dockerfile.base` was created 46 days later in #5197 (2026-06-22), so it never inherited that line. #7563 then moved the DCode image onto the same reviewed-artifact boundary and carried the snapshot-pinned `jq` and `vim-tiny` packages across — but not the plain-apt `dos2unix`.

That is exactly the reported probe output: `vi: OK`, `jq: OK`, `dos2unix: MISSING`. The two utilities that travelled arrive through the checksum-pinned snapshot path; the one that did not travel is the only one installed through plain apt.

## Changes

- `agents/langchain-deepagents-code/Dockerfile.base`: add `"dos2unix=7.5.2-1*"` to the runtime apt layer, immediately after `e2fsprogs`, mirroring the position and pin used at `Dockerfile.base:130` and `agents/hermes/Dockerfile.base:105`.
- `test/sandbox-base-security-packages.test.ts`: run the runtime apt layer of each managed base image and assert on the `apt-get install` invocation it actually issues. Parameterized over all three images and both architectures (6 cases), so it fails when an image stops installing the utility rather than only when the literal string leaves the Dockerfile. Verified to have teeth: deleting the pin from the Deep Agents Code base fails exactly the two Deep Agents Code cases and leaves the other four passing.

The version pin transfers verbatim because the DCode runtime stage uses a base image digest byte-identical to OpenClaw's (`node:22-trixie-slim@sha256:e6d9a389...`).

## The wildcard is required, not stylistic

Debian trixie ships `dos2unix` as `7.5.2-1` on amd64 but as the binNMU `7.5.2-1+b1` on arm64. An exact `dos2unix=7.5.2-1` pin builds on amd64 and fails on arm64 — the reporter's own platform (Jetson Thor).

## Two-architecture install evidence

The patched runtime apt layer was built and run on both architectures from the pinned base image. This is a real install and a real conversion, not an `apt-get -s` simulation.

```text
# amd64 — reporter's exact probe command
ps: OK   top: OK   free: OK   uptime: OK   vmstat: OK   dos2unix: OK
dos2unix 7.5.2 (2024-01-22)
printf 'a\r\nb\r\n' | dos2unix  ->  od -c: 0000000   a  \n   b  \n

# arm64 — the reporter's platform
dpkg --print-architecture: arm64
command -v dos2unix: /usr/bin/dos2unix
installed version: 7.5.2-1+b1
printf 'x\r\ny\r\n' | dos2unix  ->  od -c: 0000000   x  \n   y  \n
```

For contrast, the exact pin fails on arm64 at resolution time:

```text
arm64: E: Version '7.5.2-1' for 'dos2unix' was not found
```

Both architectures report `0 upgraded, 1 newly installed` — the package pulls no transitive dependencies, so image surface grows by `dos2unix` alone.

## Deliberately not changed

- **Security-package inventory.** `dos2unix` is a plain apt package, not one of the 10 snapshot/rebuilt debs. OpenClaw installs it yet omits it from that inventory, and `test/sandbox-base-security-packages.test.ts` asserts the inventory with an exact `toEqual` — adding an entry there would break the contract.
- **Docs.** `docs/deployment/sandbox-hardening.mdx:20` is the repo's only `dos2unix` prose. It declares `agent-variants: ["openclaw"]`, so it does not formally cover DCode today. After this change that sentence is true of all three images, so no doc text is left needing correction. Extending the page's variant scope needs a matching `docs/index.yml` entry and a new `configure-sandboxes` slug in the deepagents tree, or `scripts/sync-agent-variant-docs.mts` hard-fails — a separate change that equally affects Hermes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the only `dos2unix` prose is `docs/deployment/sandbox-hardening.mdx:20`, which is `agent-variants: ["openclaw"]` scoped. This change makes that existing sentence true of all three images rather than requiring new or corrected text. Extending the page to the deepagents variant is a separate change that equally affects Hermes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requesting maintainer review. The change adds one Debian-pinned utility to the DCode sandbox base apt layer. It installs no setuid binaries and pulls no transitive dependencies on either architecture; it does not touch the reviewed snapshot/checksum path, the security-package inventory, capabilities, or network policy.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed. The repo's only `dos2unix` prose is `docs/deployment/sandbox-hardening.mdx:20`, which this change makes accurate for all three managed images rather than requiring an edit.
- Agent: Claude Code

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set — `npx vitest run` over the base-image surface: 13 files, 184 tests passing (`sandbox-base-runtime-tools`, `sandbox-base-security-packages`, `dcode-base-image-workflow`, `langchain-deepagents-code-profile-build-gate`, `base-image-publication`, `src/lib/sandbox-base-image/**`, `deep-agents-code-base-image`)
- [ ] Applicable broad gate passed — not applicable; this is a single-package Dockerfile change, not a broad runtime or test-harness change
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional checks run locally:

- `hadolint 2.14.0` (the checksum-pinned CI version) on the edited Dockerfile: exit 0, zero findings. `DL3008` is active — the quoted wildcard satisfies it.
- `npm run typecheck`: clean.
- Two-architecture build and probe of the patched apt layer, as quoted above.

**CI timing note for reviewers:** PR CI does not build the edited file. `base-image.yaml` triggers on push-to-main, `v*` tags, and `workflow_dispatch` only. The `managed-images.yaml` pull_request lane fires on `agents/**` but resolves the already-published `langchain-deepagents-code-sandbox-base:latest` and builds only `agents/langchain-deepagents-code/Dockerfile` — it completed in about a minute on this PR, which is consistent with no base build. The `pr-self-hosted.yaml` `build-sandbox-images` jobs likewise resolve the published base and build the production `Dockerfile`. The two-architecture evidence above stands in for that gap; happy to trigger a `workflow_dispatch` base build if you want a real in-CI build before merge.

Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dos2unix` to the runtime environment for supported security images and architectures.

* **Tests**
  * Added coverage to verify successful installation of the expected `dos2unix` package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->