### PR TITLE
test(e2e): extend legacy gateway network wait

### DIFF
--- a/test/e2e/live/openshell-gateway-upgrade-helpers.ts
+++ b/test/e2e/live/openshell-gateway-upgrade-helpers.ts
@@ -7,6 +7,7 @@ import { reviewedOldInstallerProfile } from "./openshell-gateway-upgrade-old-ins
 const NON_INTERACTIVE_INSTALLER_ARGS = ["--non-interactive", "--yes-i-accept-third-party-software"];
 const GATEWAY_VOLUME_PREFIX = "openshell-cluster-nemoclaw";
 const LEGACY_GATEWAY_DOCKER_NETWORK = "openshell-cluster-nemoclaw";
+export const GATEWAY_UPGRADE_INSTALL_TIMEOUT_MS = 35 * 60_000;
 
 export interface LegacyGatewayUpgradeFixture {
   nemoclawRef: string;
@@ -71,19 +72,28 @@ export function currentNemoclawUpgradeRef(env: NodeJS.ProcessEnv): string {
   return "HEAD";
 }
 
-export function legacyGatewayUpgradeDockerNetwork(nemoclawRef: string): string | undefined {
+export function legacyGatewayUpgradeHostFirewallOptions(nemoclawRef: string): {
+  networkName: string | undefined;
+  waitForNetworkMs: number;
+} {
+  let networkName: string | undefined;
   switch (nemoclawRef) {
     case "v0.0.36":
       // This cluster-era gateway names its bridge after the gateway; newer
       // Docker gateways use the host fixture's openshell-docker default.
-      return LEGACY_GATEWAY_DOCKER_NETWORK;
+      networkName = LEGACY_GATEWAY_DOCKER_NETWORK;
+      break;
     case "v0.0.55":
     case "v0.0.74":
     case "v0.0.89":
-      return undefined;
+      networkName = undefined;
+      break;
     default:
       throw new Error(`Unsupported gateway-upgrade network fixture: ${nemoclawRef}`);
   }
+  // The historical install creates its network after fetching and building
+  // its payload, so keep the parallel probe alive for the full install budget.
+  return { networkName, waitForNetworkMs: GATEWAY_UPGRADE_INSTALL_TIMEOUT_MS };
 }
 
 export function throwGatewayUpgradeSetupFailures(

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -46,7 +46,8 @@ import {
   currentGatewayUpgradeInstallerArgs,
   currentNemoclawUpgradeRef,
   expectedLegacyRegistryMetadata,
-  legacyGatewayUpgradeDockerNetwork,
+  GATEWAY_UPGRADE_INSTALL_TIMEOUT_MS,
+  legacyGatewayUpgradeHostFirewallOptions,
   oldGatewayUpgradeInstallerArgs,
   throwGatewayUpgradeSetupFailures,
   upgradeGatewayCleanupScript,
@@ -103,7 +104,6 @@ const OPENCLAW_MAIN_AGENT_DB = "/sandbox/.openclaw/agents/main/agent/openclaw-ag
 const LEGACY_UPDATE_CHECK_PATH = "/sandbox/.openclaw/update-check.json";
 const REGISTRY_FILE = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
 const TEST_TIMEOUT_MS = 65 * 60_000;
-const INSTALL_TIMEOUT_MS = 35 * 60_000;
 const OPENSHELL_TIMEOUT_MS = 2 * 60_000;
 
 validateSandboxName(SURVIVOR_SANDBOX);
@@ -685,7 +685,7 @@ ${installerInvocation}`,
       env,
       hiddenOpenShellDir: options.hiddenOpenShellDir,
       redactionValues,
-      timeoutMs: INSTALL_TIMEOUT_MS,
+      timeoutMs: GATEWAY_UPGRADE_INSTALL_TIMEOUT_MS,
     },
   );
   const tail = await bash(host, `tail -160 ${shellQuote(logFile)} 2>/dev/null || true`, {
@@ -1195,8 +1195,8 @@ runLinuxOpenShellGatewayUpgrade(
       firewallSetup = registerOpenShellHostMockFirewall({
         cleanup,
         host,
-        networkName: legacyGatewayUpgradeDockerNetwork(OLD_NEMOCLAW_REF),
         port: Number(new URL(fake.baseUrl).port),
+        ...legacyGatewayUpgradeHostFirewallOptions(OLD_NEMOCLAW_REF),
       });
     } catch (error) {
       await fake.close();

--- a/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
@@ -18,7 +18,8 @@ import {
   currentGatewayUpgradeInstallerArgs,
   currentNemoclawUpgradeRef,
   expectedLegacyRegistryMetadata,
-  legacyGatewayUpgradeDockerNetwork,
+  GATEWAY_UPGRADE_INSTALL_TIMEOUT_MS,
+  legacyGatewayUpgradeHostFirewallOptions,
   oldGatewayUpgradeInstallerArgs,
   throwGatewayUpgradeSetupFailures,
   upgradeGatewayCleanupScript,
@@ -103,12 +104,18 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
     expect(currentNemoclawUpgradeRef({})).toBe("HEAD");
   });
 
-  it("targets the Docker network created by each historical gateway fixture", () => {
-    expect(legacyGatewayUpgradeDockerNetwork("v0.0.36")).toBe("openshell-cluster-nemoclaw");
+  it("waits through the historical install for each gateway network", () => {
+    expect(legacyGatewayUpgradeHostFirewallOptions("v0.0.36")).toEqual({
+      networkName: "openshell-cluster-nemoclaw",
+      waitForNetworkMs: GATEWAY_UPGRADE_INSTALL_TIMEOUT_MS,
+    });
     for (const nemoclawRef of ["v0.0.55", "v0.0.74", "v0.0.89"]) {
-      expect(legacyGatewayUpgradeDockerNetwork(nemoclawRef)).toBeUndefined();
+      expect(legacyGatewayUpgradeHostFirewallOptions(nemoclawRef)).toEqual({
+        networkName: undefined,
+        waitForNetworkMs: GATEWAY_UPGRADE_INSTALL_TIMEOUT_MS,
+      });
     }
-    expect(() => legacyGatewayUpgradeDockerNetwork("v0.0.90")).toThrow(
+    expect(() => legacyGatewayUpgradeHostFirewallOptions("v0.0.90")).toThrow(
       /Unsupported gateway-upgrade network fixture/,
     );
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The v0.0.36 gateway-upgrade E2E installs its historical stack in parallel with a host firewall probe. The install took 12 minutes 36 seconds in the failing run, but the probe stopped after two minutes, so this change gives both operations the existing 35-minute install budget.

## Changes

- Share the gateway-upgrade installer timeout with the parallel Docker network probe.
- Preserve the exact `openshell-cluster-nemoclaw` network selection for v0.0.36 and the default network selection for newer historical fixtures.
- Extend the workflow-boundary test to cover the network name and wait budget together.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only internal live E2E timing and its support test; no supported user surface changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The change extends only the bounded wait for an exact validated Docker network. Network-name validation, firewall authorization, fail-closed inspection, and cleanup behavior remain unchanged. Existing negative tests still cover unsupported fixtures and firewall setup or cleanup failures.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The diff changes only live E2E timing and its regression test; it does not change a public command, configuration, output, or supported behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 36a950cd5 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts` passed 10/10; Biome and repository checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run because the change is confined to one live fixture timing boundary; targeted tests and normal hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway upgrade handling for legacy versions by applying the appropriate host firewall configuration and installation wait time.
  * Standardized gateway installation timeout behavior across upgrade scenarios.
  * Added validation for supported and unsupported gateway version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->