### PR TITLE
test(sandbox): exercise active create handoff

### DIFF
--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -511,11 +511,16 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
     const input = createInput();
     const patch = createPatch();
     const createHandoff: string[] = [];
+    let completeCreate!: () => void;
+    const createPending = new Promise<void>((resolve) => {
+      completeCreate = resolve;
+    });
     mocks.createDockerGpuSandboxCreatePatch.mockReturnValueOnce(patch);
     mocks.streamSandboxCreate.mockImplementationOnce(async (...args) => {
       const options = args[3];
       createHandoff.push("poll");
       options.onPoll();
+      await createPending;
       createHandoff.push("create-complete");
       return { status: 0, output: "Created sandbox: alpha", sawProgress: true };
     });
@@ -536,9 +541,12 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
       { name: "nofile", soft: 65_536, hard: 65_536 },
     ];
 
-    await expect(runSandboxGpuCreateFlow(input, createDeps())).resolves.toMatchObject({
-      route: "none",
-    });
+    const flow = runSandboxGpuCreateFlow(input, createDeps());
+    await vi.waitFor(() => expect(createHandoff).toEqual(["poll"]));
+    expect(patch.ensureApplied).not.toHaveBeenCalled();
+    completeCreate();
+
+    await expect(flow).resolves.toMatchObject({ route: "none" });
 
     expect(mocks.createDockerGpuSandboxCreatePatch).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -510,7 +510,18 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
   it("defers restart-safe no-GPU recreation until the create process exits (#8720)", async () => {
     const input = createInput();
     const patch = createPatch();
+    const createHandoff: string[] = [];
     mocks.createDockerGpuSandboxCreatePatch.mockReturnValueOnce(patch);
+    mocks.streamSandboxCreate.mockImplementationOnce(async (...args) => {
+      const options = args[3];
+      createHandoff.push("poll");
+      options.onPoll();
+      createHandoff.push("create-complete");
+      return { status: 0, output: "Created sandbox: alpha", sawProgress: true };
+    });
+    patch.ensureApplied.mockImplementationOnce(() => {
+      createHandoff.push("ensure-applied");
+    });
     input.sandboxGpuConfig = {
       ...input.sandboxGpuConfig,
       mode: "0",
@@ -542,11 +553,8 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
       input.sandboxEnv,
       expect.objectContaining({ waitForReadyTermination: true }),
     );
-    const onPoll = mocks.streamSandboxCreate.mock.calls[0]?.[3]?.onPoll;
-    expect(onPoll).toBeTypeOf("function");
-    onPoll();
     expect(patch.maybeApplyDuringCreate).not.toHaveBeenCalled();
-    expect(patch.ensureApplied).toHaveBeenCalledOnce();
+    expect(createHandoff).toEqual(["poll", "create-complete", "ensure-applied"]);
   });
 
   it("does not replace a native GPU container solely to persist its startup command", async () => {

--- a/test/onboard-sandbox-recreation.test.ts
+++ b/test/onboard-sandbox-recreation.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -1202,7 +1202,7 @@ const { createSandbox } = require(${onboardPath});
     );
     assert.ok(result.stdout.includes("not ready"), "should mention sandbox is not ready");
   });
-  it("continues once the sandbox is Ready even if the create stream never closes", {
+  it("waits for the create stream to close after the sandbox is Ready", {
     timeout: 20000,
   }, async () => {
     const repoRoot = path.join(import.meta.dirname, "..");
@@ -1282,6 +1282,8 @@ const realProcessKill = process.kill.bind(process);
 process.kill = (pid, signal) => {
   if (pid < 0) {
     groupKillCalls.push({ pid, signal });
+    const createCommand = commands.find((entry) => entry.command.includes("sandbox create"));
+    process.nextTick(() => createCommand.child.emit("close", signal === "SIGTERM" ? 0 : 1));
     return true;
   }
   return realProcessKill(pid, signal);
@@ -1362,8 +1364,8 @@ const { createSandbox } = require(${onboardPath});
     assert.ok(payload.sandboxListCalls >= 2);
     assert.deepEqual(payload.groupKillCalls, [{ pid: -4242, signal: "SIGTERM" }]);
     assert.deepEqual(payload.killCalls, []);
-    assert.equal(payload.unrefCalls, 1);
-    assert.equal(payload.stdoutDestroyCalls, 1);
-    assert.equal(payload.stderrDestroyCalls, 1);
+    assert.equal(payload.unrefCalls, 0);
+    assert.equal(payload.stdoutDestroyCalls, 0);
+    assert.equal(payload.stderrDestroyCalls, 0);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Tests now exercise the serialized create handoff added by #8729 at the actual lifecycle boundary. This also fixes the late shard-12 failure where the integration fixture never reported that its fake create process exited after `SIGTERM`.

## Related Issue
Follow-up to #8729 and its [CodeRabbit ordering finding](https://github.com/NVIDIA/NemoClaw/pull/8729#discussion_r3748921668).

## Changes
- Invoke the captured create poll before the mocked stream resolves and assert the poll, stream completion, and deferred `ensureApplied()` order.
- Make the existing process-group fixture emit the fake create child's close event after `SIGTERM`, matching the ownership-release contract.
- Assert that the waited-for stream is not detached, with no production-code changes or new test files.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Test fixtures now match the already-merged ownership contract; no production behavior or user-facing surface changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Test-only changes preserve the fail-closed create timeout, simulate only the expected process exit, and do not alter production lifecycle, rollback, readiness, or compatibility behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. Existing `docs/get-started/quickstart.mdx` and `docs/reference/commands.mdx` already describe the unchanged ready and recreation contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b16e5323d -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/sandbox-gpu-create-flow.test.ts src/lib/sandbox/create-stream.test.ts` (56 passed); `npx vitest run --project integration test/onboard-sandbox-recreation.test.ts -t "waits for the create stream to close"` (1 passed); the refined deferred-boundary test passed again after review feedback.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a two-test fixture correction protected by targeted tests and normal hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
