### PR TITLE
fix(inference): harden Lightning Spark profile

### DIFF
--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -275,9 +275,10 @@ $$nemoclaw onboard --profile vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-3
 ```
 
 The profile serves the public [`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4) checkpoint through a pinned ARM64 vLLM image.
-Its profile limits for one concurrent sequence are a 65,536-token context window, a 4,096-token batch limit, 0.7 GPU-memory utilization, FP8 KV cache, and one-token MTP speculative decoding.
+Its profile limits for one concurrent sequence are a 65,536-token context window, a 4,096-token batch limit, 0.65 GPU-memory utilization, FP8 KV cache, and one-token MTP speculative decoding.
 It uses vLLM's Python frontend because the pinned runtime's Rust frontend does not register the required `step3p5` reasoning and tool-call parsers.
-Physical single-DGX Spark validation covered plain chat, automatic and named structured tool calls, the 10-turn 32K-input/2K-output release workload, OpenClaw chat and file tools, cached restart, cleanup, and restoration of the original Qwen route.
+Physical single-DGX Spark validation of the pinned public revision covered direct chat, automatic and named structured tool calls, a ten-request 32K-to-41K input/2K-output release workload at about 102 output tokens/s across warm requests, OpenClaw chat and file tools, and a cached restart.
+At 0.65 utilization, the workload completed with about 33 GiB of host memory available and no NVIDIA kernel errors.
 
 <Warning title="Experimental Nemotron 3.5 Lightning vLLM Profile">
 This profile is an explicit opt-in for one DGX Spark and remains Experimental.

--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -138,6 +138,8 @@ Managed profiles and model-specific recipes use immutable image digests:
 - DGX Spark and DGX Station models without a model-specific runtime use the `linux/arm64` digest `sha256:9204569b17ee4c0eff75194b8e6e458479c8aee18953b5ab9cf359fcdac659e2` with a compressed layer size of `9.60 GB` under `nvcr.io/nvidia/vllm:26.05.post1-py3`.
 - The DGX Spark Muse Glimmer recipe uses the `linux/arm64` digest `sha256:ab0f5fc3bb81b9257a9aee801abcb0eeb94bb0523b57b2bb79349dc61e7c1e25` with a compressed layer size of `10.51 GB` under `vllm/vllm-openai`.
   It pins Hugging Face revision `d35cb79050f419c457611b1cee5c5d15b176f285` for the approximately `25.45 GB` model download.
+- The DGX Spark Nemotron 3.5 Lightning recipe uses the `linux/arm64` digest `sha256:3af90144a0926e5c5fe46ee16e5201e763dd854538b9d7ce433755f11dadaf78` with a compressed layer size of approximately `12.69 GB` under `vllm/vllm-openai`.
+  It pins Hugging Face revision `0dcd680e5585c791728c83342b311d0a0026dbeb` for the approximately `21.56 GB` model download.
 - The DGX Station Nemotron 3 Ultra express recipe uses the multi-platform index digest `sha256:0fec7ec5f3e6bc168e54899935fb0557da908a4832a1dbc88e2debcf2f889416` under `vllm/vllm-openai:v0.22.0`; on DGX Station, that index selects a `linux/arm64` manifest with a compressed layer size of `10.67 GB`.
   It also pins Hugging Face revision `183968f87ae4cedce3039313cac1fd43d112c578` for the approximately `352.38 GB` model download.
 - Generic Linux `arm64` hosts use `sha256:447995cbb57e6c7cf792cab95e9852e5f62b5fb6d2f39e030fa4eda9a54eadb4` with a compressed layer size of `9.28 GB` under `nvcr.io/nvidia/vllm:26.03.post1-py3`.
@@ -277,7 +279,8 @@ $$nemoclaw onboard --profile vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-3
 The profile serves the public [`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4) checkpoint through a pinned ARM64 vLLM image.
 Its profile limits for one concurrent sequence are a 65,536-token context window, a 4,096-token batch limit, 0.65 GPU-memory utilization, FP8 KV cache, and one-token MTP speculative decoding.
 It uses vLLM's Python frontend because the pinned runtime's Rust frontend does not register the required `step3p5` reasoning and tool-call parsers.
-Physical single-DGX Spark validation of the pinned public revision covered direct chat, automatic and named structured tool calls, a ten-request 32K-to-41K input/2K-output release workload at about 102 output tokens/s across warm requests, OpenClaw chat and file tools, and a cached restart.
+Physical single-DGX Spark validation of public revision `0dcd680e5585c791728c83342b311d0a0026dbeb` covered direct chat, automatic and named structured tool calls, a ten-request release workload with input lengths from 32,768 through 41,984 tokens and 2,048 output tokens per request, OpenClaw chat and file tools, and a cached restart.
+Requests 2 through 10 averaged about 102 output tokens/s.
 At 0.65 utilization, the workload completed with about 33 GiB of host memory available and no NVIDIA kernel errors.
 
 <Warning title="Experimental Nemotron 3.5 Lightning vLLM Profile">

--- a/managed-inference/recipes/vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1.yaml
+++ b/managed-inference/recipes/vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1.yaml
@@ -56,7 +56,7 @@ spec:
       - name: --max-num-seqs
         value: 1
       - name: --gpu-memory-utilization
-        value: 0.7
+        value: 0.65
       - name: --kv-cache-dtype
         value: fp8
       - name: --moe-backend

--- a/src/lib/inference/serving/adapter-registry.test.ts
+++ b/src/lib/inference/serving/adapter-registry.test.ts
@@ -28,6 +28,8 @@ import {
 } from "./managed-cluster-topology.js";
 import type { ManagedInferenceServingRecipe } from "./types.js";
 
+const LIGHTNING_RECIPE_ID = "vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1";
+
 function shippedRecipe(): ManagedInferenceServingRecipe {
   const recipe = loadManagedInferenceCatalog().recipes.find(
     ({ spec }) => spec.execution.materializerRef === MANAGED_CLUSTER_VLLM_MATERIALIZER_REF,
@@ -36,9 +38,9 @@ function shippedRecipe(): ManagedInferenceServingRecipe {
   return structuredClone(recipe as ManagedInferenceServingRecipe);
 }
 
-function shippedHostLocalRecipe(): ManagedInferenceServingRecipe {
+function shippedLightningRecipe(): ManagedInferenceServingRecipe {
   const recipe = loadManagedInferenceCatalog().recipes.find(
-    ({ spec }) => spec.execution.materializerRef === HOST_LOCAL_VLLM_MATERIALIZER_REF,
+    ({ metadata }) => metadata.id === LIGHTNING_RECIPE_ID,
   );
   expect(recipe).toBeDefined();
   return structuredClone(recipe as ManagedInferenceServingRecipe);
@@ -152,23 +154,7 @@ describe("managed inference adapter registries", () => {
   });
 
   it("accepts shell-quoted JSON values for host-local vLLM arguments", () => {
-    const recipe = shippedHostLocalRecipe();
-    const structuredArgument = {
-      ...recipe,
-      spec: {
-        ...recipe.spec,
-        serve: {
-          ...recipe.spec.serve,
-          arguments: [
-            ...recipe.spec.serve.arguments,
-            {
-              name: "--speculative-config",
-              value: '{"method":"mtp","num_speculative_tokens":1}',
-            },
-          ],
-        },
-      },
-    } as ManagedInferenceServingRecipe;
+    const structuredArgument = shippedLightningRecipe();
     const unsafeArgument = {
       ...structuredArgument,
       spec: {
@@ -186,6 +172,27 @@ describe("managed inference adapter registries", () => {
 
     expect(getManagedInferenceRecipeRegistrationError(structuredArgument)).toBeUndefined();
     expect(getManagedInferenceRecipeRegistrationError(unsafeArgument)).toMatch(
+      /bounded safe text/u,
+    );
+  });
+
+  it("does not broaden host-local vLLM environment values for structured arguments", () => {
+    const recipe = shippedLightningRecipe();
+    const structuredEnvironment = {
+      ...recipe,
+      spec: {
+        ...recipe.spec,
+        runtime: {
+          ...recipe.spec.runtime,
+          environment: {
+            ...recipe.spec.runtime.environment,
+            VLLM_TEST_CONFIG: '{"enabled":true}',
+          },
+        },
+      },
+    } as ManagedInferenceServingRecipe;
+
+    expect(getManagedInferenceRecipeRegistrationError(structuredEnvironment)).toMatch(
       /bounded safe text/u,
     );
   });

--- a/src/lib/inference/serving/adapter-registry.test.ts
+++ b/src/lib/inference/serving/adapter-registry.test.ts
@@ -176,7 +176,7 @@ describe("managed inference adapter registries", () => {
     );
   });
 
-  it("does not broaden host-local vLLM environment values for structured arguments", () => {
+  it("rejects structured host-local vLLM environment values", () => {
     const recipe = shippedLightningRecipe();
     const structuredEnvironment = {
       ...recipe,

--- a/src/lib/inference/serving/adapter-registry.ts
+++ b/src/lib/inference/serving/adapter-registry.ts
@@ -83,7 +83,8 @@ const PINNED_IMAGE =
 const SAFE_ENVIRONMENT_NAME = /^[A-Z][A-Z0-9_]{0,127}$/u;
 // Structured vLLM flags are passed as individual argv values after shell
 // quoting. Keep the allowlist narrow while admitting JSON objects and arrays.
-const HOST_LOCAL_SAFE_VALUE = /^[A-Za-z0-9_@%+=:,./{}[\]"-]+$/u;
+const HOST_LOCAL_SAFE_ARGUMENT_VALUE = /^[A-Za-z0-9_@%+=:,./{}[\]"-]+$/u;
+const HOST_LOCAL_SAFE_ENVIRONMENT_VALUE = /^[A-Za-z0-9_@%+=:,./-]+$/u;
 const SHA256_DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const MANAGED_CLUSTER_MATERIALIZER_OWNED_ENVIRONMENT = new Set([
   "GLOO_SOCKET_IFNAME",
@@ -413,13 +414,13 @@ function validateHostLocalVllmMaterializerRecipe(
         typeof value === "string" &&
         (Buffer.byteLength(value, "utf8") > 16_384 ||
           value.includes("\0") ||
-          !HOST_LOCAL_SAFE_VALUE.test(value)),
+          !HOST_LOCAL_SAFE_ARGUMENT_VALUE.test(value)),
     ) ||
     Object.values(recipe.spec.runtime.environment).some(
       (value) =>
         Buffer.byteLength(value, "utf8") > 4_096 ||
         value.includes("\0") ||
-        !HOST_LOCAL_SAFE_VALUE.test(value),
+        !HOST_LOCAL_SAFE_ENVIRONMENT_VALUE.test(value),
     )
   ) {
     return "host-local vLLM serving values must be bounded safe text";

--- a/test/managed-inference-catalog-compiler.test.ts
+++ b/test/managed-inference-catalog-compiler.test.ts
@@ -171,6 +171,7 @@ describe("managed inference YAML profile contract", () => {
       },
       serve: {
         arguments: expect.arrayContaining([
+          { name: "--gpu-memory-utilization", value: 0.65 },
           { name: "--tool-call-parser", value: "step3p5" },
           { name: "--reasoning-parser", value: "step3p5" },
           {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Harden the Nemotron 3.5 Lightning profile merged in #8810 using the final public-checkpoint validation completed on physical DGX Spark. This keeps JSON punctuation scoped to vLLM argument values, retains the narrower environment-value validation, and updates the recipe from 0.70 to the tested 0.65 GPU-memory setting.

## Related Issue

Follow-up to #8810 and closed child issue #8385.

## Changes

- Permit JSON object and array punctuation only in host-local vLLM argument values; environment values retain their narrower allowlist.
- Exercise the shipped Lightning recipe directly in adapter tests, including structured arguments, injection rejection, and environment-value rejection.
- Set Lightning GPU-memory utilization to 0.65 and assert that value in the catalog compiler test.
- Document the exact public revision, immutable runtime image, approximate artifact sizes, validation workload, warm throughput, and physical Spark memory/kernel result.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending maintainer review; no waiver requested.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/set-up-vllm.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8569389ba -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result: Not applicable; this profile targets one DGX Spark.
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 18 CLI tests and 8 integration tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs:prepare && npm run docs:validate` passed with zero errors (two existing warnings).
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Physical DGX Spark validation

- Public model revision: `0dcd680e5585c791728c83342b311d0a0026dbeb`.
- Runtime image: `vllm/vllm-openai@sha256:3af90144a0926e5c5fe46ee16e5201e763dd854538b9d7ce433755f11dadaf78`.
- A 0.70 setting produced an `NVRM NV_ERR_NO_MEMORY` event during startup, and 0.68 produced two during the first long chat. The tested 0.65 setting completed without NVIDIA kernel errors.
- Direct chat plus automatic and named structured tool calls passed.
- Ten requests with inputs from 32,768 through 41,984 tokens and 2,048 output tokens each generated 20,480 tokens at 99.237 output tokens/s aggregate and 102.158 output tokens/s across warm requests 2 through 10.
- OpenClaw chat and an unhinted create/read-file task passed, including an independent read of the exact file contents.
- A cached restart returned the API in 213 seconds; direct and OpenClaw chat then passed. About 33 GiB of host memory remained available.
- `nemoclaw profiles list` reported Lightning as compatible and explicit-only. With OpenShell `0.0.101`, the production `onboard --profile vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4` path completed all eight stages to a healthy gateway, dashboard, inference route, and Ready OpenClaw `2026.7.1` sandbox.
- The selector-created sandbox returned exact plain-chat output in 5 seconds and completed an unhinted create/read-file task in 20 seconds; an independent sandbox read verified the exact contents. Its managed container had catalog provenance labels, zero restarts, and no NVIDIA kernel errors after startup.
- Cleanup removed the temporary test runtime and standalone gateway. The original port-8082 route, registry files, stopped Qwen container name, Lightning filming runtime, and OpenShell `0.0.85` setup were restored; OpenClaw then returned an exact success marker through that route in about 7 seconds.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DGX Spark Nemotron 3.5 Lightning deployment details, including the pinned ARM64 image and tested model revision.
* **Bug Fixes**
  * Improved serving validation by restricting unsafe structured values in environment settings while preserving supported argument formats.
  * Adjusted GPU memory utilization to improve deployment compatibility.
* **Documentation**
  * Documented validated workload, throughput, and remaining host memory for the Lightning profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->