### PR TITLE
feat(inference): add Muse DGX Spark serving profile

### DIFF
--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -290,13 +290,19 @@ The fixed recipe intentionally rejects model and serve-argument overrides; use a
 </Warning>
 
 Muse Glimmer is an additional single-DGX Spark choice and does not change the Qwen default.
-Select `muse-glimmer-30b` to serve `Inferact/Muse-Glimmer-30B-NVFP4-W4A4` with the `muse-glimmer` alias.
+Select its stable catalog ID after confirming that `$$nemoclaw profiles list` reports it as compatible.
+
+```bash
+$$nemoclaw onboard --profile vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4
+```
+
+The profile serves `Inferact/Muse-Glimmer-30B-NVFP4-W4A4` with the `muse-glimmer` alias.
 The registered recipe configures a 32,768-token context window, 1 concurrent sequence, a 4,096-token batch limit, and 0.75 GPU-memory utilization.
 It uses `muse_glimmer` for reasoning and tool-call parsing and sets `--generation-config auto`.
 The pinned model and runtime were validated on one physical DGX Spark for a direct chat request, separated reasoning, a required structured tool call, and an OpenClaw TUI chat turn without fallback.
 Vision was not part of that validation.
-The registered defaults do not enable DFlash, pass `--quantization` or `--trust-remote-code`, or install `fastsafetensors`.
-Advanced operator arguments from `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` remain authoritative.
+The fixed profile does not enable DFlash, pass `--quantization` or `--trust-remote-code`, or install `fastsafetensors`.
+It rejects model and serve-argument overrides so its validated resource boundary remains reproducible.
 
 <Warning title="Experimental Muse Glimmer vLLM Profile">
 This profile uses a candidate runtime image that contains Muse Glimmer changes not yet merged into upstream vLLM.

--- a/managed-inference/presets/vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4.yaml
+++ b/managed-inference/presets/vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4.yaml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4
+  displayName: Muse Glimmer 30B NVFP4 W4A4 on one DGX Spark
+  supportState: experimental
+
+spec:
+  selection: explicit-only
+  priority: 460
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_spark
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_spark
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    recipeRef: vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1

--- a/managed-inference/recipes/vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1.yaml
+++ b/managed-inference/recipes/vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1
+  displayName: Muse Glimmer 30B NVFP4 W4A4 with vLLM
+
+spec:
+  backend: vllm
+
+  model:
+    id: Inferact/Muse-Glimmer-30B-NVFP4-W4A4
+    revision: d35cb79050f419c457611b1cee5c5d15b176f285
+    servedName: muse-glimmer
+    downloadSizeBytes: 25447097878
+    gated: false
+    installFastSafetensors: false
+    preparation:
+      ref: none/v1
+
+  runtime:
+    image: vllm/vllm-openai@sha256:ab0f5fc3bb81b9257a9aee801abcb0eeb94bb0523b57b2bb79349dc61e7c1e25
+    imageDownloadSizeBytes: 10507991780
+    pullTimeoutSeconds: 3600
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 34359738368
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+
+  serve:
+    authentication: bearer
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 32768
+      - name: --gpu-memory-utilization
+        value: 0.75
+      - name: --max-num-seqs
+        value: 1
+      - name: --max-num-batched-tokens
+        value: 4096
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: muse_glimmer
+      - name: --reasoning-parser
+        value: muse_glimmer
+      - name: --generation-config
+        value: auto
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: muse-glimmer

--- a/src/lib/inference/serving/catalog-loader.test.ts
+++ b/src/lib/inference/serving/catalog-loader.test.ts
@@ -32,6 +32,7 @@ const EMPTY_CATALOG: CompiledServingCatalog = {
 const EXPECTED_MANAGED_RECIPE_IDS = [
   "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
   "vllm.deepseek-v4-flash-0731.spark-dual.v1",
+  "vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1",
   "vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1",
   "vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1",
 ];
@@ -40,6 +41,7 @@ const EXPECTED_MANAGED_PRESET_IDS = [
   "llama-cpp.linux-amd64-nvidia.single.nemotron-3-nano-30b-a3b",
   "local-model-profile.vllm.spark.v1",
   "vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731",
+  "vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4",
   "vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4",
 ];
 const EXPECTED_MANAGED_SOURCE_IDS = [
@@ -47,9 +49,11 @@ const EXPECTED_MANAGED_SOURCE_IDS = [
   "llama-cpp.linux-amd64-nvidia.single.nemotron-3-nano-30b-a3b",
   "local-model-profile.vllm.spark.v1",
   "vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731",
+  "vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4",
   "vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4",
   "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
   "vllm.deepseek-v4-flash-0731.spark-dual.v1",
+  "vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1",
   "vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1",
   "vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1",
 ];

--- a/test/managed-inference-catalog-compiler.test.ts
+++ b/test/managed-inference-catalog-compiler.test.ts
@@ -23,6 +23,8 @@ const LLAMA_CPP_MODEL_DIGEST =
   "sha256:627f5b04aedc97f967332f331bd75b7a4ed2f33ca83e6ee74b44235cc1887890";
 const LIGHTNING_PROFILE_ID = "vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4";
 const LIGHTNING_RECIPE_ID = "vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1";
+const MUSE_PROFILE_ID = "vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4";
+const MUSE_RECIPE_ID = "vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1";
 
 function catalogSources(): ServingCatalogSource[] {
   return (["presets", "recipes"] as const).flatMap((kind) => {
@@ -183,6 +185,41 @@ describe("managed inference YAML profile contract", () => {
     });
   });
 
+  it("compiles the explicit DGX Spark Muse vLLM profile from YAML (#8836)", () => {
+    const catalog = compile(catalogSources());
+    const preset = catalog.presets.find(({ metadata }) => metadata.id === MUSE_PROFILE_ID);
+    const recipe = catalog.recipes.find(({ metadata }) => metadata.id === MUSE_RECIPE_ID);
+
+    expect(preset?.metadata.supportState).toBe("experimental");
+    expect(preset?.spec).toMatchObject({
+      selection: "explicit-only",
+      plan: { backend: "vllm", recipeRef: MUSE_RECIPE_ID },
+    });
+    expect(recipe?.spec).toMatchObject({
+      backend: "vllm",
+      model: {
+        id: "Inferact/Muse-Glimmer-30B-NVFP4-W4A4",
+        revision: "d35cb79050f419c457611b1cee5c5d15b176f285",
+        servedName: "muse-glimmer",
+      },
+      runtime: {
+        architecture: "arm64",
+        image:
+          "vllm/vllm-openai@sha256:ab0f5fc3bb81b9257a9aee801abcb0eeb94bb0523b57b2bb79349dc61e7c1e25",
+      },
+      execution: {
+        materializerRef: "vllm.host-local/v1",
+        lifecycleRef: "vllm.host-local.lifecycle/v1",
+      },
+      serve: {
+        arguments: expect.arrayContaining([
+          { name: "--tool-call-parser", value: "muse_glimmer" },
+          { name: "--reasoning-parser", value: "muse_glimmer" },
+        ]),
+      },
+    });
+  });
+
   it("documents the Experimental Lightning support boundary (#8385)", () => {
     const setupGuide = readFileSync(
       path.join(REPOSITORY_ROOT, "docs", "inference", "set-up-vllm.mdx"),
@@ -241,5 +278,7 @@ describe("managed inference YAML profile contract", () => {
     expect(productionSources).not.toContain(LLAMA_CPP_RECIPE_ID);
     expect(productionSources).not.toContain(LIGHTNING_PROFILE_ID);
     expect(productionSources).not.toContain(LIGHTNING_RECIPE_ID);
+    expect(productionSources).not.toContain(MUSE_PROFILE_ID);
+    expect(productionSources).not.toContain(MUSE_RECIPE_ID);
   });
 });


### PR DESCRIPTION
## Summary

Adds Muse Glimmer as an immutable, explicit-only managed vLLM serving profile for one DGX Spark.

- Adds a digest-pinned Muse recipe and stable catalog preset.
- Makes Muse selectable with `nemoclaw onboard --profile vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4`.
- Updates the vLLM guide and catalog loader/compiler coverage.

This is the catalog foundation for #8836. The curated interactive Spark picker remains in the issue because its selection must be persisted as serving-profile provenance for safe resume behavior.

## Validation

- `npm run catalog:compile`
- `npx vitest run --project cli test/managed-inference-catalog-compiler.test.ts src/lib/inference/serving/catalog-loader.test.ts src/lib/inference/serving/host-local-vllm-selection.test.ts`
- Repository pre-commit hooks, including catalog validation and TypeScript checks.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental support for serving the Muse Glimmer 30B NVFP4 W4A4 model with vLLM on a single DGX Spark.
  * Added a managed profile with required hardware, software, and driver compatibility checks.
  * Added onboarding guidance and stable catalog identification for the Muse Glimmer profile.

* **Documentation**
  * Clarified that the fixed profile does not allow model or serving-argument overrides.

* **Tests**
  * Added coverage validating catalog registration and runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->