### PR TITLE
docs(inference): clarify Lightning reasoning field and max_tokens

### DIFF
--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -289,6 +289,19 @@ Promotion requires broader validation of the pinned Python frontend and the `ste
 The fixed recipe intentionally rejects model and serve-argument overrides; use another catalog profile instead of modifying its validated resource boundary.
 </Warning>
 
+<Note title="Reading Reasoning and Sizing max_tokens for Direct Callers">
+Nemotron 3.5 Lightning is a reasoning model that emits a hidden reasoning trace before its answer.
+Two behaviors surprise direct callers of the managed vLLM endpoint; the OpenClaw agent path is unaffected because it already requests a large budget.
+
+- **Read reasoning from `reasoning`, not `reasoning_content`.**
+  The pinned vLLM runtime renamed the deprecated `reasoning_content` response field to `reasoning`, so `choices[].message.reasoning_content` is `null` even for prompts that reasoned heavily.
+  The reasoning is not discarded — read `choices[].message.reasoning` (and the `delta.reasoning` field when streaming).
+- **Send a generous `max_tokens` (at least `1024`, and more for hard prompts).**
+  The reasoning trace counts against `max_tokens`.
+  With a modest budget the model can spend the entire budget on reasoning before it reaches the answer, returning an empty `content` with `finish_reason=length`.
+  A larger budget lets the answer follow the reasoning.
+</Note>
+
 Muse Glimmer is an additional single-DGX Spark choice and does not change the Qwen default.
 Select its stable catalog ID after confirming that `$$nemoclaw profiles list` reports it as compatible.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Direct callers of the managed Nemotron 3.5 Lightning vLLM endpoint see an empty `reasoning_content` and, with a modest `max_tokens`, an empty `content`. Investigation shows neither is a NemoClaw defect: the pinned vLLM runtime renamed the deprecated `reasoning_content` field to `reasoning`, and the model's heavy reasoning trace counts against `max_tokens`. This PR documents both behaviors on the Lightning profile section.

Closes #8878.

## Reproduction
On a DGX Spark, onboarded the Lightning profile and queried its managed vLLM directly.

**Environment**
- Test machine: our DGX Spark aarch64 test host (GB10 GPU)
- NemoClaw `main` HEAD `ba0fbfca0`; managed profile `vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4`; vLLM `0.23.1rc1.dev1327`

**Observed (reproduces the report)**
```
r-count   mt=256  -> finish=length ctok=256  content_len=0   reasoning_content=null
r-count   mt=512  -> finish=length ctok=512  content_len=0   reasoning_content=null
r-count   mt=1024 -> finish=stop   ctok=798  content_len=363 reasoning_content=null
two-train mt=1024 -> finish=length ctok=1024 content_len=0   reasoning_content=null
```

**Root of the two symptoms (also observed on the same host)**
```
message keys: ['role','content','refusal','annotations','audio','function_call','reasoning']
message.reasoning        -> str, 1892 chars (the full reasoning trace)
message.reasoning_content -> absent / null
```
The reasoning is present in `reasoning`; the empty `content` at low budgets is the reasoning trace consuming `max_tokens` before the answer.

## Analysis
Two reported symptoms, neither a NemoClaw serving-recipe defect:

1. **`reasoning_content` is null.** vLLM `0.23.x` intentionally renamed the response field. From the pinned runtime's `vllm/entrypoints/openai/chat_completion/protocol.py`:
   ```python
   # Renames the deprecated `reasoning_content` field to `reasoning`
   reasoning_content = msg.pop("reasoning_content", None)
   if reasoning_content is not None and msg.get("reasoning") is None:
       msg["reasoning"] = reasoning_content
   ```
   The `step3p5` reasoning parser populates `message.reasoning`. The reasoning is not discarded; clients reading the old `reasoning_content` field see `null`. The recipe's `--reasoning-parser step3p5` is the correct model-specific parser (mirrors `qwen3`/`muse_glimmer` for the other Spark reasoning profiles); recipe arguments control the parser, not the response field name, so this is not a recipe-config issue.

2. **Empty `content` with `finish_reason=length` at low `max_tokens`.** The reasoning trace counts against `max_tokens`. A budget of 256–512 (and 1024 for hard prompts) is consumed entirely by reasoning before the answer begins. The OpenClaw agent path is unaffected because it already requests a large budget.

Because the config is correct and the reasoning is fully available, the actionable NemoClaw change is documentation (also what the issue proposes): read reasoning from `reasoning`, and size `max_tokens` for this reasoning-heavy profile.

## Fix
Adds a `<Note>` to the Nemotron 3.5 Lightning profile section of `docs/inference/set-up-vllm.mdx`:
- Read reasoning from `choices[].message.reasoning` (and `delta.reasoning` when streaming), not `reasoning_content`, which the pinned vLLM runtime renamed.
- Send a generous `max_tokens` (at least `1024`, more for hard prompts); a modest budget can be spent entirely on reasoning and return empty `content` with `finish_reason=length`.

## Changes
- `docs/inference/set-up-vllm.mdx`: Lightning profile Note on the `reasoning` field and `max_tokens` sizing for direct callers.

## Type of Change

- [x] Doc only (prose changes, no code sample modifications)

## Verification

- [x] `npx prek run` passes on the changed file
- [x] Claims verified against the live managed Lightning profile on a real DGX Spark (reasoning in `reasoning`; small budgets return empty `content` with `finish_reason=length`)
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for the user-facing behavior

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for calling the Nemotron 3.5 Lightning endpoint directly.
  - Clarified that reasoning output is available through the current `reasoning` and `delta.reasoning` fields.
  - Recommended setting `max_tokens` to at least 1024 to ensure responses include answer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->