### PR TITLE
fix(e2e): allow host mocks through UFW

### DIFF
--- a/test/e2e/fixtures/host-mock-firewall.ts
+++ b/test/e2e/fixtures/host-mock-firewall.ts
@@ -413,6 +413,9 @@ export function registerOpenShellHostMockFirewall(
       return { ...topology, changed: false, manualCommand: command, reason: "preexisting" };
     }
 
+    if (closed) {
+      throw new Error("host mock firewall setup was interrupted before applying the UFW rule");
+    }
     mutationStarted = true;
     applyInFlight = options.host.command(
       "sudo",

--- a/test/e2e/fixtures/host-mock-firewall.ts
+++ b/test/e2e/fixtures/host-mock-firewall.ts
@@ -424,6 +424,13 @@ export function registerOpenShellHostMockFirewall(
     if (closed) {
       throw new Error("host mock firewall setup was interrupted while applying the UFW rule");
     }
+    if (applied.timedOut || applied.signal !== null || applied.exitCode === null) {
+      throw remediationError(
+        `UFW rule application was not confirmed (${commandFailure(applied)})`,
+        topology,
+        options.port,
+      );
+    }
     if (applied.exitCode !== 0) {
       throw remediationError(
         `UFW rejected the exact rule (${commandFailure(applied)})`,
@@ -441,9 +448,16 @@ export function registerOpenShellHostMockFirewall(
       ["-n", "ufw", "show", "added"],
       commandOptions("host-mock-firewall-rules-after"),
     );
-    if (after.exitCode !== 0 || !snapshotContainsRule(after.stdout, rule())) {
+    if (after.exitCode !== 0) {
       throw remediationError(
-        `could not verify the exact UFW rule (${commandFailure(after)})`,
+        `could not inspect UFW after rule application (${commandFailure(after)})`,
+        topology,
+        options.port,
+      );
+    }
+    if (!snapshotContainsRule(after.stdout, rule())) {
+      throw remediationError(
+        "UFW inspection completed but the exact rule was absent",
         topology,
         options.port,
       );

--- a/test/e2e/fixtures/host-mock-firewall.ts
+++ b/test/e2e/fixtures/host-mock-firewall.ts
@@ -1,0 +1,453 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isIPv4 } from "node:net";
+
+import { buildAvailabilityProbeEnv } from "./availability-env.ts";
+import type { CleanupRegistry } from "./cleanup.ts";
+import type { HostCliClient } from "./clients/host.ts";
+import type { ShellProbeResult, ShellProbeRunOptions } from "./shell-probe.ts";
+
+const DEFAULT_NETWORK_NAME = "openshell-docker";
+const DEFAULT_NETWORK_WAIT_MS = 120_000;
+const COMMAND_TIMEOUT_MS = 30_000;
+const NETWORK_NAME_PATTERN = /^[a-zA-Z0-9_.-]{1,128}$/;
+const BRIDGE_INTERFACE_PATTERN = /^[a-zA-Z0-9_.-]{1,15}$/;
+
+type HostCommandClient = Pick<HostCliClient, "command" | "isCommandAvailable">;
+type CleanupRegistrar = Pick<CleanupRegistry, "add">;
+
+interface DockerNetworkInspect {
+  Driver?: unknown;
+  Id?: unknown;
+  IPAM?: { Config?: unknown };
+  Options?: unknown;
+}
+
+interface BridgeTopology {
+  bridgeInterface: string;
+  gatewayIp: string;
+  prefixLength: number;
+  subnet: string;
+}
+
+export interface HostMockFirewallOptions {
+  authorized?: boolean;
+  cleanup: CleanupRegistrar;
+  host: HostCommandClient;
+  networkName?: string;
+  platform?: NodeJS.Platform;
+  port: number;
+  waitForNetworkMs?: number;
+}
+
+export interface HostMockFirewallResult extends BridgeTopology {
+  changed: boolean;
+  manualCommand: string;
+  reason: "applied" | "platform_not_applicable" | "preexisting" | "ufw_inactive" | "ufw_missing";
+}
+
+function ipv4Number(value: string): number | undefined {
+  if (!isIPv4(value)) return undefined;
+  return value
+    .split(".")
+    .map(Number)
+    .reduce((result, octet) => ((result << 8) | octet) >>> 0, 0);
+}
+
+function parseBridgeCidr(value: string): { network: number; prefixLength: number } | undefined {
+  const match = value.match(/^(\d+\.\d+\.\d+\.\d+)\/(\d{1,2})$/);
+  if (!match) return undefined;
+  const network = ipv4Number(match[1]!);
+  const prefixLength = Number(match[2]);
+  if (network === undefined || prefixLength < 16 || prefixLength > 32) return undefined;
+  const mask = (0xffffffff << (32 - prefixLength)) >>> 0;
+  return (network & mask) >>> 0 === network ? { network, prefixLength } : undefined;
+}
+
+function parseBridgeTopology(stdout: string): BridgeTopology {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error("Docker returned invalid JSON while inspecting the OpenShell network");
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length !== 1 ||
+    !parsed[0] ||
+    typeof parsed[0] !== "object"
+  ) {
+    throw new Error("Docker did not return one OpenShell network inspection record");
+  }
+
+  const network = parsed[0] as DockerNetworkInspect;
+  if (network.Driver !== "bridge") {
+    throw new Error(`OpenShell network driver must be bridge; got ${String(network.Driver)}`);
+  }
+  const id = typeof network.Id === "string" ? network.Id : "";
+  if (!/^[0-9a-f]{12,64}$/i.test(id)) {
+    throw new Error("OpenShell bridge network has no valid Docker network ID");
+  }
+  const options =
+    network.Options && typeof network.Options === "object"
+      ? (network.Options as Record<string, unknown>)
+      : {};
+  const configuredInterface = options["com.docker.network.bridge.name"];
+  const bridgeInterface =
+    typeof configuredInterface === "string" && configuredInterface
+      ? configuredInterface
+      : `br-${id.slice(0, 12)}`;
+  if (!BRIDGE_INTERFACE_PATTERN.test(bridgeInterface)) {
+    throw new Error(`OpenShell bridge interface is invalid: ${bridgeInterface}`);
+  }
+
+  const ipam = Array.isArray(network.IPAM?.Config) ? network.IPAM.Config : [];
+  for (const entry of ipam) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    const subnet = typeof record.Subnet === "string" ? record.Subnet : "";
+    const gatewayIp = typeof record.Gateway === "string" ? record.Gateway : "";
+    const cidr = parseBridgeCidr(subnet);
+    const gateway = ipv4Number(gatewayIp);
+    if (!cidr || gateway === undefined) continue;
+    const mask = (0xffffffff << (32 - cidr.prefixLength)) >>> 0;
+    if ((gateway & mask) >>> 0 !== cidr.network) {
+      throw new Error(`OpenShell bridge gateway ${gatewayIp} is outside subnet ${subnet}`);
+    }
+    return { bridgeInterface, gatewayIp, prefixLength: cidr.prefixLength, subnet };
+  }
+  throw new Error("OpenShell bridge network has no narrow IPv4 subnet and gateway");
+}
+
+function commandFailure(result: ShellProbeResult): string {
+  const detail = [
+    result.timedOut ? "timed out" : undefined,
+    result.signal ? `signal ${result.signal}` : undefined,
+    result.exitCode !== null ? `exit ${result.exitCode}` : undefined,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(", ");
+  return detail || "command did not report an exit status";
+}
+
+function manualRule(topology: BridgeTopology, port: number): string[] {
+  return [
+    "allow",
+    "in",
+    "on",
+    topology.bridgeInterface,
+    "from",
+    topology.subnet,
+    "to",
+    topology.gatewayIp,
+    "port",
+    String(port),
+    "proto",
+    "tcp",
+  ];
+}
+
+function manualCommand(topology: BridgeTopology, port: number): string {
+  return `sudo ufw ${manualRule(topology, port).join(" ")}`;
+}
+
+function remediationError(reason: string, topology: BridgeTopology, port: number): Error {
+  return new Error(
+    [
+      `Could not establish OpenShell sandbox reachability for the live E2E host mock: ${reason}.`,
+      `Detected bridge=${topology.bridgeInterface} subnet=${topology.subnet} gateway=${topology.gatewayIp} port=${port}.`,
+      `Run this command manually: ${manualCommand(topology, port)}`,
+    ].join("\n"),
+  );
+}
+
+function normalizedRuleSnapshot(value: string): string {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/\s+/g, " "))
+    .filter(Boolean)
+    .join("\n");
+}
+
+function snapshotContainsRule(snapshot: string, rule: readonly string[]): boolean {
+  const expected = `ufw ${rule.join(" ")}`;
+  return normalizedRuleSnapshot(snapshot)
+    .split("\n")
+    .some((line) => line === expected);
+}
+
+function commandOptions(
+  artifactName: string,
+  timeoutMs = COMMAND_TIMEOUT_MS,
+): ShellProbeRunOptions {
+  return {
+    artifactName,
+    env: buildAvailabilityProbeEnv(),
+    timeoutMs,
+  };
+}
+
+async function waitForNetwork(
+  host: HostCommandClient,
+  networkName: string,
+  waitForNetworkMs: number,
+): Promise<ShellProbeResult> {
+  const waitSeconds = Math.max(1, Math.ceil(waitForNetworkMs / 1_000));
+  const script = `set -u
+deadline=$((SECONDS + $2))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if network_json="$(docker network inspect "$1" 2>/dev/null)"; then
+    printf '%s\n' "$network_json"
+    exit 0
+  fi
+  sleep 1
+done
+exit 124`;
+  return host.command(
+    "bash",
+    ["-c", script, "wait-openshell-network", networkName, String(waitSeconds)],
+    commandOptions("host-mock-firewall-network", waitForNetworkMs + 5_000),
+  );
+}
+
+async function verifyBridgeAddress(
+  host: HostCommandClient,
+  topology: BridgeTopology,
+  port: number,
+): Promise<void> {
+  const result = await host.command(
+    "ip",
+    ["-j", "address", "show", "dev", topology.bridgeInterface],
+    commandOptions("host-mock-firewall-bridge-address"),
+  );
+  if (result.exitCode !== 0) {
+    throw remediationError(
+      `could not inspect bridge interface (${commandFailure(result)})`,
+      topology,
+      port,
+    );
+  }
+  let addresses: unknown;
+  try {
+    addresses = JSON.parse(result.stdout);
+  } catch {
+    addresses = undefined;
+  }
+  const matches =
+    Array.isArray(addresses) &&
+    addresses.some((entry) => {
+      if (!entry || typeof entry !== "object") return false;
+      const record = entry as Record<string, unknown>;
+      if (record.ifname !== topology.bridgeInterface || !Array.isArray(record.addr_info)) {
+        return false;
+      }
+      return record.addr_info.some(
+        (address) =>
+          Boolean(address) &&
+          typeof address === "object" &&
+          (address as Record<string, unknown>).family === "inet" &&
+          (address as Record<string, unknown>).local === topology.gatewayIp &&
+          (address as Record<string, unknown>).prefixlen === topology.prefixLength,
+      );
+    });
+  if (!matches) {
+    throw remediationError(
+      `bridge interface does not own ${topology.gatewayIp}/${topology.prefixLength}`,
+      topology,
+      port,
+    );
+  }
+}
+
+export function registerOpenShellHostMockFirewall(
+  options: HostMockFirewallOptions,
+): Promise<HostMockFirewallResult> {
+  const networkName =
+    options.networkName ?? process.env.OPENSHELL_DOCKER_NETWORK_NAME ?? DEFAULT_NETWORK_NAME;
+  const waitForNetworkMs = options.waitForNetworkMs ?? DEFAULT_NETWORK_WAIT_MS;
+  const authorized = options.authorized ?? process.env.NEMOCLAW_RUN_LIVE_E2E === "1";
+  const platform = options.platform ?? process.platform;
+  if (!Number.isSafeInteger(options.port) || options.port < 1 || options.port > 65_535) {
+    throw new Error(`host mock port must be an integer from 1 through 65535; got ${options.port}`);
+  }
+  if (!NETWORK_NAME_PATTERN.test(networkName)) {
+    throw new Error(`OpenShell Docker network name is invalid: ${networkName}`);
+  }
+  if (!Number.isSafeInteger(waitForNetworkMs) || waitForNetworkMs <= 0) {
+    throw new Error("host mock firewall network wait must be a positive safe integer");
+  }
+
+  let applyInFlight: Promise<ShellProbeResult> | undefined;
+  let baselineRules: string | undefined;
+  let closed = false;
+  let mutationStarted = false;
+  let topology: BridgeTopology | undefined;
+  const rule = (): string[] => manualRule(topology!, options.port);
+
+  options.cleanup.add(`restore UFW state after host mock port ${options.port}`, async () => {
+    closed = true;
+    try {
+      await applyInFlight;
+    } catch {
+      // The state check below owns ambiguous or failed apply cleanup.
+    }
+    if (!mutationStarted || baselineRules === undefined || !topology) return;
+
+    const current = await options.host.command(
+      "sudo",
+      ["-n", "ufw", "show", "added"],
+      commandOptions("cleanup-host-mock-firewall-rules-before"),
+    );
+    if (current.exitCode !== 0) {
+      throw new Error(
+        `could not inspect UFW state during host mock cleanup (${commandFailure(current)})`,
+      );
+    }
+    const currentSnapshot = normalizedRuleSnapshot(current.stdout);
+    if (currentSnapshot === baselineRules) return;
+    if (!snapshotContainsRule(current.stdout, rule())) {
+      throw new Error("UFW state changed outside the host mock rule; cleanup did not modify it");
+    }
+
+    const deleted = await options.host.command(
+      "sudo",
+      ["-n", "ufw", "--force", "delete", ...rule()],
+      commandOptions("cleanup-host-mock-firewall-delete"),
+    );
+    if (deleted.exitCode !== 0) {
+      throw new Error(
+        `could not delete the host mock UFW rule (${commandFailure(deleted)}); run: sudo ufw --force delete ${rule().join(" ")}`,
+      );
+    }
+    const restored = await options.host.command(
+      "sudo",
+      ["-n", "ufw", "show", "added"],
+      commandOptions("cleanup-host-mock-firewall-rules-after"),
+    );
+    if (restored.exitCode !== 0) {
+      throw new Error(`could not verify restored UFW state (${commandFailure(restored)})`);
+    }
+    if (normalizedRuleSnapshot(restored.stdout) !== baselineRules) {
+      throw new Error("host mock cleanup did not restore the original UFW rules");
+    }
+  });
+
+  return (async () => {
+    if (platform !== "linux") {
+      return {
+        bridgeInterface: "not-applicable",
+        changed: false,
+        gatewayIp: "not-applicable",
+        manualCommand: "not-applicable",
+        prefixLength: 0,
+        reason: "platform_not_applicable",
+        subnet: "not-applicable",
+      };
+    }
+
+    const network = await waitForNetwork(options.host, networkName, waitForNetworkMs);
+    if (network.exitCode !== 0) {
+      throw new Error(
+        `OpenShell Docker network ${networkName} did not become inspectable (${commandFailure(network)})`,
+      );
+    }
+    topology = parseBridgeTopology(network.stdout);
+    await verifyBridgeAddress(options.host, topology, options.port);
+    const command = manualCommand(topology, options.port);
+    if (!authorized) {
+      throw remediationError(
+        "automatic firewall remediation is not authorized",
+        topology,
+        options.port,
+      );
+    }
+    if (closed) {
+      throw new Error("host mock firewall setup was interrupted before UFW inspection");
+    }
+
+    const ufwAvailable = await options.host.isCommandAvailable(
+      "ufw",
+      commandOptions("host-mock-firewall-ufw-available"),
+    );
+    if (!ufwAvailable) {
+      return { ...topology, changed: false, manualCommand: command, reason: "ufw_missing" };
+    }
+    const status = await options.host.command(
+      "sudo",
+      ["-n", "ufw", "status"],
+      commandOptions("host-mock-firewall-status"),
+    );
+    if (status.exitCode !== 0) {
+      throw remediationError(
+        `UFW status is unavailable (${commandFailure(status)})`,
+        topology,
+        options.port,
+      );
+    }
+    if (/^Status:\s*inactive\s*$/im.test(status.stdout)) {
+      return { ...topology, changed: false, manualCommand: command, reason: "ufw_inactive" };
+    }
+    if (!/^Status:\s*active\s*$/im.test(status.stdout)) {
+      throw remediationError(
+        "UFW did not report active or inactive status",
+        topology,
+        options.port,
+      );
+    }
+
+    const before = await options.host.command(
+      "sudo",
+      ["-n", "ufw", "show", "added"],
+      commandOptions("host-mock-firewall-rules-before"),
+    );
+    if (before.exitCode !== 0) {
+      throw remediationError(
+        `could not capture the original UFW rules (${commandFailure(before)})`,
+        topology,
+        options.port,
+      );
+    }
+    baselineRules = normalizedRuleSnapshot(before.stdout);
+    if (snapshotContainsRule(before.stdout, rule())) {
+      return { ...topology, changed: false, manualCommand: command, reason: "preexisting" };
+    }
+
+    mutationStarted = true;
+    applyInFlight = options.host.command(
+      "sudo",
+      ["-n", "ufw", ...rule()],
+      commandOptions("host-mock-firewall-apply"),
+    );
+    const applied = await applyInFlight;
+    applyInFlight = undefined;
+    if (closed) {
+      throw new Error("host mock firewall setup was interrupted while applying the UFW rule");
+    }
+    if (applied.exitCode !== 0) {
+      throw remediationError(
+        `UFW rejected the exact rule (${commandFailure(applied)})`,
+        topology,
+        options.port,
+      );
+    }
+    if (/Skipping adding existing rule/i.test(`${applied.stdout}\n${applied.stderr}`)) {
+      mutationStarted = false;
+      return { ...topology, changed: false, manualCommand: command, reason: "preexisting" };
+    }
+
+    const after = await options.host.command(
+      "sudo",
+      ["-n", "ufw", "show", "added"],
+      commandOptions("host-mock-firewall-rules-after"),
+    );
+    if (after.exitCode !== 0 || !snapshotContainsRule(after.stdout, rule())) {
+      throw remediationError(
+        `could not verify the exact UFW rule (${commandFailure(after)})`,
+        topology,
+        options.port,
+      );
+    }
+    return { ...topology, changed: true, manualCommand: command, reason: "applied" };
+  })();
+}

--- a/test/e2e/live/openshell-gateway-upgrade-helpers.ts
+++ b/test/e2e/live/openshell-gateway-upgrade-helpers.ts
@@ -70,6 +70,18 @@ export function currentNemoclawUpgradeRef(env: NodeJS.ProcessEnv): string {
   return "HEAD";
 }
 
+export function throwGatewayUpgradeSetupFailures(
+  results: readonly PromiseSettledResult<unknown>[],
+): void {
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length === 1) throw failures[0];
+  if (failures.length > 1) {
+    throw new AggregateError(failures, "legacy install and host mock firewall setup failed");
+  }
+}
+
 export function expectedLegacyRegistryMetadata(nemoclawRef: string): {
   nemoclawVersion: string | undefined;
   fromDockerfile: null | undefined;

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -39,6 +39,7 @@ import {
   type FakeOpenAiCompatibleServer,
   startFakeOpenAiCompatibleServer,
 } from "../fixtures/fake-openai-compatible.ts";
+import { registerOpenShellHostMockFirewall } from "../fixtures/host-mock-firewall.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import {
@@ -1187,6 +1188,17 @@ runLinuxOpenShellGatewayUpgrade(
       requireAuthModels: OPENCLAW_STATE_UPGRADE_PROOF,
       responseText: "ok",
     });
+    let firewallSetup: ReturnType<typeof registerOpenShellHostMockFirewall>;
+    try {
+      firewallSetup = registerOpenShellHostMockFirewall({
+        cleanup,
+        host,
+        port: Number(new URL(fake.baseUrl).port),
+      });
+    } catch (error) {
+      await fake.close();
+      throw error;
+    }
     cleanup.add("close compatible endpoint mock", async () => {
       await artifacts.writeJson("fake-openai-compatible-requests.json", fake.requests());
       await fake.close();
@@ -1196,7 +1208,20 @@ runLinuxOpenShellGatewayUpgrade(
     });
 
     progress.phase("install pinned legacy NemoClaw and its sandbox");
-    await installOldNemoclawAndClaw(host, artifacts, fake.baseUrl);
+    const [installResult, firewallResult] = await Promise.allSettled([
+      installOldNemoclawAndClaw(host, artifacts, fake.baseUrl),
+      firewallSetup,
+    ]);
+    if (firewallResult.status === "fulfilled") {
+      await artifacts.writeJson("host-mock-firewall.json", firewallResult.value);
+    }
+    const setupFailures = [installResult, firewallResult]
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => result.reason);
+    if (setupFailures.length === 1) throw setupFailures[0];
+    if (setupFailures.length > 1) {
+      throw new AggregateError(setupFailures, "legacy install and host mock firewall setup failed");
+    }
     const legacyStateContract = await captureOpenClawStateUpgradeProof(host, fake, artifacts);
     const hiddenOldOpenShellDir =
       OLD_NEMOCLAW_REF === "v0.0.55" ? await stageOldOpenShellInUserLocalBin(host) : undefined;

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -47,6 +47,7 @@ import {
   currentNemoclawUpgradeRef,
   expectedLegacyRegistryMetadata,
   oldGatewayUpgradeInstallerArgs,
+  throwGatewayUpgradeSetupFailures,
   upgradeGatewayCleanupScript,
   upgradeGatewayStateCleanupScript,
   validateLegacyGatewayUpgradeFixture,
@@ -1208,20 +1209,11 @@ runLinuxOpenShellGatewayUpgrade(
     });
 
     progress.phase("install pinned legacy NemoClaw and its sandbox");
-    const [installResult, firewallResult] = await Promise.allSettled([
+    const setupResults = await Promise.allSettled([
       installOldNemoclawAndClaw(host, artifacts, fake.baseUrl),
-      firewallSetup,
+      firewallSetup.then((result) => artifacts.writeJson("host-mock-firewall.json", result)),
     ]);
-    if (firewallResult.status === "fulfilled") {
-      await artifacts.writeJson("host-mock-firewall.json", firewallResult.value);
-    }
-    const setupFailures = [installResult, firewallResult]
-      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
-      .map((result) => result.reason);
-    if (setupFailures.length === 1) throw setupFailures[0];
-    if (setupFailures.length > 1) {
-      throw new AggregateError(setupFailures, "legacy install and host mock firewall setup failed");
-    }
+    throwGatewayUpgradeSetupFailures(setupResults);
     const legacyStateContract = await captureOpenClawStateUpgradeProof(host, fake, artifacts);
     const hiddenOldOpenShellDir =
       OLD_NEMOCLAW_REF === "v0.0.55" ? await stageOldOpenShellInUserLocalBin(host) : undefined;

--- a/test/e2e/support/host-mock-firewall.test.ts
+++ b/test/e2e/support/host-mock-firewall.test.ts
@@ -90,8 +90,8 @@ class FakeHost {
   ): Promise<ShellProbeResult> {
     const call = { args, command, options };
     this.calls.push(call);
-    const response = this.responses.shift();
-    if (!response) throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+    expect(this.responses, `unexpected command: ${command} ${args.join(" ")}`).not.toHaveLength(0);
+    const response = this.responses.shift() as CommandResponse;
     return typeof response === "function" ? response(call) : response;
   }
 

--- a/test/e2e/support/host-mock-firewall.test.ts
+++ b/test/e2e/support/host-mock-firewall.test.ts
@@ -216,7 +216,7 @@ describe("OpenShell live E2E host mock firewall", () => {
     host.expectNoPendingResponses();
   });
 
-  it("does not change UFW when the service is inactive or absent (#8696)", async () => {
+  it("does not change UFW when UFW is inactive or unavailable (#8696)", async () => {
     const inactiveHost = new FakeHost([
       shellResult(networkInspect()),
       shellResult(bridgeAddresses()),
@@ -244,7 +244,7 @@ describe("OpenShell live E2E host mock firewall", () => {
     expect(missingHost.calls).toHaveLength(2);
   });
 
-  it("reports the detected tuple and manual command when mutation is not authorized (#8696)", async () => {
+  it("reports the bridge, subnet, gateway, port, and manual command when mutation is not authorized (#8696)", async () => {
     const customBridge = "br-custom0";
     const host = new FakeHost([
       shellResult(networkInspect({ bridgeInterface: customBridge })),
@@ -333,7 +333,7 @@ describe("OpenShell live E2E host mock firewall", () => {
     const cleanup = new CleanupRegistry();
 
     await expect(registration(host, cleanup)).rejects.toThrow(
-      /UFW rejected the exact rule \(timed out\).*Run this command manually/s,
+      /UFW rule application was not confirmed \(timed out\).*Run this command manually/s,
     );
     await expect(cleanup.runAll()).resolves.toEqual({
       failures: [],
@@ -342,7 +342,29 @@ describe("OpenShell live E2E host mock firewall", () => {
     host.expectNoPendingResponses();
   });
 
-  it("fails cleanup when deletion does not restore the original UFW rules (#8696)", async () => {
+  it("reports rule absence after a successful UFW inspection (#8696)", async () => {
+    const host = new FakeHost([
+      shellResult(networkInspect()),
+      shellResult(bridgeAddresses()),
+      shellResult("Status: active\n"),
+      shellResult(BASELINE_RULES),
+      shellResult("Rule added\n"),
+      shellResult(BASELINE_RULES),
+      shellResult(BASELINE_RULES),
+    ]);
+    const cleanup = new CleanupRegistry();
+
+    await expect(registration(host, cleanup)).rejects.toThrow(
+      /UFW inspection completed but the exact rule was absent.*Run this command manually/s,
+    );
+    await expect(cleanup.runAll()).resolves.toEqual({
+      failures: [],
+      passed: [`restore UFW state after host mock port ${PORT}`],
+    });
+    host.expectNoPendingResponses();
+  });
+
+  it("reports a cleanup failure when UFW rejects rule deletion (#8696)", async () => {
     const host = new FakeHost([
       shellResult(networkInspect()),
       shellResult(bridgeAddresses()),

--- a/test/e2e/support/host-mock-firewall.test.ts
+++ b/test/e2e/support/host-mock-firewall.test.ts
@@ -1,0 +1,370 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { CleanupRegistry } from "../fixtures/cleanup.ts";
+import {
+  type HostMockFirewallResult,
+  registerOpenShellHostMockFirewall,
+} from "../fixtures/host-mock-firewall.ts";
+import type { ShellProbeResult, ShellProbeRunOptions } from "../fixtures/shell-probe.ts";
+
+const NETWORK_ID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const BRIDGE_INTERFACE = "br-0123456789ab";
+const SUBNET = "172.18.0.0/16";
+const GATEWAY = "172.18.0.1";
+const PORT = 31_337;
+const BASELINE_RULES = [
+  "Added user rules (see 'ufw status' for running firewall):",
+  "ufw allow 22/tcp",
+].join("\n");
+const EXACT_RULE = `ufw allow in on ${BRIDGE_INTERFACE} from ${SUBNET} to ${GATEWAY} port ${PORT} proto tcp`;
+
+type CommandCall = {
+  args: string[];
+  command: string;
+  options: ShellProbeRunOptions;
+};
+type CommandResponse =
+  | ShellProbeResult
+  | ((call: CommandCall) => Promise<ShellProbeResult> | ShellProbeResult);
+
+function shellResult(
+  stdout = "",
+  options: { exitCode?: number | null; stderr?: string; timedOut?: boolean } = {},
+): ShellProbeResult {
+  return {
+    artifacts: { result: "", stderr: "", stdout: "" },
+    command: [],
+    exitCode: options.exitCode === undefined ? 0 : options.exitCode,
+    signal: null,
+    stderr: options.stderr ?? "",
+    stdout,
+    timedOut: options.timedOut ?? false,
+  };
+}
+
+function networkInspect(options: { bridgeInterface?: string; subnet?: string } = {}): string {
+  return JSON.stringify([
+    {
+      Driver: "bridge",
+      Id: NETWORK_ID,
+      IPAM: {
+        Config: [
+          { Gateway: "fd00::1", Subnet: "fd00::/64" },
+          { Gateway: GATEWAY, Subnet: options.subnet ?? SUBNET },
+        ],
+      },
+      Options: options.bridgeInterface
+        ? { "com.docker.network.bridge.name": options.bridgeInterface }
+        : {},
+    },
+  ]);
+}
+
+function bridgeAddresses(bridgeInterface = BRIDGE_INTERFACE): string {
+  return JSON.stringify([
+    {
+      addr_info: [{ family: "inet", local: GATEWAY, prefixlen: 16 }],
+      ifname: bridgeInterface,
+    },
+  ]);
+}
+
+class FakeHost {
+  readonly calls: CommandCall[] = [];
+  readonly availabilityCalls: string[] = [];
+  private readonly responses: CommandResponse[];
+  private readonly ufwAvailable: boolean;
+
+  constructor(responses: CommandResponse[], options: { ufwAvailable?: boolean } = {}) {
+    this.responses = [...responses];
+    this.ufwAvailable = options.ufwAvailable ?? true;
+  }
+
+  async command(
+    command: string,
+    args: string[] = [],
+    options: ShellProbeRunOptions = {},
+  ): Promise<ShellProbeResult> {
+    const call = { args, command, options };
+    this.calls.push(call);
+    const response = this.responses.shift();
+    if (!response) throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+    return typeof response === "function" ? response(call) : response;
+  }
+
+  async isCommandAvailable(command: string): Promise<boolean> {
+    this.availabilityCalls.push(command);
+    return this.ufwAvailable;
+  }
+
+  expectNoPendingResponses(): void {
+    expect(this.responses).toEqual([]);
+  }
+}
+
+function registration(host: FakeHost, cleanup: CleanupRegistry, authorized = true) {
+  return registerOpenShellHostMockFirewall({
+    authorized,
+    cleanup,
+    host,
+    platform: "linux",
+    port: PORT,
+  });
+}
+
+describe("OpenShell live E2E host mock firewall", () => {
+  it("adds the detected bridge rule and restores the complete UFW baseline (#8696)", async () => {
+    const host = new FakeHost([
+      shellResult(networkInspect()),
+      shellResult(bridgeAddresses()),
+      shellResult("Status: active\n"),
+      shellResult(BASELINE_RULES),
+      shellResult("Rule added\n"),
+      shellResult(`${BASELINE_RULES}\n${EXACT_RULE}\n`),
+      shellResult(`${BASELINE_RULES}\n${EXACT_RULE}\n`),
+      shellResult("Rule deleted\n"),
+      shellResult(BASELINE_RULES),
+    ]);
+    const cleanup = new CleanupRegistry();
+
+    const setup = await registration(host, cleanup);
+
+    expect(setup).toEqual<HostMockFirewallResult>({
+      bridgeInterface: BRIDGE_INTERFACE,
+      changed: true,
+      gatewayIp: GATEWAY,
+      manualCommand: `sudo ${EXACT_RULE}`,
+      prefixLength: 16,
+      reason: "applied",
+      subnet: SUBNET,
+    });
+    expect(host.calls[0]?.command).toBe("bash");
+    expect(host.calls[0]?.args).toContain("openshell-docker");
+    expect(host.calls[1]).toMatchObject({
+      args: ["-j", "address", "show", "dev", BRIDGE_INTERFACE],
+      command: "ip",
+    });
+    expect(host.calls[4]).toMatchObject({
+      args: [
+        "-n",
+        "ufw",
+        "allow",
+        "in",
+        "on",
+        BRIDGE_INTERFACE,
+        "from",
+        SUBNET,
+        "to",
+        GATEWAY,
+        "port",
+        String(PORT),
+        "proto",
+        "tcp",
+      ],
+      command: "sudo",
+    });
+
+    expect(await cleanup.runAll()).toEqual({
+      failures: [],
+      passed: [`restore UFW state after host mock port ${PORT}`],
+    });
+    expect(host.calls[7]).toMatchObject({
+      args: [
+        "-n",
+        "ufw",
+        "--force",
+        "delete",
+        "allow",
+        "in",
+        "on",
+        BRIDGE_INTERFACE,
+        "from",
+        SUBNET,
+        "to",
+        GATEWAY,
+        "port",
+        String(PORT),
+        "proto",
+        "tcp",
+      ],
+      command: "sudo",
+    });
+    host.expectNoPendingResponses();
+  });
+
+  it("preserves a pre-existing exact UFW rule (#8696)", async () => {
+    const host = new FakeHost([
+      shellResult(networkInspect()),
+      shellResult(bridgeAddresses()),
+      shellResult("Status: active\n"),
+      shellResult(`${BASELINE_RULES}\n${EXACT_RULE}\n`),
+    ]);
+    const cleanup = new CleanupRegistry();
+
+    await expect(registration(host, cleanup)).resolves.toMatchObject({
+      changed: false,
+      reason: "preexisting",
+    });
+    expect(await cleanup.runAll()).toEqual({
+      failures: [],
+      passed: [`restore UFW state after host mock port ${PORT}`],
+    });
+    expect(host.calls).toHaveLength(4);
+    host.expectNoPendingResponses();
+  });
+
+  it("does not change UFW when the service is inactive or absent (#8696)", async () => {
+    const inactiveHost = new FakeHost([
+      shellResult(networkInspect()),
+      shellResult(bridgeAddresses()),
+      shellResult("Status: inactive\n"),
+    ]);
+    const inactiveCleanup = new CleanupRegistry();
+
+    await expect(registration(inactiveHost, inactiveCleanup)).resolves.toMatchObject({
+      changed: false,
+      reason: "ufw_inactive",
+    });
+    await inactiveCleanup.runAll();
+    expect(inactiveHost.calls).toHaveLength(3);
+
+    const missingHost = new FakeHost(
+      [shellResult(networkInspect()), shellResult(bridgeAddresses())],
+      { ufwAvailable: false },
+    );
+    const missingCleanup = new CleanupRegistry();
+    await expect(registration(missingHost, missingCleanup)).resolves.toMatchObject({
+      changed: false,
+      reason: "ufw_missing",
+    });
+    await missingCleanup.runAll();
+    expect(missingHost.calls).toHaveLength(2);
+  });
+
+  it("reports the detected tuple and manual command when mutation is not authorized (#8696)", async () => {
+    const customBridge = "br-custom0";
+    const host = new FakeHost([
+      shellResult(networkInspect({ bridgeInterface: customBridge })),
+      shellResult(bridgeAddresses(customBridge)),
+    ]);
+    const cleanup = new CleanupRegistry();
+
+    await expect(registration(host, cleanup, false)).rejects.toThrow(
+      new RegExp(
+        `bridge=${customBridge} subnet=${SUBNET.replace("/", "\\/")} gateway=${GATEWAY} port=${PORT}.*sudo ufw allow in on ${customBridge}`,
+        "s",
+      ),
+    );
+    await cleanup.runAll();
+    expect(host.availabilityCalls).toEqual([]);
+    expect(host.calls).toHaveLength(2);
+  });
+
+  it("rejects a broad bridge subnet before invoking UFW (#8696)", async () => {
+    const host = new FakeHost([shellResult(networkInspect({ subnet: "172.0.0.0/8" }))]);
+    const cleanup = new CleanupRegistry();
+
+    await expect(registration(host, cleanup)).rejects.toThrow(
+      "OpenShell bridge network has no narrow IPv4 subnet and gateway",
+    );
+    await cleanup.runAll();
+    expect(host.availabilityCalls).toEqual([]);
+    expect(host.calls).toHaveLength(1);
+  });
+
+  it("removes a rule when test interruption overlaps the apply command (#8696)", async () => {
+    let resolveApply: ((value: ShellProbeResult) => void) | undefined;
+    let markApplyStarted: (() => void) | undefined;
+    const applyStarted = new Promise<void>((resolve) => {
+      markApplyStarted = resolve;
+    });
+    const applyResult = new Promise<ShellProbeResult>((resolve) => {
+      resolveApply = resolve;
+    });
+    const host = new FakeHost([
+      shellResult(networkInspect()),
+      shellResult(bridgeAddresses()),
+      shellResult("Status: active\n"),
+      shellResult(BASELINE_RULES),
+      () => {
+        markApplyStarted?.();
+        return applyResult;
+      },
+      shellResult(`${BASELINE_RULES}\n${EXACT_RULE}\n`),
+      shellResult("Rule deleted\n"),
+      shellResult(BASELINE_RULES),
+    ]);
+    const cleanup = new CleanupRegistry();
+    const setupOutcome = registration(host, cleanup).then(
+      (value) => value,
+      (error: unknown) => error,
+    );
+    await applyStarted;
+
+    const cleanupResult = cleanup.runAll();
+    resolveApply?.(shellResult("Rule added\n"));
+
+    await expect(setupOutcome).resolves.toEqual(
+      expect.objectContaining({
+        message: "host mock firewall setup was interrupted while applying the UFW rule",
+      }),
+    );
+    await expect(cleanupResult).resolves.toEqual({
+      failures: [],
+      passed: [`restore UFW state after host mock port ${PORT}`],
+    });
+    host.expectNoPendingResponses();
+  });
+
+  it("removes a rule after an apply timeout leaves an ambiguous host state (#8696)", async () => {
+    const host = new FakeHost([
+      shellResult(networkInspect()),
+      shellResult(bridgeAddresses()),
+      shellResult("Status: active\n"),
+      shellResult(BASELINE_RULES),
+      shellResult("", { exitCode: null, timedOut: true }),
+      shellResult(`${BASELINE_RULES}\n${EXACT_RULE}\n`),
+      shellResult("Rule deleted\n"),
+      shellResult(BASELINE_RULES),
+    ]);
+    const cleanup = new CleanupRegistry();
+
+    await expect(registration(host, cleanup)).rejects.toThrow(
+      /UFW rejected the exact rule \(timed out\).*Run this command manually/s,
+    );
+    await expect(cleanup.runAll()).resolves.toEqual({
+      failures: [],
+      passed: [`restore UFW state after host mock port ${PORT}`],
+    });
+    host.expectNoPendingResponses();
+  });
+
+  it("fails cleanup when deletion does not restore the original UFW rules (#8696)", async () => {
+    const host = new FakeHost([
+      shellResult(networkInspect()),
+      shellResult(bridgeAddresses()),
+      shellResult("Status: active\n"),
+      shellResult(BASELINE_RULES),
+      shellResult("Rule added\n"),
+      shellResult(`${BASELINE_RULES}\n${EXACT_RULE}\n`),
+      shellResult(`${BASELINE_RULES}\n${EXACT_RULE}\n`),
+      shellResult("", { exitCode: 1, stderr: "delete rejected" }),
+    ]);
+    const cleanup = new CleanupRegistry();
+    await registration(host, cleanup);
+
+    await expect(cleanup.runAll()).resolves.toEqual({
+      failures: [
+        {
+          message: expect.stringContaining("could not delete the host mock UFW rule"),
+          name: `restore UFW state after host mock port ${PORT}`,
+        },
+      ],
+      passed: [],
+    });
+    host.expectNoPendingResponses();
+  });
+});

--- a/test/e2e/support/host-mock-firewall.test.ts
+++ b/test/e2e/support/host-mock-firewall.test.ts
@@ -90,8 +90,11 @@ class FakeHost {
   ): Promise<ShellProbeResult> {
     const call = { args, command, options };
     this.calls.push(call);
-    expect(this.responses, `unexpected command: ${command} ${args.join(" ")}`).not.toHaveLength(0);
-    const response = this.responses.shift() as CommandResponse;
+    const response =
+      this.responses.shift() ??
+      ((_call: CommandCall): never => {
+        throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+      });
     return typeof response === "function" ? response(call) : response;
   }
 
@@ -316,6 +319,28 @@ describe("OpenShell live E2E host mock firewall", () => {
       failures: [],
       passed: [`restore UFW state after host mock port ${PORT}`],
     });
+    host.expectNoPendingResponses();
+  });
+
+  it("does not apply a rule when cleanup starts during baseline inspection (#8696)", async () => {
+    const cleanup = new CleanupRegistry();
+    const host = new FakeHost([
+      shellResult(networkInspect()),
+      shellResult(bridgeAddresses()),
+      shellResult("Status: active\n"),
+      async () => {
+        await expect(cleanup.runAll()).resolves.toEqual({
+          failures: [],
+          passed: [`restore UFW state after host mock port ${PORT}`],
+        });
+        return shellResult(BASELINE_RULES);
+      },
+    ]);
+
+    await expect(registration(host, cleanup)).rejects.toThrow(
+      "host mock firewall setup was interrupted before applying the UFW rule",
+    );
+    expect(host.calls).toHaveLength(4);
     host.expectNoPendingResponses();
   });
 

--- a/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
@@ -19,6 +19,7 @@ import {
   currentNemoclawUpgradeRef,
   expectedLegacyRegistryMetadata,
   oldGatewayUpgradeInstallerArgs,
+  throwGatewayUpgradeSetupFailures,
   upgradeGatewayCleanupScript,
   validateLegacyGatewayUpgradeFixture,
 } from "../live/openshell-gateway-upgrade-helpers.ts";
@@ -99,6 +100,41 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
       currentNemoclawUpgradeRef({ NEMOCLAW_E2E_EXPECTED_SHA: "", GITHUB_SHA: "workflow-sha" }),
     ).toBe("workflow-sha");
     expect(currentNemoclawUpgradeRef({})).toBe("HEAD");
+  });
+
+  it("accepts successful legacy install and firewall setup results (#8696)", () => {
+    expect(() =>
+      throwGatewayUpgradeSetupFailures([
+        { status: "fulfilled", value: undefined },
+        { status: "fulfilled", value: undefined },
+      ]),
+    ).not.toThrow();
+  });
+
+  it("preserves one legacy setup failure (#8696)", () => {
+    const failure = new Error("firewall setup failed");
+    expect(() =>
+      throwGatewayUpgradeSetupFailures([
+        { status: "fulfilled", value: undefined },
+        { reason: failure, status: "rejected" },
+      ]),
+    ).toThrow(failure);
+  });
+
+  it("aggregates concurrent legacy setup failures (#8696)", () => {
+    const installFailure = new Error("legacy install failed");
+    const firewallFailure = new Error("firewall setup failed");
+    expect(() =>
+      throwGatewayUpgradeSetupFailures([
+        { reason: installFailure, status: "rejected" },
+        { reason: firewallFailure, status: "rejected" },
+      ]),
+    ).toThrow(
+      expect.objectContaining({
+        errors: [installFailure, firewallFailure],
+        message: "legacy install and host mock firewall setup failed",
+      }),
+    );
   });
 
   it("pins the registry metadata written by each historical release fixture", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Live E2E host mocks now add one temporary UFW rule after the OpenShell Docker bridge appears. The fixture limits the rule to the detected bridge interface, subnet, gateway, and mock port, then restores the original UFW rule set during cleanup.

## Related Issue

Fixes #8696

## Changes

- Add a host-mock firewall fixture that waits for the historical installer to create the OpenShell bridge, validates its IPv4 bridge interface and address, and applies one exact TCP rule. An inline rule before installation cannot derive a network that does not exist yet. The `openshell-gateway-upgrade` live E2E test is the current consumer, and `host-mock-firewall.test.ts` protects the contract.
- Register cleanup before the UFW write. Cleanup inspects UFW state after an ambiguous apply result, removes only a fixture-owned rule, and requires the complete pre-change UFW snapshot after deletion.
- Report the detected bridge, subnet, gateway, port, and manual UFW command when automatic remediation is not authorized or cannot complete.
- Add regression tests for applied, inactive, pre-existing, denied, invalid, interrupted, timed-out, cleanup-before-mutation, cleanup-failure, and concurrent setup outcomes. Existing host-only readiness coverage did not model an active default-deny UFW boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes live E2E fixture execution only. It does not change a supported command, configuration, workflow, or documented product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed input validation, live-E2E authorization, exact UFW scope, partial-write recovery, interruption cleanup, and baseline restoration. The maintainer approved issue scope in the implementation task.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change affects only live E2E fixtures, helpers, and regression tests. It does not change a supported command, configuration, workflow, or documented product behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 76b735289 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Focused E2E support coverage passed 19 tests in 2 files. `npm run test:changed` passed 10 tests in 1 file for the review repair. `npm run test:e2e-phases:check` validated 125 tests across 81 files. `npm run test-conditionals:scan -- --top 25` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic firewall setup for Linux-based host mock environments during gateway upgrades.
  * Detects the required network bridge and configures access when authorized.
  * Provides setup results and manual remediation guidance when automatic configuration is unavailable.

* **Bug Fixes**
  * Safely cleans up firewall changes without overwriting unexpected external changes.
  * Reports individual or combined gateway upgrade setup failures clearly.

* **Tests**
  * Added comprehensive coverage for firewall detection, rule management, interruptions, timeouts, and cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->