### PR TITLE
test(e2e): accept inline Shields timer recovery

### DIFF
--- a/test/e2e/live/shields-config.test.ts
+++ b/test/e2e/live/shields-config.test.ts
@@ -994,10 +994,8 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   expect(statusTimer.exitCode, resultText(statusTimer)).toBe(0);
 
   let lastTimerStatus = resultText(statusTimer);
+  expect(statusTimer.stdout).toMatch(/Shields: (?:UP|DOWN)/);
   let restored = statusTimer.stdout.includes("Shields: UP");
-  if (!restored) {
-    expect(statusTimer.stdout).toContain("Shields: DOWN");
-  }
 
   const deadline = Date.now() + TIMER_POLL_TIMEOUT_MS;
   for (let attempt = 1; !restored && Date.now() < deadline; attempt += 1) {

--- a/test/e2e/live/shields-config.test.ts
+++ b/test/e2e/live/shields-config.test.ts
@@ -989,14 +989,18 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   const timerMarker = readTimerMarker(SANDBOX_NAME);
   process.kill(timerMarker.pid, "SIGKILL");
   const statusTimer = await runNemoclaw(host, [SANDBOX_NAME, "shields", "status"], {
-    artifactName: "phase-9-status-down-before-auto-restore",
+    artifactName: "phase-9-status-after-dead-timer",
   });
-  expect(statusTimer.stdout).toContain("Shields: DOWN");
+  expect(statusTimer.exitCode, resultText(statusTimer)).toBe(0);
+
+  let lastTimerStatus = resultText(statusTimer);
+  let restored = statusTimer.stdout.includes("Shields: UP");
+  if (!restored) {
+    expect(statusTimer.stdout).toContain("Shields: DOWN");
+  }
 
   const deadline = Date.now() + TIMER_POLL_TIMEOUT_MS;
-  let restored = false;
-  let lastTimerStatus = "";
-  for (let attempt = 1; Date.now() < deadline; attempt += 1) {
+  for (let attempt = 1; !restored && Date.now() < deadline; attempt += 1) {
     const waitForRestoreAt = Math.max(0, new Date(timerMarker.restoreAt).getTime() - Date.now());
     await delay(Math.max(TIMER_POLL_INTERVAL_MS, waitForRestoreAt + 1_000));
     const poll = await runNemoclaw(host, [SANDBOX_NAME, "shields", "status"], {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Shields live E2E test now accepts `shields status` completing inline restoration immediately after the restore timer stops. Previously, the test required an intermediate Shields down report even when the command had already restored Shields up.

## Changes

- Accept an immediate `Shields: UP` result after the test stops the restore timer.
- Require `Shields: DOWN` before polling when inline restoration does not finish during the first status command.
- Preserve the final ownership, mode, state-hash, and `shields_auto_restore` audit assertions.
- Rename the status artifact to describe both valid timing outcomes.
- Close the detection gap that assumed one intermediate ordering in a concurrent recovery path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes live E2E evidence only. Existing command and runtime-control documentation already describes inline recovery through `shields status`.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The review confirmed that the final Shields posture, root ownership, locked modes, state hashes, and matching auto-restore audit entry remain required.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `test/e2e/live/shields-config.test.ts` changes only live E2E evidence for existing Shields timer recovery behavior. The initial status accepts Shields up after immediate inline restoration or Shields down before polling, while the existing final posture, ownership, hash, and audit assertions remain. Existing command and runtime-control documentation already describes interactive exact-generation recovery through `shields status`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 52897b041 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:e2e-phases:check` passed for 125 tests across 81 files. The three mapped E2E-support files passed 83 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for recovering from a dead timer.
  * Tests now handle either initial Shields status and verify restoration behavior more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->