### PR TITLE
test(e2e): use dependency-free ClawHub fixture

### DIFF
--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -189,7 +189,7 @@ async function curlStatus(
 async function expectScopedClawHubPluginLifecycle(sandbox: SandboxClient): Promise<void> {
   const install = await sandboxBash(
     sandbox,
-    "HOME=/sandbox openclaw plugins install 'clawhub:@openclaw/kitchen-sink@0.2.14' 2>&1",
+    "HOME=/sandbox openclaw plugins install 'clawhub:@onequery/openclaw-plugin@0.1.4' 2>&1",
     {
       artifactName: "tc-net-restricted-clawhub-scoped-plugin-install",
       timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
@@ -203,12 +203,12 @@ async function expectScopedClawHubPluginLifecycle(sandbox: SandboxClient): Promi
   });
   expect(list.exitCode, text(list)).toBe(0);
   expect(text(list), "the installed scoped ClawHub plugin must be enabled").toMatch(
-    /OpenClaw Kitchen Sink[^\r\n]*enabled/i,
+    /OneQuery[^\r\n]*enabled/i,
   );
 
   const inspect = await sandboxBash(
     sandbox,
-    "HOME=/sandbox openclaw plugins inspect openclaw-kitchen-sink-fixture --runtime 2>&1",
+    "HOME=/sandbox openclaw plugins inspect onequery --runtime 2>&1",
     {
       artifactName: "tc-net-restricted-clawhub-scoped-plugin-runtime-inspect",
       timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,

--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -189,7 +189,7 @@ async function curlStatus(
 async function expectScopedClawHubPluginLifecycle(sandbox: SandboxClient): Promise<void> {
   const install = await sandboxBash(
     sandbox,
-    "HOME=/sandbox openclaw plugins install 'clawhub:@onequery/openclaw-plugin@0.1.4' 2>&1",
+    "HOME=/sandbox openclaw plugins install 'clawhub:@openclaw/brave-plugin@2026.7.1' --force 2>&1",
     {
       artifactName: "tc-net-restricted-clawhub-scoped-plugin-install",
       timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
@@ -203,12 +203,12 @@ async function expectScopedClawHubPluginLifecycle(sandbox: SandboxClient): Promi
   });
   expect(list.exitCode, text(list)).toBe(0);
   expect(text(list), "the installed scoped ClawHub plugin must be enabled").toMatch(
-    /OneQuery[^\r\n]*enabled/i,
+    /Brave[^\r\n]*enabled/i,
   );
 
   const inspect = await sandboxBash(
     sandbox,
-    "HOME=/sandbox openclaw plugins inspect onequery --runtime 2>&1",
+    "HOME=/sandbox openclaw plugins inspect brave --runtime 2>&1",
     {
       artifactName: "tc-net-restricted-clawhub-scoped-plugin-runtime-inspect",
       timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The restricted-network E2E now reinstalls an official dependency-free scoped ClawHub plugin. This keeps the test focused on ClawHub install and runtime-load behavior instead of failing when the previous fixture requests a nested npm package that the zero-preset policy correctly denies.

Affected failure: E2E run 31561831175, job 94006031731.

## Related Issue

Related to #4104.

## Changes

- Replace `@openclaw/kitchen-sink@0.2.14` with the official dependency-free `@openclaw/brave-plugin@2026.7.1` fixture.
- Use OpenClaw's `--force` install mode to replace the Brave plugin already present in the managed image while retaining install-policy and safety checks.
- Update the expected plugin display name and runtime identifier.
- Preserve the zero-preset network policy and scoped ClawHub install and runtime-load assertions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change only replaces a version-pinned live E2E fixture and its package-specific assertions. The documented ClawHub and restricted-policy behavior is unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The completed review confirmed the official pinned ClawHub artifact has a clean scan, no install-time dependencies, and source-linked provenance. OpenClaw's `--force` mode overwrites the existing plugin without bypassing `security.installPolicy` or remaining install safety checks. The zero-preset policy is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Against current `main`, the effective diff changes only `test/e2e/live/network-policy.test.ts`. The scoped ClawHub install and runtime-load behavior and restricted network-policy contract remain unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9bd38ce73 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: E2E-support coverage passed 58/58, the OpenShell migration contract passed 9/9, `npm run build:cli` and `npm run typecheck:cli` passed, and `git diff --check` passed. `clawhub package inspect` resolved the exact official `@openclaw/brave-plugin@2026.7.1` artifact with runtime ID `brave`, a clean scan, and source-linked provenance.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a one-fixture live E2E correction covered by focused support and contract tests plus normal path-scoped hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
