### PR TITLE
docs(changelog): prepare v0.0.106 release entry

### DIFF
--- a/docs/changelog/2026-08-10.mdx
+++ b/docs/changelog/2026-08-10.mdx
@@ -1,0 +1,46 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.106
+
+NemoClaw v0.0.106 converges readiness across lifecycle commands, upgrades the managed OpenShell runtime to v0.0.101, and adds bounded DGX Spark vLLM choices.
+It strengthens sandbox and Hermes recovery, local inference diagnostics, endpoint policy authority, and scoped uninstall.
+It also improves update safety, image defaults, and installation failure reporting.
+
+- `nemoclaw host probe --json`, onboarding, resume, and rebuild now use one credential-free readiness report and admission policy.
+  Blocking findings stop lifecycle effects before NemoClaw changes credentials, images, gateways, policies, or sandboxes.
+  For more information, refer to [System Readiness](/user-guide/openclaw/reference/system-readiness) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- The managed OpenShell runtime now uses v0.0.101 across installation, gateways, sandboxes, supervisors, and managed agent images.
+  Existing installations retain the v0.0.99 fallback only for migration, and incompatible sandbox names stop the update before destructive work.
+  For more information, refer to [Update Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/update-sandboxes) and [Configure Runtime Identity](/user-guide/openclaw/reference/configure-runtime-identity).
+- DGX Spark Express now offers a fixed managed vLLM option, while `nvidia/Qwen3.6-35B-A3B-NVFP4` remains the default profile for one DGX Spark.
+  The additional Muse Glimmer profile remains Experimental, runs on one DGX Spark, and excludes vision and DFlash.
+  Dual DGX Spark route discovery accepts the `iproute2` `from` field, and Model Router allows a longer bounded cold start.
+  For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm) and [Set Up vLLM on Two DGX Sparks](/user-guide/openclaw/inference/local-inference/set-up-vllm-on-two-dgx-sparks).
+- The Experimental portable OpenClaw profile now maps `host.openshell.internal` to the OpenShell Podman host gateway and preserves the profile in recovery commands.
+  Cleanup targets the receipt-owned rootless Podman container and fails closed when socket or container authority cannot be proved.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- Managed llama.cpp onboarding now cleans up rejected fixed-port state and distinguishes blocked Docker bridge access from a healthy host and runtime.
+  By default, the local Ollama proxy refuses a backend that listens beyond loopback, and onboarding retries while a selected model becomes tool-call responsive.
+  For more information, refer to [Set Up llama.cpp](/user-guide/openclaw/inference/local-inference/set-up-llama-cpp) and [Use Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama).
+- Gemini 3.x managed routes now load compatibility metadata so OpenClaw preserves thought signatures across tool calls.
+  `NEMOCLAW_AGENT_TIMEOUT` now controls both the agent and provider request deadlines, while `status` waits for route convergence after automatic gateway recovery.
+  For more information, refer to [Use Google Gemini](/user-guide/openclaw/inference/hosted-inference/use-google-gemini), [Configure Inference Timeouts](/user-guide/openclaw/inference/manage-inference/configure-inference-timeouts), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Trusted-private endpoints now keep the normalized hostname and exact address pins bound from admission through policy replay.
+  Managed MCP rejects mixed public and private address answers before mutation, and managed startup rejects a symlinked corporate CA before reading it.
+  The OpenClaw image also defaults to the non-root `sandbox` user, while OpenClaw v2026.7.1 gateway self-dialback stays on loopback inside OpenShell.
+  For more information, refer to [Meet Custom Endpoint Security Requirements](/user-guide/openclaw/inference/custom-endpoints/custom-endpoint-security), [Configure Corporate CA Trust](/user-guide/openclaw/security/configure-corporate-ca-trust), and [Security Best Practices](/user-guide/openclaw/security/best-practices).
+- Hermes rebuilds restart the gateway after workspace restore and before managed MCP restoration.
+  The cron gate remains active until the replacement process passes MCP and health verification.
+  Rebuild also settles an expired Shields timer before success, while macOS profile migration uses a native atomic no-clobber rename.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/hermes/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and [Security Best Practices](/user-guide/hermes/security/best-practices).
+- Sandbox recreation and live creation now wait for OpenShell to release ownership before Docker cutover.
+  Starting a stopped sandbox waits for a transient missing supervisor and repeats recovery, readiness, and port-forward checks.
+  Legacy gateway updates reuse validated prepared backups, while rebuilds restore reviewed build contexts and retire only proven obsolete images.
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), [Update Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/update-sandboxes), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+- `nemoclaw update --fresh` now refuses older or incomparable maintained versions unless the operator supplies `--allow-downgrade`.
+  Scoped uninstall isolates gateway shutdown by namespace and preserves checkpointed state for retry after a partial failure.
+  Installer linking skips npm lifecycle scripts, launcher initialization failures produce redacted single-line errors, and LangChain Deep Agents Code images include `dos2unix`.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the August 10, 2026 release entry for v0.0.106 before the release plan captures the candidate commit. The entry groups supported user-visible changes since v0.0.105 and omits work that is private, dormant, qualification-only, internal, or outside accepted product scope.

## Changes

- Add the canonical `docs/changelog/2026-08-10.mdx` entry with the exact `v0.0.106` heading.
- Summarize readiness, OpenShell v0.0.101, bounded DGX Spark and vLLM choices, inference, sandbox lifecycle, security, Hermes, and host maintenance changes.
- Use root-absolute documentation routes and the shared dated changelog source for all published variants.
- Exclude PR #8753 from canonical release claims because no accepted issue or design decision establishes its product scope.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates dated changelog SPDX placement, version headings, forbidden terms, and link form.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-08-10.mdx`; an independent Codex Desktop subagent reviewed the writing rules and documentation style, terminology, structure, voice, code-sample presentation, links, source and test accuracy, and product scope at commit `c15039c94`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: c15039c94 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to one documentation-only release entry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — result: passed with 0 errors and 2 existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — dated changelog entries use the required parser-safe MDX SPDX block and no frontmatter.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.106.
  * Documented lifecycle readiness checks, sandbox lifecycle improvements, safer updates, and scoped uninstall capabilities.
  * Added details on OpenShell v0.0.101 adoption and DGX Spark vLLM configuration options.
  * Documented recovery and inference diagnostics, endpoint security enforcement, and installation and image updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->