### PR TITLE
fix(ci): format Hermes gateway log tail

### DIFF
--- a/src/lib/actions/sandbox/gateway-restart.ts
+++ b/src/lib/actions/sandbox/gateway-restart.ts
@@ -294,8 +294,7 @@ export function gatewayIntegrityRepairLines(
 }
 
 const HERMES_GATEWAY_LOG_TAIL_LINES = 12;
-const HERMES_GATEWAY_LOG_TAIL_COMMAND =
-  `tail -n ${String(HERMES_GATEWAY_LOG_TAIL_LINES)} /tmp/gateway.log 2>/dev/null || true`;
+const HERMES_GATEWAY_LOG_TAIL_COMMAND = `tail -n ${String(HERMES_GATEWAY_LOG_TAIL_LINES)} /tmp/gateway.log 2>/dev/null || true`;
 
 function hermesGatewayLogTail(
   sandboxName: string,


### PR DESCRIPTION
## Summary

Format the Hermes gateway log-tail constant on current `main`. The repository-wide Biome hook otherwise rewrites this line and fails unrelated PR static checks, including run `31564155093`, job `94020740879` on PR #8854.

## Changes

- Apply the current Biome formatting to `HERMES_GATEWAY_LOG_TAIL_COMMAND`.
- Preserve the exact command value and runtime behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This change only reflows an existing string literal; its value and runtime behavior are unchanged.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: There is no user-facing behavior change.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The effective diff from current `main` to commit `820239e1f` only applies Biome formatting to `HERMES_GATEWAY_LOG_TAIL_COMMAND` in `src/lib/actions/sandbox/gateway-restart.ts`. The command value and runtime behavior are unchanged. The exact all-files Biome hook and `git diff --check` pass, so no user-facing documentation change or runtime test is required.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 820239e1f -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Tests are not applicable because the string value is unchanged; `prek run biome-format --all-files` and `git diff --check` pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted the Hermes gateway log-tail command without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->