### PR TITLE
docs: complete v0.0.106 audit follow-ups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,13 @@ exception whose file, test title, and category are not in the reviewed allowlist
 rejects unused allowlist entries, so one exception cannot silently replace another. Its output and
 metrics list every accepted exception so these contracts remain visible during review.
 
+### Blueprint Image Pin Updates
+
+When the managed sandbox image changes, update both `digest` and `components.sandbox.image` in
+`nemoclaw-blueprint/blueprint.yaml` with the same SHA-256 digest. Release tooling should rewrite
+both fields together. `test/validate-blueprint.test.ts` rejects a mutable image tag or a mismatch
+between the two digest fields.
+
 ### Focused Vitest Feedback
 
 Use `npm run test:changed` for the staged, unstaged, and untracked changes in the current checkout,

--- a/docs/changelog/2026-08-10.mdx
+++ b/docs/changelog/2026-08-10.mdx
@@ -39,10 +39,12 @@ It also improves update safety, image defaults, and installation failure reporti
   Rebuild also settles an expired Shields timer before success, while macOS profile migration uses a native atomic no-clobber rename.
   For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/hermes/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and [Security Best Practices](/user-guide/hermes/security/best-practices).
 - Sandbox recreation and live creation now wait for OpenShell to release ownership before Docker cutover.
-  Starting a stopped sandbox waits for a transient missing supervisor and repeats recovery, readiness, and port-forward checks.
+  Starting a stopped OpenClaw or Hermes sandbox waits through transient supervisor absence and managed-container restart transitions before it repeats recovery, readiness, and port-forward checks.
+  A Shields up restart also keeps `/sandbox` at `root:sandbox` mode `1775` while the explicit process policy selects the sandbox workload identity.
   Legacy gateway updates reuse validated prepared backups, while rebuilds restore reviewed build contexts and retire only proven obsolete images.
   For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), [Update Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/update-sandboxes), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
 - `nemoclaw update --fresh` now refuses older or incomparable maintained versions unless the operator supplies `--allow-downgrade`.
   Scoped uninstall isolates gateway shutdown by namespace and preserves checkpointed state for retry after a partial failure.
+  Installer preflight preserves managed `fuse-overlayfs` storage remediation and accepts valid two- or three-component NVIDIA driver versions without changing the `580.65.06` minimum.
   Installer linking skips npm lifecycle scripts, launcher initialization failures produce redacted single-line errors, and LangChain Deep Agents Code images include `dos2unix`.
-  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw).
+  For more information, refer to [Prerequisites](/user-guide/openclaw/get-started/prerequisites), [Set Up llama.cpp](/user-guide/openclaw/inference/local-inference/set-up-llama-cpp), the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands), and [Uninstall NemoClaw](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/uninstall-nemoclaw).

--- a/docs/changelog/2026-08-10.mdx
+++ b/docs/changelog/2026-08-10.mdx
@@ -22,8 +22,10 @@ It also improves update safety, image defaults, and installation failure reporti
   Dual DGX Spark route discovery accepts the `iproute2` `from` field, and Model Router allows a longer bounded cold start.
   For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm) and [Set Up vLLM on Two DGX Sparks](/user-guide/openclaw/inference/local-inference/set-up-vllm-on-two-dgx-sparks).
 - The Experimental portable OpenClaw profile now maps `host.openshell.internal` to the OpenShell Podman host gateway and preserves the profile in recovery commands.
+  A host-side activation component can also supply a single-use inference descriptor that selects an OpenAI-compatible endpoint without exporting its short-lived API key.
+  An existing local runner remains installed as manual standby, and NemoClaw does not switch to it automatically.
   Cleanup targets the receipt-owned rootless Podman container and fails closed when socket or container authority cannot be proved.
-  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands) and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+  For more information, refer to [Set Up an OpenAI-Compatible Endpoint](/user-guide/openclaw/inference/custom-endpoints/set-up-openai-compatible-endpoint), the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
 - Managed llama.cpp onboarding now cleans up rejected fixed-port state and distinguishes blocked Docker bridge access from a healthy host and runtime.
   By default, the local Ollama proxy refuses a backend that listens beyond loopback, and onboarding retries while a selected model becomes tool-call responsive.
   For more information, refer to [Set Up llama.cpp](/user-guide/openclaw/inference/local-inference/set-up-llama-cpp) and [Use Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama).

--- a/docs/security/gateway-authentication-controls.mdx
+++ b/docs/security/gateway-authentication-controls.mdx
@@ -97,12 +97,6 @@ openclaw security audit --json | jq '.suppressedFindings'
 
 Remove the underlying risky condition when dashboard compatibility no longer requires it.
 
-Remove these suppressions only after the pinned OpenClaw audit contract test proves that OpenClaw natively classifies intentional loopback development HTTP without them, or after NemoClaw onboarding defaults `CHAT_UI_URL` to `https://localhost` with a generated local certificate.
-
-Regression contracts: `test/generate-openclaw-config-security-audit.test.ts` locks generated suppression scope, `test/openclaw-security-audit-suppressions-real.test.ts` locks the pinned OpenClaw check IDs and details, and `test/e2e/live/dashboard-remote-bind.test.ts` proves a clean-host remote bind leaves all three risky findings active.
-
-The preceding removal condition applies to all three contracts.
-
 ## Auto-Pair Client Allowlist
 
 The auto-pair watcher automatically approves device pairing requests from recognized clients, so you do not need to manually approve the Control UI.

--- a/docs/security/openclaw-2026.7.1-dependency-review.md
+++ b/docs/security/openclaw-2026.7.1-dependency-review.md
@@ -5,7 +5,7 @@
 
 Review date: 2026-07-21
 
-Last updated: 2026-08-07
+Last updated: 2026-08-11
 
 ## Decision
 
@@ -637,6 +637,23 @@ Regression coverage lives in `test/openclaw-2026-7-startup-compat.test.ts` and
 Remove the legacy cache repair after every supported upgrade source stops
 seeding the file or OpenClaw can migrate it across split users and a protected
 parent without a warning.
+
+## Gateway Security Audit Suppression Boundary
+
+NemoClaw's generated OpenClaw audit configuration keeps intentional loopback
+`allowInsecureAuth` findings and provenance-known loopback device-auth opt-out
+findings visible as accepted findings.
+`test/generate-openclaw-config-security-audit.test.ts` locks the generated
+suppression scope, and `test/openclaw-security-audit-suppressions-real.test.ts`
+locks the pinned OpenClaw check IDs and details.
+`test/e2e/live/dashboard-remote-bind.test.ts` proves that a clean-host remote
+bind leaves the device-auth, insecure-auth, and Host-header fallback findings
+active.
+
+Remove these suppressions only after the pinned OpenClaw audit contract proves
+that OpenClaw natively classifies intentional loopback development HTTP without
+them, or after NemoClaw onboarding defaults `CHAT_UI_URL` to
+`https://localhost` with a generated local certificate.
 
 ## Existing security and runtime contracts
 

--- a/docs/security/openclaw-2026.7.1-dependency-review.md
+++ b/docs/security/openclaw-2026.7.1-dependency-review.md
@@ -650,10 +650,12 @@ locks the pinned OpenClaw check IDs and details.
 bind leaves the device-auth, insecure-auth, and Host-header fallback findings
 active.
 
-Remove these suppressions only after the pinned OpenClaw audit contract proves
-that OpenClaw natively classifies intentional loopback development HTTP without
-them, or after NemoClaw onboarding defaults `CHAT_UI_URL` to
-`https://localhost` with a generated local certificate.
+Remove the `allowInsecureAuth` suppressions only after the pinned OpenClaw audit
+contract proves that OpenClaw natively classifies intentional loopback
+development HTTP without them, or after NemoClaw onboarding defaults
+`CHAT_UI_URL` to `https://localhost` with a generated local certificate.
+Remove the device-auth suppressions only after managed onboarding no longer
+applies the loopback device-auth compatibility opt-out.
 
 ## Existing security and runtime contracts
 

--- a/docs/security/process-controls.mdx
+++ b/docs/security/process-controls.mdx
@@ -286,15 +286,15 @@ The Dockerfile removes compilers and network probes from the runtime image.
 
 ## Image Digest Pinning
 
-The blueprint references the sandbox image by an immutable `@sha256:` digest instead of a mutable tag such as `:latest`.
-A registry compromise or accidental force-push cannot silently swap the sandbox image.
+The managed blueprint references the sandbox image by an immutable `@sha256:` digest instead of a mutable tag such as `:latest`.
+A registry-side tag change cannot silently select another managed sandbox image.
 
 | Aspect | Detail |
 |---|---|
-| Default | `nemoclaw-blueprint/blueprint.yaml` pins the sandbox image by digest. A CI regression test blocks any mutable-tag reference from merging. |
-| What you can change | Contributors bumping the sandbox image must update the digest in `blueprint.yaml`. Release tooling should rewrite the digest automatically. |
+| Default | NemoClaw selects the managed sandbox image by its exact digest. |
+| What you can change | Use the onboarding `--from` path when you need to build from a reviewed custom image. Locally built custom images do not use the managed registry digest. |
 | Risk if relaxed | Reverting to a mutable tag (`:latest`) allows a registry-side change to replace the sandbox image without any blueprint update, which is a supply-chain risk. |
-| Recommendation | Always reference the sandbox image by digest. If you build a custom image with the onboarding `--from` path, the digest constraint does not apply to your local build. |
+| Recommendation | Keep the managed digest-pinned image unless you need a reviewed custom image. Pin the custom image's base and dependencies before you build it. |
 
 <AgentOnly variant="openclaw">
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Completes the v0.0.106 changelog for four user-visible changes that merged before the tag but were omitted from the pre-tag entry. Keeps public security pages focused on operator guidance by relocating maintenance contracts to contributor guidance and the owning OpenClaw dependency review. Records PR #8753's portable inference descriptor as Experimental while leaving its existing workflow documentation unchanged.

## Changes

- Add managed-container restart-transition recovery from PR #8765, Shields parent-owner preservation from PR #8767, and managed storage remediation plus NVIDIA driver parsing from PR #8768 to the canonical v0.0.106 entry.
- Add the Experimental portable inference descriptor from PR #8753 to the v0.0.106 entry, including its short-lived credential boundary, manual standby behavior, and owning setup page.
- Keep Process Controls focused on the operator-facing immutable-image boundary and move the blueprint image-pin maintenance contract to `CONTRIBUTING.md`.
- Keep Gateway and Secret Controls focused on operator actions and move the OpenClaw audit-suppression tests and distinct removal conditions to the owning OpenClaw 2026.7.1 dependency review.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the dated-changelog, published-route, and documentation-link tests cover the changed release entry and links.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: an independent Codex Desktop documentation writer reviewed exact head `bbfed36ca`; the review verified the operator-facing security claims, the distinct `allowInsecureAuth` and device-auth suppression removal conditions against their generator branches, and the confirmed Experimental #8753 release claim. No runtime or policy behavior changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `CONTRIBUTING.md`, `docs/changelog/2026-08-10.mdx`, `docs/security/gateway-authentication-controls.mdx`, `docs/security/openclaw-2026.7.1-dependency-review.md`, and `docs/security/process-controls.mdx`; the subagent reviewed `docs/CONTRIBUTING.md`, `WRITING.md`, terminology, structure, voice, code-sample presentation, canonical ownership, factual accuracy, and product scope.
- Agent: Codex Desktop
<!-- docs-review-head-sha: bbfed36ca -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts test/check-docs-published-routes.test.ts test/check-docs-links.test.ts` passed; `npm run docs` and `git diff --check` passed again after the review correction.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to this bounded documentation-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — result: passed with zero errors and the existing light-mode accent contrast warning.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new pages.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented requirements for keeping managed sandbox image digest pins synchronized and immutable.
  - Added guidance for validating custom images and using reviewed image sources during onboarding.
  - Expanded release notes with portable inference profiles, endpoint references, cleanup behavior, startup handling, and installer details.
  - Updated security documentation with current dependency-review information and authentication-control boundaries.
  - Clarified sandbox ownership, permissions, workload identity, and managed-container restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->