### PR TITLE
fix(onboard): retry transient forward readiness

### DIFF
--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -267,6 +267,8 @@ Use these details when your first-run path needs more control.
     ```
 
     The onboard flow starts both port forwards automatically.
+    If OpenShell reports `sandbox is not ready`, NemoClaw waits 5 seconds and retries the affected forward up to three times.
+    These retries preserve the existing sandbox and selected host port.
     The Hermes dashboard URL does not include an OpenClaw `#token=` fragment.
     `nemohermes my-hermes dashboard-url --quiet` returns `http://127.0.0.1:18789/` when the default local forward is active.
     Check the API health endpoint from the host.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -398,6 +398,8 @@ Use these details when your first-run path needs more control.
     The wizard starts a background dashboard port forward and prints its URL in the ready summary.
     The default host port is `18789`.
     When that port is occupied, NemoClaw uses the next free dashboard port, such as `18790`, and includes the port in the URL.
+    If OpenShell reports `sandbox is not ready`, NemoClaw waits 5 seconds and retries the dashboard forward up to three times.
+    These retries preserve the existing sandbox and selected port.
     If the selected port becomes occupied after the sandbox build begins, onboarding rolls back the new sandbox and asks you to retry rather than print an unreachable URL.
     The installation transcript does not print the gateway token.
     Use `nemoclaw my-gpt-claw dashboard-url --quiet` to print the complete authenticated URL explicitly.

--- a/src/lib/onboard/forward-start.test.ts
+++ b/src/lib/onboard/forward-start.test.ts
@@ -937,6 +937,41 @@ describe("runDetachedForwardStartWithRetries", () => {
     expect(spawn).toHaveBeenCalledTimes(2);
   });
 
+  it("retries an OpenShell sandbox readiness rejection after a bounded settle delay", () => {
+    const fetchList = vi
+      .fn()
+      .mockReturnValueOnce(forwardListWith([]))
+      .mockReturnValue(forwardListWith([{ sandbox: "my-sandbox", port: 18789 }]));
+    const spawn = vi
+      .fn()
+      .mockImplementationOnce(({ stderr }: { stderr: number }) => {
+        fs.writeSync(
+          stderr,
+          "Error: code: 'The system is not in a state required for the operation's execution', message: \"sandbox is not ready\"\n",
+        );
+        return { pid: 784 };
+      })
+      .mockReturnValueOnce({ pid: 785 });
+    const beforeRetry = vi.fn();
+    const sleep = vi.fn();
+
+    const result = runDetachedForwardStartWithRetries(
+      spawn,
+      fetchList,
+      { port: 18789, sandboxName: "my-sandbox" },
+      beforeRetry,
+      {
+        sleepMs: sleep,
+        isPortListening: vi.fn().mockReturnValue(false),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(beforeRetry).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(5_000);
+  });
+
   it("preserves a ControlMaster listener created by the current attempt (#6099)", () => {
     const fetchList = vi.fn().mockReturnValue(forwardListWith([]));
     const spawn = vi.fn().mockImplementation(({ stderr }: { stderr: number }) => {

--- a/src/lib/onboard/forward-start.ts
+++ b/src/lib/onboard/forward-start.ts
@@ -120,8 +120,12 @@ export function looksLikeUntrackedForward(diagnostic: string): boolean {
  * once OpenShell either keeps the attempt alive until the listener is ready or
  * exposes a structured retryable outcome. Keep the fragments narrow so an
  * unrelated SSH or gateway failure cannot enter the listener-retry path.
+ * OpenShell 0.0.101 can also reject a forward during the sandbox readiness
+ * handoff. That command has already exited, so list polling cannot recover it;
+ * the retry wrapper below gives the OpenShell gateway a bounded settle interval.
  */
 export function looksLikeForwardListenerStartFailure(diagnostic: string): boolean {
+  if (/\bsandbox is not ready\b/i.test(diagnostic)) return true;
   return /ssh exited before local forward listener opened|local forward listener did not open\b/i.test(
     diagnostic,
   );
@@ -178,6 +182,7 @@ function blockingSleepMs(ms: number): void {
 // supported OpenShell version either stops retaining persistent dead rows or
 // exposes an atomic recovery operation.
 const DEAD_FORWARD_GRACE_MS = 2_000;
+const SANDBOX_READY_RETRY_SETTLE_MS = 5_000;
 
 /**
  * Build a `DetachedForwardSpawnRunner` that spawns the given argv as a
@@ -502,6 +507,7 @@ export function runDetachedForwardStartWithRetries(
   options: DetachedForwardStartOptions = {},
 ): DetachedForwardStartOutcome {
   const maxRetries = options.maxRetries ?? 3;
+  const sleepImpl = options.sleepMs ?? blockingSleepMs;
   let deadForwardRecoveryAvailable = true;
   const isPortListening = options.isPortListening ?? probeLocalPortListening;
   const runAttempt = (): DetachedForwardStartOutcome =>
@@ -527,6 +533,11 @@ export function runDetachedForwardStartWithRetries(
       if (!isRetryableStandardFailure || standardRetries >= maxRetries) break;
       if (looksLikeForwardPortConflict(attempt.diagnostic)) {
         beforeRetryCleanup();
+      }
+      if (/\bsandbox is not ready\b/i.test(attempt.diagnostic)) {
+        // Keep the existing sandbox and port ownership intact while the
+        // OpenShell gateway finishes the readiness handoff.
+        sleepImpl(SANDBOX_READY_RETRY_SETTLE_MS);
       }
       standardRetries++;
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenShell can transiently reject dashboard forwarding with `sandbox is not ready` after sandbox creation. Recognize that exact completed-command failure, wait 5 seconds, and retry through the existing three-retry bound without replacing the sandbox or selected port.

## Changes

- Classify only the exact OpenShell sandbox-readiness rejection as a completed listener-start failure.
- Wait 5 seconds before each readiness retry while preserving sandbox and port ownership.
- Keep authentication, foreign-listener ownership, and unrelated forward failures terminal.
- Add regression coverage for the rejection, settle delay, successful retry, and absence of cleanup.
- Document the bounded retry for OpenClaw and Hermes onboarding.

Root cause and prevention evidence: the [channels lifecycle job](https://github.com/NVIDIA/NemoClaw/actions/runs/31524967895/job/93900823461), [token rotation job](https://github.com/NVIDIA/NemoClaw/actions/runs/31524967895/job/93900819141), and [Hermes GPU fallback job](https://github.com/NVIDIA/NemoClaw/actions/runs/31524967895/job/93900819098) each captured the same exact OpenShell rejection. The detached forward command had exited, but the existing matcher did not classify the diagnostic as retryable, so NemoClaw polled an empty forward list for 180 seconds before failing. The new test reproduces that diagnostic and proves a delayed retry succeeds without sandbox-scoped cleanup.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the onboarding retry boundary. Entry requires the exact OpenShell readiness diagnostic; the retry does not stop or replace the sandbox or selected port; foreign ownership, authentication, and unrelated failures remain terminal; and no credential, policy, or authorization behavior changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/get-started/quickstart.mdx` and `docs/get-started/quickstart-hermes.mdx`. The documentation matches the exact diagnostic, 5-second interval, existing three-retry bound, and ownership-preserving behavior. Deep Agents Code has no dashboard forward and is unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f58714e4c -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host preparation path changed.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `vitest run --project cli src/lib/onboard/forward-start.test.ts` passed 44/44; `npm run test:changed` passed 27 files and 343 tests; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not selected because this is a focused onboarding retry matcher with direct unit and changed-scope coverage. `npm run validate:pr` passed on the exact rebased commit.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — 0 errors and 2 existing warnings; all 68 guarded routes passed.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard and port-forwarding setup now automatically retries when the sandbox is not ready.
  * Retries wait five seconds and run up to three times while preserving the existing sandbox and selected port.
  * Forwarding now avoids unnecessary cleanup during sandbox-readiness retries.

* **Documentation**
  * Updated the Quickstart and Hermes Quickstart guides to explain the automatic retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->