### PR TITLE
fix(sandbox): wait for managed supervisor on start

### DIFF
--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -85,11 +85,12 @@ import {
   type GatewayRestartFailureLayer,
   type ManagedGatewayControlCompletion,
   resolveSandboxDashboardPort,
+  waitForManagedGatewaySupervisor,
 } from "./process-recovery";
 import { runTerminalAgentConnectProbe } from "./terminal-connect-probe";
 import { applyOpenShellVmDnsMonkeypatch, shouldApplyVmDnsMonkeypatch } from "./vm-dns-monkeypatch";
 
-export { runConnectAutoPairApprovalPass };
+export { runConnectAutoPairApprovalPass, waitForManagedGatewaySupervisor };
 
 export type SandboxConnectOptions = {
   probeOnly?: boolean;

--- a/src/lib/actions/sandbox/start.test.ts
+++ b/src/lib/actions/sandbox/start.test.ts
@@ -58,6 +58,9 @@ function harness(overrides: Partial<SandboxStartDeps> = {}) {
   const restoreStartupState = vi.fn<NonNullable<SandboxStartDeps["restoreStartupState"]>>(
     () => SUCCESSFUL_RECOVERY,
   );
+  const waitForManagedGatewaySupervisor = vi.fn<
+    NonNullable<SandboxStartDeps["waitForManagedGatewaySupervisor"]>
+  >(() => false);
   const log = vi.fn<(message: string) => void>();
   const runtimeProviders = createRuntimeProviderBundleRegistry([
     [
@@ -76,6 +79,7 @@ function harness(overrides: Partial<SandboxStartDeps> = {}) {
     getSandbox,
     runtimeProviders,
     restoreStartupState,
+    waitForManagedGatewaySupervisor,
     verifyGateway,
     log,
     ...overrides,
@@ -90,6 +94,7 @@ function harness(overrides: Partial<SandboxStartDeps> = {}) {
     printDockerRuntimeDownGuidance,
     recoverDockerDriverSandbox,
     restoreStartupState,
+    waitForManagedGatewaySupervisor,
     verifyGateway,
   };
 }
@@ -162,6 +167,106 @@ describe("startSandbox", () => {
     expect(h.restoreStartupState.mock.invocationCallOrder[1]).toBeLessThan(
       h.verifyGateway.mock.invocationCallOrder[0],
     );
+  });
+
+  it("waits for a transient managed supervisor before repeating full startup recovery (#8726)", async () => {
+    const h = harness();
+    h.restoreStartupState
+      .mockReturnValueOnce({
+        ...FAILED_RECOVERY,
+        recoveryFailureLayer: "supervisor not running",
+        recoveryFailureDetail: "SUPERVISOR_NOT_RUNNING",
+      })
+      .mockReturnValueOnce(SUCCESSFUL_RECOVERY);
+    h.waitForManagedGatewaySupervisor.mockReturnValue(true);
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.restoreStartupState).toHaveBeenCalledTimes(2);
+    expect(h.waitForManagedGatewaySupervisor).toHaveBeenCalledOnce();
+    expect(h.waitForManagedGatewaySupervisor).toHaveBeenCalledWith("my-sandbox");
+    expect(h.verifyGateway).toHaveBeenCalledOnce();
+    expect(h.restoreStartupState.mock.invocationCallOrder[0]).toBeLessThan(
+      h.waitForManagedGatewaySupervisor.mock.invocationCallOrder[0],
+    );
+    expect(h.waitForManagedGatewaySupervisor.mock.invocationCallOrder[0]).toBeLessThan(
+      h.restoreStartupState.mock.invocationCallOrder[1],
+    );
+    expect(h.restoreStartupState.mock.invocationCallOrder[1]).toBeLessThan(
+      h.verifyGateway.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("preserves the first recovery failure when the managed supervisor remains absent (#8726)", async () => {
+    const h = harness();
+    h.restoreStartupState.mockReturnValue({
+      ...FAILED_RECOVERY,
+      recoveryFailureLayer: "supervisor not running",
+      recoveryFailureDetail: "SUPERVISOR_NOT_RUNNING",
+    });
+
+    await expect(startSandbox("my-sandbox", h.deps)).rejects.toThrow(
+      "supervisor not running: SUPERVISOR_NOT_RUNNING",
+    );
+    expect(h.restoreStartupState).toHaveBeenCalledOnce();
+    expect(h.waitForManagedGatewaySupervisor).toHaveBeenCalledOnce();
+    expect(h.verifyGateway).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when recovery still fails after the managed supervisor appears (#8726)", async () => {
+    const h = harness();
+    const missingSupervisor = {
+      ...FAILED_RECOVERY,
+      recoveryFailureLayer: "supervisor not running" as const,
+      recoveryFailureDetail: "SUPERVISOR_NOT_RUNNING",
+    };
+    h.restoreStartupState.mockReturnValue(missingSupervisor);
+    h.waitForManagedGatewaySupervisor.mockReturnValue(true);
+
+    await expect(startSandbox("my-sandbox", h.deps)).rejects.toThrow(
+      "supervisor not running: SUPERVISOR_NOT_RUNNING",
+    );
+    expect(h.restoreStartupState).toHaveBeenCalledTimes(2);
+    expect(h.waitForManagedGatewaySupervisor).toHaveBeenCalledOnce();
+    expect(h.verifyGateway).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["definitive supervisor failure", "supervisor unavailable", "SUPERVISOR_UNAVAILABLE"],
+    [
+      "unclassified missing-supervisor output",
+      "supervisor not running",
+      "prefix SUPERVISOR_NOT_RUNNING suffix",
+    ],
+  ] as const)("does not wait after a %s (#8726)", async (_label, layer, detail) => {
+    const h = harness();
+    h.restoreStartupState.mockReturnValue({
+      ...FAILED_RECOVERY,
+      recoveryFailureLayer: layer,
+      recoveryFailureDetail: detail,
+    });
+
+    await expect(startSandbox("my-sandbox", h.deps)).rejects.toThrow(detail);
+    expect(h.restoreStartupState).toHaveBeenCalledOnce();
+    expect(h.waitForManagedGatewaySupervisor).not.toHaveBeenCalled();
+    expect(h.verifyGateway).not.toHaveBeenCalled();
+  });
+
+  it("keeps successful legacy supervisor relaunch recovery free of a settling wait (#8726)", async () => {
+    const h = harness();
+    h.restoreStartupState.mockReturnValue({
+      ...SUCCESSFUL_RECOVERY,
+      wasRunning: false,
+      recovered: true,
+    });
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.restoreStartupState).toHaveBeenCalledOnce();
+    expect(h.waitForManagedGatewaySupervisor).not.toHaveBeenCalled();
+    expect(h.verifyGateway).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/src/lib/actions/sandbox/start.test.ts
+++ b/src/lib/actions/sandbox/start.test.ts
@@ -214,6 +214,25 @@ describe("startSandbox", () => {
     expect(h.verifyGateway).not.toHaveBeenCalled();
   });
 
+  it("preserves the first recovery failure when the managed supervisor wait throws (#8726)", async () => {
+    const h = harness();
+    h.restoreStartupState.mockReturnValue({
+      ...FAILED_RECOVERY,
+      recoveryFailureLayer: "supervisor not running",
+      recoveryFailureDetail: "SUPERVISOR_NOT_RUNNING",
+    });
+    h.waitForManagedGatewaySupervisor.mockImplementation(() => {
+      throw new Error("managed supervisor probe failed");
+    });
+
+    await expect(startSandbox("my-sandbox", h.deps)).rejects.toThrow(
+      "supervisor not running: SUPERVISOR_NOT_RUNNING",
+    );
+    expect(h.restoreStartupState).toHaveBeenCalledOnce();
+    expect(h.waitForManagedGatewaySupervisor).toHaveBeenCalledOnce();
+    expect(h.verifyGateway).not.toHaveBeenCalled();
+  });
+
   it("fails closed when recovery still fails after the managed supervisor appears (#8726)", async () => {
     const h = harness();
     const missingSupervisor = {

--- a/src/lib/actions/sandbox/start.ts
+++ b/src/lib/actions/sandbox/start.ts
@@ -54,8 +54,20 @@ export interface SandboxStartDeps {
   getSandbox?: typeof registry.getSandbox;
   runtimeProviders?: RuntimeProviderBundleRegistry;
   restoreStartupState?: (sandboxName: string) => SandboxStartupRecoveryResult;
+  waitForManagedGatewaySupervisor?: (sandboxName: string) => boolean;
   verifyGateway?: (sandboxName: string) => Promise<void>;
   log?: (message: string) => void;
+}
+
+function isMissingManagedSupervisorStartupFailure(
+  check: SandboxStartupRecoveryResult,
+  failure: string,
+): boolean {
+  return (
+    failure === "supervisor not running: SUPERVISOR_NOT_RUNNING" &&
+    check.recoveryFailureLayer === "supervisor not running" &&
+    check.recoveryFailureDetail === "SUPERVISOR_NOT_RUNNING"
+  );
 }
 
 function startupRecoveryFailure(check: SandboxStartupRecoveryResult): string | null {
@@ -132,7 +144,27 @@ export async function startSandbox(
     } catch (error) {
       throw preservedSandboxRecoveryError(name, error);
     }
-    const failure = startupRecoveryFailure(recovery);
+    let failure = startupRecoveryFailure(recovery);
+    if (failure && isMissingManagedSupervisorStartupFailure(recovery, failure)) {
+      let supervisorReady = false;
+      try {
+        const waitForSupervisor =
+          deps.waitForManagedGatewaySupervisor ??
+          (require("./connect") as typeof import("./connect")).waitForManagedGatewaySupervisor;
+        supervisorReady = waitForSupervisor(name);
+      } catch {
+        // Preserve the authoritative first recovery failure when the bounded
+        // read-only settling probe itself cannot complete.
+      }
+      if (supervisorReady) {
+        try {
+          recovery = restoreStartupState(name);
+        } catch (error) {
+          throw preservedSandboxRecoveryError(name, error);
+        }
+        failure = startupRecoveryFailure(recovery);
+      }
+    }
     if (failure) throw preservedSandboxRecoveryError(name, failure);
     log("  Checking gateway health and host forwards…");
     await (deps.verifyGateway ?? verifyGateway)(name);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Ordinary stopped-sandbox startup now waits through only an exact transient missing-supervisor result, then repeats the complete startup recovery before readiness and forward verification. Definitive or unclassified failures remain terminal, and successful legacy supervisor relaunch recovery does not incur a settling delay.

## Related Issue
Fixes #8726

## Changes
- Reuse the bounded authenticated managed-supervisor waiter after the first recovery returns exact `SUPERVISOR_NOT_RUNNING`.
- Repeat full startup restoration after the supervisor appears so Shields, MCP, managed health, OpenShell readiness, and host forwards retain their existing checks.
- Cover wait-to-success, persistent absence, second-pass failure, definitive and unclassified failures, and unchanged legacy relaunch behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing run, recovery, and command-reference pages already document full startup recovery, final readiness and forward checks, and fail-closed container preservation. This fix restores that contract for one transient race without changing commands, configuration, remediation, or stable output.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Security-rubric self-review confirmed that only the existing authenticated read-only waiter is reused, the retry gate requires the exact classified marker, the complete recovery boundary runs again, and definitive or unclassified results remain fail-closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change restores the already documented stopped-sandbox `start` recovery contract for one exact transient supervisor race. The final additional test only proves that a waiter exception preserves the existing fail-closed result; it does not change user-facing behavior or documentation ownership.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a85a4a922 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/actions/sandbox/start.test.ts` (28 passed) and `npx vitest run --project integration test/process-recovery-supervisor-relaunch.test.ts` (21 passed).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox startup recovery when the managed gateway supervisor is temporarily unavailable.
  * Startup now checks for supervisor readiness and retries recovery when the supervisor becomes available.
  * Preserved the original error when readiness checks fail or recovery cannot be completed.
  * Avoided unnecessary readiness checks for definitive or unrelated startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->