### PR TITLE
refactor(inference): share one local adapter logger factory

### DIFF
--- a/src/lib/inference/bedrock-runtime-adapter.ts
+++ b/src/lib/inference/bedrock-runtime-adapter.ts
@@ -23,9 +23,21 @@ import {
   resolveBedrockRuntimeRegion,
 } from "./bedrock-runtime";
 import {
-  DEFAULT_LOCAL_ADAPTER_STATE_DIR,
+  AdapterHttpError,
+  type BedrockRuntimeClientLike,
+  createOpenAiChatCompletion,
+  type OpenAiChatRequest,
+  parseJsonObject,
+  streamOpenAiChatCompletion,
+} from "./bedrock-runtime-translation";
+import {
+  type AdapterLogFields,
+  type AdapterLogger,
   appendLocalAdapterJsonLine,
+  createAdapterLogger,
+  DEFAULT_LOCAL_ADAPTER_STATE_DIR,
   isLocalAdapterProcess,
+  type JsonObject,
   killLocalAdapterPid,
   loadLocalAdapterPid,
   localAdapterTokenHash,
@@ -37,16 +49,7 @@ import {
   waitForLocalAdapterHealth,
   writeLocalAdapterJsonFile,
   writeLocalAdapterSecretFile,
-  type JsonObject,
 } from "./local-adapter-lifecycle";
-import {
-  AdapterHttpError,
-  createOpenAiChatCompletion,
-  parseJsonObject,
-  streamOpenAiChatCompletion,
-  type BedrockRuntimeClientLike,
-  type OpenAiChatRequest,
-} from "./bedrock-runtime-translation";
 
 export {
   AdapterHttpError,
@@ -64,9 +67,6 @@ const STATE_PATH = path.join(STATE_DIR, "bedrock-runtime-adapter.json");
 export const LOG_PATH = path.join(STATE_DIR, "bedrock-runtime-adapter.log");
 const MAX_BODY_BYTES = 2 * 1024 * 1024;
 
-type AdapterLogFields = Record<string, string | number | boolean | null | undefined>;
-type AdapterLogger = (event: string, fields?: AdapterLogFields) => void;
-
 function normalizeLogField(
   value: string | number | boolean | null | undefined,
 ): string | number | boolean | null {
@@ -75,20 +75,7 @@ function normalizeLogField(
   return value;
 }
 
-function defaultAdapterLogger(event: string, fields: AdapterLogFields = {}): void {
-  try {
-    const payload: Record<string, string | number | boolean | null> = {
-      ts: new Date().toISOString(),
-      event: normalizeLogField(event) as string,
-    };
-    for (const [key, value] of Object.entries(fields)) {
-      payload[key] = normalizeLogField(value);
-    }
-    appendLocalAdapterJsonLine(LOG_PATH, payload);
-  } catch {
-    /* best-effort diagnostics only */
-  }
-}
+const defaultAdapterLogger = createAdapterLogger(LOG_PATH, normalizeLogField);
 
 function logAdapterEvent(
   logger: AdapterLogger,

--- a/src/lib/inference/https-pin-runtime-adapter.ts
+++ b/src/lib/inference/https-pin-runtime-adapter.ts
@@ -83,7 +83,10 @@ import {
   sendForwardError,
 } from "./https-pin-runtime-adapter-forward";
 import {
+  type AdapterLogFields,
+  type AdapterLogger,
   appendLocalAdapterJsonLine,
+  createAdapterLogger,
   DEFAULT_LOCAL_ADAPTER_STATE_DIR,
   ensureLocalAdapterStateDir,
   isLocalAdapterProcess,
@@ -162,9 +165,6 @@ const ORPHANED_ROUTE_RECOVERY_BOUNDARY = {
     "Retire orphaning/manual re-registration only when a reviewed secure recovery source or capability can rehydrate every registered route after respawn without persisting plaintext credentials, exposing them to OpenShell or a sandbox, or weakening per-route token and pinned-address isolation.",
 } as const;
 
-type AdapterLogFields = Record<string, string | number | boolean | null | undefined>;
-type AdapterLogger = (event: string, fields?: AdapterLogFields) => void;
-
 function normalizeLogField(
   value: string | number | boolean | null | undefined,
 ): string | number | boolean | null {
@@ -173,20 +173,7 @@ function normalizeLogField(
   return value;
 }
 
-function defaultAdapterLogger(event: string, fields: AdapterLogFields = {}): void {
-  try {
-    const payload: Record<string, string | number | boolean | null> = {
-      ts: new Date().toISOString(),
-      event: normalizeLogField(event) as string,
-    };
-    for (const [key, value] of Object.entries(fields)) {
-      payload[key] = normalizeLogField(value);
-    }
-    appendLocalAdapterJsonLine(LOG_PATH, payload);
-  } catch {
-    /* best-effort diagnostics only */
-  }
-}
+const defaultAdapterLogger = createAdapterLogger(LOG_PATH, normalizeLogField);
 
 function logAdapterEvent(
   logger: AdapterLogger,

--- a/src/lib/inference/local-adapter-lifecycle.ts
+++ b/src/lib/inference/local-adapter-lifecycle.ts
@@ -111,6 +111,38 @@ export function appendLocalAdapterJsonLine(filePath: string, value: unknown): vo
   writePrivateLocalAdapterFile(filePath, `${JSON.stringify(value)}\n`, true);
 }
 
+export type AdapterLogFields = Record<string, string | number | boolean | null | undefined>;
+export type AdapterLogger = (event: string, fields?: AdapterLogFields) => void;
+
+/**
+ * Build the default JSON-line logger for a local inference adapter. Each
+ * adapter owns its log path, its field normalizer, and whether a failed write
+ * is reported, so all three come from the caller. A logger never throws,
+ * because diagnostics must not break the request path.
+ */
+export function createAdapterLogger(
+  logPath: string,
+  normalizeLogField: (
+    value: string | number | boolean | null | undefined,
+  ) => string | number | boolean | null,
+  reportWriteFailure: (error: unknown) => void = () => {},
+): AdapterLogger {
+  return (event: string, fields: AdapterLogFields = {}): void => {
+    try {
+      const payload: Record<string, string | number | boolean | null> = {
+        ts: new Date().toISOString(),
+        event: normalizeLogField(event) as string,
+      };
+      for (const [key, value] of Object.entries(fields)) {
+        payload[key] = normalizeLogField(value);
+      }
+      appendLocalAdapterJsonLine(logPath, payload);
+    } catch (error) {
+      reportWriteFailure(error);
+    }
+  };
+}
+
 export function readLocalAdapterJsonFile(filePath: string): JsonObject | null {
   const raw = readLocalAdapterTextFile(filePath);
   if (!raw) return null;

--- a/src/lib/inference/openrouter-runtime-adapter-common.ts
+++ b/src/lib/inference/openrouter-runtime-adapter-common.ts
@@ -6,12 +6,15 @@ import http from "node:http";
 import path from "node:path";
 
 import { compactText } from "../core/url-utils";
-import { OPENROUTER_DEFAULT_HEADERS, OPENROUTER_ENDPOINT_URL } from "./openrouter";
 import {
-  DEFAULT_LOCAL_ADAPTER_STATE_DIR,
+  type AdapterLogFields,
+  type AdapterLogger,
   appendLocalAdapterJsonLine,
+  createAdapterLogger,
+  DEFAULT_LOCAL_ADAPTER_STATE_DIR,
   type JsonObject,
 } from "./local-adapter-lifecycle";
+import { OPENROUTER_DEFAULT_HEADERS, OPENROUTER_ENDPOINT_URL } from "./openrouter";
 
 export const STATE_DIR = DEFAULT_LOCAL_ADAPTER_STATE_DIR;
 export const PID_PATH = path.join(STATE_DIR, "openrouter-runtime-adapter.pid");
@@ -22,8 +25,7 @@ export const ADAPTER_NAME = "openrouter-runtime";
 export const OPENROUTER_RUNTIME_ADAPTER_AUTHORIZATION_HASH_ENV =
   "NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_AUTHORIZATION_HASH";
 
-export type AdapterLogFields = Record<string, string | number | boolean | null | undefined>;
-export type AdapterLogger = (event: string, fields?: AdapterLogFields) => void;
+export type { AdapterLogFields, AdapterLogger };
 
 function normalizeLogField(
   value: string | number | boolean | null | undefined,
@@ -33,21 +35,10 @@ function normalizeLogField(
   return value;
 }
 
-export function defaultAdapterLogger(event: string, fields: AdapterLogFields = {}): void {
-  try {
-    const payload: Record<string, string | number | boolean | null> = {
-      ts: new Date().toISOString(),
-      event: normalizeLogField(event) as string,
-    };
-    for (const [key, value] of Object.entries(fields)) {
-      payload[key] = normalizeLogField(value);
-    }
-    appendLocalAdapterJsonLine(LOG_PATH, payload);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(`OpenRouter Runtime adapter log write failed: ${compactText(message)}`);
-  }
-}
+export const defaultAdapterLogger = createAdapterLogger(LOG_PATH, normalizeLogField, (error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`OpenRouter Runtime adapter log write failed: ${compactText(message)}`);
+});
 
 export function logAdapterEvent(
   logger: AdapterLogger,


### PR DESCRIPTION
## Summary

`bedrock-runtime-adapter.ts`, `https-pin-runtime-adapter.ts`, and `openrouter-runtime-adapter-common.ts` each declared their own `defaultAdapterLogger` with the same body. `createAdapterLogger` in `local-adapter-lifecycle.ts` now owns that construction, next to the `appendLocalAdapterJsonLine` writer it already calls.

## Related Issue

Part of #8292, the "Use one local inference-adapter logger factory" item. It does not close the issue, which lists four other consolidations.

## Changes

- Add `createAdapterLogger`, `AdapterLogger`, and `AdapterLogFields` to `src/lib/inference/local-adapter-lifecycle.ts`.
- Replace the three private `defaultAdapterLogger` declarations with calls to the factory.

Net delta: 60 insertions, 63 deletions.

## What the Factory Takes, and Why

The three adapters were not identical. Each writes to its own `LOG_PATH`, and only OpenRouter reports a failed write:

| | Bedrock | HTTPS-pin | OpenRouter |
|---|---|---|---|
| Log path | `bedrock-runtime-adapter.log` | `https-pin-runtime-adapter.log` | `openrouter-runtime-adapter.log` |
| Failed write | swallowed | swallowed | `console.error` |

The factory therefore takes the log path, the field normalizer, and a write-failure reporter that defaults to doing nothing. OpenRouter keeps its `OpenRouter Runtime adapter log write failed` message, so no observable behavior changes.

The factory keeps the invariant the three copies shared: a logger never throws, because diagnostics must not break the request path.

## Why normalizeLogField Stays Per-Adapter

I first moved `normalizeLogField` into the shared module too. That made `local-adapter-lifecycle.ts` import `compactText`, and `npm run checks:repository` then failed:

```
- src/lib/core/url-utils.ts: fan-in 29 exceeds 28.
```

The budget treats a limit as debt to reduce rather than raise, so I passed the normalizer in instead of adding the edge. That leaves `normalizeLogField` duplicated three times and makes this PR a smaller reduction than it could be.

If you would rather consolidate that too and raise the `url-utils` fan-in limit to 29, say so and I will do it in this PR.

## Verification

- `npx vitest run --project cli` over the Bedrock, HTTPS-pin, OpenRouter, and local-adapter-lifecycle suites reports `Tests 111 passed (111)`.
- `npm run typecheck:cli` reports 0 errors.
- `npm run checks:repository` passes, including the source-architecture budget.
- `pre-commit` and `pre-push` hooks passed.

`src/lib/inference/local.test.ts` and `src/lib/inference/llama-cpp/managed-installer.test.ts` fail on my machine, but they fail identically on unmodified `main` (14 failures there), so they are unrelated to this change. They depend on a container runtime this host cannot provide.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The change removes duplicate constructions without changing behavior. The four suites above already cover adapter logging, including the OpenRouter failure message.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change is internal to three adapters. It alters no command, flag, default, log path, or log line.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Requesting review. The files are under `src/lib/inference/`. The change moves logger construction only. It does not touch authentication, credential handling, redaction, or transport, and the log paths and emitted fields are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change consolidates three private functions into one exported factory. It changes no page under `docs/`, no CLI surface, and no emitted log field, so no documentation describes different behavior afterwards. The review checked the new doc comment and commit message against `WRITING.md` and confirmed each names the actor and states the reason a parameter exists. `npm run checks:repository` passed.
- Agent: `Claude Code`
<!-- docs-review-head-sha: c07cb20 -->
<!-- docs-review-agents-blob-sha: c4923a3 -->

## Verification Checklist

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set — command/result: `Tests 111 passed (111)`
- [ ] Applicable broad gate passed — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Broad gate: the change consolidates three constructions in one area, so I ran the covering suites rather than `npm test`. Doc items do not apply because no file under `docs/` changes.

---
Signed-off-by: Vishnu Rajeev <19866703+VishnuR23@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency and reliability of runtime adapter logging across supported providers.
  - Logging failures are now handled safely without interrupting adapter operation.
  - Log entries continue to include standardized timestamps and normalized event details for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->