### PR TITLE
fix(hermes): validate config lifecycle writes

### DIFF
--- a/agents/hermes/plugin/__init__.py
+++ b/agents/hermes/plugin/__init__.py
@@ -322,7 +322,14 @@ def _install_broker_url_safety_patch():
     if browser_tool is not None and hasattr(browser_tool, "_is_safe_url"):
         setattr(browser_tool, "_is_safe_url", _broker_safe_url)
         if hasattr(browser_tool, "_allow_private_urls_resolved"):
-            setattr(browser_tool, "_allow_private_urls_resolved", False)
+            config = _load_hermes_config() or {}
+            security = config.get("security", {}) if isinstance(config, dict) else {}
+            allow_private_urls = (
+                security.get("allow_private_urls") is True
+                if isinstance(security, dict)
+                else False
+            )
+            setattr(browser_tool, "_allow_private_urls_resolved", allow_private_urls)
         patched = True
 
     return patched

--- a/agents/hermes/plugin/test_private_url_opt_in.py
+++ b/agents/hermes/plugin/test_private_url_opt_in.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Browser private-URL opt-in behavior for the NemoClaw Hermes plugin (#8614)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+
+def _load_plugin_module():
+    path = os.path.join(os.path.dirname(__file__), "__init__.py")
+    spec = importlib.util.spec_from_file_location("nemoclaw_hermes_plugin_private_url", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PrivateUrlOptInTest(unittest.TestCase):
+    def _install_patch(self, config):
+        plugin = _load_plugin_module()
+        browser_tool = types.SimpleNamespace(
+            _is_safe_url=lambda _url: False,
+            _allow_private_urls_resolved=None,
+        )
+        original = sys.modules.get("tools.browser_tool")
+        sys.modules["tools.browser_tool"] = browser_tool
+        plugin._broker_mode_enabled = lambda: True
+        plugin._load_hermes_config = lambda: config
+        try:
+            self.assertTrue(plugin._install_broker_url_safety_patch())
+            return browser_tool._allow_private_urls_resolved
+        finally:
+            if original is None:
+                del sys.modules["tools.browser_tool"]
+            else:
+                sys.modules["tools.browser_tool"] = original
+
+    def test_denies_private_urls_by_default(self):
+        self.assertFalse(self._install_patch({}))
+        self.assertFalse(self._install_patch({"security": {"allow_private_urls": False}}))
+        self.assertFalse(self._install_patch({"security": {"allow_private_urls": "true"}}))
+
+    def test_allows_private_urls_only_for_explicit_boolean_opt_in(self):
+        self.assertTrue(self._install_patch({"security": {"allow_private_urls": True}}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/hermes/runtime-config-guard.py
+++ b/agents/hermes/runtime-config-guard.py
@@ -4534,6 +4534,37 @@ def _recover_config_write_transaction(hermes_dir: str, state_file: str) -> None:
     _write_restart_state(state_file, state_data, create=False)
 
 
+def _validate_hermes_config_candidate(config_bytes: bytes) -> None:
+    """Parse a candidate with Hermes' own config model before any mutation.
+
+    The guard owns the sealed write transaction, while Hermes owns the schema.
+    Loading the candidate into the bundled model catches incomplete nested objects
+    such as ``platforms.teams.home_channel`` without maintaining a second schema.
+    This function does not read or write sandbox state.
+    """
+    try:
+        config_text = config_bytes.decode("utf-8")
+        parsed = yaml.safe_load(config_text)
+    except (UnicodeDecodeError, yaml.YAMLError) as exc:
+        raise UnsafePathError("Hermes configuration is not valid YAML") from exc
+    if not isinstance(parsed, dict):
+        raise UnsafePathError("Hermes configuration must be a mapping")
+    try:
+        from gateway.config import GatewayConfig
+
+        GatewayConfig.from_dict(parsed)
+    except UnsafePathError:
+        raise
+    except Exception as exc:
+        # Configuration values can contain credentials. KeyError identifies a
+        # missing field without echoing the candidate; other parser failures
+        # report only their exception type.
+        detail = str(exc)[:300] if isinstance(exc, KeyError) else type(exc).__name__
+        raise UnsafePathError(
+            f"Hermes schema validation rejected the candidate: {detail}"
+        ) from exc
+
+
 def write_config_transaction(
     hermes_dir: str,
     hash_file: str,
@@ -4546,6 +4577,14 @@ def write_config_transaction(
     if len(config_bytes) > MAX_CONFIG_INPUT_BYTES:
         raise UnsafePathError("refusing oversized Hermes config input")
 
+    # Validate before `seal_restart` writes the restart state or opens mutable
+    # inputs. A rejected candidate must leave config, env, and both hash anchors
+    # byte-for-byte unchanged. The established exact-size boundary runs its
+    # filesystem check first when the config path is absent.
+    config_path = os.path.join(hermes_dir, "config.yaml")
+    if os.path.exists(config_path):
+        _validate_hermes_config_candidate(config_bytes)
+
     seal_restart(
         hermes_dir,
         hash_file,
@@ -4554,7 +4593,6 @@ def write_config_transaction(
         expected_config_sha256=expected_config_sha256,
     )
     committed = False
-    config_path = os.path.join(hermes_dir, "config.yaml")
     try:
         state_data = _load_restart_state(state_file)
         if _restart_state_was_locked(state_data):

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1284,7 +1284,7 @@ $$nemoclaw my-assistant config get --key model --format yaml
 Write one value into the agent configuration in a sandbox.
 The command validates every HTTP and HTTPS URL in the value, including URLs nested inside JSON objects or arrays.
 It pins an HTTP host to the validated IP address.
-Config changes are unavailable while shields are up, so lower shields with `$$nemoclaw <name> shields down` first.
+Configuration changes are unavailable while shields are up, so lower shields with `$$nemoclaw <name> shields down` first.
 
 ```bash
 $$nemoclaw my-assistant config set --key agents.defaults.model.primary --value nvidia/nemotron
@@ -1305,6 +1305,16 @@ Pass `--config-accept-new-path`, or set `NEMOCLAW_CONFIG_ACCEPT_NEW_PATH=1`, to 
 If the confirmation reaches the end of input, for example when you press `Ctrl-D` or run the command from a harness that closes stdin, the command exits non-zero without writing and repeats the same guidance.
 
 The command refuses to write `gateway` or any dotpath under `gateway.`, which holds credentials.
+
+</AgentOnly>
+<AgentOnly variant="hermes">
+
+For Hermes, the command validates the complete candidate configuration with the bundled Hermes schema before it writes configuration or integrity metadata.
+An incomplete structural object is rejected without changing the configuration or hashes.
+Private URLs remain rejected unless the existing Hermes configuration explicitly sets `security.allow_private_urls: true`.
+That opt-in allows private URLs for any Hermes configuration value. Public hostnames still receive DNS validation and pinning.
+Hermes can restart its gateway when it applies a configuration change. Use `--restart` when the command must request and verify that restart.
+`config set` changes `config.yaml` only. Hermes startup and rebuild can update managed `.env` keys and their integrity hashes without printing their values.
 
 </AgentOnly>
 <AgentOnly variant="deepagents">

--- a/handoff-issue-contract.md
+++ b/handoff-issue-contract.md
@@ -1,0 +1,97 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Issue #8614 closure contract
+
+## Reporter workflow
+
+Source: [issue body](https://github.com/NVIDIA/NemoClaw/issues/8614) and [reporter follow-up](https://github.com/NVIDIA/NemoClaw/issues/8614#issuecomment-5224815419).
+
+Environment reported by `zxman0126`: NemoClaw v0.0.102, Hermes Agent 0.19.0 sandbox, and DGX Spark GB10.
+
+1. Run `config set memory.provider`; observe an immediate gateway SIGTERM and restart.
+2. Run `config set model.supports_vision`; observe no immediate restart and a restart note.
+3. Write `platforms.teams.home_channel.chat_id` before its required `platform` field.
+4. Trigger a restart with another config write; observe `HomeChannel.from_dict` fail and the gateway enter relaunch quarantine after five exits.
+5. Rebuild the sandbox and run `config set` before `recover`; observe a compat-hash failure that a later `recover` does not repair.
+6. Rebuild again, run `recover`, and then run `config set`; observe the write succeed.
+7. Inspect `/tmp/gateway.log`, `~/.hermes/logs/agent.log`, and the integrity-frozen `.env`; observe that the useful traceback and managed `.env` writes are not disclosed by the host command.
+8. Set `security.allow_private_urls` to `true`, then set `browser.cdp_url` to `http://10.200.0.1:9223`; observe CLI rejection before Hermes receives the value.
+
+The required local reproduction uses the built worktree `./bin/nemoclaw.js`, Hermes sandbox `triage-8614`, and ports unique to this issue.
+
+## Expected behavior
+
+- NemoClaw validates a complete Hermes candidate configuration before persistence.
+- NemoClaw rejects an incomplete structural write with the missing field or path.
+- Rejection leaves the configuration file, managed `.env`, integrity hashes, gateway state, and quarantine state unchanged.
+- A valid complete structural write succeeds.
+- A successful rebuild leaves Hermes configuration writable. If the security model requires recovery, NemoClaw rejects the write before mutation and prints the exact recovery command; recovery then succeeds without another rebuild.
+- Hermes config output truthfully states possible or observed gateway restart effects and readiness or recovery state.
+- A failed Hermes restart reports a bounded, sanitized tail from `/tmp/gateway.log`.
+- Config output discloses managed `.env` effects without exposing values or secrets.
+- Private URLs remain rejected by default.
+- An explicit `security.allow_private_urls: true` opt-in permits the private `browser.cdp_url` through CLI validation and the Hermes plugin runtime override.
+- The accepted private URL works through the complete supported sandbox path.
+- A user can recover from config-driven relaunch failure without an additional rebuild when the preserved valid configuration permits recovery.
+
+## Observed behavior
+
+- Hermes candidate writes receive integrity and MCP checks but not complete Hermes structural validation.
+- An incomplete `home_channel` object persists and fails during Hermes boot.
+- Repeated gateway exits quarantine relaunch until sandbox recreation.
+- Rebuild can leave frozen-input compatibility hashes stale until gateway recovery refreshes them.
+- The first post-rebuild config write can fail after partial reconciliation, and later recovery can remain insufficient.
+- Restart effects differ by key and command output does not explain the effect accurately.
+- The actionable boot traceback remains only in the in-container `/tmp/gateway.log`.
+- Managed `TEAMS_HOME_CHANNEL*` `.env` updates are not disclosed.
+- CLI URL validation rejects private hosts without reading the explicit Hermes opt-in.
+- The Hermes plugin forces `_allow_private_urls_resolved` to false, which defeats the runtime opt-in even if CLI validation permits the URL.
+
+## Acceptance paths and sources
+
+Sources:
+
+- [Issue body](https://github.com/NVIDIA/NemoClaw/issues/8614): restart behavior, structural-write quarantine, rebuild and recovery ordering, diagnostics, managed `.env` effects, and expected recovery behavior.
+- [Reporter follow-up](https://github.com/NVIDIA/NemoClaw/issues/8614#issuecomment-5224815419): private URL default rejection and explicit opt-in.
+- `issue-8614.md`: current-code analysis and the coordinated closing scope.
+- GitHub timeline and `closedByPullRequestsReferences`, fetched before implementation: no linked pull request or review exists; the only cross-reference is another issue.
+
+Acceptance paths:
+
+1. Incomplete `platforms.teams.home_channel` write: reject before persistence; preserve files and hashes; do not restart or quarantine Hermes.
+2. Complete `platforms.teams.home_channel` write: persist the valid candidate and report managed `.env` effects.
+3. Rebuild integrity lifecycle: a direct subsequent config write succeeds, or a pre-mutation gate prints the exact `recover` command and the write succeeds after one recovery without another rebuild.
+4. Restart disclosure: output does not promise that Hermes remains running when the write can restart it; output reports readiness or the required recovery action.
+5. Restart failure: output includes useful, bounded, sanitized gateway diagnostics and excludes representative secrets.
+6. Private URL default: reject `browser.cdp_url` on a private host when the opt-in is absent or false.
+7. Private URL opt-in: accept the same URL only after explicit opt-in, preserve validation for unrelated URL risks, and pass the setting through the Hermes plugin runtime.
+8. Quarantine recovery: preserve or restore a valid configuration and provide a non-rebuild recovery path when the sandbox can recover safely.
+
+## Explicit non-goals
+
+- Do not weaken private-host rejection by default.
+- Do not add an unrestricted global SSRF bypass.
+- Do not duplicate the Hermes schema in NemoClaw when the bundled Hermes parser or schema can validate a candidate without side effects.
+- Do not expose configuration values, credentials, tokens, or an unbounded gateway log.
+- Do not claim an exact upstream restart-key matrix unless the implementation owns and verifies that matrix.
+- Do not change OpenClaw configuration behavior unless a shared owner requires the same correction.
+- Do not add Hermes behavior unrelated to this config lifecycle.
+- Do not use a rebuild as the normal repair for a rejected candidate configuration.
+- Do not open a partial PR or use `Relates to #8614` if any closure item remains unimplemented or unvalidated.
+
+## Required validation evidence
+
+Before the fix, capture the reporter failure with the built worktree `./bin/nemoclaw.js` on `yimoj-colossus-dev` after dependency installation, CLI and plugin builds, and worktree OpenShell installation. Supporting helpers, direct imports, fixtures, unit tests, and raw `openshell` commands do not replace this evidence.
+
+After the fix, capture real worktree CLI transcripts for Hermes sandbox `triage-8614` with unique ports:
+
+- incomplete `home_channel` write rejected with no persistence, hash change, restart, or quarantine;
+- valid complete `home_channel` write accepted;
+- rebuild followed by config set succeeds, or exact pre-gate recovery ordering succeeds without another rebuild;
+- forced restart failure reports a bounded sanitized diagnostic tail;
+- private `browser.cdp_url` rejected by default;
+- the same private URL accepted end to end only after explicit opt-in;
+- managed `.env` and restart effects disclosed without secret values.
+
+Automated evidence must include focused tests for candidate structural validation, atomic unchanged files and hashes, rebuild postconditions, recovery ordering, bounded log length, log redaction, managed `.env` disclosure, private URL default rejection, explicit CLI opt-in, and Hermes plugin runtime opt-in. Run targeted builds and tests, the repository pre-commit gate, independent Codex review, the signed commit and post-commit gate, and the pre-push gate including `npm test`.

--- a/src/lib/actions/sandbox/gateway-restart.test.ts
+++ b/src/lib/actions/sandbox/gateway-restart.test.ts
@@ -149,6 +149,74 @@ describe("restartSandboxGateway — host-mediated gateway restart", () => {
     );
   });
 
+  it("prints a bounded sanitized Hermes gateway-log tail after supervisor failure (#8614)", () => {
+    const restore = silenceConsole();
+    try {
+      const logLines = Array.from({ length: 15 }, (_, index) => `line-${index}`);
+      logLines[1] = "token=sk-proj-abcdefghijklmnopqrstuvwxyz0123456789";
+      logLines[14] = "Bearer super-secret-token-value";
+      const executeSandboxExecCommand = vi.fn(() => ({
+        status: 0,
+        stdout: logLines.join("\n"),
+        stderr: "",
+      }));
+      const deps = baseDeps({
+        getSessionAgent: () => ({ name: "hermes" }),
+        getSandbox: () => ({ name: "triage-8614", agent: "hermes" }),
+        requestGatewaySupervisorAction: vi.fn(() => ({
+          status: 1,
+          stdout: "GATEWAY_FAILED",
+          stderr: "",
+        })),
+        executeSandboxExecCommand,
+      });
+
+      const result = restartSandboxGateway("triage-8614", { quiet: true, deps });
+      const output = (console.error as ReturnType<typeof vi.fn>).mock.calls.flat().join("\n");
+
+      expect(result).toMatchObject({ ok: false, failureLayer: "launch failure" });
+      expect(executeSandboxExecCommand).toHaveBeenCalledWith(
+        "triage-8614",
+        "tail -n 12 /tmp/gateway.log 2>/dev/null || true",
+      );
+      expect(output).toContain("Hermes gateway log tail (sanitized):");
+      expect(output).toContain("line-3");
+      expect(output).toContain("Bearer <REDACTED>");
+      expect(output).not.toContain("line-2");
+      expect(output).not.toContain("sk-proj-abcdefghijklmnopqrstuvwxyz0123456789");
+      expect(output).not.toContain("super-secret-token-value");
+      const tail = output.split("Hermes gateway log tail (sanitized):\n")[1]?.split("\n") ?? [];
+      expect(tail).toHaveLength(12);
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not read a gateway-log tail for non-Hermes failures (#8614)", () => {
+    const restore = silenceConsole();
+    try {
+      const executeSandboxExecCommand = vi.fn(() => ({
+        status: 0,
+        stdout: "unexpected",
+        stderr: "",
+      }));
+      const deps = baseDeps({
+        requestGatewaySupervisorAction: vi.fn(() => ({
+          status: 1,
+          stdout: "GATEWAY_FAILED",
+          stderr: "",
+        })),
+        executeSandboxExecCommand,
+      });
+
+      restartSandboxGateway("alpha", { quiet: true, deps });
+
+      expect(executeSandboxExecCommand).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
   it("force-restarts through PID 1 even when a gateway might already be healthy", () => {
     const restore = silenceConsole();
     try {

--- a/src/lib/actions/sandbox/gateway-restart.ts
+++ b/src/lib/actions/sandbox/gateway-restart.ts
@@ -293,10 +293,27 @@ export function gatewayIntegrityRepairLines(
   ];
 }
 
+const HERMES_GATEWAY_LOG_TAIL_LINES = 12;
+const HERMES_GATEWAY_LOG_TAIL_COMMAND =
+  `tail -n ${String(HERMES_GATEWAY_LOG_TAIL_LINES)} /tmp/gateway.log 2>/dev/null || true`;
+
+function hermesGatewayLogTail(
+  sandboxName: string,
+  exec: (sandboxName: string, command: string) => GatewayRestartCommandResult | null,
+): string[] {
+  const result = exec(sandboxName, HERMES_GATEWAY_LOG_TAIL_COMMAND);
+  if (!result || result.status !== 0) return [];
+  return sanitizeGatewayRestartFailureDetail(result.stdout)
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .slice(-HERMES_GATEWAY_LOG_TAIL_LINES);
+}
+
 export function printGatewayRestartFailure(
   sandboxName: string,
   layer: GatewayRestartFailureLayer,
   detail: string,
+  gatewayLogTail: readonly string[] = [],
 ): void {
   console.error(`  Failure layer: ${layer} - gateway restart failed for '${sandboxName}'.`);
   if (detail.trim()) {
@@ -315,6 +332,10 @@ export function printGatewayRestartFailure(
     for (const line of hermesMcpReconciliationRemediationLines(sandboxName)) {
       console.error(`  ${line}`);
     }
+  }
+  if (gatewayLogTail.length > 0) {
+    console.error("  Hermes gateway log tail (sanitized):");
+    for (const line of gatewayLogTail) console.error(`  ${line}`);
   }
   if (isGatewayIntegrityRepairLayer(layer)) {
     for (const line of gatewayIntegrityRepairLines(sandboxName, layer)) {
@@ -414,7 +435,11 @@ export function restartSandboxGatewayWithDeps(
     restartResult.stdout.split(/\r?\n/).some((line) => line.startsWith("GATEWAY_PID="));
   if (!hasRestartMarker) {
     const failure = classifyGatewayRestartFailure(restartResult);
-    printGatewayRestartFailure(sandboxName, failure.layer, failure.detail);
+    const gatewayLogTail =
+      agentName === "hermes"
+        ? hermesGatewayLogTail(sandboxName, deps.executeSandboxExecCommand)
+        : [];
+    printGatewayRestartFailure(sandboxName, failure.layer, failure.detail, gatewayLogTail);
     return { ok: false, failureLayer: failure.layer, detail: failure.detail };
   }
 

--- a/src/lib/sandbox/compose-sandbox-config-body.test.ts
+++ b/src/lib/sandbox/compose-sandbox-config-body.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
 
-const { composeSandboxConfigBody } = require("./config") as {
+const { composeSandboxConfigBody, hermesConfigAllowsPrivateUrls } = require("./config") as {
   composeSandboxConfigBody: (
     config: Record<string, unknown>,
     target: {
@@ -15,6 +15,7 @@ const { composeSandboxConfigBody } = require("./config") as {
       configFile: string;
     },
   ) => string;
+  hermesConfigAllowsPrivateUrls: (config: Record<string, unknown>) => boolean;
 };
 
 const HERMES_TARGET = {
@@ -110,5 +111,11 @@ describe("composeSandboxConfigBody", () => {
     const written = composeSandboxConfigBody(config, HERMES_TARGET);
     expect(written.startsWith("#")).toBe(false);
     expect(YAML.parse(written)).toEqual(config);
+  });
+
+  it("keeps private URLs denied until Hermes explicitly opts in (#8614)", () => {
+    expect(hermesConfigAllowsPrivateUrls({})).toBe(false);
+    expect(hermesConfigAllowsPrivateUrls({ security: { allow_private_urls: false } })).toBe(false);
+    expect(hermesConfigAllowsPrivateUrls({ security: { allow_private_urls: true } })).toBe(true);
   });
 });

--- a/src/lib/sandbox/config.ts
+++ b/src/lib/sandbox/config.ts
@@ -99,6 +99,7 @@ interface DnsValidatedUrl {
 interface ConfigUrlValidationOptions {
   allowOpenShellBridge?: boolean;
   allowOpenShellBridgePath?: (path: readonly string[]) => boolean;
+  allowPrivateUrls?: boolean;
 }
 
 type ManagedGatewayRestart = (sandboxName: string) => { ok: boolean };
@@ -143,7 +144,13 @@ function restartSandboxAgentAfterConfigSet(
 }
 
 function buildConfigSetRestartGuidance(sandboxName: string, agentName: string): string[] {
-  if (agentName === "openclaw" || agentName === "hermes") {
+  if (agentName === "hermes") {
+    return [
+      "  Note: Hermes may restart its gateway when it applies this configuration.",
+      `  Use --restart to request and verify a restart, or run: nemoclaw ${shellQuote(sandboxName)} gateway restart`,
+    ];
+  }
+  if (agentName === "openclaw") {
     return [
       "  Note: Some config changes require a sandbox restart to take effect.",
       `  Re-run with --restart or run: nemoclaw ${shellQuote(sandboxName)} gateway restart`,
@@ -494,6 +501,19 @@ type ValidatedOpenClawCandidate = {
   privileged: import("../shields/state-dir-lock").PrivilegedExec;
 };
 
+function isHermesCompatHashRecoveryError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /compat hash (does not match frozen Hermes inputs|verification failed)/iu.test(message);
+}
+
+function hermesCompatHashRecoveryError(sandboxName: string): SandboxConfigError {
+  return new SandboxConfigError([
+    "  Hermes integrity metadata is not ready for a configuration write.",
+    `  Run: nemoclaw ${shellQuote(sandboxName)} recover`,
+    "  The configuration write was not applied.",
+  ]);
+}
+
 function writeSandboxConfig(
   sandboxName: string,
   target: AgentConfigTarget,
@@ -512,28 +532,35 @@ function writeSandboxConfig(
         "Refusing Hermes config write without the digest from the matching sandbox read.",
       );
     }
-    privilegedSandboxExec(
-      sandboxName,
-      [
-        "timeout",
-        "--signal=TERM",
-        "--kill-after=5s",
-        "2m",
-        HERMES_PYTHON,
-        "-I",
-        HERMES_RUNTIME_CONFIG_GUARD,
-        "write-config",
-        "--hermes-dir",
-        target.configDir,
-        "--hash-file",
-        HERMES_STRICT_HASH_FILE,
-        "--state-file",
-        HERMES_RESTART_SEAL_STATE,
-        "--expected-config-sha256",
-        expectedConfigSha256,
-      ],
-      { input: content, timeout: HERMES_CONFIG_GUARD_TIMEOUT_MS },
-    );
+    try {
+      privilegedSandboxExec(
+        sandboxName,
+        [
+          "timeout",
+          "--signal=TERM",
+          "--kill-after=5s",
+          "2m",
+          HERMES_PYTHON,
+          "-I",
+          HERMES_RUNTIME_CONFIG_GUARD,
+          "write-config",
+          "--hermes-dir",
+          target.configDir,
+          "--hash-file",
+          HERMES_STRICT_HASH_FILE,
+          "--state-file",
+          HERMES_RESTART_SEAL_STATE,
+          "--expected-config-sha256",
+          expectedConfigSha256,
+        ],
+        { input: content, timeout: HERMES_CONFIG_GUARD_TIMEOUT_MS },
+      );
+    } catch (error) {
+      if (isHermesCompatHashRecoveryError(error)) {
+        throw hermesCompatHashRecoveryError(sandboxName);
+      }
+      throw error;
+    }
     return;
   }
   if (target.agentName === "openclaw") {
@@ -849,6 +876,7 @@ function validateUrlValue(
 ): void {
   const parsed = parseHttpUrl(value);
   if (!parsed) return;
+  if (options.allowPrivateUrls && isPrivateHostname(parsed.hostname)) return;
   if (
     (options.allowOpenShellBridge || options.allowOpenShellBridgePath?.(pathSegments)) &&
     isAllowedOpenShellSandboxBridgeUrl(parsed)
@@ -869,6 +897,13 @@ async function validateUrlValueWithDnsResult(
   if (!parsed) return null;
 
   const hostname = parsed.hostname;
+  if (options.allowPrivateUrls && isPrivateHostname(hostname)) {
+    return {
+      protocol: parsed.protocol as "http:" | "https:",
+      originalUrl,
+      pinnedUrl: originalUrl,
+    };
+  }
   if (
     (options.allowOpenShellBridge || options.allowOpenShellBridgePath?.(pathSegments)) &&
     isAllowedOpenShellSandboxBridgeUrl(parsed)
@@ -960,6 +995,11 @@ function redactConfigValueForPreview(value: ConfigValue): ConfigValue {
 function formatConfigValueForLogs(value: ConfigValue | undefined): string {
   if (value === undefined) return "(not set)";
   return JSON.stringify(redactConfigValueForPreview(value));
+}
+
+function hermesConfigAllowsPrivateUrls(config: ConfigObject): boolean {
+  const security = config.security;
+  return isConfigObject(security) && security.allow_private_urls === true;
 }
 
 function configSetAllowsOpenShellBridge(
@@ -1264,6 +1304,7 @@ async function configSet(sandboxName: string, opts: ConfigSetOpts = {}): Promise
   let safeValue: ConfigValue;
   try {
     safeValue = await rewriteConfigUrlsWithDnsPinning(parsedValue, dnsPromises.lookup as LookupFn, {
+      allowPrivateUrls: target.agentName === "hermes" && hermesConfigAllowsPrivateUrls(config),
       allowOpenShellBridgePath: (relativePath) =>
         configSetAllowsOpenShellBridge(target.agentName, configKey, relativePath),
     });
@@ -1515,6 +1556,9 @@ export {
   configRotateToken,
   configSet,
   configSetAllowsOpenShellBridge,
+  hermesConfigAllowsPrivateUrls,
+  hermesCompatHashRecoveryError,
+  isHermesCompatHashRecoveryError,
   DEFAULT_AGENT_CONFIG,
   extractDotpath,
   findClobberingAncestor,

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -21,6 +21,8 @@ const {
   resolveAgentConfig,
   buildConfigSetRestartGuidance,
   buildRecomputeSandboxConfigHashScript,
+  hermesCompatHashRecoveryError,
+  isHermesCompatHashRecoveryError,
 } = require("../src/lib/sandbox/config");
 const { selectDirectSandboxContainer } = require("../src/lib/sandbox/privileged-exec");
 
@@ -122,6 +124,20 @@ describe("config set helpers", () => {
       }
     });
 
+    it("does not name Hermes in the OpenClaw restart note (#8614)", () => {
+      const output = buildConfigSetRestartGuidance("alpha", "openclaw").join("\n");
+
+      expect(output).not.toContain("Hermes");
+      expect(output).toContain("--restart");
+    });
+
+    it("names Hermes in the Hermes restart note (#8614)", () => {
+      const output = buildConfigSetRestartGuidance("alpha", "hermes").join("\n");
+
+      expect(output).toContain("Hermes may restart");
+      expect(output).toContain("--restart");
+    });
+
     it("uses runtime-specific guidance for custom agents", () => {
       const output = buildConfigSetRestartGuidance("custom-box", "custom-agent").join("\n");
 
@@ -129,6 +145,28 @@ describe("config set helpers", () => {
       expect(output).toContain("NemoClaw does not manage restarts for this agent");
       expect(output).not.toContain("--restart");
       expect(output).not.toContain("gateway restart");
+    });
+  });
+
+  describe("Hermes config-write recovery gate", () => {
+    it("names recover for a compat-hash refusal before a config write (#8614)", () => {
+      expect(
+        isHermesCompatHashRecoveryError(
+          new Error(
+            "compat hash does not match frozen Hermes inputs during non-root reconciliation",
+          ),
+        ),
+      ).toBe(true);
+      expect(isHermesCompatHashRecoveryError(new Error("compat hash verification failed"))).toBe(
+        true,
+      );
+      expect(isHermesCompatHashRecoveryError(new Error("Hermes schema validation rejected"))).toBe(
+        false,
+      );
+      const refusal = hermesCompatHashRecoveryError("triage-8614");
+      expect(refusal.name).toBe("SandboxConfigError");
+      expect(refusal.message).toContain("nemoclaw 'triage-8614' recover");
+      expect(refusal.message).toContain("not applied");
     });
   });
 
@@ -744,6 +782,16 @@ describe("config set helpers", () => {
             configSetAllowsOpenShellBridge("openclaw", "models.providers", relativePath),
         }),
       ).rejects.toThrow(/private/i);
+    });
+
+    it("keeps DNS pinning for public hosts after private URLs are enabled (#8614)", async () => {
+      const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+
+      await expect(
+        rewriteConfigUrlsWithDnsPinning("http://api.example.com/v1", lookup, {
+          allowPrivateUrls: true,
+        }),
+      ).resolves.toBe("http://93.184.216.34/v1");
     });
 
     it("recursively rewrites nested HTTP URLs and leaves non-URLs unchanged", async () => {

--- a/test/helpers/hermes-restart-config-seal-fixture.ts
+++ b/test/helpers/hermes-restart-config-seal-fixture.ts
@@ -19,6 +19,44 @@ export const RUNTIME_CONFIG_GUARD = path.join(
 
 const HERMES_GUARD_TIMEOUT_MS = 90_000;
 
+/**
+ * Provides the narrow GatewayConfig surface that the host-side guard fixtures need.
+ * The production guard imports Hermes' bundled gateway.config module from the image.
+ */
+function writeGatewayConfigStub(root: string): void {
+  const pythonRoot = path.join(root, "python");
+  const gatewayDir = path.join(pythonRoot, "gateway");
+  fs.mkdirSync(gatewayDir, { recursive: true });
+  fs.writeFileSync(path.join(gatewayDir, "__init__.py"), "", { mode: 0o600 });
+  fs.writeFileSync(
+    path.join(gatewayDir, "config.py"),
+    [
+      "class GatewayConfig:",
+      "    @classmethod",
+      "    def from_dict(cls, value):",
+      "        if not isinstance(value, dict):",
+      "            raise TypeError('Hermes configuration must be a mapping')",
+      "        platforms = value.get('platforms')",
+      "        if not isinstance(platforms, dict):",
+      "            return cls()",
+      "        teams = platforms.get('teams')",
+      "        if not isinstance(teams, dict):",
+      "            return cls()",
+      "        home_channel = teams.get('home_channel')",
+      "        if isinstance(home_channel, dict) and 'platform' not in home_channel:",
+      "            raise KeyError('platform')",
+      "        return cls()",
+      "",
+    ].join("\n"),
+    { mode: 0o600 },
+  );
+}
+
+export function gatewayConfigStubRoot(root: string): string {
+  writeGatewayConfigStub(root);
+  return path.join(root, "python");
+}
+
 export interface RestartFixture {
   root: string;
   sandboxDir: string;
@@ -82,6 +120,7 @@ export function createRestartFixture(): RestartFixture {
   const hash = hashInputs(configPath, envPath);
   fs.writeFileSync(hashPath, hash, { mode: 0o600 });
   fs.writeFileSync(compatHashPath, hash, { mode: 0o600 });
+  writeGatewayConfigStub(root);
 
   return {
     root,
@@ -111,10 +150,22 @@ export function allowRestartFixturePeerTraversal(fixture: RestartFixture): () =>
 }
 
 export function runWriteConfig(fixture: RestartFixture, expectedDigest: string, content: string) {
+  const wrapper = String.raw`
+import sys
+
+source_path = sys.argv[1]
+sys.path.insert(0, sys.argv[2])
+sys.argv = [source_path, *sys.argv[3:]]
+with open(source_path, "rb") as source:
+    exec(compile(source.read(), source_path, "exec"), {"__name__": "__main__", "__file__": source_path})
+`;
   return spawnSync(
     "python3",
     [
+      "-c",
+      wrapper,
       RUNTIME_CONFIG_GUARD,
+      gatewayConfigStubRoot(fixture.root),
       "write-config",
       "--hermes-dir",
       fixture.hermesDir,
@@ -125,7 +176,11 @@ export function runWriteConfig(fixture: RestartFixture, expectedDigest: string, 
       "--expected-config-sha256",
       expectedDigest,
     ],
-    { encoding: "utf-8", input: content, timeout: HERMES_GUARD_TIMEOUT_MS },
+    {
+      encoding: "utf-8",
+      input: content,
+      timeout: HERMES_GUARD_TIMEOUT_MS,
+    },
   );
 }
 

--- a/test/hermes-nonroot-strict-hash-reconciliation.test.ts
+++ b/test/hermes-nonroot-strict-hash-reconciliation.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { gatewayConfigStubRoot } from "./helpers/hermes-restart-config-seal-fixture";
 const RUNTIME_CONFIG_GUARD = path.join(
   import.meta.dirname,
   "..",
@@ -81,11 +82,30 @@ function writeConfigArgs(fixture: ReconciliationFixture, expectedDigest: string)
 }
 
 function runSourceWrite(fixture: ReconciliationFixture, expectedDigest: string, content: string) {
-  return spawnSync("python3", [RUNTIME_CONFIG_GUARD, ...writeConfigArgs(fixture, expectedDigest)], {
-    encoding: "utf-8",
-    input: content,
-    timeout: 5000,
-  });
+  const wrapper = String.raw`
+import sys
+
+source_path = sys.argv[1]
+sys.path.insert(0, sys.argv[2])
+sys.argv = [source_path, *sys.argv[3:]]
+with open(source_path, "rb") as source:
+    exec(compile(source.read(), source_path, "exec"), {"__name__": "__main__", "__file__": source_path})
+`;
+  return spawnSync(
+    "python3",
+    [
+      "-c",
+      wrapper,
+      RUNTIME_CONFIG_GUARD,
+      gatewayConfigStubRoot(fixture.root),
+      ...writeConfigArgs(fixture, expectedDigest),
+    ],
+    {
+      encoding: "utf-8",
+      input: content,
+      timeout: 5000,
+    },
+  );
 }
 
 function runManagedNonrootWrite(
@@ -99,6 +119,7 @@ import os
 import sys
 
 source = sys.argv[1]
+sys.path.insert(0, sys.argv[2])
 spec = importlib.util.spec_from_file_location("nemoclaw_runtime_config_guard_fixture", source)
 if spec is None or spec.loader is None:
     raise SystemExit("could not load runtime guard fixture")
@@ -107,13 +128,23 @@ sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 module._managed_nonroot_reconciliation_is_allowed = lambda: True
 module._sandbox_identity = lambda: (os.geteuid(), os.getegid())
-sys.argv = [source, *sys.argv[2:]]
+sys.argv = [source, *sys.argv[3:]]
 raise SystemExit(module.main())
 `;
   return spawnSync(
     "python3",
-    ["-c", wrapper, RUNTIME_CONFIG_GUARD, ...writeConfigArgs(fixture, expectedDigest)],
-    { encoding: "utf-8", input: content, timeout: 5000 },
+    [
+      "-c",
+      wrapper,
+      RUNTIME_CONFIG_GUARD,
+      gatewayConfigStubRoot(fixture.root),
+      ...writeConfigArgs(fixture, expectedDigest),
+    ],
+    {
+      encoding: "utf-8",
+      input: content,
+      timeout: 5000,
+    },
   );
 }
 
@@ -123,6 +154,7 @@ import importlib.util
 import sys
 
 source = sys.argv[1]
+sys.path.insert(0, sys.argv[2])
 spec = importlib.util.spec_from_file_location("nemoclaw_runtime_config_guard_shields_fixture", source)
 if spec is None or spec.loader is None:
     raise SystemExit("could not load runtime guard fixture")
@@ -130,7 +162,7 @@ module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 module._managed_nonroot_reconciliation_is_allowed = lambda: True
-sys.argv = [source, *sys.argv[2:]]
+sys.argv = [source, *sys.argv[3:]]
 raise SystemExit(module.main())
 `;
   return spawnSync(
@@ -139,6 +171,7 @@ raise SystemExit(module.main())
       "-c",
       wrapper,
       RUNTIME_CONFIG_GUARD,
+      gatewayConfigStubRoot(fixture.root),
       "begin-shields-transition",
       "--hermes-dir",
       fixture.hermesDir,

--- a/test/hermes-restart-config-seal-transition.test.ts
+++ b/test/hermes-restart-config-seal-transition.test.ts
@@ -187,6 +187,13 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
       expect(mode(fixture.sandboxDir)).toBe(0o1775);
       expect(strictHashIsValid(fixture)).toBe(true);
     } finally {
+      for (const pathname of [fixture.sandboxDir, fixture.hermesDir]) {
+        try {
+          fs.chmodSync(pathname, 0o770);
+        } catch {
+          // A failed transition can remove the fixture directory.
+        }
+      }
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }
   });

--- a/test/hermes-runtime-config-guard.test.ts
+++ b/test/hermes-runtime-config-guard.test.ts
@@ -56,6 +56,34 @@ print(json.dumps(guard.SEALED_FILE_NAMES))
   });
 });
 
+describe("Hermes candidate schema validation (#8614)", () => {
+  it("rejects an incomplete home_channel before a sealed write transaction starts", () => {
+    const result = runPythonHarness(`${loadGuardModule}
+import json
+import types
+
+guard.seal_restart = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must not seal"))
+guard.os.path.exists = lambda value: value.endswith("config.yaml")
+class GatewayConfig:
+    @classmethod
+    def from_dict(cls, value):
+        home_channel = value["platforms"]["teams"]["home_channel"]
+        if "platform" not in home_channel:
+            raise KeyError("platforms.teams.home_channel.platform")
+sys.modules["gateway.config"] = types.SimpleNamespace(GatewayConfig=GatewayConfig)
+try:
+    guard.write_config_transaction(
+        "/unused", "/unused-hash", "/unused-state", "a" * 64,
+        b"platforms:\\n  teams:\\n    home_channel:\\n      chat_id: 19:triage8614\\n",
+    )
+except guard.UnsafePathError as exc:
+    print(json.dumps(str(exc)))
+`);
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toContain("platforms.teams.home_channel.platform");
+  });
+});
+
 describe("Hermes runtime config hash refresh race protection", () => {
   it("creates an absent private runtime directory through its pinned parent", () => {
     const result = runPythonHarness(`${loadGuardModule}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes configuration writes now validate the complete candidate before changing configuration or integrity metadata. The lifecycle also reports truthful restart effects, bounded redacted restart diagnostics, targeted recovery guidance, and an explicit private-URL opt-in while retaining public-host DNS validation and pinning.

## Related Issue

Fixes #8614

## Changes

- Validate complete Hermes configuration candidates with the bundled Hermes schema before starting a sealed write transaction. Tests verify that structurally incomplete writes preserve configuration, environment, and integrity hashes.
- Read the existing Hermes `security.allow_private_urls` boolean as the explicit opt-in required by the CLI and plugin. Public hosts continue through DNS validation and pinning; private URLs remain denied by default.
- Report Hermes restart behavior and `--restart` verification accurately, and direct pre-write compatibility-hash failures to `nemoclaw '<sandbox>' recover`.
- Include at most 12 redacted lines from `/tmp/gateway.log` when Hermes supervisor restart fails, without exposing credential-shaped values.
- Document Hermes validation, restart, managed `.env`, recovery, and private-URL behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Pi security and correctness reviewers found no actionable blockers after repairs; explicit private-URL opt-in, DNS pinning, pre-mutation integrity, and diagnostic redaction received focused review and tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/commands.mdx`; changed code comments, diagnostics, and behavior-oriented test titles
- Agent: Pi documentation writer reviewer
<!-- docs-review-head-sha: 17f2e6cbe -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Focused Hermes/config/restart Vitest suites passed; `python3 -m unittest agents.hermes.plugin.test_private_url_opt_in` passed; CLI typecheck and plugin build passed. Real CLI E2E verified atomic rejection with unchanged hashes, a valid write, post-rebuild write recovery, bounded restart diagnostics, default private-URL denial, and explicit opt-in acceptance.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Local `npm test` did not pass because the handoff hook leaked into temporary Git fixtures and unrelated environment-dependent baseline tests failed. The issue-focused suites passed; CI remains authoritative for the broad gate.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hermes configuration changes are now validated before being saved, preventing invalid or incomplete updates.
  - Private URL access requires an explicit configuration opt-in; public hosts continue to receive DNS validation.
  - Hermes gateway restart failures now include a sanitized, concise log excerpt to aid troubleshooting.
  - Recovery guidance is clearer when configuration integrity checks fail.

- **Bug Fixes**
  - Prevented unintended enabling of private URL access during browser safety updates.

- **Documentation**
  - Updated configuration command guidance and Hermes-specific behavior, safeguards, and restart requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->