### PR TITLE
test(e2e): pin Jetson dispatch v1 contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 /docs/resources/starter-prompt.md text eol=lf
 /docs/resources/prompt-assets/*.md text eol=lf
 /docs/resources/local-credential-form.html text eol=lf
+/tools/e2e/contracts/v1/jetson-dispatch.json text eol=lf
 
 /skills/nemoclaw/** linguist-generated=true
 /skills/nemoclaw/**/*.md diff=markdown

--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -88,10 +88,12 @@ content, and a noncanonical archive.
 
 The static vectors in
 `tools/e2e/contracts/v1/jetson-dispatch.json` are the compatibility boundary
-shared with the operator-owned service. They include one request, queued and
-completed responses, one artifact, and rejected request examples. Change the
-contract version, parser tests, client tests, and vectors together when an
-incompatible wire change is required.
+shared with the operator-owned service. Contract v1 is immutable at SHA-256
+`d50e381860ec131e92f78c25272bfdcbacb790adc9552c3aaf0778427171314c`.
+The receiver's CI and deployment gate compare its copy against NemoClaw
+`main`. The vectors include one request, queued and completed responses, one
+artifact, and rejected request examples. Publish a coordinated v2 contract
+instead of editing v1 when an incompatible wire change is required.
 
 ## Trusted GitHub Dispatch
 

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -14,6 +15,7 @@ import {
 import {
   JETSON_DISPATCH_AUDIENCE,
   JETSON_DISPATCH_CONTRACT_VERSION,
+  JETSON_DISPATCH_V1_SHA256,
   type JetsonDispatchArtifact,
   type JetsonDispatchRequest,
   type JetsonDispatchStatus,
@@ -32,9 +34,10 @@ interface CompatibilityVectors {
   queuedResponse: unknown;
 }
 
-const vectors = JSON.parse(
-  fs.readFileSync(path.join(process.cwd(), "tools/e2e/contracts/v1/jetson-dispatch.json"), "utf8"),
-) as CompatibilityVectors;
+const vectorBytes = fs.readFileSync(
+  path.join(process.cwd(), "tools/e2e/contracts/v1/jetson-dispatch.json"),
+);
+const vectors = JSON.parse(vectorBytes.toString("utf8")) as CompatibilityVectors;
 const request = parseJetsonDispatchRequest(vectors.request);
 const queuedStatus = parseJetsonDispatchStatusResponse(vectors.queuedResponse);
 const completedStatus = parseJetsonDispatchStatus(vectors.completedStatus);
@@ -49,6 +52,10 @@ afterEach(() => {
 });
 
 describe("Jetson dispatch static HTTP contract", () => {
+  it("keeps the published v1 bytes immutable (#8142)", () => {
+    expect(createHash("sha256").update(vectorBytes).digest("hex")).toBe(JETSON_DISPATCH_V1_SHA256);
+  });
+
   it("accepts every version 1.0.0 compatibility vector (#8142)", () => {
     expect(vectors.contractVersion).toBe(JETSON_DISPATCH_CONTRACT_VERSION);
     expect(request).toEqual(vectors.request);

--- a/tools/e2e/jetson-dispatch-contract.mts
+++ b/tools/e2e/jetson-dispatch-contract.mts
@@ -4,6 +4,8 @@
 import { createHash } from "node:crypto";
 
 export const JETSON_DISPATCH_CONTRACT_VERSION = "1.0.0";
+export const JETSON_DISPATCH_V1_SHA256 =
+  "d50e381860ec131e92f78c25272bfdcbacb790adc9552c3aaf0778427171314c";
 export const JETSON_DISPATCH_AUDIENCE = "nemoclaw-jetson-dispatch";
 export const JETSON_DISPATCH_TARGET = "jetson-nvmap-gpu";
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Pin the retained Jetson dispatch v1 compatibility-vector bytes so the NemoClaw controller and the operator-owned receiver cannot silently drift. The receiver can now gate CI and deployment against one immutable SHA-256 value; incompatible changes require a coordinated v2 contract.

## Related Issue

Follow-up to #8142.

## Changes

- Export the SHA-256 fingerprint of the immutable v1 Jetson dispatch vectors.
- Assert the exact vector bytes in the E2E-support contract suite.
- Pin LF line endings so checkout settings cannot change the hashed bytes.
- Document that the operator-owned receiver checks this fingerprint against NemoClaw `main` and that incompatible changes require v2.

The repositories cannot share a build-time package because the receiver is operator-owned infrastructure. The static vector is their release boundary, protected by `jetson-dispatch-client.test.ts` here and the receiver's CI/deployment compatibility gate.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the immutable contract boundary, cross-repository gate, byte handling, and failure behavior; no blocking findings remain.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/docs/jetson-dispatch.md`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6d0e0746f -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/jetson-dispatch-client.test.ts`: 36/36 passed; `npm run typecheck:cli`: passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this is a narrow retained-contract test and documentation change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Jetson dispatch v1 compatibility contract is immutable and must match the published reference.
  * Documented that incompatible wire changes require a coordinated v2 contract.

* **Tests**
  * Added automated verification that the v1 compatibility contract matches its published SHA-256 checksum.
  * Standardized contract file line endings for consistent validation across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->