### PR TITLE
test(e2e): capture #8849 overlayfs readiness mismatch

### DIFF
--- a/test/e2e/live/overlayfs-autofix.test.ts
+++ b/test/e2e/live/overlayfs-autofix.test.ts
@@ -138,6 +138,7 @@ test.skipIf(overlayfsAutofixNotInRuntimePath())(
       e2ePhases: [
         "confirm Docker overlayfs eligibility",
         "enable containerd snapshotter mode",
+        "capture host-probe readiness before onboarding",
         "install with the overlayfs auto-fix enabled",
         "confirm patched cluster image reuse",
         "reproduce the failure with the auto-fix disabled",
@@ -154,6 +155,7 @@ test.skipIf(overlayfsAutofixNotInRuntimePath())(
       preservedBoundaries: [
         "real Docker daemon feature flip through sudo-managed /etc/docker/daemon.json",
         "real Docker daemon restart and docker info overlayfs/containerd-snapshotter probe",
+        "real node ./bin/nemoclaw.js host probe before onboarding",
         "real install.sh --non-interactive onboarding with hosted compatible inference",
         "real local nemoclaw-cluster:*fuse-overlayfs* Docker image build/cache check",
         "real OpenShell gateway container image/log inspection",
@@ -296,6 +298,21 @@ sudo systemctl restart docker`,
       skip("Docker overlayfs is active but DriverStatus does not advertise the v1 snapshotter"));
 
     await preCleanup(host, apiKey, "phase-2-pre-cleanup");
+
+    progress.phase("capture host-probe readiness before onboarding");
+    const hostProbe = await host.command("node", ["./bin/nemoclaw.js", "host", "probe"], {
+      artifactName: "phase-2-host-probe-before-onboard",
+      cwd: process.cwd(),
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 60_000,
+    });
+    await artifacts.writeText("phase-2-host-probe-before-onboard.log", text(hostProbe));
+    expect(
+      hostProbe.exitCode,
+      `host probe must expose the current mismatch: ${text(hostProbe)}`,
+    ).toBe(2);
+    expect(text(hostProbe)).toContain("System readiness: incompatible");
+    expect(text(hostProbe)).toContain("host.docker.storage_incompatible");
 
     progress.phase("install with the overlayfs auto-fix enabled");
     const positive = await host.command("bash", ["install.sh", "--non-interactive"], {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This draft exists only to run the trusted `overlayfs-autofix` job against unchanged product code. The E2E assertion captures the reported contradiction on an ephemeral runner: real `node ./bin/nemoclaw.js host probe` returns incompatible and exit 2, then the real installer/onboarding reaches Ready on the same converted Docker daemon.

## Related Issue

Evidence for #8849. This draft does not close or partially resolve the issue.

## Changes

- Add the reporter's real host-probe command to the existing overlayfs autofix E2E before onboarding.
- Assert current pre-fix output and exit status only; no product source is changed.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This temporary draft changes only pre-fix E2E evidence and no product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending; this draft is only an exact-revision E2E trigger.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `blocked`
- Evidence: Final implementation and review are not complete; this draft exists only to collect pre-fix E2E evidence.
- Agent: Pi CLI
<!-- docs-review-head-sha: 63b7d77d1 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

Not applicable.

## Verification

- `npx biome check test/e2e/live/overlayfs-autofix.test.ts`
- `npm run typecheck`
- `npm run test:e2e-phases:check`
- Handoff `pre-commit`, `post-commit`, and `pre-push` gates

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>
