### PR TITLE
fix(e2e): restore protected Ollama service lifecycle

### DIFF
--- a/test/e2e/live/gpu-e2e-helpers.ts
+++ b/test/e2e/live/gpu-e2e-helpers.ts
@@ -228,7 +228,8 @@ export async function cleanupGpu(host: HostCliClient, sandbox: SandboxClient): P
       timeoutMs: 60_000,
     }),
   );
-  await cleanupOllama(host, "cleanup-ollama-processes");
+  const ollamaCleanup = await cleanupOllama(host, "cleanup-ollama-processes");
+  expect(ollamaCleanup.exitCode, resultText(ollamaCleanup)).toBe(0);
 }
 
 export async function cleanupOllama(

--- a/test/e2e/live/gpu-e2e-helpers.ts
+++ b/test/e2e/live/gpu-e2e-helpers.ts
@@ -235,14 +235,53 @@ export async function cleanupOllama(
   host: HostCliClient,
   artifactName: string,
 ): Promise<ShellProbeResult> {
-  return await host.command(
-    "bash",
-    [
-      "-lc",
-      "systemctl --user stop ollama 2>/dev/null || true; systemctl stop ollama 2>/dev/null || true; pkill -f '[o]llama serve' 2>/dev/null || true; pkill -f '[o]llama-auth-proxy' 2>/dev/null || true",
-    ],
-    { artifactName, env: env(), timeoutMs: 30_000 },
-  );
+  return await host.command("bash", ["-lc", ollamaCleanupScript()], {
+    artifactName,
+    env: env(),
+    timeoutMs: 30_000,
+  });
+}
+
+export function ollamaCleanupScript(): string {
+  return `set -euo pipefail
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl --user stop ollama.service >/dev/null 2>&1 || true
+  if systemctl cat ollama.service >/dev/null 2>&1; then
+    if [ "$(id -u)" -eq 0 ]; then
+      systemctl stop ollama.service
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+      sudo -n systemctl stop ollama.service
+    else
+      echo 'Ollama system service exists but passwordless sudo is unavailable' >&2
+      exit 1
+    fi
+  fi
+fi
+pkill -f '[o]llama-auth-proxy' >/dev/null 2>&1 || true
+pkill -f '[o]llama serve' >/dev/null 2>&1 || true
+if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  sudo -n pkill -f '[o]llama serve' >/dev/null 2>&1 || true
+fi
+
+if pgrep -f '[o]llama serve' >/dev/null 2>&1; then
+  echo 'Ollama cleanup left a daemon process' >&2
+  pgrep -af '[o]llama serve' >&2 || true
+  exit 1
+fi
+if node -e '
+  const net = require("node:net");
+  const socket = net.createConnection({ host: "127.0.0.1", port: 11434 });
+  const finish = (code) => {
+    socket.destroy();
+    process.exit(code);
+  };
+  socket.setTimeout(2_000, () => finish(1));
+  socket.once("connect", () => finish(0));
+  socket.once("error", () => finish(1));
+'; then
+  echo 'Ollama cleanup left a listener on 127.0.0.1:11434' >&2
+  exit 1
+fi`;
 }
 
 export function assertNvidiaAvailable(

--- a/test/e2e/live/gpu-e2e-helpers.ts
+++ b/test/e2e/live/gpu-e2e-helpers.ts
@@ -243,7 +243,10 @@ export async function cleanupOllama(
   });
 }
 
-export function ollamaCleanupScript(): string {
+export function ollamaCleanupScript(listenerPort = 11434): string {
+  if (!Number.isInteger(listenerPort) || listenerPort < 1 || listenerPort > 65_535) {
+    throw new Error(`invalid Ollama listener port: ${String(listenerPort)}`);
+  }
   return `set -euo pipefail
 if command -v systemctl >/dev/null 2>&1; then
   systemctl --user stop ollama.service >/dev/null 2>&1 || true
@@ -269,18 +272,8 @@ if pgrep -f '[o]llama serve' >/dev/null 2>&1; then
   pgrep -af '[o]llama serve' >&2 || true
   exit 1
 fi
-if node -e '
-  const net = require("node:net");
-  const socket = net.createConnection({ host: "127.0.0.1", port: 11434 });
-  const finish = (code) => {
-    socket.destroy();
-    process.exit(code);
-  };
-  socket.setTimeout(2_000, () => finish(1));
-  socket.once("connect", () => finish(0));
-  socket.once("error", () => finish(1));
-'; then
-  echo 'Ollama cleanup left a listener on 127.0.0.1:11434' >&2
+if (exec 3<>/dev/tcp/127.0.0.1/${listenerPort}) 2>/dev/null; then
+  echo 'Ollama cleanup left a listener on 127.0.0.1:${listenerPort}' >&2
   exit 1
 fi`;
 }

--- a/test/e2e/live/gpu-e2e.test.ts
+++ b/test/e2e/live/gpu-e2e.test.ts
@@ -213,7 +213,8 @@ test("GPU Ollama onboard enables CUDA, auth proxy, and sandbox inference", {
   assertNvidiaAvailable(nvidia, skip);
 
   await ensureOllama(host);
-  await cleanupOllama(host, "pre-cleanup-ollama");
+  const ollamaCleanup = await cleanupOllama(host, "pre-cleanup-ollama");
+  expect(ollamaCleanup.exitCode, resultText(ollamaCleanup)).toBe(0);
 
   progress.phase("install Ollama and GPU sandbox");
   const install = await host.command("bash", ["install.sh", "--non-interactive"], {

--- a/test/e2e/live/managed-image-protected-runtime-helpers.ts
+++ b/test/e2e/live/managed-image-protected-runtime-helpers.ts
@@ -126,11 +126,16 @@ async function qualifyEveryAgent(
   }
 }
 
+export const PROTECTED_OLLAMA_READY_ATTEMPTS = 20;
+export const PROTECTED_OLLAMA_CURL_MAX_SECONDS = 5;
+export const PROTECTED_OLLAMA_READY_SLEEP_SECONDS = 1;
+export const PROTECTED_OLLAMA_START_TIMEOUT_MS = 150_000;
+
 export function protectedOllamaStartScript(logPath: string): string {
   if (!path.isAbsolute(logPath) || /[\0\r\n]/u.test(logPath)) {
     throw new Error(`protected Ollama log path must be absolute: ${JSON.stringify(logPath)}`);
   }
-  const logPathLiteral = JSON.stringify(logPath);
+  const logPathLiteral = `'${logPath.replaceAll("'", "'\\''")}'`;
   return `set -euo pipefail
 log_path=${logPathLiteral}
 : >"$log_path"
@@ -175,8 +180,8 @@ else
   restart_mode=manual
 fi
 
-for _ in $(seq 1 120); do
-  if curl -fsS --connect-timeout 2 --max-time 5 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+for _ in $(seq 1 ${PROTECTED_OLLAMA_READY_ATTEMPTS}); do
+  if curl -fsS --connect-timeout 2 --max-time ${PROTECTED_OLLAMA_CURL_MAX_SECONDS} http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
     printf 'restart_mode=%s\n' "$restart_mode"
     exit 0
   fi
@@ -186,7 +191,7 @@ for _ in $(seq 1 120); do
     diagnose_ollama
     exit 1
   fi
-  sleep 1
+  sleep ${PROTECTED_OLLAMA_READY_SLEEP_SECONDS}
 done
 
 echo 'Ollama did not become ready on 127.0.0.1:11434' >&2
@@ -209,7 +214,7 @@ export async function startProtectedOllama(host: HostCliClient): Promise<string>
     {
       artifactName: "start-managed-image-ollama",
       env: gpuEnv(),
-      timeoutMs: 150_000,
+      timeoutMs: PROTECTED_OLLAMA_START_TIMEOUT_MS,
     },
   );
   expect(start.exitCode, resultText(start)).toBe(0);

--- a/test/e2e/live/managed-image-protected-runtime-helpers.ts
+++ b/test/e2e/live/managed-image-protected-runtime-helpers.ts
@@ -194,8 +194,10 @@ diagnose_ollama
 exit 1`;
 }
 
-async function startProtectedOllama(host: HostCliClient): Promise<string> {
+export async function startProtectedOllama(host: HostCliClient): Promise<string> {
   await ensureOllama(host);
+  const cleanup = await cleanupOllama(host, "pre-cleanup-managed-image-ollama");
+  expect(cleanup.exitCode, resultText(cleanup)).toBe(0);
   const start = await host.command(
     "bash",
     [

--- a/test/e2e/live/managed-image-protected-runtime-helpers.ts
+++ b/test/e2e/live/managed-image-protected-runtime-helpers.ts
@@ -126,20 +126,80 @@ async function qualifyEveryAgent(
   }
 }
 
+export function protectedOllamaStartScript(logPath: string): string {
+  if (!path.isAbsolute(logPath) || /[\0\r\n]/u.test(logPath)) {
+    throw new Error(`protected Ollama log path must be absolute: ${JSON.stringify(logPath)}`);
+  }
+  const logPathLiteral = JSON.stringify(logPath);
+  return `set -euo pipefail
+log_path=${logPathLiteral}
+: >"$log_path"
+restart_mode=''
+sudo_prefix=()
+if [ "$(id -u)" -eq 0 ]; then
+  sudo_prefix=()
+elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  sudo_prefix=(sudo -n)
+fi
+
+diagnose_ollama() {
+  tail -n 200 "$log_path" >&2 || true
+  if [ "$restart_mode" = system ]; then
+    "\${sudo_prefix[@]}" journalctl -u ollama.service --no-pager -n 200 >&2 || true
+  elif [ "$restart_mode" = user ]; then
+    journalctl --user -u ollama.service --no-pager -n 200 >&2 || true
+  fi
+}
+
+system_service=0
+if command -v systemctl >/dev/null 2>&1 &&
+  { [ "$(id -u)" -eq 0 ] || [ "\${#sudo_prefix[@]}" -gt 0 ]; } &&
+  "\${sudo_prefix[@]}" systemctl cat ollama.service >/dev/null 2>&1; then
+  system_service=1
+fi
+
+if [ "$system_service" -eq 1 ]; then
+  restart_mode=system
+  if ! "\${sudo_prefix[@]}" systemctl restart ollama.service; then
+    echo 'Ollama system service restart failed' >&2
+    diagnose_ollama
+    exit 1
+  fi
+elif command -v systemctl >/dev/null 2>&1 && systemctl --user restart ollama.service; then
+  restart_mode=user
+else
+  nohup setsid -f env OLLAMA_HOST=127.0.0.1:11434 ollama serve >"$log_path" 2>&1
+  restart_mode=manual
+fi
+
+for _ in $(seq 1 120); do
+  if curl -fsS --connect-timeout 2 --max-time 5 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+    printf 'restart_mode=%s\n' "$restart_mode"
+    exit 0
+  fi
+  if [ "$restart_mode" = system ] &&
+    "\${sudo_prefix[@]}" systemctl is-failed --quiet ollama.service; then
+    echo 'Ollama system service failed before becoming ready' >&2
+    diagnose_ollama
+    exit 1
+  fi
+  sleep 1
+done
+
+echo 'Ollama did not become ready on 127.0.0.1:11434' >&2
+diagnose_ollama
+exit 1`;
+}
+
 async function startProtectedOllama(host: HostCliClient): Promise<string> {
   await ensureOllama(host);
-  await cleanupOllama(host, "pre-cleanup-managed-image-ollama");
   const start = await host.command(
     "bash",
     [
       "-lc",
-      `set -euo pipefail
-OLLAMA_HOST=127.0.0.1:11434 nohup ollama serve >"${process.env.RUNNER_TEMP ?? "/tmp"}/managed-image-ollama.log" 2>&1 &
-for _ in $(seq 1 120); do
-  curl -fsS --connect-timeout 2 http://127.0.0.1:11434/api/tags >/dev/null 2>&1 && exit 0
-  sleep 1
-done
-exit 1`,
+      protectedOllamaStartScript(
+        path.join(process.env.RUNNER_TEMP ?? "/tmp", "managed-image-ollama.log"),
+      ),
     ],
     {
       artifactName: "start-managed-image-ollama",
@@ -356,7 +416,8 @@ export async function qualifyProtectedManagedImageRuntime(
   });
   cleanup.trackDisposable("stop protected Ollama runtime", async () => {
     killStaleProxy();
-    await cleanupOllama(host, "cleanup-managed-image-ollama");
+    const result = await cleanupOllama(host, "cleanup-managed-image-ollama");
+    expect(result.exitCode, resultText(result)).toBe(0);
   });
 
   let activePhase = "validate protected host runtime";
@@ -384,7 +445,8 @@ export async function qualifyProtectedManagedImageRuntime(
     });
     await proveOllamaGpuPlacement(host);
     killStaleProxy();
-    await cleanupOllama(host, "stop-ollama-before-vllm");
+    const ollamaCleanup = await cleanupOllama(host, "stop-ollama-before-vllm");
+    expect(ollamaCleanup.exitCode, resultText(ollamaCleanup)).toBe(0);
 
     activePhase = "qualify all managed agents with GPU-backed vLLM";
     progress.phase("qualify all managed agents with GPU-backed vLLM");

--- a/test/e2e/live/managed-image-protected-runtime-helpers.ts
+++ b/test/e2e/live/managed-image-protected-runtime-helpers.ts
@@ -153,13 +153,16 @@ diagnose_ollama() {
 
 system_service=0
 if command -v systemctl >/dev/null 2>&1 &&
-  { [ "$(id -u)" -eq 0 ] || [ "\${#sudo_prefix[@]}" -gt 0 ]; } &&
-  "\${sudo_prefix[@]}" systemctl cat ollama.service >/dev/null 2>&1; then
+  systemctl cat ollama.service >/dev/null 2>&1; then
   system_service=1
 fi
 
 if [ "$system_service" -eq 1 ]; then
   restart_mode=system
+  if [ "$(id -u)" -ne 0 ] && [ "\${#sudo_prefix[@]}" -eq 0 ]; then
+    echo 'Ollama system service is installed but cannot be restarted without root or passwordless sudo' >&2
+    exit 1
+  fi
   if ! "\${sudo_prefix[@]}" systemctl restart ollama.service; then
     echo 'Ollama system service restart failed' >&2
     diagnose_ollama

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -8,9 +8,12 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import type { HostCliClient } from "../fixtures/clients/host.ts";
+import type { SandboxClient } from "../fixtures/clients/sandbox.ts";
 import {
   assertAgentExecutionSucceeded,
   buildLlamaCppCompatibilityTargetEnv,
+  cleanupGpu,
   env,
   hasExactReadyPhase,
   ollamaCleanupScript,
@@ -281,6 +284,58 @@ describe("GPU E2E helpers", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("restarts an available Ollama user service without a manual daemon", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-start-user-service-"));
+    try {
+      const bin = path.join(root, "bin");
+      const calls = path.join(root, "calls.log");
+      const logPath = path.join(root, "ollama.log");
+      mkdirSync(bin);
+      for (const [command, body] of [
+        ["id", 'printf "1000\\n"\n'],
+        ["sudo", "exit 1\n"],
+        [
+          "systemctl",
+          'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\ncase "$*" in\n  "cat ollama.service") exit 1 ;;\n  "--user restart ollama.service") exit 0 ;;\n  *) exit 1 ;;\nesac\n',
+        ],
+        ["setsid", 'printf "setsid %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        ["curl", "exit 0\n"],
+      ] as const) {
+        const commandPath = path.join(bin, command);
+        writeFileSync(commandPath, `#!/bin/sh\n${body}`);
+        chmodSync(commandPath, 0o755);
+      }
+
+      const stdout = execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+        encoding: "utf8",
+        env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
+      });
+      expect(stdout).toBe("restart_mode=user\n");
+      const commandLog = readFileSync(calls, "utf8");
+      expect(commandLog).toContain("systemctl cat ollama.service");
+      expect(commandLog).toContain("systemctl --user restart ollama.service");
+      expect(commandLog).not.toContain("setsid");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stops GPU setup when Ollama cleanup leaves a listener", async () => {
+    const success = { exitCode: 0, stderr: "", stdout: "" };
+    const host = {
+      command: async (command: string) =>
+        command === "bash"
+          ? { exitCode: 1, stderr: "Ollama still listens on 127.0.0.1:11434", stdout: "" }
+          : success,
+    } as unknown as HostCliClient;
+    const sandbox = {
+      cleanupSandbox: async () => success,
+      openshell: async () => success,
+    } as unknown as SandboxClient;
+
+    await expect(cleanupGpu(host, sandbox)).rejects.toThrow(/still listens/u);
   });
 
   it("bootstraps the new llama.cpp target through the trusted pre-merge GPU lane", () => {

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync } from "node:child_process";
+import { once } from "node:events";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -21,11 +23,33 @@ import {
   shouldBootstrapLlamaCppGenericGpuTarget,
 } from "../live/gpu-e2e-helpers.ts";
 import {
+  PROTECTED_OLLAMA_CURL_MAX_SECONDS,
+  PROTECTED_OLLAMA_READY_ATTEMPTS,
+  PROTECTED_OLLAMA_READY_SLEEP_SECONDS,
+  PROTECTED_OLLAMA_START_TIMEOUT_MS,
   protectedOllamaStartScript,
   startProtectedOllama,
 } from "../live/managed-image-protected-runtime-helpers.ts";
 
 const GPU_MODEL = "qwen3.5:9b";
+const SYNC_E2E_CHILD_OPTIONS = { killSignal: "SIGKILL" as const, timeout: 5_000 };
+
+function loopbackPort(server: ReturnType<typeof createServer>): number {
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("loopback server has no TCP port");
+  return address.port;
+}
+
+async function unusedLoopbackPort(): Promise<number> {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = loopbackPort(server);
+  const closed = once(server, "close");
+  server.close();
+  await closed;
+  return port;
+}
 
 interface AgentOutputOverrides {
   status?: string;
@@ -126,25 +150,27 @@ const invalidExecutionProofs: Array<{
 ];
 
 describe("GPU E2E helpers", () => {
-  it("stops the Ollama system service before cleanup completes", () => {
+  it("stops the Ollama system service before cleanup completes", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-cleanup-"));
+    const listenerPort = await unusedLoopbackPort();
     try {
       const bin = path.join(root, "bin");
       const calls = path.join(root, "calls.log");
       mkdirSync(bin);
       for (const [command, body] of [
+        ["id", 'printf "1000\\n"\n'],
         ["sudo", 'printf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
         ["systemctl", 'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
         ["pkill", "exit 1\n"],
         ["pgrep", "exit 1\n"],
-        ["node", "exit 1\n"],
       ] as const) {
         const commandPath = path.join(bin, command);
         writeFileSync(commandPath, `#!/bin/sh\n${body}`);
         chmodSync(commandPath, 0o755);
       }
 
-      execFileSync("bash", ["-c", ollamaCleanupScript()], {
+      execFileSync("bash", ["-c", ollamaCleanupScript(listenerPort)], {
+        ...SYNC_E2E_CHILD_OPTIONS,
         env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
       });
       const commandLog = readFileSync(calls, "utf8");
@@ -156,8 +182,12 @@ describe("GPU E2E helpers", () => {
     }
   });
 
-  it("rejects cleanup when an Ollama listener remains", () => {
+  it("rejects cleanup when an Ollama listener remains", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-stale-listener-"));
+    const server = createServer();
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const listenerPort = loopbackPort(server);
     try {
       const bin = path.join(root, "bin");
       mkdirSync(bin);
@@ -165,7 +195,6 @@ describe("GPU E2E helpers", () => {
         ["systemctl", "exit 1\n"],
         ["pkill", "exit 1\n"],
         ["pgrep", "exit 1\n"],
-        ["node", "exit 0\n"],
       ] as const) {
         const commandPath = path.join(bin, command);
         writeFileSync(commandPath, `#!/bin/sh\n${body}`);
@@ -173,14 +202,33 @@ describe("GPU E2E helpers", () => {
       }
 
       expect(() =>
-        execFileSync("bash", ["-c", ollamaCleanupScript()], {
+        execFileSync("bash", ["-c", ollamaCleanupScript(listenerPort)], {
+          ...SYNC_E2E_CHILD_OPTIONS,
           env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
           stdio: "pipe",
         }),
       ).toThrow();
     } finally {
+      const closed = once(server, "close");
+      server.close();
+      await closed;
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("quotes protected Ollama log paths as shell data", () => {
+    const script = protectedOllamaStartScript("/tmp/$(touch injected)-$USER-`id`-'quoted.log");
+
+    expect(script).toContain("log_path='/tmp/$(touch injected)-$USER-`id`-'\\''quoted.log'");
+  });
+
+  it("keeps protected Ollama readiness inside the host command timeout", () => {
+    const maximumReadinessMs =
+      PROTECTED_OLLAMA_READY_ATTEMPTS *
+      (PROTECTED_OLLAMA_CURL_MAX_SECONDS + PROTECTED_OLLAMA_READY_SLEEP_SECONDS) *
+      1_000;
+
+    expect(PROTECTED_OLLAMA_START_TIMEOUT_MS).toBeGreaterThan(maximumReadinessMs);
   });
 
   it("restarts the protected Ollama daemon through its installed system service", () => {
@@ -190,6 +238,9 @@ describe("GPU E2E helpers", () => {
       const calls = path.join(root, "calls.log");
       const logPath = path.join(root, "ollama.log");
       mkdirSync(bin);
+      const idPath = path.join(bin, "id");
+      writeFileSync(idPath, '#!/bin/sh\nprintf "1000\\n"\n');
+      chmodSync(idPath, 0o755);
       const sudoPath = path.join(bin, "sudo");
       writeFileSync(
         sudoPath,
@@ -204,6 +255,7 @@ describe("GPU E2E helpers", () => {
       chmodSync(systemctlPath, 0o755);
 
       const stdout = execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+        ...SYNC_E2E_CHILD_OPTIONS,
         encoding: "utf8",
         env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
       });
@@ -222,6 +274,7 @@ describe("GPU E2E helpers", () => {
       const logPath = path.join(root, "ollama.log");
       mkdirSync(bin);
       for (const [command, body] of [
+        ["id", 'printf "1000\\n"\n'],
         [
           "sudo",
           'printf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\ncase "$*" in\n  "-n systemctl restart ollama.service") exit 1 ;;\n  *) exit 0 ;;\nesac\n',
@@ -237,6 +290,7 @@ describe("GPU E2E helpers", () => {
 
       expect(() =>
         execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+          ...SYNC_E2E_CHILD_OPTIONS,
           env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
           stdio: "pipe",
         }),
@@ -244,6 +298,45 @@ describe("GPU E2E helpers", () => {
       const commandLog = readFileSync(calls, "utf8");
       expect(commandLog).toContain("systemctl cat ollama.service");
       expect(commandLog).toContain("sudo -n systemctl restart ollama.service");
+      expect(commandLog).not.toContain("systemctl --user restart ollama.service");
+      expect(commandLog).not.toContain("setsid");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stops when the restarted Ollama system service enters the failed state", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-start-failed-state-"));
+    try {
+      const bin = path.join(root, "bin");
+      const calls = path.join(root, "calls.log");
+      const logPath = path.join(root, "ollama.log");
+      mkdirSync(bin);
+      for (const [command, body] of [
+        ["id", 'printf "1000\\n"\n'],
+        [
+          "sudo",
+          'printf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\ncase "$*" in\n  "-n systemctl is-failed --quiet ollama.service") exit 0 ;;\n  *) exit 0 ;;\nesac\n',
+        ],
+        ["systemctl", 'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        ["setsid", 'printf "setsid %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        ["curl", "exit 1\n"],
+      ] as const) {
+        const commandPath = path.join(bin, command);
+        writeFileSync(commandPath, `#!/bin/sh\n${body}`);
+        chmodSync(commandPath, 0o755);
+      }
+
+      expect(() =>
+        execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+          ...SYNC_E2E_CHILD_OPTIONS,
+          env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
+          stdio: "pipe",
+        }),
+      ).toThrow();
+      const commandLog = readFileSync(calls, "utf8");
+      expect(commandLog).toContain("sudo -n systemctl restart ollama.service");
+      expect(commandLog).toContain("sudo -n systemctl is-failed --quiet ollama.service");
       expect(commandLog).not.toContain("systemctl --user restart ollama.service");
       expect(commandLog).not.toContain("setsid");
     } finally {
@@ -275,6 +368,7 @@ describe("GPU E2E helpers", () => {
 
       expect(() =>
         execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+          ...SYNC_E2E_CHILD_OPTIONS,
           env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
           stdio: "pipe",
         }),
@@ -312,6 +406,7 @@ describe("GPU E2E helpers", () => {
       }
 
       const stdout = execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+        ...SYNC_E2E_CHILD_OPTIONS,
         encoding: "utf8",
         env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
       });
@@ -331,16 +426,15 @@ describe("GPU E2E helpers", () => {
       const bin = path.join(root, "bin");
       const calls = path.join(root, "calls.log");
       const logPath = path.join(root, "ollama.log");
+      const readyPath = path.join(root, "ollama-ready");
       mkdirSync(bin);
       for (const [command, body] of [
         ["id", 'printf "1000\\n"\n'],
         ["sudo", "exit 1\n"],
         ["systemctl", 'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\nexit 1\n'],
-        ["setsid", 'printf "setsid %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
-        [
-          "curl",
-          'for _ in $(seq 1 50); do\n  grep -q "^setsid " "$FAKE_CALLS" && exit 0\n  sleep 0.01\ndone\nexit 1\n',
-        ],
+        ["setsid", 'printf "setsid %s\\n" "$*" >>"$FAKE_CALLS"\nshift\nexec "$@"\n'],
+        ["ollama", 'printf "ollama-executed %s\\n" "$*" >>"$FAKE_CALLS"\n: >"$FAKE_READY"\n'],
+        ["curl", 'printf "curl-probe %s\\n" "$*" >>"$FAKE_CALLS"\ntest -f "$FAKE_READY"\n'],
       ] as const) {
         const commandPath = path.join(bin, command);
         writeFileSync(commandPath, `#!/bin/sh\n${body}`);
@@ -348,14 +442,24 @@ describe("GPU E2E helpers", () => {
       }
 
       const stdout = execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+        ...SYNC_E2E_CHILD_OPTIONS,
         encoding: "utf8",
-        env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
+        env: {
+          ...process.env,
+          FAKE_CALLS: calls,
+          FAKE_READY: readyPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
       });
       expect(stdout).toBe("restart_mode=manual\n");
       const commandLog = readFileSync(calls, "utf8");
       expect(commandLog).toContain("systemctl cat ollama.service");
       expect(commandLog).toContain("systemctl --user restart ollama.service");
       expect(commandLog).toContain("setsid -f env OLLAMA_HOST=127.0.0.1:11434 ollama serve");
+      expect(commandLog).toContain("ollama-executed serve");
+      expect(commandLog).toContain(
+        "curl-probe -fsS --connect-timeout 2 --max-time 5 http://127.0.0.1:11434/api/tags",
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -20,7 +20,10 @@ import {
   openClawModelConfigProjectionScript,
   shouldBootstrapLlamaCppGenericGpuTarget,
 } from "../live/gpu-e2e-helpers.ts";
-import { protectedOllamaStartScript } from "../live/managed-image-protected-runtime-helpers.ts";
+import {
+  protectedOllamaStartScript,
+  startProtectedOllama,
+} from "../live/managed-image-protected-runtime-helpers.ts";
 
 const GPU_MODEL = "qwen3.5:9b";
 
@@ -356,6 +359,33 @@ describe("GPU E2E helpers", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("rejects a stale Ollama listener before protected startup", async () => {
+    const artifacts: string[] = [];
+    const host = {
+      command: async (
+        _command: string,
+        _args: string[],
+        options: { artifactName?: string } = {},
+      ) => {
+        artifacts.push(options.artifactName ?? "");
+        if (options.artifactName === "command-v-ollama") {
+          return { exitCode: 0, stderr: "", stdout: "/usr/local/bin/ollama\n" };
+        }
+        if (options.artifactName === "pre-cleanup-managed-image-ollama") {
+          return {
+            exitCode: 1,
+            stderr: "Ollama still listens on 127.0.0.1:11434",
+            stdout: "",
+          };
+        }
+        throw new Error(`unexpected command after failed cleanup: ${options.artifactName ?? ""}`);
+      },
+    } as unknown as HostCliClient;
+
+    await expect(startProtectedOllama(host)).rejects.toThrow(/still listens/u);
+    expect(artifacts).toEqual(["command-v-ollama", "pre-cleanup-managed-image-ollama"]);
   });
 
   it("stops GPU setup when Ollama cleanup leaves a listener", async () => {

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -13,9 +13,11 @@ import {
   buildLlamaCppCompatibilityTargetEnv,
   env,
   hasExactReadyPhase,
+  ollamaCleanupScript,
   openClawModelConfigProjectionScript,
   shouldBootstrapLlamaCppGenericGpuTarget,
 } from "../live/gpu-e2e-helpers.ts";
+import { protectedOllamaStartScript } from "../live/managed-image-protected-runtime-helpers.ts";
 
 const GPU_MODEL = "qwen3.5:9b";
 
@@ -118,6 +120,131 @@ const invalidExecutionProofs: Array<{
 ];
 
 describe("GPU E2E helpers", () => {
+  it("stops the Ollama system service before cleanup completes", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-cleanup-"));
+    try {
+      const bin = path.join(root, "bin");
+      const calls = path.join(root, "calls.log");
+      mkdirSync(bin);
+      for (const [command, body] of [
+        ["sudo", 'printf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        ["systemctl", 'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        ["pkill", "exit 1\n"],
+        ["pgrep", "exit 1\n"],
+        ["node", "exit 1\n"],
+      ] as const) {
+        const commandPath = path.join(bin, command);
+        writeFileSync(commandPath, `#!/bin/sh\n${body}`);
+        chmodSync(commandPath, 0o755);
+      }
+
+      execFileSync("bash", ["-c", ollamaCleanupScript()], {
+        env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
+      });
+      const commandLog = readFileSync(calls, "utf8");
+      expect(commandLog).toContain("systemctl --user stop ollama.service");
+      expect(commandLog).toContain("sudo -n systemctl stop ollama.service");
+      expect(commandLog).toContain("sudo -n pkill -f [o]llama serve");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects cleanup when an Ollama listener remains", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-stale-listener-"));
+    try {
+      const bin = path.join(root, "bin");
+      mkdirSync(bin);
+      for (const [command, body] of [
+        ["systemctl", "exit 1\n"],
+        ["pkill", "exit 1\n"],
+        ["pgrep", "exit 1\n"],
+        ["node", "exit 0\n"],
+      ] as const) {
+        const commandPath = path.join(bin, command);
+        writeFileSync(commandPath, `#!/bin/sh\n${body}`);
+        chmodSync(commandPath, 0o755);
+      }
+
+      expect(() =>
+        execFileSync("bash", ["-c", ollamaCleanupScript()], {
+          env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+          stdio: "pipe",
+        }),
+      ).toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("restarts the protected Ollama daemon through its installed system service", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-start-"));
+    try {
+      const bin = path.join(root, "bin");
+      const calls = path.join(root, "calls.log");
+      const logPath = path.join(root, "ollama.log");
+      mkdirSync(bin);
+      const sudoPath = path.join(bin, "sudo");
+      writeFileSync(
+        sudoPath,
+        '#!/bin/sh\nprintf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\ncase "$*" in\n  "-n systemctl is-failed --quiet ollama.service") exit 1 ;;\n  *) exit 0 ;;\nesac\n',
+      );
+      chmodSync(sudoPath, 0o755);
+      const curlPath = path.join(bin, "curl");
+      writeFileSync(curlPath, "#!/bin/sh\nexit 0\n");
+      chmodSync(curlPath, 0o755);
+      const systemctlPath = path.join(bin, "systemctl");
+      writeFileSync(systemctlPath, "#!/bin/sh\nexit 0\n");
+      chmodSync(systemctlPath, 0o755);
+
+      const stdout = execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+        encoding: "utf8",
+        env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
+      });
+      expect(stdout).toBe("restart_mode=system\n");
+      expect(readFileSync(calls, "utf8")).toContain("sudo -n systemctl restart ollama.service");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not fall back when the installed Ollama system service restart fails", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-start-failure-"));
+    try {
+      const bin = path.join(root, "bin");
+      const calls = path.join(root, "calls.log");
+      const logPath = path.join(root, "ollama.log");
+      mkdirSync(bin);
+      for (const [command, body] of [
+        [
+          "sudo",
+          'printf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\ncase "$*" in\n  "-n systemctl restart ollama.service") exit 1 ;;\n  *) exit 0 ;;\nesac\n',
+        ],
+        ["systemctl", 'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        ["setsid", 'printf "setsid %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        ["curl", "exit 0\n"],
+      ] as const) {
+        const commandPath = path.join(bin, command);
+        writeFileSync(commandPath, `#!/bin/sh\n${body}`);
+        chmodSync(commandPath, 0o755);
+      }
+
+      expect(() =>
+        execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+          env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
+          stdio: "pipe",
+        }),
+      ).toThrow();
+      const commandLog = readFileSync(calls, "utf8");
+      expect(commandLog).toContain("sudo -n systemctl cat ollama.service");
+      expect(commandLog).toContain("sudo -n systemctl restart ollama.service");
+      expect(commandLog).not.toContain("systemctl --user restart ollama.service");
+      expect(commandLog).not.toContain("setsid");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("bootstraps the new llama.cpp target through the trusted pre-merge GPU lane", () => {
     expect(
       shouldBootstrapLlamaCppGenericGpuTarget({

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -236,8 +236,46 @@ describe("GPU E2E helpers", () => {
         }),
       ).toThrow();
       const commandLog = readFileSync(calls, "utf8");
-      expect(commandLog).toContain("sudo -n systemctl cat ollama.service");
+      expect(commandLog).toContain("systemctl cat ollama.service");
       expect(commandLog).toContain("sudo -n systemctl restart ollama.service");
+      expect(commandLog).not.toContain("systemctl --user restart ollama.service");
+      expect(commandLog).not.toContain("setsid");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an installed Ollama system service without restart permission", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-start-unprivileged-"));
+    try {
+      const bin = path.join(root, "bin");
+      const calls = path.join(root, "calls.log");
+      const logPath = path.join(root, "ollama.log");
+      mkdirSync(bin);
+      for (const [command, body] of [
+        ["id", 'printf "id %s\\n" "$*" >>"$FAKE_CALLS"\nprintf "1000\\n"\n'],
+        ["sudo", 'printf "sudo %s\\n" "$*" >>"$FAKE_CALLS"\nexit 1\n'],
+        [
+          "systemctl",
+          'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\ncase "$*" in\n  "cat ollama.service") exit 0 ;;\n  *) exit 1 ;;\nesac\n',
+        ],
+        ["setsid", 'printf "setsid %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        ["curl", "exit 0\n"],
+      ] as const) {
+        const commandPath = path.join(bin, command);
+        writeFileSync(commandPath, `#!/bin/sh\n${body}`);
+        chmodSync(commandPath, 0o755);
+      }
+
+      expect(() =>
+        execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+          env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
+          stdio: "pipe",
+        }),
+      ).toThrow();
+      const commandLog = readFileSync(calls, "utf8");
+      expect(commandLog).toContain("systemctl cat ollama.service");
+      expect(commandLog).not.toContain("systemctl restart ollama.service");
       expect(commandLog).not.toContain("systemctl --user restart ollama.service");
       expect(commandLog).not.toContain("setsid");
     } finally {

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { once } from "node:events";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -36,7 +37,7 @@ const SYNC_E2E_CHILD_OPTIONS = { killSignal: "SIGKILL" as const, timeout: 5_000 
 
 function loopbackPort(server: ReturnType<typeof createServer>): number {
   const address = server.address();
-  if (!address || typeof address === "string") throw new Error("loopback server has no TCP port");
+  assert(address && typeof address !== "string", "loopback server has no TCP port");
   return address.port;
 }
 
@@ -474,17 +475,20 @@ describe("GPU E2E helpers", () => {
         options: { artifactName?: string } = {},
       ) => {
         artifacts.push(options.artifactName ?? "");
-        if (options.artifactName === "command-v-ollama") {
-          return { exitCode: 0, stderr: "", stdout: "/usr/local/bin/ollama\n" };
+        switch (options.artifactName) {
+          case "command-v-ollama":
+            return { exitCode: 0, stderr: "", stdout: "/usr/local/bin/ollama\n" };
+          case "pre-cleanup-managed-image-ollama":
+            return {
+              exitCode: 1,
+              stderr: "Ollama still listens on 127.0.0.1:11434",
+              stdout: "",
+            };
+          default:
+            throw new Error(
+              `unexpected command after failed cleanup: ${options.artifactName ?? ""}`,
+            );
         }
-        if (options.artifactName === "pre-cleanup-managed-image-ollama") {
-          return {
-            exitCode: 1,
-            stderr: "Ollama still listens on 127.0.0.1:11434",
-            stdout: "",
-          };
-        }
-        throw new Error(`unexpected command after failed cleanup: ${options.artifactName ?? ""}`);
       },
     } as unknown as HostCliClient;
 

--- a/test/e2e/support/gpu-e2e-helpers.test.ts
+++ b/test/e2e/support/gpu-e2e-helpers.test.ts
@@ -322,6 +322,42 @@ describe("GPU E2E helpers", () => {
     }
   });
 
+  it("starts a manual Ollama daemon when no service is available", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "nemoclaw-ollama-start-manual-"));
+    try {
+      const bin = path.join(root, "bin");
+      const calls = path.join(root, "calls.log");
+      const logPath = path.join(root, "ollama.log");
+      mkdirSync(bin);
+      for (const [command, body] of [
+        ["id", 'printf "1000\\n"\n'],
+        ["sudo", "exit 1\n"],
+        ["systemctl", 'printf "systemctl %s\\n" "$*" >>"$FAKE_CALLS"\nexit 1\n'],
+        ["setsid", 'printf "setsid %s\\n" "$*" >>"$FAKE_CALLS"\nexit 0\n'],
+        [
+          "curl",
+          'for _ in $(seq 1 50); do\n  grep -q "^setsid " "$FAKE_CALLS" && exit 0\n  sleep 0.01\ndone\nexit 1\n',
+        ],
+      ] as const) {
+        const commandPath = path.join(bin, command);
+        writeFileSync(commandPath, `#!/bin/sh\n${body}`);
+        chmodSync(commandPath, 0o755);
+      }
+
+      const stdout = execFileSync("bash", ["-c", protectedOllamaStartScript(logPath)], {
+        encoding: "utf8",
+        env: { ...process.env, FAKE_CALLS: calls, PATH: `${bin}:${process.env.PATH}` },
+      });
+      expect(stdout).toBe("restart_mode=manual\n");
+      const commandLog = readFileSync(calls, "utf8");
+      expect(commandLog).toContain("systemctl cat ollama.service");
+      expect(commandLog).toContain("systemctl --user restart ollama.service");
+      expect(commandLog).toContain("setsid -f env OLLAMA_HOST=127.0.0.1:11434 ollama serve");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("stops GPU setup when Ollama cleanup leaves a listener", async () => {
     const success = { exitCode: 0, stderr: "", stdout: "" };
     const host = {


### PR DESCRIPTION
## Summary

Restores the protected managed-image GPU test's Ollama lifecycle after the official installer creates a system service. Startup now uses that installed service as the single authority and fails with diagnostics if it cannot restart; cleanup stops supported service forms and rejects any remaining daemon process or TCP listener.

## Related Issue

Part of #7744.

## Changes

- restart the installed Ollama system service instead of starting a second login-shell daemon
- stop system and user service forms during cleanup, then remove remaining test-owned Ollama processes
- verify cleanup at both the process and TCP-listener boundaries
- shell-quote generated log paths, keep readiness within the host timeout, and remove the cleanup probe's Node.js dependency
- cover system- and user-service startup, manual fallback, failed-state detection, cleanup, and real stale-listener rejection

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes trusted live E2E qualification and support tests only; public commands, configuration, defaults, and supported behavior do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed the service boundary and failure paths. The installed system unit remains the single startup authority, restart failure stops the test, cleanup does not change credentials or policy, and regressions cover both failure boundaries.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed the full branch diff, including `test/e2e/live/gpu-e2e-helpers.ts`, `test/e2e/live/gpu-e2e.test.ts`, `test/e2e/live/managed-image-protected-runtime-helpers.ts`, and `test/e2e/support/gpu-e2e-helpers.test.ts`. These changes affect E2E lifecycle verification only. Focused E2E-support tests passed 40/40; semantic phase tests passed 20/20; the conditional-growth scan, Biome, repository checks, `git diff --check`, and normal commit hooks passed.
- Agent: Codex CLI (`/root/docs_review_ollama_lifecycle`)
<!-- docs-review-head-sha: 2698df348 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/gpu-e2e-helpers.test.ts` (40 passed); `npx vitest run --project e2e-support test/e2e/support/e2e-semantic-phase-check.test.ts` (20 passed); `npm run test-conditionals:scan -- --top 25`, Biome, and `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this change is isolated to live E2E helpers and their support tests.
- [ ] Protected live E2E passes — final exact-head manual run [31415077434](https://github.com/NVIDIA/NemoClaw/actions/runs/31415077434) is in progress for commit `2698df348`. The protected workflow executes its qualification helper from trusted `main`, so this pre-merge run validates exact candidate images but cannot exercise the PR's helper change; post-merge `main` evidence remains required.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama service cleanup to stop lingering processes and verify that its network port is released.
  * Improved protected Ollama startup with service recovery, readiness checks, permission handling, and clearer diagnostics when startup fails.
  * Prevented runtime startup from proceeding when Ollama cleanup is incomplete or unsuccessful.

* **Tests**
  * Added coverage for service shutdown, stale listeners, protected service restarts, user-service handling, startup failure scenarios, and cleanup error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



