### PR TITLE
test(e2e): refresh Hermes MCP maintenance window

### DIFF
--- a/test/e2e/live/mcp-bridge-hermes-lifecycle.ts
+++ b/test/e2e/live/mcp-bridge-hermes-lifecycle.ts
@@ -190,6 +190,44 @@ export async function assertHermesManagedAddSurvivesLockedGatewayRestartAndState
 }
 
 /**
+ * Rebuild can outlive the inherited Shields-down timer and correctly return
+ * with lockdown restored. Normalize the posture first so an already-down
+ * sandbox cannot retain an almost-expired timer, then open a fresh window for
+ * the final managed MCP mutation.
+ */
+export async function reopenHermesMcpMaintenanceWindow(
+  host: HostCliClient,
+  sandboxName: string,
+): Promise<void> {
+  const shieldsUp = await host.nemoclaw([sandboxName, "shields", "up"], {
+    artifactName: "hermes-mcp-shields-up-before-post-rebuild-remove",
+    env: buildAvailabilityProbeEnv(),
+    redactionValues: [HOST_SECRET, ROTATED_HOST_SECRET],
+    timeoutMs: 3 * 60_000,
+  });
+  expectExitZero(shieldsUp, "normalize Hermes shields before post-rebuild MCP removal");
+
+  const shieldsDown = await host.nemoclaw(
+    [
+      sandboxName,
+      "shields",
+      "down",
+      "--timeout",
+      "15m",
+      "--reason",
+      "Post-rebuild MCP removal E2E",
+    ],
+    {
+      artifactName: "hermes-mcp-shields-down-before-post-rebuild-remove",
+      env: buildAvailabilityProbeEnv(),
+      redactionValues: [HOST_SECRET, ROTATED_HOST_SECRET],
+      timeoutMs: 3 * 60_000,
+    },
+  );
+  expectExitZero(shieldsDown, "open a fresh Hermes MCP maintenance window after rebuild");
+}
+
+/**
  * Inject a first-reload failure around the packaged transaction helper, then
  * require its real rollback reload to restore the prior config, both integrity
  * anchors, and a healthy managed gateway in the live sandbox.

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -38,6 +38,7 @@ import {
   assertHermesManagedAddSurvivesLockedGatewayRestartAndStateLayout,
   assertHermesReloadRollback,
   assertHermesRemovalSurvivesGatewayRestart,
+  reopenHermesMcpMaintenanceWindow,
 } from "./mcp-bridge-hermes-lifecycle.ts";
 import {
   buildMcpBridgeExactMainEnv,
@@ -1226,6 +1227,7 @@ mcpBridgeShardTest("hermes")(
       artifactName: "hermes-real-mcp-tool-call-after-rebuild",
       expectedSecret: ROTATED_HOST_SECRET,
     });
+    await reopenHermesMcpMaintenanceWindow(host, HERMES_SANDBOX_NAME);
     await removeBridgeAndAssertEmpty(host, sandbox, {
       agent: "hermes",
       adapter: "hermes-config",

--- a/test/e2e/support/mcp-bridge-hermes-lifecycle.test.ts
+++ b/test/e2e/support/mcp-bridge-hermes-lifecycle.test.ts
@@ -3,8 +3,55 @@
 
 import { describe, expect, it } from "vitest";
 
-import { SandboxClient } from "../fixtures/clients/sandbox.ts";
-import { assertHermesReloadRollback } from "../live/mcp-bridge-hermes-lifecycle.ts";
+import { type CommandRunner, HostCliClient, SandboxClient } from "../fixtures/clients/index.ts";
+import type {
+  ShellProbeResult,
+  ShellProbeRunOptions,
+  TrustedShellCommand,
+} from "../fixtures/shell-probe.ts";
+import {
+  assertHermesReloadRollback,
+  reopenHermesMcpMaintenanceWindow,
+} from "../live/mcp-bridge-hermes-lifecycle.ts";
+
+interface RunnerCall {
+  command: string;
+  args: string[];
+  options?: ShellProbeRunOptions;
+}
+
+function shellResult(exitCode = 0): ShellProbeResult {
+  return {
+    command: [],
+    exitCode,
+    signal: null,
+    timedOut: false,
+    stdout: "",
+    stderr: "",
+    artifacts: {
+      stdout: "/tmp/stdout",
+      stderr: "/tmp/stderr",
+      result: "/tmp/result",
+    },
+  };
+}
+
+class RecordingRunner implements CommandRunner {
+  readonly calls: RunnerCall[] = [];
+  private readonly responses: ShellProbeResult[];
+
+  constructor(responses: ShellProbeResult[] = []) {
+    this.responses = [...responses];
+  }
+
+  async run(
+    command: TrustedShellCommand,
+    options?: ShellProbeRunOptions,
+  ): Promise<ShellProbeResult> {
+    this.calls.push({ command: command.command, args: [...command.args], options });
+    return this.responses.shift() ?? shellResult();
+  }
+}
 
 function sandboxWithInspectionState(state: string): SandboxClient {
   return new SandboxClient({
@@ -46,5 +93,57 @@ describe("Hermes MCP live rollback inspection", () => {
       actual: { ok: true, state: "current" },
       expected: { ok: true, state: "matched" },
     });
+  });
+});
+
+describe("Hermes MCP post-rebuild maintenance", () => {
+  it("opens a fresh Shields-down timer before the final config mutation", async () => {
+    const runner = new RecordingRunner();
+    const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
+
+    await reopenHermesMcpMaintenanceWindow(host, "hermes-e2e");
+
+    expect(runner.calls).toEqual([
+      expect.objectContaining({
+        command: "nemoclaw",
+        args: ["hermes-e2e", "shields", "up"],
+        options: expect.objectContaining({
+          artifactName: "hermes-mcp-shields-up-before-post-rebuild-remove",
+          timeoutMs: 3 * 60_000,
+        }),
+      }),
+      expect.objectContaining({
+        command: "nemoclaw",
+        args: [
+          "hermes-e2e",
+          "shields",
+          "down",
+          "--timeout",
+          "15m",
+          "--reason",
+          "Post-rebuild MCP removal E2E",
+        ],
+        options: expect.objectContaining({
+          artifactName: "hermes-mcp-shields-down-before-post-rebuild-remove",
+          timeoutMs: 3 * 60_000,
+        }),
+      }),
+    ]);
+  });
+
+  it("keeps Shields up when posture normalization fails", async () => {
+    const runner = new RecordingRunner([shellResult(1)]);
+    const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
+
+    await expect(reopenHermesMcpMaintenanceWindow(host, "hermes-e2e")).rejects.toThrow(
+      "normalize Hermes shields before post-rebuild MCP removal failed: exit=1",
+    );
+
+    expect(runner.calls).toEqual([
+      expect.objectContaining({
+        command: "nemoclaw",
+        args: ["hermes-e2e", "shields", "up"],
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes MCP bridge live E2E now opens a fresh 15-minute Shields maintenance window after rebuild verification and before the final MCP removal. This prevents a long rebuild from inheriting an expired timer while preserving fail-closed behavior.

## Changes

- Normalize Shields to the protected posture before opening the post-rebuild maintenance window. A direct `shields down` is insufficient because an already-down sandbox can retain an almost-expired timer.
- Open a fresh 15-minute Shields-down window immediately before the final managed MCP removal in the Hermes live lane.
- Add focused coverage for the exact Shields command order and for the failure path that must never lower Shields when posture normalization fails.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is test-only sequencing; production commands, defaults, security controls, recovery behavior, and user-facing contracts are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Test-only Shields sequencing was reviewed. `shields up` must succeed before `shields down`, and the negative regression proves a failed normalization never unlocks the sandbox.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `68a2538f4` changes only E2E sequencing and regression coverage. Existing MCP and Shields docs already require a 15-minute Hermes maintenance window, describe rebuild's separate recovery window, and document fail-closed relocking.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 68a2538f4 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/mcp-bridge-hermes-lifecycle.test.ts` — 4 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for reopening a 15-minute maintenance window during the Hermes MCP lifecycle.
  * Verified that Shields are restored before maintenance begins and remain available if normalization fails.
  * Added checks for maintenance timeout, reason, and artifact metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->