### PR TITLE
feat(onboard): activate portable runtime inference

### DIFF
--- a/docs/inference/set-up-openai-compatible-endpoint.mdx
+++ b/docs/inference/set-up-openai-compatible-endpoint.mdx
@@ -4,8 +4,8 @@
 title: "Set Up an OpenAI-Compatible Endpoint"
 sidebar-title: "OpenAI-Compatible Endpoint"
 description: "Connect NemoClaw to a self-hosted or custom OpenAI-compatible inference endpoint."
-description-agent: "Shows how to configure an OpenAI-compatible endpoint for NemoClaw, including raw model files and non-interactive onboarding."
-keywords: ["nemoclaw openai compatible endpoint", "custom inference endpoint", "self-hosted inference"]
+description-agent: "Shows how to configure an OpenAI-compatible endpoint for NemoClaw, including portable inference descriptors, raw model files, and non-interactive onboarding."
+keywords: ["nemoclaw openai compatible endpoint", "portable inference descriptor", "custom inference endpoint", "self-hosted inference"]
 content:
   type: "how_to"
 ---
@@ -63,6 +63,98 @@ For an HTTP URL using the exact host `localhost`, `127.0.0.1`, or `[::1]` and po
 Other URLs still require `COMPATIBLE_API_KEY`.
 
 Refer to [Choose a Compatible Inference API](choose-compatible-inference-api) for the probe order and runtime API selection.
+
+## Supply a Portable Inference Descriptor
+
+A host-side activation component can select a compatible endpoint for the portable experimental profile.
+The component must write the descriptor before the installer or onboarding command starts.
+The activation component owns authentication to the descriptor source and writes only the five resolved inference fields.
+
+<Warning>
+The descriptor contains an API key.
+Use a real `/run/nemoclaw` directory owned by root or the user who runs NemoClaw.
+Do not permit group or other users to write that directory.
+Publish the descriptor only at `/run/nemoclaw/portable-inference.json`.
+Use a regular file with one hard link, mode `0600`, and ownership by the user who runs NemoClaw.
+Do not add descriptor-source locations or source credentials to the descriptor.
+Do not include the descriptor or its values in a repository, image, log, shell argument, artifact, or activation-component persistent state.
+Use a short-lived API key and set `expiresAt` to that credential's expiration time.
+</Warning>
+
+Create a temporary regular file in `/run/nemoclaw` with the required owner and mode `0600`.
+Write the complete JSON.
+Close the temporary file.
+Rename that file to `/run/nemoclaw/portable-inference.json`.
+This atomic replacement prevents NemoClaw from reading a partial descriptor.
+The descriptor uses this schema:
+
+```json
+{
+  "schemaVersion": 1,
+  "apiKey": "<short-lived-api-key>",
+  "baseUrl": "https://inference.example.com/v1",
+  "model": "example-model",
+  "expiresAt": "<future-ISO-8601-UTC-timestamp>"
+}
+```
+
+Each field has one required purpose:
+
+| Field | Requirement |
+|---|---|
+| `schemaVersion` | Use the integer `1`. |
+| `apiKey` | Supply the short-lived API key for the compatible endpoint. |
+| `baseUrl` | Supply an HTTPS compatible endpoint base URL without credentials, a query, or a fragment. NemoClaw applies its existing endpoint and server-side request forgery (SSRF) policy. |
+| `model` | Supply the provider model ID. |
+| `expiresAt` | Supply a future ISO 8601 UTC timestamp that matches the API key lifetime. |
+
+Run the portable installer after the final descriptor is available:
+
+<AgentOnly variant="openclaw">
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --experimental-profile portable --fresh
+```
+
+</AgentOnly>
+<AgentOnly variant="hermes">
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=hermes bash -s -- --experimental-profile portable --fresh
+```
+
+</AgentOnly>
+<AgentOnly variant="deepagents">
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=langchain-deepagents-code bash -s -- --experimental-profile portable --fresh
+```
+
+</AgentOnly>
+
+The portable profile handles the descriptor as follows:
+
+| Descriptor state | Onboarding result |
+|---|---|
+| Absent | NemoClaw keeps the existing portable behavior. The local Podman `qwen3-vl:4b` model remains the active inference route. |
+| Directory and file metadata meet the requirements above, and the descriptor is valid | NemoClaw makes the compatible endpoint model the active inference route. If the local Podman `qwen3-vl:4b` runner already exists, NemoClaw leaves it installed as standby. |
+| File passes the metadata checks but contains malformed JSON, an invalid schema, an expired credential, or a rejected endpoint | NemoClaw deletes the descriptor and exits before it changes gateway, provider, sandbox, or onboarding state. |
+| Directory or file metadata does not meet the requirements above | NemoClaw does not read or delete the filesystem entry. It exits before onboarding changes state. The activation component or operator must atomically replace the entry. |
+
+OpenShell keeps one active inference route.
+The local runner is standby only when it already exists.
+OpenShell does not automatically switch to that runner when the compatible endpoint is unavailable.
+Use [Switch Inference Providers](../manage-inference/switch-providers) when you need to change the active route.
+
+NemoClaw consumes and deletes a descriptor only after its file metadata passes these checks.
+It deletes an admitted descriptor whether it accepts or rejects the descriptor content.
+During onboarding, NemoClaw holds the API key in an asynchronous in-process credential scope instead of `process.env`.
+Unrelated child processes do not inherit the API key.
+Compatible-endpoint validation reads the scoped value, and provider registration passes it explicitly to OpenShell.
+After registration, OpenShell holds the provider credential and adds it to managed inference requests.
+NemoClaw does not write the API key into the sandbox or its persistent state.
+The upstream credential expiration still controls the registered credential's lifetime.
+The activation component must supply a new descriptor for each onboarding attempt that needs the compatible endpoint.
 
 ## Serve a Raw Model File
 

--- a/docs/inference/set-up-openai-compatible-endpoint.mdx
+++ b/docs/inference/set-up-openai-compatible-endpoint.mdx
@@ -104,7 +104,7 @@ Each field has one required purpose:
 |---|---|
 | `schemaVersion` | Use the integer `1`. |
 | `apiKey` | Supply the short-lived API key for the compatible endpoint. |
-| `baseUrl` | Supply an HTTPS compatible endpoint base URL without credentials, a query, or a fragment. NemoClaw applies its existing endpoint and server-side request forgery (SSRF) policy. |
+| `baseUrl` | Supply a compatible endpoint base URL that uses HTTPS, without credentials, a query, or a fragment. NemoClaw applies its existing endpoint and server-side request forgery (SSRF) policy. |
 | `model` | Supply the provider model ID. |
 | `expiresAt` | Supply a future ISO 8601 UTC timestamp that matches the API key lifetime. |
 
@@ -137,14 +137,20 @@ The portable profile handles the descriptor as follows:
 | Descriptor state | Onboarding result |
 |---|---|
 | Absent | NemoClaw keeps the existing portable behavior. The local Podman `qwen3-vl:4b` model remains the active inference route. |
-| Directory and file metadata meet the requirements above, and the descriptor is valid | NemoClaw makes the compatible endpoint model the active inference route. If the local Podman `qwen3-vl:4b` runner already exists, NemoClaw leaves it installed as standby. |
+| Directory and file metadata meet the requirements above, the descriptor is valid, and the authenticated onboarding checks pass | NemoClaw makes the compatible endpoint model the active inference route. If the local Podman `qwen3-vl:4b` runner already exists, NemoClaw leaves it installed as standby. |
 | File passes the metadata checks but contains malformed JSON, an invalid schema, an expired credential, or a rejected endpoint | NemoClaw deletes the descriptor and exits before it changes gateway, provider, sandbox, or onboarding state. |
-| Directory or file metadata does not meet the requirements above | NemoClaw does not read or delete the filesystem entry. It exits before onboarding changes state. The activation component or operator must atomically replace the entry. |
+| Descriptor is valid, but the endpoint, selected model, or configured route fails an authenticated onboarding check | NemoClaw deletes the descriptor and exits without reporting onboarding success. The compatible route may already be configured. NemoClaw does not activate an existing local runner automatically. |
+| Descriptor entry is present, but directory or file metadata does not meet the requirements above | NemoClaw does not read or delete the filesystem entry. It exits before onboarding changes state. The activation component or operator must atomically replace the entry. |
 
 OpenShell keeps one active inference route.
 The local runner is standby only when it already exists.
 OpenShell does not automatically switch to that runner when the compatible endpoint is unavailable.
 Use [Switch Inference Providers](../manage-inference/switch-providers) when you need to change the active route.
+
+Endpoint validation is a point-in-time onboarding check, not continuous health monitoring.
+During onboarding, NemoClaw sends an authenticated Chat Completions request for the selected model.
+After route setup, applicable flows also verify that the sandbox receives non-empty assistant content through `inference.local`.
+These checks do not provide continuous availability monitoring or automatic failover.
 
 NemoClaw consumes and deletes a descriptor only after its file metadata passes these checks.
 It deletes an admitted descriptor whether it accepts or rejects the descriptor content.

--- a/src/lib/credentials/scoped-overrides.ts
+++ b/src/lib/credentials/scoped-overrides.ts
@@ -5,7 +5,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 const scopedCredentialOverrides = new AsyncLocalStorage<ReadonlyMap<string, string>>();
 
-/** Make normalized credential overrides available to one asynchronous call tree. */
+/** Make validated credential overrides available to one asynchronous call tree. */
 export async function withCredentialOverrides<T>(
   values: Readonly<Record<string, string>>,
   operation: () => Promise<T> | T,
@@ -13,9 +13,11 @@ export async function withCredentialOverrides<T>(
   const inherited = scopedCredentialOverrides.getStore();
   const overrides = new Map(inherited ?? []);
   for (const [key, rawValue] of Object.entries(values)) {
-    const value = rawValue.replace(/\r/g, "").trim();
-    if (!value) throw new Error(`Scoped credential '${key}' must not be empty.`);
-    overrides.set(key, value);
+    if (/[\u0000\r\n]/u.test(rawValue)) {
+      throw new Error(`Scoped credential '${key}' must not contain NUL, CR, or LF.`);
+    }
+    if (!rawValue.trim()) throw new Error(`Scoped credential '${key}' must not be empty.`);
+    overrides.set(key, rawValue);
   }
   return scopedCredentialOverrides.run(overrides, operation);
 }

--- a/src/lib/credentials/scoped-overrides.ts
+++ b/src/lib/credentials/scoped-overrides.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const scopedCredentialOverrides = new AsyncLocalStorage<ReadonlyMap<string, string>>();
+
+/** Make normalized credential overrides available to one asynchronous call tree. */
+export async function withCredentialOverrides<T>(
+  values: Readonly<Record<string, string>>,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  const inherited = scopedCredentialOverrides.getStore();
+  const overrides = new Map(inherited ?? []);
+  for (const [key, rawValue] of Object.entries(values)) {
+    const value = rawValue.replace(/\r/g, "").trim();
+    if (!value) throw new Error(`Scoped credential '${key}' must not be empty.`);
+    overrides.set(key, value);
+  }
+  return scopedCredentialOverrides.run(overrides, operation);
+}
+
+export function getScopedCredentialOverride(key: string): string | null {
+  return scopedCredentialOverrides.getStore()?.get(key) ?? null;
+}

--- a/src/lib/credentials/store.ts
+++ b/src/lib/credentials/store.ts
@@ -4,9 +4,9 @@
 // Host-side credential helpers.
 //
 // The OpenShell gateway is the system of record for provider credentials.
-// This module holds them only in the current process environment so they
-// can be passed through to `openshell provider create/update --credential KEY`
-// during onboarding. Nothing is written to disk.
+// This module exposes staged process-environment values and asynchronous
+// in-process overrides. Callers pass the selected value explicitly to
+// `openshell provider create/update --credential KEY`. Nothing is written to disk.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -19,6 +19,9 @@ import { createPromptActivityCleanup } from "../core/prompt-activity";
 import { listMessagingCredentialMetadata } from "../messaging/channels";
 import { rejectSymlinksOnPath } from "../state/config-io";
 import { nemoclawStateRoot } from "../state/state-root";
+import { getScopedCredentialOverride } from "./scoped-overrides";
+
+export { withCredentialOverrides } from "./scoped-overrides";
 
 const UNSAFE_HOME_PATHS = new Set(["/tmp", "/var/tmp", "/dev/shm", "/"]);
 
@@ -182,8 +185,10 @@ export function saveCredential(key: string, value: CredentialInput): void {
   }
 }
 
-/** Return the staged value for `key` from the current process env, or null. */
+/** Return the scoped or staged value for `key`, or null. */
 export function getCredential(key: string): string | null {
+  const scoped = getScopedCredentialOverride(key);
+  if (scoped) return scoped;
   const raw = process.env[key];
   if (!raw) return null;
   const normalized = normalizeCredentialValue(raw);
@@ -200,10 +205,11 @@ function getLegacyCredentialAlias(envName: string): string | null {
 
 /**
  * Canonical entry point for provider credential resolution (PR #2306).
- * Resolves the credential for `envName` from `process.env`, falling back
- * to a one-time on-demand stage of any pre-fix `~/.nemoclaw/credentials.json`,
- * and writes the resolved value back into `process.env` so downstream
- * code that reads `process.env[envName]` directly sees it.
+ * Resolves an asynchronous in-process override before `process.env`.
+ * Without an override, falls back to a one-time on-demand stage of any
+ * pre-fix `~/.nemoclaw/credentials.json` and writes the resolved value back
+ * into `process.env` for downstream compatibility. A scoped override never
+ * enters `process.env` through this function.
  *
  * Returns the resolved value, or `null` if neither env nor the legacy
  * file produced one.
@@ -218,6 +224,8 @@ function getLegacyCredentialAlias(envName: string): string | null {
  * guard inside the staging helper itself.
  */
 export function resolveProviderCredential(envName: string): string | null {
+  const scoped = getScopedCredentialOverride(envName);
+  if (scoped) return scoped;
   let value = getCredential(envName) || getLegacyCredentialAlias(envName);
   if (!value) {
     stageLegacyCredentialsToEnv();

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -492,7 +492,7 @@ describe("onboard command options", () => {
     expect(env.NEMOCLAW_SERVING_PRESET).toBeUndefined();
   });
 
-  it("prepares and scopes portable profile defaults around onboarding", async () => {
+  it("keeps local portable defaults when no descriptor is present", async () => {
     const env: NodeJS.ProcessEnv = {
       NEMOCLAW_EXPERIMENTAL_PROFILE: "previous-profile",
       NEMOCLAW_PROVIDER: "previous-provider",
@@ -506,6 +506,7 @@ describe("onboard command options", () => {
     await runOnboardCommand({
       flags: { "experimental-profile": "portable" },
       env,
+      loadPortableInferenceDescriptor: async () => null,
       runOnboard: async () => {
         for (const key of [
           "NEMOCLAW_EXPERIMENTAL_PROFILE",

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -7,10 +7,12 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { getCredential } from "../credentials/store";
 import { loadServingCatalog } from "../inference/serving/catalog-loader";
 import { servingProfileProvenance } from "../inference/serving/profile-provenance";
 import { resolveOnboardOptions, runOnboardCommand } from "./command";
 import type { OnboardFlags } from "./command-support";
+import { PortableInferenceDescriptorError } from "./experimental/portable-inference-descriptor";
 import { invalidGatewayManagementDeclarationError } from "./gateway-management";
 import { GatewayAuthorityError } from "./gateway-teardown-authority";
 import {
@@ -248,6 +250,7 @@ describe("onboard command options", () => {
       autoYes: true,
       noOllamaAutostart: true,
       experimentalProfile: null,
+      portableInferenceActivation: null,
       servingProfile: null,
       servingProfileProvenance: null,
     });
@@ -276,6 +279,7 @@ describe("onboard command options", () => {
       autoYes: false,
       noOllamaAutostart: false,
       experimentalProfile: null,
+      portableInferenceActivation: null,
       servingProfile: null,
       servingProfileProvenance: null,
     });
@@ -535,6 +539,69 @@ describe("onboard command options", () => {
       NEMOCLAW_POLICY_TIER: "previous-tier",
       NEMOCLAW_TOOL_DISCLOSURE: "progressive",
     });
+  });
+
+  it("configures portable onboarding from an admitted descriptor without exporting its credential", async () => {
+    vi.stubEnv("COMPATIBLE_API_KEY", undefined);
+    const env: NodeJS.ProcessEnv = {};
+    const runOnboard = vi.fn(async (options) => {
+      expect(options.portableInferenceActivation).toEqual({
+        schemaVersion: 1,
+        baseUrl: "https://inference.example.test/v1",
+        model: "vendor/model-1",
+        expiresAt: "2026-08-10T18:05:00Z",
+      });
+      expect(env).toMatchObject({
+        NEMOCLAW_PROVIDER: "custom",
+        NEMOCLAW_MODEL: "vendor/model-1",
+        NEMOCLAW_ENDPOINT_URL: "https://inference.example.test/v1",
+        NEMOCLAW_PREFERRED_API: "openai-completions",
+      });
+      expect(env.COMPATIBLE_API_KEY).toBeUndefined();
+      expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
+      expect(getCredential("COMPATIBLE_API_KEY")).toBe("runtime-only-secret");
+    });
+
+    await runOnboardCommand({
+      flags: { "experimental-profile": "portable" },
+      env,
+      loadPortableInferenceDescriptor: async () => ({
+        schemaVersion: 1,
+        apiKey: "runtime-only-secret",
+        baseUrl: "https://inference.example.test/v1",
+        model: "vendor/model-1",
+        expiresAt: "2026-08-10T18:05:00Z",
+      }),
+      runOnboard,
+    });
+
+    expect(runOnboard).toHaveBeenCalledOnce();
+    expect(env.NEMOCLAW_PROVIDER).toBeUndefined();
+    expect(env.NEMOCLAW_ENDPOINT_URL).toBeUndefined();
+    expect(getCredential("COMPATIBLE_API_KEY")).toBeNull();
+  });
+
+  it("fails before onboarding when a present portable descriptor is invalid", async () => {
+    const env: NodeJS.ProcessEnv = {};
+    const errors: string[] = [];
+    const runOnboard = vi.fn(async () => {});
+
+    await expect(
+      runOnboardCommand({
+        flags: { "experimental-profile": "portable" },
+        env,
+        loadPortableInferenceDescriptor: async () => {
+          throw new PortableInferenceDescriptorError("Runtime inference descriptor has expired.");
+        },
+        runOnboard,
+        error: (message = "") => errors.push(message),
+        exit: exitWithCode,
+      }),
+    ).rejects.toThrow("exit:1");
+
+    expect(runOnboard).not.toHaveBeenCalled();
+    expect(env).toEqual({});
+    expect(errors).toEqual(["  Runtime inference descriptor has expired."]);
   });
 
   it("scopes an agents manifest to one onboarding run", async () => {

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { formatAgentAliasSuffix, resolveAgentNameAlias } from "../agent/aliases";
+import { withCredentialOverrides } from "../credentials/scoped-overrides";
 import { loadServingCatalog } from "../inference/serving/catalog-loader";
 import { NEMOCLAW_SERVING_PRESET_ENV } from "../inference/serving/managed-cluster-discovery";
 import {
@@ -30,6 +31,12 @@ import {
   type ExperimentalOnboardProfile,
   PORTABLE_EXPERIMENTAL_PROFILE,
 } from "./docker-driver-platform";
+import {
+  loadPortableInferenceDescriptor,
+  PORTABLE_INFERENCE_CREDENTIAL_ENV,
+  type PortableInferenceActivation,
+  PortableInferenceDescriptorError,
+} from "./experimental/portable-inference-descriptor";
 import { GatewayManagementDeclarationError } from "./gateway-management";
 import { GatewayAuthorityError, gatewayAuthorityFailureLines } from "./gateway-teardown-authority";
 import {
@@ -64,6 +71,7 @@ export interface OnboardCommandOptions {
   autoYes: boolean;
   noOllamaAutostart: boolean;
   experimentalProfile: ExperimentalOnboardProfile | null;
+  portableInferenceActivation: PortableInferenceActivation | null;
   servingProfile: string | null;
   servingProfileProvenance: ServingProfileProvenance | null;
 }
@@ -81,6 +89,7 @@ export interface ResolveOnboardOptionsDeps {
 export interface RunOnboardCommandDeps extends ResolveOnboardOptionsDeps {
   flags: OnboardFlags;
   runOnboard: (options: OnboardCommandOptions) => Promise<void>;
+  loadPortableInferenceDescriptor?: typeof loadPortableInferenceDescriptor;
 }
 
 function fail(deps: ResolveOnboardOptionsDeps, message: string): never {
@@ -366,6 +375,7 @@ export function resolveOnboardOptions(
     autoYes: withPortableDefault(flags.yes, experimentalProfile),
     noOllamaAutostart: withPortableDefault(flags["no-ollama-autostart"], experimentalProfile),
     experimentalProfile,
+    portableInferenceActivation: null,
     servingProfile: activeServingProfileId(servingProfileProvenance),
     servingProfileProvenance,
   };
@@ -396,6 +406,9 @@ function handleOnboardCommandError(error: unknown, deps: RunOnboardCommandDeps):
   if (error instanceof GatewayManagementDeclarationError) {
     fail(deps, `  ${error.message}`);
   }
+  if (error instanceof PortableInferenceDescriptorError) {
+    fail(deps, `  ${error.message}`);
+  }
   // Gateway-authority refusals are reported, never rethrown. Recreation is not
   // selected in one place: `--recreate-sandbox` sets the flag, but `runOnboard`
   // independently honours NEMOCLAW_RECREATE_SANDBOX and reaches the same
@@ -418,11 +431,14 @@ function applyPortableEnvironment(
   env: NodeJS.ProcessEnv,
 ): () => void {
   if (!options.experimentalProfile) return () => {};
+  const activation = options.portableInferenceActivation;
   const portableEnvDefaults = {
     [EXPERIMENTAL_PROFILE_ENV]: options.experimentalProfile ?? undefined,
     [TOOL_DISCLOSURE_ENV]: "direct",
-    NEMOCLAW_PROVIDER: "ollama",
-    NEMOCLAW_MODEL: "qwen3-vl:4b",
+    NEMOCLAW_PROVIDER: activation ? "custom" : "ollama",
+    NEMOCLAW_MODEL: activation?.model ?? "qwen3-vl:4b",
+    NEMOCLAW_ENDPOINT_URL: activation?.baseUrl,
+    NEMOCLAW_PREFERRED_API: activation ? "openai-completions" : undefined,
     NEMOCLAW_OLLAMA_NO_AUTOSTART: "1",
     NEMOCLAW_POLICY_MODE: "suggested",
     NEMOCLAW_POLICY_TIER: "personal",
@@ -468,13 +484,43 @@ function toolDisclosureEnvironmentOverride(
   return flags["tool-disclosure"] !== undefined ? options.toolDisclosure : null;
 }
 
+async function activatePortableInference(
+  options: OnboardCommandOptions,
+  deps: RunOnboardCommandDeps,
+  env: NodeJS.ProcessEnv,
+): Promise<{
+  options: OnboardCommandOptions;
+  credentialOverrides: Readonly<Record<string, string>>;
+}> {
+  if (!options.experimentalProfile) return { options, credentialOverrides: {} };
+  const descriptor = await (
+    deps.loadPortableInferenceDescriptor ?? loadPortableInferenceDescriptor
+  )({ env });
+  if (!descriptor) return { options, credentialOverrides: {} };
+  return {
+    options: {
+      ...options,
+      portableInferenceActivation: {
+        schemaVersion: descriptor.schemaVersion,
+        baseUrl: descriptor.baseUrl,
+        model: descriptor.model,
+        expiresAt: descriptor.expiresAt,
+      },
+    },
+    credentialOverrides: { [PORTABLE_INFERENCE_CREDENTIAL_ENV]: descriptor.apiKey },
+  };
+}
+
 export async function runOnboardCommand(deps: RunOnboardCommandDeps): Promise<void> {
-  const options = resolveOnboardOptions(deps.flags, deps);
+  const resolvedOptions = resolveOnboardOptions(deps.flags, deps);
   const env = deps.env ?? process.env;
   let restorePortableEnvironment = () => {};
   let restoreServingProfileEnvironment = () => {};
   const previousAgentsManifest = env.NEMOCLAW_EXTRA_AGENTS_JSON;
+  let options = resolvedOptions;
   try {
+    const activation = await activatePortableInference(resolvedOptions, deps, env);
+    options = activation.options;
     restorePortableEnvironment = applyPortableEnvironment(options, env);
     restoreServingProfileEnvironment = applyServingProfileEnvironment(options, env);
     if (options.noOllamaAutostart) env.NEMOCLAW_OLLAMA_NO_AUTOSTART = "1";
@@ -484,7 +530,7 @@ export async function runOnboardCommand(deps: RunOnboardCommandDeps): Promise<vo
     const toolDisclosure = toolDisclosureEnvironmentOverride(options, deps.flags);
     if (toolDisclosure) env[TOOL_DISCLOSURE_ENV] = toolDisclosure;
     if (options.agentsManifest) applyAgentsManifestEnv(options.agentsManifest, env);
-    await deps.runOnboard(options);
+    await withCredentialOverrides(activation.credentialOverrides, () => deps.runOnboard(options));
   } catch (error) {
     handleOnboardCommandError(error, deps);
   } finally {

--- a/src/lib/onboard/credential-env.ts
+++ b/src/lib/onboard/credential-env.ts
@@ -4,8 +4,8 @@
 import { resolveProviderCredential } from "../credentials/store";
 
 /**
- * Resolve a credential into process.env[envName] so subsequent gateway upserts
- * can read it via `--credential <ENV>`.
+ * Resolve and return a credential for host-side callers. Scoped overrides are
+ * returned without exporting them to `process.env`.
  */
 export function hydrateCredentialEnv(
   envName: string | null | undefined,

--- a/src/lib/onboard/experimental/portable-inference-descriptor.test.ts
+++ b/src/lib/onboard/experimental/portable-inference-descriptor.test.ts
@@ -88,6 +88,16 @@ describe("portable runtime inference descriptor", () => {
       /ISO 8601 UTC timestamp/,
     ],
     ["an extra field", descriptor({ region: "us-test-1" }), /exactly these fields/],
+    ["a surrounding-space API key", descriptor({ apiKey: " secret" }), /apiKey.*format/],
+    ["a newline-bearing API key", descriptor({ apiKey: "secret\nheader" }), /apiKey.*format/],
+    ["a carriage-return API key", descriptor({ apiKey: "secret\rheader" }), /apiKey.*format/],
+    ["a NUL-bearing API key", descriptor({ apiKey: "secret\0tail" }), /apiKey.*format/],
+    ["an oversized API key", descriptor({ apiKey: "a".repeat(16 * 1024 + 1) }), /apiKey.*format/],
+    [
+      "a control character in the model",
+      descriptor({ model: "vendor/model\u0001" }),
+      /model.*format/,
+    ],
     [
       "a query-bearing endpoint",
       descriptor({ baseUrl: "https://example.test/v1?target=x" }),
@@ -108,6 +118,17 @@ describe("portable runtime inference descriptor", () => {
         resolveEndpointHost: publicResolver,
       }),
     ).rejects.toThrow(expected);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it("deletes an admitted descriptor that exceeds the file-size limit", async () => {
+    const directory = createDirectory();
+    const filePath = path.join(directory, "portable-inference.json");
+    fs.writeFileSync(filePath, "x".repeat(64 * 1024 + 1), { mode: 0o600 });
+
+    await expect(loadPortableInferenceDescriptor({ filePath, now: () => NOW })).rejects.toThrow(
+      /65536-byte limit/,
+    );
     expect(fs.existsSync(filePath)).toBe(false);
   });
 

--- a/src/lib/onboard/experimental/portable-inference-descriptor.test.ts
+++ b/src/lib/onboard/experimental/portable-inference-descriptor.test.ts
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  loadPortableInferenceDescriptor,
+  PortableInferenceDescriptorError,
+} from "./portable-inference-descriptor";
+
+const NOW = Date.parse("2026-08-10T18:00:00Z");
+const TEST_API_KEY = "descriptor-test-secret";
+const testDirectories: string[] = [];
+
+function createDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-inference-descriptor-"));
+  fs.chmodSync(directory, 0o700);
+  testDirectories.push(directory);
+  return directory;
+}
+
+function descriptor(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    apiKey: TEST_API_KEY,
+    baseUrl: "https://inference.example.test/v1",
+    model: "vendor/model-1",
+    expiresAt: "2026-08-10T18:05:00Z",
+    ...overrides,
+  };
+}
+
+function writeDescriptor(directory: string, value: unknown = descriptor(), mode = 0o600): string {
+  const filePath = path.join(directory, "portable-inference.json");
+  fs.writeFileSync(filePath, JSON.stringify(value), { mode: 0o600 });
+  fs.chmodSync(filePath, mode);
+  return filePath;
+}
+
+const publicResolver = async () => [{ address: "93.184.216.34", family: 4 }];
+
+afterEach(() => {
+  for (const directory of testDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("portable runtime inference descriptor", () => {
+  it("returns no activation when the descriptor is absent", async () => {
+    const filePath = path.join(createDirectory(), "portable-inference.json");
+
+    await expect(loadPortableInferenceDescriptor({ filePath, now: () => NOW })).resolves.toBeNull();
+  });
+
+  it("consumes a descriptor that passes file admission before returning the secret", async () => {
+    const filePath = writeDescriptor(createDirectory(), {
+      ...descriptor(),
+      baseUrl: "https://inference.example.test/v1/chat/completions",
+    });
+
+    await expect(
+      loadPortableInferenceDescriptor({
+        filePath,
+        now: () => NOW,
+        resolveEndpointHost: publicResolver,
+      }),
+    ).resolves.toEqual({
+      schemaVersion: 1,
+      apiKey: TEST_API_KEY,
+      baseUrl: "https://inference.example.test/v1",
+      model: "vendor/model-1",
+      expiresAt: "2026-08-10T18:05:00Z",
+    });
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it.each([
+    ["malformed JSON", "{", /valid UTF-8 JSON/],
+    ["an expired value", descriptor({ expiresAt: "2026-08-10T17:59:59Z" }), /expired/],
+    [
+      "an impossible calendar date",
+      descriptor({ expiresAt: "2026-02-30T18:05:00Z" }),
+      /ISO 8601 UTC timestamp/,
+    ],
+    ["an extra field", descriptor({ region: "us-test-1" }), /exactly these fields/],
+    [
+      "a query-bearing endpoint",
+      descriptor({ baseUrl: "https://example.test/v1?target=x" }),
+      /query or fragment/,
+    ],
+  ])("deletes an admitted descriptor containing %s", async (_label, value, expected) => {
+    const directory = createDirectory();
+    const filePath = path.join(directory, "portable-inference.json");
+    fs.writeFileSync(filePath, typeof value === "string" ? value : JSON.stringify(value), {
+      mode: 0o600,
+    });
+    fs.chmodSync(filePath, 0o600);
+
+    await expect(
+      loadPortableInferenceDescriptor({
+        filePath,
+        now: () => NOW,
+        resolveEndpointHost: publicResolver,
+      }),
+    ).rejects.toThrow(expected);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it("rejects a loopback endpoint before any credential-bearing request", async () => {
+    const filePath = writeDescriptor(
+      createDirectory(),
+      descriptor({ baseUrl: "https://127.0.0.1:8443/v1" }),
+    );
+    let resolverCalled = false;
+
+    await expect(
+      loadPortableInferenceDescriptor({
+        filePath,
+        now: () => NOW,
+        resolveEndpointHost: async () => {
+          resolverCalled = true;
+          return [{ address: "127.0.0.1", family: 4 }];
+        },
+      }),
+    ).rejects.toThrow(/private\/internal address/);
+    expect(resolverCalled).toBe(false);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it("rejects a public name that resolves to a private address", async () => {
+    const filePath = writeDescriptor(createDirectory());
+
+    await expect(
+      loadPortableInferenceDescriptor({
+        filePath,
+        now: () => NOW,
+        resolveEndpointHost: async () => [{ address: "10.0.0.8", family: 4 }],
+      }),
+    ).rejects.toThrow(/private\/internal address/);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it("admits a private endpoint for its exact trusted host", async () => {
+    const filePath = writeDescriptor(createDirectory());
+
+    await expect(
+      loadPortableInferenceDescriptor({
+        filePath,
+        env: { NEMOCLAW_TRUSTED_PRIVATE_INFERENCE_HOSTS: "inference.example.test" },
+        now: () => NOW,
+        resolveEndpointHost: async () => [{ address: "10.0.0.8", family: 4 }],
+      }),
+    ).resolves.toMatchObject({ baseUrl: "https://inference.example.test/v1" });
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it("omits the API key from a DNS resolution error", async () => {
+    const filePath = writeDescriptor(
+      createDirectory(),
+      descriptor({ baseUrl: "https://unresolvable.example.test/v1" }),
+    );
+
+    let caught: unknown;
+    try {
+      await loadPortableInferenceDescriptor({
+        filePath,
+        now: () => NOW,
+        resolveEndpointHost: async () => {
+          throw new Error("resolver failed");
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(PortableInferenceDescriptorError);
+    expect(String(caught)).not.toContain(TEST_API_KEY);
+  });
+
+  it("leaves a symlink in place without reading or deleting its target", async () => {
+    const directory = createDirectory();
+    const targetPath = path.join(directory, "target.json");
+    const filePath = path.join(directory, "portable-inference.json");
+    fs.writeFileSync(targetPath, JSON.stringify(descriptor()), { mode: 0o600 });
+    fs.symlinkSync(targetPath, filePath);
+
+    await expect(loadPortableInferenceDescriptor({ filePath, now: () => NOW })).rejects.toThrow(
+      /must not be a symbolic link/,
+    );
+    expect(fs.lstatSync(filePath).isSymbolicLink()).toBe(true);
+    expect(fs.existsSync(targetPath)).toBe(true);
+  });
+
+  it("leaves a FIFO in place without opening it", async () => {
+    const filePath = path.join(createDirectory(), "portable-inference.json");
+    execFileSync("mkfifo", [filePath]);
+    const openSpy = vi.spyOn(fs, "openSync");
+
+    try {
+      await expect(loadPortableInferenceDescriptor({ filePath, now: () => NOW })).rejects.toThrow(
+        /must be a regular file/,
+      );
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(fs.lstatSync(filePath).isFIFO()).toBe(true);
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("leaves a wrong-mode file in place", async () => {
+    const filePath = writeDescriptor(createDirectory(), descriptor(), 0o640);
+
+    await expect(loadPortableInferenceDescriptor({ filePath, now: () => NOW })).rejects.toThrow(
+      /mode 0600/,
+    );
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("leaves a hard-linked descriptor in place", async () => {
+    const directory = createDirectory();
+    const filePath = writeDescriptor(directory);
+    const secondPath = path.join(directory, "second-link.json");
+    fs.linkSync(filePath, secondPath);
+
+    await expect(loadPortableInferenceDescriptor({ filePath, now: () => NOW })).rejects.toThrow(
+      /exactly one hard link/,
+    );
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.existsSync(secondPath)).toBe(true);
+  });
+
+  it("leaves a descriptor inside a group-writable directory in place", async () => {
+    const directory = createDirectory();
+    const filePath = writeDescriptor(directory);
+    fs.chmodSync(directory, 0o770);
+
+    await expect(loadPortableInferenceDescriptor({ filePath, now: () => NOW })).rejects.toThrow(
+      /must not be writable by group or others/,
+    );
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+});

--- a/src/lib/onboard/experimental/portable-inference-descriptor.ts
+++ b/src/lib/onboard/experimental/portable-inference-descriptor.ts
@@ -102,7 +102,8 @@ function openDescriptor(filePath: string): number | null {
     return fs.openSync(filePath, fs.constants.O_RDONLY | noFollow | nonBlocking | closeOnExec);
   } catch (error) {
     if (isErrnoException(error) && error.code === "ENOENT") return null;
-    throw descriptorError(`cannot open ${filePath} without following links or blocking.`);
+    const code = isErrnoException(error) && error.code ? ` (${error.code})` : "";
+    throw descriptorError(`cannot open ${filePath} without following links or blocking${code}.`);
   }
 }
 
@@ -247,7 +248,9 @@ function parseDescriptor(bytes: Buffer): PortableInferenceDescriptor {
     throw descriptorError("baseUrl must use HTTPS and must not contain a query or fragment.");
   }
   if (parsedUrl.username || parsedUrl.password || record.baseUrl.length > ENDPOINT_MAX_LENGTH) {
-    throw descriptorError("baseUrl must not contain credentials or exceed 2048 bytes.");
+    throw descriptorError(
+      "baseUrl must not contain credentials or exceed the 2048-character limit.",
+    );
   }
   const endpointSuffixes = ["/responses", "/chat/completions", "/completions", "/models"];
   let pathname = parsedUrl.pathname.replace(/\/+$/, "");

--- a/src/lib/onboard/experimental/portable-inference-descriptor.ts
+++ b/src/lib/onboard/experimental/portable-inference-descriptor.ts
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { TextDecoder } from "node:util";
+
+import { isErrnoException } from "../../core/errno";
+import { parseTrustedPrivateInferenceHostsFromEnv } from "../../inference/endpoint-ssrf-preflight";
+import {
+  assertEndpointResolvesPublic,
+  type EndpointDnsLookupFn,
+} from "../../security/trusted-private-endpoint";
+
+export const PORTABLE_INFERENCE_DESCRIPTOR_PATH = "/run/nemoclaw/portable-inference.json";
+export const PORTABLE_INFERENCE_CREDENTIAL_ENV = "COMPATIBLE_API_KEY";
+
+const DESCRIPTOR_SCHEMA_VERSION = 1;
+const DESCRIPTOR_MAX_BYTES = 64 * 1024;
+const API_KEY_MAX_LENGTH = 16 * 1024;
+const MODEL_MAX_LENGTH = 512;
+const ENDPOINT_MAX_LENGTH = 2048;
+const DESCRIPTOR_KEYS = ["apiKey", "baseUrl", "expiresAt", "model", "schemaVersion"].sort();
+const ISO_UTC_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+export interface PortableInferenceDescriptor {
+  readonly schemaVersion: 1;
+  readonly apiKey: string;
+  readonly baseUrl: string;
+  readonly model: string;
+  readonly expiresAt: string;
+}
+
+export type PortableInferenceActivation = Omit<PortableInferenceDescriptor, "apiKey">;
+
+export class PortableInferenceDescriptorError extends Error {
+  readonly code = "EPORTABLEINFERENCEDESCRIPTOR";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "PortableInferenceDescriptorError";
+  }
+}
+
+interface LoadPortableInferenceDescriptorOptions {
+  readonly filePath?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly now?: () => number;
+  readonly currentUid?: () => number;
+  readonly resolveEndpointHost?: EndpointDnsLookupFn;
+}
+
+function descriptorError(message: string): PortableInferenceDescriptorError {
+  return new PortableInferenceDescriptorError(`Runtime inference descriptor ${message}`);
+}
+
+function parseIsoUtcTimestamp(value: string): number | null {
+  if (!ISO_UTC_TIMESTAMP.test(value)) return null;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return null;
+
+  const withoutZulu = value.slice(0, -1);
+  const [wholeSeconds, fraction = ""] = withoutZulu.split(".");
+  const canonical = `${wholeSeconds}.${fraction.padEnd(3, "0")}Z`;
+  return new Date(parsed).toISOString() === canonical ? parsed : null;
+}
+
+function currentEffectiveUid(): number {
+  const uid = process.geteuid?.() ?? process.getuid?.();
+  if (uid === undefined) {
+    throw descriptorError("cannot verify the current user on this platform.");
+  }
+  return uid;
+}
+
+function assertDescriptorDirectory(filePath: string, uid: number): void {
+  const directoryPath = path.dirname(filePath);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(directoryPath);
+  } catch {
+    throw descriptorError(`cannot inspect its directory at ${directoryPath}.`);
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw descriptorError(`directory ${directoryPath} must be a real directory.`);
+  }
+  if (stat.uid !== 0 && stat.uid !== uid) {
+    throw descriptorError(`directory ${directoryPath} must be owned by root or the current user.`);
+  }
+  if ((stat.mode & 0o022) !== 0) {
+    throw descriptorError(`directory ${directoryPath} must not be writable by group or others.`);
+  }
+}
+
+function openDescriptor(filePath: string): number | null {
+  const noFollow = fs.constants.O_NOFOLLOW ?? 0;
+  const nonBlocking = fs.constants.O_NONBLOCK ?? 0;
+  const closeOnExec =
+    (fs.constants as typeof fs.constants & { readonly O_CLOEXEC?: number }).O_CLOEXEC ?? 0;
+  try {
+    return fs.openSync(filePath, fs.constants.O_RDONLY | noFollow | nonBlocking | closeOnExec);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") return null;
+    throw descriptorError(`cannot open ${filePath} without following links or blocking.`);
+  }
+}
+
+function assertDescriptorMetadata(filePath: string, stat: fs.Stats, uid: number): void {
+  if (!stat.isFile()) throw descriptorError(`${filePath} must be a regular file.`);
+  if (stat.uid !== uid) throw descriptorError(`${filePath} must be owned by the current user.`);
+  if ((stat.mode & 0o777) !== 0o600) {
+    throw descriptorError(`${filePath} must have mode 0600.`);
+  }
+  if (stat.nlink !== 1) throw descriptorError(`${filePath} must have exactly one hard link.`);
+}
+
+function readDescriptorBytes(fd: number): Buffer {
+  const buffer = Buffer.alloc(DESCRIPTOR_MAX_BYTES + 1);
+  let offset = 0;
+  try {
+    while (offset < buffer.length) {
+      const bytesRead = fs.readSync(fd, buffer, offset, buffer.length - offset, null);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset > DESCRIPTOR_MAX_BYTES) {
+      throw descriptorError(`exceeds the ${String(DESCRIPTOR_MAX_BYTES)}-byte limit.`);
+    }
+    return buffer.subarray(0, offset);
+  } catch (error) {
+    buffer.fill(0);
+    throw error;
+  }
+}
+
+function consumeOpenedDescriptor(filePath: string, opened: fs.Stats): void {
+  let current: fs.Stats;
+  try {
+    current = fs.lstatSync(filePath);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") return;
+    throw descriptorError(`cannot verify ${filePath} before consuming it.`);
+  }
+  if (current.isSymbolicLink() || current.dev !== opened.dev || current.ino !== opened.ino) {
+    throw descriptorError(`${filePath} changed while it was being consumed.`);
+  }
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    throw descriptorError(`cannot remove ${filePath} after reading it.`);
+  }
+}
+
+function readAndConsumeDescriptor(filePath: string, currentUid: () => number): Buffer | null {
+  let present: fs.Stats;
+  try {
+    present = fs.lstatSync(filePath);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") return null;
+    throw descriptorError(`cannot inspect ${filePath}.`);
+  }
+  const uid = currentUid();
+  assertDescriptorDirectory(filePath, uid);
+  if (present.isSymbolicLink()) {
+    throw descriptorError(`${filePath} must not be a symbolic link.`);
+  }
+  assertDescriptorMetadata(filePath, present, uid);
+  const fd = openDescriptor(filePath);
+  if (fd === null) return null;
+
+  let opened: fs.Stats;
+  let bytes: Buffer | null = null;
+  let readError: unknown;
+  try {
+    opened = fs.fstatSync(fd);
+    assertDescriptorMetadata(filePath, opened, uid);
+    try {
+      bytes = readDescriptorBytes(fd);
+    } catch (error) {
+      readError = error;
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  consumeOpenedDescriptor(filePath, opened!);
+  if (readError) throw readError;
+  return bytes!;
+}
+
+function parseDescriptor(bytes: Buffer): PortableInferenceDescriptor {
+  let parsed: unknown;
+  try {
+    const raw = utf8Decoder.decode(bytes);
+    parsed = JSON.parse(raw);
+  } catch {
+    throw descriptorError("must contain valid UTF-8 JSON.");
+  } finally {
+    bytes.fill(0);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw descriptorError("must contain one JSON object.");
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (
+    keys.length !== DESCRIPTOR_KEYS.length ||
+    keys.some((key, index) => key !== DESCRIPTOR_KEYS[index])
+  ) {
+    throw descriptorError(`must contain exactly these fields: ${DESCRIPTOR_KEYS.join(", ")}.`);
+  }
+  if (record.schemaVersion !== DESCRIPTOR_SCHEMA_VERSION) {
+    throw descriptorError(`schemaVersion must be ${String(DESCRIPTOR_SCHEMA_VERSION)}.`);
+  }
+  if (typeof record.apiKey !== "string" || record.apiKey.length === 0) {
+    throw descriptorError("apiKey must be a non-empty string.");
+  }
+  if (
+    record.apiKey.length > API_KEY_MAX_LENGTH ||
+    record.apiKey !== record.apiKey.trim() ||
+    /[\u0000\r\n]/u.test(record.apiKey)
+  ) {
+    throw descriptorError("apiKey has an invalid length or format.");
+  }
+  if (
+    typeof record.model !== "string" ||
+    record.model.length === 0 ||
+    record.model.length > MODEL_MAX_LENGTH ||
+    record.model !== record.model.trim() ||
+    /[\u0000-\u001f\u007f]/u.test(record.model)
+  ) {
+    throw descriptorError("model has an invalid length or format.");
+  }
+  if (typeof record.baseUrl !== "string" || record.baseUrl !== record.baseUrl.trim()) {
+    throw descriptorError("baseUrl must be a non-empty HTTP(S) URL.");
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(record.baseUrl);
+  } catch {
+    throw descriptorError("baseUrl must be a non-empty HTTP(S) URL.");
+  }
+  if (parsedUrl.protocol !== "https:" || parsedUrl.search || parsedUrl.hash) {
+    throw descriptorError("baseUrl must use HTTPS and must not contain a query or fragment.");
+  }
+  if (parsedUrl.username || parsedUrl.password || record.baseUrl.length > ENDPOINT_MAX_LENGTH) {
+    throw descriptorError("baseUrl must not contain credentials or exceed 2048 bytes.");
+  }
+  const endpointSuffixes = ["/responses", "/chat/completions", "/completions", "/models"];
+  let pathname = parsedUrl.pathname.replace(/\/+$/, "");
+  for (const suffix of endpointSuffixes) {
+    if (pathname === suffix) {
+      pathname = "";
+      break;
+    }
+    if (pathname.endsWith(suffix)) {
+      pathname = pathname.slice(0, -suffix.length);
+      break;
+    }
+  }
+  pathname = pathname.replace(/\/+$/, "");
+  parsedUrl.pathname = pathname || "/";
+  const baseUrl =
+    parsedUrl.pathname === "/" ? parsedUrl.origin : `${parsedUrl.origin}${parsedUrl.pathname}`;
+
+  if (typeof record.expiresAt !== "string") {
+    throw descriptorError("expiresAt must be an ISO 8601 UTC timestamp.");
+  }
+  const expiresAt = parseIsoUtcTimestamp(record.expiresAt);
+  if (expiresAt === null) {
+    throw descriptorError("expiresAt must be an ISO 8601 UTC timestamp.");
+  }
+
+  return {
+    schemaVersion: DESCRIPTOR_SCHEMA_VERSION,
+    apiKey: record.apiKey,
+    baseUrl,
+    model: record.model,
+    expiresAt: record.expiresAt,
+  };
+}
+
+export async function loadPortableInferenceDescriptor(
+  options: LoadPortableInferenceDescriptorOptions = {},
+): Promise<PortableInferenceDescriptor | null> {
+  const filePath = options.filePath ?? PORTABLE_INFERENCE_DESCRIPTOR_PATH;
+  const bytes = readAndConsumeDescriptor(filePath, options.currentUid ?? currentEffectiveUid);
+  if (bytes === null) return null;
+
+  const descriptor = parseDescriptor(bytes);
+  if (Date.parse(descriptor.expiresAt) <= (options.now ?? Date.now)()) {
+    throw descriptorError("has expired.");
+  }
+
+  const env = options.env ?? process.env;
+  const preflight = await assertEndpointResolvesPublic(
+    descriptor.baseUrl,
+    options.resolveEndpointHost,
+    { trustedPrivateHosts: parseTrustedPrivateInferenceHostsFromEnv(env) },
+  );
+  if (!preflight.ok) {
+    throw descriptorError(`baseUrl failed endpoint policy: ${preflight.reason ?? "rejected"}.`);
+  }
+  return descriptor;
+}

--- a/src/lib/onboard/inference-providers/remote-openai-surface.test.ts
+++ b/src/lib/onboard/inference-providers/remote-openai-surface.test.ts
@@ -3,7 +3,9 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { withCredentialOverrides } from "../../credentials/scoped-overrides";
 import { noAuthProxy } from "../../inference/ollama/proxy";
+import { hydrateCredentialEnv } from "../credential-env";
 import { setupRemoteProviderInference } from "./remote";
 import type { RemoteProviderDeps } from "./types";
 
@@ -41,6 +43,7 @@ function createHarness() {
     configKeys: ["ANTHROPIC_BASE_URL"],
   }));
   const deleteGatewayProvider = vi.fn(() => ({ ok: true }));
+  const hydrateCredential = vi.fn((_name: string) => "test-secret");
   const exitProcess = vi.fn((code: number): never => {
     throw new Error(`EXIT_CALLED:${code}`);
   });
@@ -88,7 +91,7 @@ function createHarness() {
         skipVerify: true,
       },
     },
-    hydrateCredentialEnv: vi.fn(() => "test-secret"),
+    hydrateCredentialEnv: hydrateCredential,
     promptValidationRecovery: vi.fn(async () => "selection" as const),
     classifyApplyFailure: vi.fn(() => "unknown"),
     LOCAL_INFERENCE_TIMEOUT_SECS: 60,
@@ -120,6 +123,49 @@ function createHarness() {
 afterEach(() => {
   vi.mocked(noAuthProxy).mockReset();
   delete process.env[NO_AUTH_ENV];
+  vi.unstubAllEnvs();
+});
+
+describe("OpenAI-compatible scoped credential registration", () => {
+  it("passes the scoped key only in the authorized provider-registration environment", async () => {
+    vi.stubEnv("COMPATIBLE_API_KEY", undefined);
+    const harness = createHarness();
+    harness.deps.hydrateCredentialEnv.mockImplementation((name: string) => {
+      const value = hydrateCredentialEnv(name);
+      if (!value) {
+        throw new Error(`Missing scoped credential '${name}'.`);
+      }
+      return value;
+    });
+
+    await withCredentialOverrides({ COMPATIBLE_API_KEY: "runtime-only-secret" }, async () => {
+      await expect(
+        setupRemoteProviderInference(
+          {
+            sandboxName: SANDBOX,
+            model: MODEL,
+            provider: "compatible-endpoint",
+            endpointUrl: "https://inference.example/v1",
+            credentialEnv: "COMPATIBLE_API_KEY",
+            preferredInferenceApi: "openai-completions",
+            pinnedAddresses: ["93.184.216.34"],
+          },
+          harness.deps,
+        ),
+      ).resolves.toEqual({ done: false });
+
+      expect(harness.upsertProvider).toHaveBeenCalledWith(
+        "compatible-endpoint",
+        "openai",
+        "COMPATIBLE_API_KEY",
+        "https://inference.example/v1",
+        { COMPATIBLE_API_KEY: "runtime-only-secret" },
+      );
+      expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
+    });
+
+    expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
+  });
 });
 
 describe("custom Anthropic provider replacement on the OpenAI surface", () => {

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -136,31 +136,46 @@ describe("host-side credential staging", () => {
 
   it("scopes a runtime credential without exporting or enumerating it", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
-    const credentials = await importCredentialsModule(home);
+    try {
+      const credentials = await importCredentialsModule(home);
 
-    await credentials.withCredentialOverrides(
-      { COMPATIBLE_API_KEY: "runtime-only-secret" },
-      async () => {
-        await Promise.resolve();
-        expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBe("runtime-only-secret");
-        expect(credentials.resolveProviderCredential("COMPATIBLE_API_KEY")).toBe(
-          "runtime-only-secret",
-        );
-        expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
-        expect(credentials.loadCredentials()).not.toHaveProperty("COMPATIBLE_API_KEY");
-        expect(credentials.listCredentialKeys()).not.toContain("COMPATIBLE_API_KEY");
+      await credentials.withCredentialOverrides(
+        { COMPATIBLE_API_KEY: "runtime-only-secret" },
+        async () => {
+          await Promise.resolve();
+          expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBe("runtime-only-secret");
+          expect(credentials.resolveProviderCredential("COMPATIBLE_API_KEY")).toBe(
+            "runtime-only-secret",
+          );
+          expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
+          expect(credentials.loadCredentials()).not.toHaveProperty("COMPATIBLE_API_KEY");
+          expect(credentials.listCredentialKeys()).not.toContain("COMPATIBLE_API_KEY");
 
-        const child = spawnSync(
-          process.execPath,
-          ["-e", "process.stdout.write(process.env.COMPATIBLE_API_KEY || '')"],
-          { encoding: "utf8" },
-        );
-        expect(child.status).toBe(0);
-        expect(child.stdout).toBe("");
-      },
-    );
+          const child = spawnSync(
+            process.execPath,
+            ["-e", "process.stdout.write(process.env.COMPATIBLE_API_KEY || '')"],
+            { encoding: "utf8" },
+          );
+          expect(child.status).toBe(0);
+          expect(child.stdout).toBe("");
+        },
+      );
 
-    expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBeNull();
+      expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBeNull();
+      await credentials.withCredentialOverrides(
+        { COMPATIBLE_API_KEY: " runtime-only-secret " },
+        async () => {
+          expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBe(" runtime-only-secret ");
+        },
+      );
+      for (const value of ["secret\nheader", "secret\rheader", "secret\0tail"]) {
+        await expect(
+          credentials.withCredentialOverrides({ COMPATIBLE_API_KEY: value }, async () => {}),
+        ).rejects.toThrow(/must not contain NUL, CR, or LF/);
+      }
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it("returns null for missing or blank credential values", async () => {

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -115,7 +115,7 @@ describe("host-side credential staging", () => {
     expect(credentials.listCredentialKeys()).toEqual(["NVIDIA_INFERENCE_API_KEY"]);
   });
 
-  it("getCredential reads only from process.env", async () => {
+  it("getCredential does not read the legacy credentials file", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
 
     // A pre-existing legacy file must NOT bleed into getCredential — the
@@ -132,6 +132,35 @@ describe("host-side credential staging", () => {
 
     vi.stubEnv("NVIDIA_INFERENCE_API_KEY", "  nvapi-from-env \n");
     expect(credentials.getCredential("NVIDIA_INFERENCE_API_KEY")).toBe("nvapi-from-env");
+  });
+
+  it("scopes a runtime credential without exporting or enumerating it", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
+    const credentials = await importCredentialsModule(home);
+
+    await credentials.withCredentialOverrides(
+      { COMPATIBLE_API_KEY: "runtime-only-secret" },
+      async () => {
+        await Promise.resolve();
+        expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBe("runtime-only-secret");
+        expect(credentials.resolveProviderCredential("COMPATIBLE_API_KEY")).toBe(
+          "runtime-only-secret",
+        );
+        expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
+        expect(credentials.loadCredentials()).not.toHaveProperty("COMPATIBLE_API_KEY");
+        expect(credentials.listCredentialKeys()).not.toContain("COMPATIBLE_API_KEY");
+
+        const child = spawnSync(
+          process.execPath,
+          ["-e", "process.stdout.write(process.env.COMPATIBLE_API_KEY || '')"],
+          { encoding: "utf8" },
+        );
+        expect(child.status).toBe(0);
+        expect(child.stdout).toBe("");
+      },
+    );
+
+    expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBeNull();
   });
 
   it("returns null for missing or blank credential values", async () => {


### PR DESCRIPTION
## Summary

Add an optional, single-use runtime inference descriptor for the portable experimental profile. A valid descriptor selects an OpenAI-compatible endpoint without exporting its API key; an absent descriptor preserves local `qwen3-vl:4b` behavior, and an existing local runner remains installed as manual standby.

## Changes

- Admit `/run/nemoclaw/portable-inference.json` only from a protected directory and a current-user-owned regular file with mode `0600` and one hard link.
- Open without following links or blocking, bound reads to 64 KiB, reject schema, timestamp, endpoint, and SSRF-policy violations, and consume every admitted descriptor once.
- Scope the descriptor API key to the onboarding asynchronous call tree so existing credential consumers can use it without adding it to `process.env`, child processes, persisted state, or credential listings. The current consumer is compatible-endpoint validation and OpenShell provider registration; `scopes a runtime credential without exporting or enumerating it` protects the boundary.
- Select the compatible endpoint as the one active route when the descriptor is valid. OpenShell does not automatically fail over to the existing local runner.
- Document activation, atomic publication, custody, cleanup, route behavior, and manual switching. Add negative tests for unsafe metadata, FIFO blocking, malformed content, impossible or expired timestamps, credential exposure, and rejected endpoints.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer security review passed for secret handling, strict input and filesystem admission, endpoint policy, process exposure, authorization boundary, redaction, dependencies, and runtime configuration.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/inference/set-up-openai-compatible-endpoint.mdx`; reviewed the completed source, tests, terminology, structure, voice, and code-sample presentation against the implementation and repository writing rules.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 91ccff7ee -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — feature validation passed 98 CLI tests and 52 integration tests; follow-up validation passed 73 CLI tests and 46 credential integration tests; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — Not applicable; this focused onboarding and credential-boundary change is covered by targeted tests and path-scoped hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors; 2 existing warnings remain.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for portable inference descriptors during onboarding.
  * Configures temporary custom endpoints, models, and runtime-only credentials.
  * Added secure descriptor validation, expiration checks, HTTPS endpoint validation, and cleanup after use.
  * Added scoped credential overrides that remain isolated from environment variables, persistence, and child processes.

* **Documentation**
  * Expanded setup guidance for portable inference descriptors, including schema, security requirements, installation, validation, and cleanup.

* **Bug Fixes**
  * Invalid or unsafe descriptors now fail onboarding cleanly without starting the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->