### PR TITLE
refactor(onboard): centralize readiness authority wiring

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -572,8 +572,7 @@ import {
   type MessagingChannelConfig,
 } from "./messaging-channel-config";
 import { streamGatewayStart } from "./onboard/gateway";
-// biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
-import { adoptPackagedGatewayAuthorityAfterTrustedInstall, bindGatewayAuthorityToCheckpoint, checkpointGatewayAuthority } from "./onboard/gateway-authority-checkpoint";
+import * as gatewayAuthorityCheckpoint from "./onboard/gateway-authority-checkpoint";
 import { createGatewayHostRuntime } from "./onboard/gateway-host-runtime";
 import {
   mergeRequiredHermesToolGatewayPolicyPresets,
@@ -586,11 +585,7 @@ import { getValidatedMessagingTokenByEnvKey } from "./onboard/messaging-token";
 import * as ollamaFlow from "./onboard/ollama-probe-failure";
 import { runOllamaStartupOrGate } from "./onboard/ollama-startup";
 import * as recreateJournal from "./onboard/onboard-recreate-journal";
-import type {
-  DockerDriverBinaryOverrides,
-  OpenShellInstallDeps,
-  OpenShellInstallResult,
-} from "./onboard/openshell-install";
+import type { OpenShellInstallDeps, OpenShellInstallResult } from "./onboard/openshell-install";
 import { createOnboardPolicyApplication } from "./onboard/policy-selection";
 import {
   printLowMemoryWarning,
@@ -1103,26 +1098,12 @@ function installOpenshell(): OpenShellInstallResult {
     log: console.log,
   });
 }
-function areRequiredDockerDriverBinariesPresent(
-  platform: NodeJS.Platform = process.platform,
-  binaries: DockerDriverBinaryOverrides = {},
-  arch: NodeJS.Architecture = process.arch,
-): boolean {
-  return openshellInstallFlow.areRequiredDockerDriverBinariesPresent(
-    getOpenShellInstallDeps(),
-    platform,
-    binaries,
-    arch,
-  );
-}
-
-function ensureOpenshellForOnboard(
-  exitProcess: (code: number) => never = (code) => process.exit(code),
-  persistTrustedGatewayOwner?: (owner: import("./onboard/gateway-ownership").GatewayOwner) => void,
-): OpenShellInstallResult {
-  // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
-  return openshellInstallFlow.ensureOpenshellForOnboard(getOpenShellInstallDeps(exitProcess), { afterSuccessfulInstall: () => adoptPackagedGatewayOwnerAfterTrustedInstall(persistTrustedGatewayOwner) });
-}
+const { areRequiredDockerDriverBinariesPresent, ensureOpenshellForOnboard } =
+  openshellInstallFlow.createOnboardOpenShellInstallBindings({
+    getInstallDeps: getOpenShellInstallDeps,
+    afterSuccessfulInstall: (persistTrustedGatewayOwner) =>
+      adoptPackagedGatewayOwnerAfterTrustedInstall(persistTrustedGatewayOwner),
+  });
 
 function getOpenShellInstallDeps(
   exitProcess: (code: number) => never = (code) => process.exit(code),
@@ -1380,15 +1361,29 @@ function attachGatewayMetadataIfNeeded({
 // ── Step 1: Preflight ────────────────────────────────────────────
 
 type PreflightOptions = import("./onboard/fatal-runtime-preflight").FatalRuntimePreflightOptions;
-// biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
-async function collectOnboardGatewayReadiness() { return preflightGatewayAuthority.collectOnboardGatewayReadiness({ gatewayName: () => GATEWAY_NAME, gatewayPort: () => GATEWAY_PORT, resolveOwner: getGatewayOwner, probeAttachment: machineGatewayOwnerDeps.probeGatewayAttachment }); }
+const onboardPreflightGatewayAuthority =
+  preflightGatewayAuthority.createOnboardPreflightGatewayAuthority({
+    gatewayName: () => GATEWAY_NAME,
+    gatewayPort: () => GATEWAY_PORT,
+    getGatewayOwnerDeps: () => machineGatewayOwnerDeps,
+    isNonInteractive,
+    ensureOpenshellForOnboard,
+    updateSession: onboardSession.updateSession,
+    adoptPackagedGatewayAuthorityAfterTrustedInstall:
+      gatewayAuthorityCheckpoint.adoptPackagedGatewayAuthorityAfterTrustedInstall,
+    checkPortAvailable,
+    isDockerDriverGatewayPortListener,
+    getGatewayReuseSnapshot,
+    selectNamedGatewayForReuseIfNeeded,
+    refreshDockerDriverGatewayReuseState,
+  });
 
 async function preflight(
   preflightOpts: PreflightOptions = {},
 ): Promise<ReturnType<typeof nim.detectGpu>> {
   step(1, 8, "Preflight checks");
-  // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
-  const { gpu, host, sandboxGpuConfig } = await fatalRuntimePreflight.runReadinessGatedRuntimePreflight(preflightOpts, { nonInteractive: isNonInteractive(), collectGatewayReadiness: collectOnboardGatewayReadiness });
+  const { gpu, host, sandboxGpuConfig } =
+    await onboardPreflightGatewayAuthority.runRuntimePreflight(preflightOpts);
 
   await preflightUtils.checkContainerRuntimeResources(host, {
     ignored: process.env.NEMOCLAW_IGNORE_RUNTIME_RESOURCES === "1",
@@ -1396,8 +1391,10 @@ async function preflight(
     confirm: () => promptYesNoOrDefault("  Continue with onboarding?", null, false),
   });
 
-  // biome-ignore format: keep src/lib/onboard.ts net-neutral for growth guardrail.
-  const { externallySupervised: gatewayExternallySupervised, gatewayReuseState: initialGatewayReuseState } = await preflightGatewayAuthority.preparePreflightGatewayAuthority({ collectGatewayReadiness: collectOnboardGatewayReadiness, ensureOpenshell: (persistTrustedGatewayOwner) => ensureOpenshellForOnboard((code) => process.exit(code), persistTrustedGatewayOwner), persistTrustedGatewayOwner: (owner) => { onboardSession.updateSession((session) => { adoptPackagedGatewayAuthorityAfterTrustedInstall(session, owner); }); }, gatewayPort: GATEWAY_PORT, portConflict: { checkPortAvailable, getGatewayPortCheckOptions: dockerDriverGatewayEnv.getGatewayPortCheckOptions, isDockerDriverGatewayPortListener, exitProcess: (code) => process.exit(code) }, getGatewayReuseSnapshot, selectNamedGatewayForReuseIfNeeded, refreshDockerDriverGatewayReuseState });
+  const {
+    externallySupervised: gatewayExternallySupervised,
+    gatewayReuseState: initialGatewayReuseState,
+  } = await onboardPreflightGatewayAuthority.prepareGatewayAuthority();
   let gatewayReuseState = initialGatewayReuseState;
 
   // Verify the legacy gateway container is actually running — openshell CLI
@@ -3686,7 +3683,7 @@ async function preflightAuthoritativeRebuildTarget(
             },
             {
               nonInteractive: true,
-              collectGatewayReadiness: collectOnboardGatewayReadiness,
+              collectGatewayReadiness: onboardPreflightGatewayAuthority.collectGatewayReadiness,
               exitProcess: (code) =>
                 fail(`onboard runtime preflight exited with code ${String(code)}`),
             },
@@ -3695,13 +3692,13 @@ async function preflightAuthoritativeRebuildTarget(
           ensureOpenshellForOnboard((code) =>
             fail(`OpenShell component preflight exited with code ${String(code)}`),
           ),
-        assertGatewayReadiness: collectOnboardGatewayReadiness,
+        assertGatewayReadiness: onboardPreflightGatewayAuthority.collectGatewayReadiness,
         inferenceRouteReady: (p, m) => isInferenceRouteReady(authoritativeGateway.name, p, m),
         captureForwardList: () => runCaptureOpenshell(["forward", "list"], { ignoreError: true }),
         checkPort: (port) => checkPortAvailable(port),
       },
     );
-    return checkpointGatewayAuthority(getGatewayOwner());
+    return gatewayAuthorityCheckpoint.checkpointGatewayAuthority(getGatewayOwner());
   } finally {
     resetGatewayOwnerBinding();
     GATEWAY_NAME = previous.gatewayName;
@@ -3917,7 +3914,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
     const resolvedGatewayOwner = getGatewayOwner();
     let checkpointedGatewayOwner = resolvedGatewayOwner;
     session = onboardSession.updateSession((currentSession) => {
-      checkpointedGatewayOwner = bindGatewayAuthorityToCheckpoint(
+      checkpointedGatewayOwner = gatewayAuthorityCheckpoint.bindGatewayAuthorityToCheckpoint(
         currentSession,
         resolvedGatewayOwner,
       );
@@ -4014,7 +4011,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
       getInitialGatewayReuseState: () =>
         selectNamedGatewayForReuseIfNeeded(getGatewayReuseSnapshot()).gatewayReuseState,
       assertGatewayReadiness: async () => {
-        await collectOnboardGatewayReadiness();
+        await onboardPreflightGatewayAuthority.collectGatewayReadiness();
       },
       gatewayName: GATEWAY_NAME,
       recreateSandbox: isRecreateSandbox,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3677,18 +3677,13 @@ async function preflightAuthoritativeRebuildTarget(
         resolveBaselinePolicy: resolveSandboxBaselinePolicy,
         bindGatewayAuthority: () => bindGatewayOwner(getGatewayOwner()),
         runFatalRuntimePreflight: async () =>
-          fatalRuntimePreflight.runReadinessGatedRuntimePreflight(
+          onboardPreflightGatewayAuthority.runRuntimePreflight(
             {
               sandboxGpu: opts.sandboxGpu,
               sandboxGpuDevice: opts.sandboxGpuDevice,
               noGpu: opts.noGpu,
             },
-            {
-              nonInteractive: true,
-              collectGatewayReadiness: onboardPreflightGatewayAuthority.collectGatewayReadiness,
-              exitProcess: (code) =>
-                fail(`onboard runtime preflight exited with code ${String(code)}`),
-            },
+            (code) => fail(`onboard runtime preflight exited with code ${String(code)}`),
           ),
         ensureOpenshell: () =>
           ensureOpenshellForOnboard((code) =>

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1365,6 +1365,8 @@ const onboardPreflightGatewayAuthority =
   preflightGatewayAuthority.createOnboardPreflightGatewayAuthority({
     gatewayName: () => GATEWAY_NAME,
     gatewayPort: () => GATEWAY_PORT,
+    collectGatewayReadiness: (deps) =>
+      preflightGatewayAuthority.collectOnboardGatewayReadiness(deps),
     getGatewayOwnerDeps: () => machineGatewayOwnerDeps,
     isNonInteractive,
     ensureOpenshellForOnboard,

--- a/src/lib/onboard/machine/preflight-gateway-authority.test.ts
+++ b/src/lib/onboard/machine/preflight-gateway-authority.test.ts
@@ -107,14 +107,18 @@ describe("preflight gateway authority", () => {
     const runRuntimePreflight = vi
       .spyOn(fatalRuntimePreflight, "runReadinessGatedRuntimePreflight")
       .mockImplementation(async () => ({}) as never);
+    const exitProcess = vi.fn((_code: number): never => {
+      throw new Error("exit");
+    });
 
-    await authority.runRuntimePreflight({});
+    await authority.runRuntimePreflight({}, exitProcess);
 
     expect(runRuntimePreflight).toHaveBeenCalledWith(
       {},
       {
         nonInteractive: true,
         collectGatewayReadiness: authority.collectGatewayReadiness,
+        exitProcess,
       },
     );
 

--- a/src/lib/onboard/machine/preflight-gateway-authority.test.ts
+++ b/src/lib/onboard/machine/preflight-gateway-authority.test.ts
@@ -4,7 +4,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayReadinessProjection } from "../../readiness/gateway";
 import type { Session } from "../../state/onboard-session";
-import * as fatalRuntimePreflight from "../fatal-runtime-preflight";
 import type { GatewayOwner } from "../gateway-ownership";
 import {
   createOnboardPreflightGatewayAuthority,
@@ -42,15 +41,13 @@ describe("preflight gateway authority", () => {
       findings: [],
       evidence: [],
     };
-    const collectReadiness = vi
-      .spyOn(fatalRuntimePreflight, "collectOnboardGatewayReadiness")
-      .mockImplementation(async (collectorDeps) => {
-        events.push("collect readiness");
-        expect(collectorDeps.gatewayName?.()).toBe("nemoclaw");
-        expect(collectorDeps.gatewayPort?.()).toBe(8080);
-        expect(collectorDeps.resolveOwner?.()).toBe(owner);
-        return gatewayReadiness;
-      });
+    const collectReadiness = vi.fn(async (collectorDeps) => {
+      events.push("collect readiness");
+      expect(collectorDeps.gatewayName?.()).toBe("nemoclaw");
+      expect(collectorDeps.gatewayPort?.()).toBe(8080);
+      expect(collectorDeps.resolveOwner?.()).toBe(owner);
+      return gatewayReadiness;
+    });
     const session = {} as Session;
     const deps = {
       gatewayName: vi.fn(() => "nemoclaw"),
@@ -58,6 +55,7 @@ describe("preflight gateway authority", () => {
         events.push("read gateway port");
         return 8080;
       }),
+      collectGatewayReadiness: collectReadiness,
       getGatewayOwnerDeps: vi.fn(() => ({
         resolveGatewayOwner: vi.fn(() => owner),
         probeGatewayAttachment: vi.fn(),

--- a/src/lib/onboard/machine/preflight-gateway-authority.test.ts
+++ b/src/lib/onboard/machine/preflight-gateway-authority.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayReadinessProjection } from "../../readiness/gateway";
 import type { Session } from "../../state/onboard-session";
+import * as fatalRuntimePreflight from "../fatal-runtime-preflight";
 import type { GatewayOwner } from "../gateway-ownership";
 import {
   createOnboardPreflightGatewayAuthority,
@@ -103,6 +104,19 @@ describe("preflight gateway authority", () => {
       }),
     };
     const authority = createOnboardPreflightGatewayAuthority(deps);
+    const runRuntimePreflight = vi
+      .spyOn(fatalRuntimePreflight, "runReadinessGatedRuntimePreflight")
+      .mockImplementation(async () => ({}) as never);
+
+    await authority.runRuntimePreflight({});
+
+    expect(runRuntimePreflight).toHaveBeenCalledWith(
+      {},
+      {
+        nonInteractive: true,
+        collectGatewayReadiness: authority.collectGatewayReadiness,
+      },
+    );
 
     await expect(authority.prepareGatewayAuthority()).resolves.toEqual({
       externallySupervised: false,

--- a/src/lib/onboard/machine/preflight-gateway-authority.test.ts
+++ b/src/lib/onboard/machine/preflight-gateway-authority.test.ts
@@ -3,13 +3,133 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayReadinessProjection } from "../../readiness/gateway";
-import { preparePreflightGatewayAuthority } from "./preflight-gateway-authority";
+import type { Session } from "../../state/onboard-session";
+import * as fatalRuntimePreflight from "../fatal-runtime-preflight";
+import type { GatewayOwner } from "../gateway-ownership";
+import {
+  createOnboardPreflightGatewayAuthority,
+  preparePreflightGatewayAuthority,
+} from "./preflight-gateway-authority";
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("preflight gateway authority", () => {
+  it("assembles the default readiness path lazily and preserves preflight order", async () => {
+    const events: string[] = [];
+    const owner: GatewayOwner = {
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      mode: "nemoclaw-managed",
+      source: "standalone",
+      endpoint: null,
+      stateDir: null,
+      supervisor: null,
+      requiredCapabilities: [],
+    };
+    const gatewayReadiness: GatewayReadinessProjection = {
+      observations: [
+        { id: "gateway.management.mode", state: "present", value: "nemoclaw-managed" },
+      ],
+      capabilities: [
+        { id: "gateway.authority.resolved", state: "present" },
+        { id: "gateway.attachment.valid", state: "present" },
+        { id: "gateway.reuse.ready", state: "present" },
+        { id: "gateway.version.compatible", state: "present" },
+        { id: "gateway.port.uncontested", state: "present" },
+      ],
+      findings: [],
+      evidence: [],
+    };
+    const collectReadiness = vi
+      .spyOn(fatalRuntimePreflight, "collectOnboardGatewayReadiness")
+      .mockImplementation(async (collectorDeps) => {
+        events.push("collect readiness");
+        expect(collectorDeps.gatewayName()).toBe("nemoclaw");
+        expect(collectorDeps.gatewayPort()).toBe(8080);
+        expect(collectorDeps.resolveOwner()).toBe(owner);
+        return gatewayReadiness;
+      });
+    const session = {} as Session;
+    const deps = {
+      gatewayName: vi.fn(() => "nemoclaw"),
+      gatewayPort: vi.fn(() => {
+        events.push("read gateway port");
+        return 8080;
+      }),
+      getGatewayOwnerDeps: vi.fn(() => ({
+        resolveGatewayOwner: vi.fn(() => owner),
+        probeGatewayAttachment: vi.fn(),
+      })),
+      isNonInteractive: vi.fn(() => true),
+      ensureOpenshellForOnboard: vi.fn(
+        (_exitProcess: (code: number) => never, persist: (value: GatewayOwner) => void) => {
+          events.push("ensure openshell");
+          persist(owner);
+        },
+      ),
+      updateSession: vi.fn((mutator: (value: Session) => Session | void) => {
+        events.push("update session");
+        mutator(session);
+        return session;
+      }),
+      adoptPackagedGatewayAuthorityAfterTrustedInstall: vi.fn(
+        (value: Session, adoptedOwner: GatewayOwner) => {
+          events.push("adopt authority");
+          expect(value).toBe(session);
+          return adoptedOwner;
+        },
+      ),
+      checkPortAvailable: vi.fn(async () => {
+        events.push("check port");
+        return { ok: true };
+      }),
+      isDockerDriverGatewayPortListener: vi.fn(() => false),
+      getGatewayReuseSnapshot: vi.fn(() => {
+        events.push("get reuse snapshot");
+        return {
+          gatewayStatus: "",
+          gwInfo: "",
+          activeGatewayInfo: "",
+          gatewayReuseState: "healthy" as const,
+        };
+      }),
+      selectNamedGatewayForReuseIfNeeded: vi.fn((snapshot) => {
+        events.push("select named gateway");
+        return snapshot;
+      }),
+      refreshDockerDriverGatewayReuseState: vi.fn(async (state) => {
+        events.push("refresh reuse state");
+        return state;
+      }),
+    };
+    const authority = createOnboardPreflightGatewayAuthority(deps);
+
+    await expect(authority.prepareGatewayAuthority()).resolves.toEqual({
+      externallySupervised: false,
+      gatewayReuseState: "healthy",
+    });
+
+    expect(events).toEqual([
+      "read gateway port",
+      "ensure openshell",
+      "update session",
+      "adopt authority",
+      "collect readiness",
+      "read gateway port",
+      "check port",
+      "get reuse snapshot",
+      "select named gateway",
+      "refresh reuse state",
+    ]);
+    expect(deps.getGatewayOwnerDeps).toHaveBeenCalledOnce();
+    expect(deps.gatewayPort).toHaveBeenCalledTimes(2);
+    expect(collectReadiness).toHaveBeenCalledWith(
+      expect.objectContaining({ gatewayName: deps.gatewayName, gatewayPort: deps.gatewayPort }),
+    );
+  });
+
   it("rejects a blocked refreshed projection before reuse or lifecycle handling (#7411)", async () => {
     const gatewayReadiness: GatewayReadinessProjection = {
       observations: [],

--- a/src/lib/onboard/machine/preflight-gateway-authority.test.ts
+++ b/src/lib/onboard/machine/preflight-gateway-authority.test.ts
@@ -46,9 +46,9 @@ describe("preflight gateway authority", () => {
       .spyOn(fatalRuntimePreflight, "collectOnboardGatewayReadiness")
       .mockImplementation(async (collectorDeps) => {
         events.push("collect readiness");
-        expect(collectorDeps.gatewayName()).toBe("nemoclaw");
-        expect(collectorDeps.gatewayPort()).toBe(8080);
-        expect(collectorDeps.resolveOwner()).toBe(owner);
+        expect(collectorDeps.gatewayName?.()).toBe("nemoclaw");
+        expect(collectorDeps.gatewayPort?.()).toBe(8080);
+        expect(collectorDeps.resolveOwner?.()).toBe(owner);
         return gatewayReadiness;
       });
     const session = {} as Session;

--- a/src/lib/onboard/machine/preflight-gateway-authority.ts
+++ b/src/lib/onboard/machine/preflight-gateway-authority.ts
@@ -40,6 +40,9 @@ export interface PreflightGatewayAuthority {
 
 export interface OnboardPreflightGatewayAuthorityDeps
   extends Pick<OnboardGatewayReadinessCollectorDeps, "gatewayName" | "gatewayPort"> {
+  collectGatewayReadiness(
+    deps: OnboardGatewayReadinessCollectorDeps,
+  ): Promise<GatewayReadinessProjection>;
   getGatewayOwnerDeps(): {
     resolveGatewayOwner(): GatewayOwner;
     probeGatewayAttachment: OnboardGatewayReadinessCollectorDeps["probeAttachment"];
@@ -64,7 +67,7 @@ export interface OnboardPreflightGatewayAuthorityDeps
 export function createOnboardPreflightGatewayAuthority(deps: OnboardPreflightGatewayAuthorityDeps) {
   const collectGatewayReadiness = () => {
     const ownerDeps = deps.getGatewayOwnerDeps();
-    return collectOnboardGatewayReadiness({
+    return deps.collectGatewayReadiness({
       gatewayName: deps.gatewayName,
       gatewayPort: deps.gatewayPort,
       resolveOwner: ownerDeps.resolveGatewayOwner,

--- a/src/lib/onboard/machine/preflight-gateway-authority.ts
+++ b/src/lib/onboard/machine/preflight-gateway-authority.ts
@@ -3,6 +3,8 @@
 
 import type { GatewayReadinessProjection } from "../../readiness/gateway";
 import type { GatewayReuseState } from "../../state/gateway";
+import type { Session } from "../../state/onboard-session";
+import { getGatewayPortCheckOptions } from "../docker-driver-gateway-env";
 import * as fatalRuntimePreflight from "../fatal-runtime-preflight";
 import type { GatewayOwner } from "../gateway-ownership";
 import {
@@ -34,6 +36,72 @@ export interface PreparePreflightGatewayAuthorityDeps {
 export interface PreflightGatewayAuthority {
   externallySupervised: boolean;
   gatewayReuseState: GatewayReuseState;
+}
+
+export interface OnboardPreflightGatewayAuthorityDeps
+  extends Pick<OnboardGatewayReadinessCollectorDeps, "gatewayName" | "gatewayPort"> {
+  getGatewayOwnerDeps(): {
+    resolveGatewayOwner(): GatewayOwner;
+    probeGatewayAttachment: OnboardGatewayReadinessCollectorDeps["probeAttachment"];
+  };
+  isNonInteractive(): boolean;
+  ensureOpenshellForOnboard(
+    exitProcess: (code: number) => never,
+    persistTrustedGatewayOwner: (owner: GatewayOwner) => void,
+  ): void;
+  updateSession(mutator: (session: Session) => Session | void): Session;
+  adoptPackagedGatewayAuthorityAfterTrustedInstall(
+    session: Session,
+    owner: GatewayOwner,
+  ): GatewayOwner;
+  checkPortAvailable: GatewayPortConflictDeps["checkPortAvailable"];
+  isDockerDriverGatewayPortListener: GatewayPortConflictDeps["isDockerDriverGatewayPortListener"];
+  getGatewayReuseSnapshot(): GatewayReuseSnapshot;
+  selectNamedGatewayForReuseIfNeeded(snapshot: GatewayReuseSnapshot): GatewayReuseSnapshot;
+  refreshDockerDriverGatewayReuseState(state: GatewayReuseState): Promise<GatewayReuseState>;
+}
+
+export function createOnboardPreflightGatewayAuthority(deps: OnboardPreflightGatewayAuthorityDeps) {
+  const collectGatewayReadiness = () => {
+    const ownerDeps = deps.getGatewayOwnerDeps();
+    return collectOnboardGatewayReadiness({
+      gatewayName: deps.gatewayName,
+      gatewayPort: deps.gatewayPort,
+      resolveOwner: ownerDeps.resolveGatewayOwner,
+      probeAttachment: ownerDeps.probeGatewayAttachment,
+    });
+  };
+  return {
+    collectGatewayReadiness,
+    runRuntimePreflight: (
+      options: Parameters<typeof fatalRuntimePreflight.runReadinessGatedRuntimePreflight>[0],
+    ) =>
+      fatalRuntimePreflight.runReadinessGatedRuntimePreflight(options, {
+        nonInteractive: deps.isNonInteractive(),
+        collectGatewayReadiness,
+      }),
+    prepareGatewayAuthority: () =>
+      preparePreflightGatewayAuthority({
+        collectGatewayReadiness,
+        ensureOpenshell: (persistTrustedGatewayOwner) =>
+          deps.ensureOpenshellForOnboard((code) => process.exit(code), persistTrustedGatewayOwner),
+        persistTrustedGatewayOwner: (owner) => {
+          deps.updateSession((session) => {
+            deps.adoptPackagedGatewayAuthorityAfterTrustedInstall(session, owner);
+          });
+        },
+        gatewayPort: deps.gatewayPort(),
+        portConflict: {
+          checkPortAvailable: deps.checkPortAvailable,
+          getGatewayPortCheckOptions,
+          isDockerDriverGatewayPortListener: deps.isDockerDriverGatewayPortListener,
+          exitProcess: (code) => process.exit(code),
+        },
+        getGatewayReuseSnapshot: deps.getGatewayReuseSnapshot,
+        selectNamedGatewayForReuseIfNeeded: deps.selectNamedGatewayForReuseIfNeeded,
+        refreshDockerDriverGatewayReuseState: deps.refreshDockerDriverGatewayReuseState,
+      }),
+  };
 }
 
 export function collectOnboardGatewayReadiness(

--- a/src/lib/onboard/machine/preflight-gateway-authority.ts
+++ b/src/lib/onboard/machine/preflight-gateway-authority.ts
@@ -78,10 +78,14 @@ export function createOnboardPreflightGatewayAuthority(deps: OnboardPreflightGat
     collectGatewayReadiness,
     runRuntimePreflight: (
       options: Parameters<typeof fatalRuntimePreflight.runReadinessGatedRuntimePreflight>[0],
+      exitProcess?: NonNullable<
+        Parameters<typeof fatalRuntimePreflight.runReadinessGatedRuntimePreflight>[1]["exitProcess"]
+      >,
     ) =>
       fatalRuntimePreflight.runReadinessGatedRuntimePreflight(options, {
         nonInteractive: deps.isNonInteractive(),
         collectGatewayReadiness,
+        ...(exitProcess ? { exitProcess } : {}),
       }),
     prepareGatewayAuthority: () =>
       preparePreflightGatewayAuthority({

--- a/src/lib/onboard/openshell-install.test.ts
+++ b/src/lib/onboard/openshell-install.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  createOnboardOpenShellInstallBindings,
   ensureOpenshellForOnboard,
   type OpenShellInstallDeps,
   type OpenShellInstallResult,
@@ -48,6 +49,44 @@ function makeDeps(overrides: Partial<OpenShellInstallDeps> = {}) {
 }
 
 describe("ensureOpenshellForOnboard", () => {
+  it("binds lazy install dependencies and forwards trusted-owner persistence", () => {
+    const installResult: OpenShellInstallResult = {
+      installed: true,
+      localBin: "/tmp/openshell",
+      futureShellPathHint: null,
+    };
+    const getInstallDeps = vi.fn((exit?: (code: number) => never) =>
+      makeDeps({
+        isOpenshellInstalled: () => false,
+        installOpenshell: () => installResult,
+        exit: exit ?? makeDeps().exit,
+      }),
+    );
+    const afterSuccessfulInstall = vi.fn();
+    const bindings = createOnboardOpenShellInstallBindings({
+      getInstallDeps,
+      afterSuccessfulInstall,
+    });
+    const exitProcess = vi.fn((code: number): never => {
+      throw new Error(`exit ${code}`);
+    });
+    const persistTrustedGatewayOwner = vi.fn();
+
+    expect(
+      bindings.areRequiredDockerDriverBinariesPresent("linux", {
+        gatewayBin: "/tmp/gateway",
+        sandboxBin: "/tmp/sandbox",
+      }),
+    ).toBe(true);
+    expect(bindings.ensureOpenshellForOnboard(exitProcess, persistTrustedGatewayOwner)).toEqual(
+      installResult,
+    );
+
+    expect(getInstallDeps).toHaveBeenNthCalledWith(1);
+    expect(getInstallDeps).toHaveBeenNthCalledWith(2, exitProcess);
+    expect(afterSuccessfulInstall).toHaveBeenCalledWith(persistTrustedGatewayOwner);
+  });
+
   it("runs trusted post-install reconciliation only after a successful install", () => {
     const afterSuccessfulInstall = vi.fn();
     const deps = makeDeps({

--- a/src/lib/onboard/openshell-install.ts
+++ b/src/lib/onboard/openshell-install.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { GatewayOwner } from "./gateway-ownership";
+
 export type OpenShellInstallResult = {
   installed?: boolean;
   localBin: string | null;
@@ -100,6 +102,38 @@ export type DockerDriverBinaryOverrides = {
   sandboxBin?: string | null;
   vmDriverBin?: string | null;
 };
+
+export interface OnboardOpenShellInstallBindingDeps {
+  getInstallDeps(exitProcess?: (code: number) => never): OpenShellInstallDeps;
+  afterSuccessfulInstall(persistTrustedGatewayOwner?: (owner: GatewayOwner) => void): void;
+}
+
+export function createOnboardOpenShellInstallBindings(deps: OnboardOpenShellInstallBindingDeps): {
+  areRequiredDockerDriverBinariesPresent(
+    platform?: NodeJS.Platform,
+    binaries?: DockerDriverBinaryOverrides,
+    arch?: NodeJS.Architecture,
+  ): boolean;
+  ensureOpenshellForOnboard(
+    exitProcess?: (code: number) => never,
+    persistTrustedGatewayOwner?: (owner: GatewayOwner) => void,
+  ): OpenShellInstallResult;
+} {
+  return {
+    areRequiredDockerDriverBinariesPresent: (
+      platform = process.platform,
+      binaries = {},
+      arch = process.arch,
+    ) => areRequiredDockerDriverBinariesPresent(deps.getInstallDeps(), platform, binaries, arch),
+    ensureOpenshellForOnboard: (
+      exitProcess = (code) => process.exit(code),
+      persistTrustedGatewayOwner,
+    ) =>
+      ensureOpenshellForOnboard(deps.getInstallDeps(exitProcess), {
+        afterSuccessfulInstall: () => deps.afterSuccessfulInstall(persistTrustedGatewayOwner),
+      }),
+  };
+}
 
 export type OpenShellInstallDeps = {
   isLinuxDockerDriverGatewayEnabled: (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This refactor removes five formatter exemptions that survived the entrypoint-budget work in #8738. It moves the default OpenShell installation and readiness/gateway-authority dependency assembly into the existing modules that own those contracts.

The install, trusted authority checkpoint, readiness, port-conflict, and gateway-reuse order is unchanged. `src/lib/onboard.ts` becomes one line smaller, its measured fan-out falls from 211 to 210, and no configuration or supported behavior changes.

## Changes

- Add a typed OpenShell onboarding binding for the existing install and binary-presence paths.
- Add a typed preflight gateway-authority binding for the existing readiness, authority, port-conflict, and reuse paths.
- Preserve the existing readiness-collector override seam through explicit dependency injection.
- Replace compressed `onboard.ts` wiring with formatted calls and remove five growth-guardrail formatter suppressions.
- Add focused tests for lazy dependency resolution, trusted-owner persistence, dynamic gateway values, custom rebuild exit handling, and the preserved preflight event order.
- Route authoritative rebuild through the same readiness-authority seam instead of retaining a parallel fatal-preflight call.

The current consumers are the standard onboarding preflight and authoritative rebuild readiness paths. Existing owner modules now assemble their canonical dependencies; no new extension or configuration surface is introduced.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: No flag, environment variable, default, output, public API, persistence schema, lifecycle effect, or failure order changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the revision-specific nine-category review with PASS in every category and no findings: https://github.com/NVIDIA/NemoClaw/pull/8909#issuecomment-5270029524
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing system-readiness, command-reference, recovery, and troubleshooting pages already document the preserved install, authority-recording, readiness, port-conflict, and reuse order; the follow-up only completes the internal readiness-authority cutover.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a1dad111f -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 82 focused assertions passed across OpenShell install, gateway-authority preflight, fatal readiness, readiness presentation, gateway sequence, checkpoint, and host-runtime contracts; the revision-specific authority unit test passes 2/2 and proves the rebuild exit handler reaches the canonical preflight context; `npm run build:cli`, `npm run typecheck:cli`, source architecture, source shape, and test-size checks passed. The existing macOS integration test advances past the readiness-collector regression and then encounters an unrelated host Homebrew trust probe; the Linux CI rerun is authoritative.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused internal dependency-wiring refactor.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>
