### PR TITLE
fix(cli): accept tagged trusted gateway identity

### DIFF
--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { isDockerDriverGatewayProcessIdentity } from "../onboard/docker-driver-gateway-process-identity";
 import type { GatewayOwner } from "../onboard/gateway-ownership";
 import { resetTraceForTests, TRACE_FILE_ENV } from "../trace";
 
@@ -31,8 +32,8 @@ import {
   classifyManagedGatewayVersionDrift,
   classifyManagedGatewayVersionSource,
   createProductionGatewayReadinessDependencies,
-  gatewayExecutableSamplesMatchTrustedBinary,
   gatewayProcessIdentityMatchesTrustedBinary,
+  gatewayProcessSamplesMatchTrustedBinary,
   parseDarwinLsofExecutable,
 } from "./gateway-production";
 
@@ -151,6 +152,69 @@ describe("managed gateway port readiness (#7411)", () => {
     expect(subprocess.spawnSync).not.toHaveBeenCalled();
   });
 
+  it("accepts the owned gateway tag with trusted Linux executable and environment evidence (#8755)", () => {
+    const trusted = "/opt/openshell/bin/openshell-gateway";
+    const input = {
+      pid: 999_999,
+      gatewayBin: trusted,
+      captureProcessArgs: () => "openshell-gateway[nemoclaw=nemoclaw;port=8080]",
+      processIdentityMatchesGatewayBinary: (identity: string) =>
+        gatewayProcessIdentityMatchesTrustedBinary(
+          identity,
+          trusted,
+          "nemoclaw",
+          8080,
+          trusted,
+          "linux",
+        ),
+      requireDockerDriverEnv: true,
+      hasDockerDriverGatewayEnv: () => false,
+    };
+
+    expect(isDockerDriverGatewayProcessIdentity(input)).toBe(false);
+    expect(
+      isDockerDriverGatewayProcessIdentity({
+        ...input,
+        hasDockerDriverGatewayEnv: () => true,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    [
+      "a foreign executable",
+      "openshell-gateway[nemoclaw=nemoclaw;port=8080]",
+      "/tmp/foreign-gateway",
+      "linux",
+    ],
+    [
+      "a different gateway target",
+      "openshell-gateway[nemoclaw=nemoclaw-8081;port=8081]",
+      "/opt/openshell/bin/openshell-gateway",
+      "linux",
+    ],
+    ["no executable evidence", "openshell-gateway[nemoclaw=nemoclaw;port=8080]", null, "linux"],
+    [
+      "a macOS direct listener",
+      "openshell-gateway[nemoclaw=nemoclaw;port=8080]",
+      "/opt/openshell/bin/openshell-gateway",
+      "darwin",
+    ],
+  ] as const)("rejects the owned gateway tag with %s (#8755)", (_case, identity, executable, platform) => {
+    const trusted = "/opt/openshell/bin/openshell-gateway";
+
+    expect(
+      gatewayProcessIdentityMatchesTrustedBinary(
+        identity,
+        trusted,
+        "nemoclaw",
+        8080,
+        executable,
+        platform,
+      ),
+    ).toBe(false);
+  });
+
   it("rejects trusted-looking argv on macOS without package-service identity", () => {
     const trusted = "/opt/homebrew/opt/openshell/bin/openshell-gateway";
     const spoofedArgv = `${trusted} --name nemoclaw-readiness-test --port 8080`;
@@ -167,16 +231,24 @@ describe("managed gateway port readiness (#7411)", () => {
     ).toBe(false);
   });
 
-  it("rejects an executable change while a listener PID remains stable", () => {
+  it("rejects a listener when Linux process samples change (#8755)", () => {
     const trusted = "/opt/openshell/bin/openshell-gateway";
 
-    expect(gatewayExecutableSamplesMatchTrustedBinary(trusted, trusted, trusted)).toBe(true);
+    expect(gatewayProcessSamplesMatchTrustedBinary("41", "41", trusted, trusted, trusted)).toBe(
+      true,
+    );
     expect(
-      gatewayExecutableSamplesMatchTrustedBinary(trusted, "/tmp/foreign-gateway", trusted),
+      gatewayProcessSamplesMatchTrustedBinary("41", "41", trusted, "/tmp/foreign-gateway", trusted),
     ).toBe(false);
     expect(
-      gatewayExecutableSamplesMatchTrustedBinary("/tmp/foreign-gateway", trusted, trusted),
+      gatewayProcessSamplesMatchTrustedBinary("41", "41", "/tmp/foreign-gateway", trusted, trusted),
     ).toBe(false);
+    expect(gatewayProcessSamplesMatchTrustedBinary("41", "42", trusted, trusted, trusted)).toBe(
+      false,
+    );
+    expect(gatewayProcessSamplesMatchTrustedBinary(null, null, trusted, trusted, trusted)).toBe(
+      false,
+    );
   });
 
   it("uses the main macOS executable vnode before dyld or later mappings", () => {

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -309,6 +309,17 @@ describe("managed gateway port readiness (#7411)", () => {
     expect(classifyManagedGatewayPortConflict(false, listener, "healthy", false, "unknown")).toBe(
       "unknown",
     );
+    expect(
+      classifyManagedGatewayPortConflict(false, listener, "healthy", false, "mismatch", true),
+    ).toBe("owner-mismatch");
+  });
+
+  it("accepts a target-bound listener when managed endpoint text is unavailable (#8755)", () => {
+    const listener = { pids: [41], unverifiedPids: [], complete: true };
+
+    expect(
+      classifyManagedGatewayPortConflict(false, listener, "healthy", false, "unknown", true),
+    ).toBe("none");
   });
 
   it("accepts one legacy Docker proxy only when the exact cluster endpoint owns the port", () => {

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -450,12 +450,15 @@ export function classifyManagedGatewayPortConflict(
   reuseState: GatewayReuseState | "unknown",
   legacyClusterBound = false,
   endpointBinding: ManagedGatewayEndpointBinding = "not-applicable",
+  hasTargetBoundListenerEvidence = false,
 ): GatewayPortConflictState {
   const listenerCount = listenerScan.pids.length + listenerScan.unverifiedPids.length;
   if (listenerCount > 1) return "multiple-owners";
   const liveManagedState = reuseState === "healthy" || reuseState === "active-unnamed";
   if (liveManagedState && endpointBinding === "mismatch") return "owner-mismatch";
-  if (liveManagedState && endpointBinding === "unknown") return "unknown";
+  if (liveManagedState && endpointBinding === "unknown" && !hasTargetBoundListenerEvidence) {
+    return "unknown";
+  }
   if (portAvailable) {
     if (listenerCount > 0 || liveManagedState) return "unknown";
     return "none";
@@ -547,11 +550,13 @@ export function createProductionGatewayReadinessDependencies(
   const openshellBin = resolveTrustedOpenshellBinary(probeEnv);
   const trustedGatewayBin = resolveTrustedGatewayBinary(openshellBin);
   const trustedVersionBinaryByPid = new Map<number, string>();
+  const trustedTargetBoundPids = new Set<number>();
 
   function observeDirectGatewayBinary(pid: number): string | null {
     if (process.platform !== "linux" || !trustedGatewayBin) return null;
     const generationBefore = readLinuxProcessStartTime(pid);
     const executableBefore = readLinuxProcessExecutable(pid);
+    let targetBoundIdentity = false;
     const exactTrustedBinary = isDockerDriverGatewayProcessIdentity({
       pid,
       gatewayBin: trustedGatewayBin,
@@ -559,15 +564,22 @@ export function createProductionGatewayReadinessDependencies(
         const result = captureReadonly(["ps", "-p", String(candidatePid), "-o", "args="], probeEnv);
         return result.exitCode === 0 ? result.stdout : "";
       },
-      processIdentityMatchesGatewayBinary: (identity) =>
-        gatewayProcessIdentityMatchesTrustedBinary(
+      processIdentityMatchesGatewayBinary: (identity) => {
+        const matches = gatewayProcessIdentityMatchesTrustedBinary(
           identity,
           trustedGatewayBin,
           gatewayName,
           gatewayPort,
           executableBefore,
           process.platform,
-        ),
+        );
+        if (matches) {
+          const argv0 = cleanGatewayProcessToken(identity.trim().split(/\s+/, 1)[0] ?? "");
+          const target = ownedHostGatewayTarget(path.basename(argv0));
+          targetBoundIdentity = target?.name === gatewayName && target.port === gatewayPort;
+        }
+        return matches;
+      },
       requireDockerDriverEnv: true,
       hasDockerDriverGatewayEnv: (candidatePid) =>
         hasDockerDriverGatewayEnvironment(
@@ -577,16 +589,18 @@ export function createProductionGatewayReadinessDependencies(
     });
     const executableAfter = readLinuxProcessExecutable(pid);
     const generationAfter = readLinuxProcessStartTime(pid);
-    return exactTrustedBinary &&
+    const stableTrustedBinary =
+      exactTrustedBinary &&
       gatewayProcessSamplesMatchTrustedBinary(
         generationBefore,
         generationAfter,
         executableBefore,
         executableAfter,
         trustedGatewayBin,
-      )
-      ? trustedGatewayBin
-      : null;
+      );
+    if (!stableTrustedBinary) return null;
+    if (targetBoundIdentity) trustedTargetBoundPids.add(pid);
+    return trustedGatewayBin;
   }
 
   function observePackagedServiceGatewayBinary(pid: number): string | null {
@@ -685,6 +699,7 @@ export function createProductionGatewayReadinessDependencies(
     );
     const portCheck = await checkGatewayPortAvailable();
     trustedVersionBinaryByPid.clear();
+    trustedTargetBoundPids.clear();
     const listenerScan = listenerHelpers.getDockerDriverGatewayPortListenerScan(portCheck, {
       gatewayBin: trustedGatewayBin,
     });
@@ -757,6 +772,7 @@ export function createProductionGatewayReadinessDependencies(
       reuseState,
       legacyClusterBound,
       endpointBinding,
+      listenerScan.pids.length === 1 && trustedTargetBoundPids.has(listenerScan.pids[0] ?? -1),
     );
     return {
       reuseState,

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -44,6 +44,7 @@ import {
   gatewayProcessCmdlineMatches,
   OPENSHELL_GATEWAY_PROCESS_NAMES,
 } from "../onboard/gateway-process-identity";
+import { ownedHostGatewayTarget } from "../onboard/gateway-process-target-identity";
 import { resolveOpenshell } from "../onboard/openshell-cli";
 import { checkPortAvailable } from "../onboard/preflight";
 import type {
@@ -162,6 +163,21 @@ export function gatewayExecutableSamplesMatchTrustedBinary(
   );
 }
 
+/** Require one Linux process generation and the trusted executable across both samples. */
+export function gatewayProcessSamplesMatchTrustedBinary(
+  generationBefore: string | null,
+  generationAfter: string | null,
+  executableBefore: string | null,
+  executableAfter: string | null,
+  trustedBinary: string | null,
+): boolean {
+  return (
+    generationBefore !== null &&
+    generationAfter === generationBefore &&
+    gatewayExecutableSamplesMatchTrustedBinary(executableBefore, executableAfter, trustedBinary)
+  );
+}
+
 function resolveTrustedOpenshellBinary(env: NodeJS.ProcessEnv): string | null {
   const commandV = captureReadonly(["sh", "-c", 'command -v "$1"', "--", "openshell"], env);
   return resolveOpenshell({
@@ -187,7 +203,7 @@ function resolveTrustedGatewayBinary(openshell: string | null): string | null {
   return null;
 }
 
-/** Require the observed argv0 to resolve to the independently selected binary. */
+/** Require the trusted Linux executable plus a trusted path or owned target tag. */
 export function gatewayProcessIdentityMatchesTrustedBinary(
   identity: string,
   trustedGatewayBin: string | null,
@@ -201,11 +217,18 @@ export function gatewayProcessIdentityMatchesTrustedBinary(
   // untrusted and only the positively identified Homebrew service is eligible.
   if (!trustedGatewayBin || platform !== "linux") return false;
   const argv0 = cleanGatewayProcessToken(identity.trim().split(/\s+/, 1)[0] ?? "");
-  const actual = argv0 ? normalizeExecutablePath(argv0) : null;
   const expected = normalizeExecutablePath(trustedGatewayBin);
-  if (!actual || !expected || actual !== expected) return false;
-  if (!actualExecutablePath || normalizeExecutablePath(actualExecutablePath) !== expected) {
+  if (
+    !expected ||
+    !actualExecutablePath ||
+    normalizeExecutablePath(actualExecutablePath) !== expected
+  ) {
     return false;
+  }
+  const taggedTarget = ownedHostGatewayTarget(path.basename(argv0));
+  if (!taggedTarget) {
+    const actual = argv0 ? normalizeExecutablePath(argv0) : null;
+    if (!actual || !expected || actual !== expected) return false;
   }
   return gatewayProcessCmdlineMatches(identity, trustedGatewayBin, {
     expectedOpenShellGateway: { name: gatewayName, port: gatewayPort },
@@ -555,9 +578,9 @@ export function createProductionGatewayReadinessDependencies(
     const executableAfter = readLinuxProcessExecutable(pid);
     const generationAfter = readLinuxProcessStartTime(pid);
     return exactTrustedBinary &&
-      generationBefore !== null &&
-      generationAfter === generationBefore &&
-      gatewayExecutableSamplesMatchTrustedBinary(
+      gatewayProcessSamplesMatchTrustedBinary(
+        generationBefore,
+        generationAfter,
         executableBefore,
         executableAfter,
         trustedGatewayBin,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Linux readiness now recognizes the target-bound OpenShell gateway tag when the kernel-backed executable matches the independently trusted gateway binary. The existing Docker-driver environment, target, and stable process-sampling checks still fail closed.

## Related Issue

Fixes #8755

## Changes

- Accept `openshell-gateway[nemoclaw=<name>;port=<port>]` as process identity only after `/proc/<pid>/exe` matches the trusted gateway binary and the tag matches the configured target.
- Let that fully verified target-bound listener establish port ownership when OpenShell does not print endpoint text; explicit endpoint mismatch and incomplete or ambiguous listener evidence still fail closed.
- Extract the combined process-generation and executable-sample predicate used by the production readiness collector so focused tests can protect both stability requirements.
- Add regression coverage for the OpenShell v0.0.101 tag and for foreign executables, another gateway target, missing executable evidence, missing Docker-driver environment evidence, macOS direct attribution, executable drift, and process-generation drift.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `docs/reference/system-readiness.mdx` already documents the independently resolved, kernel-backed executable match and stable process-sampling contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The change retains fail-closed executable, environment, target, platform, and process-generation gates. Focused negative tests cover each changed or adjacent attribution boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/reference/system-readiness.mdx` already documents the exact gateway target, independently resolved kernel-backed executable identity, and stable process-sampling contract implemented by this change.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e06614370 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: affected source tests passed 57/57; `npm run test:changed` passed 72/72; `npm run build:cli`, `npm run typecheck:cli`, `npm run test:titles:check`, and `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway readiness validation by confirming process identity across multiple checks.
  * Added stronger protection against unrelated gateway processes being accepted.
  * Improved handling of process or executable changes and missing verification evidence.
  * Added support for validating gateway listeners on macOS.
  * Improved detection of listeners associated with the intended gateway target when endpoint details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->