### PR TITLE
test(e2e): distinguish managed image rollback backup

### DIFF
--- a/scripts/checks/run-managed-image-openshell-e2e.ts
+++ b/scripts/checks/run-managed-image-openshell-e2e.ts
@@ -271,7 +271,24 @@ export function managedImageOpenShellBasePolicyPath(agent: ManagedStartupAgent):
   );
 }
 
-function commandResult(argv: readonly string[], env: NodeJS.ProcessEnv, timeout = 20_000) {
+export interface ManagedImageCommandResult {
+  readonly error?: Error;
+  readonly status: number | null;
+  readonly stdout: string | null;
+  readonly stderr: string | null;
+}
+
+export type ManagedImageCommandRunner = (
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv,
+  timeout?: number,
+) => ManagedImageCommandResult;
+
+function commandResult(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv,
+  timeout = 20_000,
+): ManagedImageCommandResult {
   const [command, ...args] = argv;
   if (!command) throw new Error("command argv must not be empty");
   return spawnSync(command, args, {
@@ -283,13 +300,13 @@ function commandResult(argv: readonly string[], env: NodeJS.ProcessEnv, timeout 
   });
 }
 
-function commandDetail(result: ReturnType<typeof commandResult>): string {
+function commandDetail(result: ManagedImageCommandResult): string {
   return `${result.error?.message ?? ""}\n${result.stdout ?? ""}\n${result.stderr ?? ""}`
     .trim()
     .slice(-8_000);
 }
 
-function isDockerNotFound(result: ReturnType<typeof commandResult>): boolean {
+function isDockerNotFound(result: ManagedImageCommandResult): boolean {
   return (
     result.status !== 0 &&
     /(?:no such (?:container|network|object)|not found)/iu.test(commandDetail(result))
@@ -390,25 +407,65 @@ export function managedImageOpenShellProbe(
       : agent === "hermes"
         ? "/usr/bin/curl -fsS --max-time 5 http://127.0.0.1:8642/health >/dev/null"
         : "/usr/local/bin/dcode --version >/dev/null";
+  const readinessLabel =
+    agent === "openclaw"
+      ? "OpenClaw health endpoint"
+      : agent === "hermes"
+        ? "Hermes health endpoint"
+        : "LangChain Deep Agents Code version command";
+  const probeStep = (label: string, command: string) =>
+    `if ! ${command}; then\n  printf '%s\\n' ${JSON.stringify(
+      `managed-image startup probe failed: ${label}`,
+    )} >&2\n  exit 1\nfi`;
   return [
-    "set -eu",
-    `test -x ${
-      agent === "openclaw"
-        ? "/usr/local/bin/openclaw"
-        : agent === "hermes"
-          ? "/usr/local/bin/hermes"
-          : "/usr/local/bin/dcode"
-    }`,
-    `grep -F ${JSON.stringify(model)} ${JSON.stringify(managedConfigPath(agent))} >/dev/null`,
-    "test ! -L /run/nemoclaw/managed-startup-runtime.env",
-    'test "$(stat -c "%u:%g:%a" /run/nemoclaw/managed-startup-runtime.env)" = "0:0:444"',
-    "test ! -L /run/nemoclaw/managed-startup-complete.json",
-    'test "$(stat -c "%u:%g:%a" /run/nemoclaw/managed-startup-complete.json)" = "0:0:444"',
-    "test -s /usr/local/share/nemoclaw/corporate-ca.pem",
-    'test "$(stat -c "%u:%g:%a" /usr/local/share/nemoclaw/corporate-ca.pem)" = "0:0:444"',
-    "test -s /run/nemoclaw/managed-startup-ca-bundle.pem",
-    'test "$(stat -c "%u:%g:%a" /run/nemoclaw/managed-startup-ca-bundle.pem)" = "0:0:444"',
-    healthProbe,
+    "set -u",
+    probeStep(
+      `${agent} executable`,
+      `test -x ${
+        agent === "openclaw"
+          ? "/usr/local/bin/openclaw"
+          : agent === "hermes"
+            ? "/usr/local/bin/hermes"
+            : "/usr/local/bin/dcode"
+      }`,
+    ),
+    probeStep(
+      `${agent} managed model configuration`,
+      `grep -F ${JSON.stringify(model)} ${JSON.stringify(managedConfigPath(agent))} >/dev/null`,
+    ),
+    probeStep(
+      "managed runtime environment must not be a symbolic link",
+      "test ! -L /run/nemoclaw/managed-startup-runtime.env",
+    ),
+    probeStep(
+      "managed runtime environment owner, group, and mode must equal 0:0:444",
+      'test "$(stat -c "%u:%g:%a" /run/nemoclaw/managed-startup-runtime.env)" = "0:0:444"',
+    ),
+    probeStep(
+      "managed startup completion must not be a symbolic link",
+      "test ! -L /run/nemoclaw/managed-startup-complete.json",
+    ),
+    probeStep(
+      "managed startup completion owner, group, and mode must equal 0:0:444",
+      'test "$(stat -c "%u:%g:%a" /run/nemoclaw/managed-startup-complete.json)" = "0:0:444"',
+    ),
+    probeStep(
+      "corporate CA file must exist and be nonempty",
+      "test -s /usr/local/share/nemoclaw/corporate-ca.pem",
+    ),
+    probeStep(
+      "corporate CA owner, group, and mode must equal 0:0:444",
+      'test "$(stat -c "%u:%g:%a" /usr/local/share/nemoclaw/corporate-ca.pem)" = "0:0:444"',
+    ),
+    probeStep(
+      "managed startup CA bundle must exist and be nonempty",
+      "test -s /run/nemoclaw/managed-startup-ca-bundle.pem",
+    ),
+    probeStep(
+      "managed startup CA bundle owner, group, and mode must equal 0:0:444",
+      'test "$(stat -c "%u:%g:%a" /run/nemoclaw/managed-startup-ca-bundle.pem)" = "0:0:444"',
+    ),
+    probeStep(readinessLabel, healthProbe),
   ].join("\n");
 }
 
@@ -631,8 +688,12 @@ function parseImmutableManifestReference(image: string): {
   };
 }
 
-function resolveLocalImageContentId(image: string, env: NodeJS.ProcessEnv): string {
-  const inspect = commandResult(["docker", "image", "inspect", "--format", "{{.Id}}", image], env);
+function resolveLocalImageContentId(
+  image: string,
+  env: NodeJS.ProcessEnv,
+  runCommand: ManagedImageCommandRunner = commandResult,
+): string {
+  const inspect = runCommand(["docker", "image", "inspect", "--format", "{{.Id}}", image], env);
   const contentId = String(inspect.stdout ?? "").trim();
   if (inspect.status !== 0 || !/^sha256:[a-f0-9]{64}$/u.test(contentId)) {
     throw new Error(
@@ -642,25 +703,31 @@ function resolveLocalImageContentId(image: string, env: NodeJS.ProcessEnv): stri
   return contentId;
 }
 
+export function managedImageHarnessContainerListArgs(
+  sandbox: string,
+  includeStopped: boolean,
+): string[] {
+  return [
+    "docker",
+    "ps",
+    includeStopped ? "-aq" : "-q",
+    "--no-trunc",
+    "--filter",
+    "label=openshell.ai/managed-by=openshell",
+    "--filter",
+    `label=openshell.ai/sandbox-name=${sandbox}`,
+  ];
+}
+
 function exactHarnessContainerIds(
   input: Inputs,
   networkName: string,
   env: NodeJS.ProcessEnv,
+  includeStopped = true,
+  runCommand: ManagedImageCommandRunner = commandResult,
 ): { candidateCount: number; exactIds: string[] } {
-  const expectedContentId = resolveLocalImageContentId(input.image, env);
-  const list = commandResult(
-    [
-      "docker",
-      "ps",
-      "-aq",
-      "--no-trunc",
-      "--filter",
-      "label=openshell.ai/managed-by=openshell",
-      "--filter",
-      `label=openshell.ai/sandbox-name=${input.sandbox}`,
-    ],
-    env,
-  );
+  const expectedContentId = resolveLocalImageContentId(input.image, env, runCommand);
+  const list = runCommand(managedImageHarnessContainerListArgs(input.sandbox, includeStopped), env);
   if (list.status !== 0) {
     throw new Error(`could not resolve the OpenShell sandbox container: ${commandDetail(list)}`);
   }
@@ -670,7 +737,7 @@ function exactHarnessContainerIds(
     .filter(Boolean);
   const exactIds: string[] = [];
   for (const candidate of candidates) {
-    const inspect = commandResult(["docker", "inspect", candidate], env);
+    const inspect = runCommand(["docker", "inspect", candidate], env);
     if (inspect.status !== 0) continue;
     try {
       const records = JSON.parse(String(inspect.stdout ?? "")) as Array<{
@@ -694,18 +761,36 @@ function exactHarnessContainerIds(
   return { candidateCount: candidates.length, exactIds };
 }
 
-function assertExactSandboxImage(
+export function assertExactSandboxImage(
   input: Inputs,
   networkName: string,
   env: NodeJS.ProcessEnv,
+  runCommand: ManagedImageCommandRunner = commandResult,
 ): string {
-  const resolved = exactHarnessContainerIds(input, networkName, env);
+  // A managed-bootstrap transaction keeps its stopped rollback backup until
+  // commit. Qualify the one running replacement here; rollback cleanup below
+  // continues to inspect every stopped and running container.
+  const resolved = exactHarnessContainerIds(input, networkName, env, false, runCommand);
   if (resolved.candidateCount !== 1 || resolved.exactIds.length !== 1) {
     throw new Error(
-      `OpenShell did not launch exactly one harness-owned PR image container: found ${resolved.candidateCount} labeled and ${resolved.exactIds.length} exact`,
+      `OpenShell did not launch exactly one running harness-owned PR image container: found ${resolved.candidateCount} running labeled and ${resolved.exactIds.length} running exact`,
     );
   }
   return resolved.exactIds[0] ?? "";
+}
+
+export function assertFailedBootstrapContainerCleanup(
+  input: Inputs,
+  networkName: string,
+  env: NodeJS.ProcessEnv,
+  runCommand: ManagedImageCommandRunner = commandResult,
+): void {
+  const resolved = exactHarnessContainerIds(input, networkName, env, true, runCommand);
+  if (resolved.candidateCount !== 0 || resolved.exactIds.length !== 0) {
+    throw new Error(
+      `managed-bootstrap rollback retained a failed held sandbox: found ${resolved.candidateCount} labeled and ${resolved.exactIds.length} exact containers`,
+    );
+  }
 }
 
 function assertFailedSandboxAbsent(
@@ -928,12 +1013,7 @@ async function run<T extends ManagedImageOpenShellE2eLocalInferenceEvidence = ne
         error instanceof Error &&
         error.message.includes("protected-e2e-injected-bootstrap-completion-failure")
       ) {
-        const resolved = exactHarnessContainerIds(input, networkName, launch.sandboxEnv);
-        if (resolved.candidateCount !== 0 || resolved.exactIds.length !== 0) {
-          throw new Error(
-            `managed-bootstrap rollback retained a failed held sandbox: found ${resolved.candidateCount} labeled and ${resolved.exactIds.length} exact containers`,
-          );
-        }
+        assertFailedBootstrapContainerCleanup(input, networkName, launch.sandboxEnv);
         assertFailedSandboxAbsent(onboard, input, launch.sandboxEnv);
         failureInjectionQualified = true;
         process.stdout.write(

--- a/test/managed-image-protected-runtime-contract.test.ts
+++ b/test/managed-image-protected-runtime-contract.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -17,6 +18,8 @@ import {
   withManagedImageLocalInferenceProfile,
 } from "../scripts/checks/managed-image-protected-runtime-contract.ts";
 import {
+  assertExactSandboxImage,
+  assertFailedBootstrapContainerCleanup,
   createProtectedManagedImageBootstrapInput,
   MANAGED_IMAGE_OPENSHELL_SUPERVISOR_ARGV,
   managedImageLocalInferenceBaseUrl,
@@ -125,6 +128,52 @@ describe("protected managed-image runtime contract", () => {
       removeManagedImageGatewayStateIfSafe(stateDir, { failed: [], ownershipFailures: [] }, 0),
     ).toBe(true);
     expect(fs.existsSync(stateDir)).toBe(false);
+  });
+
+  it("qualifies only the running exact image and retains stopped rollback cleanup evidence (#7744)", () => {
+    const calls: string[][] = [];
+    const contentId = `sha256:${"b".repeat(64)}`;
+    const containerId = "c".repeat(64);
+    const input = parseManagedImageOpenShellE2eInputs([
+      "--agent",
+      "openclaw",
+      "--image",
+      IMAGE,
+      "--sandbox",
+      VALID_SANDBOX,
+    ]);
+    const runCommand = (argv: readonly string[]) => {
+      calls.push([...argv]);
+      if (argv[1] === "image") return { status: 0, stdout: `${contentId}\n`, stderr: "" };
+      if (argv[1] === "ps") {
+        return {
+          status: 0,
+          stdout: argv[2] === "-q" ? `${containerId}\n` : "",
+          stderr: "",
+        };
+      }
+      return {
+        status: 0,
+        stdout: `${JSON.stringify([
+          {
+            Config: {
+              Labels: {
+                "openshell.ai/managed-by": "openshell",
+                "openshell.ai/sandbox-name": VALID_SANDBOX,
+              },
+            },
+            Image: contentId,
+            NetworkSettings: { Networks: { "managed-network": {} } },
+          },
+        ])}\n`,
+        stderr: "",
+      };
+    };
+
+    expect(assertExactSandboxImage(input, "managed-network", {}, runCommand)).toBe(containerId);
+    assertFailedBootstrapContainerCleanup(input, "managed-network", {}, runCommand);
+
+    expect(calls.filter((argv) => argv[1] === "ps").map((argv) => argv[2])).toEqual(["-q", "-aq"]);
   });
 
   it("assigns every protected agent and route a unique OpenShell-compatible sandbox name (#8497)", () => {
@@ -254,7 +303,22 @@ describe("protected managed-image runtime contract", () => {
       sandbox: managedImageProtectedSandboxName(agent, "nim"),
     });
     expect(path.isAbsolute(managedImageOpenShellBasePolicyPath(agent))).toBe(true);
-    expect(managedImageOpenShellProbe(agent)).toContain("managed-startup-complete.json");
+    const probe = managedImageOpenShellProbe(agent);
+    const syntax = spawnSync("/bin/sh", ["-n", "-c", probe], { encoding: "utf8" });
+    expect(syntax.status, syntax.stderr).toBe(0);
+    expect(probe).toContain("managed-startup-complete.json");
+    expect(probe).toContain(
+      `managed-image startup probe failed: ${
+        agent === "openclaw"
+          ? "OpenClaw health endpoint"
+          : agent === "hermes"
+            ? "Hermes health endpoint"
+            : "LangChain Deep Agents Code version command"
+      }`,
+    );
+    expect(probe).toContain(
+      "managed-image startup probe failed: managed startup completion owner, group, and mode must equal 0:0:444",
+    );
   });
 
   it("rewrites only the inference route while preserving the managed agent profile", () => {

--- a/test/managed-image-protected-runtime-contract.test.ts
+++ b/test/managed-image-protected-runtime-contract.test.ts
@@ -22,6 +22,8 @@ import {
   assertFailedBootstrapContainerCleanup,
   createProtectedManagedImageBootstrapInput,
   MANAGED_IMAGE_OPENSHELL_SUPERVISOR_ARGV,
+  type ManagedImageCommandResult,
+  type ManagedImageCommandRunner,
   managedImageLocalInferenceBaseUrl,
   managedImageOpenShellBasePolicyPath,
   managedImageOpenShellCommittedProbe,
@@ -34,6 +36,49 @@ import { resolveOnboardManagedBootstrapLaunch } from "../src/lib/onboard/managed
 
 const IMAGE = `localhost:5000/nemoclaw-managed-protected/openclaw@sha256:${"a".repeat(64)}`;
 const VALID_SANDBOX = "managed-openclaw";
+
+const SUCCESS_WITHOUT_OUTPUT: ManagedImageCommandResult = {
+  status: 0,
+  stdout: "",
+  stderr: "",
+};
+
+function managedContainerInspectResult(contentId: string): ManagedImageCommandResult {
+  return {
+    status: 0,
+    stdout: `${JSON.stringify([
+      {
+        Config: {
+          Labels: {
+            "openshell.ai/managed-by": "openshell",
+            "openshell.ai/sandbox-name": VALID_SANDBOX,
+          },
+        },
+        Image: contentId,
+        NetworkSettings: { Networks: { "managed-network": {} } },
+      },
+    ])}\n`,
+    stderr: "",
+  };
+}
+
+function createManagedImageCommandRunner(
+  contentId: string,
+  containerId: string,
+  listScope: "-q" | "-aq",
+  listOutput: string,
+  calls: string[][],
+): ManagedImageCommandRunner {
+  const responses = new Map<string, ManagedImageCommandResult>([
+    ["docker image inspect", { status: 0, stdout: `${contentId}\n`, stderr: "" }],
+    [`docker ps ${listScope}`, { status: 0, stdout: listOutput, stderr: "" }],
+    [`docker inspect ${containerId}`, managedContainerInspectResult(contentId)],
+  ]);
+  return (argv) => {
+    calls.push([...argv]);
+    return responses.get(argv.slice(0, 3).join(" ")) ?? SUCCESS_WITHOUT_OUTPUT;
+  };
+}
 
 describe("protected managed-image runtime contract", () => {
   it("binds the public and protected managed-image plans to one supervisor argv (#7744)", () => {
@@ -130,7 +175,7 @@ describe("protected managed-image runtime contract", () => {
     expect(fs.existsSync(stateDir)).toBe(false);
   });
 
-  it("qualifies only the running exact image and retains stopped rollback cleanup evidence (#7744)", () => {
+  it("qualifies the running exact image before rollback cleanup (#7744)", () => {
     const calls: string[][] = [];
     const contentId = `sha256:${"b".repeat(64)}`;
     const containerId = "c".repeat(64);
@@ -142,38 +187,51 @@ describe("protected managed-image runtime contract", () => {
       "--sandbox",
       VALID_SANDBOX,
     ]);
-    const runCommand = (argv: readonly string[]) => {
-      calls.push([...argv]);
-      if (argv[1] === "image") return { status: 0, stdout: `${contentId}\n`, stderr: "" };
-      if (argv[1] === "ps") {
-        return {
-          status: 0,
-          stdout: argv[2] === "-q" ? `${containerId}\n` : "",
-          stderr: "",
-        };
-      }
-      return {
-        status: 0,
-        stdout: `${JSON.stringify([
-          {
-            Config: {
-              Labels: {
-                "openshell.ai/managed-by": "openshell",
-                "openshell.ai/sandbox-name": VALID_SANDBOX,
-              },
-            },
-            Image: contentId,
-            NetworkSettings: { Networks: { "managed-network": {} } },
-          },
-        ])}\n`,
-        stderr: "",
-      };
-    };
+    const runningCommand = createManagedImageCommandRunner(
+      contentId,
+      containerId,
+      "-q",
+      `${containerId}\n`,
+      calls,
+    );
+    const cleanedCommand = createManagedImageCommandRunner(
+      contentId,
+      containerId,
+      "-aq",
+      "",
+      calls,
+    );
 
-    expect(assertExactSandboxImage(input, "managed-network", {}, runCommand)).toBe(containerId);
-    assertFailedBootstrapContainerCleanup(input, "managed-network", {}, runCommand);
+    expect(assertExactSandboxImage(input, "managed-network", {}, runningCommand)).toBe(containerId);
+    assertFailedBootstrapContainerCleanup(input, "managed-network", {}, cleanedCommand);
 
     expect(calls.filter((argv) => argv[1] === "ps").map((argv) => argv[2])).toEqual(["-q", "-aq"]);
+  });
+
+  it("rejects a stopped labeled container after failed bootstrap cleanup (#7744)", () => {
+    const contentId = `sha256:${"b".repeat(64)}`;
+    const containerId = "c".repeat(64);
+    const input = parseManagedImageOpenShellE2eInputs([
+      "--agent",
+      "openclaw",
+      "--image",
+      IMAGE,
+      "--sandbox",
+      VALID_SANDBOX,
+    ]);
+    const runCommand = createManagedImageCommandRunner(
+      contentId,
+      containerId,
+      "-aq",
+      `${containerId}\n`,
+      [],
+    );
+
+    expect(() =>
+      assertFailedBootstrapContainerCleanup(input, "managed-network", {}, runCommand),
+    ).toThrow(
+      "managed-bootstrap rollback retained a failed held sandbox: found 1 labeled and 1 exact containers",
+    );
   });
 
   it("assigns every protected agent and route a unique OpenShell-compatible sandbox name (#8497)", () => {


### PR DESCRIPTION
## Summary

The protected managed-image main E2E counted the stopped managed-bootstrap rollback backup as a second active PR-image container. This change qualifies exactly one running replacement while preserving all-container rollback cleanup, and replaces empty startup-probe failures with the exact failed condition.

## Changes

- Use running-only Docker discovery when qualifying the active exact-image replacement.
- Continue including stopped containers when proving failed-bootstrap rollback cleanup.
- Model active qualification and post-rollback cleanup as distinct lifecycle states, including rejection of a retained stopped container.
- Report the exact managed-startup predicate that has not passed, including agent-specific health or version checks.
- Exercise the consuming qualification and cleanup paths with an injected command runner and validate every generated agent probe with the system shell parser.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes protected live E2E qualification and failure evidence only; production and public behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Running-only selection is limited to active qualification. Failed-bootstrap cleanup still lists every stopped and running labeled container and refuses retained state.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed both files in the complete PR diff. The change improves protected live E2E qualification, cleanup evidence, and diagnostics without changing production code, a public command, configuration, workflow, or supported behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 136ad516e -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/managed-image-protected-runtime-contract.test.ts` passed 32/32; `npm run typecheck:cli` passed; `npm run test-conditionals:scan -- --top 25` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Linux PR CI is the authoritative broad gate for this protected E2E-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Failure evidence

- [main E2E run 31524967895, duplicate-container assertion](https://github.com/NVIDIA/NemoClaw/actions/runs/31524967895/job/93906851093)
- [main E2E run 31532408138, startup-probe timeout without a condition diagnostic](https://github.com/NVIDIA/NemoClaw/actions/runs/31532408138/job/93924933438)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed image validation with clearer, specific startup failure messages.
  - Added checks for executable availability, configuration, filesystem links, ownership and permissions, certificates, and readiness.
  - Strengthened container image matching and rollback cleanup verification.

- **Tests**
  - Expanded protected runtime coverage for running and stopped containers.
  - Added validation for image, label, and network matching.
  - Added checks for shell probe failures and completion-file permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
