### PR TITLE
fix(sandbox): serialize live create handoff

### DIFF
--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -507,8 +507,10 @@ describe("runSandboxGpuCreateFlow proof authorization", () => {
 });
 
 describe("runSandboxGpuCreateFlow native failure and readiness", () => {
-  it("threads restart-safe startup resource limits on the no-GPU Docker route", async () => {
+  it("defers restart-safe no-GPU recreation until the create process exits (#8720)", async () => {
     const input = createInput();
+    const patch = createPatch();
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValueOnce(patch);
     input.sandboxGpuConfig = {
       ...input.sandboxGpuConfig,
       mode: "0",
@@ -534,6 +536,17 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
         requiredUlimits: input.requiredUlimits,
       }),
     );
+    expect(mocks.streamSandboxCreate).toHaveBeenCalledWith(
+      "openshell",
+      ["sandbox", "create"],
+      input.sandboxEnv,
+      expect.objectContaining({ waitForReadyTermination: true }),
+    );
+    const onPoll = mocks.streamSandboxCreate.mock.calls[0]?.[3]?.onPoll;
+    expect(onPoll).toBeTypeOf("function");
+    onPoll();
+    expect(patch.maybeApplyDuringCreate).not.toHaveBeenCalled();
+    expect(patch.ensureApplied).toHaveBeenCalledOnce();
   });
 
   it("does not replace a native GPU container solely to persist its startup command", async () => {

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -128,6 +128,10 @@ export function createSandboxGpuCreateAttemptRunner(
           },
         })
       : null;
+    const persistRestartSafeStartup =
+      input.persistStartupCommand === true && (route !== "native" || hasRequiredUlimits);
+    const deferRestartSafeCutover =
+      !managedLifecycle && !compatibility && persistRestartSafeStartup;
     const runtimePatch =
       managedLifecycle?.patch ??
       createDockerGpuSandboxCreatePatch({
@@ -135,8 +139,7 @@ export function createSandboxGpuCreateAttemptRunner(
         // The startup clone preserves native CDI devices, so DCode can apply its
         // exact required limits without replacing the native GPU envelope.
         // Other native routes are not swapped solely to persist a command.
-        persistStartupCommand:
-          input.persistStartupCommand === true && (route !== "native" || hasRequiredUlimits),
+        persistStartupCommand: persistRestartSafeStartup,
         externalRecreation: false,
         sandboxName: input.sandboxName,
         gpuDevice: input.sandboxGpuConfig.sandboxGpuDevice,
@@ -161,13 +164,16 @@ export function createSandboxGpuCreateAttemptRunner(
           const list = deps.runCaptureOpenshell(["sandbox", "list"], { ignoreError: true });
           return isSandboxReady(list, input.sandboxName);
         },
-        onPoll: () => runtimePatch.maybeApplyDuringCreate(),
+        onPoll: () => {
+          if (!deferRestartSafeCutover) runtimePatch.maybeApplyDuringCreate();
+        },
         readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent(
           input.terminalAgent,
           input.sandboxEnv,
         ),
         failureCheck: runtimePatch.createFailureMessage,
         traceEvent: addTraceEvent,
+        waitForReadyTermination: deferRestartSafeCutover,
         initialPhase:
           compatibility && (input.prebuild.imageRef || state.compatibilityArgv)
             ? "create"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Live onboarding now waits for the OpenShell create client to release ownership before applying restart-safe Docker recreation. Previously the active onboarding path bypassed the existing ownership barrier, so recreation could race the still-running create process and leave fresh sandboxes unready.

## Related Issue
Follow-up to #8720. This is complementary to the stopped-sandbox recovery change in #8728.

## Changes
- Reuse `streamSandboxCreate`'s existing `waitForReadyTermination` barrier in the active unmanaged, non-compatibility restart-safe path.
- Suppress the existing poll-time recreation in that path so the existing `ensureApplied()` cutover runs only after create ownership is released.
- Tighten the existing no-GPU Docker-route test to cover the barrier, suppressed early patch, and deferred cutover without adding a new test file.
- Leave stopped-sandbox recovery, timing thresholds, legacy upgrades, and MCP coverage unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores the documented onboarding-ready contract without changing commands, configuration, remediation, or intended output.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The change only gates the existing restart-safe recreation on release of create-process ownership. Existing failure classification, managed lifecycle handling, compatibility recreation, rollback, and readiness checks remain unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. Existing `docs/reference/commands.mdx` and `docs/get-started/quickstart.mdx` already own the unchanged create, ready, and dashboard contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e8d9724b9 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/sandbox-gpu-create-flow.test.ts src/lib/sandbox/create-stream.test.ts` (56 passed); `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the change is a focused two-file onboarding sequencing fix covered by targeted tests and normal hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
