### PR TITLE
fix(inference): retry local Ollama tool-call validation

### DIFF
--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -95,7 +95,7 @@ The starter list includes `qwen3.6:35b` and selects it by default when current G
 When another GPU workload consumes most of the available memory, NemoClaw selects the largest starter model that still fits.
 It pulls the selected model, loads it into memory, and validates it before continuing.
 
-During strict tool-call validation, NemoClaw retries an HTTP `200` response when it contains neither a structured tool call nor tool-call JSON in plain message text.
+During strict tool-call validation, Local Ollama can retry an HTTP `200` response when it contains neither a structured tool call nor tool-call JSON in plain message text.
 NemoClaw waits 5, 15, and 30 seconds between the retry attempts.
 If all four responses omit a tool call, onboarding stops and reports `missing structured tool call` without displaying the response body.
 Other compatible endpoints do not use this retry.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -95,6 +95,12 @@ The starter list includes `qwen3.6:35b` and selects it by default when current G
 When another GPU workload consumes most of the available memory, NemoClaw selects the largest starter model that still fits.
 It pulls the selected model, loads it into memory, and validates it before continuing.
 
+During strict tool-call validation, NemoClaw retries an HTTP `200` response when it contains neither a structured tool call nor tool-call JSON in plain message text.
+NemoClaw waits 5, 15, and 30 seconds between the retry attempts.
+If all four responses omit a tool call, onboarding stops and reports `missing structured tool call` without displaying the response body.
+Other compatible endpoints do not use this retry.
+
+
 <AgentOnly variant="openclaw">
 When Ollama reports a loaded-model context length, NemoClaw uses it for the `contextWindow` written to `openclaw.json` unless you set `NEMOCLAW_CONTEXT_WINDOW`.
 Onboarding stops when the selected model does not declare tool support or returns tool-call JSON as plain message text instead of structured tool calls.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -95,9 +95,10 @@ The starter list includes `qwen3.6:35b` and selects it by default when current G
 When another GPU workload consumes most of the available memory, NemoClaw selects the largest starter model that still fits.
 It pulls the selected model, loads it into memory, and validates it before continuing.
 
-During strict tool-call validation, Local Ollama can retry an HTTP `200` response when it contains neither a structured tool call nor tool-call JSON in plain message text.
-NemoClaw waits 5, 15, and 30 seconds between the retry attempts.
-If all four responses omit a tool call, onboarding stops and reports `missing structured tool call` without displaying the response body.
+During strict tool-call validation, NemoClaw retries a Local Ollama HTTP `200` response only when it omits both a structured tool call and tool-call JSON in plain message text.
+This retry does not apply to a reasoning-only response, which receives one retry with a larger output token limit.
+NemoClaw waits 5, 15, and 30 seconds before the second, third, and fourth validation requests.
+If all four qualifying responses omit both forms of tool call, onboarding stops and reports `missing structured tool call` without displaying the response body.
 Other compatible endpoints do not use this retry.
 
 

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -100,7 +100,7 @@ For Local Ollama strict tool-call validation, NemoClaw uses the missing-tool-cal
 - Ollama returns HTTP `200`.
 - The response contains no structured tool call.
 - The response contains no tool-call JSON in plain message text.
-- The response did not stop at the output token limit after producing only reasoning.
+- The response does not stop at the output token limit after producing only reasoning.
 
 If a response stops at the output token limit after producing only reasoning, NemoClaw retries once with a larger output token limit.
 NemoClaw waits 5, 15, and 30 seconds before the second, third, and fourth validation requests.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -100,9 +100,9 @@ During strict tool-call validation, NemoClaw retries a response from the Local O
 - Ollama returns HTTP `200`.
 - The response contains no structured tool call.
 - The response contains no tool-call JSON in plain message text.
-- The response is not reasoning-only.
+- The response did not stop at the output token limit after producing only reasoning.
 
-If the response is reasoning-only, NemoClaw retries once with a larger output token limit.
+If a response stops at the output token limit after producing only reasoning, NemoClaw retries once with a larger output token limit.
 NemoClaw waits 5, 15, and 30 seconds before the second, third, and fourth validation requests.
 If four consecutive responses meet these conditions, onboarding stops and reports `missing structured tool call` without displaying the response body.
 Other compatible endpoints do not use this retry.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -95,7 +95,7 @@ The starter list includes `qwen3.6:35b` and selects it by default when current G
 When another GPU workload consumes most of the available memory, NemoClaw selects the largest starter model that still fits.
 It pulls the selected model, loads it into memory, and validates it before continuing.
 
-During strict tool-call validation, NemoClaw retries a response from the Local Ollama provider only when all these conditions apply:
+For Local Ollama strict tool-call validation, NemoClaw uses the missing-tool-call retry schedule only when all these conditions apply:
 
 - Ollama returns HTTP `200`.
 - The response contains no structured tool call.
@@ -105,7 +105,7 @@ During strict tool-call validation, NemoClaw retries a response from the Local O
 If a response stops at the output token limit after producing only reasoning, NemoClaw retries once with a larger output token limit.
 NemoClaw waits 5, 15, and 30 seconds before the second, third, and fourth validation requests.
 If four consecutive responses meet these conditions, onboarding stops and reports `missing structured tool call` without displaying the response body.
-Other compatible endpoints do not use this retry.
+NemoClaw does not apply the missing-tool-call retry schedule to other compatible endpoints.
 
 
 <AgentOnly variant="openclaw">

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -95,10 +95,16 @@ The starter list includes `qwen3.6:35b` and selects it by default when current G
 When another GPU workload consumes most of the available memory, NemoClaw selects the largest starter model that still fits.
 It pulls the selected model, loads it into memory, and validates it before continuing.
 
-During strict tool-call validation, NemoClaw retries a Local Ollama HTTP `200` response only when it omits both a structured tool call and tool-call JSON in plain message text.
-This retry does not apply to a reasoning-only response, which receives one retry with a larger output token limit.
+During strict tool-call validation, NemoClaw retries a response from the Local Ollama provider only when all these conditions apply:
+
+- Ollama returns HTTP `200`.
+- The response contains no structured tool call.
+- The response contains no tool-call JSON in plain message text.
+- The response is not reasoning-only.
+
+If the response is reasoning-only, NemoClaw retries once with a larger output token limit.
 NemoClaw waits 5, 15, and 30 seconds before the second, third, and fourth validation requests.
-If all four qualifying responses omit both forms of tool call, onboarding stops and reports `missing structured tool call` without displaying the response body.
+If four consecutive responses meet these conditions, onboarding stops and reports `missing structured tool call` without displaying the response body.
 Other compatible endpoints do not use this retry.
 
 

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -108,6 +108,17 @@ describe("local inference helpers", () => {
     });
   });
 
+  it("enables retries for missing structured tool calls only when Ollama tool calls are required (#8714)", () => {
+    expect(buildOllamaProbeOptions(false)).toMatchObject({
+      requireChatCompletionsToolCalling: true,
+      retryChatCompletionsToolReadiness: true,
+    });
+    expect(buildOllamaProbeOptions(true)).toMatchObject({
+      requireChatCompletionsToolCalling: false,
+      retryChatCompletionsToolReadiness: false,
+    });
+  });
+
   it("builds a credential-free Docker Desktop probe for Windows-host Ollama (#8127)", () => {
     expect(getWindowsHostOllamaDockerReachabilityArgs()).toEqual([
       "run",

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -1614,6 +1614,8 @@ export function validateOllamaModel(
 export function buildOllamaProbeOptions(allowToolsIncompatible: boolean): {
   skipResponsesProbe: true;
   requireChatCompletionsToolCalling: boolean;
+  retryChatCompletionsToolReadiness: boolean;
+
   allowHostDockerInternal: boolean;
   probeFromDocker: { expectedPort: number } | null;
 } {
@@ -1621,6 +1623,8 @@ export function buildOllamaProbeOptions(allowToolsIncompatible: boolean): {
   return {
     skipResponsesProbe: true,
     requireChatCompletionsToolCalling: !allowToolsIncompatible,
+    retryChatCompletionsToolReadiness: !allowToolsIncompatible,
+
     allowHostDockerInternal: windowsHostOllama,
     probeFromDocker: windowsHostOllama ? { expectedPort: OLLAMA_PORT } : null,
   };

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -922,6 +922,100 @@ exit 0
       );
     });
 
+    it("retries Local Ollama validation when HTTP 200 omits a structured tool call (#8714)", () => {
+      const body = `n=$(cat "${HARNESS_COUNTER}")
+n=$((n + 1))
+echo "$n" > "${HARNESS_COUNTER}"
+if [ "$n" -eq 1 ]; then
+  printf '%s' '{"choices":[{"finish_reason":"stop","message":{"content":"OK"}}]}' > "$outfile"
+else
+  printf '%s' '{"choices":[{"finish_reason":"tool_calls","message":{"tool_calls":[{"type":"function","function":{"name":"emit_ok","arguments":{}}}]}}]}' > "$outfile"
+fi
+printf '200'
+`;
+      withFakeCurlProbe(
+        {
+          script: makeFakeCurlScript(body),
+          dirPrefix: "nemoclaw-ollama-tool-readiness-probe-",
+        },
+        ({ lines, counter }) => {
+          const result = probeOpenAiLikeEndpoint(
+            "http://127.0.0.1:11434/v1",
+            "nemotron-3-nano:30b",
+            "",
+            {
+              skipResponsesProbe: true,
+              requireChatCompletionsToolCalling: true,
+              retryChatCompletionsToolReadiness: true,
+            },
+          );
+
+          expect(result).toMatchObject({ ok: true, api: "openai-completions" });
+          expect(fs.readFileSync(counter, "utf8").trim()).toBe("2");
+          expect(lines).toContain(
+            "  Chat Completions API validation did not return a structured tool call; retrying in 5s...",
+          );
+        },
+      );
+    });
+
+    it("does not retry missing structured tool calls for generic endpoints (#8714)", () => {
+      const body = `n=$(cat "${HARNESS_COUNTER}")
+n=$((n + 1))
+echo "$n" > "${HARNESS_COUNTER}"
+printf '%s' '{"choices":[{"finish_reason":"stop","message":{"content":"OK"}}]}' > "$outfile"
+printf '200'
+`;
+      withFakeCurlProbe(
+        { script: makeFakeCurlScript(body), dirPrefix: "nemoclaw-generic-tool-probe-" },
+        ({ counter }) => {
+          const result = probeOpenAiLikeEndpoint(
+            "https://api.example.com/v1",
+            "tool-model",
+            "sk-test",
+            { skipResponsesProbe: true, requireChatCompletionsToolCalling: true },
+          );
+
+          expect(result).toMatchObject({ ok: false });
+          expect(fs.readFileSync(counter, "utf8").trim()).toBe("1");
+        },
+      );
+    });
+
+    it("stops retrying Local Ollama validation after the backoff schedule when structured tool calls remain missing (#8714)", () => {
+      const body = `n=$(cat "${HARNESS_COUNTER}")
+n=$((n + 1))
+echo "$n" > "${HARNESS_COUNTER}"
+printf '%s' '{"choices":[{"finish_reason":"stop","message":{"content":"OK"}}]}' > "$outfile"
+printf '200'
+`;
+      withFakeCurlProbe(
+        { script: makeFakeCurlScript(body), dirPrefix: "nemoclaw-ollama-tool-timeout-" },
+        ({ counter }) => {
+          const result = probeOpenAiLikeEndpoint(
+            "http://127.0.0.1:11434/v1",
+            "nemotron-3-nano:30b",
+            "",
+            {
+              skipResponsesProbe: true,
+              requireChatCompletionsToolCalling: true,
+              retryChatCompletionsToolReadiness: true,
+            },
+          );
+
+          expect(result).toMatchObject({
+            ok: false,
+            failures: [
+              expect.objectContaining({
+                diagnosticCodes: ["openai-chat-missing-structured-tool-call"],
+              }),
+            ],
+          });
+          expect(fs.readFileSync(counter, "utf8").trim()).toBe("4");
+        },
+      );
+    });
+
     it("keeps GPT-5 timeout retries strict when tool calling is required (#6642)", () => {
       const script = `#!/usr/bin/env bash
 outfile=""

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -464,6 +464,8 @@ function probeChatCompletionsToolCalling(endpointUrl, model, apiKey, options = {
       curlStatus: result.curlStatus,
       body: result.body,
       stderr: result.stderr,
+      diagnosticCodes: ["openai-chat-missing-structured-tool-call"],
+
       message: `HTTP ${result.httpStatus}: Chat Completions did not return a tool call`,
       ...(reasoningRetryAttempted ? { reasoningRetryAttempted: true } : {}),
     };
@@ -820,6 +822,15 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
     const chatCompletionsProbe = {
       name: "Chat Completions API",
       api: "openai-completions",
+      retryReason: (result) =>
+        options.retryChatCompletionsToolReadiness === true &&
+        result.reasoningRetryAttempted !== true &&
+        result.curlStatus === 0 &&
+        result.httpStatus === 200 &&
+        result.diagnosticCodes?.includes("openai-chat-missing-structured-tool-call")
+          ? "did not return a structured tool call"
+          : null,
+
       execute: () =>
         options.requireChatCompletionsToolCalling === true
           ? probeChatCompletionsToolCalling(endpointUrl, model, apiKey, {
@@ -952,6 +963,8 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
         curlStatus: result.curlStatus,
         message: result.message,
         body: result.body,
+        diagnosticCodes: result.diagnosticCodes,
+
         reasoningRetryAttempted: result.reasoningRetryAttempted === true,
       });
     }

--- a/src/lib/inference/openai-validation-session.test.ts
+++ b/src/lib/inference/openai-validation-session.test.ts
@@ -43,6 +43,87 @@ describe("OpenAI validation keepalive sequence", () => {
     expect(harness.legacyProbe).not.toHaveBeenCalled();
   });
 
+  it("retries native validation until a structured tool call appears (#8714)", async () => {
+    const observedBodies: Array<Record<string, unknown>> = [];
+    const server = http.createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        observedBodies.push(JSON.parse(body));
+        response.setHeader("content-type", "application/json");
+        response.end(
+          observedBodies.length === 1
+            ? '{"choices":[{"finish_reason":"stop","message":{"content":"OK"}}]}'
+            : '{"choices":[{"finish_reason":"tool_calls","message":{"tool_calls":[{"type":"function","function":{"name":"emit_ok","arguments":{}}}]}}]}',
+        );
+      });
+    });
+    const port = await listen(server);
+    const harness = createOpenAiValidationTestDeps();
+    vi.stubEnv("NEMOCLAW_TEST_NO_SLEEP", "1");
+
+    const result = await probeOpenAiLikeEndpointWithValidationSession(
+      `http://provider.example.test:${port}/v1`,
+      "nemotron-3-nano:30b",
+      "test-key",
+      {
+        skipResponsesProbe: true,
+        requireChatCompletionsToolCalling: true,
+        retryChatCompletionsToolReadiness: true,
+      },
+      harness,
+    );
+
+    expect(result).toMatchObject({ ok: true, api: "openai-completions" });
+    expect(observedBodies).toHaveLength(2);
+    expect(harness.legacyProbe).not.toHaveBeenCalled();
+  });
+
+  it("stops native validation after structured tool calls remain missing (#8714)", async () => {
+    const observedBodies: Array<Record<string, unknown>> = [];
+    const server = http.createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        observedBodies.push(JSON.parse(body));
+        response.setHeader("content-type", "application/json");
+        response.end('{"choices":[{"finish_reason":"stop","message":{"content":"OK"}}]}');
+      });
+    });
+    const port = await listen(server);
+    const harness = createOpenAiValidationTestDeps();
+    vi.stubEnv("NEMOCLAW_TEST_NO_SLEEP", "1");
+
+    const result = await probeOpenAiLikeEndpointWithValidationSession(
+      `http://provider.example.test:${port}/v1`,
+      "nemotron-3-nano:30b",
+      "test-key",
+      {
+        skipResponsesProbe: true,
+        requireChatCompletionsToolCalling: true,
+        retryChatCompletionsToolReadiness: true,
+      },
+      harness,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      failures: [
+        expect.objectContaining({
+          diagnosticCodes: ["openai-chat-missing-structured-tool-call"],
+        }),
+      ],
+    });
+    expect(observedBodies).toHaveLength(4);
+    expect(harness.legacyProbe).not.toHaveBeenCalled();
+  });
+
   it("retries reasoning-only tool-call truncation on the native connection", async () => {
     const observedBodies: Array<Record<string, unknown>> = [];
     const server = http.createServer((request, response) => {

--- a/src/lib/inference/openai-validation-session.test.ts
+++ b/src/lib/inference/openai-validation-session.test.ts
@@ -124,6 +124,46 @@ describe("OpenAI validation keepalive sequence", () => {
     expect(harness.legacyProbe).not.toHaveBeenCalled();
   });
 
+  it("uses one larger-token retry when a readiness response contains only reasoning (#8714)", async () => {
+    const observedBodies: Array<Record<string, unknown>> = [];
+    const server = http.createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        observedBodies.push(JSON.parse(body));
+        response.setHeader("content-type", "application/json");
+        const replies = [
+          '{"choices":[{"finish_reason":"stop","message":{"content":"OK"}}]}',
+          '{"choices":[{"finish_reason":"length","message":{"content":"","reasoning_content":"Planning the tool call."}}]}',
+          '{"choices":[{"finish_reason":"tool_calls","message":{"tool_calls":[{"type":"function","function":{"name":"emit_ok","arguments":{}}}]}}]}',
+        ];
+        response.end(replies[observedBodies.length - 1]);
+      });
+    });
+    const port = await listen(server);
+    const harness = createOpenAiValidationTestDeps();
+    vi.stubEnv("NEMOCLAW_TEST_NO_SLEEP", "1");
+
+    const result = await probeOpenAiLikeEndpointWithValidationSession(
+      `http://provider.example.test:${port}/v1`,
+      "nemotron-3-nano:30b",
+      "test-key",
+      {
+        skipResponsesProbe: true,
+        requireChatCompletionsToolCalling: true,
+        retryChatCompletionsToolReadiness: true,
+      },
+      harness,
+    );
+
+    expect(result).toMatchObject({ ok: true, api: "openai-completions" });
+    expect(observedBodies.map((body) => body.max_tokens)).toEqual([256, 256, 1024]);
+    expect(harness.legacyProbe).not.toHaveBeenCalled();
+  });
+
   it("retries reasoning-only tool-call truncation on the native connection", async () => {
     const observedBodies: Array<Record<string, unknown>> = [];
     const server = http.createServer((request, response) => {

--- a/src/lib/inference/openai-validation-session.test.ts
+++ b/src/lib/inference/openai-validation-session.test.ts
@@ -43,7 +43,7 @@ describe("OpenAI validation keepalive sequence", () => {
     expect(harness.legacyProbe).not.toHaveBeenCalled();
   });
 
-  it("retries the validation session after HTTP 200 omits a structured tool call (#8714)", async () => {
+  it("retries the validation session after an HTTP 200 response omits a structured tool call (#8714)", async () => {
     const observedBodies: Array<Record<string, unknown>> = [];
     const server = http.createServer((request, response) => {
       let body = "";

--- a/src/lib/inference/openai-validation-session.test.ts
+++ b/src/lib/inference/openai-validation-session.test.ts
@@ -43,7 +43,7 @@ describe("OpenAI validation keepalive sequence", () => {
     expect(harness.legacyProbe).not.toHaveBeenCalled();
   });
 
-  it("retries native validation until a structured tool call appears (#8714)", async () => {
+  it("retries the validation session after HTTP 200 omits a structured tool call (#8714)", async () => {
     const observedBodies: Array<Record<string, unknown>> = [];
     const server = http.createServer((request, response) => {
       let body = "";
@@ -82,7 +82,7 @@ describe("OpenAI validation keepalive sequence", () => {
     expect(harness.legacyProbe).not.toHaveBeenCalled();
   });
 
-  it("stops native validation after structured tool calls remain missing (#8714)", async () => {
+  it("stops the validation session after four HTTP 200 responses omit structured tool calls (#8714)", async () => {
     const observedBodies: Array<Record<string, unknown>> = [];
     const server = http.createServer((request, response) => {
       let body = "";

--- a/src/lib/inference/openai-validation-session.ts
+++ b/src/lib/inference/openai-validation-session.ts
@@ -97,6 +97,7 @@ function chatToolPayload(model: string, maxTokens = STRICT_TOOL_PROBE_INITIAL_TO
 function failedChatValidation(
   result: CurlProbeResult,
   failureMessage: string,
+  diagnosticCodes?: string[],
 ): OpenAiValidationResult {
   const failure = {
     name: "Chat Completions API with tool calling",
@@ -104,6 +105,7 @@ function failedChatValidation(
     curlStatus: result.curlStatus,
     message: failureMessage,
     body: result.body,
+    ...(diagnosticCodes ? { diagnosticCodes } : {}),
   };
   return {
     ok: false,
@@ -118,7 +120,11 @@ function failedChatToolCall(result: CurlProbeResult, leaked: boolean): OpenAiVal
       "Use an endpoint/runtime that returns structured tool_calls (for Hermes on local inference, " +
       "prefer vLLM with --tool-call-parser hermes)."
     : `HTTP ${result.httpStatus}: Chat Completions did not return a tool call`;
-  return failedChatValidation(result, failureMessage);
+  return failedChatValidation(
+    result,
+    failureMessage,
+    leaked ? undefined : ["openai-chat-missing-structured-tool-call"],
+  );
 }
 
 function failedChatValidationAfterReasoningRetry(): OpenAiValidationResult {
@@ -263,6 +269,7 @@ export async function probeOpenAiLikeEndpointWithValidationSession(
     return deps.legacyProbe(endpointUrl, model, apiKey, options);
   };
   let retriedReasoningTruncation = false;
+  let retriedToolReadiness = false;
 
   try {
     if (!options.skipResponsesProbe) {
@@ -336,17 +343,36 @@ export async function probeOpenAiLikeEndpointWithValidationSession(
               }),
             retryTransientHttp,
           );
-        const initial = await requestChat();
-        if (!requireToolCall || !initial.ok || !isReasoningOnlyLengthResponse(initial.body)) {
-          return initial;
+        let result = await requestChat();
+        if (!requireToolCall || !result.ok) return result;
+        if (isReasoningOnlyLengthResponse(result.body)) {
+          retriedReasoningTruncation = true;
+          console.log(STRICT_TOOL_PROBE_REASONING_RETRY_MESSAGE);
+          addTraceEvent("tool_call_reasoning_retry", {
+            initial_max_tokens: STRICT_TOOL_PROBE_INITIAL_TOKENS,
+            retry_max_tokens: STRICT_TOOL_PROBE_RETRY_TOKENS,
+          });
+          return requestChat(STRICT_TOOL_PROBE_RETRY_TOKENS, false);
         }
-        retriedReasoningTruncation = true;
-        console.log(STRICT_TOOL_PROBE_REASONING_RETRY_MESSAGE);
-        addTraceEvent("tool_call_reasoning_retry", {
-          initial_max_tokens: STRICT_TOOL_PROBE_INITIAL_TOKENS,
-          retry_max_tokens: STRICT_TOOL_PROBE_RETRY_TOKENS,
-        });
-        return requestChat(STRICT_TOOL_PROBE_RETRY_TOKENS, false);
+        for (const delayMs of RETRY_DELAYS_MS) {
+          if (
+            options.retryChatCompletionsToolReadiness !== true ||
+            result.httpStatus !== 200 ||
+            deps.hasChatCompletionsToolCall(result.body) ||
+            deps.hasChatCompletionsToolCallLeak(result.body)
+          ) {
+            break;
+          }
+          retriedToolReadiness = true;
+          console.log(
+            `  Chat Completions API validation did not return a structured tool call; retrying in ${Math.round(delayMs / 1000)}s...`,
+          );
+          addTraceEvent("tool_call_readiness_retry", { delay_ms: delayMs });
+          await waitForRetry(delayMs);
+          result = await requestChat(STRICT_TOOL_PROBE_INITIAL_TOKENS, false);
+          if (!result.ok) break;
+        }
+        return result;
       },
     );
     if (chat.curlStatus !== 0) {
@@ -362,7 +388,7 @@ export async function probeOpenAiLikeEndpointWithValidationSession(
     if (requireToolCall) {
       if (!deps.hasChatCompletionsToolCall(chat.body)) {
         const leaked = deps.hasChatCompletionsToolCallLeak(chat.body);
-        if (retriedReasoningTruncation) {
+        if (retriedReasoningTruncation || retriedToolReadiness) {
           return failedChatToolCall(chat, leaked);
         }
         return nativeFailureFallback(

--- a/src/lib/inference/openai-validation-session.ts
+++ b/src/lib/inference/openai-validation-session.ts
@@ -343,9 +343,8 @@ export async function probeOpenAiLikeEndpointWithValidationSession(
               }),
             retryTransientHttp,
           );
-        let result = await requestChat();
-        if (!requireToolCall || !result.ok) return result;
-        if (isReasoningOnlyLengthResponse(result.body)) {
+        const retryReasoningOnly = (candidate: CurlProbeResult) => {
+          if (!isReasoningOnlyLengthResponse(candidate.body)) return null;
           retriedReasoningTruncation = true;
           console.log(STRICT_TOOL_PROBE_REASONING_RETRY_MESSAGE);
           addTraceEvent("tool_call_reasoning_retry", {
@@ -353,7 +352,11 @@ export async function probeOpenAiLikeEndpointWithValidationSession(
             retry_max_tokens: STRICT_TOOL_PROBE_RETRY_TOKENS,
           });
           return requestChat(STRICT_TOOL_PROBE_RETRY_TOKENS, false);
-        }
+        };
+        let result = await requestChat();
+        if (!requireToolCall || !result.ok) return result;
+        const initialReasoningRetry = retryReasoningOnly(result);
+        if (initialReasoningRetry) return initialReasoningRetry;
         for (const delayMs of RETRY_DELAYS_MS) {
           if (
             options.retryChatCompletionsToolReadiness !== true ||
@@ -371,6 +374,8 @@ export async function probeOpenAiLikeEndpointWithValidationSession(
           await waitForRetry(delayMs);
           result = await requestChat(STRICT_TOOL_PROBE_INITIAL_TOKENS, false);
           if (!result.ok) break;
+          const reasoningRetry = retryReasoningOnly(result);
+          if (reasoningRetry) return reasoningRetry;
         }
         return result;
       },

--- a/src/lib/inference/openai-validation-session.ts
+++ b/src/lib/inference/openai-validation-session.ts
@@ -27,6 +27,8 @@ export interface OpenAiValidationOptions {
   extraHeaders?: readonly string[];
   requireResponsesToolCalling?: boolean;
   requireChatCompletionsToolCalling?: boolean;
+  retryChatCompletionsToolReadiness?: boolean;
+
   skipResponsesProbe?: boolean;
   probeStreaming?: boolean;
   isWsl?: boolean;

--- a/src/lib/inference/probe-retry.ts
+++ b/src/lib/inference/probe-retry.ts
@@ -82,13 +82,17 @@ function executeProbeWithHttpRetry(probe) {
         curl_status: result.curlStatus,
       });
       for (const delayMs of HTTP_PROBE_RETRY_DELAYS_MS) {
-        if (!shouldRetryHttpProbe(result)) break;
+        const customReason = probe.retryReason?.(result);
+        const httpRetry = shouldRetryHttpProbe(result);
+        if (!httpRetry && !customReason) break;
+        const reason = customReason || `returned HTTP ${result.httpStatus}`;
         console.log(
-          `  ${probe.name} validation returned HTTP ${result.httpStatus}; retrying in ${Math.round(delayMs / 1000)}s...`,
+          `  ${probe.name} validation ${reason}; retrying in ${Math.round(delayMs / 1000)}s...`,
         );
         trace.addTraceEvent("probe_retry_sleep", {
           delay_ms: delayMs,
           http_status: result.httpStatus,
+          retry_reason: customReason ? "semantic_readiness" : "http_status",
         });
         sleepSync(delayMs);
         attempt += 1;

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -91,6 +91,8 @@ export interface InferenceSelectionValidationHelpers {
       extraHeaders?: readonly string[];
       requireResponsesToolCalling?: boolean;
       requireChatCompletionsToolCalling?: boolean;
+      retryChatCompletionsToolReadiness?: boolean;
+
       skipResponsesProbe?: boolean;
       probeStreaming?: boolean;
       allowHostDockerInternal?: boolean;
@@ -258,6 +260,8 @@ export function createInferenceSelectionValidationHelpers(
       extraHeaders?: readonly string[];
       requireResponsesToolCalling?: boolean;
       requireChatCompletionsToolCalling?: boolean;
+      retryChatCompletionsToolReadiness?: boolean;
+
       skipResponsesProbe?: boolean;
       probeStreaming?: boolean;
       allowHostDockerInternal?: boolean;

--- a/src/lib/onboard/probe-diagnostics.test.ts
+++ b/src/lib/onboard/probe-diagnostics.test.ts
@@ -92,4 +92,23 @@ describe("summarizeProbeForDisplay", () => {
       "timeout",
     );
   });
+  it("surfaces a missing structured tool call without raw provider text (#8714)", () => {
+    const summary = summarizeProbeForDisplay({
+      message: "raw provider response with secret-key",
+      failures: [
+        {
+          name: "Chat Completions API",
+          httpStatus: 200,
+          curlStatus: 0,
+          message: "raw provider response with secret-key",
+          body: "raw provider response with secret-key",
+          diagnosticCodes: ["openai-chat-missing-structured-tool-call"],
+        },
+      ],
+    });
+
+    expect(summary).toBe("Chat Completions API: missing structured tool call");
+    expect(summary).not.toContain("secret-key");
+    expect(summary).not.toContain("raw provider response");
+  });
 });

--- a/src/lib/onboard/probe-diagnostics.ts
+++ b/src/lib/onboard/probe-diagnostics.ts
@@ -9,6 +9,7 @@ const SAFE_PROBE_DIAGNOSTICS = new Map<string, string>([
   ["anthropic-streaming-missing-content-block-delta", "missing content_block_delta"],
   ["anthropic-streaming-missing-message-start", "missing message_start"],
   ["anthropic-streaming-missing-message-stop", "missing message_stop"],
+  ["openai-chat-missing-structured-tool-call", "missing structured tool call"],
 ]);
 
 function summarizeSafeProbeDiagnostics(value: unknown): string[] {

--- a/test/fixtures/strict-tool-call-probe-driver.ts
+++ b/test/fixtures/strict-tool-call-probe-driver.ts
@@ -366,10 +366,12 @@ function assertChatCompletionRequests(requests, expectedCount) {
     const result = await validate(endpoint, recoveryCalls);
     assert.deepEqual(result, { ok: false, retry: "retry" });
     const requests = readRequests();
-    assert.equal(requests.length, 2);
-    assertChatCompletionRequests(requests, 1);
+    assert.equal(requests.length, 5);
+    assertChatCompletionRequests(requests, 4);
     assert.equal(recoveryCalls.length, 1);
-    console.log("[PASS] strict validation fails closed when no structured tool_call is returned");
+    console.log(
+      "[PASS] strict validation retries three times and stops after four responses omit structured tool calls",
+    );
   });
 })().catch((error) => {
   console.error(error && error.stack ? error.stack : error);

--- a/test/strict-tool-call-probe.test.ts
+++ b/test/strict-tool-call-probe.test.ts
@@ -44,7 +44,7 @@ const EXPECTED_PASS_MARKERS = [
   "[PASS] strict validation succeeds with structured tool_calls",
   "[PASS] Local Ollama onboarding caller enforces strict Chat Completions validation",
   "[PASS] strict validation retries a transient 502 and keeps bounded payloads",
-  "[PASS] strict validation fails closed when no structured tool_call is returned",
+  "[PASS] strict validation retries three times and stops after four responses omit structured tool calls",
 ];
 
 describe("strict Chat Completions tool-call probe (#4537)", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Local Ollama onboarding now retries an HTTP 200 Chat Completions response that omits a structured tool call while the selected model becomes tool-call responsive. Generic endpoints retain the existing behavior, and exhausted retries report the missing structured tool call without provider response content.

## Related Issue

Fixes #8714

## Changes

- Mark missing structured tool calls with a credential-free diagnostic code.
- Extend the existing 5, 15, and 30-second probe backoff only when Local Ollama requires tool calls. An internal option is necessary because the shared probe also validates generic endpoints; inferring retry behavior from a loopback URL would change those consumers. The issue #8714 regression tests protect this scope.
- Add regression coverage for retry success, bounded exhaustion, generic endpoint behavior, and redacted diagnostics.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Self-review confirmed that retries reuse the existing endpoint and auth configuration, log only fixed diagnostic text, remain bounded, and do not change generic endpoint behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/inference/set-up-ollama.mdx`; generated OpenClaw and Hermes variants document the qualifying conditions, 5/15/30-second waits, four-request limit, larger-token reasoning retry, safe diagnostic, and generic-endpoint exclusion.
- Agent: Pi CLI
<!-- docs-review-head-sha: ba0eb6a05bc9a2dbdf7c4051edb34e50113ab74a -->
<!-- docs-review-agents-blob-sha: c4923a3e367681ea6f796fb595f3b97497d92fa0 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` did not change.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/inference/onboard-probes.test.ts src/lib/inference/local.test.ts src/lib/onboard/probe-diagnostics.test.ts src/lib/inference/openai-validation-session.test.ts` — 4 files and 137 tests passed; `npx vitest run --project integration test/strict-tool-call-probe.test.ts` — 1 file and 1 test passed; `npm run docs` — 0 errors and 2 existing warnings.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local model validation by retrying responses that lack structured tool calls.
  * Added clearer diagnostics for tool-call readiness failures.
  * Retry behavior now distinguishes readiness issues from HTTP errors.
  * Windows-host validation avoids unsupported tool-call retries.
  * Reasoning-only responses receive an appropriate retry before validation stops.
* **Security**
  * User-facing diagnostics show safe failure labels without exposing provider responses or secrets.
* **Documentation**
  * Documented Local Ollama tool-call validation and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->