### PR TITLE
fix(security): strip gateway token from descendants

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -5162,6 +5162,24 @@ arm_openclaw_gateway_supervisor_cleanup() {
   trap clear_in_container_gateway_marker EXIT
 }
 
+launch_openclaw_gateway_process() {
+  local log_mode="$1"
+  shift
+  case "$log_mode" in
+    append)
+      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" >>/tmp/gateway.log 2>&1 &
+      ;;
+    truncate)
+      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" >/tmp/gateway.log 2>&1 &
+      ;;
+    *)
+      echo "[gateway] invalid gateway log mode: $log_mode" >&2
+      return 1
+      ;;
+  esac
+  GATEWAY_PID=$!
+}
+
 launch_openclaw_gateway() {
   # Drop the gateway marker whenever this supervisor exits -- clean gateway
   # exit (`exit 0` below), a forwarded signal (cleanup_openclaw_on_signal ends
@@ -5174,10 +5192,10 @@ launch_openclaw_gateway() {
   # script -- keeps it in place.
   arm_openclaw_gateway_supervisor_cleanup
   mark_in_container_gateway
-  nohup "${STEP_DOWN_PREFIX_GATEWAY[@]}" env HOME=/sandbox sh -c \
+  launch_openclaw_gateway_process truncate \
+    "${STEP_DOWN_PREFIX_GATEWAY[@]}" env HOME=/sandbox sh -c \
     'umask 0007; exec "$@" >>/tmp/gateway.log 2>&1' sh \
-    "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" &
-  GATEWAY_PID=$!
+    "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}"
   if ! capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY; then
     # An uncaptured numeric PID is never safe to signal: Bash may already have
     # reaped the short-lived child and the kernel may have reused its PID. Fail
@@ -5197,8 +5215,8 @@ launch_openclaw_gateway() {
 launch_openclaw_gateway_non_root() {
   arm_openclaw_gateway_supervisor_cleanup
   mark_in_container_gateway
-  nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
-  GATEWAY_PID=$!
+  launch_openclaw_gateway_process truncate \
+    "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}"
   capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY || exit 1
   record_gateway_pid "$GATEWAY_PID" "$GATEWAY_PID_START_IDENTITY"
   echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)" >&2
@@ -5868,8 +5886,8 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "[gateway] pid $EXITED_GATEWAY_PID exited (rc=$RC); respawning (#$RESPAWN_COUNT in 60s window) in 2s" >&2
     sleep 2
     prepare_openclaw_automatic_respawn || exit 1
-    nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >>/tmp/gateway.log 2>&1 &
-    GATEWAY_PID=$!
+    launch_openclaw_gateway_process append \
+      "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}"
     capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY || exit 1
     record_gateway_pid "$GATEWAY_PID" "$GATEWAY_PID_START_IDENTITY"
     # shellcheck disable=SC2034  # read by cleanup_on_signal from sandbox-init.sh

--- a/test/nemoclaw-start-gateway-token-env.test.ts
+++ b/test/nemoclaw-start-gateway-token-env.test.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import { extractShellFunctionFromSource } from "./support/shell-function-extractor";
+
+const START_SCRIPT = path.resolve(import.meta.dirname, "../scripts/nemoclaw-start.sh");
+
+describe("OpenClaw gateway credential environment", () => {
+  it.each([
+    "truncate",
+    "append",
+  ])("removes the dashboard token from a %s gateway launch (#8693)", (logMode) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-token-env-"));
+    const gatewayLog = path.join(tmpDir, "gateway.log");
+    const source = fs.readFileSync(START_SCRIPT, "utf8");
+    const launch = extractShellFunctionFromSource(
+      source,
+      "launch_openclaw_gateway_process",
+    ).replaceAll("/tmp/gateway.log", gatewayLog);
+    const script = [
+      "set -euo pipefail",
+      launch,
+      "export OPENCLAW_GATEWAY_TOKEN=dashboard-secret",
+      `launch_openclaw_gateway_process ${logMode} sh -c 'printf "%s\\n" "\${OPENCLAW_GATEWAY_TOKEN-unset}"'`,
+      'wait "$GATEWAY_PID"',
+    ].join("\n");
+
+    try {
+      const result = spawnSync("bash", ["-c", script], { encoding: "utf8", timeout: 5000 });
+      expect(result.status, result.stderr).toBe(0);
+      expect(fs.readFileSync(gatewayLog, "utf8")).toBe("unset\n");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an unknown gateway log mode before launch (#8693)", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-token-env-"));
+    const gatewayLog = path.join(tmpDir, "gateway.log");
+    const source = fs.readFileSync(START_SCRIPT, "utf8");
+    const launch = extractShellFunctionFromSource(
+      source,
+      "launch_openclaw_gateway_process",
+    ).replaceAll("/tmp/gateway.log", gatewayLog);
+    const result = spawnSync(
+      "bash",
+      ["-c", [launch, "launch_openclaw_gateway_process invalid true"].join("\n")],
+      { encoding: "utf8", timeout: 5000 },
+    );
+
+    try {
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("invalid gateway log mode: invalid");
+      expect(fs.existsSync(gatewayLog)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed OpenClaw gateway launches and automatic respawns no longer inherit `OPENCLAW_GATEWAY_TOKEN`, so descendants of those gateway processes do not receive that ambient environment value.

This is a bounded defense-in-depth improvement for #8693. It does not remove the token from OpenClaw configuration, the generated runtime environment file, or other same-UID sandbox-readable surfaces. The issue's host-side/injection-only credential design remains blocked on the OpenShell/OpenClaw runtime architecture and threat-model decision.

## Related Issue

Refs #8693

## Changes

- Centralize root, non-root, and automatic-respawn gateway process launches behind one helper.
- Remove `OPENCLAW_GATEWAY_TOKEN` with the absolute `/usr/bin/env` boundary before privilege step-down or OpenClaw execution.
- Preserve the existing truncate-on-initial-launch and append-on-respawn gateway log behavior.
- Reject unknown log modes before starting a process.
- Add real-shell behavioral coverage for both log modes, token removal, and invalid-mode failure.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal child-process environment boundary without changing a command, option, configuration surface, token location, or documented lifecycle. Existing documentation already treats the gateway token as a password.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the completed diff against the nine-category security rubric. `/usr/bin/env` is absolute to avoid sandbox-user `PATH` substitution; `"$@"` preserves argv boundaries; only the ambient token is removed; launch PID identity, privilege step-down, redirection modes, restart accounting, and fail-closed invalid-mode handling are preserved. Real-shell tests prove the credential is absent in both launch modes and no process starts for an invalid mode. No new secret, auth bypass, dependency, configuration weakening, or cryptographic behavior is introduced.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The diff changes only the managed OpenClaw gateway launch/respawn environment and focused tests. It does not change a user command, option, configuration surface, token location, or token lifecycle. Documenting sandbox-wide isolation would exceed the evidence because the token remains present in same-UID configuration/runtime surfaces.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a19af892be -->
<!-- docs-review-agents-blob-sha: c4923a3e36 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a valid `Signed-off-by:` line and the commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-message, and pre-push hooks passed
- [x] Targeted behavior tests pass: 3 focused integration tests passed; CLI type checking passed
- [ ] Applicable broad gate passed — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway startup reliability across initial launches and automatic restarts.
  * Prevented gateway authentication tokens from being exposed to launched processes.
  * Added validation to stop startup when an unsupported logging mode is requested.
  * Improved gateway log handling for both fresh launches and respawns.

* **Tests**
  * Added coverage for token protection, logging modes, and invalid startup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->