### PR TITLE
fix(snapshot): persist clone gateway port

### DIFF
--- a/src/lib/actions/sandbox/snapshot-restore-clone-ports.test.ts
+++ b/src/lib/actions/sandbox/snapshot-restore-clone-ports.test.ts
@@ -42,6 +42,7 @@ describe("runSandboxSnapshot restore: clone dashboard port identity", () => {
             provider: "nvidia-nim",
             model: "nvidia/model-a",
             dashboardPort: 18790,
+            gatewayName: "nemoclaw-18080",
           }
         : registeredClone,
     );
@@ -75,10 +76,40 @@ describe("runSandboxSnapshot restore: clone dashboard port identity", () => {
       expect.objectContaining({
         name: "beta",
         dashboardPort: 18901,
-        gatewayName: "nemoclaw",
-        gatewayPort: 8080,
+        gatewayName: "nemoclaw-18080",
+        gatewayPort: 18080,
       }),
     );
+  });
+
+  it("keeps a --force destination when the source gateway binding is invalid (#7227)", async () => {
+    f.getSandboxMock.mockImplementation((name) => ({
+      name: name ?? "alpha",
+      agent: "openclaw",
+      imageTag: `nemoclaw-${name}:test`,
+      openshellDriver: "docker",
+      provider: "nvidia-nim",
+      model: "nvidia/model-a",
+      dashboardPort: 18790,
+      gatewayName: name === "alpha" ? "other-8080" : "nemoclaw",
+    }));
+    f.parseLiveSandboxNamesMock.mockReturnValue(new Set(["alpha", "beta"]));
+    f.captureOpenshellMock.mockImplementation((args) =>
+      f.openshellResponses(args, {
+        "sandbox exec": { status: 0, output: f.dcodeProbeOutput("no-runtime") },
+        "sandbox list": { status: 0, output: "alpha Ready\nbeta Ready\n" },
+      }),
+    );
+    f.getLatestBackupMock.mockReturnValue({ ...f.latestBackupFixture });
+    const { runSandboxSnapshot } = await import("./snapshot");
+
+    await expect(
+      runSandboxSnapshot("alpha", { kind: "restore", to: "beta", force: true, yes: true }),
+    ).rejects.toThrow("Invalid persisted sandbox gateway binding");
+
+    expect(f.lifecycleMock.events).not.toContain("delete");
+    expect(f.streamSandboxCreateMock).not.toHaveBeenCalled();
+    expect(f.registerSandboxMock).not.toHaveBeenCalled();
   });
 
   it("keeps a Hermes clone rebuildable with its new public port and inherited internal port (#6746)", async () => {

--- a/src/lib/actions/sandbox/snapshot-restore-clone-ports.test.ts
+++ b/src/lib/actions/sandbox/snapshot-restore-clone-ports.test.ts
@@ -27,7 +27,7 @@ vi.mock("../../onboard/dashboard-port", () => ({
 beforeEach(f.resetSnapshotRestoreMocks);
 afterEach(f.cleanupSnapshotRestoreMocks);
 describe("runSandboxSnapshot restore: clone dashboard port identity", () => {
-  it("allocates the auto-created clone its own dashboard port instead of inheriting the source's (#6746)", async () => {
+  it("registers a legacy source clone with complete dashboard and gateway ports (#7227)", async () => {
     let registeredClone: f.SandboxRecord | null = null;
     f.registerSandboxMock.mockImplementation(
       (entry) => (registeredClone = entry as f.SandboxRecord),
@@ -75,6 +75,8 @@ describe("runSandboxSnapshot restore: clone dashboard port identity", () => {
       expect.objectContaining({
         name: "beta",
         dashboardPort: 18901,
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
       }),
     );
   });

--- a/src/lib/actions/sandbox/snapshot-restore-test-fixture.ts
+++ b/src/lib/actions/sandbox/snapshot-restore-test-fixture.ts
@@ -43,6 +43,7 @@ export type SandboxRecord = {
   }>;
   fromDockerfile?: string | null;
   gatewayName?: string | null;
+  gatewayPort?: number | null;
   imageTag?: string | null;
   workload?: SandboxWorkloadReceipt;
   openshellDriver?: string | null;

--- a/src/lib/actions/sandbox/snapshot.ts
+++ b/src/lib/actions/sandbox/snapshot.ts
@@ -361,6 +361,8 @@ async function autoCreateSandboxFromSource(
   srcName: string,
   dstName: string,
   srcEntry: SandboxEntry | { name: string },
+  sourceGatewayName: string,
+  sourceGatewayPort: number,
   fromImage: string,
   createPolicyPath: string,
   dstDashboardPort: number | null,
@@ -369,13 +371,6 @@ async function autoCreateSandboxFromSource(
   const openshellBin = getOpenshellBinary();
   const sourceObservabilityEnabled =
     (srcEntry as { observabilityEnabled?: boolean }).observabilityEnabled === true;
-  const sourceGatewayName = resolveSandboxGatewayName(
-    srcEntry as { gatewayName?: string | null; gatewayPort?: number | null },
-  );
-  const sourceGatewayPort = resolveGatewayPortFromName(sourceGatewayName);
-  if (sourceGatewayPort === null) {
-    throw new Error(`Cannot resolve gateway port for snapshot source '${srcName}'.`);
-  }
   const startupCommand = [
     "env",
     `NEMOCLAW_OBSERVABILITY=${sourceObservabilityEnabled ? "1" : "0"}`,
@@ -1288,6 +1283,13 @@ async function runSnapshotRestoreUnlocked(
         );
         snapshotExit(1);
       }
+      const lockedGatewayPort = resolveGatewayPortFromName(lockedGatewayName);
+      if (lockedGatewayPort === null) {
+        console.error(
+          `  Cannot resolve the gateway port for source sandbox '${sandboxName}' — aborting before changing '${targetSandbox}'.`,
+        );
+        snapshotExit(1);
+      }
       const compatibility = checkGatewayRouteCompatibility({
         gatewayName: sourceGatewayName,
         sandboxName: targetSandbox,
@@ -1320,6 +1322,8 @@ async function runSnapshotRestoreUnlocked(
           sandboxName,
           targetSandbox,
           lockedSourceEntry,
+          lockedGatewayName,
+          lockedGatewayPort,
           lockedFromImage,
           clonePolicy.policyPath,
           dstDashboardPort,

--- a/src/lib/actions/sandbox/snapshot.ts
+++ b/src/lib/actions/sandbox/snapshot.ts
@@ -33,7 +33,10 @@ import {
   withDashboardPortReservationLock,
 } from "../../onboard/dashboard-port";
 import { isValidForwardPort } from "../../onboard/dashboard-runtime";
-import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
+import {
+  resolveGatewayPortFromName,
+  resolveSandboxGatewayName,
+} from "../../onboard/gateway-binding";
 import { resolveHermesDashboardOnboardState } from "../../onboard/hermes-dashboard";
 import {
   isDcodeAgent,
@@ -366,6 +369,13 @@ async function autoCreateSandboxFromSource(
   const openshellBin = getOpenshellBinary();
   const sourceObservabilityEnabled =
     (srcEntry as { observabilityEnabled?: boolean }).observabilityEnabled === true;
+  const sourceGatewayName = resolveSandboxGatewayName(
+    srcEntry as { gatewayName?: string | null; gatewayPort?: number | null },
+  );
+  const sourceGatewayPort = resolveGatewayPortFromName(sourceGatewayName);
+  if (sourceGatewayPort === null) {
+    throw new Error(`Cannot resolve gateway port for snapshot source '${srcName}'.`);
+  }
   const startupCommand = [
     "env",
     `NEMOCLAW_OBSERVABILITY=${sourceObservabilityEnabled ? "1" : "0"}`,
@@ -453,6 +463,11 @@ async function autoCreateSandboxFromSource(
       (srcEntry as SandboxEntry).hermesDashboardEnabled === true
         ? dstDashboardPort
         : (srcEntry as SandboxEntry).hermesDashboardPort,
+    // A legacy source may have only a gateway name (or neither binding
+    // field). Register the new clone with the complete canonical binding so
+    // stop/start, recovery, and later snapshots can address its gateway.
+    gatewayName: sourceGatewayName,
+    gatewayPort: sourceGatewayPort,
   });
 
   const sourceAgent = (srcEntry as SandboxEntry).agent || "openclaw";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Snapshot restore now writes a complete canonical OpenShell gateway binding when it auto-creates a destination from a legacy or name-only source registry row. The restored sandbox keeps the source gateway identity and persists its resolved `gatewayPort`, so subsequent start, recovery, reboot, and snapshot operations do not fail lifecycle registration checks.

## Related Issue

Fixes #7227

## Changes

- Resolve the source sandbox's canonical gateway name and port before creating a snapshot clone.
- Persist both `gatewayName` and `gatewayPort` on the new clone instead of copying an incomplete legacy binding.
- Extend the clone-port regression coverage for name-only non-default sources and prove invalid source bindings preserve an existing `--force` destination.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This makes the existing documented snapshot-clone lifecycle contract hold for legacy source records; it adds no command, flag, prerequisite, output, state location, or supported workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: NemoClaw's nine-category security rubric was applied to `9e62f2ad4`; no findings. The clone derives the port only through the existing validated gateway-name resolver, validates before any destructive destination mutation, fails closed if resolution is impossible, and does not widen credential, command, filesystem, network, or authorization boundaries.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/manage-sandboxes/backup-restore.mdx`, `docs/reference/commands.mdx`, and `docs/reference/troubleshooting.mdx` already describe auto-created snapshot destinations and the required `gatewayName`/`gatewayPort` lifecycle binding.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9e62f2ad4 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/actions/sandbox/snapshot-restore-clone-ports.test.ts src/lib/actions/sandbox/snapshot.test.ts src/lib/actions/sandbox/snapshot-restore-offline-source.test.ts src/lib/actions/sandbox/snapshot-auto-create-failure.test.ts` passed 54 tests.
- [x] Applicable broad gate passed — `npm run checks:repository` and `npm run typecheck:cli` passed; the normal hooks also passed repository, source-shape, size-budget, secret, and incremental CLI checks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Snapshot-restored clones now retain the correct gateway name and port.
* Improved compatibility with legacy clones containing dashboard and gateway configuration.
* Restores are prevented when the source gateway port cannot be determined.
* Invalid gateway bindings are rejected before any existing data is deleted or a new clone is created.
* Newly created clones consistently register their validated gateway details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->