### PR TITLE
fix(onboard): narrow forward readiness retry

### DIFF
--- a/src/lib/onboard/forward-start.test.ts
+++ b/src/lib/onboard/forward-start.test.ts
@@ -942,18 +942,25 @@ describe("runDetachedForwardStartWithRetries", () => {
       .fn()
       .mockReturnValueOnce(forwardListWith([]))
       .mockReturnValue(forwardListWith([{ sandbox: "my-sandbox", port: 18789 }]));
+    const events: string[] = [];
     const spawn = vi
       .fn()
       .mockImplementationOnce(({ stderr }: { stderr: number }) => {
+        events.push("spawn-1");
         fs.writeSync(
           stderr,
           "Error: code: 'The system is not in a state required for the operation's execution', message: \"sandbox is not ready\"\n",
         );
         return { pid: 784 };
       })
-      .mockReturnValueOnce({ pid: 785 });
+      .mockImplementationOnce(() => {
+        events.push("spawn-2");
+        return { pid: 785 };
+      });
     const beforeRetry = vi.fn();
-    const sleep = vi.fn();
+    const sleep = vi.fn((ms: number) => {
+      events.push(`sleep-${ms}`);
+    });
 
     const result = runDetachedForwardStartWithRetries(
       spawn,
@@ -969,7 +976,43 @@ describe("runDetachedForwardStartWithRetries", () => {
     expect(result.ok).toBe(true);
     expect(beforeRetry).not.toHaveBeenCalled();
     expect(spawn).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledOnce();
     expect(sleep).toHaveBeenCalledWith(5_000);
+    expect(events).toEqual(["spawn-1", "sleep-5000", "spawn-2"]);
+  });
+
+  it("does not retry a composite authentication diagnostic that mentions readiness", () => {
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const delays: number[] = [];
+    const spawn = vi.fn().mockImplementation(({ stderr }: { stderr: number }) => {
+      fs.writeSync(
+        stderr,
+        "Permission denied (publickey); previous attempt reported Error: code: 'The system is not in a state required for the operation's execution', message: \"sandbox is not ready\"\n",
+      );
+      return { pid: 784 };
+    });
+
+    const result = runDetachedForwardStartWithRetries(
+      spawn,
+      vi.fn().mockReturnValue(forwardListWith([])),
+      { port: 18789, sandboxName: "my-sandbox" },
+      vi.fn(),
+      {
+        overallTimeoutMs: 1_000,
+        pollIntervalMs: 500,
+        sleepMs: (ms) => {
+          delays.push(ms);
+          now += ms;
+        },
+        isPortListening: vi.fn().mockReturnValue(false),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("timeout");
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(delays).not.toContain(5_000);
   });
 
   it("preserves a ControlMaster listener created by the current attempt (#6099)", () => {
@@ -1089,6 +1132,11 @@ describe("looksLikeForwardListenerStartFailure", () => {
   it("matches only definitive listener termination diagnostics", () => {
     expect(
       looksLikeForwardListenerStartFailure(
+        "Error: code: 'The system is not in a state required for the operation's execution', message: \"sandbox is not ready\"",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeForwardListenerStartFailure(
         "local forward listener did not open on 127.0.0.1:18789 within 10000ms",
       ),
     ).toBe(true);
@@ -1099,6 +1147,11 @@ describe("looksLikeForwardListenerStartFailure", () => {
     ).toBe(true);
     expect(looksLikeForwardListenerStartFailure("Permission denied (publickey)")).toBe(false);
     expect(looksLikeForwardListenerStartFailure("gateway transport unavailable")).toBe(false);
+    expect(
+      looksLikeForwardListenerStartFailure(
+        'Permission denied (publickey); previous attempt reported "sandbox is not ready"',
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/lib/onboard/forward-start.ts
+++ b/src/lib/onboard/forward-start.ts
@@ -106,6 +106,13 @@ export function looksLikeUntrackedForward(diagnostic: string): boolean {
   );
 }
 
+const OPENSHELL_SANDBOX_NOT_READY_DIAGNOSTIC =
+  /^Error: code: 'The system is not in a state required for the operation's execution', message: "sandbox is not ready"$/i;
+
+function looksLikeSandboxNotReadyForwardStart(diagnostic: string): boolean {
+  return OPENSHELL_SANDBOX_NOT_READY_DIAGNOSTIC.test(diagnostic);
+}
+
 /**
  * True only after openshell reports that the SSH process has definitively
  * stopped waiting for its local listener. Unlike the broader untracked-
@@ -125,7 +132,7 @@ export function looksLikeUntrackedForward(diagnostic: string): boolean {
  * the retry wrapper below gives the OpenShell gateway a bounded settle interval.
  */
 export function looksLikeForwardListenerStartFailure(diagnostic: string): boolean {
-  if (/\bsandbox is not ready\b/i.test(diagnostic)) return true;
+  if (looksLikeSandboxNotReadyForwardStart(diagnostic)) return true;
   return /ssh exited before local forward listener opened|local forward listener did not open\b/i.test(
     diagnostic,
   );
@@ -534,7 +541,7 @@ export function runDetachedForwardStartWithRetries(
       if (looksLikeForwardPortConflict(attempt.diagnostic)) {
         beforeRetryCleanup();
       }
-      if (/\bsandbox is not ready\b/i.test(attempt.diagnostic)) {
+      if (looksLikeSandboxNotReadyForwardStart(attempt.diagnostic)) {
         // Keep the existing sandbox and port ownership intact while the
         // OpenShell gateway finishes the readiness handoff.
         sleepImpl(SANDBOX_READY_RETRY_SETTLE_MS);


### PR DESCRIPTION
## Summary

This follow-up to #8826 limits the 5-second forward retry to the exact completed OpenShell readiness diagnostic. Composite authentication or gateway diagnostics that merely mention `sandbox is not ready` remain outside the readiness retry path.

## Changes

- Use one exact OpenShell readiness matcher for listener-failure classification and the settle delay.
- Verify the successful retry order is first spawn, one 5-second delay, then second spawn.
- Verify a composite authentication diagnostic does not trigger the readiness retry or delay.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The existing quickstarts already describe the qualifying exact OpenShell response and bounded retry; the follow-up prevents unrelated composite failures from entering that documented path.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The exact matcher keeps unrelated authentication and gateway failures terminal. Focused, affected, type-check, committed-range, and independent documentation reviews passed at the exact head.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `src/lib/onboard/forward-start.ts` narrows the existing documented retry to the exact OpenShell diagnostic; `src/lib/onboard/forward-start.test.ts` verifies retry order and composite-diagnostic behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 78f258b70 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/forward-start.test.ts` passed 45 tests; `npm run test:changed` passed 344 tests; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this narrow matcher and focused test change; exact `npm run validate:pr` passed against current main.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of sandbox readiness failures during startup.
  - Automatically retries eligible readiness failures for up to five seconds.
  - Prevents authentication errors that merely mention sandbox readiness from being retried.
  - Improved classification of listener startup failures for more reliable recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->