### PR TITLE
docs: add v0.0.107 changelog

### DIFF
--- a/docs/changelog/2026-08-11.mdx
+++ b/docs/changelog/2026-08-11.mdx
@@ -1,0 +1,53 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.107
+
+NemoClaw v0.0.107 adds an Experimental NVIDIA Nemotron 3.5 Lightning profile for one DGX Spark and awaitable Slack readiness for automation.
+It improves cold-start onboarding, dashboard forwarding, Windows-host Ollama, Hermes operations, sandbox recovery, and CLI inventory output.
+It also strengthens Hermes Shields state changes and removes sensitive values from more diagnostics.
+
+- An explicit-only Experimental managed vLLM profile now runs NVIDIA Nemotron 3.5 Lightning 30B-A3B NVFP4 on one DGX Spark.
+  The profile pins the validated public checkpoint, ARM64 runtime image, parsers, resource settings, and structured serving arguments while the Qwen profile remains the automatic Spark Express default.
+  Managed single-host vLLM setup also stops before credentials, storage, downloads, or container changes when another process owns the serving port.
+  For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm).
+  Related changes: [PR #8810](https://github.com/NVIDIA/NemoClaw/pull/8810), [PR #8813](https://github.com/NVIDIA/NemoClaw/pull/8813), and [PR #8699](https://github.com/NVIDIA/NemoClaw/pull/8699).
+- Cold Model Router onboarding now allows a running prefill router up to 10 minutes to download and load its routing model.
+  The startup check stops sooner if the router process exits and terminates a router that does not become healthy before the deadline.
+  For more information, refer to [Set Up Model Router](/user-guide/openclaw/inference/hosted-inference/set-up-model-router).
+  Related change: [PR #8825](https://github.com/NVIDIA/NemoClaw/pull/8825).
+- OpenClaw and Hermes onboarding now retry the exact completed OpenShell `sandbox is not ready` forwarding failure after 5 seconds, within the existing three-retry bound.
+  The retry preserves the sandbox and selected port, while authentication, gateway, port-ownership, and unrelated failures remain terminal.
+  For more information, refer to the [OpenClaw Quickstart](/user-guide/openclaw/get-started/quickstart) and [Hermes Quickstart](/user-guide/hermes/get-started/quickstart).
+  Related changes: [PR #8826](https://github.com/NVIDIA/NemoClaw/pull/8826) and [PR #8828](https://github.com/NVIDIA/NemoClaw/pull/8828).
+- On WSL with Docker Desktop, onboarding now reuses a reachable Windows-host Ollama daemon without applying an unrelated Linux systemd override.
+  The local Linux Ollama path retains its existing override behavior.
+  For more information, refer to [Use Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama) and [Additional Setup for Windows Machines](/user-guide/openclaw/get-started/additional-setup/windows-preparation).
+  Related change: [PR #8634](https://github.com/NVIDIA/NemoClaw/pull/8634).
+- `nemoclaw <sandbox> channels status --channel slack --wait` now waits for OpenClaw Slack registration, effective policy coverage, runtime, Socket Mode, and account readiness.
+  Structured output distinguishes ready, waiting, terminal, paused, unsupported, and timeout results without returning tokens or free-text probe errors.
+  For more information, refer to [Set Up Slack](/user-guide/openclaw/manage-sandboxes/messaging-channels/set-up-slack) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+  Related change: [PR #8566](https://github.com/NVIDIA/NemoClaw/pull/8566).
+- Hermes dashboard pairing and the Hermes gateway now share the durable WhatsApp session path.
+  Sandboxes with credentials in a legacy dashboard path receive cleanup and re-pairing guidance, and Hermes skill installs, updates, and removals now direct users to start a new chat session instead of restarting the gateway.
+  For more information, refer to [Set Up WhatsApp](/user-guide/hermes/manage-sandboxes/messaging-channels/set-up-whatsapp) and the [Hermes CLI Commands Reference](/user-guide/hermes/reference/commands).
+  Related changes: [PR #8229](https://github.com/NVIDIA/NemoClaw/pull/8229) and [PR #8535](https://github.com/NVIDIA/NemoClaw/pull/8535).
+- Managed Hermes Docker images now use durable, provider-bound state mutation for Shields transitions.
+  NemoClaw validates the exact request and receipt, holds gateway startup behind the current fence, preserves rollback and recovery across controller restarts, and keeps older images on the existing compatibility path.
+  For more information, refer to [Understand Runtime Changes](/user-guide/hermes/manage-sandboxes/configure-sandboxes/understand-runtime-changes), [Troubleshooting](/user-guide/hermes/reference/troubleshooting), and [Trusted Computing Base](/user-guide/hermes/security/trusted-computing-base).
+  Related change: [PR #8658](https://github.com/NVIDIA/NemoClaw/pull/8658).
+- Rebuild and recovery now reuse a gateway-managed web-search credential only with exact sandbox, provider, and recreate-journal ownership evidence.
+  Legacy supervisor recovery retries temporary state-backup transport failures after restart, cleans incomplete backups before retrying, and keeps integrity or cleanup failures terminal.
+  Failed OpenShell forward-list queries also remain distinct from an empty list, so cleanup does not stop a forward when it cannot establish ownership.
+  For more information, refer to [Credential Storage](/user-guide/openclaw/security/credential-storage), [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
+  Related changes: [PR #8774](https://github.com/NVIDIA/NemoClaw/pull/8774), [PR #8787](https://github.com/NVIDIA/NemoClaw/pull/8787), and [PR #8529](https://github.com/NVIDIA/NemoClaw/pull/8529).
+- `nemoclaw list --json` and global `nemoclaw status --json` now report `openclaw` for a registry entry without an explicit agent, matching the text and sandbox-scoped status surfaces.
+  The commands reference also uses the configured `main` OpenClaw agent in agent and session examples instead of the nonexistent `work` agent.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+  Related changes: [PR #8710](https://github.com/NVIDIA/NemoClaw/pull/8710) and [PR #8817](https://github.com/NVIDIA/NemoClaw/pull/8817).
+- A malformed MCP server URL diagnostic no longer echoes the rejected value, which can contain embedded credentials.
+  Managed-image discovery diagnostics now redact every nonempty named token or password value, including values shorter than 10 characters.
+  For more information, refer to [Add an MCP Server](/user-guide/openclaw/manage-sandboxes/mcp-servers/add-an-mcp-server), [Troubleshoot MCP Servers](/user-guide/openclaw/reference/troubleshoot-mcp-servers), and [Security Best Practices](/user-guide/openclaw/security/best-practices).
+  Related changes: [PR #8707](https://github.com/NVIDIA/NemoClaw/pull/8707) and [PR #8744](https://github.com/NVIDIA/NemoClaw/pull/8744).

--- a/docs/changelog/2026-08-11.mdx
+++ b/docs/changelog/2026-08-11.mdx
@@ -22,7 +22,7 @@ It also strengthens Hermes Shields state changes and removes sensitive values fr
   The retry preserves the sandbox and selected port, while authentication, gateway, port-ownership, and unrelated failures remain terminal.
   For more information, refer to the [OpenClaw Quickstart](/user-guide/openclaw/get-started/quickstart) and [Hermes Quickstart](/user-guide/hermes/get-started/quickstart).
   Related changes: [PR #8826](https://github.com/NVIDIA/NemoClaw/pull/8826) and [PR #8828](https://github.com/NVIDIA/NemoClaw/pull/8828).
-- On WSL with Docker Desktop, onboarding now reuses a reachable Windows-host Ollama daemon without applying an unrelated Linux systemd override.
+- On WSL 2 with Docker Desktop, onboarding now reuses a reachable Windows-host Ollama daemon without applying an unrelated Linux systemd override.
   The local Linux Ollama path retains its existing override behavior.
   For more information, refer to [Use Ollama](/user-guide/openclaw/inference/local-inference/set-up-ollama) and [Additional Setup for Windows Machines](/user-guide/openclaw/get-started/additional-setup/windows-preparation).
   Related change: [PR #8634](https://github.com/NVIDIA/NemoClaw/pull/8634).
@@ -31,20 +31,22 @@ It also strengthens Hermes Shields state changes and removes sensitive values fr
   For more information, refer to [Set Up Slack](/user-guide/openclaw/manage-sandboxes/messaging-channels/set-up-slack) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
   Related change: [PR #8566](https://github.com/NVIDIA/NemoClaw/pull/8566).
 - Hermes dashboard pairing and the Hermes gateway now share the durable WhatsApp session path.
-  Sandboxes with credentials in a legacy dashboard path receive cleanup and re-pairing guidance, and Hermes skill installs, updates, and removals now direct users to start a new chat session instead of restarting the gateway.
+  Sandboxes with credentials in a legacy dashboard path receive cleanup and re-pairing guidance.
+  Hermes skill installs, updates, and removals now direct users to start a new chat session instead of restarting the gateway.
   For more information, refer to [Set Up WhatsApp](/user-guide/hermes/manage-sandboxes/messaging-channels/set-up-whatsapp) and the [Hermes CLI Commands Reference](/user-guide/hermes/reference/commands).
   Related changes: [PR #8229](https://github.com/NVIDIA/NemoClaw/pull/8229) and [PR #8535](https://github.com/NVIDIA/NemoClaw/pull/8535).
-- Managed Hermes Docker images now use durable, provider-bound state mutation for Shields transitions.
-  NemoClaw validates the exact request and receipt, holds gateway startup behind the current fence, preserves rollback and recovery across controller restarts, and keeps older images on the existing compatibility path.
+- Current NemoClaw-managed Hermes images on the Docker driver now use the durable runtime provider state mutation contract for Shields transitions.
+  NemoClaw validates the exact request and receipt, holds Hermes gateway startup behind the current fence, and preserves rollback and recovery across controller restarts.
+  An older managed image uses the sealed-plan compatibility path only after NemoClaw proves that the runtime-provider capability is absent.
   For more information, refer to [Understand Runtime Changes](/user-guide/hermes/manage-sandboxes/configure-sandboxes/understand-runtime-changes), [Troubleshooting](/user-guide/hermes/reference/troubleshooting), and [Trusted Computing Base](/user-guide/hermes/security/trusted-computing-base).
   Related change: [PR #8658](https://github.com/NVIDIA/NemoClaw/pull/8658).
-- Rebuild and recovery now reuse a gateway-managed web-search credential only with exact sandbox, provider, and recreate-journal ownership evidence.
+- `nemoclaw <sandbox> rebuild --yes` now reuses a web search credential registered with the OpenShell gateway only when the rebuild hands onboarding a recreate journal for the same sandbox and target intent after deletion, and the live binding matches the exact sandbox-scoped provider name, provider type, and credential key.
   Legacy supervisor recovery retries temporary state-backup transport failures after restart, cleans incomplete backups before retrying, and keeps integrity or cleanup failures terminal.
   Failed OpenShell forward-list queries also remain distinct from an empty list, so cleanup does not stop a forward when it cannot establish ownership.
   For more information, refer to [Credential Storage](/user-guide/openclaw/security/credential-storage), [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes), and [Troubleshooting](/user-guide/openclaw/reference/troubleshooting).
   Related changes: [PR #8774](https://github.com/NVIDIA/NemoClaw/pull/8774), [PR #8787](https://github.com/NVIDIA/NemoClaw/pull/8787), and [PR #8529](https://github.com/NVIDIA/NemoClaw/pull/8529).
 - `nemoclaw list --json` and global `nemoclaw status --json` now report `openclaw` for a registry entry without an explicit agent, matching the text and sandbox-scoped status surfaces.
-  The commands reference also uses the configured `main` OpenClaw agent in agent and session examples instead of the nonexistent `work` agent.
+  The commands reference also uses the default `main` OpenClaw agent in agent and session examples instead of `work`, which a clean onboarding does not configure.
   For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
   Related changes: [PR #8710](https://github.com/NVIDIA/NemoClaw/pull/8710) and [PR #8817](https://github.com/NVIDIA/NemoClaw/pull/8817).
 - A malformed MCP server URL diagnostic no longer echoes the rejected value, which can contain embedded credentials.


### PR DESCRIPTION
## Summary

Add the canonical August 11 changelog entry for v0.0.107 before release planning.
The entry covers all 18 user-visible changes since v0.0.106 and links each behavior to its owning documentation and pull request.

## Changes

- Add `docs/changelog/2026-08-11.mdx` with the exact `## v0.0.107` heading and parser-safe SPDX comment.
- Summarize the source-verified inference, onboarding, messaging, recovery, runtime, inventory, and diagnostic changes in the release range.
- Link the 18 included user-visible pull requests and their existing published documentation routes.
- Exclude 12 test, CI, skill-process, refactor, and generated-artifact changes that do not change supported user behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This documentation-only PR records behavior already implemented and tested in the included release commits.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/changelog/2026-08-11.mdx`; the documentation-only change was reviewed against `docs/CONTRIBUTING.md`, `WRITING.md`, the controlled word list, documentation style, source and tests for the release claims, and the v0.0.107 release policy. Changelog tests passed 6/6, all published routes resolved, and `npm run docs` completed with 0 errors and 2 existing warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6b68a790e -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/changelog-docs.test.ts` passed 6/6; `npm run docs` completed with 0 errors and 2 existing warnings.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental Nemotron 3.5 Lightning profile.
  * Added Hermes WhatsApp and dashboard improvements.
  * Added durable Shields transition handling.

* **Bug Fixes**
  * Improved model-router startup, sandbox forwarding retries, and WSL Ollama reuse.
  * Improved Slack readiness handling and rebuild/recovery safety.
  * Corrected CLI inventory defaults and expanded diagnostic redaction.

* **Documentation**
  * Added the v0.0.107 changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->