### PR TITLE
ci(e2e): update Brev CLI to 0.6.334

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -707,8 +707,8 @@ jobs:
         name: Prepare the trusted lane
         env:
           BREV_API_KEY: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.BREV_API_KEY || '' }}
-          BREV_CLI_SHA256: 5a6e70374db9be33f85f299161733b4a8409840d47638c781429b96e8d53704f
-          BREV_CLI_VERSION: 0.6.330
+          BREV_CLI_SHA256: d4aa49db1716f10308a6587778a676a0c0076bd48a212d86a421ab9550bc8f32
+          BREV_CLI_VERSION: 0.6.334
           BREV_ORG_ID: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.BREV_ORG_ID || '' }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

This PR updates the Brev CLI used by `Exact staging Brev Launchable` from 0.6.330 to 0.6.334. Version 0.6.334 includes the base-image forwarding fix required for a Launchable to create a workspace from its configured image family.

## Changes

- Pin the Linux amd64 Brev CLI archive to version 0.6.334.
- Replace the archive SHA-256 with the digest from the published checksum manifest and verified download.
- Preserve the existing fixed-version and checksum verification controls.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The Launchable E2E compares the booted image URI with the producer handoff. The focused workflow contract protects the lane selection and trust boundaries.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change updates an internal E2E dependency pin and does not change a user-facing command, default, configuration, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The dependency audit verified the published tag, required fix ancestry, archive digest, unchanged credential guards, unchanged authorization, failure propagation, and workspace cleanup boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `.github/workflows/e2e.yaml` changes only the Brev CLI version and verified archive digest. No documentation pins this version.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4d2b72a52 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec -- vitest run --project e2e-support test/e2e/support/e2e-workflow.test.ts` passed 45 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the staging end-to-end testing environment to use a newer Brev CLI version.
  * Refreshed the CLI integrity checksum for improved verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->