### PR TITLE
fix(onboard): allow cold Model Router startup

### DIFF
--- a/docs/inference/set-up-model-router.mdx
+++ b/docs/inference/set-up-model-router.mdx
@@ -17,6 +17,8 @@ OpenShell registers it as an OpenAI-compatible provider while the sandbox remain
 The Model Router option uses the `routed` inference profile in `nemoclaw-blueprint/blueprint.yaml`.
 During onboarding, NemoClaw starts the router proxy on host port `4000`, waits for its health endpoint, and registers the `nvidia-router` provider with OpenShell.
 The sandbox does not call port `4000` directly.
+On a host without cached routing-model files, Model Router downloads and loads its routing model before the health endpoint responds.
+NemoClaw gives a running router up to 10 minutes to pass its health check and stops onboarding sooner if the process exits.
 
 ```text
 Sandbox agent -> OpenShell -> Model Router on port 4000 -> NVIDIA API

--- a/src/lib/onboard/model-router.ts
+++ b/src/lib/onboard/model-router.ts
@@ -29,6 +29,7 @@ import {
   doesModelRouterProcessOwnPort,
   findModelRouterPidForPort,
   isRouterHealthy,
+  ROUTER_HEALTH_TIMEOUT_MS as ROUTER_HEALTH_REQUEST_TIMEOUT_MS,
   stopModelRouterProcess,
 } from "./model-router-process";
 import { prepareModelRouterVenv } from "./model-router-python";
@@ -40,10 +41,12 @@ export {
   type ModelRouterCommandProvisioner,
 } from "./model-router-command";
 
-// The prefill router loads its routing model before it serves /health.
-// Allow that model load to finish while keeping the startup wait bounded.
-const ROUTER_HEALTH_RETRIES = 60;
+// The prefill router downloads and loads its routing model before it serves
+// /health. Allow a cold host to finish while bounding both elapsed time and
+// the number of health checks.
+const ROUTER_HEALTH_RETRIES = 300;
 const ROUTER_HEALTH_INTERVAL_MS = 2000;
+const ROUTER_STARTUP_TIMEOUT_MS = 10 * 60_000;
 const MODEL_ROUTER_RELATIVE_DIR = path.join("nemoclaw-blueprint", "router", "llm-router");
 const MODEL_ROUTER_VENV_DIR = path.join(
   nemoclawStateRoot(os.homedir(), GATEWAY_PORT),
@@ -102,8 +105,9 @@ export type StartModelRouterDeps = {
   ) => ModelRouterSpawnedProcess;
   resolveProviderCredential: (name: string) => string | null;
   buildSubprocessEnv: (extra: Record<string, string>) => Record<string, string>;
-  isRouterHealthy: (port: number) => Promise<boolean>;
+  isRouterHealthy: (port: number, timeoutMs?: number) => Promise<boolean>;
   sleep: (milliseconds: number) => Promise<void>;
+  now: () => number;
   isProcessAlive: (pid: number) => boolean;
   terminateProcess: (pid: number) => void;
   getProviderKey: () => string;
@@ -207,6 +211,7 @@ function createStartModelRouterDeps(): StartModelRouterDeps {
     buildSubprocessEnv,
     isRouterHealthy,
     sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+    now: () => performance.now(),
     isProcessAlive: (pid) => {
       try {
         process.kill(pid, 0);
@@ -313,10 +318,20 @@ export async function startModelRouter(
     );
   }
 
-  for (let attempt = 0; attempt < ROUTER_HEALTH_RETRIES; attempt++) {
-    await deps.sleep(ROUTER_HEALTH_INTERVAL_MS);
+  const startupDeadline = deps.now() + ROUTER_STARTUP_TIMEOUT_MS;
+  let healthAttempts = 0;
+  while (healthAttempts < ROUTER_HEALTH_RETRIES && deps.now() < startupDeadline) {
+    const delayMs = Math.min(ROUTER_HEALTH_INTERVAL_MS, startupDeadline - deps.now());
+    await deps.sleep(delayMs);
     if (childExited) break;
-    const healthy = await deps.isRouterHealthy(port);
+    const remainingMs = startupDeadline - deps.now();
+    if (remainingMs <= 0) break;
+    const healthTimeoutMs = Math.max(
+      1,
+      Math.min(ROUTER_HEALTH_REQUEST_TIMEOUT_MS, Math.ceil(remainingMs)),
+    );
+    healthAttempts += 1;
+    const healthy = await deps.isRouterHealthy(port, healthTimeoutMs);
     const processAlive = deps.isProcessAlive(pid);
     if (healthy && processAlive) return pid;
     if (!processAlive) {
@@ -331,7 +346,7 @@ export async function startModelRouter(
     // already dead
   }
   throw new Error(
-    `Model router failed to become healthy on port ${port} after ${ROUTER_HEALTH_RETRIES} attempts` +
+    `Model Router failed to become healthy on port ${port} within ${ROUTER_STARTUP_TIMEOUT_MS / 1000} seconds (completed health checks: ${healthAttempts})` +
       (childExitDetail ? ` (${childExitDetail})` : ""),
   );
 }

--- a/test/onboard-model-router.test.ts
+++ b/test/onboard-model-router.test.ts
@@ -379,7 +379,7 @@ describe("onboard Model Router setup", () => {
     );
   });
 
-  it("starts a Model Router whose health check passes after 16 retry intervals", async () => {
+  it("starts a Model Router whose health check passes after 61 retry intervals", async () => {
     const pid = 12_345;
     const sleep = vi.fn(async () => undefined);
     const terminateProcess = vi.fn();
@@ -403,7 +403,7 @@ describe("onboard Model Router setup", () => {
         buildSubprocessEnv: () => ({}),
         isRouterHealthy: async () => {
           healthProbe += 1;
-          return healthProbe > 16;
+          return healthProbe > 61;
         },
         sleep,
         isProcessAlive: () => true,
@@ -413,12 +413,12 @@ describe("onboard Model Router setup", () => {
     );
 
     assert.equal(startedPid, pid);
-    assert.equal(healthProbe, 17);
-    assert.equal(sleep.mock.calls.length, 16);
+    assert.equal(healthProbe, 62);
+    assert.equal(sleep.mock.calls.length, 61);
     assert.equal(terminateProcess.mock.calls.length, 0);
   });
 
-  it("requests termination for a Model Router that stays unhealthy after 60 retry intervals", async () => {
+  it("requests termination for a Model Router that stays unhealthy after 300 retry intervals", async () => {
     const pid = 12_345;
     const sleep = vi.fn(async () => undefined);
     const terminateProcess = vi.fn();
@@ -448,11 +448,57 @@ describe("onboard Model Router setup", () => {
           getProviderKey: () => "",
         },
       ),
-      /failed to become healthy on port 45680 after 60 attempts/,
+      /failed to become healthy on port 45680 within 600 seconds \(completed health checks: 300\)/,
     );
 
-    assert.equal(isRouterHealthy.mock.calls.length, 61);
-    assert.equal(sleep.mock.calls.length, 60);
+    assert.equal(isRouterHealthy.mock.calls.length, 301);
+    assert.equal(sleep.mock.calls.length, 300);
+    assert.deepEqual(terminateProcess.mock.calls, [[pid]]);
+  });
+
+  it("stops when the 10-minute Model Router startup deadline expires", async () => {
+    const pid = 12_345;
+    const terminateProcess = vi.fn();
+    let nowMs = 0;
+    const sleep = vi.fn(async (milliseconds: number) => {
+      nowMs += milliseconds;
+    });
+    const isRouterHealthy = vi.fn(async (_port: number, timeoutMs = 0) => {
+      nowMs += timeoutMs;
+      return false;
+    });
+
+    await assert.rejects(
+      startModelRouter(
+        { port: 45_681, pool_config_path: "router/test-pool.yaml" },
+        {
+          rootDir: "/test/repo",
+          homeDir: "/test/home",
+          ensureModelRouterCommand: () => "/test/model-router",
+          mkdirSync: () => undefined,
+          runProxyConfig: () => ({ status: 0 }),
+          spawnProxy: () => ({
+            pid,
+            onError: () => undefined,
+            onExit: () => undefined,
+            unref: () => undefined,
+          }),
+          resolveProviderCredential: () => null,
+          buildSubprocessEnv: () => ({}),
+          isRouterHealthy,
+          sleep,
+          now: () => nowMs,
+          isProcessAlive: () => true,
+          terminateProcess,
+          getProviderKey: () => "",
+        },
+      ),
+      /failed to become healthy on port 45681 within 600 seconds \(completed health checks: 120\)/,
+    );
+
+    assert.equal(nowMs, 600_000);
+    assert.equal(isRouterHealthy.mock.calls.length, 121);
+    assert.equal(sleep.mock.calls.length, 120);
     assert.deepEqual(terminateProcess.mock.calls, [[pid]]);
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Cold Model Router onboarding could fail after two minutes while the live prefill router was still downloading or loading its routing model. Give an alive router a bounded 10-minute startup window, keep the health-check count capped, and document the behavior.

## Changes

- Enforce a 10-minute startup deadline in addition to the 300-attempt cap.
- Bound each health request by the time remaining before that deadline.
- Keep process-liveness checks and terminate a router that exits or never becomes healthy.
- Add regression coverage for success beyond the former 60-attempt boundary and for the combined delay-and-request deadline.
- Document cold routing-model initialization and the startup deadline in `docs/inference/set-up-model-router.mdx`.

Root cause and prevention evidence: [current-main E2E](https://github.com/NVIDIA/NemoClaw/actions/runs/31524967895/job/93900818905) reproduced the failure at the existing 60-attempt boundary while the child remained alive. The earlier unit test crossed only the former 15-attempt boundary and did not model health-request time. The new tests cross 60 attempts and simulate both the two-second interval and three-second request timeout through the 600-second deadline.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the onboarding and inference change. The router must remain alive, every probe is bounded by the remaining deadline, the attempt cap remains fail-closed, terminal failure requests child termination, and credential handling is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/inference/set-up-model-router.mdx`. Reviewed the generated OpenClaw, Hermes, and Deep Agents Code variants. The documentation matches the enforced 10-minute startup deadline and early process-exit behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b209d44 -->
<!-- docs-review-agents-blob-sha: c4923a3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host preparation path changed.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/onboard-model-router.test.ts --coverage=false` passed 16/16 after the final amendment.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not selected because this is a focused onboarding wait-bound change with direct integration coverage. `npm run validate:pr` passed before the final terminology-only amendment; normal commit and push hooks cover the final diff.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — 0 errors and 2 existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Model Router startup reliability by allowing up to 10 minutes for health checks.
  * Prevented health checks from exceeding the remaining startup time.
  * Enhanced startup failure messages with elapsed time and completed health-check details.

* **Documentation**
  * Documented model file downloading, loading, and health-readiness behavior during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->