### PR TITLE
fix(recovery): preserve repeated Docker recreation

### DIFF
--- a/src/lib/actions/sandbox/process-recovery.test.ts
+++ b/src/lib/actions/sandbox/process-recovery.test.ts
@@ -166,6 +166,56 @@ describe("recreated sandbox OpenShell readiness", () => {
     expect(sleeps).toEqual([3]);
   });
 
+  it("keeps an empty read-only probe inconclusive after exact replacement re-registration", () => {
+    const captureOpenshellImpl = vi
+      .fn()
+      .mockReturnValueOnce({
+        status: 1,
+        output: OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR.trim(),
+        stdout: "",
+        stderr: OPENSHELL_TRANSIENT_ERROR_PHASE_STDERR,
+      })
+      .mockReturnValueOnce({ status: 1, output: "", stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, output: "", stdout: "", stderr: "" });
+    const beforeProbe = vi.fn(() => true);
+    const sleeps: number[] = [];
+
+    expect(
+      waitForRecreatedSandboxOpenShellReady("recreated-box", {
+        beforeProbe,
+        captureOpenshellImpl,
+        intervalSeconds: 3,
+        sleepImpl: (seconds) => sleeps.push(seconds),
+        timeoutSeconds: 6,
+      }),
+    ).toBe(true);
+    expect(beforeProbe).toHaveBeenCalledTimes(3);
+    expect(captureOpenshellImpl).toHaveBeenCalledTimes(3);
+    expect(sleeps).toEqual([3, 3]);
+  });
+
+  it("keeps an empty first OpenShell failure terminal", () => {
+    const captureOpenshellImpl = vi.fn(() => ({
+      status: 1,
+      output: "",
+      stdout: "",
+      stderr: "",
+    }));
+    const sleeps: number[] = [];
+
+    expect(
+      waitForRecreatedSandboxOpenShellReady("recreated-box", {
+        beforeProbe: () => true,
+        captureOpenshellImpl,
+        intervalSeconds: 3,
+        sleepImpl: (seconds) => sleeps.push(seconds),
+        timeoutSeconds: 30,
+      }),
+    ).toBe(false);
+    expect(captureOpenshellImpl).toHaveBeenCalledOnce();
+    expect(sleeps).toEqual([]);
+  });
+
   it("rides out a transient Error phase past the old 30s budget by default (#7227)", () => {
     // No timeoutSeconds option and no env override: the default recovery budget
     // must be large enough (120s, aligned with connect's readiness wait) to keep

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -818,6 +818,7 @@ function waitForRecreatedSandboxOpenShellReadyResult(
       ? Math.max(1, Math.floor(timeoutSeconds / intervalSeconds) + 1)
       : Math.max(1, Math.floor(timeoutSeconds) + 1);
   let lastOpenshellError: string | undefined;
+  let observedRetryableReRegistrationState = false;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const preGuardRemainingMs = deadlineMs - now();
@@ -861,8 +862,25 @@ function waitForRecreatedSandboxOpenShellReadyResult(
     // mutation outcome to reconcile. Treat that exact timeout as inconclusive
     // and retry behind the pinned managed-health guard on the next iteration.
     // All other unexpected OpenShell failures remain definitive.
+    const retryableReRegistrationState = isRetryableOpenshellReRegistrationState(
+      result,
+      sandboxName,
+    );
+    if (retryableReRegistrationState) observedRetryableReRegistrationState = true;
+    const emptyReadOnlyProbeAfterReRegistration =
+      observedRetryableReRegistrationState &&
+      result.status === 1 &&
+      !result.error &&
+      String(result.stdout ?? "").trim() === "" &&
+      String(result.stderr ?? "").trim() === "";
+    // OpenShell can briefly return an empty exit-1 result after first exposing
+    // the exact replacement re-registration state. Keep that result
+    // inconclusive only inside the same bounded wait and behind the pinned
+    // managed-health guard. It is never accepted as Ready, and an empty first
+    // failure or any diagnostic-bearing unknown failure remains terminal.
     if (
-      !isRetryableOpenshellReRegistrationState(result, sandboxName) &&
+      !retryableReRegistrationState &&
+      !emptyReadOnlyProbeAfterReRegistration &&
       !isCommandTimeout(result)
     ) {
       return {

--- a/src/lib/actions/sandbox/supervisor-relaunch.test.ts
+++ b/src/lib/actions/sandbox/supervisor-relaunch.test.ts
@@ -486,6 +486,23 @@ describe("relaunchManagedSupervisorSession", () => {
     expect(deps.removeBackup).toHaveBeenCalledWith("alpha", "/tmp/rebuild-backups/alpha/recovery");
   });
 
+  it("reports a redacted verbose diagnostic for quiet recovery failures", () => {
+    vi.stubEnv("NEMOCLAW_REBUILD_VERBOSE", "1");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const deps = baseDeps({
+      backupState: vi.fn(() => {
+        throw new Error("OPENAI_API_KEY=sk-recovery-secret backup finalization failed");
+      }),
+    });
+
+    expect(relaunchManagedSupervisorSession("alpha", { quiet: true, deps })).toBeNull();
+    const output = errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Trusted container recovery could not start");
+    expect(output).toContain("OPENAI_API_KEY=<REDACTED>");
+    expect(output).toContain("backup finalization failed");
+    expect(output).not.toContain("sk-recovery-secret");
+  });
+
   it("preserves the recreation diagnostic when state-backup cleanup throws", () => {
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/src/lib/actions/sandbox/supervisor-relaunch.ts
+++ b/src/lib/actions/sandbox/supervisor-relaunch.ts
@@ -301,7 +301,7 @@ export function relaunchManagedSupervisorSession(
         // Preserve the recreation failure that stopped container recovery.
       }
     }
-    if (!quiet) {
+    if (!quiet || process.env.NEMOCLAW_REBUILD_VERBOSE === "1") {
       const detail = error instanceof Error ? error.message : String(error);
       console.error(`  Trusted container recovery could not start: ${redactFull(redact(detail))}`);
     }

--- a/src/lib/onboard/docker-gpu-patch-clone.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-clone.test.ts
@@ -64,6 +64,28 @@ describe("Docker GPU clone envelope", () => {
     expect(shouldOmitOpenShellOciImageUser(inspect, NEMOCLAW_STARTUP_ARGV)).toBe(false);
   });
 
+  it("preserves the exact workspace compatibility metadata across another recreation (#8662)", () => {
+    const inspect = openShellOciWorkspaceInspect();
+    inspect.Config!.Env = inspect.Config!.Env!.filter(
+      (entry) => !entry.startsWith("OPENSHELL_OCI_IMAGE_USER="),
+    );
+
+    const args = buildDockerGpuCloneRunArgs(inspect, buildDockerGpuMode("startup-command"), {
+      openshellSandboxCommand: NEMOCLAW_STARTUP_ARGV,
+    });
+
+    expect(shouldOmitOpenShellOciImageUser(inspect, NEMOCLAW_STARTUP_ARGV)).toBe(false);
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--env",
+        "OPENSHELL_SANDBOX_UID=",
+        "--env",
+        "OPENSHELL_SANDBOX_GID=",
+      ]),
+    );
+    expect(args).not.toEqual(expect.arrayContaining(["--env", "OPENSHELL_OCI_IMAGE_USER=sandbox"]));
+  });
+
   it.each([
     {
       name: "missing sandbox GID",
@@ -94,6 +116,30 @@ describe("Docker GPU clone envelope", () => {
     {
       name: "duplicate OCI user",
       mutate: (environment: string[]) => [...environment, "OPENSHELL_OCI_IMAGE_USER=sandbox"],
+    },
+    {
+      name: "already-applied metadata without a sandbox GID",
+      mutate: (environment: string[]) =>
+        environment.filter(
+          (entry) =>
+            !entry.startsWith("OPENSHELL_OCI_IMAGE_USER=") && entry !== "OPENSHELL_SANDBOX_GID=",
+        ),
+    },
+    {
+      name: "already-applied metadata with a non-empty sandbox UID",
+      mutate: (environment: string[]) =>
+        environment
+          .filter((entry) => !entry.startsWith("OPENSHELL_OCI_IMAGE_USER="))
+          .map((entry) =>
+            entry === "OPENSHELL_SANDBOX_UID=" ? "OPENSHELL_SANDBOX_UID=998" : entry,
+          ),
+    },
+    {
+      name: "already-applied metadata with a duplicate sandbox UID",
+      mutate: (environment: string[]) => [
+        ...environment.filter((entry) => !entry.startsWith("OPENSHELL_OCI_IMAGE_USER=")),
+        "OPENSHELL_SANDBOX_UID=",
+      ],
     },
   ])("rejects $name in OpenShell's protected identity metadata (#8662)", ({ mutate }) => {
     const inspect = openShellOciWorkspaceInspect();

--- a/src/lib/onboard/docker-gpu-patch-clone.ts
+++ b/src/lib/onboard/docker-gpu-patch-clone.ts
@@ -375,6 +375,16 @@ function validateOpenShellOciIdentityMetadata(environment: readonly string[]): b
     // OpenShell through v0.0.85 did not publish OCI identity metadata.
     return false;
   }
+  if (
+    ociUsers.length === 0 &&
+    sandboxUids.length === 1 &&
+    sandboxUids[0] === `${OPENSHELL_SANDBOX_UID_ENV}=` &&
+    sandboxGids.length === 1 &&
+    sandboxGids[0] === `${OPENSHELL_SANDBOX_GID_ENV}=`
+  ) {
+    // A prior reviewed recreation already removed only the OCI-user marker.
+    return false;
+  }
   const ociUserPrefix = `${OPENSHELL_OCI_IMAGE_USER_ENV}=`;
   if (
     ociUsers.length !== 1 ||


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

A repeated Docker recreation could reject the exact OpenShell workspace identity metadata produced by the prior reviewed recreation. After that correction, legacy recovery could still terminate an otherwise bounded readiness wait when OpenShell returned an empty exit-1 no-op probe after recognizing the replacement sandbox. This change preserves the exact already-applied compatibility state and keeps only that later empty probe inconclusive, while all malformed identity states and definitive readiness failures remain terminal.

The existing verbose recovery diagnostic also now exposes caught errors through the established redaction boundary. It identified the repeated [gateway recovery E2E failure](https://github.com/NVIDIA/NemoClaw/actions/runs/31557525437/job/93993019592) before the functional corrections were applied.

## Changes

- Accept a prior recreation's exact compatibility state: no OCI-user marker and exactly one empty sandbox UID and GID.
- Continue rejecting partial, duplicate, and non-empty workspace identity metadata.
- After an exact retryable same-sandbox re-registration result, keep only a later status-1 probe with no error and empty output inconclusive within the existing deadline.
- Rerun the pinned managed-health guard before every readiness probe and continue requiring status 0 without a command error for Ready.
- Keep empty first failures, diagnostic-bearing failures, health-guard failures, and deadline expiry terminal.
- Report a caught legacy recovery exception when verbose diagnostics are enabled, while preserving default quiet behavior and existing redaction.
- Add focused coverage for repeat recreation, rejected identity variants, readiness retry boundaries, verbose diagnostics, and credential-canary removal.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing recovery documentation already describes the bounded OpenShell re-registration wait, managed-health requirement, fail-closed behavior, rollback outcome, and Docker compatibility controls. This correction changes no command, setting, default, readiness success criterion, or operator procedure.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The maintainer explicitly approved accepting only the exact already-applied state with the OCI-user marker absent and exactly one empty UID and GID. Tests prove that partial, duplicate, and non-empty metadata remains rejected. The readiness retry remains bounded by the existing deadline and pinned managed-health guard, and the diagnostic output remains opt-in behind the existing redactors.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `src/lib/actions/sandbox/process-recovery.ts` keeps only an exact empty exit-1 OpenShell no-op probe inconclusive after a recognized replacement re-registration state, within the existing readiness deadline and behind the pinned managed-health guard. Status 0 without a command error remains the only Ready result; empty first failures, unknown diagnostics, guard failures, and deadline expiry remain terminal. Its tests verify the new accepted sequence and adjacent fail-closed boundaries. The previously reviewed changes retain redacted opt-in recovery diagnostics and accept only the exact already-applied Docker identity envelope while rejecting malformed metadata. Existing recovery and timeout documentation already states the 120-second OpenShell re-registration budget, managed-health requirement, fail-closed behavior, and rollback outcome, so no supported command, option, default, or operator procedure requires a documentation update.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f8b8f20a7 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Focused Docker clone, supervisor relaunch, process recovery, and gateway fixture support coverage passed 3 files and 114 tests at `f8b8f20a7`; Biome, CLI typecheck, `git diff --check`, and `npm run validate:pr` also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a bounded recovery-state classification correction with focused source and E2E-support coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
