### PR TITLE
fix(onboard): route portable gateway reachability probe

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -775,8 +775,8 @@ If passwordless sudo, UFW, or active UFW is unavailable, NemoClaw falls back to 
 For the portable experimental profile, the helper maps `host.openshell.internal` to the OpenShell Podman host gateway instead of the inspected network gateway.
 This path does not use Docker bridge UFW remediation.
 If the probe fails, onboarding prints user-scoped Podman restart commands and a rerun command that preserves `--experimental-profile portable`.
-Tune the wait via `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
-The poll count is clamped to a minimum of `1` so the probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).
+To tune the existing-gateway HTTP health poll, use `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
+The poll count is clamped to a minimum of `1` so the health probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).
 
 #### `--from <Dockerfile>`
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -774,7 +774,7 @@ If passwordless sudo, UFW, or active UFW is unavailable, NemoClaw falls back to 
 
 For the portable experimental profile, the helper maps `host.openshell.internal` to the OpenShell Podman host gateway instead of the inspected network gateway.
 This path does not use Docker bridge UFW remediation.
-On a failed portable TCP probe, onboarding prints commands for the user-scoped Podman service and socket.
+After all portable TCP probe attempts fail, onboarding prints commands for the user-scoped Podman service and socket.
 The rerun command preserves `--experimental-profile portable`.
 To tune the existing-gateway HTTP health poll, use `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
 The poll count is clamped to a minimum of `1` so the health probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -774,7 +774,8 @@ If passwordless sudo, UFW, or active UFW is unavailable, NemoClaw falls back to 
 
 For the portable experimental profile, the helper maps `host.openshell.internal` to the OpenShell Podman host gateway instead of the inspected network gateway.
 This path does not use Docker bridge UFW remediation.
-If the portable TCP probe cannot connect, onboarding prints user-scoped Podman restart commands and a rerun command that preserves `--experimental-profile portable`.
+On a failed portable TCP probe, onboarding prints commands for the user-scoped Podman service and socket.
+The rerun command preserves `--experimental-profile portable`.
 To tune the existing-gateway HTTP health poll, use `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
 The poll count is clamped to a minimum of `1` so the health probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -774,7 +774,7 @@ If passwordless sudo, UFW, or active UFW is unavailable, NemoClaw falls back to 
 
 For the portable experimental profile, the helper maps `host.openshell.internal` to the OpenShell Podman host gateway instead of the inspected network gateway.
 This path does not use Docker bridge UFW remediation.
-If the probe fails, onboarding prints user-scoped Podman restart commands and a rerun command that preserves `--experimental-profile portable`.
+If the portable TCP probe cannot connect, onboarding prints user-scoped Podman restart commands and a rerun command that preserves `--experimental-profile portable`.
 To tune the existing-gateway HTTP health poll, use `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
 The poll count is clamped to a minimum of `1` so the health probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -771,6 +771,10 @@ For Linux Docker-driver gateways, onboarding also checks that a helper container
 If a host firewall blocks that sandbox path, onboarding exits with a `sudo ufw allow from <subnet> to <gateway-ip> port <gateway-port> proto tcp` command before it reports the gateway healthy.
 Set `NEMOCLAW_AUTO_FIX_FIREWALL=1` to opt in to automatic UFW remediation for this specific failure: NemoClaw uses `sudo -n` only, validates the Docker bridge subnet/gateway/port, applies the narrow UFW rule only after a proven TCP reachability failure, and re-probes before continuing.
 If passwordless sudo, UFW, or active UFW is unavailable, NemoClaw falls back to the manual guidance path without prompting for a password.
+
+For the portable experimental profile, the helper maps `host.openshell.internal` to the OpenShell Podman host gateway instead of the inspected network gateway.
+This path does not use Docker bridge UFW remediation.
+If the probe fails, onboarding prints user-scoped Podman restart commands and a rerun command that preserves `--experimental-profile portable`.
 Tune the wait via `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
 The poll count is clamped to a minimum of `1` so the probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -775,6 +775,8 @@ If passwordless sudo, UFW, or active UFW is unavailable, NemoClaw falls back to 
 For the portable experimental profile, the helper maps `host.openshell.internal` to the OpenShell Podman host gateway instead of the inspected network gateway.
 This path does not use Docker bridge UFW remediation.
 After all portable TCP probe attempts fail, onboarding prints commands for the user-scoped Podman service and socket.
+
+Onboarding prints the same commands when the portable probe cannot reach the user-scoped Podman service.
 The printed rerun command keeps the portable experimental profile selected.
 To tune the existing-gateway HTTP health poll, use `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
 The poll count is clamped to a minimum of `1` so the health probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -775,7 +775,7 @@ If passwordless sudo, UFW, or active UFW is unavailable, NemoClaw falls back to 
 For the portable experimental profile, the helper maps `host.openshell.internal` to the OpenShell Podman host gateway instead of the inspected network gateway.
 This path does not use Docker bridge UFW remediation.
 After all portable TCP probe attempts fail, onboarding prints commands for the user-scoped Podman service and socket.
-The rerun command preserves `--experimental-profile portable`.
+The printed rerun command keeps the portable experimental profile selected.
 To tune the existing-gateway HTTP health poll, use `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
 The poll count is clamped to a minimum of `1` so the health probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -3054,6 +3054,48 @@ Then rerun portable onboarding:
 $$nemoclaw onboard --experimental-profile portable
 ```
 
+### Portable Host Gateway Is Unreachable
+
+The portable experimental profile maps `host.openshell.internal` to the OpenShell Podman host gateway.
+Do not apply the Docker bridge UFW command when portable onboarding reports this route as unreachable.
+
+Portable onboarding reports output like this:
+
+```text
+✗ Sandbox containers cannot reach the gateway at host.openshell.internal:8080.
+  The probe mapped host.openshell.internal to the OpenShell Podman host gateway.
+```
+
+Restart the user-scoped Podman service and enable its socket:
+
+```bash
+systemctl --user try-restart podman.service
+systemctl --user enable --now podman.socket
+```
+
+These commands restart the current user's Podman service and keep its API socket active.
+They do not change system services or credentials.
+
+Verify that the socket is active:
+
+```bash
+systemctl --user is-active podman.socket
+```
+
+Expected output:
+
+```text
+active
+```
+
+Then rerun portable onboarding:
+
+```bash
+$$nemoclaw onboard --experimental-profile portable
+```
+
+Continue only when onboarding no longer reports that the OpenShell Podman host gateway is unreachable.
+
 <AgentOnly variant="hermes">
 
 ## Hermes

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -3076,7 +3076,8 @@ systemctl --user enable --now podman.socket
 
 The first command does not start an inactive service.
 The second command enables and starts the current user's Podman API socket.
-These commands do not change system services or credentials.
+These commands affect only the current user's Podman units.
+They do not read or write credentials.
 
 Verify that the socket is active:
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -3059,6 +3059,8 @@ $$nemoclaw onboard --experimental-profile portable
 The portable experimental profile maps `host.openshell.internal` to the OpenShell Podman host gateway.
 Do not apply the Docker bridge UFW command when portable onboarding reports this route as unreachable.
 
+Use the same procedure when onboarding reports that the Podman service is unreachable for the portable gateway probe.
+
 Portable onboarding reports output like this:
 
 ```text

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -3066,15 +3066,17 @@ Portable onboarding reports output like this:
   The probe mapped host.openshell.internal to the OpenShell Podman host gateway.
 ```
 
-Restart the user-scoped Podman service and enable its socket:
+If `podman.service` is active, restart it.
+Then enable and start the user-scoped Podman socket:
 
 ```bash
 systemctl --user try-restart podman.service
 systemctl --user enable --now podman.socket
 ```
 
-These commands restart the current user's Podman service and keep its API socket active.
-They do not change system services or credentials.
+The first command does not start an inactive service.
+The second command enables and starts the current user's Podman API socket.
+These commands do not change system services or credentials.
 
 Verify that the socket is active:
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -3099,7 +3099,7 @@ Then rerun portable onboarding:
 $$nemoclaw onboard --experimental-profile portable
 ```
 
-Continue only when onboarding no longer reports that the OpenShell Podman host gateway is unreachable.
+Continue only when onboarding no longer reports that the Podman service or OpenShell Podman host gateway is unreachable.
 
 <AgentOnly variant="hermes">
 

--- a/src/lib/onboard/docker-driver-platform.ts
+++ b/src/lib/onboard/docker-driver-platform.ts
@@ -5,24 +5,15 @@ import { resolveCurrentOpenShellComputePlan, usesManagedDockerGateway } from "./
 
 export { resolveCurrentOpenShellComputePlan } from "./compute/plan";
 
-export const EXPERIMENTAL_PROFILE_ENV = "NEMOCLAW_EXPERIMENTAL_PROFILE";
-export const PORTABLE_EXPERIMENTAL_PROFILE = "portable";
-export const PORTABLE_HOST_GATEWAY_IP = "169.254.1.2";
-export const PORTABLE_LOCAL_REGISTRY = "localhost:5000";
-
-export type ExperimentalOnboardProfile = typeof PORTABLE_EXPERIMENTAL_PROFILE;
-
-export function resolveExperimentalOnboardProfile(
-  env: NodeJS.ProcessEnv = process.env,
-): ExperimentalOnboardProfile | null {
-  return env[EXPERIMENTAL_PROFILE_ENV] === PORTABLE_EXPERIMENTAL_PROFILE
-    ? PORTABLE_EXPERIMENTAL_PROFILE
-    : null;
-}
-
-export function isPortableExperimentalProfile(env: NodeJS.ProcessEnv = process.env): boolean {
-  return resolveExperimentalOnboardProfile(env) === PORTABLE_EXPERIMENTAL_PROFILE;
-}
+export {
+  type ExperimentalOnboardProfile,
+  EXPERIMENTAL_PROFILE_ENV,
+  isPortableExperimentalProfile,
+  PORTABLE_EXPERIMENTAL_PROFILE,
+  PORTABLE_HOST_GATEWAY_IP,
+  PORTABLE_LOCAL_REGISTRY,
+  resolveExperimentalOnboardProfile,
+} from "./experimental/portable-profile";
 
 export function isLinuxDockerDriverGatewayEnabled(
   platform: NodeJS.Platform = process.platform,

--- a/src/lib/onboard/experimental/portable-profile.ts
+++ b/src/lib/onboard/experimental/portable-profile.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const EXPERIMENTAL_PROFILE_ENV = "NEMOCLAW_EXPERIMENTAL_PROFILE";
+export const PORTABLE_EXPERIMENTAL_PROFILE = "portable";
+export const PORTABLE_HOST_GATEWAY_IP = "169.254.1.2";
+export const PORTABLE_LOCAL_REGISTRY = "localhost:5000";
+
+export type ExperimentalOnboardProfile = typeof PORTABLE_EXPERIMENTAL_PROFILE;
+
+export function resolveExperimentalOnboardProfile(
+  env: NodeJS.ProcessEnv = process.env,
+): ExperimentalOnboardProfile | null {
+  return env[EXPERIMENTAL_PROFILE_ENV] === PORTABLE_EXPERIMENTAL_PROFILE
+    ? PORTABLE_EXPERIMENTAL_PROFILE
+    : null;
+}
+
+export function isPortableExperimentalProfile(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveExperimentalOnboardProfile(env) === PORTABLE_EXPERIMENTAL_PROFILE;
+}

--- a/src/lib/onboard/gateway-sandbox-reachability-severity.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability-severity.test.ts
@@ -74,7 +74,7 @@ describe("sandbox bridge reachability severity (#6004)", () => {
               gatewayIp: "172.18.0.1",
             }),
           }),
-        ).rejects.toThrow("sandbox-bridge unreachable");
+        ).rejects.toThrow("cannot reach the OpenShell gateway");
         expect(warn.mock.calls[0]?.[0]).toMatch(
           /^  \x1b\[33m⚠ NEMOCLAW_AUTO_FIX_FIREWALL=1 set but could not auto-apply UFW rule/,
         );

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -123,6 +123,28 @@ describe("isSandboxBridgeGatewayReachable", () => {
     expect(result.detail).toContain("not found");
   });
 
+  it("classifies an unavailable portable daemon before route inspection completes", async () => {
+    vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+    const runtimeProbeImpl = vi.fn(() => ({
+      status: 1,
+      stderr: "Cannot connect to Podman. Verify the user service and socket.",
+    }));
+
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectNetworkImpl: () => undefined,
+      runtimeProbeImpl,
+      usesHostGatewayRouteImpl: () => false,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "docker_daemon_unreachable",
+      networkName: "openshell-docker",
+    });
+    expect(result.detail).toContain("Cannot connect to Podman");
+    expect(runtimeProbeImpl).toHaveBeenCalledOnce();
+  });
+
   it("does not call helper DNS failures firewall failures", async () => {
     const result = await isSandboxBridgeGatewayReachable({
       inspectNetworkImpl: () => ({ subnet: "172.19.0.0/16", gatewayIp: "172.19.0.1" }),

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -89,6 +89,23 @@ describe("isSandboxBridgeGatewayReachable", () => {
     expect(seen.args.join(" ")).toContain("nc -zw7 host.openshell.internal 9090");
   });
 
+  it("routes portable profile probes through the OpenShell Podman host gateway", async () => {
+    vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+    const seen: { args: readonly string[] } = { args: [] };
+
+    await isSandboxBridgeGatewayReachable({
+      inspectNetworkImpl: () => ({ subnet: "10.89.0.0/24", gatewayIp: "10.89.0.1" }),
+      usesHostGatewayRouteImpl: () => false,
+      runImpl: (args) => {
+        seen.args = args;
+        return { status: 0 };
+      },
+    });
+
+    expect(seen.args).toContain("host.openshell.internal:169.254.1.2");
+    expect(seen.args).not.toContain("host.openshell.internal:10.89.0.1");
+  });
+
   it("does not call a missing Docker network a firewall failure", async () => {
     const result = await isSandboxBridgeGatewayReachable({
       inspectNetworkImpl: () => undefined,

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -501,7 +501,9 @@ describe("formatSandboxBridgeUnreachableMessage", () => {
       gatewayIp: "169.254.1.2",
     });
     expect(msg).toContain("OpenShell Podman host gateway");
-    expect(msg).toContain("Restart Podman");
+    expect(msg).toContain("systemctl --user try-restart podman.service");
+    expect(msg).toContain("systemctl --user enable --now podman.socket");
+    expect(msg).toContain("nemoclaw onboard --experimental-profile portable");
     expect(msg).not.toContain("Restart Docker");
     expect(msg).not.toContain("ufw allow");
   });

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -89,7 +89,7 @@ describe("isSandboxBridgeGatewayReachable", () => {
     expect(seen.args.join(" ")).toContain("nc -zw7 host.openshell.internal 9090");
   });
 
-  it("routes portable profile probes through the OpenShell Podman host gateway", async () => {
+  it("routes probes for the portable experimental profile through the OpenShell Podman host gateway", async () => {
     vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
     const seen: { args: readonly string[] } = { args: [] };
 
@@ -102,7 +102,11 @@ describe("isSandboxBridgeGatewayReachable", () => {
       },
     });
 
-    expect(result).toMatchObject({ ok: true, gatewayIp: "169.254.1.2", routeKind: "host_gateway" });
+    expect(result).toMatchObject({
+      ok: true,
+      gatewayIp: "169.254.1.2",
+      routeKind: "portable_host_gateway",
+    });
 
     expect(seen.args).toContain("host.openshell.internal:169.254.1.2");
     expect(seen.args).not.toContain("host.openshell.internal:10.89.0.1");
@@ -484,6 +488,21 @@ describe("formatSandboxBridgeUnreachableMessage", () => {
       subnet: "172.19.0.0/16",
     });
     expect(msg).toContain("host-gateway");
+    expect(msg).not.toContain("ufw allow");
+  });
+
+  it("reports Podman recovery for portable host-gateway failures", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "tcp_failed",
+      routeKind: "portable_host_gateway",
+      networkName: "openshell-docker",
+      subnet: "10.89.0.0/24",
+      gatewayIp: "169.254.1.2",
+    });
+    expect(msg).toContain("OpenShell Podman host gateway");
+    expect(msg).toContain("Restart Podman");
+    expect(msg).not.toContain("Restart Docker");
     expect(msg).not.toContain("ufw allow");
   });
 });

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -93,7 +93,7 @@ describe("isSandboxBridgeGatewayReachable", () => {
     vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
     const seen: { args: readonly string[] } = { args: [] };
 
-    await isSandboxBridgeGatewayReachable({
+    const result = await isSandboxBridgeGatewayReachable({
       inspectNetworkImpl: () => ({ subnet: "10.89.0.0/24", gatewayIp: "10.89.0.1" }),
       usesHostGatewayRouteImpl: () => false,
       runImpl: (args) => {
@@ -101,6 +101,8 @@ describe("isSandboxBridgeGatewayReachable", () => {
         return { status: 0 };
       },
     });
+
+    expect(result).toMatchObject({ ok: true, gatewayIp: "169.254.1.2", routeKind: "host_gateway" });
 
     expect(seen.args).toContain("host.openshell.internal:169.254.1.2");
     expect(seen.args).not.toContain("host.openshell.internal:10.89.0.1");

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -698,7 +698,7 @@ describe("verifySandboxBridgeGatewayReachableOrExit host-gateway retry", () => {
           retryDelayMs: 25,
           sleepMsImpl,
         }),
-      ).rejects.toThrow("sandbox-bridge unreachable");
+      ).rejects.toThrow("cannot reach the OpenShell gateway");
       expect(reachabilityImpl).toHaveBeenCalledTimes(3);
       expect(sleepMsImpl).toHaveBeenCalledTimes(2);
       expect(sleepMsImpl).toHaveBeenNthCalledWith(1, 25);
@@ -729,7 +729,7 @@ describe("verifySandboxBridgeGatewayReachableOrExit host-gateway retry", () => {
           reachabilityImpl,
           sleepMsImpl,
         }),
-      ).rejects.toThrow("sandbox-bridge unreachable");
+      ).rejects.toThrow("cannot reach the OpenShell gateway");
       expect(reachabilityImpl).toHaveBeenCalledTimes(10);
       expect(sleepMsImpl).toHaveBeenCalledTimes(9);
       expect(sleepMsImpl).toHaveBeenCalledWith(1000);
@@ -761,7 +761,7 @@ describe("verifySandboxBridgeGatewayReachableOrExit host-gateway retry", () => {
           retryDelayMs: 25,
           sleepMsImpl,
         }),
-      ).rejects.toThrow("sandbox-bridge unreachable");
+      ).rejects.toThrow("cannot reach the OpenShell gateway");
       expect(reachabilityImpl).toHaveBeenCalledTimes(1);
       expect(sleepMsImpl).not.toHaveBeenCalled();
       expect(error).toHaveBeenCalledWith(expect.stringContaining("ufw allow"));
@@ -827,7 +827,7 @@ describe("verifySandboxBridgeGatewayReachableOrExit UFW auto-apply (#4265)", () 
         autoApplyOptedInImpl: () => true,
         reachabilityImpl,
       }),
-    ).rejects.toThrow("sandbox-bridge unreachable");
+    ).rejects.toThrow("cannot reach the OpenShell gateway");
     expect(reachabilityImpl).toHaveBeenCalledTimes(2);
     expect(error).toHaveBeenCalledWith(expect.stringContaining("ufw allow"));
     log.mockRestore();
@@ -843,7 +843,7 @@ describe("verifySandboxBridgeGatewayReachableOrExit UFW auto-apply (#4265)", () 
         autoApplyOptedInImpl: () => true,
         reachabilityImpl: () => tcpFailure,
       }),
-    ).rejects.toThrow("sandbox-bridge unreachable");
+    ).rejects.toThrow("cannot reach the OpenShell gateway");
     expect(warn).not.toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith(expect.stringContaining("ufw allow"));
     warn.mockRestore();

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -507,6 +507,20 @@ describe("formatSandboxBridgeUnreachableMessage", () => {
     expect(msg).not.toContain("Restart Docker");
     expect(msg).not.toContain("ufw allow");
   });
+
+  it("reports Podman recovery when the portable profile cannot reach its daemon", () => {
+    vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "docker_daemon_unreachable",
+      detail: "Cannot connect to the container runtime",
+    });
+    expect(msg).toContain("Podman service is not reachable");
+    expect(msg).toContain("systemctl --user try-restart podman.service");
+    expect(msg).toContain("systemctl --user enable --now podman.socket");
+    expect(msg).toContain("nemoclaw onboard --experimental-profile portable");
+    expect(msg).not.toContain("Restart the Docker daemon");
+  });
 });
 
 describe("tryAutoApplyUfwRule (#4265)", () => {
@@ -683,6 +697,31 @@ describe("verifySandboxBridgeGatewayReachableOrExit host-gateway retry", () => {
     } finally {
       log.mockRestore();
     }
+  });
+
+  it("retries a transient portable host-gateway TCP failure", async () => {
+    const portableFailure = {
+      ...hostGatewayTcpFailure,
+      routeKind: "portable_host_gateway" as const,
+      gatewayIp: "169.254.1.2",
+    };
+    const reachabilityImpl = vi
+      .fn()
+      .mockResolvedValueOnce(portableFailure)
+      .mockResolvedValueOnce({ ...portableFailure, ok: true as const, reason: "ok" as const });
+    const sleepMsImpl = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await verifySandboxBridgeGatewayReachableOrExit(true, {
+      reachabilityImpl,
+      retryAttempts: 3,
+      retryDelayMs: 25,
+      sleepMsImpl,
+    });
+
+    expect(reachabilityImpl).toHaveBeenCalledTimes(2);
+    expect(sleepMsImpl).toHaveBeenCalledOnce();
+    expect(sleepMsImpl).toHaveBeenCalledWith(25);
   });
 
   it("fails after exhausting persistent host-gateway tcp failures", async () => {

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -471,7 +471,10 @@ export function formatSandboxBridgeUnreachableMessage(
     return [
       failLine(`Sandbox containers cannot reach the gateway at ${HOST_INTERNAL_NAME}:${port}.`),
       `    The probe mapped ${HOST_INTERNAL_NAME} to the OpenShell Podman host gateway.`,
-      `    Restart Podman and the OpenShell gateway, then re-run \`${cliName()} onboard\`.`,
+      "    Restart the user-scoped Podman service and socket:",
+      "      systemctl --user try-restart podman.service",
+      "      systemctl --user enable --now podman.socket",
+      `    Then rerun \`${cliName()} onboard --experimental-profile portable\` to restart the OpenShell gateway.`,
     ].join("\n");
   }
 

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -471,8 +471,9 @@ export function formatSandboxBridgeUnreachableMessage(
     return [
       failLine(`Sandbox containers cannot reach the gateway at ${HOST_INTERNAL_NAME}:${port}.`),
       `    The probe mapped ${HOST_INTERNAL_NAME} to the OpenShell Podman host gateway.`,
-      "    If active, restart the user-scoped Podman service, then enable and start its socket:",
+      "    If the user-scoped Podman service is active, restart it:",
       "      systemctl --user try-restart podman.service",
+      "    Enable and start the user-scoped Podman socket:",
       "      systemctl --user enable --now podman.socket",
       `    Then rerun \`${cliName()} onboard --experimental-profile portable\`.`,
     ].join("\n");

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -455,6 +455,20 @@ export function formatSandboxBridgeUnreachableMessage(
       .join("\n");
   }
 
+  if (result.reason === "docker_daemon_unreachable" && isPortableExperimentalProfile()) {
+    return [
+      failLine("Podman service is not reachable for the portable gateway probe."),
+      result.detail ? `    ${result.detail}` : undefined,
+      "    If the user-scoped Podman service is active, restart it:",
+      "      systemctl --user try-restart podman.service",
+      "    Enable and start the user-scoped Podman socket:",
+      "      systemctl --user enable --now podman.socket",
+      `    Then rerun \`${cliName()} onboard --experimental-profile portable\`.`,
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n");
+  }
+
   if (result.reason === "docker_daemon_unreachable") {
     return [
       failLine("Docker daemon is not reachable for the sandbox bridge probe."),

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -48,7 +48,7 @@ export type SandboxBridgeReachabilityReason =
   | "probe_timeout"
   | "veth_unsupported"
   | "docker_daemon_unreachable";
-export type SandboxBridgeRouteKind = "bridge_gateway" | "host_gateway";
+export type SandboxBridgeRouteKind = "bridge_gateway" | "host_gateway" | "portable_host_gateway";
 
 export interface DockerBridgeNetworkInfo {
   subnet?: string;
@@ -177,7 +177,7 @@ function buildOpenShellDockerRoute(
       networkName,
       subnet: network.subnet,
       gatewayIp: portableHostGatewayIp,
-      routeKind: "host_gateway",
+      routeKind: "portable_host_gateway",
       addHosts: [`${HOST_INTERNAL_NAME}:${portableHostGatewayIp}`],
     };
   }
@@ -467,6 +467,14 @@ export function formatSandboxBridgeUnreachableMessage(
       .join("\n");
   }
 
+  if (result.routeKind === "portable_host_gateway") {
+    return [
+      failLine(`Sandbox containers cannot reach the gateway at ${HOST_INTERNAL_NAME}:${port}.`),
+      `    The probe mapped ${HOST_INTERNAL_NAME} to the OpenShell Podman host gateway.`,
+      `    Restart Podman and the OpenShell gateway, then re-run \`${cliName()} onboard\`.`,
+    ].join("\n");
+  }
+
   if (result.routeKind === "host_gateway") {
     return [
       failLine(`Sandbox containers cannot reach the gateway at ${HOST_INTERNAL_NAME}:${port}.`),
@@ -518,7 +526,10 @@ const SILENT_UFW_AUTO_APPLY_REASONS = new Set<UfwAutoApplyResult["reason"]>([
 ]);
 
 function isRetriableHostGatewayFailure(reach: SandboxBridgeReachabilityResult): boolean {
-  return reach.routeKind === "host_gateway" && reach.reason === "tcp_failed";
+  return (
+    (reach.routeKind === "host_gateway" || reach.routeKind === "portable_host_gateway") &&
+    reach.reason === "tcp_failed"
+  );
 }
 
 function sleepMs(ms: number): Promise<void> {

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -93,6 +93,8 @@ export interface SandboxBridgeReachabilityOptions {
   runImpl?: (args: readonly string[], timeoutMs: number) => SandboxBridgeProbeRunResult;
   inspectNetworkImpl?: (networkName: string) => DockerBridgeNetworkInfo | undefined;
   usesHostGatewayRouteImpl?: () => boolean;
+
+  runtimeProbeImpl?: () => SandboxBridgeProbeRunResult;
   /** Inject a precomputed image-cache result; bypasses real pre-pull. */
   ensureImageCachedOverride?: import("./preflight").EnsureProbeImageCachedResult;
 }
@@ -283,14 +285,34 @@ export async function isSandboxBridgeGatewayReachable(
   const usesHostGatewayRoute = opts.usesHostGatewayRouteImpl ?? defaultUsesHostGatewayRoute;
   const runImpl = opts.runImpl ?? defaultRunImpl;
 
+  const portableProfile = isPortableExperimentalProfile();
+  const runtimeProbe =
+    opts.runtimeProbeImpl ??
+    (() =>
+      defaultRunImpl(
+        ["info", "--format", "{{.ServerVersion}}"],
+        timeoutSec * 1000 + PROBE_RUN_OVERHEAD_MS,
+      ));
+
   const network = inspectNetwork(networkName);
   const route = buildOpenShellDockerRoute(
     networkName,
     network,
     usesHostGatewayRoute(),
-    isPortableExperimentalProfile() ? PORTABLE_HOST_GATEWAY_IP : undefined,
+    portableProfile ? PORTABLE_HOST_GATEWAY_IP : undefined,
   );
   if (!route) {
+    if (portableProfile) {
+      const runtimeResult = runtimeProbe();
+      if (runtimeResult.status !== 0) {
+        return {
+          ok: false,
+          reason: "docker_daemon_unreachable",
+          networkName,
+          detail: summarizeProbeResult(runtimeResult),
+        };
+      }
+    }
     return {
       ok: false,
       reason: "probe_unavailable",

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -471,7 +471,7 @@ export function formatSandboxBridgeUnreachableMessage(
     return [
       failLine(`Sandbox containers cannot reach the gateway at ${HOST_INTERNAL_NAME}:${port}.`),
       `    The probe mapped ${HOST_INTERNAL_NAME} to the OpenShell Podman host gateway.`,
-      "    Restart the user-scoped Podman service and socket:",
+      "    If active, restart the user-scoped Podman service, then enable and start its socket:",
       "      systemctl --user try-restart podman.service",
       "      systemctl --user enable --now podman.socket",
       `    Then rerun \`${cliName()} onboard --experimental-profile portable\` to restart the OpenShell gateway.`,

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -474,7 +474,7 @@ export function formatSandboxBridgeUnreachableMessage(
       "    If active, restart the user-scoped Podman service, then enable and start its socket:",
       "      systemctl --user try-restart podman.service",
       "      systemctl --user enable --now podman.socket",
-      `    Then rerun \`${cliName()} onboard --experimental-profile portable\` to restart the OpenShell gateway.`,
+      `    Then rerun \`${cliName()} onboard --experimental-profile portable\`.`,
     ].join("\n");
   }
 

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -568,14 +568,12 @@ export async function verifySandboxBridgeGatewayReachableOrExit(
     attempt += 1
   ) {
     console.log(
-      `  Docker-driver sandbox bridge probe attempt ${attempt - 1}/${retryAttempts} failed (${reach.reason}); retrying in ${retryDelayMs} ms...`,
+      `  OpenShell gateway reachability probe attempt ${attempt - 1}/${retryAttempts} failed (${reach.reason}); retrying in ${retryDelayMs} ms...`,
     );
     await sleep(retryDelayMs);
     reach = await reachability({ port });
     if (reach.ok) {
-      console.log(
-        `  ✓ Docker-driver sandbox bridge reachable on attempt ${attempt}/${retryAttempts}`,
-      );
+      console.log(`  ✓ OpenShell gateway reachable on attempt ${attempt}/${retryAttempts}`);
       return;
     }
   }
@@ -613,7 +611,7 @@ export async function verifySandboxBridgeGatewayReachableOrExit(
   if (exitOnFailure) {
     process.exit(1);
   }
-  throw new Error(`Docker-driver sandbox-bridge unreachable (${reach.reason})`);
+  throw new Error(`Sandbox containers cannot reach the OpenShell gateway (${reach.reason})`);
 }
 
 export const __test = {

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -17,6 +17,10 @@ import { failLine, warnLine } from "../cli/terminal-style";
 import { GATEWAY_PORT } from "../core/ports";
 import { cliDisplayName, cliName } from "./branding";
 import {
+  isPortableExperimentalProfile,
+  PORTABLE_HOST_GATEWAY_IP,
+} from "./experimental/portable-profile";
+import {
   DOCKER_DESKTOP_WSL_INTEGRATION_HINT,
   ensureProbeImageCached,
   isDockerDaemonUnreachable,
@@ -165,8 +169,18 @@ function buildOpenShellDockerRoute(
   networkName: string,
   network: DockerBridgeNetworkInfo | undefined,
   usesHostGatewayRoute: boolean,
+  portableHostGatewayIp?: string,
 ): OpenShellDockerRoute | undefined {
   if (!network) return undefined;
+  if (portableHostGatewayIp) {
+    return {
+      networkName,
+      subnet: network.subnet,
+      gatewayIp: portableHostGatewayIp,
+      routeKind: "host_gateway",
+      addHosts: [`${HOST_INTERNAL_NAME}:${portableHostGatewayIp}`],
+    };
+  }
   if (usesHostGatewayRoute) {
     return {
       networkName,
@@ -270,7 +284,12 @@ export async function isSandboxBridgeGatewayReachable(
   const runImpl = opts.runImpl ?? defaultRunImpl;
 
   const network = inspectNetwork(networkName);
-  const route = buildOpenShellDockerRoute(networkName, network, usesHostGatewayRoute());
+  const route = buildOpenShellDockerRoute(
+    networkName,
+    network,
+    usesHostGatewayRoute(),
+    isPortableExperimentalProfile() ? PORTABLE_HOST_GATEWAY_IP : undefined,
+  );
   if (!route) {
     return {
       ok: false,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable-profile gateway reachability probes now map `host.openshell.internal` to the OpenShell Podman host gateway instead of the inspected Podman network gateway. Onboarding uses route-specific recovery guidance and preserves the portable profile in the rerun command.

E2E root cause: portable profile / sandbox bridge reachability / probe maps `host.openshell.internal` to the Podman network gateway instead of the OpenShell host gateway
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/31382319323 (run 31382319323, attempt 1)
Failed jobs: portable-launch (93435056045, https://github.com/NVIDIA/NemoClaw/actions/runs/31382319323/job/93435056045)
Signature: sandbox containers cannot reach `host.openshell.internal:8080` through `10.89.0.1`; the portable contract uses `169.254.1.2`
Scope: one root cause

## Changes

- Add regression coverage for the portable probe route, returned route metadata, TCP retries, daemon inspection failures, and recovery output.
- Route portable-profile probes through the existing OpenShell Podman host-gateway constant and preserve daemon failures before route metadata exists.
- Keep portable, Docker host-gateway, and Docker bridge diagnostics distinct while sharing route-neutral retry output.
- Move portable-profile constants into a leaf module because a direct platform-module import creates a runtime dependency cycle. The repository architecture check protects the cycle-free contract.
- Document the Podman recovery procedure in `docs/reference/commands.mdx` and `docs/reference/troubleshooting.mdx`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: All nine security-rubric categories pass. The route uses a fixed compile-time address and does not change credentials, authentication, TLS, gateway binding, dependencies, or policy. Recovery commands are printed for the operator and are not executed by NemoClaw.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `docs/reference/commands.mdx` and `docs/reference/troubleshooting.mdx` against the implementation, tests, writing rules, and all generated agent variants. The pages distinguish portable Podman recovery from Docker UFW remediation and describe the user-scoped service and socket effects.
- Agent: Pi CLI
<!-- docs-review-head-sha: 036f2c0c9 -->
<!-- docs-review-agents-blob-sha: c4923a3e367681ea6f796fb595f3b97497d92fa0 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` did not change.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/gateway-sandbox-reachability.test.ts src/lib/onboard/gateway-sandbox-reachability-severity.test.ts` — 53 tests passed; `npm run checks:repository` — passed with 0 source dependency cycles.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — `npm run docs` passed with 0 errors and 2 existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an experimental portable onboarding profile.
  - Portable environments now use the appropriate host gateway and local registry configuration.
  - Improved sandbox connectivity by mapping the internal host address to the portable environment gateway.

- **Bug Fixes**
  - Improved reachability checks, retries, and error handling for portable environments.
  - Added clearer recovery guidance for unreachable Podman gateways and excluded unnecessary Docker firewall remediation.

- **Documentation**
  - Added portable onboarding connectivity details and troubleshooting steps, including service and socket verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->