### PR TITLE
test(e2e): wait for stable gateway recovery state

### DIFF
--- a/test/e2e/fixtures/clients/gateway.ts
+++ b/test/e2e/fixtures/clients/gateway.ts
@@ -89,6 +89,19 @@ export interface HostGatewayRuntime {
   id: string;
 }
 
+function isMissingManagedSupervisorProof(result: ShellProbeResult): boolean {
+  const stderrLines = result.stderr
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return (
+    result.exitCode === 1 &&
+    result.stdout.trim() === "" &&
+    stderrLines.length === 1 &&
+    stderrLines[0] === "SUPERVISOR_NOT_RUNNING"
+  );
+}
+
 export class GatewayClient {
   private readonly host: HostCliClient;
   private readonly sandbox: SandboxClient;
@@ -183,6 +196,11 @@ export class GatewayClient {
    * Wait until the trusted root controller proves that a restarted legacy
    * container has no managed supervisor. This keeps the live E2E recovery test
    * out of the brief process-churn window after OpenShell becomes reachable.
+   * The fixture owns this wait because Docker restart and OpenShell readiness
+   * can complete before the container process table settles, while production
+   * recovery must keep treating uncertain controller output as terminal. Remove
+   * the wait when OpenShell readiness guarantees the controller absence proof
+   * remains stable across the settle interval.
    */
   async waitForMissingManagedSupervisor(
     containerId: string,
@@ -200,46 +218,40 @@ export class GatewayClient {
       attempts,
       delayMs,
       sleep,
-      probe: async (_attempt, artifactName) =>
-        await this.host.command(
-          "docker",
-          [
-            "exec",
-            "--env",
-            "LD_PRELOAD=",
-            "--env",
-            "PYTHONPATH=",
-            "--user",
-            "root",
-            containerId,
-            "/usr/local/bin/nemoclaw-gateway-control",
-            "probe",
-            randomBytes(32).toString("hex"),
-          ],
-          {
-            artifactName,
-            env: probeEnv(),
-            timeoutMs: 30_000,
-          },
-        ),
+      probe: async (_attempt, artifactName) => {
+        const runProbe = async (name: string) =>
+          await this.host.command(
+            "docker",
+            [
+              "exec",
+              "--env",
+              "LD_PRELOAD=",
+              "--env",
+              "PYTHONPATH=",
+              "--user",
+              "root",
+              containerId,
+              "/usr/local/bin/nemoclaw-gateway-control",
+              "probe",
+              randomBytes(32).toString("hex"),
+            ],
+            {
+              artifactName: name,
+              env: probeEnv(),
+              timeoutMs: 30_000,
+            },
+          );
+        const initial = await runProbe(artifactName);
+        if (!isMissingManagedSupervisorProof(initial) || settleMs <= 0) return initial;
+        await sleep(settleMs);
+        return await runProbe(`${artifactName}-after-settle`);
+      },
       accept: (result, attempt) => {
-        const stderrLines = result.stderr
-          .split(/\r?\n/)
-          .map((line) => line.trim())
-          .filter(Boolean);
-        if (
-          result.exitCode === 1 &&
-          result.stdout.trim() === "" &&
-          stderrLines.length === 1 &&
-          stderrLines[0] === "SUPERVISOR_NOT_RUNNING"
-        ) {
-          return true;
-        }
+        if (isMissingManagedSupervisorProof(result)) return true;
         options.onRetry?.(attempt);
         return false;
       },
     });
-    if (settleMs > 0) await sleep(settleMs);
   }
 
   // ─── Guard-chain recovery probes (#2478, #2701) ────────────────────

--- a/test/e2e/fixtures/clients/gateway.ts
+++ b/test/e2e/fixtures/clients/gateway.ts
@@ -96,6 +96,8 @@ function isMissingManagedSupervisorProof(result: ShellProbeResult): boolean {
     .filter(Boolean);
   return (
     result.exitCode === 1 &&
+    result.timedOut === false &&
+    result.signal === null &&
     result.stdout.trim() === "" &&
     stderrLines.length === 1 &&
     stderrLines[0] === "SUPERVISOR_NOT_RUNNING"

--- a/test/e2e/fixtures/clients/gateway.ts
+++ b/test/e2e/fixtures/clients/gateway.ts
@@ -1,8 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { randomBytes } from "node:crypto";
+
 import { buildAvailabilityProbeEnv } from "../availability-env.ts";
 import type { NemoClawInstance } from "../phases/onboarding.ts";
+import { pollUntil } from "../polling.ts";
 import type { ShellProbeResult, ShellProbeRunOptions } from "../shell-probe.ts";
 import { assertExitZero } from "./command.ts";
 import type { HostCliClient } from "./host.ts";
@@ -66,6 +69,14 @@ export interface ExpectPidStableOptions extends ShellProbeRunOptions {
   durationSeconds: number;
   /** Polling interval in seconds. Defaults to 3. */
   pollIntervalSeconds?: number;
+}
+
+export interface WaitForMissingManagedSupervisorOptions {
+  attempts?: number;
+  delayMs?: number;
+  settleMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  onRetry?: (attempt: number) => void;
 }
 
 export interface GatewayProcessIdentity {
@@ -166,6 +177,69 @@ export class GatewayClient {
       throw new Error(`openshell status did not report connected gateway '${gatewayName}'.`);
     }
     return result;
+  }
+
+  /**
+   * Wait until the trusted root controller proves that a restarted legacy
+   * container has no managed supervisor. This keeps the live E2E recovery test
+   * out of the brief process-churn window after OpenShell becomes reachable.
+   */
+  async waitForMissingManagedSupervisor(
+    containerId: string,
+    options: WaitForMissingManagedSupervisorOptions = {},
+  ): Promise<void> {
+    const attempts = options.attempts ?? 12;
+    const delayMs = options.delayMs ?? 3_000;
+    const settleMs = options.settleMs ?? delayMs;
+    const sleep =
+      options.sleep ??
+      ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+
+    await pollUntil({
+      artifactPrefix: "legacy-restart-supervisor-absent",
+      attempts,
+      delayMs,
+      sleep,
+      probe: async (_attempt, artifactName) =>
+        await this.host.command(
+          "docker",
+          [
+            "exec",
+            "--env",
+            "LD_PRELOAD=",
+            "--env",
+            "PYTHONPATH=",
+            "--user",
+            "root",
+            containerId,
+            "/usr/local/bin/nemoclaw-gateway-control",
+            "probe",
+            randomBytes(32).toString("hex"),
+          ],
+          {
+            artifactName,
+            env: probeEnv(),
+            timeoutMs: 30_000,
+          },
+        ),
+      accept: (result, attempt) => {
+        const stderrLines = result.stderr
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean);
+        if (
+          result.exitCode === 1 &&
+          result.stdout.trim() === "" &&
+          stderrLines.length === 1 &&
+          stderrLines[0] === "SUPERVISOR_NOT_RUNNING"
+        ) {
+          return true;
+        }
+        options.onRetry?.(attempt);
+        return false;
+      },
+    });
+    if (settleMs > 0) await sleep(settleMs);
   }
 
   // ─── Guard-chain recovery probes (#2478, #2701) ────────────────────

--- a/test/e2e/live/gateway-guard-recovery.test.ts
+++ b/test/e2e/live/gateway-guard-recovery.test.ts
@@ -467,6 +467,9 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
   });
   expect(legacyRestart.exitCode, resultText(legacyRestart)).toBe(0);
   await waitForSandboxExecAfterContainerRestart(host, instance.sandboxName, progress);
+  await gateway.waitForMissingManagedSupervisor(legacyContainerId, {
+    onRetry: (attempt) => progress.event(`managed supervisor absence proof retry ${attempt}`),
+  });
 
   progress.phase("recover legacy managed supervisor and inference");
   const legacyCredentialCanary = "nemoclaw-e2e-recovery-secret-6635";

--- a/test/e2e/support/e2e-recovery-helpers.test.ts
+++ b/test/e2e/support/e2e-recovery-helpers.test.ts
@@ -21,6 +21,8 @@ interface ScriptedReply {
   stdout?: string;
   stderr?: string;
   exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  timedOut?: boolean;
 }
 
 /**
@@ -52,8 +54,8 @@ class ScriptedRunner implements CommandRunner {
     return {
       command: [command.command, ...command.args],
       exitCode: reply.exitCode ?? 0,
-      signal: null,
-      timedOut: false,
+      signal: reply.signal ?? null,
+      timedOut: reply.timedOut ?? false,
       stdout: reply.stdout ?? "",
       stderr: reply.stderr ?? "",
       artifacts: {
@@ -175,6 +177,23 @@ describe("GatewayClient recovery helpers (#2701)", () => {
         stdout: "unexpected output\n",
         stderr: "SUPERVISOR_NOT_RUNNING\n",
       });
+      const gateway = buildGateway(runner);
+
+      await expect(
+        gateway.waitForMissingManagedSupervisor("container-123", {
+          attempts: 1,
+          delayMs: 0,
+          settleMs: 0,
+        }),
+      ).rejects.toThrow(/polling exhausted/);
+    });
+
+    it.each([
+      { condition: "timed out", reply: { timedOut: true } },
+      { condition: "terminated by a signal", reply: { signal: "SIGTERM" as const } },
+    ])("does not accept a probe that $condition", async ({ reply }) => {
+      const runner = new ScriptedRunner();
+      runner.queue({ exitCode: 1, stderr: "SUPERVISOR_NOT_RUNNING\n", ...reply });
       const gateway = buildGateway(runner);
 
       await expect(

--- a/test/e2e/support/e2e-recovery-helpers.test.ts
+++ b/test/e2e/support/e2e-recovery-helpers.test.ts
@@ -107,6 +107,7 @@ describe("GatewayClient recovery helpers (#2701)", () => {
           stderr: "SUPERVISOR_UNAVAILABLE\nNEMOCLAW_CONTROL_STAGE=discover-supervisor\n",
         },
         { exitCode: 1, stderr: "SUPERVISOR_NOT_RUNNING\n" },
+        { exitCode: 1, stderr: "SUPERVISOR_NOT_RUNNING\n" },
       );
       const gateway = buildGateway(runner);
       const sleep = vi.fn(async (milliseconds: number) => {
@@ -129,8 +130,9 @@ describe("GatewayClient recovery helpers (#2701)", () => {
         "sleep-3000",
         "probe-not-running",
         "sleep-3000",
+        "probe-not-running",
       ]);
-      expect(runner.calls).toHaveLength(2);
+      expect(runner.calls).toHaveLength(3);
       for (const call of runner.calls) {
         expect(call.command).toBe("docker");
         expect(call.args.slice(0, -1)).toEqual([
@@ -164,6 +166,52 @@ describe("GatewayClient recovery helpers (#2701)", () => {
           settleMs: 0,
         }),
       ).rejects.toThrow(/polling exhausted/);
+    });
+
+    it("does not accept missing-supervisor output with stdout", async () => {
+      const runner = new ScriptedRunner();
+      runner.queue({
+        exitCode: 1,
+        stdout: "unexpected output\n",
+        stderr: "SUPERVISOR_NOT_RUNNING\n",
+      });
+      const gateway = buildGateway(runner);
+
+      await expect(
+        gateway.waitForMissingManagedSupervisor("container-123", {
+          attempts: 1,
+          delayMs: 0,
+          settleMs: 0,
+        }),
+      ).rejects.toThrow(/polling exhausted/);
+    });
+
+    it("retries when supervisor absence changes during the settle interval", async () => {
+      const runner = new ScriptedRunner();
+      runner.queue(
+        { exitCode: 1, stderr: "SUPERVISOR_NOT_RUNNING\n" },
+        { exitCode: 0, stdout: "SUPERVISOR_RUNNING\n" },
+        { exitCode: 1, stderr: "SUPERVISOR_NOT_RUNNING\n" },
+        { exitCode: 0, stdout: "SUPERVISOR_RUNNING\n" },
+      );
+      const gateway = buildGateway(runner);
+      const sleep = vi.fn(async () => undefined);
+      const onRetry = vi.fn();
+
+      await expect(
+        gateway.waitForMissingManagedSupervisor("container-123", {
+          attempts: 2,
+          delayMs: 0,
+          settleMs: 3_000,
+          sleep,
+          onRetry,
+        }),
+      ).rejects.toThrow(/polling exhausted/);
+
+      expect(sleep).toHaveBeenCalledTimes(2);
+      expect(onRetry).toHaveBeenNthCalledWith(1, 1);
+      expect(onRetry).toHaveBeenNthCalledWith(2, 2);
+      expect(runner.calls).toHaveLength(4);
     });
   });
 

--- a/test/e2e/support/e2e-recovery-helpers.test.ts
+++ b/test/e2e/support/e2e-recovery-helpers.test.ts
@@ -190,7 +190,7 @@ describe("GatewayClient recovery helpers (#2701)", () => {
 
     it.each([
       { condition: "timed out", reply: { timedOut: true } },
-      { condition: "terminated by a signal", reply: { signal: "SIGTERM" as const } },
+      { condition: "was terminated by a signal", reply: { signal: "SIGTERM" as const } },
     ])("does not accept a probe that $condition", async ({ reply }) => {
       const runner = new ScriptedRunner();
       runner.queue({ exitCode: 1, stderr: "SUPERVISOR_NOT_RUNNING\n", ...reply });

--- a/test/e2e/support/e2e-recovery-helpers.test.ts
+++ b/test/e2e/support/e2e-recovery-helpers.test.ts
@@ -35,6 +35,8 @@ class ScriptedRunner implements CommandRunner {
   readonly calls: RunnerCall[] = [];
   private replies: ScriptedReply[] = [];
 
+  constructor(private readonly observe?: (call: RunnerCall, reply: ScriptedReply) => void) {}
+
   queue(...replies: ScriptedReply[]): void {
     this.replies.push(...replies);
   }
@@ -43,8 +45,10 @@ class ScriptedRunner implements CommandRunner {
     command: TrustedShellCommand,
     options?: ShellProbeRunOptions,
   ): Promise<ShellProbeResult> {
-    this.calls.push({ command: command.command, args: [...command.args], options });
+    const call = { command: command.command, args: [...command.args], options };
+    this.calls.push(call);
     const reply = this.replies.shift() ?? {};
+    this.observe?.(call, reply);
     return {
       command: [command.command, ...command.args],
       exitCode: reply.exitCode ?? 0,
@@ -89,6 +93,80 @@ function buildGateway(runner: ScriptedRunner): GatewayClient {
 }
 
 describe("GatewayClient recovery helpers (#2701)", () => {
+  describe("waitForMissingManagedSupervisor", () => {
+    it("waits for the exact missing-supervisor proof and a quiet settle", async () => {
+      const events: string[] = [];
+      const runner = new ScriptedRunner((_call, reply) => {
+        events.push(
+          reply.stderr === "SUPERVISOR_NOT_RUNNING\n" ? "probe-not-running" : "probe-unavailable",
+        );
+      });
+      runner.queue(
+        {
+          exitCode: 1,
+          stderr: "SUPERVISOR_UNAVAILABLE\nNEMOCLAW_CONTROL_STAGE=discover-supervisor\n",
+        },
+        { exitCode: 1, stderr: "SUPERVISOR_NOT_RUNNING\n" },
+      );
+      const gateway = buildGateway(runner);
+      const sleep = vi.fn(async (milliseconds: number) => {
+        events.push(`sleep-${milliseconds}`);
+      });
+      const onRetry = vi.fn();
+
+      await gateway.waitForMissingManagedSupervisor("container-123", {
+        attempts: 3,
+        delayMs: 3_000,
+        settleMs: 3_000,
+        sleep,
+        onRetry,
+      });
+
+      expect(onRetry).toHaveBeenCalledOnce();
+      expect(onRetry).toHaveBeenCalledWith(1);
+      expect(events).toEqual([
+        "probe-unavailable",
+        "sleep-3000",
+        "probe-not-running",
+        "sleep-3000",
+      ]);
+      expect(runner.calls).toHaveLength(2);
+      for (const call of runner.calls) {
+        expect(call.command).toBe("docker");
+        expect(call.args.slice(0, -1)).toEqual([
+          "exec",
+          "--env",
+          "LD_PRELOAD=",
+          "--env",
+          "PYTHONPATH=",
+          "--user",
+          "root",
+          "container-123",
+          "/usr/local/bin/nemoclaw-gateway-control",
+          "probe",
+        ]);
+        expect(call.args.at(-1)).toMatch(/^[0-9a-f]{64}$/);
+      }
+    });
+
+    it("does not accept a composite missing-supervisor diagnostic", async () => {
+      const runner = new ScriptedRunner();
+      runner.queue({
+        exitCode: 1,
+        stderr: "SUPERVISOR_NOT_RUNNING\nNEMOCLAW_CONTROL_STAGE=discover-supervisor\n",
+      });
+      const gateway = buildGateway(runner);
+
+      await expect(
+        gateway.waitForMissingManagedSupervisor("container-123", {
+          attempts: 1,
+          delayMs: 0,
+          settleMs: 0,
+        }),
+      ).rejects.toThrow(/polling exhausted/);
+    });
+  });
+
   describe("expectGuardChainActive", () => {
     it("passes when proxy-env.sh contains the default safety-net + ciao markers", async () => {
       const runner = new ScriptedRunner();


### PR DESCRIPTION
## Summary

The gateway guard recovery live E2E failed twice because it started production recovery while the OpenShell container process table was still settling after a Docker restart. This change requires the gateway controller exact absence proof both before and after a settle interval, without weakening production fail-closed behavior.

## Changes

- Add an E2E client helper that accepts only the exact `SUPERVISOR_NOT_RUNNING` diagnostic from the expected container.
- Require the supervisor probe to complete without a timeout or signal before its output can prove absence.
- Re-probe after the settle interval and resume bounded polling if supervisor absence changes.
- Cover successful stabilization and refusal of composite stderr, nonempty stdout, timed-out or signaled probes, and a supervisor that reappears during settle.
- Document the Docker/OpenShell synchronization boundary and removal condition.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes live E2E synchronization and evidence only; production recovery and public behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The helper executes only the existing gateway probe inside the exact discovered container, accepts only a normally completed exit 1 with empty stdout and the single exact `SUPERVISOR_NOT_RUNNING` stderr line twice across the settle interval, and leaves production recovery classification unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed all three changed files against the documentation and writing rules. The tests and fixture now require exact, completed, stable supervisor-absence evidence and reject timed-out, signaled, composite, or changing results. No user-facing documentation surface changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: ddd7e082d -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/e2e-recovery-helpers.test.ts` passed 38/38; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: The full E2E-support run passed 2,466 tests; seven unrelated macOS environment tests failed. Linux PR CI is the authoritative broad gate.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Failure evidence

- [main E2E run 31524967895, gateway recovery job](https://github.com/NVIDIA/NemoClaw/actions/runs/31524967895/job/93900819059)
- [main E2E run 31532408138, repeated gateway recovery job](https://github.com/NVIDIA/NemoClaw/actions/runs/31532408138/job/93918775194)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery reliability after restarting legacy keepalive containers by confirming the managed supervisor is no longer running before recovery begins.
  * Added polling, retry handling, and settling delays for more consistent gateway state detection.
  * Strengthened gateway diagnostics to reject incomplete or unexpected probe responses.
* **Tests**
  * Expanded coverage for supervisor detection, retry behavior, timing, gateway probes, and recovery diagnostics.
  * Added coverage for supervisor state changes during the settling period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
