### PR TITLE
test(e2e): accept logged policy fetch denial

### DIFF
--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -242,8 +242,10 @@ async function expectEncodedSlashConfinedToClawHub(
     `https://openclaw.ai${encodedPath}`,
     "tc-net-permissive-non-clawhub-encoded-slash",
   );
+  // Undici can report the same denied CONNECT as `UND_ERR_SOCKET` or `fetch failed`.
+  // The OpenShell gateway log below provides the authoritative denial evidence.
   expect(nonClawhubStatus, `encoded slashes must fail closed outside ClawHub`).toMatch(
-    /^(?:STATUS_403|ERROR_UND_ERR_SOCKET)/,
+    /^(?:STATUS_403|ERROR_(?:UND_ERR_SOCKET|fetch failed))/,
   );
   const denial = await waitForDeniedReasonLog(host, {
     endpoint: ENCODED_SLASH_DENIED_ENDPOINT,


### PR DESCRIPTION
## Summary

The live network-policy test now accepts Undici's generic `fetch failed` wrapper for an encoded-slash CONNECT denial. The test still requires the exact OpenShell gateway denial event, so the policy check remains fail-closed.

## Changes

- Accept `ERROR_fetch failed` alongside the existing 403 and `UND_ERR_SOCKET` transport results.
- Keep the authoritative gateway-log assertions for the endpoint, `NET:OPEN`, `DENIED`, policy, L7 engine, and encoded-slash reason.
- Address the failure reproduced by [main E2E run 31524967895](https://github.com/NVIDIA/NemoClaw/actions/runs/31524967895/job/93900818681).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes live E2E evidence classification only; public behavior and interfaces are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The broader transport result cannot pass independently; the test still requires the exact OpenShell gateway denial event and all policy-denial fields.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `test/e2e/live/network-policy.test.ts` changes live E2E evidence classification only; public behavior and interfaces remain unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b619fd4d5 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: This is a live E2E assertion; the preliminary main run reproduced the new Undici result and retained the exact denial log. The release-candidate E2E will validate the completed change set.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encoded-slash denial errors by recognizing additional network error formats while continuing to support HTTP 403 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->