### PR TITLE
test(e2e): preserve MCP discovery diagnostics

### DIFF
--- a/test/e2e/live/mcp-bridge-tool-discovery.ts
+++ b/test/e2e/live/mcp-bridge-tool-discovery.ts
@@ -40,11 +40,26 @@ export function shouldRetryMcpDiscoveryAfterRestart(
 }
 
 type McpToolDiscoveryStatusJson = {
-  provider: Record<string, unknown> & { credentialResolution?: unknown };
-  policy?: unknown;
-  adapter?: unknown;
-  trustedPrivateTarget?: unknown;
-  toolDiscovery: {
+  provider: Record<string, unknown> & {
+    registryPresent: boolean;
+    gatewayPresent: boolean | null;
+    attached: boolean | null;
+    credentialReady: boolean | null;
+    credentialResolution?: unknown;
+  };
+  policy: Record<string, unknown> & {
+    registryPresent: boolean;
+    gatewayPresent: boolean | null;
+  };
+  adapter: Record<string, unknown> & {
+    registered: boolean | null;
+    detail?: unknown;
+  };
+  trustedPrivateTarget?: Record<string, unknown> & {
+    state: "match" | "drift" | "unresolved";
+    detail?: unknown;
+  };
+  toolDiscovery: Record<string, unknown> & {
     ok: boolean;
     count: number;
     tools: string[];
@@ -59,11 +74,34 @@ function buildMcpToolDiscoveryDiagnostics(
   expectedSecret: string,
 ): Record<string, unknown> {
   return {
-    provider: status.provider,
-    policy: status.policy,
-    adapter: status.adapter,
-    trustedPrivateTarget: status.trustedPrivateTarget,
-    toolDiscovery: status.toolDiscovery,
+    provider: {
+      registryPresent: status.provider.registryPresent,
+      gatewayPresent: status.provider.gatewayPresent,
+      attached: status.provider.attached,
+      credentialReady: status.provider.credentialReady,
+      credentialResolutionPresent: status.provider.credentialResolution !== undefined,
+    },
+    policy: {
+      registryPresent: status.policy.registryPresent,
+      gatewayPresent: status.policy.gatewayPresent,
+    },
+    adapter: {
+      registered: status.adapter.registered,
+      detailPresent: status.adapter.detail !== undefined,
+    },
+    trustedPrivateTarget: status.trustedPrivateTarget
+      ? {
+          state: status.trustedPrivateTarget.state,
+          detailPresent: status.trustedPrivateTarget.detail !== undefined,
+        }
+      : null,
+    toolDiscovery: {
+      ok: status.toolDiscovery.ok,
+      count: status.toolDiscovery.count,
+      tools: [...status.toolDiscovery.tools],
+      truncated: status.toolDiscovery.truncated,
+      ...(status.toolDiscovery.detail !== undefined ? { detail: status.toolDiscovery.detail } : {}),
+    },
     requests: requests.map((request) => ({
       httpMethod: request.method,
       rpcMethod: request.rpcMethod ?? null,

--- a/test/e2e/live/mcp-bridge-tool-discovery.ts
+++ b/test/e2e/live/mcp-bridge-tool-discovery.ts
@@ -3,6 +3,7 @@
 
 import { expect } from "vitest";
 
+import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { assertExitZero } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
@@ -39,7 +40,10 @@ export function shouldRetryMcpDiscoveryAfterRestart(
 }
 
 type McpToolDiscoveryStatusJson = {
-  provider: { credentialResolution?: unknown };
+  provider: Record<string, unknown> & { credentialResolution?: unknown };
+  policy?: unknown;
+  adapter?: unknown;
+  trustedPrivateTarget?: unknown;
   toolDiscovery: {
     ok: boolean;
     count: number;
@@ -48,6 +52,33 @@ type McpToolDiscoveryStatusJson = {
     detail?: string;
   };
 };
+
+function buildMcpToolDiscoveryDiagnostics(
+  status: McpToolDiscoveryStatusJson,
+  requests: readonly FakeMcpRequest[],
+  expectedSecret: string,
+): Record<string, unknown> {
+  return {
+    provider: status.provider,
+    policy: status.policy,
+    adapter: status.adapter,
+    trustedPrivateTarget: status.trustedPrivateTarget,
+    toolDiscovery: status.toolDiscovery,
+    requests: requests.map((request) => ({
+      httpMethod: request.method,
+      rpcMethod: request.rpcMethod ?? null,
+      responseStatus: request.responseStatus ?? null,
+      responseHasResult: request.responseHasResult ?? null,
+      sessionMetadataPresent: {
+        sessionId: Boolean(request.sessionId),
+        protocolVersion: Boolean(request.protocolVersion),
+        negotiatedSessionId: Boolean(request.negotiatedSessionId),
+        negotiatedProtocolVersion: Boolean(request.negotiatedProtocolVersion),
+      },
+      credentialRewriteMatched: request.auth === `Bearer ${expectedSecret}`,
+    })),
+  };
+}
 
 export async function assertAuthenticatedMcpRediscovery(
   target: AuthenticatedMcpDiscoveryTarget | undefined,
@@ -174,6 +205,7 @@ export async function assertAuthenticatedMcpToolDiscovery(
   host: HostCliClient,
   fakeMcp: FakeMcpHttpsServer,
   options: {
+    artifacts: Pick<ArtifactSink, "writeJson">;
     sandboxName: string;
     artifactPrefix: string;
     credentialKey?: string;
@@ -202,7 +234,6 @@ export async function assertAuthenticatedMcpToolDiscovery(
     );
     assertExitZero(status, `${options.artifactPrefix} mcp status --tools --json`);
     statusJson = JSON.parse(status.stdout) as McpToolDiscoveryStatusJson;
-    expect(statusJson.provider.credentialResolution).toBeUndefined();
     if (
       !shouldRetryMcpToolDiscoveryTransportFailure(
         statusJson.toolDiscovery,
@@ -218,6 +249,12 @@ export async function assertAuthenticatedMcpToolDiscovery(
     await new Promise((resolve) => setTimeout(resolve, MCP_TOOL_DISCOVERY_RETRY_DELAY_MS));
   }
   if (!status || !statusJson) throw new Error("MCP tool discovery did not run");
+  const discoveryRequests = fakeMcp.requests.slice(requestOffset);
+  await options.artifacts.writeJson(
+    `${options.artifactPrefix}-mcp-tool-discovery-diagnostics.json`,
+    buildMcpToolDiscoveryDiagnostics(statusJson, discoveryRequests, options.hostSecret),
+  );
+  expect(statusJson.provider.credentialResolution).toBeUndefined();
   expect(statusJson.toolDiscovery).toMatchObject({
     ok: true,
     count: 2,
@@ -225,7 +262,6 @@ export async function assertAuthenticatedMcpToolDiscovery(
     truncated: false,
   });
   expect(status.stdout).not.toContain(options.hostSecret);
-  const discoveryRequests = fakeMcp.requests.slice(requestOffset);
   const discoveryProtocolRequests = discoveryRequests.filter(
     (request) =>
       (request.method === "POST" || request.method === "DELETE") && request.path === "/mcp",

--- a/test/e2e/live/mcp-bridge-trusted-private.ts
+++ b/test/e2e/live/mcp-bridge-trusted-private.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import type { CleanupRegistry } from "../fixtures/cleanup.ts";
 import { assertExitZero as expectExitZero } from "../fixtures/clients/command.ts";
@@ -36,6 +37,7 @@ export async function assertTrustedPrivateMcpRebindingDenied(
   cleanup: CleanupRegistry,
   options: {
     adapter: McpDnsRebindingAdapter;
+    artifacts: Pick<ArtifactSink, "writeJson">;
     artifactPrefix: string;
     assertSecretAbsent: (
       sandbox: SandboxClient,
@@ -164,6 +166,7 @@ export async function assertTrustedPrivateMcpRebindingDenied(
     `${options.artifactPrefix}-dns-rebinding-secret-absent-from-sandbox`,
   );
   await assertAuthenticatedMcpToolDiscovery(host, rebindMcp, {
+    artifacts: options.artifacts,
     sandboxName: options.sandboxName,
     artifactPrefix: `${options.artifactPrefix}-trusted-private`,
     credentialKey: REBIND_CREDENTIAL_KEY,

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -779,6 +779,7 @@ test("mcp-bridge", {
     artifactPrefix: "openclaw",
   });
   await assertAuthenticatedMcpToolDiscovery(host, fakeMcp, {
+    artifacts,
     sandboxName: OPENCLAW_SANDBOX_NAME,
     artifactPrefix: "openclaw",
     hostSecret: HOST_SECRET,
@@ -848,6 +849,7 @@ test("mcp-bridge", {
 
   await assertTrustedPrivateMcpRebindingDenied(host, sandbox, cleanup, {
     adapter: "mcporter",
+    artifacts,
     artifactPrefix: "openclaw",
     assertSecretAbsent: assertSecretAbsentFromSandbox,
     cleanupBridge: cleanupMcpBridge,
@@ -1096,6 +1098,7 @@ mcpBridgeShardTest("hermes")(
       },
     });
     await assertAuthenticatedMcpToolDiscovery(host, fakeMcp, {
+      artifacts,
       sandboxName: HERMES_SANDBOX_NAME,
       artifactPrefix: "hermes",
       hostSecret: HOST_SECRET,
@@ -1134,6 +1137,7 @@ mcpBridgeShardTest("hermes")(
     };
     await assertTrustedPrivateMcpRebindingDenied(host, sandbox, cleanup, {
       adapter: "hermes-config",
+      artifacts,
       artifactPrefix: "hermes",
       assertSecretAbsent: assertSecretAbsentFromSandbox,
       cleanupBridge: cleanupMcpBridge,
@@ -1321,6 +1325,7 @@ mcpBridgeShardTest("deepagents")(
       artifactPrefix: "deepagents",
     });
     await assertAuthenticatedMcpToolDiscovery(host, fakeMcp, {
+      artifacts,
       sandboxName: DEEPAGENTS_SANDBOX_NAME,
       artifactPrefix: "deepagents",
       hostSecret: HOST_SECRET,
@@ -1336,6 +1341,7 @@ mcpBridgeShardTest("deepagents")(
     await assertSecretAbsentFromSandbox(sandbox, DEEPAGENTS_SANDBOX_NAME, ["/sandbox/.deepagents"]);
     await assertTrustedPrivateMcpRebindingDenied(host, sandbox, cleanup, {
       adapter: "deepagents-config",
+      artifacts,
       artifactPrefix: "deepagents",
       assertSecretAbsent: assertSecretAbsentFromSandbox,
       cleanupBridge: cleanupMcpBridge,

--- a/test/e2e/support/mcp-bridge-tool-discovery.test.ts
+++ b/test/e2e/support/mcp-bridge-tool-discovery.test.ts
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ArtifactSink } from "../fixtures/artifacts.ts";
 import { shouldRetryMcpMutationAfterConcurrencyConflict } from "../live/mcp-bridge-cleanup.ts";
 import {
   type FakeMcpHttpsServer,
@@ -22,6 +27,7 @@ const EXPECTED_SECRET = "expected-secret";
 const EXPECTED_RESULT_TOKEN = "expected-result";
 const SESSION_ID = "fake-session-1";
 const PROTOCOL_VERSION = "2025-03-26";
+const STATUS_SECRET = "unregistered-sensitive-status-value";
 
 function request(rpcMethod: string, overrides: Partial<FakeMcpRequest> = {}): FakeMcpRequest {
   return {
@@ -69,10 +75,13 @@ const BRIDGE_TOOLS = ["tool_search", "tool_describe", "tool_call"].map((name) =>
 }));
 
 let compatibleMock: StartedHttpServer | undefined;
+let artifactRoot: string | undefined;
 
 afterEach(async () => {
   await compatibleMock?.close();
   compatibleMock = undefined;
+  if (artifactRoot) await fs.rm(artifactRoot, { recursive: true, force: true });
+  artifactRoot = undefined;
 });
 
 async function startDeferredCompatibleMock(): Promise<StartedHttpServer> {
@@ -188,16 +197,29 @@ describe("authenticated MCP rediscovery evidence", () => {
 describe("authenticated MCP tool discovery transport retry", () => {
   it("writes redacted boundary diagnostics before a discovery failure (#8746)", async () => {
     const statusJson = {
-      provider: { attached: true, credentialReady: true },
-      policy: { gatewayPresent: true },
-      adapter: { registered: true },
-      trustedPrivateTarget: { state: "match" },
+      provider: {
+        registryPresent: true,
+        gatewayPresent: true,
+        attached: true,
+        credentialReady: true,
+        credentialResolution: { detail: STATUS_SECRET },
+        token: STATUS_SECRET,
+      },
+      policy: { registryPresent: true, gatewayPresent: true, token: STATUS_SECRET },
+      adapter: { registered: true, detail: STATUS_SECRET, sessionId: STATUS_SECRET },
+      trustedPrivateTarget: {
+        state: "match" as const,
+        host: STATUS_SECRET,
+        recordedPins: [STATUS_SECRET],
+        detail: STATUS_SECRET,
+      },
       toolDiscovery: {
         ok: false,
         count: 0,
         tools: [],
         truncated: false,
         detail: "MCP tool discovery request failed",
+        credential: STATUS_SECRET,
       },
     };
     const fakeMcp = { requests: [] } as unknown as FakeMcpHttpsServer;
@@ -207,7 +229,8 @@ describe("authenticated MCP tool discovery transport retry", () => {
         return { exitCode: 0, stdout: JSON.stringify(statusJson), stderr: "" };
       }),
     } as unknown as Parameters<typeof assertAuthenticatedMcpToolDiscovery>[0];
-    const artifacts = { writeJson: vi.fn().mockResolvedValue("diagnostics.json") };
+    artifactRoot = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-mcp-diagnostics-"));
+    const artifacts = new ArtifactSink(artifactRoot);
 
     await expect(
       assertAuthenticatedMcpToolDiscovery(host, fakeMcp, {
@@ -219,28 +242,46 @@ describe("authenticated MCP tool discovery transport retry", () => {
       }),
     ).rejects.toThrow();
 
-    expect(artifacts.writeJson).toHaveBeenCalledWith(
+    const artifactPath = path.join(
+      artifactRoot,
       "openclaw-trusted-private-mcp-tool-discovery-diagnostics.json",
-      {
-        ...statusJson,
-        requests: [
-          {
-            httpMethod: "POST",
-            rpcMethod: "initialize",
-            responseStatus: 200,
-            responseHasResult: true,
-            sessionMetadataPresent: {
-              sessionId: false,
-              protocolVersion: false,
-              negotiatedSessionId: true,
-              negotiatedProtocolVersion: true,
-            },
-            credentialRewriteMatched: true,
-          },
-        ],
-      },
     );
-    const diagnostics = JSON.stringify(artifacts.writeJson.mock.calls[0]?.[1]);
+    const diagnostics = await fs.readFile(artifactPath, "utf8");
+    expect(JSON.parse(diagnostics)).toEqual({
+      provider: {
+        registryPresent: true,
+        gatewayPresent: true,
+        attached: true,
+        credentialReady: true,
+        credentialResolutionPresent: true,
+      },
+      policy: { registryPresent: true, gatewayPresent: true },
+      adapter: { registered: true, detailPresent: true },
+      trustedPrivateTarget: { state: "match", detailPresent: true },
+      toolDiscovery: {
+        ok: false,
+        count: 0,
+        tools: [],
+        truncated: false,
+        detail: "MCP tool discovery request failed",
+      },
+      requests: [
+        {
+          httpMethod: "POST",
+          rpcMethod: "initialize",
+          responseStatus: 200,
+          responseHasResult: true,
+          sessionMetadataPresent: {
+            sessionId: false,
+            protocolVersion: false,
+            negotiatedSessionId: true,
+            negotiatedProtocolVersion: true,
+          },
+          credentialRewriteMatched: true,
+        },
+      ],
+    });
+    expect(diagnostics).not.toContain(STATUS_SECRET);
     expect(diagnostics).not.toContain(EXPECTED_SECRET);
     expect(diagnostics).not.toContain(SESSION_ID);
     expect(diagnostics).not.toContain(PROTOCOL_VERSION);

--- a/test/e2e/support/mcp-bridge-tool-discovery.test.ts
+++ b/test/e2e/support/mcp-bridge-tool-discovery.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../live/mcp-bridge-servers.ts";
 import {
   assertAuthenticatedMcpDiscoveryWithOneRestart,
+  assertAuthenticatedMcpToolDiscovery,
   hasSuccessfulAuthenticatedMcpDiscovery,
   shouldRetryMcpDiscoveryAfterRestart,
   shouldRetryMcpToolDiscoveryTransportFailure,
@@ -185,6 +186,66 @@ describe("authenticated MCP rediscovery evidence", () => {
 });
 
 describe("authenticated MCP tool discovery transport retry", () => {
+  it("writes redacted boundary diagnostics before a discovery failure (#8746)", async () => {
+    const statusJson = {
+      provider: { attached: true, credentialReady: true },
+      policy: { gatewayPresent: true },
+      adapter: { registered: true },
+      trustedPrivateTarget: { state: "match" },
+      toolDiscovery: {
+        ok: false,
+        count: 0,
+        tools: [],
+        truncated: false,
+        detail: "MCP tool discovery request failed",
+      },
+    };
+    const fakeMcp = { requests: [] } as unknown as FakeMcpHttpsServer;
+    const host = {
+      nemoclaw: vi.fn(async () => {
+        fakeMcp.requests.push(successfulInitialize());
+        return { exitCode: 0, stdout: JSON.stringify(statusJson), stderr: "" };
+      }),
+    } as unknown as Parameters<typeof assertAuthenticatedMcpToolDiscovery>[0];
+    const artifacts = { writeJson: vi.fn().mockResolvedValue("diagnostics.json") };
+
+    await expect(
+      assertAuthenticatedMcpToolDiscovery(host, fakeMcp, {
+        artifacts,
+        sandboxName: "sandbox",
+        artifactPrefix: "openclaw-trusted-private",
+        hostSecret: EXPECTED_SECRET,
+        progress: { event: vi.fn() },
+      }),
+    ).rejects.toThrow();
+
+    expect(artifacts.writeJson).toHaveBeenCalledWith(
+      "openclaw-trusted-private-mcp-tool-discovery-diagnostics.json",
+      {
+        ...statusJson,
+        requests: [
+          {
+            httpMethod: "POST",
+            rpcMethod: "initialize",
+            responseStatus: 200,
+            responseHasResult: true,
+            sessionMetadataPresent: {
+              sessionId: false,
+              protocolVersion: false,
+              negotiatedSessionId: true,
+              negotiatedProtocolVersion: true,
+            },
+            credentialRewriteMatched: true,
+          },
+        ],
+      },
+    );
+    const diagnostics = JSON.stringify(artifacts.writeJson.mock.calls[0]?.[1]);
+    expect(diagnostics).not.toContain(EXPECTED_SECRET);
+    expect(diagnostics).not.toContain(SESSION_ID);
+    expect(diagnostics).not.toContain(PROTOCOL_VERSION);
+  });
+
   it("retries one generic transport failure before any request reaches the fixture", () => {
     expect(
       shouldRetryMcpToolDiscoveryTransportFailure(

--- a/test/e2e/support/mcp-bridge-tool-discovery.test.ts
+++ b/test/e2e/support/mcp-bridge-tool-discovery.test.ts
@@ -75,13 +75,14 @@ const BRIDGE_TOOLS = ["tool_search", "tool_describe", "tool_call"].map((name) =>
 }));
 
 let compatibleMock: StartedHttpServer | undefined;
-let artifactRoot: string | undefined;
+const artifactRoots: string[] = [];
 
 afterEach(async () => {
   await compatibleMock?.close();
   compatibleMock = undefined;
-  if (artifactRoot) await fs.rm(artifactRoot, { recursive: true, force: true });
-  artifactRoot = undefined;
+  await Promise.all(
+    artifactRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
 });
 
 async function startDeferredCompatibleMock(): Promise<StartedHttpServer> {
@@ -229,7 +230,8 @@ describe("authenticated MCP tool discovery transport retry", () => {
         return { exitCode: 0, stdout: JSON.stringify(statusJson), stderr: "" };
       }),
     } as unknown as Parameters<typeof assertAuthenticatedMcpToolDiscovery>[0];
-    artifactRoot = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-mcp-diagnostics-"));
+    const artifactRoot = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-mcp-diagnostics-"));
+    artifactRoots.push(artifactRoot);
     const artifacts = new ArtifactSink(artifactRoot);
 
     await expect(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preserve redacted MCP tool-discovery status and request evidence before live E2E assertions run. This lets issue #8746 distinguish discovery-runtime startup, policy or credential handling, and MCP protocol failures without recording credentials or session identifiers.

## Related Issue

Refs #8746

## Changes

- Write an explicit safe projection of provider, policy, adapter, trusted-private target, and `toolDiscovery` status to the live E2E artifact set.
- Record request order, HTTP and RPC results, session-metadata presence, and synthetic credential-rewrite matches without recording secret or session values.
- Add a real-artifact regression test proving diagnostics are written before a failed discovery assertion and exclude sensitive raw status, credential, and session values.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal live E2E evidence only; no supported user interface or behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Diagnostic status objects use an explicit safe projection, credential and session evidence is boolean-only, and real-artifact regression coverage verifies that seeded sensitive raw status, credential, and session values are absent.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The PR adds sanitized internal E2E diagnostics and regression coverage without changing user-facing behavior or supported interfaces. The final follow-up only makes test cleanup unconditional. The focused E2E-support test, test-conditionals scanner, and normal Git hooks passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8c39ccdb5 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/mcp-bridge-tool-discovery.test.ts` passed 25/25; `npm run build:cli` and `npm run typecheck:cli` passed. The OpenClaw MCP bridge passed twice on OpenShell v0.0.101 with two trusted-private tools discovered, artifact credential scans clear, and cleanup complete: [run 31413260063](https://github.com/NVIDIA/NemoClaw/actions/runs/31413260063) and [run 31414578417](https://github.com/NVIDIA/NemoClaw/actions/runs/31414578417).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
