### PR TITLE
docs(changelog): follow up v0.0.106 release entry

### DIFF
--- a/docs/changelog/2026-08-10.mdx
+++ b/docs/changelog/2026-08-10.mdx
@@ -11,6 +11,8 @@ It also improves update safety, image defaults, and installation failure reporti
 
 - `nemoclaw host probe --json`, onboarding, resume, and rebuild now use one credential-free readiness report and admission policy.
   Blocking findings stop lifecycle effects before NemoClaw changes credentials, images, gateways, policies, or sandboxes.
+  Gateway readiness accepts OpenShell v0.0.101 `Server:` endpoint output and target-bound process tags only when trusted listener evidence matches the configured gateway.
+  It preserves the selected gateway's stale state when a gateway-scoped OpenShell status check cannot connect, so onboarding can reconcile the registered gateway.
   For more information, refer to [System Readiness](/user-guide/openclaw/reference/system-readiness) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
 - The managed OpenShell runtime now uses v0.0.101 across installation, gateways, sandboxes, supervisors, and managed agent images.
   Existing installations retain the v0.0.99 fallback only for migration, and incompatible sandbox names stop the update before destructive work.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR updates the August 10, 2026 v0.0.106 release entry with gateway readiness fixes that merged after PR #8756.
PRs #8765, #8767, and #8768 remain outside this entry because they are open and do not carry the `v0.0.106` release label.

## Changes

- Document acceptance of OpenShell v0.0.101 `Server:` endpoint output and target-bound process tags when trusted listener evidence matches the configured gateway.
- Document preservation of selected-gateway stale state so onboarding can reconcile a registered gateway when a gateway-scoped OpenShell status check cannot connect.
- Record evidence-backed exclusions for internal image, startup, qualification, proxy-environment, CI, and test-harness changes in PRs #8754, #8609, #8762, #8432, #8766, and #8581.
- Exclude PRs #8765, #8767, and #8768 because their changes are absent from `main` and the PRs do not carry the `v0.0.106` release label.
  The release entry must be updated after any of those PRs merges for v0.0.106.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/changelog-docs.test.ts` validates dated changelog SPDX placement, version headings, forbidden terms, and link form.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-08-10.mdx`; an independent Codex Desktop subagent reviewed the writing rules and documentation style, terminology, structure, voice, code-sample presentation, links, source and test accuracy, release meaning, product scope, and evidence-backed exclusions at commit `190bf882c`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 190bf882c -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to a documentation-only release-entry update.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — result: passed with 0 errors and 2 existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no page was added.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway readiness detection for OpenShell v0.0.101 endpoint output.
  * Process tags are now accepted only when they match trusted listener information for the configured gateway.
  * Preserved stale gateway status during connection failures to support accurate onboarding reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->