### PR TITLE
fix(e2e): accept confirmed Hermes Shields posture

### DIFF
--- a/test/e2e/live/mcp-bridge-hermes-lifecycle.ts
+++ b/test/e2e/live/mcp-bridge-hermes-lifecycle.ts
@@ -10,12 +10,20 @@ import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect } from "../fixtures/e2e-test.ts";
 import { MCP_BRIDGE_TEST_CREDENTIALS } from "../fixtures/mcp-bridge-credentials.ts";
+import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 const SERVER_NAME = "fake";
 const HOST_SECRET = MCP_BRIDGE_TEST_CREDENTIALS.host;
 const ROTATED_HOST_SECRET = MCP_BRIDGE_TEST_CREDENTIALS.rotatedHost;
 const INSPECTION_CONTROL_MARKER = "MCP_INSPECT_FORGED_CONTROL_LINE";
 const REGISTRY_FILE = path.join(process.env.HOME ?? os.homedir(), ".nemoclaw", "sandboxes.json");
+
+function targetSandboxDoesNotExist(result: ShellProbeResult, sandboxName: string): boolean {
+  const expected = `Sandbox '${sandboxName}' does not exist.`;
+  return resultText(result)
+    .split(/\r?\n/u)
+    .some((line) => line.trim() === expected);
+}
 
 export async function assertHermesConfig(
   sandbox: SandboxClient,
@@ -225,6 +233,36 @@ export async function reopenHermesMcpMaintenanceWindow(
     },
   );
   expectExitZero(shieldsDown, "open a fresh Hermes MCP maintenance window after rebuild");
+}
+
+export async function lowerHermesShieldsForCleanup(
+  host: HostCliClient,
+  sandboxName: string,
+): Promise<void> {
+  const shieldsDown = await host.nemoclaw(
+    [sandboxName, "shields", "down", "--timeout", "5m", "--reason", "E2E cleanup"],
+    {
+      artifactName: "cleanup-hermes-shields-down",
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 3 * 60_000,
+    },
+  );
+  if (shieldsDown.exitCode === 0 || targetSandboxDoesNotExist(shieldsDown, sandboxName)) {
+    return;
+  }
+
+  const shieldsStatus = await host.nemoclaw([sandboxName, "shields", "status"], {
+    artifactName: "cleanup-hermes-shields-status-after-down-error",
+    env: buildAvailabilityProbeEnv(),
+    timeoutMs: 60_000,
+  });
+  if (targetSandboxDoesNotExist(shieldsStatus, sandboxName)) {
+    return;
+  }
+  expect(
+    shieldsStatus.exitCode === 0 && shieldsStatus.stdout.includes("Shields: DOWN"),
+    `Hermes Shields cleanup could not confirm DOWN posture\n${resultText(shieldsDown)}\n${resultText(shieldsStatus)}`,
+  ).toBe(true);
 }
 
 /**

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -38,6 +38,7 @@ import {
   assertHermesManagedAddSurvivesLockedGatewayRestartAndStateLayout,
   assertHermesReloadRollback,
   assertHermesRemovalSurvivesGatewayRestart,
+  lowerHermesShieldsForCleanup,
   reopenHermesMcpMaintenanceWindow,
 } from "./mcp-bridge-hermes-lifecycle.ts";
 import {
@@ -1168,16 +1169,7 @@ mcpBridgeShardTest("hermes")(
     await rebuildWithoutMcpHostSecret(host, HERMES_SANDBOX_NAME, "hermes");
     await captureHermesGatewayIdentity(sandbox, "hermes-gateway-identity-after-mcp-restore");
     cleanup.add("lower Hermes Shields before teardown", async () => {
-      const result = await host.nemoclaw(
-        [HERMES_SANDBOX_NAME, "shields", "down", "--timeout", "5m", "--reason", "E2E cleanup"],
-        {
-          artifactName: "cleanup-hermes-shields-down",
-          env: buildAvailabilityProbeEnv(),
-          timeoutMs: 3 * 60_000,
-        },
-      );
-      const sandboxMissing = /not found|does not exist/iu.test(resultText(result));
-      expect(result.exitCode === 0 || sandboxMissing).toBe(true);
+      await lowerHermesShieldsForCleanup(host, HERMES_SANDBOX_NAME);
     });
     cleanup.add("capture Hermes post-rebuild MCP evidence", async () => {
       await artifacts.writeJson(

--- a/test/e2e/support/mcp-bridge-hermes-lifecycle.test.ts
+++ b/test/e2e/support/mcp-bridge-hermes-lifecycle.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "../fixtures/shell-probe.ts";
 import {
   assertHermesReloadRollback,
+  lowerHermesShieldsForCleanup,
   reopenHermesMcpMaintenanceWindow,
 } from "../live/mcp-bridge-hermes-lifecycle.ts";
 
@@ -20,14 +21,14 @@ interface RunnerCall {
   options?: ShellProbeRunOptions;
 }
 
-function shellResult(exitCode = 0): ShellProbeResult {
+function shellResult(exitCode = 0, stdout = "", stderr = ""): ShellProbeResult {
   return {
     command: [],
     exitCode,
     signal: null,
     timedOut: false,
-    stdout: "",
-    stderr: "",
+    stdout,
+    stderr,
     artifacts: {
       stdout: "/tmp/stdout",
       stderr: "/tmp/stderr",
@@ -145,5 +146,63 @@ describe("Hermes MCP post-rebuild maintenance", () => {
         args: ["hermes-e2e", "shields", "up"],
       }),
     ]);
+  });
+});
+
+describe("Hermes MCP cleanup posture", () => {
+  it("accepts an already-down Shields posture", async () => {
+    const runner = new RecordingRunner([
+      shellResult(1, "", "Config is already unlocked for hermes-e2e"),
+      shellResult(0, "  Shields: DOWN (temporarily unlocked)\n"),
+    ]);
+    const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
+
+    await lowerHermesShieldsForCleanup(host, "hermes-e2e");
+
+    expect(runner.calls).toEqual([
+      expect.objectContaining({
+        command: "nemoclaw",
+        args: ["hermes-e2e", "shields", "down", "--timeout", "5m", "--reason", "E2E cleanup"],
+      }),
+      expect.objectContaining({
+        command: "nemoclaw",
+        args: ["hermes-e2e", "shields", "status"],
+      }),
+    ]);
+  });
+
+  it("rejects cleanup when Shields remain up", async () => {
+    const runner = new RecordingRunner([
+      shellResult(1, "", "required executable does not exist"),
+      shellResult(0, "  Shields: UP\n"),
+    ]);
+    const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
+
+    await expect(lowerHermesShieldsForCleanup(host, "hermes-e2e")).rejects.toThrow(
+      "Hermes Shields cleanup could not confirm DOWN posture",
+    );
+  });
+
+  it("rejects unrelated absence output from Shields status", async () => {
+    const runner = new RecordingRunner([
+      shellResult(1, "", "Config transition failed"),
+      shellResult(1, "", "provider configuration not found"),
+    ]);
+    const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
+
+    await expect(lowerHermesShieldsForCleanup(host, "hermes-e2e")).rejects.toThrow(
+      "Hermes Shields cleanup could not confirm DOWN posture",
+    );
+  });
+
+  it("accepts cleanup after the sandbox is removed", async () => {
+    const runner = new RecordingRunner([
+      shellResult(1, "", "  Sandbox 'hermes-e2e' does not exist.\n"),
+    ]);
+    const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
+
+    await lowerHermesShieldsForCleanup(host, "hermes-e2e");
+
+    expect(runner.calls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Stops the Hermes MCP E2E from treating an already-down Shields posture as a cleanup failure. When `shields down` returns nonzero, cleanup now verifies authoritative status and accepts only the exact target sandbox being absent or a confirmed `Shields: DOWN` result.

## Changes

- move Hermes Shields cleanup classification into a focused lifecycle helper
- verify current Shields status after a nonzero down command
- reject `UP`, unrelated missing-command, missing-provider, and other unconfirmed results
- cover confirmed-down, failed-down, and exact removed-sandbox cleanup paths

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes live E2E cleanup classification only; public commands, configuration, output, and supported behavior do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Cleanup accepts only exact target-sandbox removal or an authoritative successful `Shields: DOWN` status. Regressions prove unrelated absence text and `Shields: UP` remain failures.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `test/e2e/live/mcp-bridge-hermes-lifecycle.ts`, `test/e2e/live/mcp-bridge.test.ts`, `test/e2e/support/mcp-bridge-hermes-lifecycle.test.ts`
- Agent: Codex Desktop
<!-- docs-review-head-sha: ccdba036f -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/mcp-bridge-hermes-lifecycle.test.ts` (8 passed); `npx vitest run --project e2e-support test/e2e/support/e2e-semantic-phase-check.test.ts` (20 passed); Biome and `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this change is isolated to one live E2E cleanup path and focused support tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hermes environment cleanup during end-to-end testing.
  - Cleanup now handles already-removed sandboxes and existing Shields-down states gracefully.
  - Added validation to detect and report cases where Shields remain active or unrelated errors occur.

- **Tests**
  - Expanded coverage for successful cleanup, sandbox removal, persistent Shields-up states, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->