### PR TITLE
fix(onboard): honor explicit fresh recreation

### DIFF
--- a/src/lib/onboard/machine/handlers/sandbox-create-intent-boundary.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-create-intent-boundary.test.ts
@@ -96,7 +96,7 @@ describe("sandbox create intent machine boundary", () => {
           disabledChannelNames: [],
           extraPlaceholderKeys: [],
         },
-        recreate: expect.any(Boolean),
+        recreate: false,
         toolDisclosure: "progressive",
         observabilityEnabled: false,
         extraProviders: [],
@@ -115,6 +115,20 @@ describe("sandbox create intent machine boundary", () => {
 
     expect(resolvedIntents[1]).toEqual(resolvedIntents[0]);
     expect(resolvedIntents[2]).toEqual(resolvedIntents[0]);
+  });
+
+  it("carries an explicit recreate request through a fresh sandbox decision (#8847)", async () => {
+    const session = createSession({ sandboxName: "same-sandbox" });
+    const { deps, calls } = createDeps();
+
+    await handleSandboxState({
+      ...baseOptions(deps, session),
+      fresh: true,
+      recreateSandbox: () => true,
+      sandboxName: "same-sandbox",
+    });
+
+    expect(calls.createSandbox.mock.calls[0]?.at(-1)).toMatchObject({ recreate: true });
   });
 
   it("checkpoints a known sandbox name before an interrupted web-search prompt (#6743)", async () => {

--- a/src/lib/onboard/machine/handlers/sandbox-resume.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-resume.ts
@@ -115,6 +115,13 @@ export function replacesSameNameSandbox(decision: SandboxResumeDecision): boolea
   return decision.kind === "recreate" && decision.removeRegistryEntry;
 }
 
+export function requiresSandboxRecreation(
+  decision: Exclude<SandboxResumeDecision, { readonly kind: "reuse" }>,
+  explicitlyRequested: boolean,
+): boolean {
+  return explicitlyRequested || decision.kind !== "create";
+}
+
 export function mcpRegistryRemovalBlockReason(
   decision: SandboxResumeDecision,
   sandboxName: string | null,

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -116,6 +116,7 @@ import {
   hasHermesCompatibleAnthropicInferenceRouteDrift,
   mcpRegistryRemovalBlockReason,
   replacesSameNameSandbox,
+  requiresSandboxRecreation,
   resolveToolDisclosureResumeSignals,
   type SandboxResumeDecision,
 } from "./sandbox-resume";
@@ -1456,7 +1457,7 @@ class SandboxStateFlow<
     });
     return {
       resolved,
-      recreate: decision.kind !== "create",
+      recreate: requiresSandboxRecreation(decision, this.options.recreateSandbox(false)),
       toolDisclosure: toolDisclosureOrDefault(state.session?.toolDisclosure),
       observabilityEnabled: state.session?.observabilityEnabled === true,
       ...(reuseRegisteredCredentials ? { reuseRegisteredCredentials: true as const } : {}),

--- a/test/e2e/e2e-cloud-experimental/checks/04-deepagents-code-fresh-reonboard.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/04-deepagents-code-fresh-reonboard.sh
@@ -263,7 +263,8 @@ if ! reonboard_output="$(
     NEMOCLAW_SANDBOX_NAME="$SANDBOX_NAME" \
     OPENSHELL_GATEWAY=nemoclaw \
     "$CLI" onboard --agent langchain-deepagents-code --name "$SANDBOX_NAME" \
-    --fresh --non-interactive --observability --yes --yes-i-accept-third-party-software 2>&1
+    --fresh --recreate-sandbox --non-interactive --observability --yes \
+    --yes-i-accept-third-party-software 2>&1
 )"; then
   fail "same-name --fresh re-onboard failed: $reonboard_output"
 fi


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw onboard --fresh --recreate-sandbox` could report success while reusing a ready sandbox. This change carries the explicit recreation request into the complete create intent so the existing sandbox is replaced as documented.

The dropped request was observed in main E2E run [31551836429](https://github.com/NVIDIA/NemoClaw/actions/runs/31551836429), job [93976244147](https://github.com/NVIDIA/NemoClaw/actions/runs/31551836429/job/93976244147). The same run's Deep Agents job [93976243188](https://github.com/NVIDIA/NemoClaw/actions/runs/31551836429/job/93976243188) also expected a same-name fresh re-onboard to recreate the sandbox but did not request the documented `--recreate-sandbox` action.

## Related Issue

Fixes #8847

## Changes

- Preserve an explicit recreation request when a fresh onboarding session reaches the sandbox create boundary.
- Cover ordinary fresh creation and explicit fresh recreation as distinct create intents.
- Make the Deep Agents live re-onboard check explicitly request the destructive recreation that its backup and restore assertions require.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: `docs/reference/commands.mdx`, `docs/reference/cli-selection-guide.mdx`, and `docs/get-started/quickstart-langchain-deepagents-code.mdx` already document that this command replaces the completed sandbox; the change restores and exercises that contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer self-review confirmed that the change only preserves an existing boolean lifecycle intent. It does not change credentials, authorization, policy, trust boundaries, or destructive ownership checks.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change restores the documented `onboard --fresh --name <sandbox-name> --recreate-sandbox` behavior and updates the Deep Agents Code live E2E command to exercise that existing contract. `docs/reference/commands.mdx`, `docs/reference/cli-selection-guide.mdx`, and `docs/get-started/quickstart-langchain-deepagents-code.mdx` already document both required flags. The change adds no command, flag, default, output, or documentation claim. The refreshed effective diff passes whitespace and Bash syntax checks and does not involve `v0.0.104`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 20c0a0d87 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm run test:changed` passed 229 tests in 17 files; the three focused sandbox suites passed 56 tests; the related E2E-support file passed 32 tests; Bash syntax and hook ShellCheck passed for the live script.
- [x] Applicable broad gate passed — Not applicable: this is a narrow sandbox-intent correction. `npm run typecheck:cli` and Biome passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox creation now correctly distinguishes between fresh, resumed, and explicitly recreated sandboxes.
  * Re-onboarding with the recreation option now reliably creates a new sandbox.

* **Tests**
  * Added coverage verifying recreation requests are propagated correctly.
  * Updated onboarding checks to validate the expected recreation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->