### PR TITLE
fix(onboard): retain recreation failure evidence

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -423,6 +423,7 @@ const {
 const gatewayReuse: typeof import("./onboard/gateway-reuse") = require("./onboard/gateway-reuse");
 const messagingConfig: typeof import("./onboard/messaging-config") = require("./onboard/messaging-config");
 const {
+  buildMessagingCredentialRecreateDiagnosticLines,
   detectMessagingCredentialRotation,
   getMessagingChannelForEnvKey,
   getRecordedMessagingChannelsForResume: getRecordedMessagingChannelsForResumeFromState,
@@ -803,8 +804,10 @@ const {
   formatEnvAssignment,
   parsePolicyPresetEnv,
 } = urlUtils;
-const { hydrateCredentialEnv }: typeof import("./onboard/credential-env") =
-  require("./onboard/credential-env");
+const {
+  collectCredentialEnvSensitiveValues,
+  hydrateCredentialEnv,
+}: typeof import("./onboard/credential-env") = require("./onboard/credential-env");
 
 const { summarizeCurlFailure, summarizeProbeFailure } = httpProbe;
 
@@ -2222,6 +2225,11 @@ async function createSandboxWithBaseImageResolution(
   });
   const hermesDashboardState = hermesDashboardForwarding.resolveStateForPort(effectivePort);
   const { messagingTokenDefs, hasMessagingTokens } = messagingCapabilities;
+  let credentialRecreateDiagnosticLines: string[] = [];
+  const recreateDiagnosticSensitiveValues = collectCredentialEnvSensitiveValues(
+    process.env,
+    messagingTokenDefs.map(({ token }) => token),
+  );
 
   // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
   const { existingEntry, preservedMcpState, liveExists, effectiveToolDisclosure, toolDisclosureMigrationNeeded, toolDisclosureMigrationNote } = toolDisclosureFlow.prepareSandboxToolDisclosure(sandboxName, preparedBuildContext?.rebuildTarget?.fromDockerfile ? preparedBuildContext.stagedDockerfile : fromDockerfile, isRecreateSandbox(createIntent?.recreate), inspectSandboxForCreate, createIntent?.toolDisclosure ?? null);
@@ -2449,6 +2457,10 @@ async function createSandboxWithBaseImageResolution(
 
     if (credentialRotation.changed && existingSandboxState === "ready") {
       const rotatedNames = credentialRotation.changedProviders.join(", ");
+      credentialRecreateDiagnosticLines = buildMessagingCredentialRecreateDiagnosticLines(
+        messagingTokenDefs,
+        credentialRotation.changedProviders,
+      );
       console.log(`  Messaging credential(s) rotated: ${rotatedNames}`);
       console.log("  Rebuilding sandbox to propagate new credentials to the L7 proxy...");
       if (!shouldSkipPreRecreateBackup(process.env)) {
@@ -2582,6 +2594,8 @@ async function createSandboxWithBaseImageResolution(
       sandboxEnv,
       sandboxStartupCommand,
       lifecycleGeneration: recreateRuntime.targetGeneration,
+      failureDiagnosticSummaryLines: credentialRecreateDiagnosticLines,
+      failureDiagnosticSensitiveValues: recreateDiagnosticSensitiveValues,
       prebuild,
       restoreBackupPath,
       terminalAgent: agentDefs.isTerminalAgent(agent),
@@ -2611,11 +2625,23 @@ async function createSandboxWithBaseImageResolution(
 
   if (manageDashboard) {
     console.log("  Waiting for NemoClaw dashboard to become ready...");
-    sandboxReadinessTracing.waitForDashboardReadyWithTrace({
+    const dashboardReady = sandboxReadinessTracing.waitForDashboardReadyWithTrace({
       sandboxName,
       port: effectiveDashboardPort,
-      runCaptureOpenshell,
+      runCaptureOpenshell: (args, options) => {
+        const output = runCaptureOpenshell(args, options);
+        runtimePatch.recordLifecycleObservation({
+          stage: "dashboard_readiness",
+          event: "health_probe",
+          output,
+        });
+        return output;
+      },
       sleep: sleepSeconds,
+    });
+    runtimePatch.recordLifecycleObservation({
+      stage: "dashboard_readiness",
+      event: dashboardReady ? "ready" : "timeout",
     });
   }
 
@@ -2640,6 +2666,28 @@ async function createSandboxWithBaseImageResolution(
   if (manageDashboard) {
     actualDashboardPort = ensureDashboardForward(sandboxName, chatUiUrl, {
       rollbackSandboxOnFailure: true,
+      beforeSandboxRollback: (context) => {
+        runtimePatch.recordLifecycleObservation({
+          stage: "dashboard_forward",
+          event: context.reason,
+          output: context.forwardListOutput ?? undefined,
+        });
+        runtimePatch.captureLifecycleFailureDiagnostics({
+          error: context.error,
+          cleanupReason: context.reason,
+          cleanupStartedAt: context.cleanupStartedAt,
+          forwardDiagnostic: context.forwardDiagnostic,
+          forwardListOutput: context.forwardListOutput,
+          additionalSummaryLines: [
+            ...(context.dashboardPort !== undefined || context.forwardPort === undefined
+              ? [`dashboard_port=${String(context.dashboardPort ?? effectiveDashboardPort)}`]
+              : []),
+            ...(context.forwardPort !== undefined
+              ? [`forward_port=${String(context.forwardPort)}`]
+              : []),
+          ],
+        });
+      },
     });
     if (actualDashboardPort !== Number(getDashboardForwardPort(chatUiUrl))) {
       chatUiUrl = `http://127.0.0.1:${actualDashboardPort}`;

--- a/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
@@ -69,6 +69,8 @@ export function createGpuPatchFixture() {
     waitForSupervisorReconnectIfNeeded: vi.fn(),
     commitAfterReady: vi.fn(),
     selectedMode: vi.fn(() => null),
+    recordLifecycleObservation: vi.fn(),
+    captureLifecycleFailureDiagnostics: vi.fn(() => null),
     printReadinessFailureIfEnabled: vi.fn(),
     verifyGpuOrExit: vi.fn(() => VERIFIED_GPU_PROOF),
   };

--- a/src/lib/onboard/credential-env.test.ts
+++ b/src/lib/onboard/credential-env.test.ts
@@ -3,7 +3,8 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { hydrateCredentialEnv } from "./credential-env";
+import { collectCredentialEnvSensitiveValues, hydrateCredentialEnv } from "./credential-env";
+import { buildMessagingCredentialRecreateDiagnosticLines } from "./messaging-credentials";
 
 const ORIGINAL_TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 
@@ -35,5 +36,42 @@ describe("hydrateCredentialEnv", () => {
     expect(hydrated).toBe("stored-telegram-token");
     expect(process.env.TELEGRAM_BOT_TOKEN).toBe("stored-telegram-token");
     expect(missing).toBeNull();
+  });
+});
+
+describe("collectCredentialEnvSensitiveValues", () => {
+  it("collects supported and conventionally named credentials without benign values", () => {
+    expect(
+      collectCredentialEnvSensitiveValues(
+        {
+          COMPATIBLE_API_KEY: "opaque-compatible-key",
+          CUSTOM_AUTH_TOKEN: "opaque-auth-token",
+          PATH: "/usr/bin",
+          LOG_LEVEL: "debug",
+        },
+        ["opaque-messaging-token", "opaque-compatible-key", null],
+      ),
+    ).toEqual(["opaque-compatible-key", "opaque-auth-token", "opaque-messaging-token"]);
+  });
+});
+
+describe("credential recreation diagnostic inputs", () => {
+  it("records provider identities and change categories without token values or hashes", () => {
+    const lines = buildMessagingCredentialRecreateDiagnosticLines(
+      [
+        { name: "sandbox-telegram-bridge", envKey: "TELEGRAM_BOT_TOKEN", token: "secret-a" },
+        { name: "sandbox-discord-bridge", envKey: "DISCORD_BOT_TOKEN", token: "secret-b" },
+      ],
+      ["sandbox-discord-bridge"],
+    );
+
+    expect(lines).toEqual([
+      "recreate_reason=messaging_credential_rotation",
+      "provider_identities=sandbox-discord-bridge,sandbox-telegram-bridge",
+      "changed_credential_hash_providers=sandbox-discord-bridge",
+      "unchanged_credential_hash_providers=sandbox-telegram-bridge",
+    ]);
+    expect(lines.join("\n")).not.toContain("secret-a");
+    expect(lines.join("\n")).not.toContain("secret-b");
   });
 });

--- a/src/lib/onboard/credential-env.ts
+++ b/src/lib/onboard/credential-env.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { resolveProviderCredential } from "../credentials/store";
+import { shouldStripCredentialEnv } from "../security/credential-env";
 
 /**
  * Resolve a credential into process.env[envName] so subsequent gateway upserts
@@ -13,4 +14,25 @@ export function hydrateCredentialEnv(
 ): string | null {
   if (!envName) return null;
   return resolveCredential(envName);
+}
+
+/**
+ * Return only credential values that must be treated as opaque redaction
+ * canaries. Names are discarded so callers cannot accidentally serialize the
+ * host environment while preparing failure diagnostics.
+ */
+export function collectCredentialEnvSensitiveValues(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  additionalValues: Iterable<string | null | undefined> = [],
+): string[] {
+  return [
+    ...new Set([
+      ...Object.entries(env)
+        .filter(([name, value]) => Boolean(value) && shouldStripCredentialEnv(name))
+        .map(([, value]) => value as string),
+      ...[...additionalValues].filter(
+        (value): value is string => typeof value === "string" && value.length > 0,
+      ),
+    ]),
+  ];
 }

--- a/src/lib/onboard/dashboard-forward-control.ts
+++ b/src/lib/onboard/dashboard-forward-control.ts
@@ -3,8 +3,24 @@
 
 import { bestEffortForwardStopForSandbox } from "./forward-cleanup";
 
+export type DashboardForwardRollbackContext = {
+  sandboxName: string;
+  reason:
+    | "dashboard_port_allocation_failed"
+    | "dashboard_port_reallocation_refused"
+    | "dashboard_forward_start_failed"
+    | "messaging_forward_start_failed";
+  cleanupStartedAt: string;
+  error: unknown;
+  dashboardPort?: number;
+  forwardPort?: number;
+  forwardDiagnostic?: string | null;
+  forwardListOutput?: string | null;
+};
+
 export interface DashboardForwardOptions {
   rollbackSandboxOnFailure?: boolean;
+  beforeSandboxRollback?: (context: DashboardForwardRollbackContext) => void;
   preserveSandboxPorts?: Array<number | string>;
   allowPortReallocation?: boolean;
 }

--- a/src/lib/onboard/dashboard.ts
+++ b/src/lib/onboard/dashboard.ts
@@ -18,6 +18,7 @@ import * as dashboardAccess from "./dashboard-access";
 import {
   createSandboxForwardStopper,
   type DashboardForwardOptions,
+  type DashboardForwardRollbackContext,
   normalizeDashboardForwardOptions,
 } from "./dashboard-forward-control";
 import {
@@ -241,7 +242,29 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
     return lines;
   }
 
-  function rollbackSandboxAndExit(sandboxName: string, err: unknown): never {
+  function rollbackSandboxAndExit(
+    sandboxName: string,
+    err: unknown,
+    context: Omit<DashboardForwardRollbackContext, "sandboxName" | "cleanupStartedAt" | "error"> & {
+      diagnosticError?: unknown;
+    },
+    beforeSandboxRollback?: DashboardForwardOptions["beforeSandboxRollback"],
+  ): never {
+    const { diagnosticError, ...diagnosticContext } = context;
+    try {
+      beforeSandboxRollback?.({
+        sandboxName,
+        cleanupStartedAt: new Date().toISOString(),
+        error: diagnosticError ?? err,
+        ...diagnosticContext,
+      });
+    } catch (diagnosticError) {
+      console.warn(
+        `  ⚠ Could not capture sandbox diagnostics before cleanup: ${deps.redact(
+          diagnosticError instanceof Error ? diagnosticError.message : String(diagnosticError),
+        )}`,
+      );
+    }
     const delResult = deps.runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
     for (const line of buildOrphanedSandboxRollbackMessage(
       sandboxName,
@@ -253,6 +276,17 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
     process.exit(1);
   }
 
+  function captureForwardListBeforeRollback(): string | null {
+    try {
+      return deps.runCaptureOpenshell(["forward", "list"], {
+        ignoreError: true,
+        timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+      });
+    } catch {
+      return null;
+    }
+  }
+
   function ensureDashboardForward(
     sandboxName: string,
     chatUiUrl = `http://127.0.0.1:${CONTROL_UI_PORT}`,
@@ -260,6 +294,7 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
   ): number {
     const { rollbackSandboxOnFailure, preservedPorts, allowPortReallocation } =
       normalizeDashboardForwardOptions(options);
+    const { beforeSandboxRollback } = options;
     const messagingForward = resolveMessagingHostForwardForSandbox(sandboxName);
     if (messagingForward) preservedPorts.add(String(messagingForward.port));
     const preferredPort = Number(getDashboardForwardPort(chatUiUrl));
@@ -290,7 +325,12 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
       );
     } catch (err) {
       if (!rollbackSandboxOnFailure) throw err;
-      rollbackSandboxAndExit(sandboxName, err);
+      rollbackSandboxAndExit(
+        sandboxName,
+        err,
+        { reason: "dashboard_port_allocation_failed" },
+        beforeSandboxRollback,
+      );
     }
 
     if (actualPort !== preferredPort) {
@@ -306,7 +346,12 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
             `CHAT_UI_URL=${preferredPort}. Free the port and re-run \`${deps.cliName()} onboard\`, ` +
             `or pass \`--control-ui-port <N>\` to pick a different dashboard port.`,
         );
-        rollbackSandboxAndExit(sandboxName, err);
+        rollbackSandboxAndExit(
+          sandboxName,
+          err,
+          { reason: "dashboard_port_reallocation_refused", dashboardPort: preferredPort },
+          beforeSandboxRollback,
+        );
       }
       console.warn(`  ! Port ${preferredPort} is taken. Using port ${actualPort} instead.`);
     }
@@ -349,7 +394,18 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
                 `or pass \`--control-ui-port <N>\` to pick a different dashboard port.`
             : `Failed to start dashboard forward on port ${actualPort}: ${fwdDiagnostic.slice(0, 240)}`,
         );
-        rollbackSandboxAndExit(sandboxName, err);
+        rollbackSandboxAndExit(
+          sandboxName,
+          err,
+          {
+            reason: "dashboard_forward_start_failed",
+            dashboardPort: actualPort,
+            diagnosticError: new Error("Dashboard forward failed before sandbox cleanup."),
+            forwardDiagnostic: fwdDiagnostic,
+            forwardListOutput: captureForwardListBeforeRollback(),
+          },
+          beforeSandboxRollback,
+        );
       }
       if (looksLikePortConflict) {
         console.warn(
@@ -376,6 +432,7 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
           buildRollbackMessage: buildOrphanedSandboxRollbackMessage,
           cliName: deps.cliName,
           forwardPortsToStop: [actualPort],
+          beforeSandboxRollback,
         },
       });
     }

--- a/src/lib/onboard/docker-gpu-diagnostic-redaction.test.ts
+++ b/src/lib/onboard/docker-gpu-diagnostic-redaction.test.ts
@@ -11,6 +11,7 @@ import {
   buildDockerGpuMode,
   collectDockerGpuPatchDiagnostics,
   type DockerContainerInspect,
+  type DockerContainerState,
   printDockerGpuPatchFailureAndExit,
 } from "./docker-gpu-patch";
 
@@ -42,8 +43,10 @@ describe("Docker GPU diagnostic redaction", () => {
       "nemoclaw-start",
     ].join(" ");
     const suffixCanary = ["redaction", "sentinel"].join("-");
+    const unallowlistedStateCanary = "future-runtime-payload-8690";
     const inspect: DockerContainerInspect = {
       Id: "new-container-id",
+      Image: `sha256:${"d".repeat(64)}`,
       Name: `/openshell-alpha-${canaries.inspect}`,
       Config: {
         Image: "openshell/sandbox:test",
@@ -61,6 +64,17 @@ describe("Docker GPU diagnostic redaction", () => {
         RestartPolicy: { Name: "unless-stopped" },
         GroupAdd: ["1000"],
       },
+      State: {
+        Status: "running",
+        Running: true,
+        ExitCode: 0,
+        Health: {
+          Status: "healthy",
+          FailingStreak: 0,
+          Log: [{ Output: unallowlistedStateCanary }],
+        },
+        FutureRuntimeField: unallowlistedStateCanary,
+      } as DockerContainerInspect["State"],
       NetworkSettings: {
         Networks: {
           "openshell-docker": {
@@ -117,7 +131,13 @@ describe("Docker GPU diagnostic redaction", () => {
               Status: "exited",
               ExitCode: 125,
               Error: `useful state context ${canaries.containerState}`,
-            },
+              FutureRuntimeField: unallowlistedStateCanary,
+              Health: {
+                Status: "unhealthy",
+                FailingStreak: 2,
+                Log: [{ Output: unallowlistedStateCanary }],
+              },
+            } as DockerContainerState,
           },
           classification: {
             kind: "patched_container_failed",
@@ -157,6 +177,7 @@ describe("Docker GPU diagnostic redaction", () => {
       const published = `${diagnostics?.summaryLines.join("\n")}\n${Object.values(contents).join("\n")}`;
       for (const canary of Object.values(canaries)) expect(published).not.toContain(canary);
       expect(published).not.toContain(suffixCanary);
+      expect(published).not.toContain(unallowlistedStateCanary);
 
       expect(contents["summary.txt"]).toContain("failure_kind=patched_container_failed");
       expect(contents["summary.txt"]).toContain("useful failure context <REDACTED>");
@@ -165,8 +186,15 @@ describe("Docker GPU diagnostic redaction", () => {
       );
       expect(contents["openshell-sandbox-get.txt"]).toContain("useful get context <REDACTED>");
       expect(contents["docker-network-summary.txt"]).toContain("network_mode=openshell-docker");
+      expect(contents["docker-network-summary.txt"]).toContain(`image_id=sha256:${"d".repeat(64)}`);
       const state = JSON.parse(contents["patched-container-state.json"]);
       expect(state.Error).toBe("useful state context <REDACTED>");
+      expect(state).toEqual({
+        Status: "exited",
+        ExitCode: 125,
+        Error: "useful state context <REDACTED>",
+        Health: { Status: "unhealthy", FailingStreak: 2 },
+      });
       const inspected = JSON.parse(contents["docker-inspect.json"]);
       expect(inspected[0].Config.Env).toEqual([
         "OPENSHELL_SANDBOX_COMMAND=<REDACTED>",
@@ -174,6 +202,13 @@ describe("Docker GPU diagnostic redaction", () => {
       ]);
       expect(inspected[0].Config.Labels).toEqual({ "openshell.ai/sandbox-name": "alpha" });
       expect(inspected[0].Config.Cmd).toEqual(["hidden", "<1 additional arguments omitted>"]);
+      expect(inspected[0].Image).toBe(`sha256:${"d".repeat(64)}`);
+      expect(inspected[0].State).toEqual({
+        Status: "running",
+        Running: true,
+        ExitCode: 0,
+        Health: { Status: "healthy", FailingStreak: 0 },
+      });
 
       const fullInspectOrders = dockerCapture.mock.calls
         .map(([args], index) => ({ args, order: dockerCapture.mock.invocationCallOrder[index] }))
@@ -185,6 +220,113 @@ describe("Docker GPU diagnostic redaction", () => {
       );
     } finally {
       writeFileSpy.mockRestore();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { label: "exact", observed: ["a".repeat(64)], expected: "yes" },
+    { label: "wrong", observed: ["b".repeat(64)], expected: "no" },
+    { label: "missing", observed: [], expected: "missing" },
+    {
+      label: "ambiguous",
+      observed: ["a".repeat(64), "b".repeat(64)],
+      expected: "ambiguous",
+    },
+  ])("records $label replacement identity evidence (#8690)", ({ observed, expected }) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-container-identity-"));
+    const expectedId = "a".repeat(64);
+    try {
+      const diagnostics = collectDockerGpuPatchDiagnostics(
+        "alpha",
+        {
+          context: {
+            sandboxName: "alpha",
+            newContainerId: expectedId,
+          },
+        },
+        {
+          dockerCapture: vi.fn((args: readonly string[]) =>
+            args[0] === "ps" && args.includes("--no-trunc") ? `${observed.join("\n")}\n` : "",
+          ),
+          dockerLogs: vi.fn(() => ""),
+          homedir: () => tmpDir,
+          now: () => new Date("2026-07-02T00:10:00Z"),
+        },
+      );
+
+      const summary = fs.readFileSync(path.join(diagnostics?.dir ?? "", "summary.txt"), "utf8");
+      expect(summary).toContain(`expected_container_id=${expectedId}`);
+      expect(summary).toContain("container_identity_query=succeeded");
+      expect(summary).toContain(`container_identity_match=${expected}`);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records unknown identity when the Docker label query fails (#8690)", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-container-query-failure-"));
+    const expectedId = "a".repeat(64);
+    try {
+      const diagnostics = collectDockerGpuPatchDiagnostics(
+        "alpha",
+        {
+          context: {
+            sandboxName: "alpha",
+            newContainerId: expectedId,
+          },
+        },
+        {
+          dockerCapture: vi.fn((args: readonly string[]) => {
+            if (args[0] === "ps" && args.includes("--no-trunc")) {
+              throw new Error("Docker query timed out");
+            }
+            return "";
+          }),
+          dockerLogs: vi.fn(() => ""),
+          homedir: () => tmpDir,
+          now: () => new Date("2026-07-02T00:11:00Z"),
+        },
+      );
+
+      const summary = fs.readFileSync(path.join(diagnostics?.dir ?? "", "summary.txt"), "utf8");
+      expect(summary).toContain("observed_container_ids=unknown");
+      expect(summary).toContain("container_identity_query=failed");
+      expect(summary).toContain("container_identity_match=unknown");
+      expect(summary).not.toContain("container_identity_match=missing");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps oversized lifecycle evidence bounded and valid JSON (#8690)", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-lifecycle-json-"));
+    try {
+      const diagnostics = collectDockerGpuPatchDiagnostics(
+        "alpha",
+        {
+          lifecycleObservations: Array.from({ length: 200 }, (_, attempt) => ({
+            at: "2026-07-02T00:20:00Z",
+            stage: "sandbox_readiness" as const,
+            event: "phase_probe",
+            attempt,
+            output: "alpha Ready ".repeat(125),
+          })),
+        },
+        {
+          dockerCapture: vi.fn(() => ""),
+          dockerLogs: vi.fn(() => ""),
+          homedir: () => tmpDir,
+          now: () => new Date("2026-07-02T00:20:00Z"),
+        },
+      );
+      const lifecyclePath = path.join(diagnostics?.dir ?? "", "lifecycle-history.json");
+      const published = fs.readFileSync(lifecyclePath, "utf8");
+
+      expect(() => JSON.parse(published)).not.toThrow();
+      expect(JSON.parse(published)).toMatchObject({ diagnosticTruncated: true });
+      expect(fs.statSync(lifecyclePath).size).toBeLessThanOrEqual(256_000);
+    } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/src/lib/onboard/docker-gpu-diagnostic-redaction.ts
+++ b/src/lib/onboard/docker-gpu-diagnostic-redaction.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { redact, redactFull } from "../security/redact";
-import type { DockerContainerInspect } from "./docker-gpu-patch-types";
+import type { DockerContainerInspect, DockerContainerState } from "./docker-gpu-patch-types";
 
 const SENSITIVE_ENV_KEY =
   /(?:api_?key|private_?key|(?:^|_)key$|token|secret|password|credential|authorization|cookie|proxy)/i;
@@ -46,6 +46,7 @@ export type DockerGpuDiagnosticRedactor = {
   rememberInspect(inspect: DockerContainerInspect): void;
   redactText(text: string): string;
   redactValue(value: unknown): unknown;
+  sanitizeState(state: DockerContainerState): DockerContainerState;
   sanitizeInspect(inspect: DockerContainerInspect): DockerContainerInspect;
 };
 
@@ -105,6 +106,32 @@ export function createDockerGpuDiagnosticRedactor(
       Object.entries(value).map(([key, entry]) => [redactText(key), redactValue(entry, seen)]),
     );
   };
+  const sanitizeState = (state: DockerContainerState): DockerContainerState => ({
+    ...(typeof state.Status === "string" ? { Status: redactText(state.Status) } : {}),
+    ...(typeof state.Running === "boolean" ? { Running: state.Running } : {}),
+    ...(typeof state.Paused === "boolean" ? { Paused: state.Paused } : {}),
+    ...(typeof state.Restarting === "boolean" ? { Restarting: state.Restarting } : {}),
+    ...(typeof state.OOMKilled === "boolean" ? { OOMKilled: state.OOMKilled } : {}),
+    ...(typeof state.Dead === "boolean" ? { Dead: state.Dead } : {}),
+    ...(typeof state.ExitCode === "number" ? { ExitCode: state.ExitCode } : {}),
+    ...(typeof state.Error === "string" ? { Error: redactText(state.Error) } : {}),
+    ...(typeof state.StartedAt === "string" ? { StartedAt: redactText(state.StartedAt) } : {}),
+    ...(typeof state.FinishedAt === "string" ? { FinishedAt: redactText(state.FinishedAt) } : {}),
+    ...(state.Health === null
+      ? { Health: null }
+      : state.Health && typeof state.Health === "object"
+        ? {
+            Health: {
+              ...(typeof state.Health.Status === "string"
+                ? { Status: redactText(state.Health.Status) }
+                : {}),
+              ...(typeof state.Health.FailingStreak === "number"
+                ? { FailingStreak: state.Health.FailingStreak }
+                : {}),
+            },
+          }
+        : {}),
+  });
   const sanitizeInspect = (inspect: DockerContainerInspect): DockerContainerInspect => {
     const envKeys = [...inspectEnv(inspect).keys()].sort();
     const labels = Object.fromEntries(
@@ -124,7 +151,10 @@ export function createDockerGpuDiagnosticRedactor(
     );
     return {
       Id: inspect.Id ? redactText(inspect.Id) : inspect.Id,
+      Image: inspect.Image ? redactText(inspect.Image) : inspect.Image,
       Name: inspect.Name ? redactText(inspect.Name) : inspect.Name,
+      Created: inspect.Created ? redactText(inspect.Created) : inspect.Created,
+      RestartCount: inspect.RestartCount,
       Config: {
         Image: inspect.Config?.Image ? redactText(inspect.Config.Image) : inspect.Config?.Image,
         User: inspect.Config?.User ? redactText(inspect.Config.User) : inspect.Config?.User,
@@ -147,8 +177,9 @@ export function createDockerGpuDiagnosticRedactor(
           : inspect.HostConfig?.RestartPolicy,
         GroupAdd: inspect.HostConfig?.GroupAdd?.map(redactText),
       },
+      State: inspect.State ? sanitizeState(inspect.State) : inspect.State,
       NetworkSettings: { Networks: networks },
     };
   };
-  return { rememberInspect, redactText, redactValue, sanitizeInspect };
+  return { rememberInspect, redactText, redactValue, sanitizeState, sanitizeInspect };
 }

--- a/src/lib/onboard/docker-gpu-patch-diagnostics.ts
+++ b/src/lib/onboard/docker-gpu-patch-diagnostics.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -22,12 +23,13 @@ import type {
   DockerGpuPatchFailureContext,
   DockerGpuPatchMode,
   DockerGpuPatchSandboxSnapshot,
+  DockerRecreateLifecycleObservation,
 } from "./docker-gpu-patch-types";
 import {
-  findOpenShellDockerSandboxContainerIds,
   OPENSHELL_MANAGED_BY_LABEL,
   OPENSHELL_MANAGED_BY_VALUE,
   OPENSHELL_SANDBOX_NAME_LABEL,
+  queryOpenShellDockerSandboxContainers,
 } from "./openshell-docker-sandbox-containers";
 
 function stringArray(value: string[] | string | null | undefined): string[] {
@@ -41,10 +43,41 @@ function envKey(env: string): string {
   return index === -1 ? env : env.slice(0, index);
 }
 
+const MAX_DIAGNOSTIC_FILE_BYTES = 256_000;
+const MAX_JSON_TRAILING_PREVIEW_BYTES = 96_000;
+
+function boundTextToUtf8Bytes(content: string, maxBytes = MAX_DIAGNOSTIC_FILE_BYTES): string {
+  const normalized = content.endsWith("\n") ? content : `${content}\n`;
+  if (Buffer.byteLength(normalized) <= maxBytes) return normalized;
+  const marker = `[diagnostic truncated to complete trailing lines within ${String(maxBytes)} bytes]\n`;
+  const tailBudget = Math.max(0, maxBytes - Buffer.byteLength(marker));
+  const bytes = Buffer.from(normalized);
+  let tail = bytes.subarray(Math.max(0, bytes.length - tailBudget)).toString("utf8");
+  const firstNewline = tail.indexOf("\n");
+  if (firstNewline < 0) return `${marker}[oversized single-line diagnostic omitted]\n`;
+  tail = tail.slice(firstNewline + 1);
+  while (Buffer.byteLength(marker) + Buffer.byteLength(tail) > maxBytes) tail = tail.slice(1);
+  return `${marker}${tail}`;
+}
+
 function writeTextFile(dir: string, name: string, content: string): void {
-  fs.writeFileSync(path.join(dir, name), content.endsWith("\n") ? content : `${content}\n`, {
+  fs.writeFileSync(path.join(dir, name), boundTextToUtf8Bytes(content), {
     mode: 0o600,
   });
+}
+
+function writeJsonFile(dir: string, name: string, value: unknown): void {
+  const serialized = `${JSON.stringify(value, null, 2)}\n`;
+  if (Buffer.byteLength(serialized) <= MAX_DIAGNOSTIC_FILE_BYTES) {
+    fs.writeFileSync(path.join(dir, name), serialized, { mode: 0o600 });
+    return;
+  }
+  const bounded = {
+    diagnosticTruncated: true,
+    originalBytes: Buffer.byteLength(serialized),
+    trailingPreview: boundTextToUtf8Bytes(serialized, MAX_JSON_TRAILING_PREVIEW_BYTES),
+  };
+  fs.writeFileSync(path.join(dir, name), `${JSON.stringify(bounded, null, 2)}\n`, { mode: 0o600 });
 }
 
 function uniqueStrings(values: Array<string | null | undefined>): string[] {
@@ -57,6 +90,13 @@ function sanitizePathPart(value: string): string {
 
 function timestampForPath(now: Date): string {
   return now.toISOString().replace(/[:.]/g, "-");
+}
+
+function fingerprintSandboxLiveIdentity(getOutput: string): string | null {
+  const clean = String(getOutput).replace(/\x1b\[[0-9;]*m/g, "");
+  const id = clean.match(/^\s*Id:\s+(\S+)\s*$/im)?.[1];
+  if (!id || id.length > 512) return null;
+  return createHash("sha256").update(id).digest("hex");
 }
 
 const DIAGNOSTIC_ENV_KEYS = new Set([
@@ -84,6 +124,7 @@ export function formatDockerInspectNetworkSummary(
     `target=${target}`,
     `id=${inspect.Id ?? "unknown"}`,
     `name=${String(inspect.Name || "").replace(/^\/+/, "") || "unknown"}`,
+    `image_id=${inspect.Image ?? "unknown"}`,
     `image=${inspect.Config?.Image ?? "unknown"}`,
     `network_mode=${inspect.HostConfig?.NetworkMode ?? "unknown"}`,
   ];
@@ -138,6 +179,35 @@ function confirmationValue(value: boolean | undefined): string {
   return value === true ? "yes" : value === false ? "no" : "unknown";
 }
 
+function diagnosticContainerId(value: string | null | undefined): string | null {
+  const normalized = fullDockerContainerId(value);
+  if (normalized) return normalized;
+  const fallback = String(value ?? "").trim();
+  return fallback || null;
+}
+
+function queryDiagnosticContainerIds(
+  sandboxName: string,
+  deps: DockerGpuPatchDeps,
+  capture: NonNullable<DockerGpuPatchDeps["dockerCapture"]>,
+) {
+  return queryOpenShellDockerSandboxContainers(sandboxName, {
+    dockerRun:
+      deps.dockerRun ??
+      ((args, options) => {
+        try {
+          return {
+            status: 0,
+            stdout: capture(args, { ...options, ignoreError: false }),
+            stderr: "",
+          };
+        } catch {
+          return { status: 1, stdout: "", stderr: "docker ps did not complete successfully" };
+        }
+      }),
+  });
+}
+
 export function collectDockerGpuPatchDiagnostics(
   sandboxName: string,
   options: {
@@ -149,11 +219,19 @@ export function collectDockerGpuPatchDiagnostics(
     additionalSummaryLines?: readonly string[];
     additionalSensitiveValues?: readonly string[];
     dockerTopOutput?: string | null;
+    lifecycleGeneration?: string | null;
+    lifecycleObservations?: readonly DockerRecreateLifecycleObservation[];
+    lifecycleObservationDroppedCount?: number;
+    cleanupReason?: string | null;
+    cleanupStartedAt?: string | null;
+    forwardDiagnostic?: string | null;
+    forwardListOutput?: string | null;
+    captureStage?: "pre-rollback" | "post-cutover-pre-cleanup";
     /**
      * The caller captured evidence before rollback and cannot yet determine
      * whether manual cleanup will be required.
      */
-    cleanupDisposition?: "pending-rollback";
+    cleanupDisposition?: "pending-rollback" | "pending-sandbox-delete";
   } = {},
   deps: DockerGpuPatchDeps = {},
 ): DockerGpuPatchDiagnostics | null {
@@ -180,12 +258,8 @@ export function collectDockerGpuPatchDiagnostics(
   const snapshot = options.snapshot ?? null;
   const classification = options.classification ?? null;
   const redactor = createDockerGpuDiagnosticRedactor(options.additionalSensitiveValues);
-  let discoveredContainerIds: string[] = [];
-  try {
-    discoveredContainerIds = findOpenShellDockerSandboxContainerIds(sandboxName, deps);
-  } catch {
-    discoveredContainerIds = [];
-  }
+  const containerIdentityQuery = queryDiagnosticContainerIds(sandboxName, deps, capture);
+  const discoveredContainerIds = containerIdentityQuery.ids;
   const containerTargets = uniqueStrings([
     ...(context
       ? [context.oldContainerId, context.newContainerId, context.backupContainerName]
@@ -212,10 +286,11 @@ export function collectDockerGpuPatchDiagnostics(
     writeTextFile(dir, name, redactor.redactText(content));
   };
   const writeDiagnosticJson = (name: string, value: unknown): void => {
-    writeTextFile(dir, name, JSON.stringify(redactor.redactValue(value), null, 2));
+    writeJsonFile(dir, name, redactor.redactValue(value));
   };
 
   const cleanupPendingRollback = options.cleanupDisposition === "pending-rollback";
+  const cleanupPendingSandboxDelete = options.cleanupDisposition === "pending-sandbox-delete";
   const prePatchRestored = context?.rolledBack === true;
   const replacementId = fullDockerContainerId(context?.newContainerId);
   const inspectConfirmsReplacementPresent =
@@ -229,10 +304,26 @@ export function collectDockerGpuPatchDiagnostics(
     snapshotConfirmsReplacementPresent || inspectConfirmsReplacementPresent
       ? "present"
       : (context?.replacementPresence ?? "unknown");
+  const expectedContainerId = diagnosticContainerId(context?.newContainerId);
+  const observedContainerIds = discoveredContainerIds
+    .map(diagnosticContainerId)
+    .filter((value): value is string => value !== null);
+  const containerIdentityMatch =
+    expectedContainerId === null || !containerIdentityQuery.ok
+      ? "unknown"
+      : observedContainerIds.length !== 1
+        ? observedContainerIds.length === 0
+          ? "missing"
+          : "ambiguous"
+        : observedContainerIds[0] === expectedContainerId
+          ? "yes"
+          : "no";
   let cleanupDisposition: DockerGpuPatchDiagnostics["cleanupDisposition"];
   let cleanupCommands: string[] = [];
   if (cleanupPendingRollback) {
     cleanupDisposition = "pending_rollback";
+  } else if (cleanupPendingSandboxDelete) {
+    cleanupDisposition = "pending_sandbox_delete";
   } else if (!prePatchRestored) {
     cleanupDisposition = "unknown";
   } else if (replacementPresence === "absent") {
@@ -259,7 +350,16 @@ export function collectDockerGpuPatchDiagnostics(
     `old_container_id=${redactor.redactText(context?.oldContainerId ?? "unknown")}`,
     `new_container_id=${redactor.redactText(context?.newContainerId ?? "unknown")}`,
     `backup_container_name=${redactor.redactText(context?.backupContainerName ?? "none")}`,
-    `rolled_back=${cleanupPendingRollback ? "pending" : context?.rolledBack === true ? "yes" : context?.rolledBack === false ? "failed" : "no"}`,
+    `lifecycle_generation=${redactor.redactText(options.lifecycleGeneration ?? "unknown")}`,
+    `lifecycle_history_dropped=${String(options.lifecycleObservationDroppedCount ?? 0)}`,
+    `capture_stage=${options.captureStage?.replaceAll("-", "_") ?? "unspecified"}`,
+    `expected_container_id=${redactor.redactText(expectedContainerId ?? "unknown")}`,
+    `observed_container_ids=${redactor.redactText(containerIdentityQuery.ok ? observedContainerIds.join(",") || "none" : "unknown")}`,
+    `container_identity_query=${containerIdentityQuery.ok ? "succeeded" : "failed"}`,
+    `container_identity_match=${containerIdentityMatch}`,
+    `cleanup_reason=${redactor.redactText(options.cleanupReason ?? "unknown")}`,
+    `cleanup_started_at=${redactor.redactText(options.cleanupStartedAt ?? "unknown")}`,
+    `rolled_back=${cleanupPendingRollback ? "pending" : cleanupPendingSandboxDelete ? "not_applicable" : context?.rolledBack === true ? "yes" : context?.rolledBack === false ? "failed" : "no"}`,
     ...(context?.replacementStopConfirmed !== undefined
       ? [`replacement_stop_confirmed=${confirmationValue(context.replacementStopConfirmed)}`]
       : []),
@@ -300,12 +400,39 @@ export function collectDockerGpuPatchDiagnostics(
       ...describePatchedContainerState(snapshot.patchedContainerState).map(redactor.redactText),
     );
   }
+  let sandboxGetOutput = "";
+  if (deps.runCaptureOpenshell) {
+    try {
+      sandboxGetOutput = deps.runCaptureOpenshell(["sandbox", "get", sandboxName], {
+        ignoreError: true,
+        timeout: DOCKER_GPU_PATCH_TIMEOUT_MS,
+      });
+    } catch {
+      // The standalone capture loop below still records the other evidence.
+    }
+  }
+  const liveIdentityFingerprint = fingerprintSandboxLiveIdentity(sandboxGetOutput);
+  summaryLines.push(
+    `openshell_identity_fingerprint=${redactor.redactText(liveIdentityFingerprint ?? "unknown")}`,
+  );
   writeDiagnosticText("summary.txt", summaryLines.join("\n"));
   if (snapshot?.patchedContainerState) {
-    writeDiagnosticJson("patched-container-state.json", snapshot.patchedContainerState);
+    writeDiagnosticJson(
+      "patched-container-state.json",
+      redactor.sanitizeState(snapshot.patchedContainerState),
+    );
   }
   if (options.dockerTopOutput?.trim())
     writeDiagnosticText("docker-top.txt", options.dockerTopOutput);
+  if (options.lifecycleObservations?.length) {
+    writeDiagnosticJson("lifecycle-history.json", options.lifecycleObservations);
+  }
+  if (options.forwardDiagnostic?.trim()) {
+    writeDiagnosticText("forward-start.txt", options.forwardDiagnostic);
+  }
+  if (options.forwardListOutput?.trim()) {
+    writeDiagnosticText("forward-list.txt", options.forwardListOutput);
+  }
 
   try {
     const ps = capture(
@@ -357,14 +484,33 @@ export function collectDockerGpuPatchDiagnostics(
       })
       .join("\n");
     if (containerLogs.trim()) writeDiagnosticText("docker-logs.txt", containerLogs);
+    const expectedTarget = context?.newContainerId ?? discoveredContainerIds[0] ?? null;
+    if (expectedTarget) {
+      for (const [fileName, logPath] of [
+        ["managed-startup.log", "/tmp/nemoclaw-start.log"],
+        ["openclaw-gateway.log", "/tmp/gateway.log"],
+      ] as const) {
+        try {
+          const output = capture(
+            ["exec", expectedTarget, "sh", "-c", `test -f ${logPath} && tail -n 240 ${logPath}`],
+            { ignoreError: true, timeout: DOCKER_GPU_PATCH_TIMEOUT_MS },
+          );
+          if (output.trim()) writeDiagnosticText(fileName, output);
+        } catch {
+          // Best effort.
+        }
+      }
+    }
   }
 
   if (deps.runCaptureOpenshell) {
     const captures: Array<[string, string[]]> = [
-      ["openshell-sandbox-get.txt", ["sandbox", "get", sandboxName]],
+      ["openshell-version.txt", ["--version"]],
       ["openshell-sandbox-list.txt", ["sandbox", "list"]],
+      ["openshell-forward-list.txt", ["forward", "list"]],
       ["openshell-logs.txt", ["doctor", "logs", "--name", "nemoclaw"]],
     ];
+    if (sandboxGetOutput.trim()) writeDiagnosticText("openshell-sandbox-get.txt", sandboxGetOutput);
     for (const [fileName, args] of captures) {
       try {
         const output = deps.runCaptureOpenshell(args, {

--- a/src/lib/onboard/docker-gpu-patch-types.ts
+++ b/src/lib/onboard/docker-gpu-patch-types.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ManagedBootstrapRuntimeLifecycleObservation } from "./managed-bootstrap/runtime-create";
+
 type DockerRunResult = {
   status?: number | null;
   stdout?: string | Buffer | null;
@@ -136,9 +138,16 @@ export type DockerGpuCloneRunOptions = {
 export type DockerGpuPatchDiagnostics = {
   dir: string;
   cleanupCommands: string[];
-  cleanupDisposition: "manual" | "not_required" | "pending_rollback" | "unknown";
+  cleanupDisposition:
+    | "manual"
+    | "not_required"
+    | "pending_rollback"
+    | "pending_sandbox_delete"
+    | "unknown";
   summaryLines: string[];
 };
+
+export type DockerRecreateLifecycleObservation = ManagedBootstrapRuntimeLifecycleObservation;
 
 /**
  * Subset of `docker inspect --format '{{json .State}}'` fields surfaced when
@@ -199,6 +208,8 @@ export type DockerContainerInspect = {
   Id?: string;
   Image?: string;
   Name?: string;
+  Created?: string;
+  RestartCount?: number;
   Config?: {
     Image?: string;
     AttachStdin?: boolean;
@@ -216,12 +227,7 @@ export type DockerContainerInspect = {
     StopTimeout?: number | null;
     Volumes?: Record<string, unknown> | null;
   } | null;
-  State?: {
-    Running?: boolean;
-    Paused?: boolean;
-    Restarting?: boolean;
-    Dead?: boolean;
-  } | null;
+  State?: DockerContainerState | null;
   HostConfig?: {
     Binds?: string[] | null;
     Mounts?: Array<{

--- a/src/lib/onboard/docker-gpu-patch.ts
+++ b/src/lib/onboard/docker-gpu-patch.ts
@@ -201,6 +201,7 @@ export function printDockerGpuPatchFailureAndExit(
     context?: DockerGpuPatchFailureContext | null;
     selectedMode?: DockerGpuPatchMode | null;
     additionalSummaryLines?: readonly string[];
+    additionalSensitiveValues?: readonly string[];
     /**
      * Classification captured while the replacement container still existed.
      * The failure path cannot rely on that replacement remaining inspectable
@@ -236,12 +237,13 @@ export function printDockerGpuPatchFailureAndExit(
       snapshot,
       classification,
       additionalSummaryLines: deps.additionalSummaryLines,
+      additionalSensitiveValues: deps.additionalSensitiveValues,
     },
     deps,
   );
   const errorMessage =
     error instanceof Error && error.message
-      ? createDockerGpuDiagnosticRedactor().redactText(error.message)
+      ? createDockerGpuDiagnosticRedactor(deps.additionalSensitiveValues).redactText(error.message)
       : "";
   console.error("");
   console.error("  Docker GPU patch failed.");
@@ -270,6 +272,7 @@ export function printDockerGpuReadinessFailure(
   deps: Pick<DockerGpuPatchDeps, "runCaptureOpenshell" | "dockerCapture"> & {
     context?: DockerGpuPatchFailureContext | null;
     additionalSummaryLines?: readonly string[];
+    additionalSensitiveValues?: readonly string[];
   },
 ): void {
   const context = deps.context ?? null;
@@ -288,6 +291,7 @@ export function printDockerGpuReadinessFailure(
       snapshot,
       classification,
       additionalSummaryLines: deps.additionalSummaryLines,
+      additionalSensitiveValues: deps.additionalSensitiveValues,
     },
     inspectDeps,
   );
@@ -305,6 +309,7 @@ export function printDockerGpuProofFailure(
   deps: Pick<DockerGpuPatchDeps, "runCaptureOpenshell" | "dockerCapture"> & {
     context?: DockerGpuPatchFailureContext | null;
     additionalSummaryLines?: readonly string[];
+    additionalSensitiveValues?: readonly string[];
   },
 ): void {
   const context = deps.context ?? null;
@@ -326,6 +331,7 @@ export function printDockerGpuProofFailure(
       snapshot,
       classification,
       additionalSummaryLines: deps.additionalSummaryLines,
+      additionalSensitiveValues: deps.additionalSensitiveValues,
     },
     inspectDeps,
   );

--- a/src/lib/onboard/docker-gpu-pre-rollback-diagnostics.test.ts
+++ b/src/lib/onboard/docker-gpu-pre-rollback-diagnostics.test.ts
@@ -31,10 +31,14 @@ describe("Docker GPU pre-rollback diagnostics (#6110)", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gpu-pre-rollback-"));
     const secretCanary = "pre-rollback-secret-canary-value";
     const discoveredSecretCanary = "discovered-only-secret-canary-value";
+    const callbackSecretCanary = "callback-only-secret-canary-value";
     const inspectOutput = JSON.stringify([
       {
         Id: "new-container-id",
+        Image: `sha256:${"f".repeat(64)}`,
         Name: "/openshell-alpha",
+        Created: "2026-07-01T22:59:00Z",
+        RestartCount: 2,
         Config: {
           Image: "openshell/sandbox:test",
           Cmd: null,
@@ -47,6 +51,14 @@ describe("Docker GPU pre-rollback diagnostics (#6110)", () => {
           },
         },
         HostConfig: { NetworkMode: "openshell-docker" },
+        State: {
+          Status: "running",
+          Running: true,
+          ExitCode: 0,
+          StartedAt: "2026-07-01T22:59:01Z",
+          FinishedAt: "0001-01-01T00:00:00Z",
+          Health: { Status: "healthy", FailingStreak: 0 },
+        },
         NetworkSettings: { Networks: { "openshell-docker": {} } },
       },
     ]);
@@ -81,13 +93,27 @@ describe("Docker GPU pre-rollback diagnostics (#6110)", () => {
       ["inspect old-container-id", "[]"],
       ["inspect backup-container", "[]"],
       ["inspect discovered-container-id", discoveredInspectOutput],
+      [
+        "exec new-container-id sh -c test -f /tmp/nemoclaw-start.log && tail -n 240 /tmp/nemoclaw-start.log",
+        `managed startup active ${callbackSecretCanary}\n`,
+      ],
+      [
+        "exec new-container-id sh -c test -f /tmp/gateway.log && tail -n 240 /tmp/gateway.log",
+        `OpenClaw gateway active ${callbackSecretCanary}\n`,
+      ],
     ]);
     const dockerCapture = vi.fn((args: readonly string[], _options?: Record<string, unknown>) => {
       return dockerResponses.get(args.join(" ")) ?? "";
     });
     const openshellResponses = new Map([
-      ["sandbox get", `Phase: Error\ndetail=${secretCanary} ${discoveredSecretCanary}\n`],
+      [
+        "sandbox get",
+        `Id: openshell-sandbox-id\nPhase: Error\ndetail=${secretCanary} ${discoveredSecretCanary}\n`,
+      ],
       ["sandbox list", `alpha  Error  ${secretCanary} ${discoveredSecretCanary}\n`],
+      ["--version", "openshell 0.0.101\n"],
+      ["forward list", `alpha 18789 failed ${callbackSecretCanary}\n`],
+      ["doctor logs", `gateway reconnect log ${callbackSecretCanary}\n`],
     ]);
     const runCaptureOpenshell = vi.fn(
       (args: string[], _options?: Record<string, unknown>) =>
@@ -99,21 +125,55 @@ describe("Docker GPU pre-rollback diagnostics (#6110)", () => {
     );
 
     try {
-      const captured = captureDockerGpuPreRollbackDiagnostics("alpha", patchResult(), {
-        dockerCapture,
-        dockerLogs,
-        homedir: () => tmpDir,
-        now: () => new Date("2026-07-01T23:00:00Z"),
-        runCaptureOpenshell,
-      });
+      const captured = captureDockerGpuPreRollbackDiagnostics(
+        "alpha",
+        patchResult(),
+        {
+          dockerCapture,
+          dockerLogs,
+          homedir: () => tmpDir,
+          now: () => new Date("2026-07-01T23:00:00Z"),
+          runCaptureOpenshell,
+        },
+        {
+          captureStage: "post-cutover-pre-cleanup",
+          additionalSensitiveValues: [callbackSecretCanary],
+          additionalSummaryLines: [
+            "recreate_reason=messaging_credential_rotation",
+            "changed_credential_hash_providers=alpha-discord-bridge",
+          ],
+          cleanupReason: "dashboard_forward_start_failed",
+          cleanupStartedAt: "2026-07-01T23:00:01Z",
+          lifecycleGeneration: "generation-2",
+          lifecycleObservationDroppedCount: 3,
+          lifecycleObservations: [
+            {
+              at: "2026-07-01T23:00:00Z",
+              stage: "sandbox_readiness",
+              event: "phase_probe",
+              output: `alpha Ready ${callbackSecretCanary}`,
+            },
+          ],
+          forwardDiagnostic: `sandbox is not ready ${callbackSecretCanary}`,
+          forwardListOutput: `alpha 18789 dead ${callbackSecretCanary}`,
+        },
+      );
       const diagnostics = captured?.diagnostics;
 
       expect(diagnostics?.dir).toBeTruthy();
       const summary = fs.readFileSync(path.join(diagnostics?.dir ?? "", "summary.txt"), "utf-8");
       expect(diagnostics?.cleanupCommands).toEqual([]);
-      expect(summary).toContain("rolled_back=pending");
-      expect(summary).toContain("cleanup_disposition=pending_rollback");
+      expect(summary).toContain("capture_stage=post_cutover_pre_cleanup");
+      expect(summary).toContain("rolled_back=not_applicable");
+      expect(summary).toContain("cleanup_disposition=pending_sandbox_delete");
       expect(summary).toContain("cleanup_required=unknown");
+      expect(summary).toContain("lifecycle_generation=generation-2");
+      expect(summary).toContain("lifecycle_history_dropped=3");
+      expect(summary).toContain("expected_container_id=new-container-id");
+      expect(summary).toContain("container_identity_match=ambiguous");
+      expect(summary).toContain("cleanup_reason=dashboard_forward_start_failed");
+      expect(summary).toContain("changed_credential_hash_providers=alpha-discord-bridge");
+      expect(summary).toMatch(/openshell_identity_fingerprint=[a-f0-9]{64}/);
       expect(summary).not.toContain("openshell sandbox delete");
       expect(
         fs.readFileSync(path.join(diagnostics?.dir ?? "", "docker-top.txt"), "utf-8"),
@@ -126,19 +186,49 @@ describe("Docker GPU pre-rollback diagnostics (#6110)", () => {
       );
       expect(inspect[0]).toMatchObject({
         Id: "new-container-id",
+        Image: `sha256:${"f".repeat(64)}`,
         Config: {
           Image: "openshell/sandbox:test",
           Cmd: null,
           Env: ["OPENSHELL_SANDBOX_COMMAND=<REDACTED>"],
         },
         HostConfig: { NetworkMode: "openshell-docker" },
+        Created: "2026-07-01T22:59:00Z",
+        RestartCount: 2,
+        State: {
+          Status: "running",
+          Running: true,
+          ExitCode: 0,
+          StartedAt: "2026-07-01T22:59:01Z",
+          FinishedAt: "0001-01-01T00:00:00Z",
+          Health: { Status: "healthy", FailingStreak: 0 },
+        },
       });
+      expect(
+        fs.readFileSync(path.join(diagnostics?.dir ?? "", "lifecycle-history.json"), "utf-8"),
+      ).toContain("alpha Ready <REDACTED>");
+      expect(
+        fs.readFileSync(path.join(diagnostics?.dir ?? "", "forward-start.txt"), "utf-8"),
+      ).toContain("sandbox is not ready <REDACTED>");
+      expect(
+        fs.readFileSync(path.join(diagnostics?.dir ?? "", "openshell-version.txt"), "utf-8"),
+      ).toContain("openshell 0.0.101");
+      expect(
+        fs.readFileSync(path.join(diagnostics?.dir ?? "", "openshell-forward-list.txt"), "utf-8"),
+      ).toContain("alpha 18789 failed <REDACTED>");
+      expect(
+        fs.readFileSync(path.join(diagnostics?.dir ?? "", "managed-startup.log"), "utf-8"),
+      ).toContain("managed startup active <REDACTED>");
+      expect(
+        fs.readFileSync(path.join(diagnostics?.dir ?? "", "openclaw-gateway.log"), "utf-8"),
+      ).toContain("OpenClaw gateway active <REDACTED>");
       const diagnosticContents = fs
         .readdirSync(diagnostics?.dir ?? "")
         .map((name) => fs.readFileSync(path.join(diagnostics?.dir ?? "", name), "utf-8"))
         .join("\n");
       expect(diagnosticContents).not.toContain(secretCanary);
       expect(diagnosticContents).not.toContain(discoveredSecretCanary);
+      expect(diagnosticContents).not.toContain(callbackSecretCanary);
       expect(diagnosticContents).not.toContain("untrusted.secret");
       const returnedClassification = JSON.stringify(captured?.classification);
       expect(returnedClassification).not.toContain(secretCanary);
@@ -172,7 +262,7 @@ describe("Docker GPU pre-rollback diagnostics (#6110)", () => {
         expect(Number(options?.timeout)).toBeLessThanOrEqual(2_000);
       }
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining("Pre-rollback diagnostics saved:"),
+        expect.stringContaining("Pre-cleanup diagnostics saved:"),
       );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -331,6 +421,8 @@ describe("Docker GPU pre-rollback diagnostics (#6110)", () => {
       );
       expect(`${summary}\n${state}`).not.toContain(canary);
       expect(summary).toContain("sandbox_list_row=alpha Error <REDACTED>");
+      expect(summary).toContain("container_identity_query=failed");
+      expect(summary).toContain("container_identity_match=unknown");
       expect(JSON.parse(state).Error).toBe("state <REDACTED>");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/lib/onboard/docker-gpu-pre-rollback-diagnostics.ts
+++ b/src/lib/onboard/docker-gpu-pre-rollback-diagnostics.ts
@@ -23,6 +23,7 @@ import type {
   DockerGpuPatchFailureClassification,
   DockerGpuPatchFailureContext,
   DockerGpuPatchResult,
+  DockerRecreateLifecycleObservation,
 } from "./docker-gpu-patch-types";
 
 const PRE_ROLLBACK_DIAGNOSTICS_TOTAL_BUDGET_MS = 10_000;
@@ -66,7 +67,12 @@ function boundedDiagnosticsDeps(deps: PreRollbackDiagnosticsDeps): PreRollbackDi
     ...deps,
     dockerCapture: (args, options) => {
       const bounded = boundedOptions(options);
-      if (!bounded) return "";
+      if (!bounded) {
+        if (options?.ignoreError === false) {
+          throw new Error("Diagnostic capture budget exhausted before Docker query.");
+        }
+        return "";
+      }
       return capture(args, bounded);
     },
     dockerLogs: (containerName, options) => {
@@ -135,6 +141,20 @@ export type DockerGpuPreRollbackDiagnostics = {
   diagnostics: DockerGpuPatchDiagnostics | null;
 };
 
+export type DockerRecreateFailureDiagnosticOptions = {
+  error?: unknown;
+  additionalSummaryLines?: readonly string[];
+  additionalSensitiveValues?: readonly string[];
+  cleanupReason?: string | null;
+  cleanupStartedAt?: string | null;
+  lifecycleGeneration?: string | null;
+  lifecycleObservations?: readonly DockerRecreateLifecycleObservation[];
+  lifecycleObservationDroppedCount?: number;
+  forwardDiagnostic?: string | null;
+  forwardListOutput?: string | null;
+  captureStage?: "pre-rollback" | "post-cutover-pre-cleanup";
+};
+
 function logsShowMissingManagedStartupCommand(logs: string): boolean {
   return MISSING_MANAGED_STARTUP_COMMAND_LOG.test(logs);
 }
@@ -143,7 +163,9 @@ export function captureDockerGpuPreRollbackDiagnostics(
   sandboxName: string,
   result: DockerGpuPatchResult,
   deps: PreRollbackDiagnosticsDeps = {},
+  options: DockerRecreateFailureDiagnosticOptions = {},
 ): DockerGpuPreRollbackDiagnostics | null {
+  const captureStage = options.captureStage ?? "pre-rollback";
   const context: DockerGpuPatchFailureContext = {
     sandboxName,
     oldContainerId: result.oldContainerId,
@@ -160,11 +182,10 @@ export function captureDockerGpuPreRollbackDiagnostics(
     { patchedContainerId: result.newContainerId },
     diagnosticDeps,
   );
-  const additionalSensitiveValues = primeSensitiveDiagnosticValues(
-    sandboxName,
-    result,
-    diagnosticDeps,
-  );
+  const additionalSensitiveValues = [
+    ...primeSensitiveDiagnosticValues(sandboxName, result, diagnosticDeps),
+    ...(options.additionalSensitiveValues ?? []),
+  ];
   let patchedContainerLogs = "";
   try {
     const logs = diagnosticDeps.dockerLogs ?? defaultDockerLogs;
@@ -194,16 +215,30 @@ export function captureDockerGpuPreRollbackDiagnostics(
   const diagnostics = collectDockerGpuPatchDiagnostics(
     sandboxName,
     {
+      error: options.error,
       context,
       selectedMode: result.mode,
       snapshot,
       classification,
       additionalSensitiveValues,
+      additionalSummaryLines: options.additionalSummaryLines,
       dockerTopOutput,
-      cleanupDisposition: "pending-rollback",
+      cleanupReason: options.cleanupReason,
+      cleanupStartedAt: options.cleanupStartedAt,
+      lifecycleGeneration: options.lifecycleGeneration,
+      lifecycleObservations: options.lifecycleObservations,
+      lifecycleObservationDroppedCount: options.lifecycleObservationDroppedCount,
+      forwardDiagnostic: options.forwardDiagnostic,
+      forwardListOutput: options.forwardListOutput,
+      captureStage,
+      cleanupDisposition:
+        captureStage === "pre-rollback" ? "pending-rollback" : "pending-sandbox-delete",
     },
     diagnosticDeps,
   );
-  if (diagnostics) console.error(`  Pre-rollback diagnostics saved: ${diagnostics.dir}`);
+  if (diagnostics) {
+    const label = captureStage === "pre-rollback" ? "Pre-rollback" : "Pre-cleanup";
+    console.error(`  ${label} diagnostics saved: ${diagnostics.dir}`);
+  }
   return { classification: redactedClassification, diagnostics };
 }

--- a/src/lib/onboard/docker-gpu-sandbox-create-diagnostics.test.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create-diagnostics.test.ts
@@ -29,6 +29,16 @@ const RESULT: DockerGpuPatchResult = {
   backupRemoved: false,
 };
 
+const STARTUP_RESULT: DockerGpuPatchResult = {
+  ...RESULT,
+  mode: {
+    kind: "startup-command",
+    label: "persistent sandbox startup command",
+    device: "",
+    args: [],
+  },
+};
+
 describe("Docker GPU create diagnostics fail-safety (#6110)", () => {
   afterEach(() => vi.restoreAllMocks());
 
@@ -69,9 +79,7 @@ describe("Docker GPU create diagnostics fail-safety (#6110)", () => {
     expect(finalizeBackup).toHaveBeenCalledWith({ result: RESULT, supervisorReady: false }, deps);
     expect(onPatchFailureExit).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "Could not capture the failed GPU container before rollback: disk full",
-      ),
+      "  ⚠ Could not capture the failed container before rollback.",
     );
   });
 
@@ -85,7 +93,9 @@ describe("Docker GPU create diagnostics fail-safety (#6110)", () => {
     };
     const recreatePatch = vi.fn(() => RESULT);
     const waitForSupervisor = vi.fn(() => false);
-    const capturePreRollbackDiagnostics = vi.fn(() => null);
+    const capturePreRollbackDiagnostics = vi.fn<typeof captureDockerGpuPreRollbackDiagnostics>(
+      () => null,
+    );
     const finalizeBackup = vi.fn(() => ({
       backupRemoved: false,
       rolledBack: true,
@@ -112,7 +122,12 @@ describe("Docker GPU create diagnostics fail-safety (#6110)", () => {
       expect.objectContaining({ waitForSupervisor: false }),
       deps,
     );
-    expect(capturePreRollbackDiagnostics).toHaveBeenCalledWith("alpha", RESULT, deps);
+    expect(capturePreRollbackDiagnostics).toHaveBeenCalledWith(
+      "alpha",
+      RESULT,
+      deps,
+      expect.objectContaining({ cleanupReason: "supervisor_reconnect_failed" }),
+    );
     expect(capturePreRollbackDiagnostics.mock.invocationCallOrder[0]).toBeLessThan(
       finalizeBackup.mock.invocationCallOrder[0],
     );
@@ -195,6 +210,111 @@ describe("Docker GPU create diagnostics fail-safety (#6110)", () => {
       expect.any(Error),
       expect.objectContaining({ preRollbackClassification: null }),
     );
+  });
+
+  it("retains startup replacement evidence after backup finalization and before cleanup (#8690)", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const secretCanary = "opaque-diagnostic-secret";
+    const deps = {
+      runOpenshell: vi.fn(() => ({ status: 0 })),
+      runCaptureOpenshell: vi.fn(() => "alpha Error"),
+      sleep: vi.fn(),
+      dockerCapture: vi.fn(() => ""),
+    };
+    const capturePreRollbackDiagnostics = vi.fn<typeof captureDockerGpuPreRollbackDiagnostics>(
+      () => null,
+    );
+    const finalizeBackup = vi.fn(() => ({
+      backupRemoved: true,
+      rolledBack: false,
+    }));
+    const patch = createDockerGpuSandboxCreatePatch({
+      route: "none",
+      persistStartupCommand: true,
+      sandboxName: "alpha",
+      openshellSandboxCommand: ["env", "nemoclaw-start"],
+      timeoutSecs: 60,
+      lifecycleGeneration: "generation-2",
+      diagnosticSummaryLines: ["changed_credential_hash_providers=alpha-discord-bridge"],
+      diagnosticSensitiveValues: [secretCanary],
+      deps,
+      overrides: {
+        recreateStartupPatch: vi.fn(() => STARTUP_RESULT),
+        waitForSupervisor: vi.fn((_name, _timeout, reconnectDeps) => {
+          reconnectDeps.runOpenshell?.(["sandbox", "exec", "-n", "alpha", "--", "true"]);
+          reconnectDeps.runCaptureOpenshell?.(["sandbox", "list"]);
+          return true;
+        }),
+        capturePreRollbackDiagnostics,
+        finalizeBackup,
+      },
+    });
+
+    await patch.ensureApplied();
+    patch.waitForSupervisorReconnectIfNeeded();
+    await patch.commitAfterReady();
+    for (let attempt = 0; attempt < 130; attempt += 1) {
+      patch.recordLifecycleObservation({
+        stage: "sandbox_readiness",
+        event: "phase_probe",
+        attempt,
+        output: `alpha Ready poll ${String(attempt)}`,
+      });
+    }
+    patch.recordLifecycleObservation({
+      stage: "dashboard_readiness",
+      event: "timeout",
+      output: `${"x".repeat(1_600)}${secretCanary}`,
+    });
+    patch.captureLifecycleFailureDiagnostics({
+      error: new Error("sandbox is not ready"),
+      cleanupReason: "dashboard_forward_start_failed",
+      cleanupStartedAt: "2026-08-10T00:00:00Z",
+      forwardDiagnostic: `sandbox is not ready ${secretCanary}`,
+      forwardListOutput: "",
+    });
+
+    expect(capturePreRollbackDiagnostics).toHaveBeenCalledWith(
+      "alpha",
+      STARTUP_RESULT,
+      deps,
+      expect.objectContaining({
+        additionalSummaryLines: expect.arrayContaining([
+          "selected_gpu_route=none",
+          "changed_credential_hash_providers=alpha-discord-bridge",
+        ]),
+        additionalSensitiveValues: [secretCanary],
+        cleanupReason: "dashboard_forward_start_failed",
+        captureStage: "post-cutover-pre-cleanup",
+        lifecycleGeneration: "generation-2",
+        lifecycleObservationDroppedCount: 8,
+        lifecycleObservations: expect.arrayContaining([
+          expect.objectContaining({
+            stage: "container_recreate",
+            event: "replacement_started",
+            output: expect.stringContaining("new_container_id=new-container-id"),
+          }),
+          expect.objectContaining({ stage: "supervisor_reconnect", event: "exec_probe" }),
+          expect.objectContaining({
+            stage: "supervisor_reconnect",
+            event: "sandbox_phase_probe",
+            output: "alpha Error",
+          }),
+          expect.objectContaining({ stage: "supervisor_reconnect", event: "reconnected" }),
+          expect.objectContaining({ stage: "backup_finalize", event: "backup_removed" }),
+          expect.objectContaining({ stage: "dashboard_readiness", event: "timeout" }),
+        ]),
+      }),
+    );
+    const lifecycleObservations = capturePreRollbackDiagnostics.mock.calls[0]?.[3]
+      ?.lifecycleObservations as readonly { stage: string; event: string }[];
+    expect(JSON.stringify(lifecycleObservations)).not.toContain(secretCanary);
+    expect(JSON.stringify(lifecycleObservations)).toContain(
+      "oversized single-line lifecycle output omitted",
+    );
+    expect(
+      lifecycleObservations.findIndex(({ stage }) => stage === "backup_finalize"),
+    ).toBeLessThan(lifecycleObservations.findIndex(({ stage }) => stage === "dashboard_readiness"));
   });
 
   it("uses exact-ID cleanup when a restored sandbox retains the failed replacement (#7996)", () => {

--- a/src/lib/onboard/docker-gpu-sandbox-create-lifecycle.test.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create-lifecycle.test.ts
@@ -239,7 +239,12 @@ describe("createDockerGpuSandboxCreatePatch composed flow", () => {
     patch.maybeApplyDuringCreate();
     patch.waitForSupervisorReconnectIfNeeded();
 
-    expect(capturePreRollbackDiagnostics).toHaveBeenCalledWith("alpha", result, deps);
+    expect(capturePreRollbackDiagnostics).toHaveBeenCalledWith(
+      "alpha",
+      result,
+      deps,
+      expect.objectContaining({ cleanupReason: "supervisor_reconnect_failed" }),
+    );
     expect(capturePreRollbackDiagnostics.mock.invocationCallOrder[0]).toBeLessThan(
       finalizeBackup.mock.invocationCallOrder[0],
     );

--- a/src/lib/onboard/docker-gpu-sandbox-create.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create.ts
@@ -3,6 +3,7 @@
 
 import { getSandboxFailurePhase } from "../state/gateway";
 import type { SandboxGpuProofResult } from "../state/registry";
+import { createDockerGpuDiagnosticRedactor } from "./docker-gpu-diagnostic-redaction";
 import {
   getDockerGpuSupervisorReconnectTimeoutSecs,
   printDockerGpuPatchFailureAndExit,
@@ -19,8 +20,13 @@ import type {
   DockerGpuPatchFailureContext,
   DockerGpuPatchMode,
   DockerGpuPatchResult,
+  DockerRecreateLifecycleObservation,
 } from "./docker-gpu-patch-types";
-import { captureDockerGpuPreRollbackDiagnostics } from "./docker-gpu-pre-rollback-diagnostics";
+import {
+  captureDockerGpuPreRollbackDiagnostics,
+  type DockerGpuPreRollbackDiagnostics,
+  type DockerRecreateFailureDiagnosticOptions,
+} from "./docker-gpu-pre-rollback-diagnostics";
 import type { SelectedDockerGpuRoute } from "./docker-gpu-route";
 import { adaptDockerGpuRouteForPatch } from "./docker-gpu-route-patch-adapter";
 import { isDockerDesktopWslRuntime } from "./docker-gpu-sandbox-create-plan";
@@ -83,6 +89,9 @@ type DockerGpuSandboxCreatePatchOptions = {
   openshellSandboxCommand?: readonly string[] | null;
   requiredUlimits?: Parameters<RecreateStartupPatchFn>[0]["requiredUlimits"];
   timeoutSecs: number;
+  lifecycleGeneration?: string | null;
+  diagnosticSummaryLines?: readonly string[];
+  diagnosticSensitiveValues?: readonly string[];
   backend?: DockerGpuPatchBackend;
   /**
    * Whether the host is Docker Desktop WSL. Defaults to the cached
@@ -130,6 +139,12 @@ export type DockerGpuSandboxCreatePatch = {
    */
   commitAfterReady: () => Promise<void>;
   selectedMode: () => DockerGpuPatchMode | null;
+  recordLifecycleObservation: (
+    observation: Omit<DockerRecreateLifecycleObservation, "at"> & { at?: string },
+  ) => void;
+  captureLifecycleFailureDiagnostics: (
+    options: DockerRecreateFailureDiagnosticOptions,
+  ) => DockerGpuPreRollbackDiagnostics | null;
   /**
    * Print the Docker GPU readiness-failure block (including the Error-phase
    * classification + patched container State diagnostics) when the
@@ -160,6 +175,35 @@ export function createDockerGpuSandboxCreatePatch(
   let cutoverFinalization: Promise<void> | null = null;
   let cutoverFinalizationOutcome: "commit" | "rollback" | null = null;
   let cutoverFinalizationFailure: Error | null = null;
+  const lifecycleObservations: DockerRecreateLifecycleObservation[] = [];
+  let lifecycleObservationDroppedCount = 0;
+  const lifecycleRedactor = createDockerGpuDiagnosticRedactor(options.diagnosticSensitiveValues);
+  const boundLifecycleOutput = (value: string | undefined): string | undefined => {
+    if (value === undefined) return undefined;
+    const redacted = lifecycleRedactor.redactText(value);
+    if (Buffer.byteLength(redacted) <= 1_500) return redacted;
+    const tail = Buffer.from(redacted).subarray(-1_500).toString("utf8");
+    const firstNewline = tail.indexOf("\n");
+    return firstNewline < 0
+      ? "[oversized single-line lifecycle output omitted]"
+      : `[lifecycle output truncated to complete trailing lines]\n${tail.slice(firstNewline + 1)}`;
+  };
+  const recordLifecycleObservation = (
+    observation: Omit<DockerRecreateLifecycleObservation, "at"> & { at?: string },
+  ): void => {
+    const output = boundLifecycleOutput(observation.output);
+    lifecycleObservations.push({
+      ...observation,
+      ...(output === undefined ? {} : { output }),
+      at: observation.at ?? new Date().toISOString(),
+    });
+    if (lifecycleObservations.length > 128) {
+      // Preserve the create/replacement anchors while retaining the newest
+      // readiness and cleanup evidence around the failure.
+      lifecycleObservations.splice(16, 1);
+      lifecycleObservationDroppedCount += 1;
+    }
+  };
 
   const findContainerIds =
     options.overrides?.findContainerIds ?? findOpenShellDockerSandboxContainerIds;
@@ -179,6 +223,27 @@ export function createDockerGpuSandboxCreatePatch(
     homedir: options.deps.homedir,
     now: options.deps.now,
   };
+  const mergeFailureDiagnosticOptions = (
+    diagnosticOptions: DockerRecreateFailureDiagnosticOptions = {},
+  ) => ({
+    ...diagnosticOptions,
+    additionalSummaryLines: [
+      ...(routeAdapter.additionalSummaryLines ?? []),
+      ...(options.diagnosticSummaryLines ?? []),
+      ...(diagnosticOptions.additionalSummaryLines ?? []),
+    ],
+    additionalSensitiveValues: [
+      ...(options.diagnosticSensitiveValues ?? []),
+      ...(diagnosticOptions.additionalSensitiveValues ?? []),
+    ],
+    lifecycleGeneration: options.lifecycleGeneration ?? null,
+    lifecycleObservations,
+    lifecycleObservationDroppedCount,
+    captureStage:
+      cutoverFinalized && cutoverFinalizationOutcome === "commit"
+        ? ("post-cutover-pre-cleanup" as const)
+        : ("pre-rollback" as const),
+  });
 
   const applyOptions = {
     sandboxName: options.sandboxName,
@@ -207,6 +272,11 @@ export function createDockerGpuSandboxCreatePatch(
     if (!recreationEnabled) return;
     result = recreateSelectedPatch(false, deps);
     needsSupervisorWait = true;
+    recordLifecycleObservation({
+      stage: "container_recreate",
+      event: "replacement_started",
+      output: `old_container_id=${result.oldContainerId}\nnew_container_id=${result.newContainerId}\nbackup_container_name=${result.backupContainerName}`,
+    });
     console.log(`  ✓ Docker container mode selected: ${result.mode.label}`);
   };
 
@@ -262,7 +332,11 @@ export function createDockerGpuSandboxCreatePatch(
     onPatchFailureExit(options.sandboxName, patchError, {
       runCaptureOpenshell: options.deps.runCaptureOpenshell,
       dockerCapture: options.deps.dockerCapture,
-      additionalSummaryLines: routeAdapter.additionalSummaryLines,
+      additionalSummaryLines: [
+        ...routeAdapter.additionalSummaryLines,
+        ...(options.diagnosticSummaryLines ?? []),
+      ],
+      additionalSensitiveValues: options.diagnosticSensitiveValues,
     });
   };
   const selectedMode = (): DockerGpuPatchMode | null =>
@@ -317,7 +391,11 @@ export function createDockerGpuSandboxCreatePatch(
       if (!rollbackError) return;
       onPatchFailureExit(options.sandboxName, rollbackError, {
         ...failureDiagnosticDeps,
-        additionalSummaryLines: routeAdapter.additionalSummaryLines,
+        additionalSummaryLines: [
+          ...routeAdapter.additionalSummaryLines,
+          ...(options.diagnosticSummaryLines ?? []),
+        ],
+        additionalSensitiveValues: options.diagnosticSensitiveValues,
         context: {
           ...failureContext(),
           rolledBack: false,
@@ -348,11 +426,35 @@ export function createDockerGpuSandboxCreatePatch(
         options.sandboxName,
         supervisorReconnectTimeoutSecs,
         {
-          runOpenshell: options.deps.runOpenshell,
-          runCaptureOpenshell: options.deps.runCaptureOpenshell,
+          runOpenshell: options.deps.runOpenshell
+            ? (args, runOptions) => {
+                const reconnectResult = options.deps.runOpenshell?.(args, runOptions) ?? {};
+                recordLifecycleObservation({
+                  stage: "supervisor_reconnect",
+                  event: "exec_probe",
+                  status: reconnectResult.status ?? null,
+                });
+                return reconnectResult;
+              }
+            : undefined,
+          runCaptureOpenshell: options.deps.runCaptureOpenshell
+            ? (args, runOptions) => {
+                const output = options.deps.runCaptureOpenshell?.(args, runOptions) ?? "";
+                recordLifecycleObservation({
+                  stage: "supervisor_reconnect",
+                  event: "sandbox_phase_probe",
+                  output,
+                });
+                return output;
+              }
+            : undefined,
           sleep: options.deps.sleep,
         },
       );
+      recordLifecycleObservation({
+        stage: "supervisor_reconnect",
+        event: supervisorReady ? "reconnected" : "failed",
+      });
       if (supervisorReady) {
         // Reconnect completes the legacy recreation check. Keep its rollback
         // backup until the caller accepts authoritative Ready and the required
@@ -368,11 +470,18 @@ export function createDockerGpuSandboxCreatePatch(
       if (result) {
         try {
           preRollbackClassification =
-            captureFailedClone(options.sandboxName, result, options.deps)?.classification ?? null;
-        } catch (error) {
-          console.warn(
-            `  ⚠ Could not capture the failed GPU container before rollback: ${error instanceof Error ? error.message : String(error)}`,
-          );
+            captureFailedClone(
+              options.sandboxName,
+              result,
+              options.deps,
+              mergeFailureDiagnosticOptions({
+                error: new Error("OpenShell supervisor did not reconnect before rollback."),
+                cleanupReason: "supervisor_reconnect_failed",
+                cleanupStartedAt: new Date().toISOString(),
+              }),
+            )?.classification ?? null;
+        } catch {
+          console.warn("  ⚠ Could not capture the failed container before rollback.");
         }
       }
       const finalizeOutcome = result
@@ -389,7 +498,11 @@ export function createDockerGpuSandboxCreatePatch(
         dockerLogs: options.deps.dockerLogs,
         homedir: options.deps.homedir,
         now: options.deps.now,
-        additionalSummaryLines: routeAdapter.additionalSummaryLines,
+        additionalSummaryLines: [
+          ...routeAdapter.additionalSummaryLines,
+          ...(options.diagnosticSummaryLines ?? []),
+        ],
+        additionalSensitiveValues: options.diagnosticSensitiveValues,
         preRollbackClassification,
         context: {
           sandboxName: options.sandboxName,
@@ -420,7 +533,11 @@ export function createDockerGpuSandboxCreatePatch(
         onPatchFailureExit(options.sandboxName, failure, {
           runCaptureOpenshell: options.deps.runCaptureOpenshell,
           dockerCapture: options.deps.dockerCapture,
-          additionalSummaryLines: routeAdapter.additionalSummaryLines,
+          additionalSummaryLines: [
+            ...routeAdapter.additionalSummaryLines,
+            ...(options.diagnosticSummaryLines ?? []),
+          ],
+          additionalSensitiveValues: options.diagnosticSensitiveValues,
         });
         throw failure;
       }
@@ -455,7 +572,11 @@ export function createDockerGpuSandboxCreatePatch(
             onPatchFailureExit(options.sandboxName, failure, {
               runCaptureOpenshell: options.deps.runCaptureOpenshell,
               dockerCapture: options.deps.dockerCapture,
-              additionalSummaryLines: routeAdapter.additionalSummaryLines,
+              additionalSummaryLines: [
+                ...routeAdapter.additionalSummaryLines,
+                ...(options.diagnosticSummaryLines ?? []),
+              ],
+              additionalSensitiveValues: options.diagnosticSensitiveValues,
               context: {
                 ...failureContext(),
                 rolledBack: rollbackError === null,
@@ -468,6 +589,10 @@ export function createDockerGpuSandboxCreatePatch(
           ? finalizeBackup({ result, supervisorReady: true }, options.deps)
           : null;
         cutoverFinalized = true;
+        recordLifecycleObservation({
+          stage: "backup_finalize",
+          event: finalizeOutcome?.backupRemoved ? "backup_removed" : "backup_removal_failed",
+        });
         if (!finalizeOutcome || finalizeOutcome.backupRemoved) return;
         const failure = new Error(
           "Managed startup passed Ready, but its rollback backup could not be removed.",
@@ -476,7 +601,11 @@ export function createDockerGpuSandboxCreatePatch(
         onPatchFailureExit(options.sandboxName, failure, {
           runCaptureOpenshell: options.deps.runCaptureOpenshell,
           dockerCapture: options.deps.dockerCapture,
-          additionalSummaryLines: routeAdapter.additionalSummaryLines,
+          additionalSummaryLines: [
+            ...routeAdapter.additionalSummaryLines,
+            ...(options.diagnosticSummaryLines ?? []),
+          ],
+          additionalSensitiveValues: options.diagnosticSensitiveValues,
           context: failureContext(),
         });
         throw failure;
@@ -497,13 +626,29 @@ export function createDockerGpuSandboxCreatePatch(
       return selectedMode();
     },
 
+    recordLifecycleObservation,
+
+    captureLifecycleFailureDiagnostics(diagnosticOptions) {
+      if (!result) return null;
+      return captureFailedClone(
+        options.sandboxName,
+        result,
+        options.deps,
+        mergeFailureDiagnosticOptions(diagnosticOptions),
+      );
+    },
+
     printReadinessFailureIfEnabled() {
       if (!routeAdapter.enabled) return;
       printDockerGpuReadinessFailure(options.sandboxName, selectedMode(), {
         runCaptureOpenshell: options.deps.runCaptureOpenshell,
         dockerCapture: options.deps.dockerCapture,
         context: failureContext(),
-        additionalSummaryLines: routeAdapter.additionalSummaryLines,
+        additionalSummaryLines: [
+          ...routeAdapter.additionalSummaryLines,
+          ...(options.diagnosticSummaryLines ?? []),
+        ],
+        additionalSensitiveValues: options.diagnosticSensitiveValues,
       });
     },
 
@@ -533,7 +678,11 @@ export function createDockerGpuSandboxCreatePatch(
             runCaptureOpenshell: options.deps.runCaptureOpenshell,
             dockerCapture: options.deps.dockerCapture,
             context: currentFailureContext,
-            additionalSummaryLines: routeAdapter.additionalSummaryLines,
+            additionalSummaryLines: [
+              ...routeAdapter.additionalSummaryLines,
+              ...(options.diagnosticSummaryLines ?? []),
+            ],
+            additionalSensitiveValues: options.diagnosticSensitiveValues,
           });
           const rollbackError = await rollbackAfterFailure();
           if (rollbackError) {
@@ -559,7 +708,11 @@ export function createDockerGpuSandboxCreatePatch(
           runCaptureOpenshell: options.deps.runCaptureOpenshell,
           dockerCapture: options.deps.dockerCapture,
           context: routeAdapter.enabled ? currentFailureContext : null,
-          additionalSummaryLines: routeAdapter.additionalSummaryLines,
+          additionalSummaryLines: [
+            ...routeAdapter.additionalSummaryLines,
+            ...(options.diagnosticSummaryLines ?? []),
+          ],
+          additionalSensitiveValues: options.diagnosticSensitiveValues,
         });
         const rollbackError = await rollbackAfterFailure();
         if (rollbackError) {

--- a/src/lib/onboard/docker-startup-command-sandbox-create.test.ts
+++ b/src/lib/onboard/docker-startup-command-sandbox-create.test.ts
@@ -144,7 +144,12 @@ describe("Docker startup-command sandbox creation", () => {
     patch.maybeApplyDuringCreate();
     patch.waitForSupervisorReconnectIfNeeded();
 
-    expect(capturePreRollbackDiagnostics).toHaveBeenCalledWith("alpha", result, deps);
+    expect(capturePreRollbackDiagnostics).toHaveBeenCalledWith(
+      "alpha",
+      result,
+      deps,
+      expect.objectContaining({ cleanupReason: "supervisor_reconnect_failed" }),
+    );
     expect(capturePreRollbackDiagnostics.mock.invocationCallOrder[0]).toBeLessThan(
       finalizeBackup.mock.invocationCallOrder[0],
     );

--- a/src/lib/onboard/managed-bootstrap/runtime-create.ts
+++ b/src/lib/onboard/managed-bootstrap/runtime-create.ts
@@ -37,6 +37,35 @@ export interface ManagedBootstrapRuntimeLimit {
   readonly hard: number;
 }
 
+export interface ManagedBootstrapRuntimeLifecycleObservation {
+  readonly at: string;
+  readonly stage:
+    | "create_stream"
+    | "container_recreate"
+    | "supervisor_reconnect"
+    | "sandbox_readiness"
+    | "backup_finalize"
+    | "dashboard_readiness"
+    | "dashboard_forward";
+  readonly event: string;
+  readonly attempt?: number;
+  readonly status?: number | null;
+  readonly output?: string;
+}
+
+export interface ManagedBootstrapRuntimeFailureDiagnosticOptions {
+  readonly error?: unknown;
+  readonly additionalSummaryLines?: readonly string[];
+  readonly additionalSensitiveValues?: readonly string[];
+  readonly cleanupReason?: string | null;
+  readonly cleanupStartedAt?: string | null;
+  readonly lifecycleGeneration?: string | null;
+  readonly lifecycleObservations?: readonly ManagedBootstrapRuntimeLifecycleObservation[];
+  readonly lifecycleObservationDroppedCount?: number;
+  readonly forwardDiagnostic?: string | null;
+  readonly forwardListOutput?: string | null;
+}
+
 /** Provider-neutral lifecycle surface consumed by sandbox-create coordinators. */
 export interface ManagedBootstrapRuntimePatch {
   maybeApplyDuringCreate(): void | Promise<void>;
@@ -52,6 +81,12 @@ export interface ManagedBootstrapRuntimePatch {
     readonly device: string;
     readonly args: readonly string[];
   } | null;
+  recordLifecycleObservation(
+    observation: Omit<ManagedBootstrapRuntimeLifecycleObservation, "at"> & { at?: string },
+  ): void;
+  captureLifecycleFailureDiagnostics(
+    options: ManagedBootstrapRuntimeFailureDiagnosticOptions,
+  ): unknown;
   printReadinessFailureIfEnabled(): void;
   verifyGpuOrExit(
     verifyDirectSandboxGpu: (sandboxName: string) => SandboxGpuProofResult,

--- a/src/lib/onboard/messaging-credentials.ts
+++ b/src/lib/onboard/messaging-credentials.ts
@@ -78,3 +78,19 @@ export function detectMessagingCredentialRotation(
   }
   return { changed: changedProviders.length > 0, changedProviders };
 }
+
+export function buildMessagingCredentialRecreateDiagnosticLines(
+  tokenDefs: readonly MessagingTokenDefinition[],
+  changedProviders: readonly string[],
+): string[] {
+  const changedProviderNames = new Set(changedProviders);
+  const providerNames = tokenDefs.map(({ name }) => name).sort();
+  return [
+    "recreate_reason=messaging_credential_rotation",
+    `provider_identities=${providerNames.join(",") || "none"}`,
+    `changed_credential_hash_providers=${[...changedProviderNames].sort().join(",") || "none"}`,
+    `unchanged_credential_hash_providers=${
+      providerNames.filter((name) => !changedProviderNames.has(name)).join(",") || "none"
+    }`,
+  ];
+}

--- a/src/lib/onboard/messaging-host-forward.test.ts
+++ b/src/lib/onboard/messaging-host-forward.test.ts
@@ -170,10 +170,22 @@ describe("ensureMessagingHostForwardIfConfigured", () => {
   });
 
   it("rolls back and exits when the forward cannot be started", () => {
+    const callOrder: string[] = [];
     const ensureForward = vi.fn(() => false);
-    const runOpenshell = vi.fn((args: string[]) => ({
-      status: args[0] === "sandbox" && args[1] === "delete" ? 0 : 0,
-    }));
+    const runOpenshell = vi.fn((args: string[]) => {
+      if (args[0] === "forward" && args[1] === "stop") callOrder.push("stop");
+      if (args[0] === "sandbox" && args[1] === "delete") callOrder.push("delete");
+      return { status: 0 };
+    });
+    const beforeSandboxRollback = vi.fn((context) => {
+      callOrder.push("diagnostics");
+      expect(context).toMatchObject({
+        sandboxName: "demo",
+        reason: "messaging_forward_start_failed",
+        forwardPort: 3978,
+      });
+      expect(context).not.toHaveProperty("dashboardPort");
+    });
     const errors: string[] = [];
 
     expect(() =>
@@ -186,6 +198,7 @@ describe("ensureMessagingHostForwardIfConfigured", () => {
           runOpenshell,
           cliName: () => "nemoclaw",
           forwardPortsToStop: ["18789", undefined, 3978],
+          beforeSandboxRollback,
           error: (message = "") => errors.push(message),
           exit: (code) => {
             throw new Error(`process.exit(${code})`);
@@ -208,9 +221,38 @@ describe("ensureMessagingHostForwardIfConfigured", () => {
       ignoreError: true,
     });
     expect(runOpenshell).toHaveBeenCalledTimes(3);
+    expect(callOrder).toEqual(["diagnostics", "stop", "stop", "delete"]);
     expect(errors.join("\n")).toContain("rollback:true");
     expect(errors.join("\n")).toContain(
       "Failed to start Microsoft Teams webhook forward on port 3978",
     );
+  });
+
+  it("does not let diagnostic capture failure block messaging forward cleanup", () => {
+    const runOpenshell = vi.fn(() => ({ status: 0 }));
+
+    expect(() =>
+      ensureMessagingHostForwardIfConfigured({
+        sandboxName: "demo",
+        plan: makePlan(),
+        ensureForward: vi.fn(() => false),
+        note: vi.fn(),
+        rollbackOnFailure: {
+          runOpenshell,
+          cliName: () => "nemoclaw",
+          beforeSandboxRollback: () => {
+            throw new Error("diagnostic failure");
+          },
+          exit: (code) => {
+            throw new Error(`process.exit(${code})`);
+          },
+          buildRollbackMessage: () => [],
+        },
+      }),
+    ).toThrow("process.exit(1)");
+
+    expect(runOpenshell).toHaveBeenCalledWith(["sandbox", "delete", "demo"], {
+      ignoreError: true,
+    });
   });
 });

--- a/src/lib/onboard/messaging-host-forward.ts
+++ b/src/lib/onboard/messaging-host-forward.ts
@@ -10,6 +10,7 @@ import { hydrateDerivedSandboxMessagingPlanFields } from "../messaging/hydration
 import type { SandboxMessagingHostForwardPlan } from "../messaging/manifest";
 import { parseSandboxMessagingPlan } from "../messaging/plan-validation";
 import * as registry from "../state/registry";
+import type { DashboardForwardOptions } from "./dashboard-forward-control";
 
 type RunOpenshell = (
   args: string[],
@@ -25,6 +26,7 @@ export interface MessagingHostForwardRollbackOptions {
   ) => readonly string[];
   readonly cliName: () => string;
   readonly forwardPortsToStop?: readonly (number | string | null | undefined)[];
+  readonly beforeSandboxRollback?: DashboardForwardOptions["beforeSandboxRollback"];
   readonly error?: (message?: string) => void;
   readonly exit?: (code: number) => never;
 }
@@ -104,6 +106,21 @@ function abortMessagingHostForwardFailure({
   readonly forward: SandboxMessagingHostForwardPlan;
   readonly rollback: MessagingHostForwardRollbackOptions;
 }): never {
+  const error = new Error(
+    `Failed to start ${forward.label} forward on port ${forward.port}. Free the port and ` +
+      `re-run \`${rollback.cliName()} onboard\`, or choose a different messaging channel port.`,
+  );
+  try {
+    rollback.beforeSandboxRollback?.({
+      sandboxName,
+      reason: "messaging_forward_start_failed",
+      cleanupStartedAt: new Date().toISOString(),
+      error,
+      forwardPort: forward.port,
+    });
+  } catch {
+    // Best-effort evidence capture must never prevent owned-sandbox cleanup.
+  }
   const portsToStop = new Set<string>();
   for (const port of rollback.forwardPortsToStop ?? []) {
     if (port !== null && port !== undefined && String(port).trim() !== "") {
@@ -118,10 +135,6 @@ function abortMessagingHostForwardFailure({
   const deleteResult = rollback.runOpenshell(["sandbox", "delete", sandboxName], {
     ignoreError: true,
   });
-  const error = new Error(
-    `Failed to start ${forward.label} forward on port ${forward.port}. Free the port and ` +
-      `re-run \`${rollback.cliName()} onboard\`, or choose a different messaging channel port.`,
-  );
   const writeError = rollback.error ?? console.error;
   for (const line of rollback.buildRollbackMessage(sandboxName, error, deleteResult.status === 0)) {
     writeError(line);

--- a/src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts
+++ b/src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts
@@ -221,6 +221,8 @@ describe("RuntimeProviderBundle registry contract", () => {
         waitForSupervisorReconnectIfNeeded: vi.fn(),
         commitAfterReady: vi.fn(),
         selectedMode: vi.fn(() => null),
+        recordLifecycleObservation: vi.fn(),
+        captureLifecycleFailureDiagnostics: vi.fn(() => null),
         printReadinessFailureIfEnabled: vi.fn(),
         verifyGpuOrExit: vi.fn(async (verify) => verify("alpha")),
       },

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -627,8 +627,49 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
     expect(output).not.toContain("super-secret-create-value");
   });
 
+  it("captures replacement evidence before rolling back a nonzero create (#8690)", async () => {
+    mocks.streamSandboxCreate.mockResolvedValueOnce({
+      status: 17,
+      output: "policy application failed",
+      sawProgress: true,
+    });
+    const callOrder: string[] = [];
+    const patch = createPatch();
+    patch.captureLifecycleFailureDiagnostics.mockImplementation(() => {
+      callOrder.push("capture");
+      return null;
+    });
+    patch.rollbackManagedStartupAfterCreateFailure.mockImplementation(async () => {
+      callOrder.push("rollback");
+    });
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
+    mockExit(17);
+
+    await expect(runSandboxGpuCreateFlow(createInput(), createDeps())).rejects.toThrow(
+      "process.exit:17",
+    );
+
+    expect(callOrder).toEqual(["capture", "rollback"]);
+    expect(patch.captureLifecycleFailureDiagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cleanupReason: "create_stream_failed",
+        additionalSummaryLines: ["create_stream_status=17"],
+      }),
+    );
+  });
+
   it("does not retry compatibility for a non-GPU native readiness failure (#6110)", async () => {
     mockReadinessFailure();
+    const callOrder: string[] = [];
+    const patch = createPatch();
+    patch.captureLifecycleFailureDiagnostics.mockImplementation(() => {
+      callOrder.push("capture");
+      return null;
+    });
+    patch.rollbackManagedStartupAfterCreateFailure.mockImplementation(async () => {
+      callOrder.push("rollback");
+    });
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
     const deps = createDeps();
     vi.mocked(deps.runCaptureOpenshell).mockReturnValue(
       "gpu-device-initialization-failed Failed\nother-sandbox Error NVIDIA GPU device unavailable",
@@ -643,6 +684,16 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
       expect.objectContaining({ ignoreError: true }),
     );
     expect(mocks.streamSandboxCreate).toHaveBeenCalledOnce();
+    expect(callOrder).toEqual(["capture", "rollback"]);
+    expect(patch.captureLifecycleFailureDiagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cleanupReason: "sandbox_readiness_terminal_failure_phase",
+        additionalSummaryLines: expect.arrayContaining([
+          "readiness_reason=terminal_failure_phase",
+          "readiness_failure_phase=Failed",
+        ]),
+      }),
+    );
   });
 
   it("preserves a nonzero create status when separate readiness polling fails (#6110)", async () => {

--- a/src/lib/onboard/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.ts
@@ -82,6 +82,8 @@ export interface SandboxGpuCreateFlowInput {
   sandboxEnv: NodeJS.ProcessEnv;
   sandboxStartupCommand: string[];
   lifecycleGeneration?: SandboxEntry["lifecycleGeneration"];
+  failureDiagnosticSummaryLines?: readonly string[];
+  failureDiagnosticSensitiveValues?: readonly string[];
   prebuild: SandboxPrebuildResult;
   restoreBackupPath: string | null;
   terminalAgent: boolean;

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -143,6 +143,9 @@ export function createSandboxGpuCreateAttemptRunner(
         openshellSandboxCommand: input.sandboxStartupCommand,
         requiredUlimits: input.requiredUlimits,
         timeoutSecs: input.sandboxReadyTimeoutSecs,
+        lifecycleGeneration: input.lifecycleGeneration,
+        diagnosticSummaryLines: input.failureDiagnosticSummaryLines,
+        diagnosticSensitiveValues: input.failureDiagnosticSensitiveValues,
         backend: input.sandboxGpuConfig.hostGpuPlatform === "jetson" ? "jetson" : "generic",
         deps,
       });
@@ -159,7 +162,13 @@ export function createSandboxGpuCreateAttemptRunner(
       streamSandboxCreate(createExecutable, createExecutableArgs, input.sandboxEnv, {
         readyCheck: () => {
           const list = deps.runCaptureOpenshell(["sandbox", "list"], { ignoreError: true });
-          return isSandboxReady(list, input.sandboxName);
+          const ready = isSandboxReady(list, input.sandboxName);
+          runtimePatch.recordLifecycleObservation({
+            stage: "create_stream",
+            event: ready ? "ready" : "not_ready",
+            output: list,
+          });
+          return ready;
         },
         onPoll: () => runtimePatch.maybeApplyDuringCreate(),
         readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent(
@@ -198,7 +207,15 @@ export function createSandboxGpuCreateAttemptRunner(
               const readiness = sandboxReadinessTracing.waitForCreatedSandboxReadyWithTrace({
                 sandboxName: input.sandboxName,
                 timeoutSecs: input.sandboxReadyTimeoutSecs,
-                runCaptureOpenshell: deps.runCaptureOpenshell,
+                runCaptureOpenshell: (args, options) => {
+                  const output = deps.runCaptureOpenshell(args, options);
+                  runtimePatch.recordLifecycleObservation({
+                    stage: "sandbox_readiness",
+                    event: "managed_incomplete_probe",
+                    output,
+                  });
+                  return output;
+                },
                 isSandboxReady,
                 getSandboxFailurePhase,
                 stableReadyPolls: REPLACEMENT_STABLE_READY_POLLS,
@@ -252,10 +269,28 @@ export function createSandboxGpuCreateAttemptRunner(
     } else {
       createResult = await streamCreate();
     }
+    runtimePatch.recordLifecycleObservation({
+      stage: "create_stream",
+      event: "complete",
+      status: createResult.status,
+      output: createResult.output,
+    });
     if (!state.firstCreateOutput) state.firstCreateOutput = createResult.output;
     await runtimePatch.exitOnPatchError();
     if (createResult.status !== 0) {
       const failure = classifySandboxCreateFailure(createResult.output);
+      if (failure.kind !== "sandbox_create_incomplete") {
+        try {
+          runtimePatch.captureLifecycleFailureDiagnostics({
+            error: new Error(`Sandbox create stream exited with code ${createResult.status}.`),
+            cleanupReason: "create_stream_failed",
+            cleanupStartedAt: new Date().toISOString(),
+            additionalSummaryLines: [`create_stream_status=${String(createResult.status)}`],
+          });
+        } catch {
+          console.warn("  ⚠ Could not capture sandbox create diagnostics before cleanup.");
+        }
+      }
       if (failure.kind === "sandbox_create_incomplete") {
         console.warn("");
         if (managedIncompleteCreateRecovered) {
@@ -334,11 +369,24 @@ export function createSandboxGpuCreateAttemptRunner(
     const readiness = sandboxReadinessTracing.waitForCreatedSandboxReadyWithTrace({
       sandboxName: input.sandboxName,
       timeoutSecs: input.sandboxReadyTimeoutSecs,
-      runCaptureOpenshell: deps.runCaptureOpenshell,
+      runCaptureOpenshell: (args, options) => {
+        const output = deps.runCaptureOpenshell(args, options);
+        runtimePatch.recordLifecycleObservation({
+          stage: "sandbox_readiness",
+          event: "phase_probe",
+          output,
+        });
+        return output;
+      },
       isSandboxReady,
       getSandboxFailurePhase,
       stableReadyPolls: compatibility || managedBootstrap ? REPLACEMENT_STABLE_READY_POLLS : 1,
       sleep: deps.sleep,
+    });
+    runtimePatch.recordLifecycleObservation({
+      stage: "sandbox_readiness",
+      event: readiness.ready ? "accepted" : readiness.reason,
+      output: readiness.failurePhase ?? undefined,
     });
     if (!readiness.ready) {
       console.error("");
@@ -347,6 +395,21 @@ export function createSandboxGpuCreateAttemptRunner(
         input.sandboxName,
         input.sandboxReadyTimeoutSecs,
       );
+      try {
+        runtimePatch.captureLifecycleFailureDiagnostics({
+          error: new Error(
+            `Sandbox readiness failed (${readiness.reason}${readiness.failurePhase ? `: ${readiness.failurePhase}` : ""}).`,
+          ),
+          cleanupReason: `sandbox_readiness_${readiness.reason}`,
+          cleanupStartedAt: new Date().toISOString(),
+          additionalSummaryLines: [
+            `readiness_reason=${readiness.reason}`,
+            `readiness_failure_phase=${readiness.failurePhase ?? "none"}`,
+          ],
+        });
+      } catch {
+        console.warn("  ⚠ Could not capture sandbox readiness diagnostics before cleanup.");
+      }
       const canClassifyNativeReadiness =
         route === "native" &&
         input.gpuRoutePlan === "native-with-fallback" &&

--- a/test/e2e/fixtures/onboard-failure-artifacts.ts
+++ b/test/e2e/fixtures/onboard-failure-artifacts.ts
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { type ArtifactSink, slugifyArtifactName } from "./artifacts.ts";
+
+const MAX_RETAINED_FILE_BYTES = 512_000;
+const MAX_RETAINED_FILES = 24;
+const MAX_RETAINED_TOTAL_BYTES = 2_000_000;
+const REPORTED_DIAGNOSTIC_PREFIXES = [
+  "Pre-rollback diagnostics saved:",
+  "Pre-cleanup diagnostics saved:",
+] as const;
+const ALLOWED_DIAGNOSTIC_FILES = new Set([
+  "summary.txt",
+  "patched-container-state.json",
+  "docker-top.txt",
+  "lifecycle-history.json",
+  "forward-start.txt",
+  "forward-list.txt",
+  "docker-ps.txt",
+  "docker-inspect.json",
+  "docker-network-summary.txt",
+  "docker-logs.txt",
+  "managed-startup.log",
+  "openclaw-gateway.log",
+  "openshell-sandbox-get.txt",
+  "openshell-version.txt",
+  "openshell-sandbox-list.txt",
+  "openshell-forward-list.txt",
+  "openshell-logs.txt",
+]);
+
+function containedRealPath(candidate: string, stateRootRealPath: string): string | null {
+  try {
+    const stat = fs.lstatSync(candidate);
+    if (stat.isSymbolicLink()) return null;
+    const resolved = fs.realpathSync(candidate);
+    return resolved.startsWith(`${stateRootRealPath}${path.sep}`) ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function reportedDiagnosticDirectory(output: string): string | null {
+  const reported = output
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, "")
+    .split(/\r?\n/u)
+    .map((line) => {
+      const trimmed = line.trimStart();
+      const prefix = REPORTED_DIAGNOSTIC_PREFIXES.find((candidate) =>
+        trimmed.startsWith(candidate),
+      );
+      return prefix ? trimmed.slice(prefix.length).trim() : "";
+    })
+    .filter(Boolean);
+  return reported.at(-1) ?? null;
+}
+
+function readBoundedRegularFile(
+  candidate: string,
+  stateRootRealPath: string,
+  remainingBytes: number,
+): { content: string; size: number } | null {
+  const source = containedRealPath(candidate, stateRootRealPath);
+  if (!source) return null;
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(source, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    const openedStat = fs.fstatSync(descriptor);
+    if (
+      !openedStat.isFile() ||
+      openedStat.size > MAX_RETAINED_FILE_BYTES ||
+      openedStat.size > remainingBytes
+    ) {
+      return null;
+    }
+    const verifiedSource = containedRealPath(source, stateRootRealPath);
+    if (verifiedSource !== source) return null;
+    const verifiedStat = fs.statSync(verifiedSource);
+    if (verifiedStat.dev !== openedStat.dev || verifiedStat.ino !== openedStat.ino) return null;
+    const buffer = Buffer.alloc(openedStat.size);
+    const bytesRead = fs.readSync(descriptor, buffer, 0, openedStat.size, 0);
+    return { content: buffer.subarray(0, bytesRead).toString("utf8"), size: bytesRead };
+  } catch {
+    return null;
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+  }
+}
+
+export async function retainOnboardFailureArtifacts(options: {
+  artifacts: ArtifactSink;
+  artifactName: string;
+  diagnosticOutput: string;
+  homeDir: string;
+  sandboxName: string;
+}): Promise<string[]> {
+  const stateRoot = path.join(options.homeDir, ".nemoclaw");
+  let stateRootRealPath: string;
+  try {
+    stateRootRealPath = fs.realpathSync(stateRoot);
+  } catch {
+    return [];
+  }
+  const reportedDir = reportedDiagnosticDirectory(options.diagnosticOutput);
+  if (!reportedDir || !path.isAbsolute(reportedDir)) return [];
+  const expectedSuffix = `-${options.sandboxName}-docker-gpu-patch`;
+  const diagnosticDir = containedRealPath(reportedDir, stateRootRealPath);
+  if (!diagnosticDir || !path.basename(diagnosticDir).endsWith(expectedSuffix)) return [];
+
+  const retained: string[] = [];
+  let totalBytes = 0;
+  let files: fs.Dirent[];
+  try {
+    files = fs.readdirSync(diagnosticDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  for (const file of files.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (retained.length >= MAX_RETAINED_FILES) break;
+    if (!file.isFile() || file.isSymbolicLink() || !ALLOWED_DIAGNOSTIC_FILES.has(file.name)) {
+      continue;
+    }
+    const bounded = readBoundedRegularFile(
+      path.join(diagnosticDir, file.name),
+      stateRootRealPath,
+      MAX_RETAINED_TOTAL_BYTES - totalBytes,
+    );
+    if (!bounded) continue;
+    const relativePath = path.join(
+      "onboard-failures",
+      slugifyArtifactName(options.artifactName),
+      path.basename(diagnosticDir),
+      file.name,
+    );
+    await options.artifacts.writeText(relativePath, bounded.content);
+    retained.push(relativePath);
+    totalBytes += bounded.size;
+  }
+  return retained.sort();
+}

--- a/test/e2e/fixtures/token-rotation-order.ts
+++ b/test/e2e/fixtures/token-rotation-order.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const TOKEN_ROTATION_ORDER_ENV = "NEMOCLAW_TOKEN_ROTATION_ORDER";
+
+export type TokenRotationOrder = "telegram-first" | "discord-first";
+export type SequentialTokenRotationProvider = "telegram" | "discord";
+
+export interface TokenRotationTokenSet {
+  readonly telegram: string;
+  readonly discord: string;
+  readonly slackBot: string;
+  readonly slackApp: string;
+}
+
+export interface SequentialTokenRotationStep {
+  readonly provider: SequentialTokenRotationProvider;
+  readonly displayName: "Telegram" | "Discord";
+  readonly artifactSlug: "telegram" | "discord";
+  readonly phaseNumber: number;
+  readonly reusePhaseNumber: number;
+  readonly providerSuffixes: readonly ["telegram-bridge"] | readonly ["discord-bridge"];
+  readonly tokens: TokenRotationTokenSet;
+}
+
+const ORDERED_PROVIDERS = Object.freeze({
+  "telegram-first": Object.freeze(["telegram", "discord"] as const),
+  "discord-first": Object.freeze(["discord", "telegram"] as const),
+}) satisfies Readonly<Record<TokenRotationOrder, readonly SequentialTokenRotationProvider[]>>;
+
+export const TOKEN_ROTATION_PROVIDER_SUFFIXES = Object.freeze([
+  "telegram-bridge",
+  "discord-bridge",
+  "slack-bridge",
+  "slack-app",
+] as const);
+
+export function parseTokenRotationOrder(value: string | undefined): TokenRotationOrder {
+  const selector = value?.trim();
+  // Keep the hosted target on the reversed order while #8690 is under
+  // diagnosis; historical artifacts already cover Telegram-first.
+  if (!selector) return "discord-first";
+  if (selector === "telegram-first" || selector === "discord-first") return selector;
+  throw new Error(`${TOKEN_ROTATION_ORDER_ENV} must be 'telegram-first' or 'discord-first'.`);
+}
+
+function rotateProviderToken(
+  current: TokenRotationTokenSet,
+  replacement: TokenRotationTokenSet,
+  provider: SequentialTokenRotationProvider,
+): TokenRotationTokenSet {
+  return Object.freeze(
+    provider === "telegram"
+      ? { ...current, telegram: replacement.telegram }
+      : { ...current, discord: replacement.discord },
+  );
+}
+
+export function buildSequentialTokenRotationSteps(
+  order: TokenRotationOrder,
+  initial: TokenRotationTokenSet,
+  replacement: TokenRotationTokenSet,
+): readonly SequentialTokenRotationStep[] {
+  let current: TokenRotationTokenSet = Object.freeze({ ...initial });
+  return Object.freeze(
+    ORDERED_PROVIDERS[order].map((provider, index) => {
+      current = rotateProviderToken(current, replacement, provider);
+      const phaseNumber = 2 + index * 2;
+      return Object.freeze(
+        provider === "telegram"
+          ? {
+              provider,
+              displayName: "Telegram" as const,
+              artifactSlug: "telegram" as const,
+              phaseNumber,
+              reusePhaseNumber: phaseNumber + 1,
+              providerSuffixes: Object.freeze(["telegram-bridge"] as const),
+              tokens: current,
+            }
+          : {
+              provider,
+              displayName: "Discord" as const,
+              artifactSlug: "discord" as const,
+              phaseNumber,
+              reusePhaseNumber: phaseNumber + 1,
+              providerSuffixes: Object.freeze(["discord-bridge"] as const),
+              tokens: current,
+            },
+      );
+    }),
+  );
+}
+
+export function tokenRotationPhaseNames(
+  steps: readonly SequentialTokenRotationStep[],
+): readonly string[] {
+  return Object.freeze(
+    steps.flatMap((step) => [
+      `rotate only the ${step.displayName} provider`,
+      `reuse the sandbox after the unchanged ${step.displayName} token`,
+    ]),
+  );
+}

--- a/test/e2e/live/token-rotation.test.ts
+++ b/test/e2e/live/token-rotation.test.ts
@@ -13,7 +13,16 @@ import { resultText } from "../fixtures/clients/command.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
+import { retainOnboardFailureArtifacts } from "../fixtures/onboard-failure-artifacts.ts";
 import { CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/paths.ts";
+import {
+  buildSequentialTokenRotationSteps,
+  parseTokenRotationOrder,
+  TOKEN_ROTATION_ORDER_ENV,
+  TOKEN_ROTATION_PROVIDER_SUFFIXES,
+  type TokenRotationTokenSet,
+  tokenRotationPhaseNames,
+} from "../fixtures/token-rotation-order.ts";
 
 // Keep this free-standing and direct: the contract is the real CLI +
 // OpenShell/provider boundary for messaging credential reuse/rotation, not the
@@ -30,21 +39,14 @@ const PHASE_TIMEOUT_MS = 40 * 60_000;
 
 process.env.NEMOCLAW_CLI_BIN ??= CLI_ENTRYPOINT;
 
-interface TokenSet {
-  telegram: string;
-  discord: string;
-  slackBot: string;
-  slackApp: string;
-}
-
-const TOKEN_A: TokenSet = {
+const TOKEN_A: TokenRotationTokenSet = {
   telegram: process.env.TELEGRAM_BOT_TOKEN_A ?? "test-fake-token-A-rotation-e2e",
   discord: process.env.DISCORD_BOT_TOKEN_A ?? "dc-a-rotation-e2e",
   slackBot: process.env.SLACK_BOT_TOKEN_A ?? "xoxb-fake-A-rotation-e2e",
   slackApp: process.env.SLACK_APP_TOKEN_A ?? "xapp-fake-A-rotation-e2e",
 };
 
-const TOKEN_B: TokenSet = {
+const TOKEN_B: TokenRotationTokenSet = {
   telegram: process.env.TELEGRAM_BOT_TOKEN_B ?? "test-fake-token-B-rotation-e2e",
   discord: process.env.DISCORD_BOT_TOKEN_B ?? "dc-b-rotation-e2e",
   slackBot: process.env.SLACK_BOT_TOKEN_B ?? "xoxb-fake-B-rotation-e2e",
@@ -65,11 +67,18 @@ type RegistrySandboxEntry = {
   };
 };
 
+const TOKEN_ROTATION_ORDER = parseTokenRotationOrder(process.env[TOKEN_ROTATION_ORDER_ENV]);
+const SEQUENTIAL_ROTATION_STEPS = buildSequentialTokenRotationSteps(
+  TOKEN_ROTATION_ORDER,
+  TOKEN_A,
+  TOKEN_B,
+);
+
 function stripAnsi(value: string): string {
   return value.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");
 }
 
-function onboardEnv(endpointUrl: string, tokens: TokenSet): NodeJS.ProcessEnv {
+function onboardEnv(endpointUrl: string, tokens: TokenRotationTokenSet): NodeJS.ProcessEnv {
   return {
     ...buildAvailabilityProbeEnv(),
     COMPATIBLE_API_KEY: "token-rotation-compatible-e2e",
@@ -173,7 +182,7 @@ function redactionValues(): string[] {
 async function runInstall(
   host: import("../fixtures/clients/host.ts").HostCliClient,
   endpointUrl: string,
-  tokens: TokenSet,
+  tokens: TokenRotationTokenSet,
   extraEnv: NodeJS.ProcessEnv = {},
 ) {
   return host.command("bash", ["install.sh", "--non-interactive"], {
@@ -189,13 +198,14 @@ async function runInstall(
 }
 
 async function runOnboard(
+  artifacts: import("../fixtures/artifacts.ts").ArtifactSink,
   host: import("../fixtures/clients/host.ts").HostCliClient,
   endpointUrl: string,
-  tokens: TokenSet,
+  tokens: TokenRotationTokenSet,
   artifactName: string,
   extraEnv: NodeJS.ProcessEnv = {},
 ) {
-  return host.command("node", [CLI_ENTRYPOINT, "onboard", "--non-interactive"], {
+  const result = await host.command("node", [CLI_ENTRYPOINT, "onboard", "--non-interactive"], {
     artifactName,
     env: {
       ...onboardEnv(endpointUrl, tokens),
@@ -204,6 +214,23 @@ async function runOnboard(
     redactionValues: redactionValues(),
     timeoutMs: ONBOARD_TIMEOUT_MS,
   });
+  if (result.exitCode !== 0) {
+    artifacts.addRedactionValues(redactionValues());
+    try {
+      await retainOnboardFailureArtifacts({
+        artifacts,
+        artifactName,
+        diagnosticOutput: resultText(result),
+        homeDir: process.env.HOME ?? "/tmp",
+        sandboxName: SANDBOX_NAME,
+      });
+    } catch (error) {
+      await artifacts.writeJson(`${artifactName}-diagnostic-retention-error.json`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return result;
 }
 
 async function assertSandboxRunning(
@@ -273,10 +300,7 @@ test(
       e2ePhases: [
         "confirm Docker and start hermetic inference",
         "install the sandbox and confirm provider hashes",
-        "rotate only the Telegram provider",
-        "reuse the sandbox after the unchanged Telegram token",
-        "rotate only the Discord provider",
-        "reuse the sandbox after the unchanged Discord token",
+        ...tokenRotationPhaseNames(SEQUENTIAL_ROTATION_STEPS),
         "rotate only the Slack providers",
         "reuse the sandbox and record rotation evidence",
       ],
@@ -330,6 +354,7 @@ test(
       },
       documentedException:
         "The replacement uses the legacy-supported fake OpenAI-compatible endpoint path so the messaging credential-rotation guard is not blocked by unrelated NVIDIA endpoint 429 rate limits.",
+      providerOrder: TOKEN_ROTATION_ORDER,
       contract: [
         "first onboard stores messaging credential hashes and creates provider attachments",
         "rotating Telegram rebuilds and names only telegram-bridge",
@@ -481,72 +506,60 @@ test(
     }
     await assertSandboxRunning(host, "phase-1-sandbox-running-after-install");
 
-    progress.phase("rotate only the Telegram provider");
-    const telegram = await runOnboard(
-      host,
-      fakeOpenAI.baseUrl,
-      { ...TOKEN_A, telegram: TOKEN_B.telegram },
-      "phase-2-rotate-telegram",
-    );
-    const telegramText = resultText(telegram);
-    expect(telegram.exitCode, telegramText).toBe(0);
-    expectRotationOutput(
-      telegramText,
-      [`${SANDBOX_NAME}-telegram-bridge`],
-      [
-        `${SANDBOX_NAME}-discord-bridge`,
-        `${SANDBOX_NAME}-slack-bridge`,
-        `${SANDBOX_NAME}-slack-app`,
-      ],
-    );
-    await assertSandboxRunning(host, "phase-2-sandbox-running-after-telegram-rotation");
+    for (const step of SEQUENTIAL_ROTATION_STEPS) {
+      if (step.provider === "telegram") {
+        progress.phase("rotate only the Telegram provider");
+      } else {
+        progress.phase("rotate only the Discord provider");
+      }
+      const rotation = await runOnboard(
+        artifacts,
+        host,
+        fakeOpenAI.baseUrl,
+        step.tokens,
+        `phase-${step.phaseNumber}-rotate-${step.artifactSlug}`,
+      );
+      const rotationText = resultText(rotation);
+      expect(rotation.exitCode, rotationText).toBe(0);
+      const expectedProviders = step.providerSuffixes.map(
+        (suffix) => `${SANDBOX_NAME}-${suffix}`,
+      );
+      const expectedProviderSuffixes = new Set<string>(step.providerSuffixes);
+      const forbiddenProviders = TOKEN_ROTATION_PROVIDER_SUFFIXES.filter(
+        (suffix) => !expectedProviderSuffixes.has(suffix),
+      ).map((suffix) => `${SANDBOX_NAME}-${suffix}`);
+      expectRotationOutput(rotationText, expectedProviders, forbiddenProviders);
+      await assertSandboxRunning(
+        host,
+        `phase-${step.phaseNumber}-sandbox-running-after-${step.artifactSlug}-rotation`,
+      );
 
-    progress.phase("reuse the sandbox after the unchanged Telegram token");
-    const afterTelegramSame = await runOnboard(
-      host,
-      fakeOpenAI.baseUrl,
-      { ...TOKEN_A, telegram: TOKEN_B.telegram },
-      "phase-3-same-after-telegram",
-    );
-    const afterTelegramSameText = resultText(afterTelegramSame);
-    expect(afterTelegramSame.exitCode, afterTelegramSameText).toBe(0);
-    expect(afterTelegramSameText).toContain(`Sandbox '${SANDBOX_NAME}' exists and is ready`);
-    expect(afterTelegramSameText).toContain("reusing it");
-
-    progress.phase("rotate only the Discord provider");
-    const discord = await runOnboard(
-      host,
-      fakeOpenAI.baseUrl,
-      { ...TOKEN_A, telegram: TOKEN_B.telegram, discord: TOKEN_B.discord },
-      "phase-4-rotate-discord",
-    );
-    const discordText = resultText(discord);
-    expect(discord.exitCode, discordText).toBe(0);
-    expectRotationOutput(
-      discordText,
-      [`${SANDBOX_NAME}-discord-bridge`],
-      [
-        `${SANDBOX_NAME}-telegram-bridge`,
-        `${SANDBOX_NAME}-slack-bridge`,
-        `${SANDBOX_NAME}-slack-app`,
-      ],
-    );
-    await assertSandboxRunning(host, "phase-4-sandbox-running-after-discord-rotation");
-
-    progress.phase("reuse the sandbox after the unchanged Discord token");
-    const afterDiscordSame = await runOnboard(
-      host,
-      fakeOpenAI.baseUrl,
-      { ...TOKEN_A, telegram: TOKEN_B.telegram, discord: TOKEN_B.discord },
-      "phase-5-same-after-discord",
-    );
-    const afterDiscordSameText = resultText(afterDiscordSame);
-    expect(afterDiscordSame.exitCode, afterDiscordSameText).toBe(0);
-    expect(afterDiscordSameText).toContain(`Sandbox '${SANDBOX_NAME}' exists and is ready`);
-    expect(afterDiscordSameText).toContain("reusing it");
+      if (step.provider === "telegram") {
+        progress.phase("reuse the sandbox after the unchanged Telegram token");
+      } else {
+        progress.phase("reuse the sandbox after the unchanged Discord token");
+      }
+      const unchanged = await runOnboard(
+        artifacts,
+        host,
+        fakeOpenAI.baseUrl,
+        step.tokens,
+        `phase-${step.reusePhaseNumber}-same-after-${step.artifactSlug}`,
+      );
+      const unchangedText = resultText(unchanged);
+      expect(unchanged.exitCode, unchangedText).toBe(0);
+      expect(unchangedText).toContain(`Sandbox '${SANDBOX_NAME}' exists and is ready`);
+      expect(unchangedText).toContain("reusing it");
+    }
 
     progress.phase("rotate only the Slack providers");
-    const slack = await runOnboard(host, fakeOpenAI.baseUrl, TOKEN_B, "phase-6-rotate-slack");
+    const slack = await runOnboard(
+      artifacts,
+      host,
+      fakeOpenAI.baseUrl,
+      TOKEN_B,
+      "phase-6-rotate-slack",
+    );
     const slackText = resultText(slack);
     expect(slack.exitCode, slackText).toBe(0);
     expectRotationOutput(
@@ -558,6 +571,7 @@ test(
 
     progress.phase("reuse the sandbox and record rotation evidence");
     const afterSlackSame = await runOnboard(
+      artifacts,
       host,
       fakeOpenAI.baseUrl,
       TOKEN_B,
@@ -579,6 +593,7 @@ test(
         slackRotationIsolated: true,
         unchangedTokensReuseSandbox: true,
       },
+      providerOrder: TOKEN_ROTATION_ORDER,
     });
   },
 );

--- a/test/e2e/support/onboard-failure-artifacts.test.ts
+++ b/test/e2e/support/onboard-failure-artifacts.test.ts
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { ArtifactSink } from "../fixtures/artifacts.ts";
+import { retainOnboardFailureArtifacts } from "../fixtures/onboard-failure-artifacts.ts";
+
+describe("onboard failure artifact retention", () => {
+  it("copies only bounded regular diagnostic files through the redacting sink (#8690)", async () => {
+    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-failure-artifacts-"));
+    const homeDir = path.join(temporaryRoot, "home");
+    const outputDir = path.join(temporaryRoot, "artifacts");
+    const failureDir = path.join(
+      homeDir,
+      ".nemoclaw",
+      "onboard-failures",
+      "2026-08-10T00-00-00-000Z-alpha-docker-gpu-patch",
+    );
+    const secretCanary = "opaque-artifact-secret";
+    fs.mkdirSync(failureDir, { recursive: true });
+    fs.writeFileSync(path.join(failureDir, "summary.txt"), `phase=Error ${secretCanary}\n`);
+    fs.writeFileSync(path.join(failureDir, "not-allowlisted.txt"), "must not publish\n");
+    fs.symlinkSync(path.join(failureDir, "summary.txt"), path.join(failureDir, "forward-list.txt"));
+    fs.writeFileSync(path.join(failureDir, "docker-logs.txt"), "x".repeat(512_001));
+    const staleFailureDir = path.join(
+      homeDir,
+      ".nemoclaw",
+      "onboard-failures",
+      "2026-08-09T00-00-00-000Z-alpha-docker-gpu-patch",
+    );
+    fs.mkdirSync(staleFailureDir, { recursive: true });
+    fs.writeFileSync(path.join(staleFailureDir, "summary.txt"), "stale bundle\n");
+    const artifacts = new ArtifactSink(outputDir, [secretCanary]);
+
+    try {
+      const retained = await retainOnboardFailureArtifacts({
+        artifacts,
+        artifactName: "phase-4-rotate-discord",
+        diagnosticOutput: `  Pre-cleanup diagnostics saved: ${failureDir}\n`,
+        homeDir,
+        sandboxName: "alpha",
+      });
+
+      expect(retained).toHaveLength(1);
+      expect(retained[0]).toMatch(/summary\.txt$/u);
+      const published = fs.readFileSync(path.join(outputDir, retained[0] ?? ""), "utf8");
+      expect(published).toBe("phase=Error [REDACTED]\n");
+      expect(JSON.stringify(retained)).not.toContain("forward-list.txt");
+      expect(JSON.stringify(retained)).not.toContain("docker-logs.txt");
+      expect(JSON.stringify(retained)).not.toContain("not-allowlisted.txt");
+      expect(JSON.stringify(retained)).not.toContain(path.basename(staleFailureDir));
+    } finally {
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("caps the current reported bundle by aggregate bytes (#8690)", async () => {
+    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-failure-bounds-"));
+    const homeDir = path.join(temporaryRoot, "home");
+    const outputDir = path.join(temporaryRoot, "artifacts");
+    const failureDir = path.join(
+      homeDir,
+      ".nemoclaw",
+      "onboard-failures",
+      "2026-08-10T00-00-00-000Z-alpha-docker-gpu-patch",
+    );
+    fs.mkdirSync(failureDir, { recursive: true });
+    for (const name of [
+      "docker-inspect.json",
+      "docker-logs.txt",
+      "docker-network-summary.txt",
+      "docker-ps.txt",
+      "docker-top.txt",
+    ]) {
+      fs.writeFileSync(path.join(failureDir, name), "x".repeat(450_000));
+    }
+    const artifacts = new ArtifactSink(outputDir);
+
+    try {
+      const retained = await retainOnboardFailureArtifacts({
+        artifacts,
+        artifactName: "phase-2-rotate-discord",
+        diagnosticOutput: `Pre-rollback diagnostics saved: ${failureDir}\n`,
+        homeDir,
+        sandboxName: "alpha",
+      });
+
+      expect(retained).toHaveLength(4);
+      const totalBytes = retained.reduce(
+        (total, relativePath) => total + fs.statSync(path.join(outputDir, relativePath)).size,
+        0,
+      );
+      expect(totalBytes).toBeLessThanOrEqual(2_000_000);
+    } finally {
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not read bytes appended after the file bound is established (#8690)", async () => {
+    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-failure-append-"));
+    const homeDir = path.join(temporaryRoot, "home");
+    const outputDir = path.join(temporaryRoot, "artifacts");
+    const failureDir = path.join(
+      homeDir,
+      ".nemoclaw",
+      "onboard-failures",
+      "2026-08-10T00-00-00-000Z-alpha-docker-gpu-patch",
+    );
+    const summaryPath = path.join(failureDir, "summary.txt");
+    fs.mkdirSync(failureDir, { recursive: true });
+    fs.writeFileSync(summaryPath, "bounded snapshot\n");
+    const originalReadSync = fs.readSync.bind(fs);
+    let appended = false;
+    const readSpy = vi.spyOn(fs, "readSync").mockImplementation(((
+      ...args: Parameters<typeof fs.readSync>
+    ) => {
+      if (!appended) {
+        fs.appendFileSync(summaryPath, "must not cross the established bound\n");
+        appended = true;
+      }
+      return originalReadSync(...args);
+    }) as typeof fs.readSync);
+    const artifacts = new ArtifactSink(outputDir);
+
+    try {
+      const retained = await retainOnboardFailureArtifacts({
+        artifacts,
+        artifactName: "phase-4-rotate-discord",
+        diagnosticOutput: `Pre-cleanup diagnostics saved: ${failureDir}\n`,
+        homeDir,
+        sandboxName: "alpha",
+      });
+
+      expect(retained).toHaveLength(1);
+      expect(fs.readFileSync(path.join(outputDir, retained[0] ?? ""), "utf8")).toBe(
+        "bounded snapshot\n",
+      );
+    } finally {
+      readSpy.mockRestore();
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/e2e/support/token-rotation-order.test.ts
+++ b/test/e2e/support/token-rotation-order.test.ts
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSequentialTokenRotationSteps,
+  parseTokenRotationOrder,
+  TOKEN_ROTATION_ORDER_ENV,
+  TOKEN_ROTATION_PROVIDER_SUFFIXES,
+  type TokenRotationTokenSet,
+  tokenRotationPhaseNames,
+} from "../fixtures/token-rotation-order.ts";
+
+const TOKEN_A: TokenRotationTokenSet = {
+  telegram: "telegram-a",
+  discord: "discord-a",
+  slackBot: "slack-bot-a",
+  slackApp: "slack-app-a",
+};
+
+const TOKEN_B: TokenRotationTokenSet = {
+  telegram: "telegram-b",
+  discord: "discord-b",
+  slackBot: "slack-bot-b",
+  slackApp: "slack-app-b",
+};
+
+describe("token-rotation provider order", () => {
+  it("defaults to Discord-first so the hosted diagnostic run reverses historical coverage", () => {
+    expect(parseTokenRotationOrder(undefined)).toBe("discord-first");
+    expect(parseTokenRotationOrder("")).toBe("discord-first");
+    expect(parseTokenRotationOrder("  ")).toBe("discord-first");
+  });
+
+  it("accepts only the two explicit provider-order selectors", () => {
+    expect(parseTokenRotationOrder("telegram-first")).toBe("telegram-first");
+    expect(parseTokenRotationOrder("discord-first")).toBe("discord-first");
+    expect(parseTokenRotationOrder(" discord-first ")).toBe("discord-first");
+
+    for (const selector of ["Discord-first", "slack-first", "discord-first; exit 0"]) {
+      expect(() => parseTokenRotationOrder(selector)).toThrow(
+        `${TOKEN_ROTATION_ORDER_ENV} must be 'telegram-first' or 'discord-first'.`,
+      );
+    }
+  });
+
+  it("keeps the existing Telegram-first sequence and accumulates only completed rotations", () => {
+    const steps = buildSequentialTokenRotationSteps("telegram-first", TOKEN_A, TOKEN_B);
+
+    expect(steps).toEqual([
+      expect.objectContaining({
+        provider: "telegram",
+        displayName: "Telegram",
+        artifactSlug: "telegram",
+        phaseNumber: 2,
+        reusePhaseNumber: 3,
+        providerSuffixes: ["telegram-bridge"],
+        tokens: { ...TOKEN_A, telegram: TOKEN_B.telegram },
+      }),
+      expect.objectContaining({
+        provider: "discord",
+        displayName: "Discord",
+        artifactSlug: "discord",
+        phaseNumber: 4,
+        reusePhaseNumber: 5,
+        providerSuffixes: ["discord-bridge"],
+        tokens: {
+          ...TOKEN_A,
+          telegram: TOKEN_B.telegram,
+          discord: TOKEN_B.discord,
+        },
+      }),
+    ]);
+  });
+
+  it("reverses Telegram and Discord without changing cumulative token isolation", () => {
+    const steps = buildSequentialTokenRotationSteps("discord-first", TOKEN_A, TOKEN_B);
+
+    expect(steps).toEqual([
+      expect.objectContaining({
+        provider: "discord",
+        displayName: "Discord",
+        artifactSlug: "discord",
+        phaseNumber: 2,
+        reusePhaseNumber: 3,
+        providerSuffixes: ["discord-bridge"],
+        tokens: { ...TOKEN_A, discord: TOKEN_B.discord },
+      }),
+      expect.objectContaining({
+        provider: "telegram",
+        displayName: "Telegram",
+        artifactSlug: "telegram",
+        phaseNumber: 4,
+        reusePhaseNumber: 5,
+        providerSuffixes: ["telegram-bridge"],
+        tokens: {
+          ...TOKEN_A,
+          telegram: TOKEN_B.telegram,
+          discord: TOKEN_B.discord,
+        },
+      }),
+    ]);
+    expect(steps.every((step) => step.tokens.slackBot === TOKEN_A.slackBot)).toBe(true);
+    expect(steps.every((step) => step.tokens.slackApp === TOKEN_A.slackApp)).toBe(true);
+  });
+
+  it("builds phase metadata and provider-exclusion sets from the selected order", () => {
+    const steps = buildSequentialTokenRotationSteps("discord-first", TOKEN_A, TOKEN_B);
+
+    expect(tokenRotationPhaseNames(steps)).toEqual([
+      "rotate only the Discord provider",
+      "reuse the sandbox after the unchanged Discord token",
+      "rotate only the Telegram provider",
+      "reuse the sandbox after the unchanged Telegram token",
+    ]);
+    for (const step of steps) {
+      const expected = new Set<string>(step.providerSuffixes);
+      expect(TOKEN_ROTATION_PROVIDER_SUFFIXES.filter((suffix) => expected.has(suffix))).toEqual(
+        step.providerSuffixes,
+      );
+      expect(
+        TOKEN_ROTATION_PROVIDER_SUFFIXES.filter((suffix) => !expected.has(suffix)),
+      ).toHaveLength(3);
+    }
+  });
+});

--- a/test/onboard-dashboard.test.ts
+++ b/test/onboard-dashboard.test.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { OPENSHELL_PROBE_TIMEOUT_MS } from "../src/lib/adapters/openshell/timeouts";
 import type { AgentDefinition } from "../src/lib/agent/defs";
 import { loadAgent } from "../src/lib/agent/defs";
 import { printDashboardUi } from "../src/lib/agent/onboard";
@@ -221,6 +222,137 @@ describe("onboard dashboard helpers", () => {
     ).toHaveLength(1);
     expect(stopArgs).not.toContainEqual(["forward", "stop", String(foreignPort), "other-sandbox"]);
     expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("captures dashboard-forward failure evidence before destructive sandbox cleanup (#8690)", () => {
+    const callOrder: string[] = [];
+    const beforeSandboxRollback = vi.fn((context) => {
+      callOrder.push("diagnostics");
+      expect(context).toMatchObject({
+        sandboxName: "my-sandbox",
+        reason: "dashboard_forward_start_failed",
+        dashboardPort: 18789,
+      });
+      expect(context.forwardDiagnostic).toContain("ENOENT");
+      expect(context.error).toMatchObject({
+        message: "Dashboard forward failed before sandbox cleanup.",
+      });
+    });
+    const runOpenshell = vi.fn((args: string[]) => {
+      if (args.join(" ") === "sandbox delete my-sandbox") callOrder.push("delete");
+      return { status: 0 };
+    });
+    const helpers = createOnboardDashboardHelpers({
+      runOpenshell,
+      runCaptureOpenshell: vi.fn(() => ""),
+      openshellArgv: () => ["/definitely/missing/openshell"],
+      cliName: () => "nemoclaw",
+      agentProductName: () => "NemoClaw",
+      getProviderLabel: (provider: string) => provider,
+      note: vi.fn(),
+      isWsl: () => false,
+      redact: (value: unknown) => String(value),
+      sleep: vi.fn(),
+      printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("test-exit");
+    }) as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      helpers.ensureDashboardForward("my-sandbox", "http://127.0.0.1:18789", {
+        rollbackSandboxOnFailure: true,
+        beforeSandboxRollback,
+      }),
+    ).toThrow("test-exit");
+
+    expect(callOrder).toEqual(["diagnostics", "delete"]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("does not let diagnostic capture failure block owned-sandbox cleanup (#8690)", () => {
+    const runOpenshell = vi.fn(() => ({ status: 0 }));
+    const helpers = createOnboardDashboardHelpers({
+      runOpenshell,
+      runCaptureOpenshell: vi.fn(() => ""),
+      openshellArgv: () => ["/definitely/missing/openshell"],
+      cliName: () => "nemoclaw",
+      agentProductName: () => "NemoClaw",
+      getProviderLabel: (provider: string) => provider,
+      note: vi.fn(),
+      isWsl: () => false,
+      redact: (value: unknown) => String(value),
+      sleep: vi.fn(),
+      printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
+    });
+    vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("test-exit");
+    }) as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() =>
+      helpers.ensureDashboardForward("my-sandbox", "http://127.0.0.1:18789", {
+        rollbackSandboxOnFailure: true,
+        beforeSandboxRollback: () => {
+          throw new Error("diagnostic sink unavailable");
+        },
+      }),
+    ).toThrow("test-exit");
+
+    expect(runOpenshell).toHaveBeenCalledWith(["sandbox", "delete", "my-sandbox"], {
+      ignoreError: true,
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("diagnostic sink unavailable"));
+  });
+
+  it("does not let forward-list evidence capture block owned-sandbox cleanup (#8690)", () => {
+    const runOpenshell = vi.fn(() => ({ status: 0 }));
+    const runCaptureOpenshell = vi.fn((_args: string[], options?: Record<string, unknown>) => {
+      if (options?.ignoreError === true && options?.timeout === OPENSHELL_PROBE_TIMEOUT_MS) {
+        throw new Error("forward list unavailable");
+      }
+      return "";
+    });
+    const beforeSandboxRollback = vi.fn();
+    const helpers = createOnboardDashboardHelpers({
+      runOpenshell,
+      runCaptureOpenshell,
+      openshellArgv: () => ["/definitely/missing/openshell"],
+      cliName: () => "nemoclaw",
+      agentProductName: () => "NemoClaw",
+      getProviderLabel: (provider: string) => provider,
+      note: vi.fn(),
+      isWsl: () => false,
+      redact: (value: unknown) => String(value),
+      sleep: vi.fn(),
+      printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
+    });
+    vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("test-exit");
+    }) as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      helpers.ensureDashboardForward("my-sandbox", "http://127.0.0.1:18789", {
+        rollbackSandboxOnFailure: true,
+        beforeSandboxRollback,
+      }),
+    ).toThrow("test-exit");
+
+    expect(beforeSandboxRollback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "dashboard_forward_start_failed",
+        forwardListOutput: null,
+      }),
+    );
+    expect(runOpenshell).toHaveBeenCalledWith(["sandbox", "delete", "my-sandbox"], {
+      ignoreError: true,
+    });
   });
 
   it("starts declared non-dashboard agent port forwards without cleaning up the dashboard forward", () => {

--- a/test/onboard-prepared-build-context.test.ts
+++ b/test/onboard-prepared-build-context.test.ts
@@ -105,6 +105,8 @@ dockerGpuSandboxCreate.createDockerGpuSandboxCreatePatch = () => ({
   waitForSupervisorReconnectIfNeeded: () => {},
   commitAfterReady: async () => {},
   selectedMode: () => null,
+  recordLifecycleObservation: () => {},
+  captureLifecycleFailureDiagnostics: () => null,
   printReadinessFailureIfEnabled: () => {},
   verifyGpuOrExit: async (verify) => verify(sandboxName),
 });

--- a/test/onboard-terminal-dashboard.test.ts
+++ b/test/onboard-terminal-dashboard.test.ts
@@ -74,6 +74,8 @@ dockerGpuSandboxCreate.createDockerGpuSandboxCreatePatch = () => ({
   waitForSupervisorReconnectIfNeeded: () => {},
   commitAfterReady: async () => {},
   selectedMode: () => null,
+  recordLifecycleObservation: () => {},
+  captureLifecycleFailureDiagnostics: () => null,
   printReadinessFailureIfEnabled: () => {},
   verifyGpuOrExit: async (verify) => verify(sandboxName),
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preserve bounded, redacted evidence when credential-driven sandbox recreation fails so issue #8690 can be diagnosed before rollback or cleanup destroys the relevant state. This diagnostic-first change does not alter recreation, readiness, rollback, or recovery behavior and does not yet claim a causal fix.

## Related Issue

Fixes #8690

## Changes

- Capture lifecycle, Docker, OpenShell, sandbox identity, and selected startup evidence before rollback or sandbox deletion across early and late recreation failure paths.
- Bound and redact the evidence bundle, distinguish pre-rollback from post-cutover cleanup, and report old, replacement, and backup container identity without treating failed identity queries as absence.
- Parameterize the credential-rotation provider order, use Discord-first in hosted E2E coverage to reverse the historical sequence, and retain only the exact reported diagnostic bundle under strict path, file, count, size, symlink, inode, and redaction controls.
- Add focused unit, integration, and E2E-support coverage for evidence collection, lifecycle disposition, identity-query failures, provider-order semantics, and artifact-retention safety.
- Current status: diagnostic instrumentation only; no retry, timeout, readiness bypass, or other causal workaround is introduced.
- Remaining work: run the exact hosted Discord-first credential-rotation scenario on this PR commit, compare the retained evidence with OpenShell lifecycle behavior and the latest CPU-only reproduction, implement a causal fix here if NemoClaw is responsible or document the upstream blocker, and complete CI and automated review follow-up.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change extends an existing bounded, redacted onboarding-failure bundle and live E2E evidence capture without changing the documented credential-rotation, recreation, rollback, recovery, command, flag, or configuration workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: An independent nine-category security review covered all 33 changed files and passed with no findings; a PR-bound review will be recorded before the hosted live run.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change extends an existing bounded, redacted onboarding-failure bundle and live E2E evidence capture. It does not change the documented credential-rotation, recreation, rollback, or recovery workflow. Reviewed `docs/reference/troubleshooting.mdx`, `docs/security/credential-rotation.mdx`, `docs/manage-sandboxes/lifecycle.mdx`, `docs/reference/host-files-and-state.mdx`, and guide routing in `docs/index.yml`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 58b9e0612 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 84 focused CLI tests, 23 focused integration tests, and 8 E2E-support tests passed; `npm run typecheck:cli`, repository checks, E2E phase validation, source-shape, test-project, title, size, formatting, and diff checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
