### PR TITLE
fix(rebuild): settle expired Shields before success

### DIFF
--- a/src/lib/actions/sandbox/backup-shields-window.ts
+++ b/src/lib/actions/sandbox/backup-shields-window.ts
@@ -3,6 +3,7 @@
 
 import { RD as _RD, G, R, YW } from "../../cli/terminal-style";
 import * as shields from "../../shields";
+import { isShieldsTimerDeadlineExpired } from "../../state/mcp-lifecycle-lock/shields-timer-authority";
 
 export interface BackupShieldsWindow {
   relocked: boolean;
@@ -58,7 +59,10 @@ export function relockBackupShieldsWindow(
   sandboxStillExists: boolean,
   options: BackupShieldsWindowOptions,
 ): boolean {
-  if (!window.wasLocked || window.relocked) return true;
+  if (window.relocked) return true;
+  // A deferred timer can expire while rebuild owns the lifecycle lock; settle it before success.
+  if (!window.wasLocked && !options.deferAutoRestoreWhileOwnerAlive) return true;
+  if (!window.wasLocked && !isShieldsTimerDeadlineExpired(sandboxName)) return true;
   if (!sandboxStillExists) {
     console.warn("");
     console.warn(`  ${YW}⚠${R} Cannot re-apply shields lockdown — sandbox no longer exists.`);

--- a/test/e2e/live/mcp-bridge-hermes-http.ts
+++ b/test/e2e/live/mcp-bridge-hermes-http.ts
@@ -44,6 +44,24 @@ export function buildHermesMcpChatProbeScript(payload: string, resultToken: stri
   ].join("\n");
 }
 
+export function buildHermesMcpRuntimeDiagnosticsScript(): string {
+  return [
+    "set -eu",
+    "set -a",
+    "[ ! -f /sandbox/.hermes/.env ] || . /sandbox/.hermes/.env",
+    "set +a",
+    "{",
+    'for log in /tmp/nemoclaw-start.log /tmp/gateway.log; do printf \'== %s ==\\n\' "$log"; tail -n 100 "$log" 2>&1 || true; done',
+    "printf '%s\\n' '== permissions =='",
+    "stat -c '%a %U:%G %n' /sandbox /sandbox/.hermes /sandbox/.hermes/logs 2>&1 || true",
+    "printf '%s\\n' '== managed supervisor =='",
+    "cat /run/nemoclaw/gateway-control/status 2>&1 || true",
+    "printf '%s\\n' '== gateway identity =='",
+    "cat /sandbox/.hermes/runtime/gateway.pid 2>&1 || true",
+    `} | /usr/bin/python3 -I -S -c ${shellQuote(FAILURE_BODY_EMITTER)} /dev/stdin`,
+  ].join("\n");
+}
+
 function sanitizedPreview(text: string, explicitValues: Iterable<string>): string {
   const sanitized = redactString(text, explicitValues)
     .replace(/\u001b\[[0-?]*[ -/]*[@-~]/gu, "")

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -1175,9 +1175,8 @@ mcpBridgeShardTest("hermes")(
           timeoutMs: 3 * 60_000,
         },
       );
-      if (result.exitCode !== 0 && !/not found|does not exist/iu.test(resultText(result))) {
-        expectExitZero(result, "lower Hermes Shields before teardown");
-      }
+      const sandboxMissing = /not found|does not exist/iu.test(resultText(result));
+      expect(result.exitCode === 0 || sandboxMissing).toBe(true);
     });
     cleanup.add("capture Hermes post-rebuild MCP evidence", async () => {
       await artifacts.writeJson(

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -29,6 +29,7 @@ import {
 import {
   assertHermesMcpHttpResponse,
   buildHermesMcpChatProbeScript,
+  buildHermesMcpRuntimeDiagnosticsScript,
   HERMES_MCP_FAILURE_CAPTURE_BYTES,
 } from "./mcp-bridge-hermes-http.ts";
 import {
@@ -592,6 +593,29 @@ async function assertRealAdapterToolCall(
   expect(calls.at(-1)?.auth).not.toContain("openshell:resolve:env");
 }
 
+async function captureHermesGatewayIdentity(
+  sandbox: SandboxClient,
+  artifactName: string,
+): Promise<void> {
+  const result = await sandbox.execShell(
+    HERMES_SANDBOX_NAME,
+    trustedSandboxShellScript(
+      [
+        "set -eu",
+        "/usr/bin/python3 -I -S - <<'PY'",
+        "import json, pathlib",
+        "record = json.loads(pathlib.Path('/sandbox/.hermes/runtime/gateway.pid').read_text())",
+        "pid = record if isinstance(record, int) else record['pid']",
+        "fields = pathlib.Path(f'/proc/{pid}/stat').read_text().rsplit(')', 1)[1].split()",
+        "print(json.dumps({'pid': pid, 'start_time': int(fields[19])}, sort_keys=True))",
+        "PY",
+      ].join("\n"),
+    ),
+    { artifactName, env: buildAvailabilityProbeEnv(), timeoutMs: 60_000 },
+  );
+  expectExitZero(result, artifactName);
+}
+
 async function rotateBridgeCredential(
   host: HostCliClient,
   sandboxName: string,
@@ -1139,7 +1163,50 @@ mcpBridgeShardTest("hermes")(
       "hermes-assert-secrets-absent-after-rotation",
     );
     const rebuildDiscoveryOffset = fakeMcp.requests.length;
+    await captureHermesGatewayIdentity(sandbox, "hermes-gateway-identity-before-rebuild");
     await rebuildWithoutMcpHostSecret(host, HERMES_SANDBOX_NAME, "hermes");
+    await captureHermesGatewayIdentity(sandbox, "hermes-gateway-identity-after-mcp-restore");
+    cleanup.add("lower Hermes Shields before teardown", async () => {
+      const result = await host.nemoclaw(
+        [HERMES_SANDBOX_NAME, "shields", "down", "--timeout", "5m", "--reason", "E2E cleanup"],
+        {
+          artifactName: "cleanup-hermes-shields-down",
+          env: buildAvailabilityProbeEnv(),
+          timeoutMs: 3 * 60_000,
+        },
+      );
+      if (result.exitCode !== 0 && !/not found|does not exist/iu.test(resultText(result))) {
+        expectExitZero(result, "lower Hermes Shields before teardown");
+      }
+    });
+    cleanup.add("capture Hermes post-rebuild MCP evidence", async () => {
+      await artifacts.writeJson(
+        "hermes-post-rebuild-mcp-requests.json",
+        fakeMcp.requests.slice(rebuildDiscoveryOffset).map((request) => ({
+          authenticated: request.auth === `Bearer ${ROTATED_HOST_SECRET}`,
+          path: request.path,
+          responseHasResult: request.responseHasResult,
+          responseStatus: request.responseStatus,
+          rpcMethod: request.rpcMethod,
+        })),
+      );
+      await host.nemoclaw([HERMES_SANDBOX_NAME, "shields", "status"], {
+        artifactName: "hermes-post-rebuild-shields-status",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 60_000,
+      });
+      await sandbox.execShell(
+        HERMES_SANDBOX_NAME,
+        trustedSandboxShellScript(buildHermesMcpRuntimeDiagnosticsScript()),
+        {
+          artifactName: "hermes-post-rebuild-runtime-diagnostics",
+          captureLimitBytes: 32_768,
+          env: buildAvailabilityProbeEnv(),
+          redactionValues: [HOST_SECRET, ROTATED_HOST_SECRET, COMPATIBLE_KEY, TOOL_CHALLENGE],
+          timeoutMs: 60_000,
+        },
+      );
+    });
     await assertAuthenticatedMcpDiscovery(fakeMcp, {
       requestOffset: rebuildDiscoveryOffset,
       expectedSecret: ROTATED_HOST_SECRET,

--- a/test/e2e/support/mcp-bridge-hermes-http.test.ts
+++ b/test/e2e/support/mcp-bridge-hermes-http.test.ts
@@ -32,9 +32,6 @@ describe("Hermes MCP HTTP failure diagnostics", () => {
   it("sends one authenticated request without retrying and redacts its API key from failure output (#8697)", () => {
     const token = "fixture-result-token";
     const script = buildHermesMcpChatProbeScript('{"messages":[]}', token);
-    expect(script.match(/\bcurl "\$@"/gu)).toHaveLength(1);
-    expect(script).not.toMatch(/\bretry\b/iu);
-    expect(script).toContain("Authorization: Bearer ${API_SERVER_KEY}");
 
     const directory = mkdtempSync(path.join(tmpdir(), "nemoclaw-hermes-mcp-http-"));
     const bodyFile = path.join(directory, "body");

--- a/test/rebuild-shields-window.test.ts
+++ b/test/rebuild-shields-window.test.ts
@@ -8,21 +8,24 @@ const shieldsMock = vi.hoisted(() => ({
   shieldsDown: vi.fn(),
   shieldsUp: vi.fn(),
 }));
+const timerMock = vi.hoisted(() => ({ isShieldsTimerDeadlineExpired: vi.fn() }));
 
 vi.mock("../src/lib/shields", () => shieldsMock);
+vi.mock("../src/lib/state/mcp-lifecycle-lock/shields-timer-authority", () => timerMock);
 
-import {
-  openRebuildShieldsWindow,
-  relockRebuildShieldsWindow,
-} from "../src/lib/actions/sandbox/rebuild-shields";
 import {
   openBackupShieldsWindow,
   relockBackupShieldsWindow,
 } from "../src/lib/actions/sandbox/backup-shields-window";
+import {
+  openRebuildShieldsWindow,
+  relockRebuildShieldsWindow,
+} from "../src/lib/actions/sandbox/rebuild-shields";
 
 describe("rebuild shields window", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    timerMock.isShieldsTimerDeadlineExpired.mockReturnValue(false);
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -132,7 +135,7 @@ describe("rebuild shields window", () => {
     );
   });
 
-  it("does nothing when shields were already mutable", () => {
+  it("does nothing when Shields were already mutable", () => {
     shieldsMock.isShieldsDown.mockReturnValue(true);
 
     const window = openRebuildShieldsWindow("mutable-sandbox", "nemoclaw");
@@ -142,5 +145,25 @@ describe("rebuild shields window", () => {
     expect(shieldsMock.shieldsDown).not.toHaveBeenCalled();
     expect(relockRebuildShieldsWindow("mutable-sandbox", window!, true, "nemoclaw")).toBe(true);
     expect(shieldsMock.shieldsUp).not.toHaveBeenCalled();
+
+    timerMock.isShieldsTimerDeadlineExpired.mockReturnValue(true);
+    expect(
+      relockBackupShieldsWindow("mutable-sandbox", window!, true, {
+        operation: "backup-all",
+        reason: "backup",
+        retryCommand: "nemoclaw backup-all",
+        shieldsUpCommand: "nemoclaw mutable-sandbox shields up",
+      }),
+    ).toBe(true);
+    expect(shieldsMock.shieldsUp).not.toHaveBeenCalled();
+  });
+
+  it("settles an elapsed Shields timer before rebuild returns (#8697)", () => {
+    timerMock.isShieldsTimerDeadlineExpired.mockReturnValue(true);
+    const window = { relocked: false, wasLocked: false };
+
+    expect(relockRebuildShieldsWindow("mutable-sandbox", window, true, "nemoclaw")).toBe(true);
+    expect(shieldsMock.shieldsUp).toHaveBeenCalledOnce();
+    expect(window.relocked).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

A long Hermes rebuild can outlive an inherited Shields auto-restore timer. NemoClaw now settles an expired deferred timer through the existing fenced Shields-up path before reporting rebuild success, which prevents lockdown from racing the first post-rebuild tool call.

The live E2E lane now records bounded, redacted HTTP, runtime, fixture, Shields, and cleanup evidence for this boundary.

## Related Issue

Fixes #8697

## Changes

- Restrict the production change to rebuild windows that defer automatic Shields restoration while the lifecycle owner is alive. If that timer expires during rebuild, the existing Shields-up operation settles the timer before rebuild returns success.
- Preserve ordinary backup behavior when the sandbox already had Shields down.
- Record gateway process identity before rebuild and after MCP restoration.
- Record post-rebuild fixture requests without credentials or request bodies. The record includes only the authentication result, method, path, response status, and result presence.
- Capture bounded Hermes logs, filesystem permissions, managed-supervisor status, gateway identity, and Shields status. Existing artifact redaction removes known credentials.
- Lower Shields before MCP and sandbox cleanup. The cleanup registry uses last-in, first-out order, so evidence capture runs first, Shields-down runs second, and older cleanup operations run afterward.

### Confirmed evidence

- Merged PR #8703 added bounded HTTP failure diagnostics for #8697.
- Trusted-main run `31364512126`, Hermes job `93380168425`, completed rebuild in 845,292 ms.
- The first post-rebuild request returned HTTP 500 in 295 ms with `Permission denied: '/sandbox/.hermes/logs'`.
- The inherited Shields timer deadline had elapsed while rebuild held the lifecycle lock. The detached timer applied lockdown when the lock became available.
- The failed run predates the fixture-request ledger in this PR. Its failure location indicates that the request ended before the MCP fixture, but the artifact does not directly record that result.

### Root cause and correction

The failure was not stale MCP configuration or credential rotation. The overdue Shields timer made `/sandbox/.hermes` read-only immediately after rebuild released its lifecycle lock. Rebuild now settles that timer with the existing fenced Shields-up state transition before it reports success.

### Remaining validation

- Run the canonical trusted `mcp-bridge (hermes)` lane on the exact PR commit.
- Confirm the first post-rebuild request returns `MCP_AUTH_REWRITE_OK::nemoclaw-authenticated-mcp-proof`.
- Confirm the fixture records exactly one authenticated `tools/call` with the rotated provider credential.
- Confirm the final evidence records the expected gateway identities, Shields state, redaction, and cleanup result.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change corrects an internal timer-settlement race and adds test evidence. It does not change a command, option, configuration, output contract, or recovery procedure.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex security review covered all nine repository categories and found no actionable finding. The trusted-main live E2E run remains pending.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing rebuild documentation already states that the detached auto-lock timer remains authoritative until rebuild commits a successful Shields-up state. `docs/` is unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d5d0788d0 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 8 timer tests, 63 rebuild/reconciliation tests, 88 Hermes transaction/convergence/integrity tests, 13 E2E support tests, and 2 bounded HTTP diagnostic tests passed. `npm run typecheck:cli` and `npx prek run --from-ref origin/main --to-ref HEAD` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable. The diff changes one lifecycle decision and focused live evidence.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backup protection windows that could remain unlocked after their automatic restore timer expired.
  * Rebuilding protection settings now correctly settles expired timers and reapplies lockdown when required.

* **Tests**
  * Expanded coverage for timer expiration, relocking behavior, and rebuild workflows.
  * Improved diagnostics captured during runtime and gateway lifecycle testing, with sensitive values redacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->