### PR TITLE
test(cli): stabilize rebuild preflight timeout

### DIFF
--- a/test/rebuild-credential-preflight.test.ts
+++ b/test/rebuild-credential-preflight.test.ts
@@ -15,7 +15,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { execTimeout } from "./helpers/timeouts";
+import { execTimeout, testTimeoutOptions } from "./helpers/timeouts";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const NODE_BIN = path.dirname(process.execPath);
@@ -387,37 +387,41 @@ describe("atomic rebuild process contracts (#2273)", () => {
     expect(registryHasSandbox(fixture)).toBe(true);
   });
 
-  it("keeps a Ready DCode sandbox usable when its stored route returns 401 (#6195)", () => {
-    const fixture = createFixture({
-      agent: "langchain-deepagents-code",
-      provider: "compatible-endpoint",
-      credentialEnv: "COMPATIBLE_API_KEY",
-      providerRegistered: true,
-      inferenceProbeHttpStatus: 401,
-    });
+  it(
+    "keeps a Ready DCode sandbox usable when its stored route returns 401 (#6195)",
+    testTimeoutOptions(30_000),
+    () => {
+      const fixture = createFixture({
+        agent: "langchain-deepagents-code",
+        provider: "compatible-endpoint",
+        credentialEnv: "COMPATIBLE_API_KEY",
+        providerRegistered: true,
+        inferenceProbeHttpStatus: 401,
+      });
 
-    const result = runRebuild(fixture, {
-      NEMOCLAW_PROVIDER_KEY: "obviously-invalid-ambient-credential",
-    });
-    const output = `${result.stderr || ""}${result.stdout || ""}`;
+      const result = runRebuild(fixture, {
+        NEMOCLAW_PROVIDER_KEY: "obviously-invalid-ambient-credential",
+      });
+      const output = `${result.stderr || ""}${result.stdout || ""}`;
 
-    expect(result.status).not.toBe(0);
-    expect(output).toContain("HTTP 401");
-    expect(output).toContain("Sandbox is untouched");
-    expect(output).not.toContain("Backing up sandbox state");
-    expect(output).not.toContain("Deleting old sandbox");
-    expect(output).not.toContain("Creating new sandbox with current image");
-    expect(fs.existsSync(fixture.deleteMarker)).toBe(false);
-    expect(registryHasSandbox(fixture)).toBe(true);
+      expect(result.status).not.toBe(0);
+      expect(output).toContain("HTTP 401");
+      expect(output).toContain("Sandbox is untouched");
+      expect(output).not.toContain("Backing up sandbox state");
+      expect(output).not.toContain("Deleting old sandbox");
+      expect(output).not.toContain("Creating new sandbox with current image");
+      expect(fs.existsSync(fixture.deleteMarker)).toBe(false);
+      expect(registryHasSandbox(fixture)).toBe(true);
 
-    const marker = runCli(fixture, [
-      fixture.sandboxName,
-      "exec",
-      "--",
-      "cat",
-      "/sandbox/rebuild-atomicity-marker.txt",
-    ]);
-    expect(marker.status, marker.stderr).toBe(0);
-    expect(marker.stdout).toContain("dcode-atomicity-marker");
-  });
+      const marker = runCli(fixture, [
+        fixture.sandboxName,
+        "exec",
+        "--",
+        "cat",
+        "/sandbox/rebuild-atomicity-marker.txt",
+      ]);
+      expect(marker.status, marker.stderr).toBe(0);
+      expect(marker.stdout).toContain("dcode-atomicity-marker");
+    },
+  );
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Give the retained rebuild credential-preflight process test an environment-aware 30-second Vitest budget. The case consistently needs 16–19 seconds after the readiness fixture began starting a real ephemeral gateway, so the default 15-second budget fails despite the product assertions succeeding.

## Changes

- Apply the existing `testTimeoutOptions` helper to the DCode HTTP 401 rebuild case.
- Preserve every assertion that the failed preflight leaves the sandbox usable and untouched.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only Vitest's per-test timeout budget. CLI behavior, interfaces, output, and operator workflows are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `91808d83f` changes only `test/rebuild-credential-preflight.test.ts`; the timeout helper controls Vitest's per-test budget and all product assertions remain unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 91808d83f -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/rebuild-credential-preflight.test.ts --reporter=verbose` passed 2/2 in 25.19 seconds. The same tests both passed with coverage instrumentation in 21.59 seconds; the focused coverage command then reported expected repository-wide threshold failures because it ran only one file.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: CI will run the aggregate projects; this one-file test-budget correction does not change production or shared test-harness behavior.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout allowed for the DCode rebuild preflight test to improve reliability during longer-running test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->