### PR TITLE
test(e2e): refresh scoped ClawHub fixture

### DIFF
--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -189,7 +189,7 @@ async function curlStatus(
 async function expectScopedClawHubPluginLifecycle(sandbox: SandboxClient): Promise<void> {
   const install = await sandboxBash(
     sandbox,
-    "HOME=/sandbox openclaw plugins install 'clawhub:@openclaw/sherpa-onnx-tts@2026.6.8' 2>&1",
+    "HOME=/sandbox openclaw plugins install 'clawhub:@openclaw/kitchen-sink@0.2.14' 2>&1",
     {
       artifactName: "tc-net-restricted-clawhub-scoped-plugin-install",
       timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
@@ -203,12 +203,12 @@ async function expectScopedClawHubPluginLifecycle(sandbox: SandboxClient): Promi
   });
   expect(list.exitCode, text(list)).toBe(0);
   expect(text(list), "the installed scoped ClawHub plugin must be enabled").toMatch(
-    /Sherpa ONNX TTS[^\r\n]*enabled/i,
+    /OpenClaw Kitchen Sink[^\r\n]*enabled/i,
   );
 
   const inspect = await sandboxBash(
     sandbox,
-    "HOME=/sandbox openclaw plugins inspect sherpa-onnx-tts --runtime 2>&1",
+    "HOME=/sandbox openclaw plugins inspect openclaw-kitchen-sink-fixture --runtime 2>&1",
     {
       artifactName: "tc-net-restricted-clawhub-scoped-plugin-runtime-inspect",
       timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The live network-policy E2E now uses the maintained, credential-free `@openclaw/kitchen-sink@0.2.14` scoped ClawHub plugin. The removed `@openclaw/sherpa-onnx-tts@2026.6.8` fixture made main E2E fail with `Package not found on ClawHub.`

Affected main E2E run: `31551836429`. Affected job: `93976243928` (`Network policy live-probes`).

## Related Issue

Addresses #4104.

## Changes

- Replace the removed scoped ClawHub fixture with the version-pinned Kitchen Sink fixture.
- Update the enabled-plugin and loaded-runtime expectations for the replacement fixture.
- Preserve the scoped-path install coverage and the encoded-slash denial outside ClawHub.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the owning live network-policy E2E installs, lists, and inspects the exact scoped fixture while retaining the non-ClawHub denial probe.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only an internal live-test fixture and its package-specific expectations; supported NemoClaw behavior is unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: nine-category self-review confirmed the external test dependency remains version-pinned, scoped to the E2E sandbox, and credential-free. The authoritative ClawHub-only encoded-slash allow and non-ClawHub denial assertions are unchanged. No credential, authorization, configuration, logging, cryptography, or runtime policy behavior changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `test/e2e/live/network-policy.test.ts` changes only an internal live E2E fixture and its package-specific expectations. It does not change user-facing NemoClaw behavior or documentation claims.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1a5c71f1f -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx --no-install biome check test/e2e/live/network-policy.test.ts` passed; `npm run test:e2e-phases:check` passed with 125 tests across 81 files. The live package-install boundary remains for CI.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run for this one-fixture live E2E change. A local `e2e-support` run passed 2,460 tests and had 17 unrelated macOS service/timing failures; CI remains authoritative.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the plugin lifecycle validation to use the OpenClaw Kitchen Sink fixture.
  * Adjusted plugin listing and runtime inspection checks to match the Kitchen Sink plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->