### PR TITLE
test(e2e): wait for Brev host SSH

### DIFF
--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -52,7 +52,7 @@ function fixture(
   const timeoutBlock = path.join(root, "timeout-block");
   fs.mkdirSync(bin);
   fs.mkdirSync(workDir);
-  if (options.blockRefresh) fs.writeFileSync(timeoutBlock, "block\n");
+  fs.writeFileSync(timeoutBlock, "block\n");
 
   executable(
     path.join(bin, "timeout"),
@@ -205,7 +205,7 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     FAKE_SOURCE_REPOSITORY: options.sourceRepository ?? "NVIDIA/NemoClaw",
     FAKE_SOURCE_PATH: options.sourcePath ?? "/opt/nemoclaw-image/NemoClaw",
     FAKE_STATE: state,
-    FAKE_TIMEOUT_BLOCK: timeoutBlock,
+    FAKE_TIMEOUT_BLOCK: options.blockRefresh ? timeoutBlock : path.join(root, "timeout-disabled"),
     GH_TOKEN: "github-test-token",
     GITHUB_RUN_ATTEMPT: "1",
     GITHUB_RUN_ID: "789",

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -22,6 +22,7 @@ function executable(file: string, source: string): void {
 
 function fixture(
   options: {
+    blockRefresh?: boolean;
     bootImage?: string;
     deleteFails?: boolean;
     e2eFails?: boolean;
@@ -48,10 +49,26 @@ function fixture(
   const state = path.join(root, "workspace.json");
   const calls = path.join(root, "calls.log");
   const sshAttempts = path.join(root, "ssh-attempts");
+  const timeoutBlock = path.join(root, "timeout-block");
   fs.mkdirSync(bin);
   fs.mkdirSync(workDir);
+  if (options.blockRefresh) fs.writeFileSync(timeoutBlock, "block\n");
 
-  executable(path.join(bin, "timeout"), '#!/usr/bin/env bash\nshift\nexec "$@"\n');
+  executable(
+    path.join(bin, "timeout"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+duration="$1"
+shift
+printf 'timeout %s %s\n' "$duration" "$*" >> "$FAKE_CALLS"
+if [ -f "$FAKE_TIMEOUT_BLOCK" ] && [ "\${1:-} \${2:-}" = "brev refresh" ]; then
+  rm -f "$FAKE_TIMEOUT_BLOCK"
+  /bin/sleep "\${duration%s}"
+  exit 124
+fi
+exec "$@"
+`,
+  );
   executable(
     path.join(bin, "sleep"),
     '#!/usr/bin/env bash\nprintf "sleep %s\\n" "$*" >> "$FAKE_CALLS"\n',
@@ -134,11 +151,17 @@ esac
     `#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${*: -1}" = true ]; then
+  expected=(-T -o BatchMode=yes -o ConnectTimeout=10 -o ConnectionAttempts=1 -o NumberOfPasswordPrompts=0 -o RequestTTY=no -o LogLevel=ERROR "$INSTANCE_NAME-host" true)
+  [ "$#" -eq "\${#expected[@]}" ]
+  received=("$@")
+  for index in "\${!expected[@]}"; do
+    [ "\${received[$index]}" = "\${expected[$index]}" ]
+  done
   attempts=0
   [ ! -f "$FAKE_SSH_ATTEMPTS" ] || attempts="$(cat "$FAKE_SSH_ATTEMPTS")"
   attempts=$((attempts + 1))
   printf '%s\n' "$attempts" > "$FAKE_SSH_ATTEMPTS"
-  printf 'ssh host readiness attempt %s\n' "$attempts" >> "$FAKE_CALLS"
+  printf 'ssh host readiness attempt %s: %s\n' "$attempts" "$*" >> "$FAKE_CALLS"
   [ "$attempts" -ge "$FAKE_SSH_READY_AFTER" ]
   exit
 fi
@@ -182,6 +205,7 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     FAKE_SOURCE_REPOSITORY: options.sourceRepository ?? "NVIDIA/NemoClaw",
     FAKE_SOURCE_PATH: options.sourcePath ?? "/opt/nemoclaw-image/NemoClaw",
     FAKE_STATE: state,
+    FAKE_TIMEOUT_BLOCK: timeoutBlock,
     GH_TOKEN: "github-test-token",
     GITHUB_RUN_ATTEMPT: "1",
     GITHUB_RUN_ID: "789",
@@ -211,6 +235,9 @@ describe("focused staging Brev Launchable lane", () => {
     );
     expect(commands).toContain("create nclaw-e2e-test-1 --launchable env-staging123");
     expect(commands.match(/ssh host readiness attempt/gu)).toHaveLength(3);
+    expect(commands).toContain(
+      "ssh host readiness attempt 1: -T -o BatchMode=yes -o ConnectTimeout=10 -o ConnectionAttempts=1 -o NumberOfPasswordPrompts=0 -o RequestTTY=no -o LogLevel=ERROR nclaw-e2e-test-1-host true",
+    );
     expect(fs.readFileSync(sshAttempts, "utf8").trim()).toBe("3");
     expect(commands).toContain("ssh preinstalled full-e2e.test.ts");
     expect(commands).not.toContain("nvapi-test-value");
@@ -320,6 +347,22 @@ describe("focused staging Brev Launchable lane", () => {
       status: "ABSENT",
     });
   });
+
+  it("caps a blocking refresh by the host SSH deadline and deletes the workspace", () => {
+    const { calls, env, state, workDir } = fixture({ blockRefresh: true });
+    const startedAt = performance.now();
+    const result = run({ ...env, BREV_HOST_SSH_TIMEOUT_SECONDS: "1" });
+    const elapsedMs = performance.now() - startedAt;
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("host SSH readiness timed out");
+    expect(elapsedMs).toBeLessThan(10_000);
+    expect(fs.readFileSync(calls, "utf8")).toContain("timeout 1s brev refresh");
+    expect(fs.readFileSync(calls, "utf8")).not.toMatch(/brev exec|full-e2e\.test\.ts/u);
+    expect(fs.existsSync(state)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(path.join(workDir, "cleanup.json"), "utf8"))).toMatchObject({
+      status: "ABSENT",
+    });
+  }, 90_000);
 
   it("preserves the booted image when the provision receipt is missing", () => {
     const { calls, env, state, workDir } = fixture({ missingProvisionReceipt: true });

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -36,6 +36,7 @@ function fixture(
     repoSha?: string;
     runtimeOverrides?: boolean;
     schemaVersion?: number;
+    sshReadyAfter?: number;
     sourceRepository?: string;
     sourcePath?: string;
   } = {},
@@ -46,6 +47,7 @@ function fixture(
   const workDir = path.join(root, "evidence");
   const state = path.join(root, "workspace.json");
   const calls = path.join(root, "calls.log");
+  const sshAttempts = path.join(root, "ssh-attempts");
   fs.mkdirSync(bin);
   fs.mkdirSync(workDir);
 
@@ -131,6 +133,15 @@ esac
     path.join(bin, "ssh"),
     `#!/usr/bin/env bash
 set -euo pipefail
+if [ "\${*: -1}" = true ]; then
+  attempts=0
+  [ ! -f "$FAKE_SSH_ATTEMPTS" ] || attempts="$(cat "$FAKE_SSH_ATTEMPTS")"
+  attempts=$((attempts + 1))
+  printf '%s\n' "$attempts" > "$FAKE_SSH_ATTEMPTS"
+  printf 'ssh host readiness attempt %s\n' "$attempts" >> "$FAKE_CALLS"
+  [ "$attempts" -ge "$FAKE_SSH_READY_AFTER" ]
+  exit
+fi
 script="$(cat)"
 grep -q 'NEMOCLAW_E2E_SETUP_MODE=preinstalled-launchable' <<<"$script"
 grep -q 'NEMOCLAW_SOURCE_PATH=/opt/nemoclaw-image/NemoClaw' <<<"$script"
@@ -166,6 +177,8 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     FAKE_REPO_SHA: options.repoSha ?? candidateSha,
     FAKE_RUNTIME_OVERRIDES: options.runtimeOverrides ? "true" : "false",
     FAKE_SCHEMA_VERSION: String(options.schemaVersion ?? 1),
+    FAKE_SSH_ATTEMPTS: sshAttempts,
+    FAKE_SSH_READY_AFTER: String(options.sshReadyAfter ?? 1),
     FAKE_SOURCE_REPOSITORY: options.sourceRepository ?? "NVIDIA/NemoClaw",
     FAKE_SOURCE_PATH: options.sourcePath ?? "/opt/nemoclaw-image/NemoClaw",
     FAKE_STATE: state,
@@ -178,7 +191,7 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     RUNNER_TEMP: root,
     WORK_DIR: workDir,
   };
-  return { calls, env, state, workDir };
+  return { calls, env, sshAttempts, state, workDir };
 }
 
 function run(env: NodeJS.ProcessEnv) {
@@ -187,7 +200,7 @@ function run(env: NodeJS.ProcessEnv) {
 
 describe("focused staging Brev Launchable lane", () => {
   it("binds the producer run, verifies the clean booted SHA, runs E2E, and deletes (#6943)", () => {
-    const { calls, env, state, workDir } = fixture();
+    const { calls, env, sshAttempts, state, workDir } = fixture({ sshReadyAfter: 3 });
     const result = run(env);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     const commands = fs.readFileSync(calls, "utf8");
@@ -197,6 +210,8 @@ describe("focused staging Brev Launchable lane", () => {
       commands.indexOf("create nclaw-e2e-test-1 --launchable env-staging123"),
     );
     expect(commands).toContain("create nclaw-e2e-test-1 --launchable env-staging123");
+    expect(commands.match(/ssh host readiness attempt/gu)).toHaveLength(3);
+    expect(fs.readFileSync(sshAttempts, "utf8").trim()).toBe("3");
     expect(commands).toContain("ssh preinstalled full-e2e.test.ts");
     expect(commands).not.toContain("nvapi-test-value");
     expect(commands).not.toMatch(/rsync|install\.sh|npm (?:ci|install)|git clone/u);
@@ -281,13 +296,25 @@ describe("focused staging Brev Launchable lane", () => {
       expect(fs.readFileSync(boot.calls, "utf8")).not.toContain("full-e2e.test.ts");
       expect(fs.existsSync(boot.state)).toBe(false);
     }
-  });
+  }, 90_000);
 
   it("reports E2E failure only after verified workspace cleanup", () => {
     const { env, state, workDir } = fixture({ e2eFails: true });
     const result = run(env);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("full E2E failed");
+    expect(fs.existsSync(state)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(path.join(workDir, "cleanup.json"), "utf8"))).toMatchObject({
+      status: "ABSENT",
+    });
+  });
+
+  it("fails after host SSH readiness times out and deletes the workspace", () => {
+    const { calls, env, state, workDir } = fixture({ sshReadyAfter: Number.MAX_SAFE_INTEGER });
+    const result = run({ ...env, BREV_HOST_SSH_TIMEOUT_SECONDS: "1" });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("host SSH readiness timed out");
+    expect(fs.readFileSync(calls, "utf8")).not.toMatch(/brev exec|full-e2e\.test\.ts/u);
     expect(fs.existsSync(state)).toBe(false);
     expect(JSON.parse(fs.readFileSync(path.join(workDir, "cleanup.json"), "utf8"))).toMatchObject({
       status: "ABSENT",

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -22,7 +22,6 @@ function executable(file: string, source: string): void {
 
 function fixture(
   options: {
-    blockRefresh?: boolean;
     bootImage?: string;
     deleteFails?: boolean;
     e2eFails?: boolean;
@@ -40,6 +39,7 @@ function fixture(
     sshReadyAfter?: number;
     sourceRepository?: string;
     sourcePath?: string;
+    timeoutBlockCommand?: "brev refresh" | "ssh -T";
   } = {},
 ) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-launchable-e2e-"));
@@ -61,7 +61,7 @@ set -euo pipefail
 duration="$1"
 shift
 printf 'timeout %s %s\n' "$duration" "$*" >> "$FAKE_CALLS"
-if [ -f "$FAKE_TIMEOUT_BLOCK" ] && [ "\${1:-} \${2:-}" = "brev refresh" ]; then
+if [ -f "$FAKE_TIMEOUT_BLOCK" ] && [ "\${1:-} \${2:-}" = "$FAKE_TIMEOUT_BLOCK_COMMAND" ]; then
   rm -f "$FAKE_TIMEOUT_BLOCK"
   /bin/sleep "\${duration%s}"
   exit 124
@@ -151,12 +151,11 @@ esac
     `#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${*: -1}" = true ]; then
-  expected=(-T -o BatchMode=yes -o ConnectTimeout=10 -o ConnectionAttempts=1 -o NumberOfPasswordPrompts=0 -o RequestTTY=no -o LogLevel=ERROR "$INSTANCE_NAME-host" true)
-  [ "$#" -eq "\${#expected[@]}" ]
-  received=("$@")
-  for index in "\${!expected[@]}"; do
-    [ "\${received[$index]}" = "\${expected[$index]}" ]
+  required=(-T "-o BatchMode=yes" "-o ConnectTimeout=10" "-o ConnectionAttempts=1" "-o NumberOfPasswordPrompts=0" "-o RequestTTY=no" "-o LogLevel=ERROR")
+  for argument in "\${required[@]}"; do
+    [[ " $* " == *" $argument "* ]]
   done
+  [ "\${*: -2:1}" = "$INSTANCE_NAME-host" ]
   attempts=0
   [ ! -f "$FAKE_SSH_ATTEMPTS" ] || attempts="$(cat "$FAKE_SSH_ATTEMPTS")"
   attempts=$((attempts + 1))
@@ -205,7 +204,10 @@ printf 'NEMOCLAW_FULL_E2E_PASSED\\n'
     FAKE_SOURCE_REPOSITORY: options.sourceRepository ?? "NVIDIA/NemoClaw",
     FAKE_SOURCE_PATH: options.sourcePath ?? "/opt/nemoclaw-image/NemoClaw",
     FAKE_STATE: state,
-    FAKE_TIMEOUT_BLOCK: options.blockRefresh ? timeoutBlock : path.join(root, "timeout-disabled"),
+    FAKE_TIMEOUT_BLOCK: options.timeoutBlockCommand
+      ? timeoutBlock
+      : path.join(root, "timeout-disabled"),
+    FAKE_TIMEOUT_BLOCK_COMMAND: options.timeoutBlockCommand ?? "",
     GH_TOKEN: "github-test-token",
     GITHUB_RUN_ATTEMPT: "1",
     GITHUB_RUN_ID: "789",
@@ -235,9 +237,23 @@ describe("focused staging Brev Launchable lane", () => {
     );
     expect(commands).toContain("create nclaw-e2e-test-1 --launchable env-staging123");
     expect(commands.match(/ssh host readiness attempt/gu)).toHaveLength(3);
-    expect(commands).toContain(
-      "ssh host readiness attempt 1: -T -o BatchMode=yes -o ConnectTimeout=10 -o ConnectionAttempts=1 -o NumberOfPasswordPrompts=0 -o RequestTTY=no -o LogLevel=ERROR nclaw-e2e-test-1-host true",
+    const readinessCall = commands
+      .split("\n")
+      .find((line) => line.startsWith("ssh host readiness attempt 1: "));
+    expect(readinessCall).toBeDefined();
+    const readinessArgs = readinessCall?.split(": ").at(1)?.split(" ") ?? [];
+    expect(readinessArgs).toEqual(
+      expect.arrayContaining([
+        "-T",
+        "BatchMode=yes",
+        "ConnectTimeout=10",
+        "ConnectionAttempts=1",
+        "NumberOfPasswordPrompts=0",
+        "RequestTTY=no",
+        "LogLevel=ERROR",
+      ]),
     );
+    expect(readinessArgs.slice(-2)).toEqual(["nclaw-e2e-test-1-host", "true"]);
     expect(fs.readFileSync(sshAttempts, "utf8").trim()).toBe("3");
     expect(commands).toContain("ssh preinstalled full-e2e.test.ts");
     expect(commands).not.toContain("nvapi-test-value");
@@ -349,7 +365,7 @@ describe("focused staging Brev Launchable lane", () => {
   });
 
   it("caps a blocking refresh by the host SSH deadline and deletes the workspace", () => {
-    const { calls, env, state, workDir } = fixture({ blockRefresh: true });
+    const { calls, env, state, workDir } = fixture({ timeoutBlockCommand: "brev refresh" });
     const startedAt = performance.now();
     const result = run({ ...env, BREV_HOST_SSH_TIMEOUT_SECONDS: "1" });
     const elapsedMs = performance.now() - startedAt;
@@ -357,6 +373,22 @@ describe("focused staging Brev Launchable lane", () => {
     expect(result.stderr).toContain("host SSH readiness timed out");
     expect(elapsedMs).toBeLessThan(10_000);
     expect(fs.readFileSync(calls, "utf8")).toContain("timeout 1s brev refresh");
+    expect(fs.readFileSync(calls, "utf8")).not.toMatch(/brev exec|full-e2e\.test\.ts/u);
+    expect(fs.existsSync(state)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(path.join(workDir, "cleanup.json"), "utf8"))).toMatchObject({
+      status: "ABSENT",
+    });
+  }, 90_000);
+
+  it("caps a blocking SSH probe by the host SSH deadline and deletes the workspace", () => {
+    const { calls, env, state, workDir } = fixture({ timeoutBlockCommand: "ssh -T" });
+    const startedAt = performance.now();
+    const result = run({ ...env, BREV_HOST_SSH_TIMEOUT_SECONDS: "2" });
+    const elapsedMs = performance.now() - startedAt;
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("host SSH readiness timed out");
+    expect(elapsedMs).toBeLessThan(10_000);
+    expect(fs.readFileSync(calls, "utf8")).toContain("timeout 2s ssh -T");
     expect(fs.readFileSync(calls, "utf8")).not.toMatch(/brev exec|full-e2e\.test\.ts/u);
     expect(fs.existsSync(state)).toBe(false);
     expect(JSON.parse(fs.readFileSync(path.join(workDir, "cleanup.json"), "utf8"))).toMatchObject({

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -41,17 +41,27 @@ workspace() {
 wait_for_host_ssh() {
   local timeout_seconds="${BREV_HOST_SSH_TIMEOUT_SECONDS:-600}"
   local deadline=$((SECONDS + timeout_seconds))
+  local remaining refresh_timeout sleep_seconds ssh_timeout
   log "Waiting for host SSH access"
   while [ "$SECONDS" -lt "$deadline" ]; do
-    timeout 60s brev refresh >/dev/null 2>&1 || true
-    if timeout 15s ssh -T -o BatchMode=yes -o ConnectTimeout=10 \
+    remaining=$((deadline - SECONDS))
+    [ "$remaining" -gt 0 ] || break
+    refresh_timeout=$((remaining < 60 ? remaining : 60))
+    timeout "${refresh_timeout}s" brev refresh >/dev/null 2>&1 || true
+    remaining=$((deadline - SECONDS))
+    [ "$remaining" -gt 0 ] || break
+    ssh_timeout=$((remaining < 15 ? remaining : 15))
+    if timeout "${ssh_timeout}s" ssh -T -o BatchMode=yes -o ConnectTimeout=10 \
       -o ConnectionAttempts=1 -o NumberOfPasswordPrompts=0 \
       -o RequestTTY=no -o LogLevel=ERROR "${INSTANCE_NAME}-host" true \
       >/dev/null 2>&1; then
       log "SSH access to ${INSTANCE_NAME}-host succeeded"
       return 0
     fi
-    sleep "${POLL_SECONDS:-15}"
+    remaining=$((deadline - SECONDS))
+    [ "$remaining" -gt 0 ] || break
+    sleep_seconds="${POLL_SECONDS:-15}"
+    sleep "$((sleep_seconds < remaining ? sleep_seconds : remaining))"
   done
   die "host SSH readiness timed out"
 }

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -38,6 +38,24 @@ workspace() {
       else error("workspace name is ambiguous") end'
 }
 
+wait_for_host_ssh() {
+  local timeout_seconds="${BREV_HOST_SSH_TIMEOUT_SECONDS:-600}"
+  local deadline=$((SECONDS + timeout_seconds))
+  log "Waiting for host SSH access"
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    timeout 60s brev refresh >/dev/null 2>&1 || true
+    if timeout 15s ssh -T -o BatchMode=yes -o ConnectTimeout=10 \
+      -o ConnectionAttempts=1 -o NumberOfPasswordPrompts=0 \
+      -o RequestTTY=no -o LogLevel=ERROR "${INSTANCE_NAME}-host" true \
+      >/dev/null 2>&1; then
+      log "SSH access to ${INSTANCE_NAME}-host succeeded"
+      return 0
+    fi
+    sleep "${POLL_SECONDS:-15}"
+  done
+  die "host SSH readiness timed out"
+}
+
 cleanup() {
   local record deadline absent=0 workspace_id=""
   record="$(workspace || true)"
@@ -176,6 +194,7 @@ jq -e '.status == "RUNNING" and (.shell_status // .shellStatus) == "READY" and
   <<<"${ready:-null}" >/dev/null || die "workspace readiness timed out"
 workspace_id="$(jq -r '.id // ""' <<<"$ready")"
 log "Workspace $INSTANCE_NAME ($workspace_id) is ready"
+wait_for_host_ssh
 
 # Record the booted image before reading the baked runtime receipt so a stale
 # Launchable image remains visible when the receipt is absent.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The trusted Brev Launchable E2E lane now waits for host SSH access after the Brev API reports the workspace running. Previously, the first image-metadata probe could exhaust the Brev CLI's internal SSH retry window and fail before the exact image check.

## Changes

- Add a bounded host SSH access check before the first `brev exec` image-metadata probe, with each refresh, SSH probe, and sleep capped by the remaining deadline.
- Keep a persistent SSH failure fail-closed and run the existing workspace deletion and absence verification.
- Model delayed and unavailable SSH access plus a blocking Brev refresh in the integration fixture.
- Validate the noninteractive SSH target and every security-relevant option without depending on argument order.
- Cover a blocked SSH process and prove the outer timeout still leads to verified cleanup.
- Give the existing synchronous multi-case negative test enough time to run its added SSH processes.
- Record the escaped-defect detection gap: the previous fixture always made SSH available on the first attempt, so it did not cover delayed host access after API readiness.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal trusted-main E2E harness. It does not change a public CLI, configuration, API, policy, default, or supported user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The completed security-rubric review found no wider credential or authorization boundary. The fixed `ssh true` probe receives no inference credential, discards output, cannot bypass the exact image and runtime checks, and triggers verified workspace deletion after timeout.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `c28af0738` changes only the trusted Brev Launchable E2E harness and its integration regression tests. It adds an internal direct-host SSH readiness check, caps refresh, SSH, and sleep operations by one remaining deadline, and verifies required SSH options, retries, timeout cleanup, a blocking refresh, and a blocking SSH probe. No public CLI, configuration, API, policy, default, supported user workflow, documentation, or navigation path changed. All 8 focused integration tests passed in 43.24 seconds; the local test-conditionals scan completed; ShellCheck passed; repository shfmt produced no diff; `git diff --check` passed; normal pre-commit and commit-msg hooks passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: c28af0738 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec -- vitest run --project integration test/brev-launchable-e2e.test.ts --reporter=verbose` passed all eight tests in 43.24 seconds. The local test-conditionals scan completed, `shellcheck` passed, and repository `shfmt` settings produced no diff.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote workspace startup by verifying SSH connectivity before running workflows.
  * Added retries for temporary SSH readiness delays.
  * Added bounded refresh and SSH readiness timeouts.
  * Workspaces are now cleaned up when readiness checks time out or connectivity remains unavailable.

* **Tests**
  * Expanded end-to-end coverage for successful retries, SSH readiness timeouts, blocked refreshes, and blocked SSH checks.
  * Increased test time limits to better accommodate slower environment initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->