### PR TITLE
fix(onboard): reserve dashboard port during build

### DIFF
--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -267,8 +267,12 @@ Use these details when your first-run path needs more control.
     ```
 
     The onboard flow starts both port forwards automatically.
+    For a new sandbox, NemoClaw reserves the selected dashboard loopback port through sandbox preparation and the image build.
+    If another listener claims the port before NemoClaw binds the reservation, NemoClaw selects another port before changing sandbox resources.
     If OpenShell reports `sandbox is not ready`, NemoClaw waits 5 seconds and retries the affected forward up to three times.
     These retries preserve the existing sandbox and selected host port.
+    NemoClaw releases the reservation immediately before OpenShell starts the dashboard forward.
+    If forwarding then fails, onboarding removes the new sandbox and tells you to resolve the reported error before retrying.
     The Hermes dashboard URL does not include an OpenClaw `#token=` fragment.
     `nemohermes my-hermes dashboard-url --quiet` returns `http://127.0.0.1:18789/` when the default local forward is active.
     Check the API health endpoint from the host.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -401,9 +401,12 @@ Use these details when your first-run path needs more control.
     The wizard starts a background dashboard port forward and prints its URL in the ready summary.
     The default host port is `18789`.
     When that port is occupied, NemoClaw uses the next free dashboard port, such as `18790`, and includes the port in the URL.
+    For a new sandbox, NemoClaw reserves the selected loopback port through sandbox preparation and the image build.
+    If another listener claims the port before NemoClaw binds the reservation, NemoClaw selects another port before changing sandbox resources.
     If OpenShell reports `sandbox is not ready`, NemoClaw waits 5 seconds and retries the dashboard forward up to three times.
     These retries preserve the existing sandbox and selected port.
-    If the selected port becomes occupied after the sandbox build begins, onboarding rolls back the new sandbox and asks you to retry rather than print an unreachable URL.
+    NemoClaw releases the reservation immediately before OpenShell starts the dashboard forward.
+    If forwarding then fails, onboarding removes the new sandbox and tells you to resolve the reported error before retrying.
     The installation transcript does not print the gateway token.
     Use `nemoclaw my-gpt-claw dashboard-url --quiet` to print the complete authenticated URL explicitly.
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -306,7 +306,10 @@ If another sandbox already owns the dashboard port, onboarding scans ports `1878
 If all ports in that range are occupied, the error lists the owner for each port and suggests using `--control-ui-port` with a port outside the range.
 
 On macOS, the port check also tries a privileged `lsof` probe without prompting for a password so root-owned listeners are detected before the sandbox build starts.
-If a port becomes occupied after preflight but before `openshell forward start` runs, onboarding deletes the just-created sandbox and exits with a retry message instead of leaving a sandbox with an unreachable dashboard URL.
+For a new sandbox, NemoClaw reserves the selected loopback port through sandbox preparation and the image build.
+If another listener claims the port before NemoClaw binds the reservation, NemoClaw selects another port before changing sandbox resources.
+NemoClaw releases the reservation immediately before `openshell forward start` runs.
+If forwarding then fails, onboarding removes the new sandbox and tells you to resolve the reported error before retrying.
 
 When a previous onboard, upgrade, or sandbox crash leaves a stale `openclaw-gateway` host process holding the dashboard port, `$$nemoclaw onboard --fresh`, `$$nemoclaw <name> destroy` (when destroying the last sandbox), and `$$nemoclaw uninstall` automatically sweep the dashboard port range and signal `SIGTERM` then `SIGKILL` to recover.
 The sweep only targets processes owned by the current user whose command line matches `openclaw-gateway` or `openshell forward` markers, and skips dashboard ports owned by other live sandboxes.
@@ -1923,7 +1926,7 @@ Onboarding ends with:
 
 ```text
   Sandbox 'my-assistant' was created but did not become ready within 180s.
-  The orphaned sandbox has been removed — you can safely retry.
+  Retry: $$nemoclaw onboard
 ```
 
 This is a separate budget from `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT`.
@@ -1943,7 +1946,9 @@ $$nemoclaw onboard
 ```
 
 The variable accepts seconds and applies to the readiness wait only.
-When the deadline expires, NemoClaw deletes the partially-created sandbox before printing the retry hint, so the next `$$nemoclaw onboard` starts from a clean state.
+When the deadline expires, NemoClaw tries to delete the partially created sandbox.
+After successful cleanup, the output ends with `Retry: $$nemoclaw onboard`.
+If cleanup fails, NemoClaw instead reports that the failed sandbox could not be removed and prints `Manual cleanup: openshell sandbox delete "<name>"`.
 If readiness still fails after the extended budget, inspect the gateway and sandbox status:
 
 ```bash

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2183,11 +2183,6 @@ async function createSandboxWithBaseImageResolution(
     ({ effectivePort, chatUiUrl } = dashboardSelection);
     dashboardPortReservationScope.current = dashboardSelection.reservation;
   }
-  const releaseDashboardPortReservation = async (): Promise<void> => {
-    const reservation = dashboardPortReservationScope.current;
-    dashboardPortReservationScope.current = null;
-    await reservation?.release();
-  };
   const hermesDashboardForwarding = onboardHermesDashboard.createHermesDashboardOnboardForwarding({
     agentName: agent?.name,
     env: process.env,
@@ -2204,7 +2199,7 @@ async function createSandboxWithBaseImageResolution(
   // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
   let recreateRuntime: import("./onboard/sandbox-recreate-transaction").SandboxRecreateRuntime | recreateJournal.OwnedSandboxRecreateRuntime = sandboxRecreateTransaction.createSandboxRecreateRuntime(onboardSession, createIntent?.recreateTransaction, sandboxName, GATEWAY_NAME, existingEntry, getSandboxRecreateObservation, note);
   const restoreReusedSandboxDashboard = async (selectionVerified: boolean): Promise<void> => {
-    await releaseDashboardPortReservation();
+    await dashboardPortReservationScope.release();
     ({ chatUiUrl } = sandboxReuse.applyReusedSandboxDashboardState({
       sandboxName,
       chatUiUrl,
@@ -2616,7 +2611,7 @@ async function createSandboxWithBaseImageResolution(
   let actualDashboardPort = 0;
   let finalHermesDashboardState = hermesDashboardState;
   if (manageDashboard) {
-    await releaseDashboardPortReservation();
+    await dashboardPortReservationScope.release();
     actualDashboardPort = ensureDashboardForward(sandboxName, chatUiUrl, {
       rollbackSandboxOnFailure: true,
     });
@@ -2746,34 +2741,16 @@ type CreateSandboxArgs =
 
 async function createSandbox(...args: CreateSandboxArgs): Promise<string> {
   const computePlan = dockerDriverPlatform.resolveCurrentOpenShellComputePlan();
-  return withDashboardPortReservationScope((dashboardPortReservationScope) =>
-    createSandboxWithBaseImageResolution(
-      baseImageResolutionFlow.createBaseImageResolutionContext({ fresh: false }),
-      computePlan,
-      null,
-      false,
-      null,
-      dashboardPortReservationScope,
-      ...args,
-    ),
-  );
+  // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+  return withDashboardPortReservationScope((dashboardPortReservationScope) => createSandboxWithBaseImageResolution(baseImageResolutionFlow.createBaseImageResolutionContext({ fresh: false }), computePlan, null, false, null, dashboardPortReservationScope, ...args));
 }
 
 async function createSandboxWithTemporaryManagedRuntime(
   ...args: CreateSandboxArgs
 ): Promise<string> {
   const computePlan = dockerDriverPlatform.resolveCurrentOpenShellComputePlan();
-  return withDashboardPortReservationScope((dashboardPortReservationScope) =>
-    createSandboxWithBaseImageResolution(
-      baseImageResolutionFlow.createBaseImageResolutionContext({ fresh: false }),
-      computePlan,
-      null,
-      true,
-      null,
-      dashboardPortReservationScope,
-      ...args,
-    ),
-  );
+  // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
+  return withDashboardPortReservationScope((dashboardPortReservationScope) => createSandboxWithBaseImageResolution(baseImageResolutionFlow.createBaseImageResolutionContext({ fresh: false }), computePlan, null, true, null, dashboardPortReservationScope, ...args));
 }
 
 // ── Step 3: Inference selection ──────────────────────────────────

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -497,7 +497,8 @@ const { ensureUsageNoticeConsent } = require("./onboard/usage-notice");
 const {
   findAvailableDashboardPort,
   preflightDashboardPortRangeAvailability,
-  resolveCreateSandboxDashboardPort,
+  reserveCreateSandboxDashboardPort,
+  withDashboardPortReservationScope,
 } = require("./onboard/dashboard-port") as typeof import("./onboard/dashboard-port");
 const authoritativeRebuildTarget: typeof import("./onboard/authoritative-rebuild-target") =
   require("./onboard/authoritative-rebuild-target");
@@ -2116,6 +2117,7 @@ async function createSandboxWithBaseImageResolution(
   managedWorkloadRebuild: import("./onboard/workload/rebuild").ManagedWorkloadRebuildHandoff | null,
   tempManagedRuntime: boolean,
   tempManagedRuntimeCatalog: string | null,
+  dashboardPortReservationScope: import("./onboard/dashboard-port").DashboardPortReservationScope,
   gpu: ReturnType<typeof nim.detectGpu>,
   model: string,
   provider: string,
@@ -2168,7 +2170,7 @@ async function createSandboxWithBaseImageResolution(
   let effectivePort = 0,
     chatUiUrl = "";
   if (manageDashboard) {
-    ({ effectivePort, chatUiUrl } = resolveCreateSandboxDashboardPort({
+    const dashboardSelection = await reserveCreateSandboxDashboardPort({
       sandboxName,
       controlUiPort,
       chatUiUrlEnv: process.env.CHAT_UI_URL,
@@ -2177,8 +2179,15 @@ async function createSandboxWithBaseImageResolution(
       defaultPort: DASHBOARD_PORT,
       forwardListOutput: runCaptureOpenshell(["forward", "list"], { ignoreError: true }),
       warn: (message) => console.warn(message),
-    }));
+    });
+    ({ effectivePort, chatUiUrl } = dashboardSelection);
+    dashboardPortReservationScope.current = dashboardSelection.reservation;
   }
+  const releaseDashboardPortReservation = async (): Promise<void> => {
+    const reservation = dashboardPortReservationScope.current;
+    dashboardPortReservationScope.current = null;
+    await reservation?.release();
+  };
   const hermesDashboardForwarding = onboardHermesDashboard.createHermesDashboardOnboardForwarding({
     agentName: agent?.name,
     env: process.env,
@@ -2194,7 +2203,8 @@ async function createSandboxWithBaseImageResolution(
   const { existingEntry, preservedMcpState, liveExists, effectiveToolDisclosure, toolDisclosureMigrationNeeded, toolDisclosureMigrationNote } = toolDisclosureFlow.prepareSandboxToolDisclosure(sandboxName, preparedBuildContext?.rebuildTarget?.fromDockerfile ? preparedBuildContext.stagedDockerfile : fromDockerfile, isRecreateSandbox(createIntent?.recreate), inspectSandboxForCreate, createIntent?.toolDisclosure ?? null);
   // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
   let recreateRuntime: import("./onboard/sandbox-recreate-transaction").SandboxRecreateRuntime | recreateJournal.OwnedSandboxRecreateRuntime = sandboxRecreateTransaction.createSandboxRecreateRuntime(onboardSession, createIntent?.recreateTransaction, sandboxName, GATEWAY_NAME, existingEntry, getSandboxRecreateObservation, note);
-  const restoreReusedSandboxDashboard = (selectionVerified: boolean): void => {
+  const restoreReusedSandboxDashboard = async (selectionVerified: boolean): Promise<void> => {
+    await releaseDashboardPortReservation();
     ({ chatUiUrl } = sandboxReuse.applyReusedSandboxDashboardState({
       sandboxName,
       chatUiUrl,
@@ -2213,7 +2223,7 @@ async function createSandboxWithBaseImageResolution(
     }));
   };
   if (recreateRuntime.acceptedTarget) {
-    restoreReusedSandboxDashboard(true);
+    await restoreReusedSandboxDashboard(true);
     return sandboxName;
   }
   // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
@@ -2370,7 +2380,7 @@ async function createSandboxWithBaseImageResolution(
                 "  Pass --recreate-sandbox or set NEMOCLAW_RECREATE_SANDBOX=1 to force recreation.",
               );
             }
-            restoreReusedSandboxDashboard(!selectionDrift.unknown);
+            await restoreReusedSandboxDashboard(!selectionDrift.unknown);
             return sandboxName;
           }
         } else {
@@ -2400,7 +2410,7 @@ async function createSandboxWithBaseImageResolution(
           if (await promptYesNoOrDefault("  Reuse existing sandbox?", null, true)) {
             policyPresetCarry.seedReusedSandboxPolicyPresets(sandboxName, isNonInteractive());
             upsertMessagingProviders(messagingTokenDefs);
-            restoreReusedSandboxDashboard(!selectionDrift.unknown);
+            await restoreReusedSandboxDashboard(!selectionDrift.unknown);
             return sandboxName;
           }
         }
@@ -2468,7 +2478,7 @@ async function createSandboxWithBaseImageResolution(
     }
     if (!createIntent?.recreateTransaction) recreateRuntime = openRecreateJournal();
     // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
-    if (recreateRuntime.acceptedTarget) { if ("complete" in recreateRuntime) recreateRuntime.complete(); restoreReusedSandboxDashboard(true); return sandboxName; }
+    if (recreateRuntime.acceptedTarget) { if ("complete" in recreateRuntime) recreateRuntime.complete(); await restoreReusedSandboxDashboard(true); return sandboxName; }
     const previousEntry: SandboxEntry | null = registry.getSandbox(sandboxName);
     // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
     baseImageResolutionFlow.captureBaseResolution(baseImageResolutionContext, previousEntry?.imageTag);
@@ -2606,6 +2616,7 @@ async function createSandboxWithBaseImageResolution(
   let actualDashboardPort = 0;
   let finalHermesDashboardState = hermesDashboardState;
   if (manageDashboard) {
+    await releaseDashboardPortReservation();
     actualDashboardPort = ensureDashboardForward(sandboxName, chatUiUrl, {
       rollbackSandboxOnFailure: true,
     });
@@ -2727,6 +2738,7 @@ type CreateSandboxArgs =
     unknown,
     unknown,
     unknown,
+    unknown,
     ...infer Args,
   ]
     ? Args
@@ -2734,13 +2746,16 @@ type CreateSandboxArgs =
 
 async function createSandbox(...args: CreateSandboxArgs): Promise<string> {
   const computePlan = dockerDriverPlatform.resolveCurrentOpenShellComputePlan();
-  return createSandboxWithBaseImageResolution(
-    baseImageResolutionFlow.createBaseImageResolutionContext({ fresh: false }),
-    computePlan,
-    null,
-    false,
-    null,
-    ...args,
+  return withDashboardPortReservationScope((dashboardPortReservationScope) =>
+    createSandboxWithBaseImageResolution(
+      baseImageResolutionFlow.createBaseImageResolutionContext({ fresh: false }),
+      computePlan,
+      null,
+      false,
+      null,
+      dashboardPortReservationScope,
+      ...args,
+    ),
   );
 }
 
@@ -2748,13 +2763,16 @@ async function createSandboxWithTemporaryManagedRuntime(
   ...args: CreateSandboxArgs
 ): Promise<string> {
   const computePlan = dockerDriverPlatform.resolveCurrentOpenShellComputePlan();
-  return createSandboxWithBaseImageResolution(
-    baseImageResolutionFlow.createBaseImageResolutionContext({ fresh: false }),
-    computePlan,
-    null,
-    true,
-    null,
-    ...args,
+  return withDashboardPortReservationScope((dashboardPortReservationScope) =>
+    createSandboxWithBaseImageResolution(
+      baseImageResolutionFlow.createBaseImageResolutionContext({ fresh: false }),
+      computePlan,
+      null,
+      true,
+      null,
+      dashboardPortReservationScope,
+      ...args,
+    ),
   );
 }
 
@@ -4226,14 +4244,18 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
             planRegisteredExtraProviders(gatewayName, { runOpenshell }),
           resolveSandboxCreateIntent: sandboxCreateIntentResolver.resolve,
           createSandbox: preparedDcodeRuntime.bindCreateSandbox(
-            createSandboxWithBaseImageResolution.bind(
-              null,
-              baseImageResolutionContext,
-              onboardingComputePlan,
-              opts.managedWorkloadRebuild ?? null,
-              opts.tempManagedRuntime === true,
-              opts.tempManagedRuntimeCatalog ?? null,
-            ),
+            (...createArgs) =>
+              withDashboardPortReservationScope((dashboardPortReservationScope) =>
+                createSandboxWithBaseImageResolution(
+                  baseImageResolutionContext,
+                  onboardingComputePlan,
+                  opts.managedWorkloadRebuild ?? null,
+                  opts.tempManagedRuntime === true,
+                  opts.tempManagedRuntimeCatalog ?? null,
+                  dashboardPortReservationScope,
+                  ...createArgs,
+                ),
+              ),
           ),
           updateSandboxRegistry: (name, updates) => registry.updateSandbox(name, updates),
           getSandboxAgentRegistryFields,

--- a/src/lib/onboard/dashboard-port.test.ts
+++ b/src/lib/onboard/dashboard-port.test.ts
@@ -4,6 +4,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
+import { createServer, type Server } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -15,9 +16,38 @@ import {
   findDashboardForwardOwner,
   getRegistryOccupiedDashboardPorts,
   preflightDashboardPortRangeAvailability,
+  reserveCreateSandboxDashboardPort,
+  reserveDashboardPort,
   resolveCreateSandboxDashboardPort,
   withDashboardPortReservationLock,
+  withDashboardPortReservationScope,
 } from "./dashboard-port";
+
+async function listenOnLoopback(port: number): Promise<Server> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return server;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function unusedLoopbackPort(): Promise<number> {
+  const server = await listenOnLoopback(0);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("loopback listener did not report a TCP address");
+  }
+  await closeServer(server);
+  return address.port;
+}
 
 describe("findDashboardForwardOwner", () => {
   it("parses openshell forward list column format (#2169)", () => {
@@ -220,6 +250,67 @@ describe("resolveCreateSandboxDashboardPort", () => {
 
     assert.equal(result.preferredPort, 19000);
     assert.equal(result.chatUiUrl, "http://127.0.0.1:19000");
+  });
+});
+
+describe("dashboard port reservation", () => {
+  it("holds the selected port during creation and releases it after failure (#8798)", async () => {
+    const port = await unusedLoopbackPort();
+
+    await assert.rejects(
+      withDashboardPortReservationScope(async (scope) => {
+        scope.current = await reserveDashboardPort(port);
+        await assert.rejects(
+          listenOnLoopback(port),
+          (error: NodeJS.ErrnoException) => error.code === "EADDRINUSE",
+        );
+        throw new Error("sandbox build failed");
+      }),
+      /sandbox build failed/,
+    );
+
+    const listener = await listenOnLoopback(port);
+    await closeServer(listener);
+  });
+
+  it("reselects before sandbox creation when a listener wins the allocation race (#8798)", async () => {
+    const attempts: number[] = [];
+    const warnings: string[] = [];
+    const released: number[] = [];
+    const result = await reserveCreateSandboxDashboardPort(
+      {
+        sandboxName: "cursor",
+        controlUiPort: null,
+        chatUiUrlEnv: null,
+        persistedPort: null,
+        agentForwardPort: null,
+        defaultPort: 18789,
+        forwardListOutput: "",
+        registryOccupiedPorts: new Map(),
+        findAvailablePort: (_sandboxName, preferredPort, _forwardList, _bound, occupied) =>
+          occupied?.has(String(preferredPort)) ? 18790 : preferredPort,
+        warn: (message) => warnings.push(message),
+      },
+      async (port) => {
+        attempts.push(port);
+        if (attempts.length === 1) {
+          throw Object.assign(new Error("address in use"), { code: "EADDRINUSE" });
+        }
+        return {
+          port,
+          release: async () => {
+            released.push(port);
+          },
+        };
+      },
+    );
+
+    assert.deepEqual(attempts, [18789, 18790]);
+    assert.equal(result.effectivePort, 18790);
+    assert.equal(result.chatUiUrl, "http://127.0.0.1:18790");
+    assert.deepEqual(warnings, ["  ! Port 18789 is taken. Using port 18790 instead."]);
+    await result.reservation?.release();
+    assert.deepEqual(released, [18790]);
   });
 });
 

--- a/src/lib/onboard/dashboard-port.test.ts
+++ b/src/lib/onboard/dashboard-port.test.ts
@@ -41,10 +41,10 @@ async function closeServer(server: Server): Promise<void> {
 async function unusedLoopbackPort(): Promise<number> {
   const server = await listenOnLoopback(0);
   const address = server.address();
-  if (!address || typeof address === "string") {
-    await closeServer(server);
-    throw new Error("loopback listener did not report a TCP address");
-  }
+  assert.ok(
+    address && typeof address !== "string",
+    "loopback listener did not report a TCP address",
+  );
   await closeServer(server);
   return address.port;
 }
@@ -292,16 +292,16 @@ describe("dashboard port reservation", () => {
         warn: (message) => warnings.push(message),
       },
       async (port) => {
+        const attempt = attempts.length;
         attempts.push(port);
-        if (attempts.length === 1) {
-          throw Object.assign(new Error("address in use"), { code: "EADDRINUSE" });
-        }
-        return {
-          port,
-          release: async () => {
-            released.push(port);
-          },
-        };
+        return attempt === 0
+          ? Promise.reject(Object.assign(new Error("address in use"), { code: "EADDRINUSE" }))
+          : Promise.resolve({
+              port,
+              release: async () => {
+                released.push(port);
+              },
+            });
       },
     );
 

--- a/src/lib/onboard/dashboard-port.ts
+++ b/src/lib/onboard/dashboard-port.ts
@@ -337,6 +337,7 @@ export interface DashboardPortReservation {
 
 export interface DashboardPortReservationScope {
   current: DashboardPortReservation | null;
+  release(): Promise<void>;
 }
 
 export interface ReservedCreateSandboxDashboardPortResult extends CreateSandboxDashboardPortResult {
@@ -509,13 +510,18 @@ export async function reserveCreateSandboxDashboardPort(
 export async function withDashboardPortReservationScope<T>(
   operation: (scope: DashboardPortReservationScope) => Promise<T>,
 ): Promise<T> {
-  const scope: DashboardPortReservationScope = { current: null };
+  const scope: DashboardPortReservationScope = {
+    current: null,
+    async release() {
+      const reservation = this.current;
+      this.current = null;
+      await reservation?.release();
+    },
+  };
   try {
     return await operation(scope);
   } finally {
-    const reservation = scope.current;
-    scope.current = null;
-    await reservation?.release();
+    await scope.release();
   }
 }
 

--- a/src/lib/onboard/dashboard-port.ts
+++ b/src/lib/onboard/dashboard-port.ts
@@ -14,6 +14,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { createServer } from "node:net";
 import os from "node:os";
 
 import {
@@ -329,6 +330,19 @@ export interface CreateSandboxDashboardPortResult {
   chatUiUrl: string;
 }
 
+export interface DashboardPortReservation {
+  port: number;
+  release(): Promise<void>;
+}
+
+export interface DashboardPortReservationScope {
+  current: DashboardPortReservation | null;
+}
+
+export interface ReservedCreateSandboxDashboardPortResult extends CreateSandboxDashboardPortResult {
+  reservation: DashboardPortReservation | null;
+}
+
 function normalizeChatUiUrlForParsing(chatUiUrl: string): string {
   return chatUiUrl.includes("://") ? chatUiUrl : `http://${chatUiUrl}`;
 }
@@ -393,6 +407,116 @@ export function resolveCreateSandboxDashboardPort(
     effectivePort,
     chatUiUrl: buildCreateSandboxChatUiUrl(input.chatUiUrlEnv, input.controlUiPort, effectivePort),
   };
+}
+
+/**
+ * Bind the selected host port until sandbox creation can start its OpenShell
+ * forward. The server closes attempted connections and does not keep the
+ * process alive. The reservation closes on normal release or process exit.
+ */
+export async function reserveDashboardPort(port: number): Promise<DashboardPortReservation> {
+  const server = createServer((socket) => socket.destroy());
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.removeListener("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.removeListener("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen({ host: "127.0.0.1", port, exclusive: true });
+  });
+  server.unref();
+
+  let released = false;
+  const closeOnExit = () => {
+    if (server.listening) server.close();
+  };
+  process.once("exit", closeOnExit);
+
+  return {
+    port,
+    async release() {
+      if (released) return;
+      released = true;
+      process.removeListener("exit", closeOnExit);
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error && (error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING") {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+function isAddressInUse(error: unknown): boolean {
+  return typeof error === "object" && error !== null && Reflect.get(error, "code") === "EADDRINUSE";
+}
+
+/**
+ * Select and bind a dashboard port before sandbox preparation begins. If a
+ * listener wins the gap between the allocation probe and bind, classify that
+ * port as occupied and select again before any sandbox side effect.
+ *
+ * A live forward owned by the target sandbox already holds its port while the
+ * caller decides whether to reuse or recreate that sandbox.
+ */
+export async function reserveCreateSandboxDashboardPort(
+  input: CreateSandboxDashboardPortInput,
+  reservePort: (port: number) => Promise<DashboardPortReservation> = reserveDashboardPort,
+): Promise<ReservedCreateSandboxDashboardPortResult> {
+  const occupied = new Map(
+    input.registryOccupiedPorts ?? getRegistryOccupiedDashboardPorts(input.sandboxName),
+  );
+  const forwardOwner = getOccupiedPorts(input.forwardListOutput);
+  while (true) {
+    const result = resolveCreateSandboxDashboardPort({
+      ...input,
+      registryOccupiedPorts: occupied,
+      warn: undefined,
+    });
+    if (forwardOwner.get(String(result.effectivePort)) === input.sandboxName) {
+      if (result.effectivePort !== result.preferredPort) {
+        input.warn?.(
+          `  ! Port ${result.preferredPort} is taken. Using port ${result.effectivePort} instead.`,
+        );
+      }
+      return { ...result, reservation: null };
+    }
+    try {
+      const reservation = await reservePort(result.effectivePort);
+      if (result.effectivePort !== result.preferredPort) {
+        input.warn?.(
+          `  ! Port ${result.preferredPort} is taken. Using port ${result.effectivePort} instead.`,
+        );
+      }
+      return { ...result, reservation };
+    } catch (error) {
+      if (!isAddressInUse(error)) throw error;
+      occupied.set(String(result.effectivePort), "non-OpenShell host listener");
+    }
+  }
+}
+
+/** Release a dashboard reservation after both successful and failed creation. */
+export async function withDashboardPortReservationScope<T>(
+  operation: (scope: DashboardPortReservationScope) => Promise<T>,
+): Promise<T> {
+  const scope: DashboardPortReservationScope = { current: null };
+  try {
+    return await operation(scope);
+  } finally {
+    const reservation = scope.current;
+    scope.current = null;
+    await reservation?.release();
+  }
 }
 
 /**

--- a/src/lib/onboard/dashboard.ts
+++ b/src/lib/onboard/dashboard.ts
@@ -233,7 +233,9 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
       `  ${err instanceof Error ? err.message : String(err)}`,
     ];
     if (deleteSucceeded) {
-      lines.push("  The orphaned sandbox has been removed — you can safely retry.");
+      lines.push(
+        "  The orphaned sandbox has been removed. Resolve the error above before retrying.",
+      );
     } else {
       lines.push("  Could not remove the orphaned sandbox. Manual cleanup:");
       lines.push(`    openshell sandbox delete "${sandboxName}"`);

--- a/test/onboard-dashboard.test.ts
+++ b/test/onboard-dashboard.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import { createServer } from "node:net";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentDefinition } from "../src/lib/agent/defs";
@@ -115,6 +116,57 @@ describe("onboard dashboard helpers", () => {
     expect(getPortConflictServiceHints("linux").join("\n")).toMatch(
       /systemctl --user stop openclaw-gateway.service/,
     );
+  });
+
+  it("deletes the built sandbox and exits 1 when the committed port becomes occupied (#8798)", async () => {
+    const listener = createServer();
+    await new Promise<void>((resolve, reject) => {
+      listener.once("error", reject);
+      listener.listen(0, "127.0.0.1", resolve);
+    });
+    const address = listener.address();
+    if (!address || typeof address === "string") {
+      throw new Error("loopback listener did not report a TCP address");
+    }
+    const runOpenshell = vi.fn(() => ({ status: 0 }));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${String(code)})`);
+    }) as typeof process.exit);
+    const helpers = createOnboardDashboardHelpers({
+      runOpenshell,
+      runCaptureOpenshell: vi.fn(() => ""),
+      openshellArgv: (args: string[]) => [process.execPath, "-e", "", ...args],
+      cliName: () => "nemoclaw",
+      agentProductName: () => "NemoClaw",
+      getProviderLabel: (provider: string) => provider,
+      note: vi.fn(),
+      isWsl: () => false,
+      redact: (value: unknown) => String(value),
+      sleep: vi.fn(),
+      printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
+    });
+
+    try {
+      expect(() =>
+        helpers.ensureDashboardForward("my-sandbox", `http://127.0.0.1:${String(address.port)}`, {
+          rollbackSandboxOnFailure: true,
+        }),
+      ).toThrow("process.exit(1)");
+      expect(runOpenshell).toHaveBeenCalledWith(["sandbox", "delete", "my-sandbox"], {
+        ignoreError: true,
+      });
+      expect(errorSpy.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+        "The orphaned sandbox has been removed. Resolve the error above before retrying.",
+      );
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+      await new Promise<void>((resolve, reject) => {
+        listener.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("uses sandbox-scoped forward stops for same-sandbox dashboard cleanup", () => {

--- a/test/onboard-dashboard.test.ts
+++ b/test/onboard-dashboard.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
-import { createServer } from "node:net";
+import { type AddressInfo, createServer } from "node:net";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentDefinition } from "../src/lib/agent/defs";
@@ -125,10 +125,12 @@ describe("onboard dashboard helpers", () => {
       listener.listen(0, "127.0.0.1", resolve);
     });
     const address = listener.address();
-    if (!address || typeof address === "string") {
-      throw new Error("loopback listener did not report a TCP address");
-    }
+    expect(address && typeof address !== "string").toBe(true);
+    const targetPort = (address as AddressInfo).port;
     const runOpenshell = vi.fn(() => ({ status: 0 }));
+    const openshellArgv = vi.fn(() => {
+      throw new Error("forward start must not run after host-bound port detection");
+    });
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${String(code)})`);
@@ -136,7 +138,7 @@ describe("onboard dashboard helpers", () => {
     const helpers = createOnboardDashboardHelpers({
       runOpenshell,
       runCaptureOpenshell: vi.fn(() => ""),
-      openshellArgv: (args: string[]) => [process.execPath, "-e", "", ...args],
+      openshellArgv,
       cliName: () => "nemoclaw",
       agentProductName: () => "NemoClaw",
       getProviderLabel: (provider: string) => provider,
@@ -150,14 +152,19 @@ describe("onboard dashboard helpers", () => {
 
     try {
       expect(() =>
-        helpers.ensureDashboardForward("my-sandbox", `http://127.0.0.1:${String(address.port)}`, {
+        helpers.ensureDashboardForward("my-sandbox", `http://127.0.0.1:${String(targetPort)}`, {
           rollbackSandboxOnFailure: true,
         }),
       ).toThrow("process.exit(1)");
+      expect(openshellArgv).not.toHaveBeenCalled();
       expect(runOpenshell).toHaveBeenCalledWith(["sandbox", "delete", "my-sandbox"], {
         ignoreError: true,
       });
-      expect(errorSpy.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+      const errorOutput = errorSpy.mock.calls.map(([line]) => String(line)).join("\n");
+      expect(errorOutput).toContain(
+        `Dashboard port ${String(targetPort)} became host-bound during sandbox build`,
+      );
+      expect(errorOutput).toContain(
         "The orphaned sandbox has been removed. Resolve the error above before retrying.",
       );
     } finally {

--- a/test/onboard-rollback.test.ts
+++ b/test/onboard-rollback.test.ts
@@ -44,7 +44,9 @@ describe("ghost-sandbox rollback message (#2174)", () => {
     expect(lines[0]).toBe("");
     expect(lines).toContain("  Could not allocate a dashboard port for 'alpha'.");
     expect(lines).toContain("  All dashboard ports in range 18789-18798 are occupied");
-    expect(lines).toContain("  The orphaned sandbox has been removed — you can safely retry.");
+    expect(lines).toContain(
+      "  The orphaned sandbox has been removed. Resolve the error above before retrying.",
+    );
     expect(lines.some((l: string) => l.includes("Manual cleanup"))).toBeFalsy();
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Onboarding now binds the selected dashboard loopback port before sandbox preparation and holds it through the image build. If another listener wins the initial bind race, NemoClaw selects another port before changing sandbox resources; late forwarding failures still roll back the new sandbox without promising that an unresolved error is safe to retry.

## Related Issue
Fixes #8798

## Changes
- Add a scoped loopback reservation for the dashboard port and use it from every onboarding sandbox-create entry point. A second availability probe cannot close the bind-to-build race, so the reservation stays open until OpenShell starts the forward; focused tests cover holding, failure cleanup, and pre-build reselection.
- Release the reservation immediately before the dashboard forward starts and from the outer scope after every failed create path.
- Keep late forward failure non-zero and replace the unconditional safe-retry message with guidance to resolve the reported error.
- Document the reservation and cleanup behavior for OpenClaw and Hermes, with shared troubleshooting output for all applicable agent variants.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Local review confirmed the reservation binds only to `127.0.0.1`, rejects connections, does not keep the process alive, and releases idempotently after success or failure. The change does not alter credentials, policy, or public exposure.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/get-started/quickstart.mdx`, `docs/get-started/quickstart-hermes.mdx`, `docs/reference/troubleshooting.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: adfb6b22d -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/dashboard-port.test.ts` (30 passed); `npx vitest run --project integration test/onboard-dashboard.test.ts test/onboard-rollback.test.ts` (21 passed); `npm run test:changed` (131 files and 1,580 tests passed); `npm run docs` (route check passed, Fern 0 errors)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard port handling during sandbox setup and forwarding.
  * Automatically retries with another available port when conflicts occur.
  * Removes newly created sandboxes when dashboard forwarding fails.
  * Preserves retry behavior for sandboxes that are not ready.

* **Documentation**
  * Updated quickstart and troubleshooting guidance for port conflicts, cleanup, and retry commands.

* **Tests**
  * Added coverage for port reservation, conflict recovery, forwarding failures, and cleanup messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->