### PR TITLE
fix(readiness): align remediable storage surfaces

### DIFF
--- a/docs/reference/system-readiness.mdx
+++ b/docs/reference/system-readiness.mdx
@@ -111,12 +111,13 @@ The Docker storage capabilities separate the current host configuration from Nem
 | Capability ID | Result represented |
 | --- | --- |
 | `host.docker.storage_compatible` | The current Docker storage configuration supports nested overlay mounts without remediation. |
-| `host.docker.storage_remediation_available` | NemoClaw can build a patched cluster image for a non-WSL Linux host using Docker with an `overlayfs` containerd-snapshotter conflict. |
+| `host.docker.storage_remediation_available` | NemoClaw can build a patched OpenShell gateway image for a non-WSL Linux host using Docker with an `overlayfs` containerd-snapshotter conflict. |
 
 Use `host.docker.storage_compatible` for pre-mutation host diagnosis.
 For public NemoClaw lifecycle admission, require either `host.docker.storage_compatible` or `host.docker.storage_remediation_available`.
 When remediation is available, `host.docker.storage_compatible` remains `absent`.
-The report also retains `host.docker.storage_incompatible`, status `incompatible`, and exit code `2` because `host probe` does not change the host.
+When `host.docker.storage_remediation_available` is `present` and storage is the only blocking finding, `host probe` reports a warning and exits `0` with status `supported`.
+When remediation is unavailable or another blocking finding exists, `host probe` retains the blocking storage finding, status `incompatible`, and exit code `2`.
 Evaluate every other blocking finding before you run onboarding.
 The remediation capability does not prove that a later image build or gateway attachment succeeds.
 Use these storage capabilities when the lifecycle may create or recreate a gateway.

--- a/src/lib/inference/serving/resolver.ts
+++ b/src/lib/inference/serving/resolver.ts
@@ -4,6 +4,10 @@
 import { checkSystemReadinessSchemaVersion } from "../../readiness/compatibility.js";
 import { getSystemReadinessReferenceErrors } from "../../readiness/references.js";
 import {
+  hasRemediableStorageConflict,
+  STORAGE_COMPATIBLE_CAPABILITY,
+} from "../../readiness/storage-remediation.js";
+import {
   getManagedInferenceMaterializerDescriptor,
   getManagedInferenceRecipeRegistrationError,
   getManagedInferenceTopologyQualificationDescriptor,
@@ -70,35 +74,6 @@ function explicitIntentWithoutPreset(intent: ManagedInferenceSelectionIntent): b
     hasText(intent.provider) ||
     hasText(intent.vllmModel) ||
     (intent.vllmExtraArguments?.length ?? 0) > 0
-  );
-}
-
-const STORAGE_COMPATIBLE_CAPABILITY = "host.docker.storage_compatible";
-const STORAGE_REMEDIATION_CAPABILITY = "host.docker.storage_remediation_available";
-const STORAGE_INCOMPATIBLE_FINDING = "host.docker.storage_incompatible";
-
-function capabilityState(
-  report: ManagedInferenceReadinessSource["report"],
-  id: string,
-): "present" | "absent" | "unknown" | undefined {
-  const matches = report.capabilities.filter((capability) => capability.id === id);
-  return matches.length === 1 ? matches[0]!.state : undefined;
-}
-
-function hasRemediableStorageConflict(report: ManagedInferenceReadinessSource["report"]): boolean {
-  const blocking = report.findings.filter(
-    ({ severity }) => severity === "fatal" || severity === "blocking",
-  );
-  return (
-    report.status === "incompatible" &&
-    report.exitCode === 2 &&
-    blocking.length === 1 &&
-    blocking[0]!.id === STORAGE_INCOMPATIBLE_FINDING &&
-    blocking[0]!.severity === "blocking" &&
-    blocking[0]!.capabilityIds?.length === 1 &&
-    blocking[0]!.capabilityIds[0] === STORAGE_COMPATIBLE_CAPABILITY &&
-    capabilityState(report, STORAGE_COMPATIBLE_CAPABILITY) === "absent" &&
-    capabilityState(report, STORAGE_REMEDIATION_CAPABILITY) === "present"
   );
 }
 

--- a/src/lib/readiness/host.test.ts
+++ b/src/lib/readiness/host.test.ts
@@ -397,7 +397,7 @@ describe("host readiness projection (#7408)", () => {
     expect(result.status).toBe("supported");
   });
 
-  it("reports supported remediation for the containerd overlay conflict (#7770)", () => {
+  it("reports an available containerd overlay remediation as a supported warning (#8849)", () => {
     const result = report({
       dockerStorageDriver: "overlayfs",
       dockerUsesContainerdSnapshotter: true,
@@ -406,8 +406,32 @@ describe("host readiness projection (#7408)", () => {
 
     expect(state(result, "host.docker.storage_compatible")).toBe("absent");
     expect(state(result, "host.docker.storage_remediation_available")).toBe("present");
-    expect(findingIds(result)).toContain("host.docker.storage_incompatible");
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        id: "host.docker.storage_incompatible",
+        severity: "warning",
+        summary: expect.stringContaining("patched OpenShell gateway image"),
+      }),
+    );
+    expect(result).toMatchObject({ status: "supported", exitCode: 0 });
+  });
+
+  it("keeps a remediable storage conflict incompatible when another blocker exists (#8849)", () => {
+    const result = report({
+      dockerStorageDriver: "overlayfs",
+      dockerUsesContainerdSnapshotter: true,
+      hasNestedOverlayConflict: true,
+      isUnsupportedRuntime: true,
+      runtime: "podman",
+    });
+
     expect(result).toMatchObject({ status: "incompatible", exitCode: 2 });
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "host.docker.storage_incompatible", severity: "blocking" }),
+        expect.objectContaining({ id: "host.docker.runtime_unsupported", severity: "blocking" }),
+      ]),
+    );
   });
 
   it("reports no remediation when the containerd snapshotter is absent (#7770)", () => {

--- a/src/lib/readiness/host.ts
+++ b/src/lib/readiness/host.ts
@@ -19,6 +19,7 @@ import {
 } from "./platform-qualification.js";
 import { buildSystemReadinessProbeEnv, createSystemReadinessCapture } from "./probe-env.js";
 import { sanitizeReadinessText } from "./sanitize.js";
+import { hasRemediableStorageConflict } from "./storage-remediation.js";
 import {
   type EvidenceScalar,
   type FindingSeverity,
@@ -563,7 +564,7 @@ export function projectHostReadiness(
     : hasUnknown
       ? ({ status: "inconclusive", exitCode: 3 } as const)
       : ({ status: "supported", exitCode: 0 } as const);
-  return {
+  const report: SystemReadinessReport = {
     schemaVersion: SYSTEM_READINESS_SCHEMA_VERSION,
     ...outcome,
     mutated: false,
@@ -577,6 +578,23 @@ export function projectHostReadiness(
     qualifications,
     findings,
     evidence,
+  };
+  if (!hasRemediableStorageConflict(report)) return report;
+
+  return {
+    ...report,
+    status: "supported",
+    exitCode: 0,
+    findings: report.findings.map((entry) =>
+      entry.id === "host.docker.storage_incompatible"
+        ? {
+            ...entry,
+            severity: "warning",
+            summary:
+              "The Docker storage configuration requires NemoClaw to use a patched OpenShell gateway image for nested overlay mounts.",
+          }
+        : entry,
+    ),
   };
 }
 

--- a/src/lib/readiness/onboard-admission.test.ts
+++ b/src/lib/readiness/onboard-admission.test.ts
@@ -30,8 +30,9 @@ function capability(id: string, state: ReadinessCapability["state"]): ReadinessC
 function finding(
   id: string,
   severity: ReadinessFinding["severity"] = "blocking",
+  capabilityIds?: readonly string[],
 ): ReadinessFinding {
-  return { id, severity, summary: id };
+  return { id, severity, summary: id, capabilityIds };
 }
 
 function requiredCapabilities(): ReadinessCapability[] {
@@ -279,7 +280,7 @@ describe("onboarding readiness admission (#7411)", () => {
     ).toMatchObject({ admitted: false, findingIds: ["host.docker.unavailable"] });
   });
 
-  it("admits the documented storage exception only when remediation is present", () => {
+  it("admits only the complete remediable storage report (#8849)", () => {
     let capabilities = withCapabilityState(
       requiredCapabilities(),
       ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageCompatible,
@@ -290,7 +291,9 @@ describe("onboarding readiness admission (#7411)", () => {
       ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageRemediationAvailable,
       "present",
     );
-    const storageFinding = finding(ONBOARD_READINESS_FINDING_IDS.storageIncompatible);
+    const storageFinding = finding(ONBOARD_READINESS_FINDING_IDS.storageIncompatible, "blocking", [
+      ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageCompatible,
+    ]);
 
     expect(
       evaluateOnboardReadinessAdmission(
@@ -309,6 +312,82 @@ describe("onboarding readiness admission (#7411)", () => {
     ).toMatchObject({
       admitted: false,
       findingIds: [ONBOARD_READINESS_FINDING_IDS.storageIncompatible],
+    });
+  });
+
+  it("fails closed for unavailable, unknown, malformed, and mixed storage reports (#8849)", () => {
+    let capabilities = withCapabilityState(
+      requiredCapabilities(),
+      ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageCompatible,
+      "absent",
+    );
+    const storageFinding = finding(ONBOARD_READINESS_FINDING_IDS.storageIncompatible, "blocking", [
+      ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageCompatible,
+    ]);
+
+    for (const remediationState of ["absent", "unknown"] as const) {
+      capabilities = withCapabilityState(
+        capabilities,
+        ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageRemediationAvailable,
+        remediationState,
+      );
+      expect(
+        evaluateOnboardReadinessAdmission(
+          report({ capabilities, findings: [storageFinding], status: "incompatible" }),
+          DEFAULT_OPTIONS,
+        ),
+      ).toMatchObject({
+        admitted: false,
+        findingIds: [ONBOARD_READINESS_FINDING_IDS.storageIncompatible],
+      });
+    }
+    expect(
+      evaluateOnboardReadinessAdmission(
+        report({
+          capabilities: capabilities.filter(
+            ({ id }) => id !== ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageRemediationAvailable,
+          ),
+          findings: [storageFinding],
+          status: "incompatible",
+        }),
+        DEFAULT_OPTIONS,
+      ),
+    ).toMatchObject({
+      admitted: false,
+      findingIds: [ONBOARD_READINESS_FINDING_IDS.storageIncompatible],
+      capabilityIds: [ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageRemediationAvailable],
+    });
+
+    const remediableCapabilities = withCapabilityState(
+      capabilities,
+      ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageRemediationAvailable,
+      "present",
+    );
+    expect(
+      evaluateOnboardReadinessAdmission(
+        report({
+          capabilities: remediableCapabilities,
+          findings: [finding(ONBOARD_READINESS_FINDING_IDS.storageIncompatible)],
+          status: "incompatible",
+        }),
+        DEFAULT_OPTIONS,
+      ),
+    ).toMatchObject({
+      admitted: false,
+      findingIds: [ONBOARD_READINESS_FINDING_IDS.storageIncompatible],
+    });
+    expect(
+      evaluateOnboardReadinessAdmission(
+        report({
+          capabilities: remediableCapabilities,
+          findings: [storageFinding, finding("host.example.blocked")],
+          status: "incompatible",
+        }),
+        DEFAULT_OPTIONS,
+      ),
+    ).toMatchObject({
+      admitted: false,
+      findingIds: [ONBOARD_READINESS_FINDING_IDS.storageIncompatible, "host.example.blocked"],
     });
   });
 

--- a/src/lib/readiness/onboard-admission.ts
+++ b/src/lib/readiness/onboard-admission.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { hasRemediableStorageConflict } from "./storage-remediation.js";
 import type { ReadinessCapability, ReadinessFinding, SystemReadinessReport } from "./types";
 
 export const ONBOARD_READINESS_ADMISSION_REASON_IDS = {
@@ -98,7 +99,7 @@ function isBlocking(finding: ReadinessFinding): boolean {
 
 function canWaiveFinding(
   finding: ReadinessFinding,
-  capabilities: ReadonlyMap<string, ReadinessCapability>,
+  report: SystemReadinessReport | undefined,
   options: Readonly<OnboardReadinessAdmissionOptions>,
   managedGateway: boolean,
 ): boolean {
@@ -120,12 +121,7 @@ function canWaiveFinding(
     return true;
   }
   return (
-    options.allowStorageRemediation &&
-    finding.id === ONBOARD_READINESS_FINDING_IDS.storageIncompatible &&
-    capabilityState(
-      capabilities,
-      ONBOARD_REQUIRED_CAPABILITY_IDS.dockerStorageRemediationAvailable,
-    ) === "present"
+    options.allowStorageRemediation && report !== undefined && hasRemediableStorageConflict(report)
   );
 }
 
@@ -246,7 +242,7 @@ function decisionFor(
  * closed before lifecycle effects begin.
  */
 export function evaluateOnboardReadinessAdmission(
-  report: Readonly<OnboardReadinessInput>,
+  report: Readonly<SystemReadinessReport>,
   options: Readonly<OnboardReadinessAdmissionOptions>,
 ): OnboardReadinessAdmissionDecision {
   const capabilities = new Map(report.capabilities.map((entry) => [entry.id, entry]));
@@ -255,7 +251,7 @@ export function evaluateOnboardReadinessAdmission(
   const findingIds: string[] = [];
   for (const finding of report.findings) {
     if (!isBlocking(finding)) continue;
-    if (canWaiveFinding(finding, capabilities, options, managedGateway)) {
+    if (canWaiveFinding(finding, report, options, managedGateway)) {
       waivedFindingIds.push(finding.id);
     } else findingIds.push(finding.id);
   }
@@ -277,7 +273,7 @@ export function evaluateOnboardGatewayReadinessAdmission(
     if (
       canWaiveFinding(
         finding,
-        capabilities,
+        undefined,
         {
           explicitlyOptedOutGpuPassthrough: false,
           allowUnsupportedRuntime: false,

--- a/src/lib/readiness/storage-remediation.ts
+++ b/src/lib/readiness/storage-remediation.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReadinessCapability, SystemReadinessReport } from "./types.js";
+
+export const STORAGE_COMPATIBLE_CAPABILITY = "host.docker.storage_compatible";
+const STORAGE_REMEDIATION_CAPABILITY = "host.docker.storage_remediation_available";
+const STORAGE_INCOMPATIBLE_FINDING = "host.docker.storage_incompatible";
+
+function capabilityState(
+  report: SystemReadinessReport,
+  id: string,
+): ReadinessCapability["state"] | undefined {
+  const matches = report.capabilities.filter((capability) => capability.id === id);
+  return matches.length === 1 ? matches[0]!.state : undefined;
+}
+
+export function hasRemediableStorageConflict(report: SystemReadinessReport): boolean {
+  const blocking = report.findings.filter(
+    ({ severity }) => severity === "fatal" || severity === "blocking",
+  );
+  return (
+    report.status === "incompatible" &&
+    report.exitCode === 2 &&
+    blocking.length === 1 &&
+    blocking[0]!.id === STORAGE_INCOMPATIBLE_FINDING &&
+    blocking[0]!.severity === "blocking" &&
+    blocking[0]!.capabilityIds?.length === 1 &&
+    blocking[0]!.capabilityIds[0] === STORAGE_COMPATIBLE_CAPABILITY &&
+    capabilityState(report, STORAGE_COMPATIBLE_CAPABILITY) === "absent" &&
+    capabilityState(report, STORAGE_REMEDIATION_CAPABILITY) === "present"
+  );
+}

--- a/test/e2e/live/overlayfs-autofix.test.ts
+++ b/test/e2e/live/overlayfs-autofix.test.ts
@@ -138,7 +138,9 @@ test.skipIf(overlayfsAutofixNotInRuntimePath())(
       e2ePhases: [
         "confirm Docker overlayfs eligibility",
         "enable containerd snapshotter mode",
+        "verify host probe admits remediable storage",
         "install with the overlayfs auto-fix enabled",
+        "verify OpenClaw agent JSON parity",
         "confirm patched cluster image reuse",
         "reproduce the failure with the auto-fix disabled",
       ],
@@ -151,10 +153,13 @@ test.skipIf(overlayfsAutofixNotInRuntimePath())(
       id: "overlayfs-autofix",
       sandboxName: SANDBOX_NAME,
       issue: "#2481",
+      relatedIssues: ["#8849"],
       preservedBoundaries: [
         "real Docker daemon feature flip through sudo-managed /etc/docker/daemon.json",
         "real Docker daemon restart and docker info overlayfs/containerd-snapshotter probe",
+        "real node ./bin/nemoclaw.js host probe with remediable storage warning",
         "real install.sh --non-interactive onboarding with hosted compatible inference",
+        "real node ./bin/nemoclaw.js list --json and scoped status --json agent parity",
         "real local nemoclaw-cluster:*fuse-overlayfs* Docker image build/cache check",
         "real OpenShell gateway container image/log inspection",
         "real NEMOCLAW_DISABLE_OVERLAY_FIX=1 negative install attempt with bounded timeout",
@@ -297,6 +302,22 @@ sudo systemctl restart docker`,
 
     await preCleanup(host, apiKey, "phase-2-pre-cleanup");
 
+    progress.phase("verify host probe admits remediable storage");
+    const hostProbe = await host.command("node", ["./bin/nemoclaw.js", "host", "probe"], {
+      artifactName: "phase-2-host-probe-remediable",
+      cwd: process.cwd(),
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 60_000,
+    });
+    await artifacts.writeText("phase-2-host-probe-remediable.log", text(hostProbe));
+    expect(
+      hostProbe.exitCode,
+      `host probe must classify the remediation as supported: ${text(hostProbe)}`,
+    ).toBe(0);
+    expect(text(hostProbe)).toContain("System readiness: supported");
+    expect(text(hostProbe)).toContain("[warning] host.docker.storage_incompatible");
+    expect(text(hostProbe)).toContain("patched OpenShell gateway image");
+
     progress.phase("install with the overlayfs auto-fix enabled");
     const positive = await host.command("bash", ["install.sh", "--non-interactive"], {
       artifactName: "phase-3-install-autofix-on",
@@ -311,6 +332,37 @@ sudo systemctl restart docker`,
       `install.sh + onboard failed with auto-fix on: ${text(positive)}`,
     ).toBe(0);
     expect(text(positive)).toContain("Detected Docker 26+ containerd-snapshotter overlayfs");
+
+    progress.phase("verify OpenClaw agent JSON parity");
+    const list = await host.command("node", ["./bin/nemoclaw.js", "list", "--json"], {
+      artifactName: "phase-3-list-json",
+      cwd: process.cwd(),
+      env: overlayEnv(apiKey),
+      redactionValues,
+      timeoutMs: 60_000,
+    });
+    const status = await host.command(
+      "node",
+      ["./bin/nemoclaw.js", SANDBOX_NAME, "status", "--json"],
+      {
+        artifactName: "phase-3-scoped-status-json",
+        cwd: process.cwd(),
+        env: overlayEnv(apiKey),
+        redactionValues,
+        timeoutMs: 60_000,
+      },
+    );
+    expect(list.exitCode, `list --json failed: ${text(list)}`).toBe(0);
+    expect(status.exitCode, `scoped status --json failed: ${text(status)}`).toBe(0);
+    const listJson = JSON.parse(list.stdout) as {
+      sandboxes?: Array<{ name?: string; agent?: string }>;
+    };
+    const listSandbox = listJson.sandboxes?.find(({ name }) => name === SANDBOX_NAME);
+    const statusJson = JSON.parse(status.stdout) as { agent?: string };
+    expect(listSandbox?.agent, "list --json must report the OpenClaw agent").toBe("openclaw");
+    expect(statusJson.agent, "scoped status --json must report the OpenClaw agent").toBe(
+      "openclaw",
+    );
 
     const patchedImageResult = await bash(
       host,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw host probe` and onboarding now use one storage-remediation classifier. A containerd-snapshotter overlayfs conflict that NemoClaw can remediate is reported as a warning with supported status and exit code 0. Missing remediation, malformed reports, and additional blockers remain incompatible.

This draft is the final implementation PR. It has no closing keyword while the required exact-head `overlayfs-autofix` E2E remains pending.

## Related Issue

Issue #8849. Add `Fixes #8849` only after the exact-head reporter workflow passes.

## Changes

- Reuse the shared `hasRemediableStorageConflict` predicate across host readiness, onboarding admission, and managed inference.
- Report the sole auto-remediable storage conflict as a warning without changing the observation-only host probe contract.
- Keep missing, unknown, malformed, non-remediable, and mixed-blocker reports fail-closed.
- Extend the existing live overlayfs test to run real `node ./bin/nemoclaw.js host probe`, then real installer/onboarding, then real `list --json` and sandbox-scoped `status --json` agent checks on the same ephemeral runner.
- Document the public readiness result.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Fresh-context nine-category Pi CLI review passed eight categories and recorded one non-blocking testing warning; the missing-capability negative test was then added and passed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/system-readiness.mdx`; `npm run docs` passed with 0 errors and two existing Fern warnings.
- Agent: Pi CLI
<!-- docs-review-head-sha: c23457f43 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

Not applicable. The changed live test uses an ephemeral GitHub runner and restores its Docker daemon.

## Verification

Passed:

- `npx vitest run src/lib/readiness/host.test.ts src/lib/readiness/onboard-admission.test.ts src/lib/inference/serving/resolver.test.ts test/sandbox-agent-surface-parity.test.ts` — 80 tests
- `npx vitest run --project cli src/lib/readiness/` — 214 tests
- `npx vitest run --project cli src/lib/inference/serving/` — 289 tests
- `npm run typecheck`
- `npm run typecheck:cli`
- `npm run test:e2e-phases:check`
- `npm run docs` — 0 errors, two existing Fern warnings
- Biome checks and `git diff --check`
- Handoff `before-fix`, `pre-commit`, `post-commit`, and `pre-push` gates
- Commit `c23457f4359d197161cd3fdb05f898a57a749fe1` is GPG-signed, DCO-signed, and GitHub Verified.

`npm test` ran 28,973 tests: 28,819 passed, 80 skipped, and 74 failed outside the changed readiness, inference-serving, E2E, and documentation paths. Representative failures reproduce independently of this change: host corporate-CA auto-import causes Dockerfile fixture failures, package installation reports `ERESOLVE`, and uninstall metadata tests return exit 1. The focused changed paths above pass. No unrelated failure is marked accepted here.

Pending exact-head E2E:

- Real `node ./bin/nemoclaw.js host probe` on containerd-snapshotter overlayfs must exit 0 with `System readiness: supported` and `[warning] host.docker.storage_incompatible`.
- The subsequent real installer/onboarding must reach Ready on that same daemon.
- Real `node ./bin/nemoclaw.js list --json` and `node ./bin/nemoclaw.js e2e-overlayfs status --json` must both report `openclaw`.

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>
